### PR TITLE
refactor(frontend): use/get split for asset info retrieval

### DIFF
--- a/frontend/app/src/components/AssetBalances.vue
+++ b/frontend/app/src/components/AssetBalances.vue
@@ -64,7 +64,7 @@ const sort = ref<DataTableSortData<AssetBalanceWithPrice>>({
 
 const debouncedSearch = refDebounced(search, 200);
 
-const { assetInfo, assetName, assetSymbol } = useAssetSelectInfo();
+const { getAssetInfo } = useAssetSelectInfo();
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 const statistics = useStatisticsStore();
 const { totalNetWorth } = storeToRefs(statistics);
@@ -82,8 +82,8 @@ function expand(item: AssetBalanceWithPrice) {
   set(expanded, isExpanded(item.asset) ? [] : [item]);
 }
 
-function assetFilter(item: Nullable<AssetBalance>) {
-  return assetFilterByKeyword(item, get(debouncedSearch), assetName, assetSymbol);
+function assetFilter(item: Nullable<AssetBalance>): boolean {
+  return assetFilterByKeyword(item, get(debouncedSearch), getAssetInfo);
 }
 
 const filteredBalances = computed(() => balances.filter(assetFilter));
@@ -179,7 +179,7 @@ const rowAppendLabelColspan = computed(() => {
 
 useRememberTableSorting<AssetBalanceWithPrice>(TableId.ASSET_BALANCES, sort, tableHeaders);
 
-const sorted = computed<AssetBalanceWithPrice[]>(() => sortAssetBalances([...get(filteredBalances)], get(sort), assetInfo));
+const sorted = computed<AssetBalanceWithPrice[]>(() => sortAssetBalances([...get(filteredBalances)], get(sort), getAssetInfo));
 </script>
 
 <template>

--- a/frontend/app/src/components/accounts/manual-balances/ManualBalancesForm.vue
+++ b/frontend/app/src/components/accounts/manual-balances/ManualBalancesForm.vue
@@ -54,7 +54,7 @@ const tags = computed<string[]>({
 const amount = useBigNumberModel(rawAmount);
 const { manualLabels } = useManualBalanceData();
 const { tradeLocations } = storeToRefs(useLocationStore());
-const { assetInfo } = useAssetInfoRetrieval();
+const { getAssetInfo } = useAssetInfoRetrieval();
 
 const rules = {
   amount: {
@@ -120,7 +120,7 @@ watch(asset, (asset) => {
   if (!(asset && !('identifier' in get(modelValue)) && !get(locationTouched))) {
     return;
   }
-  const info = get(assetInfo(asset));
+  const info = getAssetInfo(asset);
   const evmChain = info?.evmChain;
   if (!evmChain) {
     return;

--- a/frontend/app/src/components/assets/AssetLink.vue
+++ b/frontend/app/src/components/assets/AssetLink.vue
@@ -14,8 +14,8 @@ defineSlots<{
 }>();
 
 const address = reactify(getAddressFromEvmIdentifier)(() => asset);
-const { assetInfo } = useAssetInfoRetrieval();
-const assetDetails = assetInfo(() => asset);
+const { useAssetInfo } = useAssetInfoRetrieval();
+const assetDetails = useAssetInfo(() => asset);
 const { navigateToDetails } = useAssetPageNavigation(() => asset);
 </script>
 

--- a/frontend/app/src/components/assets/AssetValueRow.vue
+++ b/frontend/app/src/components/assets/AssetValueRow.vue
@@ -22,7 +22,7 @@ const { identifier, isCollectionParent = false } = defineProps<{
 const { assetPriceInfo } = useAggregatedBalances();
 const { assetPrice } = usePriceUtils();
 
-const { assetName } = useAssetInfoRetrieval();
+const { getAssetField } = useAssetInfoRetrieval();
 const { refreshPrice } = usePriceRefresh();
 const { isLoading } = useStatusStore();
 
@@ -59,7 +59,7 @@ function showDeleteConfirmation() {
   show(
     {
       message: t('assets.custom_price.delete.message', {
-        asset: get(assetName(identifier)) ?? identifier,
+        asset: getAssetField(identifier, 'name') || identifier,
       }),
       title: t('assets.custom_price.delete.tooltip'),
     },

--- a/frontend/app/src/components/graphs/MissingDailyPrices.vue
+++ b/frontend/app/src/components/graphs/MissingDailyPrices.vue
@@ -29,14 +29,14 @@ const refreshedHistoricalPrices = ref<Record<string, BigNumber>>({});
 const sort = ref<DataTableSortData<EditableMissingPrice>>([]);
 const tab = ref(0);
 
-const { assetName } = useAssetInfoRetrieval();
+const { useAssetField } = useAssetInfoRetrieval();
 const store = useHistoricCachePriceStore();
 const { failedDailyPrices, resolvedFailedDailyPrices } = storeToRefs(store);
 const { resetHistoricalPricesData } = store;
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 const { addHistoricalPrice, deleteHistoricalPrice, editHistoricalPrice, fetchHistoricalPrices } = useAssetPricesApi();
 
-const name = assetName(asset);
+const name = useAssetField(() => asset, 'name');
 
 const failedPrices = computed<FailedHistoricalAssetPriceResponse>(() => get(failedDailyPrices)[asset]);
 

--- a/frontend/app/src/components/helper/AssetDetails.vue
+++ b/frontend/app/src/components/helper/AssetDetails.vue
@@ -33,9 +33,9 @@ const emit = defineEmits<{
   refresh: [];
 }>();
 
-const { assetInfo } = useAssetInfoRetrieval();
+const { useAssetInfo } = useAssetInfoRetrieval();
 
-const assetDetails = assetInfo(() => asset, computed<AssetResolutionOptions>(() => ({
+const assetDetails = useAssetInfo(() => asset, computed<AssetResolutionOptions>(() => ({
   associate: enableAssociation,
   collectionParent: isCollectionParent,
   ...resolutionOptions,

--- a/frontend/app/src/components/helper/AssetDetailsMenuContent.vue
+++ b/frontend/app/src/components/helper/AssetDetailsMenuContent.vue
@@ -35,9 +35,9 @@ const { ignoreAsset, useIsAssetIgnored } = useIgnoredAssetsStore();
 const isSpamAsset = computed<boolean>(() => asset.isSpam);
 const isIgnoredAsset = useIsAssetIgnored(identifier);
 const { markAssetsAsSpam } = useSpamAsset();
-const { assetContractInfo, refetchAssetInfo } = useAssetInfoRetrieval();
+const { refetchAssetInfo, useAssetContractInfo } = useAssetInfoRetrieval();
 
-const contractInfo = assetContractInfo(identifier);
+const contractInfo = useAssetContractInfo(identifier);
 
 function actionClick(action: ConfirmType) {
   set(confirm, true);

--- a/frontend/app/src/components/helper/NftDetails.vue
+++ b/frontend/app/src/components/helper/NftDetails.vue
@@ -16,14 +16,14 @@ const { identifier, size = '50px', styled } = defineProps<{
   size?: string;
 }>();
 
-const { assetInfo } = useAssetInfoRetrieval();
+const { useAssetInfo } = useAssetInfoRetrieval();
 
 const frontendStore = useFrontendSettingsStore();
 
 const { whitelistedDomainsForNftImages } = storeToRefs(frontendStore);
 const { updateSetting } = frontendStore;
 
-const balanceData = assetInfo(() => identifier);
+const balanceData = useAssetInfo(() => identifier);
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/app/src/components/helper/display/icons/AssetIcon.vue
+++ b/frontend/app/src/components/helper/display/icons/AssetIcon.vue
@@ -53,7 +53,7 @@ const abortController = ref<AbortController>();
 
 const { checkIfAssetExists, getAssetImageUrl } = useAssetIconStore();
 const { currencies } = useCurrencies();
-const { assetInfo } = useAssetInfoRetrieval();
+const { useAssetInfo } = useAssetInfoRetrieval();
 
 const mappedIdentifier = computed<string>(() => {
   const id = getIdentifierFromSymbolMap(identifier);
@@ -66,7 +66,7 @@ const currency = computed<string | undefined>(() => {
   return fiatCurrencies.find(({ tickerSymbol }) => tickerSymbol === id)?.unicodeSymbol;
 });
 
-const asset = assetInfo(mappedIdentifier, () => resolutionOptions);
+const asset = useAssetInfo(mappedIdentifier, () => resolutionOptions);
 const url = reactify(getAssetImageUrl)(mappedIdentifier);
 
 const isCustomAsset = computed(() => get(asset)?.isCustomAsset ?? false);

--- a/frontend/app/src/components/history/events/HistoryEventAsset.vue
+++ b/frontend/app/src/components/history/events/HistoryEventAsset.vue
@@ -4,7 +4,7 @@ import { type AssetInfoWithId, Zero } from '@rotki/common';
 import { useTemplateRef } from 'vue';
 import AssetDetails from '@/components/helper/AssetDetails.vue';
 import AssetDetailsMenuContent from '@/components/helper/AssetDetailsMenuContent.vue';
-import { type AssetResolutionOptions, useAssetInfoRetrieval } from '@/composables/assets/retrieval';
+import { NO_COLLECTION_RESOLVE, useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { useRefMap } from '@/composables/utils/useRefMap';
 import { AssetAmountDisplay, AssetValueDisplay } from '@/modules/amount-display/components';
 
@@ -18,21 +18,18 @@ const emit = defineEmits<{
   refresh: [];
 }>();
 
-const { assetSymbol, assetInfo } = useAssetInfoRetrieval();
+const { useAssetField, useAssetInfo } = useAssetInfoRetrieval();
 
 const showBalance = computed<boolean>(() => event.eventType !== 'informational');
 
 const eventAsset = useRefMap(() => event, ({ asset }) => asset);
 
-const symbol = assetSymbol(eventAsset, {
-  collectionParent: false,
-});
+const symbol = useAssetField(eventAsset, 'symbol', NO_COLLECTION_RESOLVE);
 
 const menuOpened = ref<boolean>(false);
 const menuContentRef = useTemplateRef<InstanceType<typeof AssetDetailsMenuContent>>('menuContentRef');
 
-const ASSET_RESOLUTION_OPTIONS: AssetResolutionOptions = { collectionParent: false };
-const assetDetails = assetInfo(eventAsset, ASSET_RESOLUTION_OPTIONS);
+const assetDetails = useAssetInfo(eventAsset, NO_COLLECTION_RESOLVE);
 
 const currentAsset = computed<AssetInfoWithId>(() => ({
   ...get(assetDetails),
@@ -76,7 +73,7 @@ function openMenuHandler(event: MouseEvent): void {
           hide-menu
           optimize-for-virtual-scroll
           :asset="event.asset"
-          :resolution-options="ASSET_RESOLUTION_OPTIONS"
+          :resolution-options="NO_COLLECTION_RESOLVE"
           @refresh="emit('refresh')"
         />
         <div

--- a/frontend/app/src/components/price-manager/historic/HistoricPriceForm.vue
+++ b/frontend/app/src/components/price-manager/historic/HistoricPriceForm.vue
@@ -21,15 +21,15 @@ const { editMode = false } = defineProps<{
   editMode?: boolean;
 }>();
 
-const { assetSymbol } = useAssetInfoRetrieval();
+const { useAssetField } = useAssetInfoRetrieval();
 
 const fromAsset = useRefPropVModel(modelValue, 'fromAsset');
 const toAsset = useRefPropVModel(modelValue, 'toAsset');
 const price = useRefPropVModel(modelValue, 'price');
 const timestamp = useRefPropVModel(modelValue, 'timestamp');
 
-const fromAssetSymbol = assetSymbol(fromAsset);
-const toAssetSymbol = assetSymbol(toAsset);
+const fromAssetSymbol = useAssetField(fromAsset, 'symbol');
+const toAssetSymbol = useAssetField(toAsset, 'symbol');
 
 const numericPrice = bigNumberifyFromRef(price);
 

--- a/frontend/app/src/components/price-manager/latest/LatestPriceForm.vue
+++ b/frontend/app/src/components/price-manager/latest/LatestPriceForm.vue
@@ -21,14 +21,14 @@ const { disableFromAsset = false, editMode = false } = defineProps<{
   editMode?: boolean;
 }>();
 
-const { assetSymbol } = useAssetInfoRetrieval();
+const { useAssetField } = useAssetInfoRetrieval();
 
 const fromAsset = useRefPropVModel(modelValue, 'fromAsset');
 const toAsset = useRefPropVModel(modelValue, 'toAsset');
 const price = useRefPropVModel(modelValue, 'price');
 
-const fromAssetSymbol = assetSymbol(fromAsset);
-const toAssetSymbol = assetSymbol(toAsset);
+const fromAssetSymbol = useAssetField(fromAsset, 'symbol');
+const toAssetSymbol = useAssetField(toAsset, 'symbol');
 
 const numericPrice = bigNumberifyFromRef(price);
 

--- a/frontend/app/src/components/settings/data-security/oracle/OracleCacheManagement.vue
+++ b/frontend/app/src/components/settings/data-security/oracle/OracleCacheManagement.vue
@@ -87,7 +87,7 @@ const rows = computed<OracleCacheEntry[]>(() => {
 const pending = useIsTaskRunning(TaskType.CREATE_PRICE_CACHE);
 
 const { notify } = useNotificationsStore();
-const { assetSymbol } = useAssetInfoRetrieval();
+const { getAssetField } = useAssetInfoRetrieval();
 
 async function clearCache(entry: OracleCacheMeta) {
   const { fromAsset, toAsset } = entry;
@@ -101,8 +101,8 @@ async function clearCache(entry: OracleCacheMeta) {
 
     const message = t('oracle_cache_management.clear_error', {
       error: getErrorMessage(error),
-      fromAsset: get(assetSymbol(fromAsset)),
-      toAsset: get(assetSymbol(toAsset)),
+      fromAsset: getAssetField(fromAsset, 'symbol'),
+      toAsset: getAssetField(toAsset, 'symbol'),
     });
 
     notify({
@@ -129,8 +129,8 @@ async function fetchPrices() {
   if (!('message' in status))
     await load();
 
-  const from = get(assetSymbol(fromAssetVal));
-  const to = get(assetSymbol(toAssetVal));
+  const from = getAssetField(fromAssetVal, 'symbol');
+  const to = getAssetField(toAssetVal, 'symbol');
   const message = status.success
     ? t('oracle_cache_management.notification.success', {
         fromAsset: from,
@@ -161,8 +161,8 @@ function clearFilter() {
 const { show } = useConfirmStore();
 
 function showDeleteConfirmation(entry: OracleCacheMeta) {
-  const deleteFromAsset = entry?.fromAsset ? get(assetSymbol(entry.fromAsset)) : '';
-  const deleteToAsset = entry?.toAsset ? get(assetSymbol(entry.toAsset)) : '';
+  const deleteFromAsset = entry?.fromAsset ? getAssetField(entry.fromAsset, 'symbol') : '';
+  const deleteToAsset = entry?.toAsset ? getAssetField(entry.toAsset, 'symbol') : '';
 
   show(
     {

--- a/frontend/app/src/components/table-filter/SelectionChip.spec.ts
+++ b/frontend/app/src/components/table-filter/SelectionChip.spec.ts
@@ -8,7 +8,7 @@ import SelectionChip from '@/components/table-filter/SelectionChip.vue';
 
 vi.mock('@/composables/assets/retrieval', () => ({
   useAssetInfoRetrieval: vi.fn().mockReturnValue({
-    assetInfo: vi.fn().mockImplementation(identifier => ({
+    getAssetInfo: vi.fn().mockImplementation((identifier: string | undefined) => ({
       identifier,
       evmChain: 'ethereum',
       symbol: 'ETH',

--- a/frontend/app/src/components/table-filter/SuggestedItem.spec.ts
+++ b/frontend/app/src/components/table-filter/SuggestedItem.spec.ts
@@ -10,8 +10,14 @@ import { truncateAddress } from '@/utils/truncate';
 
 vi.mock('@/composables/assets/retrieval', (): Record<string, unknown> => ({
   useAssetInfoRetrieval: vi.fn().mockReturnValue({
-    assetInfo: vi.fn().mockImplementation((identifier: string): Record<string, unknown> => ({
+    getAssetInfo: vi.fn().mockImplementation((identifier: string | undefined): Record<string, unknown> => ({
       identifier,
+      evmChain: 'ethereum',
+      symbol: 'SYMBOL 2',
+      isCustomAsset: false,
+      name: 'Name 2',
+    })),
+    useAssetInfo: vi.fn().mockImplementation(() => ref({
       evmChain: 'ethereum',
       symbol: 'SYMBOL 2',
       isCustomAsset: false,

--- a/frontend/app/src/components/table-filter/SuggestedItem.vue
+++ b/frontend/app/src/components/table-filter/SuggestedItem.vue
@@ -24,7 +24,7 @@ const search = ref<string>('');
 const inputWidth = computed(() => Math.min(get(search).length + 2, 25));
 const editInput = useTemplateRef<InstanceType<typeof HTMLInputElement>>('editInput');
 
-const { assetInfo } = useAssetInfoRetrieval();
+const { getAssetInfo } = useAssetInfoRetrieval();
 const { getChainName } = useSupportedChains();
 
 const isBoolean = computed(() => {
@@ -42,7 +42,7 @@ const asset = computed<{ identifier: string; symbol: string } | undefined>(() =>
   let usedAsset, identifier;
   if (typeof value === 'string') {
     identifier = value;
-    usedAsset = get(assetInfo(value));
+    usedAsset = getAssetInfo(value);
   }
   else {
     identifier = value.identifier;

--- a/frontend/app/src/composables/assets/asset-select-info.spec.ts
+++ b/frontend/app/src/composables/assets/asset-select-info.spec.ts
@@ -30,48 +30,48 @@ describe('useAssetSelectInfo', () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
       const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
-      const result = assetSelectInfo.assetInfo(undefined);
-      expect(get(result)).toBeNull();
+      const result = assetSelectInfo.getAssetInfo(undefined);
+      expect(result).toBeNull();
     });
 
     it('should return null when identifier is empty string', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
       const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
-      const result = assetSelectInfo.assetInfo('');
-      expect(get(result)).toBeNull();
+      const result = assetSelectInfo.getAssetInfo('');
+      expect(result).toBeNull();
     });
 
     it('should return empty string for symbol when identifier is undefined', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
       const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
-      const result = assetSelectInfo.assetSymbol(undefined);
-      expect(get(result)).toBe('');
+      const result = assetSelectInfo.getAssetField(undefined, 'symbol');
+      expect(result).toBe('');
     });
 
     it('should return empty string for symbol when identifier is empty', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
       const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
-      const result = assetSelectInfo.assetSymbol('');
-      expect(get(result)).toBe('');
+      const result = assetSelectInfo.getAssetField('', 'symbol');
+      expect(result).toBe('');
     });
 
     it('should return empty string for name when identifier is undefined', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
       const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
-      const result = assetSelectInfo.assetName(undefined);
-      expect(get(result)).toBe('');
+      const result = assetSelectInfo.getAssetField(undefined, 'name');
+      expect(result).toBe('');
     });
 
     it('should return empty string for name when identifier is empty', async () => {
       const { useAssetSelectInfo } = await import('@/composables/assets/asset-select-info');
       const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
-      const result = assetSelectInfo.assetName('');
-      expect(get(result)).toBe('');
+      const result = assetSelectInfo.getAssetField('', 'name');
+      expect(result).toBe('');
     });
   });
 
@@ -81,9 +81,9 @@ describe('useAssetSelectInfo', () => {
       const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
 
       const identifier = ref<string | undefined>(undefined);
-      const nameResult = assetSelectInfo.assetName(identifier);
-      const symbolResult = assetSelectInfo.assetSymbol(identifier);
-      const infoResult = assetSelectInfo.assetInfo(identifier);
+      const nameResult = assetSelectInfo.useAssetField(identifier, 'name');
+      const symbolResult = assetSelectInfo.useAssetField(identifier, 'symbol');
+      const infoResult = assetSelectInfo.useAssetInfo(identifier);
 
       // Initially all return default values for undefined
       expect(get(nameResult)).toBe('');
@@ -123,7 +123,7 @@ describe('useAssetSelectInfo', () => {
       });
 
       const undefinedId = `UNDEFINED_TEST_${Date.now()}`;
-      const result = assetSelectInfo.assetInfo(undefinedId);
+      const result = assetSelectInfo.useAssetInfo(undefinedId);
 
       // Initially null
       expect(get(result)).toBeNull();

--- a/frontend/app/src/composables/assets/asset-select-info.ts
+++ b/frontend/app/src/composables/assets/asset-select-info.ts
@@ -1,8 +1,10 @@
 import type { AssetInfo } from '@rotki/common';
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { AssetStringField } from '@/composables/assets/retrieval';
 import type { AssetMap } from '@/types/asset';
+import { startPromise } from '@shared/utils';
 import { useAssetInfoApi } from '@/composables/api/assets/info';
-import { getAssociatedAssetIdentifier, processAssetInfo, useAssetAssociationMap } from '@/composables/assets/common';
+import { processAssetInfo, useResolveAssetIdentifier } from '@/composables/assets/common';
 import { chunkArray } from '@/utils/data';
 import { logger } from '@/utils/logging';
 
@@ -10,20 +12,23 @@ interface AssetWithResolutionStatus extends AssetInfo {
   resolved: boolean;
 }
 
+type PlainAssetInfoReturn = (identifier: string | undefined) => AssetWithResolutionStatus | null;
+
 interface UseAssetSelectInfoReturn {
-  assetInfo: (identifier: MaybeRefOrGetter<string | undefined>) => ComputedRef<AssetWithResolutionStatus | null>;
-  assetSymbol: (identifier: MaybeRefOrGetter<string | undefined>) => ComputedRef<string>;
-  assetName: (identifier: MaybeRefOrGetter<string | undefined>) => ComputedRef<string>;
+  getAssetField: (identifier: string | undefined, field: AssetStringField) => string;
+  getAssetInfo: PlainAssetInfoReturn;
+  useAssetField: (identifier: MaybeRefOrGetter<string | undefined>, field: AssetStringField) => ComputedRef<string>;
+  useAssetInfo: (identifier: MaybeRefOrGetter<string | undefined>) => ComputedRef<AssetWithResolutionStatus | null>;
 }
 
 export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoReturn => {
   const queuedAssets: Set<string> = new Set();
   const pendingAssets: Set<string> = new Set();
-  const assetCache = ref<Record<string, AssetInfo | null>>({});
-  const collectionCache = ref<Record<string, AssetInfo | null>>({});
+  const assetCache = shallowRef<Record<string, AssetInfo | null>>({});
+  const collectionCache = shallowRef<Record<string, AssetInfo | null>>({});
 
   const { assetMapping } = useAssetInfoApi();
-  const assetAssociationMap = useAssetAssociationMap();
+  const resolveAssetIdentifier = useResolveAssetIdentifier();
 
   async function getAssetMapping(identifiers: string[]): Promise<AssetMap | undefined> {
     try {
@@ -38,7 +43,7 @@ export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoR
   async function retrieveAssetInfo(identifiers: string[]): Promise<{ assets: Record<string, AssetInfo | null>; collections: Record<string, AssetInfo | null> }> {
     const assetInfoMap: Record<string, AssetInfo | null> = {};
     const collectionInfoMap: Record<string, AssetInfo | null> = {};
-    const ids = identifiers.map(id => getAssociatedAssetIdentifier(id, get(assetAssociationMap)));
+    const ids = identifiers.map(id => resolveAssetIdentifier(id));
 
     for (const chunk of chunkArray(ids, 50)) {
       const mappings = await getAssetMapping(chunk);
@@ -80,14 +85,8 @@ export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoR
       logger.debug(`Processing batch of ${assetsToProcess.length} asset requests for AssetSelect`);
 
       const { assets, collections } = await retrieveAssetInfo(assetsToProcess);
-      set(assetCache, {
-        ...get(assetCache),
-        ...assets,
-      });
-      set(collectionCache, {
-        ...get(collectionCache),
-        ...collections,
-      });
+      set(assetCache, Object.assign({}, get(assetCache), assets));
+      set(collectionCache, Object.assign({}, get(collectionCache), collections));
 
       pendingAssets.clear();
     }
@@ -96,28 +95,24 @@ export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoR
     }
   }, 1500);
 
-  function getAssetInformation(assetId: string): void {
+  function queueAssetInformation(key: string): void {
     const cache = get(assetCache);
-    const key = getAssociatedAssetIdentifier(assetId, get(assetAssociationMap));
     if (cache[key] !== undefined || queuedAssets.has(key) || pendingAssets.has(key)) {
       return;
     }
 
     queuedAssets.add(key);
-    processBatch()
-      .then()
-      .catch(error => logger.error(error));
+    startPromise(processBatch());
   }
 
-  const assetInfo = (
-    identifier: MaybeRefOrGetter<string | undefined>,
-  ): ComputedRef<AssetWithResolutionStatus | null> => computed(() => {
-    const id = toValue(identifier);
-    if (!id)
+  const getAssetInfo: PlainAssetInfoReturn = (
+    identifier: string | undefined,
+  ): AssetWithResolutionStatus | null => {
+    if (!identifier)
       return null;
 
-    const key = getAssociatedAssetIdentifier(id, get(assetAssociationMap));
-    getAssetInformation(key);
+    const key = resolveAssetIdentifier(identifier);
+    queueAssetInformation(key);
 
     const cache = get(assetCache);
     const data = cache[key];
@@ -127,7 +122,7 @@ export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoR
     }
 
     const collectionData = data.collectionId ? get(collectionCache)[data.collectionId] : null;
-    const processedInfo = processAssetInfo(data, id, collectionData);
+    const processedInfo = processAssetInfo(data, identifier, collectionData);
 
     if (!processedInfo) {
       return null;
@@ -137,33 +132,32 @@ export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoR
       ...processedInfo,
       resolved: true,
     };
-  });
+  };
 
-  const assetSymbol = (
+  const useAssetInfo = (
     identifier: MaybeRefOrGetter<string | undefined>,
-  ): ComputedRef<string> => computed(() => {
-    const id = toValue(identifier);
-    if (!id)
+  ): ComputedRef<AssetWithResolutionStatus | null> =>
+    computed<AssetWithResolutionStatus | null>(() => getAssetInfo(toValue(identifier)));
+
+  const getAssetField = (
+    identifier: string | undefined,
+    field: AssetStringField,
+  ): string => {
+    if (!identifier)
       return '';
+    return getAssetInfo(identifier)?.[field] ?? '';
+  };
 
-    const info = get(assetInfo(id));
-    return info?.symbol || '';
-  });
-
-  const assetName = (
+  const useAssetField = (
     identifier: MaybeRefOrGetter<string | undefined>,
-  ): ComputedRef<string> => computed(() => {
-    const id = toValue(identifier);
-    if (!id)
-      return '';
-
-    const info = get(assetInfo(id));
-    return info?.name || '';
-  });
+    field: AssetStringField,
+  ): ComputedRef<string> =>
+    computed<string>(() => getAssetField(toValue(identifier), field));
 
   return {
-    assetInfo,
-    assetName,
-    assetSymbol,
+    getAssetField,
+    getAssetInfo,
+    useAssetField,
+    useAssetInfo,
   };
 });

--- a/frontend/app/src/composables/assets/common.ts
+++ b/frontend/app/src/composables/assets/common.ts
@@ -1,22 +1,16 @@
-import type { ComputedRef } from 'vue';
 import { type AssetInfo, getAddressFromEvmIdentifier, isEvmIdentifier } from '@rotki/common';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { CUSTOM_ASSET } from '@/types/asset';
 
-export function useAssetAssociationMap(): ComputedRef<Record<string, string>> {
+export function useResolveAssetIdentifier(): (identifier: string) => string {
   const { treatEth2AsEth } = storeToRefs(useGeneralSettingsStore());
 
-  return computed<Record<string, string>>(() => {
-    const associationMap: Record<string, string> = {};
-    if (get(treatEth2AsEth))
-      associationMap.ETH2 = 'ETH';
+  return (identifier: string): string => {
+    if (get(treatEth2AsEth) && identifier === 'ETH2')
+      return 'ETH';
 
-    return associationMap;
-  });
-}
-
-export function getAssociatedAssetIdentifier(identifier: string, associationMap: Record<string, string>): string {
-  return associationMap[identifier] ?? identifier;
+    return identifier;
+  };
 }
 
 function getAssetNameFallback(id: string): string {

--- a/frontend/app/src/composables/assets/retrieval.spec.ts
+++ b/frontend/app/src/composables/assets/retrieval.spec.ts
@@ -1,5 +1,4 @@
 import type { ERC20Token } from '@/types/blockchain/accounts';
-import { updateGeneralSettings } from '@test/utils/general-settings';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAssetInfoApi } from '@/composables/api/assets/info';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
@@ -38,28 +37,6 @@ describe('useAssetRetrieval', () => {
     vi.spyOn(assetCacheStore, 'resolve');
     assetInfoRetrieval = useAssetInfoRetrieval();
     api = useAssetInfoApi();
-  });
-
-  describe('getAssociatedAssetIdentifier', () => {
-    it('should treat ETH2 as ETH when enabled', () => {
-      updateGeneralSettings({
-        treatEth2AsEth: true,
-      });
-
-      const result = get(assetInfoRetrieval.getAssociatedAssetIdentifier('ETH2'));
-
-      expect(result).toBe('ETH');
-    });
-
-    it('should not treat ETH2 as ETH when disabled', () => {
-      updateGeneralSettings({
-        treatEth2AsEth: false,
-      });
-
-      const result = get(assetInfoRetrieval.getAssociatedAssetIdentifier('ETH2'));
-
-      expect(result).toBe('ETH2');
-    });
   });
 
   describe('fetchTokenDetails', () => {
@@ -102,12 +79,12 @@ describe('useAssetRetrieval', () => {
     });
   });
 
-  describe('assetInfo, assetName, and assetSymbol', () => {
+  describe('getAssetInfo and getAssetField', () => {
     it('should handle falsy identifier', () => {
       const identifier = undefined;
-      expect(get(assetInfoRetrieval.assetInfo(identifier))).toBeNull();
-      expect(get(assetInfoRetrieval.assetName(identifier))).toBe('');
-      expect(get(assetInfoRetrieval.assetName(identifier))).toBe('');
+      expect(assetInfoRetrieval.getAssetInfo(identifier)).toBeNull();
+      expect(assetInfoRetrieval.getAssetField(identifier, 'name')).toBe('');
+      expect(assetInfoRetrieval.getAssetField(identifier, 'symbol')).toBe('');
     });
 
     it('should handle custom asset', () => {
@@ -119,7 +96,7 @@ describe('useAssetRetrieval', () => {
         isCustomAsset: true,
       }));
 
-      const result = get(assetInfoRetrieval.assetInfo(identifier));
+      const result = assetInfoRetrieval.getAssetInfo(identifier);
 
       expect(assetCacheStore.resolve).toHaveBeenCalledWith(identifier);
 
@@ -129,8 +106,8 @@ describe('useAssetRetrieval', () => {
         isCustomAsset: true,
       });
 
-      expect(get(assetInfoRetrieval.assetName(identifier))).toEqual(assetName);
-      expect(get(assetInfoRetrieval.assetSymbol(identifier))).toEqual(assetName);
+      expect(assetInfoRetrieval.getAssetField(identifier, 'name')).toEqual(assetName);
+      expect(assetInfoRetrieval.getAssetField(identifier, 'symbol')).toEqual(assetName);
     });
 
     it('should handle custom asset type', () => {
@@ -142,7 +119,7 @@ describe('useAssetRetrieval', () => {
         assetType: CUSTOM_ASSET,
       }));
 
-      const result = get(assetInfoRetrieval.assetInfo(identifier));
+      const result = assetInfoRetrieval.getAssetInfo(identifier);
 
       expect(assetCacheStore.resolve).toHaveBeenCalledWith(identifier);
 
@@ -152,8 +129,8 @@ describe('useAssetRetrieval', () => {
         isCustomAsset: true,
       });
 
-      expect(get(assetInfoRetrieval.assetName(identifier))).toEqual(assetName);
-      expect(get(assetInfoRetrieval.assetSymbol(identifier))).toEqual(assetName);
+      expect(assetInfoRetrieval.getAssetField(identifier, 'name')).toEqual(assetName);
+      expect(assetInfoRetrieval.getAssetField(identifier, 'symbol')).toEqual(assetName);
     });
 
     it('should handle asset with collection parent when isCollectionParent is true', () => {
@@ -179,15 +156,15 @@ describe('useAssetRetrieval', () => {
         collectionId,
       }));
 
-      const result = get(assetInfoRetrieval.assetInfo(identifier));
+      const result = assetInfoRetrieval.getAssetInfo(identifier);
 
       expect(result).toMatchObject({
         name: collectionName,
         symbol: assetSymbol,
       });
 
-      expect(get(assetInfoRetrieval.assetName(identifier))).toEqual(collectionName);
-      expect(get(assetInfoRetrieval.assetSymbol(identifier))).toEqual(assetSymbol);
+      expect(assetInfoRetrieval.getAssetField(identifier, 'name')).toEqual(collectionName);
+      expect(assetInfoRetrieval.getAssetField(identifier, 'symbol')).toEqual(assetSymbol);
     });
 
     it('should handle asset with collection parent when isCollectionParent is false', () => {
@@ -213,10 +190,10 @@ describe('useAssetRetrieval', () => {
         collectionId,
       }));
 
-      const result = get(assetInfoRetrieval.assetInfo(identifier, {
+      const result = assetInfoRetrieval.getAssetInfo(identifier, {
         associate: true,
         collectionParent: false,
-      }));
+      });
 
       expect(result).toMatchObject({
         name: assetName,
@@ -229,7 +206,7 @@ describe('useAssetRetrieval', () => {
       const identifier = `eip155:1/erc20:${address}`;
       vi.mocked(assetCacheStore.resolve).mockReturnValue(null);
 
-      const result = get(assetInfoRetrieval.assetInfo(identifier));
+      const result = assetInfoRetrieval.getAssetInfo(identifier);
       const fallbackName = `EVM Token: ${address}`;
 
       expect(result).toMatchObject({
@@ -237,8 +214,8 @@ describe('useAssetRetrieval', () => {
         symbol: fallbackName,
       });
 
-      expect(get(assetInfoRetrieval.assetName(identifier))).toEqual(fallbackName);
-      expect(get(assetInfoRetrieval.assetSymbol(identifier))).toEqual(fallbackName);
+      expect(assetInfoRetrieval.getAssetField(identifier, 'name')).toEqual(fallbackName);
+      expect(assetInfoRetrieval.getAssetField(identifier, 'symbol')).toEqual(fallbackName);
     });
   });
 });

--- a/frontend/app/src/composables/assets/retrieval.ts
+++ b/frontend/app/src/composables/assets/retrieval.ts
@@ -14,7 +14,7 @@ import {
   Severity,
 } from '@rotki/common';
 import { type AssetSearchParams, useAssetInfoApi } from '@/composables/api/assets/info';
-import { getAssociatedAssetIdentifier, processAssetInfo, useAssetAssociationMap } from '@/composables/assets/common';
+import { processAssetInfo, useResolveAssetIdentifier } from '@/composables/assets/common';
 import { useSupportedChains } from '@/composables/info/chains';
 import { getErrorMessage, useNotifications } from '@/modules/notifications/use-notifications';
 import { useAssetCacheStore } from '@/store/assets/asset-cache';
@@ -28,6 +28,8 @@ export interface AssetResolutionOptions {
   collectionParent?: boolean;
 }
 
+export const NO_COLLECTION_RESOLVE: AssetResolutionOptions = { collectionParent: false } as const;
+
 interface AssetWithResolutionStatus extends AssetInfoWithId {
   resolved: boolean;
 }
@@ -38,64 +40,63 @@ interface AssetContractInfo {
   nftId?: string;
 }
 
+export type AssetStringField = 'symbol' | 'name';
+
+export type PlainAssetInfoReturn = (identifier: string | undefined, options?: AssetResolutionOptions) => AssetWithResolutionStatus | null;
+
 export type AssetInfoReturn = (identifier: MaybeRefOrGetter<string | undefined>, options?: MaybeRefOrGetter<AssetResolutionOptions>) => ComputedRef<AssetWithResolutionStatus | null>;
 
-export type AssetSymbolReturn = (identifier: MaybeRefOrGetter<string | undefined>, options?: MaybeRefOrGetter<AssetResolutionOptions>) => ComputedRef<string>;
-
-export type AssetNameReturn = (identifier: MaybeRefOrGetter<string | undefined>, options?: MaybeRefOrGetter<AssetResolutionOptions>) => ComputedRef<string>;
+type PlainAssetContractInfoReturn = (identifier: string | undefined, options?: AssetResolutionOptions) => AssetContractInfo | undefined;
 
 type AssetContractInfoReturn = (identifier: MaybeRefOrGetter<string | undefined>, options?: MaybeRefOrGetter<AssetResolutionOptions>) => ComputedRef<AssetContractInfo | undefined>;
 
 interface UseAssetInfoRetrievalReturn {
-  assetAssociationMap: ComputedRef<Record<string, string>>;
-  assetContractInfo: AssetContractInfoReturn;
-  assetInfo: AssetInfoReturn;
-  assetName: AssetNameReturn;
   assetSearch: (params: AssetSearchParams) => Promise<AssetsWithId>;
-  assetSymbol: AssetSymbolReturn;
   fetchTokenDetails: (payload: EvmChainAddress) => Promise<ERC20Token>;
-  getAssetSymbol: (identifier: string | undefined, options?: AssetResolutionOptions) => string;
-  getAssociatedAssetIdentifier: (identifier: string) => ComputedRef<string>;
+  getAssetContractInfo: PlainAssetContractInfoReturn;
+  getAssetField: (identifier: string | undefined, field: AssetStringField, options?: AssetResolutionOptions) => string;
+  getAssetInfo: PlainAssetInfoReturn;
+  getTokenAddress: (identifier: string, options?: AssetResolutionOptions) => string;
   refetchAssetInfo: (key: string) => void;
-  tokenAddress: (identifier: MaybeRefOrGetter<string>, options?: AssetResolutionOptions) => ComputedRef<string>;
+  useAssetContractInfo: AssetContractInfoReturn;
+  useAssetField: (identifier: MaybeRefOrGetter<string | undefined>, field: AssetStringField, options?: MaybeRefOrGetter<AssetResolutionOptions>) => ComputedRef<string>;
+  useAssetInfo: AssetInfoReturn;
+  useTokenAddress: (identifier: MaybeRefOrGetter<string>, options?: MaybeRefOrGetter<AssetResolutionOptions>) => ComputedRef<string>;
 }
 
 export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
   const { t } = useI18n({ useScope: 'global' });
   const { assetSearch: assetSearchCaller, erc20details } = useAssetInfoApi();
-  const { queueIdentifier, resolve: resolveAsset } = useAssetCacheStore();
+  const assetCacheStore = useAssetCacheStore();
+  const { queueIdentifier, resolve: resolveAsset } = assetCacheStore;
+  const { fetchedAssetCollections } = storeToRefs(assetCacheStore);
   const { notify, notifyError } = useNotifications();
   const { awaitTask } = useTaskStore();
 
   const { getChain } = useSupportedChains();
 
-  const assetAssociationMap = useAssetAssociationMap();
+  const resolveAssetIdentifier = useResolveAssetIdentifier();
 
-  const getAssociatedAssetIdentifierComputed = (identifier: string): ComputedRef<string> =>
-    computed(() => getAssociatedAssetIdentifier(identifier, get(assetAssociationMap)));
-
-  const assetInfo = (
-    identifier: MaybeRefOrGetter<string | undefined>,
-    options: MaybeRefOrGetter<AssetResolutionOptions> = {},
-  ): ComputedRef<(AssetInfoWithId & { resolved: boolean }) | null> => computed(() => {
-    const id = toValue(identifier);
-    if (!id)
+  const getAssetInfo: PlainAssetInfoReturn = (
+    identifier: string | undefined,
+    options: AssetResolutionOptions = {},
+  ): AssetWithResolutionStatus | null => {
+    if (!identifier)
       return null;
 
     const {
       associate = true,
       collectionParent = true,
-    } = toValue(options);
+    } = options;
 
-    const key = associate ? get(getAssociatedAssetIdentifierComputed(id)) : id;
+    const key = associate ? resolveAssetIdentifier(identifier) : identifier;
     const data = resolveAsset(key);
 
-    const { fetchedAssetCollections } = storeToRefs(useAssetCacheStore());
     const collectionData = collectionParent && data?.collectionId
       ? get(fetchedAssetCollections)[data.collectionId]
       : null;
 
-    const processedInfo = processAssetInfo(data, id, collectionData);
+    const processedInfo = processAssetInfo(data, identifier, collectionData);
 
     if (!processedInfo) {
       return null;
@@ -106,47 +107,39 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
       identifier: key,
       resolved: !!data,
     };
-  });
-
-  const assetSymbol = (
-    identifier: MaybeRefOrGetter<string | undefined>,
-    options?: MaybeRefOrGetter<AssetResolutionOptions>,
-  ): ComputedRef<string> => computed(() => {
-    const id = toValue(identifier);
-    if (!id)
-      return '';
-
-    const symbol = get(assetInfo(id, options))?.symbol;
-    return symbol || '';
-  });
-
-  const getAssetSymbol = (identifier: string | undefined, options?: AssetResolutionOptions): string => {
-    if (!identifier)
-      return '';
-    return get(assetInfo(identifier, options))?.symbol ?? '';
   };
 
-  const assetName = (
+  const useAssetInfo: AssetInfoReturn = (
     identifier: MaybeRefOrGetter<string | undefined>,
-    options?: MaybeRefOrGetter<AssetResolutionOptions>,
-  ): ComputedRef<string> => computed(() => {
-    const id = toValue(identifier);
-    if (!id)
+    options: MaybeRefOrGetter<AssetResolutionOptions> = {},
+  ): ComputedRef<AssetWithResolutionStatus | null> =>
+    computed<AssetWithResolutionStatus | null>(() => getAssetInfo(toValue(identifier), toValue(options)));
+
+  const getAssetField = (
+    identifier: string | undefined,
+    field: AssetStringField,
+    options?: AssetResolutionOptions,
+  ): string => {
+    if (!identifier)
       return '';
+    return getAssetInfo(identifier, options)?.[field] ?? '';
+  };
 
-    const name = get(assetInfo(id, options))?.name;
-    return name || '';
-  });
-
-  const assetContractInfo = (
+  const useAssetField = (
     identifier: MaybeRefOrGetter<string | undefined>,
+    field: AssetStringField,
     options?: MaybeRefOrGetter<AssetResolutionOptions>,
-  ): ComputedRef<AssetContractInfo | undefined> => computed(() => {
-    const id = toValue(identifier);
-    if (!id)
+  ): ComputedRef<string> =>
+    computed<string>(() => getAssetField(toValue(identifier), field, toValue(options)));
+
+  const getAssetContractInfo: PlainAssetContractInfoReturn = (
+    identifier: string | undefined,
+    options?: AssetResolutionOptions,
+  ): AssetContractInfo | undefined => {
+    if (!identifier)
       return undefined;
 
-    const asset = get(assetInfo(id, options));
+    const asset = getAssetInfo(identifier, options);
 
     if (!asset)
       return undefined;
@@ -183,13 +176,24 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
     }
 
     return undefined;
-  });
+  };
 
-  const tokenAddress = (
+  const useAssetContractInfo: AssetContractInfoReturn = (
+    identifier: MaybeRefOrGetter<string | undefined>,
+    options?: MaybeRefOrGetter<AssetResolutionOptions>,
+  ): ComputedRef<AssetContractInfo | undefined> =>
+    computed<AssetContractInfo | undefined>(() => getAssetContractInfo(toValue(identifier), toValue(options)));
+
+  const getTokenAddress = (
+    identifier: string,
+    options?: AssetResolutionOptions,
+  ): string => getAssetContractInfo(identifier, options)?.address || '';
+
+  const useTokenAddress = (
     identifier: MaybeRefOrGetter<string>,
     options?: MaybeRefOrGetter<AssetResolutionOptions>,
   ): ComputedRef<string> =>
-    computed(() => get(assetContractInfo(identifier, options))?.address || '');
+    computed<string>(() => getTokenAddress(toValue(identifier), toValue(options)));
 
   const fetchTokenDetails = async (payload: EvmChainAddress): Promise<ERC20Token> => {
     try {
@@ -233,16 +237,16 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
   };
 
   return {
-    assetAssociationMap,
-    assetContractInfo,
-    assetInfo,
-    assetName,
     assetSearch,
-    assetSymbol,
     fetchTokenDetails,
-    getAssetSymbol,
-    getAssociatedAssetIdentifier: getAssociatedAssetIdentifierComputed,
+    getAssetContractInfo,
+    getAssetField,
+    getAssetInfo,
+    getTokenAddress,
     refetchAssetInfo: queueIdentifier,
-    tokenAddress,
+    useAssetContractInfo,
+    useAssetField,
+    useAssetInfo,
+    useTokenAddress,
   };
 }

--- a/frontend/app/src/composables/assets/spam.ts
+++ b/frontend/app/src/composables/assets/spam.ts
@@ -24,7 +24,7 @@ export function useSpamAsset(): UseSpamAssetReturn {
   const { fetchWhitelistedAssets } = useWhitelistedAssetsStore();
   const { fetchIgnoredAssets } = useIgnoredAssetsStore();
 
-  const { getAssetSymbol } = useAssetInfoRetrieval();
+  const { getAssetField } = useAssetInfoRetrieval();
   const { manualBalancesAssets } = useManualBalanceData();
   const markAssetsAsSpam = async (tokens: string[]): Promise<ActionStatus> => {
     try {
@@ -45,7 +45,7 @@ export function useSpamAsset(): UseSpamAssetReturn {
         showErrorMessage(
           t('ignore.spam.warning.manual_balances_title'),
           t('ignore.spam.warning.manual_balances_message', {
-            assets: includedInManualBalances.map(item => getAssetSymbol(item)).join(', '),
+            assets: includedInManualBalances.map(item => getAssetField(item, 'symbol')).join(', '),
           }),
         );
       }

--- a/frontend/app/src/composables/balances/asset-summary.spec.ts
+++ b/frontend/app/src/composables/balances/asset-summary.spec.ts
@@ -23,7 +23,7 @@ describe('summarizeAssetProtocols with chains', () => {
 
     const result = summarizeAssetProtocols(
       {
-        associatedAssets: {},
+        resolveIdentifier: (id: string): string => id,
         sources: mockSources,
       },
       {
@@ -69,7 +69,7 @@ describe('summarizeAssetProtocols with chains', () => {
 
     const result = summarizeAssetProtocols(
       {
-        associatedAssets: {},
+        resolveIdentifier: (id: string): string => id,
         sources: mockSources,
       },
       {
@@ -129,7 +129,7 @@ describe('summarizeAssetProtocols with chains', () => {
 
     const result = summarizeAssetProtocols(
       {
-        associatedAssets: {},
+        resolveIdentifier: (id: string): string => id,
         sources: mockSources,
       },
       {

--- a/frontend/app/src/composables/balances/asset-summary.ts
+++ b/frontend/app/src/composables/balances/asset-summary.ts
@@ -8,13 +8,13 @@ import {
 import { sortDesc } from '@/utils/bignumbers';
 
 /**
- * Configuration for asset sources and associations
+ * Configuration for asset sources and identifier resolution
  */
 interface AssetSourceConfig {
   /** Asset protocol balances from different sources */
   sources: Record<string, AssetProtocolBalances>;
-  /** Map of associated assets */
-  associatedAssets: Record<string, string>;
+  /** Resolves an asset identifier to its canonical form */
+  resolveIdentifier: (id: string) => string;
 }
 
 /**
@@ -79,7 +79,7 @@ export function summarizeAssetProtocols(
 ): AssetBalanceWithPriceAndChains[] {
   const aggregatedBalances = aggregateSourceBalances(
     sourceConfig.sources,
-    sourceConfig.associatedAssets,
+    sourceConfig.resolveIdentifier,
     filterConfig.isAssetIgnored,
     filterConfig.hideIgnored,
   );

--- a/frontend/app/src/composables/balances/balance-transformations.ts
+++ b/frontend/app/src/composables/balances/balance-transformations.ts
@@ -190,7 +190,7 @@ function aggregateBalanceForProtocol(
  */
 export function aggregateSourceBalances(
   sources: Record<string, AssetProtocolBalances | AssetProtocolBalancesWithChains>,
-  associatedAssets: Record<string, string>,
+  resolveIdentifier: (id: string) => string,
   isAssetIgnored: (identifier: string) => boolean,
   hideIgnored: boolean,
 ): AssetProtocolBalancesWithManual {
@@ -200,7 +200,7 @@ export function aggregateSourceBalances(
     const isManualSource = sourceType === 'manual';
 
     for (const asset in source) {
-      const identifier = associatedAssets[asset] ?? asset;
+      const identifier = resolveIdentifier(asset);
       if (isAssetIgnored(identifier) && hideIgnored) {
         continue;
       }

--- a/frontend/app/src/composables/balances/location-breakdown.ts
+++ b/frontend/app/src/composables/balances/location-breakdown.ts
@@ -15,11 +15,11 @@ import { aggregateTotals } from '@/utils/blockchain/accounts';
  */
 export function getBlockchainLocationBreakdown(
   balances: Balances,
-  assetAssociationMap: Record<string, string>,
+  resolveIdentifier: (id: string) => string,
   skipIdentifier: (asset: string) => boolean,
 ): AssetBalances {
   return aggregateTotals(balances, 'assets', {
-    assetAssociationMap,
+    resolveIdentifier,
     skipIdentifier,
   });
 }
@@ -44,7 +44,7 @@ export function getExchangeByLocationBalances(
 export function useLocationBreakdown(
   location: MaybeRefOrGetter<string>,
   blockchainBalances: MaybeRefOrGetter<Balances>,
-  assetAssociationMap: MaybeRefOrGetter<Record<string, string>>,
+  resolveIdentifier: (id: string) => string,
   manualBalances: MaybeRefOrGetter<ManualBalanceWithValue[]>,
   useBaseExchangeBalances: (exchange?: MaybeRefOrGetter<string>) => MaybeRefOrGetter<AssetProtocolBalances>,
   isAssetIgnored: (identifier: string) => boolean,
@@ -55,7 +55,6 @@ export function useLocationBreakdown(
 ): ComputedRef<AssetBalanceWithPrice[]> {
   return computed<AssetBalanceWithPrice[]>(() => {
     const selectedLocation = toValue(location);
-    const associatedAssets = toValue(assetAssociationMap);
 
     const sources: Record<string, AssetProtocolBalances> = {
       blockchain: selectedLocation === TRADE_LOCATION_BLOCKCHAIN
@@ -69,7 +68,7 @@ export function useLocationBreakdown(
       ),
     };
 
-    return summarizeAssetProtocols({ associatedAssets, sources }, { hideIgnored: true, isAssetIgnored }, {
+    return summarizeAssetProtocols({ resolveIdentifier, sources }, { hideIgnored: true, isAssetIgnored }, {
       getAssetPrice,
       noPrice,
     }, {

--- a/frontend/app/src/composables/balances/use-aggregated-balances.ts
+++ b/frontend/app/src/composables/balances/use-aggregated-balances.ts
@@ -3,7 +3,7 @@ import type { AssetPriceInfo } from '@/types/prices';
 import { type AssetBalanceWithPrice, type AssetBalanceWithPriceAndChains, type BigNumber, type ExclusionSource, NoPrice, Zero } from '@rotki/common';
 import { storeToRefs } from 'pinia';
 import { computed, type ComputedRef, type MaybeRefOrGetter } from 'vue';
-import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
+import { useResolveAssetIdentifier } from '@/composables/assets/common';
 import { summarizeAssetProtocols } from '@/composables/balances/asset-summary';
 import { blockchainToAssetProtocolBalances, manualToAssetProtocolBalances } from '@/composables/balances/balance-transformations';
 import { getBlockchainLocationBreakdown, getExchangeByLocationBalances, useLocationBreakdown } from '@/composables/balances/location-breakdown';
@@ -35,7 +35,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
   const { balances: blockchainBalances, manualBalances, manualLiabilities } = storeToRefs(useBalancesStore());
   const { manualBalanceByLocation } = useManualBalanceData();
 
-  const { assetAssociationMap } = useAssetInfoRetrieval();
+  const resolveAssetIdentifier = useResolveAssetIdentifier();
   const { useCollectionId, useCollectionMainAsset } = useCollectionInfo();
 
   const balances = (
@@ -47,8 +47,6 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
       const exchange = get(useBaseExchangeBalances());
       const manual = manualToAssetProtocolBalances(get(manualBalances));
       const blockchain = blockchainToAssetProtocolBalances(get(blockchainBalances));
-      const associatedAssets = get(assetAssociationMap);
-
       const allSources = {
         blockchain,
         exchanges: exchange,
@@ -62,7 +60,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
           return acc;
         }, {} as Record<'blockchain' | 'exchanges' | 'manual', typeof blockchain>);
 
-      return summarizeAssetProtocols({ associatedAssets, sources: filteredSources }, { hideIgnored, isAssetIgnored }, {
+      return summarizeAssetProtocols({ resolveIdentifier: resolveAssetIdentifier, sources: filteredSources }, { hideIgnored, isAssetIgnored }, {
         getAssetPrice,
         noPrice: NoPrice,
       }, {
@@ -79,8 +77,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
         exchanges: {},
         manual: manualToAssetProtocolBalances(get(manualLiabilities)),
       };
-      const associatedAssets = get(assetAssociationMap);
-      return summarizeAssetProtocols({ associatedAssets, sources }, { hideIgnored, isAssetIgnored }, {
+      return summarizeAssetProtocols({ resolveIdentifier: resolveAssetIdentifier, sources }, { hideIgnored, isAssetIgnored }, {
         getAssetPrice,
         noPrice: NoPrice,
       }, {
@@ -100,7 +97,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
     const accountAddress = address ? toValue(address) : undefined;
     const blockchain = blockchainToAssetProtocolBalances(get(blockchainBalances), key, filter, accountAddress);
     return summarizeAssetProtocols({
-      associatedAssets: get(assetAssociationMap),
+      resolveIdentifier: resolveAssetIdentifier,
       sources: { blockchain, exchanges: {}, manual: {} },
     }, {
       hideIgnored: true,
@@ -120,7 +117,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
   ): ComputedRef<AssetBalanceWithPriceAndChains[]> => computed<AssetBalanceWithPriceAndChains[]>(() => {
     const exchanges = get(useBaseExchangeBalances(exchange));
     return summarizeAssetProtocols({
-      associatedAssets: get(assetAssociationMap),
+      resolveIdentifier: resolveAssetIdentifier,
       sources: { blockchain: {}, exchanges, manual: {} },
     }, {
       hideIgnored: true,
@@ -176,7 +173,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
   });
 
   const balancesByLocation = computed<Record<string, BigNumber>>(() => {
-    const blockchainAssets = getBlockchainLocationBreakdown(get(blockchainBalances), get(assetAssociationMap), asset => isAssetIgnored(asset));
+    const blockchainAssets = getBlockchainLocationBreakdown(get(blockchainBalances), resolveAssetIdentifier, asset => isAssetIgnored(asset));
     const blockchainTotal = bigNumberSum(Object.values(blockchainAssets).map(asset => asset.value));
     const map: Record<string, BigNumber> = {
       [TRADE_LOCATION_BLOCKCHAIN]: blockchainTotal,
@@ -209,7 +206,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
     useLocationBreakdown: (location: MaybeRefOrGetter<string>) => useLocationBreakdown(
       location,
       blockchainBalances,
-      assetAssociationMap,
+      resolveAssetIdentifier,
       manualBalances,
       useBaseExchangeBalances,
       isAssetIgnored,

--- a/frontend/app/src/composables/dashboard/use-dashboard-asset-data.ts
+++ b/frontend/app/src/composables/dashboard/use-dashboard-asset-data.ts
@@ -21,15 +21,15 @@ export function useDashboardAssetData(
   balances: MaybeRefOrGetter<AssetBalanceWithPrice[]>,
   sort: MaybeRefOrGetter<DataTableSortData<AssetBalanceWithPrice>>,
 ): UseDashboardAssetDataReturn {
-  const search = ref<string>('');
+  const search = shallowRef<string>('');
   const debouncedSearch = refDebounced(search, 200);
 
   const { totalNetWorth } = useDashboardStores();
-  const { assetInfo, assetName, assetSymbol } = useAssetSelectInfo();
+  const { getAssetInfo } = useAssetSelectInfo();
   const { missingCustomAssets } = useManualBalanceData();
 
   function assetFilter(item: Nullable<AssetBalance>): boolean {
-    return assetFilterByKeyword(item, get(debouncedSearch), assetName, assetSymbol);
+    return assetFilterByKeyword(item, get(debouncedSearch), getAssetInfo);
   }
 
   function isAssetMissing(item: AssetBalanceWithPrice): boolean {
@@ -50,7 +50,7 @@ export function useDashboardAssetData(
 
   const sorted = computed<AssetBalanceWithPrice[]>(() => {
     const filteredBalances = toValue(balances).filter(assetFilter);
-    return sortAssetBalances(filteredBalances, toValue(sort), assetInfo);
+    return sortAssetBalances(filteredBalances, toValue(sort), getAssetInfo);
   });
 
   return {

--- a/frontend/app/src/composables/filters/events.ts
+++ b/frontend/app/src/composables/filters/events.ts
@@ -18,7 +18,7 @@ import { useHistoryEventCounterpartyMappings } from '@/composables/history/event
 import { useHistoryStore } from '@/store/history';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
 import { arrayify } from '@/utils/array';
-import { assetDeserializer, assetSuggestions } from '@/utils/assets';
+import { assetSuggestions } from '@/utils/assets';
 import { uniqueStrings } from '@/utils/data';
 import { dateDeserializer, dateRangeValidator, dateSerializer, getDateInputISOFormat } from '@/utils/date';
 import {
@@ -80,7 +80,7 @@ export function useHistoryEventFilter(
   const { dateInputFormat } = storeToRefs(useFrontendSettingsStore());
   const { historyEventTypeGlobalMapping, historyEventTypes } = useHistoryEventMappings();
   const { counterparties } = useHistoryEventCounterpartyMappings();
-  const { assetInfo, assetSearch } = useAssetInfoRetrieval();
+  const { assetSearch, getAssetInfo } = useAssetInfoRetrieval();
   const { associatedLocations } = storeToRefs(useHistoryStore());
   const { t } = useI18n({ useScope: 'global' });
 
@@ -122,7 +122,7 @@ export function useHistoryEventFilter(
       {
         asset: true,
         description: t('transactions.filter.asset'),
-        deserializer: assetDeserializer(assetInfo),
+        deserializer: getAssetInfo,
         key: HistoryEventFilterKeys.ASSET,
         keyValue: HistoryEventFilterValueKeys.ASSET,
         suggestions: assetSuggestions(assetSearch, locationString),

--- a/frontend/app/src/composables/filters/manual-balances.ts
+++ b/frontend/app/src/composables/filters/manual-balances.ts
@@ -4,7 +4,7 @@ import type { MatchedKeyword, SearchMatcher } from '@/types/filtering';
 import z from 'zod/v4';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { CommaSeparatedStringSchema } from '@/types/route';
-import { assetDeserializer, assetSuggestions } from '@/utils/assets';
+import { assetSuggestions } from '@/utils/assets';
 
 enum ManualBalanceFilterKeys {
   LOCATION = 'location',
@@ -26,7 +26,7 @@ export function useManualBalanceFilter(locations: MaybeRef<string[]>): FilterSch
   const filters = ref<Filters>({});
 
   const { t } = useI18n({ useScope: 'global' });
-  const { assetInfo, assetSearch } = useAssetInfoRetrieval();
+  const { assetSearch, getAssetInfo } = useAssetInfoRetrieval();
 
   const matchers = computed<Matcher[]>(() => {
     const selectedLocation = get(filters)?.location;
@@ -52,7 +52,7 @@ export function useManualBalanceFilter(locations: MaybeRef<string[]>): FilterSch
       {
         asset: true,
         description: t('common.asset'),
-        deserializer: assetDeserializer(assetInfo),
+        deserializer: getAssetInfo,
         key: ManualBalanceFilterKeys.ASSET,
         keyValue: ManualBalanceFilterValueKeys.ASSET,
         suggestions: assetSuggestions(assetSearch, locationString),

--- a/frontend/app/src/composables/history/events/notes.spec.ts
+++ b/frontend/app/src/composables/history/events/notes.spec.ts
@@ -5,12 +5,19 @@ import { useFrontendSettingsStore } from '@/store/settings/frontend';
 
 vi.mock('@/composables/assets/retrieval', () => ({
   useAssetInfoRetrieval: vi.fn().mockReturnValue({
-    assetSymbol: vi.fn().mockImplementation((identifier) => {
-      if (isEvmIdentifier(identifier))
-        return 'USDC';
-
-      if (identifier === '0xdeadbeef')
+    getAssetField: vi.fn().mockImplementation((identifier: string | undefined, field: string) => {
+      if (!identifier)
         return '';
+
+      if (field === 'symbol') {
+        if (isEvmIdentifier(identifier))
+          return 'USDC';
+
+        if (identifier === '0xdeadbeef')
+          return '';
+
+        return identifier;
+      }
 
       return identifier;
     }),

--- a/frontend/app/src/composables/history/events/notes.ts
+++ b/frontend/app/src/composables/history/events/notes.ts
@@ -49,7 +49,7 @@ interface UseHistoryEventsNoteReturn {
 }
 
 export function useHistoryEventNote(): UseHistoryEventsNoteReturn {
-  const { assetSymbol } = useAssetInfoRetrieval();
+  const { getAssetField } = useAssetInfoRetrieval();
   const { scrambleData, scrambleIdentifier } = useScramble();
 
   function separateByPunctuation(word: string): string[] {
@@ -199,7 +199,7 @@ export function useHistoryEventNote(): UseHistoryEventsNoteReturn {
     noTxRef,
     validatorIndex,
   }: FormatNoteParams): ComputedRef<NoteFormat[]> => computed<NoteFormat[]>(() => {
-    const asset = get(assetSymbol(toValue(assetId), { collectionParent: false }));
+    const asset = getAssetField(toValue(assetId), 'symbol', { collectionParent: false });
     const extraDataVal = toValue(extraData);
 
     let notesVal = toValue(notes);
@@ -229,7 +229,7 @@ export function useHistoryEventNote(): UseHistoryEventsNoteReturn {
       noTxRef: toValue(noTxRef),
       shouldFormatAllAmount: counterpartyVal === 'gnosis_pay',
       getCleanWord,
-      getAssetSymbol: (id: string) => get(assetSymbol(id)),
+      getAssetSymbol: (id: string) => getAssetField(id, 'symbol'),
     };
 
     for (const [index, wordItem] of processedWords.entries()) {

--- a/frontend/app/src/composables/history/events/use-unmatched-asset-movements.ts
+++ b/frontend/app/src/composables/history/events/use-unmatched-asset-movements.ts
@@ -54,7 +54,7 @@ const triggerAutoMatchLoading = ref<boolean>(false);
 export const useUnmatchedAssetMovements = createSharedComposable((): UseUnmatchedAssetMovementsReturn => {
   const { t } = useI18n({ useScope: 'global' });
   const { showErrorMessage, showSuccessMessage } = useNotifications();
-  const { assetInfo } = useAssetInfoRetrieval();
+  const { getAssetInfo } = useAssetInfoRetrieval();
   const { awaitTask, useIsTaskRunning } = useTaskStore();
 
   const { fetchHistoryEvents } = useHistoryEventsApi();
@@ -72,7 +72,7 @@ export const useUnmatchedAssetMovements = createSharedComposable((): UseUnmatche
   function addIsFiat(movements: RawUnmatchedAssetMovement[]): UnmatchedAssetMovement[] {
     return movements.map(movement => ({
       ...movement,
-      isFiat: get(assetInfo(movement.asset))?.assetType === 'fiat',
+      isFiat: getAssetInfo(movement.asset)?.assetType === 'fiat',
     }));
   }
 

--- a/frontend/app/src/composables/settings/use-asset-statistic-state.ts
+++ b/frontend/app/src/composables/settings/use-asset-statistic-state.ts
@@ -29,10 +29,10 @@ export function useAssetStatisticState(asset: MaybeRefOrGetter<string | undefine
 
   const { useHistoricalAssetBalances: enabled } = storeToRefs(useFrontendSettingsStore());
 
-  const { assetName } = useAssetInfoRetrieval();
+  const { useAssetField } = useAssetInfoRetrieval();
   const stateForAsset = useLocalStorage<Record<string, number>>('rotki.remember-state-for-asset', {});
 
-  const name = assetName(asset);
+  const name = useAssetField(asset, 'name');
 
   const rememberStateForAsset = computed<boolean>({
     get() {

--- a/frontend/app/src/modules/amount-display/components/AssetAmountDisplay.spec.ts
+++ b/frontend/app/src/modules/amount-display/components/AssetAmountDisplay.spec.ts
@@ -10,11 +10,11 @@ import { useCurrencies } from '@/types/currencies';
 import { CurrencyLocation } from '@/types/currency-location';
 import { getDefaultFrontendSettings } from '@/types/settings/frontend-settings';
 
-const mockAssetInfo = vi.fn().mockImplementation(() => computed(() => ({ symbol: 'ETH' })));
+const mockUseAssetInfo = vi.fn().mockImplementation(() => computed(() => ({ symbol: 'ETH' })));
 
 vi.mock('@/composables/assets/retrieval', () => ({
-  useAssetInfoRetrieval: (): { assetInfo: typeof mockAssetInfo } => ({
-    assetInfo: mockAssetInfo,
+  useAssetInfoRetrieval: (): { useAssetInfo: typeof mockUseAssetInfo } => ({
+    useAssetInfo: mockUseAssetInfo,
   }),
 }));
 
@@ -32,7 +32,7 @@ describe('modules/amount-display/components/AssetAmountDisplay', () => {
       uiFloatingPrecision: 2,
     });
 
-    mockAssetInfo.mockClear();
+    mockUseAssetInfo.mockClear();
   });
 
   afterEach(() => {
@@ -179,8 +179,8 @@ describe('modules/amount-display/components/AssetAmountDisplay', () => {
         },
       });
 
-      expect(mockAssetInfo).toHaveBeenCalled();
-      const optionsArg = mockAssetInfo.mock.calls[0][1];
+      expect(mockUseAssetInfo).toHaveBeenCalled();
+      const optionsArg = mockUseAssetInfo.mock.calls[0][1];
       expect(get(optionsArg)).toEqual({ collectionParent: true });
     });
 
@@ -194,8 +194,8 @@ describe('modules/amount-display/components/AssetAmountDisplay', () => {
         },
       });
 
-      expect(mockAssetInfo).toHaveBeenCalled();
-      const optionsArg = mockAssetInfo.mock.calls[0][1];
+      expect(mockUseAssetInfo).toHaveBeenCalled();
+      const optionsArg = mockUseAssetInfo.mock.calls[0][1];
       expect(get(optionsArg)).toEqual({ collectionParent: false });
     });
   });

--- a/frontend/app/src/modules/amount-display/components/AssetAmountDisplay.vue
+++ b/frontend/app/src/modules/amount-display/components/AssetAmountDisplay.vue
@@ -45,9 +45,9 @@ defineOptions({
 const { amount, asset = '', noCollectionParent, noScramble } = defineProps<Props>();
 
 // Composables
-const { assetInfo } = useAssetInfoRetrieval();
+const { useAssetInfo } = useAssetInfoRetrieval();
 const resolutionOptions = computed(() => ({ collectionParent: !noCollectionParent }));
-const info = assetInfo(() => asset, resolutionOptions);
+const info = useAssetInfo(() => asset, resolutionOptions);
 const { scrambledValue } = useScrambledValue({ value: () => amount, noScramble: () => noScramble });
 
 // Computed - returns empty string if no asset provided

--- a/frontend/app/src/modules/asset-manager/solana-token-migration/SolanaTokenMigrationForm.vue
+++ b/frontend/app/src/modules/asset-manager/solana-token-migration/SolanaTokenMigrationForm.vue
@@ -30,13 +30,13 @@ const { t } = useI18n({ useScope: 'global' });
 const address = useRefPropVModel(modelValue, 'address');
 const decimals = useRefPropVModel(modelValue, 'decimals');
 const tokenKind = useRefPropVModel(modelValue, 'tokenKind');
-const { assetInfo } = useAssetInfoRetrieval();
+const { getAssetInfo } = useAssetInfoRetrieval();
 
 const assetDetails = computed<string | undefined>(() => {
   if (!oldAsset) {
     return undefined;
   }
-  const details = get(assetInfo(oldAsset));
+  const details = getAssetInfo(oldAsset);
 
   if (!details) {
     return oldAsset;

--- a/frontend/app/src/modules/assets/use-collection-info.ts
+++ b/frontend/app/src/modules/assets/use-collection-info.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, MaybeRef } from 'vue';
 import type { AssetMap } from '@/types/asset';
 import { useAssetInfoApi } from '@/composables/api/assets/info';
-import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
+import { useResolveAssetIdentifier } from '@/composables/assets/common';
 import { useCollectionMappingStore } from '@/modules/assets/use-collection-mapping-store';
 import { chunkArray } from '@/utils/data';
 import { logger } from '@/utils/logging';
@@ -20,9 +20,8 @@ export const useCollectionInfo = createSharedComposable((): UseCollectionInfoRet
   const queuedAssets: Set<string> = new Set();
   const pendingAssets: Set<string> = new Set();
 
-  const { assetAssociationMap } = useAssetInfoRetrieval();
   const { assetToCollection, collectionMainAsset } = storeToRefs(useCollectionMappingStore());
-
+  const resolveAssetIdentifier = useResolveAssetIdentifier();
   const { assetMapping } = useAssetInfoApi();
 
   async function getAssetMapping(identifiers: string[]): Promise<AssetMap | undefined> {
@@ -38,7 +37,7 @@ export const useCollectionInfo = createSharedComposable((): UseCollectionInfoRet
   async function retrieveCollectionId(identifiers: string[]): Promise<CollectionInfo> {
     const assetToCollection: Record<string, string | null> = {};
     const collectionMainAsset: Record<string, string | null> = {};
-    const ids = identifiers.map(id => get(assetAssociationMap)[id] ?? id);
+    const ids = identifiers.map(id => resolveAssetIdentifier(id));
     for (const chunk of chunkArray(ids, 50)) {
       const mappings = await getAssetMapping(chunk);
       if (mappings === undefined) {

--- a/frontend/app/src/modules/balances/blockchain/use-blockchain-account-data.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-blockchain-account-data.ts
@@ -12,7 +12,7 @@ import type { Collection } from '@/types/collection';
 import { type AssetBalance, type Balance, Blockchain, Zero } from '@rotki/common';
 import { omit } from 'es-toolkit';
 import { isEmpty } from 'es-toolkit/compat';
-import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
+import { useResolveAssetIdentifier } from '@/composables/assets/common';
 import { useSupportedChains } from '@/composables/info/chains';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
@@ -44,11 +44,11 @@ interface UseBlockchainAccountDataReturn {
 function toAssetBalances(
   balances: Record<string, ProtocolBalances>,
   isIgnored: (asset: string) => boolean,
-  assetAssociationMap: Record<string, string>,
+  resolveIdentifier: (id: string) => string,
 ): AssetBalance[] {
   const intermediate: Record<string, Balance> = {};
   for (const [assetIdentifier, balance] of Object.entries(balances)) {
-    const identifier = assetAssociationMap?.[assetIdentifier] ?? assetIdentifier;
+    const identifier = resolveIdentifier(assetIdentifier);
     if (isIgnored(identifier))
       continue;
 
@@ -73,13 +73,12 @@ export function useBlockchainAccountData(): UseBlockchainAccountDataReturn {
   const { addressNameSelector } = useAddressesNamesStore();
   const { getChainAccountType } = useSupportedChains();
   const { isAssetIgnored } = useIgnoredAssetsStore();
-  const { assetAssociationMap } = useAssetInfoRetrieval();
+  const resolveAssetIdentifier = useResolveAssetIdentifier();
 
   const getAccountBalances = (
     balances: Balances,
     chain: string,
     address: string,
-    assetAssociationMap: Record<string, string>,
   ): AccountBalances => {
     const chainAssets = balances[chain] ?? {};
     const addressAssets = chainAssets[address];
@@ -88,8 +87,8 @@ export function useBlockchainAccountData(): UseBlockchainAccountDataReturn {
       const { assets, liabilities } = addressAssets;
 
       return {
-        assets: toAssetBalances(assets, isAssetIgnored, assetAssociationMap),
-        liabilities: !liabilities ? [] : toAssetBalances(liabilities, isAssetIgnored, assetAssociationMap),
+        assets: toAssetBalances(assets, isAssetIgnored, resolveAssetIdentifier),
+        liabilities: !liabilities ? [] : toAssetBalances(liabilities, isAssetIgnored, resolveAssetIdentifier),
       };
     }
 
@@ -102,7 +101,7 @@ export function useBlockchainAccountData(): UseBlockchainAccountDataReturn {
   const getAccountDetails = (
     chain: string,
     address: string,
-  ): AccountBalances => getAccountBalances(get(balances), get(chain), get(address), get(assetAssociationMap));
+  ): AccountBalances => getAccountBalances(get(balances), get(chain), get(address));
 
   const useAccountTags = (address: MaybeRefOrGetter<string>): ComputedRef<string[]> => computed<string[]>(() => {
     const accountData = get(accounts);

--- a/frontend/app/src/modules/balances/services/use-loopring-balance-service.ts
+++ b/frontend/app/src/modules/balances/services/use-loopring-balance-service.ts
@@ -3,7 +3,7 @@ import type { AssetProtocolBalances } from '@/types/blockchain/balances';
 import type { TaskMeta } from '@/types/task';
 import { Blockchain } from '@rotki/common';
 import { useBlockchainBalancesApi } from '@/composables/api/balances/blockchain';
-import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
+import { useResolveAssetIdentifier } from '@/composables/assets/common';
 import { useStatusUpdater } from '@/composables/status';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
@@ -30,7 +30,7 @@ export function useLoopringBalanceService(): UseLoopringBalanceServiceReturn {
   const { updateAccounts } = useBlockchainAccountsStore();
   const { t } = useI18n({ useScope: 'global' });
   const { activeModules } = storeToRefs(useGeneralSettingsStore());
-  const { getAssociatedAssetIdentifier } = useAssetInfoRetrieval();
+  const resolveAssetIdentifier = useResolveAssetIdentifier();
 
   const fetchLoopringBalances = async (refresh: boolean): Promise<void> => {
     if (!get(activeModules).includes(Module.LOOPRING))
@@ -76,8 +76,7 @@ export function useLoopringBalanceService(): UseLoopringBalanceServiceReturn {
       const assets: AssetProtocolBalances = {};
       for (const loopringAssets of Object.values(loopringBalances)) {
         for (const [asset, value] of Object.entries(loopringAssets)) {
-          const identifier = getAssociatedAssetIdentifier(asset);
-          const associatedAsset: string = get(identifier) ?? asset;
+          const associatedAsset: string = resolveAssetIdentifier(asset);
           const ownedAsset = assets[associatedAsset];
 
           if (!ownedAsset)

--- a/frontend/app/src/modules/balances/use-asset-balances-breakdown.ts
+++ b/frontend/app/src/modules/balances/use-asset-balances-breakdown.ts
@@ -3,7 +3,7 @@ import type { Accounts, AssetBreakdown, Balances } from '@/types/blockchain/acco
 import type { ExchangeData } from '@/types/exchanges';
 import type { ManualBalanceWithValue } from '@/types/manual-balances';
 import { Zero } from '@rotki/common';
-import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
+import { useResolveAssetIdentifier } from '@/composables/assets/common';
 import { useSupportedChains } from '@/composables/info/chains';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
@@ -33,18 +33,17 @@ export function useAssetBalancesBreakdown(): UseAssetBalancesBreakdownReturn {
   const { balances, exchangeBalances, manualBalances, manualLiabilities } = storeToRefs(useBalancesStore());
   const { accounts } = storeToRefs(useBlockchainAccountsStore());
   const { getEvmChainName } = useSupportedChains();
-  const { assetAssociationMap } = useAssetInfoRetrieval();
+  const resolveAssetIdentifier = useResolveAssetIdentifier();
 
   const getExchangeAssetBreakdown = (
     balances: ExchangeData,
     asset: string,
-    assetAssociationMap: Record<string, string>,
   ): AssetBreakdown[] => {
     const breakdown: AssetBreakdown[] = [];
     for (const exchange in balances) {
       const exchangeData = balances[exchange];
       for (const exchangeDataAsset in exchangeData) {
-        if ((assetAssociationMap?.[exchangeDataAsset] ?? exchangeDataAsset) !== asset)
+        if (resolveAssetIdentifier(exchangeDataAsset) !== asset)
           continue;
 
         breakdown.push({
@@ -61,11 +60,10 @@ export function useAssetBalancesBreakdown(): UseAssetBalancesBreakdownReturn {
   function getManualBalancesAssetBreakdown(
     balances: ManualBalanceWithValue[],
     asset: string,
-    assetAssociationMap: Record<string, string>,
   ): AssetBreakdown[] {
     const breakdown: AssetBreakdown[] = [];
     for (const balance of balances) {
-      if ((assetAssociationMap?.[balance.asset] ?? balance.asset) !== asset)
+      if (resolveAssetIdentifier(balance.asset) !== asset)
         continue;
 
       breakdown.push({
@@ -83,7 +81,6 @@ export function useAssetBalancesBreakdown(): UseAssetBalancesBreakdownReturn {
     data: BreakdownData,
     asset: string,
     isLiability: boolean = false,
-    associatedIdentifiers: Record<string, string> = {},
     filters: BreakdownFilters = {},
   ): AssetBreakdown[] {
     const breakdown: AssetBreakdown[] = [];
@@ -103,7 +100,8 @@ export function useAssetBalancesBreakdown(): UseAssetBalancesBreakdownReturn {
           continue;
 
         const balance = chainBalanceData[address];
-        const identifiers = associatedIdentifiers[asset] ? [asset, associatedIdentifiers[asset]] : [asset];
+        const resolved = resolveAssetIdentifier(asset);
+        const identifiers = resolved !== asset ? [asset, resolved] : [asset];
         for (const identifier of identifiers) {
           const assetBalance = balance[isLiability ? 'liabilities' : 'assets'][identifier];
           if (!assetBalance)
@@ -142,23 +140,20 @@ export function useAssetBalancesBreakdown(): UseAssetBalancesBreakdownReturn {
 
     const onlyBlockchain = chains.length > 0 || groupId !== undefined || blockchainOnly;
 
-    const associatedIdentifiers = get(assetAssociationMap);
     data.push(...getBlockchainAssetBreakdown(
       { accounts: get(accounts), balances: get(balances) },
       asset,
       liabilities,
-      associatedIdentifiers,
       filters,
     ));
 
     if (!onlyBlockchain) {
       const balances = liabilities ? get(manualLiabilities) : get(manualBalances);
-      data.push(...getManualBalancesAssetBreakdown(balances, asset, associatedIdentifiers));
+      data.push(...getManualBalancesAssetBreakdown(balances, asset));
       if (!liabilities) {
         data.push(...getExchangeAssetBreakdown(
           get(exchangeBalances),
           asset,
-          associatedIdentifiers,
         ));
       }
     }

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -34,14 +34,9 @@ vi.mock('@/modules/balances/use-balances-store', () => ({
   }),
 }));
 
-vi.mock('@/composables/assets/retrieval', async () => {
-  const { ref } = await import('vue');
-  return ({
-    useAssetInfoRetrieval: vi.fn().mockReturnValue({
-      getAssociatedAssetIdentifier: vi.fn().mockReturnValue(ref()),
-    }),
-  });
-});
+vi.mock('@/composables/assets/common', () => ({
+  useResolveAssetIdentifier: vi.fn(() => (asset: string): string => asset),
+}));
 
 vi.mock('@/composables/api/balances/blockchain', () => ({
   useBlockchainBalancesApi: vi.fn().mockReturnValue({

--- a/frontend/app/src/modules/dashboard/liquidity-pools/PoolDetails.vue
+++ b/frontend/app/src/modules/dashboard/liquidity-pools/PoolDetails.vue
@@ -26,7 +26,7 @@ const sort = ref<DataTableSortData<AssetBalanceWithPrice>>({
 
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 const { assetPrice } = usePriceUtils();
-const { assetInfo } = useAssetSelectInfo();
+const { getAssetInfo } = useAssetSelectInfo();
 const premium = usePremium();
 const { t } = useI18n({ useScope: 'global' });
 
@@ -68,7 +68,7 @@ const sorted = computed<AssetBalanceWithPrice[]>(() => {
     value: item.userBalance.value,
   }));
 
-  return sortAssetBalances(transformed, get(sort), assetInfo);
+  return sortAssetBalances(transformed, get(sort), getAssetInfo);
 });
 </script>
 

--- a/frontend/app/src/modules/dashboard/liquidity-pools/use-pool-balances.ts
+++ b/frontend/app/src/modules/dashboard/liquidity-pools/use-pool-balances.ts
@@ -74,7 +74,7 @@ export function usePoolBalances(): UsePoolBalancesReturn {
 
   const { isLoading } = useStatusStore();
   const { getSushiswapBalances, getUniswapV2Balances } = usePoolApi();
-  const { assetSymbol } = useAssetInfoRetrieval();
+  const { getAssetField } = useAssetInfoRetrieval();
 
   const loading = logicOr(
     isLoading(Section.POOLS_UNISWAP_V2),
@@ -112,7 +112,7 @@ export function usePoolBalances(): UsePoolBalancesReturn {
   const total = computed<BigNumber>(() => bigNumberSum(get(balances).map(item => item.value)));
 
   const getPoolName = (type: PoolType, assets: string[]): string => {
-    const concatAssets = (assets: string[]): string => assets.map(asset => get(assetSymbol(asset))).join('-');
+    const concatAssets = (assets: string[]): string => assets.map(asset => getAssetField(asset, 'symbol')).join('-');
 
     const data = [{
       identifier: PoolType.UNISWAP_V2,

--- a/frontend/app/src/modules/history/balances/HistoricalBalancesTable.vue
+++ b/frontend/app/src/modules/history/balances/HistoricalBalancesTable.vue
@@ -25,7 +25,7 @@ const sort = ref<DataTableSortData<AssetBalanceWithPrice>>({
   direction: 'desc' as const,
 });
 
-const { assetInfo } = useAssetSelectInfo();
+const { getAssetInfo } = useAssetSelectInfo();
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 const { createKey, isPending } = useHistoricCachePriceStore();
 
@@ -75,7 +75,7 @@ const tableHeaders = computed<DataTableColumn<AssetBalanceWithPrice>[]>(() => [{
   sortable: true,
 }]);
 
-const sorted = computed<AssetBalanceWithPrice[]>(() => sortAssetBalances([...balances], get(sort), assetInfo));
+const sorted = computed<AssetBalanceWithPrice[]>(() => sortAssetBalances([...balances], get(sort), getAssetInfo));
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/balances/use-historical-balances.ts
+++ b/frontend/app/src/modules/history/balances/use-historical-balances.ts
@@ -116,7 +116,7 @@ export function useHistoricalBalances(): UseHistoricalBalancesReturn {
 
     return summarizeAssetProtocols(
       {
-        associatedAssets: {},
+        resolveIdentifier: (id: string): string => id,
         sources: { historical: sources },
       },
       {

--- a/frontend/app/src/modules/history/events/composables/use-history-event-item.spec.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-event-item.spec.ts
@@ -17,7 +17,7 @@ vi.mock('@/composables/info/chains', () => ({
 
 vi.mock('@/composables/assets/retrieval', () => ({
   useAssetInfoRetrieval: vi.fn(() => ({
-    assetInfo: vi.fn(() => ref({ protocol: undefined })),
+    useAssetInfo: vi.fn(() => ref({ protocol: undefined })),
   })),
 }));
 

--- a/frontend/app/src/modules/history/events/composables/use-history-event-item.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-event-item.ts
@@ -38,12 +38,12 @@ export function useHistoryEventItem(
 ): UseHistoryEventItemReturn {
   const { event, selection } = props;
   const { getChain } = useSupportedChains();
-  const { assetInfo } = useAssetInfoRetrieval();
+  const { useAssetInfo } = useAssetInfoRetrieval();
   const { useIsAssetIgnored } = useIgnoredAssetsStore();
 
   const eventAsset = computed<string>(() => toValue(event).asset);
   const isIgnoredAsset = useIsAssetIgnored(eventAsset);
-  const asset = assetInfo(eventAsset, { collectionParent: false });
+  const asset = useAssetInfo(eventAsset, { collectionParent: false });
   const isSpam = computed<boolean>(() => get(asset)?.protocol === 'spam');
   const hiddenEvent = logicOr(isIgnoredAsset, isSpam);
 

--- a/frontend/app/src/modules/history/events/composables/use-history-matched-movement-item.spec.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-matched-movement-item.spec.ts
@@ -17,8 +17,9 @@ vi.mock('@/composables/info/chains', () => ({
 }));
 
 vi.mock('@/composables/assets/retrieval', () => ({
+  NO_COLLECTION_RESOLVE: { collectionParent: false },
   useAssetInfoRetrieval: vi.fn(() => ({
-    getAssetSymbol: vi.fn((asset: string) => asset.toUpperCase()),
+    getAssetField: vi.fn((asset: string) => asset.toUpperCase()),
   })),
 }));
 

--- a/frontend/app/src/modules/history/events/composables/use-history-matched-movement-item.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-matched-movement-item.ts
@@ -2,7 +2,7 @@ import type { ComputedRef, Ref } from 'vue';
 import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/composables/use-selection-mode';
 import type { HistoryEventEntry } from '@/types/history/events/schemas';
 import { type Blockchain, HistoryEventEntryType } from '@rotki/common';
-import { type AssetResolutionOptions, useAssetInfoRetrieval } from '@/composables/assets/retrieval';
+import { NO_COLLECTION_RESOLVE, useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { useSupportedChains } from '@/composables/info/chains';
 import { useLocations } from '@/composables/locations';
 import { isEventMissingAccountingRule } from '@/utils/history/events';
@@ -31,7 +31,7 @@ export interface UseHistoryMatchedMovementItemReturn {
   eventTypeLabel: ComputedRef<string>;
 }
 
-const ASSET_RESOLUTION_OPTIONS: AssetResolutionOptions = { collectionParent: false };
+const ASSET_RESOLUTION_OPTIONS = NO_COLLECTION_RESOLVE;
 
 export function useHistoryMatchedMovementItem(
   props: UseHistoryMatchedMovementItemProps,
@@ -39,7 +39,7 @@ export function useHistoryMatchedMovementItem(
   const { events, selection } = props;
   const { t } = useI18n({ useScope: 'global' });
   const { getChain } = useSupportedChains();
-  const { getAssetSymbol } = useAssetInfoRetrieval();
+  const { getAssetField } = useAssetInfoRetrieval();
 
   const { locationData } = useLocations();
 
@@ -114,7 +114,7 @@ export function useHistoryMatchedMovementItem(
     const secondary = get(secondaryEvent);
 
     const amount = primary.amount;
-    const asset = getAssetSymbol(primary.asset, ASSET_RESOLUTION_OPTIONS);
+    const asset = getAssetField(primary.asset, 'symbol', ASSET_RESOLUTION_OPTIONS);
     const exchangeLabel = primary.locationLabel || get(locationData(primary.location))?.name || '';
     const addressLabel = secondary?.locationLabel || (secondary && get(locationData(secondary.location))?.name) || '';
 
@@ -136,7 +136,7 @@ export function useHistoryMatchedMovementItem(
     if (fee.length === 0)
       return notes;
 
-    const feeText = fee.map(item => `${item.amount.toFixed()} ${getAssetSymbol(item.asset, ASSET_RESOLUTION_OPTIONS)}`).join('; ');
+    const feeText = fee.map(item => `${item.amount.toFixed()} ${getAssetField(item.asset, 'symbol', ASSET_RESOLUTION_OPTIONS)}`).join('; ');
     return t('history_events_list_swap.fee_description', { feeText, notes });
   });
 

--- a/frontend/app/src/modules/history/events/composables/use-history-swap-item.spec.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-swap-item.spec.ts
@@ -18,9 +18,10 @@ vi.mock('@/composables/info/chains', () => ({
 }));
 
 vi.mock('@/composables/assets/retrieval', () => ({
+  NO_COLLECTION_RESOLVE: { collectionParent: false },
   useAssetInfoRetrieval: vi.fn(() => ({
-    assetInfo: (assetRef: Ref<string>): ComputedRef<{ protocol?: string }> => computed(() => mockAssetInfoMap.get(get(assetRef)) ?? {}),
-    getAssetSymbol: vi.fn((asset: string) => asset.toUpperCase()),
+    useAssetInfo: (assetRef: Ref<string>): ComputedRef<{ protocol?: string }> => computed(() => mockAssetInfoMap.get(get(assetRef)) ?? {}),
+    getAssetField: vi.fn((asset: string) => asset.toUpperCase()),
   })),
 }));
 

--- a/frontend/app/src/modules/history/events/composables/use-history-swap-item.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-swap-item.ts
@@ -2,7 +2,7 @@ import type { Blockchain } from '@rotki/common';
 import type { ComputedRef, Ref } from 'vue';
 import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/composables/use-selection-mode';
 import type { HistoryEventEntry } from '@/types/history/events/schemas';
-import { type AssetResolutionOptions, useAssetInfoRetrieval } from '@/composables/assets/retrieval';
+import { NO_COLLECTION_RESOLVE, useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { useSupportedChains } from '@/composables/info/chains';
 import { useIgnoredAssetsStore } from '@/store/assets/ignored';
 import { isEventMissingAccountingRule } from '@/utils/history/events';
@@ -37,7 +37,7 @@ export interface UseHistorySwapItemReturn {
   compactNotes: ComputedRef<string | undefined>;
 }
 
-const ASSET_RESOLUTION_OPTIONS: AssetResolutionOptions = { collectionParent: false };
+const ASSET_RESOLUTION_OPTIONS = NO_COLLECTION_RESOLVE;
 
 export function useHistorySwapItem(
   props: UseHistorySwapItemProps,
@@ -45,7 +45,7 @@ export function useHistorySwapItem(
   const { events, selection } = props;
   const { t } = useI18n({ useScope: 'global' });
   const { getChain } = useSupportedChains();
-  const { assetInfo, getAssetSymbol } = useAssetInfoRetrieval();
+  const { getAssetField, useAssetInfo } = useAssetInfoRetrieval();
   const { isAssetIgnored } = useIgnoredAssetsStore();
 
   const primaryEvent = computed<HistoryEventEntry>(() => get(events)[0]);
@@ -99,8 +99,8 @@ export function useHistorySwapItem(
 
   const spendAsset = computed<string>(() => get(spendEvent)?.asset ?? '');
   const receiveAsset = computed<string>(() => get(receiveEvent)?.asset ?? '');
-  const spendAssetInfo = assetInfo(spendAsset, ASSET_RESOLUTION_OPTIONS);
-  const receiveAssetInfo = assetInfo(receiveAsset, ASSET_RESOLUTION_OPTIONS);
+  const spendAssetInfo = useAssetInfo(spendAsset, ASSET_RESOLUTION_OPTIONS);
+  const receiveAssetInfo = useAssetInfo(receiveAsset, ASSET_RESOLUTION_OPTIONS);
 
   const isSpendHidden = computed<boolean>(() => {
     const asset = get(spendAsset);
@@ -129,7 +129,7 @@ export function useHistorySwapItem(
     const spendNotes = spend.length === 1
       ? {
           spendAmount: spend[0].amount,
-          spendAsset: getAssetSymbol(spend[0].asset, ASSET_RESOLUTION_OPTIONS),
+          spendAsset: getAssetField(spend[0].asset, 'symbol', ASSET_RESOLUTION_OPTIONS),
         }
       : {
           spendAmount: spend.length,
@@ -139,7 +139,7 @@ export function useHistorySwapItem(
     const receiveNotes = receive.length === 1
       ? {
           receiveAmount: receive[0].amount,
-          receiveAsset: getAssetSymbol(receive[0].asset, ASSET_RESOLUTION_OPTIONS),
+          receiveAsset: getAssetField(receive[0].asset, 'symbol', ASSET_RESOLUTION_OPTIONS),
         }
       : {
           receiveAmount: receive.length,
@@ -156,7 +156,7 @@ export function useHistorySwapItem(
     if (fee.length === 0)
       return notes;
 
-    const feeText = fee.map(item => `${item.amount.toFixed()} ${getAssetSymbol(item.asset, ASSET_RESOLUTION_OPTIONS)}`).join('; ');
+    const feeText = fee.map(item => `${item.amount.toFixed()} ${getAssetField(item.asset, 'symbol', ASSET_RESOLUTION_OPTIONS)}`).join('; ');
     return t('history_events_list_swap.fee_description', { feeText, notes });
   });
 

--- a/frontend/app/src/modules/onchain/send/TradeAssetDisplay.vue
+++ b/frontend/app/src/modules/onchain/send/TradeAssetDisplay.vue
@@ -18,11 +18,11 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { assetName, assetSymbol } = useAssetInfoRetrieval();
+const { useAssetField } = useAssetInfoRetrieval();
 const { getEvmChainName } = useSupportedChains();
 
-const symbol = assetSymbol(data.asset, { collectionParent: false });
-const name = assetName(data.asset, { collectionParent: false });
+const symbol = useAssetField(data.asset, 'symbol', { collectionParent: false });
+const name = useAssetField(data.asset, 'name', { collectionParent: false });
 </script>
 
 <template>

--- a/frontend/app/src/modules/prices/use-historical-price-fetcher.ts
+++ b/frontend/app/src/modules/prices/use-historical-price-fetcher.ts
@@ -18,7 +18,7 @@ export function useHistoricalPriceFetcher(): UseHistoricalPriceFetcherReturn {
 
   const api = useStatisticsApi();
   const { awaitTask } = useTaskStore();
-  const { assetName } = useAssetInfoRetrieval();
+  const { getAssetField } = useAssetInfoRetrieval();
   const { notifyError } = useNotifications();
   const { failedDailyPrices, resolvedFailedDailyPrices } = storeToRefs(useHistoricCachePriceStore());
 
@@ -68,7 +68,7 @@ export function useHistoricalPriceFetcher(): UseHistoricalPriceFetcherReturn {
       });
       const { result } = await awaitTask<HistoricalAssetPriceResponse, TaskMeta>(taskId, taskType, {
         description: t('actions.balances.historic_fetch_price.daily.task.detail', {
-          asset: get(assetName(payload.asset)),
+          asset: getAssetField(payload.asset, 'name'),
         }),
         title: t('actions.balances.historic_fetch_price.daily.task.title'),
       });

--- a/frontend/app/src/pages/assets/[identifier].vue
+++ b/frontend/app/src/pages/assets/[identifier].vue
@@ -41,7 +41,7 @@ const route = useRoute();
 
 const { coingeckoAsset, cryptocompareAsset } = externalLinks;
 
-const { assetContractInfo, assetInfo, assetName, assetSymbol, refetchAssetInfo } = useAssetInfoRetrieval();
+const { refetchAssetInfo, useAssetContractInfo, useAssetInfo } = useAssetInfoRetrieval();
 const premium = usePremium();
 const { balances } = useAggregatedBalances();
 
@@ -58,10 +58,8 @@ const assetRetrievalOption = computed<AssetResolutionOptions>(() => ({
   collectionParent: get(isCollectionParent),
 }));
 
-const name = assetName(() => identifier, assetRetrievalOption);
-const symbol = assetSymbol(() => identifier, assetRetrievalOption);
-const asset = assetInfo(() => identifier, assetRetrievalOption);
-const contractInfo = assetContractInfo(() => identifier, assetRetrievalOption);
+const asset = useAssetInfo(() => identifier, assetRetrievalOption);
+const contractInfo = useAssetContractInfo(() => identifier, assetRetrievalOption);
 
 const {
   loadingIgnore,
@@ -73,9 +71,7 @@ const {
 } = useAssetPageActions({
   asset,
   identifier: computed<string>(() => identifier),
-  name,
   refetchAssetInfo,
-  symbol,
 });
 
 const isCustomAsset = computed(() => get(asset)?.isCustomAsset);
@@ -140,9 +136,9 @@ function goToEdit(): void {
           v-if="!isCustomAsset"
           class="flex flex-col"
         >
-          <span class="text-h5 font-medium">{{ symbol }}</span>
+          <span class="text-h5 font-medium">{{ asset?.symbol }}</span>
           <span class="text-body-2 text-rui-text-secondary">
-            {{ name }}
+            {{ asset?.name }}
           </span>
         </div>
 
@@ -150,7 +146,7 @@ function goToEdit(): void {
           v-else
           class="flex flex-col"
         >
-          <span class="text-h5 font-medium">{{ name }}</span>
+          <span class="text-h5 font-medium">{{ asset?.name }}</span>
           <span class="text-body-2 text-rui-text-secondary">
             {{ asset?.customAssetType }}
           </span>

--- a/frontend/app/src/pages/assets/use-asset-page-actions.ts
+++ b/frontend/app/src/pages/assets/use-asset-page-actions.ts
@@ -5,15 +5,15 @@ import { useWhitelistedAssetsStore } from '@/store/assets/whitelisted';
 
 interface AssetWithSpamStatus {
   isSpam?: boolean;
+  name?: string | null;
+  symbol?: string | null;
   [key: string]: unknown;
 }
 
 interface UseAssetPageActionsOptions {
   asset: ComputedRef<AssetWithSpamStatus | null>;
   identifier: Ref<string>;
-  name: ComputedRef<string | undefined>;
   refetchAssetInfo: (id: string) => void;
-  symbol: ComputedRef<string | undefined>;
 }
 
 interface UseAssetPageActionsReturn {
@@ -28,7 +28,7 @@ interface UseAssetPageActionsReturn {
 }
 
 export function useAssetPageActions(options: UseAssetPageActionsOptions): UseAssetPageActionsReturn {
-  const { asset, identifier, name, refetchAssetInfo, symbol } = options;
+  const { asset, identifier, refetchAssetInfo } = options;
 
   const { ignoreAssetWithConfirmation, unignoreAsset, useIsAssetIgnored } = useIgnoredAssetsStore();
   const { useIsAssetWhitelisted, unWhitelistAsset, whitelistAsset } = useWhitelistedAssetsStore();
@@ -66,7 +66,8 @@ export function useAssetPageActions(options: UseAssetPageActionsOptions): UseAss
         await unignoreAsset(id);
       }
       else {
-        await ignoreAssetWithConfirmation(id, get(symbol) || get(name));
+        const info = get(asset);
+        await ignoreAssetWithConfirmation(id, info?.symbol || info?.name);
       }
     }
     finally {

--- a/frontend/app/src/premium/premium-apis.ts
+++ b/frontend/app/src/premium/premium-apis.ts
@@ -31,17 +31,17 @@ import { isNft } from '@/utils/nft';
 import { truncateAddress } from '@/utils/truncate';
 
 export function assetsApi(): AssetsApi {
-  const { assetInfo, assetName, assetSymbol, tokenAddress } = useAssetInfoRetrieval();
+  const { getAssetInfo, useAssetInfo, useTokenAddress } = useAssetInfoRetrieval();
 
   return {
-    assetInfo,
-    assetSymbol: (identifier: MaybeRef<string>) => computed(() => {
+    assetInfo: useAssetInfo,
+    assetSymbol: (identifier: MaybeRef<string>) => computed<string>(() => {
       if (isNft(get(identifier)))
-        return get(assetName(identifier));
+        return getAssetInfo(get(identifier))?.name ?? '';
 
-      return get(assetSymbol(identifier));
+      return getAssetInfo(get(identifier))?.symbol ?? '';
     }),
-    tokenAddress: (identifier: MaybeRef<string>) => tokenAddress(identifier),
+    tokenAddress: (identifier: MaybeRef<string>) => useTokenAddress(identifier),
   };
 }
 

--- a/frontend/app/src/store/assets/ignored.ts
+++ b/frontend/app/src/store/assets/ignored.ts
@@ -17,7 +17,7 @@ export const useIgnoredAssetsStore = defineStore('assets/ignored', () => {
   const { addIgnoredAssets, getIgnoredAssets, removeIgnoredAssets } = useAssetIgnoreApi();
   const { show } = useConfirmStore();
 
-  const { getAssetSymbol } = useAssetInfoRetrieval();
+  const { getAssetField } = useAssetInfoRetrieval();
   const { manualBalancesAssets } = useManualBalanceData();
 
   const fetchIgnoredAssets = async (): Promise<void> => {
@@ -54,7 +54,7 @@ export const useIgnoredAssetsStore = defineStore('assets/ignored', () => {
         showErrorMessage(
           t('ignore.warning.manual_balances_title'),
           t('ignore.warning.manual_balances_message', {
-            assets: includedInManualBalances.map(item => getAssetSymbol(item)).join(', '),
+            assets: includedInManualBalances.map(item => getAssetField(item, 'symbol')).join(', '),
           }),
         );
       }

--- a/frontend/app/src/store/staking/kraken.spec.ts
+++ b/frontend/app/src/store/staking/kraken.spec.ts
@@ -16,10 +16,8 @@ vi.mock('@/composables/api/staking/kraken', () => ({
   })),
 }));
 
-vi.mock('@/composables/assets/retrieval', () => ({
-  useAssetInfoRetrieval: vi.fn(() => ({
-    getAssociatedAssetIdentifier: vi.fn((asset: string) => computed(() => asset)),
-  })),
+vi.mock('@/composables/assets/common', () => ({
+  useResolveAssetIdentifier: vi.fn(() => (asset: string): string => asset),
 }));
 
 vi.mock('@/store/notifications', () => ({

--- a/frontend/app/src/store/staking/kraken.ts
+++ b/frontend/app/src/store/staking/kraken.ts
@@ -7,7 +7,7 @@ import type { TaskMeta } from '@/types/task';
 import { type AssetBalance, Zero } from '@rotki/common';
 import { omit } from 'es-toolkit';
 import { useKrakenApi } from '@/composables/api/staking/kraken';
-import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
+import { useResolveAssetIdentifier } from '@/composables/assets/common';
 import { useStatusUpdater } from '@/composables/status';
 import { getErrorMessage, useNotifications } from '@/modules/notifications/use-notifications';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
@@ -48,7 +48,7 @@ export const useKrakenStakingStore = defineStore('staking/kraken', () => {
 
   const api = useKrakenApi();
 
-  const { getAssociatedAssetIdentifier } = useAssetInfoRetrieval();
+  const resolveAssetIdentifier = useResolveAssetIdentifier();
   const { t } = useI18n({ useScope: 'global' });
 
   const events = computed<KrakenStakingEvents>(() => {
@@ -58,7 +58,7 @@ export const useKrakenStakingStore = defineStore('staking/kraken', () => {
     const receivedAssets: Record<string, AssetBalance> = {};
 
     received.forEach((item: AssetBalance) => {
-      const associatedAsset: string = get(getAssociatedAssetIdentifier(item.asset));
+      const associatedAsset: string = resolveAssetIdentifier(item.asset);
 
       const receivedAsset = receivedAssets[associatedAsset];
 

--- a/frontend/app/src/utils/assets.ts
+++ b/frontend/app/src/utils/assets.ts
@@ -1,6 +1,4 @@
-import type { ComputedRef } from 'vue';
 import type { AssetSearchParams } from '@/composables/api/assets/info';
-import type { AssetNameReturn, AssetSymbolReturn } from '@/composables/assets/retrieval';
 import {
   type AssetBalance,
   type AssetInfoWithId,
@@ -188,15 +186,15 @@ export function getSortItems<T extends AssetBalance>(getInfo: (identifier: strin
 export function assetFilterByKeyword(
   item: Nullable<AssetBalance>,
   search: string,
-  assetName: AssetNameReturn,
-  assetSymbol: AssetSymbolReturn,
+  getAssetInfo: (identifier: string | undefined) => { name?: string | null; symbol?: string | null } | null,
 ): boolean {
   const keyword = getTextToken(search);
   if (!keyword || !item)
     return true;
 
-  const name = getTextToken(get(assetName(item.asset)));
-  const symbol = getTextToken(get(assetSymbol(item.asset)));
+  const info = getAssetInfo(item.asset);
+  const name = getTextToken(info?.name ?? '');
+  const symbol = getTextToken(info?.symbol ?? '');
   return symbol.includes(keyword) || name.includes(keyword);
 }
 
@@ -226,8 +224,4 @@ export function assetSuggestions(assetSearch: (params: AssetSearchParams) => Pro
     pending = null;
     return result;
   }, 200);
-}
-
-export function assetDeserializer(assetInfo: (identifier: string) => ComputedRef<AssetInfoWithId | null>): (identifier: string) => AssetInfoWithId | null {
-  return (identifier: string): AssetInfoWithId | null => get(assetInfo(identifier)) || null;
 }

--- a/frontend/app/src/utils/balances.ts
+++ b/frontend/app/src/utils/balances.ts
@@ -5,7 +5,7 @@ import type {
   Writeable,
 } from '@rotki/common';
 import type { DataTableSortData } from '@rotki/ui-library';
-import type { AssetInfoReturn } from '@/composables/assets/retrieval';
+import type { PlainAssetInfoReturn } from '@/composables/assets/retrieval';
 import type { AssetBreakdown } from '@/types/blockchain/accounts';
 import { getSortItems } from '@/utils/assets';
 import { sortDesc, zeroBalance } from '@/utils/bignumbers';
@@ -34,8 +34,8 @@ export function sum(balances: { value: BigNumber }[]): BigNumber {
   return bigNumberSum(balances.map(account => account.value));
 }
 
-export function sortAssetBalances<T extends AssetBalance = AssetBalanceWithPrice>(data: T[], sort: DataTableSortData<T>, assetInfo: AssetInfoReturn): T[] {
-  const sortItems = getSortItems<T>(asset => get(assetInfo(asset)));
+export function sortAssetBalances<T extends AssetBalance = AssetBalanceWithPrice>(data: T[], sort: DataTableSortData<T>, getAssetInfo: PlainAssetInfoReturn): T[] {
+  const sortItems = getSortItems<T>(asset => getAssetInfo(asset));
 
   const sortBy = get(sort);
   if (!Array.isArray(sortBy) && sortBy?.column)

--- a/frontend/app/src/utils/blockchain/accounts/index.ts
+++ b/frontend/app/src/utils/blockchain/accounts/index.ts
@@ -267,7 +267,7 @@ export function convertBtcBalances(
 interface GeneratorFilters {
   chains?: string[];
   skipIdentifier?: (asset: string) => boolean;
-  assetAssociationMap?: Record<string, string>;
+  resolveIdentifier?: (id: string) => string;
 }
 
 export function* iterateAssets(
@@ -276,8 +276,8 @@ export function* iterateAssets(
   filters: GeneratorFilters = {},
 ): Generator<[string, Balance]> {
   const {
-    assetAssociationMap = {},
     chains = [],
+    resolveIdentifier = (id: string): string => id,
     skipIdentifier = (): boolean => false,
   } = filters;
   for (const chain of Object.keys(balances)) {
@@ -294,7 +294,7 @@ export function* iterateAssets(
         if (skipIdentifier(identifier))
           continue;
 
-        const assetIdentifier = assetAssociationMap[identifier] ?? identifier;
+        const assetIdentifier = resolveIdentifier(identifier);
         const balance = Object.values(protocolBalances).reduce((previousValue, currentValue) => ({
           amount: previousValue.amount.plus(currentValue.amount),
           value: previousValue.value.plus(currentValue.value),


### PR DESCRIPTION
## Summary

- Split `useAssetInfoRetrieval` and `useAssetSelectInfo` into plain (`get*`) and reactive (`use*`) variants — plain functions hold the logic, reactive ones wrap in `computed()`. This eliminates the widespread `get(fn(x))` anti-pattern where consumers created a computed only to immediately unwrap it.
- Replaced the over-engineered `useAssetAssociationMap` (Record threading) + `getAssociatedAssetIdentifier` system with a single `useResolveAssetIdentifier()` function that returns `(id: string) => string`. The entire system existed solely to map ETH2 to ETH.
- Unified `assetSymbol`/`assetName`/`getAssetSymbol` into `getAssetField`/`useAssetField` with `AssetStringField` type (`'symbol' | 'name'`).
- Removed `assetDeserializer` utility (now a direct passthrough with `getAssetInfo`).
- Added `NO_COLLECTION_RESOLVE` shared constant replacing 13+ scattered `{ collectionParent: false }` object literals.
- Hoisted `storeToRefs(useAssetCacheStore())` out of computed body in `retrieval.ts` (perf fix).
- Used `shallowRef` for caches in `asset-select-info.ts`.
- Updated all ~50 consumers and ~10 test files.

## Test plan

- [x] `pnpm run lint:fix` passes (0 errors)
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test:unit` passes (238 files, 2739 tests)