### PR TITLE
fix: value distribution schema backward compat

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11766` Value distribution graphs will now work correctly by fixing the schema types to match the backend response.
 * :bug:`-` Beefy Finance harvest call rewards will now be properly decoded as part of the beefy side of a transaction.
 * :bug:`-` Depositing via Pendle v3 router should be now properly decoded by rotki.
 * :bug:`-` Bridging ETH from mainnet to Optimism will no longer duplicate the event under some weird circumstances.

--- a/frontend/app/src/premium/premium.ts
+++ b/frontend/app/src/premium/premium.ts
@@ -5,7 +5,7 @@ import { useStatisticsApi } from '@/composables/api/statistics/statistics-api';
 import { app } from '@/main';
 import { logger } from '@/utils/logging';
 
-const PREMIUM_COMPONENTS_VERSION = 27;
+const PREMIUM_COMPONENTS_VERSION = 28;
 
 type PremiumLibrary = {
   install: (app: App) => void;

--- a/frontend/common/src/statistics/index.ts
+++ b/frontend/common/src/statistics/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod/v4';
-import { AssetEntry, Balance } from '../balances';
+import { AssetBalance, AssetEntry, Balance } from '../balances';
 import { NumericString } from '../numbers';
 
 const TimedEntry = z.object({ time: z.number().positive() });
@@ -33,12 +33,23 @@ export const LocationData = z.array(LocationDataItem);
 
 export type LocationData = z.infer<typeof LocationData>;
 
+/**
+ * Legacy schema (PREMIUM_COMPONENTS_VERSION <= 27): had AssetBalance (asset, amount, value) + time.
+ * This was incorrect as the API returns {asset, time, usdValue} without amount/value.
+ * Kept for backward compatibility with premium components using version 27.
+ * TODO: Remove LegacyTimedAssetBalance and the union when we bump components to v16.
+ */
+const LegacyTimedAssetBalance = z.object({
+  ...AssetBalance.shape,
+  ...TimedEntry.shape,
+});
+
 const TimedAssetBalance = z.object({
   ...AssetEntry.shape,
   ...AssetDistribution.shape,
 });
 
-export const TimedAssetBalances = z.array(TimedAssetBalance);
+export const TimedAssetBalances = z.union([z.array(TimedAssetBalance), z.array(LegacyTimedAssetBalance)]);
 
 export type TimedAssetBalances = z.infer<typeof TimedAssetBalances>;
 


### PR DESCRIPTION
## Summary
- Keep both the legacy (v27) and corrected `TimedAssetBalance` schemas as a `z.union` so premium components can handle data from both v27 and v28+
- Bump `PREMIUM_COMPONENTS_VERSION` to 28
- Add changelog entry for #11766

PR #11769 fixed the schema types but was a breaking change. v1.42.0 shipped with version 27 using the old wrong schema (`AssetBalance + TimedEntry`) which parsed `amount`/`value` instead of `usdValue` from the backend. If premium components update to only accept the new correct schema, they fail when loaded by v1.42.0.

## Test plan
- [ ] Verify value distribution graphs render correctly on latest
- [ ] Verify premium components still load on v1.42.0