### PR TITLE
Refactor internal-transactions pull/redecode flow

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 * :bug:`-` Curve deposits with add liquidity + stake will now be properly decoded.
 * :bug:`-` Curve deposits via intermediate pools will now be properly decoded.
 * :bug:`-` cowswap swaps using both versions of the monerium tokens will now be properly decoded.
+* :bug:`11777` Redecoding a single EVM transaction will no longer remove existing transaction data if indexers are temporarily unavailable.
 * :bug:`11708` Users can now mark Solana tokens as spam in addition to EVM tokens.
 * :bug:`11709` History events page will now properly refresh after marking an asset as spam or ignoring it from the context menu.
 * :bug:`-` Registering a new device is now more reliable when rotki runs in container environments.

--- a/rotkehlchen/api/services/transactions.py
+++ b/rotkehlchen/api/services/transactions.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 from sqlcipher3 import dbapi2 as sqlcipher
 
 from rotkehlchen.assets.utils import token_normalized_value
+from rotkehlchen.chain.evm.constants import GENESIS_HASH
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.chain.evm.types import NodeName
 from rotkehlchen.chain.gnosis.modules.gnosis_pay.constants import CPT_GNOSIS_PAY
@@ -64,6 +65,7 @@ if TYPE_CHECKING:
         BlockchainAddress,
         BTCTxId,
         ChecksumEvmAddress,
+        EvmInternalTransaction,
         EVMTxHash,
         SolanaAddress,
     )
@@ -803,17 +805,20 @@ class TransactionsService:
             tx_ref: EVMTxHash,
             delete_custom: bool,
     ) -> None:
-        with self.rotkehlchen.data.db.user_write() as write_cursor:
-            write_cursor.execute(
-                'DELETE FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
-                (tx_ref, chain.to_chain_id().serialize_for_db()),
-            )
+        chain_manager = self.rotkehlchen.chains_aggregator.get_chain_manager(
+            blockchain=chain,
+        )
 
         try:
-            chain_manager = self.rotkehlchen.chains_aggregator.get_chain_manager(
-                blockchain=chain,
-            )
-            chain_manager.transactions.get_or_query_transaction_receipt(tx_hash=tx_ref)
+            if tx_ref == GENESIS_HASH:
+                transaction, _ = chain_manager.transactions.ensure_genesis_tx_data_exists()
+                raw_receipt_data = chain_manager.transactions.evm_inquirer.get_transaction_receipt(
+                    tx_hash=tx_ref,
+                )
+            else:
+                transaction, raw_receipt_data = chain_manager.transactions.evm_inquirer.get_transaction_by_hash(  # noqa: E501
+                    tx_hash=tx_ref,
+                )
         except RemoteError as e:
             raise InputError(
                 f'hash {tx_ref!s} does not correspond to a transaction at {chain.name}. {e!s}',
@@ -821,13 +826,54 @@ class TransactionsService:
         except DeserializationError as e:
             raise InputError(str(e)) from e
 
+        dbevmtx = DBEvmTx(self.rotkehlchen.data.db)
+        parent_hash_internal_txs: list[EvmInternalTransaction] = []
+        if transaction.to_address is not None:  # internal transactions only through contracts
+            parent_hash_internal_txs, _ = chain_manager.transactions._query_internal_transactions_for_parent_hash(  # noqa: E501
+                parent_tx_hash=tx_ref,
+                address=None,
+                return_queried_hashes=False,
+                known_parent_timestamps={tx_ref: transaction.timestamp},
+            )
+
+        with self.rotkehlchen.data.db.user_write() as write_cursor:
+            write_cursor.execute(
+                'DELETE FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+                (tx_ref, chain_manager.node_inquirer.chain_id.serialize_for_db()),
+            )
+            dbevmtx.add_transactions(
+                write_cursor=write_cursor,
+                evm_transactions=[transaction],
+                relevant_address=None,
+            )
+            dbevmtx.add_or_ignore_receipt_data(
+                write_cursor=write_cursor,
+                chain_id=chain_manager.node_inquirer.chain_id,
+                data=raw_receipt_data,
+            )
+            if transaction.to_address is not None:  # internal transactions only through contracts
+                chain_manager.transactions._replace_internal_transactions_for_parent_hash(
+                    write_cursor=write_cursor,
+                    parent_tx_hash=tx_ref,
+                    transactions=parent_hash_internal_txs,
+                )
+
         events = chain_manager.transactions_decoder.decode_and_get_transaction_hashes(
             tx_hashes=[tx_ref],
             send_ws_notifications=True,
             ignore_cache=True,
             delete_customized=delete_custom,
         )
+        self._maybe_notify_missing_credentials_after_decode(
+            chain=chain,
+            events=events,
+        )
 
+    def _maybe_notify_missing_credentials_after_decode(
+            self,
+            chain: SUPPORTED_EVM_CHAINS_TYPE,
+            events: list[Any],
+    ) -> None:
         if not has_premium_check(self.rotkehlchen.premium):
             return
 

--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -367,9 +367,9 @@ class EvmTransactions(ABC):  # noqa: B024
             )
 
     @overload
