### PR TITLE
fix(frontend): no fallback to current price for historic events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Historic event values will no longer incorrectly fallback to the current price when the historic price is not available.
 * :bug:`-` Curve deposits via intermediate pools will now be properly decoded.
 * :bug:`-` cowswap swaps using both versions of the monerium tokens will now be properly decoded.
 * :bug:`11708` Users can now mark Solana tokens as spam in addition to EVM tokens.

--- a/frontend/app/src/modules/amount-display/composables/use-asset-value.spec.ts
+++ b/frontend/app/src/modules/amount-display/composables/use-asset-value.spec.ts
@@ -110,6 +110,20 @@ describe('modules/amount-display/composables/use-asset-value', () => {
     });
   });
 
+  describe('historic price', () => {
+    it('should not fallback to current price when historic price is unavailable', () => {
+      const { price, value } = useAssetValue({
+        amount: bigNumberify(2),
+        asset: 'ETH',
+        timestamp: { ms: 1700000000000 },
+      });
+
+      // Historic price not found → should return zero, not the current price (2000)
+      expect(get(price).toNumber()).toBe(0);
+      expect(get(value).toNumber()).toBe(0);
+    });
+  });
+
   describe('loading', () => {
     it('should return false when no timestamp', () => {
       const { loading } = useAssetValue({

--- a/frontend/app/src/modules/amount-display/composables/use-asset-value.ts
+++ b/frontend/app/src/modules/amount-display/composables/use-asset-value.ts
@@ -78,12 +78,13 @@ export function useAssetValue(options: UseAssetValueOptions): UseAssetValueRetur
       return Zero;
     }
 
-    // If historic timestamp is provided, use historic price
+    // If historic timestamp is provided, use historic price (no fallback to current price)
     if (ts > 0) {
       const historicPrice = get(historicPriceInCurrentCurrency(assetVal, ts));
       if (historicPrice.gt(0)) {
         return historicPrice;
       }
+      return Zero;
     }
 
     // If known price is provided and price is in current currency, use known price


### PR DESCRIPTION
## Summary
- When a historic price lookup fails for a timestamped event, the display now returns zero instead of falling through to the current/latest price, which would show misleading values.

## Test plan
- [x] Added unit test verifying that historic price lookup with unavailable price returns zero instead of current price
- [x] All existing `use-asset-value` tests pass (13/13)