### PR TITLE
Always allow to register devices

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,11 @@
 .idea
 .mypy_cache
 .pytest_cache
+.venv
 .run
 build
 chromedriverlog.txt
+colibri/target
 frontend/app/.env.development.local
 frontend/app/.idea
 frontend/app/.nyc_output

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 * :bug:`11708` Users can now mark Solana tokens as spam in addition to EVM tokens.
 * :bug:`11709` History events page will now properly refresh after marking an asset as spam or ignoring it from the context menu.
-* :feature:`11702` Zerox Base Swaps through the latest settler will now be properly decoded.
+* :bug:`-` Registering a new device is now more reliable when rotki runs in container environments.
 * :feature:`11702` Zerox Base Swaps through the latest settler  will now be properly decoded.
 
 * :release:`1.42.0 <2025-02-20>`

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -6,10 +6,12 @@ import logging
 import os
 import platform
 import re
+import secrets
 import time
 from base64 import b64decode, b64encode
 from binascii import Error as BinasciiError
 from collections.abc import Sequence
+from contextlib import suppress
 from enum import Enum
 from http import HTTPStatus
 from json import JSONDecodeError
@@ -52,6 +54,9 @@ log = RotkehlchenLogsAdapter(logger)
 DOCKER_PLATFORM_KEY: Final = 'docker'
 DOCKER_SHORT_ID_HASH_LENGTH: Final = 12
 KUBERNETES_PLATFORM_KEY: Final = 'kubernetes'
+CONTAINER_FALLBACK_ID_FILE: Final = Path('/opt/rotki/.container-id')
+DOCKER_ENTRYPOINT_PATH: Final = '/opt/rotki/entrypoint.py'
+UNKNOWN_CONTAINER_FALLBACK_ID_PREFIX: Final = 'unknown-container'
 
 
 class RemoteMetadata(NamedTuple):
@@ -203,6 +208,43 @@ def get_podman_container_id(mountinfo: str) -> str | None:
     return None
 
 
