### PR TITLE
fix(frontend): gate sync progress from background WS

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 * :bug:`-` Gearbox withdrawals should now always have the correct order of events.
 * :bug:`-` Gearbox deposit through some wrapper routes will now be properly decoded.
 * :feature:`9024` rotki now supports yearn in all EVM chains.
+* :bug:`11798` Sync progress panel will no longer appear during idle periods when backend background tasks send WebSocket status messages.
 * :bug:`11797` Adding an ETH account on a fresh instance will no longer trigger unnecessary ETH2 and Uniswap balance queries when no validators exist and no events have been decoded.
 * :bug:`11783` Matched withdrawal from exchange to account will now correctly show the destination address instead of displaying the exchange name for both from and to labels.
 * :bug:`11782` Adding a new EVM account will no longer trigger a redundant initial balance fetch before token detection. Balances are now fetched only once after tokens are detected.

--- a/frontend/app/src/composables/history/events/tx/use-refresh-transactions.spec.ts
+++ b/frontend/app/src/composables/history/events/tx/use-refresh-transactions.spec.ts
@@ -34,11 +34,13 @@ const mockExchanges: Exchange[] = [
 const mockTxQueryStatusStore = {
   initializeQueryStatus: vi.fn(),
   resetQueryStatus: vi.fn(),
+  stopSyncing: vi.fn(),
 };
 
 const mockEventsQueryStatusStore = {
   initializeQueryStatus: vi.fn(),
   resetQueryStatus: vi.fn(),
+  stopSyncing: vi.fn(),
 };
 
 const mockHistoryTransactionAccounts = {
@@ -60,6 +62,7 @@ const mockHistoryTransactionDecoding = {
 const mockHistoryStore = {
   resetDecodingSyncProgress: vi.fn(),
   resetUndecodedTransactionsStatus: vi.fn(),
+  stopDecodingSyncProgress: vi.fn(),
 };
 
 const mockTransactionSync = {

--- a/frontend/app/src/composables/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/composables/history/events/tx/use-refresh-transactions.ts
@@ -25,12 +25,12 @@ interface UseRefreshTransactionsReturn {
 export function useRefreshTransactions(): UseRefreshTransactionsReturn {
   const queue = new LimitedParallelizationQueue(1);
 
-  const { initializeQueryStatus, resetQueryStatus } = useTxQueryStatusStore();
-  const { initializeQueryStatus: initializeExchangeEventsQueryStatus, resetQueryStatus: resetExchangesQueryStatus } = useEventsQueryStatusStore();
+  const { initializeQueryStatus, resetQueryStatus, stopSyncing: stopTxSyncing } = useTxQueryStatusStore();
+  const { initializeQueryStatus: initializeExchangeEventsQueryStatus, resetQueryStatus: resetExchangesQueryStatus, stopSyncing: stopEventsSyncing } = useEventsQueryStatusStore();
   const { getAllAccounts } = useHistoryTransactionAccounts();
   const { fetchDisabled, isFirstLoad, resetStatus, setStatus } = useStatusUpdater(Section.HISTORY);
   const { fetchUndecodedTransactionsBreakdown, fetchUndecodedTransactionsStatus } = useHistoryTransactionDecoding();
-  const { resetDecodingSyncProgress, resetUndecodedTransactionsStatus } = useHistoryStore();
+  const { resetDecodingSyncProgress, resetUndecodedTransactionsStatus, stopDecodingSyncProgress } = useHistoryStore();
   const { isDecodableChains } = useSupportedChains();
 
   const { syncTransactionsByChains } = useTransactionSync();
@@ -183,6 +183,9 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
       finishRefresh();
       setStatus(Status.LOADED);
       onHistoryFinished();
+      stopTxSyncing();
+      stopEventsSyncing();
+      stopDecodingSyncProgress();
     }
 
     // After refresh is complete, check if there are pending accounts or exchanges to refresh

--- a/frontend/app/src/modules/sync-progress/composables/use-sync-progress.spec.ts
+++ b/frontend/app/src/modules/sync-progress/composables/use-sync-progress.spec.ts
@@ -141,6 +141,7 @@ describe('useSyncProgress', () => {
 
     it('should be true when there is decoding activity', () => {
       const historyStore = useHistoryStore();
+      historyStore.resetDecodingSyncProgress();
       historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
 
       const { isActive } = useSyncProgress();
@@ -187,6 +188,7 @@ describe('useSyncProgress', () => {
   describe('decoding progress', () => {
     it('should calculate decoding progress correctly', () => {
       const historyStore = useHistoryStore();
+      historyStore.resetDecodingSyncProgress();
       historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
 
       const { decoding } = useSyncProgress();
@@ -201,6 +203,7 @@ describe('useSyncProgress', () => {
 
     it('should filter out chains with total 0', () => {
       const historyStore = useHistoryStore();
+      historyStore.resetDecodingSyncProgress();
       historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 0, 0));
 
       const { decoding } = useSyncProgress();
@@ -256,6 +259,7 @@ describe('useSyncProgress', () => {
       ]);
 
       const historyStore = useHistoryStore();
+      historyStore.resetDecodingSyncProgress();
       historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 100));
 
       const { overallProgress } = useSyncProgress();
@@ -383,6 +387,7 @@ describe('useSyncProgress', () => {
   describe('decoding cancellation handling', () => {
     it('should mark decoding as cancelled', () => {
       const historyStore = useHistoryStore();
+      historyStore.resetDecodingSyncProgress();
       historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
       historyStore.markDecodingCancelled('eth');
 
@@ -399,6 +404,7 @@ describe('useSyncProgress', () => {
       ]);
 
       const historyStore = useHistoryStore();
+      historyStore.resetDecodingSyncProgress();
       historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
       historyStore.markDecodingCancelled('eth');
 
@@ -408,6 +414,7 @@ describe('useSyncProgress', () => {
 
     it('should include cancelled decoding in hasCancelled', () => {
       const historyStore = useHistoryStore();
+      historyStore.resetDecodingSyncProgress();
       historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
       historyStore.markDecodingCancelled('eth');
 
@@ -418,6 +425,7 @@ describe('useSyncProgress', () => {
 
     it('should treat cancelled decoding as 100% for overall progress', () => {
       const historyStore = useHistoryStore();
+      historyStore.resetDecodingSyncProgress();
       historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
       historyStore.markDecodingCancelled('eth');
 

--- a/frontend/app/src/store/history/index.ts
+++ b/frontend/app/src/store/history/index.ts
@@ -30,6 +30,7 @@ export const useHistoryStore = defineStore('history', () => {
   // Separate state for sync progress indicator - only updated by websocket messages,
   // not reset by fetchUndecodedTransactionsBreakdown
   const decodingSyncProgress = ref<Record<string, DecodingStatusEntry>>({});
+  const decodingSyncing = ref<boolean>(false);
 
   const receivingProtocolCacheStatus = ref<boolean>(false);
 
@@ -55,7 +56,10 @@ export const useHistoryStore = defineStore('history', () => {
       ...get(undecodedTransactionsStatus),
       [data.chain]: data,
     });
-    // Also update sync progress state (used by sync progress indicator)
+    // Only update sync progress when a user-initiated sync is active
+    if (!get(decodingSyncing))
+      return;
+
     // Guard: don't overwrite cancelled entries
     const currentSync = get(decodingSyncProgress);
     if (currentSync[data.chain]?.cancelled) {
@@ -72,6 +76,10 @@ export const useHistoryStore = defineStore('history', () => {
       ...get(undecodedTransactionsStatus),
       ...data,
     });
+
+    // Only update sync progress when a user-initiated sync is active
+    if (!get(decodingSyncing))
+      return;
 
     // Also update sync progress, but only if:
     // 1. The chain doesn't exist in sync progress yet (initialization), OR
@@ -151,6 +159,11 @@ export const useHistoryStore = defineStore('history', () => {
 
   const resetDecodingSyncProgress = (): void => {
     set(decodingSyncProgress, {});
+    set(decodingSyncing, true);
+  };
+
+  const stopDecodingSyncProgress = (): void => {
+    set(decodingSyncing, false);
   };
 
   const resetProtocolCacheUpdatesStatus = (): void => {
@@ -236,6 +249,7 @@ export const useHistoryStore = defineStore('history', () => {
     decodingStatus,
     decodingSyncProgress,
     decodingSyncStatus,
+    decodingSyncing,
     eventsModificationCounter,
     fetchAssociatedLocations,
     fetchLocationLabels,
@@ -253,6 +267,7 @@ export const useHistoryStore = defineStore('history', () => {
     setProtocolCacheStatus,
     setUndecodedTransactionsStatus,
     signalEventsModified,
+    stopDecodingSyncProgress,
     transactionStatusSummary,
     undecodedTransactionsStatus,
     updateUndecodedTransactionsStatus,

--- a/frontend/app/src/store/history/query-status/events-query-status.ts
+++ b/frontend/app/src/store/history/query-status/events-query-status.ts
@@ -9,11 +9,12 @@ export const useEventsQueryStatusStore = defineStore('history/events-query-statu
     item.status === HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED
     || item.status === HistoryEventsQueryStatus.CANCELLED;
 
-  const { isAllFinished, markCancelled, queryStatus, removeQueryStatus, resetQueryStatus }
+  const { isAllFinished, markCancelled, queryStatus, removeQueryStatus, resetQueryStatus, stopSyncing, syncing }
     = createQueryStatusState<HistoryEventsQueryData>(isStatusFinished, createKey);
 
   const initializeQueryStatus = (data: { location: string; name: string }[]): void => {
     resetQueryStatus();
+    set(syncing, true);
 
     const status = { ...get(queryStatus) };
     const now = millisecondsToSeconds(Date.now());
@@ -31,6 +32,9 @@ export const useEventsQueryStatusStore = defineStore('history/events-query-statu
   };
 
   const setQueryStatus = (data: HistoryEventsQueryData): void => {
+    if (!get(syncing))
+      return;
+
     const status = { ...get(queryStatus) };
     const key = createKey(data);
 
@@ -62,6 +66,8 @@ export const useEventsQueryStatusStore = defineStore('history/events-query-statu
     removeQueryStatus,
     resetQueryStatus,
     setQueryStatus,
+    stopSyncing,
+    syncing,
   };
 });
 

--- a/frontend/app/src/store/history/query-status/index.ts
+++ b/frontend/app/src/store/history/query-status/index.ts
@@ -2,17 +2,25 @@ import type { ComputedRef, Ref } from 'vue';
 
 interface QueryStatusStateReturn<T> {
   queryStatus: Ref<Record<string, T>>;
+  syncing: Ref<boolean>;
   isAllFinished: ComputedRef<boolean>;
   markCancelled: (key: string, cancelledStatus: T) => void;
   removeQueryStatus: (key: string) => void;
   resetQueryStatus: () => void;
+  stopSyncing: () => void;
 }
 
 export function createQueryStatusState<T>(isStatusFinished: (item: T) => boolean, createKey: (item: T) => string): QueryStatusStateReturn<T> {
   const queryStatus = ref<Record<string, T>>({});
+  const syncing = ref<boolean>(false);
 
   const resetQueryStatus = (): void => {
     set(queryStatus, {});
+    set(syncing, false);
+  };
+
+  const stopSyncing = (): void => {
+    set(syncing, false);
   };
 
   const markCancelled = (key: string, cancelledStatus: T): void => {
@@ -41,5 +49,7 @@ export function createQueryStatusState<T>(isStatusFinished: (item: T) => boolean
     queryStatus,
     removeQueryStatus,
     resetQueryStatus,
+    stopSyncing,
+    syncing,
   };
 }

--- a/frontend/app/src/store/history/query-status/tx-query-status.spec.ts
+++ b/frontend/app/src/store/history/query-status/tx-query-status.spec.ts
@@ -63,8 +63,23 @@ describe('store/history/query-status/tx-query-status', () => {
   });
 
   describe('setUnifiedTxQueryStatus', () => {
+    it('should discard updates when syncing is false', () => {
+      const store = useTxQueryStatusStore();
+
+      store.setUnifiedTxQueryStatus({
+        address: '0x123',
+        chain: 'ETH',
+        period: [0, 1000],
+        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED,
+        subtype: 'evm',
+      });
+
+      expect(Object.keys(get(store.queryStatus))).toHaveLength(0);
+    });
+
     it('should ignore ACCOUNT_CHANGE status', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         address: '0x123',
@@ -79,6 +94,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
     it('should handle bitcoin transactions with multiple addresses', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         addresses: ['bc1abc', 'bc1def'],
@@ -104,6 +120,7 @@ describe('store/history/query-status/tx-query-status', () => {
     describe('evm transaction status', () => {
       it('should set originalPeriodEnd from period[1] on STARTED status', () => {
         const store = useTxQueryStatusStore();
+        store.syncing = true;
 
         store.setUnifiedTxQueryStatus({
           address: '0x123',
@@ -119,6 +136,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
       it('should preserve originalPeriodEnd on subsequent updates', () => {
         const store = useTxQueryStatusStore();
+        store.syncing = true;
 
         // First: STARTED with period end
         store.setUnifiedTxQueryStatus({
@@ -145,6 +163,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
       it('should NOT set originalPeriodStart from STARTED status period[1]', () => {
         const store = useTxQueryStatusStore();
+        store.syncing = true;
 
         // STARTED status should only set originalPeriodEnd, not originalPeriodStart
         // This is the fix for the 100% progress bug
@@ -163,6 +182,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
       it('should set originalPeriodStart from first QUERYING status with non-zero period[1]', () => {
         const store = useTxQueryStatusStore();
+        store.syncing = true;
 
         // STARTED status - should NOT set originalPeriodStart
         store.setUnifiedTxQueryStatus({
@@ -189,6 +209,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
       it('should use period[0] as originalPeriodStart when non-zero', () => {
         const store = useTxQueryStatusStore();
+        store.syncing = true;
 
         store.setUnifiedTxQueryStatus({
           address: '0x123',
@@ -204,6 +225,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
       it('should preserve originalPeriodStart on subsequent updates', () => {
         const store = useTxQueryStatusStore();
+        store.syncing = true;
 
         // First update sets originalPeriodStart
         store.setUnifiedTxQueryStatus({
@@ -231,6 +253,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
     it('should normalize chain to lowercase', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         address: '0x123',
@@ -247,6 +270,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
     it('should not overwrite cancelled entries with WS updates', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       // Set initial status
       store.setUnifiedTxQueryStatus({
@@ -275,6 +299,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
     it('should not overwrite cancelled bitcoin entries with WS updates', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       // Set initial bitcoin status
       store.setUnifiedTxQueryStatus({
@@ -361,6 +386,7 @@ describe('store/history/query-status/tx-query-status', () => {
   describe('markAddressCancelled', () => {
     it('should set status to CANCELLED', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         address: '0x123',
@@ -378,6 +404,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
     it('should preserve other fields when cancelling', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         address: '0x123',
@@ -399,6 +426,7 @@ describe('store/history/query-status/tx-query-status', () => {
   describe('isAddressCancelled', () => {
     it('should return true for cancelled addresses', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         address: '0x123',
@@ -414,6 +442,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
     it('should return false for non-cancelled addresses', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         address: '0x123',
@@ -447,6 +476,7 @@ describe('store/history/query-status/tx-query-status', () => {
   describe('isAllFinished', () => {
     it('should return true when all EVM statuses are finished', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         address: '0x123',
@@ -469,6 +499,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
     it('should return false when any EVM status is not finished', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         address: '0x123',
@@ -491,6 +522,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
     it('should use DECODING_FINISHED for bitcoin status', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         addresses: ['bc1abc'],
@@ -514,6 +546,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
     it('should treat CANCELLED as finished', () => {
       const store = useTxQueryStatusStore();
+      store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         address: '0x123',

--- a/frontend/app/src/store/history/query-status/tx-query-status.ts
+++ b/frontend/app/src/store/history/query-status/tx-query-status.ts
@@ -109,10 +109,13 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
     queryStatus,
     removeQueryStatus: remove,
     resetQueryStatus,
+    stopSyncing,
+    syncing,
   } = createQueryStatusState<TxQueryStatusData>(isStatusFinished, createKey);
 
   const initializeQueryStatus = (data: ChainAddress[]): void => {
     resetQueryStatus();
+    set(syncing, true);
 
     const status = { ...get(queryStatus) };
     const now = millisecondsToSeconds(Date.now());
@@ -135,6 +138,9 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
   };
 
   const setUnifiedTxQueryStatus = (data: UnifiedTransactionStatusData): void => {
+    if (!get(syncing))
+      return;
+
     if (data.status === TransactionsQueryStatus.ACCOUNT_CHANGE) {
       return;
     }
@@ -246,6 +252,8 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
     resetQueryStatus,
     setEvmlikeStatus,
     setUnifiedTxQueryStatus,
+    stopSyncing,
+    syncing,
   };
 });
 


### PR DESCRIPTION
## Summary
- Backend periodic tasks send WebSocket status messages (`TRANSACTION_STATUS`, `HISTORY_EVENTS_STATUS`, `PROGRESS_UPDATES`) that populate the same query status stores used by user-initiated syncs, causing `SyncProgressPanel` to appear when idle
- Added an explicit `syncing` flag to tx/events query status stores and a `decodingSyncing` flag to the history store's decoding sync progress
- WS handlers (`setUnifiedTxQueryStatus`, `setQueryStatus`, decoding sync updates) now early-return when their respective syncing flag is false
- The flag is set to `true` during `initializeQueryStatus`/`resetDecodingSyncProgress` and closed in `refreshTransactions`' finally block via `stopSyncing`/`stopDecodingSyncProgress`

Closes #11798

## Test plan
- [x] All existing tests updated and passing (91 tests across 3 files)
- [x] New test added verifying WS updates are discarded when `syncing` is false
- [x] Lint passes cleanly
- [ ] Manual: verify sync progress panel appears during user-initiated refresh
- [ ] Manual: verify sync progress panel does NOT appear during idle when backend background tasks run