### PR TITLE
refactor(frontend): use/get split for status store

### DIFF
--- a/frontend/app/src/components/accounts/EvmAccountPageButtons.vue
+++ b/frontend/app/src/components/accounts/EvmAccountPageButtons.vue
@@ -4,7 +4,7 @@ import AccountBalancesExportImport from '@/components/accounts/AccountBalancesEx
 import BlockchainBalanceRefreshBehaviourMenu
   from '@/components/dashboard/blockchain-balance/BlockchainBalanceRefreshBehaviourMenu.vue';
 import { useBlockchainAccountLoading } from '@/composables/accounts/blockchain/use-account-loading';
-import { useStatusStore } from '@/store/status';
+import { useSectionStatus } from '@/composables/status';
 import { useTaskStore } from '@/store/tasks';
 import { Section } from '@/types/status';
 import { TaskType } from '@/types/task-type';
@@ -22,11 +22,11 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 const { isSectionLoading, refreshDisabled } = useBlockchainAccountLoading('evm');
-const { isLoading } = useStatusStore();
 const { useIsTaskRunning } = useTaskStore();
+const { isLoading: eth2Loading } = useSectionStatus(Section.BLOCKCHAIN, Blockchain.ETH2);
 
 const isEth2Loading = logicOr(
-  isLoading(Section.BLOCKCHAIN, Blockchain.ETH2),
+  eth2Loading,
   useIsTaskRunning(TaskType.FETCH_ETH2_VALIDATORS),
 );
 </script>

--- a/frontend/app/src/components/accounts/manual-balances/use-manual-balance-table-actions.ts
+++ b/frontend/app/src/components/accounts/manual-balances/use-manual-balance-table-actions.ts
@@ -1,9 +1,9 @@
 import type { ComputedRef } from 'vue';
 import type { ManualBalance, ManualBalanceWithPrice } from '@/types/manual-balances';
 import { omit } from 'es-toolkit';
+import { useSectionStatus } from '@/composables/status';
 import { useManualBalances } from '@/modules/balances/manual/use-manual-balances';
 import { useConfirmStore } from '@/store/confirm';
