### PR TITLE
fix: multi-trade event removal sequence index conflict

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11788` Removing a sub-event from a multi-trade event group will no longer fail with a sequence index conflict error.
 * :bug:`-` Claiming Pendle rewards from old pools, or claiming multiple rewards in one transaction should now be decoded properly by rotki.
 * :bug:`-` ETH staking historyMEV/proposer payout rewards are combined more reliably with block proposal even when beaconcha.in relay data is unavailable.
 * :bug:`11766` Value distribution graphs will now work correctly by fixing the schema types to match the backend response.

--- a/rotkehlchen/api/rest_helpers/history_events.py
+++ b/rotkehlchen/api/rest_helpers/history_events.py
@@ -98,25 +98,31 @@ def edit_grouped_swap_events(
     May raise InputError if a new event is added that collides
     with the sequence index of an existing event.
     """
-    edited_identifiers, new_events = [], []
+    events_to_edit, new_events = [], []
+    edited_identifiers = set()
     for event in events:
         if event.identifier is None:  # No existing identifier - this is a new event.
             new_events.append(event)
-        else:  # Already has an identifier - edit existing event.
-            events_db.edit_history_event(
-                write_cursor=write_cursor,
-                event=event,
-                mapping_state=HistoryMappingState.CUSTOMIZED,
-            )
-            edited_identifiers.append(event.identifier)
+        else:  # Already has an identifier - will be edited after deletions.
+            events_to_edit.append(event)
+            edited_identifiers.add(event.identifier)
 
-    if identifiers != edited_identifiers:  # There are identifiers with no corresponding events - these events need to be deleted.  # noqa: E501
-        ids_to_delete = tuple(set(identifiers) - set(edited_identifiers))
+    # Deletions must happen before edits, since edited events may be assigned
+    # sequence indices that were previously held by the deleted events.
+    ids_to_delete = tuple(set(identifiers) - edited_identifiers)
+    if ids_to_delete:
         placeholders = ','.join(['?'] * len(ids_to_delete))
         events_db.delete_events_and_track(
             write_cursor=write_cursor,
             where_clause=f'WHERE identifier IN ({placeholders})',
             where_bindings=ids_to_delete,
+        )
+
+    for event in events_to_edit:
+        events_db.edit_history_event(
+            write_cursor=write_cursor,
+            event=event,
+            mapping_state=HistoryMappingState.CUSTOMIZED,
         )
 
     for event in new_events:

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -1405,6 +1405,86 @@ def test_add_edit_evm_swap_events(rotkehlchen_api_server: 'APIServer') -> None:
             address=addr2,
         )]
 
+    # Remove a receive event from the multi-trade group. The fee event (id=5, seq_idx=4) should
+    # shift to seq_idx=3, taking the sequence index of the removed receive event (id=8, seq_idx=3).
+    # This tests that deletions happen before edits to avoid sequence_index conflicts.
+    entry['identifiers'] = [1, 2, 3, 8, 5]  # update to match current DB state
+    entry['receive'] = [entry['receive'][0]]  # type: ignore[index]  # keep only the first receive
+    entry['fee'] = [{'identifier': 5, 'amount': '0.0012', 'asset': A_WETH.identifier}]
+    assert_proper_sync_response_with_result(requests.patch(
+        api_url_for(rotkehlchen_api_server, 'historyeventresource'),
+        json=entry,
+    ))
+    with rotki.data.db.conn.read_ctx() as cursor:
+        multi_trade_events = [
+            e for e in db.get_history_events_internal(
+                cursor=cursor,
+                filter_query=HistoryEventFilterQuery.make(),
+                aggregate_by_group_ids=False,
+            ) if e.group_identifier == 'test_id'
+        ]
+        assert len(multi_trade_events) == 4
+        assert multi_trade_events[0] == EvmSwapEvent(
+            identifier=1,
+            group_identifier='test_id',
+            sequence_index=0,
+            timestamp=TimestampMS(1569924575000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.MULTI_TRADE,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_ETH,
+            amount=FVal('0.16'),
+            location_label=location_label,
+            notes='Example note',
+            tx_ref=tx_hash,
+            counterparty=counterparty,
+            address=addr1,
+        )
+        assert multi_trade_events[1] == EvmSwapEvent(
+            identifier=2,
+            group_identifier='test_id',
+            sequence_index=1,
+            timestamp=TimestampMS(1569924575000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.MULTI_TRADE,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_WBNB,
+            amount=FVal('0.54'),
+            location_label=location_label,
+            tx_ref=tx_hash,
+            counterparty=counterparty,
+            address=addr1,
+        )
+        assert multi_trade_events[2] == EvmSwapEvent(
+            identifier=3,
+            group_identifier='test_id',
+            sequence_index=2,
+            timestamp=TimestampMS(1569924575000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.MULTI_TRADE,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            asset=A_WBTC,
+            amount=FVal('0.003'),
+            location_label='0x706A70067BE19BdadBea3600Db0626859Ff25D74',
+            tx_ref=tx_hash,
+            counterparty=counterparty,
+            address=addr1,
+        )
+        assert multi_trade_events[3] == EvmSwapEvent(
+            identifier=5,
+            group_identifier='test_id',
+            sequence_index=3,
+            timestamp=TimestampMS(1569924575000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.MULTI_TRADE,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_WETH,
+            amount=FVal('0.0012'),
+            tx_ref=tx_hash,
+            counterparty=counterparty,
+            address=addr1,
+        )
+
     # Check event serialization.
     assert generate_events_response(data=[events[5]])[0]['entry'] == {
         'timestamp': 1569924576000,


### PR DESCRIPTION
## Summary
- Fixes the order of operations in `edit_grouped_swap_events()` to delete removed events before editing remaining ones, preventing `IntegrityError` when sequence indices shift
- Adds a test case that removes a receive event from a multi-trade group, verifying the fee event correctly takes the freed sequence index

## Test plan
- [x] Existing test `test_add_edit_evm_swap_events` passes
- [x] New test case fails without the fix (verified by stashing the fix and running)
- [x] Linting and type checking pass

Closes #11788