+def is_running_in_rotki_docker_image() -> bool:
+    """Return whether rotki appears to run in the official docker image."""
+    try:
+        init_cmdline = Path('/proc/1/cmdline').read_bytes().decode('utf-8', errors='ignore')
+    except OSError:
+        init_cmdline = ''
+
+    if DOCKER_ENTRYPOINT_PATH in init_cmdline:
+        return True
+
+    try:
+        parent_cmdline = Path(f'/proc/{os.getppid()}/cmdline').read_bytes().decode('utf-8', errors='ignore')  # noqa: E501
+    except OSError:
+        return False
+
+    return DOCKER_ENTRYPOINT_PATH in parent_cmdline
+
+
+def get_or_create_fallback_container_id() -> str | None:
+    """Get a persistent container-local identifier or create one if needed."""
+    try:
+        with open(CONTAINER_FALLBACK_ID_FILE, mode='x', encoding='utf-8') as write_file:
+            fallback_id = f'{UNKNOWN_CONTAINER_FALLBACK_ID_PREFIX}-{secrets.token_hex(4)}'
+            write_file.write(fallback_id)
+            return fallback_id
+    except FileExistsError:
+        with suppress(OSError):
+            return CONTAINER_FALLBACK_ID_FILE.read_text(encoding='utf-8').strip() or None
+    except OSError as e:
+        log.error(
+            f'Failed to persist fallback container identifier at {CONTAINER_FALLBACK_ID_FILE} due to {e}',  # noqa: E501
+        )
+        return None
+
+    return None
+
+
 def extended_get_machine_id(username: str) -> str:
     """Wrapper around machineid.hashed_id that checks the hostname in the case of
     kubernetes being detected in the environment.
@@ -234,18 +276,26 @@ def check_docker_container() -> tuple[str, str] | None:
     if (pod_name := get_kubernetes_pod_name()) is not None:
         return (pod_name, KUBERNETES_PLATFORM_KEY)
 
+    mountinfo = ''
     try:
         mountinfo = Path('/proc/self/mountinfo').read_text(encoding='utf-8')
     except OSError as e:
         log.error(f'Failed to read /proc/self/mountinfo due to {e}')
-        return None
 
-    if (podman_container_id := get_podman_container_id(mountinfo)) is not None:
-        return (podman_container_id[:DOCKER_SHORT_ID_HASH_LENGTH], DOCKER_PLATFORM_KEY)
+    if mountinfo != '':
+        if (podman_container_id := get_podman_container_id(mountinfo)) is not None:
+            return (podman_container_id[:DOCKER_SHORT_ID_HASH_LENGTH], DOCKER_PLATFORM_KEY)
 
-    if 'docker' in mountinfo:
-        match = re.search(r'docker/containers/([a-f0-9]+)/hostname', mountinfo)
-        return (match.group(1)[:DOCKER_SHORT_ID_HASH_LENGTH], DOCKER_PLATFORM_KEY) if match else None  # noqa: E501
+        if 'docker' in mountinfo:
+            match = re.search(r'docker/containers/([a-f0-9]+)/hostname', mountinfo)
+            if match is not None:
+                return (match.group(1)[:DOCKER_SHORT_ID_HASH_LENGTH], DOCKER_PLATFORM_KEY)
+
+    if (
+        is_running_in_rotki_docker_image() and
+        (fallback_container_id := get_or_create_fallback_container_id()) is not None
+    ):
+        return (fallback_container_id, DOCKER_PLATFORM_KEY)
 
     return None
 

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -24,13 +24,17 @@ from rotkehlchen.errors.api import (
     RotkehlchenPermissionError,
 )
 from rotkehlchen.premium.premium import (
+    DOCKER_ENTRYPOINT_PATH,
     DOCKER_PLATFORM_KEY,
     KUBERNETES_PLATFORM_KEY,
+    UNKNOWN_CONTAINER_FALLBACK_ID_PREFIX,
     Premium,
     PremiumCredentials,
     check_docker_container,
     extended_get_machine_id,
     get_kubernetes_pod_name,
+    get_or_create_fallback_container_id,
+    is_running_in_rotki_docker_image,
 )
 from rotkehlchen.tests.utils.constants import A_GBP, DEFAULT_TESTS_MAIN_CURRENCY
 from rotkehlchen.tests.utils.decoders import patch_decoder_reload_data
@@ -939,3 +943,31 @@ def test_extended_get_machine_id_uses_container_identifier():
             digestmod=hashlib.sha256,
         ).hexdigest()
         assert extended_get_machine_id(username) == expected
+
+
+def test_get_or_create_fallback_container_id_persists(tmp_path: Path) -> None:
+    fallback_path = tmp_path / 'rotki-container-id'
+    with patch('rotkehlchen.premium.premium.CONTAINER_FALLBACK_ID_FILE', fallback_path):
+        generated_id = get_or_create_fallback_container_id()
+        assert generated_id is not None
+        assert generated_id.startswith(f'{UNKNOWN_CONTAINER_FALLBACK_ID_PREFIX}-')
+        assert generated_id == fallback_path.read_text(encoding='utf-8').strip()
+        assert get_or_create_fallback_container_id() == generated_id
+
+
+def test_check_docker_container_uses_fallback_identifier() -> None:
+    fallback_id = 'f' * 32
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch('rotkehlchen.premium.premium.Path.read_text', return_value='rootfs / rw'),
+        patch('rotkehlchen.premium.premium.is_running_in_rotki_docker_image', return_value=True),
+        patch('rotkehlchen.premium.premium.get_or_create_fallback_container_id', return_value=fallback_id),  # noqa: E501
+    ):
+        assert check_docker_container() == (fallback_id, DOCKER_PLATFORM_KEY)
+
+
+def test_is_running_in_rotki_docker_image_detects_init_cmdline() -> None:
+    with (
+        patch('rotkehlchen.premium.premium.Path.read_bytes', return_value=f'python3\x00{DOCKER_ENTRYPOINT_PATH}\x00'.encode()),  # noqa: E501
+    ):
+        assert is_running_in_rotki_docker_image() is True


### PR DESCRIPTION
When the app is running in a container under a system that we don't know instead of failing to register the device it  will create one that will live as long as the container lives.
