### PR TITLE
refactor(frontend): modernize to Vue 3.5+ patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,6 +260,38 @@ async function fetchData() {
     filters?: Record<string, string>;
   }>();
   ```
+- **Reactive prop passing rules** — destructured props are reactive in `computed()`, `watch()`, and templates, but they are **not** `Ref<T>` objects. When passing to composables or watchers:
+  ```typescript
+  const { category, chains, address } = defineProps<{
+    category: string;
+    chains: string[];
+    address: string;
+  }>();
+
+  // ✅ watch() — wrap in getter
+  watch(() => category, (val) => { ... });
+
+  // ✅ MaybeRefOrGetter<T> param — pass as getter
+  const helper = useMyComposable(() => category);
+
+  // ✅ MaybeRef<T> or Ref<T> param — wrap with toRef
+  const data = useOtherComposable(toRef(() => chains));
+
+  // ✅ computed() — use directly (reactive)
+  const label = computed<string>(() => `${category}-${address}`);
+
+  // ❌ Don't use toRef when a getter suffices (MaybeRefOrGetter)
+  const helper = useMyComposable(toRef(() => category));
+
+  // ❌ Don't use toRefs(props) — destructure directly
+  const props = defineProps<{ ... }>();
+  const { category } = toRefs(props);
+  ```
+
+##### Composable argument conventions
+- When authoring composables, accept `MaybeRefOrGetter<T>` for maximum flexibility and use `toValue()` internally to normalize inputs
+- `toValue()` handles plain values, refs, and getter functions uniformly
+- Use `onWatcherCleanup()` (Vue 3.5+) instead of `onCleanup` callback parameter for cleaner extraction into helper functions
 
 ##### Emits — typed tuple syntax
 - Use the typed tuple syntax for emit definitions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,38 @@ async function fetchData() {
     filters?: Record<string, string>;
   }>();
   ```
+- **Reactive prop passing rules** — destructured props are reactive in `computed()`, `watch()`, and templates, but they are **not** `Ref<T>` objects. When passing to composables or watchers:
+  ```typescript
+  const { category, chains, address } = defineProps<{
+    category: string;
+    chains: string[];
+    address: string;
+  }>();
+
+  // ✅ watch() — wrap in getter
+  watch(() => category, (val) => { ... });
+
+  // ✅ MaybeRefOrGetter<T> param — pass as getter
+  const helper = useMyComposable(() => category);
+
+  // ✅ MaybeRef<T> or Ref<T> param — wrap with toRef
+  const data = useOtherComposable(toRef(() => chains));
+
+  // ✅ computed() — use directly (reactive)
+  const label = computed<string>(() => `${category}-${address}`);
+
+  // ❌ Don't use toRef when a getter suffices (MaybeRefOrGetter)
+  const helper = useMyComposable(toRef(() => category));
+
+  // ❌ Don't use toRefs(props) — destructure directly
+  const props = defineProps<{ ... }>();
+  const { category } = toRefs(props);
+  ```
+
+##### Composable argument conventions
+- When authoring composables, accept `MaybeRefOrGetter<T>` for maximum flexibility and use `toValue()` internally to normalize inputs
+- `toValue()` handles plain values, refs, and getter functions uniformly
+- Use `onWatcherCleanup()` (Vue 3.5+) instead of `onCleanup` callback parameter for cleaner extraction into helper functions
 
 ##### Emits — typed tuple syntax
 - Use the typed tuple syntax for emit definitions:

--- a/frontend/app/src/components/GlobalSearch.vue
+++ b/frontend/app/src/components/GlobalSearch.vue
@@ -16,14 +16,9 @@ import { FiatDisplay } from '@/modules/amount-display/components';
 import { useAppRoutes } from '@/router/routes';
 import { useSessionSettingsStore } from '@/store/settings/session';
 
