### PR TITLE
Replace internal tx query cache keys with tx mapping state

### DIFF
--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -20,6 +20,7 @@ from rotkehlchen.chain.evm.types import EvmAccount
 from rotkehlchen.chain.structures import TimestampOrBlockRange
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.db.cache import DBCacheDynamic
+from rotkehlchen.db.constants import TX_INTERNALS_QUERIED
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
 from rotkehlchen.db.ranges import DBQueryRanges
@@ -1080,45 +1081,36 @@ class EvmTransactions(ABC):  # noqa: B024
             from_address: 'ChecksumEvmAddress | None' = None,
     ) -> list[EvmInternalTransaction]:
         """Queries the internal transactions of a parent tx_hash, saves them in the DB and returns
-        them. `to_address` and `user_address` are used to check if they have been queried before,
-        to avoid querying them again if there was no internal transaction.
+        them. Uses tx mappings to avoid querying the same parent hash repeatedly.
 
         May raise:
         - RemoteError if there is a problem querying the data sources or transaction hash does
         not exist."""
-        # check cache if this parent hash was queried before for this receiver and affected address
+        # check if full internal txs for this parent tx and chain have already been queried.
         with self.database.conn.read_ctx() as cursor:
-            affected_address = self.database.get_dynamic_cache(
-                cursor=cursor,
-                name=DBCacheDynamic.EXTRA_INTERNAL_TX,
-                chain_id=chain_id.value,
-                receiver=to_address,
-                tx_hash=str(tx_hash),
-            )
-        if affected_address == user_address:  # if we have queried them before
-            return self.dbevmtx.get_evm_internal_transactions(
-                parent_tx_hash=tx_hash,
-                blockchain=CHAINID_TO_SUPPORTED_BLOCKCHAIN[self.evm_inquirer.chain_id],
-                from_address=from_address,
-                to_address=to_address,
+            was_queried = cursor.execute(
+                'SELECT 1 FROM evm_tx_mappings WHERE tx_id IN ('
+                'SELECT identifier FROM evm_transactions '
+                'WHERE tx_hash=? AND chain_id=?) AND value=?',
+                (tx_hash, chain_id.serialize_for_db(), TX_INTERNALS_QUERIED),
+            ).fetchone() is not None
+
+        if was_queried is False:
+            self._query_and_save_internal_transactions_for_parent_hash(parent_tx_hash=tx_hash)
+            with self.database.user_write() as write_cursor:
+                write_cursor.execute(
+                    'INSERT OR IGNORE INTO evm_tx_mappings(tx_id, value) '
+                    'SELECT identifier, ? FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+                    (TX_INTERNALS_QUERIED, tx_hash, chain_id.serialize_for_db()),
+                )
+            log.debug(
+                f'Queried full internal txs for {tx_hash!s} on {chain_id.to_name()} '
+                f'for {user_address} with filters from={from_address} to={to_address}.',
             )
 
-        # else query again and save the DB cache to avoid querying it again
-        self._query_and_save_internal_transactions_for_parent_hash(
-            parent_tx_hash=tx_hash,
-        )
-        with self.database.user_write() as write_cursor:
-            self.database.set_dynamic_cache(
-                write_cursor=write_cursor,
-                name=DBCacheDynamic.EXTRA_INTERNAL_TX,
-                value=user_address,
-                chain_id=chain_id.value,
-                receiver=to_address,
-                tx_hash=str(tx_hash),
-            )
         return self.dbevmtx.get_evm_internal_transactions(
             parent_tx_hash=tx_hash,
-            blockchain=CHAINID_TO_SUPPORTED_BLOCKCHAIN[self.evm_inquirer.chain_id],
+            blockchain=CHAINID_TO_SUPPORTED_BLOCKCHAIN[chain_id],
             from_address=from_address,
             to_address=to_address,
         )

--- a/rotkehlchen/data_migrations/constants.py
+++ b/rotkehlchen/data_migrations/constants.py
@@ -1,3 +1,3 @@
 from typing import Final
 
-LAST_USERDB_DATA_MIGRATION: Final = 22
+LAST_USERDB_DATA_MIGRATION: Final = 23

--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -12,6 +12,7 @@ from rotkehlchen.data_migrations.migrations.migration_11 import data_migration_1
 from rotkehlchen.data_migrations.migrations.migration_20 import data_migration_20
 from rotkehlchen.data_migrations.migrations.migration_21 import data_migration_21
 from rotkehlchen.data_migrations.migrations.migration_22 import data_migration_22
+from rotkehlchen.data_migrations.migrations.migration_23 import data_migration_23
 from rotkehlchen.data_migrations.migrations.migrations_13 import data_migration_13
 from rotkehlchen.data_migrations.migrations.migrations_14 import data_migration_14
 from rotkehlchen.data_migrations.migrations.migrations_18 import data_migration_18
@@ -47,6 +48,7 @@ MIGRATION_LIST = [  # remember to bump LAST_USERDB_DATA_MIGRATION if editing thi
     MigrationRecord(version=20, function=data_migration_20),
     MigrationRecord(version=21, function=data_migration_21),
     MigrationRecord(version=22, function=data_migration_22),
+    MigrationRecord(version=23, function=data_migration_23),
 ]
 
 

--- a/rotkehlchen/data_migrations/migrations/migration_23.py
+++ b/rotkehlchen/data_migrations/migrations/migration_23.py
@@ -1,0 +1,62 @@
+import logging
+from typing import TYPE_CHECKING
+
+from rotkehlchen.db.constants import EXTRAINTERNALTXPREFIX, TX_INTERNALS_QUERIED
+from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
+from rotkehlchen.utils.hexbytes import hexstring_to_bytes
+from rotkehlchen.utils.progress import perform_userdb_migration_steps, progress_step
+
+if TYPE_CHECKING:
+    from rotkehlchen.data_migrations.progress import MigrationProgressHandler
+    from rotkehlchen.rotkehlchen import Rotkehlchen
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+@enter_exit_debug_log()
+def data_migration_23(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressHandler') -> None:
+    """Introduced at v1.42.1
+    - Move extrainternaltx dynamic cache entries to evm_tx_mappings(TX_INTERNALS_QUERIED)
+    """
+    @progress_step(description='Migrating internal transaction query cache to tx mappings')
+    def _migrate_internal_tx_cache_to_mappings(rotki: 'Rotkehlchen') -> None:
+        with rotki.data.db.conn.write_ctx() as write_cursor:
+            rows = write_cursor.execute(
+                'SELECT name FROM key_value_cache WHERE name LIKE ? ESCAPE ?',
+                (f'{EXTRAINTERNALTXPREFIX}\\_%', '\\'),
+            )
+            mapping_tuples: list[tuple[int, bytes, int]] = []
+            for cache_key, in rows:
+                split_key = cache_key.split('_', 3)
+                if len(split_key) != 4:
+                    log.error(f'Skipping malformed {EXTRAINTERNALTXPREFIX} cache key: {cache_key}')
+                    continue
+
+                _, raw_chain_id, _, raw_tx_hash = split_key
+                try:
+                    mapping_tuples.append((
+                        TX_INTERNALS_QUERIED,
+                        hexstring_to_bytes(raw_tx_hash),
+                        int(raw_chain_id),
+                    ))
+                except (ValueError, DeserializationError) as e:
+                    log.error(
+                        f'Failed to parse {EXTRAINTERNALTXPREFIX} cache key {cache_key} due to {e!s}',  # noqa: E501
+                    )
+
+            if len(mapping_tuples) != 0:
+                write_cursor.executemany(
+                    'INSERT OR IGNORE INTO evm_tx_mappings(tx_id, value) '
+                    'SELECT identifier, ? FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+                    mapping_tuples,
+                )
+
+            # Cleanup after migration. Runtime no longer reads these keys.
+            write_cursor.execute(
+                'DELETE FROM key_value_cache WHERE name LIKE ? ESCAPE ?',
+                (f'{EXTRAINTERNALTXPREFIX}\\_%', '\\'),
+            )
+
+    perform_userdb_migration_steps(rotki, progress_handler, should_vacuum=False)

--- a/rotkehlchen/db/constants.py
+++ b/rotkehlchen/db/constants.py
@@ -17,6 +17,8 @@ USER_CREDENTIAL_MAPPING_KEYS: Final = (KRAKEN_ACCOUNT_TYPE_KEY, KRAKEN_FUTURES_A
 # -- EVM transactions attributes values -- used in evm_tx_mappings
 TX_DECODED: Final = 0
 TX_SPAM: Final = 1
+# Marks that full parent-hash internal transactions were queried and persisted for this tx.
+TX_INTERNALS_QUERIED: Final = 2
 
 # -- history_events_mappings values --
 HISTORY_MAPPING_KEY_STATE: Final = 'state'

--- a/rotkehlchen/db/dbtx.py
+++ b/rotkehlchen/db/dbtx.py
@@ -65,13 +65,15 @@ class DBCommonTx(ABC, Generic[T_Address, T_Transaction, T_TxHash, T_TxFilterQuer
         column, base_query = self._get_txs_not_decoded_column_and_query()
         query, bindings = filter_query.prepare()
         with self.db.conn.read_ctx() as cursor:
-            cursor.execute(f'SELECT {column} FROM {base_query} {query}', bindings)
+            # DISTINCT avoids duplicates when a tx has multiple non-decoded mapping rows.
+            cursor.execute(f'SELECT DISTINCT {column} FROM {base_query} {query}', bindings)
             return [self.deserialize_tx_hash_from_db(x[0]) for x in cursor]
 
     def count_hashes_not_decoded(self, filter_query: T_TxNotDecodedFilterQuery) -> int:
         """Count the number of txs that have not been decoded."""
-        _, base_query = self._get_txs_not_decoded_column_and_query()
+        column, base_query = self._get_txs_not_decoded_column_and_query()
         query, bindings = filter_query.prepare()
         with self.db.conn.read_ctx() as cursor:
-            cursor.execute(f'SELECT COUNT(*) FROM {base_query} {query}', bindings)
+            # Match get_transaction_hashes_not_decoded() semantics and count unique txs.
+            cursor.execute(f'SELECT COUNT(DISTINCT {column}) FROM {base_query} {query}', bindings)
             return cursor.fetchone()[0]

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -21,6 +21,7 @@ from rotkehlchen.chain.scroll.constants import SCROLL_GENESIS
 from rotkehlchen.db.constants import (
     EXTRAINTERNALTXPREFIX,
     TX_DECODED,
+    TX_INTERNALS_QUERIED,
     TX_SPAM,
 )
 from rotkehlchen.db.dbtx import DBCommonTx
@@ -559,8 +560,8 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
         )
         # Delete all remaining evm_tx_mappings so decoding can happen again
         write_cursor.executemany(
-            'DELETE FROM evm_tx_mappings WHERE tx_id=? AND value IN (?, ?)',
-            [(x, TX_DECODED, TX_SPAM) for x in tx_ids],
+            'DELETE FROM evm_tx_mappings WHERE tx_id=? AND value IN (?, ?, ?)',
+            [(x, TX_DECODED, TX_SPAM, TX_INTERNALS_QUERIED) for x in tx_ids],
         )
         # Delete any key_value_cache entries
         write_cursor.executemany(

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -470,7 +470,7 @@ CREATE TABLE IF NOT EXISTS used_query_ranges (
 );
 """
 
-# Currently this table is used only to store a flag that shows whether a transaction is decoded.
+# Stores per-transaction state flags (e.g. decoded, spam, internals queried).
 DB_CREATE_EVM_TX_MAPPINGS = """
 CREATE TABLE IF NOT EXISTS evm_tx_mappings (
     tx_id INTEGER NOT NULL,

--- a/rotkehlchen/tests/data_migrations/test_migrations.py
+++ b/rotkehlchen/tests/data_migrations/test_migrations.py
@@ -19,8 +19,9 @@ from rotkehlchen.data_migrations.manager import (
     DataMigrationManager,
     MigrationRecord,
 )
-from rotkehlchen.db.constants import UpdateType
+from rotkehlchen.db.constants import EXTRAINTERNALTXPREFIX, TX_INTERNALS_QUERIED, UpdateType
 from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.exchanges.manager import ExchangeManager
 from rotkehlchen.externalapis.coingecko import Coingecko
 from rotkehlchen.fval import FVal
@@ -32,12 +33,14 @@ from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.tests.utils.blockchain import setup_evm_addresses_activity_mock
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.tests.utils.exchanges import check_saved_events_for_exchange
-from rotkehlchen.tests.utils.factories import make_evm_address
+from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
 from rotkehlchen.types import (
     SPAM_PROTOCOL,
     SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
     CacheType,
+    ChainID,
     ChecksumEvmAddress,
+    EvmTransaction,
     Location,
     SupportedBlockchain,
     Timestamp,
@@ -756,3 +759,103 @@ def test_migration_19(
         f'{BRIDGE_QUERIED_ADDRESS_PREFIX}{gnosis_accounts[0]}',
         f'transactions_{gnosis_accounts[0]}',
     }
+
+
+@pytest.mark.parametrize('perform_upgrades_at_unlock', [False])
+@pytest.mark.parametrize('data_migration_version', [22])
+def test_migration_23(database: DBHandler) -> None:
+    """Test migration 23.
+
+    - Move extrainternaltx cache keys to evm_tx_mappings(TX_INTERNALS_QUERIED)
+    - Delete migrated (and malformed) extrainternaltx cache keys
+    """
+    rotki = MockRotkiForMigrations(database)
+    dbevmtx = DBEvmTx(database)
+    tx_hash_1 = make_evm_tx_hash()
+    tx_hash_2 = make_evm_tx_hash()
+    tx_1 = EvmTransaction(
+        tx_hash=tx_hash_1,
+        chain_id=ChainID.ETHEREUM,
+        timestamp=Timestamp(1700000000),
+        block_number=1,
+        from_address=(address_1 := make_evm_address()),
+        to_address=make_evm_address(),
+        value=0,
+        gas=1,
+        gas_price=1,
+        gas_used=1,
+        input_data=b'',
+        nonce=1,
+    )
+    tx_2 = EvmTransaction(
+        tx_hash=tx_hash_2,
+        chain_id=ChainID.OPTIMISM,
+        timestamp=Timestamp(1700000001),
+        block_number=2,
+        from_address=(address_2 := make_evm_address()),
+        to_address=make_evm_address(),
+        value=0,
+        gas=1,
+        gas_price=1,
+        gas_used=1,
+        input_data=b'',
+        nonce=2,
+    )
+    with database.user_write() as write_cursor:
+        dbevmtx.add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[tx_1, tx_2],
+            relevant_address=address_1,
+        )
+        write_cursor.executemany(
+            'INSERT INTO key_value_cache(name, value) VALUES(?, ?)',
+            [
+                (
+                    f'{EXTRAINTERNALTXPREFIX}_{ChainID.ETHEREUM.value}_{make_evm_address()}_{tx_hash_1!s}',
+                    str(address_1),
+                ),
+                (
+                    f'{EXTRAINTERNALTXPREFIX}_{ChainID.ETHEREUM.value}_{make_evm_address()}_{tx_hash_1!s}',
+                    str(address_1),
+                ),  # same tx, different receiver
+                (
+                    f'{EXTRAINTERNALTXPREFIX}_{ChainID.OPTIMISM.value}_{make_evm_address()}_{tx_hash_2!s}',
+                    str(address_2),
+                ),
+                (f'{EXTRAINTERNALTXPREFIX}_invalid_chain_None_0x1234', str(address_1)),
+            ],
+        )
+
+    with database.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM key_value_cache WHERE name LIKE ? ESCAPE ?',
+            (f'{EXTRAINTERNALTXPREFIX}\\_%', '\\'),
+        ).fetchone()[0] == 4
+
+    with patch(
+        'rotkehlchen.data_migrations.manager.MIGRATION_LIST',
+        new=[next(
+            migration for migration in MIGRATION_LIST if migration.version == 23
+        )],
+    ):
+        migration_manager = DataMigrationManager(rotki)
+        migration_manager.maybe_migrate_data()
+        assert migration_manager.progress_handler.current_round_total_steps == migration_manager.progress_handler.current_round_current_step  # noqa: E501
+
+    with database.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM key_value_cache WHERE name LIKE ? ESCAPE ?',
+            (f'{EXTRAINTERNALTXPREFIX}\\_%', '\\'),
+        ).fetchone()[0] == 0
+        tx_1_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (tx_hash_1, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
+        tx_2_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (tx_hash_2, ChainID.OPTIMISM.serialize_for_db()),
+        ).fetchone()[0]
+        assert set(cursor.execute(
+            'SELECT tx_id, value FROM evm_tx_mappings WHERE value=?',
+            (TX_INTERNALS_QUERIED,),
+        ).fetchall()) == {(tx_1_id, TX_INTERNALS_QUERIED), (tx_2_id, TX_INTERNALS_QUERIED)}

--- a/rotkehlchen/tests/unit/decoders/test_odos_v1.py
+++ b/rotkehlchen/tests/unit/decoders/test_odos_v1.py
@@ -18,6 +18,7 @@ from rotkehlchen.constants.assets import (
     A_WETH,
     A_WETH_ARB,
 )
+from rotkehlchen.db.constants import TX_INTERNALS_QUERIED
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.evm_swap import EvmSwapEvent
@@ -172,6 +173,15 @@ def test_swap_token_to_eth_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts
         address=ARB_ROUTER,
     )]
     assert expected_events == events
+    with arbitrum_one_inquirer.database.conn.read_ctx() as cursor:
+        assert (
+            cursor.execute(
+                'SELECT COUNT(*) FROM evm_tx_mappings WHERE tx_id IN ('
+                'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?) '
+                'AND value=?',
+                (tx_hash, arbitrum_one_inquirer.chain_id.serialize_for_db(), TX_INTERNALS_QUERIED),
+            ).fetchone()[0] == 1
+        ), 'Expected TX_INTERNALS_QUERIED mapping to be persisted for this transaction'
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_odos_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_odos_v2.py
@@ -27,6 +27,7 @@ from rotkehlchen.constants.assets import (
     A_WETH,
 )
 from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.db.constants import TX_INTERNALS_QUERIED
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.evm_swap import EvmSwapEvent
@@ -132,6 +133,15 @@ def test_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
         address=ETH_ROUTER,
     )]
     assert expected_events == events
