### PR TITLE
fix(frontend): skip initial balance fetch for EVM accounts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11782` Adding a new EVM account will no longer trigger a redundant initial balance fetch before token detection. Balances are now fetched only once after tokens are detected.
 * :feature:`-` Claiming Degen airdrop 1 will now be properly decoded by rotki.
 * :bug:`11788` Removing a sub-event from a multi-trade event group will no longer fail with a sequence index conflict error.
 * :bug:`-` Claiming Pendle rewards from old pools, or claiming multiple rewards in one transaction should now be decoded properly by rotki.

--- a/frontend/app/src/composables/balances/index.ts
+++ b/frontend/app/src/composables/balances/index.ts
@@ -50,8 +50,8 @@ export const useBalances = createSharedComposable(() => {
 
   const fetch = async (): Promise<void> => {
     await fetchExchangeRates();
-    startPromise(fetchBalances());
     await Promise.allSettled([fetchManualBalances(), refreshAccounts(), fetchConnectedExchangeBalances()]);
+    startPromise(fetchBalances());
   };
 
   const autoRefresh = async (): Promise<void> => {

--- a/frontend/app/src/composables/blockchain/index.ts
+++ b/frontend/app/src/composables/blockchain/index.ts
@@ -35,7 +35,7 @@ export function useBlockchains(): UseBlockchainsReturn {
 
   const addEvmAccounts = async (payload: AddAccountsPayload, options?: AddAccountsOption): Promise<void> => {
     const onComplete = async (params: { addedAccounts: any[]; modulesToEnable?: any[] }): Promise<void> =>
-      accountAdditionService.completeAccountAddition(params, refreshAccounts);
+      accountAdditionService.completeAccountAddition(params, refreshAccounts, fetchAccounts);
 
     if (payload.payload.length === 1) {
       const addResult = await accountAdditionService.addSingleEvmAddress(payload.payload[0]);
@@ -78,7 +78,7 @@ export function useBlockchains(): UseBlockchainsReturn {
     }
 
     const onComplete = async (params: { addedAccounts: ChainAddress[]; chain: string; isXpub?: boolean; modulesToEnable?: any[] }): Promise<void> =>
-      accountAdditionService.completeAccountAddition(params, refreshAccounts);
+      accountAdditionService.completeAccountAddition(params, refreshAccounts, fetchAccounts);
 
     if (filteredPayload.length === 1 || isXpub) {
       const addResult = await accountAdditionService.addSingleAccount(isXpub ? payload : filteredPayload[0], chain);

--- a/frontend/app/src/composables/blockchain/use-account-addition-service.ts
+++ b/frontend/app/src/composables/blockchain/use-account-addition-service.ts
@@ -57,6 +57,8 @@ interface ChainAccountAdditionParams {
 
 type RefreshAccountsCallback = (params: RefreshAccountsParams) => Promise<void>;
 
+type FetchAccountsCallback = (blockchain?: string | string[], refreshEns?: boolean) => Promise<void>;
+
 type EvmCompletionCallback = (params: EvmAccountAdditionParams) => Promise<void>;
 
 type ChainCompletionCallback = (params: ChainAccountAdditionParams) => Promise<void>;
@@ -73,7 +75,7 @@ interface UseAccountAdditionServiceReturn {
   addMultipleEvmAccounts: (payload: AddAccountsPayload, onComplete: EvmCompletionCallback) => Promise<void>;
   addSingleAccount: (account: AccountPayload | XpubAccountPayload, chain: string) => Promise<AccountAdditionSuccess | AccountAdditionFailure>;
   addSingleEvmAddress: (account: AccountPayload) => Promise<EvmAccountAdditionSuccess | EvmAccountAdditionFailure>;
-  completeAccountAddition: (params: AccountAdditionParams, onRefreshAccounts: RefreshAccountsCallback) => Promise<void>;
+  completeAccountAddition: (params: AccountAdditionParams, onRefreshAccounts: RefreshAccountsCallback, onFetchAccounts?: FetchAccountsCallback) => Promise<void>;
   getNewAccountPayload: (chain: string, payload: AccountPayload[]) => AccountPayload[];
 }
 
@@ -101,6 +103,7 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
   const completeAccountAddition = async (
     params: AccountAdditionParams,
     onRefreshAccounts: RefreshAccountsCallback,
+    onFetchAccounts?: FetchAccountsCallback,
   ): Promise<void> => {
     const {
       addedAccounts,
@@ -111,7 +114,18 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
 
     // Refresh tags first in case new system tags (like 'Contract') were created
     await fetchTags();
-    await onRefreshAccounts({ addresses: addedAccounts.map(item => item.address), blockchain: chain, isXpub });
+
+    const chainsSupportsTransactions = !chain || supportsTransactions(chain);
+    if (chainsSupportsTransactions && onFetchAccounts) {
+      // For EVM chains, only load account metadata without fetching balances.
+      // Token detection will run next, and the detectionStatus watcher in the
+      // tokens store will trigger a balance refresh after detection completes.
+      await onFetchAccounts(chain, true);
+    }
+    else {
+      await onRefreshAccounts({ addresses: addedAccounts.map(item => item.address), blockchain: chain, isXpub });
+    }
+
     const chains = chain ? [chain] : get(supportedChains).map(chain => chain.id);
     // Sort accounts by chain, so they are called in order
     const sortedAccounts = addedAccounts.sort(CHAIN_ORDER_COMPARATOR(chains));


### PR DESCRIPTION
Closes #11782

## Summary
- For EVM chains, account addition now calls `fetchAccounts` (metadata only) instead of `refreshAccounts` (metadata + balances) before token detection
- The existing `detectionStatus` watcher in the tokens store triggers the single balance refresh after detection completes, avoiding a redundant initial fetch
- Moves the snapshot `fetchBalances()` call to after all balance sources have loaded so it captures current state

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test:unit` passes (235 files, 2659 tests)
- [ ] Manual test: add a new EVM account on a fresh instance and verify only one balance query happens (after token detection)