-    def _query_and_save_internal_transactions_for_range_or_parent_hash(
+    def _query_and_save_internal_transactions_for_range(
             self,
-            period_or_hash: TimestampOrBlockRange | EVMTxHash,
+            period: TimestampOrBlockRange,
             address: ChecksumEvmAddress | None = None,
             location_string: str | None = None,
             update_ranges: bool = True,
@@ -378,9 +378,9 @@ class EvmTransactions(ABC):  # noqa: B024
         ...
 
     @overload
-    def _query_and_save_internal_transactions_for_range_or_parent_hash(
+    def _query_and_save_internal_transactions_for_range(
             self,
-            period_or_hash: TimestampOrBlockRange | EVMTxHash,
+            period: TimestampOrBlockRange,
             address: ChecksumEvmAddress | None = None,
             location_string: str | None = None,
             update_ranges: bool = True,
@@ -389,9 +389,9 @@ class EvmTransactions(ABC):  # noqa: B024
         ...
 
     @overload
-    def _query_and_save_internal_transactions_for_range_or_parent_hash(
+    def _query_and_save_internal_transactions_for_range(
             self,
-            period_or_hash: TimestampOrBlockRange | EVMTxHash,
+            period: TimestampOrBlockRange,
             address: ChecksumEvmAddress | None = None,
             location_string: str | None = None,
             update_ranges: bool = True,
@@ -399,132 +399,273 @@ class EvmTransactions(ABC):  # noqa: B024
     ) -> list[EVMTxHash] | None:
         ...
 
-    def _query_and_save_internal_transactions_for_range_or_parent_hash(
+    def _query_and_save_internal_transactions_for_range(
             self,
-            period_or_hash: TimestampOrBlockRange | EVMTxHash,
+            period: TimestampOrBlockRange,
             address: ChecksumEvmAddress | None = None,
             location_string: str | None = None,
             update_ranges: bool = True,
             return_queried_hashes: bool = False,
     ) -> list[EVMTxHash] | None:
-        """Helper function to abstract internal tx querying for different range types
-        or for a specific parent transaction hash.
-
-        If address is None, then etherscan query will return all internal transactions.
-
-        If update_ranges is True, updates the database tracking for this query range.
-        Otherwise, data is fetched without updating the query range.
-        """
-        query_period_or_hash: TimestampOrBlockRange | EVMTxHash
-        if isinstance(period_or_hash, TimestampOrBlockRange):
-            is_parent_hash_query = False
-            query_period_or_hash = self.evm_inquirer.maybe_timestamp_to_block_range(
-                period=period_or_hash,
-            )
-            queried_from_ts = Timestamp(period_or_hash.from_value) if period_or_hash.range_type == 'timestamps' else None  # noqa: E501
+        """Query internal txs for a time/block range and persist them incrementally."""
+        queried_hashes: list[EVMTxHash] | None = [] if return_queried_hashes else None
+        parent_tx_timestamps: dict[EVMTxHash, Timestamp] = {}
+        if period.range_type == 'timestamps':
+            assert location_string, 'should always be given for timestamps'
+            queried_from_ts = Timestamp(period.from_value)
         else:
-            is_parent_hash_query = True
-            query_period_or_hash = period_or_hash
             queried_from_ts = None
 
-        parent_tx_timestamps: dict[EVMTxHash, Timestamp] = {}
-        parent_hash_internal_txs: list[EvmInternalTransaction] = []
+        for new_internal_txs in self.evm_inquirer.get_transactions(
+                account=address,
+                period_or_hash=self.evm_inquirer.maybe_timestamp_to_block_range(period=period),
+                action='txlistinternal',
+        ):
+            if len(internal_txs_with_timestamps := self._process_internal_transactions_batch(
+                new_internal_txs=new_internal_txs,
+                address=address,
+                parent_tx_timestamps=parent_tx_timestamps,
+                queried_hashes=queried_hashes,
+            )) == 0:
+                continue
+
+            with self.database.conn.write_ctx() as write_cursor:
+                self.dbevmtx.add_evm_internal_transactions(
+                    write_cursor=write_cursor,
+                    transactions=[entry[0] for entry in internal_txs_with_timestamps],
+                    relevant_address=None,
+                )
+
+            if queried_from_ts is None:
+                continue
+
+            for _, timestamp in internal_txs_with_timestamps:
+                queried_to_ts = Timestamp(max(queried_from_ts, timestamp))
+                log.debug(f'Internal {self.evm_inquirer.chain_name} transactions for {address} -> update range {queried_from_ts} - {queried_to_ts}')  # noqa: E501
+                if update_ranges:  # update last queried time for address
+                    assert location_string is not None, 'should always be given for timestamps'
+                    with self.database.conn.write_ctx() as write_cursor:
+                        self.dbranges.update_used_query_range(
+                            write_cursor=write_cursor,
+                            location_string=location_string,
+                            queried_ranges=[(queried_from_ts, queried_to_ts)],
+                        )
+
+                self.msg_aggregator.add_message(
+                    message_type=WSMessageType.TRANSACTION_STATUS,
+                    data={
+                        'address': address,
+                        'chain': self.evm_inquirer.blockchain.value,
+                        'subtype': str(TransactionStatusSubType.EVM),
+                        'period': [period.from_value, timestamp],
+                        'status': str(TransactionStatusStep.QUERYING_INTERNAL_TRANSACTIONS),
+                    },
+                )
+                queried_from_ts = queried_to_ts
+
+        return queried_hashes
+
+    @overload
+    def _query_and_save_internal_transactions_for_parent_hash(
+            self,
+            parent_tx_hash: EVMTxHash,
+            address: ChecksumEvmAddress | None = None,
+            return_queried_hashes: Literal[True] = True,
+    ) -> list[EVMTxHash]:
+        ...
+
+    @overload
+    def _query_and_save_internal_transactions_for_parent_hash(
+            self,
+            parent_tx_hash: EVMTxHash,
+            address: ChecksumEvmAddress | None = None,
+            return_queried_hashes: Literal[False] = False,
+    ) -> None:
+        ...
+
+    @overload
+    def _query_and_save_internal_transactions_for_parent_hash(
+            self,
+            parent_tx_hash: EVMTxHash,
+            address: ChecksumEvmAddress | None = None,
+            return_queried_hashes: bool = False,
+    ) -> list[EVMTxHash] | None:
+        ...
+
+    def _query_and_save_internal_transactions_for_parent_hash(
+            self,
+            parent_tx_hash: EVMTxHash,
+            address: ChecksumEvmAddress | None = None,
+            return_queried_hashes: bool = False,
+    ) -> list[EVMTxHash] | None:
+        """Query internal txs for a parent hash and atomically replace DB internals."""
+        parent_hash_internal_txs, queried_hashes = (
+            self._query_internal_transactions_for_parent_hash(
+                parent_tx_hash=parent_tx_hash,
+                address=address,
+                return_queried_hashes=return_queried_hashes,
+            )
+        )
+        with self.database.user_write() as write_cursor:
+            self._replace_internal_transactions_for_parent_hash(
+                write_cursor=write_cursor,
+                parent_tx_hash=parent_tx_hash,
+                transactions=parent_hash_internal_txs,
+            )
+        return queried_hashes
+
+    def _query_internal_transactions(
+            self,
+            query_period_or_hash: TimestampOrBlockRange | EVMTxHash,
+            address: ChecksumEvmAddress | None,
+            return_queried_hashes: bool,
+            known_parent_timestamps: dict[EVMTxHash, Timestamp] | None = None,
+    ) -> tuple[list[tuple[EvmInternalTransaction, Timestamp]], list[EVMTxHash] | None]:
+        """Query internal transactions and normalize parent-transaction state.
+
+        This helper is shared by both range and parent-hash flows and has no
+        side effects on internal-transactions persistence.
+        For each non-zero-value internal transaction it ensures the parent
+        transaction exists in the DB via `get_or_create_transaction`.
+        """
+        internal_txs_with_timestamps: list[tuple[EvmInternalTransaction, Timestamp]] = []
+        parent_tx_timestamps: dict[EVMTxHash, Timestamp] = (
+            known_parent_timestamps.copy() if known_parent_timestamps is not None else {}
+        )
         queried_hashes: list[EVMTxHash] | None = [] if return_queried_hashes else None
         for new_internal_txs in self.evm_inquirer.get_transactions(
                 account=address,
                 period_or_hash=query_period_or_hash,
                 action='txlistinternal',
         ):
-            if len(new_internal_txs) == 0:
-                continue
+            internal_txs_with_timestamps.extend(self._process_internal_transactions_batch(
+                new_internal_txs=new_internal_txs,
+                address=address,
+                parent_tx_timestamps=parent_tx_timestamps,
+                queried_hashes=queried_hashes,
+            ))
 
-            existing_hashes: set[EVMTxHash] = set()
-            if queried_hashes is not None:
-                parent_hashes = [
-                    internal_tx.parent_tx_hash
-                    for internal_tx in new_internal_txs
-                    if internal_tx.value != 0
-                ]
-                if len(parent_hashes) != 0:
-                    with self.database.conn.read_ctx() as cursor:
-                        existing_hashes = self._get_existing_evm_tx_hashes(
-                            cursor=cursor,
-                            tx_hashes=parent_hashes,
-                        )
+        return internal_txs_with_timestamps, queried_hashes
 
-            for internal_tx in new_internal_txs:
-                if internal_tx.value == 0:
-                    continue  # Only reason we need internal is for ether transfer. Ignore 0
+    def _process_internal_transactions_batch(
+            self,
+            new_internal_txs: list[EvmInternalTransaction],
+            address: ChecksumEvmAddress | None,
+            parent_tx_timestamps: dict[EVMTxHash, Timestamp],
+            queried_hashes: list[EVMTxHash] | None,
+    ) -> list[tuple[EvmInternalTransaction, Timestamp]]:
+        """Normalize a fetched internal-tx batch and return txs with parent timestamps."""
+        if len(new_internal_txs) == 0:
+            return []
 
-                # make sure internal transaction parent transactions are in the DB.
-                # new_internal_txs potentially contains internal txs of different parents.
-                if internal_tx.parent_tx_hash not in parent_tx_timestamps:
-                    with self.database.conn.read_ctx() as cursor:
-                        tx, _ = self.get_or_create_transaction(
-                            cursor=cursor,
-                            tx_hash=internal_tx.parent_tx_hash,
-                            relevant_address=address,
-                        )
-                    if queried_hashes is not None and tx.tx_hash not in existing_hashes:
-                        queried_hashes.append(tx.tx_hash)
-                        existing_hashes.add(tx.tx_hash)
-
-                    timestamp = tx.timestamp
-                    parent_tx_timestamps[internal_tx.parent_tx_hash] = timestamp
-                else:
-                    timestamp = parent_tx_timestamps[internal_tx.parent_tx_hash]
-
-                if is_parent_hash_query:
-                    parent_hash_internal_txs.append(internal_tx)
-                else:
-                    with self.database.conn.write_ctx() as write_cursor:
-                        self.dbevmtx.add_evm_internal_transactions(
-                            write_cursor=write_cursor,
-                            transactions=[internal_tx],
-                            relevant_address=None,  # no need to re-associate address
-                        )
-
-                if queried_from_ts is not None:
-                    assert location_string, 'should always be given for timestamps'
-                    assert isinstance(period_or_hash, TimestampOrBlockRange), 'timestamp ranges only'  # noqa: E501
-                    queried_to_ts = Timestamp(max(queried_from_ts, timestamp))
-                    log.debug(f'Internal {self.evm_inquirer.chain_name} transactions for {address} -> update range {queried_from_ts} - {queried_to_ts}')  # noqa: E501
-                    if update_ranges:  # update last queried time for address
-                        with self.database.conn.write_ctx() as write_cursor:
-                            self.dbranges.update_used_query_range(
-                                write_cursor=write_cursor,
-                                location_string=location_string,
-                                queried_ranges=[(queried_from_ts, queried_to_ts)],
-                            )
-
-                    self.msg_aggregator.add_message(
-                        message_type=WSMessageType.TRANSACTION_STATUS,
-                        data={
-                            'address': address,
-                            'chain': self.evm_inquirer.blockchain.value,
-                            'subtype': str(TransactionStatusSubType.EVM),
-                            'period': [period_or_hash.from_value, timestamp],
-                            'status': str(TransactionStatusStep.QUERYING_INTERNAL_TRANSACTIONS),
-                        },
-                    )
-                    queried_from_ts = queried_to_ts
-
-        if is_parent_hash_query:
-            assert not isinstance(query_period_or_hash, TimestampOrBlockRange)
-            parent_tx_hash = query_period_or_hash
-            with self.database.user_write() as write_cursor:
-                self.dbevmtx.delete_evm_internal_transactions_by_parent_tx_hash(
-                    write_cursor=write_cursor,
-                    parent_tx_hash=parent_tx_hash,
-                    chain_id=self.evm_inquirer.chain_id,
+        existing_hashes: set[EVMTxHash] = set()
+        if queried_hashes is not None and len(parent_hashes := [
+            internal_tx.parent_tx_hash
+            for internal_tx in new_internal_txs
+            if internal_tx.value != 0
+        ]) != 0:
+            with self.database.conn.read_ctx() as cursor:
+                existing_hashes = self._get_existing_evm_tx_hashes(
+                    cursor=cursor,
+                    tx_hashes=parent_hashes,
                 )
-                if len(parent_hash_internal_txs) != 0:
-                    self.dbevmtx.add_evm_internal_transactions(
-                        write_cursor=write_cursor,
-                        transactions=parent_hash_internal_txs,
-                        relevant_address=None,
+
+        internal_txs_with_timestamps: list[tuple[EvmInternalTransaction, Timestamp]] = []
+        for internal_tx in new_internal_txs:
+            if internal_tx.value == 0:
+                continue  # Only reason we need internal is for ether transfer. Ignore 0
+
+            # make sure internal transaction parent transactions are in the DB.
+            # new_internal_txs potentially contains internal txs of different parents.
+            if internal_tx.parent_tx_hash not in parent_tx_timestamps:
+                with self.database.conn.read_ctx() as cursor:
+                    tx, _ = self.get_or_create_transaction(
+                        cursor=cursor,
+                        tx_hash=internal_tx.parent_tx_hash,
+                        relevant_address=address,
                     )
-        return queried_hashes
+                if queried_hashes is not None and tx.tx_hash not in existing_hashes:
+                    queried_hashes.append(tx.tx_hash)
+                    existing_hashes.add(tx.tx_hash)
+
+                timestamp = tx.timestamp
+                parent_tx_timestamps[internal_tx.parent_tx_hash] = timestamp
+            else:
+                timestamp = parent_tx_timestamps[internal_tx.parent_tx_hash]
+
+            internal_txs_with_timestamps.append((internal_tx, timestamp))
+
+        return internal_txs_with_timestamps
+
+    @overload
+    def _query_internal_transactions_for_parent_hash(
+            self,
+            parent_tx_hash: EVMTxHash,
+            address: ChecksumEvmAddress | None = None,
+            return_queried_hashes: Literal[True] = True,
+            known_parent_timestamps: dict[EVMTxHash, Timestamp] | None = None,
+    ) -> tuple[list[EvmInternalTransaction], list[EVMTxHash]]:
+        ...
+
+    @overload
+    def _query_internal_transactions_for_parent_hash(
+            self,
+            parent_tx_hash: EVMTxHash,
+            address: ChecksumEvmAddress | None = None,
+            return_queried_hashes: Literal[False] = False,
+            known_parent_timestamps: dict[EVMTxHash, Timestamp] | None = None,
+    ) -> tuple[list[EvmInternalTransaction], None]:
+        ...
+
+    @overload
+    def _query_internal_transactions_for_parent_hash(
+            self,
+            parent_tx_hash: EVMTxHash,
+            address: ChecksumEvmAddress | None = None,
+            return_queried_hashes: bool = False,
+            known_parent_timestamps: dict[EVMTxHash, Timestamp] | None = None,
+    ) -> tuple[list[EvmInternalTransaction], list[EVMTxHash] | None]:
+        ...
+
+    def _query_internal_transactions_for_parent_hash(
+            self,
+            parent_tx_hash: EVMTxHash,
+            address: ChecksumEvmAddress | None = None,
+            return_queried_hashes: bool = False,
+            known_parent_timestamps: dict[EVMTxHash, Timestamp] | None = None,
+    ) -> tuple[list[EvmInternalTransaction], list[EVMTxHash] | None]:
+        """Fetch internal txs for a parent hash without replacing DB internals.
+
+        This method only performs querying/deserialization and parent-tx
+        normalization. The caller decides when/how to persist using
+        `_replace_internal_transactions_for_parent_hash`.
+        """
+        internal_txs_with_timestamps, queried_hashes = self._query_internal_transactions(
+            query_period_or_hash=parent_tx_hash,
+            address=address,
+            return_queried_hashes=return_queried_hashes,
+            known_parent_timestamps=known_parent_timestamps,
+        )
+        return [entry[0] for entry in internal_txs_with_timestamps], queried_hashes
+
+    def _replace_internal_transactions_for_parent_hash(
+            self,
+            write_cursor: 'DBCursor',
+            parent_tx_hash: EVMTxHash,
+            transactions: list[EvmInternalTransaction],
+    ) -> None:
+        """Atomically replace all internal tx rows for a single parent tx hash."""
+        self.dbevmtx.delete_evm_internal_transactions_by_parent_tx_hash(
+            write_cursor=write_cursor,
+            parent_tx_hash=parent_tx_hash,
+            chain_id=self.evm_inquirer.chain_id,
+        )
+        if len(transactions) != 0:
+            self.dbevmtx.add_evm_internal_transactions(
+                write_cursor=write_cursor,
+                transactions=transactions,
+                relevant_address=None,
+            )
 
     def _get_internal_transactions_for_ranges(
             self,
@@ -547,9 +688,9 @@ class EvmTransactions(ABC):  # noqa: B024
         for query_start_ts, query_end_ts in ranges_to_query:
             log.debug(f'Querying {self.evm_inquirer.chain_name} internal transactions for {address} -> {query_start_ts} - {query_end_ts}')  # noqa: E501
             try:
-                self._query_and_save_internal_transactions_for_range_or_parent_hash(
+                self._query_and_save_internal_transactions_for_range(
                     address=address,
-                    period_or_hash=TimestampOrBlockRange(
+                    period=TimestampOrBlockRange(
                         range_type='timestamps',
                         from_value=query_start_ts,
                         to_value=query_end_ts,
@@ -936,8 +1077,8 @@ class EvmTransactions(ABC):  # noqa: B024
             )
 
         # else query again and save the DB cache to avoid querying it again
-        self._query_and_save_internal_transactions_for_range_or_parent_hash(
-            period_or_hash=tx_hash,
+        self._query_and_save_internal_transactions_for_parent_hash(
+            parent_tx_hash=tx_hash,
         )
         with self.database.user_write() as write_cursor:
             self.database.set_dynamic_cache(
@@ -1052,9 +1193,9 @@ class EvmTransactions(ABC):  # noqa: B024
                 transaction, tx_receipt = self.get_or_create_transaction(cursor=cursor, tx_hash=tx_hash, relevant_address=None)  # noqa: E501
 
             if transaction.to_address is not None:  # internal transactions only through contracts  # noqa: E501
-                self._query_and_save_internal_transactions_for_range_or_parent_hash(
+                self._query_and_save_internal_transactions_for_parent_hash(
                     address=None,  # get all internal transactions for the parent hash
-                    period_or_hash=tx_hash,
+                    parent_tx_hash=tx_hash,
                 )
         return tx_receipt
 
@@ -1227,9 +1368,9 @@ class EvmTransactions(ABC):  # noqa: B024
             update_ranges=False,
             return_queried_hashes=return_queried_hashes,
         )
-        internal_hashes = self._query_and_save_internal_transactions_for_range_or_parent_hash(
+        internal_hashes = self._query_and_save_internal_transactions_for_range(
             address=address,
-            period_or_hash=period,
+            period=period,
             location_string=location_string,
             update_ranges=False,
             return_queried_hashes=return_queried_hashes,

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1,6 +1,7 @@
 import os
 import random
 from contextlib import ExitStack
+from dataclasses import replace
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, _patch, patch
@@ -13,6 +14,7 @@ from requests import Response
 from rotkehlchen.accounting.types import EventAccountingRuleStatus
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
+from rotkehlchen.chain.evm.constants import GENESIS_HASH
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
@@ -31,6 +33,7 @@ from rotkehlchen.db.filtering import (
 )
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.ranges import DBQueryRanges
+from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.externalapis.etherscan import Etherscan
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -71,6 +74,7 @@ from rotkehlchen.types import (
     ApiKey,
     ChainID,
     ChecksumEvmAddress,
+    EvmInternalTransaction,
     EvmTransaction,
     ExternalService,
     ExternalServiceApiCredentials,
@@ -306,6 +310,46 @@ def _write_transactions_to_db(
                     location_string=f'{prefix}_{address}',
                     queried_ranges=[(start_ts, end_ts)],
                 )
+
+
+def _prepare_repull_test_transaction(db: 'DBHandler') -> tuple[DBEvmTx, EvmTransaction]:
+    """Insert a tx, receipt, and one internal tx used by repull regression tests."""
+    dbevmtx = DBEvmTx(db)
+    transaction = make_ethereum_transaction(tx_hash=make_evm_tx_hash())
+    with db.user_write() as write_cursor:
+        dbevmtx.add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[transaction],
+            relevant_address=transaction.from_address,
+        )
+        dbevmtx.add_or_ignore_receipt_data(
+            write_cursor=write_cursor,
+            chain_id=ChainID.ETHEREUM,
+            data=txreceipt_to_data(EvmTxReceipt(
+                tx_hash=transaction.tx_hash,
+                chain_id=ChainID.ETHEREUM,
+                contract_address=None,
+                status=True,
+                tx_type=2,
+                logs=[],
+            )),
+        )
+        dbevmtx.add_evm_internal_transactions(
+            write_cursor=write_cursor,
+            transactions=[EvmInternalTransaction(
+                parent_tx_hash=transaction.tx_hash,
+                chain_id=ChainID.ETHEREUM,
+                trace_id=0,
+                from_address=transaction.from_address,
+                to_address=transaction.to_address,
+                value=1,
+                gas=21000,
+                gas_used=21000,
+            )],
+            relevant_address=None,
+        )
+
+    return dbevmtx, transaction
 
 
 def remove_added_event_fields(returned_events: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -1475,6 +1519,229 @@ def test_repulling_transaction_with_internal_txs(rotkehlchen_api_server: 'APISer
     assert events_before_redecoding == events_after_redecoding
 
 
+@pytest.mark.parametrize('have_decoders', [True])
+@pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
+def test_repulling_transaction_fetch_error_does_not_drop_existing_data(
+        rotkehlchen_api_server: 'APIServer',
+) -> None:
+    """Ensure a tx repull failure does not drop the existing tx/receipt/internal tx rows."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    dbevmtx, transaction = _prepare_repull_test_transaction(rotki.data.db)
+    tx_hash = transaction.tx_hash
+
+    tx_filter = EvmTransactionsFilterQuery.make(tx_hash=tx_hash, chain_id=ChainID.ETHEREUM)
+    with rotki.data.db.conn.read_ctx() as cursor:
+        tx_count_before = len(dbevmtx.get_transactions(cursor=cursor, filter_=tx_filter))
+        receipt_before = dbevmtx.get_receipt(cursor=cursor, tx_hash=tx_hash, chain_id=ChainID.ETHEREUM)  # noqa: E501
+    internal_before = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    )
+    assert tx_count_before == 1
+    assert receipt_before is not None
+    assert len(internal_before) > 0
+
+    with patch.object(
+        rotki.chains_aggregator.ethereum.node_inquirer,
+        'get_transaction_by_hash',
+        side_effect=RemoteError('indexer temporarily unavailable'),
+    ):
+        response = requests.put(
+            api_url_for(rotkehlchen_api_server, 'transactionsdecodingresource'),
+            json={'async_query': False, 'chain': 'eth', 'tx_refs': [str(tx_hash)]},
+        )
+    assert_error_response(
+        response=response,
+        contained_in_msg='does not correspond to a transaction',
+        status_code=HTTPStatus.CONFLICT,
+    )
+
+    with rotki.data.db.conn.read_ctx() as cursor:
+        tx_count_after = len(dbevmtx.get_transactions(cursor=cursor, filter_=tx_filter))
+        receipt_after = dbevmtx.get_receipt(cursor=cursor, tx_hash=tx_hash, chain_id=ChainID.ETHEREUM)  # noqa: E501
+    internal_after = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    )
+
+    assert tx_count_after == tx_count_before
+    assert receipt_after == receipt_before
+    assert internal_after == internal_before
+
+
+@pytest.mark.parametrize('have_decoders', [True])
+@pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
+def test_repulling_transaction_internal_fetch_error_restores_previous_internal_txs(
+        rotkehlchen_api_server: 'APIServer',
+) -> None:
+    """Ensure old internal txs are restored if internal-tx repull fails."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    dbevmtx, transaction = _prepare_repull_test_transaction(rotki.data.db)
+    tx_hash = transaction.tx_hash
+
+    internal_before = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    )
+    assert len(internal_before) > 0
+    fresh_transaction = make_ethereum_transaction(
+        tx_hash=tx_hash,
+        timestamp=Timestamp(transaction.timestamp + 1),
+    )
+
+    with (
+        patch.object(
+            rotki.chains_aggregator.ethereum.node_inquirer,
+            'get_transaction_by_hash',
+            return_value=(fresh_transaction, txreceipt_to_data(EvmTxReceipt(
+                tx_hash=tx_hash,
+                chain_id=ChainID.ETHEREUM,
+                contract_address=None,
+                status=True,
+                tx_type=2,
+                logs=[],
+            ))),
+        ),
+        patch.object(
+            rotki.chains_aggregator.ethereum.transactions,
+            '_query_internal_transactions_for_parent_hash',
+            side_effect=RemoteError('internal indexer unavailable'),
+        ),
+    ):
+        response = requests.put(
+            api_url_for(rotkehlchen_api_server, 'transactionsdecodingresource'),
+            json={'async_query': False, 'chain': 'eth', 'tx_refs': [str(tx_hash)]},
+        )
+    assert_error_response(
+        response=response,
+        contained_in_msg='internal indexer unavailable',
+        status_code=HTTPStatus.BAD_GATEWAY,
+    )
+
+    internal_after = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    )
+    assert internal_after == internal_before
+
+
+@pytest.mark.parametrize('have_decoders', [True])
+@pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
+def test_repulling_transaction_internal_replace_failure_rolls_back_tx_data(
+        rotkehlchen_api_server: 'APIServer',
+) -> None:
+    """Ensure tx+receipt replacement is rolled back if internal replacement fails."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    dbevmtx, transaction = _prepare_repull_test_transaction(rotki.data.db)
+    tx_hash = transaction.tx_hash
+
+    tx_filter = EvmTransactionsFilterQuery.make(tx_hash=tx_hash, chain_id=ChainID.ETHEREUM)
+    with rotki.data.db.conn.read_ctx() as cursor:
+        tx_before = dbevmtx.get_transactions(cursor=cursor, filter_=tx_filter)[0]
+        receipt_before = dbevmtx.get_receipt(cursor=cursor, tx_hash=tx_hash, chain_id=ChainID.ETHEREUM)  # noqa: E501
+    internal_before = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    )
+    assert receipt_before is not None
+    fresh_transaction = make_ethereum_transaction(
+        tx_hash=tx_hash,
+        timestamp=Timestamp(transaction.timestamp + 1),
+    )
+
+    with (
+        patch.object(
+            rotki.chains_aggregator.ethereum.node_inquirer,
+            'get_transaction_by_hash',
+            return_value=(fresh_transaction, txreceipt_to_data(EvmTxReceipt(
+                tx_hash=tx_hash,
+                chain_id=ChainID.ETHEREUM,
+                contract_address=None,
+                status=True,
+                tx_type=2,
+                logs=[],
+            ))),
+        ),
+        patch.object(
+            rotki.chains_aggregator.ethereum.transactions,
+            '_query_internal_transactions_for_parent_hash',
+            return_value=(internal_before, None),
+        ),
+        patch.object(
+            rotki.chains_aggregator.ethereum.transactions,
+            '_replace_internal_transactions_for_parent_hash',
+            side_effect=RemoteError('failed replacing internals'),
+        ),
+    ):
+        response = requests.put(
+            api_url_for(rotkehlchen_api_server, 'transactionsdecodingresource'),
+            json={'async_query': False, 'chain': 'eth', 'tx_refs': [str(tx_hash)]},
+        )
+    assert_error_response(
+        response=response,
+        contained_in_msg='failed replacing internals',
+        status_code=HTTPStatus.BAD_GATEWAY,
+    )
+
+    with rotki.data.db.conn.read_ctx() as cursor:
+        tx_after = dbevmtx.get_transactions(cursor=cursor, filter_=tx_filter)[0]
+        receipt_after = dbevmtx.get_receipt(cursor=cursor, tx_hash=tx_hash, chain_id=ChainID.ETHEREUM)  # noqa: E501
+    internal_after = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    )
+    assert tx_after == tx_before
+    assert receipt_after == receipt_before
+    assert internal_after == internal_before
+
+
+@pytest.mark.parametrize('have_decoders', [True])
+@pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
+def test_redecode_genesis_uses_genesis_data_path(
+        rotkehlchen_api_server: 'APIServer',
+) -> None:
+    """Ensure redecode handles genesis tx hash without indexer tx-by-hash query."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    genesis_tx = replace(
+        make_ethereum_transaction(tx_hash=GENESIS_HASH, timestamp=Timestamp(1)),
+        to_address=None,  # skip internal tx querying for this mocked path
+    )
+    genesis_receipt = EvmTxReceipt(
+        tx_hash=GENESIS_HASH,
+        chain_id=ChainID.ETHEREUM,
+        contract_address=None,
+        status=True,
+        tx_type=2,
+        logs=[],
+    )
+    with (
+        patch.object(
+            rotki.chains_aggregator.ethereum.transactions,
+            'ensure_genesis_tx_data_exists',
+            return_value=(genesis_tx, genesis_receipt),
+        ),
+        patch.object(
+            rotki.chains_aggregator.ethereum.node_inquirer,
+            'get_transaction_receipt',
+            return_value=txreceipt_to_data(genesis_receipt),
+        ),
+        patch.object(
+            rotki.chains_aggregator.ethereum.node_inquirer,
+            'get_transaction_by_hash',
+            side_effect=AssertionError('genesis path should not query tx by hash'),
+        ),
+        patch.object(
+            rotki.chains_aggregator.ethereum.transactions_decoder,
+            'decode_and_get_transaction_hashes',
+            return_value=[],
+        ),
+    ):
+        assert_proper_response(requests.put(
+            api_url_for(rotkehlchen_api_server, 'transactionsdecodingresource'),
+            json={'chain': 'eth', 'tx_refs': [str(GENESIS_HASH)]},
+        ))
+
+
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('have_decoders', [True])
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1]])
@@ -1599,13 +1866,43 @@ def test_monerium_gnosis_pay_events_update(
 
     monerium_instance_mock = MagicMock()
     gnosis_pay_instance_mock = MagicMock()
+
+    def mocked_get_tx_by_hash(chain_id: ChainID, tx_hash: bytes) -> tuple[EvmTransaction, dict[str, Any]]:  # noqa: E501
+        return EvmTransaction(
+            tx_hash=deserialize_evm_tx_hash(tx_hash),
+            chain_id=chain_id,
+            timestamp=Timestamp(1),
+            block_number=1,
+            from_address=make_evm_address(),
+            to_address=None,  # skip internal tx querying for this mocked path
+            value=1,
+            gas=1,
+            gas_price=1,
+            gas_used=1,
+            input_data=b'',
+            nonce=0,
+        ), txreceipt_to_data(EvmTxReceipt(
+            tx_hash=deserialize_evm_tx_hash(tx_hash),
+            chain_id=chain_id,
+            contract_address=None,
+            status=True,
+            tx_type=2,
+            logs=[],
+        ))
+
     with (
         patch('rotkehlchen.chain.evm.decoding.monerium.decoder.init_monerium', return_value=monerium_instance_mock),  # noqa: E501
         patch('rotkehlchen.chain.gnosis.modules.gnosis_pay.decoder.init_gnosis_pay', return_value=gnosis_pay_instance_mock),  # noqa: E501
-        patch.object(rotki.chains_aggregator.gnosis.transactions, 'get_or_query_transaction_receipt', lambda **kwargs: None),  # noqa: E501
-        patch.object(rotki.chains_aggregator.arbitrum_one.transactions, 'get_or_query_transaction_receipt', lambda **kwargs: None),  # noqa: E501
-        patch.object(rotki.chains_aggregator.gnosis.transactions, 'get_or_create_transaction', lambda **kwargs: (None, None)),  # noqa: E501
-        patch.object(rotki.chains_aggregator.arbitrum_one.transactions, 'get_or_create_transaction', lambda **kwargs: (None, None)),  # noqa: E501
+        patch.object(
+            rotki.chains_aggregator.gnosis.node_inquirer,
+            'get_transaction_by_hash',
+            side_effect=lambda tx_hash: mocked_get_tx_by_hash(ChainID.GNOSIS, tx_hash),
+        ),
+        patch.object(
+            rotki.chains_aggregator.arbitrum_one.node_inquirer,
+            'get_transaction_by_hash',
+            side_effect=lambda tx_hash: mocked_get_tx_by_hash(ChainID.ARBITRUM_ONE, tx_hash),
+        ),
         patch.object(
             rotki.chains_aggregator.gnosis.transactions_decoder,
             '_get_or_decode_transaction_events',
@@ -1663,8 +1960,31 @@ def test_notify_missing_credentials_on_redecode(
             counterparty=counterparty,
         )
         with (
-            patch.object(rotki.chains_aggregator.gnosis.transactions, 'get_or_query_transaction_receipt', lambda **kwargs: None),  # noqa: E501
-            patch.object(rotki.chains_aggregator.gnosis.transactions, 'get_or_create_transaction', lambda **kwargs: (None, None)),  # noqa: E501
+            patch.object(
+                rotki.chains_aggregator.gnosis.node_inquirer,
+                'get_transaction_by_hash',
+                return_value=(EvmTransaction(
+                    tx_hash=event.tx_ref,
+                    chain_id=ChainID.GNOSIS,
+                    timestamp=Timestamp(1),
+                    block_number=1,
+                    from_address=make_evm_address(),
+                    to_address=None,  # skip internal tx querying for this mocked path
+                    value=1,
+                    gas=1,
+                    gas_price=1,
+                    gas_used=1,
+                    input_data=b'',
+                    nonce=0,
+                ), txreceipt_to_data(EvmTxReceipt(
+                    tx_hash=event.tx_ref,
+                    chain_id=ChainID.GNOSIS,
+                    contract_address=None,
+                    status=True,
+                    tx_type=2,
+                    logs=[],
+                ))),
+            ),
             patch.object(
                 target=rotki.chains_aggregator.gnosis.transactions_decoder,
                 attribute='decode_and_get_transaction_hashes',

--- a/rotkehlchen/tests/external_apis/test_monerium.py
+++ b/rotkehlchen/tests/external_apis/test_monerium.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import replace
 from http import HTTPStatus
 from typing import Any
 from unittest.mock import patch
@@ -10,6 +11,7 @@ import requests
 from rotkehlchen.api.server import APIServer
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
+from rotkehlchen.chain.evm.structures import EvmTxReceipt
 from rotkehlchen.constants.assets import A_ETH_EURE
 from rotkehlchen.constants.misc import ONE
 from rotkehlchen.db.cache import DBCacheStatic
@@ -24,8 +26,10 @@ from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.fixtures.messages import MockedWsMessage
 from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response
+from rotkehlchen.tests.utils.ethereum import txreceipt_to_data
+from rotkehlchen.tests.utils.factories import make_ethereum_transaction
 from rotkehlchen.tests.utils.premium import MockResponse
-from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
+from rotkehlchen.types import ChainID, Location, TimestampMS, deserialize_evm_tx_hash
 from rotkehlchen.utils.misc import ts_now
 
 
@@ -261,13 +265,31 @@ def test_query_info_on_redecode_request(rotkehlchen_api_server: APIServer) -> No
         return [gnosis_event]
 
     response_txt = '[{"id":"YYYY","profile":"PP","accountId":"PP","address":"0xbCCeE6Ff2bCAfA95300D222D316A29140c4746da","kind":"redeem","amount":"2353.57","currency":"eur","totalFee":"0","fees":[],"counterpart":{"details":{"name":"Yabir Benchakhtir","country":"ES","lastName":"Benchakhtir","firstName":"Yabir"},"identifier":{"iban":"ESXX KKKK OOOO IIII KKKK LLLL","standard":"iban"}},"memo":"Venta inversion","supportingDocumentId":"","chain":"gnosis","network":"mainnet","meta":{"state":"processed","txHashes":["0x10d953610921f39d9d20722082077e03ec8db8d9c75e4b301d0d552119fd0354"],"placedBy":"ii","placedAt":"2024-04-19T13:45:00.287212Z","processedAt":"2024-04-19T13:45:00.287212Z","approvedAt":"2024-04-19T13:45:00.287212Z","confirmedAt":"2024-04-19T13:45:00.287212Z","receivedAmount":"2353.57","sentAmount":"2353.57"}}]'  # noqa: E501
+    gnosis_transaction = replace(
+        make_ethereum_transaction(tx_hash=gnosishash),
+        chain_id=ChainID.GNOSIS,
+    )
     with (
         patch(
             'rotkehlchen.externalapis.monerium.Monerium._query',
             return_value={'orders': json.loads(response_txt)},
         ),
         patch('rotkehlchen.chain.evm.decoding.decoder.EVMTransactionDecoder.decode_and_get_transaction_hashes', new=add_event),  # noqa: E501
-        patch('rotkehlchen.chain.evm.transactions.EvmTransactions.get_or_query_transaction_receipt', return_value=None),  # noqa: E501
+        patch.object(
+            rotki.chains_aggregator.gnosis.node_inquirer,
+            'get_transaction_by_hash',
+            return_value=(
+                gnosis_transaction,
+                txreceipt_to_data(EvmTxReceipt(
+                    tx_hash=gnosishash,
+                    chain_id=ChainID.GNOSIS,
+                    contract_address=None,
+                    status=True,
+                    tx_type=2,
+                    logs=[],
+                )),
+            ),
+        ),
     ):
         response = requests.put(
             api_url_for(

--- a/rotkehlchen/tests/unit/decoders/test_rainbow.py
+++ b/rotkehlchen/tests/unit/decoders/test_rainbow.py
@@ -346,7 +346,7 @@ def test_rainbow_swap_on_binance_sc(binance_sc_inquirer, binance_sc_accounts):
     original_query_and_save = EvmTransactions(
         evm_inquirer=binance_sc_inquirer,
         database=binance_sc_inquirer.database,
-    )._query_and_save_internal_transactions_for_range_or_parent_hash
+    )._query_and_save_internal_transactions_for_parent_hash
 
     def mock_query_and_save_internal_txs(*args, **kwargs):
         """On the initial attempt to query, add an unrelated internal tx to ensure all needed
@@ -375,7 +375,7 @@ def test_rainbow_swap_on_binance_sc(binance_sc_inquirer, binance_sc_accounts):
             original_query_and_save(*args, **kwargs)
 
     with patch(
-        'rotkehlchen.chain.evm.transactions.EvmTransactions._query_and_save_internal_transactions_for_range_or_parent_hash',
+        'rotkehlchen.chain.evm.transactions.EvmTransactions._query_and_save_internal_transactions_for_parent_hash',
         side_effect=mock_query_and_save_internal_txs,
     ):
         events, _ = get_decoded_events_of_transaction(evm_inquirer=binance_sc_inquirer, tx_hash=tx_hash)  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_zerox.py
+++ b/rotkehlchen/tests/unit/decoders/test_zerox.py
@@ -1745,7 +1745,7 @@ def test_farcaster_zerox_swap(base_inquirer, base_accounts):
 def test_base_settler_zerox_swap(base_inquirer, base_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x304022641c44fd883a788e9fc962160a674f74835e1af4b13bc1afa882bcf17f')  # noqa: E501
     with patch(  # ignore internal transactions since not needed and atm no base indexer gives them
-        'rotkehlchen.chain.evm.transactions.EvmTransactions._query_and_save_internal_transactions_for_range_or_parent_hash',
+        'rotkehlchen.chain.evm.transactions.EvmTransactions._query_and_save_internal_transactions_for_parent_hash',
         return_value=[],
     ):
         events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)

--- a/rotkehlchen/tests/unit/test_evm_transactions.py
+++ b/rotkehlchen/tests/unit/test_evm_transactions.py
@@ -218,9 +218,9 @@ def test_query_and_save_internal_transactions_returns_only_new_hashes(
         'get_transaction_by_hash',
         side_effect=_mock_get_transaction_by_hash,
     ):
-        queried_hashes = ethereum_manager.transactions._query_and_save_internal_transactions_for_range_or_parent_hash(  # noqa: E501
+        queried_hashes = ethereum_manager.transactions._query_and_save_internal_transactions_for_range(  # noqa: E501
             address=address,
-            period_or_hash=TimestampOrBlockRange(range_type='blocks', from_value=0, to_value=1),
+            period=TimestampOrBlockRange(range_type='blocks', from_value=0, to_value=1),
             return_queried_hashes=True,
         )
 
@@ -279,8 +279,8 @@ def test_query_single_parent_hash_replaces_existing_internal_transactions(
             gas_used=0,
         )]]),
     ):
-        ethereum_manager.transactions._query_and_save_internal_transactions_for_range_or_parent_hash(
-            period_or_hash=parent_tx.tx_hash,
+        ethereum_manager.transactions._query_and_save_internal_transactions_for_parent_hash(
+            parent_tx_hash=parent_tx.tx_hash,
         )
 
     with database.conn.read_ctx() as cursor:


### PR DESCRIPTION
`TransactionsService._decode_given_evm_tx` now fetches tx+receipt first, and only then replaces DB data (instead of deleting first).

I split internal transactions logic by intent:
- query only for parent hash internal txs
- explicit DB replace for parent hash internal txs
- explicit range query+save path

This avoids mixed `query and save` behavuor and makes call sites clearer.

I also made tx/receipt/internal replacement atomic in a single DB write transaction, so failures don't leave partial state.

Finally, range internal tx queries now persist incrementally per batch/page, preserving partial progress if a later remote call fails.

Closes #11777