### PR TITLE
fix(tests): improve test assertion quality

### DIFF
--- a/frontend/app/src/components/AssetBalances.spec.ts
+++ b/frontend/app/src/components/AssetBalances.spec.ts
@@ -29,12 +29,12 @@ describe('asset-balances', () => {
     await wrapper.setProps({ loading: true });
     await nextTick();
 
-    expect(wrapper.find('tbody td div[role=progressbar]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody td div[role=progressbar]').exists()).toBe(true);
 
     await wrapper.setProps({ loading: false });
     await nextTick();
 
-    expect(wrapper.find('tbody td div[role=progressbar]').exists()).toBeFalsy();
+    expect(wrapper.find('tbody td div[role=progressbar]').exists()).toBe(false);
     expect(wrapper.find('tbody tr td p').text()).toMatch('data_table.no_data');
   });
 });

--- a/frontend/app/src/components/accounts/AccountBalances.spec.ts
+++ b/frontend/app/src/components/accounts/AccountBalances.spec.ts
@@ -76,7 +76,7 @@ describe('account-balances', () => {
 
     await nextTick();
 
-    expect(wrapper.find('tbody td div[role=progressbar]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody td div[role=progressbar]').exists()).toBe(true);
 
     remove(1);
     useStatusStore().setStatus({
@@ -86,7 +86,7 @@ describe('account-balances', () => {
     });
     await nextTick();
 
-    expect(wrapper.find('tbody td div[role=progressbar]').exists()).toBeFalsy();
+    expect(wrapper.find('tbody td div[role=progressbar]').exists()).toBe(false);
     expect(wrapper.find('tbody tr td p').text()).toMatch('data_table.no_data');
   });
 });

--- a/frontend/app/src/components/defi/wizard/ModuleSelector.spec.ts
+++ b/frontend/app/src/components/defi/wizard/ModuleSelector.spec.ts
@@ -47,7 +47,7 @@ describe('module-selector', () => {
   });
 
   it('should display active modules', () => {
-    expect(wrapper.find<HTMLInputElement>('[data-cy=eth2-module-switch] input').element.checked).toBeTruthy();
+    expect(wrapper.find<HTMLInputElement>('[data-cy=eth2-module-switch] input').element.checked).toBe(true);
   });
 
   it('should disable module on click', async () => {
@@ -57,11 +57,11 @@ describe('module-selector', () => {
       accounting: {},
       other: { havePremium: false, premiumShouldSync: false },
     });
-    expect(wrapper.find<HTMLInputElement>('[data-cy=eth2-module-switch] input').element.checked).toBeTruthy();
+    expect(wrapper.find<HTMLInputElement>('[data-cy=eth2-module-switch] input').element.checked).toBe(true);
     await wrapper.find('[data-cy=eth2-module-switch] input').trigger('input', { target: false });
     await nextTick();
     await flushPromises();
-    expect(wrapper.find<HTMLInputElement>('[data-cy=eth2-module-switch] input').element.checked).toBeFalsy();
+    expect(wrapper.find<HTMLInputElement>('[data-cy=eth2-module-switch] input').element.checked).toBe(false);
     expect(settingsStore.activeModules).toEqual([]);
   });
 });

--- a/frontend/app/src/components/inputs/DateTimePicker.spec.ts
+++ b/frontend/app/src/components/inputs/DateTimePicker.spec.ts
@@ -8,7 +8,7 @@ import { setupDayjs } from '@/utils/date';
 
 function getEmittedValue(wrapper: VueWrapper, event: string, callIndex: number): number {
   const emitted = wrapper.emitted(event);
-  expect(emitted).toBeTruthy();
+  expect(emitted).toBeDefined();
   const value = emitted![callIndex][0];
   expect(value).toEqual(expect.any(Number));
   return Number(value);

--- a/frontend/app/src/components/inputs/TagInput.spec.ts
+++ b/frontend/app/src/components/inputs/TagInput.spec.ts
@@ -109,7 +109,7 @@ describe('tag-input', () => {
     expect(wrapper.emitted('update:modelValue')![1]).toEqual([emitted]);
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(wrapper.find('[role=menu-content]').exists()).toBeTruthy();
-    expect(wrapper.find('[role=menu-content] button:nth-child(2)').exists()).toBeFalsy();
+    expect(wrapper.find('[role=menu-content]').exists()).toBe(true);
+    expect(wrapper.find('[role=menu-content] button:nth-child(2)').exists()).toBe(false);
   });
 });