-withDefaults(
-  defineProps<{
-    isMini?: boolean;
-  }>(),
-  {
-    isMini: false,
-  },
-);
+const { isMini = false } = defineProps<{
+  isMini?: boolean;
+}>();
 
 interface SearchItem {
   value: number;
@@ -47,7 +42,7 @@ const { appRoutes } = useAppRoutes();
 const open = ref<boolean>(false);
 const isMac = ref<boolean>(false);
 
-const input = ref<any>(null);
+const input = useTemplateRef<any>('input');
 const selected = ref<number>();
 const search = ref<string>('');
 const loading = ref<boolean>(false);

--- a/frontend/app/src/components/NavigationMenu.vue
+++ b/frontend/app/src/components/NavigationMenu.vue
@@ -28,14 +28,9 @@ interface DividerItem {
 
 type MenuItem = NavItem | NavGroupItem | DividerItem;
 
-withDefaults(
-  defineProps<{
-    isMini?: boolean;
-  }>(),
-  {
-    isMini: false,
-  },
-);
+const { isMini = false } = defineProps<{
+  isMini?: boolean;
+}>();
 
 const { appRoutes } = useAppRoutes();
 const navItems = computed<MenuItem[]>(() => {

--- a/frontend/app/src/components/NavigationMenuItem.vue
+++ b/frontend/app/src/components/NavigationMenuItem.vue
@@ -4,29 +4,17 @@ import type { Component } from 'vue';
 import type { RouteLocationRaw } from 'vue-router';
 import AppImage from '@/components/common/AppImage.vue';
 
-const props = withDefaults(
-  defineProps<{
-    mini?: boolean;
-    icon?: RuiIcons;
-    text: string;
-    image?: string;
-    iconComponent?: Component;
-    active?: boolean;
-    subMenu?: boolean;
-    parent?: boolean;
-    to?: RouteLocationRaw;
-  }>(),
-  {
-    active: false,
-    icon: undefined,
-    iconComponent: undefined,
-    image: '',
-    mini: false,
-    parent: false,
-    subMenu: false,
-    to: undefined,
-  },
-);
+const { mini = false, icon, text, image = '', iconComponent, active = false, subMenu = false, parent = false, to } = defineProps<{
+  mini?: boolean;
+  icon?: RuiIcons;
+  text: string;
+  image?: string;
+  iconComponent?: Component;
+  active?: boolean;
+  subMenu?: boolean;
+  parent?: boolean;
+  to?: RouteLocationRaw;
+}>();
 
 defineSlots<{
   default: () => any;
@@ -36,8 +24,8 @@ const router = useRouter();
 
 const [DefineImage, ReuseImage] = createReusableTemplate();
 
-const outer = ref<HTMLDivElement>();
-const inner = ref<HTMLDivElement>();
+const outer = useTemplateRef<HTMLDivElement>('outer');
+const inner = useTemplateRef<HTMLDivElement>('inner');
 const { height: innerHeight } = useElementSize(inner);
 const subMenuExpanded = ref<boolean>(false);
 
@@ -55,11 +43,11 @@ function toggleExpand(): void {
 }
 
 function onBodyClick(): void {
-  if (!props.parent)
+  if (!parent)
     return;
 
-  if (props.to && !get(subMenuExpanded)) {
-    router.push(props.to);
+  if (to && !get(subMenuExpanded)) {
+    router.push(to);
     toggleExpand();
   }
   else {
@@ -68,7 +56,7 @@ function onBodyClick(): void {
 }
 
 onMounted(() => {
-  if (props.parent && props.active)
+  if (parent && active)
     set(subMenuExpanded, true);
 });
 </script>

--- a/frontend/app/src/components/account-management/create-account/credentials/CreateAccountCredentials.vue
+++ b/frontend/app/src/components/account-management/create-account/credentials/CreateAccountCredentials.vue
@@ -7,15 +7,10 @@ const form = defineModel<LoginCredentials>('form', { required: true });
 const passwordConfirm = defineModel<string>('passwordConfirm', { required: true });
 const userPrompted = defineModel<boolean>('userPrompted', { required: true });
 
-withDefaults(
-  defineProps<{
-    syncDatabase?: boolean;
-    loading: boolean;
-  }>(),
-  {
-    syncDatabase: false,
-  },
-);
+const { loading, syncDatabase = false } = defineProps<{
+  syncDatabase?: boolean;
+  loading: boolean;
+}>();
 
 const emit = defineEmits<{
   back: [];

--- a/frontend/app/src/components/account-management/create-account/credentials/CreateAccountCredentialsForm.vue
+++ b/frontend/app/src/components/account-management/create-account/credentials/CreateAccountCredentialsForm.vue
@@ -10,14 +10,9 @@ const valid = defineModel<boolean>('valid', { required: true });
 const passwordConfirm = defineModel<string>('passwordConfirm', { required: true });
 const userPrompted = defineModel<boolean>('userPrompted', { required: true });
 
-withDefaults(
-  defineProps<{
-    loading?: boolean;
-  }>(),
-  {
-    loading: false,
-  },
-);
+const { loading = false } = defineProps<{
+  loading?: boolean;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/app/src/components/account-management/create-account/premium/CreateAccountPremiumForm.vue
+++ b/frontend/app/src/components/account-management/create-account/premium/CreateAccountPremiumForm.vue
@@ -8,30 +8,28 @@ import { toMessages } from '@/utils/validation';
 const form = defineModel<PremiumSetup>('form', { required: true });
 const valid = defineModel<boolean>('valid', { required: true });
 
-const props = defineProps<{
+const { loading, enabled } = defineProps<{
   loading: boolean;
   enabled: boolean;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { enabled } = toRefs(props);
-
 const apiKey = useRefPropVModel(form, 'apiKey');
 const apiSecret = useRefPropVModel(form, 'apiSecret');
 const syncDatabase = useRefPropVModel(form, 'syncDatabase');
 
-watch(enabled, (enabled) => {
+watch(() => enabled, (enabled) => {
   if (!enabled)
     set(syncDatabase, false);
 });
 
 const rules = {
   apiKey: {
-    required: helpers.withMessage(t('premium_credentials.validation.non_empty_key'), requiredIf(enabled)),
+    required: helpers.withMessage(t('premium_credentials.validation.non_empty_key'), requiredIf(() => enabled)),
   },
   apiSecret: {
-    required: helpers.withMessage(t('premium_credentials.validation.non_empty_secret'), requiredIf(enabled)),
+    required: helpers.withMessage(t('premium_credentials.validation.non_empty_secret'), requiredIf(() => enabled)),
   },
 };
 

--- a/frontend/app/src/components/account-management/login/LoginForm.vue
+++ b/frontend/app/src/components/account-management/login/LoginForm.vue
@@ -61,8 +61,8 @@ const customBackendSessionOnly = ref<boolean>(false);
 const customBackendSaved = ref<boolean>(false);
 const dynamicMessageDialog = ref<boolean>(false);
 
-const usernameRef: Ref = ref();
-const passwordRef: Ref = ref();
+const usernameRef = useTemplateRef('usernameRef');
+const passwordRef = useTemplateRef('passwordRef');
 
 const { savedRememberPassword, savedRememberUsername, savedUsername } = useRememberSettings();
 const { activeWelcomeMessages, welcomeMessage } = useDynamicMessages();

--- a/frontend/app/src/components/account-management/login/WelcomeMessageDisplay.vue
+++ b/frontend/app/src/components/account-management/login/WelcomeMessageDisplay.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
   messages: WelcomeMessage[];
 }>();
 
-const svg = ref();
+const svg = ref<string>();
 
 const { onNavigate, onPause, onResume, step, steps } = useRandomStepper(props.messages.length);
 

--- a/frontend/app/src/components/accounts/AccountBalanceAggregatedAssets.vue
+++ b/frontend/app/src/components/accounts/AccountBalanceAggregatedAssets.vue
@@ -4,16 +4,15 @@ import { useAggregatedBalances } from '@/composables/balances/use-aggregated-bal
 
 const selected = defineModel<string[] | undefined>('selected', { required: true });
 
-const props = defineProps<{
+const { groupId, chains, selectionMode } = defineProps<{
   groupId: string;
   chains: string[];
   selectionMode?: boolean;
 }>();
 
-const { chains, groupId } = toRefs(props);
-
 const { useBlockchainBalances } = useAggregatedBalances();
-const balances = useBlockchainBalances(chains, groupId);
+
+const balances = useBlockchainBalances(() => chains, () => groupId);
 </script>
 
 <template>

--- a/frontend/app/src/components/accounts/AccountBalances.vue
+++ b/frontend/app/src/components/accounts/AccountBalances.vue
@@ -18,7 +18,7 @@ import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-ac
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { getGroupId } from '@/utils/blockchain/accounts/utils';
 
-const props = defineProps<{
+const { category } = defineProps<{
   category: string;
 }>();
 
@@ -26,7 +26,6 @@ const emit = defineEmits<{
   edit: [account: AccountManageState];
 }>();
 
-const { category } = toRefs(props);
 const { t } = useI18n({ useScope: 'global' });
 
 const visibleTags = ref<string[]>([]);
@@ -47,7 +46,7 @@ const {
   pagination,
   sort,
 } = useAccountBalancesPagination({
-  category,
+  category: () => category,
   chainExclusionFilter,
   expanded,
   query,
@@ -55,9 +54,9 @@ const {
   visibleTags,
 });
 
-const { isLoadingActive, isDetectingTokens, refreshDisabled } = useBlockchainAccountLoading(category);
+const { isLoadingActive, isDetectingTokens, refreshDisabled } = useBlockchainAccountLoading(() => category);
 
-const { chainIds, isEvm } = useAccountCategoryHelper(category);
+const { chainIds, isEvm } = useAccountCategoryHelper(() => category);
 
 const { refreshClick } = useAccountBalancesRefresh({
   chainIds,
@@ -74,7 +73,7 @@ const {
 } = useAccountAssetSelection(fetchData);
 
 // Computed
-const isSolana = computed<boolean>(() => get(category) === 'solana');
+const isSolana = computed<boolean>(() => category === 'solana');
 const showSelectionToggle = computed<boolean>(() => get(isEvm) || get(isSolana));
 
 const anyExpansion = computed<boolean>(() => get(accounts).data.some(item => item.expansion));

--- a/frontend/app/src/components/accounts/AccountBalancesDefaultPage.vue
+++ b/frontend/app/src/components/accounts/AccountBalancesDefaultPage.vue
@@ -10,21 +10,19 @@ import { useBlockchainAccountLoading } from '@/composables/accounts/blockchain/u
 import { useAccountCategoryHelper } from '@/composables/accounts/use-account-category-helper';
 import { useAccountImportProgressStore } from '@/store/use-account-import-progress-store';
 
-const props = defineProps<{
+const { category, title } = defineProps<{
   category: string;
   title: string;
 }>();
-
-const { category } = toRefs(props);
 
 const { t } = useI18n({ useScope: 'global' });
 
 const account = ref<AccountManageState>();
 const table = useTemplateRef<InstanceType<typeof AccountBalances>>('table');
 const { importingAccounts } = storeToRefs(useAccountImportProgressStore());
-const { isSectionLoading, refreshDisabled } = useBlockchainAccountLoading(category);
+const { isSectionLoading, refreshDisabled } = useBlockchainAccountLoading(() => category);
 
-const { chainIds } = useAccountCategoryHelper(category);
+const { chainIds } = useAccountCategoryHelper(() => category);
 
 const route = useRoute();
 const router = useRouter();

--- a/frontend/app/src/components/accounts/AccountGroupDetailsTable.vue
+++ b/frontend/app/src/components/accounts/AccountGroupDetailsTable.vue
@@ -17,7 +17,7 @@ import { getAccountAddress } from '@/utils/blockchain/accounts/utils';
 const query = defineModel<LocationQuery>('query', { default: () => ({}), required: false });
 const selected = defineModel<string[] | undefined>('selected', { required: true });
 
-const props = defineProps<{
+const { groupId, chains, tags, category, selectionMode } = defineProps<{
   groupId: string;
   chains: string[];
   tags?: string[];
@@ -28,8 +28,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   edit: [account: AccountManageState];
 }>();
-
-const { category } = toRefs(props);
 
 const expanded = ref<string[]>([]);
 
@@ -58,12 +56,12 @@ const {
   },
   query,
   requestParams: computed(() => ({
-    chain: props.chains,
-    groupId: props.groupId,
-    tags: props.tags,
+    chain: chains,
+    groupId,
+    tags,
   })),
 });
-useBlockchainAccountLoading(category);
+useBlockchainAccountLoading(() => category);
 
 watchImmediate([accountsState, balances], () => {
   fetchData();

--- a/frontend/app/src/components/accounts/AccountTopTokens.vue
+++ b/frontend/app/src/components/accounts/AccountTopTokens.vue
@@ -9,25 +9,23 @@ import { ValueDisplay } from '@/modules/amount-display/components';
 import { sortDesc } from '@/utils/bignumbers';
 import { getAccountAddress, isXpubAccount } from '@/utils/blockchain/accounts/utils';
 
-const props = defineProps<{
+const { chains, row, loading } = defineProps<{
   chains: string[];
   row: BlockchainAccountBalance;
   loading: boolean;
 }>();
 
-const { chains } = toRefs(props);
 const { useBlockchainBalances } = useAggregatedBalances();
 const router = useRouter();
 
-const address = computed<string>(() => getAccountAddress(props.row));
-const balances = useBlockchainBalances(chains, address);
+const address = computed<string>(() => getAccountAddress(row));
+const balances = useBlockchainBalances(() => chains, address);
 
 const topTokens = computed<AssetBalance[]>(() => get(balances)
   .map(balance => pick(balance, ['asset', 'amount', 'value']))
   .sort((a, b) => sortDesc(a.value, b.value)));
 
 const assets = computed<AssetBalance[]>(() => {
-  const row = props.row;
   if (isXpubAccount(row) && row.nativeAsset) {
     return [{
       amount: row.amount || Zero,

--- a/frontend/app/src/components/accounts/balances/AccountBalanceDetails.vue
+++ b/frontend/app/src/components/accounts/balances/AccountBalanceDetails.vue
@@ -4,20 +4,19 @@ import { useAggregatedBalances } from '@/composables/balances/use-aggregated-bal
 
 const selected = defineModel<string[] | undefined>('selected', { required: true });
 
-const props = defineProps<{
+const { chain, address, selectionMode } = defineProps<{
   chain: string;
   address: string;
   selectionMode?: boolean;
 }>();
 
-const { address, chain } = toRefs(props);
 const { t } = useI18n({ useScope: 'global' });
 const { useBlockchainBalances } = useAggregatedBalances();
 
-const chains = computed<string[]>(() => [chain.value]);
+const chains = computed<string[]>(() => [chain]);
 
-const assets = useBlockchainBalances(chains, address);
-const liabilities = useBlockchainBalances(chains, address, 'liabilities');
+const assets = useBlockchainBalances(chains, () => address);
+const liabilities = useBlockchainBalances(chains, () => address, 'liabilities');
 </script>
 
 <template>

--- a/frontend/app/src/components/accounts/blockchain/AddressInput.vue
+++ b/frontend/app/src/components/accounts/blockchain/AddressInput.vue
@@ -10,14 +10,13 @@ import { toMessages } from '@/utils/validation';
 const addresses = defineModel<string[]>('addresses', { required: true });
 const errorMessages = defineModel<ValidationErrors>('errorMessages', { required: true });
 
-const props = defineProps<{
+const { disabled, multi, showWalletImport } = defineProps<{
   disabled: boolean;
   multi: boolean;
   showWalletImport?: boolean;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const { disabled } = toRefs(props);
 
 const address = ref<string>('');
 const userAddresses = ref<string>('');
@@ -41,7 +40,7 @@ const entries = computed(() => {
 });
 
 function onPasteMulti(event: ClipboardEvent) {
-  if (get(disabled))
+  if (disabled)
     return;
 
   const paste = trimOnPaste(event);
@@ -50,7 +49,7 @@ function onPasteMulti(event: ClipboardEvent) {
 }
 
 function onPasteAddress(event: ClipboardEvent) {
-  if (get(disabled))
+  if (disabled)
     return;
 
   const paste = trimOnPaste(event);

--- a/frontend/app/src/components/accounts/blockchain/TokenDetection.vue
+++ b/frontend/app/src/components/accounts/blockchain/TokenDetection.vue
@@ -2,15 +2,13 @@
 import DateDisplay from '@/components/display/DateDisplay.vue';
 import { useTokenDetection } from '@/composables/balances/token-detection';
 
-const props = defineProps<{
+const { address, loading, chains } = defineProps<{
   address: string;
   loading: boolean;
   chains: string[];
 }>();
 
-const { address, chains } = toRefs(props);
-
-const { detectedTokens, detectingTokens, detectTokens } = useTokenDetection(chains, address);
+const { detectedTokens, detectingTokens, detectTokens } = useTokenDetection(() => chains, () => address);
 
 const { t } = useI18n({ useScope: 'global' });
 </script>

--- a/frontend/app/src/components/accounts/blockchain/XpubInput.vue
+++ b/frontend/app/src/components/accounts/blockchain/XpubInput.vue
@@ -13,14 +13,12 @@ import { getKeyType, getPrefix, isPrefixed, keyType, XpubPrefix, type XpubType }
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const xpub = defineModel<XpubPayload | undefined>('xpub');
 
-const props = defineProps<{
+const { disabled, blockchain } = defineProps<{
   disabled: boolean;
   blockchain: BtcChains;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { blockchain, disabled } = toRefs(props);
 
 const xpubKey = ref<string>('');
 const derivationPath = ref<string>('');
@@ -43,7 +41,7 @@ function setXpubKeyType(value: string) {
 }
 
 function onPasteXpub(event: ClipboardEvent) {
-  if (get(disabled))
+  if (disabled)
     return;
 
   const paste = trimOnPaste(event);
@@ -54,7 +52,7 @@ function onPasteXpub(event: ClipboardEvent) {
 }
 
 const keyTypeListData = computed<XpubType[]>(() => {
-  if (get(blockchain) === Blockchain.BTC)
+  if (blockchain === Blockchain.BTC)
     return keyType;
 
   return keyType.filter(item => ![XpubPrefix.ZPUB, XpubPrefix.P2TR].includes(item.value));
@@ -102,7 +100,7 @@ watchImmediate(xpub, (xpub) => {
     set(derivationPath, xpub?.derivationPath || '');
 });
 
-watch(blockchain, () => {
+watch(() => blockchain, () => {
   set(xpubKeyPrefix, get(keyTypeListData)[0].value);
 });
 

--- a/frontend/app/src/components/accounts/exchanges/ExchangeAmountRow.vue
+++ b/frontend/app/src/components/accounts/exchanges/ExchangeAmountRow.vue
@@ -4,16 +4,15 @@ import LocationDisplay from '@/components/history/LocationDisplay.vue';
 import { useLocations } from '@/composables/locations';
 import { FiatDisplay } from '@/modules/amount-display/components';
 
-const props = defineProps<{
+const { balance, exchange } = defineProps<{
   balance: BigNumber;
   exchange: string;
 }>();
 
-const { exchange } = toRefs(props);
 const { exchangeName } = useLocations();
 
 const name = computed<string>(() => {
-  if (!get(exchange))
+  if (!exchange)
     return '';
 
   return exchangeName(exchange);

--- a/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
+++ b/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
@@ -20,7 +20,7 @@ import { useManualBalancesOrLiabilities } from '@/modules/balances/manual/use-ma
 import { TableId, useRememberTableSorting } from '@/modules/table/use-remember-table-sorting';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 
-const props = defineProps<{
+const { title, type } = defineProps<{
   title: string;
   type: 'liabilities' | 'balances';
 }>();
@@ -30,14 +30,12 @@ const emit = defineEmits<{
   edit: [value: ManualBalance];
 }>();
 
-const { type } = toRefs(props);
-
 const { t } = useI18n({ useScope: 'global' });
 
 const tags = ref<string[]>([]);
 
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
-const { dataSource, fetch, locations } = useManualBalancesOrLiabilities(type);
+const { dataSource, fetch, locations } = useManualBalancesOrLiabilities(() => type);
 const { prepareForEdit, pricesLoading, refresh, refreshing, showDeleteConfirmation } = useManualBalanceTableActions();
 
 const {

--- a/frontend/app/src/components/address-book-manager/AddressBookForm.vue
+++ b/frontend/app/src/components/address-book-manager/AddressBookForm.vue
@@ -21,14 +21,9 @@ const modelValue = defineModel<AddressBookPayload>({ required: true });
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-withDefaults(
-  defineProps<{
-    editMode?: boolean;
-  }>(),
-  {
-    editMode: false,
-  },
-);
+const { editMode = false } = defineProps<{
+  editMode?: boolean;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -85,7 +80,7 @@ function fetchNames() {
   });
 }
 
-const chainOptions = computed(() => [
+const chainOptions = computed<string[]>(() => [
   'all',
   ...get(supportedChains).map(item => item.id).filter(item => item !== Blockchain.ETH2),
 ]);

--- a/frontend/app/src/components/address-book-manager/AddressBookTable.vue
+++ b/frontend/app/src/components/address-book-manager/AddressBookTable.vue
@@ -11,7 +11,7 @@ const paginationModel = defineModel<TablePaginationData>('pagination', { require
 
 const sortModel = defineModel<DataTableSortData<AddressBookEntry>>('sort', { required: true });
 
-const props = defineProps<{
+const { collection, location, loading } = defineProps<{
   collection: Collection<AddressBookEntry>;
   location: AddressBookLocation;
   loading: boolean;
@@ -21,8 +21,6 @@ const emit = defineEmits<{
   edit: [item: AddressBookEntry];
   refresh: [];
 }>();
-
-const { location } = toRefs(props);
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/app/src/components/asset-manager/MergeDialog.vue
+++ b/frontend/app/src/components/asset-manager/MergeDialog.vue
@@ -10,7 +10,7 @@ type Errors = Partial<Record<'targetIdentifier' | 'sourceIdentifier', string[]>>
 
 const display = defineModel<boolean>({ required: true });
 
-const props = defineProps<{
+const { sourceIdentifier: propSourceIdentifier, targetIdentifier: propTargetIdentifier } = defineProps<{
   sourceIdentifier?: string;
   targetIdentifier?: string;
 }>();
@@ -18,8 +18,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   merged: [events: { sourceIdentifier: string; targetIdentifier: string }];
 }>();
-
-const { sourceIdentifier: propSourceIdentifier, targetIdentifier: propTargetIdentifier } = toRefs(props);
 
 const done = ref(false);
 const errorMessages = ref<Errors>({});
@@ -108,13 +106,13 @@ const excluded = computed(() => {
   return [source];
 });
 
-watch([display, propSourceIdentifier, propTargetIdentifier], ([isDisplayed, propSourceIdentifier, propTargetIdentifier]) => {
+watch([display, () => propSourceIdentifier, () => propTargetIdentifier], ([isDisplayed, propSource, propTarget]) => {
   if (isDisplayed) {
-    if (propSourceIdentifier) {
-      set(sourceIdentifier, propSourceIdentifier);
+    if (propSource) {
+      set(sourceIdentifier, propSource);
     }
-    if (propTargetIdentifier) {
-      set(targetIdentifier, propTargetIdentifier);
+    if (propTarget) {
+      set(targetIdentifier, propTarget);
     }
   }
 });

--- a/frontend/app/src/components/asset-manager/RestoreAssetDbButton.vue
+++ b/frontend/app/src/components/asset-manager/RestoreAssetDbButton.vue
@@ -11,12 +11,9 @@ import { useTaskStore } from '@/store/tasks';
 import { DialogType } from '@/types/dialogs';
 import { TaskType } from '@/types/task-type';
 
-withDefaults(
-  defineProps<{
-    dropdown?: boolean;
-  }>(),
-  { dropdown: false },
-);
+const { dropdown = false } = defineProps<{
+  dropdown?: boolean;
+}>();
 
 type ResetType = 'soft' | 'hard';
 

--- a/frontend/app/src/components/asset-manager/cex-mapping/ManageCexMappingForm.vue
+++ b/frontend/app/src/components/asset-manager/cex-mapping/ManageCexMappingForm.vue
@@ -15,14 +15,9 @@ const forAllExchanges = defineModel<boolean>('forAllExchanges', { required: true
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-withDefaults(
-  defineProps<{
-    editMode?: boolean;
-  }>(),
-  {
-    editMode: false,
-  },
-);
+const { editMode = false } = defineProps<{
+  editMode?: boolean;
+}>();
 
 const EXCLUDED_EXCHANGES = [
   'binanceus',

--- a/frontend/app/src/components/asset-manager/custom/CustomAssetTable.vue
+++ b/frontend/app/src/components/asset-manager/custom/CustomAssetTable.vue
@@ -19,14 +19,11 @@ const expandedModel = defineModel<CustomAsset[]>('expanded', { required: true })
 
 const filtersModel = defineModel<Filters>('filters', { required: true });
 
-withDefaults(
-  defineProps<{
-    assets: CustomAsset[];
-    matchers: Matcher[];
-    loading?: boolean;
-  }>(),
-  { loading: false },
-);
+const { assets, matchers, loading = false } = defineProps<{
+  assets: CustomAsset[];
+  matchers: Matcher[];
+  loading?: boolean;
+}>();
 
 const emit = defineEmits<{
   'edit': [asset: CustomAsset];

--- a/frontend/app/src/components/asset-manager/managed/ManagedAssetIgnoreSwitch.vue
+++ b/frontend/app/src/components/asset-manager/managed/ManagedAssetIgnoreSwitch.vue
@@ -9,17 +9,11 @@ interface AssetForIgnoreSwitch {
   protocol?: string | null;
 }
 
-const props = withDefaults(
-  defineProps<{
-    asset: AssetForIgnoreSwitch;
-    loading?: boolean;
-    menuLoading?: boolean;
-  }>(),
-  {
-    loading: false,
-    menuLoading: false,
-  },
-);
+const { asset, loading = false, menuLoading = false } = defineProps<{
+  asset: AssetForIgnoreSwitch;
+  loading?: boolean;
+  menuLoading?: boolean;
+}>();
 
 const emit = defineEmits<{
   'toggle-ignore': [];
@@ -32,14 +26,14 @@ const { t } = useI18n({ useScope: 'global' });
 const { useIsAssetIgnored } = useIgnoredAssetsStore();
 const { useIsAssetWhitelisted } = useWhitelistedAssetsStore();
 
-const identifier = computed<string>(() => props.asset.identifier);
-const isSpam = computed<boolean>(() => props.asset.protocol === 'spam');
-const showMoreOptions = computed<boolean>(() => isSpammableAssetType(props.asset.assetType));
+const identifier = computed<string>(() => asset.identifier);
+const isSpam = computed<boolean>(() => asset.protocol === 'spam');
+const showMoreOptions = computed<boolean>(() => isSpammableAssetType(asset.assetType));
 
 const isIgnored = useIsAssetIgnored(identifier);
 const isWhitelisted = useIsAssetWhitelisted(identifier);
 
-const isLoading = computed<boolean>(() => props.loading || props.menuLoading);
+const isLoading = computed<boolean>(() => loading || menuLoading);
 
 const isIgnoringDisabled = computed<boolean>(() => get(isSpam) || get(isWhitelisted) || get(isLoading));
 

--- a/frontend/app/src/components/assets/AssetLocations.vue
+++ b/frontend/app/src/components/assets/AssetLocations.vue
@@ -14,11 +14,9 @@ import { FiatDisplay, ValueDisplay } from '@/modules/amount-display/components';
 import { TableId, useRememberTableSorting } from '@/modules/table/use-remember-table-sorting';
 import { CURRENCY_USD } from '@/types/currencies';
 
-const props = defineProps<{ identifier: string }>();
+const { identifier } = defineProps<{ identifier: string }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { identifier } = toRefs(props);
 
 const sort = ref<DataTableSortData<AssetLocation>>({
   column: 'amount',
@@ -41,7 +39,7 @@ const {
   totalValue,
   visibleAssetLocations,
 } = useAssetLocationsData({
-  identifier,
+  identifier: () => identifier,
   locationFilter,
   onlyTags,
   selectedAccounts,

--- a/frontend/app/src/components/assets/use-asset-locations-data.ts
+++ b/frontend/app/src/components/assets/use-asset-locations-data.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { AddressData, AssetBreakdown, BlockchainAccount } from '@/types/blockchain/accounts';
 import { type BigNumber, type Blockchain, toSentenceCase } from '@rotki/common';
 import { useAggregatedBalances } from '@/composables/balances/use-aggregated-balances';
@@ -19,7 +19,7 @@ export interface AssetLocation extends AssetBreakdown {
 export type AssetLocations = AssetLocation[];
 
 interface UseAssetLocationsDataOptions {
-  identifier: Ref<string>;
+  identifier: MaybeRefOrGetter<string>;
   locationFilter: Ref<string>;
   onlyTags: Ref<string[]>;
   selectedAccounts: Ref<BlockchainAccount<AddressData>[]>;
@@ -49,7 +49,7 @@ export function useAssetLocationsData(options: UseAssetLocationsDataOptions): Us
   const totalValue = computed<BigNumber>(() => get(assetPriceInfo(identifier)).value);
 
   const assetLocations = computed<AssetLocations>(() => {
-    const breakdowns = get(useAssetBreakdown(get(identifier)));
+    const breakdowns = get(useAssetBreakdown(toValue(identifier)));
     return breakdowns.map((item: AssetBreakdown) => {
       const account = item.address ? getAccountByAddress(item.address, item.location) : undefined;
       return {

--- a/frontend/app/src/components/calendar/CalendarDateNavigator.vue
+++ b/frontend/app/src/components/calendar/CalendarDateNavigator.vue
@@ -21,7 +21,7 @@ const { t } = useI18n({ useScope: 'global' });
 const datetime = ref<number>(0);
 const open = ref(false);
 
-const activatorRef = ref();
+const activatorRef = useTemplateRef<any>('activatorRef');
 const menuContainerRef = useTemplateRef<InstanceType<typeof HTMLDivElement>>('menuContainerRef');
 
 const { focused: menuFocusedWithin } = useFocusWithin(menuContainerRef);

--- a/frontend/app/src/components/calendar/CalendarEventList.vue
+++ b/frontend/app/src/components/calendar/CalendarEventList.vue
@@ -4,7 +4,7 @@ import dayjs, { type Dayjs } from 'dayjs';
 
 const selectedDate = defineModel<Dayjs>('selectedDate', { required: true });
 
-const props = defineProps<{
+const { event, visibleDate } = defineProps<{
   visibleDate: Dayjs;
   event: CalendarEvent;
 }>();
@@ -13,40 +13,38 @@ const emit = defineEmits<{
   edit: [event: CalendarEvent];
 }>();
 
-function edit(event: CalendarEvent) {
-  emit('edit', event);
+function edit(calendarEvent: CalendarEvent) {
+  emit('edit', calendarEvent);
 }
 
-const { event } = toRefs(props);
-
-const time = computed(() => dayjs(get(event).timestamp * 1000).format('HH:mm'));
+const time = computed<string>(() => dayjs(event.timestamp * 1000).format('HH:mm'));
 
 const MAX_LENGTH = 70;
 
 const showTooltip = computed<boolean>(() => {
-  const description = get(event).description;
-  return description !== undefined && description.length > MAX_LENGTH;
+  const desc = event.description;
+  return desc !== undefined && desc.length > MAX_LENGTH;
 });
 
 const description = computed<string>(() => {
-  const description = get(event).description;
-  if (description === undefined) {
+  const desc = event.description;
+  if (desc === undefined) {
     return '';
   }
   if (!get(showTooltip))
-    return description;
+    return desc;
 
-  return `${description.slice(0, MAX_LENGTH)}...`;
+  return `${desc.slice(0, MAX_LENGTH)}...`;
 });
 
 const { t } = useI18n({ useScope: 'global' });
 
-function onEventClicked(event: CalendarEvent) {
-  if (!get(selectedDate).isSame(props.visibleDate, 'month')) {
-    set(selectedDate, dayjs(event.timestamp * 1000));
+function onEventClicked(calendarEvent: CalendarEvent) {
+  if (!get(selectedDate).isSame(visibleDate, 'month')) {
+    set(selectedDate, dayjs(calendarEvent.timestamp * 1000));
   }
 
-  edit(event);
+  edit(calendarEvent);
 }
 </script>
 

--- a/frontend/app/src/components/calendar/CalendarGrid.vue
+++ b/frontend/app/src/components/calendar/CalendarGrid.vue
@@ -6,7 +6,7 @@ import CalendarWeekdays from '@/components/calendar/CalendarWeekdays.vue';
 
 const selectedDate = defineModel<Dayjs>('selectedDate', { required: true });
 
-const props = defineProps<{
+const { eventsWithDate, today, visibleDate } = defineProps<{
   today: Dayjs;
   visibleDate: Dayjs;
   eventsWithDate: (CalendarEvent & { date: string })[];
@@ -30,17 +30,15 @@ function add(day: Dayjs): void {
   emit('add', day);
 }
 
-const { eventsWithDate, today, visibleDate } = toRefs(props);
-
-const month = computed(() => Number(get(visibleDate).format('M')));
-const year = computed(() => Number(get(visibleDate).format('YYYY')));
+const month = computed<number>(() => Number(visibleDate.format('M')));
+const year = computed<number>(() => Number(visibleDate.format('YYYY')));
 
 function getWeekday(date: string | Dayjs) {
   const dayjsValue = typeof date === 'string' ? dayjs(date) : date;
   return dayjsValue.weekday();
 }
 
-const numberOfDaysInMonth = computed<number>(() => dayjs(get(visibleDate)).daysInMonth());
+const numberOfDaysInMonth = computed<number>(() => dayjs(visibleDate).daysInMonth());
 
 const currentMonthDays = computed(() =>
   [...new Array(get(numberOfDaysInMonth))].map((_, index) => ({
@@ -94,7 +92,7 @@ watchImmediate(days, (days) => {
 });
 
 function getEvents(day: Dayjs) {
-  return get(eventsWithDate).filter(item => item.date === day.format('YYYY-MM-DD'));
+  return eventsWithDate.filter(item => item.date === day.format('YYYY-MM-DD'));
 }
 </script>
 

--- a/frontend/app/src/components/calendar/CalendarMonthDayItem.vue
+++ b/frontend/app/src/components/calendar/CalendarMonthDayItem.vue
@@ -2,7 +2,7 @@
 import type { Dayjs } from 'dayjs';
 import type { CalendarEvent } from '@/types/history/calendar';
 
-const props = defineProps<{
+const { day, events, isPast, isToday, isSelected } = defineProps<{
   day: {
     date: Dayjs;
     isCurrentMonth: boolean;
@@ -19,9 +19,7 @@ const emit = defineEmits<{
   'add': [];
 }>();
 
-const { day, events, isPast } = toRefs(props);
-
-const label = computed(() => get(day).date.format('D'));
+const label = computed<string>(() => day.date.format('D'));
 
 function selectDate() {
   emit('select-date');
@@ -35,15 +33,14 @@ function add() {
   emit('add');
 }
 
-const visibleEvents = computed(() => {
-  const eventsVal = get(events);
-  if (eventsVal.length <= 3)
-    return eventsVal;
+const visibleEvents = computed<CalendarEvent[]>(() => {
+  if (events.length <= 3)
+    return events;
 
-  return eventsVal.slice(0, 2);
+  return events.slice(0, 2);
 });
 
-const hidden = computed(() => get(events).length - get(visibleEvents).length);
+const hidden = computed<number>(() => events.length - get(visibleEvents).length);
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/app/src/components/calendar/CalendarReminderEntry.vue
+++ b/frontend/app/src/components/calendar/CalendarReminderEntry.vue
@@ -7,15 +7,13 @@ import { toMessages } from '@/utils/validation';
 
 const modelValue = defineModel<CalendarReminderTemporaryPayload>({ required: true });
 
-const props = defineProps<{
+const { latest } = defineProps<{
   latest: boolean;
 }>();
 
 const emit = defineEmits<{
   delete: [];
 }>();
-
-const { latest } = toRefs(props);
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -159,9 +157,9 @@ function triggerUpdate() {
   }
 }
 
-const amountInputWrapper = ref();
+const amountInputWrapper = useTemplateRef<InstanceType<typeof AmountInput>>('amountInputWrapper');
 onMounted(() => {
-  if (get(latest)) {
+  if (latest) {
     const input = get(amountInputWrapper)?.$el.querySelector('input');
     input?.select();
   }

--- a/frontend/app/src/components/common/FullSizeContent.vue
+++ b/frontend/app/src/components/common/FullSizeContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const wrapper = ref();
+const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
 const topOffset = ref<number>(0);
 
 useResizeObserver(wrapper, (a) => {
@@ -8,8 +8,9 @@ useResizeObserver(wrapper, (a) => {
 });
 
 onMounted(() => {
-  if (get(wrapper))
-    set(topOffset, get(wrapper).offsetTop + 156);
+  const el = get(wrapper);
+  if (el)
+    set(topOffset, el.offsetTop + 156);
 });
 </script>
 

--- a/frontend/app/src/components/common/ListItem.vue
+++ b/frontend/app/src/components/common/ListItem.vue
@@ -1,22 +1,12 @@
 <script setup lang="ts">
-const props = withDefaults(
-  defineProps<{
-    size?: 'sm' | 'md' | 'lg';
-    title?: string;
-    subtitle?: string;
-    noPadding?: boolean;
-    noHover?: boolean;
-    loading?: boolean;
-  }>(),
-  {
-    loading: false,
-    noHover: false,
-    noPadding: false,
-    size: 'sm',
-    subtitle: '',
-    title: '',
-  },
-);
+const { size = 'sm', title = '', subtitle = '', noPadding = false, noHover = false, loading = false } = defineProps<{
+  size?: 'sm' | 'md' | 'lg';
+  title?: string;
+  subtitle?: string;
+  noPadding?: boolean;
+  noHover?: boolean;
+  loading?: boolean;
+}>();
 
 defineSlots<{
   default: () => any;
@@ -25,10 +15,10 @@ defineSlots<{
   subtitle: () => any;
 }>();
 
-const avatarSizeClasses = computed(() => {
-  if (props.size === 'md')
+const avatarSizeClasses = computed<string>(() => {
+  if (size === 'md')
     return 'w-10 h-10';
-  else if (props.size === 'lg')
+  else if (size === 'lg')
     return 'w-12 h-12';
 
   return 'w-8 h-8';

--- a/frontend/app/src/components/common/PaginatedCards.vue
+++ b/frontend/app/src/components/common/PaginatedCards.vue
@@ -3,12 +3,11 @@ import { type TablePaginationData, useBreakpoint } from '@rotki/ui-library';
 
 type GetKey = (item: any) => string;
 
-const props = defineProps<{
+const { items, identifier } = defineProps<{
   items: any[];
   identifier: GetKey;
 }>();
 
-const { items } = toRefs(props);
 const { isXlAndDown, isXs } = useBreakpoint();
 const page = ref(1);
 const itemsPerPage = ref(8);
@@ -33,7 +32,7 @@ const paginationData = computed({
       limit: get(itemsPerPage),
       limits: get(limits),
       page: get(page),
-      total: get(items).length,
+      total: items.length,
     };
   },
   set(value: TablePaginationData) {
@@ -44,14 +43,14 @@ const paginationData = computed({
 
 const visible = computed(() => {
   const start = (get(page) - 1) * get(itemsPerPage);
-  return get(items).slice(start, start + get(itemsPerPage));
+  return items.slice(start, start + get(itemsPerPage));
 });
 
 watchImmediate(firstLimit, () => {
   set(itemsPerPage, get(firstLimit));
 });
 
-watch([items, firstLimit], () => set(page, 1));
+watch([() => items, firstLimit], () => set(page, 1));
 </script>
 
 <template>

--- a/frontend/app/src/components/common/RotkiLogo.vue
+++ b/frontend/app/src/components/common/RotkiLogo.vue
@@ -6,18 +6,11 @@ defineOptions({
   inheritAttrs: false,
 });
 
-withDefaults(
-  defineProps<{
-    uniqueKey?: LogoProps['uniqueKey'];
-    text?: LogoProps['text'];
-    size?: LogoProps['size'];
-  }>(),
-  {
-    size: undefined,
-    text: false,
-    uniqueKey: undefined,
-  },
-);
+const { text = false, uniqueKey, size } = defineProps<{
+  uniqueKey?: LogoProps['uniqueKey'];
+  text?: LogoProps['text'];
+  size?: LogoProps['size'];
+}>();
 
 const branch = checkIfDevelopment() ? 'develop' : 'main';
 </script>

--- a/frontend/app/src/components/common/SimpleTable.vue
+++ b/frontend/app/src/components/common/SimpleTable.vue
@@ -6,27 +6,21 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const props = withDefaults(
-  defineProps<{
-    variant?: 'default' | 'outlined';
-    height?: string | number;
-  }>(),
-  {
-    height: undefined,
-    variant: 'outlined',
-  },
-);
+const { variant = 'outlined', height } = defineProps<{
+  variant?: 'default' | 'outlined';
+  height?: string | number;
+}>();
 
 defineSlots<{
   default: () => any;
 }>();
 
 const style = computed<StyleValue | undefined>(() => {
-  if (!props.height)
+  if (!height)
     return undefined;
 
   return {
-    height: toRem(props.height),
+    height: toRem(height),
   };
 });
 </script>

--- a/frontend/app/src/components/dashboard/SnapshotImportDialog.vue
+++ b/frontend/app/src/components/dashboard/SnapshotImportDialog.vue
@@ -11,16 +11,10 @@ const locationFile = defineModel<File>('locationFile', {
   default: undefined,
 });
 
-withDefaults(
-  defineProps<{
-    loading?: boolean;
-    persistent?: boolean;
-  }>(),
-  {
-    loading: false,
-    persistent: false,
-  },
-);
+const { loading = false, persistent = false } = defineProps<{
+  loading?: boolean;
+  persistent?: boolean;
+}>();
 
 const emit = defineEmits<{
   import: [];

--- a/frontend/app/src/components/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue
+++ b/frontend/app/src/components/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue
@@ -5,18 +5,11 @@ import { FiatDisplay } from '@/modules/amount-display/components';
 
 const model = defineModel<string>({ default: '', required: true });
 
-withDefaults(
-  defineProps<{
-    locations?: string[];
-    previewLocationBalance?: Record<string, BigNumber> | null;
-    optionalShowExisting?: boolean;
-  }>(),
-  {
-    locations: () => [],
-    optionalShowExisting: false,
-    previewLocationBalance: null,
-  },
-);
+const { locations = [], optionalShowExisting = false, previewLocationBalance = null } = defineProps<{
+  locations?: string[];
+  previewLocationBalance?: Record<string, BigNumber> | null;
+  optionalShowExisting?: boolean;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/app/src/components/dashboard/edit-snapshot/EditBalancesSnapshotTable.vue
+++ b/frontend/app/src/components/dashboard/edit-snapshot/EditBalancesSnapshotTable.vue
@@ -24,7 +24,7 @@ import { isNft } from '@/utils/nft';
 
 const modelValue = defineModel<Snapshot>({ required: true });
 
-const props = defineProps<{
+const { timestamp } = defineProps<{
   timestamp: number;
 }>();
 
@@ -35,8 +35,6 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 type IndexedBalanceSnapshot = BalanceSnapshot & { index: number; categoryLabel: string };
-
-const { timestamp } = toRefs(props);
 
 const openDialog = ref<boolean>(false);
 const stateUpdated = ref<boolean>(false);
@@ -196,7 +194,7 @@ function add(): void {
     assetIdentifier: '',
     category: BalanceType.ASSET,
     location: '',
-    timestamp: get(timestamp),
+    timestamp,
     usdValue: '',
   });
   set(openDialog, true);
@@ -282,7 +280,7 @@ function updateData(
     else {
       locationDataSnapshot.push({
         location,
-        timestamp: get(timestamp),
+        timestamp,
         usdValue: calculatedBalance!.after,
       });
     }
@@ -321,7 +319,7 @@ async function save(): Promise<boolean> {
   set(submitting, true);
   const index = get(indexToEdit);
   const val = get(modelValue);
-  const timestampVal = get(timestamp);
+  const timestampVal = timestamp;
 
   const balancesSnapshot = [...val.balancesSnapshot];
   const payload = {

--- a/frontend/app/src/components/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue
+++ b/frontend/app/src/components/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue
@@ -12,14 +12,9 @@ import { toMessages } from '@/utils/validation';
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 const model = defineModel<LocationDataSnapshotPayload>({ required: true });
 
-withDefaults(
-  defineProps<{
-    excludedLocations?: string[];
-  }>(),
-  {
-    excludedLocations: () => [],
-  },
-);
+const { excludedLocations = [] } = defineProps<{
+  excludedLocations?: string[];
+}>();
 
 const location = useRefPropVModel(model, 'location');
 const value = useRefPropVModel(model, 'usdValue');

--- a/frontend/app/src/components/dashboard/edit-snapshot/EditLocationDataSnapshotTable.vue
+++ b/frontend/app/src/components/dashboard/edit-snapshot/EditLocationDataSnapshotTable.vue
@@ -15,7 +15,7 @@ import { CURRENCY_USD } from '@/types/currencies';
 
 const modelValue = defineModel<LocationDataSnapshot[]>({ required: true });
 
-const props = defineProps<{
+const { timestamp } = defineProps<{
   timestamp: number;
 }>();
 
@@ -26,8 +26,6 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 type IndexedLocationDataSnapshot = LocationDataSnapshot & { index: number };
-
-const { timestamp } = toRefs(props);
 
 const openDialog = ref<boolean>(false);
 const stateUpdated = ref<boolean>(false);
@@ -104,7 +102,7 @@ function add(): void {
   set(editedIndex, null);
   set(formModel, {
     location: '',
-    timestamp: get(timestamp),
+    timestamp,
     usdValue: '',
   });
   set(
@@ -128,7 +126,7 @@ async function save(): Promise<boolean> {
   set(submitting, true);
   const index = get(editedIndex);
   const val = get(modelValue);
-  const timestampVal = get(timestamp);
+  const timestampVal = timestamp;
 
   const convertedUsdValue
     = get(currencySymbol) === CURRENCY_USD

--- a/frontend/app/src/components/dashboard/edit-snapshot/EditSnapshotDialog.vue
+++ b/frontend/app/src/components/dashboard/edit-snapshot/EditSnapshotDialog.vue
@@ -10,7 +10,7 @@ import { useNotificationsStore } from '@/store/notifications';
 import { useStatisticsStore } from '@/store/statistics';
 import { sortDesc } from '@/utils/bignumbers';
 
-const props = defineProps<{
+const { timestamp } = defineProps<{
   timestamp: number;
 }>();
 
@@ -18,8 +18,6 @@ const emit = defineEmits<{
   close: [];
   finish: [];
 }>();
-
-const { timestamp } = toRefs(props);
 
 const snapshotData = ref<Snapshot | null>(null);
 const step = ref<number>(1);
@@ -40,7 +38,7 @@ const locationDataSnapshot = computed<LocationDataSnapshot[]>(() => {
 });
 
 async function fetchSnapshotData() {
-  const result = await api.getSnapshotData(get(timestamp));
+  const result = await api.getSnapshotData(timestamp);
 
   const { balancesSnapshot, locationDataSnapshot } = result;
   balancesSnapshot.sort((a, b) => sortDesc(a.usdValue, b.usdValue));
@@ -106,7 +104,7 @@ async function save(): Promise<boolean> {
   };
 
   try {
-    result = await api.updateSnapshotData(get(timestamp), payload);
+    result = await api.updateSnapshotData(timestamp, payload);
 
     if (!result)
       notifyError();

--- a/frontend/app/src/components/dashboard/edit-snapshot/EditSnapshotTotal.vue
+++ b/frontend/app/src/components/dashboard/edit-snapshot/EditSnapshotTotal.vue
@@ -14,7 +14,7 @@ import { toMessages } from '@/utils/validation';
 
 const modelValue = defineModel<LocationDataSnapshot[]>({ required: true });
 
-const props = defineProps<{
+const { timestamp, balancesSnapshot } = defineProps<{
   timestamp: number;
   balancesSnapshot: BalanceSnapshot[];
 }>();
@@ -24,8 +24,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { balancesSnapshot, timestamp } = toRefs(props);
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 const { createKey, historicPriceInCurrentCurrency, isPending } = useHistoricCachePriceStore();
 
@@ -36,13 +34,13 @@ const isCurrencyCurrencyUsd = computed<boolean>(() => get(currencySymbol) === CU
 const rate = computed<BigNumber>(() => {
   if (get(isCurrencyCurrencyUsd))
     return One;
-  return get(historicPriceInCurrentCurrency(CURRENCY_USD, get(timestamp)));
+  return get(historicPriceInCurrentCurrency(CURRENCY_USD, timestamp));
 });
 
-const fetchingRate = isPending(createKey(CURRENCY_USD, get(timestamp)));
+const fetchingRate = isPending(createKey(CURRENCY_USD, timestamp));
 
 const assetTotal = computed<BigNumber>(() => {
-  const numbers = get(balancesSnapshot).map((item: BalanceSnapshot) => {
+  const numbers = balancesSnapshot.map((item: BalanceSnapshot) => {
     if (item.category === 'asset')
       return item.usdValue;
 
@@ -64,7 +62,7 @@ const locationTotal = computed<BigNumber>(() => {
 });
 
 const nftsTotal = computed<BigNumber>(() => {
-  const numbers = get(balancesSnapshot).map((item: BalanceSnapshot) => {
+  const numbers = balancesSnapshot.map((item: BalanceSnapshot) => {
     if (!isNft(item.assetIdentifier))
       return Zero;
 
@@ -146,7 +144,7 @@ const v$ = useVuelidate(
 
 const suggestionsLabel = computed(() => ({
   asset: t('dashboard.snapshot.edit.dialog.total.use_calculated_asset', {
-    length: get(balancesSnapshot).length,
+    length: balancesSnapshot.length,
   }),
   location: t('dashboard.snapshot.edit.dialog.total.use_calculated_location', {
     length: get(modelValue).length,

--- a/frontend/app/src/components/defi/ActiveModules.vue
+++ b/frontend/app/src/components/defi/ActiveModules.vue
@@ -13,11 +13,9 @@ interface ModuleWithStatus {
   readonly enabled: boolean;
 }
 
-const props = defineProps<{
+const { modules } = defineProps<{
   modules: Module[];
 }>();
-
-const { modules } = toRefs(props);
 const manageModule = ref<Nullable<Module>>(null);
 const confirmEnable = ref<Nullable<Module>>(null);
 
@@ -29,7 +27,7 @@ const { activeModules } = storeToRefs(useGeneralSettingsStore());
 
 const moduleStatus = computed(() => {
   const active = get(activeModules);
-  return get(modules)
+  return modules
     .map(module => ({
       enabled: active.includes(module),
       identifier: module,

--- a/frontend/app/src/components/defi/DefiIcon.vue
+++ b/frontend/app/src/components/defi/DefiIcon.vue
@@ -11,17 +11,11 @@ defineOptions({
   inheritAttrs: false,
 });
 
-withDefaults(
-  defineProps<{
-    item: Item;
-    size?: string;
-    vertical?: boolean;
-  }>(),
-  {
-    size: '1.5rem',
-    vertical: false,
-  },
-);
+const { item, size = '1.5rem', vertical = false } = defineProps<{
+  item: Item;
+  size?: string;
+  vertical?: boolean;
+}>();
 </script>
 
 <template>

--- a/frontend/app/src/components/defi/ModuleNotActive.vue
+++ b/frontend/app/src/components/defi/ModuleNotActive.vue
@@ -20,7 +20,7 @@ function icon(module: Module): string {
 
 const { t } = useI18n({ useScope: 'global' });
 
-const wrapper = ref();
+const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
 const { top } = useElementBounding(wrapper);
 </script>
 

--- a/frontend/app/src/components/defi/QueriedAddressDialog.vue
+++ b/frontend/app/src/components/defi/QueriedAddressDialog.vue
@@ -13,11 +13,9 @@ import { useQueriedAddressesStore } from '@/store/session/queried-addresses';
 import { type Module, SUPPORTED_MODULES } from '@/types/modules';
 import { getAccountAddress } from '@/utils/blockchain/accounts/utils';
 
-const props = defineProps<{ module: Module }>();
+const { module } = defineProps<{ module: Module }>();
 
 const emit = defineEmits<{ close: [] }>();
-
-const { module } = toRefs(props);
 
 const selectedAccounts = ref<BlockchainAccount<AddressData>[]>([]);
 const ETH = Blockchain.ETH;
@@ -33,43 +31,39 @@ const { t } = useI18n({ useScope: 'global' });
 const accounts = computed<BlockchainAccount[]>(() => getAccounts(ETH));
 
 const currentModule = computed(() => {
-  const currentModule = get(module);
-  if (!currentModule)
+  if (!module)
     return undefined;
 
-  return SUPPORTED_MODULES.find(({ identifier }) => identifier === currentModule);
+  return SUPPORTED_MODULES.find(({ identifier }) => identifier === module);
 });
 
 const moduleName = useRefMap(currentModule, m => m?.name);
 const moduleIcon = useRefMap(currentModule, m => m?.icon);
 
 const addresses = computed(() => {
-  const currentModule = get(module);
-  if (!currentModule)
+  if (!module)
     return [];
 
   const addresses = get(queriedAddresses);
-  const index = transformCase(currentModule, true) as CamelCase<Module>;
+  const index = transformCase(module, true) as CamelCase<Module>;
   return addresses[index] ?? [];
 });
 
 const usableAddresses = computed(() => {
-  const currentModule = get(module);
   const accountList = getAddresses(Blockchain.ETH);
   const moduleAddresses = get(addresses);
-  if (!currentModule || moduleAddresses.length === 0)
+  if (!module || moduleAddresses.length === 0)
     return accountList;
 
   return accountList.filter(address => !moduleAddresses.includes(address));
 });
 
 async function addAddress() {
-  const currentModule = get(module);
   const currentAccount = get(selectedAccounts);
-  assert(currentModule && currentAccount.length > 0);
+  assert(module && currentAccount.length > 0);
   await addQueriedAddress({
     address: getAccountAddress(currentAccount[0]),
-    module: currentModule,
+    module,
   });
   set(selectedAccounts, []);
 }

--- a/frontend/app/src/components/defi/airdrops/AirdropDisplay.vue
+++ b/frontend/app/src/components/defi/airdrops/AirdropDisplay.vue
@@ -3,7 +3,7 @@ import AppImage from '@/components/common/AppImage.vue';
 import { useAirdropsMetadata } from '@/composables/defi/airdrops/metadata';
 import { getPublicProtocolImagePath } from '@/utils/file';
 
-const props = defineProps<{
+const { source, iconUrl, icon } = defineProps<{
   source: string;
   iconUrl?: string;
   icon?: string;
@@ -11,16 +11,14 @@ const props = defineProps<{
 
 const { getAirdropImageUrl, getAirdropName, loading } = useAirdropsMetadata();
 
-const { icon, source } = toRefs(props);
+const name = getAirdropName(() => source);
+const image = getAirdropImageUrl(() => source);
 
-const name = getAirdropName(source);
-const image = getAirdropImageUrl(source);
-const imageFromIconName = computed(() => {
-  const iconVal = get(icon);
-  if (!iconVal)
+const imageFromIconName = computed<string | undefined>(() => {
+  if (!icon)
     return undefined;
 
-  return getPublicProtocolImagePath(iconVal);
+  return getPublicProtocolImagePath(icon);
 });
 </script>
 

--- a/frontend/app/src/components/dialogs/MessageDialog.vue
+++ b/frontend/app/src/components/dialogs/MessageDialog.vue
@@ -2,7 +2,7 @@
 import type { Message } from '@rotki/common';
 import type { RuiIcons } from '@rotki/ui-library';
 
-const props = defineProps<{
+const { message } = defineProps<{
   message: Message;
 }>();
 
@@ -10,11 +10,9 @@ const emit = defineEmits<{
   dismiss: [];
 }>();
 
-const { message } = toRefs(props);
-
 const { t } = useI18n({ useScope: 'global' });
 
-const icon = computed<RuiIcons>(() => (get(props.message.success) ? 'lu-circle-check' : 'lu-circle-alert'));
+const icon = computed<RuiIcons>(() => (message.success ? 'lu-circle-check' : 'lu-circle-alert'));
 </script>
 
 <template>

--- a/frontend/app/src/components/display/EnsAvatar.vue
+++ b/frontend/app/src/components/display/EnsAvatar.vue
@@ -6,31 +6,25 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const props = withDefaults(
-  defineProps<{
-    address: string;
-    avatar?: boolean;
-    size?: string | number;
-  }>(),
-  {
-    avatar: false,
-    size: '24px',
-  },
-);
+const { address, avatar = false, size = '24px' } = defineProps<{
+  address: string;
+  avatar?: boolean;
+  size?: string | number;
+}>();
 
 const success = ref<boolean>(false);
 const failed = ref<boolean>(false);
 
 const { getEnsAvatarUrl } = useAddressesNamesStore();
 
-const avatarUrl = computed<string | null>(() => get(getEnsAvatarUrl(props.address)));
+const avatarUrl = computed<string | null>(() => get(getEnsAvatarUrl(address)));
 
 const { getBlockie } = useBlockie();
 
-const style = computed(() => ({
-  height: props.size,
-  width: props.size,
-  minWidth: props.size,
+const style = computed<Record<string, string | number>>(() => ({
+  height: size,
+  width: size,
+  minWidth: size,
 }));
 </script>
 

--- a/frontend/app/src/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/components/display/LabeledAddressDisplay.vue
@@ -11,32 +11,26 @@ import { useAddressesNamesStore } from '@/store/blockchain/accounts/addresses-na
 import { getAccountAddress, getAccountLabel, getChain, isXpubAccount } from '@/utils/blockchain/accounts/utils';
 import { findAddressKnownPrefix, truncateAddress } from '@/utils/truncate';
 
-const props = defineProps<{
+const { account } = defineProps<{
   account: BlockchainAccount | BlockchainAccountBalance;
 }>();
-
-const { account } = toRefs(props);
 const { scrambleAddress, scrambleData, scrambleIdentifier, shouldShowAmount } = useScramble();
 const { addressNameSelector, ensNameSelector } = useAddressesNamesStore();
 const { t } = useI18n({ useScope: 'global' });
 
-const accountAddress = computed<string>(() => getAccountAddress(get(account)));
+const accountAddress = computed<string>(() => getAccountAddress(account));
 
 const derivationPath = computed<string | undefined>(() => {
-  const accountInfo = get(account);
-  if ('xpub' in accountInfo.data)
-    return accountInfo.data.derivationPath;
+  if ('xpub' in account.data)
+    return account.data.derivationPath;
 
   return undefined;
 });
 
-const isXpub = computed<boolean>(() => {
-  const accountInfo = get(account);
-  return 'xpub' in accountInfo.data;
-});
+const isXpub = computed<boolean>(() => 'xpub' in account.data);
 
 const label = computed<string>(() => {
-  const label = getAccountLabel(get(account));
+  const label = getAccountLabel(account);
 
   if (consistOfNumbers(label))
     return scrambleIdentifier(label);
@@ -48,11 +42,10 @@ const aliasName = computed<string>(() => {
   if (get(scrambleData))
     return '';
 
-  const accountData = get(account);
-  const chain = getChain(accountData);
+  const chain = getChain(account);
   const labelVal = get(label);
 
-  if (isXpubAccount(accountData)) {
+  if (isXpubAccount(account)) {
     return labelVal;
   }
   const name = get(addressNameSelector(get(accountAddress), chain));
@@ -72,7 +65,7 @@ const ensName = computed<string | null>(() => {
 
 const address = computed<string>(() => scrambleAddress(get(accountAddress)));
 
-const displayedLabel = ref<HTMLDivElement>();
+const displayedLabel = useTemplateRef<HTMLDivElement>('displayedLabel');
 const { width: displayedLabelWidth } = useElementSize(displayedLabel);
 
 const labelDisplayed = computed(() => {

--- a/frontend/app/src/components/display/SuccessDisplay.vue
+++ b/frontend/app/src/components/display/SuccessDisplay.vue
@@ -1,14 +1,8 @@
 <script setup lang="ts">
-withDefaults(
-  defineProps<{
-    success?: boolean;
-    size?: string | number;
-  }>(),
-  {
-    size: 20,
-    success: false,
-  },
-);
+const { success = false, size = 20 } = defineProps<{
+  success?: boolean;
+  size?: string | number;
+}>();
 </script>
 
 <template>

--- a/frontend/app/src/components/exchanges/BinanceSavingDetail.vue
+++ b/frontend/app/src/components/exchanges/BinanceSavingDetail.vue
@@ -13,13 +13,11 @@ import { useGeneralSettingsStore } from '@/store/settings/general';
 import { useStatusStore } from '@/store/status';
 import { Section } from '@/types/status';
 
-const props = defineProps<{
+const { exchange } = defineProps<{
   exchange: 'binance' | 'binanceus';
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { exchange } = toRefs(props);
 
 const savingsAssets = ref<string[]>([]);
 const savingsReceived = ref<AssetBalance[]>([]);
@@ -31,7 +29,7 @@ const loading = isSectionLoading(Section.EXCHANGE_SAVINGS);
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 
 const defaultParams = computed(() => ({
-  location: get(exchange).toString(),
+  location: exchange.toString(),
 }));
 
 const {
@@ -54,7 +52,7 @@ const {
     direction: 'asc',
   },
   history: 'router',
-  locationOverview: exchange,
+  locationOverview: () => exchange,
 });
 
 const receivedTableSort = ref<DataTableSortData<AssetBalance>>({

--- a/frontend/app/src/components/graphs/NewGraphTooltipWrapper.vue
+++ b/frontend/app/src/components/graphs/NewGraphTooltipWrapper.vue
@@ -1,14 +1,9 @@
 <script setup lang="ts">
 import type { TooltipData } from '@/composables/graphs';
 
-withDefaults(
-  defineProps<{
-    tooltipOption?: TooltipData;
-  }>(),
-  {
-    tooltipOption: undefined,
-  },
-);
+const { tooltipOption } = defineProps<{
+  tooltipOption?: TooltipData;
+}>();
 
 defineSlots<{
   default: () => any;

--- a/frontend/app/src/components/helper/AssetDetailsMenuContent.vue
+++ b/frontend/app/src/components/helper/AssetDetailsMenuContent.vue
@@ -8,7 +8,7 @@ import HashLink from '@/modules/common/links/HashLink.vue';
 import { useIgnoredAssetsStore } from '@/store/assets/ignored';
 import { isSpammableAssetType } from '@/types/asset';
 
-const props = defineProps<{
+const { asset, hideActions, isCollectionParent, iconOnly } = defineProps<{
   asset: NftAsset;
   hideActions: boolean;
   isCollectionParent: boolean;
@@ -21,20 +21,18 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { asset, isCollectionParent } = toRefs(props);
+const symbol = useRefMap(() => asset, asset => asset.symbol ?? '');
+const name = useRefMap(() => asset, asset => asset.name ?? '');
+const identifier = useRefMap(() => asset, asset => asset.identifier);
 
-const symbol = useRefMap(asset, asset => asset.symbol ?? '');
-const name = useRefMap(asset, asset => asset.name ?? '');
-const identifier = useRefMap(asset, asset => asset.identifier);
-
-const { navigateToDetails } = useAssetPageNavigation(identifier, isCollectionParent);
+const { navigateToDetails } = useAssetPageNavigation(identifier, () => isCollectionParent);
 
 type ConfirmType = 'ignore' | 'mark_as_spam';
 const confirm = ref(false);
 const confirmType = ref<ConfirmType>('ignore');
 
 const { ignoreAsset, useIsAssetIgnored } = useIgnoredAssetsStore();
-const isSpamAsset = computed<boolean>(() => get(asset).isSpam);
+const isSpamAsset = computed<boolean>(() => asset.isSpam);
 const isIgnoredAsset = useIsAssetIgnored(identifier);
 const { markAssetsAsSpam } = useSpamAsset();
 const { assetContractInfo, refetchAssetInfo } = useAssetInfoRetrieval();

--- a/frontend/app/src/components/helper/BinancePairsSelector.vue
+++ b/frontend/app/src/components/helper/BinancePairsSelector.vue
@@ -9,7 +9,7 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const props = defineProps<{
+const { name, edit, location, errorMessages } = defineProps<{
   name: string;
   edit: boolean;
   location: string;
@@ -21,8 +21,6 @@ const emit = defineEmits<{
 }>();
 
 const MAX_RETRIES = 3;
-
-const { edit, errorMessages, location, name } = toRefs(props);
 
 const updateSelection = (value: string[]) => emit('update:selection', value);
 
@@ -101,7 +99,7 @@ async function queryAllMarkets() {
   try {
     const markets = await backoff(
       MAX_RETRIES,
-      () => api.queryBinanceMarkets(get(location)),
+      () => api.queryBinanceMarkets(location),
       1000, // Initial delay of 1 second
     );
     set(allMarkets, markets);
@@ -121,9 +119,9 @@ async function queryAllMarkets() {
 }
 
 async function loadUserMarkets() {
-  if (get(edit)) {
+  if (edit) {
     try {
-      const markets = await api.queryBinanceUserMarkets(get(name), get(location));
+      const markets = await api.queryBinanceUserMarkets(name, location);
       set(queriedMarkets, markets);
       set(selection, markets);
     }

--- a/frontend/app/src/components/helper/CopyButton.vue
+++ b/frontend/app/src/components/helper/CopyButton.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-const props = defineProps<{
+const { value, tooltip, size } = defineProps<{
   value: string;
   tooltip: string;
   size?: 'sm' | 'lg';
 }>();
 
-const { value } = toRefs(props);
-const { copy } = useClipboard({ source: value });
+const { copy } = useClipboard({ source: () => value });
 </script>
 
 <template>

--- a/frontend/app/src/components/helper/InternalLink.vue
+++ b/frontend/app/src/components/helper/InternalLink.vue
@@ -5,21 +5,12 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const props = withDefaults(
-  defineProps<{
-    to: RouteLocationRaw;
-    exact?: boolean;
-    activeClass?: string;
-    exactActiveClass?: string;
-    replace?: boolean;
-  }>(),
-  {
-    activeClass: '',
-    exact: false,
-    exactActiveClass: '',
-    replace: false,
-  },
-);
+const { to, activeClass = '', exactActiveClass = '', replace = false } = defineProps<{
+  to: RouteLocationRaw;
+  activeClass?: string;
+  exactActiveClass?: string;
+  replace?: boolean;
+}>();
 
 defineSlots<{
   default: () => any;
@@ -30,7 +21,10 @@ defineSlots<{
   <RouterLink
     #default="{ href, navigate, isActive, isExactActive }"
     custom
-    v-bind="props"
+    :to="to"
+    :replace="replace"
+    :active-class="activeClass"
+    :exact-active-class="exactActiveClass"
   >
     <a
       :class="{

--- a/frontend/app/src/components/helper/LazyLoader.vue
+++ b/frontend/app/src/components/helper/LazyLoader.vue
@@ -8,7 +8,7 @@ defineSlots<{
   default: () => any;
 }>();
 
-const wrapper = ref();
+const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
 const appear = ref<boolean>(initialAppear);
 const appearDebounced = refDebounced(appear, 200);
 const height = ref<string>('max-content');

--- a/frontend/app/src/components/helper/MenuTooltipButton.vue
+++ b/frontend/app/src/components/helper/MenuTooltipButton.vue
@@ -5,25 +5,15 @@ defineOptions({
   inheritAttrs: false,
 });
 
-withDefaults(
-  defineProps<{
-    tooltip: string;
-    retainFocusOnClick?: boolean;
-    className?: string;
-    href?: string;
-    variant?: ButtonProps['variant'];
-    size?: ButtonProps['size'];
-    customColor?: boolean;
-  }>(),
-  {
-    className: '',
-    customColor: false,
-    href: undefined,
-    retainFocusOnClick: false,
-    size: undefined,
-    variant: 'text',
-  },
-);
+const { tooltip, retainFocusOnClick = false, className = '', href, variant = 'text', size, customColor = false } = defineProps<{
+  tooltip: string;
+  retainFocusOnClick?: boolean;
+  className?: string;
+  href?: string;
+  variant?: ButtonProps['variant'];
+  size?: ButtonProps['size'];
+  customColor?: boolean;
+}>();
 </script>
 
 <template>

--- a/frontend/app/src/components/helper/ProgressScreen.vue
+++ b/frontend/app/src/components/helper/ProgressScreen.vue
@@ -1,20 +1,17 @@
 <script setup lang="ts">
 import FullSizeContent from '@/components/common/FullSizeContent.vue';
 
-const props = withDefaults(
-  defineProps<{
-    progress?: string;
-  }>(),
-  { progress: '' },
-);
+const { progress = '' } = defineProps<{
+  progress?: string;
+}>();
 
 defineSlots<{
   default: () => any;
   message: () => any;
 }>();
 
-const progress = computed(() => {
-  const currentProgress = props.progress;
+const progressValue = computed<string | number>(() => {
+  const currentProgress = progress;
   if (!currentProgress)
     return 0;
 
@@ -22,7 +19,7 @@ const progress = computed(() => {
   return Number.isNaN(number) ? 0 : number.toFixed(2);
 });
 
-const percentage = useToNumber(progress);
+const percentage = useToNumber(progressValue);
 
 const { t } = useI18n({ useScope: 'global' });
 </script>

--- a/frontend/app/src/components/helper/RefreshButton.vue
+++ b/frontend/app/src/components/helper/RefreshButton.vue
@@ -1,15 +1,9 @@
 <script setup lang="ts">
-withDefaults(
-  defineProps<{
-    loading?: boolean;
-    tooltip: string;
-    disabled?: boolean;
-  }>(),
-  {
-    disabled: false,
-    loading: false,
-  },
-);
+const { tooltip, loading = false, disabled = false } = defineProps<{
+  loading?: boolean;
+  tooltip: string;
+  disabled?: boolean;
+}>();
 
 const emit = defineEmits<{
   refresh: [];

--- a/frontend/app/src/components/helper/RowActions.vue
+++ b/frontend/app/src/components/helper/RowActions.vue
@@ -1,26 +1,14 @@
 <script setup lang="ts">
-const props = withDefaults(
-  defineProps<{
-    disabled?: boolean;
-    editDisabled?: boolean;
-    editTooltip?: string;
-    noEdit?: boolean;
-    deleteDisabled?: boolean;
-    deleteTooltip?: string;
-    noDelete?: boolean;
-    align?: 'start' | 'center' | 'end';
-  }>(),
-  {
-    align: 'start',
-    deleteDisabled: false,
-    deleteTooltip: '',
-    disabled: false,
-    editDisabled: false,
-    editTooltip: '',
-    noDelete: false,
-    noEdit: false,
-  },
-);
+const { disabled = false, editDisabled = false, editTooltip = '', noEdit = false, deleteDisabled = false, deleteTooltip = '', noDelete = false, align = 'start' } = defineProps<{
+  disabled?: boolean;
+  editDisabled?: boolean;
+  editTooltip?: string;
+  noEdit?: boolean;
+  deleteDisabled?: boolean;
+  deleteTooltip?: string;
+  noDelete?: boolean;
+  align?: 'start' | 'center' | 'end';
+}>();
 
 const emit = defineEmits<{
   'edit-click': [];
@@ -36,7 +24,7 @@ const justify = computed<string>(() => {
     end: 'justify-end',
     start: 'justify-start',
   } as const;
-  return justify[props.align];
+  return justify[align];
 });
 </script>
 

--- a/frontend/app/src/components/helper/TabNavigation.vue
+++ b/frontend/app/src/components/helper/TabNavigation.vue
@@ -2,21 +2,14 @@
 import type { RouteLocationRaw } from 'vue-router';
 import { getClass, type TabContent } from '@/types/tabs';
 
-withDefaults(
-  defineProps<{
-    tabs: TabContent[];
-    hideRouterView?: boolean;
-    child?: boolean;
-    plain?: boolean;
-  }>(),
-  {
-    child: false,
-    hideRouterView: false,
-    plain: false,
-  },
-);
+const { tabs, hideRouterView = false, child = false, plain = false } = defineProps<{
+  tabs: TabContent[];
+  hideRouterView?: boolean;
+  child?: boolean;
+  plain?: boolean;
+}>();
 
-const model = ref('');
+const model = ref<string>('');
 
 const router = useRouter();
 

--- a/frontend/app/src/components/history/IgnoreButtons.vue
+++ b/frontend/app/src/components/history/IgnoreButtons.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
-withDefaults(
-  defineProps<{
-    disabled?: boolean;
-    disabledActions?: { ignore?: boolean; unIgnore?: boolean };
-  }>(),
-  { disabled: false, disabledActions: undefined },
-);
+const { disabled = false, disabledActions } = defineProps<{
+  disabled?: boolean;
+  disabledActions?: { ignore?: boolean; unIgnore?: boolean };
+}>();
 
 const emit = defineEmits<{
   ignore: [ignored: boolean];

--- a/frontend/app/src/components/history/IgnoredInAccountingIcon.vue
+++ b/frontend/app/src/components/history/IgnoredInAccountingIcon.vue
@@ -1,14 +1,9 @@
 <script setup lang="ts">
 import BadgeDisplay from '@/components/history/BadgeDisplay.vue';
 
-withDefaults(
-  defineProps<{
-    mobile?: boolean;
-  }>(),
-  {
-    mobile: false,
-  },
-);
+const { mobile = false } = defineProps<{
+  mobile?: boolean;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 </script>

--- a/frontend/app/src/components/history/events/HistoryEventAction.vue
+++ b/frontend/app/src/components/history/events/HistoryEventAction.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { HistoryEventEntry } from '@/types/history/events/schemas';
 
-const props = defineProps<{
+const { event, canUnlink } = defineProps<{
   event: HistoryEventEntry;
   canUnlink?: boolean;
 }>();
@@ -12,12 +12,10 @@ const emit = defineEmits<{
 
 const vueRouter = useRouter();
 
-const { event } = toRefs(props);
-
 const { t } = useI18n({ useScope: 'global' });
 
 function onEditRule(): void {
-  const entry = get(event);
+  const entry = event;
 
   const data = {
     counterparty: '',

--- a/frontend/app/src/components/history/events/HistoryEventAsset.vue
+++ b/frontend/app/src/components/history/events/HistoryEventAsset.vue
@@ -8,7 +8,7 @@ import { type AssetResolutionOptions, useAssetInfoRetrieval } from '@/composable
 import { useRefMap } from '@/composables/utils/useRefMap';
 import { AssetAmountDisplay, AssetValueDisplay } from '@/modules/amount-display/components';
 
-const props = defineProps<{
+const { event, dense, disableOptions } = defineProps<{
   event: HistoryEventEntry;
   dense?: boolean;
   disableOptions?: boolean;
@@ -18,12 +18,11 @@ const emit = defineEmits<{
   refresh: [];
 }>();
 
-const { event } = toRefs(props);
 const { assetSymbol, assetInfo } = useAssetInfoRetrieval();
 
-const showBalance = computed<boolean>(() => get(event).eventType !== 'informational');
+const showBalance = computed<boolean>(() => event.eventType !== 'informational');
 
-const eventAsset = useRefMap(event, ({ asset }) => asset);
+const eventAsset = useRefMap(() => event, ({ asset }) => asset);
 
 const symbol = assetSymbol(eventAsset, {
   collectionParent: false,

--- a/frontend/app/src/components/history/events/HistoryEventForm.vue
+++ b/frontend/app/src/components/history/events/HistoryEventForm.vue
@@ -26,16 +26,14 @@ interface HistoryEventFormProps {
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<HistoryEventFormProps>();
+const { data } = defineProps<HistoryEventFormProps>();
 
 const { t } = useI18n({ useScope: 'global' });
-const { data } = toRefs(props);
 
 const entryType = ref<HistoryEventEntryType>(HistoryEventEntryType.HISTORY_EVENT);
 const form = useTemplateRef<ComponentPublicInstance<FormComponent>>('form');
 
 const isEvmGroupAdd = computed<boolean>(() => {
-  const data = props.data;
   if (data.type !== 'group-add') {
     return false;
   }
@@ -43,7 +41,6 @@ const isEvmGroupAdd = computed<boolean>(() => {
 });
 
 const isSolanaGroupAdd = computed<boolean>(() => {
-  const data = props.data;
   if (data.type !== 'group-add') {
     return false;
   }
@@ -89,7 +86,7 @@ async function save() {
   return await get(form).save();
 }
 
-watchImmediate(data, (data) => {
+watchImmediate(() => data, (data) => {
   if (!data) {
     return;
   }

--- a/frontend/app/src/components/history/events/HistoryEventType.vue
+++ b/frontend/app/src/components/history/events/HistoryEventType.vue
@@ -8,7 +8,7 @@ import HistoryEventTypeCombination from '@/components/history/events/HistoryEven
 import HistoryEventTypeCounterparty from '@/components/history/events/HistoryEventTypeCounterparty.vue';
 import { useHistoryEventMappings } from '@/composables/history/events/mapping';
 
-const props = defineProps<{
+const { event, groupLocationLabel, icon, highlight, hideStateChips } = defineProps<{
   event: HistoryEventEntry;
   chain: Blockchain;
   groupLocationLabel?: string;
@@ -17,23 +17,20 @@ const props = defineProps<{
   hideStateChips?: boolean;
 }>();
 
-const { event } = toRefs(props);
-
 const { getEventTypeData } = useHistoryEventMappings();
-const attrs = getEventTypeData(event);
+const attrs = getEventTypeData(() => event);
 
-const isInformational = computed<boolean>(() => get(event).eventType === 'informational');
+const isInformational = computed<boolean>(() => event.eventType === 'informational');
 
-const eventStates = computed<HistoryEventState[]>(() => get(event).states ?? []);
+const eventStates = computed<HistoryEventState[]>(() => event.states ?? []);
 
 const showLocationLabel = computed<boolean>(() => {
-  const eventLabel = get(event).locationLabel;
+  const eventLabel = event.locationLabel;
   if (!eventLabel)
     return false;
 
-  const groupLabel = props.groupLocationLabel;
   // Show only when different from group (or no group context)
-  return !groupLabel || eventLabel !== groupLabel;
+  return !groupLocationLabel || eventLabel !== groupLocationLabel;
 });
 </script>
 

--- a/frontend/app/src/components/history/events/HistoryEventTypeCounterparty.vue
+++ b/frontend/app/src/components/history/events/HistoryEventTypeCounterparty.vue
@@ -7,13 +7,11 @@ import { useScramble } from '@/composables/scramble';
 import { useAddressesNamesStore } from '@/store/blockchain/accounts/addresses-names';
 import { getPublicProtocolImagePath } from '@/utils/file';
 
-const props = defineProps<{
+const { counterparty, location, address } = defineProps<{
   counterparty?: string;
   location: string;
   address?: string;
 }>();
-
-const { address, counterparty, location } = toRefs(props);
 
 const { getEventCounterpartyData } = useHistoryEventCounterpartyMappings();
 const { addressNameSelector } = useAddressesNamesStore();
@@ -22,7 +20,7 @@ const { scrambleAddress, scrambleData } = useScramble();
 
 const { isDark } = useRotkiTheme();
 
-const counterpartyData = getEventCounterpartyData(counterparty);
+const counterpartyData = getEventCounterpartyData(() => counterparty);
 
 const useDarkModeImage = computed(() => get(isDark) && get(counterpartyData)?.darkmodeImage);
 
@@ -44,22 +42,19 @@ const counterpartyImageSrc = computed<string | undefined>(() => {
 });
 
 const addressAliasName = computed<string | undefined>(() => {
-  const addressVal = get(address);
-  if (!addressVal || get(scrambleData)) {
+  if (!address || get(scrambleData)) {
     return undefined;
   }
 
-  return get(addressNameSelector(addressVal, getChain(get(location))));
+  return get(addressNameSelector(address, getChain(location)));
 });
 
 const displayAddress = computed<string | undefined>(() => {
-  const addressVal = get(address);
-
-  if (!addressVal) {
+  if (!address) {
     return undefined;
   }
 
-  return scrambleAddress(addressVal);
+  return scrambleAddress(address);
 });
 </script>
 

--- a/frontend/app/src/components/history/events/HistoryEventsAction.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsAction.vue
@@ -32,7 +32,7 @@ import {
   toLocationAndTxRef,
 } from '@/utils/history/events';
 
-const props = defineProps<{
+const { event, loading, duplicateHandlingStatus } = defineProps<{
   event: HistoryEventEntry;
   loading: boolean;
   duplicateHandlingStatus?: DuplicateHandlingStatus;
@@ -55,26 +55,22 @@ const {
 
 const { confirmAndFixDuplicate, confirmAndMarkNonDuplicated, fixLoading, ignoreLoading } = useCustomizedEventDuplicates();
 
-const { duplicateHandlingStatus, event } = toRefs(props);
-
-const isAutoFixable = computed<boolean>(() => get(duplicateHandlingStatus) === DuplicateHandlingStatus.AUTO_FIX);
-const isDuplicate = computed<boolean>(() => !!get(duplicateHandlingStatus) && get(duplicateHandlingStatus) !== DuplicateHandlingStatus.IGNORED);
+const isAutoFixable = computed<boolean>(() => duplicateHandlingStatus === DuplicateHandlingStatus.AUTO_FIX);
+const isDuplicate = computed<boolean>(() => !!duplicateHandlingStatus && duplicateHandlingStatus !== DuplicateHandlingStatus.IGNORED);
 
 const showMenu = ref<boolean>(false);
 
 const evmEvent = computed<EvmHistoryEvent | EvmSwapEvent | undefined>(() => {
-  const currentEvent = get(event);
-  if (isEvmSwapEvent(currentEvent) || isEvmEvent(currentEvent)) {
-    return currentEvent;
+  if (isEvmSwapEvent(event) || isEvmEvent(event)) {
+    return event;
   }
 
   return undefined;
 });
 
 const solanaEvent = computed<SolanaEvent | SolanaSwapEvent | undefined>(() => {
-  const currentEvent = get(event);
-  if (isSolanaSwapEvent(currentEvent) || isSolanaEvent(currentEvent)) {
-    return currentEvent;
+  if (isSolanaSwapEvent(event) || isSolanaEvent(event)) {
+    return event;
   }
 
   return undefined;
@@ -83,7 +79,6 @@ const solanaEvent = computed<SolanaEvent | SolanaSwapEvent | undefined>(() => {
 const eventWithDecoding = computed<DecodableEventType | undefined>(() => get(evmEvent) || get(solanaEvent));
 
 const eventWithTxRef = computed<{ location: string; txRef: string } | undefined>(() => {
-  const currentEvent = get(event);
   const evm = get(evmEvent);
   const solana = get(solanaEvent);
   if (evm) {
@@ -100,17 +95,17 @@ const eventWithTxRef = computed<{ location: string; txRef: string } | undefined>
     };
   }
 
-  if (isOnlineHistoryEvent(currentEvent) && 'txRef' in currentEvent && currentEvent.txRef) {
+  if (isOnlineHistoryEvent(event) && 'txRef' in event && event.txRef) {
     return {
-      location: currentEvent.location,
-      txRef: currentEvent.txRef,
+      location: event.location,
+      txRef: event.txRef,
     };
   }
 
   return undefined;
 });
 
-const blockEvent = isEthBlockEventRef(event);
+const blockEvent = isEthBlockEventRef(() => event);
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -161,7 +156,7 @@ function openReportDialog(): void {
   const description = [
     t('actions.history_events.report_issue.description_intro'),
     txRef ? t('actions.history_events.report_issue.tx_hash', { hash: txRef }) : '',
-    t('actions.history_events.report_issue.location', { location: get(event).location }),
+    t('actions.history_events.report_issue.location', { location: event.location }),
     '',
     t('actions.history_events.report_issue.more_detail'),
     t('actions.history_events.report_issue.placeholder'),
@@ -174,7 +169,7 @@ function openReportDialog(): void {
 }
 
 function confirmFixDuplicate(): void {
-  const groupIdentifier = get(event).groupIdentifier;
+  const groupIdentifier = event.groupIdentifier;
   if (!groupIdentifier)
     return;
 
@@ -182,7 +177,7 @@ function confirmFixDuplicate(): void {
 }
 
 function confirmIgnoreDuplicate(): void {
-  const groupIdentifier = get(event).groupIdentifier;
+  const groupIdentifier = event.groupIdentifier;
   if (!groupIdentifier)
     return;
 

--- a/frontend/app/src/components/history/events/HistoryEventsAlerts.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsAlerts.vue
@@ -9,7 +9,7 @@ import { Section } from '@/types/status';
 
 const show = defineModel<boolean>('show', { required: true });
 
-const props = defineProps<{
+const { processing, mainPage } = defineProps<{
   processing: boolean;
   mainPage: boolean;
 }>();
@@ -21,8 +21,6 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 const router = useRouter();
 
-const { mainPage, processing } = toRefs(props);
-
 const { isFirstLoad } = useStatusUpdater(Section.HISTORY);
 
 const {
@@ -32,7 +30,7 @@ const {
   unmatchedCount,
 } = useUnmatchedAssetMovements();
 
-const loading = useRefWithDebounce(logicOr(processing, autoMatchLoading), 200);
+const loading = useRefWithDebounce(logicOr(() => processing, autoMatchLoading), 200);
 
 const {
   autoFixCount,
@@ -50,7 +48,7 @@ const showManualReviewDuplicates = computed<boolean>(() => get(manualReviewCount
 const hasAlerts = logicOr(showUnmatchedMovements, showAutoFixDuplicates, showManualReviewDuplicates);
 const refreshing = logicOr(unmatchedLoading, duplicatesLoading);
 
-const showAlerts = logicAnd(mainPage, hasAlerts, show);
+const showAlerts = logicAnd(() => mainPage, hasAlerts, show);
 
 function closeAlerts(): void {
   set(show, false);
@@ -74,7 +72,7 @@ async function viewDuplicates(groupIds: string[], status: DuplicateHandlingStatu
 }
 
 watchImmediate(loading, async (isLoading) => {
-  if (!isLoading && get(mainPage) && !isFirstLoad()) {
+  if (!isLoading && mainPage && !isFirstLoad()) {
     await Promise.all([
       refreshUnmatchedAssetMovements(),
       fetchCustomizedEventDuplicates(),

--- a/frontend/app/src/components/history/events/HistoryEventsExport.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsExport.vue
@@ -11,12 +11,10 @@ import { useTaskStore } from '@/store/tasks';
 import { TaskType } from '@/types/task-type';
 import { isTaskCancelled } from '@/utils';
 
-const props = defineProps<{
+const { filters, matchExactEvents } = defineProps<{
   matchExactEvents: boolean;
   filters: HistoryEventRequestPayload;
 }>();
-
-const { filters, matchExactEvents } = toRefs(props);
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -30,8 +28,8 @@ const { notify } = useNotificationsStore();
 async function createCsv(directoryPath?: string): Promise<{ result: boolean | { filePath: string }; message?: string } | null> {
   try {
     const { taskId } = await exportHistoryEventsCSV({
-      ...omit(get(filters), ['limit', 'offset', 'aggregateByGroupIds']),
-      matchExactEvents: get(matchExactEvents),
+      ...omit(filters, ['limit', 'offset', 'aggregateByGroupIds']),
+      matchExactEvents,
     }, directoryPath);
     const { result } = await awaitTask<boolean | { filePath: string }, TaskMeta>(taskId, TaskType.EXPORT_HISTORY_EVENTS, {
       title: t('actions.history_events_export.title'),

--- a/frontend/app/src/components/history/events/HistoryEventsFiltersChips.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsFiltersChips.vue
@@ -3,7 +3,7 @@ import { DuplicateHandlingStatus } from '@/composables/history/events/types';
 import { useCustomizedEventDuplicates } from '@/composables/history/events/use-customized-event-duplicates';
 import { useConfirmStore } from '@/store/confirm';
 
-const props = defineProps<{
+const { groupIdentifiers, duplicateHandlingStatus } = defineProps<{
   groupIdentifiers?: string[];
   duplicateHandlingStatus?: DuplicateHandlingStatus;
 }>();
@@ -23,14 +23,9 @@ const {
   manualReviewGroupIds,
 } = useCustomizedEventDuplicates();
 
-const { duplicateHandlingStatus, groupIdentifiers } = toRefs(props);
+const isAutoFixable = computed<boolean>(() => duplicateHandlingStatus === DuplicateHandlingStatus.AUTO_FIX);
 
-const isAutoFixable = computed<boolean>(() => get(duplicateHandlingStatus) === DuplicateHandlingStatus.AUTO_FIX);
-
-const hasGroupIdentifiers = computed<boolean>(() => {
-  const ids = get(groupIdentifiers);
-  return !!ids && ids.length > 0;
-});
+const hasGroupIdentifiers = computed<boolean>(() => !!groupIdentifiers && groupIdentifiers.length > 0);
 
 const duplicateChipText = computed<string>(() => {
   if (get(isAutoFixable))
@@ -45,7 +40,7 @@ const currentValidGroupIds = computed<string[]>(() =>
 
 // Calculate the difference between URL params and current valid IDs
 const duplicateChanges = computed<{ resolved: number; added: number; remaining: string[] }>(() => {
-  const urlIds = get(groupIdentifiers) ?? [];
+  const urlIds = groupIdentifiers ?? [];
   const validIds = get(currentValidGroupIds);
 
   if (urlIds.length === 0)
@@ -105,7 +100,7 @@ function removeDuplicateEventsParam(): void {
 }
 
 async function fixDuplicateEvent(): Promise<void> {
-  const ids = get(groupIdentifiers);
+  const ids = groupIdentifiers;
   if (!ids || ids.length === 0)
     return;
 
@@ -117,7 +112,7 @@ async function fixDuplicateEvent(): Promise<void> {
 }
 
 function confirmFixDuplicate(): void {
-  const count = get(groupIdentifiers)?.length ?? 0;
+  const count = groupIdentifiers?.length ?? 0;
   show({
     message: t('customized_event_duplicates.actions.fix_selected_confirm', { count }),
     primaryAction: t('common.actions.confirm'),

--- a/frontend/app/src/components/history/events/HistoryEventsIdentifier.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsIdentifier.vue
@@ -8,14 +8,12 @@ import {
   isWithdrawalEventRef,
 } from '@/utils/history/events';
 
-const props = defineProps<{
+const { event, groupEvents } = defineProps<{
   event: HistoryEventEntry;
   groupEvents?: HistoryEventEntry[];
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { event } = toRefs(props);
 
 const { is2xlAndUp, isMd } = useBreakpoint();
 
@@ -31,11 +29,11 @@ const truncateLength = computed<number>(() => {
   return 8;
 });
 
-const blockEvent = isEthBlockEventRef(event);
-const withdrawEvent = isWithdrawalEventRef(event);
-const assetMovementEvent = isAssetMovementEventRef(event);
+const blockEvent = isEthBlockEventRef(() => event);
+const withdrawEvent = isWithdrawalEventRef(() => event);
+const assetMovementEvent = isAssetMovementEventRef(() => event);
+
 const eventWithTxRef = computed<{ location: string; txRef: string } | undefined>(() => {
-  const event = props.event;
   if ('txRef' in event && event.txRef) {
     return {
       location: event.location,
@@ -46,13 +44,13 @@ const eventWithTxRef = computed<{ location: string; txRef: string } | undefined>
 });
 
 const allTxRefs = computed<{ location: string; txRef: string }[]>(() => {
-  if (!get(assetMovementEvent) || !props.groupEvents)
+  if (!get(assetMovementEvent) || !groupEvents)
     return [];
 
   const seen = new Set<string>();
   const result: { location: string; txRef: string }[] = [];
 
-  for (const child of props.groupEvents) {
+  for (const child of groupEvents) {
     if (!('txRef' in child) || !child.txRef || seen.has(child.txRef))
       continue;
 
@@ -73,8 +71,7 @@ const hashMenuOpen = ref<boolean>(false);
 const translationKey = computed<string>(() => {
   // consider an evm swap event as a case of evm event
   // as they are both evm events and have the same header
-  const eventVal = get(event);
-  let entryType = eventVal.entryType;
+  let entryType = event.entryType;
   const specialTypesWithTxRef: HistoryEventEntryType[] = [
     HistoryEventEntryType.ETH_DEPOSIT_EVENT,
     HistoryEventEntryType.ASSET_MOVEMENT_EVENT,

--- a/frontend/app/src/components/history/events/HistoryEventsListItemAction.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsListItemAction.vue
@@ -18,7 +18,7 @@ import {
   isEvmEvent,
 } from '@/utils/history/events';
 
-const props = defineProps<{
+const { item, index, completeGroupEvents, canUnlink, collapsed, collapseAction } = defineProps<{
   item: HistoryEventEntry;
   index: number;
   /**
@@ -42,9 +42,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const COLLAPSE_ACTION_CLASSES = 'w-0 group-hover/row:w-auto 2xl:!w-24 2xl:opacity-0 2xl:group-hover/row:opacity-100 2xl:focus-within:opacity-100';
 
-const { item } = toRefs(props);
-
-const hasMissingRule = computed<boolean>(() => isEventMissingAccountingRule(get(item)));
+const hasMissingRule = computed<boolean>(() => isEventMissingAccountingRule(item));
 
 function hideEditDeleteActions(item: HistoryEventEntry, index: number): boolean {
   const isSwapButNotSpend = isSwapTypeEvent(item.entryType) && index !== 0;
@@ -55,15 +53,15 @@ function hideEditDeleteActions(item: HistoryEventEntry, index: number): boolean 
 function getEmittedEvent(item: HistoryEvent): HistoryEventEditData {
   if (isSwapTypeEvent(item.entryType)) {
     return {
-      eventsInGroup: props.completeGroupEvents as GroupEditableHistoryEvents[],
+      eventsInGroup: completeGroupEvents as GroupEditableHistoryEvents[],
       type: 'edit-group',
     };
   }
 
   if (isGroupEditableHistoryEvent(item)) {
-    const idx = props.completeGroupEvents.findIndex(e => e.identifier === item.identifier);
+    const idx = completeGroupEvents.findIndex(e => e.identifier === item.identifier);
     const eventsInGroup: GroupEditableHistoryEvents[] = [item];
-    const nextEvent = props.completeGroupEvents[idx + 1];
+    const nextEvent = completeGroupEvents[idx + 1];
     if (nextEvent && isAssetMovementEvent(nextEvent) && nextEvent.eventSubtype === 'fee')
       eventsInGroup.push(nextEvent);
 
@@ -84,14 +82,14 @@ function editEvent(item: HistoryEvent) {
 }
 
 function deleteEvent(item: HistoryEventEntry) {
-  const isSingleEvmEvent = isEvmEvent(item) && props.completeGroupEvents.length === 1;
+  const isSingleEvmEvent = isEvmEvent(item) && completeGroupEvents.length === 1;
   const payload: HistoryEventDeletePayload = isSingleEvmEvent
     ? {
         event: item,
         type: 'ignore',
       }
     : {
-        ids: isGroupEditableHistoryEvent(item) || isSwapTypeEvent(item.entryType) ? props.completeGroupEvents.map(event => event.identifier) : [item.identifier],
+        ids: isGroupEditableHistoryEvent(item) || isSwapTypeEvent(item.entryType) ? completeGroupEvents.map(event => event.identifier) : [item.identifier],
         type: 'delete',
       };
 

--- a/frontend/app/src/components/history/events/PotentialMatchesList.vue
+++ b/frontend/app/src/components/history/events/PotentialMatchesList.vue
@@ -27,7 +27,7 @@ const onlyExpectedAssets = defineModel<boolean>('onlyExpectedAssets', { required
 
 const tolerancePercentage = defineModel<string>('tolerancePercentage', { required: true });
 
-const props = defineProps<{
+const { movement, matches, loading, isPinned, highlightedIdentifier } = defineProps<{
   movement: UnmatchedAssetMovement;
   matches: PotentialMatchRow[];
   loading: boolean;
@@ -43,15 +43,13 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { isPinned } = toRefs(props);
-
 const { getHistoryEventSubTypeName, getHistoryEventTypeName } = useHistoryEventMappings();
 
 const [DefineRowActions, ReuseRowActions] = createReusableTemplate<{ row: PotentialMatchRow }>();
 
-const pinnedColumnClass = usePinnedColumnClass(isPinned);
-const pinnedAssetColumnClass = usePinnedAssetColumnClass(isPinned);
-const pinnedSimpleTableClass = usePinnedSimpleTableClass(isPinned);
+const pinnedColumnClass = usePinnedColumnClass(() => isPinned);
+const pinnedAssetColumnClass = usePinnedAssetColumnClass(() => isPinned);
+const pinnedSimpleTableClass = usePinnedSimpleTableClass(() => isPinned);
 
 function createColumns(isPinned: boolean, baseClass: ColumnClassConfig, assetClass: ColumnClassConfig): DataTableColumn<PotentialMatchRow>[] {
   const columns: DataTableColumn<PotentialMatchRow>[] = [
@@ -94,7 +92,7 @@ function createColumns(isPinned: boolean, baseClass: ColumnClassConfig, assetCla
   return columns;
 }
 
-const columns = computed<DataTableColumn<PotentialMatchRow>[]>(() => createColumns(props.isPinned ?? false, get(pinnedColumnClass), get(pinnedAssetColumnClass)));
+const columns = computed<DataTableColumn<PotentialMatchRow>[]>(() => createColumns(isPinned ?? false, get(pinnedColumnClass), get(pinnedAssetColumnClass)));
 
 function isSelected(row: PotentialMatchRow): boolean {
   return get(selectedMatchIds).includes(row.entry.identifier);
@@ -112,11 +110,11 @@ function toggleSelection(row: PotentialMatchRow): void {
 }
 
 function getRowClass(row: PotentialMatchRow): string {
-  return row.entry.identifier === props.highlightedIdentifier ? '!bg-rui-success/15' : '';
+  return row.entry.identifier === highlightedIdentifier ? '!bg-rui-success/15' : '';
 }
 
 const movementEntry = computed<HistoryEventEntry>(() => {
-  const { entry, ...meta } = getEventEntryFromCollection(props.movement.events);
+  const { entry, ...meta } = getEventEntryFromCollection(movement.events);
   return { ...entry, ...meta };
 });
 
@@ -124,13 +122,13 @@ const searchControlsEl = useTemplateRef<HTMLElement>('searchControls');
 const { height: searchControlsHeight } = useElementSize(searchControlsEl);
 
 const tableClass = computed<string>(() => {
-  if (props.isPinned)
+  if (isPinned)
     return '!overflow-auto !max-h-none';
   return 'table-inside-dialog !max-h-[calc(100vh-33rem)]';
 });
 
 const pinnedTableStyle = computed<Record<string, string> | undefined>(() => {
-  if (!props.isPinned)
+  if (!isPinned)
     return undefined;
   return { height: `calc(100vh - 28.4rem - ${get(searchControlsHeight)}px)` };
 });

--- a/frontend/app/src/components/history/events/UnmatchedMovementsList.vue
+++ b/frontend/app/src/components/history/events/UnmatchedMovementsList.vue
@@ -22,7 +22,14 @@ interface UnmatchedMovementRow {
 
 const selected = defineModel<string[]>('selected', { required: true });
 
-const props = defineProps<{
+const {
+  movements,
+  highlightedGroupIdentifier,
+  ignoreLoading,
+  isPinned,
+  showRestore,
+  loading,
+} = defineProps<{
   movements: UnmatchedAssetMovement[];
   highlightedGroupIdentifier?: string;
   ignoreLoading?: boolean;
@@ -41,10 +48,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { isPinned } = toRefs(props);
-
-const pinnedColumnClass = usePinnedColumnClass(isPinned);
-const pinnedAssetColumnClass = usePinnedAssetColumnClass(isPinned);
+const pinnedColumnClass = usePinnedColumnClass(() => isPinned);
+const pinnedAssetColumnClass = usePinnedAssetColumnClass(() => isPinned);
 
 function createColumns(isPinned: boolean, baseClass: ColumnClassConfig, assetClass: ColumnClassConfig): DataTableColumn<UnmatchedMovementRow>[] {
   const columns: DataTableColumn<UnmatchedMovementRow>[] = [
@@ -89,10 +94,10 @@ function createColumns(isPinned: boolean, baseClass: ColumnClassConfig, assetCla
   return columns;
 }
 
-const columns = computed<DataTableColumn<UnmatchedMovementRow>[]>(() => createColumns(props.isPinned ?? false, get(pinnedColumnClass), get(pinnedAssetColumnClass)));
+const columns = computed<DataTableColumn<UnmatchedMovementRow>[]>(() => createColumns(isPinned ?? false, get(pinnedColumnClass), get(pinnedAssetColumnClass)));
 
 const rows = computed<UnmatchedMovementRow[]>(() =>
-  props.movements.map((movement) => {
+  movements.map((movement) => {
     const { entry, ...meta } = getEventEntryFromCollection(movement.events);
     const eventEntry = { ...entry, ...meta };
     return {
@@ -108,7 +113,7 @@ const rows = computed<UnmatchedMovementRow[]>(() =>
 );
 
 const emptyDescription = computed<string>(() =>
-  props.showRestore
+  showRestore
     ? t('asset_movement_matching.dialog.no_ignored')
     : t('asset_movement_matching.dialog.no_unmatched'),
 );
@@ -117,14 +122,14 @@ const descriptionEl = useTemplateRef<HTMLElement>('description');
 const { height: descriptionHeight } = useElementSize(descriptionEl);
 
 const pinnedTableStyle = computed<Record<string, string> | undefined>(() => {
-  if (!props.isPinned)
+  if (!isPinned)
     return undefined;
   return { height: `calc(100vh - 15.4rem - ${get(descriptionHeight)}px)` };
 });
 
 function getRowClass(row: UnmatchedMovementRow): string {
   const classes = ['transition-all'];
-  if (row.groupIdentifier === props.highlightedGroupIdentifier) {
+  if (row.groupIdentifier === highlightedGroupIdentifier) {
     classes.push('!bg-rui-warning/15');
   }
   return classes.join(' ');

--- a/frontend/app/src/components/history/events/tx/TransactionFormDialog.vue
+++ b/frontend/app/src/components/history/events/tx/TransactionFormDialog.vue
@@ -8,14 +8,9 @@ import { useMessageStore } from '@/store/message';
 
 const modelValue = defineModel<AddTransactionHashPayload | undefined>({ required: true });
 
-withDefaults(
-  defineProps<{
-    loading?: boolean;
-  }>(),
-  {
-    loading: false,
-  },
-);
+const { loading = false } = defineProps<{
+  loading?: boolean;
+}>();
 
 const emit = defineEmits<{
   reload: [event: LocationAndTxRef];
@@ -26,7 +21,7 @@ const { t } = useI18n({ useScope: 'global' });
 const submitting = ref<boolean>(false);
 const errorMessages = ref<Record<string, string[]>>({});
 const form = useTemplateRef<InstanceType<typeof TransactionForm>>('form');
-const stateUpdated = ref(false);
+const stateUpdated = ref<boolean>(false);
 
 const { setMessage } = useMessageStore();
 const { addTransactionHash } = useHistoryTransactions();

--- a/frontend/app/src/components/import/FileUpload.vue
+++ b/frontend/app/src/components/import/FileUpload.vue
@@ -23,10 +23,10 @@ const emit = defineEmits<{
   'update:error-message': [message: string];
 }>();
 
-const wrapper = ref<HTMLDivElement>();
+const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
 
 const error = ref('');
-const select = ref<HTMLInputElement>();
+const select = useTemplateRef<HTMLInputElement>('select');
 const { t } = useI18n({ useScope: 'global' });
 
 function isValidFile(file: File, acceptString: string) {

--- a/frontend/app/src/components/inputs/AutoCompleteWithSearchSync.vue
+++ b/frontend/app/src/components/inputs/AutoCompleteWithSearchSync.vue
@@ -10,11 +10,9 @@ const model = defineModel<string>({
   },
 });
 
-const props = defineProps<{
+const { items } = defineProps<{
   items: string[];
 }>();
-
-const { items } = toRefs(props);
 
 const search = ref<string>('');
 

--- a/frontend/app/src/components/inputs/DateTimeRangePicker.vue
+++ b/frontend/app/src/components/inputs/DateTimeRangePicker.vue
@@ -11,28 +11,16 @@ interface QuickOption {
 const start = defineModel<number | undefined>('start', { required: true });
 const end = defineModel<number | undefined>('end', { required: true });
 
-const props = withDefaults(
-  defineProps<{
-    allowEmpty?: boolean;
-    dense?: boolean;
-    disabled?: boolean;
-    endErrorMessages?: string[];
-    endLabel?: string;
-    maxEndDate?: number | 'now';
-    startErrorMessages?: string[];
-    startLabel?: string;
-  }>(),
-  {
-    allowEmpty: false,
-    dense: false,
-    disabled: false,
-    endErrorMessages: () => [],
-    endLabel: '',
-    maxEndDate: undefined,
-    startErrorMessages: () => [],
-    startLabel: '',
-  },
-);
+const { allowEmpty = false, dense = false, disabled = false, endErrorMessages = [], endLabel = '', maxEndDate, startErrorMessages = [], startLabel = '' } = defineProps<{
+  allowEmpty?: boolean;
+  dense?: boolean;
+  disabled?: boolean;
+  endErrorMessages?: string[];
+  endLabel?: string;
+  maxEndDate?: number | 'now';
+  startErrorMessages?: string[];
+  startLabel?: string;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -48,8 +36,8 @@ const quickOptions: QuickOption[] = [
   { label: t('date_time_range_picker.last_1_year'), unit: 'year', value: 1 },
 ];
 
-const startLabelComputed = computed<string>(() => props.startLabel || t('generate.labels.start_date'));
-const endLabelComputed = computed<string>(() => props.endLabel || t('generate.labels.end_date'));
+const startLabelComputed = computed<string>(() => startLabel || t('generate.labels.start_date'));
+const endLabelComputed = computed<string>(() => endLabel || t('generate.labels.end_date'));
 
 const invalidRange = computed<boolean>(() => {
   const startVal = get(start);
@@ -61,14 +49,14 @@ const startErrorMessagesComputed = computed<string[]>(() => {
   if (get(invalidRange)) {
     return [t('generate.validation.end_after_start')];
   }
-  return props.startErrorMessages;
+  return startErrorMessages;
 });
 
 const endErrorMessagesComputed = computed<string[]>(() => {
   if (get(invalidRange)) {
     return [' '];
   }
-  return props.endErrorMessages;
+  return endErrorMessages;
 });
 
 function applyQuickOption(option: QuickOption): void {

--- a/frontend/app/src/components/inputs/TagFilter.vue
+++ b/frontend/app/src/components/inputs/TagFilter.vue
@@ -5,16 +5,10 @@ import { useTagStore } from '@/store/session/tags';
 
 const model = defineModel<string[]>({ required: true });
 
-withDefaults(
-  defineProps<{
-    disabled?: boolean;
-    hideDetails?: boolean;
-  }>(),
-  {
-    disabled: false,
-    hideDetails: false,
-  },
-);
+const { disabled = false, hideDetails = false } = defineProps<{
+  disabled?: boolean;
+  hideDetails?: boolean;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/app/src/components/inputs/TagInput.vue
+++ b/frontend/app/src/components/inputs/TagInput.vue
@@ -9,15 +9,10 @@ import { renameTagInList } from '@/utils/tags';
 
 const modelValue = defineModel<string[]>({ required: true });
 
-withDefaults(
-  defineProps<{
-    disabled?: boolean;
-    label?: string;
-  }>(),
-  {
-    label: 'Tags',
-  },
-);
+const { disabled, label = 'Tags' } = defineProps<{
+  disabled?: boolean;
+  label?: string;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 const store = useTagStore();
@@ -29,7 +24,7 @@ const newTag = ref<Tag | undefined>(undefined);
 const editMode = ref<boolean>(false);
 const originalName = ref<string>('');
 
-const newTagBackground = ref(randomColor());
+const newTagBackground = ref<string>(randomColor());
 
 function remove(tag: string) {
   const tags = get(modelValue);

--- a/frontend/app/src/components/locations/LocationAssets.vue
+++ b/frontend/app/src/components/locations/LocationAssets.vue
@@ -3,16 +3,14 @@ import AssetBalances from '@/components/AssetBalances.vue';
 import { useBalancesLoading } from '@/composables/balances/loading';
 import { useAggregatedBalances } from '@/composables/balances/use-aggregated-balances';
 
-const props = defineProps<{
+const { identifier } = defineProps<{
   identifier: string;
 }>();
-
-const { identifier } = toRefs(props);
 
 const { t } = useI18n({ useScope: 'global' });
 
 const { useLocationBreakdown } = useAggregatedBalances();
-const locationBreakdown = useLocationBreakdown(identifier);
+const locationBreakdown = useLocationBreakdown(() => identifier);
 
 const { loadingBalances } = useBalancesLoading();
 </script>

--- a/frontend/app/src/components/notes/UserNotesList.vue
+++ b/frontend/app/src/components/notes/UserNotesList.vue
@@ -23,7 +23,7 @@ function getDefaultForm() {
   };
 }
 
-const wrapper = ref<any>(null);
+const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
 
 const showDeleteConfirmation = ref<boolean>(false);
 const idToDelete = ref<number | null>(null);

--- a/frontend/app/src/components/premium/GetPremiumButton.vue
+++ b/frontend/app/src/components/premium/GetPremiumButton.vue
@@ -2,14 +2,9 @@
 import ExternalLink from '@/components/helper/ExternalLink.vue';
 import { usePremium } from '@/composables/premium';
 
-withDefaults(
-  defineProps<{
-    hideOnSmallScreen?: boolean;
-  }>(),
-  {
-    hideOnSmallScreen: false,
-  },
-);
+const { hideOnSmallScreen = false } = defineProps<{
+  hideOnSmallScreen?: boolean;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 const premium = usePremium();

--- a/frontend/app/src/components/price-manager/historic/HistoricPriceForm.vue
+++ b/frontend/app/src/components/price-manager/historic/HistoricPriceForm.vue
@@ -17,14 +17,9 @@ const modelValue = defineModel<HistoricalPriceFormPayload>({ required: true });
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-withDefaults(
-  defineProps<{
-    editMode?: boolean;
-  }>(),
-  {
-    editMode: false,
-  },
-);
+const { editMode = false } = defineProps<{
+  editMode?: boolean;
+}>();
 
 const { assetSymbol } = useAssetInfoRetrieval();
 

--- a/frontend/app/src/components/price-manager/historic/HistoricPriceFormDialog.vue
+++ b/frontend/app/src/components/price-manager/historic/HistoricPriceFormDialog.vue
@@ -7,14 +7,9 @@ import { useHistoricPrices } from '@/composables/price-manager/historic';
 
 const modelValue = defineModel<HistoricalPriceFormPayload | undefined>({ required: true });
 
-const props = withDefaults(
-  defineProps<{
-    editMode?: boolean;
-  }>(),
-  {
-    editMode: false,
-  },
-);
+const { editMode = false } = defineProps<{
+  editMode?: boolean;
+}>();
 
 const emit = defineEmits<{
   refresh: [];
@@ -25,10 +20,10 @@ const { t } = useI18n({ useScope: 'global' });
 const loading = ref<boolean>(false);
 const errorMessages = ref<Record<string, string[]>>({});
 const form = useTemplateRef<InstanceType<typeof HistoricPriceForm>>('form');
-const stateUpdated = ref(false);
+const stateUpdated = ref<boolean>(false);
 
 const dialogTitle = computed<string>(() =>
-  props.editMode
+  editMode
     ? t('price_management.dialog.edit_title')
     : t('price_management.dialog.add_title'),
 );
@@ -45,7 +40,6 @@ async function save() {
     return false;
 
   const data = get(modelValue);
-  const editMode = props.editMode;
   set(loading, true);
   const success = await saveAction(data, editMode);
 

--- a/frontend/app/src/components/price-manager/latest/LatestPriceForm.vue
+++ b/frontend/app/src/components/price-manager/latest/LatestPriceForm.vue
@@ -16,16 +16,10 @@ const modelValue = defineModel<ManualPriceFormPayload>({ required: true });
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-withDefaults(
-  defineProps<{
-    disableFromAsset?: boolean;
-    editMode?: boolean;
-  }>(),
-  {
-    disableFromAsset: false,
-    editMode: false,
-  },
-);
+const { disableFromAsset = false, editMode = false } = defineProps<{
+  disableFromAsset?: boolean;
+  editMode?: boolean;
+}>();
 
 const { assetSymbol } = useAssetInfoRetrieval();
 

--- a/frontend/app/src/components/profitloss/AccountingSettingsDisplay.vue
+++ b/frontend/app/src/components/profitloss/AccountingSettingsDisplay.vue
@@ -4,9 +4,8 @@ import type { BaseAccountingSettings, CostBasisMethod } from '@/types/user';
 import SuccessDisplay from '@/components/display/SuccessDisplay.vue';
 import { useCostBasisMethod } from '@/composables/reports';
 
-const props = defineProps<{ accountingSettings: BaseAccountingSettings }>();
+const { accountingSettings } = defineProps<{ accountingSettings: BaseAccountingSettings }>();
 
-const { accountingSettings } = toRefs(props);
 const { t } = useI18n({ useScope: 'global' });
 const { costBasisMethodData } = useCostBasisMethod();
 
@@ -16,7 +15,7 @@ function taxFreePeriod(period: number) {
 }
 
 const costBasisMethodItem = computed<ActionDataEntry<CostBasisMethod> | null>(() => {
-  const method = get(accountingSettings).costBasisMethod;
+  const method = accountingSettings.costBasisMethod;
   if (!method)
     return null;
 
@@ -29,7 +28,7 @@ interface Item {
 }
 
 const items = computed<Item[]>(() => {
-  const settings = get(accountingSettings);
+  const settings = accountingSettings;
   const items = [
     {
       data: settings.calculatePastCostBasis,

--- a/frontend/app/src/components/profitloss/ExportReportCsv.vue
+++ b/frontend/app/src/components/profitloss/ExportReportCsv.vue
@@ -4,15 +4,10 @@ import { useInterop } from '@/composables/electron-interop';
 import { useMessageStore } from '@/store/message';
 import { useReportsStore } from '@/store/reports';
 
-const props = withDefaults(
-  defineProps<{
-    list?: boolean;
-    reportId: number;
-  }>(),
-  {
-    list: false,
-  },
-);
+const { list = false, reportId } = defineProps<{
+  list?: boolean;
+  reportId: number;
+}>();
 
 const { createCsv } = useReportsStore();
 const { setMessage } = useMessageStore();
@@ -37,10 +32,10 @@ async function exportCSV() {
       if (!directory)
         return;
 
-      await createCsv(props.reportId, directory);
+      await createCsv(reportId, directory);
     }
     else {
-      const result = await downloadReportCSV(props.reportId);
+      const result = await downloadReportCSV(reportId);
       if (!result.success)
         showMessage(result.message ?? t('profit_loss_report.download_failed'));
     }
@@ -50,7 +45,7 @@ async function exportCSV() {
   }
 }
 
-const label = computed(() => (appSession ? t('common.actions.export_csv') : t('common.actions.download_csv')));
+const label = computed<string>(() => (appSession ? t('common.actions.export_csv') : t('common.actions.download_csv')));
 </script>
 
 <template>

--- a/frontend/app/src/components/profitloss/ProfitLossEventType.vue
+++ b/frontend/app/src/components/profitloss/ProfitLossEventType.vue
@@ -2,14 +2,13 @@
 import { useHistoryEventMappings } from '@/composables/history/events/mapping';
 import { useRefMap } from '@/composables/utils/useRefMap';
 
-const props = defineProps<{
+const { type } = defineProps<{
   type: string;
 }>();
 
 const { getAccountingEventTypeData } = useHistoryEventMappings();
 
-const { type } = toRefs(props);
-const data = getAccountingEventTypeData(type);
+const data = getAccountingEventTypeData(() => type);
 const icon = useRefMap(data, ({ icon }) => icon);
 const label = useRefMap(data, ({ label }) => label);
 </script>

--- a/frontend/app/src/components/profitloss/ReportMissingAcquisitions.vue
+++ b/frontend/app/src/components/profitloss/ReportMissingAcquisitions.vue
@@ -21,7 +21,7 @@ interface MappedGroupedItems {
   acquisitions: MissingAcquisition[];
 }
 
-const props = defineProps<{
+const { items, isPinned } = defineProps<{
   items: MissingAcquisition[];
   isPinned: boolean;
 }>();
@@ -34,15 +34,13 @@ defineSlots<{
   actions: () => any;
 }>();
 
-const { isPinned, items } = toRefs(props);
-
 const router = useRouter();
 const { ignoreAsset, useIsAssetIgnored } = useIgnoredAssetsStore();
 
 const groupedMissingAcquisitions = computed<MappedGroupedItems[]>(() => {
   const grouped: GroupedItems = {};
 
-  get(items).forEach((item: MissingAcquisition) => {
+  items.forEach((item: MissingAcquisition) => {
     if (grouped[item.asset])
       grouped[item.asset].push(item);
     else grouped[item.asset] = [item];
@@ -87,7 +85,7 @@ const headers = computed<DataTableColumn<MappedGroupedItems>[]>(() => [{
   key: 'asset',
   label: t('common.asset'),
   sortable: true,
-}, ...(get(isPinned)
+}, ...(isPinned
   ? []
   : [
     {

--- a/frontend/app/src/components/profitloss/ReportMissingPrices.vue
+++ b/frontend/app/src/components/profitloss/ReportMissingPrices.vue
@@ -12,7 +12,7 @@ import { TableId, useRememberTableSorting } from '@/modules/table/use-remember-t
 import { useHistoricCachePriceStore } from '@/store/prices/historic';
 import { ApiValidationError } from '@/types/api/errors';
 
-const props = defineProps<{
+const { items, isPinned } = defineProps<{
   items: MissingPrice[];
   isPinned: boolean;
 }>();
@@ -22,7 +22,6 @@ defineSlots<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const { isPinned, items } = toRefs(props);
 const prices = ref<HistoricalPrice[]>([]);
 const errorMessages = ref<Record<string, string[]>>({});
 const refreshing = ref<boolean>(false);
@@ -43,7 +42,7 @@ async function getHistoricalPrices(): Promise<void> {
 }
 
 const formattedItems = computed<EditableMissingPrice[]>(() =>
-  get(items).map((item) => {
+  items.map((item) => {
     const savedHistoricalPrice = get(prices).find(
       price => price.fromAsset === item.fromAsset && price.toAsset === item.toAsset && price.timestamp === item.time,
     );
@@ -108,7 +107,7 @@ async function updatePrice(item: EditableMissingPrice) {
 }
 
 const headers = computed<DataTableColumn<EditableMissingPrice>[]>(() => {
-  const pinned = get(isPinned);
+  const pinned = isPinned;
   return [
     {
       key: 'fromAsset',

--- a/frontend/app/src/components/profitloss/ReportPeriodSelector.vue
+++ b/frontend/app/src/components/profitloss/ReportPeriodSelector.vue
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import { Quarter } from '@/types/settings/frontend-settings';
 import { convertToTimestamp } from '@/utils/date';
 
-const props = defineProps<{
+const { year, quarter } = defineProps<{
   year: string | 'custom';
   quarter: Quarter;
 }>();
@@ -30,8 +30,6 @@ const QUARTER_ENDS: { [quarter in Quarter]: string } = {
   [Quarter.Q4]: '31/12',
 };
 
-const { quarter, year } = toRefs(props);
-
 const { t } = useI18n({ useScope: 'global' });
 
 function updatePeriod(period: PeriodChangedEvent | null) {
@@ -44,7 +42,7 @@ function updateSelection(change: SelectionChangedEvent) {
 
 function startDateTime(selection: Quarter): number {
   const startDate = QUARTER_STARTS[selection];
-  return convertToTimestamp(`${startDate}/${get(year)} 00:00`);
+  return convertToTimestamp(`${startDate}/${year} 00:00`);
 }
 
 function isStartAfterNow(selection: Quarter) {
@@ -52,12 +50,12 @@ function isStartAfterNow(selection: Quarter) {
   return start > dayjs().unix();
 }
 
-const start = computed<number>(() => startDateTime(get(quarter)));
-const isCustom = computed<boolean>(() => get(year) === 'custom');
-const isAllTime = computed<boolean>(() => get(year) === 'all-time');
+const start = computed<number>(() => startDateTime(quarter));
+const isCustom = computed<boolean>(() => year === 'custom');
+const isAllTime = computed<boolean>(() => year === 'all-time');
 const end = computed<number>(() => {
-  const endDate = QUARTER_ENDS[get(quarter)];
-  return convertToTimestamp(`${endDate}/${get(year)} 23:59:59`);
+  const endDate = QUARTER_ENDS[quarter];
+  return convertToTimestamp(`${endDate}/${year} 23:59:59`);
 });
 
 const periodEventPayload = computed<PeriodChangedEvent>(() => ({
@@ -66,10 +64,10 @@ const periodEventPayload = computed<PeriodChangedEvent>(() => ({
 }));
 
 onMounted(() => {
-  updatePeriod(get(year) !== 'custom' ? get(periodEventPayload) : null);
+  updatePeriod(year !== 'custom' ? get(periodEventPayload) : null);
 });
 
-watch([year, quarter], () => {
+watch([() => year, () => quarter], () => {
   if (get(isCustom))
     updatePeriod(null);
   else if (get(isAllTime))
@@ -98,7 +96,7 @@ const olderPeriods = computed<string[]>(() => {
   return periods;
 });
 
-const isOlderYearSelected = computed<boolean>(() => get(olderPeriods).includes(get(year)));
+const isOlderYearSelected = computed<boolean>(() => get(olderPeriods).includes(year));
 
 function selectAllTime(): void {
   updateSelection({ quarter: Quarter.ALL, year: 'all-time' });
@@ -132,18 +130,16 @@ const subPeriods = [
 ];
 
 function onChange(change: { year?: string; quarter?: Quarter }) {
-  const yearVal = get(year);
-  const quarterVal = get(quarter);
   updateSelection({
-    quarter: change?.quarter ?? quarterVal,
-    year: change?.year ?? yearVal,
+    quarter: change?.quarter ?? quarter,
+    year: change?.year ?? year,
   });
-  updatePeriod(yearVal !== 'custom' ? get(periodEventPayload) : null);
+  updatePeriod(year !== 'custom' ? get(periodEventPayload) : null);
 }
 
 const yearModel = computed({
   get() {
-    return get(year);
+    return year;
   },
   set(year) {
     onChange({ year });
@@ -152,7 +148,7 @@ const yearModel = computed({
 
 const quarterModel = computed({
   get() {
-    return get(quarter);
+    return quarter;
   },
   set(quarter) {
     onChange({ quarter });

--- a/frontend/app/src/components/profitloss/ReportProfitLossEventAction.vue
+++ b/frontend/app/src/components/profitloss/ReportProfitLossEventAction.vue
@@ -13,12 +13,10 @@ import { useMessageStore } from '@/store/message';
 import { useHistoricCachePriceStore } from '@/store/prices/historic';
 import { toMessages } from '@/utils/validation';
 
-const props = defineProps<{
+const { event, currency } = defineProps<{
   event: ProfitLossEvent;
   currency: string;
 }>();
-
-const { currency, event } = toRefs(props);
 
 const { resetHistoricalPricesData } = useHistoricCachePriceStore();
 const { getHistoricPrice } = usePriceTaskManager();
@@ -31,17 +29,17 @@ const price = ref<string>('');
 async function openEditHistoricPriceDialog() {
   set(showDialog, true);
   set(fetchingPrice, true);
-  const { assetIdentifier, timestamp } = get(event);
+  const { assetIdentifier, timestamp } = event;
   const historicPrice = await getHistoricPrice({
     fromAsset: assetIdentifier,
     timestamp,
-    toAsset: get(currency),
+    toAsset: currency,
   });
   set(price, historicPrice.isPositive() ? historicPrice.toFixed() : '0');
   set(fetchingPrice, false);
 }
 
-const timestamp = useRefMap(event, item => item.timestamp);
+const timestamp = useRefMap(() => event, item => item.timestamp);
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -68,10 +66,10 @@ async function savePrice(payload: HistoricalPriceFormPayload) {
 
 async function updatePrice() {
   const payload: HistoricalPriceFormPayload = {
-    fromAsset: get(event).assetIdentifier,
+    fromAsset: event.assetIdentifier,
     price: get(price),
-    timestamp: get(event).timestamp,
-    toAsset: get(currency),
+    timestamp: event.timestamp,
+    toAsset: currency,
   };
 
   try {

--- a/frontend/app/src/components/settings/AssetBalanceStatisticSourceSetting.vue
+++ b/frontend/app/src/components/settings/AssetBalanceStatisticSourceSetting.vue
@@ -3,7 +3,7 @@ import MenuTooltipButton from '@/components/helper/MenuTooltipButton.vue';
 import SettingsOption from '@/components/settings/controls/SettingsOption.vue';
 import { useAssetStatisticState } from '@/composables/settings/use-asset-statistic-state';
 
-const props = defineProps<{
+const { asset } = defineProps<{
   asset?: string;
 }>();
 
@@ -11,27 +11,25 @@ const emit = defineEmits<{
   preference: [preference?: 'events' | 'snapshot'];
 }>();
 
-const { asset } = toRefs(props);
-
 const {
   getPreference,
   name,
   rememberStateForAsset,
   suppressIfPerAsset,
   useHistoricalAssetBalances,
-} = useAssetStatisticState(asset);
+} = useAssetStatisticState(() => asset);
 
 const { t } = useI18n({ useScope: 'global' });
 
 watch(useHistoricalAssetBalances, () => {
-  if (!isDefined(asset) || !get(rememberStateForAsset)) {
+  if (!asset || !get(rememberStateForAsset)) {
     return;
   }
 
-  emit('preference', getPreference(get(asset)));
+  emit('preference', getPreference(asset));
 });
 
-watchImmediate(asset, (asset) => {
+watchImmediate(() => asset, (asset) => {
   if (!asset || !get(rememberStateForAsset)) {
     return;
   }

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleFormDialog.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleFormDialog.vue
@@ -10,18 +10,11 @@ import { ApiValidationError } from '@/types/api/errors';
 
 const modelValue = defineModel<AccountingRuleEntry | undefined>({ required: true });
 
-const props = withDefaults(
-  defineProps<{
-    editMode?: boolean;
-    loading?: boolean;
-    eventIds?: number[];
-  }>(),
-  {
-    editMode: false,
-    eventIds: undefined,
-    loading: false,
-  },
-);
+const { editMode = false, loading = false, eventIds } = defineProps<{
+  editMode?: boolean;
+  loading?: boolean;
+  eventIds?: number[];
+}>();
 
 const emit = defineEmits<{
   refresh: [];
@@ -29,12 +22,12 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const submitting = ref(false);
+const submitting = ref<boolean>(false);
 const errorMessages = ref<Record<string, string[]>>({});
 const form = useTemplateRef<InstanceType<typeof AccountingRuleForm>>('form');
-const stateUpdated = ref(false);
+const stateUpdated = ref<boolean>(false);
 
-const dialogTitle = computed<string>(() => props.editMode
+const dialogTitle = computed<string>(() => editMode
   ? t('accounting_settings.rule.edit')
   : t('accounting_settings.rule.add'));
 
@@ -52,7 +45,6 @@ async function save() {
 
   const data = get(modelValue);
   let success;
-  const editMode = props.editMode;
   set(submitting, true);
   try {
     if (editMode) {
@@ -61,8 +53,8 @@ async function save() {
     else {
       const ruleData = omit(data, ['identifier']);
       // Include eventIds if provided (for custom accounting rules)
-      if (props.eventIds) {
-        ruleData.eventIds = props.eventIds;
+      if (eventIds) {
+        ruleData.eventIds = eventIds;
       }
       success = await addAccountingRule(ruleData);
     }

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleWithLinkedSetting.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleWithLinkedSetting.vue
@@ -6,13 +6,12 @@ import { useRefPropVModel } from '@/utils/model';
 
 const modelValue = defineModel<AccountingRuleWithLinkedProperty>({ required: true });
 
-const props = defineProps<{
+const { identifier, label, hint } = defineProps<{
   identifier: string;
   label: string;
   hint: string;
 }>();
 
-const { identifier } = toRefs(props);
 const { t } = useI18n({ useScope: 'global' });
 
 const value = useRefPropVModel(modelValue, 'value');
@@ -23,7 +22,7 @@ function updateModelValue(newValue: AccountingRuleWithLinkedProperty): void {
 
 const { accountingRuleLinkedMappingData } = useAccountingRuleMappings();
 
-const linkableSettingOptions = accountingRuleLinkedMappingData(identifier);
+const linkableSettingOptions = accountingRuleLinkedMappingData(() => identifier);
 
 const linkedModel = computed<boolean>({
   get() {
@@ -69,7 +68,7 @@ const linkedPropertyValue = computed<boolean | null>(() => {
   return get(item.state);
 });
 
-const elemID = computed(() => `${get(identifier)}-switch`);
+const elemID = computed(() => `${identifier}-switch`);
 </script>
 
 <template>

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleWithLinkedSettingDisplay.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleWithLinkedSettingDisplay.vue
@@ -3,22 +3,19 @@ import type { AccountingRuleWithLinkedProperty } from '@/types/settings/accounti
 import SuccessDisplay from '@/components/display/SuccessDisplay.vue';
 import { useAccountingRuleMappings } from '@/composables/settings/accounting/rule-mapping';
 
-const props = defineProps<{
+const { identifier, item } = defineProps<{
   identifier: string;
   item: AccountingRuleWithLinkedProperty;
 }>();
-
-const { identifier, item } = toRefs(props);
 
 const { t } = useI18n({ useScope: 'global' });
 
 const { accountingRuleLinkedMappingData } = useAccountingRuleMappings();
 
-const linkableSettingOptions = accountingRuleLinkedMappingData(identifier);
+const linkableSettingOptions = accountingRuleLinkedMappingData(() => identifier);
 
 const selectedLinkableSetting = computed(() => {
-  const itemVal = get(item);
-  const linkedProperty = itemVal.linkedSetting;
+  const linkedProperty = item.linkedSetting;
   if (linkedProperty) {
     const foundItem = get(linkableSettingOptions).find(item => item.identifier === linkedProperty);
 
@@ -34,7 +31,7 @@ const value = computed<boolean>(() => {
   if (selectedLinkableSettingVal)
     return get(selectedLinkableSettingVal).state;
 
-  return get(item).value;
+  return item.value;
 });
 </script>
 

--- a/frontend/app/src/components/settings/api-keys/ServiceKeyCard.vue
+++ b/frontend/app/src/components/settings/api-keys/ServiceKeyCard.vue
@@ -4,31 +4,20 @@ import BigDialog from '@/components/dialogs/BigDialog.vue';
 import PremiumLock from '@/components/premium/PremiumLock.vue';
 import { usePremium } from '@/composables/premium';
 
-const props = withDefaults(
-  defineProps<{
-    name?: string;
-    title: string;
-    subtitle?: string;
-    imageSrc: string;
-    needPremium?: boolean;
-    roundedIcon?: boolean;
-    keySet?: boolean;
-    hideAction?: boolean;
-    primaryAction?: string;
-    actionDisabled?: boolean;
-    addButtonText?: string;
-    editButtonText?: string;
-  }>(),
-  {
-    actionDisabled: false,
-    hideAction: false,
-    keySet: false,
-    needPremium: false,
-    primaryAction: '',
-    roundedIcon: false,
-    subtitle: '',
-  },
-);
+const { name, title, subtitle = '', imageSrc, needPremium = false, roundedIcon = false, keySet = false, hideAction = false, primaryAction = '', actionDisabled = false, addButtonText, editButtonText } = defineProps<{
+  name?: string;
+  title: string;
+  subtitle?: string;
+  imageSrc: string;
+  needPremium?: boolean;
+  roundedIcon?: boolean;
+  keySet?: boolean;
+  hideAction?: boolean;
+  primaryAction?: string;
+  actionDisabled?: boolean;
+  addButtonText?: string;
+  editButtonText?: string;
+}>();
 
 const emit = defineEmits<{
   confirm: [];
@@ -53,7 +42,7 @@ const route = useRoute();
 const router = useRouter();
 
 watch(route, async (route) => {
-  if (!props.name)
+  if (!name)
     return;
 
   const { query } = route;
@@ -62,7 +51,7 @@ watch(route, async (route) => {
   }
   const { service, ...restQuery } = query;
 
-  if (service === props.name) {
+  if (service === name) {
     nextTick(() => {
       setOpen(true);
     });
@@ -70,11 +59,11 @@ watch(route, async (route) => {
   }
 }, { immediate: true });
 
-const addButtonTextComputed = computed<string>(() => props.addButtonText || t('external_services.actions.enter_api_key'));
+const addButtonTextComputed = computed<string>(() => addButtonText || t('external_services.actions.enter_api_key'));
 
-const editButtonTextComputed = computed<string>(() => props.editButtonText || t('external_services.actions.replace_key'));
+const editButtonTextComputed = computed<string>(() => editButtonText || t('external_services.actions.replace_key'));
 
-const primaryActionTextComputed = computed<string>(() => props.primaryAction || (props.keySet
+const primaryActionTextComputed = computed<string>(() => primaryAction || (keySet
   ? t('external_services.actions.replace_key')
   : t('external_services.actions.save_key')));
 

--- a/frontend/app/src/components/settings/api-keys/external/BlockscoutApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/BlockscoutApiKey.vue
@@ -7,22 +7,21 @@ import { useExternalApiKeys } from '@/composables/settings/api-keys/external';
 import { useNotificationsStore } from '@/store/notifications';
 import { isBlockscoutKey } from '@/types/external';
 
-const props = defineProps<{ evmChain: string; chainName: string }>();
-const { evmChain } = toRefs(props);
+const { evmChain, chainName } = defineProps<{ evmChain: string; chainName: string }>();
 
 const name = 'blockscout';
 const { t } = useI18n({ useScope: 'global' });
 
 const { actionStatus, apiKey, confirmDelete, getName, loading, save } = useExternalApiKeys(t);
 
-const key = apiKey(name, evmChain);
-const status = actionStatus(name, evmChain);
-const identifier = computed(() => getName(name, get(evmChain)));
+const key = apiKey(name, () => evmChain);
+const status = actionStatus(name, () => evmChain);
+const identifier = computed(() => getName(name, evmChain));
 
 const { prioritized, remove: removeNotification } = useNotificationsStore();
 
 function removeBlockscoutNotification() {
-  const notification = prioritized.find(data => data.i18nParam?.props?.key === get(evmChain));
+  const notification = prioritized.find(data => data.i18nParam?.props?.key === evmChain);
 
   if (!notification)
     return;
@@ -31,7 +30,7 @@ function removeBlockscoutNotification() {
 }
 
 const link = computed(() => {
-  const location = camelCase(get(evmChain));
+  const location = camelCase(evmChain);
   if (isBlockscoutKey(location))
     return blockscoutLinks[location];
 

--- a/frontend/app/src/components/settings/general/AskUserUponSizeDiscrepancySetting.vue
+++ b/frontend/app/src/components/settings/general/AskUserUponSizeDiscrepancySetting.vue
@@ -2,15 +2,12 @@
 import SettingsOption from '@/components/settings/controls/SettingsOption.vue';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 
-withDefaults(
-  defineProps<{
-    dialog?: boolean;
-    confirm?: boolean;
-  }>(),
-  { confirm: false, dialog: false },
-);
+const { dialog = false, confirm = false } = defineProps<{
+  dialog?: boolean;
+  confirm?: boolean;
+}>();
 
-const value = ref(false);
+const value = ref<boolean>(false);
 const { askUserUponSizeDiscrepancy } = storeToRefs(useGeneralSettingsStore());
 
 watchImmediate(askUserUponSizeDiscrepancy, (askUser) => {

--- a/frontend/app/src/components/settings/general/TimeFrameSettings.vue
+++ b/frontend/app/src/components/settings/general/TimeFrameSettings.vue
@@ -6,7 +6,7 @@ import { useFrontendSettingsStore } from '@/store/settings/frontend';
 import { useSessionSettingsStore } from '@/store/settings/session';
 import { isPeriodAllowed } from '@/utils/settings';
 
-const props = defineProps<{
+const { currentSessionTimeframe, message, value, visibleTimeframes } = defineProps<{
   message: { error: string; success: string };
   value: TimeFrameSetting;
   visibleTimeframes: TimeFramePeriod[];
@@ -18,13 +18,11 @@ const emit = defineEmits<{
   'visible-timeframes-change': [timeframes: TimeFrameSetting[]];
 }>();
 
-const { currentSessionTimeframe, message, value, visibleTimeframes } = toRefs(props);
-
 const timeframes = Object.values(TimeFramePeriod);
 const { t } = useI18n({ useScope: 'global' });
 const premium = usePremium();
 
-const appendedVisibleTimeframes = computed(() => [TimeFramePersist.REMEMBER, ...get(visibleTimeframes)]);
+const appendedVisibleTimeframes = computed(() => [TimeFramePersist.REMEMBER, ...visibleTimeframes]);
 
 const invisibleTimeframes = computed(() => timeframes.filter(item => !isTimeframeVisible(item)));
 
@@ -33,12 +31,12 @@ const selectableTimeframes = computed(() =>
 );
 
 const text = computed<string>(() => {
-  const { error, success } = get(message);
+  const { error, success } = message;
   return success || error;
 });
 
 function isTimeframeVisible(timeframe: TimeFramePeriod): boolean {
-  return get(visibleTimeframes).includes(timeframe);
+  return visibleTimeframes.includes(timeframe);
 }
 
 function isTimeframesToggleable(timeframe: TimeFrameSetting) {
@@ -76,16 +74,16 @@ async function updateVisibleTimeframes(newTimeFrames: TimeFramePeriod[], replace
 }
 
 async function addVisibleTimeframe(timeframe: TimeFramePeriod) {
-  await updateVisibleTimeframes([...get(visibleTimeframes), timeframe]);
+  await updateVisibleTimeframes([...visibleTimeframes, timeframe]);
 }
 
 async function removeVisibleTimeframe(timeframe: TimeFrameSetting) {
-  if (timeframe === get(value))
+  if (timeframe === value)
     timeframeChange(TimeFramePersist.REMEMBER);
 
   await updateVisibleTimeframes(
-    get(visibleTimeframes).filter(item => item !== timeframe),
-    timeframe === get(currentSessionTimeframe),
+    visibleTimeframes.filter(item => item !== timeframe),
+    timeframe === currentSessionTimeframe,
   );
 }
 </script>

--- a/frontend/app/src/components/settings/general/rpc/BlockchainRpcNodeManager.vue
+++ b/frontend/app/src/components/settings/general/rpc/BlockchainRpcNodeManager.vue
@@ -18,13 +18,11 @@ import {
   getPlaceholderNode,
 } from '@/types/settings/rpc';
 
-const props = defineProps<{
+const { chain } = defineProps<{
   chain: Blockchain;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { chain } = toRefs(props);
 
 const nodes = ref<BlockchainRpcNodeList>([]);
 const state = ref<BlockchainRpcNodeManageState>();
@@ -36,9 +34,9 @@ const { setMessage } = useMessageStore();
 const { connectedNodes, failedToConnect } = storeToRefs(usePeriodicStore());
 const { show } = useConfirmStore();
 const { getChainName } = useSupportedChains();
-const api = useEvmNodesApi(chain);
+const api = useEvmNodesApi(() => chain);
 
-const chainName = getChainName(chain);
+const chainName = getChainName(() => chain);
 const anyDisconnected = computed(() => get(nodes).some(node => !isNodeConnected(node) && node.active));
 
 async function loadNodes(): Promise<void> {
@@ -49,7 +47,7 @@ async function loadNodes(): Promise<void> {
     notify({
       message: error.message,
       title: t('evm_rpc_node_manager.loading_error.title', {
-        chain: get(chain),
+        chain,
       }),
     });
   }
@@ -65,7 +63,7 @@ function editRpcNode(node: BlockchainRpcNode) {
 function addNewRpcNode() {
   set(state, {
     mode: 'add',
-    node: getPlaceholderNode(get(chain)),
+    node: getPlaceholderNode(chain),
   });
 }
 
@@ -80,7 +78,7 @@ async function deleteNode(node: BlockchainRpcNode) {
       description: error.message,
       success: false,
       title: t('evm_rpc_node_manager.delete_error.title', {
-        chain: get(chain),
+        chain,
       }),
     });
   }
@@ -108,8 +106,7 @@ function isEtherscan(item: BlockchainRpcNode) {
 }
 
 function isNodeInDataset(dataset: Record<string, string[]>, item: BlockchainRpcNode): boolean {
-  const chainVal = get(chain);
-  const blockchain = camelCase(chainVal);
+  const blockchain = camelCase(chain);
   const nodes = dataset?.[blockchain] || [];
   return nodes.includes(item.name);
 }

--- a/frontend/app/src/components/snapshots/ConfirmSnapshotConflictReplacementDialog.vue
+++ b/frontend/app/src/components/snapshots/ConfirmSnapshotConflictReplacementDialog.vue
@@ -6,7 +6,7 @@ import AssetDetails from '@/components/helper/AssetDetails.vue';
 import NftDetails from '@/components/helper/NftDetails.vue';
 import { isNft } from '@/utils/nft';
 
-const props = defineProps<{
+const { snapshot } = defineProps<{
   snapshot: BalanceSnapshot | null;
 }>();
 const emit = defineEmits<{
@@ -15,11 +15,9 @@ const emit = defineEmits<{
 }>();
 const { t } = useI18n({ useScope: 'global' });
 
-const { snapshot } = toRefs(props);
+const display = computed<boolean>(() => !!snapshot);
 
-const display = computed<boolean>(() => !!get(snapshot));
-
-const asset = computed<string>(() => get(snapshot)?.assetIdentifier ?? '');
+const asset = computed<string>(() => snapshot?.assetIdentifier ?? '');
 </script>
 
 <template>

--- a/frontend/app/src/components/staking/kraken/KrakenStakingOverview.vue
+++ b/frontend/app/src/components/staking/kraken/KrakenStakingOverview.vue
@@ -4,18 +4,13 @@ import ValueAccuracyHint from '@/components/helper/hint/ValueAccuracyHint.vue';
 import { FiatDisplay } from '@/modules/amount-display/components';
 import { sum } from '@/utils/balances';
 
-const props = defineProps<{
+const { earned } = defineProps<{
   loading: boolean;
   totalHistorical: BigNumber;
   earned: AssetBalance[];
 }>();
 
-const { earned } = toRefs(props);
-
-const totalCurrent = computed<BigNumber>(() => {
-  const earnedAssets = get(earned);
-  return sum(earnedAssets);
-});
+const totalCurrent = computed<BigNumber>(() => sum(earned));
 
 const { t } = useI18n({ useScope: 'global' });
 </script>

--- a/frontend/app/src/components/staking/liquity/LiquityStake.vue
+++ b/frontend/app/src/components/staking/liquity/LiquityStake.vue
@@ -4,14 +4,9 @@ import BalanceDisplay from '@/components/display/BalanceDisplay.vue';
 import { useStatusStore } from '@/store/status';
 import { Section } from '@/types/status';
 
-withDefaults(
-  defineProps<{
-    stake?: LiquityStakingDetailEntry | null;
-  }>(),
-  {
-    stake: null,
-  },
-);
+const { stake = null } = defineProps<{
+  stake?: LiquityStakingDetailEntry | null;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/app/src/components/status/notifications/Notification.vue
+++ b/frontend/app/src/components/status/notifications/Notification.vue
@@ -129,7 +129,7 @@ function doAction(id: number, action: NotificationAction) {
     dismiss(id);
 }
 
-const message = ref();
+const message = useTemplateRef<HTMLDivElement>('message');
 const MAX_HEIGHT = 64;
 
 const { height } = useElementSize(message);

--- a/frontend/app/src/components/status/notifications/NotificationSidebar.vue
+++ b/frontend/app/src/components/status/notifications/NotificationSidebar.vue
@@ -17,7 +17,7 @@ enum TabCategory {
   ERROR = 'error',
 }
 
-const contentWrapper = ref();
+const contentWrapper = useTemplateRef<HTMLDivElement>('contentWrapper');
 const selectedTab = ref<TabCategory>(TabCategory.VIEW_ALL);
 const initialAppear = ref<boolean>(false);
 const pendingTasksExpanded = ref<boolean>(false);

--- a/frontend/app/src/components/status/notifications/PendingTask.vue
+++ b/frontend/app/src/components/status/notifications/PendingTask.vue
@@ -7,25 +7,24 @@ import { useReportsStore } from '@/store/reports';
 import { TaskType } from '@/types/task-type';
 import { calculatePercentage } from '@/utils/calculation';
 
-const props = defineProps<{ task: Task<TaskMeta> }>();
+const { task } = defineProps<{ task: Task<TaskMeta> }>();
 const emit = defineEmits<{
   cancel: [task: Task<TaskMeta>];
 }>();
 
-const { task } = toRefs(props);
 const { progress: taskProgress } = storeToRefs(useReportsStore());
 const { historicalDailyPriceStatus } = storeToRefs(useHistoricCachePriceStore());
 const { t } = useI18n({ useScope: 'global' });
 
 const hasDeterminateProgress = computed(() => {
-  const { type } = get(task);
+  const { type } = task;
   return type === TaskType.TRADE_HISTORY || type === TaskType.FETCH_DAILY_HISTORIC_PRICE;
 });
 
-const time = computed<string>(() => dayjs(task.value.time).format('LLL'));
+const time = computed<string>(() => dayjs(task.time).format('LLL'));
 
 const progress = computed<number | undefined>(() => {
-  const { type } = get(task);
+  const { type } = task;
   if (type === TaskType.TRADE_HISTORY) {
     return parseInt(get(taskProgress));
   }

--- a/frontend/app/src/components/status/sync/AutomaticSyncSetting.vue
+++ b/frontend/app/src/components/status/sync/AutomaticSyncSetting.vue
@@ -6,18 +6,12 @@ defineOptions({
   inheritAttrs: false,
 });
 
-withDefaults(
-  defineProps<{
-    disabled?: boolean;
-    dense?: boolean;
-  }>(),
-  {
-    dense: false,
-    disabled: false,
-  },
-);
+const { disabled = false, dense = false } = defineProps<{
+  disabled?: boolean;
+  dense?: boolean;
+}>();
 
-const sync = ref(false);
+const sync = ref<boolean>(false);
 const { premiumSync } = storeToRefs(usePremiumStore());
 
 watchImmediate(premiumSync, (premiumSync) => {

--- a/frontend/app/src/components/status/update/AssetConflictDialog.vue
+++ b/frontend/app/src/components/status/update/AssetConflictDialog.vue
@@ -7,7 +7,7 @@ import BigDialog from '@/components/dialogs/BigDialog.vue';
 import AssetConflictRow from '@/components/status/update/AssetConflictRow.vue';
 import { uniqueObjects, uniqueStrings } from '@/utils/data';
 
-const props = defineProps<{
+const { conflicts } = defineProps<{
   conflicts: AssetUpdateConflictResult[];
 }>();
 
@@ -17,8 +17,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { conflicts } = toRefs(props);
 
 const tableHeaders = computed<DataTableColumn<AssetUpdateConflictResult>[]>(() => [
   {
@@ -44,7 +42,7 @@ const resolution = ref<ConflictResolution>({});
 const strategyModeForAll = ref<ConflictResolutionStrategy>();
 const resolutionLength = computed(() => Object.keys(get(resolution)).length);
 const activeStrategyForAll = computed(() => {
-  if (get(conflicts).length === 0 || get(resolutionLength) !== get(conflicts).length)
+  if (conflicts.length === 0 || get(resolutionLength) !== conflicts.length)
     return { local: false, remote: false };
 
   const strategy = get(strategyModeForAll);
@@ -53,10 +51,10 @@ const activeStrategyForAll = computed(() => {
 });
 
 function setResolution(strategy: ConflictResolutionStrategy) {
-  const length = get(conflicts).length;
+  const length = conflicts.length;
   const resolutionStrategy: Writeable<ConflictResolution> = {};
   for (let i = 0; i < length; i++) {
-    const conflict = get(conflicts)[i];
+    const conflict = conflicts[i];
     resolutionStrategy[conflict.identifier] = strategy;
   }
 
@@ -89,11 +87,11 @@ function isDiff(conflict: AssetUpdateConflictResult, field: AssetKey) {
 
 const remaining = computed(() => {
   const resolved = get(resolutionLength);
-  return uniqueObjects(get(conflicts), ({ identifier }) => identifier).length - resolved;
+  return uniqueObjects(conflicts, ({ identifier }) => identifier).length - resolved;
 });
 
 const warnDuplicate = computed<boolean>(() => {
-  const identifiers = get(conflicts)
+  const identifiers = conflicts
     .map(({ identifier }) => identifier)
     .sort();
   const uniqueIdentifiers = identifiers.filter(uniqueStrings);
@@ -101,14 +99,14 @@ const warnDuplicate = computed<boolean>(() => {
 });
 
 const duplicateIdentifiers = computed<string[]>(() =>
-  get(conflicts)
+  conflicts
     .map(({ identifier }) => identifier)
     .sort()
     .filter((e, i, a) => a.indexOf(e) !== i),
 );
 
 const valid = computed<boolean>(() => {
-  const identifiers = get(conflicts)
+  const identifiers = conflicts
     .map(({ identifier }) => identifier)
     .filter(uniqueStrings)
     .sort();

--- a/frontend/app/src/components/status/update/AssetUpdateStatus.vue
+++ b/frontend/app/src/components/status/update/AssetUpdateStatus.vue
@@ -1,30 +1,24 @@
 <script setup lang="ts">
-const props = defineProps<{
+const { remoteVersion, status } = defineProps<{
   status: 'checking' | 'applying';
   remoteVersion: number;
 }>();
 
-const { remoteVersion, status } = toRefs(props);
-
 const { t } = useI18n({ useScope: 'global' });
 
 const title = computed(() => {
-  const updateStatus = get(status);
-
-  if (updateStatus === 'checking')
+  if (status === 'checking')
     return t('asset_update_status.checking.title');
 
   return t('asset_update_status.applying.title');
 });
 
 const message = computed(() => {
-  const updateStatus = get(status);
-
-  if (updateStatus === 'checking')
+  if (status === 'checking')
     return t('asset_update_status.checking.message');
 
   return t('asset_update_status.applying.message', {
-    remoteVersion: get(remoteVersion),
+    remoteVersion,
   });
 });
 </script>

--- a/frontend/app/src/components/table-filter/FilterDropdown.vue
+++ b/frontend/app/src/components/table-filter/FilterDropdown.vue
@@ -7,7 +7,7 @@ import { compareTextByKeyword } from '@/utils/assets';
 import { logger } from '@/utils/logging';
 import { splitSearch } from '@/utils/search';
 
-const props = defineProps<{
+const { keyword, matchers, selectedMatcher, selectedSuggestion } = defineProps<{
   matches: MatchedKeywordWithBehaviour<any>;
   matchers: SearchMatcher<any>[];
   selectedMatcher?: SearchMatcher<any>;
@@ -21,9 +21,7 @@ const emit = defineEmits<{
   'apply-filter': [item: Suggestion];
 }>();
 
-const { keyword, selectedMatcher, selectedSuggestion } = toRefs(props);
-
-const keywordSplit = computed(() => splitSearch(get(keyword)));
+const keywordSplit = computed(() => splitSearch(keyword));
 
 const lastSuggestion = ref<Suggestion | null>(null);
 const suggested = ref<Suggestion[]>([]);
@@ -47,7 +45,7 @@ function applyFilter(item: Suggestion) {
     emit('apply-filter', item);
 }
 
-watch(selectedSuggestion, (index) => {
+watch(() => selectedSuggestion, (index) => {
   updateSuggestion(get(suggested), index);
 });
 
@@ -62,7 +60,7 @@ watch(suggested, (value) => {
   }
 });
 
-watch([keyword, selectedMatcher], async ([keyword, selectedMatcher]) => {
+watch([() => keyword, () => selectedMatcher], async ([keyword, selectedMatcher]) => {
   if (!keyword || !selectedMatcher)
     return [];
 
@@ -143,7 +141,7 @@ watch([keyword, selectedMatcher], async ([keyword, selectedMatcher]) => {
 
 const { t } = useI18n({ useScope: 'global' });
 
-watch(selectedSuggestion, async () => {
+watch(() => selectedSuggestion, async () => {
   await nextTick(() => {
     document.getElementsByClassName('highlightedMatcher')[0]?.scrollIntoView?.({ block: 'nearest' });
   });

--- a/frontend/app/src/components/table-filter/SavedFilterManagement.vue
+++ b/frontend/app/src/components/table-filter/SavedFilterManagement.vue
@@ -5,7 +5,7 @@ import SuggestedItem from '@/components/table-filter/SuggestedItem.vue';
 import { useSavedFilter } from '@/composables/filters/saved';
 import { useMessageStore } from '@/store/message';
 
-const props = defineProps<{
+const { disabled, location, matchers, selection } = defineProps<{
   matchers: SearchMatcher<any>[];
   selection: Suggestion[];
   location: SavedFilterLocation;
@@ -17,8 +17,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { location, matchers, selection } = toRefs(props);
 
 const open = ref<boolean>(false);
 
@@ -46,14 +44,14 @@ const { start: startAnimation } = useTimeoutFn(
 );
 
 function isAsset(searchKey: string): boolean {
-  const found = get(matchers).find(({ key }) => key === searchKey);
+  const found = matchers.find(({ key }) => key === searchKey);
   return !!found && 'asset' in found;
 }
 
-const { addFilter, deleteFilter, savedFilters } = useSavedFilter(location, isAsset);
+const { addFilter, deleteFilter, savedFilters } = useSavedFilter(() => location, isAsset);
 
 const filtersList = computed(() => {
-  const matcherKeys = get(matchers).map(item => item.key);
+  const matcherKeys = matchers.map(item => item.key);
   return get(savedFilters)
     // Filter out keys that doesn't supported in the matchers list
     .map(filters => filters.filter(filter => matcherKeys.includes(filter.key)))
@@ -72,7 +70,7 @@ const filtersList = computed(() => {
 const { setMessage } = useMessageStore();
 
 async function addToSavedFilter() {
-  const status = await addFilter(get(selection));
+  const status = await addFilter(selection);
   if (status.success) {
     if (get(isPending)) {
       stop();

--- a/frontend/app/src/components/table-filter/SelectionChip.vue
+++ b/frontend/app/src/components/table-filter/SelectionChip.vue
@@ -8,7 +8,7 @@ defineOptions({
 
 const expandedGroupKey = defineModel<string | undefined>('expandedGroupKey');
 
-const props = defineProps<{
+const { item } = defineProps<{
   item: Suggestion;
   chipAttrs: Record<string, unknown>;
   displayType: 'normal' | 'grouped' | 'hidden';
@@ -26,12 +26,10 @@ const emit = defineEmits<{
   'remove-grouped-item': [item: Suggestion];
 }>();
 
-const { item } = toRefs(props);
-
-const isMenuOpen = computed<boolean>(() => get(expandedGroupKey) === get(item).key);
+const isMenuOpen = computed<boolean>(() => get(expandedGroupKey) === item.key);
 
 function onMenuUpdate(value: boolean): void {
-  set(expandedGroupKey, value ? get(item).key : undefined);
+  set(expandedGroupKey, value ? item.key : undefined);
 }
 </script>
 

--- a/frontend/app/src/components/table-filter/TableFilter.vue
+++ b/frontend/app/src/components/table-filter/TableFilter.vue
@@ -35,7 +35,7 @@ defineSlots<{
   tooltip: () => any;
 }>();
 
-const input = ref();
+const input = useTemplateRef<any>('input');
 const search = ref<string>('');
 const selectedSuggestion = ref<number>(0);
 const suggestedFilter = ref<Suggestion>({

--- a/frontend/app/src/components/tags/TagDisplay.vue
+++ b/frontend/app/src/components/tags/TagDisplay.vue
@@ -2,18 +2,11 @@
 import TagIcon from '@/components/tags/TagIcon.vue';
 import { useTagStore } from '@/store/session/tags';
 
-withDefaults(
-  defineProps<{
-    tags?: string[];
-    small?: boolean;
-    wrapperClass?: string;
-  }>(),
-  {
-    small: false,
-    tags: () => [],
-    wrapperClass: '',
-  },
-);
+const { tags = [], small = false, wrapperClass = '' } = defineProps<{
+  tags?: string[];
+  small?: boolean;
+  wrapperClass?: string;
+}>();
 
 const { allTags } = storeToRefs(useTagStore());
 </script>

--- a/frontend/app/src/components/tags/TagFormDialog.vue
+++ b/frontend/app/src/components/tags/TagFormDialog.vue
@@ -7,16 +7,10 @@ import { useTagStore } from '@/store/session/tags';
 
 const modelValue = defineModel<Tag | undefined>({ required: true });
 
-const props = withDefaults(
-  defineProps<{
-    editMode?: boolean;
-    originalName?: string;
-  }>(),
-  {
-    editMode: false,
-    originalName: '',
-  },
-);
+const { editMode = false, originalName = '' } = defineProps<{
+  editMode?: boolean;
+  originalName?: string;
+}>();
 
 const emit = defineEmits<{
   saved: [{ tag: Tag; originalName: string }];
@@ -42,11 +36,11 @@ async function save() {
     set(submitting, false);
     return;
   }
-  const originalName = props.originalName || newTag.name;
-  const status = await (props.editMode ? editTag(newTag, originalName) : addTag(newTag));
+  const tagOriginalName = originalName || newTag.name;
+  const status = await (editMode ? editTag(newTag, tagOriginalName) : addTag(newTag));
 
   if (status.success) {
-    emit('saved', { tag: newTag, originalName });
+    emit('saved', { tag: newTag, originalName: tagOriginalName });
     closeDialog();
   }
   set(submitting, false);

--- a/frontend/app/src/components/tags/TagIcon.vue
+++ b/frontend/app/src/components/tags/TagIcon.vue
@@ -5,17 +5,11 @@ defineOptions({
   inheritAttrs: false,
 });
 
-withDefaults(
-  defineProps<{
-    tag: Tag;
-    small?: boolean;
-    showDescription?: boolean;
-  }>(),
-  {
-    showDescription: false,
-    small: false,
-  },
-);
+const { tag, small = false, showDescription = false } = defineProps<{
+  tag: Tag;
+  small?: boolean;
+  showDescription?: boolean;
+}>();
 </script>
 
 <template>

--- a/frontend/app/src/composables/accounts/use-account-balances-pagination.ts
+++ b/frontend/app/src/composables/accounts/use-account-balances-pagination.ts
@@ -1,5 +1,5 @@
 import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
-import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter, Ref, WritableComputedRef } from 'vue';
 import type {
   BlockchainAccountGroupWithBalance,
   BlockchainAccountRequestPayload,
@@ -18,7 +18,7 @@ import { useBlockchainAccountData } from '@/modules/balances/blockchain/use-bloc
 import { fromUriEncoded, toUriEncoded } from '@/utils/route-uri';
 
 interface UseAccountBalancesPaginationOptions {
-  category: Ref<string>;
+  category: MaybeRefOrGetter<string>;
   visibleTags: Ref<string[]>;
   chainExclusionFilter: Ref<Record<string, string[]>>;
   tab: Ref<number>;
@@ -57,7 +57,7 @@ export function useAccountBalancesPagination(
   const filterSchema = useBlockchainAccountFilter(t, category);
 
   const extraParams = computed<RawLocationQuery>(() => ({
-    category: get(category),
+    category: toValue(category),
     tags: get(visibleTags),
   }));
 

--- a/frontend/app/src/composables/api/settings/evm-nodes-api.ts
+++ b/frontend/app/src/composables/api/settings/evm-nodes-api.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
 import { Blockchain } from '@rotki/common';
 import { omit } from 'es-toolkit';
 import { api } from '@/modules/api/rotki-api';
@@ -14,8 +14,8 @@ interface UseEvmNodesApiReturn {
   reConnectNode: (identifier?: number) => Promise<boolean>;
 }
 
-export function useEvmNodesApi(chain: MaybeRef<string> = Blockchain.ETH): UseEvmNodesApiReturn {
-  const url = computed<string>(() => `/blockchains/${get(chain)}/nodes`);
+export function useEvmNodesApi(chain: MaybeRefOrGetter<string> = Blockchain.ETH): UseEvmNodesApiReturn {
+  const url = computed<string>(() => `/blockchains/${toValue(chain)}/nodes`);
 
   const fetchEvmNodes = async (): Promise<BlockchainRpcNodeList> => {
     const response = await api.get<BlockchainRpcNodeList>(get(url));

--- a/frontend/app/src/composables/assets/retrieval.ts
+++ b/frontend/app/src/composables/assets/retrieval.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRef, MaybeRefOrGetter } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { ERC20Token } from '@/types/blockchain/accounts';
 import type { EvmChainAddress } from '@/types/history/events';
 import type { TaskMeta } from '@/types/task';
@@ -40,11 +40,11 @@ interface AssetContractInfo {
 
 export type AssetInfoReturn = (identifier: MaybeRefOrGetter<string | undefined>, options?: MaybeRefOrGetter<AssetResolutionOptions>) => ComputedRef<AssetWithResolutionStatus | null>;
 
-export type AssetSymbolReturn = (identifier: MaybeRef<string | undefined>, options?: MaybeRef<AssetResolutionOptions>) => ComputedRef<string>;
+export type AssetSymbolReturn = (identifier: MaybeRefOrGetter<string | undefined>, options?: MaybeRefOrGetter<AssetResolutionOptions>) => ComputedRef<string>;
 
-export type AssetNameReturn = (identifier: MaybeRef<string | undefined>, options?: MaybeRef<AssetResolutionOptions>) => ComputedRef<string>;
+export type AssetNameReturn = (identifier: MaybeRefOrGetter<string | undefined>, options?: MaybeRefOrGetter<AssetResolutionOptions>) => ComputedRef<string>;
 
-type AssetContractInfoReturn = (identifier: MaybeRef<string | undefined>, options?: MaybeRef<AssetResolutionOptions>) => ComputedRef<AssetContractInfo | undefined>;
+type AssetContractInfoReturn = (identifier: MaybeRefOrGetter<string | undefined>, options?: MaybeRefOrGetter<AssetResolutionOptions>) => ComputedRef<AssetContractInfo | undefined>;
 
 interface UseAssetInfoRetrievalReturn {
   assetAssociationMap: ComputedRef<Record<string, string>>;
@@ -57,7 +57,7 @@ interface UseAssetInfoRetrievalReturn {
   getAssetSymbol: (identifier: string | undefined, options?: AssetResolutionOptions) => string;
   getAssociatedAssetIdentifier: (identifier: string) => ComputedRef<string>;
   refetchAssetInfo: (key: string) => void;
-  tokenAddress: (identifier: MaybeRef<string>, options?: AssetResolutionOptions) => ComputedRef<string>;
+  tokenAddress: (identifier: MaybeRefOrGetter<string>, options?: AssetResolutionOptions) => ComputedRef<string>;
 }
 
 export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
@@ -109,10 +109,10 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
   });
 
   const assetSymbol = (
-    identifier: MaybeRef<string | undefined>,
-    options?: MaybeRef<AssetResolutionOptions>,
+    identifier: MaybeRefOrGetter<string | undefined>,
+    options?: MaybeRefOrGetter<AssetResolutionOptions>,
   ): ComputedRef<string> => computed(() => {
-    const id = get(identifier);
+    const id = toValue(identifier);
     if (!id)
       return '';
 
@@ -127,10 +127,10 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
   };
 
   const assetName = (
-    identifier: MaybeRef<string | undefined>,
-    options?: MaybeRef<AssetResolutionOptions>,
+    identifier: MaybeRefOrGetter<string | undefined>,
+    options?: MaybeRefOrGetter<AssetResolutionOptions>,
   ): ComputedRef<string> => computed(() => {
-    const id = get(identifier);
+    const id = toValue(identifier);
     if (!id)
       return '';
 
@@ -139,10 +139,10 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
   });
 
   const assetContractInfo = (
-    identifier: MaybeRef<string | undefined>,
-    options?: MaybeRef<AssetResolutionOptions>,
+    identifier: MaybeRefOrGetter<string | undefined>,
+    options?: MaybeRefOrGetter<AssetResolutionOptions>,
   ): ComputedRef<AssetContractInfo | undefined> => computed(() => {
-    const id = get(identifier);
+    const id = toValue(identifier);
     if (!id)
       return undefined;
 
@@ -186,8 +186,8 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
   });
 
   const tokenAddress = (
-    identifier: MaybeRef<string>,
-    options?: MaybeRef<AssetResolutionOptions>,
+    identifier: MaybeRefOrGetter<string>,
+    options?: MaybeRefOrGetter<AssetResolutionOptions>,
   ): ComputedRef<string> =>
     computed(() => get(assetContractInfo(identifier, options))?.address || '');
 

--- a/frontend/app/src/composables/balances/location-breakdown.ts
+++ b/frontend/app/src/composables/balances/location-breakdown.ts
@@ -4,7 +4,7 @@ import type { Balances } from '@/types/blockchain/accounts';
 import type { AssetProtocolBalances } from '@/types/blockchain/balances';
 import type { ExchangeInfo } from '@/types/exchanges';
 import type { ManualBalanceWithValue } from '@/types/manual-balances';
-import { computed, type ComputedRef, type MaybeRef } from 'vue';
+import { computed, type ComputedRef, type MaybeRefOrGetter } from 'vue';
 import { summarizeAssetProtocols } from '@/composables/balances/asset-summary';
 import { blockchainToAssetProtocolBalances, manualToAssetProtocolBalances } from '@/composables/balances/balance-transformations';
 import { TRADE_LOCATION_BLOCKCHAIN } from '@/data/defaults';
@@ -42,11 +42,11 @@ export function getExchangeByLocationBalances(
  * Hook for getting location breakdown
  */
 export function useLocationBreakdown(
-  location: MaybeRef<string>,
-  blockchainBalances: MaybeRef<Balances>,
-  assetAssociationMap: MaybeRef<Record<string, string>>,
-  manualBalances: MaybeRef<ManualBalanceWithValue[]>,
-  useBaseExchangeBalances: (exchange?: MaybeRef<string>) => MaybeRef<AssetProtocolBalances>,
+  location: MaybeRefOrGetter<string>,
+  blockchainBalances: MaybeRefOrGetter<Balances>,
+  assetAssociationMap: MaybeRefOrGetter<Record<string, string>>,
+  manualBalances: MaybeRefOrGetter<ManualBalanceWithValue[]>,
+  useBaseExchangeBalances: (exchange?: MaybeRefOrGetter<string>) => MaybeRefOrGetter<AssetProtocolBalances>,
   isAssetIgnored: (identifier: string) => boolean,
   useCollectionId: (asset: string) => { value: string | undefined },
   useCollectionMainAsset: (collectionId: string) => { value: string | undefined },
@@ -54,18 +54,18 @@ export function useLocationBreakdown(
   noPrice: BigNumber,
 ): ComputedRef<AssetBalanceWithPrice[]> {
   return computed<AssetBalanceWithPrice[]>(() => {
-    const selectedLocation = get(location);
-    const associatedAssets = get(assetAssociationMap);
+    const selectedLocation = toValue(location);
+    const associatedAssets = toValue(assetAssociationMap);
 
     const sources: Record<string, AssetProtocolBalances> = {
       blockchain: selectedLocation === TRADE_LOCATION_BLOCKCHAIN
-        ? blockchainToAssetProtocolBalances(get(blockchainBalances))
+        ? blockchainToAssetProtocolBalances(toValue(blockchainBalances))
         : {},
       exchanges: selectedLocation === TRADE_LOCATION_BLOCKCHAIN
         ? {}
-        : get(useBaseExchangeBalances(selectedLocation)),
+        : toValue(useBaseExchangeBalances(selectedLocation)),
       manual: manualToAssetProtocolBalances(
-        get(manualBalances).filter(balance => balance.location === selectedLocation),
+        toValue(manualBalances).filter(balance => balance.location === selectedLocation),
       ),
     };
 

--- a/frontend/app/src/composables/balances/token-detection.ts
+++ b/frontend/app/src/composables/balances/token-detection.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRef } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { EthDetectedTokensInfo } from '@/types/balances';
 import { assert } from '@rotki/common';
 import { useBalanceQueue } from '@/composables/balances/use-balance-queue';
@@ -12,19 +12,19 @@ import { arrayify } from '@/utils/array';
 interface UseTokenDetectionReturn {
   detectingTokens: ComputedRef<boolean>;
   detectedTokens: ComputedRef<EthDetectedTokensInfo>;
-  getEthDetectedTokensInfo: (chain: MaybeRef<string>, address: MaybeRef<string | null>) => ComputedRef<EthDetectedTokensInfo>;
+  getEthDetectedTokensInfo: (chain: MaybeRefOrGetter<string>, address: MaybeRefOrGetter<string | null>) => ComputedRef<EthDetectedTokensInfo>;
   detectTokens: (addresses?: string[]) => Promise<void>;
   detectTokensOfAllAddresses: () => Promise<void>;
 }
 
-export function useTokenDetection(chain: MaybeRef<string | string[]>, accountAddress: MaybeRef<string | null> = null): UseTokenDetectionReturn {
+export function useTokenDetection(chain: MaybeRefOrGetter<string | string[]>, accountAddress: MaybeRefOrGetter<string | null> = null): UseTokenDetectionReturn {
   const { useIsTaskRunning } = useTaskStore();
   const { fetchDetectedTokens: fetchDetectedTokensCaller, getEthDetectedTokensInfo } = useBlockchainTokensStore();
   const { addresses } = useAccountAddresses();
   const { supportsTransactions } = useSupportedChains();
   const { queueTokenDetection } = useBalanceQueue();
 
-  const chains = computed<string[]>(() => arrayify(get(chain)));
+  const chains = computed<string[]>(() => arrayify(toValue(chain)));
 
   const isDetectingTaskRunning = (blockchain: string, address: string | null): ComputedRef<boolean> =>
     computed(() => get(
@@ -35,7 +35,7 @@ export function useTokenDetection(chain: MaybeRef<string | string[]>, accountAdd
     ));
 
   const detectingTokens = computed<boolean>(() => {
-    const address = get(accountAddress);
+    const address = toValue(accountAddress);
     return get(chains).some(blockchain => get(isDetectingTaskRunning(blockchain, address)));
   });
 
@@ -67,7 +67,7 @@ export function useTokenDetection(chain: MaybeRef<string | string[]>, accountAdd
   };
 
   const detectTokens = async (addressList: string[] = []): Promise<void> => {
-    const address = get(accountAddress);
+    const address = toValue(accountAddress);
     assert(address || addressList.length > 0);
     const usedAddresses = address ? [address] : addressList;
     const chainsValue = get(chains);

--- a/frontend/app/src/composables/balances/use-aggregated-balances.ts
+++ b/frontend/app/src/composables/balances/use-aggregated-balances.ts
@@ -2,7 +2,7 @@ import type { EthBalance } from '@/types/blockchain/balances';
 import type { AssetPriceInfo } from '@/types/prices';
 import { type AssetBalanceWithPrice, type AssetBalanceWithPriceAndChains, type BigNumber, type ExclusionSource, NoPrice, Zero } from '@rotki/common';
 import { storeToRefs } from 'pinia';
-import { computed, type ComputedRef, type MaybeRef, type MaybeRefOrGetter } from 'vue';
+import { computed, type ComputedRef, type MaybeRefOrGetter } from 'vue';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { summarizeAssetProtocols } from '@/composables/balances/asset-summary';
 import { blockchainToAssetProtocolBalances, manualToAssetProtocolBalances } from '@/composables/balances/balance-transformations';
@@ -22,9 +22,9 @@ interface UseAggregatedBalancesReturn {
   liabilities: (hideIgnored?: boolean) => ComputedRef<AssetBalanceWithPriceAndChains[]>;
   assetPriceInfo: (identifier: MaybeRefOrGetter<string>, groupCollection?: MaybeRefOrGetter<boolean>) => ComputedRef<AssetPriceInfo>;
   assets: ComputedRef<string[]>;
-  useBlockchainBalances: (chains: MaybeRef<string[]>, address?: MaybeRef<string>, key?: keyof EthBalance) => ComputedRef<AssetBalanceWithPriceAndChains[]>;
-  useExchangeBalances: (exchange?: MaybeRef<string>) => ComputedRef<AssetBalanceWithPriceAndChains[]>;
-  useLocationBreakdown: (location: MaybeRef<string>) => ComputedRef<AssetBalanceWithPriceAndChains[]>;
+  useBlockchainBalances: (chains: MaybeRefOrGetter<string[]>, address?: MaybeRefOrGetter<string>, key?: keyof EthBalance) => ComputedRef<AssetBalanceWithPriceAndChains[]>;
+  useExchangeBalances: (exchange?: MaybeRefOrGetter<string>) => ComputedRef<AssetBalanceWithPriceAndChains[]>;
+  useLocationBreakdown: (location: MaybeRefOrGetter<string>) => ComputedRef<AssetBalanceWithPriceAndChains[]>;
   balancesByLocation: ComputedRef<Record<string, BigNumber>>;
 }
 
@@ -91,13 +91,13 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
     });
 
   const useBlockchainBalances = (
-    chains: MaybeRef<string[]> = [],
-    address?: MaybeRef<string>,
+    chains: MaybeRefOrGetter<string[]> = [],
+    address?: MaybeRefOrGetter<string>,
     key: keyof EthBalance = 'assets',
   ): ComputedRef<AssetBalanceWithPriceAndChains[]> => computed<AssetBalanceWithPriceAndChains[]>(() => {
-    const selectedChains = get(chains);
+    const selectedChains = toValue(chains);
     const filter = selectedChains.length > 0 ? selectedChains : undefined;
-    const accountAddress = address ? get(address) : undefined;
+    const accountAddress = address ? toValue(address) : undefined;
     const blockchain = blockchainToAssetProtocolBalances(get(blockchainBalances), key, filter, accountAddress);
     return summarizeAssetProtocols({
       associatedAssets: get(assetAssociationMap),
@@ -116,7 +116,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
   });
 
   const useExchangeBalances = (
-    exchange?: MaybeRef<string>,
+    exchange?: MaybeRefOrGetter<string>,
   ): ComputedRef<AssetBalanceWithPriceAndChains[]> => computed<AssetBalanceWithPriceAndChains[]>(() => {
     const exchanges = get(useBaseExchangeBalances(exchange));
     return summarizeAssetProtocols({
@@ -206,7 +206,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
     liabilities,
     useBlockchainBalances,
     useExchangeBalances,
-    useLocationBreakdown: (location: MaybeRef<string>) => useLocationBreakdown(
+    useLocationBreakdown: (location: MaybeRefOrGetter<string>) => useLocationBreakdown(
       location,
       blockchainBalances,
       assetAssociationMap,

--- a/frontend/app/src/composables/defi/airdrops/metadata.ts
+++ b/frontend/app/src/composables/defi/airdrops/metadata.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
 import type { ProtocolMetadata } from '@/types/defi';
 import { transformCase } from '@rotki/common';
 import { camelCase } from 'es-toolkit';
@@ -25,23 +25,23 @@ export const useAirdropsMetadata = createSharedComposable(() => {
     { evaluating: loading },
   );
 
-  const getAirdropData = (identifier: MaybeRef<string>): ComputedRef<ProtocolMetadata | undefined> =>
-    useArrayFind(metadata, item => camelCase(item.identifier) === camelCase(get(identifier)));
+  const getAirdropData = (identifier: MaybeRefOrGetter<string>): ComputedRef<ProtocolMetadata | undefined> =>
+    useArrayFind(metadata, item => camelCase(item.identifier) === camelCase(toValue(identifier)));
 
-  const getAirdropName = (identifier: MaybeRef<string>): ComputedRef<string> =>
+  const getAirdropName = (identifier: MaybeRefOrGetter<string>): ComputedRef<string> =>
     useValueOrDefault(
       useRefMap(getAirdropData(identifier), i => i?.name),
       identifier,
     );
 
-  const getAirdropImageUrl = (identifier: Ref<string>): ComputedRef<string> =>
+  const getAirdropImageUrl = (identifier: MaybeRefOrGetter<string>): ComputedRef<string> =>
     computed(() => {
       const data = get(getAirdropData(identifier));
 
       if (data?.iconUrl)
         return data.iconUrl;
 
-      const image = data?.icon ?? `${transformCase(get(identifier), false)}.svg`;
+      const image = data?.icon ?? `${transformCase(toValue(identifier), false)}.svg`;
 
       return getPublicProtocolImagePath(image);
     });

--- a/frontend/app/src/composables/filters/blockchain-account.ts
+++ b/frontend/app/src/composables/filters/blockchain-account.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
 import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 import type { MatchedKeywordWithBehaviour, SearchMatcher } from '@/types/filtering';
 import { z } from 'zod/v4';
@@ -23,13 +23,13 @@ export type Matcher = SearchMatcher<BlockchainAccountFilterKeys, BlockchainAccou
 
 export type Filters = MatchedKeywordWithBehaviour<BlockchainAccountFilterValueKeys>;
 
-export function useBlockchainAccountFilter(t: ReturnType<typeof useI18n>['t'], category: MaybeRef<string>): FilterSchema<Filters, Matcher> {
+export function useBlockchainAccountFilter(t: ReturnType<typeof useI18n>['t'], category: MaybeRefOrGetter<string>): FilterSchema<Filters, Matcher> {
   const filters = ref<Filters>({});
 
   const { chainIds, isEvm } = useAccountCategoryHelper(category);
   const { addressNameSelector } = useAddressesNamesStore();
 
-  const filterableChains = computed(() => {
+  const filterableChains = computed<string[]>(() => {
     const evm = get(isEvm);
     const ids = get(chainIds);
     if (!evm)

--- a/frontend/app/src/composables/filters/saved.ts
+++ b/frontend/app/src/composables/filters/saved.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRef } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { ActionStatus } from '@/types/action';
 import type { BaseSuggestion, SavedFilterLocation, Suggestion } from '@/types/filtering';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
@@ -13,7 +13,7 @@ interface UseSavedFilterReturn {
 }
 
 export function useSavedFilter(
-  location: MaybeRef<SavedFilterLocation>,
+  location: MaybeRefOrGetter<SavedFilterLocation>,
   isAsset: (key: string) => boolean,
 ): UseSavedFilterReturn {
   const frontendStore = useFrontendSettingsStore();
@@ -22,7 +22,7 @@ export function useSavedFilter(
   const { savedFilters: allSavedFilters } = storeToRefs(frontendStore);
 
   const savedFilters = computed<Suggestion[][]>(() => {
-    const baseSuggestions = get(allSavedFilters)[get(location)] || [];
+    const baseSuggestions = get(allSavedFilters)[toValue(location)] || [];
 
     return baseSuggestions.map(suggestions =>
       suggestions.map(suggestion => ({
@@ -38,14 +38,14 @@ export function useSavedFilter(
 
   const saveFilters = async (filters: BaseSuggestion[][]): Promise<ActionStatus> => {
     const allSaved = { ...get(allSavedFilters) };
-    allSaved[get(location)] = filters;
+    allSaved[toValue(location)] = filters;
     return updateSetting({
       savedFilters: allSaved,
     });
   };
 
   const addFilter = async (newFilter: Suggestion[]): Promise<ActionStatus> => {
-    const currentFilters = get(allSavedFilters)[get(location)] || [];
+    const currentFilters = get(allSavedFilters)[toValue(location)] || [];
 
     if (currentFilters.length >= LIMIT_PER_LOCATION) {
       return {

--- a/frontend/app/src/composables/history/events/mapping/counterparty.ts
+++ b/frontend/app/src/composables/history/events/mapping/counterparty.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef, MaybeRefOrGetter } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
 import type { ActionDataEntry } from '@/types/action';
 import { isValidEthAddress, toHumanReadable } from '@rotki/common';
 import { startPromise } from '@shared/utils';
@@ -65,9 +65,9 @@ export const useHistoryEventCounterpartyMappings = createSharedComposable(() => 
   }
 
   const getEventCounterpartyData = (
-    counterparty: MaybeRef<string | undefined>,
+    counterparty: MaybeRefOrGetter<string | undefined>,
   ): ComputedRef<ActionDataEntry | undefined> => computed(() => {
-    const counterpartyVal = get(counterparty);
+    const counterpartyVal = toValue(counterparty);
     const excludedCounterparty = ['gas'];
 
     if (counterpartyVal && excludedCounterparty.includes(counterpartyVal))

--- a/frontend/app/src/composables/history/events/mapping/index.ts
+++ b/frontend/app/src/composables/history/events/mapping/index.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
 import type { ActionDataEntry } from '@/types/action';
 import type {
   HistoryEventCategoryDetailWithId,
@@ -14,7 +14,7 @@ import { useLocationStore } from '@/store/locations';
 import { useNotificationsStore } from '@/store/notifications';
 import { uniqueStrings } from '@/utils/data';
 
-type Event = MaybeRef<{
+type Event = MaybeRefOrGetter<{
   eventType: string;
   eventSubtype: string;
   counterparty?: string | null;
@@ -100,7 +100,7 @@ export const useHistoryEventMappings = createSharedComposable(() => {
     }));
 
   const getEventType = (event: Event): ComputedRef<string | undefined> => computed(() => {
-    const { entryType, eventSubtype, eventType, isExit, location } = get(event);
+    const { entryType, eventSubtype, eventType, isExit, location } = toValue(event);
 
     if (entryType === HistoryEventEntryType.ETH_WITHDRAWAL_EVENT) {
       const withdrawalEntryType = get(historyEventTypeByEntryTypeMapping)[entryType]
@@ -149,7 +149,7 @@ export const useHistoryEventMappings = createSharedComposable(() => {
   ): ComputedRef<HistoryEventCategoryDetailWithId> => computed(() => {
     const defaultKey = 'default';
     const type = get(getEventType(event));
-    const { counterparty, eventSubtype, eventType } = get(event);
+    const { counterparty, eventSubtype, eventType } = toValue(event);
     const counterpartyVal = counterparty || defaultKey;
     const data = type && get(transactionEventTypesData)[type];
 
@@ -168,8 +168,8 @@ export const useHistoryEventMappings = createSharedComposable(() => {
     return getFallbackData(showFallbackLabel, eventSubtype, eventType);
   });
 
-  const getAccountingEventTypeData = (type: MaybeRef<string>): ComputedRef<ActionDataEntry> => computed(() => {
-    const typeVal = get(type);
+  const getAccountingEventTypeData = (type: MaybeRefOrGetter<string>): ComputedRef<ActionDataEntry> => computed(() => {
+    const typeVal = toValue(type);
     return (
       get(accountingEventsTypeData).find(({ identifier }) => identifier === typeVal) || {
         icon: 'lu-circle-question-mark',

--- a/frontend/app/src/composables/history/events/use-pinned-column-class.ts
+++ b/frontend/app/src/composables/history/events/use-pinned-column-class.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 
 export interface ColumnClassConfig {
   class?: string;
@@ -10,20 +10,20 @@ const PINNED_COLUMN_CLASS: ColumnClassConfig = { cellClass: '!px-2 !text-xs', cl
 const PINNED_ASSET_COLUMN_CLASS: ColumnClassConfig = { cellClass: '!pl-1 !pr-0', class: `!pl-1 !pr-0 ${PINNED_HEADER_CLASS}` };
 const PINNED_SIMPLE_TABLE_CLASS = '!text-xs [&_th]:!px-2 [&_td]:!px-2';
 
-export function usePinnedColumnClass(isPinned: Ref<boolean | undefined>): ComputedRef<ColumnClassConfig> {
+export function usePinnedColumnClass(isPinned: MaybeRefOrGetter<boolean | undefined>): ComputedRef<ColumnClassConfig> {
   return computed<ColumnClassConfig>(() =>
-    get(isPinned) ? PINNED_COLUMN_CLASS : {},
+    toValue(isPinned) ? PINNED_COLUMN_CLASS : {},
   );
 }
 
-export function usePinnedAssetColumnClass(isPinned: Ref<boolean | undefined>): ComputedRef<ColumnClassConfig> {
+export function usePinnedAssetColumnClass(isPinned: MaybeRefOrGetter<boolean | undefined>): ComputedRef<ColumnClassConfig> {
   return computed<ColumnClassConfig>(() =>
-    get(isPinned) ? PINNED_ASSET_COLUMN_CLASS : {},
+    toValue(isPinned) ? PINNED_ASSET_COLUMN_CLASS : {},
   );
 }
 
-export function usePinnedSimpleTableClass(isPinned: Ref<boolean | undefined>): ComputedRef<string> {
+export function usePinnedSimpleTableClass(isPinned: MaybeRefOrGetter<boolean | undefined>): ComputedRef<string> {
   return computed<string>(() =>
-    get(isPinned) ? PINNED_SIMPLE_TABLE_CLASS : '[&_table_td]:!py-0',
+    toValue(isPinned) ? PINNED_SIMPLE_TABLE_CLASS : '[&_table_td]:!py-0',
   );
 }

--- a/frontend/app/src/composables/settings/accounting/rule-mapping.ts
+++ b/frontend/app/src/composables/settings/accounting/rule-mapping.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
 import type { AccountingRuleLinkedSettingMap } from '@/types/settings/accounting';
 import { assert, toHumanReadable, transformCase } from '@rotki/common';
 import { useAccountingApi } from '@/composables/api/settings/accounting-api';
@@ -21,9 +21,9 @@ export const useAccountingRuleMappings = createSharedComposable(() => {
 
   const stateIsBoolean = (state: MaybeRef<any>): state is MaybeRef<boolean> => typeof get(state) === 'boolean';
 
-  const accountingRuleLinkedMappingData = (key: MaybeRef<string>): ComputedRef<AccountingRuleLinkedSettingMap[]> =>
+  const accountingRuleLinkedMappingData = (key: MaybeRefOrGetter<string>): ComputedRef<AccountingRuleLinkedSettingMap[]> =>
     computed(() => {
-      const data = get(accountingRuleLinkedMapping)[get(key)];
+      const data = get(accountingRuleLinkedMapping)[toValue(key)];
 
       if (!data)
         return [];

--- a/frontend/app/src/composables/settings/api-keys/external/index.ts
+++ b/frontend/app/src/composables/settings/api-keys/external/index.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type ServiceKey from '@/components/settings/api-keys/ServiceKey.vue';
 import type { ConfirmationMessage } from '@/modules/history/events/composables/use-deletion-strategies';
 import type { ExternalServiceKey, ExternalServiceKeys, ExternalServiceName } from '@/types/user';
@@ -27,8 +27,8 @@ interface Status {
 interface UseExternalApiKeysReturn {
   loading: Ref<boolean>;
   getName: (name: ExternalServiceName, chain?: string) => string;
-  apiKey: (name: MaybeRef<ExternalServiceName>, chain?: MaybeRef<string>) => ComputedRef<string>;
-  actionStatus: (name: MaybeRef<ExternalServiceName>, chain?: MaybeRef<string>) => ComputedRef<Status | undefined>;
+  apiKey: (name: MaybeRefOrGetter<ExternalServiceName>, chain?: MaybeRefOrGetter<string>) => ComputedRef<string>;
+  actionStatus: (name: MaybeRefOrGetter<ExternalServiceName>, chain?: MaybeRefOrGetter<string>) => ComputedRef<Status | undefined>;
   load: () => Promise<void>;
   save: (payload: ExternalServiceKey, postConfirmAction?: () => Promise<void> | void) => Promise<void>;
   confirmDelete: (name: string, postConfirmAction?: () => Promise<void> | void, confirmation?: Partial<ConfirmationMessage>) => void;
@@ -56,18 +56,18 @@ export const useExternalApiKeys = createSharedComposable((t: ReturnType<typeof u
   );
 
   const apiKey = (
-    name: MaybeRef<ExternalServiceName>,
-    chain?: MaybeRef<string>,
+    name: MaybeRefOrGetter<ExternalServiceName>,
+    chain?: MaybeRefOrGetter<string>,
   ): ComputedRef<string> => computed(() => {
     const items = get(keys);
-    const service = get(name);
+    const service = toValue(name);
 
     if (!items)
       return '';
 
     if (service === 'blockscout') {
       const itemService = items[service];
-      const chainId = get(chain);
+      const chainId = toValue(chain);
       assert(chainId, `missing chain for ${service}`);
 
       const transformedChainId = transformCase(chainId, true);
@@ -89,10 +89,10 @@ export const useExternalApiKeys = createSharedComposable((t: ReturnType<typeof u
   });
 
   const actionStatus = (
-    name: MaybeRef<ExternalServiceName>,
-    chain?: MaybeRef<string>,
+    name: MaybeRefOrGetter<ExternalServiceName>,
+    chain?: MaybeRefOrGetter<string>,
   ): ComputedRef<Status | undefined> => computed(() => {
-    const key = getName(get(name), get(chain));
+    const key = getName(toValue(name), toValue(chain));
     return get(status)[key];
   });
 

--- a/frontend/app/src/composables/settings/use-asset-statistic-state.ts
+++ b/frontend/app/src/composables/settings/use-asset-statistic-state.ts
@@ -1,5 +1,5 @@
 import { omit } from 'es-toolkit';
-import { computed, type ComputedRef, type Ref, type WritableComputedRef } from 'vue';
+import { computed, type ComputedRef, type MaybeRefOrGetter, type Ref, type WritableComputedRef } from 'vue';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
 import { logger } from '@/utils/logging';
@@ -24,7 +24,7 @@ interface UseAssetStatisticsStateReturn {
   useHistoricalAssetBalances: Ref<boolean, boolean>;
 }
 
-export function useAssetStatisticState(asset: Ref<string | undefined>): UseAssetStatisticsStateReturn {
+export function useAssetStatisticState(asset: MaybeRefOrGetter<string | undefined>): UseAssetStatisticsStateReturn {
   const useHistoricalAssetBalances = ref<boolean>(false);
 
   const { useHistoricalAssetBalances: enabled } = storeToRefs(useFrontendSettingsStore());
@@ -36,24 +36,26 @@ export function useAssetStatisticState(asset: Ref<string | undefined>): UseAsset
 
   const rememberStateForAsset = computed<boolean>({
     get() {
-      if (!isDefined(asset)) {
+      const assetValue = toValue(asset);
+      if (!assetValue) {
         return false;
       }
-      return get(stateForAsset)[get(asset)] !== undefined;
+      return get(stateForAsset)[assetValue] !== undefined;
     },
     set(enabled: boolean) {
-      if (!isDefined(asset)) {
+      const assetValue = toValue(asset);
+      if (!assetValue) {
         return;
       }
       if (enabled) {
         set(stateForAsset, {
           ...get(stateForAsset),
-          [get(asset)]: get(useHistoricalAssetBalances) ? Preference.EVENTS : Preference.SNAPSHOT,
+          [assetValue]: get(useHistoricalAssetBalances) ? Preference.EVENTS : Preference.SNAPSHOT,
         });
       }
       else {
         set(stateForAsset, {
-          ...omit(get(stateForAsset), [get(asset)]),
+          ...omit(get(stateForAsset), [assetValue]),
         });
       }
     },
@@ -78,17 +80,18 @@ export function useAssetStatisticState(asset: Ref<string | undefined>): UseAsset
   }
 
   watch(useHistoricalAssetBalances, (enabled) => {
-    if (!(get(rememberStateForAsset)) || !isDefined(asset)) {
+    const assetValue = toValue(asset);
+    if (!(get(rememberStateForAsset)) || !assetValue) {
       return;
     }
 
     set(stateForAsset, {
       ...get(stateForAsset),
-      [get(asset)]: enabled ? Preference.EVENTS : Preference.SNAPSHOT,
+      [assetValue]: enabled ? Preference.EVENTS : Preference.SNAPSHOT,
     });
   });
 
-  watch(asset, (asset) => {
+  watch(() => toValue(asset), (asset) => {
     if (!asset) {
       return;
     }

--- a/frontend/app/src/composables/use-pagination-filter/index.ts
+++ b/frontend/app/src/composables/use-pagination-filter/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
 import type { FetchError } from 'ofetch';
-import type { ComputedRef, MaybeRef, Ref, WritableComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef, MaybeRefOrGetter, Ref, WritableComputedRef } from 'vue';
 import type { FilterSchema, Sorting } from '@/composables/use-pagination-filter/types';
 import type { TableId } from '@/modules/table/use-remember-table-sorting';
 import type { Collection } from '@/types/collection';
@@ -48,7 +48,7 @@ interface UsePaginationFiltersOptions<
   TSuggestionMatcher extends SearchMatcher<string, string> | void = undefined,
 > {
   history?: false | 'router' | 'external';
-  locationOverview?: Ref<string>;
+  locationOverview?: MaybeRefOrGetter<string>;
   filterSchema?: () => FilterSchema<TFilter, TSuggestionMatcher>;
   onUpdateFilters?: (query: LocationQuery) => void;
   extraParams?: ComputedRef<RawLocationQuery>;
@@ -225,7 +225,7 @@ export function usePaginationFilters<
     const offset = (page - 1) * limit;
 
     const selectedFilters = get(filters);
-    const location = get(locationOverview);
+    const location = toValue(locationOverview);
     if (location && typeof selectedFilters === 'object' && 'location' in selectedFilters)
       selectedFilters.location = location;
 
@@ -340,7 +340,7 @@ export function usePaginationFilters<
     const sorting = get(internalSorting);
     const selectedFilters = get(filters);
 
-    const location = get(locationOverview);
+    const location = toValue(locationOverview);
     if (location && typeof selectedFilters === 'object' && 'location' in selectedFilters)
       selectedFilters.location = location;
 

--- a/frontend/app/src/composables/utils/useValueOrDefault/index.ts
+++ b/frontend/app/src/composables/utils/useValueOrDefault/index.ts
@@ -1,11 +1,11 @@
-import type { ComputedRef, MaybeRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 
-export function useValueOrDefault<T, D>(item: Ref<T | undefined>, defaultValue: MaybeRef<D>): ComputedRef<T | D> {
+export function useValueOrDefault<T, D>(item: MaybeRefOrGetter<T | undefined>, defaultValue: MaybeRefOrGetter<D>): ComputedRef<T | D> {
   return computed(() => {
-    const value = get(item);
+    const value = toValue(item);
     if (value)
       return value;
 
-    return get(defaultValue);
+    return toValue(defaultValue);
   });
 }

--- a/frontend/app/src/modules/asset-manager/counterparty-mapping/ManageCounterpartyMappingForm.vue
+++ b/frontend/app/src/modules/asset-manager/counterparty-mapping/ManageCounterpartyMappingForm.vue
@@ -13,14 +13,9 @@ const modelValue = defineModel<CounterpartyMapping>({ required: true });
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-withDefaults(
-  defineProps<{
-    editMode?: boolean;
-  }>(),
-  {
-    editMode: false,
-  },
-);
+const { editMode = false } = defineProps<{
+  editMode?: boolean;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/app/src/modules/asset-manager/solana-token-migration/SolanaTokenMigrationForm.vue
+++ b/frontend/app/src/modules/asset-manager/solana-token-migration/SolanaTokenMigrationForm.vue
@@ -20,14 +20,12 @@ const modelValue = defineModel<SolanaTokenMigrationData>({ required: true });
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<{
+const { loading, oldAsset } = defineProps<{
   loading?: boolean;
   oldAsset?: string;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { oldAsset } = toRefs(props);
 
 const address = useRefPropVModel(modelValue, 'address');
 const decimals = useRefPropVModel(modelValue, 'decimals');
@@ -35,21 +33,20 @@ const tokenKind = useRefPropVModel(modelValue, 'tokenKind');
 const { assetInfo } = useAssetInfoRetrieval();
 
 const assetDetails = computed<string | undefined>(() => {
-  if (!isDefined(oldAsset)) {
+  if (!oldAsset) {
     return undefined;
   }
-  const identifier = get(oldAsset);
-  const details = get(assetInfo(identifier));
+  const details = get(assetInfo(oldAsset));
 
   if (!details) {
-    return identifier;
+    return oldAsset;
   }
 
   let description = '';
   if (details.symbol) {
     description += `[${details.symbol}] `;
   }
-  return `${description}${details.name} (${identifier})`;
+  return `${description}${details.name} (${oldAsset})`;
 });
 
 const decimalsModel = computed({

--- a/frontend/app/src/modules/balances/blockchain/use-blockchain-account-data.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-blockchain-account-data.ts
@@ -37,7 +37,7 @@ interface UseBlockchainAccountDataReturn {
   getAccountDetails: (chain: string, address: string) => AccountBalances;
   getBlockchainAccounts: (chain: string) => BlockchainAccountWithBalance[];
   useAccountTags: (address: MaybeRefOrGetter<string>) => ComputedRef<string[]>;
-  getAccountsByCategory: (category: MaybeRef<string>) => ComputedRef<BlockchainAccountGroupWithBalance[]>;
+  getAccountsByCategory: (category: MaybeRefOrGetter<string>) => ComputedRef<BlockchainAccountGroupWithBalance[]>;
   getAccountList: (accountData: Accounts, balanceData: Balances) => BlockchainAccountWithBalance[];
 }
 
@@ -223,12 +223,12 @@ export function useBlockchainAccountData(): UseBlockchainAccountDataReturn {
     return entries;
   }
 
-  const getAccountsByCategory = (category: MaybeRef<string>): ComputedRef<BlockchainAccountGroupWithBalance[]> => computed(() => {
+  const getAccountsByCategory = (category: MaybeRefOrGetter<string>): ComputedRef<BlockchainAccountGroupWithBalance[]> => computed(() => {
     const accountData = get(accounts);
     const balanceData = get(balances);
     const groups = getGroups(accountData, balanceData);
 
-    return groups.filter(item => item.category === get(category));
+    return groups.filter(item => item.category === toValue(category));
   });
 
   const fetchAccounts = async (

--- a/frontend/app/src/modules/balances/exchanges/use-exchange-data.ts
+++ b/frontend/app/src/modules/balances/exchanges/use-exchange-data.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRef } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { AssetProtocolBalances } from '@/types/blockchain/balances';
 import type { Exchange, ExchangeInfo } from '@/types/exchanges';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
@@ -8,7 +8,7 @@ import { sortDesc } from '@/utils/bignumbers';
 import { balanceSum, exchangeAssetSum } from '@/utils/calculation';
 
 interface UseExchangeDataReturn {
-  useBaseExchangeBalances: (exchange?: MaybeRef<string>) => ComputedRef<AssetProtocolBalances>;
+  useBaseExchangeBalances: (exchange?: MaybeRefOrGetter<string>) => ComputedRef<AssetProtocolBalances>;
   exchanges: ComputedRef<ExchangeInfo[]>;
   syncingExchanges: ComputedRef<Exchange[]>;
   isSameExchange: (a: Exchange, b: Exchange) => boolean;
@@ -31,10 +31,10 @@ export function useExchangeData(): UseExchangeDataReturn {
   });
 
   const useBaseExchangeBalances = (
-    exchange?: MaybeRef<string>,
+    exchange?: MaybeRefOrGetter<string>,
   ): ComputedRef<AssetProtocolBalances> => computed<AssetProtocolBalances>(() => {
     const balances = get(exchangeBalances);
-    const name = exchange ? get(exchange) : undefined;
+    const name = exchange ? toValue(exchange) : undefined;
     const protocolBalances: AssetProtocolBalances = {};
 
     for (const [exchange, assets] of Object.entries(balances)) {

--- a/frontend/app/src/modules/balances/manual/use-manual-balances-or-liabilities.ts
+++ b/frontend/app/src/modules/balances/manual/use-manual-balances-or-liabilities.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRef, MaybeRefOrGetter } from 'vue';
 import type { Collection } from '@/types/collection';
 import type {
   ManualBalanceRequestPayload,
@@ -16,11 +16,11 @@ interface UseManualBalancesOrLiabilitiesReturn {
 }
 
 export function useManualBalancesOrLiabilities(
-  type: Ref<'liabilities' | 'balances'>,
+  type: MaybeRefOrGetter<'liabilities' | 'balances'>,
 ): UseManualBalancesOrLiabilitiesReturn {
   const { manualBalances, manualLiabilities } = storeToRefs(useBalancesStore());
   const { fetchBalances, fetchLiabilities } = useManualBalancePagination();
-  const dataSource = computed<ManualBalanceWithValue[]>(() => (get(type) === 'liabilities' ? get(manualLiabilities) : get(manualBalances)));
+  const dataSource = computed<ManualBalanceWithValue[]>(() => (toValue(type) === 'liabilities' ? get(manualLiabilities) : get(manualBalances)));
 
   const locations = computed<string[]>(() => [
     ...get(manualBalances).map(item => item.location),
@@ -29,7 +29,7 @@ export function useManualBalancesOrLiabilities(
 
   const fetch = async (
     payload: MaybeRef<ManualBalanceRequestPayload>,
-  ): Promise<Collection<ManualBalanceWithPrice>> => get(type) === 'liabilities' ? fetchLiabilities(payload) : fetchBalances(payload);
+  ): Promise<Collection<ManualBalanceWithPrice>> => toValue(type) === 'liabilities' ? fetchLiabilities(payload) : fetchBalances(payload);
 
   return {
     dataSource,

--- a/frontend/app/src/modules/balances/protocols/ProtocolIcon.vue
+++ b/frontend/app/src/modules/balances/protocols/ProtocolIcon.vue
@@ -5,7 +5,7 @@ import { useProtocolData } from '@/modules/balances/protocols/use-protocol-data'
 import { useProxyProtocol } from '@/modules/balances/protocols/use-proxy-protocol';
 import HashLink from '@/modules/common/links/HashLink.vue';
 
-const props = defineProps<{
+const { protocol, size = 20, hideTooltip } = defineProps<{
   protocol: string;
   size?: number;
   hideTooltip?: boolean;
@@ -15,11 +15,9 @@ defineSlots<{
   default?: (props: { protocol: string }) => any;
 }>();
 
-const { protocol, size = 20 } = toRefs(props);
+const { isProxy, parsedProtocol, proxyAddress } = useProxyProtocol(() => protocol);
 
-const { isProxy, parsedProtocol, proxyAddress } = useProxyProtocol(protocol);
-
-const showTooltip = computed<boolean>(() => get(isProxy) && !!get(proxyAddress) && !props.hideTooltip);
+const showTooltip = computed<boolean>(() => get(isProxy) && !!get(proxyAddress) && !hideTooltip);
 
 const { protocolData } = useProtocolData(parsedProtocol);
 

--- a/frontend/app/src/modules/balances/protocols/ProtocolMenuItem.vue
+++ b/frontend/app/src/modules/balances/protocols/ProtocolMenuItem.vue
@@ -5,14 +5,13 @@ import { AssetAmountDisplay, FiatDisplay, ValueDisplay } from '@/modules/amount-
 import ProtocolIcon from '@/modules/balances/protocols/ProtocolIcon.vue';
 import { useProtocolData } from '@/modules/balances/protocols/use-protocol-data';
 
-const props = defineProps<{
+const { protocolBalance, asset, loading } = defineProps<{
   protocolBalance: ProtocolBalance;
   asset?: string;
   loading?: boolean;
 }>();
 
-const { protocolBalance } = toRefs(props);
-const protocol = useRefMap(protocolBalance, balance => balance.protocol);
+const protocol = useRefMap(() => protocolBalance, balance => balance.protocol);
 
 const { t } = useI18n({ useScope: 'global' });
 const { protocolData } = useProtocolData(protocol);

--- a/frontend/app/src/modules/balances/protocols/ProtocolTooltipIcon.vue
+++ b/frontend/app/src/modules/balances/protocols/ProtocolTooltipIcon.vue
@@ -8,14 +8,13 @@ import { useProxyProtocol } from '@/modules/balances/protocols/use-proxy-protoco
 import HashLink from '@/modules/common/links/HashLink.vue';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
 
-const props = defineProps<{
+const { protocolBalance, asset, loading } = defineProps<{
   protocolBalance: ProtocolBalance;
   asset?: string;
   loading?: boolean;
 }>();
 
-const { protocolBalance } = toRefs(props);
-const protocol = useRefMap(protocolBalance, balance => balance.protocol);
+const protocol = useRefMap(() => protocolBalance, balance => balance.protocol);
 
 const { shouldShowAmount } = storeToRefs(useFrontendSettingsStore());
 const { t } = useI18n({ useScope: 'global' });

--- a/frontend/app/src/modules/balances/protocols/components/ChainBalanceTooltipIcon.vue
+++ b/frontend/app/src/modules/balances/protocols/components/ChainBalanceTooltipIcon.vue
@@ -5,19 +5,17 @@ import { useSupportedChains } from '@/composables/info/chains';
 import { AssetAmountDisplay, FiatDisplay, ValueDisplay } from '@/modules/amount-display/components';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
 
-const props = defineProps<{
+const { chainId } = defineProps<{
   chainId: string;
   chainBalance: Balance;
   asset?: string;
   loading?: boolean;
 }>();
 
-const { chainId } = toRefs(props);
-
 const { shouldShowAmount } = storeToRefs(useFrontendSettingsStore());
 const { getChainName } = useSupportedChains();
 
-const chainName = getChainName(chainId);
+const chainName = getChainName(() => chainId);
 </script>
 
 <template>

--- a/frontend/app/src/modules/balances/protocols/use-proxy-protocol.ts
+++ b/frontend/app/src/modules/balances/protocols/use-proxy-protocol.ts
@@ -1,5 +1,4 @@
-import { get } from '@vueuse/core';
-import { computed, type ComputedRef, type MaybeRef } from 'vue';
+import { computed, type ComputedRef, type MaybeRefOrGetter, toValue } from 'vue';
 
 interface UseProxyProtocolReturn {
   isProxy: ComputedRef<boolean>;
@@ -7,11 +6,11 @@ interface UseProxyProtocolReturn {
   proxyAddress: ComputedRef<string | undefined>;
 }
 
-export function useProxyProtocol(protocol: MaybeRef<string>): UseProxyProtocolReturn {
-  const isProxy = computed<boolean>(() => get(protocol).startsWith('proxy:'));
+export function useProxyProtocol(protocol: MaybeRefOrGetter<string>): UseProxyProtocolReturn {
+  const isProxy = computed<boolean>(() => toValue(protocol).startsWith('proxy:'));
 
   const parsedProtocol = computed<string>(() => {
-    const value = get(protocol);
+    const value = toValue(protocol);
     if (get(isProxy)) {
       const parts = value.split(':');
       return parts[1] ?? value;
@@ -23,7 +22,7 @@ export function useProxyProtocol(protocol: MaybeRef<string>): UseProxyProtocolRe
     if (!get(isProxy))
       return undefined;
 
-    const parts = get(protocol).split(':');
+    const parts = toValue(protocol).split(':');
     return parts[2];
   });
 

--- a/frontend/app/src/modules/common/links/CopyButton.vue
+++ b/frontend/app/src/modules/common/links/CopyButton.vue
@@ -1,12 +1,10 @@
 <script lang="ts" setup>
 import CopyTooltip from '@/components/helper/CopyTooltip.vue';
 
-const props = defineProps<{
+const { text, size } = defineProps<{
   text: string;
   size: string | number;
 }>();
-
-const { text } = toRefs(props);
 
 const { t } = useI18n({ useScope: 'global' });
 </script>

--- a/frontend/app/src/modules/dashboard/Dashboard.vue
+++ b/frontend/app/src/modules/dashboard/Dashboard.vue
@@ -29,8 +29,8 @@ const nftEnabled = isModuleEnabled(Module.NFTS);
 const { loadingBalancesAndDetection: isAnyLoading } = useBalancesLoading();
 const dismissedMessage = useSessionStorage('rotki.messages.dash.dismissed', false);
 
-const dashboardRef = ref<HTMLElement>();
-const floatingRef = ref<HTMLElement>();
+const dashboardRef = useTemplateRef<HTMLElement>('dashboardRef');
+const floatingRef = useTemplateRef<HTMLElement>('floatingRef');
 const dashboardWidth = ref(0);
 
 const { width } = useElementSize(dashboardRef);

--- a/frontend/app/src/modules/dashboard/graph/NetWorthChart.vue
+++ b/frontend/app/src/modules/dashboard/graph/NetWorthChart.vue
@@ -9,11 +9,9 @@ import { FiatDisplay } from '@/modules/amount-display/components';
 import { useNetValueChartConfig } from '@/modules/dashboard/graph/use-net-value-chart-config';
 import { useNetValueEventHandlers } from '@/modules/dashboard/graph/use-net-value-event-handlers';
 
-const props = defineProps<{
+const { chartData } = defineProps<{
   chartData: NetValueChartData;
 }>();
-
-const { chartData } = toRefs(props);
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -26,10 +24,10 @@ const showExportSnapshotDialog = ref<boolean>(false);
 
 const { isDark } = useRotkiTheme();
 
-const { chartOption } = useNetValueChartConfig(chartData);
+const { chartOption } = useNetValueChartConfig(() => chartData);
 const { setupChartEventHandlers, setupZoomToolHandler, tooltipData } = useNetValueEventHandlers({
   chartContainer,
-  chartData,
+  chartData: () => chartData,
   chartInstance,
   onHover: (timestamp: number, balance: BigNumber) => {
     set(selectedTimestamp, timestamp);

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-chart-config.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-chart-config.ts
@@ -7,7 +7,7 @@ import type {
   YAXisComponentOption,
 } from 'echarts';
 import type { DataZoomComponentOption, GridComponentOption } from 'echarts/components';
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { NetValueChartData } from '@/modules/dashboard/graph/types';
 import { useGraph } from '@/composables/graphs';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
@@ -21,9 +21,9 @@ interface UseNetValueChartConfigReturn {
   chartOption: ComputedRef<EChartsOption>;
 }
 
-export function useNetValueChartConfig(chartData: Ref<NetValueChartData>): UseNetValueChartConfigReturn {
+export function useNetValueChartConfig(chartData: MaybeRefOrGetter<NetValueChartData>): UseNetValueChartConfigReturn {
   const data = computed<number[][]>(() => {
-    const { data, times } = get(chartData);
+    const { data, times } = toValue(chartData);
     if (!(times?.length && data?.length)) {
       return [];
     }

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.ts
@@ -1,5 +1,5 @@
 import type { EChartsType } from 'echarts/core';
-import type { Ref, ShallowRef } from 'vue';
+import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue';
 import type VChart from 'vue-echarts';
 import type { NetValueChartData } from '@/modules/dashboard/graph/types';
 import { assert, type BigNumber } from '@rotki/common';
@@ -8,7 +8,7 @@ import { type TooltipData, useGraphTooltip } from '@/composables/graphs';
 interface UseNetValueEventHandlersParams {
   chartInstance: Readonly<ShallowRef<InstanceType<typeof VChart> | null>>;
   chartContainer: Readonly<ShallowRef<HTMLElement | null>>;
-  chartData: Ref<NetValueChartData>;
+  chartData: MaybeRefOrGetter<NetValueChartData>;
   onHover: (timestamp: number, value: BigNumber) => void;
 }
 
@@ -98,7 +98,7 @@ export function useNetValueEventHandlers(params: UseNetValueEventHandlersParams)
       const { axesInfo, dataIndex } = event;
       const xAxisInfo = axesInfo?.[0];
 
-      const { data: netValues, snapshotCount } = get(chartData);
+      const { data: netValues, snapshotCount } = toValue(chartData);
       const netValue = netValues[dataIndex];
       const currentBalance = dataIndex === netValues.length - 1;
       const isSnapshot = dataIndex < snapshotCount;

--- a/frontend/app/src/modules/dashboard/progress/components/BalanceQuerySection.vue
+++ b/frontend/app/src/modules/dashboard/progress/components/BalanceQuerySection.vue
@@ -17,11 +17,9 @@ interface Props {
   processingPercentage: number;
 }
 
-const props = defineProps<Props>();
+const { processingMessage, processingPercentage, progress } = defineProps<Props>();
 
-const { processingMessage, processingPercentage, progress } = toRefs(props);
-
-const currentOperationData = computed(() => get(progress).currentOperationData);
+const currentOperationData = computed(() => progress.currentOperationData);
 </script>
 
 <template>

--- a/frontend/app/src/modules/dashboard/progress/components/HistoryQuerySection.vue
+++ b/frontend/app/src/modules/dashboard/progress/components/HistoryQuerySection.vue
@@ -19,11 +19,9 @@ interface Props {
   processingPercentage: number;
 }
 
-const props = defineProps<Props>();
+const { processingMessage, processingPercentage, progress } = defineProps<Props>();
 
-const { processingMessage, processingPercentage, progress } = toRefs(props);
-
-const currentOperationData = computed(() => get(progress).currentOperationData);
+const currentOperationData = computed(() => progress.currentOperationData);
 </script>
 
 <template>

--- a/frontend/app/src/modules/dashboard/progress/components/IdleQuerySection.vue
+++ b/frontend/app/src/modules/dashboard/progress/components/IdleQuerySection.vue
@@ -10,15 +10,14 @@ interface Props {
   lastQueriedTimestamp: number;
 }
 
-const props = defineProps<Props>();
-
 const {
   isNeverQueried,
   justUpdated,
   lastQueriedDisplay,
   lastQueriedTimestamp,
   longQuery,
-} = toRefs(props);
+  hasUndecodedTxs,
+} = defineProps<Props>();
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/app/src/modules/dashboard/summary/BlockchainBalanceCardList.vue
+++ b/frontend/app/src/modules/dashboard/summary/BlockchainBalanceCardList.vue
@@ -13,16 +13,14 @@ interface BlockChainBalanceCardListProps {
   total: BlockchainTotal;
 }
 
-const props = defineProps<BlockChainBalanceCardListProps>();
-
-const { total } = toRefs(props);
+const { total } = defineProps<BlockChainBalanceCardListProps>();
 
 const { getBlockchainRedirectLink, getChainName } = useSupportedChains();
 
-const chain = useRefMap(total, ({ chain }) => chain);
+const chain = useRefMap(() => total, ({ chain }) => chain);
 const name = getChainName(chain);
 
-const navTarget = computed<RouteLocationRaw>(() => getBlockchainRedirectLink(props.total.chain));
+const navTarget = computed<RouteLocationRaw>(() => getBlockchainRedirectLink(total.chain));
 </script>
 
 <template>

--- a/frontend/app/src/modules/dashboard/summary/ManualBalanceCardList.vue
+++ b/frontend/app/src/modules/dashboard/summary/ManualBalanceCardList.vue
@@ -7,21 +7,19 @@ import { useLocations } from '@/composables/locations';
 import { FiatDisplay } from '@/modules/amount-display/components';
 import { Routes } from '@/router/routes';
 
-const props = defineProps<{
+const { name, amount } = defineProps<{
   name: string;
   amount: BigNumber;
 }>();
 
-const { name } = toRefs(props);
-
 const manualBalancesRoute = computed<RouteLocationRaw>(() => ({
   path: `${Routes.BALANCES_MANUAL}/assets`,
-  query: { location: get(name) },
+  query: { location: name },
 }));
 
 const { locationData } = useLocations();
 
-const location = locationData(name);
+const location = locationData(() => name);
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/balances/HistoricalBalancesFilter.vue
+++ b/frontend/app/src/modules/history/balances/HistoricalBalancesFilter.vue
@@ -30,16 +30,14 @@ const selectedProtocol = defineModel<string>('selectedProtocol');
 const source = defineModel<HistoricalBalanceSource>('source', { required: true });
 const selectedAccount = defineModel<BlockchainAccount<AddressData>>('selectedAccount');
 
-const props = withDefaults(defineProps<{
+const { fieldErrors = {} } = defineProps<{
   fieldErrors?: ValidationErrors;
-}>(), {
-  fieldErrors: () => ({}),
-});
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
 
 const assetErrors = computed<string[]>(() => {
-  const errors = props.fieldErrors.asset;
+  const errors = fieldErrors.asset;
   if (!errors)
     return [];
   return arrayify(errors);

--- a/frontend/app/src/modules/history/balances/HistoricalBalancesTable.vue
+++ b/frontend/app/src/modules/history/balances/HistoricalBalancesTable.vue
@@ -10,15 +10,13 @@ import { useHistoricCachePriceStore } from '@/store/prices/historic';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { sortAssetBalances } from '@/utils/balances';
 
-const props = defineProps<{
+const { balances, loading, timestamp } = defineProps<{
   balances: AssetBalanceWithPrice[];
   loading?: boolean;
   timestamp?: number;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { balances } = toRefs(props);
 
 const expanded = ref<AssetBalanceWithPrice[]>([]);
 
@@ -32,10 +30,9 @@ const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 const { createKey, isPending } = useHistoricCachePriceStore();
 
 function isPriceLoading(asset: string): boolean {
-  const ts = props.timestamp;
-  if (!ts)
+  if (!timestamp)
     return false;
-  return get(isPending(createKey(asset, ts)));
+  return get(isPending(createKey(asset, timestamp)));
 }
 
 const isExpanded = (asset: string): boolean => some(get(expanded), { asset });
@@ -78,7 +75,7 @@ const tableHeaders = computed<DataTableColumn<AssetBalanceWithPrice>[]>(() => [{
   sortable: true,
 }]);
 
-const sorted = computed<AssetBalanceWithPrice[]>(() => sortAssetBalances([...get(balances)], get(sort), assetInfo));
+const sorted = computed<AssetBalanceWithPrice[]>(() => sortAssetBalances([...balances], get(sort), assetInfo));
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -23,7 +23,20 @@ import HistoryEventsVirtualHeader from './HistoryEventsVirtualHeader.vue';
 const sort = defineModel<DataTableSortData<HistoryEventEntry>>('sort', { required: true });
 const pagination = defineModel<TablePaginationData>('pagination', { required: true });
 
-const props = defineProps<{
+const {
+  groups: rawGroups,
+  pageParams,
+  excludeIgnored,
+  groupLoading,
+  hasActiveFilters,
+  tableHeightOffset,
+  identifiers,
+  highlightedIdentifiers,
+  highlightTypes,
+  hideActions,
+  selection,
+  duplicateHandlingStatus,
+} = defineProps<{
   groups: Collection<HistoryEventRow>;
   pageParams: HistoryEventRequestPayload | undefined;
   excludeIgnored: boolean;
@@ -50,11 +63,10 @@ const { t } = useI18n({ useScope: 'global' });
 const DEFAULT_TABLE_HEIGHT_OFFSET = 390;
 
 const tableContainerStyle = computed<{ height: string }>(() => ({
-  height: `calc(100vh - ${props.tableHeightOffset ?? DEFAULT_TABLE_HEIGHT_OFFSET}px)`,
+  height: `calc(100vh - ${tableHeightOffset ?? DEFAULT_TABLE_HEIGHT_OFFSET}px)`,
 }));
 
 const RedecodeConfirmationDialog = defineAsyncComponent(() => import('./RedecodeConfirmationDialog.vue'));
-const { groupLoading, groups: rawGroups, pageParams } = toRefs(props);
 
 // Event data management
 const {
@@ -78,11 +90,11 @@ const {
   toggleShowIgnoredAssets,
   total,
 } = useHistoryEventsData({
-  excludeIgnored: toRef(props, 'excludeIgnored'),
-  groupLoading,
-  groups: rawGroups,
-  identifiers: toRef(props, 'identifiers'),
-  pageParams,
+  excludeIgnored: () => excludeIgnored,
+  groupLoading: () => groupLoading,
+  groups: () => rawGroups,
+  identifiers: () => identifiers,
+  pageParams: () => pageParams,
 }, emit);
 
 // Virtual rows - flatten groups into virtual row list
@@ -107,8 +119,8 @@ const {
   flattenedRows,
   getRowHeight,
   getCardHeight,
-  highlightedIdentifiers: computed(() => props.highlightedIdentifiers),
-  highlightTypes: computed(() => props.highlightTypes),
+  highlightedIdentifiers: () => highlightedIdentifiers,
+  highlightTypes: () => highlightTypes,
   loading,
   pagination,
 });

--- a/frontend/app/src/modules/history/events/composables/use-history-events-data.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-events-data.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { HistoryEventsTableEmitFn } from '@/modules/history/events/types';
 import type { Collection } from '@/types/collection';
@@ -18,11 +18,11 @@ import { logger } from '@/utils/logging';
 import { useCompleteEvents } from './use-complete-events';
 
 interface UseHistoryEventsDataOptions {
-  groups: Ref<Collection<HistoryEventRow>>;
-  pageParams: Ref<HistoryEventRequestPayload | undefined>;
-  excludeIgnored: Ref<boolean>;
-  groupLoading: Ref<boolean>;
-  identifiers?: Ref<string[] | undefined>;
+  groups: MaybeRefOrGetter<Collection<HistoryEventRow>>;
+  pageParams: MaybeRefOrGetter<HistoryEventRequestPayload | undefined>;
+  excludeIgnored: MaybeRefOrGetter<boolean>;
+  groupLoading: MaybeRefOrGetter<boolean>;
+  identifiers?: MaybeRefOrGetter<string[] | undefined>;
 }
 
 interface UseHistoryEventsDataReturn {
@@ -107,11 +107,11 @@ export function useHistoryEventsData(
 
     try {
       const response = await fetchHistoryEvents({
-        ...get(pageParams),
+        ...toValue(pageParams),
         aggregateByGroupIds: false,
         excludeIgnoredAssets: false,
         groupIdentifiers: groupIds,
-        identifiers: get(identifiers),
+        identifiers: toValue(identifiers),
         limit: -1,
         offset: 0,
       }, { tags: [EVENTS_CANCEL_TAG] });
@@ -182,7 +182,7 @@ export function useHistoryEventsData(
   /** Events grouped by groupIdentifier, with both hidden and ignored-asset events filtered out. */
   const displayedEventsMapped = computed<Record<string, HistoryEventRow[]>>(() => {
     const base = get(completeEventsMapped);
-    if (!get(excludeIgnored))
+    if (!toValue(excludeIgnored))
       return base;
 
     const showingIgnored = get(groupsShowingIgnoredAssets);
@@ -229,7 +229,7 @@ export function useHistoryEventsData(
 
   // Track which groups have events hidden due to ignored assets filter
   const groupsWithHiddenIgnoredAssets = computed<Set<string>>(() => {
-    if (!get(excludeIgnored))
+    if (!toValue(excludeIgnored))
       return new Set();
 
     const all = get(completeEventsMapped);
@@ -286,7 +286,7 @@ export function useHistoryEventsData(
   });
 
   // Cancel stale events fetch as soon as new groups fetch starts
-  watch(groupLoading, (loading) => {
+  watch(() => toValue(groupLoading), (loading) => {
     if (loading)
       api.cancelByTag(EVENTS_CANCEL_TAG);
   });

--- a/frontend/app/src/modules/history/events/composables/use-virtual-scroll-highlight.ts
+++ b/frontend/app/src/modules/history/events/composables/use-virtual-scroll-highlight.ts
@@ -1,5 +1,5 @@
 import type { TablePaginationData } from '@rotki/ui-library';
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { VirtualRow } from './use-virtual-rows';
 import type { HighlightType } from '@/composables/history/events/types';
 import type { HistoryEventEntry } from '@/types/history/events/schemas';
@@ -12,8 +12,8 @@ interface UseVirtualScrollHighlightOptions {
   flattenedRows: ComputedRef<VirtualRow[]>;
   getRowHeight: (index: number) => number;
   getCardHeight: (index: number) => number;
-  highlightedIdentifiers: ComputedRef<string[] | undefined>;
-  highlightTypes: ComputedRef<Record<string, HighlightType> | undefined>;
+  highlightedIdentifiers: MaybeRefOrGetter<string[] | undefined>;
+  highlightTypes: MaybeRefOrGetter<Record<string, HighlightType> | undefined>;
   loading: Ref<boolean>;
   pagination: Ref<TablePaginationData>;
 }
@@ -129,7 +129,7 @@ export function useVirtualScrollHighlight(options: UseVirtualScrollHighlightOpti
    * Check if an event should be highlighted.
    */
   function isHighlighted(event: HistoryEventEntry): boolean {
-    const identifiers = get(highlightedIdentifiers);
+    const identifiers = toValue(highlightedIdentifiers);
     if (!identifiers || identifiers.length === 0)
       return false;
     return identifiers.includes(event.identifier.toString());
@@ -139,7 +139,7 @@ export function useVirtualScrollHighlight(options: UseVirtualScrollHighlightOpti
    * Get the highlight type for an event.
    */
   function getHighlightType(event: HistoryEventEntry): HighlightType | undefined {
-    const types = get(highlightTypes);
+    const types = toValue(highlightTypes);
     if (!types)
       return undefined;
     return types[event.identifier.toString()];
@@ -149,7 +149,7 @@ export function useVirtualScrollHighlight(options: UseVirtualScrollHighlightOpti
    * Check if any event in a swap/movement group should be highlighted.
    */
   function isSwapHighlighted(swapEvents: HistoryEventEntry[]): boolean {
-    const identifiers = get(highlightedIdentifiers);
+    const identifiers = toValue(highlightedIdentifiers);
     if (!identifiers || identifiers.length === 0)
       return false;
     return swapEvents.some(e => identifiers.includes(e.identifier.toString()));
@@ -159,7 +159,7 @@ export function useVirtualScrollHighlight(options: UseVirtualScrollHighlightOpti
    * Get the highlight type for a swap/movement group (returns the first matched type).
    */
   function getSwapHighlightType(swapEvents: HistoryEventEntry[]): HighlightType | undefined {
-    const types = get(highlightTypes);
+    const types = toValue(highlightTypes);
     if (!types)
       return undefined;
     for (const event of swapEvents) {
@@ -170,7 +170,7 @@ export function useVirtualScrollHighlight(options: UseVirtualScrollHighlightOpti
     return undefined;
   }
 
-  watch(highlightedIdentifiers, () => {
+  watch(() => toValue(highlightedIdentifiers), () => {
     set(hasScrolledToHighlight, false);
     set(pendingHighlightScroll, true);
   });
@@ -184,7 +184,7 @@ export function useVirtualScrollHighlight(options: UseVirtualScrollHighlightOpti
     }
   });
 
-  watchDebounced([flattenedRows, highlightedIdentifiers, loading], ([rows, identifiers, isLoading]) => {
+  watchDebounced([flattenedRows, (): string[] | undefined => toValue(highlightedIdentifiers), loading], ([rows, identifiers, isLoading]) => {
     if (isLoading || !identifiers || identifiers.length === 0 || rows.length === 0 || get(hasScrolledToHighlight))
       return;
 

--- a/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.vue
@@ -25,11 +25,9 @@ interface AssetMovementEventFormProps {
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<AssetMovementEventFormProps>();
+const { data } = defineProps<AssetMovementEventFormProps>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { data } = toRefs(props);
 
 const historyEventTypesData = [{
   identifier: 'receive',
@@ -178,7 +176,7 @@ async function save(): Promise<boolean> {
     return false;
   }
 
-  const eventData = get(data);
+  const eventData = data;
   const editable = eventData.type === 'edit-group' ? eventData.eventsInGroup[0] : undefined;
 
   // Generate UUID for uniqueId if not present and not in edit mode
@@ -219,7 +217,7 @@ async function save(): Promise<boolean> {
 }
 
 function checkPropsData() {
-  const formData = get(data);
+  const formData = data;
 
   if (formData.type === 'edit-group') {
     const editable = formData.eventsInGroup[0];
@@ -230,8 +228,8 @@ function checkPropsData() {
   reset();
 }
 
-watchImmediate(data, (data, oldData) => {
-  if (isEqual(data, oldData)) {
+watchImmediate(() => data, (newData, oldData) => {
+  if (isEqual(newData, oldData)) {
     return;
   }
   checkPropsData();

--- a/frontend/app/src/modules/history/management/forms/EthBlockEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/EthBlockEventForm.vue
@@ -22,11 +22,9 @@ interface EthBlockEventFormProps {
 }
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
-const props = defineProps<EthBlockEventFormProps>();
+const { data } = defineProps<EthBlockEventFormProps>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { data } = toRefs(props);
 
 const assetPriceForm = useTemplateRef<InstanceType<typeof HistoryEventAssetPriceForm>>('assetPriceForm');
 
@@ -48,7 +46,7 @@ const rules = {
   amount: commonRules.createRequiredAmountRule(),
   blockNumber: commonRules.createRequiredBlockNumberRule(),
   feeRecipient: commonRules.createRequiredValidFeeRecipientRule(),
-  groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => get(data).type === 'edit'),
+  groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => data.type === 'edit'),
   timestamp: commonRules.createExternalValidationRule(),
   validatorIndex: commonRules.createRequiredValidatorIndexRule(),
 };
@@ -125,7 +123,7 @@ async function save(): Promise<boolean> {
     return false;
   }
 
-  const eventData = get(data);
+  const eventData = data;
   const editable = eventData.type === 'edit' ? eventData.event : undefined;
 
   const payload: NewEthBlockEventPayload = {
@@ -149,7 +147,7 @@ async function save(): Promise<boolean> {
 }
 
 function checkPropsData() {
-  const formData = get(data);
+  const formData = data;
   if (formData.type === 'edit') {
     applyEditableData(formData.event);
     return;
@@ -161,7 +159,7 @@ function checkPropsData() {
   reset();
 }
 
-watch(data, checkPropsData);
+watch(() => data, checkPropsData);
 onMounted(() => {
   checkPropsData();
 });

--- a/frontend/app/src/modules/history/management/forms/EthDepositEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/EthDepositEventForm.vue
@@ -23,11 +23,9 @@ interface EthDepositEventFormProps {
 }
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
-const props = defineProps<EthDepositEventFormProps>();
+const { data } = defineProps<EthDepositEventFormProps>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { data } = toRefs(props);
 
 const assetPriceForm = useTemplateRef<InstanceType<typeof HistoryEventAssetPriceForm>>('assetPriceForm');
 
@@ -49,7 +47,7 @@ const commonRules = createCommonRules();
 const rules = {
   amount: commonRules.createRequiredAmountRule(),
   depositor: commonRules.createRequiredValidDepositorRule(),
-  groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => get(data).type === 'edit'),
+  groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => data.type === 'edit'),
   sequenceIndex: commonRules.createRequiredSequenceIndexRule(),
   timestamp: commonRules.createExternalValidationRule(),
   txRef: commonRules.createValidTxHashRule(),
@@ -87,7 +85,7 @@ useFormStateWatcher(states, stateUpdated);
 const depositorSuggestions = computed(() => getAddresses(Blockchain.ETH));
 
 function reset() {
-  set(sequenceIndex, get(data)?.nextSequenceId || '0');
+  set(sequenceIndex, data?.nextSequenceId || '0');
   set(txRef, '');
   set(groupIdentifier, null);
   set(hasActualGroupIdentifier, false);
@@ -118,7 +116,7 @@ function applyEditableData(entry: EthDepositEvent) {
 }
 
 function applyGroupHeaderData(entry: EthDepositEvent) {
-  set(sequenceIndex, get(data)?.nextSequenceId || '0');
+  set(sequenceIndex, data?.nextSequenceId || '0');
   set(groupIdentifier, entry.groupIdentifier);
   set(txRef, entry.txRef);
   set(validatorIndex, entry.validatorIndex.toString());
@@ -135,7 +133,7 @@ async function save(): Promise<boolean> {
   if (!(await get(v$).$validate()))
     return false;
 
-  const eventData = get(data);
+  const eventData = data;
   const editable = eventData.type === 'edit' ? eventData.event : undefined;
 
   const payload: NewEthDepositEventPayload = {
@@ -160,7 +158,7 @@ async function save(): Promise<boolean> {
 }
 
 function checkPropsData() {
-  const formData = get(data);
+  const formData = data;
   if (formData.type === 'edit') {
     applyEditableData(formData.event);
     return;
@@ -172,7 +170,7 @@ function checkPropsData() {
   reset();
 }
 
-watch(data, checkPropsData);
+watch(() => data, checkPropsData);
 
 onMounted(() => {
   checkPropsData();

--- a/frontend/app/src/modules/history/management/forms/EthWithdrawalEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/EthWithdrawalEventForm.vue
@@ -23,11 +23,9 @@ interface EthWithdrawalEventFormProps {
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<EthWithdrawalEventFormProps>();
+const { data } = defineProps<EthWithdrawalEventFormProps>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { data } = toRefs(props);
 
 const assetPriceForm = useTemplateRef<InstanceType<typeof HistoryEventAssetPriceForm>>('assetPriceForm');
 
@@ -46,7 +44,7 @@ const commonRules = createCommonRules();
 
 const rules = {
   amount: commonRules.createRequiredAmountRule(),
-  groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => get(data).type === 'edit'),
+  groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => data.type === 'edit'),
   timestamp: commonRules.createExternalValidationRule(),
   validatorIndex: commonRules.createRequiredValidatorIndexRule(),
   withdrawalAddress: commonRules.createRequiredValidWithdrawalAddressRule(),
@@ -122,7 +120,7 @@ async function save(): Promise<boolean> {
   if (!(await get(v$).$validate()))
     return false;
 
-  const eventData = get(data);
+  const eventData = data;
   const editable = eventData.type === 'edit' ? eventData.event : undefined;
 
   const payload: NewEthWithdrawalEventPayload = {
@@ -145,7 +143,7 @@ async function save(): Promise<boolean> {
 }
 
 function checkPropsData() {
-  const formData = get(data);
+  const formData = data;
   if (formData.type === 'edit') {
     applyEditableData(formData.event);
     return;
@@ -157,7 +155,7 @@ function checkPropsData() {
   reset();
 }
 
-watch(data, checkPropsData);
+watch(() => data, checkPropsData);
 onMounted(() => {
   checkPropsData();
 });

--- a/frontend/app/src/modules/history/management/forms/EvmEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/EvmEventForm.vue
@@ -23,11 +23,9 @@ interface HistoryEventFormProps {
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<HistoryEventFormProps>();
+const { data } = defineProps<HistoryEventFormProps>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { data } = toRefs(props);
 
 const { counterparties } = useHistoryEventCounterpartyMappings();
 
@@ -85,7 +83,7 @@ const { v$, captureEditModeStateFromRefs, shouldSkipSaveFromRefs } = useEventFor
     counterparty: commonRules.createValidCounterpartyRule(counterparties),
     eventSubtype: commonRules.createRequiredEventSubtypeRule(),
     eventType: commonRules.createRequiredEventTypeRule(),
-    groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => get(data).type === 'edit'),
+    groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => data.type === 'edit'),
     location: commonRules.createRequiredLocationRule(),
     locationLabel: commonRules.createExternalValidationRule(),
     notes: commonRules.createExternalValidationRule(),
@@ -99,7 +97,7 @@ const { v$, captureEditModeStateFromRefs, shouldSkipSaveFromRefs } = useEventFor
 });
 
 function reset() {
-  set(sequenceIndex, get(data)?.nextSequenceId || '0');
+  set(sequenceIndex, data?.nextSequenceId || '0');
   set(txRef, '');
   set(groupIdentifier, null);
   set(hasActualGroupIdentifier, false);
@@ -142,7 +140,7 @@ function applyEditableData(entry: EvmHistoryEvent) {
 }
 
 function applyGroupHeaderData(entry: EvmHistoryEvent) {
-  set(sequenceIndex, get(data)?.nextSequenceId || '0');
+  set(sequenceIndex, data?.nextSequenceId || '0');
   set(groupIdentifier, entry.groupIdentifier);
   set(location, entry.location || get(lastLocation));
   set(address, entry.address ?? '');
@@ -156,7 +154,7 @@ async function save(): Promise<boolean> {
     return false;
   }
 
-  const eventData = get(data);
+  const eventData = data;
   const editable = eventData.type === 'edit' ? eventData.event : undefined;
   const userNotes = get(notes).trim();
 
@@ -188,7 +186,7 @@ async function save(): Promise<boolean> {
 }
 
 function checkPropsData() {
-  const formData = get(data);
+  const formData = data;
   if (formData.type === 'edit') {
     applyEditableData(formData.event);
     return;
@@ -206,7 +204,7 @@ watch(location, (location: string) => {
     set(lastLocation, location);
 });
 
-watch(data, checkPropsData);
+watch(() => data, checkPropsData);
 
 onMounted(() => {
   checkPropsData();

--- a/frontend/app/src/modules/history/management/forms/OnlineHistoryEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/OnlineHistoryEventForm.vue
@@ -18,11 +18,9 @@ import { bigNumberifyFromRef } from '@/utils/bignumbers';
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<{ data: StandaloneEventData<OnlineHistoryEvent> }>();
+const { data } = defineProps<{ data: StandaloneEventData<OnlineHistoryEvent> }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { data } = toRefs(props);
 
 const lastLocation = useLocalStorage('rotki.history_event.location', TRADE_LOCATION_EXTERNAL);
 
@@ -65,7 +63,7 @@ const {
     asset: commonRules.createRequiredAssetRule(),
     eventSubtype: commonRules.createRequiredEventSubtypeRule(),
     eventType: commonRules.createRequiredEventTypeRule(),
-    groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => get(data).type === 'edit'),
+    groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => data.type === 'edit'),
     location: commonRules.createRequiredLocationRule(),
     locationLabel: commonRules.createExternalValidationRule(),
     notes: commonRules.createExternalValidationRule(),
@@ -89,7 +87,7 @@ const locationLabelSuggestions = computed(() =>
 );
 
 function reset() {
-  set(sequenceIndex, get(data)?.nextSequenceId || '0');
+  set(sequenceIndex, data?.nextSequenceId || '0');
   set(groupIdentifier, '');
   set(hasActualGroupIdentifier, false);
   set(timestamp, dayjs().valueOf());
@@ -124,7 +122,7 @@ function applyEditableData(entry: OnlineHistoryEvent) {
 }
 
 function applyGroupHeaderData(entry: OnlineHistoryEvent) {
-  set(sequenceIndex, get(data)?.nextSequenceId || '0');
+  set(sequenceIndex, data?.nextSequenceId || '0');
   set(location, entry.location || get(lastLocation));
   set(locationLabel, entry.locationLabel ?? '');
   set(groupIdentifier, entry.groupIdentifier);
@@ -136,7 +134,7 @@ async function save(): Promise<boolean> {
     return false;
   }
 
-  const eventData = get(data);
+  const eventData = data;
   const editable = eventData.type === 'edit' ? eventData.event : undefined;
   const userNotes = get(notes).trim();
 
@@ -167,7 +165,7 @@ async function save(): Promise<boolean> {
 }
 
 function checkPropsData() {
-  const formData = get(data);
+  const formData = data;
   if (formData.type === 'edit') {
     applyEditableData(formData.event);
     return;
@@ -184,7 +182,7 @@ watch(location, (location: string) => {
     set(lastLocation, location);
 });
 
-watch(data, checkPropsData);
+watch(() => data, checkPropsData);
 
 onMounted(() => {
   checkPropsData();

--- a/frontend/app/src/modules/history/management/forms/SolanaEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/SolanaEventForm.vue
@@ -26,11 +26,9 @@ interface HistoryEventFormProps {
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<HistoryEventFormProps>();
+const { data } = defineProps<HistoryEventFormProps>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { data } = toRefs(props);
 
 const { counterparties } = useHistoryEventCounterpartyMappings();
 
@@ -66,7 +64,7 @@ const rules = {
   counterparty: commonRules.createValidCounterpartyRule(counterparties),
   eventSubtype: commonRules.createRequiredEventSubtypeRule(),
   eventType: commonRules.createRequiredEventTypeRule(),
-  groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => get(data).type === 'edit'),
+  groupIdentifier: commonRules.createRequiredGroupIdentifierRule(() => data.type === 'edit'),
   location: commonRules.createRequiredLocationRule(),
   locationLabel: commonRules.createExternalValidationRule(),
   notes: commonRules.createExternalValidationRule(),
@@ -108,7 +106,7 @@ const v$ = useVuelidate(
 useFormStateWatcher(states, stateUpdated);
 
 function reset() {
-  set(sequenceIndex, get(data)?.nextSequenceId || '0');
+  set(sequenceIndex, data?.nextSequenceId || '0');
   set(txRef, '');
   set(groupIdentifier, null);
   set(hasActualGroupIdentifier, false);
@@ -149,7 +147,7 @@ function applyEditableData(entry: SolanaEvent) {
 }
 
 function applyGroupHeaderData(entry: SolanaEvent) {
-  set(sequenceIndex, get(data)?.nextSequenceId || '0');
+  set(sequenceIndex, data?.nextSequenceId || '0');
   set(groupIdentifier, entry.groupIdentifier);
   set(address, entry.address ?? '');
   set(locationLabel, entry.locationLabel ?? '');
@@ -167,8 +165,7 @@ async function save(): Promise<boolean> {
     return false;
   }
 
-  const eventData = get(data);
-  const editable = eventData.type === 'edit' ? eventData.event : undefined;
+  const editable = data.type === 'edit' ? data.event : undefined;
   const userNotes = get(notes).trim();
 
   const payload: NewSolanaEventPayload = {
@@ -198,20 +195,19 @@ async function save(): Promise<boolean> {
 }
 
 function checkPropsData() {
-  const formData = get(data);
-  if (formData.type === 'edit') {
-    applyEditableData(formData.event);
+  if (data.type === 'edit') {
+    applyEditableData(data.event);
     return;
   }
 
-  if (formData.type === 'group-add') {
-    applyGroupHeaderData(formData.group);
+  if (data.type === 'group-add') {
+    applyGroupHeaderData(data.group);
     return;
   }
   reset();
 }
 
-watch(data, checkPropsData);
+watch(() => data, checkPropsData);
 
 onMounted(() => {
   checkPropsData();

--- a/frontend/app/src/modules/onchain/send/TradeAddressDisplay.vue
+++ b/frontend/app/src/modules/onchain/send/TradeAddressDisplay.vue
@@ -2,7 +2,7 @@
 import EnsAvatar from '@/components/display/EnsAvatar.vue';
 import { useAddressesNamesStore } from '@/store/blockchain/accounts/addresses-names';
 
-const props = defineProps<{
+const { address, chain, name, readonly, dense } = defineProps<{
   address: string;
   chain?: string;
   name?: string;
@@ -10,16 +10,15 @@ const props = defineProps<{
   dense?: boolean;
 }>();
 
-const { address, chain, name } = toRefs(props);
-
 const { addressNameSelector } = useAddressesNamesStore();
 
+const addressName = addressNameSelector(computed<string>(() => address), computed<string>(() => chain ?? ''));
+
 const aliasName = computed<string | undefined>(() => {
-  const forceName = get(name);
-  if (forceName) {
-    return forceName;
+  if (name) {
+    return name;
   }
-  return get(addressNameSelector(get(address), get(chain)));
+  return get(addressName);
 });
 </script>
 

--- a/frontend/app/src/modules/onchain/send/TradeAmountInput.vue
+++ b/frontend/app/src/modules/onchain/send/TradeAmountInput.vue
@@ -10,7 +10,7 @@ import { bigNumberifyFromRef } from '@/utils/bignumbers';
 
 const model = defineModel<string>({ required: true });
 
-const props = defineProps<{
+const { asset, chain, address, max, amountExceeded, loading } = defineProps<{
   asset: string;
   chain: string;
   address?: string;
@@ -21,15 +21,13 @@ const props = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { address, asset, chain } = toRefs(props);
-
 const fiatValue = ref<string>('0');
 const isAmountSelected = ref<boolean>(true);
 
 const { currency } = storeToRefs(useGeneralSettingsStore());
 
-const { getAssetDetail } = useTradableAsset(address);
-const assetDetail = getAssetDetail(asset, chain);
+const { getAssetDetail } = useTradableAsset(computed<string | undefined>(() => address));
+const assetDetail = getAssetDetail(computed<string>(() => asset), computed<string>(() => chain));
 const price = useRefMap(assetDetail, m => m?.price);
 const fiatValueToBigNumber = bigNumberifyFromRef(fiatValue);
 const amountToBigNumber = bigNumberifyFromRef(model);
@@ -72,10 +70,10 @@ function swapInput(): void {
 }
 
 function setMax(): void {
-  set(model, props.max);
+  set(model, max);
   const priceVal = get(price);
   if (get(isAmountSelected) && priceVal) {
-    set(fiatValue, bigNumberify(props.max).multipliedBy(priceVal).toString());
+    set(fiatValue, bigNumberify(max).multipliedBy(priceVal).toString());
   }
 }
 

--- a/frontend/app/src/modules/onchain/send/TradeAssetSelector.vue
+++ b/frontend/app/src/modules/onchain/send/TradeAssetSelector.vue
@@ -13,7 +13,7 @@ import { TaskType } from '@/types/task-type';
 const asset = defineModel<string>({ required: true });
 const chain = defineModel<string>('chain', { required: true });
 
-const props = defineProps<{
+const { address, amount } = defineProps<{
   address?: string;
   amount: BigNumber | undefined;
 }>();
@@ -23,14 +23,12 @@ const emit = defineEmits<{
   'refresh': [];
 }>();
 
-const { address } = toRefs(props);
-
 const openDialog = ref(false);
 const internalChain = ref<string>(Blockchain.ETH);
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { allOwnedAssets, getAssetDetail } = useTradableAsset(address);
+const { allOwnedAssets, getAssetDetail } = useTradableAsset(computed<string | undefined>(() => address));
 
 const { connected, connectedAddress, supportedChainsForConnectedAccount } = storeToRefs(useWalletStore());
 const { useIsTaskRunning } = useTaskStore();
@@ -103,7 +101,7 @@ watchImmediate(chain, (chain) => {
 
 function redetectTokens() {
   const chain = get(internalChain);
-  const addressVal = get(address);
+  const addressVal = address;
 
   if (addressVal && chain) {
     useTokenDetection(chain, addressVal).detectTokens();

--- a/frontend/app/src/modules/onchain/wallet-bridge/ConnectionLogs.vue
+++ b/frontend/app/src/modules/onchain/wallet-bridge/ConnectionLogs.vue
@@ -5,13 +5,11 @@ interface LogEntry {
   type: 'info' | 'success' | 'error';
 }
 
-const props = defineProps<{
+const { logs } = defineProps<{
   logs: LogEntry[];
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { logs } = toRefs(props);
 </script>
 
 <template>

--- a/frontend/app/src/modules/onchain/wallet-bridge/ElectronConnectionStatus.vue
+++ b/frontend/app/src/modules/onchain/wallet-bridge/ElectronConnectionStatus.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const props = defineProps<{
+const { isConnected, isConnecting, error, onRetryConnection, onDisconnect } = defineProps<{
   isConnected: boolean;
   isConnecting: boolean;
   error?: string;
@@ -8,8 +8,6 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { error, isConnected, isConnecting, onDisconnect, onRetryConnection } = toRefs(props);
 </script>
 
 <template>

--- a/frontend/app/src/pages/accounts/evm/[[tab]].vue
+++ b/frontend/app/src/pages/accounts/evm/[[tab]].vue
@@ -24,11 +24,9 @@ definePage({
   props: true,
 });
 
-const props = defineProps<{
+const { tab } = defineProps<{
   tab: string;
 }>();
-
-const { tab } = toRefs(props);
 
 const { t } = useI18n({ useScope: 'global' });
 const router = useRouter();
@@ -42,7 +40,7 @@ const { importingAccounts } = storeToRefs(useAccountImportProgressStore());
 const { isModuleEnabled } = useModules();
 const isEth2Enabled = isModuleEnabled(Module.ETH2);
 
-const isAccountsTabSelected = computed(() => get(tab) === 'accounts');
+const isAccountsTabSelected = computed<boolean>(() => tab === 'accounts');
 
 const { chainIds } = useAccountCategoryHelper(category);
 const usedChainIds = computed(() => {

--- a/frontend/app/src/pages/assets/[identifier].vue
+++ b/frontend/app/src/pages/assets/[identifier].vue
@@ -31,11 +31,9 @@ defineOptions({
   name: 'AssetBreakdown',
 });
 
-const props = defineProps<{
+const { identifier } = defineProps<{
   identifier: string;
 }>();
-
-const { identifier } = toRefs(props);
 
 const { t } = useI18n({ useScope: 'global' });
 const router = useRouter();
@@ -60,10 +58,10 @@ const assetRetrievalOption = computed<AssetResolutionOptions>(() => ({
   collectionParent: get(isCollectionParent),
 }));
 
-const name = assetName(identifier, assetRetrievalOption);
-const symbol = assetSymbol(identifier, assetRetrievalOption);
-const asset = assetInfo(identifier, assetRetrievalOption);
-const contractInfo = assetContractInfo(identifier, assetRetrievalOption);
+const name = assetName(() => identifier, assetRetrievalOption);
+const symbol = assetSymbol(() => identifier, assetRetrievalOption);
+const asset = assetInfo(() => identifier, assetRetrievalOption);
+const contractInfo = assetContractInfo(() => identifier, assetRetrievalOption);
 
 const {
   loadingIgnore,
@@ -74,7 +72,7 @@ const {
   toggleWhitelistAsset,
 } = useAssetPageActions({
   asset,
-  identifier,
+  identifier: computed<string>(() => identifier),
   name,
   refetchAssetInfo,
   symbol,
@@ -93,7 +91,7 @@ const collectionId = computed<number | undefined>(() => {
 const editRoute = computed(() => ({
   path: get(isCustomAsset) ? '/asset-manager/custom' : '/asset-manager/managed',
   query: {
-    id: get(identifier),
+    id: identifier,
   },
 }));
 
@@ -101,13 +99,13 @@ const collectionBalance = computed<AssetBalanceWithPrice[]>(() => {
   if (!get(isCollectionParent))
     return [];
 
-  return get(aggregatedBalances).find(data => data.asset === get(identifier))?.breakdown || [];
+  return get(aggregatedBalances).find(data => data.asset === identifier)?.breakdown || [];
 });
 
 const collectionAssetWithPrice = computed<string | undefined>(() => {
   const collectionBalanceVal = get(collectionBalance);
 
-  const id = get(identifier);
+  const id = identifier;
 
   if (collectionBalanceVal.length === 0) {
     return id;

--- a/frontend/app/src/pages/balances/exchange/[[exchange]].vue
+++ b/frontend/app/src/pages/balances/exchange/[[exchange]].vue
@@ -27,12 +27,10 @@ definePage({
   props: true,
 });
 
-const props = defineProps<{ exchange?: string }>();
+const { exchange } = defineProps<{ exchange?: string }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const selectedTab = ref<string | undefined>(props.exchange ?? undefined);
-
-const { exchange } = toRefs(props);
+const selectedTab = ref<string | undefined>(exchange ?? undefined);
 const { useIsTaskRunning } = useTaskStore();
 const { useExchangeBalances } = useAggregatedBalances();
 const { refreshExchangeSavings } = useBinanceSavings();
@@ -93,7 +91,7 @@ function openExchangeDetails() {
 }
 
 const balances = computed(() => {
-  const currentExchange = get(exchange);
+  const currentExchange = exchange;
   if (!currentExchange)
     return [];
 
@@ -111,7 +109,7 @@ function navigate() {
 
 const exchangeDetailTabs = ref<number>(0);
 
-watch(exchange, () => {
+watch(() => exchange, () => {
   set(exchangeDetailTabs, 0);
 });
 

--- a/frontend/app/src/pages/locations/[identifier].vue
+++ b/frontend/app/src/pages/locations/[identifier].vue
@@ -18,13 +18,12 @@ defineOptions({
   name: 'LocationBreakdown',
 });
 
-const props = defineProps<{
+const { identifier } = defineProps<{
   identifier: string;
 }>();
 
-const { identifier } = toRefs(props);
 const { locationData } = useLocations();
-const location = locationData(identifier);
+const location = locationData(() => identifier);
 </script>
 
 <template>

--- a/frontend/app/src/store/blockchain/tokens.ts
+++ b/frontend/app/src/store/blockchain/tokens.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
 import type { EthDetectedTokensInfo, EvmTokensRecord } from '@/types/balances';
 import type { BlockchainAssetBalances } from '@/types/blockchain/balances';
 import type { TaskMeta } from '@/types/task';
@@ -111,16 +111,16 @@ export const useBlockchainTokensStore = defineStore('blockchain/tokens', () => {
   };
 
   const getEthDetectedTokensInfo = (
-    chain: MaybeRef<string>,
-    address: MaybeRef<string | null>,
+    chain: MaybeRefOrGetter<string>,
+    address: MaybeRefOrGetter<string | null>,
   ): ComputedRef<EthDetectedTokensInfo> => computed<EthDetectedTokensInfo>(() => {
-    const blockchain = get(chain);
+    const blockchain = toValue(chain);
     if (!supportsTransactions(blockchain))
       return noTokens();
 
     const state = get(tokensState);
     const detected: EvmTokensRecord | undefined = state[blockchain];
-    const addr = get(address);
+    const addr = toValue(address);
 
     if (!addr)
       return noTokens();

--- a/frontend/app/src/utils/collection.ts
+++ b/frontend/app/src/utils/collection.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { Collection, CollectionResponse } from '@/types/collection';
 import { type BigNumber, Zero } from '@rotki/common';
 import { usePremium } from '@/composables/premium';
@@ -30,7 +30,7 @@ export function defaultCollectionState<T>(): Collection<T> {
 
 type TotalValue = BigNumber | undefined | null;
 
-export function getCollectionData<T>(collection: Ref<Collection<T>>): {
+export function getCollectionData<T>(collection: MaybeRefOrGetter<Collection<T>>): {
   data: ComputedRef<T[]>;
   limit: ComputedRef<number>;
   found: ComputedRef<number>;
@@ -38,12 +38,12 @@ export function getCollectionData<T>(collection: Ref<Collection<T>>): {
   entriesFoundTotal: ComputedRef<number | undefined>;
   totalValue: ComputedRef<TotalValue>;
 } {
-  const data = computed<T[]>(() => get(collection).data);
-  const limit = computed<number>(() => get(collection).limit);
-  const found = computed<number>(() => get(collection).found);
-  const total = computed<number>(() => get(collection).total);
-  const entriesFoundTotal = computed<number | undefined>(() => get(collection).entriesFoundTotal);
-  const totalValue = computed<TotalValue>(() => get(collection).totalValue);
+  const data = computed<T[]>(() => toValue(collection).data);
+  const limit = computed<number>(() => toValue(collection).limit);
+  const found = computed<number>(() => toValue(collection).found);
+  const total = computed<number>(() => toValue(collection).total);
+  const entriesFoundTotal = computed<number | undefined>(() => toValue(collection).entriesFoundTotal);
+  const totalValue = computed<TotalValue>(() => toValue(collection).totalValue);
 
   return {
     data,

--- a/frontend/app/src/utils/history/events.ts
+++ b/frontend/app/src/utils/history/events.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRef } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { LocationAndTxRef } from '@/types/history/events';
 import { HistoryEventEntryType } from '@rotki/common';
 import { snakeCase } from 'es-toolkit';
@@ -47,9 +47,9 @@ function isWithdrawalEvent(event: HistoryEvent): event is EthWithdrawalEvent {
   return isWithdrawalEventType(event.entryType);
 }
 
-export function isWithdrawalEventRef(event: MaybeRef<HistoryEvent>): ComputedRef<EthWithdrawalEvent | undefined> {
+export function isWithdrawalEventRef(event: MaybeRefOrGetter<HistoryEvent>): ComputedRef<EthWithdrawalEvent | undefined> {
   return computed(() => {
-    const eventVal = get(event);
+    const eventVal = toValue(event);
     return isWithdrawalEvent(eventVal) ? eventVal : undefined;
   });
 }
@@ -62,9 +62,9 @@ export function isEthBlockEvent<T extends HistoryEvent>(event: T): event is T & 
   return isEthBlockEventType(event.entryType);
 }
 
-export function isEthBlockEventRef(event: MaybeRef<HistoryEvent>): ComputedRef<EthBlockEvent | undefined> {
+export function isEthBlockEventRef(event: MaybeRefOrGetter<HistoryEvent>): ComputedRef<EthBlockEvent | undefined> {
   return computed(() => {
-    const eventVal = get(event);
+    const eventVal = toValue(event);
     return isEthBlockEvent(eventVal) ? eventVal : undefined;
   });
 }
@@ -89,9 +89,9 @@ export function isAssetMovementEvent(event: HistoryEvent): event is AssetMovemen
   return isAssetMovementEventType(event.entryType);
 }
 
-export function isAssetMovementEventRef(event: MaybeRef<HistoryEvent>): ComputedRef<AssetMovementEvent | undefined> {
+export function isAssetMovementEventRef(event: MaybeRefOrGetter<HistoryEvent>): ComputedRef<AssetMovementEvent | undefined> {
   return computed(() => {
-    const eventVal = get(event);
+    const eventVal = toValue(event);
     return isAssetMovementEvent(eventVal) ? eventVal : undefined;
   });
 }


### PR DESCRIPTION
## Summary
- Replace `withDefaults` with destructured prop defaults (Vue 3.5+)
- Remove `toRefs(props)` pattern across ~100 components in favor of direct destructured props
- Convert template refs from `ref()` to `useTemplateRef()` (Vue 3.5+)
- Update ~20 composables from `MaybeRef<T>` / `Ref<T>` parameters to `MaybeRefOrGetter<T>` with `toValue()` internally, allowing callers to pass simple getter functions `() => prop` instead of `toRef(() => prop)`
- Add reactive prop passing and composable argument conventions to CLAUDE.md / AGENTS.md

188 files changed, 1003 insertions(+), 1413 deletions(-)

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint:fix` passes
- [x] All 2613 unit tests pass across 236 test files
- [ ] Manual smoke test of key flows (login, account balances, history events)