### PR TITLE
fix(frontend): correct from/to labels in matched movements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`9024` rotki now supports yearn in all EVM chains.
+* :bug:`11783` Matched withdrawal from exchange to account will now correctly show the destination address instead of displaying the exchange name for both from and to labels.
 * :bug:`11782` Adding a new EVM account will no longer trigger a redundant initial balance fetch before token detection. Balances are now fetched only once after tokens are detected.
 * :feature:`-` Claiming Degen airdrop 1 will now be properly decoded by rotki.
 * :bug:`11788` Removing a sub-event from a multi-trade event group will no longer fail with a sequence index conflict error.

--- a/frontend/app/src/modules/history/events/composables/use-history-matched-movement-item.spec.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-matched-movement-item.spec.ts
@@ -358,6 +358,151 @@ describe('useHistoryMatchedMovementItem', () => {
     });
   });
 
+  describe('compactNotes', () => {
+    it('should show "from exchange to address" for withdrawal events', () => {
+      const events = ref([
+        createMockEvent(HistoryEventEntryType.ASSET_MOVEMENT_EVENT, {
+          identifier: 1,
+          asset: 'ETH',
+          amount: bigNumberify('1.0'),
+          eventType: 'withdrawal',
+          eventSubtype: 'none',
+          location: 'kraken',
+          locationLabel: 'Kraken Exchange',
+        }),
+        createMockEvent(HistoryEventEntryType.EVM_EVENT, {
+          identifier: 2,
+          asset: 'ETH',
+          amount: bigNumberify('1.0'),
+          eventType: 'receive',
+          eventSubtype: 'none',
+          location: 'ethereum',
+          locationLabel: '0x8454...3000',
+        }),
+      ]);
+      const { compactNotes } = useHistoryMatchedMovementItem({ events });
+      const notes = get(compactNotes)!;
+
+      // The from_part should contain the exchange (Kraken Exchange)
+      expect(notes).toContain('Kraken Exchange');
+      // The to_part should contain the on-chain address
+      expect(notes).toContain('0x8454...3000');
+      // Verify from contains exchange and to contains address
+      expect(notes).toContain('from_part::Kraken Exchange');
+      expect(notes).toContain('to_part::0x8454...3000');
+    });
+
+    it('should show "to exchange from address" for deposit events', () => {
+      const events = ref([
+        createMockEvent(HistoryEventEntryType.ASSET_MOVEMENT_EVENT, {
+          identifier: 1,
+          asset: 'ETH',
+          amount: bigNumberify('1.0'),
+          eventType: 'deposit',
+          eventSubtype: 'receive',
+          location: 'kraken',
+          locationLabel: 'Kraken Exchange',
+        }),
+        createMockEvent(HistoryEventEntryType.EVM_EVENT, {
+          identifier: 2,
+          asset: 'ETH',
+          amount: bigNumberify('1.0'),
+          eventType: 'spend',
+          eventSubtype: 'none',
+          location: 'ethereum',
+          locationLabel: '0x8454...3000',
+        }),
+      ]);
+      const { compactNotes } = useHistoryMatchedMovementItem({ events });
+      const notes = get(compactNotes)!;
+
+      // The to_part should contain the exchange (Kraken Exchange)
+      expect(notes).toContain('to_part::Kraken Exchange');
+      // The from_part should contain the on-chain address
+      expect(notes).toContain('from_part::0x8454...3000');
+    });
+
+    it('should select correct secondary event when adjustment events are present', () => {
+      // Simulates: primary is ASSET_MOVEMENT_EVENT (kraken withdrawal),
+      // there's a SEND adjustment event (also kraken), and the actual counterpart is an EVM_EVENT (ACCOUNT DEPOSIT)
+      const events = ref([
+        createMockEvent(HistoryEventEntryType.ASSET_MOVEMENT_EVENT, {
+          identifier: 1,
+          asset: 'USDC',
+          amount: bigNumberify('100.0'),
+          eventType: 'withdrawal',
+          eventSubtype: 'none',
+          location: 'kraken',
+          locationLabel: 'Kraken Exchange',
+        }),
+        // Adjustment event (same entryType as primary, small amount)
+        createMockEvent(HistoryEventEntryType.ASSET_MOVEMENT_EVENT, {
+          identifier: 2,
+          asset: 'USDC',
+          amount: bigNumberify('0.5'),
+          eventType: 'send',
+          eventSubtype: 'none',
+          location: 'kraken',
+          locationLabel: 'Kraken Exchange',
+        }),
+        // The actual counterpart (different entryType, matching amount)
+        createMockEvent(HistoryEventEntryType.EVM_EVENT, {
+          identifier: 3,
+          asset: 'USDC',
+          amount: bigNumberify('99.5'),
+          eventType: 'receive',
+          eventSubtype: 'none',
+          location: 'ethereum',
+          locationLabel: '0x8454...3000',
+        }),
+      ]);
+      const { secondaryEvent, compactNotes } = useHistoryMatchedMovementItem({ events });
+
+      // Should pick the EVM_EVENT as secondary, not the adjustment ASSET_MOVEMENT_EVENT
+      expect(get(secondaryEvent)?.identifier).toBe(3);
+      expect(get(secondaryEvent)?.entryType).toBe(HistoryEventEntryType.EVM_EVENT);
+
+      const notes = get(compactNotes)!;
+      // Should show the on-chain address, not kraken for both
+      expect(notes).toContain('to_part::0x8454...3000');
+      expect(notes).toContain('from_part::Kraken Exchange');
+    });
+
+    it('should append fee text when fee events exist', () => {
+      const events = ref([
+        createMockEvent(HistoryEventEntryType.ASSET_MOVEMENT_EVENT, {
+          identifier: 1,
+          asset: 'ETH',
+          amount: bigNumberify('1.0'),
+          eventType: 'withdrawal',
+          eventSubtype: 'none',
+          location: 'kraken',
+          locationLabel: 'Kraken Exchange',
+        }),
+        createMockEvent(HistoryEventEntryType.EVM_EVENT, {
+          identifier: 2,
+          asset: 'ETH',
+          amount: bigNumberify('1.0'),
+          eventType: 'receive',
+          eventSubtype: 'none',
+          location: 'ethereum',
+          locationLabel: '0x8454...3000',
+        }),
+        createMockEvent(HistoryEventEntryType.ASSET_MOVEMENT_EVENT, {
+          identifier: 3,
+          asset: 'ETH',
+          amount: bigNumberify('0.001'),
+          eventSubtype: 'fee',
+          location: 'kraken',
+        }),
+      ]);
+      const { compactNotes } = useHistoryMatchedMovementItem({ events });
+      const notes = get(compactNotes)!;
+
+      expect(notes).toContain('history_events_list_swap.fee_description');
+    });
+  });
+
   describe('reactivity', () => {
     it('should update primaryEvent when events change', () => {
       const events = ref(createMatchedMovementEvents());

--- a/frontend/app/src/modules/history/events/composables/use-history-matched-movement-item.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-matched-movement-item.ts
@@ -51,12 +51,21 @@ export function useHistoryMatchedMovementItem(
     return assetMovementEvent ?? get(events)[0];
   });
 
-  // Secondary event is the matching counterpart (non-fee, different from primary)
+  // Secondary event is the matching counterpart (non-fee, different from primary).
+  // Prefer events with a different entryType (e.g., EVM_EVENT vs ASSET_MOVEMENT_EVENT).
+  // Among multiple matches, pick the one with the largest amount (main counterpart, not adjustment).
   const secondaryEvent = computed<HistoryEventEntry | undefined>(() => {
-    const primaryId = get(primaryEvent).identifier;
-    return get(events).find(
-      item => item.eventSubtype !== 'fee' && item.identifier !== primaryId,
+    const primary = get(primaryEvent);
+    const candidates = get(events).filter(
+      item => item.eventSubtype !== 'fee' && item.identifier !== primary.identifier,
     );
+    if (candidates.length === 0)
+      return undefined;
+
+    const differentType = candidates.filter(item => item.entryType !== primary.entryType);
+    const pool = differentType.length > 0 ? differentType : candidates;
+
+    return pool.reduce((best, item) => (item.amount.gt(best.amount) ? item : best));
   });
 
   const hasMissingRule = computed<boolean>(() => isEventMissingAccountingRule(get(primaryEvent)));
@@ -106,13 +115,19 @@ export function useHistoryMatchedMovementItem(
 
     const amount = primary.amount;
     const asset = getAssetSymbol(primary.asset, ASSET_RESOLUTION_OPTIONS);
-    const locationLabel = primary.locationLabel || get(locationData(primary.location))?.name || '';
-    const address = secondary?.locationLabel || (secondary && get(locationData(secondary.location))?.name) || '';
+    const exchangeLabel = primary.locationLabel || get(locationData(primary.location))?.name || '';
+    const addressLabel = secondary?.locationLabel || (secondary && get(locationData(secondary.location))?.name) || '';
 
-    const to = locationLabel ? t('asset_movement_matching.compact_notes.to_part', { locationLabel }) : '';
-    const from = address ? t('asset_movement_matching.compact_notes.from_part', { address }) : '';
+    const isDeposit = primary.eventSubtype === 'receive';
+    // For deposits: to = exchange, from = address
+    // For withdrawals: from = exchange, to = address
+    const toLabel = isDeposit ? exchangeLabel : addressLabel;
+    const fromLabel = isDeposit ? addressLabel : exchangeLabel;
 
-    const notes = primary.eventSubtype === 'receive'
+    const to = toLabel ? t('asset_movement_matching.compact_notes.to_part', { locationLabel: toLabel }) : '';
+    const from = fromLabel ? t('asset_movement_matching.compact_notes.from_part', { address: fromLabel }) : '';
+
+    const notes = isDeposit
       ? t('asset_movement_matching.compact_notes.deposit', { amount, asset, to, from })
       : t('asset_movement_matching.compact_notes.withdraw', { amount, asset, from, to });
 


### PR DESCRIPTION
## Summary
- Fix secondary event selection to prefer events with a different `entryType` and pick the largest amount candidate, avoiding adjustment events being selected as the counterpart
- Fix from/to label assignment so withdrawals show "from exchange, to address" and deposits show "from address, to exchange"
- Add tests for compact notes covering withdrawal, deposit, adjustment events, and fee scenarios

Closes #11783

## Test plan
- [x] All 29 existing + new unit tests pass
- [ ] Verify matched withdrawal from exchange to account shows correct from/to labels in the UI
- [ ] Verify matched deposit from account to exchange shows correct from/to labels in the UI
- [ ] Verify movements with adjustment events (e.g., fee deducted) still show the correct counterpart address