### PR TITLE
refactor(frontend): remove useRefMap utility

### DIFF
--- a/frontend/app/src/components/account-management/login/PremiumSyncConflictAlert.vue
+++ b/frontend/app/src/components/account-management/login/PremiumSyncConflictAlert.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import LoginActionAlert from '@/components/account-management/login/LoginActionAlert.vue';
 import DateDisplay from '@/components/display/DateDisplay.vue';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { useSessionAuthStore } from '@/store/session/auth';
 
 const emit = defineEmits<{ proceed: [approval: 'yes' | 'no'] }>();
@@ -10,7 +9,8 @@ const { t } = useI18n({ useScope: 'global' });
 
 const { syncConflict } = storeToRefs(useSessionAuthStore());
 
-const lastModified = useRefMap(syncConflict, (conflict) => {
+const lastModified = computed(() => {
+  const conflict = get(syncConflict);
   if (!conflict || !conflict.payload)
     return null;
 

--- a/frontend/app/src/components/defi/QueriedAddressDialog.vue
+++ b/frontend/app/src/components/defi/QueriedAddressDialog.vue
@@ -6,7 +6,6 @@ import AppImage from '@/components/common/AppImage.vue';
 import LabeledAddressDisplay from '@/components/display/LabeledAddressDisplay.vue';
 import BlockchainAccountSelector from '@/components/helper/BlockchainAccountSelector.vue';
 import TagDisplay from '@/components/tags/TagDisplay.vue';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
 import { useQueriedAddressesStore } from '@/store/session/queried-addresses';
@@ -36,9 +35,6 @@ const currentModule = computed(() => {
 
   return SUPPORTED_MODULES.find(({ identifier }) => identifier === module);
 });
-
-const moduleName = useRefMap(currentModule, m => m?.name);
-const moduleIcon = useRefMap(currentModule, m => m?.icon);
 
 const addresses = computed(() => {
   if (!module)
@@ -93,14 +89,14 @@ function close() {
             class="icon-bg"
             size="1.5rem"
             contain
-            :src="moduleIcon"
+            :src="currentModule?.icon"
           />
           <RuiCardHeader class="p-0">
             <template #header>
               {{ t('queried_address_dialog.title') }}
             </template>
             <template #subheader>
-              {{ t('queried_address_dialog.subtitle', { module: moduleName }) }}
+              {{ t('queried_address_dialog.subtitle', { module: currentModule?.name }) }}
             </template>
           </RuiCardHeader>
 
@@ -184,7 +180,7 @@ function close() {
       >
         {{
           t('queried_address_dialog.all_address_queried', {
-            module: moduleName,
+            module: currentModule?.name,
           })
         }}
       </div>

--- a/frontend/app/src/components/display/BalanceDisplay.vue
+++ b/frontend/app/src/components/display/BalanceDisplay.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { type Balance, Zero } from '@rotki/common';
 import AssetDetails from '@/components/helper/AssetDetails.vue';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { useValueOrDefault } from '@/composables/utils/useValueOrDefault';
 import { AssetAmountDisplay, FiatDisplay } from '@/modules/amount-display/components';
 import { usePriceUtils } from '@/modules/prices/use-price-utils';
@@ -31,11 +30,11 @@ const {
 }>();
 
 const amount = useValueOrDefault(
-  useRefMap(() => value, value => value?.amount),
+  () => value?.amount,
   Zero,
 );
 const balanceValue = useValueOrDefault(
-  useRefMap(() => value, value => value?.value),
+  () => value?.value,
   Zero,
 );
 

--- a/frontend/app/src/components/display/ExchangeDisplay.vue
+++ b/frontend/app/src/components/display/ExchangeDisplay.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import AppImage from '@/components/common/AppImage.vue';
 import { useLocations } from '@/composables/locations';
-import { useRefMap } from '@/composables/utils/useRefMap';
 
 const { exchange, size = '1.5rem' } = defineProps<{
   exchange: string;
@@ -11,8 +10,6 @@ const { exchange, size = '1.5rem' } = defineProps<{
 const { locationData } = useLocations();
 
 const location = locationData(() => exchange);
-const name = useRefMap(location, location => location?.name);
-const image = useRefMap(location, location => location?.image ?? undefined);
 </script>
 
 <template>
@@ -22,8 +19,8 @@ const image = useRefMap(location, location => location?.image ?? undefined);
       :width="size"
       :height="size"
       contain
-      :src="image"
+      :src="location?.image ?? undefined"
     />
-    <div v-text="name" />
+    <div v-text="location?.name" />
   </div>
 </template>

--- a/frontend/app/src/components/helper/AssetDetailsBase.vue
+++ b/frontend/app/src/components/helper/AssetDetailsBase.vue
@@ -7,7 +7,6 @@ import ListItem from '@/components/common/ListItem.vue';
 import AssetDetailsMenuContent from '@/components/helper/AssetDetailsMenuContent.vue';
 import AssetIcon from '@/components/helper/display/icons/AssetIcon.vue';
 import { useAssetPageNavigation } from '@/composables/assets/navigation';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { useAssetCacheStore } from '@/store/assets/asset-cache';
 
 defineOptions({
@@ -47,24 +46,13 @@ const emit = defineEmits<{
 }>();
 
 const menuOpened = ref<boolean>(false);
-
-const symbol = useRefMap(() => asset, asset => asset.symbol ?? '');
-const name = useRefMap(() => asset, asset => asset.name ?? '');
-
-const { isPending } = useAssetCacheStore();
-const identifier = useRefMap(() => asset, asset => asset.identifier);
-const loading = computed<boolean>(() => get(isPending(identifier)));
-
-const [DefineImage, ReuseImage] = createReusableTemplate();
 const menuContentRef = useTemplateRef<InstanceType<typeof AssetDetailsMenuContent>>('menuContentRef');
 
-const { navigateToDetails } = useAssetPageNavigation(identifier, () => isCollectionParent);
+const { isPending } = useAssetCacheStore();
+const { navigateToDetails } = useAssetPageNavigation(() => asset.identifier, () => isCollectionParent);
+const loading = isPending(() => asset.identifier);
 
-watch(menuOpened, (menuOpened) => {
-  if (!menuOpened) {
-    get(menuContentRef)?.setConfirm(false);
-  }
-});
+const [DefineImage, ReuseImage] = createReusableTemplate();
 
 function openMenuHandler(event: MouseEvent) {
   event.preventDefault();
@@ -72,7 +60,7 @@ function openMenuHandler(event: MouseEvent) {
   set(menuOpened, !get(menuOpened));
 }
 
-function useContextMenu(attrs: Record<string, any>) {
+function useContextMenu(attrs: Record<string, unknown>) {
   return {
     ...omit(attrs, ['onClick']),
     onClick: () => {
@@ -83,6 +71,12 @@ function useContextMenu(attrs: Record<string, any>) {
     oncontextmenu: openMenuHandler,
   };
 }
+
+watch(menuOpened, (menuOpened) => {
+  if (!menuOpened) {
+    get(menuContentRef)?.setConfirm(false);
+  }
+});
 </script>
 
 <template>
@@ -117,8 +111,8 @@ function useContextMenu(attrs: Record<string, any>) {
     v-bind="$attrs"
     :size="dense ? 'sm' : 'md'"
     :loading="loading"
-    :title="asset.isCustomAsset ? name : symbol"
-    :subtitle="asset.isCustomAsset ? asset.customAssetType : name"
+    :title="asset.isCustomAsset ? asset.name : asset.symbol"
+    :subtitle="asset.isCustomAsset ? asset.customAssetType : asset.name"
   >
     <template #avatar>
       <ReuseImage />
@@ -126,7 +120,7 @@ function useContextMenu(attrs: Record<string, any>) {
   </ListItem>
   <RuiMenu
     v-else
-    :key="identifier"
+    :key="asset.identifier"
     v-model="menuOpened"
     class="flex"
     menu-class="w-[16rem] max-w-[90%]"
@@ -148,8 +142,8 @@ function useContextMenu(attrs: Record<string, any>) {
           v-bind="{ ...$attrs, ...useContextMenu(attrs) }"
           :size="dense ? 'sm' : 'md'"
           :loading="loading"
-          :title="asset.isCustomAsset ? name : symbol"
-          :subtitle="asset.isCustomAsset ? asset.customAssetType : name"
+          :title="asset.isCustomAsset ? asset.name : asset.symbol"
+          :subtitle="asset.isCustomAsset ? asset.customAssetType : asset.name"
         >
           <template #avatar>
             <ReuseImage />

--- a/frontend/app/src/components/helper/AssetDetailsMenuContent.vue
+++ b/frontend/app/src/components/helper/AssetDetailsMenuContent.vue
@@ -3,10 +3,11 @@ import type { NftAsset } from '@/types/nfts';
 import { useAssetPageNavigation } from '@/composables/assets/navigation';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { useSpamAsset } from '@/composables/assets/spam';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import HashLink from '@/modules/common/links/HashLink.vue';
 import { useIgnoredAssetsStore } from '@/store/assets/ignored';
 import { isSpammableAssetType } from '@/types/asset';
+
+type ConfirmType = 'ignore' | 'mark_as_spam';
 
 const { asset, hideActions, isCollectionParent, iconOnly } = defineProps<{
   asset: NftAsset;
@@ -21,23 +22,17 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const symbol = useRefMap(() => asset, asset => asset.symbol ?? '');
-const name = useRefMap(() => asset, asset => asset.name ?? '');
-const identifier = useRefMap(() => asset, asset => asset.identifier);
-
-const { navigateToDetails } = useAssetPageNavigation(identifier, () => isCollectionParent);
-
-type ConfirmType = 'ignore' | 'mark_as_spam';
 const confirm = ref(false);
 const confirmType = ref<ConfirmType>('ignore');
 
+const { navigateToDetails } = useAssetPageNavigation(() => asset.identifier, () => isCollectionParent);
 const { ignoreAsset, useIsAssetIgnored } = useIgnoredAssetsStore();
-const isSpamAsset = computed<boolean>(() => asset.isSpam);
-const isIgnoredAsset = useIsAssetIgnored(identifier);
 const { markAssetsAsSpam } = useSpamAsset();
+
+const isIgnoredAsset = useIsAssetIgnored(() => asset.identifier);
 const { refetchAssetInfo, useAssetContractInfo } = useAssetInfoRetrieval();
 
-const contractInfo = useAssetContractInfo(identifier);
+const contractInfo = useAssetContractInfo(() => asset.identifier);
 
 function actionClick(action: ConfirmType) {
   set(confirm, true);
@@ -45,7 +40,7 @@ function actionClick(action: ConfirmType) {
 }
 
 async function confirmAction() {
-  const id = get(identifier);
+  const id = asset.identifier;
   if (get(confirmType) === 'ignore') {
     await ignoreAsset(id);
   }
@@ -137,70 +132,68 @@ defineExpose({
               />
             </template>
           </RuiButton>
-          <template v-if="!hideActions">
-            <div
-              v-if="isIgnoredAsset || isSpamAsset"
-              class="text-xs text-rui-info bg-rui-info-lighter/[0.1] px-1 py-1 rounded-md flex items-center gap-1"
-            >
-              <RuiIcon
-                name="lu-info"
-                size="16"
-              />
-              {{ isSpamAsset ? t('assets.action.info.mark_as_spam') : t('assets.action.info.ignore') }}
+          <div
+            v-if="!hideActions && (isIgnoredAsset || asset.isSpamAsset)"
+            class="text-xs text-rui-info bg-rui-info-lighter/[0.1] px-1 py-1 rounded-md flex items-center gap-1"
+          >
+            <RuiIcon
+              name="lu-info"
+              size="16"
+            />
+            {{ asset.isSpamAsset ? t('assets.action.info.mark_as_spam') : t('assets.action.info.ignore') }}
+          </div>
+          <template v-else-if="!hideActions">
+            <RuiDivider
+              vertical
+              class="h-6"
+            />
+            <div class="w-full flex items-center gap-1">
+              <RuiTooltip
+                :open-delay="200"
+                :popper="{ placement: 'top' }"
+              >
+                <template #activator>
+                  <RuiButton
+                    variant="text"
+                    color="error"
+                    class="!py-0.5"
+                    size="sm"
+                    @click="actionClick('ignore')"
+                  >
+                    <template #append>
+                      <RuiIcon
+                        name="lu-eye-off"
+                        size="18"
+                      />
+                    </template>
+                  </RuiButton>
+                </template>
+                {{ t('assets.action.ignore') }}
+              </RuiTooltip>
+              <RuiTooltip
+                v-if="isSpammableAssetType(asset.assetType)"
+                :open-delay="200"
+                :popper="{ placement: 'top' }"
+              >
+                <template #activator>
+                  <RuiButton
+                    variant="text"
+                    color="error"
+                    class="!py-0.5"
+                    size="sm"
+                    @click="actionClick('mark_as_spam')"
+                  >
+                    <template #append>
+                      <RuiIcon
+                        name="lu-ban"
+                        size="18"
+                      />
+                    </template>
+                  </RuiButton>
+                </template>
+                {{ t('assets.action.mark_as_spam') }}
+              </RuiTooltip>
             </div>
-            <template v-else>
-              <RuiDivider
-                vertical
-                class="h-6"
-              />
-              <div class="w-full flex items-center gap-1">
-                <RuiTooltip
-                  :open-delay="200"
-                  :popper="{ placement: 'top' }"
-                >
-                  <template #activator>
-                    <RuiButton
-                      variant="text"
-                      color="error"
-                      class="!py-0.5"
-                      size="sm"
-                      @click="actionClick('ignore')"
-                    >
-                      <template #append>
-                        <RuiIcon
-                          name="lu-eye-off"
-                          size="18"
-                        />
-                      </template>
-                    </RuiButton>
-                  </template>
-                  {{ t('assets.action.ignore') }}
-                </RuiTooltip>
-                <RuiTooltip
-                  v-if="isSpammableAssetType(asset.assetType)"
-                  :open-delay="200"
-                  :popper="{ placement: 'top' }"
-                >
-                  <template #activator>
-                    <RuiButton
-                      variant="text"
-                      color="error"
-                      class="!py-0.5"
-                      size="sm"
-                      @click="actionClick('mark_as_spam')"
-                    >
-                      <template #append>
-                        <RuiIcon
-                          name="lu-ban"
-                          size="18"
-                        />
-                      </template>
-                    </RuiButton>
-                  </template>
-                  {{ t('assets.action.mark_as_spam') }}
-                </RuiTooltip>
-              </div>
-            </template>
           </template>
         </div>
       </Transition>
@@ -244,9 +237,9 @@ defineExpose({
       </div>
 
       <div class="text-xs py-0.5">
-        {{ name }}
-        <template v-if="name !== symbol">
-          {{ t('assets.asset_symbol', { symbol }) }}
+        {{ asset.name }}
+        <template v-if="asset.name !== asset.symbol">
+          {{ t('assets.asset_symbol', { symbol: asset.symbol }) }}
         </template>
       </div>
     </div>

--- a/frontend/app/src/components/history/events/HistoryEventAsset.vue
+++ b/frontend/app/src/components/history/events/HistoryEventAsset.vue
@@ -5,7 +5,6 @@ import { useTemplateRef } from 'vue';
 import AssetDetails from '@/components/helper/AssetDetails.vue';
 import AssetDetailsMenuContent from '@/components/helper/AssetDetailsMenuContent.vue';
 import { NO_COLLECTION_RESOLVE, useAssetInfoRetrieval } from '@/composables/assets/retrieval';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { AssetAmountDisplay, AssetValueDisplay } from '@/modules/amount-display/components';
 
 const { event, dense, disableOptions } = defineProps<{
@@ -18,35 +17,30 @@ const emit = defineEmits<{
   refresh: [];
 }>();
 
-const { useAssetField, useAssetInfo } = useAssetInfoRetrieval();
-
-const showBalance = computed<boolean>(() => event.eventType !== 'informational');
-
-const eventAsset = useRefMap(() => event, ({ asset }) => asset);
-
-const symbol = useAssetField(eventAsset, 'symbol', NO_COLLECTION_RESOLVE);
-
 const menuOpened = ref<boolean>(false);
 const menuContentRef = useTemplateRef<InstanceType<typeof AssetDetailsMenuContent>>('menuContentRef');
 
-const assetDetails = useAssetInfo(eventAsset, NO_COLLECTION_RESOLVE);
+const { useAssetInfo } = useAssetInfoRetrieval();
 
+const assetDetails = useAssetInfo(() => event.asset, NO_COLLECTION_RESOLVE);
+
+const showBalance = computed<boolean>(() => event.eventType !== 'informational');
 const currentAsset = computed<AssetInfoWithId>(() => ({
   ...get(assetDetails),
-  identifier: get(eventAsset),
+  identifier: event.asset,
 }));
-
-watch(menuOpened, (menuOpened) => {
-  if (!menuOpened) {
-    get(menuContentRef)?.setConfirm(false);
-  }
-});
 
 function openMenuHandler(event: MouseEvent): void {
   event.preventDefault();
   event.stopPropagation();
   set(menuOpened, !get(menuOpened));
 }
+
+watch(menuOpened, (menuOpened) => {
+  if (!menuOpened) {
+    get(menuContentRef)?.setConfirm(false);
+  }
+});
 </script>
 
 <template>
@@ -101,7 +95,7 @@ function openMenuHandler(event: MouseEvent): void {
           v-else
           class="text-truncate text-sm"
         >
-          {{ symbol }}
+          {{ assetDetails?.symbol }}
         </div>
 
         <div

--- a/frontend/app/src/components/profitloss/ProfitLossEventType.vue
+++ b/frontend/app/src/components/profitloss/ProfitLossEventType.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { useHistoryEventMappings } from '@/composables/history/events/mapping';
-import { useRefMap } from '@/composables/utils/useRefMap';
 
 const { type } = defineProps<{
   type: string;
@@ -9,17 +8,15 @@ const { type } = defineProps<{
 const { getAccountingEventTypeData } = useHistoryEventMappings();
 
 const data = getAccountingEventTypeData(() => type);
-const icon = useRefMap(data, ({ icon }) => icon);
-const label = useRefMap(data, ({ label }) => label);
 </script>
 
 <template>
   <span class="flex items-center flex-col text-no-wrap gap-1">
     <RuiIcon
-      v-if="icon"
-      :name="icon"
+      v-if="data?.icon"
+      :name="data.icon"
       color="secondary"
     />
-    {{ label }}
+    {{ data?.label }}
   </span>
 </template>

--- a/frontend/app/src/components/profitloss/ReportProfitLossEventAction.vue
+++ b/frontend/app/src/components/profitloss/ReportProfitLossEventAction.vue
@@ -7,7 +7,6 @@ import AmountInput from '@/components/inputs/AmountInput.vue';
 import AssetSelect from '@/components/inputs/AssetSelect.vue';
 import DateTimePicker from '@/components/inputs/DateTimePicker.vue';
 import { useAssetPricesApi } from '@/composables/api/assets/prices';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { usePriceTaskManager } from '@/modules/prices/use-price-task-manager';
 import { useMessageStore } from '@/store/message';
 import { useHistoricCachePriceStore } from '@/store/prices/historic';
@@ -39,8 +38,6 @@ async function openEditHistoricPriceDialog() {
   set(price, historicPrice.isPositive() ? historicPrice.toFixed() : '0');
   set(fetchingPrice, false);
 }
-
-const timestamp = useRefMap(() => event, item => item.timestamp);
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -145,7 +142,7 @@ async function updatePrice() {
               outlined
             />
             <DateTimePicker
-              :model-value="timestamp"
+              :model-value="event.timestamp"
               disabled
               type="epoch"
               variant="outlined"

--- a/frontend/app/src/components/settings/api-keys/ServiceKey.vue
+++ b/frontend/app/src/components/settings/api-keys/ServiceKey.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { useRefMap } from '@/composables/utils/useRefMap';
-
 const {
   apiKey,
   hideActions = false,
@@ -36,13 +34,13 @@ const currentValue = ref<string>('');
 const editMode = ref<boolean>(false);
 const cancellable = ref<boolean>(false);
 
-const errorMessages = useRefMap(() => status, (status) => {
+const errorMessages = computed<string[]>(() => {
   if (!status || status.success)
     return [];
   return [status.message];
 });
 
-const successMessages = useRefMap(() => status, (status) => {
+const successMessages = computed<string[]>(() => {
   if (!status || !status.success)
     return [];
   return [status.message];

--- a/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysForm.vue
+++ b/frontend/app/src/components/settings/api-keys/exchange/ExchangeKeysForm.vue
@@ -10,7 +10,6 @@ import ExchangeKeysFormStructure from '@/components/settings/api-keys/exchange/E
 import OkxRegionSelectorItem from '@/components/settings/api-keys/exchange/OkxRegionSelectorItem.vue';
 import { useFormStateWatcher } from '@/composables/form';
 import { useLocations } from '@/composables/locations';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { useLocationStore } from '@/store/locations';
 import { useSessionSettingsStore } from '@/store/settings/session';
 import { type ExchangeFormData, KrakenAccountType, OkxLocation } from '@/types/exchanges';
@@ -67,8 +66,7 @@ const isOkx = computed(() => {
   return ['okx'].includes(location);
 });
 
-const location = useRefMap(modelValue, item => item.location);
-const experimental = useIsExperimentalExchange(location);
+const experimental = useIsExperimentalExchange(() => get(modelValue).location);
 
 const showKeyWaitingTimeWarning = logicOr(isKraken, isCoinbase, isCoinbasePro);
 

--- a/frontend/app/src/components/settings/data-security/backups/BackupManager.vue
+++ b/frontend/app/src/components/settings/data-security/backups/BackupManager.vue
@@ -4,7 +4,6 @@ import { Severity } from '@rotki/common';
 import DatabaseBackups from '@/components/settings/data-security/backups/DatabaseBackups.vue';
 import SettingCategoryHeader from '@/components/settings/SettingCategoryHeader.vue';
 import { useBackupApi } from '@/composables/api/backup';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { useConfirmStore } from '@/store/confirm';
 import { useNotificationsStore } from '@/store/notifications';
 import { getErrorMessage } from '@/utils/error-handling';
@@ -15,15 +14,16 @@ const { t } = useI18n({ useScope: 'global' });
 
 const backupInfo = ref<DatabaseInfo>();
 const selected = ref<UserDbBackupWithId[]>([]);
-const loading = ref(false);
-const saving = ref(false);
-
-const backups = useRefMap(
-  backupInfo,
-  info => info?.userdb?.backups.map((x, index) => ({ ...x, id: index + 1 })) ?? [],
-);
+const loading = ref<boolean>(false);
+const saving = ref<boolean>(false);
 
 const { notify } = useNotificationsStore();
+const { createBackup, deleteBackup, info } = useBackupApi();
+const { show } = useConfirmStore();
+
+const backups = computed<UserDbBackupWithId[]>(
+  () => get(backupInfo)?.userdb?.backups.map((x, index) => ({ ...x, id: index + 1 })) ?? [],
+);
 
 const directory = computed<string>(() => {
   const info = get(backupInfo);
@@ -38,8 +38,6 @@ const directory = computed<string>(() => {
 
   return filepath.slice(0, index + 1);
 });
-
-const { createBackup, deleteBackup, info } = useBackupApi();
 
 async function loadInfo() {
   try {
@@ -155,8 +153,6 @@ async function backup() {
     set(saving, false);
   }
 }
-
-const { show } = useConfirmStore();
 
 function showMassDeleteConfirmation() {
   show(

--- a/frontend/app/src/components/settings/explorers/Explorers.vue
+++ b/frontend/app/src/components/settings/explorers/Explorers.vue
@@ -4,7 +4,6 @@ import ChainDisplay from '@/components/accounts/blockchain/ChainDisplay.vue';
 import AssetDetails from '@/components/helper/AssetDetails.vue';
 import SettingsItem from '@/components/settings/controls/SettingsItem.vue';
 import ExplorerInput from '@/components/settings/explorers/ExplorerInput.vue';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { useValueOrDefault } from '@/composables/utils/useValueOrDefault';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
 import { type ExplorerUrls, explorerUrls } from '@/types/asset/asset-urls';
@@ -41,23 +40,23 @@ const userUrls = computed(() => {
 });
 
 const addressUrl = useValueOrDefault(
-  useRefMap(userUrls, setting => setting?.address),
-  useRefMap(defaultUrls, ({ address }) => address || null),
+  () => get(userUrls)?.address,
+  () => get(defaultUrls).address || null,
 );
 
 const txUrl = useValueOrDefault(
-  useRefMap(userUrls, setting => setting?.transaction),
-  useRefMap(defaultUrls, ({ transaction }) => transaction || null),
+  () => get(userUrls)?.transaction,
+  () => get(defaultUrls).transaction || null,
 );
 
 const blockUrl = useValueOrDefault(
-  useRefMap(userUrls, setting => setting?.block),
-  useRefMap(defaultUrls, ({ block }) => block || null),
+  () => get(userUrls)?.block,
+  () => get(defaultUrls).block || null,
 );
 
 const tokenUrl = useValueOrDefault(
-  useRefMap(userUrls, setting => setting?.token),
-  useRefMap(defaultUrls, ({ token }) => token || null),
+  () => get(userUrls)?.token,
+  () => get(defaultUrls).token || null,
 );
 
 function onChange() {

--- a/frontend/app/src/components/staking/liquity/LiquityStatistics.vue
+++ b/frontend/app/src/components/staking/liquity/LiquityStatistics.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { type AssetBalance, type Balance, type BigNumber, type LiquityPoolDetailEntry, type LiquityStatisticDetails, One } from '@rotki/common';
 import BalanceDisplay from '@/components/display/BalanceDisplay.vue';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { FiatDisplay } from '@/modules/amount-display/components';
 import { usePriceUtils } from '@/modules/prices/use-price-utils';
 import { useStatusStore } from '@/store/status';
@@ -12,16 +11,17 @@ const { pool = null, statistic = null } = defineProps<{
   statistic?: LiquityStatisticDetails | null;
   pool?: LiquityPoolDetailEntry | null;
 }>();
+
+const selection = ref<'historical' | 'current'>('historical');
+
+const { t } = useI18n({ useScope: 'global' });
 const { assetPrice } = usePriceUtils();
+const { isLoading } = useStatusStore();
+
 const LUSD_ID = 'eip155:1/erc20:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0';
 const lusdPrice = assetPrice(LUSD_ID);
 
-const { t } = useI18n({ useScope: 'global' });
-
-const { isLoading } = useStatusStore();
 const loading = isLoading(Section.DEFI_LIQUITY_STATISTICS);
-
-const selection = ref<'historical' | 'current'>('historical');
 
 const statisticWithAdjustedPrice = computed<LiquityStatisticDetails | null>(() => {
   if (!statistic)
@@ -63,31 +63,27 @@ const statisticWithAdjustedPrice = computed<LiquityStatisticDetails | null>(() =
   };
 });
 
-const totalDepositedStabilityPoolBalance = useRefMap<LiquityStatisticDetails | null, Balance | null>(
-  statisticWithAdjustedPrice,
-  (data) => {
-    if (!data)
-      return null;
+const totalDepositedStabilityPoolBalance = computed<Balance | null>(() => {
+  const data = get(statisticWithAdjustedPrice);
+  if (!data)
+    return null;
 
-    return {
-      amount: data.totalDepositedStabilityPool,
-      value: data.totalDepositedStabilityPoolValue,
-    };
-  },
-);
+  return {
+    amount: data.totalDepositedStabilityPool,
+    value: data.totalDepositedStabilityPoolValue,
+  };
+});
 
-const totalWithdrawnStabilityPoolBalance = useRefMap<LiquityStatisticDetails | null, Balance | null>(
-  statisticWithAdjustedPrice,
-  (data) => {
-    if (!data)
-      return null;
+const totalWithdrawnStabilityPoolBalance = computed<Balance | null>(() => {
+  const data = get(statisticWithAdjustedPrice);
+  if (!data)
+    return null;
 
-    return {
-      amount: data.totalWithdrawnStabilityPool,
-      value: data.totalWithdrawnStabilityPoolValue,
-    };
-  },
-);
+  return {
+    amount: data.totalWithdrawnStabilityPool,
+    value: data.totalWithdrawnStabilityPoolValue,
+  };
+});
 
 /**
  * Calculate the estimated PnL, by finding difference between these two things:

--- a/frontend/app/src/composables/defi/airdrops/metadata.ts
+++ b/frontend/app/src/composables/defi/airdrops/metadata.ts
@@ -3,7 +3,6 @@ import type { ProtocolMetadata } from '@/types/defi';
 import { transformCase } from '@rotki/common';
 import { camelCase } from 'es-toolkit';
 import { useDefiApi } from '@/composables/api/defi';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { useValueOrDefault } from '@/composables/utils/useValueOrDefault';
 import { useMainStore } from '@/store/main';
 import { getPublicProtocolImagePath } from '@/utils/file';
@@ -30,7 +29,7 @@ export const useAirdropsMetadata = createSharedComposable(() => {
 
   const getAirdropName = (identifier: MaybeRefOrGetter<string>): ComputedRef<string> =>
     useValueOrDefault(
-      useRefMap(getAirdropData(identifier), i => i?.name),
+      () => get(getAirdropData(identifier))?.name,
       identifier,
     );
 

--- a/frontend/app/src/composables/defi/metadata.ts
+++ b/frontend/app/src/composables/defi/metadata.ts
@@ -1,9 +1,8 @@
-import type { MaybeRef } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
 import type { ProtocolMetadata } from '@/types/defi';
 import { decodeHtmlEntities } from '@rotki/common';
 import { camelCase } from 'es-toolkit';
 import { useDefiApi } from '@/composables/api/defi';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { useValueOrDefault } from '@/composables/utils/useValueOrDefault';
 import { useMainStore } from '@/store/main';
 import { getPublicProtocolImagePath } from '@/utils/file';
@@ -26,29 +25,32 @@ export const useDefiMetadata = createSharedComposable(() => {
     { evaluating: loading },
   );
 
-  const getDefiData = (identifier: MaybeRef<string>): ComputedRef<ProtocolMetadata | undefined> =>
-    useArrayFind(metadata, item => camelCase(item.identifier) === camelCase(get(identifier)));
+  const getDefiData = (identifier: MaybeRefOrGetter<string>): ComputedRef<ProtocolMetadata | undefined> =>
+    useArrayFind(metadata, item => camelCase(item.identifier) === camelCase(toValue(identifier)));
 
-  const getDefiDataByName = (name: MaybeRef<string>): ComputedRef<ProtocolMetadata | undefined> =>
-    useArrayFind<ProtocolMetadata>(metadata, item => decodeHtmlEntities(item.name) === decodeHtmlEntities(get(name)));
+  const getDefiDataByName = (name: MaybeRefOrGetter<string>): ComputedRef<ProtocolMetadata | undefined> =>
+    useArrayFind<ProtocolMetadata>(metadata, item => decodeHtmlEntities(item.name) === decodeHtmlEntities(toValue(name)));
 
-  const getDefiName = (identifier: MaybeRef<string>): ComputedRef<string> =>
+  const getDefiName = (identifier: MaybeRefOrGetter<string>): ComputedRef<string> =>
     useValueOrDefault(
-      useRefMap(getDefiData(identifier), i => i?.name && decodeHtmlEntities(i?.name)),
+      computed<string | undefined>(() => {
+        const data = get(getDefiData(identifier));
+        return data?.name && decodeHtmlEntities(data.name);
+      }),
       identifier,
     );
 
   const getDefiImageUrl = (identifier: string, icon: string | undefined): string => {
-    const imageName = icon ?? `${get(identifier)}.svg`;
+    const imageName = icon ?? `${identifier}.svg`;
     return getPublicProtocolImagePath(imageName);
   };
 
-  const getDefiImage = (identifier: MaybeRef<string>): ComputedRef<string> =>
-    computed(() => getDefiImageUrl(get(identifier), get(getDefiData(identifier))?.icon));
+  const getDefiImage = (identifier: MaybeRefOrGetter<string>): ComputedRef<string> =>
+    computed(() => getDefiImageUrl(toValue(identifier), get(getDefiData(identifier))?.icon));
 
-  const getDefiIdentifierByName = (name: MaybeRef<string>): ComputedRef<string> =>
+  const getDefiIdentifierByName = (name: MaybeRefOrGetter<string>): ComputedRef<string> =>
     useValueOrDefault(
-      useRefMap(getDefiDataByName(name), i => i?.identifier),
+      computed<string | undefined>(() => get(getDefiDataByName(name))?.identifier),
       name,
     );
 

--- a/frontend/app/src/composables/history/events/mapping/index.ts
+++ b/frontend/app/src/composables/history/events/mapping/index.ts
@@ -9,7 +9,6 @@ import { HistoryEventEntryType, toCapitalCase, toSentenceCase, toSnakeCase } fro
 import { startPromise } from '@shared/utils';
 import { cloneDeep } from 'es-toolkit';
 import { useHistoryEventsApi } from '@/composables/api/history/events';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { getErrorMessage, useNotifications } from '@/modules/notifications/use-notifications';
 import { useLocationStore } from '@/store/locations';
 import { uniqueStrings } from '@/utils/data';
@@ -39,12 +38,9 @@ export const useHistoryEventMappings = createSharedComposable(() => {
   const { getTransactionTypeMappings } = useHistoryEventsApi();
   const { notify } = useNotifications();
 
-  const historyEventTypeGlobalMapping = useRefMap(historyEventTypeData, ({ globalMappings }) => globalMappings);
+  const historyEventTypeGlobalMapping = computed(() => get(historyEventTypeData).globalMappings);
 
-  const historyEventTypeByEntryTypeMapping = useRefMap(
-    historyEventTypeData,
-    ({ entryTypeMappings }) => entryTypeMappings,
-  );
+  const historyEventTypeByEntryTypeMapping = computed(() => get(historyEventTypeData).entryTypeMappings);
 
   const historyEventTypes = computed<string[]>(() => Object.keys(get(historyEventTypeGlobalMapping)));
 
@@ -73,8 +69,8 @@ export const useHistoryEventMappings = createSharedComposable(() => {
     };
   });
 
-  const transactionEventTypesData: ComputedRef<HistoryEventCategoryMapping> = useRefMap(historyEventTypeData, ({ eventCategoryDetails }) => {
-    const newEventCategoryDetails = cloneDeep(eventCategoryDetails);
+  const transactionEventTypesData = computed<HistoryEventCategoryMapping>(() => {
+    const newEventCategoryDetails = cloneDeep(get(historyEventTypeData).eventCategoryDetails);
     for (const eventCategory in newEventCategoryDetails) {
       const counterpartyMappings = newEventCategoryDetails[eventCategory].counterpartyMappings;
       for (const counterparty in counterpartyMappings) {
@@ -87,8 +83,8 @@ export const useHistoryEventMappings = createSharedComposable(() => {
     return newEventCategoryDetails;
   });
 
-  const accountingEventsTypeData: Ref<ActionDataEntry[]> = useRefMap(historyEventTypeData, ({ accountingEventsIcons }) =>
-    Object.entries(accountingEventsIcons).map(([identifier, icon]) => {
+  const accountingEventsTypeData = computed<ActionDataEntry[]>(() =>
+    Object.entries(get(historyEventTypeData).accountingEventsIcons).map(([identifier, icon]) => {
       const translationId = toSnakeCase(identifier);
       const translationKey = `backend_mappings.profit_loss_event_type.${translationId}`;
 

--- a/frontend/app/src/composables/info/chains.ts
+++ b/frontend/app/src/composables/info/chains.ts
@@ -228,7 +228,7 @@ export const useSupportedChains = createSharedComposable(() => {
   };
 
   const getBlockchainRedirectLink = (blockchain: string): string => {
-    const chain = get(blockchain);
+    const chain = blockchain;
     if (chain === Blockchain.ETH2) {
       return '/staking/eth2';
     }
@@ -241,6 +241,10 @@ export const useSupportedChains = createSharedComposable(() => {
     }
     return `${basePath}?chain=${chain}`;
   };
+
+  function useBlockchainRedirectLink(blockchain: MaybeRefOrGetter<string>): ComputedRef<string> {
+    return computed<string>(() => getBlockchainRedirectLink(toValue(blockchain)));
+  }
 
   return {
     allEvmChains,
@@ -261,6 +265,7 @@ export const useSupportedChains = createSharedComposable(() => {
     getChainName,
     getEvmChainName,
     getNativeAsset,
+    useBlockchainRedirectLink,
     isBtcChains,
     isDecodableChains,
     isEvm,

--- a/frontend/app/src/composables/utils/useRefMap/index.ts
+++ b/frontend/app/src/composables/utils/useRefMap/index.ts
@@ -1,5 +1,0 @@
-import type { ComputedRef, MaybeRefOrGetter } from 'vue';
-
-export function useRefMap<I extends object | null | undefined, O>(inp: MaybeRefOrGetter<I>, map: (inp: I) => O): ComputedRef<O> {
-  return computed(() => map(toValue(inp)));
-}

--- a/frontend/app/src/modules/balances/protocols/ProtocolMenuItem.vue
+++ b/frontend/app/src/modules/balances/protocols/ProtocolMenuItem.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { type ProtocolBalance, toSentenceCase, toSnakeCase } from '@rotki/common';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { AssetAmountDisplay, FiatDisplay, ValueDisplay } from '@/modules/amount-display/components';
 import ProtocolIcon from '@/modules/balances/protocols/ProtocolIcon.vue';
 import { useProtocolData } from '@/modules/balances/protocols/use-protocol-data';
@@ -11,10 +10,8 @@ const { protocolBalance, asset, loading } = defineProps<{
   loading?: boolean;
 }>();
 
-const protocol = useRefMap(() => protocolBalance, balance => balance.protocol);
-
 const { t } = useI18n({ useScope: 'global' });
-const { protocolData } = useProtocolData(protocol);
+const { protocolData } = useProtocolData(() => protocolBalance.protocol);
 
 const dot = '•';
 </script>
@@ -22,13 +19,13 @@ const dot = '•';
 <template>
   <div class="flex items-center gap-3 py-1">
     <ProtocolIcon
-      :protocol="toSnakeCase(protocol)"
+      :protocol="toSnakeCase(protocolBalance.protocol)"
       :size="20"
     />
 
     <div class="flex flex-col flex-1">
       <div class="font-medium text-sm">
-        {{ protocolData?.name ?? toSentenceCase(protocol) }}
+        {{ protocolData?.name ?? toSentenceCase(protocolBalance.protocol) }}
         <span
           v-if="protocolBalance.containsManual"
           class="font-normal text-caption text-rui-text-secondary"

--- a/frontend/app/src/modules/balances/protocols/ProtocolTooltipIcon.vue
+++ b/frontend/app/src/modules/balances/protocols/ProtocolTooltipIcon.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
 import { Blockchain, type ProtocolBalance, toSentenceCase, transformCase } from '@rotki/common';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { AssetAmountDisplay, FiatDisplay, ValueDisplay } from '@/modules/amount-display/components';
 import ProtocolIcon from '@/modules/balances/protocols/ProtocolIcon.vue';
 import { useProtocolData } from '@/modules/balances/protocols/use-protocol-data';
@@ -14,15 +13,14 @@ const { protocolBalance, asset, loading } = defineProps<{
   loading?: boolean;
 }>();
 
-const protocol = useRefMap(() => protocolBalance, balance => balance.protocol);
-
 const { shouldShowAmount } = storeToRefs(useFrontendSettingsStore());
-const { t } = useI18n({ useScope: 'global' });
 
-const { isProxy, parsedProtocol, proxyAddress } = useProxyProtocol(protocol);
+const { t } = useI18n({ useScope: 'global' });
+const { isProxy, parsedProtocol, proxyAddress } = useProxyProtocol(() => protocolBalance.protocol);
+const { protocolData } = useProtocolData(parsedProtocol);
 
 const transformedProtocol = computed<string>(() => {
-  const value = get(protocol);
+  const value = protocolBalance.protocol;
   if (get(isProxy)) {
     const parts = value.split(':');
     // Only transform the protocol part, keep the address intact
@@ -30,8 +28,6 @@ const transformedProtocol = computed<string>(() => {
   }
   return transformCase(value);
 });
-
-const { protocolData } = useProtocolData(parsedProtocol);
 
 const name = computed<string>(() => {
   const data = get(protocolData);

--- a/frontend/app/src/modules/balances/protocols/use-protocol-data.ts
+++ b/frontend/app/src/modules/balances/protocols/use-protocol-data.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRef } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import { toSentenceCase } from '@rotki/common';
 import { useDefiMetadata } from '@/composables/defi/metadata';
 import { useHistoryEventCounterpartyMappings } from '@/composables/history/events/mapping/counterparty';
@@ -12,7 +12,7 @@ type ProtocolData = ImageProtocol | IconProtocol | undefined;
 
 interface UseProtocolDataReturn { protocolData: ComputedRef<ProtocolData> }
 
-export function useProtocolData(protocol: MaybeRef<string>, isDark: MaybeRef<boolean> = false): UseProtocolDataReturn {
+export function useProtocolData(protocol: MaybeRefOrGetter<string>, isDark: MaybeRefOrGetter<boolean> = false): UseProtocolDataReturn {
   const { locationData: useLocationData } = useLocations();
   const { getDefiData, getDefiImageUrl } = useDefiMetadata();
   const { getBaseCounterpartyData } = useHistoryEventCounterpartyMappings();
@@ -21,7 +21,7 @@ export function useProtocolData(protocol: MaybeRef<string>, isDark: MaybeRef<boo
   const defiData = getDefiData(protocol);
 
   const protocolData = computed<ProtocolData>(() => {
-    const name = get(protocol);
+    const name = toValue(protocol);
     const formattedName = toSentenceCase(name);
     if (name === 'address') {
       return {
@@ -50,7 +50,7 @@ export function useProtocolData(protocol: MaybeRef<string>, isDark: MaybeRef<boo
       }
     }
 
-    const counterparty = getBaseCounterpartyData(name, get(isDark));
+    const counterparty = getBaseCounterpartyData(name, toValue(isDark));
     if (counterparty) {
       return {
         image: counterparty.image,

--- a/frontend/app/src/modules/dashboard/summary/BlockchainBalanceCardList.vue
+++ b/frontend/app/src/modules/dashboard/summary/BlockchainBalanceCardList.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
-import type { RouteLocationRaw } from 'vue-router';
 import type { BlockchainTotal } from '@/types/blockchain';
 import { Blockchain, toSentenceCase } from '@rotki/common';
 import Eth2ValidatorLimitTooltip from '@/components/accounts/blockchain/eth2/Eth2ValidatorLimitTooltip.vue';
 import ListItem from '@/components/common/ListItem.vue';
 import ChainIcon from '@/components/helper/display/icons/ChainIcon.vue';
 import { useSupportedChains } from '@/composables/info/chains';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { FiatDisplay } from '@/modules/amount-display/components';
 
 interface BlockChainBalanceCardListProps {
@@ -15,12 +13,10 @@ interface BlockChainBalanceCardListProps {
 
 const { total } = defineProps<BlockChainBalanceCardListProps>();
 
-const { getBlockchainRedirectLink, getChainName } = useSupportedChains();
+const { useBlockchainRedirectLink, getChainName } = useSupportedChains();
 
-const chain = useRefMap(() => total, ({ chain }) => chain);
-const name = getChainName(chain);
-
-const navTarget = computed<RouteLocationRaw>(() => getBlockchainRedirectLink(total.chain));
+const name = getChainName(() => total.chain);
+const navTarget = useBlockchainRedirectLink(() => total.chain);
 </script>
 
 <template>
@@ -35,7 +31,7 @@ const navTarget = computed<RouteLocationRaw>(() => getBlockchainRedirectLink(tot
           <div class="grayscale group-hover:grayscale-0">
             <ChainIcon
               size="24px"
-              :chain="chain"
+              :chain="total.chain"
             />
           </div>
         </template>
@@ -43,7 +39,7 @@ const navTarget = computed<RouteLocationRaw>(() => getBlockchainRedirectLink(tot
           {{ toSentenceCase(name) }}
 
           <div class="flex gap-2 items-center">
-            <Eth2ValidatorLimitTooltip v-if="chain === Blockchain.ETH2" />
+            <Eth2ValidatorLimitTooltip v-if="total.chain === Blockchain.ETH2" />
 
             <FiatDisplay
               :value="total.value"

--- a/frontend/app/src/modules/onchain/send/TradeAmountInput.vue
+++ b/frontend/app/src/modules/onchain/send/TradeAmountInput.vue
@@ -2,7 +2,6 @@
 import { bigNumberify } from '@rotki/common';
 import { get, set } from '@vueuse/core';
 import AmountInput from '@/components/inputs/AmountInput.vue';
-import { useRefMap } from '@/composables/utils/useRefMap';
 import { AssetAmountDisplay, FiatDisplay } from '@/modules/amount-display/components';
 import { useTradableAsset } from '@/modules/onchain/use-tradable-asset';
 import { useGeneralSettingsStore } from '@/store/settings/general';
@@ -28,7 +27,7 @@ const { currency } = storeToRefs(useGeneralSettingsStore());
 
 const { getAssetDetail } = useTradableAsset(computed<string | undefined>(() => address));
 const assetDetail = getAssetDetail(computed<string>(() => asset), computed<string>(() => chain));
-const price = useRefMap(assetDetail, m => m?.price);
+const price = computed(() => get(assetDetail)?.price);
 const fiatValueToBigNumber = bigNumberifyFromRef(fiatValue);
 const amountToBigNumber = bigNumberifyFromRef(model);
 

--- a/frontend/app/src/store/assets/ignored.ts
+++ b/frontend/app/src/store/assets/ignored.ts
@@ -1,4 +1,4 @@
-import type { MaybeRef } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
 import type { ActionStatus } from '@/types/action';
 import { useAssetIgnoreApi } from '@/composables/api/assets/ignore';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
@@ -117,10 +117,9 @@ export const useIgnoredAssetsStore = defineStore('assets/ignored', () => {
 
   const isAssetIgnored = (asset: string): boolean => get(ignoredAssets).includes(asset);
 
-  const useIsAssetIgnored = (asset: MaybeRef<string>): ComputedRef<boolean> => computed<boolean>(() => {
-    const selectedAsset = get(asset);
-    return isAssetIgnored(selectedAsset);
-  });
+  function useIsAssetIgnored(asset: MaybeRefOrGetter<string>): ComputedRef<boolean> {
+    return computed<boolean>(() => isAssetIgnored(toValue(asset)));
+  }
 
   const addIgnoredAsset = (asset: string): void => {
     const ignored = get(ignoredAssets);

--- a/frontend/app/src/store/locations.ts
+++ b/frontend/app/src/store/locations.ts
@@ -72,7 +72,9 @@ export const useLocationStore = defineStore('locations', () => {
     return get(exchangesWithKey).filter(key => locations[key].exchangeDetails?.experimental);
   });
 
-  const useIsExperimentalExchange = (location: MaybeRef<string>): ComputedRef<boolean> => computed(() => get(experimentalExchanges).includes(get(location)));
+  function useIsExperimentalExchange(location: MaybeRefOrGetter<string>): ComputedRef<boolean> {
+    return computed(() => get(experimentalExchanges).includes(toValue(location)));
+  }
 
   return {
     allExchanges,


### PR DESCRIPTION
## Summary

- Remove the `useRefMap` composable — a one-liner wrapper around `computed(() => map(toValue(inp)))` — and replace all 41 usages across 21 files
- Simple property extractions are inlined directly in templates
- Composable arguments replaced with getter functions (`() => prop.field`) where the target accepts `MaybeRefOrGetter`
- Complex transforms replaced with explicit `computed()`
- Update `useProtocolData`, `useIsExperimentalExchange`, `useIsAssetIgnored`, and defi metadata functions from `MaybeRef` to `MaybeRefOrGetter`

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint:fix` passes (0 errors)
- [x] `pnpm run test:unit` passes (238 files, 2743 tests)