### PR TITLE
ci: clean up old docker images on nightly builds

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -331,6 +331,9 @@ jobs:
     needs:
       - build-docker
     environment: docker
+    env:
+      REGCTL: v0.11.2
+      REGCTL_SUM: 'e1d68886548b9fae0ed5744932a67ef34dbf16dd7e2445604a7fe84fb53c7aeb77844b498908914c183b58c3501ac2b6a015d7981acf152e8a0b4c8fbaa207e8'
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -348,6 +351,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Cache regctl
+        uses: actions/cache@v4
+        with:
+          path: regctl-linux-amd64
+          key: ${{ runner.os }}-regctl-${{ env.REGCTL }}
+
+      - name: Setup regctl
+        run: |
+          if [[ ! -f "regctl-linux-amd64" ]]; then
+            echo "downloading regctl ${REGCTL}"
+            curl -LO --fail-with-body "https://github.com/regclient/regclient/releases/download/${REGCTL}/regctl-linux-amd64"
+          fi
+          chmod u+x regctl-linux-amd64
+          echo "${REGCTL_SUM} regctl-linux-amd64" > regctl-linux-amd64.sha512
+          if [[ ! $(sha512sum -c regctl-linux-amd64.sha512) ]]; then
+            echo checksum failed
+            exit 1
+          fi
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -357,6 +379,21 @@ jobs:
           tags: |
             type=schedule,pattern=nightly
             type=edge,branch=build
+
+      - name: Get previous image digests
+        id: old_digests
+        continue-on-error: true
+        env:
+          REPOSITORY: ${{ github.repository }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          OLD_INDEX=$(./regctl-linux-amd64 manifest digest "${REPOSITORY}:${VERSION}" 2>/dev/null || echo "")
+          echo "index=${OLD_INDEX}" >> "$GITHUB_OUTPUT"
+          if [[ -n "${OLD_INDEX}" ]]; then
+            CHILDREN=$(./regctl-linux-amd64 manifest get "${REPOSITORY}:${VERSION}" --format raw-body \
+              | jq -r '.manifests[].digest' 2>/dev/null | tr '\n' ' ')
+            echo "children=${CHILDREN}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
@@ -372,6 +409,20 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
           docker buildx imagetools inspect "${REPOSITORY}:${VERSION}"
+
+      - name: Delete previous image
+        if: steps.old_digests.outputs.index != ''
+        env:
+          REPOSITORY: ${{ github.repository }}
+          OLD_INDEX: ${{ steps.old_digests.outputs.index }}
+          CHILDREN: ${{ steps.old_digests.outputs.children }}
+        run: |
+          for digest in ${CHILDREN}; do
+            echo "Deleting child manifest ${digest}"
+            ./regctl-linux-amd64 manifest delete "${REPOSITORY}@${digest}" --ignore-missing
+          done
+          echo "Deleting index ${OLD_INDEX}"
+          ./regctl-linux-amd64 manifest delete "${REPOSITORY}@${OLD_INDEX}" --ignore-missing
 
   notify:
     name: 'Success check'

--- a/.github/workflows/rotki_docker_publish.yaml
+++ b/.github/workflows/rotki_docker_publish.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: docker
     env:
-      REGCTL: v0.8.0
-      REGCTL_SUM: 'df25ceaadf190ec73804023657673128a62d909cca12ccd7a9a727a0b6df84b846b00a89ae581bf179528d74dce6a12fb8b7f5e55e546615b75e0a5e5c56c227'
+      REGCTL: v0.11.2
+      REGCTL_SUM: 'e1d68886548b9fae0ed5744932a67ef34dbf16dd7e2445604a7fe84fb53c7aeb77844b498908914c183b58c3501ac2b6a015d7981acf152e8a0b4c8fbaa207e8'
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- Add `regctl` to the dev builds `docker-merge` job to delete the previous `nightly`/`edge` manifest index and all child manifests (platform images + attestations) after successfully pushing the new tag
- Prevents untagged images from accumulating on Docker Hub
- Update `regctl` from v0.8.0 to v0.11.2 in both dev builds and docker publish workflows

## How it works
1. Before pushing the new manifest list, captures the current tag's index digest and all child digests
2. Pushes the new manifest list (moves the tag to the new image)
3. Deletes old child manifests (amd64, arm64, attestations) then the old index
4. Uses `--ignore-missing` and `continue-on-error` for safety on first run or if tag doesn't exist yet