### PR TITLE
Show plan indicator for premium users

### DIFF
--- a/frontend/app/shared/external-links.ts
+++ b/frontend/app/shared/external-links.ts
@@ -5,6 +5,7 @@ const DOCS_BASE_URL = `https://docs.rotki.com/${DOCS_SUBFOLDER}`;
 const USAGE_GUIDE_URL = `${DOCS_BASE_URL}usage-guides/`;
 const CONTRIBUTE_URL = `${DOCS_BASE_URL}contribution-guides/`;
 const GITHUB_BASE_URL = 'https://github.com/rotki/rotki/';
+const UTM_PARAMS = '?utm_source=rotki_app&utm_medium=desktop&utm_campaign=upgrade';
 
 // Cannot be checked with fetch because it always returns 400
 export const TWITTER_URL = 'https://twitter.com/rotkiapp';
@@ -27,10 +28,10 @@ export const blockscoutLinks = {
 };
 
 export const externalLinks = {
-  premium: `${BASE_URL}products`,
+  premium: `${BASE_URL}products${UTM_PARAMS}`,
   premiumDevices: `${DOCS_BASE_URL}premium/devices`,
   sponsor: `${BASE_URL}sponsor/mint`,
-  manageSubscriptions: `${BASE_URL}home/subscription`,
+  manageSubscriptions: `${BASE_URL}home/subscription${UTM_PARAMS}`,
   usageGuide: USAGE_GUIDE_URL,
   usageGuideSection: {
     dockerWarning: `${USAGE_GUIDE_URL}using-rotki-from-mobile#docker`,

--- a/frontend/app/src/components/premium/GetPremiumButton.vue
+++ b/frontend/app/src/components/premium/GetPremiumButton.vue
@@ -1,20 +1,20 @@
 <script setup lang="ts">
 import { externalLinks } from '@shared/external-links';
 import ExternalLink from '@/components/helper/ExternalLink.vue';
-import { usePremium } from '@/composables/premium';
+import { usePremiumHelper } from '@/composables/premium';
 
-withDefaults(
-  defineProps<{
-    hideOnSmallScreen?: boolean;
-  }>(),
-  {
-    hideOnSmallScreen: false,
-  },
-);
+const { hideOnSmallScreen = false } = defineProps<{
+  hideOnSmallScreen?: boolean;
+}>();
 
 const { t } = useI18n({ useScope: 'global' });
-const premium = usePremium();
+const { currentTier, premium } = usePremiumHelper();
 const { isLgAndDown } = useBreakpoint();
+
+const tierLabel = computed<string>(() => {
+  const tier = get(currentTier);
+  return tier ? t('premium_placeholder.current_plan', { tier }) : t('premium_placeholder.upgrade_plan');
+});
 </script>
 
 <template>
@@ -26,9 +26,9 @@ const { isLgAndDown } = useBreakpoint();
     >
       <template #activator>
         <ExternalLink
+          v-if="!premium"
           custom
-          :premium="!premium"
-          :url="premium ? externalLinks.manageSubscriptions : undefined"
+          premium
         >
           <RuiButton
             :class="{ '[&_span]:!hidden lg:[&_span]:!block': hideOnSmallScreen }"
@@ -40,11 +40,26 @@ const { isLgAndDown } = useBreakpoint();
             <template #prepend>
               <RuiIcon name="lu-crown" />
             </template>
-            {{ premium ? t('premium_placeholder.upgrade_plan') : t('premium_settings.get') }}
+            {{ t('premium_settings.get') }}
           </RuiButton>
         </ExternalLink>
+        <ExternalLink
+          v-else
+          custom
+          :url="externalLinks.manageSubscriptions"
+        >
+          <RuiChip
+            size="sm"
+            variant="outlined"
+            color="primary"
+            data-cy="get-premium-button"
+            class="!cursor-pointer"
+          >
+            {{ tierLabel }}
+          </RuiChip>
+        </ExternalLink>
       </template>
-      <span>{{ premium ? t('premium_placeholder.upgrade_plan') : t('premium_settings.get') }}</span>
+      <span>{{ premium ? tierLabel : t('premium_settings.get') }}</span>
     </RuiTooltip>
   </div>
 </template>

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -4625,6 +4625,7 @@
     "tooltip": "Feature is only supported with a premium subscription"
   },
   "premium_placeholder": {
+    "current_plan": "{tier} plan",
     "free_description": "This feature requires a minimum of {tier} tier.",
     "premium_description": "This feature requires a minimum of {tier} tier. Your current tier is {currentTier}.",
     "upgrade_plan": "Upgrade plan"
@@ -4643,6 +4644,7 @@
       "statistic": "The statistics view is not available",
       "title": "Graphs are not available"
     },
+    "current_plan_label": "Current plan:",
     "delete_confirmation": {
       "message": "Are you sure you want to delete the rotki premium keys for your account? If you want to re-enable premium you will have to enter your keys again.",
       "title": "Delete rotki premium keys?"
@@ -4660,6 +4662,7 @@
       "api_secret": "API Secret"
     },
     "get": "Get premium",
+    "manage_or_upgrade": "Manage or upgrade subscription",
     "premium_active": "@:premium_settings.title is active",
     "subtitle": "@:premium_settings.title is an optional subscription service to gain access to analytics, graphs, and unlock many additional features. For more information on what is available visit the {0} website.",
     "title": "rotki Premium"

--- a/frontend/app/src/pages/api-keys/premium/index.vue
+++ b/frontend/app/src/pages/api-keys/premium/index.vue
@@ -7,6 +7,7 @@ import HintMenuIcon from '@/components/HintMenuIcon.vue';
 import TablePageLayout from '@/components/layout/TablePageLayout.vue';
 import AutomaticSyncSetting from '@/components/status/sync/AutomaticSyncSetting.vue';
 import { useInterop } from '@/composables/electron-interop';
+import { usePremiumHelper } from '@/composables/premium';
 import PremiumDeviceList from '@/modules/premium/devices/components/PremiumDeviceList.vue';
 import { useConfirmStore } from '@/store/confirm';
 import { useMessageStore } from '@/store/message';
@@ -32,6 +33,7 @@ const { deletePremium, setup } = store;
 const { show } = useConfirmStore();
 const { setMessage } = useMessageStore();
 
+const { currentTier } = usePremiumHelper();
 const { openUrl, premiumUserLoggedIn } = useInterop();
 
 const mainActionText = computed<string>(() => {
@@ -210,6 +212,22 @@ onMounted(() => {
       >
         {{ t('premium_settings.premium_active') }}
       </RuiAlert>
+
+      <div
+        v-if="premium"
+        class="flex items-center justify-between mt-4 px-2"
+      >
+        <div class="flex items-center gap-3">
+          <span class="text-rui-text-secondary text-body-2">
+            {{ t('premium_settings.current_plan_label') }} <span class="font-bold text-rui-text">{{ currentTier || '—' }}</span>
+          </span>
+        </div>
+        <ExternalLink
+          :url="externalLinks.manageSubscriptions"
+          :text="t('premium_settings.manage_or_upgrade')"
+          color="primary"
+        />
+      </div>
 
       <AutomaticSyncSetting
         class="mt-6"


### PR DESCRIPTION
## Summary
- Replace the prominent "Upgrade plan" button in the app bar with a subtle outlined chip showing the current tier (e.g. "Basic plan") for premium users. Free users still see the "Get premium" button unchanged.
- Add current plan display with bold tier name and "Manage or upgrade subscription" link to the premium API key settings page.
- Add UTM tracking parameters (`utm_source=rotki_app&utm_medium=desktop&utm_campaign=upgrade`) to premium and subscription external links.

## Test plan
- [ ] Log in as free user → "Get premium" button in app bar unchanged
- [ ] Log in as premium user → subtle outlined chip with tier name in app bar
- [ ] Premium user → API Keys > Premium page shows current plan and manage/upgrade link
- [ ] Verify external premium links include UTM parameters