--- a/frontend/app/src/components/premium/GetPremiumButton.spec.ts
+++ b/frontend/app/src/components/premium/GetPremiumButton.spec.ts
@@ -28,7 +28,7 @@ describe('get-premium-button', () => {
   it('should show get premium button', () => {
     wrapper = createWrapper();
 
-    expect(wrapper.find('[data-cy=get-premium-button]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-cy=get-premium-button]').exists()).toBe(true);
   });
 
   it('should not show get premium button', () => {
@@ -38,6 +38,6 @@ describe('get-premium-button', () => {
 
     wrapper = createWrapper();
 
-    expect(wrapper.find('[data-cy=get-premium-button]').exists()).toBeFalsy();
+    expect(wrapper.find('[data-cy=get-premium-button]').exists()).toBe(false);
   });
 });

--- a/frontend/app/src/components/profitloss/ReportPeriodSelector.spec.ts
+++ b/frontend/app/src/components/profitloss/ReportPeriodSelector.spec.ts
@@ -73,7 +73,7 @@ describe('components/profitloss/ReportPeriodSelector.vue', () => {
       await vi.advanceTimersToNextTimerAsync();
 
       const selectionEvents = wrapper.emitted('update:selection')!;
-      expect(selectionEvents).toBeTruthy();
+      expect(selectionEvents).toBeDefined();
       expect(selectionEvents.at(-1)![0]).toMatchObject({
         quarter: Quarter.ALL,
         year: previousYear,
@@ -89,7 +89,7 @@ describe('components/profitloss/ReportPeriodSelector.vue', () => {
       await vi.advanceTimersToNextTimerAsync();
 
       const periodEvents = wrapper.emitted<PeriodChangedEvent[]>('update:period')!;
-      expect(periodEvents).toBeTruthy();
+      expect(periodEvents).toBeDefined();
 
       const lastPeriodEvent = periodEvents.at(-1)![0];
       expect(lastPeriodEvent).not.toBeNull();
@@ -142,14 +142,14 @@ describe('components/profitloss/ReportPeriodSelector.vue', () => {
       await vi.advanceTimersToNextTimerAsync();
 
       const selectionEvents = wrapper.emitted('update:selection')!;
-      expect(selectionEvents).toBeTruthy();
+      expect(selectionEvents).toBeDefined();
       expect(selectionEvents.at(-1)![0]).toMatchObject({
         quarter: Quarter.ALL,
         year: 'all-time',
       });
 
       const periodEvents = wrapper.emitted<PeriodChangedEvent[]>('update:period')!;
-      expect(periodEvents).toBeTruthy();
+      expect(periodEvents).toBeDefined();
       const lastPeriodEvent = periodEvents.at(-1)![0];
       expect(lastPeriodEvent.start).toBe(0);
       expect(lastPeriodEvent.end).toBeLessThanOrEqual(dayjs().unix());
@@ -167,7 +167,7 @@ describe('components/profitloss/ReportPeriodSelector.vue', () => {
       await vi.advanceTimersToNextTimerAsync();
 
       const selectionEvents = wrapper.emitted('update:selection')!;
-      expect(selectionEvents).toBeTruthy();
+      expect(selectionEvents).toBeDefined();
       expect(selectionEvents.at(-1)![0]).toMatchObject({
         year: 'custom',
       });
@@ -229,7 +229,7 @@ describe('components/profitloss/ReportPeriodSelector.vue', () => {
       await vi.advanceTimersToNextTimerAsync();
 
       const selectionEvents = wrapper.emitted('update:selection')!;
-      expect(selectionEvents).toBeTruthy();
+      expect(selectionEvents).toBeDefined();
       expect(selectionEvents.at(-1)![0]).toMatchObject({
         quarter: Quarter.Q1,
         year: currentYear,
@@ -249,7 +249,7 @@ describe('components/profitloss/ReportPeriodSelector.vue', () => {
       await vi.advanceTimersToNextTimerAsync();
 
       const periodEvents = wrapper.emitted('update:period')!;
-      expect(periodEvents).toBeTruthy();
+      expect(periodEvents).toBeDefined();
       expect(periodEvents.length).toBeGreaterThan(0);
 
       const firstPeriodEvent = periodEvents[0][0];

--- a/frontend/app/src/components/settings/general/EvmChainsToIgnoreSettings.spec.ts
+++ b/frontend/app/src/components/settings/general/EvmChainsToIgnoreSettings.spec.ts
@@ -59,10 +59,10 @@ describe('evm-chains-to-ignore-settings', () => {
 
   it('should display no warning by default', () => {
     const input = wrapper.find('.input-value');
-    expect(input.exists()).toBeTruthy();
+    expect(input.exists()).toBe(true);
     expect(input.text()).toBe('');
-    expect(wrapper.find('.selections').exists()).toBeTruthy();
-    expect(wrapper.find('.details').exists()).toBeFalsy();
+    expect(wrapper.find('.selections').exists()).toBe(true);
+    expect(wrapper.find('.details').exists()).toBe(false);
   });
 
   it('should display success if correct chain values are passed', async () => {
@@ -75,7 +75,7 @@ describe('evm-chains-to-ignore-settings', () => {
     await vi.advanceTimersByTimeAsync(2000);
     await flushPromises();
 
-    expect(wrapper.find('.details').exists()).toBeTruthy();
+    expect(wrapper.find('.details').exists()).toBe(true);
     expect(wrapper.find('.details').text()).toContain('settings.saved');
 
     expect(inputEl.value).toMatch(chains.toString());

--- a/frontend/app/src/components/table-filter/FilterDropdown.spec.ts
+++ b/frontend/app/src/components/table-filter/FilterDropdown.spec.ts
@@ -53,8 +53,8 @@ describe('filter-dropdown', () => {
 
     expect(wrapper.findAll('[data-cy=suggestions] > button')).toHaveLength(matchers.length);
     expect(
-      wrapper.find('[data-cy=suggestions] > button:nth-child(2)').classes().includes('highlightedMatcher'),
-    ).toBeTruthy();
+      wrapper.find('[data-cy=suggestions] > button:nth-child(2)').classes(),
+    ).toContain('highlightedMatcher');
   });
 
   it('should show unsupported filter message', () => {

--- a/frontend/app/src/components/table-filter/SelectionChip.spec.ts
+++ b/frontend/app/src/components/table-filter/SelectionChip.spec.ts
@@ -94,7 +94,7 @@ describe('selection-chip', () => {
 
       const chip = wrapper.findComponent({ name: 'RuiChip' });
       await chip.trigger('click');
-      expect(wrapper.emitted('click-item')).toBeTruthy();
+      expect(wrapper.emitted('click-item')).toBeDefined();
       expect(wrapper.emitted('click-item')?.[0]).toEqual([item]);
     });
 
@@ -189,7 +189,7 @@ describe('selection-chip', () => {
       const overflowBadge = wrapper.find('.bg-rui-primary');
       await overflowBadge.trigger('click');
 
-      expect(wrapper.emitted('toggle-group-menu')).toBeTruthy();
+      expect(wrapper.emitted('toggle-group-menu')).toBeDefined();
       expect(wrapper.emitted('toggle-group-menu')?.[0]).toEqual([item.key]);
     });
 
@@ -209,7 +209,7 @@ describe('selection-chip', () => {
       const removeButton = wrapper.findComponent({ name: 'RuiButton' });
       await removeButton.trigger('click');
 
-      expect(wrapper.emitted('remove-all-items')).toBeTruthy();
+      expect(wrapper.emitted('remove-all-items')).toBeDefined();
       expect(wrapper.emitted('remove-all-items')?.[0]).toEqual([item.key]);
     });
 
@@ -320,7 +320,7 @@ describe('selection-chip', () => {
       const suggestedItem = wrapper.findComponent({ name: 'SuggestedItem' });
       await suggestedItem.vm.$emit('cancel-edit', true);
 
-      expect(wrapper.emitted('cancel-edit')).toBeTruthy();
+      expect(wrapper.emitted('cancel-edit')).toBeDefined();
       expect(wrapper.emitted('cancel-edit')?.[0]).toEqual([true]);
     });
 
@@ -340,7 +340,7 @@ describe('selection-chip', () => {
       const suggestedItem = wrapper.findComponent({ name: 'SuggestedItem' });
       await suggestedItem.vm.$emit('update:search', 'new-value');
 
-      expect(wrapper.emitted('update:search')).toBeTruthy();
+      expect(wrapper.emitted('update:search')).toBeDefined();
       expect(wrapper.emitted('update:search')?.[0]).toEqual(['new-value']);
     });
   });

--- a/frontend/app/src/composables/accounts/blockie.spec.ts
+++ b/frontend/app/src/composables/accounts/blockie.spec.ts
@@ -27,10 +27,10 @@ describe('useBlockie', () => {
 
   it('should stop caching blockie after cache limit is reached', () => {
     expect(cache.size).toBe(1);
-    expect(cache.has(address)).toBeTruthy();
+    expect(cache.has(address)).toBe(true);
     for (let i = 0; i < 100; i++) getBlockie(i.toString());
 
     expect(cache.size).toBe(100);
-    expect(cache.has(address)).toBeFalsy();
+    expect(cache.has(address)).toBe(false);
   });
 });

--- a/frontend/app/src/composables/api/settings/snapshot-api.spec.ts
+++ b/frontend/app/src/composables/api/settings/snapshot-api.spec.ts
@@ -285,8 +285,8 @@ describe('composables/api/settings/snapshot-api', () => {
 
       expect(result).toBe(true);
       expect(capturedFormData).not.toBeNull();
-      expect(capturedFormData!.get('balances_snapshot_file')).toBeTruthy();
-      expect(capturedFormData!.get('location_data_snapshot_file')).toBeTruthy();
+      expect(capturedFormData!.get('balances_snapshot_file')).toBeDefined();
+      expect(capturedFormData!.get('location_data_snapshot_file')).toBeDefined();
     });
 
     it('should throw error on upload failure', async () => {

--- a/frontend/app/src/composables/filters/assets.spec.ts
+++ b/frontend/app/src/composables/filters/assets.spec.ts
@@ -3,6 +3,7 @@ import type { MaybeRef } from 'vue';
 import type * as Vue from 'vue';
 import type { AssetRequestPayload } from '@/types/asset';
 import type { Collection } from '@/types/collection';
+import { startPromise } from '@shared/utils';
 import flushPromises from 'flush-promises';
 import { afterEach, assertType, beforeAll, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { useAssetManagementApi } from '@/composables/api/assets/management';
@@ -71,7 +72,7 @@ describe('useAssetsFilter', () => {
 
       set(userAction, true);
       await nextTick();
-      fetchData().catch(() => {});
+      startPromise(fetchData());
       expect(get(isLoading)).toBe(true);
       await flushPromises();
       await flushPromises();

--- a/frontend/app/src/composables/filters/blockchain-account.spec.ts
+++ b/frontend/app/src/composables/filters/blockchain-account.spec.ts
@@ -46,7 +46,7 @@ describe('composables/filters/blockchain-account', () => {
 
       const chainMatcher = get(matchers).find(m => m.key === 'chain');
       expect(chainMatcher).toBeDefined();
-      expect('string' in chainMatcher! && chainMatcher.strictMatching).toBeFalsy();
+      expect(chainMatcher!).not.toHaveProperty('strictMatching');
     });
   });
 

--- a/frontend/app/src/composables/history/events/index.spec.ts
+++ b/frontend/app/src/composables/history/events/index.spec.ts
@@ -4,6 +4,7 @@ import type { HistoryEventRequestPayload } from '@/modules/history/events/reques
 import type { Collection } from '@/types/collection';
 import type { HistoryEvent, HistoryEventRow } from '@/types/history/events/schemas';
 import { type Account, Blockchain } from '@rotki/common';
+import { startPromise } from '@shared/utils';
 import flushPromises from 'flush-promises';
 import { afterEach, assertType, beforeAll, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { type Filters, type Matcher, useHistoryEventFilter } from '@/composables/filters/events';
@@ -97,7 +98,7 @@ describe('useHistoryEvents', () => {
 
       set(userAction, true);
       await nextTick();
-      fetchData().catch((): void => {});
+      startPromise(fetchData());
       expect(get(isLoading)).toBe(true);
       await flushPromises();
       await flushPromises();
@@ -238,7 +239,7 @@ describe('useHistoryEvents', () => {
       });
 
       set(userAction, true);
-      fetchData().catch((): void => {});
+      startPromise(fetchData());
       expect(get(isLoading)).toBe(true);
       await flushPromises();
       expect(get(isLoading)).toBe(false);

--- a/frontend/app/src/composables/history/events/use-history-event-navigation.spec.ts
+++ b/frontend/app/src/composables/history/events/use-history-event-navigation.spec.ts
@@ -69,7 +69,7 @@ describe('use-history-event-navigation', () => {
 
     requestNavigation({ targetGroupIdentifier: 'group-1' });
     expect(get(isNavigating)).toBe(true);
-    expect(get(pendingNavigation)).toBeTruthy();
+    expect(get(pendingNavigation)).toBeDefined();
 
     consumeNavigation();
 

--- a/frontend/app/src/composables/scramble.spec.ts
+++ b/frontend/app/src/composables/scramble.spec.ts
@@ -43,7 +43,7 @@ describe('useScramble', () => {
       const result = scrambleAddress(address);
 
       expect(result).not.toEqual(address);
-      expect(isValidEthAddress(result)).toBeTruthy();
+      expect(isValidEthAddress(result)).toBe(true);
     });
 
     it('should scramble identifier', () => {
@@ -52,7 +52,7 @@ describe('useScramble', () => {
       const result = scrambleIdentifier(identifier);
 
       expect(result).not.toEqual(identifier);
-      expect(consistOfNumbers(result)).toBeTruthy();
+      expect(consistOfNumbers(result)).toBe(true);
     });
 
     it('should scramble integer', () => {

--- a/frontend/app/src/composables/session/use-scheduler-state.spec.ts
+++ b/frontend/app/src/composables/session/use-scheduler-state.spec.ts
@@ -18,6 +18,9 @@ vi.mock('@/utils/logging', () => ({
   },
 }));
 
+/** Matches TEN_MINUTES_MS in use-scheduler-state.ts */
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+
 describe('composables::session::use-scheduler-state', () => {
   let scope: EffectScope;
 
@@ -52,7 +55,7 @@ describe('composables::session::use-scheduler-state', () => {
       expect(mockSetSchedulerState).not.toHaveBeenCalled();
 
       // Advance time by 10 minutes
-      vi.advanceTimersByTime(10 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS);
       await flushPromises();
 
       expect(mockSetSchedulerState).toHaveBeenCalledWith(true);
@@ -72,7 +75,7 @@ describe('composables::session::use-scheduler-state', () => {
       scheduler.onBalancesLoaded();
 
       // Advance time by 10 minutes
-      vi.advanceTimersByTime(10 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS);
       await flushPromises();
 
       // Should not call setSchedulerState again
@@ -88,13 +91,13 @@ describe('composables::session::use-scheduler-state', () => {
       scheduler.onBalancesLoaded();
 
       // Advance time partially
-      vi.advanceTimersByTime(5 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS / 2);
 
       // Cancel the timer by calling onHistoryStarted
       scheduler.onHistoryStarted();
 
       // Advance past the original timeout
-      vi.advanceTimersByTime(10 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS);
       await flushPromises();
 
       // Scheduler should not have been enabled via fallback
@@ -126,7 +129,7 @@ describe('composables::session::use-scheduler-state', () => {
       mockSetSchedulerState.mockClear();
 
       // Advance past fallback timeout
-      vi.advanceTimersByTime(10 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS);
       await flushPromises();
 
       // Should not call again
@@ -170,7 +173,7 @@ describe('composables::session::use-scheduler-state', () => {
       scheduler.reset();
 
       // Advance past timeout
-      vi.advanceTimersByTime(10 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS);
       await flushPromises();
 
       expect(mockSetSchedulerState).not.toHaveBeenCalled();
@@ -204,7 +207,7 @@ describe('composables::session::use-scheduler-state', () => {
       scheduler.onBalancesLoaded();
 
       // Advance time by just under 10 minutes
-      vi.advanceTimersByTime(10 * 60 * 1000 - 1);
+      vi.advanceTimersByTime(TEN_MINUTES_MS - 1);
       await flushPromises();
 
       expect(mockSetSchedulerState).not.toHaveBeenCalled();
@@ -223,7 +226,7 @@ describe('composables::session::use-scheduler-state', () => {
 
       scheduler.onBalancesLoaded();
 
-      vi.advanceTimersByTime(10 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS);
       await flushPromises();
 
       expect(logger.error).toHaveBeenCalledWith('Failed to enable task scheduler:', expect.any(Error));
@@ -255,7 +258,7 @@ describe('composables::session::use-scheduler-state', () => {
       scheduler.onBalancesLoaded();
 
       // User never visits history, wait for fallback
-      vi.advanceTimersByTime(10 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS);
       await flushPromises();
 
       expect(mockSetSchedulerState).toHaveBeenCalledWith(true);
@@ -304,7 +307,7 @@ describe('composables::session::use-scheduler-state', () => {
       scheduler.onBalancesLoaded();
 
       // Verify timer was started by checking it fires after 10 minutes
-      vi.advanceTimersByTime(10 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS);
       await flushPromises();
 
       expect(mockSetSchedulerState).toHaveBeenCalledWith(true);
@@ -320,7 +323,7 @@ describe('composables::session::use-scheduler-state', () => {
       scheduler.onHistoryStarted();
 
       // Verify timer was stopped - it should not fire
-      vi.advanceTimersByTime(10 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS);
       await flushPromises();
 
       expect(mockSetSchedulerState).not.toHaveBeenCalled();
@@ -354,7 +357,7 @@ describe('composables::session::use-scheduler-state', () => {
       scheduler.reset();
 
       // Verify timer was stopped
-      vi.advanceTimersByTime(10 * 60 * 1000);
+      vi.advanceTimersByTime(TEN_MINUTES_MS);
       await flushPromises();
       expect(mockSetSchedulerState).not.toHaveBeenCalled();
 

--- a/frontend/app/src/modules/accounts/table/components/table/AccountActions.spec.ts
+++ b/frontend/app/src/modules/accounts/table/components/table/AccountActions.spec.ts
@@ -305,7 +305,7 @@ describe('modules/accounts/table/components/table/AccountActions', () => {
       await rowActions.vm.$emit('edit-click');
 
       const editEvents = wrapper.emitted('edit');
-      expect(editEvents).toBeTruthy();
+      expect(editEvents).toBeDefined();
       expect(editEvents).toHaveLength(1);
       expect(editEvents![0]).toEqual(['evm', row]);
     });
@@ -327,7 +327,7 @@ describe('modules/accounts/table/components/table/AccountActions', () => {
       await rowActions.vm.$emit('delete-click');
 
       const deleteEvents = wrapper.emitted('delete');
-      expect(deleteEvents).toBeTruthy();
+      expect(deleteEvents).toBeDefined();
       expect(deleteEvents).toHaveLength(1);
       expect(deleteEvents![0]).toEqual([row]);
     });

--- a/frontend/app/src/modules/api/transformers.spec.ts
+++ b/frontend/app/src/modules/api/transformers.spec.ts
@@ -6,7 +6,7 @@ describe('transformers', () => {
   it('should transform json to camelCase', () => {
     const json = '{"amount":"10","test_label":"label","data":[{"amount":"2","usd_value":"10"}]}';
     const parsed = JSON.parse(json);
-    expect(camelCaseTransformer(parsed)).toMatchObject({
+    expect(camelCaseTransformer(parsed)).toEqual({
       amount: '10',
       data: [{ amount: '2', usdValue: '10' }],
       testLabel: 'label',
@@ -30,7 +30,7 @@ describe('transformers', () => {
       ETH: 1,
     };
 
-    expect(snakeCaseTransformer(object)).toMatchObject(JSON.parse('{"ETH":1,"BTC":2}'));
+    expect(snakeCaseTransformer(object)).toEqual(JSON.parse('{"ETH":1,"BTC":2}'));
   });
 
   it('should skip nested transformation for specified keys', () => {
@@ -85,7 +85,7 @@ describe('transformers', () => {
     const json = '{"_amount_": { "a_cbc": "1", "a_abc": "2"}}';
     const parsed = JSON.parse(json);
     const transformed = noRootCamelCaseTransformer(parsed);
-    expect(transformed).toMatchObject({
+    expect(transformed).toEqual({
       _amount_: {
         aAbc: '2',
         aCbc: '1',

--- a/frontend/app/src/modules/balances/exchanges/use-binance-savings.spec.ts
+++ b/frontend/app/src/modules/balances/exchanges/use-binance-savings.spec.ts
@@ -3,6 +3,7 @@ import type { MaybeRef } from 'vue';
 import type * as Vue from 'vue';
 import type { Collection } from '@/types/collection';
 import type { ExchangeSavingsCollection, ExchangeSavingsEvent, ExchangeSavingsRequestPayload } from '@/types/exchanges';
+import { startPromise } from '@shared/utils';
 import flushPromises from 'flush-promises';
 import { afterEach, assertType, beforeAll, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { usePaginationFilters } from '@/composables/use-pagination-filter';
@@ -83,7 +84,7 @@ describe('useBinanceSavings', () => {
 
       set(userAction, true);
       await nextTick();
-      fetchData().catch((): void => {});
+      startPromise(fetchData());
       expect(get(isLoading)).toBe(true);
       await flushPromises();
       await flushPromises();

--- a/frontend/app/src/modules/balances/nft/use-nft-balances.spec.ts
+++ b/frontend/app/src/modules/balances/nft/use-nft-balances.spec.ts
@@ -3,6 +3,7 @@ import type * as Vue from 'vue';
 import type { Collection } from '@/types/collection';
 import type { NonFungibleBalance, NonFungibleBalancesRequestPayload } from '@/types/nfbalances';
 import type { LocationQuery } from '@/types/route';
+import { startPromise } from '@shared/utils';
 import flushPromises from 'flush-promises';
 import { afterEach, assertType, beforeAll, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { usePaginationFilters } from '@/composables/use-pagination-filter';
@@ -82,7 +83,7 @@ describe('useNftBalances', () => {
 
       set(userAction, true);
       await nextTick();
-      fetchData().catch((): void => {});
+      startPromise(fetchData());
       expect(get(isLoading)).toBe(true);
       await flushPromises();
       expect(get(state).total).toBe(30);

--- a/frontend/app/src/modules/history/management/forms/EthBlockEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EthBlockEventForm.spec.ts
@@ -121,7 +121,7 @@ describe('forms/EthBlockEventForm.vue', () => {
     expect(blockNumberInput.element.value).toBe('');
     expect(validatorIndexInput.element.value).toBe('');
     expect(feeRecipientInput.element.value).toBe('');
-    expect(mevRewardCheckbox.element.checked).toBeFalsy();
+    expect(mevRewardCheckbox.element.checked).toBe(false);
   });
 
   it('should update the relevant fields when adding an event to a group', async () => {
@@ -139,7 +139,7 @@ describe('forms/EthBlockEventForm.vue', () => {
     expect(validatorIndexInput.element.value).toBe(event.validatorIndex.toString());
     expect(feeRecipientInput.element.value).toBe(event.locationLabel);
     expect(amountInput.element.value).toBe('0');
-    expect(isMevCheckbox.element.checked).toBeFalsy();
+    expect(isMevCheckbox.element.checked).toBe(false);
   });
 
   it('should update the fields when editing an event', async () => {
@@ -157,7 +157,7 @@ describe('forms/EthBlockEventForm.vue', () => {
     expect(validatorIndexInput.element.value).toBe(event.validatorIndex.toString());
     expect(feeRecipientInput.element.value).toBe(event.locationLabel);
     expect(amountInput.element.value).toBe(event.amount.toString());
-    expect(isMevCheckbox.element.checked).toBeTruthy();
+    expect(isMevCheckbox.element.checked).toBe(true);
   });
 
   it('should call addHistoryEvent when adding a new block event on save', async () => {

--- a/frontend/app/src/modules/history/management/forms/EthWithdrawalEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EthWithdrawalEventForm.spec.ts
@@ -132,7 +132,7 @@ describe('forms/EthWithdrawalEventForm.vue', () => {
 
     expect(validatorIndexInput.element.value).toBe('');
     expect(withdrawalAddressInput.element.value).toBe('');
-    expect(isExitCheckbox.element.checked).toBeFalsy();
+    expect(isExitCheckbox.element.checked).toBe(false);
   });
 
   it('should update the fields when adding an event in an existing group', async () => {
@@ -148,7 +148,7 @@ describe('forms/EthWithdrawalEventForm.vue', () => {
     expect(validatorIndexInput.element.value).toBe(event.validatorIndex.toString());
     expect(withdrawalAddressInput.element.value).toBe(event.locationLabel);
     expect(amountInput.element.value).toBe('0');
-    expect(isExitedCheckbox.element.checked).toBeFalsy();
+    expect(isExitedCheckbox.element.checked).toBe(false);
   });
 
   it('should update the fields when editing an event', async () => {
@@ -164,7 +164,7 @@ describe('forms/EthWithdrawalEventForm.vue', () => {
     expect(validatorIndexInput.element.value).toBe(event.validatorIndex.toString());
     expect(withdrawalAddressInput.element.value).toBe(event.locationLabel);
     expect(amountInput.element.value).toBe(event.amount.toString());
-    expect(isExitedCheckbox.element.checked).toBeTruthy();
+    expect(isExitedCheckbox.element.checked).toBe(true);
   });
 
   it('should add a new withdrawal event when form is submitted', async () => {

--- a/frontend/app/src/modules/history/management/forms/EvmEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EvmEventForm.spec.ts
@@ -236,7 +236,7 @@ describe('forms/EvmEventForm.vue', () => {
     expect(spans).toHaveLength(keysFromGlobalMappings.length);
 
     for (let i = 0; i < keysFromGlobalMappings.length; i++)
-      expect(keysFromGlobalMappings.includes(spans.at(i)!.text())).toBeTruthy();
+      expect(keysFromGlobalMappings).toContain(spans.at(i)!.text());
   });
 
   it('should add a new evm event when form is submitted', async () => {

--- a/frontend/app/src/modules/history/management/forms/OnlineHistoryEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/OnlineHistoryEventForm.spec.ts
@@ -222,7 +222,7 @@ describe('forms/OnlineHistoryEventForm.vue', () => {
     expect(spans).toHaveLength(keysFromGlobalMappings.length);
 
     for (let i = 0; i < keysFromGlobalMappings.length; i++)
-      expect(keysFromGlobalMappings.includes(spans.at(i)!.text())).toBeTruthy();
+      expect(keysFromGlobalMappings).toContain(spans.at(i)!.text());
   });
 
   it('should add a new online event', async () => {

--- a/frontend/app/src/modules/history/management/forms/SolanaEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/SolanaEventForm.spec.ts
@@ -237,7 +237,7 @@ describe('forms/SolanaEventForm.vue', () => {
     expect(spans).toHaveLength(keysFromGlobalMappings.length);
 
     for (let i = 0; i < keysFromGlobalMappings.length; i++)
-      expect(keysFromGlobalMappings.includes(spans.at(i)!.text())).toBeTruthy();
+      expect(keysFromGlobalMappings).toContain(spans.at(i)!.text());
   });
 
   it('should add a new solana event when form is submitted', async () => {

--- a/frontend/app/src/modules/history/management/forms/history-event-form.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/history-event-form.spec.ts
@@ -63,7 +63,7 @@ describe('component/HistoryEventForm.vue', () => {
     const entryTypeElement = entryTypeInput.element;
 
     expect(entryTypeElement.value).toBe(HistoryEventEntryType.HISTORY_EVENT);
-    expect(wrapper.find('[data-cy=history-event-form]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-cy=history-event-form]').exists()).toBe(true);
   });
 
   it.each(formTypesYouCanAddTo)('changes to proper form %s', async (value: string) => {
@@ -81,7 +81,7 @@ describe('component/HistoryEventForm.vue', () => {
     }
 
     const id = value.split(/ /g).join('-');
-    expect(wrapper.find(`[data-cy=${id}-form]`).exists(), `id: ${id}`).toBeTruthy();
+    expect(wrapper.find(`[data-cy=${id}-form]`).exists(), `id: ${id}`).toBe(true);
   });
 
   it('should only allow two options on an existing transaction', async () => {

--- a/frontend/app/src/modules/prices/use-price-refresh.spec.ts
+++ b/frontend/app/src/modules/prices/use-price-refresh.spec.ts
@@ -1,6 +1,7 @@
 import { bigNumberify, Blockchain } from '@rotki/common';
 import { createTestBalance, createTestManualBalance, createTestPriceInfo } from '@test/utils/create-data';
 import { updateGeneralSettings } from '@test/utils/general-settings';
+import flushPromises from 'flush-promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRADE_LOCATION_BANKS } from '@/data/defaults';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
@@ -205,15 +206,10 @@ describe('usePriceRefresh', () => {
       const { refreshPrice, refreshPrices } = usePriceRefresh();
 
       // Configure mock for execution order tracking
-      mockFetchPrices.mockImplementation(async (params: any) =>
-        // Add a small delay to simulate async operation
-        new Promise((resolve) => {
-          setTimeout(() => {
-            executionOrder.push(params.selectedAssets.join(','));
-            resolve({});
-          }, 10);
-        }),
-      );
+      mockFetchPrices.mockImplementation(async (params: any) => {
+        executionOrder.push(params.selectedAssets.join(','));
+        return {};
+      });
 
       // Fire multiple requests simultaneously
       const promise1 = refreshPrice('BTC');
@@ -250,14 +246,15 @@ describe('usePriceRefresh', () => {
     });
 
     it('should not start multiple queue processors simultaneously', async () => {
+      vi.useFakeTimers();
       const { refreshPrices } = usePriceRefresh();
 
-      // Configure mock to track concurrent executions
+      // Configure mock to track concurrent executions with fake-timer delays
       mockFetchPrices.mockImplementation(async () => {
         processingCount++;
         maxConcurrent = Math.max(maxConcurrent, processingCount);
 
-        return new Promise((resolve) => {
+        return new Promise<Record<string, never>>((resolve) => {
           setTimeout(() => {
             processingCount--;
             resolve({});
@@ -273,7 +270,14 @@ describe('usePriceRefresh', () => {
         refreshPrices(false, ['USDT']),
       ];
 
+      // Advance fake timers to process all queued requests
+      for (let i = 0; i < 4; i++) {
+        await vi.advanceTimersByTimeAsync(20);
+        await flushPromises();
+      }
+
       await Promise.all(promises);
+      vi.useRealTimers();
 
       // Should never have more than 1 concurrent execution
       expect(maxConcurrent).toBe(1);

--- a/frontend/app/src/modules/sync-progress/components/SyncProgressHeader.spec.ts
+++ b/frontend/app/src/modules/sync-progress/components/SyncProgressHeader.spec.ts
@@ -224,7 +224,7 @@ describe('modules/sync-progress/components/SyncProgressHeader', () => {
 
       await wrapper.trigger('click');
 
-      expect(wrapper.emitted('toggle')).toBeTruthy();
+      expect(wrapper.emitted('toggle')).toBeDefined();
     });
   });
 
@@ -252,7 +252,7 @@ describe('modules/sync-progress/components/SyncProgressHeader', () => {
       const dismissButton = wrapper.find('[data-testid="button"]');
       await dismissButton.trigger('click');
 
-      expect(wrapper.emitted('dismiss')).toBeTruthy();
+      expect(wrapper.emitted('dismiss')).toBeDefined();
     });
   });
 

--- a/frontend/app/src/pages/api-keys/external/index.spec.ts
+++ b/frontend/app/src/pages/api-keys/external/index.spec.ts
@@ -254,7 +254,7 @@ describe('external-services', () => {
       await flushPromises();
 
       expect(mock).toHaveBeenCalledWith('etherscan');
-      expect(confirmStore.visible).toBeFalsy();
+      expect(confirmStore.visible).toBe(false);
     });
 
     it('should fail deleting cryptocompare key', async () => {
@@ -277,7 +277,7 @@ describe('external-services', () => {
       await flushPromises();
 
       expect(mock).toHaveBeenCalledWith('cryptocompare');
-      expect(confirmStore.visible).toBeFalsy();
+      expect(confirmStore.visible).toBe(false);
 
       const message = wrapper
         .find('[data-cy=bottom-dialog] [data-cy=cryptocompare] [data-cy=service-key__content] .details')

--- a/frontend/app/src/store/confirm.spec.ts
+++ b/frontend/app/src/store/confirm.spec.ts
@@ -23,13 +23,13 @@ describe('useConfirmStore', () => {
     const { show } = store;
     const { visible, confirmation } = storeToRefs(store);
 
-    expect(get(visible)).toBeFalsy();
+    expect(get(visible)).toBe(false);
     expect(get(confirmation).title).toBe('');
     expect(get(confirmation).message).toBe('');
 
     show(confirmationMessage, () => {});
 
-    expect(get(visible)).toBeTruthy();
+    expect(get(visible)).toBe(true);
     expect(get(confirmation).title).toBe(title);
     expect(get(confirmation).message).toBe(message);
   });
@@ -42,17 +42,17 @@ describe('useConfirmStore', () => {
     const { show, confirm } = store;
     const { visible, confirmation } = storeToRefs(store);
 
-    expect(get(visible)).toBeFalsy();
+    expect(get(visible)).toBe(false);
 
     const onConfirm = vi.fn();
     show(confirmationMessage, onConfirm);
 
-    expect(get(visible)).toBeTruthy();
+    expect(get(visible)).toBe(true);
 
     // should call confirm callback
     await confirm();
 
-    expect(get(visible)).toBeFalsy();
+    expect(get(visible)).toBe(false);
     expect(onConfirm).toBeCalledTimes(1);
 
     vi.runAllTimers();
@@ -73,17 +73,17 @@ describe('useConfirmStore', () => {
     const { show, dismiss } = store;
     const { visible, confirmation } = storeToRefs(store);
 
-    expect(get(visible)).toBeFalsy();
+    expect(get(visible)).toBe(false);
 
     const onDismiss = vi.fn();
     show(confirmationMessage, () => {}, onDismiss);
 
-    expect(get(visible)).toBeTruthy();
+    expect(get(visible)).toBe(true);
 
     // should call dismiss callback
     await dismiss();
 
-    expect(get(visible)).toBeFalsy();
+    expect(get(visible)).toBe(false);
     expect(onDismiss).toBeCalledTimes(1);
 
     vi.runAllTimers();

--- a/frontend/app/src/store/notifications/index.spec.ts
+++ b/frontend/app/src/store/notifications/index.spec.ts
@@ -2,6 +2,9 @@ import { NotificationCategory, NotificationGroup, type NotificationPayload, Prio
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useNotificationsStore } from '@/store/notifications';
 
+/** Matches NOTIFICATION_COOLDOWN_MS in store/notifications/index.ts */
+const NOTIFICATION_COOLDOWN_MS = 60_000;
+
 describe('useNotificationsStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -76,7 +79,7 @@ describe('useNotificationsStore', () => {
       },
     ]);
 
-    vi.advanceTimersByTime(60_000);
+    vi.advanceTimersByTime(NOTIFICATION_COOLDOWN_MS);
 
     notify({
       title: 'notification-title-1',
@@ -110,7 +113,7 @@ describe('useNotificationsStore', () => {
     });
 
     displayed([1]);
-    vi.advanceTimersByTime(60_000);
+    vi.advanceTimersByTime(NOTIFICATION_COOLDOWN_MS);
     expect(get(data)[0].display).toBe(false);
     await nextTick();
     const sessionKey = sessionStorage.getItem('rotki.notification.last_display') ?? '{}';
@@ -166,7 +169,7 @@ describe('useNotificationsStore', () => {
       message: 'notification-message-1',
     });
 
-    vi.advanceTimersByTime(60_000);
+    vi.advanceTimersByTime(NOTIFICATION_COOLDOWN_MS);
 
     // add low priority notification (mostly legacy)
     notify({

--- a/frontend/app/src/store/prices/historic.spec.ts
+++ b/frontend/app/src/store/prices/historic.spec.ts
@@ -12,6 +12,9 @@ vi.mock('@/store/tasks', () => ({
   }),
 }));
 
+/** Exceeds CACHE_EXPIRY (10 min) from item-cache.ts to ensure cache invalidation */
+const PAST_CACHE_EXPIRY_MS = 1000 * 60 * 11;
+
 describe('useHistoricPricesStore', () => {
   let store: ReturnType<typeof useHistoricCachePriceStore>;
 
@@ -67,7 +70,7 @@ describe('useHistoricPricesStore', () => {
     expect(usePriceApi().queryHistoricalRates).toHaveBeenCalledOnce();
     expect(get(firstRetrieval)).toBeNull();
     expect(get(secondRetrieval)).toBeNull();
-    vi.advanceTimersByTime(1000 * 60 * 11);
+    vi.advanceTimersByTime(PAST_CACHE_EXPIRY_MS);
     const thirdRetrieval: ComputedRef<BigNumber | null> = store.retrieve(key);
     vi.advanceTimersToNextTimer();
     await flushPromises();
@@ -96,7 +99,7 @@ describe('useHistoricPricesStore', () => {
     await flushPromises();
     expect(usePriceApi().queryHistoricalRates).toHaveBeenCalledOnce();
     expect(get(firstRetrieval)).toEqual(bigNumberify(mockPrice));
-    vi.advanceTimersByTime(1000 * 60 * 11);
+    vi.advanceTimersByTime(PAST_CACHE_EXPIRY_MS);
     const secondRetrieval: ComputedRef<BigNumber | null> = store.retrieve(key);
     vi.advanceTimersToNextTimer();
     await flushPromises();

--- a/frontend/app/src/store/session/queried-addresses.spec.ts
+++ b/frontend/app/src/store/session/queried-addresses.spec.ts
@@ -35,7 +35,7 @@ describe('useQueriedAddressesStore', () => {
     await store.fetchQueriedAddresses();
     expect(api.queriedAddresses).toHaveBeenCalledTimes(1);
     expect(store.queriedAddresses).toMatchObject({});
-    expect(messageStore.message?.description).toBeTruthy();
+    expect(messageStore.message?.description).toBeDefined();
   });
 
   it('should add queried address', async () => {
@@ -65,7 +65,7 @@ describe('useQueriedAddressesStore', () => {
     await store.addQueriedAddress(payload);
     expect(api.addQueriedAddress).toHaveBeenCalledWith(payload);
     expect(store.queriedAddresses).toMatchObject({});
-    expect(messageStore.message?.description).toBeTruthy();
+    expect(messageStore.message?.description).toBeDefined();
   });
 
   it('should delete queried address', async () => {
@@ -103,6 +103,6 @@ describe('useQueriedAddressesStore', () => {
     await store.deleteQueriedAddress(payload);
     expect(api.deleteQueriedAddress).toHaveBeenCalledWith(payload);
     expect(store.queriedAddresses).toMatchObject(originalState);
-    expect(messageStore.message?.description).toBeTruthy();
+    expect(messageStore.message?.description).toBeDefined();
   });
 });


### PR DESCRIPTION
- Replace floating promises .catch(() => {}) with startPromise()
- Replace toBeTruthy()/toBeFalsy() with precise assertions (.toBe(true), .toBe(false), .toBeDefined(), .toContain(), etc.)
- Replace overly broad toMatchObject with toEqual in transformers
- Extract magic timer values to named constants (TEN_MINUTES_MS, NOTIFICATION_COOLDOWN_MS, PAST_CACHE_EXPIRY_MS)
- Replace real setTimeout in mocks with fake timers in use-price-refresh.spec.ts

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