+    with ethereum_inquirer.database.conn.read_ctx() as cursor:
+        assert (
+            cursor.execute(
+                'SELECT COUNT(*) FROM evm_tx_mappings WHERE tx_id IN ('
+                'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?) '
+                'AND value=?',
+                (tx_hash, ethereum_inquirer.chain_id.serialize_for_db(), TX_INTERNALS_QUERIED),
+            ).fetchone()[0] == 1
+        ), 'Expected TX_INTERNALS_QUERIED mapping to be persisted for this transaction'
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_paraswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_paraswap.py
@@ -23,6 +23,7 @@ from rotkehlchen.constants.assets import (
     A_WBTC,
 )
 from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.db.constants import TX_INTERNALS_QUERIED
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.evm_swap import EvmSwapEvent
@@ -175,6 +176,15 @@ def test_simple_swap_eth_fee(ethereum_inquirer, ethereum_accounts):
         address=PARASWAP_AUGUSTUS_ROUTER,
     )]
     assert expected_events == events
+    with ethereum_inquirer.database.conn.read_ctx() as cursor:
+        assert (
+            cursor.execute(
+                'SELECT COUNT(*) FROM evm_tx_mappings WHERE tx_id IN ('
+                'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?) '
+                'AND value=?',
+                (tx_hash, ethereum_inquirer.chain_id.serialize_for_db(), TX_INTERNALS_QUERIED),
+            ).fetchone()[0] == 1
+        ), 'Expected TX_INTERNALS_QUERIED mapping to be persisted for this transaction'
 
 
 @pytest.mark.vcr

