### PR TITLE
fix: propagate wallet bridge server bind errors

### DIFF
--- a/frontend/app/electron/main/app-server.ts
+++ b/frontend/app/electron/main/app-server.ts
@@ -21,78 +21,88 @@ export class AppServer {
     this.baseDirectory = baseDirectory ?? import.meta.dirname;
   }
 
-  public start(port: number, initialRoute?: string): void {
+  public async start(port: number, initialRoute?: string): Promise<void> {
     const devServerUrl = import.meta.env.VITE_DEV_SERVER_URL;
     const isDev = !!devServerUrl;
 
     if (isDev) {
-      this.startDevelopmentProxy(port, devServerUrl, initialRoute);
+      await this.startDevelopmentProxy(port, devServerUrl, initialRoute);
     }
     else {
-      this.startProductionServer(port);
+      await this.startProductionServer(port);
     }
   }
 
-  private startDevelopmentProxy(port: number, devServerUrl: string, initialRoute?: string): void {
-    const proxy = httpProxy.createProxyServer({
-      target: devServerUrl,
-      changeOrigin: true,
-    });
-
-    const server = http.createServer((req, res) => {
-      // Log incoming requests for debugging
-      this.logger.debug(`Proxy request: ${req.method} ${req.url}`);
-
-      // Proxy all requests to Vite dev server
-      proxy.web(req, res, {}, (err: Error | null) => {
-        if (err) {
-          this.logger.error('Proxy error:', err);
-          res.writeHead(HttpStatus.INTERNAL_SERVER_ERROR, { 'Content-Type': 'text/plain' });
-          res.end('Proxy error');
-        }
+  private async startDevelopmentProxy(port: number, devServerUrl: string, initialRoute?: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const proxy = httpProxy.createProxyServer({
+        target: devServerUrl,
+        changeOrigin: true,
       });
-    });
 
-    // Handle WebSocket upgrade requests (for HMR)
-    server.on('upgrade', (req, socket, head) => {
-      this.logger.debug(`WebSocket upgrade request: ${req.url}`);
-      proxy.ws(req, socket, head, {}, (err: Error | null) => {
-        if (err) {
-          this.logger.error('WebSocket proxy error:', err);
-          socket.destroy();
-        }
+      const server = http.createServer((req, res) => {
+        this.logger.debug(`Proxy request: ${req.method} ${req.url}`);
+
+        proxy.web(req, res, {}, (err: Error | null) => {
+          if (err) {
+            this.logger.error('Proxy error:', err);
+            res.writeHead(HttpStatus.INTERNAL_SERVER_ERROR, { 'Content-Type': 'text/plain' });
+            res.end('Proxy error');
+          }
+        });
       });
-    });
 
-    this.server = server;
-    server.listen(port, () => {
-      this.logger.info(`Development proxy server started at http://localhost:${port}`);
-      if (initialRoute) {
-        this.logger.info(`Initial route configured: ${initialRoute}`);
-      }
-    });
+      // Handle WebSocket upgrade requests (for HMR)
+      server.on('upgrade', (req, socket, head) => {
+        this.logger.debug(`WebSocket upgrade request: ${req.url}`);
+        proxy.ws(req, socket, head, {}, (err: Error | null) => {
+          if (err) {
+            this.logger.error('WebSocket proxy error:', err);
+            socket.destroy();
+          }
+        });
+      });
 
-    server.on('error', (error) => {
-      this.logger.error('Development proxy server error:', error);
+      server.once('error', reject);
+
+      server.listen(port, () => {
+        server.removeListener('error', reject);
+        server.on('error', (error) => {
+          this.logger.error('Development proxy server error:', error);
+        });
+
+        this.server = server;
+        this.logger.info(`Development proxy server started at http://localhost:${port}`);
+        if (initialRoute) {
+          this.logger.info(`Initial route configured: ${initialRoute}`);
+        }
+        resolve();
+      });
     });
   }
 
-  private startProductionServer(port: number): void {
-    const server = http.createServer((req, res) => {
-      this.handleProductionRequest(req, res, this.baseDirectory).catch((error) => {
-        this.logger.error('Unhandled error in production request handler:', error);
-        res.writeHead(HttpStatus.INTERNAL_SERVER_ERROR, { 'Content-Type': 'text/plain' });
-        res.end('500 Internal Server Error');
+  private async startProductionServer(port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const server = http.createServer((req, res) => {
+        this.handleProductionRequest(req, res, this.baseDirectory).catch((error) => {
+          this.logger.error('Unhandled error in production request handler:', error);
+          res.writeHead(HttpStatus.INTERNAL_SERVER_ERROR, { 'Content-Type': 'text/plain' });
+          res.end('500 Internal Server Error');
+        });
       });
-    });
 
-    this.server = server;
-    server.listen(port, () => {
-      this.logger.info(`Production server started at http://localhost:${port}`);
-    });
+      server.once('error', reject);
 
-    server.on('error', (error) => {
-      this.logger.error('Production server error:', error);
+      server.listen(port, () => {
+        server.removeListener('error', reject);
+        server.on('error', (error) => {
+          this.logger.error('Production server error:', error);
+        });
+
+        this.server = server;
+        this.logger.info(`Production server started at http://localhost:${port}`);
+        resolve();
+      });
     });
   }
 

--- a/frontend/app/electron/main/ipc-handlers/wallet-bridge-ipc-handlers.ts
+++ b/frontend/app/electron/main/ipc-handlers/wallet-bridge-ipc-handlers.ts
@@ -7,6 +7,8 @@ import { ROTKI_RPC_METHODS } from '@shared/proxy/constants';
 import { wait } from '@shared/utils';
 import { shell } from 'electron';
 
+const MAX_PORT_RETRIES = 2;
+
 interface WalletBridgeIpcHandlersCallbacks {
   sendIpcMessage: (channel: string, ...args: any[]) => void;
 }
@@ -32,46 +34,51 @@ export class WalletBridgeIpcHandlers {
   }
 
   openWalletConnectBridge = async (): Promise<void> => {
-    try {
-      // Check if servers are already running
-      const httpRunning = this.appServer.isListening();
-      const wsRunning = this.walletBridgeWebSocketServer.isListening();
-      const wsConnected = this.walletBridgeWebSocketServer.isConnected();
+    // Check if servers are already running
+    const httpRunning = this.appServer.isListening();
+    const wsRunning = this.walletBridgeWebSocketServer.isListening();
+    const wsConnected = this.walletBridgeWebSocketServer.isConnected();
 
-      if (this.walletConnectBridgePort && httpRunning && wsRunning) {
-        if (wsConnected) {
-          // Everything is running and connected, reset selected provider and open the page
-          this.logger.info(`Wallet Connect Bridge already running and connected at http://localhost:${this.walletConnectBridgePort}, resetting provider selection and opening page`);
-          await this.resetSelectedProvider();
-          await shell.openExternal(`http://localhost:${this.walletConnectBridgePort}/#/wallet-bridge`);
-        }
-        else {
-          // Servers are running but client is disconnected - reopen URL to reconnect
-          this.logger.info(`Wallet Connect Bridge servers running but client disconnected, reopening URL to reconnect`);
-          await shell.openExternal(`http://localhost:${this.walletConnectBridgePort}/#/wallet-bridge`);
-        }
-        return;
+    if (this.walletConnectBridgePort && httpRunning && wsRunning) {
+      if (wsConnected) {
+        this.logger.info(`Wallet Connect Bridge already running and connected at http://localhost:${this.walletConnectBridgePort}, resetting provider selection and opening page`);
+        await this.resetSelectedProvider();
+        await shell.openExternal(`http://localhost:${this.walletConnectBridgePort}/#/wallet-bridge`);
       }
-
-      // Servers not running or not configured, start them
-      const portNumber = await selectPort(40010);
-      this.walletConnectBridgePort = portNumber; // Store the port
-
-      this.appServer.start(portNumber, '/#/wallet-bridge');
-
-      // Start WebSocket server alongside HTTP server
-      this.walletBridgeWebSocketServer.start(portNumber + 1);
-
-      // Small delay to ensure servers are ready
-      await wait(100);
-
-      // Open the Wallet Connect Bridge in Electron (same URL in dev/prod)
-      await shell.openExternal(`http://localhost:${portNumber}/#/wallet-bridge`);
+      else {
+        this.logger.info(`Wallet Connect Bridge servers running but client disconnected, reopening URL to reconnect`);
+        await shell.openExternal(`http://localhost:${this.walletConnectBridgePort}/#/wallet-bridge`);
+      }
+      return;
     }
-    catch (error: any) {
-      this.logger.error(`Error opening Wallet Connect Bridge: ${error}`);
-    }
+
+    // Servers not running or not configured, start them with retry
+    const portNumber = await this.startServersWithRetry();
+    this.walletConnectBridgePort = portNumber;
+
+    await shell.openExternal(`http://localhost:${portNumber}/#/wallet-bridge`);
   };
+
+  private async startServersWithRetry(): Promise<number> {
+    const port = await selectPort(40010);
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= MAX_PORT_RETRIES; attempt++) {
+      const candidatePort = port + attempt;
+      try {
+        await this.appServer.start(candidatePort, '/#/wallet-bridge');
+        await this.walletBridgeWebSocketServer.start(candidatePort + 1);
+        return candidatePort;
+      }
+      catch (error) {
+        lastError = error;
+        this.performCleanup();
+        this.logger.warn(`Failed to start wallet bridge servers on port ${candidatePort}: ${String(error)}`);
+      }
+    }
+
+    throw new Error(`Failed to start wallet bridge servers after ${MAX_PORT_RETRIES + 1} attempts: ${String(lastError)}`);
+  }
 
   handleWalletBridgeHttpListening = async (): Promise<boolean> => this.appServer.isListening();
 

--- a/frontend/app/electron/main/ws.ts
+++ b/frontend/app/electron/main/ws.ts
@@ -35,57 +35,66 @@ export class WalletBridgeWebSocketServer {
   }
 
   /** Start the WebSocket server on the specified port */
-  public start(port: number): void {
+  public async start(port: number): Promise<void> {
     if (this.wsServer) {
-      return; // Already started
+      return;
     }
 
-    this.wsServer = new WebSocketServer({
-      port,
-      path: WEBSOCKET_PATH,
-    });
-
-    this.wsServer.on('connection', (ws) => {
-      const shouldNotifyReconnection = this.connectionManager.shouldNotifyReconnection();
-
-      // Register the new connection
-      const currentConnectionId = this.connectionManager.registerConnection(ws);
-
-      // Handle connection takeover if needed
-      this.connectionManager.handleConnectionTakeover(
-        currentConnectionId,
-        connectionId => this.cancelPendingRequestsForConnection(connectionId),
-      );
-
-      // Notify about connection status
-      this.connectionManager.notifyConnectionStatus(port, shouldNotifyReconnection);
-
-      // Start idle timer when connection is established
-      this.resetIdleTimer();
-
-      ws.on('message', (data) => {
-        const messageString = typeof data === 'string' ? data : data.toString();
-        this.messageHandler.handleMessage(messageString, () => this.resetIdleTimer());
+    return new Promise((resolve, reject) => {
+      const wss = new WebSocketServer({
+        port,
+        path: WEBSOCKET_PATH,
       });
 
-      ws.on('close', () => {
-        this.connectionManager.handleConnectionClose(
-          ws,
+      wss.once('error', reject);
+
+      wss.on('listening', () => {
+        wss.removeListener('error', reject);
+        wss.on('error', (error) => {
+          this.logger.error('WebSocket server error:', error);
+        });
+
+        this.wsServer = wss;
+        this.logger.info(`Wallet bridge WebSocket server started at ws://localhost:${port}${WEBSOCKET_PATH}`);
+        resolve();
+      });
+
+      wss.on('connection', (ws) => {
+        const shouldNotifyReconnection = this.connectionManager.shouldNotifyReconnection();
+
+        // Register the new connection
+        const currentConnectionId = this.connectionManager.registerConnection(ws);
+
+        // Handle connection takeover if needed
+        this.connectionManager.handleConnectionTakeover(
+          currentConnectionId,
           connectionId => this.cancelPendingRequestsForConnection(connectionId),
         );
-        this.clearIdleTimer();
-      });
 
-      ws.on('error', (error) => {
-        this.logger.error('Wallet bridge WebSocket error:', error);
+        // Notify about connection status
+        this.connectionManager.notifyConnectionStatus(port, shouldNotifyReconnection);
+
+        // Start idle timer when connection is established
+        this.resetIdleTimer();
+
+        ws.on('message', (data) => {
+          const messageString = typeof data === 'string' ? data : data.toString();
+          this.messageHandler.handleMessage(messageString, () => this.resetIdleTimer());
+        });
+
+        ws.on('close', () => {
+          this.connectionManager.handleConnectionClose(
+            ws,
+            connectionId => this.cancelPendingRequestsForConnection(connectionId),
+          );
+          this.clearIdleTimer();
+        });
+
+        ws.on('error', (error) => {
+          this.logger.error('Wallet bridge WebSocket error:', error);
+        });
       });
     });
-
-    this.wsServer.on('error', (error) => {
-      this.logger.error('WebSocket server error:', error);
-    });
-
-    this.logger.info(`Wallet bridge WebSocket server started at ws://localhost:${port}${WEBSOCKET_PATH}`);
   }
 
   private resetIdleTimer(): void {


### PR DESCRIPTION
## Summary
- Make `AppServer.start()` and `WalletBridgeWebSocketServer.start()` return `Promise<void>` that resolves on `listening` and rejects on `error`, replacing the fire-and-forget pattern
- Add port retry logic (up to 2 subsequent ports) on bind failure before giving up
- Remove the `await wait(100)` hack — server readiness is now guaranteed by the promise
- Let errors propagate through IPC to the renderer so the user sees the real cause instead of a misleading "failed to get providers" error

Closes #11800

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint:fix` passes
- [x] Run the app, open wallet bridge — works normally
- [x] Occupy port 40010 externally (`nc -l 40010`), open wallet bridge — retries on next port and succeeds, or surfaces real error