-import { useStatusStore } from '@/store/status';
 import { Section } from '@/types/status';
 
 interface UseManualBalanceTableActionsReturn {
@@ -17,11 +17,10 @@ interface UseManualBalanceTableActionsReturn {
 export function useManualBalanceTableActions(): UseManualBalanceTableActionsReturn {
   const { deleteManualBalance, fetchManualBalances } = useManualBalances();
   const { show } = useConfirmStore();
-  const { isLoading } = useStatusStore();
   const { t } = useI18n({ useScope: 'global' });
 
-  const refreshing = isLoading(Section.MANUAL_BALANCES);
-  const pricesLoading = isLoading(Section.PRICES);
+  const { isLoading: refreshing } = useSectionStatus(Section.MANUAL_BALANCES);
+  const { isLoading: pricesLoading } = useSectionStatus(Section.PRICES);
 
   async function refresh(): Promise<void> {
     await fetchManualBalances(true);

--- a/frontend/app/src/components/assets/AssetValueRow.vue
+++ b/frontend/app/src/components/assets/AssetValueRow.vue
@@ -6,12 +6,12 @@ import CardTitle from '@/components/typography/CardTitle.vue';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { useAggregatedBalances } from '@/composables/balances/use-aggregated-balances';
 import { useLatestPrices } from '@/composables/price-manager/latest';
+import { useSectionStatus } from '@/composables/status';
 import { AssetAmountDisplay, AssetValueDisplay, FiatDisplay } from '@/modules/amount-display/components';
 import { usePriceRefresh } from '@/modules/prices/use-price-refresh';
 import { usePriceUtils } from '@/modules/prices/use-price-utils';
 import { useConfirmStore } from '@/store/confirm';
 import { useGeneralSettingsStore } from '@/store/settings/general';
-import { useStatusStore } from '@/store/status';
 import { Section } from '@/types/status';
 
 const { identifier, isCollectionParent = false } = defineProps<{
@@ -24,9 +24,7 @@ const { assetPrice } = usePriceUtils();
 
 const { getAssetField } = useAssetInfoRetrieval();
 const { refreshPrice } = usePriceRefresh();
-const { isLoading } = useStatusStore();
-
-const refreshingPrices = isLoading(Section.PRICES);
+const { isLoading: refreshingPrices } = useSectionStatus(Section.PRICES);
 
 const info = assetPriceInfo(() => identifier, () => isCollectionParent);
 const price = assetPrice(() => identifier);

--- a/frontend/app/src/components/dashboard/OverallBalances.vue
+++ b/frontend/app/src/components/dashboard/OverallBalances.vue
@@ -5,12 +5,12 @@ import SnapshotActionButton from '@/components/dashboard/SnapshotActionButton.vu
 import PercentageDisplay from '@/components/display/PercentageDisplay.vue';
 import TimeframeSelector from '@/components/helper/TimeframeSelector.vue';
 import { usePremium } from '@/composables/premium';
+import { useSectionStatus } from '@/composables/status';
 import { FiatDisplay } from '@/modules/amount-display/components';
 import NetWorthChart from '@/modules/dashboard/graph/NetWorthChart.vue';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
 import { useSessionSettingsStore } from '@/store/settings/session';
 import { useStatisticsStore } from '@/store/statistics';
-import { useStatusStore } from '@/store/status';
 import { Section } from '@/types/status';
 import { isPeriodAllowed } from '@/utils/settings';
 
@@ -25,12 +25,9 @@ const { totalNetWorth } = storeToRefs(statistics);
 const frontendStore = useFrontendSettingsStore();
 const { visibleTimeframes } = storeToRefs(frontendStore);
 
-const { isLoading: isSectionLoading, shouldShowLoadingScreen } = useStatusStore();
+const { isInitialLoading, isLoading: sectionLoading } = useSectionStatus(Section.BLOCKCHAIN);
 
-const isLoading = logicOr(
-  shouldShowLoadingScreen(Section.BLOCKCHAIN),
-  isSectionLoading(Section.BLOCKCHAIN),
-);
+const isLoading = logicOr(isInitialLoading, sectionLoading);
 
 const allTimeframes = computed(() =>
   timeframes((unit, amount) => dayjs().subtract(amount, unit).startOf(TimeUnit.DAY).unix()),

--- a/frontend/app/src/components/exchanges/BinanceSavingDetail.vue
+++ b/frontend/app/src/components/exchanges/BinanceSavingDetail.vue
@@ -5,12 +5,12 @@ import type { ExchangeSavingsEvent, ExchangeSavingsRequestPayload } from '@/type
 import DateDisplay from '@/components/display/DateDisplay.vue';
 import AssetDetails from '@/components/helper/AssetDetails.vue';
 import RowAppend from '@/components/helper/RowAppend.vue';
+import { useSectionStatus } from '@/composables/status';
 import { usePaginationFilters } from '@/composables/use-pagination-filter';
 import { AssetValueDisplay, FiatDisplay, ValueDisplay } from '@/modules/amount-display';
 import { useBinanceSavings } from '@/modules/balances/exchanges/use-binance-savings';
 import { TableId, useRememberTableSorting } from '@/modules/table/use-remember-table-sorting';
 import { useGeneralSettingsStore } from '@/store/settings/general';
-import { useStatusStore } from '@/store/status';
 import { Section } from '@/types/status';
 
 const { exchange } = defineProps<{
@@ -22,10 +22,8 @@ const { t } = useI18n({ useScope: 'global' });
 const savingsAssets = ref<string[]>([]);
 const savingsReceived = ref<AssetBalance[]>([]);
 
-const { isLoading: isSectionLoading } = useStatusStore();
+const { isLoading: loading } = useSectionStatus(Section.EXCHANGE_SAVINGS);
 const { fetchExchangeSavings } = useBinanceSavings();
-
-const loading = isSectionLoading(Section.EXCHANGE_SAVINGS);
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 
 const defaultParams = computed(() => ({

--- a/frontend/app/src/components/helper/PriceRefresh.vue
+++ b/frontend/app/src/components/helper/PriceRefresh.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { useBalancesLoading } from '@/composables/balances/loading';
 import { useAggregatedBalances } from '@/composables/balances/use-aggregated-balances';
+import { useSectionStatus } from '@/composables/status';
 import { usePriceRefresh } from '@/modules/prices/use-price-refresh';
-import { useStatusStore } from '@/store/status';
 import { Section } from '@/types/status';
 
 const emit = defineEmits<{
@@ -12,11 +12,9 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 const { refreshPrices } = usePriceRefresh();
-const { isLoading } = useStatusStore();
+const { isLoading: refreshing } = useSectionStatus(Section.PRICES);
 const { loadingBalances } = useBalancesLoading();
 const { assets } = useAggregatedBalances();
-
-const refreshing = isLoading(Section.PRICES);
 const disabled = computed<boolean>(() => get(refreshing) || get(loadingBalances));
 
 async function refresh() {

--- a/frontend/app/src/components/staking/kraken/KrakenPage.vue
+++ b/frontend/app/src/components/staking/kraken/KrakenPage.vue
@@ -9,18 +9,17 @@ import TablePageLayout from '@/components/layout/TablePageLayout.vue';
 import KrakenStaking from '@/components/staking/kraken/KrakenStaking.vue';
 import KrakenStakingPagePlaceholder from '@/components/staking/kraken/KrakenStakingPagePlaceholder.vue';
 import { usePremium } from '@/composables/premium';
+import { useSectionStatus } from '@/composables/status';
 import { usePriceRefresh } from '@/modules/prices/use-price-refresh';
 import { Routes } from '@/router/routes';
 import { useHistoricCachePriceStore } from '@/store/prices/historic';
 import { useSessionSettingsStore } from '@/store/settings/session';
 import { useKrakenStakingStore } from '@/store/staking/kraken';
-import { useStatusStore } from '@/store/status';
 import { Section } from '@/types/status';
 import { getPublicProtocolImagePath } from '@/utils/file';
 
 const filters = ref<KrakenStakingDateFilter>({});
 
-const { isLoading, shouldShowLoadingScreen } = useStatusStore();
 const store = useKrakenStakingStore();
 const { $reset, load } = store;
 const { events } = toRefs(store);
@@ -40,8 +39,7 @@ const addKrakenApiKeysLink: RouteLocationRaw = {
   },
 };
 
-const loading = shouldShowLoadingScreen(Section.STAKING_KRAKEN);
-const refreshing = isLoading(Section.STAKING_KRAKEN);
+const { isInitialLoading: loading, isLoading: refreshing } = useSectionStatus(Section.STAKING_KRAKEN);
 
 const isKrakenConnected = computed<boolean>(() => {
   const exchanges = get(connectedExchanges);

--- a/frontend/app/src/components/staking/liquity/LiquityPage.vue
+++ b/frontend/app/src/components/staking/liquity/LiquityPage.vue
@@ -17,7 +17,7 @@ const modules = [Module.LIQUITY];
 const { isModuleEnabled } = useModules();
 const { fetchPools, fetchStaking, fetchStatistics, setStakingQueryStatus } = useLiquityStore();
 const { resetProtocolStatsPriceQueryStatus } = useHistoricCachePriceStore();
-const { shouldShowLoadingScreen } = useStatusStore();
+const { useShouldShowLoadingScreen } = useStatusStore();
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
 const moduleEnabled = isModuleEnabled(modules[0]);
 const premium = usePremium();
@@ -52,17 +52,17 @@ watch(currencySymbol, async () => {
   }
 });
 
-watch(shouldShowLoadingScreen(Section.DEFI_LIQUITY_STAKING), async (current, old) => {
+watch(useShouldShowLoadingScreen(Section.DEFI_LIQUITY_STAKING), async (current, old) => {
   if (!old && current)
     await fetchStaking();
 });
 
-watch(shouldShowLoadingScreen(Section.DEFI_LIQUITY_STAKING_POOLS), async (current, old) => {
+watch(useShouldShowLoadingScreen(Section.DEFI_LIQUITY_STAKING_POOLS), async (current, old) => {
   if (!old && current)
     await fetchPools();
 });
 
-watch(shouldShowLoadingScreen(Section.DEFI_LIQUITY_STATISTICS), async (current, old) => {
+watch(useShouldShowLoadingScreen(Section.DEFI_LIQUITY_STATISTICS), async (current, old) => {
   if (!old && current)
     await fetchStatistics();
 });

--- a/frontend/app/src/components/staking/liquity/LiquityPools.vue
+++ b/frontend/app/src/components/staking/liquity/LiquityPools.vue
@@ -1,15 +1,14 @@
 <script setup lang="ts">
 import type { LiquityPoolDetailEntry } from '@rotki/common';
 import BalanceDisplay from '@/components/display/BalanceDisplay.vue';
-import { useStatusStore } from '@/store/status';
+import { useSectionStatus } from '@/composables/status';
 import { Section } from '@/types/status';
 
 defineProps<{ pool: LiquityPoolDetailEntry | null }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { isLoading } = useStatusStore();
-const loading = isLoading(Section.DEFI_LIQUITY_STAKING_POOLS);
+const { isLoading: loading } = useSectionStatus(Section.DEFI_LIQUITY_STAKING_POOLS);
 </script>
 
 <template>

--- a/frontend/app/src/components/staking/liquity/LiquityStake.vue
+++ b/frontend/app/src/components/staking/liquity/LiquityStake.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { LiquityStakingDetailEntry } from '@rotki/common';
 import BalanceDisplay from '@/components/display/BalanceDisplay.vue';
-import { useStatusStore } from '@/store/status';
+import { useSectionStatus } from '@/composables/status';
 import { Section } from '@/types/status';
 
 const { stake = null } = defineProps<{
@@ -10,8 +10,7 @@ const { stake = null } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { isLoading } = useStatusStore();
-const loading = isLoading(Section.DEFI_LIQUITY_STAKING);
+const { isLoading: loading } = useSectionStatus(Section.DEFI_LIQUITY_STAKING);
 </script>
 
 <template>

--- a/frontend/app/src/components/staking/liquity/LiquityStakingDetails.vue
+++ b/frontend/app/src/components/staking/liquity/LiquityStakingDetails.vue
@@ -17,10 +17,10 @@ import TablePageLayout from '@/components/layout/TablePageLayout.vue';
 import LiquityPools from '@/components/staking/liquity/LiquityPools.vue';
 import LiquityStake from '@/components/staking/liquity/LiquityStake.vue';
 import LiquityStatistics from '@/components/staking/liquity/LiquityStatistics.vue';
+import { useSectionStatus } from '@/composables/status';
 import HashLink from '@/modules/common/links/HashLink.vue';
 import { useLiquityStore } from '@/store/defi/liquity';
 import { useHistoricCachePriceStore } from '@/store/prices/historic';
-import { useStatusStore } from '@/store/status';
 import { Section } from '@/types/status';
 import { zeroBalance } from '@/utils/bignumbers';
 import { getAccountAddress } from '@/utils/blockchain/accounts/utils';
@@ -42,8 +42,7 @@ const { staking, stakingPools, stakingQueryStatus, statistics } = storeToRefs(li
 const { getProtocolStatsPriceQueryStatus } = useHistoricCachePriceStore();
 const liquityHistoricPriceStatus = getProtocolStatsPriceQueryStatus('liquity');
 
-const { isLoading } = useStatusStore();
-const loading = isLoading(Section.DEFI_LIQUITY_STAKING);
+const { isLoading: loading } = useSectionStatus(Section.DEFI_LIQUITY_STAKING);
 
 const chains = [Blockchain.ETH];
 

--- a/frontend/app/src/components/staking/liquity/LiquityStatistics.vue
+++ b/frontend/app/src/components/staking/liquity/LiquityStatistics.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { type AssetBalance, type Balance, type BigNumber, type LiquityPoolDetailEntry, type LiquityStatisticDetails, One } from '@rotki/common';
 import BalanceDisplay from '@/components/display/BalanceDisplay.vue';
+import { useSectionStatus } from '@/composables/status';
 import { FiatDisplay } from '@/modules/amount-display/components';
 import { usePriceUtils } from '@/modules/prices/use-price-utils';
-import { useStatusStore } from '@/store/status';
 import { Section } from '@/types/status';
 import { bigNumberSum } from '@/utils/calculation';
 
@@ -16,12 +16,10 @@ const selection = ref<'historical' | 'current'>('historical');
 
 const { t } = useI18n({ useScope: 'global' });
 const { assetPrice } = usePriceUtils();
-const { isLoading } = useStatusStore();
-
 const LUSD_ID = 'eip155:1/erc20:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0';
 const lusdPrice = assetPrice(LUSD_ID);
 
-const loading = isLoading(Section.DEFI_LIQUITY_STATISTICS);
+const { isLoading: loading } = useSectionStatus(Section.DEFI_LIQUITY_STATISTICS);
 
 const statisticWithAdjustedPrice = computed<LiquityStatisticDetails | null>(() => {
   if (!statistic)

--- a/frontend/app/src/composables/accounts/blockchain/use-account-loading.ts
+++ b/frontend/app/src/composables/accounts/blockchain/use-account-loading.ts
@@ -18,7 +18,7 @@ interface UseBlockchainAccountLoadingReturn {
 export function useBlockchainAccountLoading(category: MaybeRefOrGetter<string> = ''): UseBlockchainAccountLoadingReturn {
   const { useIsTaskRunning } = useTaskStore();
   const { massDetecting } = storeToRefs(useBlockchainTokensStore());
-  const { isLoading } = useStatusStore();
+  const { useIsLoading } = useStatusStore();
 
   const { chainIds, isEvm } = useAccountCategoryHelper(category);
 
@@ -41,9 +41,9 @@ export function useBlockchainAccountLoading(category: MaybeRefOrGetter<string> =
 
   const isSectionLoading = computed<boolean>(() => {
     if (!toValue(category))
-      return get(isLoading(Section.BLOCKCHAIN));
+      return get(useIsLoading(Section.BLOCKCHAIN));
 
-    const chainsTask = get(chainIds).map(chain => isLoading(Section.BLOCKCHAIN, chain));
+    const chainsTask = get(chainIds).map(chain => useIsLoading(Section.BLOCKCHAIN, chain));
     return get(logicOr(...(chainsTask)));
   });
 

--- a/frontend/app/src/composables/accounts/use-account-import-export.ts
+++ b/frontend/app/src/composables/accounts/use-account-import-export.ts
@@ -6,11 +6,11 @@ import { type StakingValidatorManage, useAccountManage } from '@/composables/acc
 import { useBlockchains } from '@/composables/blockchain/index';
 import { CSVMissingHeadersError, useCsvImportExport } from '@/composables/common/use-csv-import-export';
 import { useSupportedChains } from '@/composables/info/chains';
+import { useSectionStatus } from '@/composables/status';
 import { useBlockchainAccountData } from '@/modules/balances/blockchain/use-blockchain-account-data';
 import { useNotifications } from '@/modules/notifications/use-notifications';
 import { useBlockchainValidatorsStore } from '@/store/blockchain/validators';
 import { useTagStore } from '@/store/session/tags';
-import { useStatusStore } from '@/store/status';
 import { useAccountImportProgressStore } from '@/store/use-account-import-progress-store';
 import { Section } from '@/types/status';
 import { awaitParallelExecution } from '@/utils/await-parallel-execution';
@@ -73,7 +73,6 @@ export function useAccountImportExport(): UseAccountImportExportReturn {
   const { ethStakingValidators } = storeToRefs(useBlockchainValidatorsStore());
   const { addAccounts, addEvmAccounts } = useBlockchains();
   const { attemptTagCreation } = useTagStore();
-  const { isLoading } = useStatusStore();
   const { save } = useAccountManage();
   const { notifyError, notifyInfo } = useNotifications();
   const { generateCSV, parseCSV } = useCsvImportExport();
@@ -83,7 +82,7 @@ export function useAccountImportExport(): UseAccountImportExportReturn {
   const { increment, setTotal, skip } = progressStore;
   const { progress } = storeToRefs(progressStore);
 
-  const blockchainLoading = isLoading(Section.BLOCKCHAIN);
+  const { isLoading: blockchainLoading } = useSectionStatus(Section.BLOCKCHAIN);
   const doneLoading = refDebounced(logicNot(blockchainLoading), 2000);
 
   const csvToAccount = (acc: CSVRow): AccountPayload => ({

--- a/frontend/app/src/composables/staking/eth/use-eth-validator-operations.ts
+++ b/frontend/app/src/composables/staking/eth/use-eth-validator-operations.ts
@@ -4,8 +4,8 @@ import type { EthereumValidator } from '@/types/blockchain/accounts';
 import { Blockchain } from '@rotki/common';
 import { useAccountDelete } from '@/composables/accounts/blockchain/use-account-delete';
 import { useEthStaking } from '@/composables/blockchain/accounts/staking';
+import { useSectionStatus } from '@/composables/status';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
-import { useStatusStore } from '@/store/status';
 import { useTaskStore } from '@/store/tasks';
 import { Section } from '@/types/status';
 import { TaskType } from '@/types/task-type';
@@ -24,9 +24,7 @@ export function useEthValidatorOperations(): UseEthValidatorOperationsReturn {
   const { fetchEthStakingValidators } = useEthStaking();
   const { fetchBlockchainBalances } = useBlockchainBalances();
   const { useIsTaskRunning } = useTaskStore();
-  const { isLoading } = useStatusStore();
-
-  const loading = isLoading(Section.BLOCKCHAIN, Blockchain.ETH2);
+  const { isLoading: loading } = useSectionStatus(Section.BLOCKCHAIN, Blockchain.ETH2);
 
   const accountOperation = logicOr(
     useIsTaskRunning(TaskType.ADD_ACCOUNT),

--- a/frontend/app/src/composables/status.spec.ts
+++ b/frontend/app/src/composables/status.spec.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useStatusStore } from '@/store/status';
+import { Section, Status } from '@/types/status';
+import { waitUntilIdle } from './status';
+
+describe('waitUntilIdle', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should resolve immediately when section is not loading', async () => {
+    const promise = waitUntilIdle(Section.BLOCKCHAIN);
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('should resolve immediately when subsection is not loading', async () => {
+    const store = useStatusStore();
+    store.setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADING, subsection: 'eth' });
+
+    const promise = waitUntilIdle(Section.BLOCKCHAIN, 'btc');
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('should wait until section stops loading', async () => {
+    const store = useStatusStore();
+    store.setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADING });
+
+    let resolved = false;
+    const promise = waitUntilIdle(Section.BLOCKCHAIN).then(() => {
+      resolved = true;
+    });
+
+    await nextTick();
+    expect(resolved).toBe(false);
+
+    store.setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADED });
+    await promise;
+    expect(resolved).toBe(true);
+  });
+
+  it('should wait until subsection stops loading', async () => {
+    const store = useStatusStore();
+    store.setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADING, subsection: 'eth' });
+
+    let resolved = false;
+    const promise = waitUntilIdle(Section.BLOCKCHAIN, 'eth').then(() => {
+      resolved = true;
+    });
+
+    await nextTick();
+    expect(resolved).toBe(false);
+
+    store.setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADED, subsection: 'eth' });
+    await promise;
+    expect(resolved).toBe(true);
+  });
+
+  it('should resolve when status transitions from REFRESHING to LOADED', async () => {
+    const store = useStatusStore();
+    store.setStatus({ section: Section.BLOCKCHAIN, status: Status.REFRESHING });
+
+    let resolved = false;
+    const promise = waitUntilIdle(Section.BLOCKCHAIN).then(() => {
+      resolved = true;
+    });
+
+    await nextTick();
+    expect(resolved).toBe(false);
+
+    store.setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADED });
+    await promise;
+    expect(resolved).toBe(true);
+  });
+});

--- a/frontend/app/src/composables/status.ts
+++ b/frontend/app/src/composables/status.ts
@@ -1,5 +1,28 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import { useStatusStore } from '@/store/status';
 import { type Section, Status } from '@/types/status';
+
+interface UseSectionStatusReturn {
+  isInitialLoading: ComputedRef<boolean>;
+  isLoading: ComputedRef<boolean>;
+}
+
+export function useSectionStatus(
+  section: MaybeRefOrGetter<Section>,
+  subsection?: MaybeRefOrGetter<string>,
+): UseSectionStatusReturn {
+  const { useIsLoading, useShouldShowLoadingScreen } = useStatusStore();
+  return {
+    isInitialLoading: useShouldShowLoadingScreen(section, subsection),
+    isLoading: useIsLoading(section, subsection),
+  };
+}
+
+export async function waitUntilIdle(section: Section, subsection?: string): Promise<void> {
+  const { getIsLoading } = useStatusStore();
+  if (getIsLoading(section, subsection))
+    await until(() => getIsLoading(section, subsection)).toBe(false);
+}
 
 interface Opts {
   section?: Section;
@@ -16,7 +39,7 @@ interface UseStatusUpdaterReturn {
 }
 
 export function useStatusUpdater(defaultSection: Section): UseStatusUpdaterReturn {
-  const { getStatus, isLoading, setStatus } = useStatusStore();
+  const { getIsLoading, getStatus, setStatus } = useStatusStore();
   const updateStatus = (status: Status, opts: Opts = {}): void => {
     const { section = defaultSection, subsection } = opts;
 
@@ -39,19 +62,19 @@ export function useStatusUpdater(defaultSection: Section): UseStatusUpdaterRetur
 
   const loading = (opts: Opts = {}): boolean => {
     const { section = defaultSection, subsection } = opts;
-    return get(isLoading(section, subsection));
+    return getIsLoading(section, subsection);
   };
 
   const isFirstLoad = (opts: Opts = {}): boolean => {
     const { section = defaultSection, subsection } = opts;
-    return get(getStatus(section, subsection)) === Status.NONE;
+    return getStatus(section, subsection) === Status.NONE;
   };
 
   const fetchDisabled = (refresh: boolean, opts: Opts = {}): boolean => !(isFirstLoad(opts) || refresh) || loading(opts);
 
   const getSectionStatus = (opts: Opts = {}): Status => {
     const { section = defaultSection, subsection } = opts;
-    return get(getStatus(section, subsection));
+    return getStatus(section, subsection);
   };
 
   return {

--- a/frontend/app/src/modules/accounts/table/composables/use-account-loading-states.ts
+++ b/frontend/app/src/modules/accounts/table/composables/use-account-loading-states.ts
@@ -18,7 +18,7 @@ export function useAccountLoadingStates<T extends BlockchainAccountBalance>(
   category: MaybeRefOrGetter<string>,
 ): UseAccountLoadingStates<T> {
   const { useIsTaskRunning } = useTaskStore();
-  const { isLoading } = useStatusStore();
+  const { getIsLoading } = useStatusStore();
   const { isSectionLoading } = useBlockchainAccountLoading(category);
 
   const accountOperation = logicOr(
@@ -31,9 +31,9 @@ export function useAccountLoadingStates<T extends BlockchainAccountBalance>(
 
   function isRowLoading(row: AccountDataRow<T>): boolean {
     if (row.type === 'account')
-      return get(isLoading(Section.BLOCKCHAIN, row.chain));
+      return getIsLoading(Section.BLOCKCHAIN, row.chain);
     else
-      return row.chains.some(chain => get(isLoading(Section.BLOCKCHAIN, chain)));
+      return row.chains.some(chain => getIsLoading(Section.BLOCKCHAIN, chain));
   }
 
   return {

--- a/frontend/app/src/modules/balances/non-fungible/composables/use-nft-data.ts
+++ b/frontend/app/src/modules/balances/non-fungible/composables/use-nft-data.ts
@@ -4,13 +4,13 @@ import type { ComputedRef, Ref } from 'vue';
 import type { IgnoredAssetsHandlingType } from '@/types/asset';
 import type { Collection } from '@/types/collection';
 import type { NonFungibleBalance, NonFungibleBalancesRequestPayload } from '@/types/nfbalances';
+import { useSectionStatus } from '@/composables/status';
 import { usePaginationFilters } from '@/composables/use-pagination-filter';
 import { useNftBalances } from '@/modules/balances/nft/use-nft-balances';
 import { TableId, useRememberTableSorting } from '@/modules/table/use-remember-table-sorting';
 import { useFrontendSettingsStore } from '@/store/settings/frontend';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { useStatisticsStore } from '@/store/statistics';
-import { useStatusStore } from '@/store/status';
 import { DashboardTableType } from '@/types/settings/frontend-settings';
 import { Section } from '@/types/status';
 import { TableColumn } from '@/types/table-column';
@@ -51,8 +51,7 @@ export function useNftData(options: UseNftDataOptions = {}): UseNftDataReturn {
     ignoredAssetsHandling: get(ignoredAssetsHandling),
   }));
 
-  const { isLoading: isSectionLoading } = useStatusStore();
-  const sectionLoading = isSectionLoading(Section.NON_FUNGIBLE_BALANCES);
+  const { isLoading: sectionLoading } = useSectionStatus(Section.NON_FUNGIBLE_BALANCES);
 
   const {
     fetchData,

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -202,8 +202,8 @@ describe('useBlockchainBalances', () => {
         }, undefined);
       };
 
-      const { isLoading } = useStatusStore();
-      const loading = isLoading(Section.BLOCKCHAIN, Blockchain.ETH);
+      const { useIsLoading } = useStatusStore();
+      const loading = useIsLoading(Section.BLOCKCHAIN, Blockchain.ETH);
 
       startPromise(call());
       assert(1);
@@ -236,8 +236,8 @@ describe('useBlockchainBalances', () => {
         }, undefined);
       };
 
-      const { isLoading } = useStatusStore();
-      const loading = isLoading(Section.BLOCKCHAIN, Blockchain.ETH);
+      const { useIsLoading } = useStatusStore();
+      const loading = useIsLoading(Section.BLOCKCHAIN, Blockchain.ETH);
 
       startPromise(call());
       assert(1);
@@ -246,6 +246,7 @@ describe('useBlockchainBalances', () => {
       assert(1);
 
       await until(loading).toBe(false);
+      await nextTick();
       assert(2);
     });
 

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -1,6 +1,7 @@
 import type { BlockchainBalancePayload, FetchBlockchainBalancePayload } from '@/types/blockchain/balances';
 import { useBalanceQueue } from '@/composables/balances/use-balance-queue';
 import { useSupportedChains } from '@/composables/info/chains';
+import { waitUntilIdle } from '@/composables/status';
 import { useValueThreshold } from '@/composables/usd-value-threshold';
 import { useStatusStore } from '@/store/status';
 import { BalanceSource } from '@/types/settings/frontend-settings';
@@ -16,23 +17,20 @@ interface UseBlockchainBalancesReturn {
 
 export function useBlockchainBalances(): UseBlockchainBalancesReturn {
   const { supportedChains } = useSupportedChains();
-  const { isLoading } = useStatusStore();
+  const { getIsLoading } = useStatusStore();
   const valueThreshold = useValueThreshold(BalanceSource.BLOCKCHAIN);
 
   // Use services
   const { handleFetch } = useBalanceProcessingService();
   const { fetchLoopringBalances } = useLoopringBalanceService();
+  const { queueBalanceQueries } = useBalanceQueue();
 
   const fetchSingleChain = async (payload: FetchBlockchainBalancePayload, periodic: boolean): Promise<void> => {
-    const loading = isLoading(Section.BLOCKCHAIN, payload.blockchain);
-
-    // Skip if already loading and this is a periodic call
-    if (get(loading) && periodic)
-      return;
-
-    // Wait for existing operation to complete if not periodic
-    if (get(loading))
-      await until(loading).toBe(false);
+    if (getIsLoading(Section.BLOCKCHAIN, payload.blockchain)) {
+      if (periodic)
+        return;
+      await waitUntilIdle(Section.BLOCKCHAIN, payload.blockchain);
+    }
 
     await handleFetch(payload, get(valueThreshold));
   };
@@ -44,7 +42,6 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
     const { addresses, blockchain, ignoreCache = false, isXpub = false } = payload;
     const chains = blockchain ? arrayify(blockchain) : get(supportedChains).map(chain => chain.id);
 
-    const { queueBalanceQueries } = useBalanceQueue();
     await queueBalanceQueries(chains, async blockchain => fetchSingleChain({ addresses, blockchain, ignoreCache, isXpub }, periodic));
   };
 

--- a/frontend/app/src/modules/dashboard/liquidity-pools/use-pool-balances.ts
+++ b/frontend/app/src/modules/dashboard/liquidity-pools/use-pool-balances.ts
@@ -5,10 +5,10 @@ import { type BigNumber, Blockchain, createEvmIdentifierFromAddress, type Writea
 import { cloneDeep, isEqual } from 'es-toolkit';
 import { useAssetInfoRetrieval } from '@/composables/assets/retrieval';
 import { usePremium } from '@/composables/premium';
+import { useSectionStatus } from '@/composables/status';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
 import { useGeneralSettingsStore } from '@/store/settings/general';
-import { useStatusStore } from '@/store/status';
 import { Module } from '@/types/modules';
 import { Section } from '@/types/status';
 import { TaskType } from '@/types/task-type';
@@ -72,14 +72,12 @@ export function usePoolBalances(): UsePoolBalancesReturn {
   const premium = usePremium();
   const { t } = useI18n({ useScope: 'global' });
 
-  const { isLoading } = useStatusStore();
   const { getSushiswapBalances, getUniswapV2Balances } = usePoolApi();
   const { getAssetField } = useAssetInfoRetrieval();
 
-  const loading = logicOr(
-    isLoading(Section.POOLS_UNISWAP_V2),
-    isLoading(Section.POOLS_SUSHISWAP),
-  );
+  const { isLoading: uniswapLoading } = useSectionStatus(Section.POOLS_UNISWAP_V2);
+  const { isLoading: sushiswapLoading } = useSectionStatus(Section.POOLS_SUSHISWAP);
+  const loading = logicOr(uniswapLoading, sushiswapLoading);
 
   const balances = computed<PoolLiquidityBalance[]>(() => {
     const uniswap = toArray(get(uniswapPoolBalances));

--- a/frontend/app/src/modules/history/events/use-history-events-status.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-status.ts
@@ -1,8 +1,8 @@
 import type { ComputedRef } from 'vue';
 import { not } from '@vueuse/math';
+import { useSectionStatus } from '@/composables/status';
 import { useEventsQueryStatusStore } from '@/store/history/query-status/events-query-status';
 import { useTxQueryStatusStore } from '@/store/history/query-status/tx-query-status';
-import { useStatusStore } from '@/store/status';
 import { useTaskStore } from '@/store/tasks';
 import { Section } from '@/types/status';
 import { TaskType } from '@/types/task-type';
@@ -20,12 +20,10 @@ interface UseHistoryEventStatusReturn {
 
 export const useHistoryEventsStatus = createSharedComposable((): UseHistoryEventStatusReturn => {
   const { useIsTaskRunning } = useTaskStore();
-  const { isLoading: isSectionLoading } = useStatusStore();
+  const { isLoading: sectionLoading } = useSectionStatus(Section.HISTORY);
 
   const { isAllFinished: isQueryingTxsFinished } = storeToRefs(useTxQueryStatusStore());
   const { isAllFinished: isQueryingOnlineEventsFinished } = storeToRefs(useEventsQueryStatusStore());
-
-  const sectionLoading = isSectionLoading(Section.HISTORY);
   const txEventsDecoding = useIsTaskRunning(TaskType.TRANSACTIONS_DECODING);
   const ethBlockEventsDecoding = useIsTaskRunning(TaskType.ETH_BLOCK_EVENTS_DECODING);
   const anyEventsDecoding = logicOr(txEventsDecoding, ethBlockEventsDecoding);

--- a/frontend/app/src/modules/staking/eth/composables/use-eth-staking-refresh.ts
+++ b/frontend/app/src/modules/staking/eth/composables/use-eth-staking-refresh.ts
@@ -2,11 +2,10 @@ import type { ComputedRef, Ref } from 'vue';
 import { Blockchain } from '@rotki/common';
 import dayjs from 'dayjs';
 import { useEthStaking } from '@/composables/blockchain/accounts/staking';
-import { useStatusUpdater } from '@/composables/status';
+import { useSectionStatus, useStatusUpdater } from '@/composables/status';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { useBlockchainValidatorsStore } from '@/store/blockchain/validators';
 import { useSessionAuthStore } from '@/store/session/auth';
-import { useStatusStore } from '@/store/status';
 import { useTaskStore } from '@/store/tasks';
 import { OnlineHistoryEventsQueryType } from '@/types/history/events/schemas';
 import { Section } from '@/types/status';
@@ -31,7 +30,6 @@ export function useEthStakingRefresh(callbacks: RefreshCallbacks): UseEthStaking
   const performanceSection = Section.STAKING_ETH2;
 
   const { username } = storeToRefs(useSessionAuthStore());
-  const { isLoading } = useStatusStore();
   const { useIsTaskRunning } = useTaskStore();
   const { stakingValidatorsLimits } = storeToRefs(useBlockchainValidatorsStore());
   const { fetchEthStakingValidators } = useEthStaking();
@@ -45,14 +43,15 @@ export function useEthStakingRefresh(callbacks: RefreshCallbacks): UseEthStaking
   const lastRefresh = createLastRefreshStorage(get(username));
 
   // Loading states
-  const performanceRefreshing = isLoading(performanceSection);
+  const { isLoading: performanceRefreshing } = useSectionStatus(performanceSection);
+  const { isLoading: eth2Loading } = useSectionStatus(Section.BLOCKCHAIN, Blockchain.ETH2);
   const blockProductionLoading = useIsTaskRunning(TaskType.QUERY_ONLINE_EVENTS, {
     queryType: OnlineHistoryEventsQueryType.BLOCK_PRODUCTIONS,
   });
 
   const refreshing = logicOr(
     performanceRefreshing,
-    isLoading(Section.BLOCKCHAIN, Blockchain.ETH2),
+    eth2Loading,
     blockProductionLoading,
   );
 

--- a/frontend/app/src/store/status.ts
+++ b/frontend/app/src/store/status.ts
@@ -1,3 +1,4 @@
+import type { MaybeRefOrGetter } from 'vue';
 import type { StatusPayload } from '@/types/action';
 import { isEmpty } from 'es-toolkit/compat';
 import { Section, Status } from '@/types/status';
@@ -58,41 +59,53 @@ export const useStatusStore = defineStore('status', () => {
   const getStatus = (section: Section, subsection: string = defaultSection): Status =>
     get(status)[section]?.[subsection] ?? Status.NONE;
 
-  const isLoading = (
+  const getIsLoading = (
     section: Section,
     subsection: string = defaultSection,
-  ): ComputedRef<boolean> => computed<boolean>(() => {
+  ): boolean => {
     const statuses = get(status)[section];
     if (!statuses)
       return false;
 
     return matchesStatus(statuses, subsection, isLoadingStatus);
-  });
+  };
 
-  const shouldShowLoadingScreen = (
+  const useIsLoading = (
+    section: MaybeRefOrGetter<Section>,
+    subsection: MaybeRefOrGetter<string> = defaultSection,
+  ): ComputedRef<boolean> => computed<boolean>(() => getIsLoading(toValue(section), toValue(subsection)));
+
+  const getIsInitialLoading = (
     section: Section,
     subsection: string = defaultSection,
-  ): ComputedRef<boolean> => computed<boolean>(() => {
+  ): boolean => {
     const statuses = get(status)[section];
     if (!statuses)
       return true;
 
     return matchesStatus(statuses, subsection, isInitialLoadingStatus);
-  });
+  };
+
+  const useShouldShowLoadingScreen = (
+    section: MaybeRefOrGetter<Section>,
+    subsection: MaybeRefOrGetter<string> = defaultSection,
+  ): ComputedRef<boolean> => computed<boolean>(() => getIsInitialLoading(toValue(section), toValue(subsection)));
 
   const detailsLoading = logicOr(
-    isLoading(Section.BLOCKCHAIN),
-    isLoading(Section.EXCHANGES),
-    isLoading(Section.MANUAL_BALANCES),
+    useIsLoading(Section.BLOCKCHAIN),
+    useIsLoading(Section.EXCHANGES),
+    useIsLoading(Section.MANUAL_BALANCES),
   );
 
   return {
     detailsLoading,
+    getIsInitialLoading,
+    getIsLoading,
     getStatus,
-    isLoading,
     resetStatus,
     setStatus,
-    shouldShowLoadingScreen,
+    useShouldShowLoadingScreen,
+    useIsLoading,
     status,
   };
 });


### PR DESCRIPTION
## Summary
- Add plain boolean getters (`getIsLoading`, `getIsInitialLoading`) to `useStatusStore` for imperative usage
- Rename reactive variants to `useIsLoading` / `useShouldShowLoadingScreen` with `MaybeRefOrGetter` params
- Introduce `useSectionStatus(section, subsection?)` composable for single-line section loading access
- Fix `get(isLoading(...))` antipattern in `use-account-loading-states` and `use-blockchain-balances`
- Migrate 17 consumer files to use the new API, 13 of which use `useSectionStatus`

## Test plan
- [x] All 2743 unit tests pass
- [x] TypeScript strict mode passes
- [x] ESLint passes with 0 errors