### PR TITLE
refactor(frontend): use/get split for external API keys

### DIFF
--- a/frontend/app/src/components/accounts/management/AccountDialog.vue
+++ b/frontend/app/src/components/accounts/management/AccountDialog.vue
@@ -35,7 +35,7 @@ const subtitle = computed<string>(() =>
 
 const { errorMessages, pending, save } = useAccountManage();
 const { loading } = useAccountLoading();
-const { apiKey } = useExternalApiKeys(t);
+const { getApiKey } = useExternalApiKeys();
 const { beaconRpcEndpoint } = storeToRefs(useGeneralSettingsStore());
 
 const isSaveDisabled = computed<boolean>(() => {
@@ -44,7 +44,7 @@ const isSaveDisabled = computed<boolean>(() => {
     return false;
 
   // Disable save button for validator addition without beaconchain API key and consensus client RPC
-  return state.type === 'validator' && !(get(apiKey('beaconchain')) || get(beaconRpcEndpoint));
+  return state.type === 'validator' && !(getApiKey('beaconchain') || get(beaconRpcEndpoint));
 });
 
 function dismiss() {

--- a/frontend/app/src/components/accounts/management/AccountForm.vue
+++ b/frontend/app/src/components/accounts/management/AccountForm.vue
@@ -46,7 +46,7 @@ const chain = useRefPropVModel(modelValue, 'chain');
 
 const { isEvm, isSolanaChains, txEvmChains } = useSupportedChains();
 const { t } = useI18n({ useScope: 'global' });
-const { apiKey } = useExternalApiKeys(t);
+const { getApiKey } = useExternalApiKeys();
 
 const { beaconRpcEndpoint, defaultEvmIndexerOrder, evmIndexersOrder } = storeToRefs(useGeneralSettingsStore());
 
@@ -85,7 +85,7 @@ const missingApiKeyService = computed<'etherscan' | 'helius' | 'beaconchain' | '
   if (currentModelValue.mode !== 'add' || !selectedChain)
     return undefined;
 
-  if (currentModelValue.type === 'validator' && !get(apiKey('beaconchain'))) {
+  if (currentModelValue.type === 'validator' && !getApiKey('beaconchain')) {
     if (!get(beaconRpcEndpoint)) {
       return 'consensusRpc';
     }
@@ -93,10 +93,10 @@ const missingApiKeyService = computed<'etherscan' | 'helius' | 'beaconchain' | '
     return 'beaconchain';
   }
 
-  if (!get(apiKey('etherscan')) && shouldShowEtherscanWarning(selectedChain))
+  if (!getApiKey('etherscan') && shouldShowEtherscanWarning(selectedChain))
     return 'etherscan';
 
-  if (isSolanaChains(selectedChain) && !get(apiKey('helius')))
+  if (isSolanaChains(selectedChain) && !getApiKey('helius'))
     return 'helius';
 
   return undefined;

--- a/frontend/app/src/components/nft/NftGallery.vue
+++ b/frontend/app/src/components/nft/NftGallery.vue
@@ -19,7 +19,7 @@ const { modules } = defineProps<{ modules: Module[] }>();
 const { t } = useI18n({ useScope: 'global' });
 const router = useRouter();
 const premium = usePremium();
-const { apiKey } = useExternalApiKeys(t);
+const { useApiKey } = useExternalApiKeys();
 
 // Use composables
 const {
@@ -50,7 +50,7 @@ const noData = computed<boolean>(() =>
   get(visibleNfts).length === 0 && !(get(selectedCollection) || get(selectedAccounts).length > 0),
 );
 
-const openSeaKey = apiKey('opensea');
+const openSeaKey = useApiKey('opensea');
 const hasOpenSeaKey = computed<boolean>(() => !!get(openSeaKey));
 
 // Methods

--- a/frontend/app/src/components/settings/api-keys/external/AlchemyApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/AlchemyApiKey.vue
@@ -10,10 +10,10 @@ const { t } = useI18n({ useScope: 'global' });
 
 const name = 'alchemy';
 
-const { actionStatus, apiKey, confirmDelete, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, loading, save } = useExternalApiKeys();
 const { saveHandler, serviceKeyRef } = useServiceKeyHandler<InstanceType<typeof ServiceKey>>();
 
-const key = apiKey(name);
+const key = useApiKey(name);
 const status = actionStatus(name);
 </script>
 

--- a/frontend/app/src/components/settings/api-keys/external/BeaconchainApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/BeaconchainApiKey.vue
@@ -10,10 +10,10 @@ import { getPublicServiceImagePath } from '@/utils/file';
 const name = 'beaconchain';
 const { t } = useI18n({ useScope: 'global' });
 
-const { actionStatus, apiKey, confirmDelete, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, loading, save } = useExternalApiKeys();
 const { saveHandler, serviceKeyRef } = useServiceKeyHandler<InstanceType<typeof ServiceKey>>();
 
-const key = apiKey(name);
+const key = useApiKey(name);
 const status = actionStatus(name);
 
 const { prioritized, remove: removeNotification } = useNotificationsStore();

--- a/frontend/app/src/components/settings/api-keys/external/BlockscoutApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/BlockscoutApiKey.vue
@@ -12,9 +12,9 @@ const { evmChain, chainName } = defineProps<{ evmChain: string; chainName: strin
 const name = 'blockscout';
 const { t } = useI18n({ useScope: 'global' });
 
-const { actionStatus, apiKey, confirmDelete, getName, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, getName, loading, save } = useExternalApiKeys();
 
-const key = apiKey(name, () => evmChain);
+const key = useApiKey(name, () => evmChain);
 const status = actionStatus(name, () => evmChain);
 const identifier = computed(() => getName(name, evmChain));
 

--- a/frontend/app/src/components/settings/api-keys/external/BlockscoutApiKeys.vue
+++ b/frontend/app/src/components/settings/api-keys/external/BlockscoutApiKeys.vue
@@ -9,7 +9,7 @@ import { getPublicServiceImagePath } from '@/utils/file';
 
 const name = 'blockscout';
 const { t } = useI18n({ useScope: 'global' });
-const { keys } = useExternalApiKeys(t);
+const { keys } = useExternalApiKeys();
 const tabIndex = ref<number>(0);
 const route = useRoute();
 const router = useRouter();

--- a/frontend/app/src/components/settings/api-keys/external/CoinGeckoApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/CoinGeckoApiKey.vue
@@ -10,10 +10,10 @@ const name = 'coingecko';
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { actionStatus, apiKey, confirmDelete, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, loading, save } = useExternalApiKeys();
 const { saveHandler, serviceKeyRef } = useServiceKeyHandler<InstanceType<typeof ServiceKey>>();
 
-const key = apiKey(name);
+const key = useApiKey(name);
 const status = actionStatus(name);
 
 const link = externalLinks.coingeckoApiKey;

--- a/frontend/app/src/components/settings/api-keys/external/CryptoCompareApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/CryptoCompareApiKey.vue
@@ -7,10 +7,10 @@ import { getPublicServiceImagePath } from '@/utils/file';
 const name = 'cryptocompare';
 const { t } = useI18n({ useScope: 'global' });
 
-const { actionStatus, apiKey, confirmDelete, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, loading, save } = useExternalApiKeys();
 const { saveHandler, serviceKeyRef } = useServiceKeyHandler<InstanceType<typeof ServiceKey>>();
 
-const key = apiKey(name);
+const key = useApiKey(name);
 const status = actionStatus(name);
 </script>
 

--- a/frontend/app/src/components/settings/api-keys/external/DefiLlamaApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/DefiLlamaApiKey.vue
@@ -10,10 +10,10 @@ const name = 'defillama';
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { actionStatus, apiKey, confirmDelete, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, loading, save } = useExternalApiKeys();
 const { saveHandler, serviceKeyRef } = useServiceKeyHandler<InstanceType<typeof ServiceKey>>();
 
-const key = apiKey(name);
+const key = useApiKey(name);
 const status = actionStatus(name);
 
 const link = externalLinks.defillamaApiKey;

--- a/frontend/app/src/components/settings/api-keys/external/EtherscanApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/EtherscanApiKey.vue
@@ -11,10 +11,10 @@ import { getPublicServiceImagePath } from '@/utils/file';
 const name = 'etherscan';
 const { t } = useI18n({ useScope: 'global' });
 
-const { actionStatus, apiKey, confirmDelete, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, loading, save } = useExternalApiKeys();
 const { saveHandler, serviceKeyRef } = useServiceKeyHandler<InstanceType<typeof ServiceKey>>();
 
-const key = apiKey(name);
+const key = useApiKey(name);
 const status = actionStatus(name);
 
 const { prioritized, remove: removeNotification } = useNotificationsStore();

--- a/frontend/app/src/components/settings/api-keys/external/HeliusApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/HeliusApiKey.vue
@@ -11,10 +11,10 @@ import { getPublicServiceImagePath } from '@/utils/file';
 const name = 'helius';
 const { t } = useI18n({ useScope: 'global' });
 
-const { actionStatus, apiKey, confirmDelete, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, loading, save } = useExternalApiKeys();
 const { saveHandler, serviceKeyRef } = useServiceKeyHandler<InstanceType<typeof ServiceKey>>();
 
-const key = apiKey(name);
+const key = useApiKey(name);
 const status = actionStatus(name);
 
 const { prioritized, remove: removeNotification } = useNotificationsStore();

--- a/frontend/app/src/components/settings/api-keys/external/LoopringApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/LoopringApiKey.vue
@@ -15,10 +15,10 @@ const router = useRouter();
 
 const { activeModules } = storeToRefs(useGeneralSettingsStore());
 const { fetchLoopringBalances } = useBlockchainBalances();
-const { actionStatus, apiKey, confirmDelete, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, loading, save } = useExternalApiKeys();
 const { saveHandler, serviceKeyRef } = useServiceKeyHandler<InstanceType<typeof ServiceKey>>();
 
-const key = apiKey(name);
+const key = useApiKey(name);
 const status = actionStatus(name);
 const isLoopringActive = useArrayIncludes(activeModules, Module.LOOPRING);
 

--- a/frontend/app/src/components/settings/api-keys/external/OpenSeaApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/OpenSeaApiKey.vue
@@ -10,10 +10,10 @@ const { t } = useI18n({ useScope: 'global' });
 
 const name = 'opensea';
 
-const { actionStatus, apiKey, confirmDelete, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, loading, save } = useExternalApiKeys();
 const { saveHandler, serviceKeyRef } = useServiceKeyHandler<InstanceType<typeof ServiceKey>>();
 
-const key = apiKey(name);
+const key = useApiKey(name);
 const status = actionStatus(name);
 </script>
 

--- a/frontend/app/src/components/settings/api-keys/external/TheGraphApiKey.vue
+++ b/frontend/app/src/components/settings/api-keys/external/TheGraphApiKey.vue
@@ -10,10 +10,10 @@ import { getPublicServiceImagePath } from '@/utils/file';
 const name = 'thegraph';
 const { t } = useI18n({ useScope: 'global' });
 
-const { actionStatus, apiKey, confirmDelete, loading, save } = useExternalApiKeys(t);
+const { actionStatus, useApiKey, confirmDelete, loading, save } = useExternalApiKeys();
 const { saveHandler, serviceKeyRef } = useServiceKeyHandler<InstanceType<typeof ServiceKey>>();
 
-const key = apiKey(name);
+const key = useApiKey(name);
 const status = actionStatus(name);
 
 const { prioritized, remove: removeNotification } = useNotificationsStore();

--- a/frontend/app/src/components/settings/evm/IndexerOrderSetting.vue
+++ b/frontend/app/src/components/settings/evm/IndexerOrderSetting.vue
@@ -41,9 +41,9 @@ const DEFAULT_TAB = 'default';
 const { getChain, getChainName, getEvmChainName, txEvmChains } = useSupportedChains();
 const { defaultEvmIndexerOrder, evmIndexersOrder } = storeToRefs(useGeneralSettingsStore());
 const { update: updateSettings } = useSettingsStore();
-const { apiKey } = useExternalApiKeys(t);
+const { getApiKey, useApiKey } = useExternalApiKeys();
 
-const etherscanApiKey = apiKey('etherscan');
+const etherscanApiKey = useApiKey('etherscan');
 
 const activeTab = ref<string>(DEFAULT_TAB);
 const showChainMenu = ref<boolean>(false);
@@ -181,8 +181,7 @@ const missingApiKeyIndexer = computed<string | null>(() => {
   else if (firstIndexer === EvmIndexer.BLOCKSCOUT) {
     const tab = get(activeTab);
     const chainId = tab === DEFAULT_TAB ? 'ethereum' : tab;
-    const blockscoutKey = apiKey('blockscout', chainId);
-    if (!get(blockscoutKey))
+    if (!getApiKey('blockscout', chainId))
       return toCapitalCase(EvmIndexer.BLOCKSCOUT);
   }
 

--- a/frontend/app/src/composables/history/events/tx/refresh-handlers.ts
+++ b/frontend/app/src/composables/history/events/tx/refresh-handlers.ts
@@ -28,7 +28,7 @@ export function useRefreshHandlers(): UseRefreshHandlersReturn {
   const { awaitTask } = useTaskStore();
   const { isModuleEnabled } = useModules();
   const isEth2Enabled = isModuleEnabled(Module.ETH2);
-  const { apiKey } = useExternalApiKeys(t);
+  const { getApiKey } = useExternalApiKeys();
   const { authenticated: moneriumAuthenticated, refreshStatus } = useMoneriumOAuth();
 
   const queryOnlineEvent = async (queryType: OnlineHistoryEventsQueryType): Promise<void> => {
@@ -40,7 +40,7 @@ export function useRefreshHandlers(): UseRefreshHandlersReturn {
     if (!get(isEth2Enabled) && eth2QueryTypes.includes(queryType))
       return;
 
-    if (!get(apiKey('gnosis_pay')) && queryType === OnlineHistoryEventsQueryType.GNOSIS_PAY) {
+    if (!getApiKey('gnosis_pay') && queryType === OnlineHistoryEventsQueryType.GNOSIS_PAY) {
       return;
     }
 

--- a/frontend/app/src/composables/settings/api-keys/external/index.ts
+++ b/frontend/app/src/composables/settings/api-keys/external/index.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { ComputedRef, DeepReadonly, MaybeRefOrGetter, Ref } from 'vue';
 import type ServiceKey from '@/components/settings/api-keys/ServiceKey.vue';
 import type { ConfirmationMessage } from '@/modules/history/events/composables/use-deletion-strategies';
 import type { ExternalServiceKey, ExternalServiceKeys, ExternalServiceName } from '@/types/user';
@@ -26,78 +26,76 @@ interface Status {
 }
 
 interface UseExternalApiKeysReturn {
-  loading: Ref<boolean>;
+  readonly loading: DeepReadonly<Ref<boolean>>;
   getName: (name: ExternalServiceName, chain?: string) => string;
-  apiKey: (name: MaybeRefOrGetter<ExternalServiceName>, chain?: MaybeRefOrGetter<string>) => ComputedRef<string>;
+  getApiKey: (name: ExternalServiceName, chain?: string) => string;
+  useApiKey: (name: MaybeRefOrGetter<ExternalServiceName>, chain?: MaybeRefOrGetter<string>) => ComputedRef<string>;
   actionStatus: (name: MaybeRefOrGetter<ExternalServiceName>, chain?: MaybeRefOrGetter<string>) => ComputedRef<Status | undefined>;
   load: () => Promise<void>;
   save: (payload: ExternalServiceKey, postConfirmAction?: () => Promise<void> | void) => Promise<void>;
   confirmDelete: (name: string, postConfirmAction?: () => Promise<void> | void, confirmation?: Partial<ConfirmationMessage>) => void;
-  keys: Ref<ExternalServiceKeys | undefined>;
+  readonly keys: DeepReadonly<Ref<ExternalServiceKeys | undefined>>;
 }
 
-export const useExternalApiKeys = createSharedComposable((t: ReturnType<typeof useI18n>['t']): UseExternalApiKeysReturn => {
+export const useExternalApiKeys = createSharedComposable((): UseExternalApiKeysReturn => {
+  const { t } = useI18n({ useScope: 'global' });
   const loading = ref<boolean>(false);
   const status = ref<Record<string, Status>>({});
+  const keys = ref<ExternalServiceKeys>();
 
   const { show } = useConfirmStore();
   const { deleteExternalServices, queryExternalServices, setExternalServices } = useExternalServicesApi();
 
   const { logged } = storeToRefs(useSessionAuthStore());
 
-  const keys: Ref<ExternalServiceKeys | undefined> = asyncComputed<ExternalServiceKeys | undefined>(
-    async () => {
-      if (get(logged))
-        return queryExternalServices();
+  function getBlockscoutApiKey(items: ExternalServiceKeys, chain: string): string {
+    const itemService = items.blockscout;
+    const transformedChainId = transformCase(chain, true);
 
-      return undefined;
-    },
-    undefined,
-    { evaluating: loading },
-  );
-
-  const apiKey = (
-    name: MaybeRefOrGetter<ExternalServiceName>,
-    chain?: MaybeRefOrGetter<string>,
-  ): ComputedRef<string> => computed(() => {
-    const items = get(keys);
-    const service = toValue(name);
-
-    if (!items)
-      return '';
-
-    if (service === 'blockscout') {
-      const itemService = items[service];
-      const chainId = toValue(chain);
-      assert(chainId, `missing chain for ${service}`);
-
-      const transformedChainId = transformCase(chainId, true);
-
-      if (itemService && transformedChainId in itemService) {
-        const chainData = itemService[transformedChainId];
-        if (chainData && 'apiKey' in chainData)
-          return chainData.apiKey || '';
-      }
-    }
-    else {
-      const itemService = items[service];
-
-      if (itemService && 'apiKey' in itemService)
-        return itemService.apiKey || '';
+    if (itemService && transformedChainId in itemService) {
+      const chainData = itemService[transformedChainId];
+      if (chainData && 'apiKey' in chainData)
+        return chainData.apiKey || '';
     }
 
     return '';
-  });
+  }
 
-  const actionStatus = (
+  function getApiKey(name: ExternalServiceName, chain?: string): string {
+    const items = get(keys);
+    if (!items)
+      return '';
+
+    if (name === 'blockscout') {
+      assert(chain, `missing chain for ${name}`);
+      return getBlockscoutApiKey(items, chain);
+    }
+
+    const itemService = items[name];
+    if (itemService && 'apiKey' in itemService)
+      return itemService.apiKey || '';
+
+    return '';
+  }
+
+  function useApiKey(
     name: MaybeRefOrGetter<ExternalServiceName>,
     chain?: MaybeRefOrGetter<string>,
-  ): ComputedRef<Status | undefined> => computed(() => {
-    const key = getName(toValue(name), toValue(chain));
-    return get(status)[key];
-  });
+  ): ComputedRef<string> {
+    return computed<string>(() => getApiKey(toValue(name), toValue(chain)));
+  }
 
-  const load = async (): Promise<void> => {
+  function actionStatus(
+    name: MaybeRefOrGetter<ExternalServiceName>,
+    chain?: MaybeRefOrGetter<string>,
+  ): ComputedRef<Status | undefined> {
+    return computed<Status | undefined>(() => {
+      const key = getName(toValue(name), toValue(chain));
+      return get(status)[key];
+    });
+  }
+
+  async function load(): Promise<void> {
     set(loading, true);
     try {
       set(keys, await queryExternalServices());
@@ -108,23 +106,23 @@ export const useExternalApiKeys = createSharedComposable((t: ReturnType<typeof u
     finally {
       set(loading, false);
     }
-  };
+  }
 
-  const resetStatus = (key: string): void => {
-    const { [key]: service, ...newStatus } = get(status);
+  function resetStatus(key: string): void {
+    const { [key]: removed, ...newStatus } = get(status);
     set(status, newStatus);
-  };
+  }
 
-  const setStatus = (key: string, message: Status): void => {
+  function setStatus(key: string, message: Status): void {
     setTimeout(() => resetStatus(key), 4500);
 
     set(status, {
       ...get(status),
       [key]: message,
     });
-  };
+  }
 
-  const save = async (payload: ExternalServiceKey, postConfirmAction?: () => Promise<void> | void): Promise<void> => {
+  async function save(payload: ExternalServiceKey, postConfirmAction?: () => Promise<void> | void): Promise<void> {
     const { name } = payload;
     resetStatus(name);
     try {
@@ -152,9 +150,9 @@ export const useExternalApiKeys = createSharedComposable((t: ReturnType<typeof u
     finally {
       set(loading, false);
     }
-  };
+  }
 
-  const deleteService = async (name: string): Promise<void> => {
+  async function deleteService(name: string): Promise<void> {
     set(loading, true);
     try {
       set(keys, await deleteExternalServices(name));
@@ -169,9 +167,9 @@ export const useExternalApiKeys = createSharedComposable((t: ReturnType<typeof u
     finally {
       set(loading, false);
     }
-  };
+  }
 
-  const confirmDelete = (name: string, postConfirmAction?: () => Promise<void> | void, confirmation: Partial<ConfirmationMessage> = {}): void => {
+  function confirmDelete(name: string, postConfirmAction?: () => Promise<void> | void, confirmation: Partial<ConfirmationMessage> = {}): void {
     resetStatus(name);
     show(
       {
@@ -185,17 +183,27 @@ export const useExternalApiKeys = createSharedComposable((t: ReturnType<typeof u
         await postConfirmAction?.();
       },
     );
-  };
+  }
+
+  watchImmediate(logged, async (isLogged) => {
+    if (isLogged) {
+      await load();
+    }
+    else {
+      set(keys, undefined);
+    }
+  });
 
   return {
     actionStatus,
-    apiKey,
     confirmDelete,
+    getApiKey,
     getName,
-    keys,
+    keys: readonly(keys),
     load,
-    loading,
+    loading: readonly(loading),
     save,
+    useApiKey,
   };
 });
 
@@ -216,6 +224,7 @@ export function useServiceKeyHandler<T extends InstanceType<typeof ServiceKey>>(
 
   return {
     saveHandler,
+    // eslint-disable-next-line @rotki/composable-return-readonly -- template ref must be writable
     serviceKeyRef,
   };
 }

--- a/frontend/app/src/modules/external-services/gnosis-pay/components/GnosisPayAuth.vue
+++ b/frontend/app/src/modules/external-services/gnosis-pay/components/GnosisPayAuth.vue
@@ -21,8 +21,8 @@ import GnosisPayWalletConnection from './GnosisPayWalletConnection.vue';
 const { t } = useI18n({ useScope: 'global' });
 
 const name = 'gnosis_pay';
-const { apiKey, confirmDelete, load, loading } = useExternalApiKeys(t);
-const key = apiKey(name);
+const { useApiKey, confirmDelete, load, loading } = useExternalApiKeys();
+const key = useApiKey(name);
 
 const serviceKeyCard = useTemplateRef<InstanceType<typeof ServiceKeyCard>>('serviceKeyCard');
 

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshProtocolEvents.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshProtocolEvents.vue
@@ -22,7 +22,7 @@ const queries: OnlineHistoryEventsQueryType[] = [
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { apiKey } = useExternalApiKeys(t);
+const { getApiKey } = useExternalApiKeys();
 const { authenticated: moneriumAuthenticated } = useMoneriumOAuth();
 
 interface QueryConfig {
@@ -31,7 +31,7 @@ interface QueryConfig {
 }
 
 const queryConfigs = computed<Record<OnlineHistoryEventsQueryType, QueryConfig>>(() => {
-  const gnosisPayEnabled = !!get(apiKey('gnosis_pay'));
+  const gnosisPayEnabled = !!getApiKey('gnosis_pay');
   const moneriumEnabled = get(moneriumAuthenticated);
 
   return {

--- a/frontend/app/src/modules/staking/eth/EthStakingPage.vue
+++ b/frontend/app/src/modules/staking/eth/EthStakingPage.vue
@@ -19,7 +19,7 @@ const { t } = useI18n({ useScope: 'global' });
 const { allowed, enabled, module } = useEthStakingAccess();
 
 // API key check (only when module is allowed and enabled)
-const { apiKey } = useExternalApiKeys(t);
+const { getApiKey } = useExternalApiKeys();
 const { beaconRpcEndpoint } = storeToRefs(useGeneralSettingsStore());
 
 const missingApiKeyService = computed<'beaconchain' | 'consensusRpc' | undefined>(() => {
@@ -27,7 +27,7 @@ const missingApiKeyService = computed<'beaconchain' | 'consensusRpc' | undefined
     return undefined;
   }
 
-  if (!get(apiKey('beaconchain'))) {
+  if (!getApiKey('beaconchain')) {
     if (!get(beaconRpcEndpoint)) {
       return 'consensusRpc';
     }

--- a/frontend/app/src/modules/statistics/wrapped/composables/use-wrapped-gnosis-pay.ts
+++ b/frontend/app/src/modules/statistics/wrapped/composables/use-wrapped-gnosis-pay.ts
@@ -20,12 +20,11 @@ interface UseWrappedGnosisPayReturn {
 }
 
 export function useWrappedGnosisPay(summary: Ref<WrapStatisticsResult | null | undefined>): UseWrappedGnosisPayReturn {
-  const { t } = useI18n({ useScope: 'global' });
   const premium = usePremium();
-  const { apiKey } = useExternalApiKeys(t);
+  const { getApiKey } = useExternalApiKeys();
   const { findCurrency } = useCurrencies();
 
-  const gnosisPayKey = computed<string | null>(() => get(apiKey('gnosis_pay')));
+  const gnosisPayKey = computed<string>(() => getApiKey('gnosis_pay'));
   const showGnosisData = computed<boolean>(() => get(premium) && !!get(gnosisPayKey));
 
   const gnosisPayResult = computed<GnosisPayResult[]>(() => {

--- a/frontend/app/src/pages/api-keys/external/index.vue
+++ b/frontend/app/src/pages/api-keys/external/index.vue
@@ -6,7 +6,7 @@ import { useExternalApiKeys } from '@/composables/settings/api-keys/external';
 const { t } = useI18n({ useScope: 'global' });
 
 const search = ref<string>('');
-const { load } = useExternalApiKeys(t);
+const { load } = useExternalApiKeys();
 
 const services = [
   {


### PR DESCRIPTION
## Summary

- Add `getApiKey()` for non-reactive access (plain value), rename `apiKey()` → `useApiKey()` (reactive `ComputedRef`)
- Move `useI18n` inside `useExternalApiKeys` composable, removing `t` parameter from all 22 callers
- Replace `asyncComputed` with `watchImmediate` + explicit `load()` for clearer data fetching
- Convert arrow functions to function declarations, expose `loading` and `keys` as `readonly` refs
- Extract `getBlockscoutApiKey` helper to reduce cyclomatic complexity

## Test plan

- [x] Typecheck passes
- [x] All 2748 unit tests pass
- [x] Lint clean