### PR TITLE
refactor(frontend): fix Vue/TS lint warnings

### DIFF
--- a/frontend/app/src/components/account-management/login/WelcomeMessageDisplay.vue
+++ b/frontend/app/src/components/account-management/login/WelcomeMessageDisplay.vue
@@ -7,15 +7,15 @@ import FadeTransition from '@/components/helper/FadeTransition.vue';
 import { useRandomStepper } from '@/composables/random-stepper';
 import { logger } from '@/utils/logging';
 
-const props = defineProps<{
+const { messages } = defineProps<{
   messages: WelcomeMessage[];
 }>();
 
 const svg = ref<string>();
 
-const { onNavigate, onPause, onResume, step, steps } = useRandomStepper(props.messages.length);
+const { onNavigate, onPause, onResume, step, steps } = useRandomStepper(messages.length);
 
-const activeItem = computed(() => props.messages[get(step) - 1]);
+const activeItem = computed(() => messages[get(step) - 1]);
 
 async function fetchSvg(): Promise<string | null> {
   const url = get(activeItem).icon;

--- a/frontend/app/src/components/accounts/AccountBalances.vue
+++ b/frontend/app/src/components/accounts/AccountBalances.vue
@@ -30,7 +30,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const visibleTags = ref<string[]>([]);
 const chainExclusionFilter = ref<Record<string, string[]>>({});
-const expandedRowContent = ref<ComponentExposed<typeof AccountExpandedRowContent>>();
+const expandedRowContent = useTemplateRef<ComponentExposed<typeof AccountExpandedRowContent>>('expandedRowContent');
 const tab = ref<number>(0);
 const expanded = ref<string[]>([]);
 const query = ref<LocationQuery>({});

--- a/frontend/app/src/components/accounts/AccountChains.vue
+++ b/frontend/app/src/components/accounts/AccountChains.vue
@@ -7,20 +7,17 @@ type Row = ({ chain: string } | { chains: string[] }) & { id: string };
 
 const chainFilter = defineModel<Record<string, string[]>>('chainFilter', { required: true });
 
-const props = defineProps<{ row: Row }>();
+const { row } = defineProps<{ row: Row }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
-const chains = computed<string[]>(() => {
-  const row = props.row;
-  return 'chains' in row ? row.chains : [row.chain];
-});
+const chains = computed<string[]>(() => 'chains' in row ? row.chains : [row.chain]);
 
 const { getChainName } = useSupportedChains();
 
 const chainStatus = computed<{ chain: string; enabled: boolean }[]>(() => {
   const activated = get(chains);
-  const filter = get(chainFilter)[props.row.id] ?? [];
+  const filter = get(chainFilter)[row.id] ?? [];
   return activated.map(chain => ({ chain, enabled: !filter.includes(chain) })).reverse();
 });
 
@@ -28,20 +25,20 @@ function updateChain(chain: string, enabled: boolean) {
   if (!(get(chains).length > 1))
     return;
 
-  const currentFilter = get(chainFilter)[props.row.id] ?? [];
+  const currentFilter = get(chainFilter)[row.id] ?? [];
   if (!enabled) {
     set(chainFilter, {
       ...get(chainFilter),
-      [props.row.id]: [...currentFilter, chain].filter(uniqueStrings),
+      [row.id]: [...currentFilter, chain].filter(uniqueStrings),
     });
   }
   else {
     const updatedFilter = { ...get(chainFilter) };
     const excluded = currentFilter.filter(entry => entry !== chain);
     if (excluded.length === 0)
-      delete updatedFilter[props.row.id];
+      delete updatedFilter[row.id];
     else
-      updatedFilter[props.row.id] = excluded;
+      updatedFilter[row.id] = excluded;
 
     set(chainFilter, updatedFilter);
   }
@@ -52,7 +49,7 @@ const anyDisabled = computed(() => get(chainStatus).some(item => !item.enabled))
 function reset() {
   set(chainFilter, {
     ...get(chainFilter),
-    [props.row.id]: [],
+    [row.id]: [],
   });
 }
 </script>

--- a/frontend/app/src/components/accounts/AccountExpandedRowContent.vue
+++ b/frontend/app/src/components/accounts/AccountExpandedRowContent.vue
@@ -24,7 +24,7 @@ const emit = defineEmits<{
   edit: [account: AccountManageState];
 }>();
 
-const detailsTable = ref<ComponentExposed<typeof AccountGroupDetailsTable>>();
+const detailsTable = useTemplateRef<ComponentExposed<typeof AccountGroupDetailsTable>>('detailsTable');
 
 async function refresh(): Promise<void> {
   if (!isDefined(detailsTable))

--- a/frontend/app/src/components/accounts/IconTokenDisplay.vue
+++ b/frontend/app/src/components/accounts/IconTokenDisplay.vue
@@ -7,7 +7,6 @@ import { useFrontendSettingsStore } from '@/store/settings/frontend';
 
 const { assets, visible = 3 } = defineProps<{
   assets: AssetBalance[];
-  loading: boolean;
   visible?: number;
   resolutionOptions?: AssetResolutionOptions;
   showChain?: boolean;

--- a/frontend/app/src/components/accounts/ModuleActivator.vue
+++ b/frontend/app/src/components/accounts/ModuleActivator.vue
@@ -7,14 +7,16 @@ import { useQueriedAddressesStore } from '@/store/session/queried-addresses';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { type Module, SUPPORTED_MODULES } from '@/types/modules';
 
-const emit = defineEmits(['update:selection']);
+const emit = defineEmits<{
+  'update:selection': [modules: Module[]];
+}>();
 
 const enabledModules = ref<Module[]>([]);
 const { activeModules } = storeToRefs(useGeneralSettingsStore());
 const queriedAddressesStore = useQueriedAddressesStore();
 const { queriedAddresses } = storeToRefs(queriedAddressesStore);
 
-function updateSelection(modules: string[]) {
+function updateSelection(modules: Module[]) {
   emit('update:selection', modules);
 }
 

--- a/frontend/app/src/components/accounts/balances/DetectTokensChainsSelectionItem.vue
+++ b/frontend/app/src/components/accounts/balances/DetectTokensChainsSelectionItem.vue
@@ -4,7 +4,7 @@ import LocationIcon from '@/components/history/LocationIcon.vue';
 import { useTaskStore } from '@/store/tasks';
 import { TaskType } from '@/types/task-type';
 
-const props = defineProps<{
+const { item } = defineProps<{
   item: EvmChainInfo;
   detecting: boolean;
   enabled: boolean;
@@ -20,7 +20,7 @@ const { useIsTaskRunning } = useTaskStore();
 const { t } = useI18n({ useScope: 'global' });
 
 const taskMeta = computed(() => ({
-  chain: props.item.id,
+  chain: item.id,
 }));
 
 const isDetectingChain = useIsTaskRunning(TaskType.FETCH_DETECTED_TOKENS, taskMeta);

--- a/frontend/app/src/components/accounts/management/AccountForm.vue
+++ b/frontend/app/src/components/accounts/management/AccountForm.vue
@@ -35,11 +35,11 @@ defineProps<{
 
 const inputMode = ref<InputMode>(InputMode.MANUAL_ADD);
 
-const form = ref<
+const form = useTemplateRef<
   | InstanceType<typeof AddressAccountForm>
   | InstanceType<typeof ValidatorAccountForm>
   | InstanceType<typeof XpubAccountForm>
->();
+>('form');
 
 const chain = useRefPropVModel(modelValue, 'chain');
 

--- a/frontend/app/src/components/accounts/management/AccountFormApiKeyAlertContent.vue
+++ b/frontend/app/src/components/accounts/management/AccountFormApiKeyAlertContent.vue
@@ -2,20 +2,20 @@
 import type { RouteLocationRaw } from 'vue-router';
 import { Routes } from '@/router/routes';
 
-const props = defineProps<{
+const { service } = defineProps<{
   service: 'etherscan' | 'helius' | 'beaconchain' | 'consensusRpc';
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
 const message = computed<string>(() => {
-  if (props.service === 'etherscan')
+  if (service === 'etherscan')
     return t('external_services.etherscan.api_key_message');
 
-  if (props.service === 'consensusRpc')
+  if (service === 'consensusRpc')
     return t('general_settings.rpc_node_setting.consensus_rpc.api_key_message');
 
-  if (props.service === 'beaconchain')
+  if (service === 'beaconchain')
     return t('external_services.beaconchain.api_key_message');
 
   return t('external_services.helius.api_key_message');

--- a/frontend/app/src/components/accounts/management/inputs/InputModeSelect.vue
+++ b/frontend/app/src/components/accounts/management/inputs/InputModeSelect.vue
@@ -7,7 +7,7 @@ import { isOfEnum } from '@/utils';
 
 const inputMode = defineModel<InputMode>('inputMode', { required: true });
 
-const props = defineProps<{
+const { blockchain } = defineProps<{
   blockchain: string;
 }>();
 
@@ -21,7 +21,7 @@ const internalValue = computed<string>({
   },
 });
 
-const isBitcoin = computed<boolean>(() => isBtcChain(props.blockchain));
+const isBitcoin = computed<boolean>(() => isBtcChain(blockchain));
 const isXpub = computed<boolean>(() => get(inputMode) === InputMode.XPUB_ADD);
 
 const { t } = useI18n({ useScope: 'global' });

--- a/frontend/app/src/components/accounts/management/types/AddressAccountForm.vue
+++ b/frontend/app/src/components/accounts/management/types/AddressAccountForm.vue
@@ -26,7 +26,9 @@ const editMode = computed(() => get(modelValue).mode === 'edit');
 const tags = computed<string[]>({
   get() {
     const model = get(modelValue);
-    return (model.mode === 'edit' ? model.data.tags : model.data.length > 0 ? model.data[0].tags : null) ?? [];
+    if (model.mode === 'edit')
+      return model.data.tags ?? [];
+    return (model.data.length > 0 ? model.data[0].tags : null) ?? [];
   },
   set(tags: string[]) {
     const model = get(modelValue);
@@ -52,7 +54,9 @@ const tags = computed<string[]>({
 const label = computed<string>({
   get() {
     const model = get(modelValue);
-    return (model.mode === 'edit' ? model.data.label : model.data.length > 0 ? model.data[0].label : null) ?? '';
+    if (model.mode === 'edit')
+      return model.data.label ?? '';
+    return (model.data.length > 0 ? model.data[0].label : null) ?? '';
   },
   set(label: string) {
     const model = get(modelValue);

--- a/frontend/app/src/components/accounts/management/types/ValidatorAccountForm.vue
+++ b/frontend/app/src/components/accounts/management/types/ValidatorAccountForm.vue
@@ -18,7 +18,7 @@ defineProps<{
 
 const validator = useRefPropVModel(modelValue, 'data');
 
-const input = ref<ComponentExposed<typeof Eth2Input>>();
+const input = useTemplateRef<ComponentExposed<typeof Eth2Input>>('input');
 
 function validate(): Promise<boolean> {
   assert(isDefined(input));

--- a/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
+++ b/frontend/app/src/components/accounts/manual-balances/ManualBalanceTable.vue
@@ -26,7 +26,6 @@ const { title, type } = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  refresh: [];
   edit: [value: ManualBalance];
 }>();
 

--- a/frontend/app/src/components/asset-manager/custom/CustomAssetForm.vue
+++ b/frontend/app/src/components/asset-manager/custom/CustomAssetForm.vue
@@ -14,7 +14,6 @@ const errors = defineModel<ValidationErrors>('errorMessages', { required: true }
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
 const { types } = defineProps<{
-  editMode?: boolean;
   types: string[];
 }>();
 

--- a/frontend/app/src/components/asset-manager/managed/ManagedAssetFormDialog.vue
+++ b/frontend/app/src/components/asset-manager/managed/ManagedAssetFormDialog.vue
@@ -10,7 +10,7 @@ import { ApiValidationError } from '@/types/api/errors';
 
 const modelValue = defineModel<SupportedAsset | undefined>({ required: true });
 
-const props = defineProps<{
+const { editMode } = defineProps<{
   editMode: boolean;
   assetTypes: string[];
 }>();
@@ -27,7 +27,7 @@ const form = useTemplateRef<InstanceType<typeof ManagedAssetForm>>('form');
 const stateUpdated = ref(false);
 
 const dialogTitle = computed<string>(() =>
-  props.editMode ? t('asset_management.edit_title') : t('asset_management.add_title'),
+  editMode ? t('asset_management.edit_title') : t('asset_management.add_title'),
 );
 
 const { setMessage } = useMessageStore();
@@ -120,7 +120,7 @@ async function save(): Promise<boolean> {
     if (typeof errors === 'string') {
       setMessage({
         description: errors,
-        title: props.editMode ? t('asset_form.edit_error') : t('asset_form.add_error'),
+        title: editMode ? t('asset_form.edit_error') : t('asset_form.add_error'),
       });
     }
     else {

--- a/frontend/app/src/components/calendar/CalendarFormDialog.vue
+++ b/frontend/app/src/components/calendar/CalendarFormDialog.vue
@@ -10,7 +10,7 @@ import { ApiValidationError } from '@/types/api/errors';
 
 const modelValue = defineModel<CalendarEvent | undefined>({ required: true });
 
-const props = defineProps<{
+const { editMode } = defineProps<{
   editMode: boolean;
   loading: boolean;
 }>();
@@ -40,7 +40,6 @@ async function save() {
     return false;
 
   const data = get(modelValue);
-  const editMode = props.editMode;
   const payload = {
     ...data,
   };
@@ -89,7 +88,7 @@ async function save() {
 }
 
 const dialogTitle = computed<string>(() =>
-  props.editMode ? t('calendar.dialog.edit.title') : t('calendar.dialog.add.title'),
+  editMode ? t('calendar.dialog.edit.title') : t('calendar.dialog.add.title'),
 );
 </script>
 

--- a/frontend/app/src/components/calendar/CalendarReminder.vue
+++ b/frontend/app/src/components/calendar/CalendarReminder.vue
@@ -8,7 +8,7 @@ import { logger } from '@/utils/logging';
 
 const modelValue = defineModel<CalendarEvent>({ required: true });
 
-const props = defineProps<{
+const { editMode } = defineProps<{
   editMode: boolean;
 }>();
 
@@ -71,7 +71,7 @@ async function addCalendarReminderHandler(reminders: CalenderReminderPayload[]) 
 }
 
 async function refreshTemporaryData() {
-  if (!props.editMode) {
+  if (!editMode) {
     return;
   }
   const item = get(modelValue);
@@ -108,7 +108,7 @@ async function addReminder(secsBefore: number = 900, inTimeReminder = false) {
 
   const item = get(modelValue);
 
-  if (!props.editMode || isSameSecsBeforeExist(secsBefore) || inTimeReminder) {
+  if (!editMode || isSameSecsBeforeExist(secsBefore) || inTimeReminder) {
     const newId = Date.now();
     const newData: CalendarReminderTemporaryPayload = {
       identifier: newId,
@@ -140,7 +140,7 @@ async function deleteData(index: number) {
   const temp = [...get(temporaryData)];
   const data = temp[index];
 
-  if (!data.isTemporary && props.editMode) {
+  if (!data.isTemporary && editMode) {
     try {
       await deleteCalendarReminder(data.identifier);
     }
@@ -167,7 +167,7 @@ async function updateData(index: number, { secsBefore }: CalendarReminderTempora
   const temp = [...get(temporaryData)];
   const data = temp[index];
 
-  if (props.editMode) {
+  if (editMode) {
     if (!data.isTemporary) {
       try {
         await editCalendarReminder({

--- a/frontend/app/src/components/calendar/CalendarUpcomingEventList.vue
+++ b/frontend/app/src/components/calendar/CalendarUpcomingEventList.vue
@@ -7,7 +7,7 @@ import DateDisplay from '@/components/display/DateDisplay.vue';
 
 const selectedDate = defineModel<Dayjs>('selectedDate', { required: true });
 
-const props = defineProps<{
+const { events } = defineProps<{
   events: CalendarEvent[];
   visibleDate: Dayjs;
 }>();
@@ -18,7 +18,7 @@ const emit = defineEmits<{
 
 const groupedEvents = computed(() => {
   const grouped: Record<string, CalendarEvent[]> = {};
-  props.events.forEach((event) => {
+  events.forEach((event) => {
     const date = dayjs(event.timestamp * 1000).format('YYYY-MM-DD');
     if (!grouped[date]) {
       grouped[date] = [];

--- a/frontend/app/src/components/common/MerchantIcon.vue
+++ b/frontend/app/src/components/common/MerchantIcon.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { RuiIcons } from '@rotki/ui-library';
 
-const props = defineProps<{
+const { code } = defineProps<{
   code: string;
 }>();
 
@@ -32,7 +32,7 @@ const mccIconMap: Record<string, RuiIcons> = {
 
 const DEFAULT_ICON = 'lu-store';
 
-const iconName = computed<string>(() => mccIconMap[props.code] ?? DEFAULT_ICON);
+const iconName = computed<string>(() => mccIconMap[code] ?? DEFAULT_ICON);
 </script>
 
 <template>

--- a/frontend/app/src/components/dashboard/DynamicMessageDisplay.vue
+++ b/frontend/app/src/components/dashboard/DynamicMessageDisplay.vue
@@ -4,7 +4,7 @@ import ExternalLink from '@/components/helper/ExternalLink.vue';
 import FadeTransition from '@/components/helper/FadeTransition.vue';
 import { useRandomStepper } from '@/composables/random-stepper';
 
-const props = defineProps<{
+const { messages } = defineProps<{
   messages: DashboardMessage[];
 }>();
 
@@ -12,9 +12,9 @@ const emit = defineEmits<{
   dismiss: [];
 }>();
 
-const { onNavigate, onPause, onResume, step, steps } = useRandomStepper(props.messages.length);
+const { onNavigate, onPause, onResume, step, steps } = useRandomStepper(messages.length);
 
-const activeItem = computed<DashboardMessage>(() => props.messages[get(step) - 1]);
+const activeItem = computed<DashboardMessage>(() => messages[get(step) - 1]);
 </script>
 
 <template>

--- a/frontend/app/src/components/defi/ActiveModules.vue
+++ b/frontend/app/src/components/defi/ActiveModules.vue
@@ -32,7 +32,11 @@ const moduleStatus = computed(() => {
       enabled: active.includes(module),
       identifier: module,
     }))
-    .sort((a, b) => (a.enabled === b.enabled ? 0 : a.enabled ? -1 : 1));
+    .sort((a, b) => {
+      if (a.enabled === b.enabled)
+        return 0;
+      return a.enabled ? -1 : 1;
+    });
 });
 
 function onModulePress(module: ModuleWithStatus) {

--- a/frontend/app/src/components/graphs/MissingDailyPrices.vue
+++ b/frontend/app/src/components/graphs/MissingDailyPrices.vue
@@ -11,7 +11,7 @@ import { useHistoricCachePriceStore } from '@/store/prices/historic';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { ApiValidationError } from '@/types/api/errors';
 
-const props = defineProps<{
+const { asset } = defineProps<{
   asset: string;
 }>();
 
@@ -35,9 +35,9 @@ const { resetHistoricalPricesData } = store;
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 const { addHistoricalPrice, deleteHistoricalPrice, editHistoricalPrice, fetchHistoricalPrices } = useAssetPricesApi();
 
-const name = assetName(props.asset);
+const name = assetName(asset);
 
-const failedPrices = computed<FailedHistoricalAssetPriceResponse>(() => get(failedDailyPrices)[props.asset]);
+const failedPrices = computed<FailedHistoricalAssetPriceResponse>(() => get(failedDailyPrices)[asset]);
 
 const headers = computed<DataTableColumn<EditableMissingPrice>[]>(() => [
   {
@@ -52,7 +52,7 @@ const headers = computed<DataTableColumn<EditableMissingPrice>[]>(() => [
 ]);
 
 const formattedItems = computed<EditableMissingPrice[]>(() => {
-  const fromAsset = props.asset;
+  const fromAsset = asset;
   const toAsset = get(currencySymbol);
 
   return get(failedPrices).noPricesTimestamps.map((time) => {

--- a/frontend/app/src/components/helper/display/icons/AssetIcon.vue
+++ b/frontend/app/src/components/helper/display/icons/AssetIcon.vue
@@ -17,7 +17,6 @@ interface AssetIconProps {
   noTooltip?: boolean;
   circle?: boolean;
   padding?: string;
-  enableAssociation?: boolean;
   showChain?: boolean;
   flat?: boolean;
   resolutionOptions?: AssetResolutionOptions;

--- a/frontend/app/src/components/helper/display/icons/GeneratedIcon.vue
+++ b/frontend/app/src/components/helper/display/icons/GeneratedIcon.vue
@@ -14,7 +14,6 @@ const {
   size: string;
   asset?: string;
   customAsset?: boolean;
-  flat?: boolean;
 }>();
 
 const dimensions = computed<Dimension>(() => {

--- a/frontend/app/src/components/history/LocationIcon.vue
+++ b/frontend/app/src/components/history/LocationIcon.vue
@@ -7,7 +7,6 @@ const { item, horizontal, icon, size = '24px', imageClass } = defineProps<{
   horizontal?: boolean;
   icon?: boolean;
   size?: string;
-  noPadding?: boolean;
   imageClass?: string;
 }>();
 

--- a/frontend/app/src/components/history/events/EventDecodingStatusDetails.vue
+++ b/frontend/app/src/components/history/events/EventDecodingStatusDetails.vue
@@ -4,16 +4,16 @@ import ChainIcon from '@/components/helper/display/icons/ChainIcon.vue';
 import { useTaskStore } from '@/store/tasks';
 import { TaskType } from '@/types/task-type';
 
-const props = defineProps<{ item: EvmUnDecodedTransactionsData }>();
+const { item } = defineProps<{ item: EvmUnDecodedTransactionsData }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
 const { useIsTaskRunning } = useTaskStore();
 
-const remaining = computed<number>(() => props.item.total - props.item.processed);
+const remaining = computed<number>(() => item.total - item.processed);
 const isComplete = computed<boolean>(() => get(remaining) === 0);
 const taskMeta = computed(() => ({
-  chain: props.item.chain,
+  chain: item.chain,
 }));
 
 const decoding = useIsTaskRunning(TaskType.TRANSACTIONS_DECODING, taskMeta);

--- a/frontend/app/src/components/history/events/HistoryEventAccount.vue
+++ b/frontend/app/src/components/history/events/HistoryEventAccount.vue
@@ -3,7 +3,7 @@ import LocationIcon from '@/components/history/LocationIcon.vue';
 import { useSupportedChains } from '@/composables/info/chains';
 import HashLink from '@/modules/common/links/HashLink.vue';
 
-const props = defineProps<{
+const { location } = defineProps<{
   location: string;
   locationLabel: string;
   dense?: boolean;
@@ -11,7 +11,7 @@ const props = defineProps<{
 
 const { matchChain } = useSupportedChains();
 
-const isExchangeLocation = computed<boolean>(() => !matchChain(props.location));
+const isExchangeLocation = computed<boolean>(() => !matchChain(location));
 </script>
 
 <template>

--- a/frontend/app/src/components/history/events/HistoryEventStateChip.vue
+++ b/frontend/app/src/components/history/events/HistoryEventStateChip.vue
@@ -2,13 +2,13 @@
 import type { HistoryEventState } from '@/types/history/events/schemas';
 import { useHistoryEventStateMapping } from '@/composables/history/events/mapping/state';
 
-const props = defineProps<{
+const { state } = defineProps<{
   state: HistoryEventState;
 }>();
 
 const { stateConfigs } = useHistoryEventStateMapping();
 
-const config = computed(() => stateConfigs[props.state]);
+const config = computed(() => stateConfigs[state]);
 </script>
 
 <template>

--- a/frontend/app/src/components/history/events/HistoryEventType.vue
+++ b/frontend/app/src/components/history/events/HistoryEventType.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { Blockchain } from '@rotki/common';
 import type { RuiIcons } from '@rotki/ui-library';
 import type { HistoryEventEntry, HistoryEventState } from '@/types/history/events/schemas';
 import HistoryEventAccount from '@/components/history/events/HistoryEventAccount.vue';
@@ -10,7 +9,6 @@ import { useHistoryEventMappings } from '@/composables/history/events/mapping';
 
 const { event, groupLocationLabel, icon, highlight, hideStateChips } = defineProps<{
   event: HistoryEventEntry;
-  chain: Blockchain;
   groupLocationLabel?: string;
   icon?: RuiIcons;
   highlight?: boolean;

--- a/frontend/app/src/components/history/events/HistoryEventsDecodingStatus.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsDecodingStatus.vue
@@ -16,7 +16,7 @@ interface LocationData {
   total: number;
 }
 
-const props = defineProps<{
+const { decodingStatus } = defineProps<{
   refreshing: boolean;
   decodingStatus: EvmUnDecodedTransactionsData[];
 }>();
@@ -53,7 +53,7 @@ const { checkMissingEventsAndRedecode } = useHistoryTransactionDecoding();
 const { protocolCacheStatus, receivingProtocolCacheStatus } = storeToRefs(useHistoryStore());
 
 function refresh() {
-  if (props.decodingStatus.length === 0)
+  if (decodingStatus.length === 0)
     emit('reset-undecoded-transactions');
 }
 
@@ -75,7 +75,7 @@ const headers: DataTableColumn<LocationData>[] = [{
 }];
 
 const total = computed<number>(() =>
-  props.decodingStatus.reduce((sum, item) => sum + (item.total - item.processed), 0),
+  decodingStatus.reduce((sum, item) => sum + (item.total - item.processed), 0),
 );
 
 const [DefineProgress, ReuseProgress] = createReusableTemplate<{
@@ -92,7 +92,7 @@ watch(isFullyDecoding, (loading) => {
 });
 
 const combinedDecodingStatus = computed(() => {
-  const data = [...props.decodingStatus].reverse();
+  const data = [...decodingStatus].reverse();
   if (!get(receivingProtocolCacheStatus))
     return data;
 

--- a/frontend/app/src/components/history/events/MatchAssetMovementsContent.vue
+++ b/frontend/app/src/components/history/events/MatchAssetMovementsContent.vue
@@ -4,7 +4,7 @@ import UnmatchedMovementsList from '@/components/history/events/UnmatchedMovemen
 import { useAssetMovementActions } from '@/composables/history/events/use-asset-movement-actions';
 import { type UnmatchedAssetMovement, useUnmatchedAssetMovements } from '@/composables/history/events/use-unmatched-asset-movements';
 
-const props = defineProps<{
+const { isPinned, onActionComplete } = defineProps<{
   highlightedGroupIdentifier?: string;
   isPinned?: boolean;
   onActionComplete?: () => Promise<void>;
@@ -41,9 +41,9 @@ const {
   restoreMovement,
   selectedIgnored,
   selectedUnmatched,
-} = useAssetMovementActions({ onActionComplete: props.onActionComplete });
+} = useAssetMovementActions({ onActionComplete });
 
-const buttonSize = computed<'sm' | undefined>(() => props.isPinned ? 'sm' : undefined);
+const buttonSize = computed<'sm' | undefined>(() => isPinned ? 'sm' : undefined);
 
 onBeforeMount(async () => {
   await refreshUnmatchedAssetMovements();

--- a/frontend/app/src/components/history/events/MatchAssetMovementsPinned.vue
+++ b/frontend/app/src/components/history/events/MatchAssetMovementsPinned.vue
@@ -12,7 +12,7 @@ import {
 import { useAreaVisibilityStore } from '@/store/session/visibility';
 import { getEventEntryFromCollection } from '@/utils/history/events';
 
-const props = defineProps<{
+const { highlightedGroupIdentifier, highlightedPotentialMatchIdentifier, potentialMatchGroupIdentifier } = defineProps<{
   highlightedGroupIdentifier?: string;
   highlightedPotentialMatchIdentifier?: number;
   potentialMatchGroupIdentifier?: string;
@@ -22,8 +22,8 @@ const { t } = useI18n({ useScope: 'global' });
 const router = useRouter();
 const route = useRoute();
 
-const activeGroupIdentifier = ref<string | undefined>(props.highlightedGroupIdentifier);
-const activePotentialMatchIdentifier = ref<number | undefined>(props.highlightedPotentialMatchIdentifier);
+const activeGroupIdentifier = ref<string | undefined>(highlightedGroupIdentifier);
+const activePotentialMatchIdentifier = ref<number | undefined>(highlightedPotentialMatchIdentifier);
 const potentialMatchMovement = ref<UnmatchedAssetMovement>();
 const showPotentialMatchesDrawer = ref<boolean>(false);
 
@@ -139,15 +139,15 @@ function navigateToHighlightedMovement(targetGroupIdentifier: string): boolean {
 
   if (movement) {
     // If potential match identifier is also provided, open the drawer and navigate to potential match
-    if (props.highlightedPotentialMatchIdentifier && props.potentialMatchGroupIdentifier) {
+    if (highlightedPotentialMatchIdentifier && potentialMatchGroupIdentifier) {
       const identifier = getEventEntryFromCollection(movement.events).entry.identifier;
       set(potentialMatchMovement, movement);
       set(showPotentialMatchesDrawer, true);
       set(activeGroupIdentifier, movement.groupIdentifier);
       showPotentialMatchInHistoryEvents(
         {
-          groupIdentifier: props.potentialMatchGroupIdentifier,
-          identifier: props.highlightedPotentialMatchIdentifier,
+          groupIdentifier: potentialMatchGroupIdentifier,
+          identifier: highlightedPotentialMatchIdentifier,
         },
         identifier,
       );
@@ -162,7 +162,7 @@ function navigateToHighlightedMovement(targetGroupIdentifier: string): boolean {
 
 // Watch for data to load and navigate to initial highlight if provided
 watch([unmatchedMovements, ignoredMovements], () => {
-  const initialHighlight = props.highlightedGroupIdentifier;
+  const initialHighlight = highlightedGroupIdentifier;
   if (!initialHighlight || get(hasNavigatedToInitialHighlight))
     return;
 
@@ -172,7 +172,7 @@ watch([unmatchedMovements, ignoredMovements], () => {
 });
 
 // Watch for prop changes to handle navigation when pinned section is already open
-watch(() => props.highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
+watch(() => highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
   // Only trigger if the highlight actually changed (not on initial mount)
   if (!newHighlight || newHighlight === oldHighlight)
     return;

--- a/frontend/app/src/components/history/events/PotentialMatchesContent.vue
+++ b/frontend/app/src/components/history/events/PotentialMatchesContent.vue
@@ -13,7 +13,7 @@ import { useGeneralSettingsStore } from '@/store/settings/general';
 import { getEventEntryFromCollection } from '@/utils/history/events';
 import { logger } from '@/utils/logging';
 
-const props = defineProps<{
+const { isPinned, movement } = defineProps<{
   movement: UnmatchedAssetMovement;
   isPinned?: boolean;
   highlightedIdentifier?: number;
@@ -57,7 +57,7 @@ const tolerancePercentage = ref<string>(getDefaultTolerancePercentage());
 function percentageToDecimal(percentage: string): string {
   return bigNumberify(percentage).dividedBy(100).toString();
 }
-const buttonSize = computed<'sm' | undefined>(() => props.isPinned ? 'sm' : undefined);
+const buttonSize = computed<'sm' | undefined>(() => isPinned ? 'sm' : undefined);
 
 function transformToMatchRow(row: HistoryEventCollectionRow, isCloseMatch: boolean): PotentialMatchRow {
   const { entry, ...meta } = getEventEntryFromCollection(row);
@@ -74,7 +74,7 @@ async function searchPotentialMatches(): Promise<void> {
   set(potentialMatches, []);
 
   try {
-    const groupIdentifier = props.movement.groupIdentifier;
+    const groupIdentifier = movement.groupIdentifier;
 
     const hours = Number.parseInt(get(searchTimeRange), 10) || getDefaultHourRange();
     const timeRangeInSeconds = hours * 60 * 60;
@@ -124,7 +124,7 @@ async function confirmMatch(): Promise<void> {
   set(matchingLoading, true);
 
   try {
-    const eventEntry = getEventEntryFromCollection(props.movement.events);
+    const eventEntry = getEventEntryFromCollection(movement.events);
     const assetMovementId = eventEntry.entry.identifier;
 
     if (!assetMovementId)
@@ -146,7 +146,7 @@ function close(): void {
   emit('close');
 }
 
-watchImmediate(() => props.movement, async () => {
+watchImmediate(() => movement, async () => {
   set(potentialMatches, []);
   set(selectedMatchIds, []);
   set(searchTimeRange, getDefaultHourRange().toString());

--- a/frontend/app/src/components/history/events/PotentialMatchesDialog.vue
+++ b/frontend/app/src/components/history/events/PotentialMatchesDialog.vue
@@ -7,7 +7,7 @@ import { useAreaVisibilityStore } from '@/store/session/visibility';
 
 const modelValue = defineModel<boolean>({ required: true });
 
-const props = defineProps<{
+const { movement } = defineProps<{
   movement: UnmatchedAssetMovement;
 }>();
 
@@ -31,7 +31,7 @@ function onMatched(): void {
 function showUnmatchedInEvents(): void {
   const pin: Pinned = {
     name: 'match-asset-movements-pinned',
-    props: { highlightedGroupIdentifier: props.movement.groupIdentifier },
+    props: { highlightedGroupIdentifier: movement.groupIdentifier },
   };
 
   set(pinned, pin);
@@ -44,7 +44,7 @@ function showPotentialMatchInEvents(data: { identifier: number; groupIdentifier:
   const pin: Pinned = {
     name: 'match-asset-movements-pinned',
     props: {
-      highlightedGroupIdentifier: props.movement.groupIdentifier,
+      highlightedGroupIdentifier: movement.groupIdentifier,
       highlightedPotentialMatchIdentifier: data.identifier,
       potentialMatchGroupIdentifier: data.groupIdentifier,
     },

--- a/frontend/app/src/components/import/ImportSource.vue
+++ b/frontend/app/src/components/import/ImportSource.vue
@@ -15,13 +15,14 @@ import { TaskType } from '@/types/task-type';
 import { isTaskCancelled } from '@/utils';
 import { toMessages } from '@/utils/validation';
 
-const { source } = defineProps<{ source: ImportSourceType; icon?: string }>();
+const { source } = defineProps<{ source: ImportSourceType }>();
 
 defineSlots<{
   'default': () => any;
   'hint': () => any;
   'upload-title': () => any;
 }>();
+
 const dateInputFormat = ref<string>();
 const uploaded = ref(false);
 const errorMessage = ref('');

--- a/frontend/app/src/components/inputs/DateTimePicker.vue
+++ b/frontend/app/src/components/inputs/DateTimePicker.vue
@@ -10,20 +10,37 @@ interface QuickOption {
 
 const modelValue = defineModel<number>({ required: true });
 
-const props = defineProps<RuiDateTimePickerProps>();
+const {
+  accuracy,
+  allowEmpty,
+  dense,
+  disabled,
+  errorMessages,
+  format,
+  hideDetails,
+  hint,
+  label,
+  maxDate,
+  minDate,
+  readonly,
+  required,
+  successMessages,
+  type,
+  variant,
+} = defineProps<RuiDateTimePickerProps>();
 
 const { t } = useI18n({ useScope: 'global' });
 
-const quickOptions: QuickOption[] = [
+const quickOptions = computed<QuickOption[]>(() => [
   { label: t('date_time_picker.one_day_before'), unit: 'day', value: 1 },
   { label: t('date_time_picker.week_before'), unit: 'week', value: 1 },
   { label: t('date_time_picker.month_before'), unit: 'month', value: 1 },
   { label: t('date_time_picker.days_before', { days: 90 }), unit: 'day', value: 90 },
   { label: t('date_time_picker.months_before', { months: 6 }), unit: 'month', value: 6 },
   { label: t('date_time_picker.year_before'), unit: 'year', value: 1 },
-];
+]);
 
-const useMilliseconds = computed<boolean>(() => props.accuracy === 'millisecond');
+const useMilliseconds = computed<boolean>(() => accuracy === 'millisecond');
 
 function applyQuickOption(option: QuickOption): void {
   const currentValue = get(modelValue);
@@ -36,7 +53,22 @@ function applyQuickOption(option: QuickOption): void {
 <template>
   <RuiDateTimePicker
     v-model="modelValue"
-    v-bind="props"
+    :accuracy="accuracy"
+    :allow-empty="allowEmpty"
+    :dense="dense"
+    :disabled="disabled"
+    :error-messages="errorMessages"
+    :format="format"
+    :hide-details="hideDetails"
+    :hint="hint"
+    :label="label"
+    :max-date="maxDate"
+    :min-date="minDate"
+    :readonly="readonly"
+    :required="required"
+    :success-messages="successMessages"
+    :type="type"
+    :variant="variant"
   >
     <template #menu-content>
       <div class="border-t border-default flex flex-col pt-2">

--- a/frontend/app/src/components/locations/LocationValueRow.vue
+++ b/frontend/app/src/components/locations/LocationValueRow.vue
@@ -3,7 +3,7 @@ import { type BigNumber, Zero } from '@rotki/common';
 import { useAggregatedBalances } from '@/composables/balances/use-aggregated-balances';
 import { FiatDisplay } from '@/modules/amount-display';
 
-const props = defineProps<{ identifier: string }>();
+const { identifier } = defineProps<{ identifier: string }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -11,7 +11,7 @@ const { balancesByLocation } = useAggregatedBalances();
 
 const totalValue = computed<BigNumber>(() => {
   const locations = get(balancesByLocation);
-  return locations?.[props.identifier] ?? Zero;
+  return locations?.[identifier] ?? Zero;
 });
 </script>
 

--- a/frontend/app/src/components/notes/UserNotesFormDialog.vue
+++ b/frontend/app/src/components/notes/UserNotesFormDialog.vue
@@ -9,7 +9,7 @@ import { logger } from '@/utils/logging';
 const open = defineModel<boolean>('open', { required: true });
 const model = defineModel<Partial<UserNote>>({ required: true });
 
-const props = defineProps<{
+const { editMode, location } = defineProps<{
   editMode: boolean;
   location: string;
 }>();
@@ -39,14 +39,12 @@ async function save() {
 
   const data = get(model);
   let success;
-  const editMode = props.editMode;
-
   set(loading, true);
   try {
     if (editMode)
       success = await updateUserNote(data);
     else
-      success = await addUserNote({ ...data, location: props.location });
+      success = await addUserNote({ ...data, location });
   }
   catch (error: any) {
     success = false;

--- a/frontend/app/src/components/profitloss/ProfitLossOverview.vue
+++ b/frontend/app/src/components/profitloss/ProfitLossOverview.vue
@@ -9,8 +9,6 @@ const {
   report,
 } = defineProps<{
   report: Report;
-  symbol?: string | null;
-  flat?: boolean;
   loading?: boolean;
 }>();
 

--- a/frontend/app/src/components/settings/HideSmallBalances.vue
+++ b/frontend/app/src/components/settings/HideSmallBalances.vue
@@ -10,7 +10,7 @@ import { BalanceSource, type BalanceValueThreshold } from '@/types/settings/fron
 import { TaskType } from '@/types/task-type';
 import { toMessages } from '@/utils/validation';
 
-const props = defineProps<{
+const { source } = defineProps<{
   source: BalanceSource;
 }>();
 
@@ -54,7 +54,7 @@ const loading = computed(() => {
 
   return get(applyToAllBalances)
     ? Object.values(loadingStates).some(Boolean)
-    : loadingStates[props.source];
+    : loadingStates[source];
 });
 
 const hint = computed(() => {
@@ -85,8 +85,8 @@ async function applyChanges(): Promise<void> {
   }
   else {
     newState = {
-      ...omit(get(balanceValueThreshold), [props.source]),
-      ...(usedNumber ? { [props.source]: usedNumber } : {}),
+      ...omit(get(balanceValueThreshold), [source]),
+      ...(usedNumber ? { [source]: usedNumber } : {}),
     };
   }
 
@@ -94,7 +94,7 @@ async function applyChanges(): Promise<void> {
 }
 
 watchImmediate([balanceValueThreshold, open], ([balanceValueThreshold]) => {
-  const data = balanceValueThreshold[props.source];
+  const data = balanceValueThreshold[source];
 
   if (data) {
     set(hide, true);

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleActionDialog.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleActionDialog.vue
@@ -2,16 +2,19 @@
 import type { AccountingRuleAction, AccountingRuleEntry } from '@/types/settings/accounting';
 import AccountingRuleEventsDialog from '@/components/settings/accounting/rule/AccountingRuleEventsDialog.vue';
 
-export interface Props {
-  hasEventSpecificRule: boolean;
-  hasGeneralRule: boolean;
+export interface ActionDialogContext {
   eventId: number;
   generalRule?: AccountingRuleEntry;
   eventSpecificRule?: AccountingRuleEntry;
+}
+
+interface Props {
+  hasEventSpecificRule: boolean;
+  hasGeneralRule: boolean;
   eventIds?: number[];
 }
 
-const props = defineProps<Props>();
+const { eventIds } = defineProps<Props>();
 
 const emit = defineEmits<{
   close: [];
@@ -23,7 +26,7 @@ const { t } = useI18n({ useScope: 'global' });
 const display = ref<boolean>(true);
 const showEventsList = ref<boolean>(false);
 
-const affectedEventsCount = computed<number>(() => props.eventIds?.length ?? 0);
+const affectedEventsCount = computed<number>(() => eventIds?.length ?? 0);
 
 function onSelect(action: AccountingRuleAction) {
   emit('select', action);

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleEventsDialog.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleEventsDialog.vue
@@ -10,7 +10,7 @@ interface Props {
   eventIds: number[];
 }
 
-const props = defineProps<Props>();
+const { eventIds } = defineProps<Props>();
 
 const emit = defineEmits<{
   close: [];
@@ -22,7 +22,7 @@ const display = ref<boolean>(true);
 
 const { fetchHistoryEvents } = useHistoryEvents();
 
-const eventIdentifiers = computed<string[]>(() => props.eventIds.map(id => id.toString()));
+const eventIdentifiers = computed<string[]>(() => eventIds.map(id => id.toString()));
 
 const {
   fetchData,

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleForm.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleForm.vue
@@ -15,13 +15,13 @@ const modelValue = defineModel<AccountingRuleEntry>({ required: true });
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<{
+const { eventIds } = defineProps<{
   eventIds?: number[];
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
-const isEventSpecificRule = computed<boolean>(() => !!props.eventIds && props.eventIds.length > 0);
+const isEventSpecificRule = computed<boolean>(() => !!eventIds && eventIds.length > 0);
 
 const counterparty = refOptional(useRefPropVModel(modelValue, 'counterparty'), '');
 const accountingTreatment = useRefPropVModel(modelValue, 'accountingTreatment');

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleSetting.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleSetting.vue
@@ -5,7 +5,7 @@ import type {
   AccountingRuleRequestPayload,
 } from '@/types/settings/accounting';
 import { z } from 'zod/v4';
-import AccountingRuleActionDialog, { type Props as AccountingRuleActionDialogProps } from '@/components/settings/accounting/rule/AccountingRuleActionDialog.vue';
+import AccountingRuleActionDialog, { type ActionDialogContext } from '@/components/settings/accounting/rule/AccountingRuleActionDialog.vue';
 import AccountingRuleConflictsDialog from '@/components/settings/accounting/rule/AccountingRuleConflictsDialog.vue';
 import AccountingRuleFormDialog from '@/components/settings/accounting/rule/AccountingRuleFormDialog.vue';
 import AccountingRuleImportDialog from '@/components/settings/accounting/rule/AccountingRuleImportDialog.vue';
@@ -52,7 +52,10 @@ const customRuleHandling = ref<CustomRuleHandling>(CustomRuleHandling.EXCLUDE);
 const modelValue = ref<AccountingRuleEntry>();
 const eventIdsForRule = ref<number[]>();
 const actionDialog = ref<boolean>(false);
-const actionDialogProps = ref<AccountingRuleActionDialogProps>();
+const actionDialogContext = ref<ActionDialogContext>();
+const actionDialogHasEventSpecific = ref<boolean>(false);
+const actionDialogHasGeneral = ref<boolean>(false);
+const actionDialogEventIds = ref<number[]>();
 
 const {
   fetchData,
@@ -183,11 +186,10 @@ function addRuleFromQuery(eventIds?: number[]): void {
 
 async function handleAddRule(eventIdNum?: number): Promise<void> {
   if (eventIdNum) {
-    set(actionDialogProps, {
-      eventId: eventIdNum,
-      hasEventSpecificRule: false,
-      hasGeneralRule: false,
-    });
+    set(actionDialogContext, { eventId: eventIdNum });
+    set(actionDialogHasEventSpecific, false);
+    set(actionDialogHasGeneral, false);
+    set(actionDialogEventIds, undefined);
     set(actionDialog, true);
     return;
   }
@@ -215,14 +217,14 @@ async function handleEditRuleWithEventId(eventIdNum: number, ruleQuery: Accounti
   const hasEventSpecificRule = !!eventSpecificRule;
   const hasGeneralRule = !!generalRule;
 
-  set(actionDialogProps, {
+  set(actionDialogContext, {
     eventId: eventIdNum,
-    eventIds: eventSpecificRule?.eventIds ?? undefined,
     eventSpecificRule,
     generalRule,
-    hasEventSpecificRule,
-    hasGeneralRule,
   });
+  set(actionDialogHasEventSpecific, hasEventSpecificRule);
+  set(actionDialogHasGeneral, hasGeneralRule);
+  set(actionDialogEventIds, eventSpecificRule?.eventIds ?? undefined);
   set(actionDialog, true);
 }
 
@@ -250,11 +252,11 @@ async function handleEditRule(eventIdNum: number | undefined, ruleQuery: Account
 }
 
 async function handleRuleAction(action: AccountingRuleAction) {
-  const props = get(actionDialogProps);
-  if (!props)
+  const ctx = get(actionDialogContext);
+  if (!ctx)
     return;
 
-  const { eventId, eventSpecificRule, generalRule } = props;
+  const { eventId, eventSpecificRule, generalRule } = ctx;
 
   switch (action) {
     case 'add-general':
@@ -459,8 +461,10 @@ const importFileDialog = ref<boolean>(false);
       />
 
       <AccountingRuleActionDialog
-        v-if="actionDialog && actionDialogProps"
-        v-bind="actionDialogProps"
+        v-if="actionDialog && actionDialogContext"
+        :has-event-specific-rule="actionDialogHasEventSpecific"
+        :has-general-rule="actionDialogHasGeneral"
+        :event-ids="actionDialogEventIds"
         @close="actionDialog = false"
         @select="handleRuleAction($event)"
       />

--- a/frontend/app/src/components/settings/accounting/rule/AccountingRuleTable.vue
+++ b/frontend/app/src/components/settings/accounting/rule/AccountingRuleTable.vue
@@ -19,10 +19,9 @@ interface AccountingRuleTableProps {
 
 const paginationModel = defineModel<TablePaginationData>('pagination', { required: true });
 
-const props = defineProps<AccountingRuleTableProps>();
+const { isCustom } = defineProps<AccountingRuleTableProps>();
 
 const emit = defineEmits<{
-  'set-page': [page: number];
   'delete-click': [item: AccountingRuleEntry];
   'edit-click': [item: AccountingRuleEntry];
 }>();
@@ -50,15 +49,15 @@ const cols = computed<DataTableColumn<AccountingRuleEntry>[]>(() => {
       label: t('transactions.events.form.resulting_combination.label'),
     },
     {
-      cellClass: props.isCustom ? '' : 'border-r border-default',
-      class: props.isCustom ? '' : 'border-r border-default',
+      cellClass: isCustom ? '' : 'border-r border-default',
+      class: isCustom ? '' : 'border-r border-default',
       key: 'counterparty',
       label: t('common.counterparty'),
     },
   );
 
   // For special rules view (custom rules with eventIds), show event IDs instead of event type/subtype/counterparty
-  if (props.isCustom) {
+  if (isCustom) {
     baseColumns.push({
       cellClass: 'py-4 border-r border-default',
       class: 'border-r border-default',

--- a/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysFormStructure.vue
+++ b/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysFormStructure.vue
@@ -5,7 +5,7 @@ interface SlotProps {
   className?: string;
 }
 
-const props = defineProps<{
+const { location } = defineProps<{
   location: string;
 }>();
 
@@ -69,7 +69,6 @@ const defaultData: Record<LocationKey, SlotProps> = {
 };
 
 const slotData = computed(() => {
-  const location = props.location;
   const locationConfig = customLabel[location] || {};
 
   return LOCATION_KEYS

--- a/frontend/app/src/components/settings/controls/SettingsOption.vue
+++ b/frontend/app/src/components/settings/controls/SettingsOption.vue
@@ -24,7 +24,10 @@ const {
   errorMessage?: string | TransformMessageCallback<string>;
 }>();
 
-const emit = defineEmits(['updated', 'finished']);
+const emit = defineEmits<{
+  updated: [];
+  finished: [];
+}>();
 const { clearAll, error, setError, setSuccess, stop, success, wait } = useClearableMessages();
 const { updateSetting } = useSettings();
 
@@ -44,11 +47,13 @@ async function updateImmediate(newValue: any) {
   set(loading, true);
   const settingValue = transform ? transform(newValue) : newValue;
 
-  const location = sessionSetting
-    ? SettingLocation.SESSION
-    : frontendSetting
-      ? SettingLocation.FRONTEND
-      : SettingLocation.GENERAL;
+  let location: SettingLocation;
+  if (sessionSetting)
+    location = SettingLocation.SESSION;
+  else if (frontendSetting)
+    location = SettingLocation.FRONTEND;
+  else
+    location = SettingLocation.GENERAL;
 
   const result = await updateSetting(setting, settingValue, location, {
     error: getMessage(errorMessage, newValue),

--- a/frontend/app/src/components/settings/general/rpc/simple/SimpleRpcNodeManager.vue
+++ b/frontend/app/src/components/settings/general/rpc/simple/SimpleRpcNodeManager.vue
@@ -8,7 +8,7 @@ import { SettingLocation, useSettings } from '@/composables/settings';
 import { useConfirmStore } from '@/store/confirm';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 
-const props = defineProps<{
+const { setting } = defineProps<{
   setting: 'ksmRpcEndpoint' | 'dotRpcEndpoint' | 'beaconRpcEndpoint' | 'btcMempoolApi';
 }>();
 
@@ -24,7 +24,7 @@ const inputUrl = ref<string>('');
 const generalSettings = storeToRefs(useGeneralSettingsStore());
 const { updateSetting } = useSettings();
 
-const value = computed(() => get(generalSettings[props.setting]));
+const value = computed(() => get(generalSettings[setting]));
 
 function addNewRpcNode() {
   set(openDialog, true);
@@ -44,7 +44,7 @@ async function save(force: boolean = false) {
 
   set(submitting, true);
 
-  const result = await updateSetting(props.setting, value, SettingLocation.GENERAL, {
+  const result = await updateSetting(setting, value, SettingLocation.GENERAL, {
     error: '',
     success: '',
   });

--- a/frontend/app/src/components/sponsorship/SponsorshipView.vue
+++ b/frontend/app/src/components/sponsorship/SponsorshipView.vue
@@ -4,7 +4,7 @@ import AppImage from '@/components/common/AppImage.vue';
 import ExternalLink from '@/components/helper/ExternalLink.vue';
 import { useMainStore } from '@/store/main';
 
-const props = defineProps<{
+const { drawer } = defineProps<{
   drawer?: boolean;
 }>();
 
@@ -52,7 +52,7 @@ const loginIndex = useLocalStorage<number>('rotki.sponsorship.login_index', -1);
 
 function getCurrentSponsor(): Sponsor {
   const length = sponsors.length;
-  if (!props.drawer) {
+  if (!drawer) {
     const loginIndexVal = get(loginIndex);
     // Login screen: determine and save the flipped index
     if (loginIndexVal === -1) {

--- a/frontend/app/src/components/status/NotificationIndicator.vue
+++ b/frontend/app/src/components/status/NotificationIndicator.vue
@@ -7,7 +7,9 @@ defineProps<{
   visible: boolean;
 }>();
 
-const emit = defineEmits(['click']);
+const emit = defineEmits<{
+  click: [];
+}>();
 const { count } = storeToRefs(useNotificationsStore());
 
 function click() {

--- a/frontend/app/src/components/status/update/AssetConflictRow.vue
+++ b/frontend/app/src/components/status/update/AssetConflictRow.vue
@@ -3,23 +3,23 @@ import type { UnderlyingToken } from '@rotki/common';
 import DateDisplay from '@/components/display/DateDisplay.vue';
 import HashLink from '@/modules/common/links/HashLink.vue';
 
-const props = defineProps<{
+const { field, value } = defineProps<{
   field: string;
   value?: string | number | boolean | null | UnderlyingToken[];
   diff: boolean;
 }>();
 
-const isStarted = computed(() => props.field === 'started');
-const isAddress = computed(() => props.field === 'address');
+const isStarted = computed(() => field === 'started');
+const isAddress = computed(() => field === 'address');
 const started = computed(() => {
-  if (typeof props.value === 'number')
-    return props.value;
+  if (typeof value === 'number')
+    return value;
 
   return undefined;
 });
 const address = computed(() => {
-  if (typeof props.value === 'string')
-    return props.value;
+  if (typeof value === 'string')
+    return value;
 
   return undefined;
 });

--- a/frontend/app/src/components/tags/TagForm.vue
+++ b/frontend/app/src/components/tags/TagForm.vue
@@ -12,10 +12,6 @@ const modelValue = defineModel<Tag>({ required: true });
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { required: true });
 
-defineProps<{
-  editMode: boolean;
-}>();
-
 const { t } = useI18n({ useScope: 'global' });
 
 const name = useRefPropVModel(modelValue, 'name');

--- a/frontend/app/src/components/wrapped/WrappedCard.vue
+++ b/frontend/app/src/components/wrapped/WrappedCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts" generic="T extends object">
 import WrappedItem from '@/components/wrapped/WrappedItem.vue';
 
-const props = defineProps<{
+const { items } = defineProps<{
   items: T[];
 }>();
 
@@ -9,12 +9,11 @@ const { t } = useI18n({ useScope: 'global' });
 
 const INITIAL_LENGTH = 5;
 
-const showMoreButton = computed(() => props.items.length > INITIAL_LENGTH);
+const showMoreButton = computed(() => items.length > INITIAL_LENGTH);
 
 const showAll = ref(false);
 
 const itemsToUse = computed(() => {
-  const items = props.items;
   if (get(showAll))
     return items;
 

--- a/frontend/app/src/composables/blockchain/use-account-operations.ts
+++ b/frontend/app/src/composables/blockchain/use-account-operations.ts
@@ -52,9 +52,11 @@ export function useAccountOperations(): UseAccountOperationsReturn {
   };
 
   const fetchAccounts = async (blockchain?: string | string[], refreshEns: boolean = false): Promise<void> => {
-    const chains = blockchain
-      ? (Array.isArray(blockchain) ? blockchain : [blockchain])
-      : get(supportedChains).map(chain => chain.id);
+    let chains: string[];
+    if (blockchain)
+      chains = Array.isArray(blockchain) ? blockchain : [blockchain];
+    else
+      chains = get(supportedChains).map(chain => chain.id);
     await awaitParallelExecution(chains, chain => chain, fetch, 2);
 
     const namesPayload: AddressBookSimplePayload[] = [];

--- a/frontend/app/src/composables/history/events/tx/index.ts
+++ b/frontend/app/src/composables/history/events/tx/index.ts
@@ -72,7 +72,11 @@ export const useHistoryTransactions = createSharedComposable(() => {
       return '';
 
     // 0 = only from, 1 = only to, 2 = both
-    const choice = from && to ? 2 : (from ? 0 : 1);
+    let choice: number;
+    if (from && to)
+      choice = 2;
+    else
+      choice = from ? 0 : 1;
     return t('actions.date_range', { from, to }, choice);
   };
 

--- a/frontend/app/src/composables/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/composables/history/events/tx/use-refresh-transactions.ts
@@ -65,11 +65,13 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
       : get(syncingExchanges);
 
     // Determine initial accounts to check
-    const allCurrentAccounts = accounts?.length
-      ? accounts
-      : fullRefresh
-        ? getAllAccounts(chains)
-        : [];
+    let allCurrentAccounts: ChainAddress[];
+    if (accounts?.length)
+      allCurrentAccounts = accounts;
+    else if (fullRefresh)
+      allCurrentAccounts = getAllAccounts(chains);
+    else
+      allCurrentAccounts = [];
 
     const newAccountsList = getNewAccounts(allCurrentAccounts);
     const hasNewAccounts = newAccountsList.length > 0;

--- a/frontend/app/src/composables/use-pagination-filter/index.ts
+++ b/frontend/app/src/composables/use-pagination-filter/index.ts
@@ -2,7 +2,7 @@
 import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
 import type { FetchError } from 'ofetch';
 import type { ComputedRef, MaybeRef, MaybeRefOrGetter, Ref, WritableComputedRef } from 'vue';
-import type { FilterSchema, Sorting } from '@/composables/use-pagination-filter/types';
+import type { FilterSchema, SingleColumnSorting, Sorting } from '@/composables/use-pagination-filter/types';
 import type { TableId } from '@/modules/table/use-remember-table-sorting';
 import type { Collection } from '@/types/collection';
 import type { PaginationRequestPayload } from '@/types/common';
@@ -331,6 +331,10 @@ export function usePaginationFilters<
     set(internalSorting, parseQueryHistory(routeQuery, defaultSorting()));
   };
 
+  function getSortColumns(sorting: SingleColumnSorting<TItem>): string[] {
+    return sorting.column ? [sorting.column as string] : [];
+  }
+
   /**
    * Returns the parsed pagination and filter query params
    * @returns {LocationQuery}
@@ -355,7 +359,7 @@ export function usePaginationFilters<
     const sortParams = isEqual(sorting, defaultSorting())
       ? undefined
       : {
-          sort: Array.isArray(sorting) ? sorting.map(item => item.column) : (sorting.column ? [sorting.column] : []),
+          sort: Array.isArray(sorting) ? sorting.map(item => item.column) : getSortColumns(sorting),
           sortOrder: Array.isArray(sorting) ? sorting.map(item => item.direction) : [sorting.direction],
         };
 

--- a/frontend/app/src/i18n.ts
+++ b/frontend/app/src/i18n.ts
@@ -5,15 +5,17 @@ import en from './locales/en.json';
 const loadedLocales = new Set<string>(['en']);
 
 export const i18n = createI18n({
-  fallbackLocale: (import.meta.env.VITE_I18N_FALLBACK_LOCALE as string | undefined) || 'en',
-  locale: (import.meta.env.VITE_I18N_LOCALE as string | undefined) || 'en',
+  fallbackLocale: import.meta.env.VITE_I18N_FALLBACK_LOCALE || 'en',
+  locale: import.meta.env.VITE_I18N_LOCALE || 'en',
   messages: { en },
   modifiers: {
-    quote: (val, type) => type === 'text' && typeof val === 'string'
-      ? `"${val}"`
-      : type === 'vnode' && typeof val === 'object' && '__v_isVNode' in val
-        ? `"${(val as any).children}"`
-        : `"${val.toString()}"`,
+    quote(val, type) {
+      if (type === 'text' && typeof val === 'string')
+        return `"${val}"`;
+      if (type === 'vnode' && typeof val === 'object' && '__v_isVNode' in val)
+        return `"${(val as any).children}"`;
+      return `"${val.toString()}"`;
+    },
   },
   silentTranslationWarn: import.meta.env.VITE_SILENT_TRANSLATION_WARN === 'true',
 });

--- a/frontend/app/src/modules/asset-manager/missing-mappings/use-missing-mappings-db.ts
+++ b/frontend/app/src/modules/asset-manager/missing-mappings/use-missing-mappings-db.ts
@@ -76,7 +76,7 @@ export function useMissingMappingsDB(): UseMappingDBReturn {
     const { data, total } = await getPage<MissingMapping, 'id'>(table, {
       limit,
       offset,
-      order: ascending.length > 0 ? (ascending[0] ? 'asc' : 'desc') : 'asc',
+      order: ascending.length > 0 && !ascending[0] ? 'desc' : 'asc',
       orderBy: orderByAttributes.length > 0 ? orderByAttributes[0] : 'location',
     }, filter);
 

--- a/frontend/app/src/modules/balances/blockchain/use-blockchain-account-data.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-blockchain-account-data.ts
@@ -139,6 +139,14 @@ export function useBlockchainAccountData(): UseBlockchainAccountDataReturn {
     return accountsWithBalances;
   };
 
+  function getExpansionType(chains: string[], hasAssets: boolean): 'accounts' | 'assets' | undefined {
+    if (chains.length > 1)
+      return 'accounts';
+    if (hasAssets)
+      return 'assets';
+    return undefined;
+  }
+
   const getGroups = (accounts: Accounts, balances: Balances): BlockchainAccountGroupWithBalance[] => {
     const accountData = omit(accounts, [Blockchain.ETH2]);
     const balanceData = omit(balances, [Blockchain.ETH2]);
@@ -172,7 +180,7 @@ export function useBlockchainAccountData(): UseBlockchainAccountDataReturn {
         category: getChainAccountType(chains[0]),
         chains,
         data: accountsForAddress.length === 1 ? accountsForAddress[0].data : { address, type: 'address' },
-        expansion: chains.length > 1 ? 'accounts' : (hasAssets ? 'assets' : undefined),
+        expansion: getExpansionType(chains, hasAssets),
         label,
         tags: tags.length > 0 ? tags : undefined,
         type: 'group',

--- a/frontend/app/src/modules/balances/protocols/components/AssetDetailsLayout.vue
+++ b/frontend/app/src/modules/balances/protocols/components/AssetDetailsLayout.vue
@@ -2,7 +2,7 @@
 import type { AssetBalanceWithPrice } from '@rotki/common';
 import { isEvmNativeToken } from '@/types/asset';
 
-const props = defineProps<{
+const { row } = defineProps<{
   row: AssetBalanceWithPrice;
 }>();
 
@@ -11,13 +11,13 @@ const { t } = useI18n({ useScope: 'global' });
 const tab = ref(0);
 
 const hasPerProtocol = computed<boolean>(() => {
-  const perProtocol = props.row.perProtocol;
+  const perProtocol = row.perProtocol;
   return (perProtocol && perProtocol.length > 1) ?? false;
 });
 
 const hasBreakdown = computed<boolean>(() => {
-  const breakdown = props.row.breakdown;
-  const isNativeToken = isEvmNativeToken(props.row.asset);
+  const breakdown = row.breakdown;
+  const isNativeToken = isEvmNativeToken(row.asset);
   const hasBreakdown = breakdown && breakdown.length > 0;
   return ((hasBreakdown && !isNativeToken) || (isNativeToken && hasBreakdown && !get(hasPerProtocol))) ?? false;
 });

--- a/frontend/app/src/modules/balances/protocols/components/ChainBalanceTooltipIcon.vue
+++ b/frontend/app/src/modules/balances/protocols/components/ChainBalanceTooltipIcon.vue
@@ -9,7 +9,6 @@ const { chainId } = defineProps<{
   chainId: string;
   chainBalance: Balance;
   asset?: string;
-  loading?: boolean;
 }>();
 
 const { shouldShowAmount } = storeToRefs(useFrontendSettingsStore());

--- a/frontend/app/src/modules/balances/protocols/components/ChainBalances.vue
+++ b/frontend/app/src/modules/balances/protocols/components/ChainBalances.vue
@@ -3,13 +3,13 @@ import type { Balance } from '@rotki/common';
 import ChainBalanceTooltipIcon from '@/modules/balances/protocols/components/ChainBalanceTooltipIcon.vue';
 import { sortDesc } from '@/utils/bignumbers';
 
-const props = defineProps<{
+const { chains } = defineProps<{
   chains: Record<string, Balance>;
   asset?: string;
   loading?: boolean;
 }>();
 
-const chainEntries = computed<[string, Balance][]>(() => Object.entries(props.chains).sort((a, b) => sortDesc(a[1].value, b[1].value)));
+const chainEntries = computed<[string, Balance][]>(() => Object.entries(chains).sort((a, b) => sortDesc(a[1].value, b[1].value)));
 </script>
 
 <template>

--- a/frontend/app/src/modules/common/links/AddressDeleteButton.vue
+++ b/frontend/app/src/modules/common/links/AddressDeleteButton.vue
@@ -8,24 +8,22 @@ interface AddressDeleteButtonProps {
   source: string | null;
 }
 
-const props = defineProps<AddressDeleteButtonProps>();
+const { text, source } = defineProps<AddressDeleteButtonProps>();
 
-const canDelete = computed<boolean>(() => {
-  const { source } = props;
-  return source === AddressNamePriority.PRIVATE_ADDRESSBOOK || source === AddressNamePriority.GLOBAL_ADDRESSBOOK;
-});
+const canDelete = computed<boolean>(() =>
+  source === AddressNamePriority.PRIVATE_ADDRESSBOOK || source === AddressNamePriority.GLOBAL_ADDRESSBOOK,
+);
 
-const location = computed<AddressBookLocation>(() => {
-  const { source } = props;
-  return source === AddressNamePriority.GLOBAL_ADDRESSBOOK ? 'global' : 'private';
-});
+const location = computed<AddressBookLocation>(() =>
+  source === AddressNamePriority.GLOBAL_ADDRESSBOOK ? 'global' : 'private',
+);
 
 const { t } = useI18n({ useScope: 'global' });
 
 const { showDeleteConfirmation } = useAddressBookDeletion(location);
 
 const entry = computed<AddressBookEntry>(() => ({
-  address: props.text,
+  address: text,
   blockchain: null,
   name: '',
 }));

--- a/frontend/app/src/modules/common/links/AddressEditButton.vue
+++ b/frontend/app/src/modules/common/links/AddressEditButton.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { useAddressBookForm } from '@/composables/address-book/form';
 
-const props = defineProps<{
+const { text, blockchain, name } = defineProps<{
   text: string;
   blockchain: string;
   name?: string;
@@ -17,9 +17,9 @@ const { showGlobalDialog } = useAddressBookForm();
 function openAddressBookForm() {
   emit('open');
   showGlobalDialog({
-    address: props.text,
-    blockchain: props.blockchain,
-    name: props.name || '',
+    address: text,
+    blockchain,
+    name: name || '',
   });
 }
 </script>

--- a/frontend/app/src/modules/common/links/LinkButton.vue
+++ b/frontend/app/src/modules/common/links/LinkButton.vue
@@ -2,7 +2,7 @@
 import { useLinks } from '@/composables/links';
 import { truncateAddress } from '@/utils/truncate';
 
-const props = defineProps<{
+const { base, text, isToken } = defineProps<{
   base: string;
   text: string;
   size: string | number;
@@ -10,12 +10,11 @@ const props = defineProps<{
 }>();
 
 const url = computed<string>(() => {
-  const isToken = props.isToken;
-  const linkText = isToken ? props.text.replace('/', '?a=') : props.text;
-  return props.base + linkText;
+  const linkText = isToken ? text.replace('/', '?a=') : text;
+  return base + linkText;
 });
 
-const displayUrl = computed<string>(() => props.base + truncateAddress(props.text, 10));
+const displayUrl = computed<string>(() => base + truncateAddress(text, 10));
 
 const { href, onLinkClick } = useLinks(url);
 const { t } = useI18n({ useScope: 'global' });

--- a/frontend/app/src/modules/dashboard/liquidity-pools/PoolIcon.vue
+++ b/frontend/app/src/modules/dashboard/liquidity-pools/PoolIcon.vue
@@ -4,7 +4,7 @@ import AssetIcon from '@/components/helper/display/icons/AssetIcon.vue';
 import { getPublicProtocolImagePath } from '@/utils/file';
 import { PoolType } from './types';
 
-const props = defineProps<{
+const { assets, type } = defineProps<{
   assets: string[];
   type: PoolType;
 }>();
@@ -18,7 +18,7 @@ const data = [{
 }] as const;
 
 const icon = computed<string | undefined>(() => {
-  const selected = data.find(({ identifier }) => identifier === props.type);
+  const selected = data.find(({ identifier }) => identifier === type);
 
   if (!selected)
     return undefined;
@@ -26,7 +26,7 @@ const icon = computed<string | undefined>(() => {
   return selected.icon;
 });
 
-const multiple = computed<boolean>(() => props.assets.length > 2);
+const multiple = computed<boolean>(() => assets.length > 2);
 </script>
 
 <template>

--- a/frontend/app/src/modules/dashboard/summary/ExchangeBox.vue
+++ b/frontend/app/src/modules/dashboard/summary/ExchangeBox.vue
@@ -11,13 +11,13 @@ interface ExchangeBoxProps {
   amount: BigNumber;
 }
 
-const props = defineProps<ExchangeBoxProps>();
+const { location } = defineProps<ExchangeBoxProps>();
 
 const { exchangeName } = useLocations();
 
 const exchangeLocationRoute = computed<string>(() => {
   const route = Routes.BALANCES_EXCHANGE;
-  return `${route}/${props.location}`;
+  return `${route}/${location}`;
 });
 </script>
 

--- a/frontend/app/src/modules/dashboard/summary/SummaryCardCreateButton.vue
+++ b/frontend/app/src/modules/dashboard/summary/SummaryCardCreateButton.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import type { RouteLocationRaw } from 'vue-router';
 
-const props = defineProps<{ to?: RouteLocationRaw }>();
+const { to } = defineProps<{ to?: RouteLocationRaw }>();
 
 const router = useRouter();
 
 function navigate() {
-  if (props.to) {
-    router.push(props.to);
+  if (to) {
+    router.push(to);
   }
 }
 </script>

--- a/frontend/app/src/modules/history/balances/NegativeBalancesDialog.vue
+++ b/frontend/app/src/modules/history/balances/NegativeBalancesDialog.vue
@@ -9,7 +9,7 @@ import { Routes } from '@/router/routes';
 
 const modelValue = defineModel<boolean>({ required: true });
 
-const props = defineProps<{
+const { negativeBalances } = defineProps<{
   negativeBalances: NegativeBalanceDetectedData[];
 }>();
 
@@ -17,10 +17,9 @@ const { t } = useI18n({ useScope: 'global' });
 const router = useRouter();
 
 const lastRunTs = computed<number | undefined>(() => {
-  const balances = props.negativeBalances;
-  if (balances.length === 0)
+  if (negativeBalances.length === 0)
     return undefined;
-  return balances[0].lastRunTs ?? undefined;
+  return negativeBalances[0].lastRunTs ?? undefined;
 });
 
 const headers = computed<DataTableColumn<NegativeBalanceDetectedData>[]>(() => [

--- a/frontend/app/src/modules/history/events/components/HistoryEventsLoadMoreRow.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsLoadMoreRow.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 defineProps<{
   hiddenCount: number;
-  totalCount: number;
 }>();
 
 const emit = defineEmits<{

--- a/frontend/app/src/modules/history/events/components/HistoryEventsSwapCollapseRow.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsSwapCollapseRow.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
-import type { HistoryEventEntry } from '@/types/history/events/schemas';
-
-const props = defineProps<{
+const { labelType } = defineProps<{
   eventCount: number;
   labelType?: 'swap' | 'movement';
-  events?: HistoryEventEntry[];
 }>();
 
 const emit = defineEmits<{
@@ -14,7 +11,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const isMovement = computed<boolean>(() => props.labelType === 'movement');
+const isMovement = computed<boolean>(() => labelType === 'movement');
 
 const { isMdAndUp } = useBreakpoint();
 </script>

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.vue
@@ -8,8 +8,6 @@ const pagination = defineModel<TablePaginationData>('pagination', { required: tr
 
 defineProps<{
   loading?: boolean;
-  total: number;
-  found: number;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
@@ -19,7 +17,9 @@ const { isSmAndDown } = useBreakpoint();
 
 function getSortArray() {
   const sortData = get(sort);
-  return Array.isArray(sortData) ? sortData : (sortData ? [sortData] : []);
+  if (Array.isArray(sortData))
+    return sortData;
+  return sortData ? [sortData] : [];
 }
 
 const sortColumn = computed<'timestamp' | undefined>({
@@ -36,9 +36,9 @@ const sortColumn = computed<'timestamp' | undefined>({
     }
     const sortArray = getSortArray();
     const currentDirection = sortArray[0]?.direction ?? 'desc';
-    const newDirection = sortArray[0]?.column === column
-      ? (currentDirection === 'asc' ? 'desc' : 'asc')
-      : 'desc';
+    let newDirection: 'asc' | 'desc' = 'desc';
+    if (sortArray[0]?.column === column)
+      newDirection = currentDirection === 'asc' ? 'desc' : 'asc';
     set(sort, [{ column, direction: newDirection }]);
   },
 });

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -48,7 +48,6 @@ const {
   highlightTypes?: Record<string, HighlightType>;
   hideActions?: boolean;
   selection?: UseHistoryEventsSelectionModeReturn;
-  matchExactEvents?: boolean;
   duplicateHandlingStatus?: DuplicateHandlingStatus;
 }>();
 

--- a/frontend/app/src/modules/history/events/components/RedecodeConfirmationDialog.vue
+++ b/frontend/app/src/modules/history/events/components/RedecodeConfirmationDialog.vue
@@ -16,7 +16,7 @@ import {
 
 const show = defineModel<boolean>('show', { required: true });
 
-const props = defineProps<{
+const { payload } = defineProps<{
   payload: PullEventPayload | undefined;
   hasCustomEvents?: boolean;
   showIndexerOptions?: boolean;
@@ -40,7 +40,6 @@ const availableIndexers = new PrioritizedListData<PrioritizedListId>([
 ]);
 
 const isEvmEvent = computed<boolean>(() => {
-  const payload = props.payload;
   if (!payload)
     return false;
 
@@ -49,7 +48,6 @@ const isEvmEvent = computed<boolean>(() => {
 });
 
 const evmChainName = computed<string | undefined>(() => {
-  const payload = props.payload;
   if (!payload)
     return undefined;
 
@@ -86,7 +84,6 @@ function resetState(): void {
 }
 
 function confirmRedecode(): void {
-  const payload = props.payload;
   if (payload) {
     const indexerOrder = get(localIndexerOrder);
     emit('confirm', {

--- a/frontend/app/src/modules/history/management/forms/EvmSwapEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/EvmSwapEventForm.vue
@@ -16,7 +16,7 @@ import { useRefPropVModel } from '@/utils/model';
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<{ data: StandaloneEventData<EvmHistoryEvent> | GroupEventData<EvmSwapEvent> }>();
+const { data } = defineProps<{ data: StandaloneEventData<EvmHistoryEvent> | GroupEventData<EvmSwapEvent> }>();
 
 const { txChainsToLocation } = useSupportedChains();
 const { emptySubEvent, handleValidationErrors, submitAllPrices, addHistoryEvent, editHistoryEvent } = useSwapEventForm();
@@ -118,7 +118,7 @@ async function save(): Promise<boolean> {
   return result.success;
 }
 
-watchImmediate(() => props.data, (data) => {
+watchImmediate(() => data, (data) => {
   if (data.type === 'group-add') {
     const group = data.group;
 

--- a/frontend/app/src/modules/history/management/forms/SolanaSwapEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/SolanaSwapEventForm.vue
@@ -16,7 +16,7 @@ import { useRefPropVModel } from '@/utils/model';
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<{ data: StandaloneEventData<SolanaEvent> | GroupEventData<SolanaSwapEvent> }>();
+const { data } = defineProps<{ data: StandaloneEventData<SolanaEvent> | GroupEventData<SolanaSwapEvent> }>();
 
 const { emptySubEvent, handleValidationErrors, submitAllPrices, addHistoryEvent, editHistoryEvent } = useSwapEventForm();
 
@@ -118,7 +118,7 @@ async function save(): Promise<boolean> {
   return result.success;
 }
 
-watchImmediate(() => props.data, (data) => {
+watchImmediate(() => data, (data) => {
   if (data.type === 'group-add') {
     const group = data.group;
 

--- a/frontend/app/src/modules/history/management/forms/SwapEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/SwapEventForm.vue
@@ -35,7 +35,7 @@ interface FormData {
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
-const props = defineProps<{ data: GroupEventData<SwapEvent> }>();
+const { data } = defineProps<{ data: GroupEventData<SwapEvent> }>();
 
 function emptyEvent(): FormData {
   return {
@@ -190,7 +190,7 @@ function getNotes(event?: SwapEvent): string {
   return event.userNotes;
 }
 
-watchImmediate(() => props.data, (data) => {
+watchImmediate(() => data, (data) => {
   if (data.type !== 'edit-group')
     return;
 

--- a/frontend/app/src/modules/history/management/forms/common/EventLocationLabel.vue
+++ b/frontend/app/src/modules/history/management/forms/common/EventLocationLabel.vue
@@ -5,7 +5,7 @@ import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-a
 
 const modelValue = defineModel<string>({ required: true });
 
-const props = defineProps<{
+const { location } = defineProps<{
   location: string;
   errorMessages: string[];
 }>();
@@ -19,7 +19,7 @@ const { getAddresses } = useAccountAddresses();
 const { matchChain } = useSupportedChains();
 
 const addressSuggestions = computed(() => {
-  const chain = matchChain(props.location);
+  const chain = matchChain(location);
   if (!chain)
     return [];
   return getAddresses(chain);

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshAddressSelection.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshAddressSelection.vue
@@ -3,17 +3,17 @@ import AccountDisplay from '@/components/display/AccountDisplay.vue';
 
 const modelValue = defineModel<string[]>({ required: true });
 
-const props = defineProps<{
+const { addresses, search } = defineProps<{
   addresses: string[];
   chain: string;
   processing: boolean;
   search: string;
 }>();
 
-const filteredAddresses = computed<string[]>(() => props.addresses.filter(matchesSearch));
+const filteredAddresses = computed<string[]>(() => addresses.filter(matchesSearch));
 
 function matchesSearch(address: string): boolean {
-  return address.toLocaleLowerCase().includes(props.search.toLocaleLowerCase());
+  return address.toLocaleLowerCase().includes(search.toLocaleLowerCase());
 }
 
 function toggleSelect(address: string): void {

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshChainItem.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshChainItem.vue
@@ -4,7 +4,7 @@ import LocationIcon from '@/components/history/LocationIcon.vue';
 
 const modelValue = defineModel<string[]>({ required: true });
 
-const props = defineProps<{
+const { addresses } = defineProps<{
   item: ChainData;
   addresses: string[];
   processing: boolean;
@@ -19,7 +19,7 @@ function toggleSelect(): void {
     set(modelValue, []);
   }
   else {
-    set(modelValue, props.addresses);
+    set(modelValue, addresses);
   }
 }
 </script>

--- a/frontend/app/src/modules/onchain/send/TradeAssetDisplay.vue
+++ b/frontend/app/src/modules/onchain/send/TradeAssetDisplay.vue
@@ -6,7 +6,7 @@ import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { useSupportedChains } from '@/composables/info/chains';
 import { FiatDisplay, ValueDisplay } from '@/modules/amount-display/components';
 
-const props = defineProps<{
+const { data } = defineProps<{
   data: TradableAsset;
   list?: boolean;
   amount?: BigNumber;
@@ -21,8 +21,8 @@ const { t } = useI18n({ useScope: 'global' });
 const { assetName, assetSymbol } = useAssetInfoRetrieval();
 const { getEvmChainName } = useSupportedChains();
 
-const symbol = assetSymbol(props.data.asset, { collectionParent: false });
-const name = assetName(props.data.asset, { collectionParent: false });
+const symbol = assetSymbol(data.asset, { collectionParent: false });
+const name = assetName(data.asset, { collectionParent: false });
 </script>
 
 <template>

--- a/frontend/app/src/modules/onchain/send/TradeHistoryItem.vue
+++ b/frontend/app/src/modules/onchain/send/TradeHistoryItem.vue
@@ -5,12 +5,12 @@ import ChainIcon from '@/components/helper/display/icons/ChainIcon.vue';
 import HistoryEventNote from '@/components/history/events/HistoryEventNote.vue';
 import HashLink from '@/modules/common/links/HashLink.vue';
 
-const props = defineProps<{
+const { item } = defineProps<{
   item: RecentTransaction;
 }>();
 
 const color = computed<'error' | 'success' | 'warning'>(() => {
-  const status = props.item.status;
+  const status = item.status;
   if (status === 'completed') {
     return 'success';
   }

--- a/frontend/app/src/modules/premium/devices/components/PremiumDeviceForm.vue
+++ b/frontend/app/src/modules/premium/devices/components/PremiumDeviceForm.vue
@@ -13,7 +13,7 @@ const errors = defineModel<ValidationErrors>('errorMessages', { required: true }
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false });
 
-const props = defineProps<{
+const { device } = defineProps<{
   device: PremiumDevice;
 }>();
 
@@ -21,7 +21,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const rules = {
   deviceName: {
-    notEqual: helpers.withMessage(t('premium_devices.form.device_name.error.not_equal'), not(sameAs(props.device.deviceName))),
+    notEqual: helpers.withMessage(t('premium_devices.form.device_name.error.not_equal'), not(sameAs(device.deviceName))),
     required: helpers.withMessage(t('premium_devices.form.device_name.error.required'), required),
   },
 };

--- a/frontend/app/src/modules/staking/eth/components/EthValidatorCombinedFilter.vue
+++ b/frontend/app/src/modules/staking/eth/components/EthValidatorCombinedFilter.vue
@@ -12,10 +12,6 @@ import { dateDeserializer, dateRangeValidator, dateSerializer, getDateInputISOFo
 
 const filter = defineModel<EthStakingCombinedFilter | undefined>('filter', { required: true });
 
-defineProps<{
-  disableStatus?: boolean;
-}>();
-
 enum Eth2StakingFilterKeys {
   START = 'start',
   END = 'end',

--- a/frontend/app/src/modules/statistics/wrapped/components/WrappedCard.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/WrappedCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts" generic="T extends object">
 import WrappedItem from '@/components/wrapped/WrappedItem.vue';
 
-const props = defineProps<{
+const { items } = defineProps<{
   items: T[];
 }>();
 
@@ -9,12 +9,11 @@ const { t } = useI18n({ useScope: 'global' });
 
 const INITIAL_LENGTH = 5;
 
-const showMoreButton = computed<boolean>(() => props.items.length > INITIAL_LENGTH);
+const showMoreButton = computed<boolean>(() => items.length > INITIAL_LENGTH);
 
 const showAll = ref<boolean>(false);
 
 const itemsToUse = computed<T[]>(() => {
-  const items = props.items;
   if (get(showAll))
     return items;
 

--- a/frontend/app/src/modules/statistics/wrapped/components/WrappedContainer.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/WrappedContainer.vue
@@ -16,7 +16,7 @@ import WrappedDateFilter from './WrappedDateFilter.vue';
 import WrappedHeader from './WrappedHeader.vue';
 import WrappedSkeletonCards from './WrappedSkeletonCards.vue';
 
-const props = defineProps<{
+const { highlightedYear } = defineProps<{
   highlightedYear?: number;
 }>();
 
@@ -46,10 +46,10 @@ const {
 } = useWrappedGnosisPay(summary);
 
 const isHighlightedYear = computed<boolean>(() => {
-  if (!isDefined(props.highlightedYear))
+  if (!isDefined(highlightedYear))
     return false;
 
-  const range = getYearRange(props.highlightedYear);
+  const range = getYearRange(highlightedYear);
   return get(start) === range.start && get(end) === range.end;
 });
 

--- a/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedExchangeCard.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedExchangeCard.vue
@@ -5,16 +5,16 @@ import { ValueDisplay } from '@/modules/amount-display/components';
 import { sortDesc } from '@/utils/bignumbers';
 import WrappedCard from '../WrappedCard.vue';
 
-const props = defineProps<{
+const { tradesByExchange } = defineProps<{
   tradesByExchange?: Record<string, BigNumber>;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
 const exchangeItems = computed<Array<[string, BigNumber]>>(() => {
-  if (!props.tradesByExchange)
+  if (!tradesByExchange)
     return [];
-  return Object.entries(props.tradesByExchange).sort((a, b) => sortDesc(a[1], b[1]));
+  return Object.entries(tradesByExchange).sort((a, b) => sortDesc(a[1], b[1]));
 });
 </script>
 

--- a/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedGasCard.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedGasCard.vue
@@ -5,7 +5,7 @@ import HashLink from '@/modules/common/links/HashLink.vue';
 import { sortDesc } from '@/utils/bignumbers';
 import WrappedCard from '../WrappedCard.vue';
 
-const props = defineProps<{
+const { ethOnGasPerAddress } = defineProps<{
   ethOnGas?: BigNumber;
   ethOnGasPerAddress?: Record<string, BigNumber>;
 }>();
@@ -14,9 +14,9 @@ const { t } = useI18n({ useScope: 'global' });
 const { isSmAndDown } = useBreakpoint();
 
 const gasPerAddressItems = computed<Array<[string, BigNumber]>>(() => {
-  if (!props.ethOnGasPerAddress)
+  if (!ethOnGasPerAddress)
     return [];
-  return Object.entries(props.ethOnGasPerAddress).sort((a, b) => sortDesc(a[1], b[1]));
+  return Object.entries(ethOnGasPerAddress).sort((a, b) => sortDesc(a[1], b[1]));
 });
 </script>
 

--- a/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedProtocolCard.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedProtocolCard.vue
@@ -10,16 +10,16 @@ interface ProtocolActivity {
   transactions: BigNumber;
 }
 
-const props = defineProps<{
+const { transactionsPerProtocol } = defineProps<{
   transactionsPerProtocol?: ProtocolActivity[];
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
 const sortedProtocols = computed<ProtocolActivity[]>(() => {
-  if (!props.transactionsPerProtocol)
+  if (!transactionsPerProtocol)
     return [];
-  return [...props.transactionsPerProtocol].sort((a, b) => sortDesc(a.transactions, b.transactions));
+  return [...transactionsPerProtocol].sort((a, b) => sortDesc(a.transactions, b.transactions));
 });
 </script>
 

--- a/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedTopDaysCard.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedTopDaysCard.vue
@@ -10,7 +10,7 @@ interface TopDay {
   amount: BigNumber;
 }
 
-const props = defineProps<{
+const { topDaysByNumberOfTransactions } = defineProps<{
   topDaysByNumberOfTransactions?: TopDay[];
 }>();
 
@@ -18,9 +18,9 @@ const { t } = useI18n({ useScope: 'global' });
 const { formatDate } = useWrappedFormatters();
 
 const sortedDays = computed<TopDay[]>(() => {
-  if (!props.topDaysByNumberOfTransactions)
+  if (!topDaysByNumberOfTransactions)
     return [];
-  return [...props.topDaysByNumberOfTransactions].sort((a, b) => sortDesc(a.amount, b.amount));
+  return [...topDaysByNumberOfTransactions].sort((a, b) => sortDesc(a.amount, b.amount));
 });
 </script>
 

--- a/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedTransactionsCard.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedTransactionsCard.vue
@@ -6,7 +6,7 @@ import { ValueDisplay } from '@/modules/amount-display/components';
 import { sortDesc } from '@/utils/bignumbers';
 import WrappedCard from '../WrappedCard.vue';
 
-const props = defineProps<{
+const { transactionsPerChain } = defineProps<{
   transactionsPerChain?: Record<string, BigNumber>;
 }>();
 
@@ -14,9 +14,9 @@ const { t } = useI18n({ useScope: 'global' });
 const { getChain } = useSupportedChains();
 
 const chainItems = computed<Array<[string, BigNumber]>>(() => {
-  if (!props.transactionsPerChain)
+  if (!transactionsPerChain)
     return [];
-  return Object.entries(props.transactionsPerChain).sort((a, b) => sortDesc(a[1], b[1]));
+  return Object.entries(transactionsPerChain).sort((a, b) => sortDesc(a[1], b[1]));
 });
 </script>
 

--- a/frontend/app/src/modules/sync-progress/components/ChainProgressList.vue
+++ b/frontend/app/src/modules/sync-progress/components/ChainProgressList.vue
@@ -2,7 +2,7 @@
 import type { ChainProgress } from '../types';
 import ChainProgressItem from './ChainProgressItem.vue';
 
-const props = defineProps<{
+const { chains } = defineProps<{
   chains: ChainProgress[];
 }>();
 
@@ -11,11 +11,11 @@ const { t } = useI18n({ useScope: 'global' });
 const showCompleted = ref<boolean>(false);
 
 const inProgressChains = computed<ChainProgress[]>(() =>
-  props.chains.filter(c => c.completed < c.total || c.total === 0),
+  chains.filter(c => c.completed < c.total || c.total === 0),
 );
 
 const completedChains = computed<ChainProgress[]>(() =>
-  props.chains.filter(c => c.completed === c.total && c.total > 0),
+  chains.filter(c => c.completed === c.total && c.total > 0),
 );
 
 const hasInProgress = computed<boolean>(() => get(inProgressChains).length > 0);

--- a/frontend/app/src/modules/sync-progress/components/DecodingProgressList.vue
+++ b/frontend/app/src/modules/sync-progress/components/DecodingProgressList.vue
@@ -2,7 +2,7 @@
 import type { DecodingProgress } from '../types';
 import DecodingProgressItem from './DecodingProgressItem.vue';
 
-const props = defineProps<{
+const { decoding } = defineProps<{
   decoding: DecodingProgress[];
 }>();
 
@@ -11,11 +11,11 @@ const { t } = useI18n({ useScope: 'global' });
 const showCompleted = ref<boolean>(false);
 
 const inProgressDecoding = computed<DecodingProgress[]>(() =>
-  props.decoding.filter(d => d.processed < d.total),
+  decoding.filter(d => d.processed < d.total),
 );
 
 const completedDecoding = computed<DecodingProgress[]>(() =>
-  props.decoding.filter(d => d.processed >= d.total),
+  decoding.filter(d => d.processed >= d.total),
 );
 
 const hasInProgress = computed<boolean>(() => get(inProgressDecoding).length > 0);

--- a/frontend/app/src/modules/sync-progress/components/LocationProgressList.vue
+++ b/frontend/app/src/modules/sync-progress/components/LocationProgressList.vue
@@ -2,7 +2,7 @@
 import { type LocationProgress, LocationStatus } from '../types';
 import LocationProgressItem from './LocationProgressItem.vue';
 
-const props = defineProps<{
+const { locations } = defineProps<{
   locations: LocationProgress[];
 }>();
 
@@ -11,11 +11,11 @@ const { t } = useI18n({ useScope: 'global' });
 const showCompleted = ref<boolean>(false);
 
 const inProgressLocations = computed<LocationProgress[]>(() =>
-  props.locations.filter(l => l.status !== LocationStatus.COMPLETE),
+  locations.filter(l => l.status !== LocationStatus.COMPLETE),
 );
 
 const completedLocations = computed<LocationProgress[]>(() =>
-  props.locations.filter(l => l.status === LocationStatus.COMPLETE),
+  locations.filter(l => l.status === LocationStatus.COMPLETE),
 );
 
 const hasInProgress = computed<boolean>(() => get(inProgressLocations).length > 0);

--- a/frontend/app/src/modules/sync-progress/components/ProtocolCacheProgressList.vue
+++ b/frontend/app/src/modules/sync-progress/components/ProtocolCacheProgressList.vue
@@ -2,7 +2,7 @@
 import type { ProtocolCacheProgress } from '../types';
 import ProtocolCacheProgressItem from './ProtocolCacheProgressItem.vue';
 
-const props = defineProps<{
+const { protocolCache } = defineProps<{
   protocolCache: ProtocolCacheProgress[];
 }>();
 
@@ -11,11 +11,11 @@ const { t } = useI18n({ useScope: 'global' });
 const showCompleted = ref<boolean>(false);
 
 const inProgressCache = computed<ProtocolCacheProgress[]>(() =>
-  props.protocolCache.filter(p => p.processed < p.total),
+  protocolCache.filter(p => p.processed < p.total),
 );
 
 const completedCache = computed<ProtocolCacheProgress[]>(() =>
-  props.protocolCache.filter(p => p.processed >= p.total),
+  protocolCache.filter(p => p.processed >= p.total),
 );
 
 const hasInProgress = computed<boolean>(() => get(inProgressCache).length > 0);

--- a/frontend/app/src/pages/balances/manual/[[tab]].vue
+++ b/frontend/app/src/pages/balances/manual/[[tab]].vue
@@ -22,7 +22,7 @@ definePage({
   props: true,
 });
 
-const props = defineProps<{
+const { tab } = defineProps<{
   tab: string;
 }>();
 
@@ -39,7 +39,7 @@ function add() {
   set(balance, {
     amount: Zero,
     asset: '',
-    balanceType: props.tab === 'liabilities' ? BalanceType.LIABILITY : BalanceType.ASSET,
+    balanceType: tab === 'liabilities' ? BalanceType.LIABILITY : BalanceType.ASSET,
     label: '',
     location: TRADE_LOCATION_EXTERNAL,
     tags: null,

--- a/frontend/app/src/pages/staking/[[location]].vue
+++ b/frontend/app/src/pages/staking/[[location]].vue
@@ -22,7 +22,7 @@ definePage({
   props: true,
 });
 
-const props = defineProps<{
+const { location: locationProp } = defineProps<{
   location: NavType | '';
 }>();
 
@@ -41,7 +41,7 @@ const lastLocation = useLocalStorage('rotki.staking.last_location', '');
 
 const location = computed({
   get() {
-    return props.location || undefined;
+    return locationProp || undefined;
   },
   set(value?: NavType) {
     set(lastLocation, value);
@@ -95,8 +95,8 @@ const page = computed(() => {
 });
 
 onMounted(async () => {
-  if (props.location) {
-    set(location, props.location);
+  if (locationProp) {
+    set(location, locationProp);
     return;
   }
   const lastLocationVal = get(lastLocation);

--- a/frontend/app/src/utils/assets.ts
+++ b/frontend/app/src/utils/assets.ts
@@ -75,8 +75,14 @@ export function getSanitizedChain(
  * Gets asset search parameters based on chain type.
  */
 export function getAssetSearchTypeParams(usedChain: string | undefined): { assetType?: string; evmChain?: string } {
+  let assetType: string | undefined;
+  if (usedChain === SOLANA_CHAIN)
+    assetType = SOLANA_TOKEN;
+  else if (usedChain)
+    assetType = EVM_TOKEN;
+
   return {
-    assetType: usedChain === SOLANA_CHAIN ? SOLANA_TOKEN : (usedChain ? EVM_TOKEN : undefined),
+    assetType,
     evmChain: usedChain === SOLANA_CHAIN ? undefined : usedChain,
   };
 }


### PR DESCRIPTION
## Summary
- Destructure `defineProps` in 66+ components (`vue/define-props-destructuring`)
- Use `useTemplateRef` instead of `ref` for template refs (`vue/prefer-use-template-ref`)
- Replace nested ternaries with if/else blocks (`no-nested-ternary`)
- Switch to type-based emit declarations (`vue/define-emits-declaration`)
- Remove unused emit declarations (`vue/no-unused-emit-declarations`)
- Remove unused component props (`vue/no-unused-properties`)
- Redesign `AccountingRuleActionDialog` to separate context data from component props
- Redesign `DateTimePicker` to pass props individually instead of `v-bind`

## Test plan
- [x] All 2612 unit tests pass
- [x] TypeScript typecheck passes
- [x] ESLint lint-staged passes