### PR TITLE
Infer mev payout txs without relay data

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` ETH staking historyMEV/proposer payout rewards are combined more reliably with block proposal even when beaconcha.in relay data is unavailable.
 * :bug:`11766` Value distribution graphs will now work correctly by fixing the schema types to match the backend response.
 * :bug:`-` Beefy Finance harvest call rewards will now be properly decoded as part of the beefy side of a transaction.
 * :bug:`-` Depositing via Pendle v3 router should be now properly decoded by rotki.

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -806,7 +806,7 @@ class DBEth2:
         if they can be found. Optionally limit to only events for the specified block numbers.
         """
         log.debug('Entered combining of blocks with tx events')
-        query = (
+        relay_query = (
             """WITH mev_rewards AS (
                 SELECT A_H.location_label, A_S.is_exit_or_blocknumber, A_S.validator_index FROM
                 history_events A_H JOIN eth_staking_events_info A_S ON A_H.identifier = A_S.identifier
@@ -818,21 +818,53 @@ class DBEth2:
             AND mev.location_label = B_H.location_label WHERE B_H.asset = ? AND B_H.type = ?
             AND B_H.subtype = ? AND mev.validator_index IS NOT NULL"""  # noqa: E501
         )
-        bindings: list[int | str] = [
+        fallback_query = (
+            """WITH block_productions AS (
+                SELECT A_H.location_label, A_S.is_exit_or_blocknumber, A_S.validator_index FROM
+                history_events A_H JOIN eth_staking_events_info A_S ON A_H.identifier = A_S.identifier
+            WHERE A_H.subtype = ? AND NOT EXISTS (
+                SELECT 1 FROM history_events M_H
+                JOIN eth_staking_events_info M_S ON M_H.identifier = M_S.identifier
+                WHERE M_H.subtype = ? AND M_S.validator_index = A_S.validator_index
+                AND M_S.is_exit_or_blocknumber = A_S.is_exit_or_blocknumber
+            ))
+            SELECT B_H.identifier, B_T.block_number, B_H.notes, B_T.tx_hash, blocks.validator_index FROM evm_transactions B_T
+            JOIN chain_events_info B_E ON B_T.tx_hash = B_E.tx_ref
+            JOIN history_events B_H ON B_E.identifier = B_H.identifier
+            JOIN block_productions blocks ON blocks.is_exit_or_blocknumber = B_T.block_number
+            AND blocks.location_label = B_T.from_address WHERE B_H.asset = ? AND B_H.type = ?
+            AND B_H.subtype = ?"""  # noqa: E501
+        )
+        relay_bindings: list[int | str] = [
             HistoryEventSubType.MEV_REWARD.serialize(),
             A_ETH.identifier,
             HistoryEventType.RECEIVE.serialize(),
             HistoryEventSubType.NONE.serialize(),
         ]
-        queries_and_bindings = []
+        fallback_bindings: list[int | str] = [
+            HistoryEventSubType.BLOCK_PRODUCTION.serialize(),
+            HistoryEventSubType.MEV_REWARD.serialize(),
+            A_ETH.identifier,
+            HistoryEventType.RECEIVE.serialize(),
+            HistoryEventSubType.NONE.serialize(),
+        ]
+        queries_and_bindings: list[tuple[str, list[int | str]]] = []
         if block_numbers is not None and len(block_numbers) > 0:
             for chunk, placeholders in get_query_chunks(data=block_numbers):
-                queries_and_bindings.append((
-                    f'{query} AND B_T.block_number IN ({placeholders})',
-                    bindings + list(chunk),
+                queries_and_bindings.extend((
+                    (
+                        f'{relay_query} AND B_T.block_number IN ({placeholders})',
+                        relay_bindings + list(chunk),
+                    ), (
+                        f'{fallback_query} AND B_T.block_number IN ({placeholders})',
+                        fallback_bindings + list(chunk),
+                    ),
                 ))
         else:
-            queries_and_bindings = [(query, bindings)]
+            queries_and_bindings = [
+                (relay_query, relay_bindings),
+                (fallback_query, fallback_bindings),
+            ]
 
         with self.db.conn.read_ctx() as cursor:
             changes = [

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -752,6 +752,98 @@ def test_combine_block_with_tx_events(eth2, database):
         assert hidden_ids == [2]
 
 
+def test_combine_block_with_tx_events_without_relay_data(eth2, database):
+    """Test mev reward event combination when relay data is missing."""
+    dbevents = DBHistoryEvents(database)
+    dbeth2 = DBEth2(database)
+    dbevmtx = DBEvmTx(database)
+    vindex = 4242
+    payout_recipient = string_to_evm_address('0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b')
+    fee_recipient = string_to_evm_address('0x690B9A9E9aa1C9dB991C7721a92d351Db4FaC990')
+    block_number = 1337
+    tx_hash = deserialize_evm_tx_hash('0x8d0969db1e536969ba2e29abf8e8945e4304d49ae14523b66cbe9be5d52df804')  # noqa: E501
+    mev_reward = FVal('0.1')
+    timestampms = TimestampMS(1666693607000)
+
+    with database.user_write() as write_cursor:
+        dbeth2.add_or_update_validators(write_cursor, [
+            ValidatorDetails(
+                validator_index=vindex,
+                validator_type=ValidatorType.DISTRIBUTING,
+                public_key=Eth2PubKey('0xadd9843b2eb53ccaf5afb52abcc0a1322308832065v6fdfb162360ca53a71ebf8775dbebd0f1f1bf6c3e823d4bf2815f7'),
+            ),
+        ])
+        database.add_blockchain_accounts(write_cursor, [BlockchainAccountData(chain=SupportedBlockchain.ETHEREUM, address=payout_recipient)])  # noqa: E501
+
+        dbevmtx.add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[EvmTransaction(
+                tx_hash=tx_hash,
+                chain_id=ChainID.ETHEREUM,
+                timestamp=Timestamp(1666693607),
+                block_number=block_number,
+                from_address=fee_recipient,
+                to_address=payout_recipient,
+                value=100000000000000000,
+                gas=27500,
+                gas_price=9213569214,
+                gas_used=0,  # irrelevant
+                input_data=b'',  # irrelevant
+                nonce=16239,
+            )],
+            relevant_address=payout_recipient,
+        )
+
+        dbevents.add_history_events(write_cursor, [
+            EthBlockEvent(
+                validator_index=vindex,
+                timestamp=timestampms,
+                amount=mev_reward,
+                fee_recipient=fee_recipient,
+                fee_recipient_tracked=False,
+                block_number=block_number,
+                is_mev_reward=False,
+            ), EvmEvent(
+                tx_ref=tx_hash,
+                sequence_index=0,
+                timestamp=timestampms,
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_ETH,
+                amount=mev_reward,
+                location_label=payout_recipient,
+                notes=f'Received {mev_reward} ETH from {fee_recipient}',
+            ),
+        ])
+
+    eth2.combine_block_with_tx_events()
+
+    with database.conn.read_ctx() as cursor:
+        events = dbevents.get_history_events_internal(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(),
+            aggregate_by_group_ids=False,
+        )
+
+    modified_event = EvmEvent(
+        identifier=2,
+        tx_ref=tx_hash,
+        sequence_index=1,
+        timestamp=timestampms,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.STAKING,
+        event_subtype=HistoryEventSubType.MEV_REWARD,
+        asset=A_ETH,
+        amount=mev_reward,
+        location_label=payout_recipient,
+        notes=f'Received {mev_reward} ETH from {fee_recipient} as mev reward for block {block_number} in {tx_hash!s}',  # noqa: E501
+        group_identifier=EthBlockEvent.form_group_identifier(block_number),
+        extra_data={'validator_index': vindex},
+    )
+    assert modified_event == events[1]
+
+
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('network_mocking', [False])
 @pytest.mark.freeze_time('2023-04-30 21:52:55 GMT')


### PR DESCRIPTION
Improves ETH validator MEV reward detection when beaconcha.in relay metadata is missing or incomplete. rotki now also infers proposer payout MEV rewards from on-chain transactions by matching ETH receive events in produced blocks where the fee recipient sends the payout transaction. This keeps existing relay-based matching intact and adds a safe fallback, reducing missed MEV reward attribution.
