### PR TITLE
refactor(frontend): use/get split for useLocations

### DIFF
--- a/frontend/app/src/components/EvmNativeTokenBreakdown.spec.ts
+++ b/frontend/app/src/components/EvmNativeTokenBreakdown.spec.ts
@@ -65,7 +65,7 @@ vi.mock('@/composables/api/assets/icon', (): Record<string, unknown> => ({
 
 vi.mock('@/composables/locations', (): Record<string, unknown> => ({
   useLocations: vi.fn().mockReturnValue({
-    locationData: vi.fn().mockImplementation((identifier): ComputedRef<{ identifier: unknown; name: unknown }> => computed<{ identifier: unknown; name: unknown }>(() => {
+    useLocationData: vi.fn().mockImplementation((identifier): ComputedRef<{ identifier: unknown; name: unknown }> => computed<{ identifier: unknown; name: unknown }>(() => {
       const val = toValue(identifier);
       return {
         identifier: val,

--- a/frontend/app/src/components/GlobalSearch.vue
+++ b/frontend/app/src/components/GlobalSearch.vue
@@ -215,7 +215,7 @@ function getExchanges(keyword: string): SearchItemWithoutValue[] {
     const name = exchange.name;
 
     return {
-      location: getLocationData(identifier) ?? undefined,
+      location: getLocationData(identifier),
       route: `${Routes.BALANCES_EXCHANGE.route}/${identifier}`,
       texts: [Routes.BALANCES.text, Routes.BALANCES_EXCHANGE.text, name],
     };

--- a/frontend/app/src/components/accounts/exchanges/ExchangeAmountRow.vue
+++ b/frontend/app/src/components/accounts/exchanges/ExchangeAmountRow.vue
@@ -9,13 +9,13 @@ const { balance, exchange } = defineProps<{
   exchange: string;
 }>();
 
-const { exchangeName } = useLocations();
+const { getExchangeName } = useLocations();
 
 const name = computed<string>(() => {
   if (!exchange)
     return '';
 
-  return exchangeName(exchange);
+  return getExchangeName(exchange);
 });
 </script>
 

--- a/frontend/app/src/components/display/ExchangeDisplay.vue
+++ b/frontend/app/src/components/display/ExchangeDisplay.vue
@@ -7,9 +7,9 @@ const { exchange, size = '1.5rem' } = defineProps<{
   size?: string;
 }>();
 
-const { locationData } = useLocations();
+const { useLocationData } = useLocations();
 
-const location = locationData(() => exchange);
+const location = useLocationData(() => exchange);
 </script>
 
 <template>

--- a/frontend/app/src/components/history/LocationDisplay.vue
+++ b/frontend/app/src/components/history/LocationDisplay.vue
@@ -20,8 +20,8 @@ const {
   horizontal?: boolean;
 }>();
 
-const { locationData } = useLocations();
-const location = locationData(() => identifier);
+const { useLocationData } = useLocations();
+const location = useLocationData(() => identifier);
 
 const route = computed<RouteLocationRaw>(() => {
   const details = detailPath;

--- a/frontend/app/src/components/history/LocationIcon.vue
+++ b/frontend/app/src/components/history/LocationIcon.vue
@@ -14,9 +14,9 @@ const emit = defineEmits<{
   click: [location: string];
 }>();
 
-const { locationData } = useLocations();
+const { useLocationData } = useLocations();
 
-const location = locationData(() => item);
+const location = useLocationData(() => item);
 </script>
 
 <template>

--- a/frontend/app/src/composables/locations.ts
+++ b/frontend/app/src/composables/locations.ts
@@ -1,25 +1,21 @@
-import type { MaybeRefOrGetter } from 'vue';
+import type { ComputedRef, DeepReadonly, MaybeRefOrGetter, Ref } from 'vue';
 import type { TradeLocationData } from '@/types/history/trade/location';
 import { useSupportedChains } from '@/composables/info/chains';
 import { useLocationStore } from '@/store/locations';
 import { isBlockchain } from '@/types/blockchain/chains';
 
-export const useLocations = createSharedComposable(() => {
+interface UseLocationsReturn {
+  getExchangeName: (location: string) => string;
+  getLocationData: (id: string) => TradeLocationData | undefined;
+  tradeLocations: DeepReadonly<Ref<TradeLocationData[]>>;
+  useLocationData: (identifier: MaybeRefOrGetter<string | null>) => ComputedRef<TradeLocationData | undefined>;
+}
+
+export function useLocations(): UseLocationsReturn {
   const { tradeLocations } = storeToRefs(useLocationStore());
-
-  const exchangeName = (location: MaybeRefOrGetter<string>): string => {
-    const exchange = get(tradeLocations).find(tl => tl.identifier === toValue(location));
-
-    return exchange?.name ?? '';
-  };
-
   const { getBlockchainRedirectLink, getChainImageUrl, getChainName, matchChain } = useSupportedChains();
 
-  const locationData = (identifier: MaybeRefOrGetter<string | null>): ComputedRef<TradeLocationData | null> => computed(() => {
-    const id = toValue(identifier);
-    if (!id)
-      return null;
-
+  function getLocationData(id: string): TradeLocationData | undefined {
     const blockchainId = id.split(' ').join('_');
 
     const chain = matchChain(blockchainId);
@@ -34,15 +30,28 @@ export const useLocations = createSharedComposable(() => {
     }
 
     const locations = get(tradeLocations);
-    return locations.find(location => location.identifier === id) ?? null;
-  });
+    return locations.find(location => location.identifier === id);
+  }
 
-  const getLocationData = (identifier: string): TradeLocationData | null => get(locationData(identifier));
+  function useLocationData(identifier: MaybeRefOrGetter<string | null>): ComputedRef<TradeLocationData | undefined> {
+    return computed<TradeLocationData | undefined>(() => {
+      const id = toValue(identifier);
+      if (!id)
+        return undefined;
+
+      return getLocationData(id);
+    });
+  }
+
+  function getExchangeName(location: string): string {
+    const exchange = get(tradeLocations).find(tl => tl.identifier === location);
+    return exchange?.name ?? '';
+  }
 
   return {
-    exchangeName,
+    getExchangeName,
     getLocationData,
-    locationData,
-    tradeLocations,
+    tradeLocations: readonly(tradeLocations),
+    useLocationData,
   };
-});
+}

--- a/frontend/app/src/modules/balances/protocols/use-protocol-data.ts
+++ b/frontend/app/src/modules/balances/protocols/use-protocol-data.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { MaybeRefOrGetter, Ref } from 'vue';
 import { toSentenceCase } from '@rotki/common';
 import { useDefiMetadata } from '@/composables/defi/metadata';
 import { useHistoryEventCounterpartyMappings } from '@/composables/history/events/mapping/counterparty';
@@ -10,10 +10,12 @@ interface IconProtocol { icon: string; type: 'icon'; name: string }
 
 type ProtocolData = ImageProtocol | IconProtocol | undefined;
 
-interface UseProtocolDataReturn { protocolData: ComputedRef<ProtocolData> }
+interface UseProtocolDataReturn {
+  protocolData: Readonly<Ref<ProtocolData>>;
+}
 
 export function useProtocolData(protocol: MaybeRefOrGetter<string>, isDark: MaybeRefOrGetter<boolean> = false): UseProtocolDataReturn {
-  const { locationData: useLocationData } = useLocations();
+  const { useLocationData } = useLocations();
   const { getDefiData, getDefiImageUrl } = useDefiMetadata();
   const { getBaseCounterpartyData } = useHistoryEventCounterpartyMappings();
 
@@ -21,57 +23,35 @@ export function useProtocolData(protocol: MaybeRefOrGetter<string>, isDark: Mayb
   const defiData = getDefiData(protocol);
 
   const protocolData = computed<ProtocolData>(() => {
-    const name = toValue(protocol);
-    const formattedName = toSentenceCase(name);
-    if (name === 'address') {
-      return {
-        icon: 'lu-wallet',
-        name: formattedName,
-        type: 'icon',
-      };
-    }
+    const protocolName = toValue(protocol);
+    const displayName = toSentenceCase(protocolName);
+
+    if (protocolName === 'address')
+      return { icon: 'lu-wallet', name: displayName, type: 'icon' };
 
     const location = get(locationData);
 
-    if (location && (location.image || location.icon)) {
-      if (location.image) {
-        return {
-          image: location.image,
-          name: location.name ?? formattedName,
-          type: 'image',
-        };
-      }
-      else if (location.icon) {
-        return {
-          icon: location.icon,
-          name: location.name ?? formattedName,
-          type: 'icon',
-        };
-      }
+    if (location) {
+      const name = location.name ?? displayName;
+      if (location.image)
+        return { image: location.image, name, type: 'image' };
+
+      if (location.icon)
+        return { icon: location.icon, name, type: 'icon' };
     }
 
-    const counterparty = getBaseCounterpartyData(name, toValue(isDark));
-    if (counterparty) {
-      return {
-        image: counterparty.image,
-        name: counterparty.label ?? formattedName,
-        type: 'image',
-      };
-    }
+    const counterparty = getBaseCounterpartyData(protocolName, toValue(isDark));
+    if (counterparty)
+      return { image: counterparty.image, name: counterparty.label ?? displayName, type: 'image' };
 
     const defi = get(defiData);
-    if (defi) {
-      return {
-        image: getDefiImageUrl(name, defi.icon),
-        name: defi.name,
-        type: 'image',
-      };
-    }
+    if (defi)
+      return { image: getDefiImageUrl(protocolName, defi.icon), name: defi.name, type: 'image' };
 
     return undefined;
   });
 
   return {
-    protocolData,
+    protocolData: readonly(protocolData),
   };
 }

--- a/frontend/app/src/modules/dashboard/summary/ExchangeBox.vue
+++ b/frontend/app/src/modules/dashboard/summary/ExchangeBox.vue
@@ -13,7 +13,7 @@ interface ExchangeBoxProps {
 
 const { location } = defineProps<ExchangeBoxProps>();
 
-const { exchangeName } = useLocations();
+const { getExchangeName } = useLocations();
 
 const exchangeLocationRoute = computed<string>(() => {
   const route = Routes.BALANCES_EXCHANGE;
@@ -37,7 +37,7 @@ const exchangeLocationRoute = computed<string>(() => {
         </div>
       </template>
       <div class="flex flex-wrap justify-between gap-1 text-rui-text">
-        {{ exchangeName(location) }}
+        {{ getExchangeName(location) }}
         <FiatDisplay
           :value="amount"
           class="font-medium"

--- a/frontend/app/src/modules/dashboard/summary/ManualBalanceCardList.vue
+++ b/frontend/app/src/modules/dashboard/summary/ManualBalanceCardList.vue
@@ -17,9 +17,9 @@ const manualBalancesRoute = computed<RouteLocationRaw>(() => ({
   query: { location: name },
 }));
 
-const { locationData } = useLocations();
+const { useLocationData } = useLocations();
 
-const location = locationData(() => name);
+const location = useLocationData(() => name);
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/events/composables/use-history-matched-movement-item.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-matched-movement-item.ts
@@ -41,7 +41,7 @@ export function useHistoryMatchedMovementItem(
   const { getChain } = useSupportedChains();
   const { getAssetField } = useAssetInfoRetrieval();
 
-  const { locationData } = useLocations();
+  const { getLocationData } = useLocations();
 
   // For asset movements, use the first non-fee asset movement event as primary
   const primaryEvent = computed<HistoryEventEntry>(() => {
@@ -115,8 +115,8 @@ export function useHistoryMatchedMovementItem(
 
     const amount = primary.amount;
     const asset = getAssetField(primary.asset, 'symbol', ASSET_RESOLUTION_OPTIONS);
-    const exchangeLabel = primary.locationLabel || get(locationData(primary.location))?.name || '';
-    const addressLabel = secondary?.locationLabel || (secondary && get(locationData(secondary.location))?.name) || '';
+    const exchangeLabel = primary.locationLabel || getLocationData(primary.location)?.name || '';
+    const addressLabel = secondary?.locationLabel || (secondary && getLocationData(secondary.location)?.name) || '';
 
     const isDeposit = primary.eventSubtype === 'receive';
     // For deposits: to = exchange, from = address

--- a/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.spec.ts
@@ -109,9 +109,9 @@ describe('forms/AssetMovementEventForm.vue', () => {
     vi.mocked(usePriceTaskManager().getHistoricPrice).mockResolvedValue(One);
 
     vi.mocked(useLocations).mockReturnValue({
-      exchangeName: vi.fn<ReturnType<typeof useLocations>['exchangeName']>(),
+      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
       getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      locationData: vi.fn<ReturnType<typeof useLocations>['locationData']>(),
+      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'kraken',
         name: 'Kraken',

--- a/frontend/app/src/modules/history/management/forms/EvmEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EvmEventForm.spec.ts
@@ -85,9 +85,9 @@ describe('forms/EvmEventForm.vue', () => {
     addHistoricalPriceMock = vi.fn<ReturnType<typeof useAssetPricesApi>['addHistoricalPrice']>();
     vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue(mapping);
     vi.mocked(useLocations).mockReturnValue({
-      exchangeName: vi.fn<ReturnType<typeof useLocations>['exchangeName']>(),
+      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
       getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      locationData: vi.fn<ReturnType<typeof useLocations>['locationData']>(),
+      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'ethereum',
         name: 'Ethereum',

--- a/frontend/app/src/modules/history/management/forms/EvmSwapEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EvmSwapEventForm.spec.ts
@@ -124,9 +124,9 @@ describe('forms/EvmSwapEventForm', () => {
     });
 
     vi.mocked(useLocations).mockReturnValue({
-      exchangeName: vi.fn<ReturnType<typeof useLocations>['exchangeName']>(),
+      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
       getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      locationData: vi.fn<ReturnType<typeof useLocations>['locationData']>(),
+      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'ethereum',
         name: 'Ethereum',

--- a/frontend/app/src/modules/history/management/forms/OnlineHistoryEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/OnlineHistoryEventForm.spec.ts
@@ -91,9 +91,9 @@ describe('forms/OnlineHistoryEventForm.vue', () => {
       getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
     });
     vi.mocked(useLocations).mockReturnValue({
-      exchangeName: vi.fn<ReturnType<typeof useLocations>['exchangeName']>(),
+      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
       getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      locationData: vi.fn<ReturnType<typeof useLocations>['locationData']>(),
+      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'kraken',
         name: 'Kraken',

--- a/frontend/app/src/modules/history/management/forms/SolanaEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/SolanaEventForm.spec.ts
@@ -86,9 +86,9 @@ describe('forms/SolanaEventForm.vue', () => {
     addHistoricalPriceMock = vi.fn<ReturnType<typeof useAssetPricesApi>['addHistoricalPrice']>();
     vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue(mapping);
     vi.mocked(useLocations).mockReturnValue({
-      exchangeName: vi.fn<ReturnType<typeof useLocations>['exchangeName']>(),
+      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
       getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      locationData: vi.fn<ReturnType<typeof useLocations>['locationData']>(),
+      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'solana',
         name: 'Solana',

--- a/frontend/app/src/modules/history/management/forms/SolanaSwapEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/SolanaSwapEventForm.spec.ts
@@ -125,9 +125,9 @@ describe('forms/SolanaSwapEventForm', () => {
     });
 
     vi.mocked(useLocations).mockReturnValue({
-      exchangeName: vi.fn<ReturnType<typeof useLocations>['exchangeName']>(),
+      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
       getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      locationData: vi.fn<ReturnType<typeof useLocations>['locationData']>(),
+      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'solana',
         name: 'Solana',

--- a/frontend/app/src/modules/history/management/forms/SwapEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/SwapEventForm.spec.ts
@@ -92,9 +92,9 @@ describe('forms/SwapEventForm', () => {
     addHistoryEventMock = vi.fn<ReturnType<typeof useHistoryEvents>['addHistoryEvent']>();
     editHistoryEventMock = vi.fn<ReturnType<typeof useHistoryEvents>['editHistoryEvent']>();
     vi.mocked(useLocations).mockReturnValue({
-      exchangeName: vi.fn<ReturnType<typeof useLocations>['exchangeName']>(),
+      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
       getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      locationData: vi.fn<ReturnType<typeof useLocations>['locationData']>(),
+      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'kraken',
         name: 'Kraken',

--- a/frontend/app/src/pages/api-keys/exchanges/index.vue
+++ b/frontend/app/src/pages/api-keys/exchanges/index.vue
@@ -35,7 +35,7 @@ const { show } = useConfirmStore();
 const { t } = useI18n({ useScope: 'global' });
 const router = useRouter();
 const route = useRoute('/api-keys/exchanges/');
-const { exchangeName } = useLocations();
+const { getExchangeName } = useLocations();
 
 const cols = computed<DataTableColumn<Exchange>[]>(() => [{
   align: 'center',
@@ -147,7 +147,7 @@ async function remove(item: Exchange) {
 function showRemoveConfirmation(item: Exchange) {
   show({
     message: t('exchange_settings.confirmation.message', {
-      location: item ? exchangeName(item.location) : '',
+      location: item ? getExchangeName(item.location) : '',
       name: item?.name ?? '',
     }),
     title: t('exchange_settings.confirmation.title'),

--- a/frontend/app/src/pages/locations/[identifier].vue
+++ b/frontend/app/src/pages/locations/[identifier].vue
@@ -22,8 +22,8 @@ const { identifier } = defineProps<{
   identifier: string;
 }>();
 
-const { locationData } = useLocations();
-const location = locationData(() => identifier);
+const { useLocationData } = useLocations();
+const location = useLocationData(() => identifier);
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- Rename `locationData` → `useLocationData` (reactive, returns `ComputedRef`)
- Rewrite `getLocationData` as a plain function (previously created a throwaway computed just to unwrap it)
- Rename `exchangeName` → `getExchangeName`
- Return `undefined` instead of `null` from both getters
- Remove `createSharedComposable` wrapper (no local state to share)
- Add explicit `UseLocationsReturn` interface with `readonly` properties
- Fix `use-history-matched-movement-item` creating computed refs inside a computed body — now uses `getLocationData` plain function
- Flatten nested conditionals in `use-protocol-data`
- Update all consumers and test mocks