### PR TITLE
refactor(frontend): use/get split for module enabled

### DIFF
--- a/frontend/app/src/components/accounts/blockchain/ChainSelect.vue
+++ b/frontend/app/src/components/accounts/blockchain/ChainSelect.vue
@@ -3,8 +3,7 @@ import type { ChainInfo } from '@/types/api/chains';
 import { Blockchain } from '@rotki/common';
 import ChainDisplay from '@/components/accounts/blockchain/ChainDisplay.vue';
 import { useSupportedChains } from '@/composables/info/chains';
-import { useModules } from '@/composables/session/modules';
-import { Module } from '@/types/modules';
+import { getModuleEnabled, Module } from '@/composables/session/modules';
 
 defineOptions({
   inheritAttrs: false,
@@ -26,14 +25,12 @@ const {
   items?: string[];
 }>();
 
-const { isModuleEnabled } = useModules();
-
 const { isEvm, supportedChains } = useSupportedChains();
 
 const { t } = useI18n({ useScope: 'global' });
 
 const filteredItems = computed<string[]>(() => {
-  const isEth2Enabled = get(isModuleEnabled(Module.ETH2));
+  const isEth2Enabled = getModuleEnabled(Module.ETH2);
 
   let data: string[] = get(supportedChains).map(({ id }) => id);
 
@@ -44,7 +41,7 @@ const filteredItems = computed<string[]>(() => {
     data = data.filter(symbol => symbol !== Blockchain.ETH2);
 
   if (evmOnly)
-    data = data.filter(symbol => isEvm(symbol as Blockchain));
+    data = data.filter(isEvm);
 
   return data;
 });

--- a/frontend/app/src/components/staking/liquity/LiquityPage.vue
+++ b/frontend/app/src/components/staking/liquity/LiquityPage.vue
@@ -4,22 +4,20 @@ import ModuleNotActive from '@/components/defi/ModuleNotActive.vue';
 import LiquityStakingDetails from '@/components/staking/liquity/LiquityStakingDetails.vue';
 import LiquityStakingPagePlaceholder from '@/components/staking/liquity/LiquityStakingPagePlaceholder.vue';
 import { usePremium } from '@/composables/premium';
-import { useModules } from '@/composables/session/modules';
+import { Module, useModuleEnabled } from '@/composables/session/modules';
 import { usePriceTaskManager } from '@/modules/prices/use-price-task-manager';
 import { useLiquityStore } from '@/store/defi/liquity';
 import { useHistoricCachePriceStore } from '@/store/prices/historic';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { useStatusStore } from '@/store/status';
-import { Module } from '@/types/modules';
 import { Section } from '@/types/status';
 
 const modules = [Module.LIQUITY];
-const { isModuleEnabled } = useModules();
+const { enabled: moduleEnabled } = useModuleEnabled(modules[0]);
 const { fetchPools, fetchStaking, fetchStatistics, setStakingQueryStatus } = useLiquityStore();
 const { resetProtocolStatsPriceQueryStatus } = useHistoricCachePriceStore();
 const { useShouldShowLoadingScreen } = useStatusStore();
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
-const moduleEnabled = isModuleEnabled(modules[0]);
 const premium = usePremium();
 const { fetchPrices } = usePriceTaskManager();
 

--- a/frontend/app/src/composables/history/events/tx/refresh-handlers.ts
+++ b/frontend/app/src/composables/history/events/tx/refresh-handlers.ts
@@ -1,7 +1,7 @@
 import type { TaskMeta } from '@/types/task';
 import { groupBy, omit } from 'es-toolkit';
 import { useHistoryEventsApi } from '@/composables/api/history/events';
-import { useModules } from '@/composables/session/modules';
+import { Module, useModuleEnabled } from '@/composables/session/modules';
 import { useExternalApiKeys } from '@/composables/settings/api-keys/external';
 import { useMoneriumOAuth } from '@/modules/external-services/monerium/use-monerium-auth';
 import { useNotifications } from '@/modules/notifications/use-notifications';
@@ -9,7 +9,6 @@ import { useEventsQueryStatusStore } from '@/store/history/query-status/events-q
 import { useTaskStore } from '@/store/tasks';
 import { type Exchange, QueryExchangeEventsPayload } from '@/types/exchanges';
 import { OnlineHistoryEventsQueryType } from '@/types/history/events/schemas';
-import { Module } from '@/types/modules';
 import { TaskType } from '@/types/task-type';
 import { isTaskCancelled } from '@/utils';
 import { awaitParallelExecution } from '@/utils/await-parallel-execution';
@@ -26,8 +25,7 @@ export function useRefreshHandlers(): UseRefreshHandlersReturn {
   const { markLocationCancelled } = useEventsQueryStatusStore();
   const { queryExchangeEvents, queryOnlineHistoryEvents } = useHistoryEventsApi();
   const { awaitTask } = useTaskStore();
-  const { isModuleEnabled } = useModules();
-  const isEth2Enabled = isModuleEnabled(Module.ETH2);
+  const { enabled: isEth2Enabled } = useModuleEnabled(Module.ETH2);
   const { getApiKey } = useExternalApiKeys();
   const { authenticated: moneriumAuthenticated, refreshStatus } = useMoneriumOAuth();
 

--- a/frontend/app/src/composables/history/events/use-unmatched-asset-movements.ts
+++ b/frontend/app/src/composables/history/events/use-unmatched-asset-movements.ts
@@ -37,8 +37,8 @@ interface UseUnmatchedAssetMovementsReturn {
   loading: Ref<boolean>;
   ignoredLoading: Ref<boolean>;
   autoMatchLoading: ComputedRef<boolean>;
-  autoMatchMinimumTier: ComputedRef<string | null>;
-  isAutoMatchAllowed: ComputedRef<boolean>;
+  autoMatchMinimumTier: Readonly<Ref<string | null>>;
+  isAutoMatchAllowed: Readonly<Ref<boolean>>;
   fetchUnmatchedAssetMovements: (onlyIgnored?: boolean) => Promise<void>;
   matchAssetMovement: (assetMovementId: number, matchedEventIds: number[]) => Promise<ActionStatus>;
   refreshUnmatchedAssetMovements: (skipIgnored?: boolean) => Promise<void>;

--- a/frontend/app/src/composables/session/modules.ts
+++ b/frontend/app/src/composables/session/modules.ts
@@ -1,27 +1,22 @@
-import type { ComputedRef } from 'vue';
-import type { Module } from '@/types/modules';
+import type { MaybeRefOrGetter, Ref } from 'vue';
 import { useGeneralSettingsStore } from '@/store/settings/general';
+import { Module } from '@/types/modules';
 
-interface UseModulesReturn {
-  isAnyModuleEnabled: (modules: Module[]) => ComputedRef<boolean>;
-  isModuleEnabled: (module: Module) => ComputedRef<boolean>;
-  activeModules: ComputedRef<Module[]>;
+export { Module };
+
+interface UseModuleEnabledReturn {
+  enabled: Readonly<Ref<boolean>>;
 }
 
-export function useModules(): UseModulesReturn {
+export function getModuleEnabled(module: Module): boolean {
+  const { activeModules } = storeToRefs(useGeneralSettingsStore());
+  return get(activeModules).includes(module);
+}
+
+export function useModuleEnabled(module: MaybeRefOrGetter<Module>): UseModuleEnabledReturn {
   const { activeModules } = storeToRefs(useGeneralSettingsStore());
 
-  const isAnyModuleEnabled = (modules: Module[]): ComputedRef<boolean> =>
-    computed(() => get(activeModules).some(module => modules.includes(module)));
+  const enabled = computed<boolean>(() => get(activeModules).includes(toValue(module)));
 
-  const isModuleEnabled = (module: Module): ComputedRef<boolean> => computed(() => {
-    const active = get(activeModules);
-    return active.includes(module);
-  });
-
-  return {
-    activeModules,
-    isAnyModuleEnabled,
-    isModuleEnabled,
-  };
+  return { enabled: readonly(enabled) };
 }

--- a/frontend/app/src/modules/dashboard/Dashboard.vue
+++ b/frontend/app/src/modules/dashboard/Dashboard.vue
@@ -7,61 +7,57 @@ import PriceRefresh from '@/components/helper/PriceRefresh.vue';
 import { useBalancesLoading } from '@/composables/balances/loading';
 import { useAggregatedBalances } from '@/composables/balances/use-aggregated-balances';
 import { useDynamicMessages } from '@/composables/dynamic-messages';
-import { useModules } from '@/composables/session/modules';
+import { Module, useModuleEnabled } from '@/composables/session/modules';
 import DashboardProgressIndicator from '@/modules/dashboard/progress/DashboardProgressIndicator.vue';
-import { Module } from '@/types/modules';
 import { DashboardTableType } from '@/types/settings/frontend-settings';
 import PoolTable from './liquidity-pools/PoolTable.vue';
 import Summary from './summary/Summary.vue';
 
 const Type = DashboardTableType;
 
+const dashboardWidth = ref<number>(0);
+const dashboardRef = useTemplateRef<HTMLElement>('dashboardRef');
+const floatingRef = useTemplateRef<HTMLElement>('floatingRef');
+
 const { t } = useI18n({ useScope: 'global' });
-const { isModuleEnabled } = useModules();
 const { balances, liabilities } = useAggregatedBalances();
 const { activeDashboardMessages } = useDynamicMessages();
 
 const aggregatedBalances = balances();
 const aggregatedLiabilities = liabilities();
 
-const nftEnabled = isModuleEnabled(Module.NFTS);
+const { enabled: nftEnabled } = useModuleEnabled(Module.NFTS);
+
+const { width } = useElementSize(dashboardRef);
+const { height: floatingHeight } = useElementBounding(floatingRef);
 
 const { loadingBalancesAndDetection: isAnyLoading } = useBalancesLoading();
 const dismissedMessage = useSessionStorage('rotki.messages.dash.dismissed', false);
 
-const dashboardRef = useTemplateRef<HTMLElement>('dashboardRef');
-const floatingRef = useTemplateRef<HTMLElement>('floatingRef');
-const dashboardWidth = ref(0);
-
-const { width } = useElementSize(dashboardRef);
-watch(width, (newWidth) => {
-  set(dashboardWidth, newWidth);
-});
-
-const showDynamicMessage = computed(() => get(activeDashboardMessages).length > 0 && !get(dismissedMessage));
-
-const { height: floatingHeight } = useElementBounding(floatingRef);
+const paddingTop = computed<number>(() => get(floatingHeight) || 0);
+const showDynamicMessage = computed<boolean>(() => get(activeDashboardMessages).length > 0 && !get(dismissedMessage));
 
 watch(floatingHeight, (newHeight, oldHeight) => {
   const diff = newHeight - oldHeight;
-  if (diff !== 0) {
-    const scrollElement = document.documentElement.scrollTop > 0 ? document.documentElement : document.body;
-    const currentScroll = scrollElement.scrollTop;
-
-    // Temporarily disable smooth scrolling
-    const originalBehavior = scrollElement.style.scrollBehavior;
-    scrollElement.style.scrollBehavior = 'auto';
-
-    scrollElement.scrollTop = currentScroll + diff;
-
-    // Restore original scroll behavior after a frame
-    requestAnimationFrame(() => {
-      scrollElement.style.scrollBehavior = originalBehavior;
-    });
+  if (diff === 0) {
+    return;
   }
+
+  const scrollElement = document.documentElement.scrollTop > 0 ? document.documentElement : document.body;
+  const currentScroll = scrollElement.scrollTop;
+  const originalBehavior = scrollElement.style.scrollBehavior;
+
+  scrollElement.style.scrollBehavior = 'auto';
+  scrollElement.scrollTop = currentScroll + diff;
+
+  requestAnimationFrame(() => {
+    scrollElement.style.scrollBehavior = originalBehavior;
+  });
 });
 
-const paddingTop = computed(() => get(floatingHeight) || 0);
+watch(width, (newWidth) => {
+  set(dashboardWidth, newWidth);
+});
 </script>
 
 <template>

--- a/frontend/app/src/modules/premium/use-feature-access.spec.ts
+++ b/frontend/app/src/modules/premium/use-feature-access.spec.ts
@@ -102,10 +102,10 @@ describe('modules/premium/use-feature-access', () => {
       expect(get(currentTier)).toBe('Lite');
     });
 
-    it('should return empty currentTier when capabilities are not loaded', () => {
+    it('should return Free currentTier when capabilities are not loaded', () => {
       const { currentTier } = useFeatureAccess(PremiumFeature.ETH_STAKING_VIEW);
 
-      expect(get(currentTier)).toBe('');
+      expect(get(currentTier)).toBe('Free');
     });
 
     it('should reactively update when capabilities change', async () => {

--- a/frontend/app/src/modules/premium/use-feature-access.ts
+++ b/frontend/app/src/modules/premium/use-feature-access.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { MaybeRefOrGetter, Ref } from 'vue';
 import { usePremiumStore } from '@/store/session/premium';
 import { PremiumFeature } from '@/types/session';
 
@@ -6,11 +6,11 @@ export { PremiumFeature };
 
 interface UseFeatureAccessReturn {
   /** Whether the user has premium and the feature is enabled for their tier */
-  allowed: ComputedRef<boolean>;
+  allowed: Readonly<Ref<boolean>>;
   /** The minimum subscription tier required for this feature, null if unknown */
-  minimumTier: ComputedRef<string | null>;
+  minimumTier: Readonly<Ref<string | null>>;
   /** The user's current subscription tier */
-  currentTier: ComputedRef<string>;
+  currentTier: Readonly<Ref<string>>;
   /** Whether the user has an active premium subscription */
   premium: Readonly<Ref<boolean>>;
 }
@@ -36,12 +36,12 @@ export function useFeatureAccess(feature: MaybeRefOrGetter<PremiumFeature>): Use
     return caps?.[toValue(feature)]?.minimumTier ?? null;
   });
 
-  const currentTier = computed<string>(() => get(capabilities)?.currentTier ?? '');
+  const currentTier = computed<string>(() => get(capabilities)?.currentTier ?? 'Free');
 
   return {
-    allowed,
-    currentTier,
-    minimumTier,
+    allowed: readonly(allowed),
+    currentTier: readonly(currentTier),
+    minimumTier: readonly(minimumTier),
     premium,
   };
 }

--- a/frontend/app/src/modules/staking/eth/composables/use-eth-staking-access.ts
+++ b/frontend/app/src/modules/staking/eth/composables/use-eth-staking-access.ts
@@ -1,22 +1,19 @@
-import type { ComputedRef } from 'vue';
-import { useModules } from '@/composables/session/modules';
+import type { Ref } from 'vue';
+import { Module, useModuleEnabled } from '@/composables/session/modules';
 import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
-import { Module } from '@/types/modules';
 
 interface UseEthStakingAccessReturn {
-  enabled: ComputedRef<boolean>;
+  enabled: Readonly<Ref<boolean>>;
   module: Module;
-  allowed: ComputedRef<boolean>;
+  allowed: Readonly<Ref<boolean>>;
 }
 
 export function useEthStakingAccess(): UseEthStakingAccessReturn {
   const module = Module.ETH2;
 
-  const { isModuleEnabled } = useModules();
+  const { enabled } = useModuleEnabled(module);
 
   const { allowed } = useFeatureAccess(PremiumFeature.ETH_STAKING_VIEW);
-
-  const enabled = isModuleEnabled(module);
 
   return {
     allowed,

--- a/frontend/app/src/pages/accounts/evm/[[tab]].vue
+++ b/frontend/app/src/pages/accounts/evm/[[tab]].vue
@@ -10,9 +10,8 @@ import EvmAccountPageButtons from '@/components/accounts/EvmAccountPageButtons.v
 import AccountDialog from '@/components/accounts/management/AccountDialog.vue';
 import TablePageLayout from '@/components/layout/TablePageLayout.vue';
 import { useAccountCategoryHelper } from '@/composables/accounts/use-account-category-helper';
-import { useModules } from '@/composables/session/modules';
+import { Module, useModuleEnabled } from '@/composables/session/modules';
 import { useAccountImportProgressStore } from '@/store/use-account-import-progress-store';
-import { Module } from '@/types/modules';
 import { NoteLocation } from '@/types/notes';
 
 definePage({
@@ -37,13 +36,12 @@ const table = useTemplateRef<InstanceType<typeof AccountBalances>>('table');
 
 const category = 'evm';
 const { importingAccounts } = storeToRefs(useAccountImportProgressStore());
-const { isModuleEnabled } = useModules();
-const isEth2Enabled = isModuleEnabled(Module.ETH2);
+const { enabled: isEth2Enabled } = useModuleEnabled(Module.ETH2);
+const { chainIds } = useAccountCategoryHelper(category);
 
 const isAccountsTabSelected = computed<boolean>(() => tab === 'accounts');
 
-const { chainIds } = useAccountCategoryHelper(category);
-const usedChainIds = computed(() => {
+const usedChainIds = computed<string[]>(() => {
   if (get(isAccountsTabSelected)) {
     return [
       'all',
@@ -87,9 +85,8 @@ function getTabLink(category: string): RouteLocationRaw {
 
 onMounted(async () => {
   const { query } = get(route);
-  if (query.add) {
-    const address = query.addressToAdd as string;
-    createNewBlockchainAccount(address);
+  if (query.add && query.addressToAdd && typeof query.addressToAdd === 'string') {
+    createNewBlockchainAccount(query.addressToAdd);
     await router.replace({ query: {} });
   }
 });

--- a/frontend/app/src/pages/balances/non-fungible/index.vue
+++ b/frontend/app/src/pages/balances/non-fungible/index.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import ModuleNotActive from '@/components/defi/ModuleNotActive.vue';
-import { useModules } from '@/composables/session/modules';
+import { Module, useModuleEnabled } from '@/composables/session/modules';
 import NonFungibleBalances from '@/modules/balances/non-fungible/components/NonFungibleBalances.vue';
-import { Module } from '@/types/modules';
 import { NoteLocation } from '@/types/notes';
 
 definePage({
@@ -12,9 +11,8 @@ definePage({
   name: 'balances-non-fungible',
 });
 
-const { isModuleEnabled } = useModules();
 const modules = [Module.NFTS];
-const enabled = isModuleEnabled(modules[0]);
+const { enabled } = useModuleEnabled(modules[0]);
 </script>
 
 <template>

--- a/frontend/app/src/pages/nfts/index.vue
+++ b/frontend/app/src/pages/nfts/index.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import ModuleNotActive from '@/components/defi/ModuleNotActive.vue';
 import NftGallery from '@/components/nft/NftGallery.vue';
-import { useModules } from '@/composables/session/modules';
-import { Module } from '@/types/modules';
+import { Module, useModuleEnabled } from '@/composables/session/modules';
 import { NoteLocation } from '@/types/notes';
 
 definePage({
@@ -13,8 +12,7 @@ definePage({
 });
 
 const modules = [Module.NFTS];
-const { isModuleEnabled } = useModules();
-const enabled = isModuleEnabled(modules[0]);
+const { enabled } = useModuleEnabled(modules[0]);
 </script>
 
 <template>

--- a/frontend/app/src/store/defi/liquity/index.ts
+++ b/frontend/app/src/store/defi/liquity/index.ts
@@ -9,8 +9,8 @@ import {
 } from '@rotki/common';
 import { useLiquityApi } from '@/composables/api/defi/liquity';
 import { usePremium } from '@/composables/premium';
-import { useModules } from '@/composables/session/modules';
 import { useStatusUpdater } from '@/composables/status';
+import { useGeneralSettingsStore } from '@/store/settings/general';
 import { Module } from '@/types/modules';
 import { Section } from '@/types/status';
 import { TaskType } from '@/types/task-type';
@@ -27,7 +27,7 @@ export const useLiquityStore = defineStore('defi/liquity', () => {
   const stakingQueryStatus = ref<CommonQueryStatusData>();
 
   const isPremium = usePremium();
-  const { activeModules } = useModules();
+  const { activeModules } = storeToRefs(useGeneralSettingsStore());
   const { t } = useI18n({ useScope: 'global' });
   const {
     fetchLiquityBalances,


### PR DESCRIPTION
## Summary

- Replace `useModules()` wrapper with standalone `useModuleEnabled(module)` and `getModuleEnabled(module)` functions
- Remove unused `isAnyModuleEnabled`
- Re-export `Module` from the composable to consolidate imports at call sites
- Accept `MaybeRefOrGetter<Module>` for reactive flexibility
- Update all 10 consumer files to use new API

## Test plan

- [x] Typecheck passes
- [x] Lint clean
- [x] 2747/2748 tests pass (1 pre-existing infra failure unrelated to changes)