### PR TITLE
Skip unnecessary ETH2 and pool balance queries on fresh accounts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`9024` rotki now supports yearn in all EVM chains.
+* :bug:`11797` Adding an ETH account on a fresh instance will no longer trigger unnecessary ETH2 and Uniswap balance queries when no validators exist and no events have been decoded.
 * :bug:`11783` Matched withdrawal from exchange to account will now correctly show the destination address instead of displaying the exchange name for both from and to labels.
 * :bug:`11782` Adding a new EVM account will no longer trigger a redundant initial balance fetch before token detection. Balances are now fetched only once after tokens are detected.
 * :feature:`-` Claiming Degen airdrop 1 will now be properly decoded by rotki.

--- a/frontend/app/src/composables/blockchain/use-account-addition-service.ts
+++ b/frontend/app/src/composables/blockchain/use-account-addition-service.ts
@@ -6,6 +6,7 @@ import { startPromise } from '@shared/utils';
 import { useBlockchainAccounts } from '@/composables/blockchain/accounts';
 import { useAccountAdditionNotifications } from '@/composables/blockchain/use-account-addition-notifications';
 import { useSupportedChains } from '@/composables/info/chains';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
 import { useBlockchainTokensStore } from '@/store/blockchain/tokens';
 import { useTagStore } from '@/store/session/tags';
@@ -82,6 +83,7 @@ interface UseAccountAdditionServiceReturn {
 export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
   const { addAccount, addEvmAccount } = useBlockchainAccounts();
   const { fetchDetected } = useBlockchainTokensStore();
+  const { trackAddedAddresses } = useBlockchainAccountsStore();
   const { fetchTags } = useTagStore();
   const { enableModule } = useSettingsStore();
   const { evmChains, supportedChains, supportsTransactions } = useSupportedChains();
@@ -114,6 +116,8 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
 
     // Refresh tags first in case new system tags (like 'Contract') were created
     await fetchTags();
+
+    trackAddedAddresses(addedAccounts.map(item => item.address));
 
     const chainsSupportsTransactions = !chain || supportsTransactions(chain);
     if (chainsSupportsTransactions && onFetchAccounts) {

--- a/frontend/app/src/composables/blockchain/use-account-operations.ts
+++ b/frontend/app/src/composables/blockchain/use-account-operations.ts
@@ -85,7 +85,7 @@ export function useAccountOperations(): UseAccountOperationsReturn {
     if (isEth || !chain) {
       pending.push(fetchLoopringBalances(false));
 
-      if (isEth)
+      if (isEth && getAddresses(Blockchain.ETH2).length > 0)
         startPromise(refreshAccounts({ blockchain: Blockchain.ETH2 }));
     }
 

--- a/frontend/app/src/modules/accounts/use-blockchain-accounts-store.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-accounts-store.ts
@@ -4,6 +4,7 @@ import { removeTags, renameTags } from '@/utils/tags';
 
 export const useBlockchainAccountsStore = defineStore('blockchain/accounts', () => {
   const accounts = ref<Accounts>({});
+  const recentlyAddedAddresses = ref<Set<string>>(new Set());
 
   const updateAccounts = (chain: string, data: BlockchainAccount[]): void => {
     set(accounts, { ...get(accounts), [chain]: data });
@@ -64,12 +65,26 @@ export const useBlockchainAccountsStore = defineStore('blockchain/accounts', () 
     set(accounts, copy);
   };
 
+  const trackAddedAddresses = (addresses: string[], ttl: number = 60_000): void => {
+    const current = new Set(get(recentlyAddedAddresses));
+    addresses.forEach(a => current.add(a));
+    set(recentlyAddedAddresses, current);
+
+    setTimeout(() => {
+      const updated = new Set(get(recentlyAddedAddresses));
+      addresses.forEach(a => updated.delete(a));
+      set(recentlyAddedAddresses, updated);
+    }, ttl);
+  };
+
   return {
     accounts,
     getAccountByAddress,
     getAccounts,
+    recentlyAddedAddresses,
     removeTag,
     renameTag,
+    trackAddedAddresses,
     updateAccountData,
     updateAccounts,
   };

--- a/frontend/app/src/modules/dashboard/liquidity-pools/use-pool-balances.ts
+++ b/frontend/app/src/modules/dashboard/liquidity-pools/use-pool-balances.ts
@@ -5,6 +5,7 @@ import { type BigNumber, Blockchain, createEvmIdentifierFromAddress, type Writea
 import { cloneDeep, isEqual } from 'es-toolkit';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { usePremium } from '@/composables/premium';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { useStatusStore } from '@/store/status';
@@ -65,10 +66,12 @@ export function usePoolBalances(): UsePoolBalancesReturn {
   const ethAddresses = computed<string[]>(() => get(addresses)[Blockchain.ETH] ?? []);
 
   const { sushiswapPoolBalances, uniswapPoolBalances } = storeToRefs(usePoolBalancesStore());
+  const { recentlyAddedAddresses } = storeToRefs(useBlockchainAccountsStore());
   const { activeModules } = storeToRefs(useGeneralSettingsStore());
 
   const premium = usePremium();
   const { t } = useI18n({ useScope: 'global' });
+
   const { isLoading } = useStatusStore();
   const { getSushiswapBalances, getUniswapV2Balances } = usePoolApi();
   const { assetSymbol } = useAssetInfoRetrieval();
@@ -225,9 +228,18 @@ export function usePoolBalances(): UsePoolBalancesReturn {
     await retrieveSushiswapBalances(refresh);
   }
 
-  watch(ethAddresses, async (addresses, previousAddresses) => {
-    if (!isEqual(addresses, previousAddresses))
-      await fetch(true);
+  watch(ethAddresses, async (current, previous) => {
+    if (isEqual(current, previous))
+      return;
+
+    const added = current.filter(a => !previous.includes(a));
+    const removed = previous.filter(a => !current.includes(a));
+    const recent = get(recentlyAddedAddresses);
+
+    if (removed.length === 0 && added.length > 0 && added.every(a => recent.has(a)))
+      return;
+
+    await fetch(true);
   });
 
   watch(premium, async (isActive, wasActive) => {


### PR DESCRIPTION
## Summary
- Guard ETH2 balance refresh to only trigger when ETH2 validators exist, preventing unnecessary queries on fresh accounts
- Track recently added addresses in the blockchain accounts store with a 60s TTL auto-cleanup, so the pool balances watcher can skip fetches triggered purely by new account additions
- Addresses are tracked before the accounts store is updated, and the watcher compares new addresses against the tracked set to decide whether to skip

Closes #11797

## Test plan
- [ ] Add an ETH account on a fresh instance — verify no ETH2 or Uniswap balance API calls fire in the network tab
- [ ] Add an ETH account on an instance with existing validators — verify ETH2 balance refresh still triggers
- [ ] Visit the liquidity pools page after adding accounts — verify pool balances load correctly via the component's `onBeforeMount`
- [ ] Remove an ETH account while on the pools page — verify pool balances refresh