### PR TITLE
Cowswap API query needs 0x prefixed uid now

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Changelog
 * :bug:`11709` History events page will now properly refresh after marking an asset as spam or ignoring it from the context menu.
 * :bug:`-` Registering a new device is now more reliable when rotki runs in container environments.
 * :bug:`-` Depositing native token + wrapped native token in Aaave v3 in the same transaction will now be properly decoded.
+* :bug:`-` Misdecoded cowswap swaps should no longer happen due to errors querying cowswap API.
 * :feature:`11702` Zerox Base Swaps through the latest settler  will now be properly decoded.
 * :bug:`-` ZKSynclite batch withdrawal on the ethereum side should now be properly decoded.
 * :bug:`-` Claiming AAVE rewards and immediately restaking them will now be properly decoded.

--- a/rotkehlchen/externalapis/cowswap.py
+++ b/rotkehlchen/externalapis/cowswap.py
@@ -90,7 +90,7 @@ class CowswapAPI:
             return int(result[1]), result[0]
 
         # else, we need to query the API
-        data = self._query(f'orders/{order_uid}')
+        data = self._query(f'orders/0x{order_uid}')
         raw_fee_amount, order_type = parse_order_data(data)
 
         with self.database.conn.write_ctx() as write_cursor:

--- a/rotkehlchen/tests/unit/decoders/test_cowswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_cowswap.py
@@ -778,7 +778,7 @@ def test_swap_gnosis_tokens(gnosis_inquirer, gnosis_accounts):
     assert events == expected_events
 
 
-# @pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xECCf11f03CEfe8A68bb01CAF66e76CEeFeaAEe5e']])
 def test_swap_gnosis_monerium(gnosis_inquirer, gnosis_accounts):
     """The annoying problem with monerium's multiple versions messing with the decoder matching"""
@@ -793,7 +793,7 @@ def test_swap_gnosis_monerium(gnosis_inquirer, gnosis_accounts):
             asset=Asset('eip155:100/erc20:0xcB444e90D8198415266c6a2724b7900fb12FC56E'),
             amount=FVal(send_amount := '15'),
             location_label=(user_address := gnosis_accounts[0]),
-            notes=f'Swap {send_amount} EURe in a cowswap market order',
+            notes=f'Swap {send_amount} EURe in a cowswap limit order',
             counterparty=CPT_COWSWAP,
             address=GPV2_SETTLEMENT_ADDRESS,
         ), EvmSwapEvent(
@@ -805,7 +805,7 @@ def test_swap_gnosis_monerium(gnosis_inquirer, gnosis_accounts):
             asset=Asset('eip155:100/erc20:0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb'),
             amount=FVal(receive_amount := '0.056204042821142175'),
             location_label=user_address,
-            notes=f'Receive {receive_amount} GNO as the result of a cowswap market order',
+            notes=f'Receive {receive_amount} GNO as the result of a cowswap limit order',
             counterparty=CPT_COWSWAP,
             address=GPV2_SETTLEMENT_ADDRESS,
         ),


### PR DESCRIPTION
Did not add a test here as the problem is in all cowswap swaps that need to touch the cowswap API. Essentially our old tests will need redecoding.


Seems like cowswap API now needs 0x prefix for uids

For example check in one of the failures in the CI:

Cassette had
https://api.cow.fi/mainnet/api/v1/orders/e24374695e725ac7ebca145974f760aa918e7211983ed761d67cee04290d925f43f9a40200310ce535edf5ea0eb71afb53779ba467520422

Fails with

```
Invalid URL: Cannot parse `uid` with value `e24374695e725ac7ebca145974f760aa918e7211983ed761d67cee04290d925f43f9a40200310ce535edf5ea0eb71afb53779ba467520422`: "e24374695e725ac7ebca145974f760aa918e7211983ed761d67cee04290d925f43f9a40200310ce535edf5ea0eb71afb53779ba467520422" can't be decoded as hex uid because it does not start with '0x'
```

Adding 0x prefix works

https://api.cow.fi/mainnet/api/v1/orders/0xe24374695e725ac7ebca145974f760aa918e7211983ed761d67cee04290d925f43f9a40200310ce535edf5ea0eb71afb53779ba467520422