### PR TITLE
refactor(frontend): pinia store performance fixes

### DIFF
--- a/frontend/app/src/components/helper/OnboardingSettingsButton.vue
+++ b/frontend/app/src/components/helper/OnboardingSettingsButton.vue
@@ -4,7 +4,7 @@ import { useMainStore } from '@/store/main';
 
 const { t } = useI18n({ useScope: 'global' });
 const visible = ref<boolean>(false);
-const { connected } = toRefs(useMainStore());
+const { connected } = storeToRefs(useMainStore());
 </script>
 
 <template>

--- a/frontend/app/src/components/profitloss/ReportActionable.vue
+++ b/frontend/app/src/components/profitloss/ReportActionable.vue
@@ -22,7 +22,7 @@ function regenerateReport() {
 const mainDialogOpen = ref<boolean>(initialOpen);
 
 const reportsStore = useReportsStore();
-const { actionableItems } = toRefs(reportsStore);
+const { actionableItems } = storeToRefs(reportsStore);
 
 const actionableItemsLength = computed(() => {
   let total = 0;

--- a/frontend/app/src/components/profitloss/ReportActionableCard.vue
+++ b/frontend/app/src/components/profitloss/ReportActionableCard.vue
@@ -33,7 +33,7 @@ function setDialog(dialog: boolean) {
 }
 
 const reportsStore = useReportsStore();
-const { actionableItems } = toRefs(reportsStore);
+const { actionableItems } = storeToRefs(reportsStore);
 
 const step = ref<number>(1);
 

--- a/frontend/app/src/components/staking/kraken/KrakenStaking.vue
+++ b/frontend/app/src/components/staking/kraken/KrakenStaking.vue
@@ -19,7 +19,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const selection = ref<'current' | 'historical'>('current');
 
-const { events } = toRefs(useKrakenStakingStore());
+const { events } = storeToRefs(useKrakenStakingStore());
 const { assetPrice } = usePriceUtils();
 
 const { getProtocolStatsPriceQueryStatus } = useHistoricCachePriceStore();

--- a/frontend/app/src/composables/defi/airdrops/metadata.ts
+++ b/frontend/app/src/composables/defi/airdrops/metadata.ts
@@ -11,7 +11,7 @@ import { getPublicProtocolImagePath } from '@/utils/file';
 export const useAirdropsMetadata = createSharedComposable(() => {
   const { fetchAirdropsMetadata } = useDefiApi();
 
-  const { connected } = toRefs(useMainStore());
+  const { connected } = storeToRefs(useMainStore());
   const loading = ref<boolean>(false);
 
   const metadata: Ref<ProtocolMetadata[]> = asyncComputed<ProtocolMetadata[]>(

--- a/frontend/app/src/composables/defi/metadata.ts
+++ b/frontend/app/src/composables/defi/metadata.ts
@@ -11,7 +11,7 @@ import { getPublicProtocolImagePath } from '@/utils/file';
 export const useDefiMetadata = createSharedComposable(() => {
   const { fetchDefiMetadata } = useDefiApi();
 
-  const { connected } = toRefs(useMainStore());
+  const { connected } = storeToRefs(useMainStore());
 
   const loading = ref<boolean>(false);
 

--- a/frontend/app/src/composables/info/chains.ts
+++ b/frontend/app/src/composables/info/chains.ts
@@ -38,7 +38,7 @@ function isSolanaChain(info: ChainInfo): info is ChainInfo {
 export const useSupportedChains = createSharedComposable(() => {
   const { fetchAllEvmChains, fetchSupportedChains } = useSupportedChainsApi();
 
-  const { connected } = toRefs(useMainStore());
+  const { connected } = storeToRefs(useMainStore());
 
   const supportedChains = asyncComputed<SupportedChains>(async () => {
     if (get(connected))

--- a/frontend/app/src/composables/scramble-settings.ts
+++ b/frontend/app/src/composables/scramble-settings.ts
@@ -13,12 +13,13 @@ interface UseScrambleSettingReturn {
 }
 
 export function useScrambleSetting(): UseScrambleSettingReturn {
+  const scrambleData = shallowRef<boolean>(false);
+  const scrambleMultiplier = shallowRef<string>('0');
+  const isUpdating = shallowRef<boolean>(false);
+  let timeoutId: ReturnType<typeof setTimeout>;
+
   const frontendStore = useFrontendSettingsStore();
   const { scrambleData: enabled, scrambleMultiplier: multiplier } = storeToRefs(frontendStore);
-
-  const scrambleData = ref<boolean>(false);
-  const scrambleMultiplier = ref<string>('0');
-  const isUpdating = ref<boolean>(false);
 
   // Debounced backend update
   const debouncedBackendUpdate = useDebounceFn(async (value: number) => {
@@ -39,14 +40,13 @@ export function useScrambleSetting(): UseScrambleSettingReturn {
 
     // Update store immediately for UI
     frontendStore.update({
-      ...frontendStore.$state.settings,
+      ...get(frontendStore.settings),
       scrambleMultiplier: numValue,
     });
 
     // Debounce backend update
     startPromise(debouncedBackendUpdate(numValue));
-
-    setTimeout(() => set(isUpdating, false), 600);
+    timeoutId = setTimeout(() => set(isUpdating, false), 600);
   }
 
   function initializeData(): void {
@@ -55,6 +55,11 @@ export function useScrambleSetting(): UseScrambleSettingReturn {
       set(scrambleMultiplier, (get(multiplier) ?? generateRandomScrambleMultiplier()).toString());
     }
   }
+
+  onScopeDispose(() => {
+    if (timeoutId)
+      clearTimeout(timeoutId);
+  });
 
   onMounted(initializeData);
 

--- a/frontend/app/src/modules/history/events/use-history-events-status.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-status.ts
@@ -22,8 +22,8 @@ export const useHistoryEventsStatus = createSharedComposable((): UseHistoryEvent
   const { useIsTaskRunning } = useTaskStore();
   const { isLoading: isSectionLoading } = useStatusStore();
 
-  const { isAllFinished: isQueryingTxsFinished } = toRefs(useTxQueryStatusStore());
-  const { isAllFinished: isQueryingOnlineEventsFinished } = toRefs(useEventsQueryStatusStore());
+  const { isAllFinished: isQueryingTxsFinished } = storeToRefs(useTxQueryStatusStore());
+  const { isAllFinished: isQueryingOnlineEventsFinished } = storeToRefs(useEventsQueryStatusStore());
 
   const sectionLoading = isSectionLoading(Section.HISTORY);
   const txEventsDecoding = useIsTaskRunning(TaskType.TRANSACTIONS_DECODING);

--- a/frontend/app/src/modules/sync-progress/composables/use-sync-progress.ts
+++ b/frontend/app/src/modules/sync-progress/composables/use-sync-progress.ts
@@ -81,13 +81,13 @@ export function useSyncProgress(): UseSyncProgressReturn {
   const eventsStore = useEventsQueryStatusStore();
   const historyStore = useHistoryStore();
 
-  const { queryStatus: txQueryStatus } = toRefs(txStore);
-  const { queryStatus: eventsQueryStatus } = toRefs(eventsStore);
+  const { queryStatus: txQueryStatus } = storeToRefs(txStore);
+  const { queryStatus: eventsQueryStatus } = storeToRefs(eventsStore);
   // Use decodingSyncStatus for sync progress - it's not reset by fetchUndecodedTransactionsBreakdown
   const {
     decodingSyncStatus: rawDecodingStatus,
     protocolCacheStatus: rawProtocolCacheStatus,
-  } = toRefs(historyStore);
+  } = storeToRefs(historyStore);
 
   const chains = useChainProgress(txQueryStatus);
 

--- a/frontend/app/src/store/blockchain/accounts/addresses-names.ts
+++ b/frontend/app/src/store/blockchain/accounts/addresses-names.ts
@@ -28,8 +28,6 @@ import { logger } from '@/utils/logging';
 export const useAddressesNamesStore = defineStore('blockchains/accounts/addresses-names', () => {
   const { enableAliasNames } = storeToRefs(useFrontendSettingsStore());
 
-  const fetchedEntries = ref<AddressBookSimplePayload[]>([]);
-  const addressesNames = ref<AddressBookEntries>([]);
   const ensNames = ref<EthNames>({});
 
   const { awaitTask } = useTaskStore();
@@ -319,14 +317,12 @@ export const useAddressesNamesStore = defineStore('blockchains/accounts/addresse
 
   return {
     addAddressBook,
-    addressesNames,
     addressInfoSelector,
     addressNameSelector,
     addressNameSourceSelector,
     deleteAddressBook,
     ensNames,
     ensNameSelector,
-    fetchedEntries,
     fetchEnsNames,
     getAddressBook,
     getAddressesWithoutNames,

--- a/frontend/app/src/store/blockchain/tokens.ts
+++ b/frontend/app/src/store/blockchain/tokens.ts
@@ -146,17 +146,13 @@ export const useBlockchainTokensStore = defineStore('blockchain/tokens', () => {
     }
   });
 
-  const { useIsTaskRunning } = useTaskStore();
+  const { isTaskRunning } = useTaskStore();
   const { fetchBlockchainBalances } = useBlockchainBalances();
 
-  const detectionStatus = computed(() => {
+  const detectionStatus = computed<Record<string, boolean>>(() => {
     const isDetecting: Record<string, boolean> = {};
     get(txEvmChains).forEach(({ id }) => {
-      isDetecting[id] = get(
-        useIsTaskRunning(TaskType.FETCH_DETECTED_TOKENS, {
-          chain: id,
-        }),
-      );
+      isDetecting[id] = isTaskRunning(TaskType.FETCH_DETECTED_TOKENS, { chain: id });
     });
 
     return isDetecting;

--- a/frontend/app/src/store/monitor.ts
+++ b/frontend/app/src/store/monitor.ts
@@ -11,14 +11,22 @@ import { useTaskStore } from '@/store/tasks';
 import { useWebsocketStore } from '@/store/websocket';
 import { logger } from '@/utils/logging';
 
-const PERIODIC = 'periodic';
-const TASK = 'task';
-const BALANCES = 'balances';
-const EVM_EVENTS_STATUS = 'evm_events_status';
-const PASSWORD_CONFIRMATION = 'password_confirmation';
+const MonitorKey = {
+  BALANCES: 'balances',
+  EVM_EVENTS_STATUS: 'evm_events_status',
+  PASSWORD_CONFIRMATION: 'password_confirmation',
+  PERIODIC: 'periodic',
+  TASK: 'task',
+} as const;
+
+const TASK_POLLING_MS = 4_000;
+const EVM_STATUS_POLLING_MS = 10 * 60 * 1_000;
+const PASSWORD_CHECK_MS = 60 * 60 * 1_000;
+const SECONDS_TO_MS = 1_000;
+const MINUTES_TO_MS = 60 * 1_000;
 
 export const useMonitorStore = defineStore('monitor', () => {
-  const monitors = ref<Record<string, any>>({});
+  const monitors: Record<string, NodeJS.Timeout> = {};
 
   const authStore = useSessionAuthStore();
   const { canRequestData, logged, username } = storeToRefs(authStore);
@@ -49,13 +57,11 @@ export const useMonitorStore = defineStore('monitor', () => {
   const connectWebSocket = async (restarting: boolean): Promise<void> => {
     try {
       await connect();
-      const activeMonitors = get(monitors);
-      if (!activeMonitors[PERIODIC]) {
+      if (!monitors[MonitorKey.PERIODIC]) {
         if (!restarting)
           fetch();
 
-        activeMonitors[PERIODIC] = setInterval(fetch, get(queryPeriod) * 1000);
-        set(monitors, activeMonitors);
+        monitors[MonitorKey.PERIODIC] = setInterval(fetch, get(queryPeriod) * SECONDS_TO_MS);
       }
     }
     catch (error: unknown) {
@@ -64,49 +70,39 @@ export const useMonitorStore = defineStore('monitor', () => {
   };
 
   const startTaskMonitoring = (restarting: boolean): void => {
-    const activeMonitors = get(monitors);
-
-    if (!activeMonitors[TASK]) {
+    if (!monitors[MonitorKey.TASK]) {
       if (!restarting)
         startPromise(monitor());
 
-      activeMonitors[TASK] = setInterval(() => startPromise(monitor()), 4000);
-      set(monitors, activeMonitors);
+      monitors[MonitorKey.TASK] = setInterval(() => startPromise(monitor()), TASK_POLLING_MS);
     }
   };
 
   const startBalanceRefresh = (): void => {
-    const period = get(refreshPeriod) * 60 * 1000;
-    const activeMonitors = get(monitors);
-    if (!activeMonitors[BALANCES] && period > 0) {
-      activeMonitors[BALANCES] = setInterval(() => {
+    const period = get(refreshPeriod) * MINUTES_TO_MS;
+    if (!monitors[MonitorKey.BALANCES] && period > 0) {
+      monitors[MonitorKey.BALANCES] = setInterval(() => {
         if (get(canRequestData))
           startPromise(autoRefresh());
       }, period);
-      set(monitors, activeMonitors);
     }
   };
 
   const startEvmStatusMonitoring = (): void => {
-    const activeMonitors = get(monitors);
-    const period = 10 * 60 * 1000; // fetch every 10 mins
-    if (!activeMonitors[EVM_EVENTS_STATUS]) {
+    if (!monitors[MonitorKey.EVM_EVENTS_STATUS]) {
       if (get(canRequestData))
         startPromise(fetchTransactionStatusSummary());
 
-      activeMonitors[EVM_EVENTS_STATUS] = setInterval(() => {
+      monitors[MonitorKey.EVM_EVENTS_STATUS] = setInterval(() => {
         if (get(canRequestData))
           startPromise(fetchTransactionStatusSummary());
-      }, period);
-      set(monitors, activeMonitors);
+      }, EVM_STATUS_POLLING_MS);
     }
   };
 
   const startPasswordConfirmationMonitoring = (): void => {
-    const activeMonitors = get(monitors);
-    const period = 60 * 60 * 1000; // check every 1 hour
-    if (!activeMonitors[PASSWORD_CONFIRMATION]) {
-      activeMonitors[PASSWORD_CONFIRMATION] = setInterval(() => {
+    if (!monitors[MonitorKey.PASSWORD_CONFIRMATION]) {
+      monitors[MonitorKey.PASSWORD_CONFIRMATION] = setInterval(() => {
         if (!get(logged))
           return;
 
@@ -115,8 +111,7 @@ export const useMonitorStore = defineStore('monitor', () => {
           return;
 
         startPromise(checkIfPasswordConfirmationNeeded(currentUsername));
-      }, period);
-      set(monitors, activeMonitors);
+      }, PASSWORD_CHECK_MS);
     }
   };
 
@@ -134,12 +129,10 @@ export const useMonitorStore = defineStore('monitor', () => {
 
   const stop = (): void => {
     disconnect();
-    const activeMonitors = get(monitors);
-    for (const key in activeMonitors) {
-      clearInterval(activeMonitors[key]);
-      delete activeMonitors[key];
+    for (const key in monitors) {
+      clearInterval(monitors[key]);
+      delete monitors[key];
     }
-    set(monitors, activeMonitors);
   };
 
   const restart = (): void => {

--- a/frontend/app/src/store/notifications/index.ts
+++ b/frontend/app/src/store/notifications/index.ts
@@ -48,13 +48,11 @@ export const useNotificationsStore = defineStore('notifications', () => {
 
   const count = computed<number>(() => get(data).length);
 
-  const nextId = computed<number>(() => {
-    const ids = get(data)
-      .map(value => value.id)
-      .sort((a, b) => b - a);
+  let nextId = 1;
 
-    return ids.length > 0 ? ids[0] + 1 : 1;
-  });
+  function getNextId(): number {
+    return nextId++;
+  }
 
   const queue = computed<NotificationData[]>(() => get(prioritized).filter(notification => notification.display));
 
@@ -110,7 +108,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
     }
     else {
       addNotifications([
-        createNotification(get(nextId), Object.assign(notificationDefaults(), {
+        createNotification(getNextId(), Object.assign(notificationDefaults(), {
           ...newData,
           group: NotificationGroup.DESERIALIZATION_ERROR,
           groupCount: 1,
@@ -169,7 +167,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
       const endpoints = [endpoint];
       const extras: BeaconchainRateLimitedExtras = { endpoints, until: newUntil || undefined };
       addNotifications([
-        createNotification(get(nextId), Object.assign(notificationDefaults(), {
+        createNotification(getNextId(), Object.assign(notificationDefaults(), {
           ...newData,
           display: true,
           extras,
@@ -182,24 +180,78 @@ export const useNotificationsStore = defineStore('notifications', () => {
     }
   }
 
+  function addNewNotification(newData: SemiPartial<NotificationPayload, 'title' | 'message'>): void {
+    const notification = createNotification(getNextId(), Object.assign(notificationDefaults(), newData));
+    const groupToFind = newData.group;
+
+    if (groupToFind && notification.display) {
+      set(lastDisplay, {
+        ...get(lastDisplay),
+        [groupToFind]: notification.date.getTime(),
+      });
+    }
+
+    addNotifications([notification]);
+  }
+
+  function updateExistingGroupNotification(
+    dataList: NotificationData[],
+    notificationIndex: number,
+    newData: SemiPartial<NotificationPayload, 'title' | 'message'>,
+  ): void {
+    const notification = dataList[notificationIndex];
+    let date = new Date();
+    let display = newData.display ?? false;
+
+    const currentTime = date.getTime();
+    const group = newData.group ?? '';
+    const lastTime = get(lastDisplay)[group] ?? 0;
+
+    if (currentTime - lastTime < NOTIFICATION_COOLDOWN_MS) {
+      date = notification.date;
+      display = false;
+    }
+
+    const newNotification: NotificationData = {
+      ...notification,
+      action: newData.action,
+      date,
+      display,
+      groupCount: newData.groupCount,
+      message: newData.message,
+      priority: newData.priority,
+      severity: newData.severity ?? notification.severity,
+      title: newData.title,
+    };
+
+    dataList.splice(notificationIndex, 1);
+    dataList.unshift(newNotification);
+    set(data, dataList);
+  }
+
+  function isBulkDuplicate(dataList: NotificationData[], newData: SemiPartial<NotificationPayload, 'title' | 'message'>): boolean {
+    if (newData.priority !== Priority.BULK)
+      return false;
+
+    const messages = dataList
+      .filter(notification => notification.priority === Priority.BULK)
+      .map(notification => notification.message);
+
+    return messages.includes(newData.message);
+  }
+
   const notify = (newData: SemiPartial<NotificationPayload, 'title' | 'message'>): void => {
     const notifications = [...get(data)];
     const dataList = take(notifications, NOTIFICATION_MAX_SIZE - 1);
 
     set(messageOverflow, notifications.length > dataList.length);
 
-    if (newData.priority === Priority.BULK) {
-      const messages = dataList.filter(notification => notification.priority === Priority.BULK)
-        .map(notification => notification.message);
+    if (isBulkDuplicate(dataList, newData))
+      return;
 
-      if (messages.includes(newData.message)) {
-        return;
-      }
-
-      if (newData.message.startsWith(DESERIALIZATION_ERROR_PREFIX)) {
-        handleDeserializationError(dataList, newData);
-        return;
-      }
+    if (newData.priority === Priority.BULK && newData.message.startsWith(DESERIALIZATION_ERROR_PREFIX)) {
+      handleDeserializationError(dataList, newData);
+      return;
     }
 
     if (newData.message.includes(BEACONCHAIN_RATE_LIMITED_PREFIX)) {
@@ -208,51 +260,12 @@ export const useNotificationsStore = defineStore('notifications', () => {
     }
 
     const groupToFind = newData.group;
-
     const notificationIndex = groupToFind ? dataList.findIndex(({ group }) => group === groupToFind) : -1;
 
-    if (notificationIndex === -1) {
-      const notification = createNotification(get(nextId), Object.assign(notificationDefaults(), newData));
-
-      if (groupToFind && notification.display) {
-        set(lastDisplay, {
-          ...get(lastDisplay),
-          [groupToFind]: notification.date.getTime(),
-        });
-      }
-
-      addNotifications([notification]);
-    }
-    else {
-      const notification = dataList[notificationIndex];
-      let date = new Date();
-      let display = newData.display ?? false;
-
-      const currentTime = date.getTime();
-      const group = groupToFind ?? '';
-      const lastTime = get(lastDisplay)[group] ?? 0;
-
-      if (currentTime - lastTime < NOTIFICATION_COOLDOWN_MS) {
-        date = notification.date;
-        display = false;
-      }
-
-      const newNotification: NotificationData = {
-        ...notification,
-        action: newData.action,
-        date,
-        display,
-        groupCount: newData.groupCount,
-        message: newData.message,
-        priority: newData.priority,
-        severity: newData.severity ?? notification.severity,
-        title: newData.title,
-      };
-
-      dataList.splice(notificationIndex, 1);
-      dataList.unshift(newNotification);
-      set(data, dataList);
-    }
+    if (notificationIndex === -1)
+      addNewNotification(newData);
+    else
+      updateExistingGroupNotification(dataList, notificationIndex, newData);
   };
 
   const displayed = (ids: number[]): void => {
@@ -282,7 +295,6 @@ export const useNotificationsStore = defineStore('notifications', () => {
     data,
     displayed,
     messageOverflow,
-    nextId,
     notify,
     prioritized,
     queue,

--- a/frontend/app/src/store/reports/index.ts
+++ b/frontend/app/src/store/reports/index.ts
@@ -86,6 +86,7 @@ export const useReportsStore = defineStore('reports', () => {
     generateReport: generateReportCaller,
   } = useReportsApi();
 
+  const { awaitTask } = useTaskStore();
   const { getProgress } = useHistoryApi();
 
   const isLatestReport = (reportId: number): ComputedRef<boolean> => computed<boolean>(() => get(lastGeneratedReport) === reportId);
@@ -186,7 +187,6 @@ export const useReportsStore = defineStore('reports', () => {
 
     const intervalId = checkProgress();
 
-    const { awaitTask } = useTaskStore();
     try {
       const { taskId } = await generateReportCaller(period);
       const { result } = await awaitTask<number, TaskMeta>(taskId, TaskType.TRADE_HISTORY, {
@@ -235,7 +235,6 @@ export const useReportsStore = defineStore('reports', () => {
 
     const intervalId = checkProgress();
 
-    const { awaitTask } = useTaskStore();
     try {
       const { taskId } = await exportReportDataCaller(payload);
       const { result } = await awaitTask<boolean | object, TaskMeta>(taskId, TaskType.TRADE_HISTORY, {

--- a/frontend/app/src/store/session/tags.ts
+++ b/frontend/app/src/store/session/tags.ts
@@ -11,9 +11,9 @@ export const useTagStore = defineStore('session/tags', () => {
 
   const tags = computed(() => Object.values(get(allTags)));
 
+  const { t } = useI18n({ useScope: 'global' });
   const { removeTag, renameTag } = useBlockchainAccountsStore();
   const { showErrorMessage } = useNotifications();
-  const { t } = useI18n({ useScope: 'global' });
   const { queryAddTag, queryDeleteTag, queryEditTag, queryTags } = useTagsApi();
 
   const addTag = async (tag: Tag): Promise<ActionStatus> => {
@@ -68,9 +68,7 @@ export const useTagStore = defineStore('session/tags', () => {
   };
 
   function tagExists(tagName: string): boolean {
-    return get(tags)
-      .map(({ name }) => name)
-      .includes(tagName);
+    return get(tags).some(({ name }) => name === tagName);
   }
 
   async function attemptTagCreation(tag: string, backgroundColor?: string): Promise<boolean> {

--- a/frontend/app/src/store/staking/kraken.ts
+++ b/frontend/app/src/store/staking/kraken.ts
@@ -17,10 +17,10 @@ import { TaskType } from '@/types/task-type';
 import { balanceSum } from '@/utils/calculation';
 import { logger } from '@/utils/logging';
 
-function defaultPagination(): KrakenStakingPagination {
+function defaultPagination(itemsPerPage: number): KrakenStakingPagination {
   return {
     ascending: [false],
-    limit: useFrontendSettingsStore().itemsPerPage,
+    limit: itemsPerPage,
     offset: 0,
     orderByAttributes: ['timestamp'],
   };
@@ -38,8 +38,13 @@ function defaultEventState(): KrakenStakingEvents {
 }
 
 export const useKrakenStakingStore = defineStore('staking/kraken', () => {
-  const pagination = ref<KrakenStakingPagination>(defaultPagination());
+  const { itemsPerPage } = storeToRefs(useFrontendSettingsStore());
+  const pagination = ref<KrakenStakingPagination>(defaultPagination(get(itemsPerPage)));
   const rawEvents = ref<KrakenStakingEvents>(defaultEventState());
+
+  watch(itemsPerPage, (newValue: number) => {
+    set(pagination, { ...get(pagination), limit: newValue });
+  });
 
   const api = useKrakenApi();
 

--- a/frontend/app/src/store/statistics/index.ts
+++ b/frontend/app/src/store/statistics/index.ts
@@ -79,62 +79,62 @@ export const useStatisticsStore = defineStore('statistics', () => {
 
   const totalNetWorth = calculateTotalValue(nftsInNetValue);
 
-  const overall = computed<Overall>(() => {
-    const currency = get(currencySymbol);
+  const scrambleEnabled = logicOr(scrambleData, logicNot(shouldShowAmount));
+
+  const balanceDelta = computed<BigNumber>(() => {
     const selectedTimeframe = get(timeframe);
     const allTimeframes = timeframes((unit, amount) => dayjs().subtract(amount, unit).startOf(TimeUnit.DAY).unix());
     const startingDate = allTimeframes[selectedTimeframe].startingDate();
-
-    const startingValue: () => BigNumber = () => {
-      const data = get(getNetValue(startingDate)).data;
-      let start = data[0];
-      if (start.isZero()) {
-        for (let i = 1; i < data.length; i++) {
-          if (data[i].gt(0)) {
-            start = data[i];
-            break;
-          }
+    const data = get(getNetValue(startingDate)).data;
+    let start = data[0];
+    if (start?.isZero()) {
+      for (let i = 1; i < data.length; i++) {
+        if (data[i].gt(0)) {
+          start = data[i];
+          break;
         }
       }
-      return start;
-    };
+    }
+    return get(totalNetWorth).minus(start ?? Zero);
+  });
 
-    const starting = startingValue();
-    const totalNW = get(totalNetWorth);
-    const balanceDelta = totalNW.minus(starting);
+  const scrambledNetWorth = useNumberScrambler({
+    enabled: scrambleEnabled,
+    multiplier: scrambleMultiplier,
+    value: totalNetWorth,
+  });
 
-    // Apply scrambling to net worth for tray display
-    const scrambledNetWorth = get(useNumberScrambler({
-      enabled: logicOr(scrambleData, logicNot(shouldShowAmount)),
-      multiplier: scrambleMultiplier,
-      value: computed(() => totalNW),
-    }));
+  const scrambledBalanceDelta = useNumberScrambler({
+    enabled: scrambleEnabled,
+    multiplier: scrambleMultiplier,
+    value: balanceDelta,
+  });
 
-    const scrambledBalanceDelta = get(useNumberScrambler({
-      enabled: logicOr(scrambleData, logicNot(shouldShowAmount)),
-      multiplier: scrambleMultiplier,
-      value: computed(() => balanceDelta),
-    }));
+  const overall = computed<Overall>(() => {
+    const currency = get(currencySymbol);
+    const selectedTimeframe = get(timeframe);
+    const delta = get(balanceDelta);
 
-    const percentage = balanceDelta.div(starting).multipliedBy(100);
+    const percentage = ((): string => {
+      const starting = get(totalNetWorth).minus(delta);
+      const pct = delta.div(starting).multipliedBy(100);
+      return pct.isFinite() ? pct.toFormat(2) : '-';
+    })();
 
     let up: boolean | undefined;
-    if (balanceDelta.isGreaterThan(0))
+    if (delta.isGreaterThan(0))
       up = true;
-    else if (balanceDelta.isLessThan(0))
+    else if (delta.isLessThan(0))
       up = false;
 
     const floatPrecision = get(floatingPrecision);
     const rounding = get(valueRoundingMode);
 
-    const delta = scrambledBalanceDelta.toFormat(floatPrecision, rounding);
-    const netWorth = scrambledNetWorth.toFormat(floatPrecision, rounding);
-
     return {
       currency,
-      delta,
-      netWorth,
-      percentage: percentage.isFinite() ? percentage.toFormat(2) : '-',
+      delta: get(scrambledBalanceDelta).toFormat(floatPrecision, rounding),
+      netWorth: get(scrambledNetWorth).toFormat(floatPrecision, rounding),
+      percentage,
       period: selectedTimeframe,
       up,
     };

--- a/frontend/app/src/store/tasks/index.ts
+++ b/frontend/app/src/store/tasks/index.ts
@@ -1,7 +1,7 @@
 import { type ActionResult, assert } from '@rotki/common';
 import { checkIfDevelopment } from '@shared/utils';
 import dayjs from 'dayjs';
-import { find, toArray } from 'es-toolkit/compat';
+import { toArray } from 'es-toolkit/compat';
 import { useTaskApi } from '@/composables/api/task';
 import { isTimeoutError } from '@/modules/api/with-retry';
 import {
@@ -97,42 +97,53 @@ export const useTaskStore = defineStore('tasks', () => {
     unlock(taskId);
   };
 
+  const tasksByType = computed<Map<TaskType, Task<TaskMeta>[]>>(() => {
+    const map = new Map<TaskType, Task<TaskMeta>[]>();
+    for (const task of Object.values(get(tasks))) {
+      const list = map.get(task.type);
+      if (list)
+        list.push(task);
+      else
+        map.set(task.type, [task]);
+    }
+    return map;
+  });
+
   const checkIfTaskIsRunning = (
-    runningTasks: TaskMap<TaskMeta>,
+    groupedTasks: Map<TaskType, Task<TaskMeta>[]>,
     type: TaskType,
     meta: Record<string, any> = {},
-  ): boolean => !!find(runningTasks, (item) => {
-    const sameType = item.type === type;
+  ): boolean => {
+    const typeTasks = groupedTasks.get(type);
+    if (!typeTasks)
+      return false;
+
     const keys = Object.keys(meta);
     if (keys.length === 0)
-      return sameType;
+      return true;
 
-    return (
-      sameType
-      && keys.every(
+    return typeTasks.some(item =>
+      keys.every(
         key =>
         // @ts-expect-error meta key has any type
           key in item.meta && item.meta[key] === meta[key],
-      )
+      ),
     );
-  });
+  };
 
   const isTaskRunning = (
     type: TaskType,
     meta: Record<string, any> = {},
-  ): boolean => checkIfTaskIsRunning(get(tasks), type, meta);
+  ): boolean => checkIfTaskIsRunning(get(tasksByType), type, meta);
 
   const useIsTaskRunning = (
     type: TaskType,
     meta: MaybeRef<Record<string, any>> = {},
-  ): ComputedRef<boolean> => computed<boolean>(() => checkIfTaskIsRunning(get(tasks), type, get(meta)));
+  ): ComputedRef<boolean> => computed<boolean>(() => checkIfTaskIsRunning(get(tasksByType), type, get(meta)));
 
   const metadata = <T extends TaskMeta>(type: TaskType): T | undefined => {
-    const task = find(Object.values(get(tasks)), item => item.type === type);
-    if (task)
-      return task.meta as T;
-
-    return undefined;
+    const typeTasks = get(tasksByType).get(type);
+    return typeTasks?.[0]?.meta as T | undefined;
   };
 
   const hasRunningTasks = computed<boolean>(() => Object.keys(get(tasks)).length > 0);
@@ -178,7 +189,7 @@ export const useTaskStore = defineStore('tasks', () => {
       if (deleted) {
         const handler = handlers[type] ?? handlers[`${type}-${id}`];
         if (!handler) {
-          remove(task.id);
+          remove(id);
         }
         else {
           lock(id);
@@ -191,7 +202,7 @@ export const useTaskStore = defineStore('tasks', () => {
     }
     catch (error_: any) {
       if (error_ instanceof TaskNotFoundError)
-        remove(task.id);
+        remove(id);
 
       return false;
     }


### PR DESCRIPTION
## Summary

- **Task store**: Index-based lookup for `useIsTaskRunning`/`isTaskRunning` — O(1) instead of O(n) per call across 121 call sites
- **Tokens store**: Fix leaked `ComputedRef` instances from `useIsTaskRunning` called inside computed body
- **Statistics store**: Fix leaked refs from `useNumberScrambler`/`logicOr`/`logicNot` called inside computed body
- **Notifications store**: Replace O(n log n) `nextId` sort with O(1) running counter; decompose `notify` into focused helpers
- **Monitor store**: Remove reactive wrapping from interval handles; replace magic numbers with named constants
- **Reports store**: Hoist `useTaskStore()` destructure to setup scope (was re-called per action invocation)
- **Scramble settings**: Use reactive getter `get(frontendStore.settings)` instead of `$state.settings` bypass
- **`toRefs` → `storeToRefs`**: Replace across 9 files (12 instances) to avoid wrapping store actions in refs
- **Addresses-names store**: Remove dead `addressesNames`/`fetchedEntries` refs
- **Tags store**: Replace `map().includes()` with `some()`
- **Kraken staking store**: Make `itemsPerPage` reactive so it reflects user setting changes

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint:fix` — 0 errors
- [x] `pnpm run test:unit` — 237 files, 2724 tests pass