### PR TITLE
Check ETH staking limits before submission

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`11817` ETH staking validator limits are now checked before submission in the add validator dialog, showing user-friendly messages with upgrade prompts instead of raw backend errors.
 * :bug:`-` Certain cases of ENS registrations with a specific refund ordering will now also be properly understood by rotki.
 * :bug:`-` Gearbox withdrawals should now always have the correct order of events.
 * :bug:`-` Gearbox deposit through some wrapper routes will now be properly decoded.

--- a/frontend/app/src/components/accounts/EvmAccountPageButtons.vue
+++ b/frontend/app/src/components/accounts/EvmAccountPageButtons.vue
@@ -9,8 +9,9 @@ import { useTaskStore } from '@/store/tasks';
 import { Section } from '@/types/status';
 import { TaskType } from '@/types/task-type';
 
-defineProps<{
+const { addDisabled = false } = defineProps<{
   isAccountsTabSelected: boolean;
+  addDisabled?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -79,16 +80,25 @@ const isEth2Loading = logicOr(
     {{ t('common.refresh') }}
   </RuiButton>
 
-  <RuiButton
-    data-cy="add-blockchain-account"
-    color="primary"
-    @click="emit('add-account')"
+  <RuiTooltip
+    :disabled="!addDisabled"
+    :open-delay="300"
   >
-    <template #prepend>
-      <RuiIcon name="lu-plus" />
+    <template #activator>
+      <RuiButton
+        data-cy="add-blockchain-account"
+        color="primary"
+        :disabled="addDisabled"
+        @click="emit('add-account')"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-plus" />
+        </template>
+        {{ t('blockchain_balances.add_account') }}
+      </RuiButton>
     </template>
-    {{ t('blockchain_balances.add_account') }}
-  </RuiButton>
+    {{ t('blockchain_balances.add_validator_premium') }}
+  </RuiTooltip>
 
   <AccountBalancesExportImport />
 </template>

--- a/frontend/app/src/components/accounts/management/AccountDialog.vue
+++ b/frontend/app/src/components/accounts/management/AccountDialog.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 import { assert } from '@rotki/common';
+import { externalLinks } from '@shared/external-links';
 import { isEqual } from 'es-toolkit';
 import AccountForm from '@/components/accounts/management/AccountForm.vue';
 import BigDialog from '@/components/dialogs/BigDialog.vue';
+import ExternalLink from '@/components/helper/ExternalLink.vue';
 import { type AccountManageState, useAccountManage } from '@/composables/accounts/blockchain/use-account-manage';
 import { useAccountLoading } from '@/composables/accounts/loading';
+import { useEthStaking } from '@/composables/blockchain/accounts/staking';
+import { usePremiumHelper } from '@/composables/premium';
 import { useExternalApiKeys } from '@/composables/settings/api-keys/external';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 
@@ -33,21 +37,46 @@ const subtitle = computed<string>(() =>
   get(model)?.mode === 'edit' ? t('blockchain_balances.form_dialog.edit_subtitle') : '',
 );
 
-const { errorMessages, pending, save } = useAccountManage();
+const { errorMessages, pending, save, saveError, saveErrorIsPremium } = useAccountManage();
 const { loading } = useAccountLoading();
 const { apiKey } = useExternalApiKeys(t);
 const { beaconRpcEndpoint } = storeToRefs(useGeneralSettingsStore());
+const { validatorsLimitInfo } = useEthStaking();
+const { currentTier, ethStakedLimit, premium } = usePremiumHelper();
+
+const isValidatorLimitReached = computed<boolean>(() => {
+  const state = get(model);
+  if (!state || state.mode === 'edit')
+    return false;
+
+  return state.type === 'validator' && get(validatorsLimitInfo).showWarning;
+});
+
+const upgradeLinkText = computed<string>(() =>
+  get(premium)
+    ? t('upgrade_row.upgrade_your_plan')
+    : t('upgrade_row.rotki_premium'),
+);
+
+const upgradeLinkUrl = computed<string | undefined>(() =>
+  get(premium) ? externalLinks.manageSubscriptions : undefined,
+);
 
 const isSaveDisabled = computed<boolean>(() => {
   const state = get(model);
   if (!state || state.mode === 'edit')
     return false;
 
+  if (get(isValidatorLimitReached))
+    return true;
+
   // Disable save button for validator addition without beaconchain API key and consensus client RPC
   return state.type === 'validator' && !(get(apiKey('beaconchain')) || get(beaconRpcEndpoint));
 });
 
 function dismiss() {
+  set(saveError, '');
+  set(saveErrorIsPremium, false);
   set(model, undefined);
 }
 
@@ -55,6 +84,7 @@ async function confirm() {
   assert(isDefined(form));
   const accountForm = get(form);
   set(errorMessages, {});
+  set(saveError, '');
   const valid = await accountForm.validate();
   if (!valid)
     return;
@@ -105,5 +135,64 @@ watch(model, (model, oldModel) => {
       :chain-ids="chainIds"
       :loading="loading"
     />
+
+    <RuiAlert
+      v-if="saveError"
+      type="error"
+      class="mt-4"
+    >
+      <template v-if="saveErrorIsPremium">
+        <i18n-t
+          scope="global"
+          keypath="blockchain_balances.eth_staking_limit_error"
+          tag="span"
+        >
+          <template #limit>
+            {{ ethStakedLimit }}
+          </template>
+          <template #currentTier>
+            {{ currentTier }}
+          </template>
+          <template #link>
+            <ExternalLink
+              :text="upgradeLinkText"
+              :url="upgradeLinkUrl"
+              premium
+              color="primary"
+            />
+          </template>
+        </i18n-t>
+      </template>
+      <template v-else>
+        {{ saveError }}
+      </template>
+    </RuiAlert>
+
+    <RuiAlert
+      v-if="isValidatorLimitReached"
+      type="error"
+      class="mt-4"
+    >
+      <i18n-t
+        scope="global"
+        keypath="blockchain_balances.validator_limit_reached"
+        tag="span"
+      >
+        <template #limit>
+          {{ validatorsLimitInfo.limit }}
+        </template>
+        <template #total>
+          {{ validatorsLimitInfo.total }}
+        </template>
+        <template #link>
+          <ExternalLink
+            :text="upgradeLinkText"
+            :url="upgradeLinkUrl"
+            premium
+            color="primary"
+          />
+        </template>
+      </i18n-t>
+    </RuiAlert>
   </BigDialog>
 </template>

--- a/frontend/app/src/composables/accounts/blockchain/use-account-manage.spec.ts
+++ b/frontend/app/src/composables/accounts/blockchain/use-account-manage.spec.ts
@@ -1,0 +1,197 @@
+import type { StakingValidatorManage } from './use-account-manage';
+import type { ActionStatus } from '@/types/action';
+import type { ValidationErrors } from '@/types/api/errors';
+import { Blockchain } from '@rotki/common';
+import { type Pinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/composables/blockchain', () => ({
+  useBlockchains: vi.fn(() => ({
+    addAccounts: vi.fn(),
+    addEvmAccounts: vi.fn(),
+    fetchAccounts: vi.fn().mockResolvedValue(undefined),
+    refreshAccounts: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('@/composables/blockchain/accounts', () => ({
+  useBlockchainAccounts: vi.fn(() => ({
+    editAccount: vi.fn(),
+    editAgnosticAccount: vi.fn(),
+  })),
+}));
+
+vi.mock('@/modules/accounts/use-blockchain-accounts-store', () => ({
+  useBlockchainAccountsStore: vi.fn(() => ({
+    updateAccountData: vi.fn(),
+    updateAccounts: vi.fn(),
+  })),
+}));
+
+vi.mock('@/store/message', () => ({
+  useMessageStore: vi.fn(() => ({
+    setMessage: vi.fn(),
+  })),
+}));
+
+const mockAddEth2Validator = vi.fn<() => Promise<ActionStatus<ValidationErrors | string>>>();
+const mockEditEth2Validator = vi.fn<() => Promise<ActionStatus<ValidationErrors | string>>>();
+
+vi.mock('@/composables/blockchain/accounts/staking', () => ({
+  useEthStaking: vi.fn(() => ({
+    addEth2Validator: mockAddEth2Validator,
+    editEth2Validator: mockEditEth2Validator,
+    updateEthStakingOwnership: vi.fn(),
+  })),
+}));
+
+const { useAccountManage } = await import('./use-account-manage');
+
+function createValidatorState(mode: 'add' | 'edit' = 'add'): StakingValidatorManage {
+  return {
+    chain: Blockchain.ETH2,
+    data: {
+      ownershipPercentage: mode === 'edit' ? '100' : undefined,
+      publicKey: '0xabc123',
+      validatorIndex: '12345',
+    },
+    mode,
+    type: 'validator',
+  };
+}
+
+describe('composables/accounts/blockchain/use-account-manage', () => {
+  let pinia: Pinia;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+
+  describe('saveValidator', () => {
+    it('should return true and clear errors on successful add', async () => {
+      mockAddEth2Validator.mockResolvedValue({ success: true });
+
+      const { save, saveError, saveErrorIsPremium } = useAccountManage();
+      const result = await save(createValidatorState());
+
+      expect(result).toBe(true);
+      expect(get(saveError)).toBe('');
+      expect(get(saveErrorIsPremium)).toBe(false);
+    });
+
+    it('should set saveError on failure with string message', async () => {
+      mockAddEth2Validator.mockResolvedValue({
+        message: 'Querying https://beaconcha.in/api/v1/validator failed due to missing API key',
+        success: false,
+      });
+
+      const { save, saveError, saveErrorIsPremium } = useAccountManage();
+      const result = await save(createValidatorState());
+
+      expect(result).toBe(false);
+      expect(get(saveError)).toBe('Querying https://beaconcha.in/api/v1/validator failed due to missing API key');
+      expect(get(saveErrorIsPremium)).toBe(false);
+    });
+
+    it('should set saveErrorIsPremium when error contains limit exceeded', async () => {
+      mockAddEth2Validator.mockResolvedValue({
+        message: 'ETH staking limit exceeded. Current staked: 38.785 ETH, limit: 128 ETH. Would be: 277.278 ETH',
+        success: false,
+      });
+
+      const { save, saveError, saveErrorIsPremium } = useAccountManage();
+      const result = await save(createValidatorState());
+
+      expect(result).toBe(false);
+      expect(get(saveError)).toContain('limit exceeded');
+      expect(get(saveErrorIsPremium)).toBe(true);
+    });
+
+    it('should set errorMessages on failure with validation errors', async () => {
+      const validationErrors: ValidationErrors = {
+        publicKey: ['Invalid public key format'],
+      };
+      mockAddEth2Validator.mockResolvedValue({
+        message: validationErrors,
+        success: false,
+      });
+
+      const { errorMessages, save, saveError } = useAccountManage();
+      const result = await save(createValidatorState());
+
+      expect(result).toBe(false);
+      expect(get(errorMessages)).toEqual(validationErrors);
+      expect(get(saveError)).toBe('');
+    });
+
+    it('should clear saveError before each save attempt', async () => {
+      mockAddEth2Validator
+        .mockResolvedValueOnce({
+          message: 'First error',
+          success: false,
+        })
+        .mockResolvedValueOnce({
+          success: true,
+        });
+
+      const { save, saveError } = useAccountManage();
+
+      await save(createValidatorState());
+      expect(get(saveError)).toBe('First error');
+
+      await save(createValidatorState());
+      expect(get(saveError)).toBe('');
+    });
+
+    it('should clear saveErrorIsPremium before each save attempt', async () => {
+      mockAddEth2Validator
+        .mockResolvedValueOnce({
+          message: 'ETH staking limit exceeded',
+          success: false,
+        })
+        .mockResolvedValueOnce({
+          message: 'Some other error',
+          success: false,
+        });
+
+      const { save, saveErrorIsPremium } = useAccountManage();
+
+      await save(createValidatorState());
+      expect(get(saveErrorIsPremium)).toBe(true);
+
+      await save(createValidatorState());
+      expect(get(saveErrorIsPremium)).toBe(false);
+    });
+
+    it('should use editEth2Validator for edit mode', async () => {
+      mockEditEth2Validator.mockResolvedValue({ success: true });
+
+      const { save } = useAccountManage();
+      const state = createValidatorState('edit');
+
+      await save(state);
+
+      expect(mockEditEth2Validator).toHaveBeenCalledWith(state.data);
+      expect(mockAddEth2Validator).not.toHaveBeenCalled();
+    });
+
+    it('should set pending during save', async () => {
+      let resolvePromise: (value: ActionStatus<ValidationErrors | string>) => void;
+      mockAddEth2Validator.mockImplementation(async () => new Promise((resolve) => {
+        resolvePromise = resolve;
+      }));
+
+      const { pending, save } = useAccountManage();
+      expect(get(pending)).toBe(false);
+
+      const savePromise = save(createValidatorState());
+      expect(get(pending)).toBe(true);
+
+      resolvePromise!({ success: true });
+      await savePromise;
+      expect(get(pending)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/composables/accounts/blockchain/use-account-manage.ts
+++ b/frontend/app/src/composables/accounts/blockchain/use-account-manage.ts
@@ -147,12 +147,16 @@ export function editBlockchainAccount(account: BlockchainAccountBalance): Accoun
 interface UseAccountManageReturn {
   pending: Ref<boolean>;
   errorMessages: Ref<ValidationErrors>;
+  saveError: Ref<string>;
+  saveErrorIsPremium: Ref<boolean>;
   save: (state: AccountManageState) => Promise<boolean>;
 }
 
 export function useAccountManage(): UseAccountManageReturn {
   const pending = ref(false);
   const errorMessages = ref<ValidationErrors>({});
+  const saveError = ref<string>('');
+  const saveErrorIsPremium = ref<boolean>(false);
 
   const { t } = useI18n({ useScope: 'global' });
 
@@ -260,6 +264,8 @@ export function useAccountManage(): UseAccountManageReturn {
 
   async function saveValidator(state: StakingValidatorManage): Promise<boolean> {
     set(pending, true);
+    set(saveError, '');
+    set(saveErrorIsPremium, false);
 
     const payload = state.data;
     const isEdit = state.mode === 'edit';
@@ -277,29 +283,8 @@ export function useAccountManage(): UseAccountManageReturn {
       }
     }
     else if (typeof result.message === 'string') {
-      let description: string;
-      let title: string;
-
-      if (isEdit) {
-        title = t('actions.edit_eth2_validator.error.title');
-        description = t('actions.edit_eth2_validator.error.description', {
-          id: payload.publicKey || payload.validatorIndex || '',
-          message: result.message,
-        });
-      }
-      else {
-        title = t('actions.add_eth2_validator.error.title');
-        description = t('actions.add_eth2_validator.error.description', {
-          id: payload.publicKey || payload.validatorIndex || '',
-          message: result.message,
-        });
-      }
-
-      setMessage({
-        description,
-        success: false,
-        title,
-      });
+      set(saveError, result.message);
+      set(saveErrorIsPremium, result.message.includes('limit exceeded'));
     }
     else {
       set(errorMessages, result.message);
@@ -326,5 +311,7 @@ export function useAccountManage(): UseAccountManageReturn {
     errorMessages,
     pending,
     save,
+    saveError,
+    saveErrorIsPremium,
   };
 }

--- a/frontend/app/src/composables/premium.ts
+++ b/frontend/app/src/composables/premium.ts
@@ -9,6 +9,7 @@ export function usePremium(): Ref<boolean> {
 
 interface UsePremiumHelperReturn {
   currentTier: Readonly<Ref<string>>;
+  ethStakedLimit: Readonly<Ref<number>>;
   premium: Readonly<Ref<boolean>>;
   showGetPremiumButton: () => void;
 }
@@ -22,10 +23,12 @@ export function usePremiumHelper(): UsePremiumHelperReturn {
     premiumUserLoggedIn(get(premium));
   };
 
-  const currentTier = computed<string>(() => get(capabilities)?.currentTier ?? '');
+  const currentTier = computed<string>(() => get(capabilities)?.currentTier ?? 'Free');
+  const ethStakedLimit = computed<number>(() => get(capabilities)?.ethStakedLimit ?? 0);
 
   return {
     currentTier: readonly(currentTier),
+    ethStakedLimit: readonly(ethStakedLimit),
     premium: readonly(premium),
     showGetPremiumButton,
   };

--- a/frontend/app/src/locales/cn.json
+++ b/frontend/app/src/locales/cn.json
@@ -139,10 +139,6 @@
   },
   "actions": {
     "add_eth2_validator": {
-      "error": {
-        "description": "添加 ETH 質押驗證器 {id} 時出錯：{message}",
-        "title": "添加 ETH 質押驗證器"
-      },
       "task": {
         "description": "添加 ETH 質押驗證器",
         "title": "添加验证器：{id}"
@@ -334,12 +330,6 @@
       "error": {
         "description": "刪除 ETH 質押驗證器失敗：{message}",
         "title": "刪除 ETH 抵押驗證器"
-      }
-    },
-    "edit_eth2_validator": {
-      "error": {
-        "description": "編輯 ETH 質押驗證器 {id} 時出錯：{message}",
-        "title": "編輯 ETH 質押驗證器"
       }
     },
     "get_accounts": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -272,10 +272,6 @@
       }
     },
     "add_eth2_validator": {
-      "error": {
-        "description": "There was an error while adding the ETH staking validator {id}: {message}",
-        "title": "Adding ETH staking validator"
-      },
       "task": {
         "description": "Adding ETH staking validator",
         "title": "Adding validator: {id}"
@@ -588,12 +584,6 @@
       },
       "task": {
         "title": "Detecting EVM accounts"
-      }
-    },
-    "edit_eth2_validator": {
-      "error": {
-        "description": "There was an error while editing the ETH staking validator {id}: {message}",
-        "title": "Editing ETH staking validator"
       }
     },
     "eth_block_events_redecoding": {
@@ -1695,7 +1685,9 @@
   },
   "blockchain_balances": {
     "add_account": "Add Account",
+    "add_validator_premium": "Adding ETH staking validators is a premium feature. Upgrade to rotki Premium to add validators.",
     "binance_warning": "Binance Smart Chain accounts can only be detected with a paid Etherscan key.",
+    "eth_staking_limit_error": "Adding this validator would exceed your {currentTier} plan's ETH staking limit of {limit} ETH. Upgrade your plan via {link} or contact us for a custom plan to increase your limit.",
     "evm_detection": {
       "title": "Detect EVM accounts",
       "tooltip": "Detect activities of all registered EVM accounts in other EVM chains, and register them."
@@ -1721,6 +1713,7 @@
     },
     "title": "Blockchain Balances per asset",
     "validator_index_label": "Ethereum validator No. {index}",
+    "validator_limit_reached": "You have reached the ETH staking validator limit ({total}/{limit}). {link} to add more validators.",
     "validators": {
       "auto_detection_info": "rotki will automatically detect validators if you add the depositor address as an Ethereum account. First, ensure the events for that depositor address are fetched and decoded in history events, where any ETH deposit events will be detected. After the events are found, manually hit the refresh button to update the validator list.",
       "consolidated": "Consolidated into:",

--- a/frontend/app/src/locales/es.json
+++ b/frontend/app/src/locales/es.json
@@ -137,10 +137,6 @@
   },
   "actions": {
     "add_eth2_validator": {
-      "error": {
-        "description": "Hubo un error al agregar el validador de ETH {id}: {message}",
-        "title": "Agregando validador de ETH"
-      },
       "task": {
         "description": "Agregando validador de ETH",
         "title": "Agregando validador: {id}"
@@ -329,12 +325,6 @@
       "error": {
         "description": "Deleting the ETH staking validators failed: {message}",
         "title": "Deleting ETH staking validators"
-      }
-    },
-    "edit_eth2_validator": {
-      "error": {
-        "description": "There was an error while editing the ETH staking validator {id}: {message}",
-        "title": "Editing ETH staking validator"
       }
     },
     "get_accounts": {

--- a/frontend/app/src/locales/fr.json
+++ b/frontend/app/src/locales/fr.json
@@ -192,10 +192,6 @@
   },
   "actions": {
     "add_eth2_validator": {
-      "error": {
-        "description": "Il y a eu une erreur lors de l'ajout du validateur de staking ETH {id} : {message}",
-        "title": "Ajout d'un validateur de staking ETH"
-      },
       "task": {
         "description": "Ajout d'un validateur de staking ETH",
         "title": "Ajout du validateur : {id}"
@@ -441,12 +437,6 @@
       },
       "task": {
         "title": "Détection des comptes EVM"
-      }
-    },
-    "edit_eth2_validator": {
-      "error": {
-        "description": "Une erreur s'est produite lors de la modification du validateur de staking ETH {id} : {message}",
-        "title": "Modification du validateur de staking ETH"
       }
     },
     "get_accounts": {

--- a/frontend/app/src/locales/gr.json
+++ b/frontend/app/src/locales/gr.json
@@ -133,10 +133,6 @@
   },
   "actions": {
     "add_eth2_validator": {
-      "error": {
-        "description": "There was an error while adding the ETH staking validator {id}: {message}",
-        "title": "Adding ETH staking validator"
-      },
       "task": {
         "description": "Adding ETH staking validator",
         "title": "Adding validator: {id}"
@@ -337,12 +333,6 @@
       "error": {
         "description": "Deleting the ETH staking validators failed: {message}",
         "title": "Deleting ETH staking validators"
-      }
-    },
-    "edit_eth2_validator": {
-      "error": {
-        "description": "There was an error while editing the ETH staking validator {id}: {message}",
-        "title": "Editing ETH staking validator"
       }
     },
     "get_accounts": {

--- a/frontend/app/src/locales/ru.json
+++ b/frontend/app/src/locales/ru.json
@@ -272,10 +272,6 @@
       }
     },
     "add_eth2_validator": {
-      "error": {
-        "description": "Ошибка при добавлении валидатора стейкинга ETH {id}: {message}",
-        "title": "Добавление валидатора стейкинга ETH"
-      },
       "task": {
         "description": "Добавление валидатора стейкинга ETH",
         "title": "Добавление валидатора: {id}"
@@ -557,12 +553,6 @@
       },
       "task": {
         "title": "Обнаружение EVM-аккаунтов"
-      }
-    },
-    "edit_eth2_validator": {
-      "error": {
-        "description": "Ошибка при редактировании валидатора стейкинга ETH {id}: {message}",
-        "title": "Редактирование валидатора стейкинга ETH"
       }
     },
     "eth_block_events_redecoding": {

--- a/frontend/app/src/pages/accounts/evm/[[tab]].vue
+++ b/frontend/app/src/pages/accounts/evm/[[tab]].vue
@@ -11,6 +11,7 @@ import AccountDialog from '@/components/accounts/management/AccountDialog.vue';
 import TablePageLayout from '@/components/layout/TablePageLayout.vue';
 import { useAccountCategoryHelper } from '@/composables/accounts/use-account-category-helper';
 import { useModules } from '@/composables/session/modules';
+import { useEthStakingAccess } from '@/modules/staking/eth/composables/use-eth-staking-access';
 import { useAccountImportProgressStore } from '@/store/use-account-import-progress-store';
 import { Module } from '@/types/modules';
 import { NoteLocation } from '@/types/notes';
@@ -42,7 +43,9 @@ const { importingAccounts } = storeToRefs(useAccountImportProgressStore());
 const { isModuleEnabled } = useModules();
 const isEth2Enabled = isModuleEnabled(Module.ETH2);
 
-const isAccountsTabSelected = computed(() => get(tab) === 'accounts');
+const isAccountsTabSelected = computed<boolean>(() => get(tab) === 'accounts');
+const { allowed: ethStakingAllowed } = useEthStakingAccess();
+const isAddDisabled = computed<boolean>(() => !get(isAccountsTabSelected) && !get(ethStakingAllowed));
 
 const { chainIds } = useAccountCategoryHelper(category);
 const usedChainIds = computed(() => {
@@ -115,6 +118,7 @@ watchImmediate(route, (route) => {
     <template #buttons>
       <EvmAccountPageButtons
         :is-accounts-tab-selected="isAccountsTabSelected"
+        :add-disabled="isAddDisabled"
         @refresh-click="get(table)?.refreshClick()"
         @refresh="get(table)?.refresh()"
         @add-account="createNewBlockchainAccount()"

--- a/frontend/app/tests/unit/specs/components/premium/get-premium-button.spec.ts
+++ b/frontend/app/tests/unit/specs/components/premium/get-premium-button.spec.ts
@@ -42,6 +42,6 @@ describe('getPremiumButton.vue', () => {
 
     const button = wrapper.find('[data-cy=get-premium-button]');
     expect(button.exists()).toBeTruthy();
-    expect(button.text()).toContain('premium_placeholder.upgrade_plan');
+    expect(button.text()).toContain('premium_placeholder.current_plan');
   });
 });


### PR DESCRIPTION
## Summary
- Check validator count limit proactively in the add validator dialog and show an inline alert with upgrade prompt when the limit is reached
- Show ETH staking limit exceeded errors inline in the dialog with tier-aware messaging and upgrade/contact links instead of raw backend error notifications
- Disable the "Add Account" button for free-tier users on the validators tab with a tooltip indicating it's a premium feature
- Add `ethStakedLimit` and default `Free` tier to `usePremiumHelper`

## Test plan
- [x] `pnpm run lint:fix` passes
- [x] `pnpm run typecheck` passes
- [x] Unit tests added for `useAccountManage` saveValidator error handling (8 tests pass)
- [ ] Manual test: open add validator dialog as free-tier user — button disabled with tooltip
- [ ] Manual test: open add validator dialog as premium user at validator limit — inline alert shown, save disabled
- [ ] Manual test: add validator that exceeds ETH staking limit — inline error with tier info and upgrade link

Closes #11817