--- a/rotkehlchen/tests/unit/decoders/test_rainbow.py
+++ b/rotkehlchen/tests/unit/decoders/test_rainbow.py
@@ -12,6 +12,7 @@ from rotkehlchen.chain.evm.decoding.rainbow.constants import (
 )
 from rotkehlchen.chain.evm.transactions import EvmTransactions
 from rotkehlchen.constants.assets import A_BSC_BNB, A_ETH, A_OP, A_POL
+from rotkehlchen.db.constants import TX_INTERNALS_QUERIED
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -87,6 +88,15 @@ def test_rainbow_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
         counterparty=CPT_RAINBOW_SWAPS,
         address=RAINBOW_ROUTER_CONTRACT,
     )]
+    with ethereum_inquirer.database.conn.read_ctx() as cursor:
+        assert (
+            cursor.execute(
+                'SELECT COUNT(*) FROM evm_tx_mappings WHERE tx_id IN ('
+                'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?) '
+                'AND value=?',
+                (tx_hash, ethereum_inquirer.chain_id.serialize_for_db(), TX_INTERNALS_QUERIED),
+            ).fetchone()[0] == 1
+        ), 'Expected TX_INTERNALS_QUERIED mapping to be persisted for this transaction'
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -12,7 +12,13 @@ from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2WithL1FeesTransaction
 from rotkehlchen.chain.evm.types import EvmAccount, string_to_evm_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH, A_SAI
-from rotkehlchen.db.constants import TX_DECODED, TX_SPAM, HistoryMappingState
+from rotkehlchen.db.constants import (
+    HISTORY_MAPPING_KEY_STATE,
+    TX_DECODED,
+    TX_INTERNALS_QUERIED,
+    TX_SPAM,
+    HistoryMappingState,
+)
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import (
     EvmEventFilterQuery,
@@ -24,6 +30,7 @@ from rotkehlchen.db.l2withl1feestx import DBL2WithL1FeesTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.base import (
     HistoryBaseEntry,
+    HistoryBaseEntryType,
     HistoryEventSubType,
     HistoryEventType,
 )
@@ -256,6 +263,17 @@ def test_query_and_decode_transactions_works_with_different_chains(
     )
     assert len(hashes) == 2
 
+    # see that setting internals queried does not duplicate undecoded txs nor count as decoded
+    with database.user_write() as write_cursor:
+        write_cursor.execute(
+            'INSERT INTO evm_tx_mappings(tx_id, value) VALUES(?, ?)',
+            (3, TX_INTERNALS_QUERIED),
+        )
+    hashes = dbevmtx.get_transaction_hashes_not_decoded(
+        filter_query=EvmTransactionsNotDecodedFilterQuery.make(chain_id=ChainID.ETHEREUM, limit=None),  # noqa: E501
+    )
+    assert len(hashes) == 2
+
     # see that setting the decoded attribute counts properly
     with database.user_write() as write_cursor:
         write_cursor.execute(
@@ -266,6 +284,80 @@ def test_query_and_decode_transactions_works_with_different_chains(
         filter_query=EvmTransactionsNotDecodedFilterQuery.make(chain_id=ChainID.ETHEREUM, limit=None),  # noqa: E501
     )
     assert len(hashes) == 1
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306', '0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])  # noqa: E501
+def test_delete_transactions_removes_internals_queried_mapping(
+        database: 'DBHandler',
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Ensure TX_INTERNALS_QUERIED mapping is removed when deleting txs for an address.
+
+    Covers the case where the tx itself is preserved due customized events.
+    """
+    tx_hash_eth, _, _ = _add_transactions_to_db(database, ethereum_accounts)
+    dbevmtx = DBEvmTx(database)
+    with database.user_write() as write_cursor:
+        tx_id = write_cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (tx_hash_eth, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
+        write_cursor.execute(
+            'INSERT INTO evm_tx_mappings(tx_id, value) VALUES(?, ?)',
+            (tx_id, TX_INTERNALS_QUERIED),
+        )
+        event_id = write_cursor.execute(
+            'INSERT INTO history_events(entry_type, group_identifier, sequence_index, '
+            'timestamp, location, location_label, asset, amount, notes, type, subtype, '
+            'extra_data, ignored) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            (
+                HistoryBaseEntryType.EVM_EVENT.value,
+                f'10x{tx_hash_eth!s}',
+                0,
+                TimestampMS(1646375440000),
+                Location.ETHEREUM.serialize_for_db(),
+                ethereum_accounts[0],
+                A_ETH.identifier,
+                '1',
+                'customized event to preserve tx',
+                HistoryEventType.SPEND.value,
+                HistoryEventSubType.NONE.value,
+                None,
+                0,
+            ),
+        ).lastrowid
+        write_cursor.execute(
+            'INSERT INTO chain_events_info(identifier, tx_ref, counterparty, address) '
+            'VALUES(?, ?, ?, ?)',
+            (event_id, tx_hash_eth, None, None),
+        )
+        write_cursor.execute(
+            'INSERT INTO history_events_mappings(parent_identifier, name, value) VALUES(?, ?, ?)',
+            (
+                event_id,
+                HISTORY_MAPPING_KEY_STATE,
+                HistoryMappingState.CUSTOMIZED.serialize_for_db(),
+            ),
+        )
+        dbevmtx.delete_transactions(
+            write_cursor=write_cursor,
+            address=ethereum_accounts[0],
+            chain=SupportedBlockchain.ETHEREUM,
+        )
+
+    with database.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (tx_hash_eth, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0] == 1  # tx is preserved by customized event
+        assert (
+            cursor.execute(
+                'SELECT COUNT(*) FROM evm_tx_mappings WHERE tx_id IN ('
+                'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?) '
+                'AND value=?',
+                (tx_hash_eth, ChainID.ETHEREUM.serialize_for_db(), TX_INTERNALS_QUERIED),
+            ).fetchone()[0] == 0
+        ), 'Expected TX_INTERNALS_QUERIED mapping to be removed with deleted tx data'
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
This change removes the fragile key_value_cache usage for extrainternaltx_* and stores the internal query completion state in evm_tx_mappings using TX_INTERNALS_QUERIED. The internal transaction ensure path now checks and writes this per transaction state directly on the transaction row set, and decoding pending queries were updated to use distinct selection and counting so extra mapping values do not create duplicates. Transaction deletion was also updated to clear this new mapping value so state stays consistent.

A new data migration 23 converts existing extrainternaltx_* cache entries into TX_INTERNALS_QUERIED mappings and then removes the legacy cache keys, so existing users keep their query state without requiring a DB schema upgrade. Tests were added and updated to verify migration behavior, deletion cleanup, and decoder flows that rely on internal transaction ensuring now create the new mapping entry. This is better because the state is now attached to transactions with proper relational semantics and cleanup behavior, instead of relying on error prone string keyed cache entries that were easy to desync and required manual invalidation logic.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
