### PR TITLE
fix(frontend): allow deletion of extra swap sub-events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11784` Users can now delete extra spend, receive, or fee sub-events from multi-asset swaps directly from the event list without opening the full edit form.
 * :feature:`11817` ETH staking validator limits are now checked before submission in the add validator dialog, showing user-friendly messages with upgrade prompts instead of raw backend errors.
 * :bug:`-` Certain cases of ENS registrations with a specific refund ordering will now also be properly understood by rotki.
 * :bug:`-` Gearbox withdrawals should now always have the correct order of events.

--- a/frontend/app/src/components/history/events/HistoryEventsListItemAction.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsListItemAction.vue
@@ -9,6 +9,11 @@ import type {
 import RowActions from '@/components/helper/RowActions.vue';
 import HistoryEventAction from '@/components/history/events/HistoryEventAction.vue';
 import {
+  hideDeleteAction,
+  hideEditAction,
+  shouldDeleteGroup,
+} from '@/modules/history/events/event-action-visibility';
+import {
   isGroupEditableHistoryEvent,
   isSwapTypeEvent,
 } from '@/modules/history/management/forms/form-guards';
@@ -45,12 +50,6 @@ const COLLAPSE_ACTION_CLASSES = 'w-0 group-hover/row:w-auto 2xl:!w-24 2xl:opacit
 const { item } = toRefs(props);
 
 const hasMissingRule = computed<boolean>(() => isEventMissingAccountingRule(get(item)));
-
-function hideEditDeleteActions(item: HistoryEventEntry, index: number): boolean {
-  const isSwapButNotSpend = isSwapTypeEvent(item.entryType) && index !== 0;
-  const isAssetMovementFee = isAssetMovementEvent(item) && item.eventSubtype === 'fee';
-  return isAssetMovementFee || isSwapButNotSpend;
-}
 
 function getEmittedEvent(item: HistoryEvent): HistoryEventEditData {
   if (isSwapTypeEvent(item.entryType)) {
@@ -91,7 +90,7 @@ function deleteEvent(item: HistoryEventEntry) {
         type: 'ignore',
       }
     : {
-        ids: isGroupEditableHistoryEvent(item) || isSwapTypeEvent(item.entryType) ? props.completeGroupEvents.map(event => event.identifier) : [item.identifier],
+        ids: shouldDeleteGroup(item, props.index) ? props.completeGroupEvents.map(event => event.identifier) : [item.identifier],
         type: 'delete',
       };
 
@@ -116,8 +115,8 @@ function deleteEvent(item: HistoryEventEntry) {
       align="end"
       :delete-tooltip="t('transactions.events.actions.delete')"
       :edit-tooltip="t('transactions.events.actions.edit')"
-      :no-delete="hideEditDeleteActions(item, index)"
-      :no-edit="hideEditDeleteActions(item, index)"
+      :no-delete="hideDeleteAction(item, index, completeGroupEvents)"
+      :no-edit="hideEditAction(item, index)"
       @edit-click="editEvent(item)"
       @delete-click="deleteEvent(item)"
     >

--- a/frontend/app/src/modules/history/events/components/HistoryEventsSwapItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsSwapItem.vue
@@ -102,6 +102,7 @@ const isCard = computed<boolean>(() => props.variant === 'card');
         />
 
         <RuiButton
+          data-cy="swap-expand"
           size="sm"
           icon
           color="primary"
@@ -204,6 +205,7 @@ const isCard = computed<boolean>(() => props.variant === 'card');
 
     <div class="relative -top-2">
       <RuiButton
+        data-cy="swap-expand"
         size="sm"
         icon
         color="primary"

--- a/frontend/app/src/modules/history/events/event-action-visibility.spec.ts
+++ b/frontend/app/src/modules/history/events/event-action-visibility.spec.ts
@@ -1,0 +1,193 @@
+import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import {
+  type AssetMovementEvent,
+  type EvmHistoryEvent,
+  type EvmSwapEvent,
+  HistoryEventAccountingRuleStatus,
+  type HistoryEventEntry,
+  type OnlineHistoryEvent,
+  type SolanaSwapEvent,
+  type SwapEvent,
+} from '@/types/history/events/schemas';
+import { hideDeleteAction, hideEditAction, shouldDeleteGroup } from './event-action-visibility';
+
+const commonFields = {
+  amount: bigNumberify('1'),
+  asset: 'ETH',
+  eventAccountingRuleStatus: HistoryEventAccountingRuleStatus.PROCESSED,
+  eventSubtype: 'spend',
+  eventType: 'trade',
+  groupIdentifier: 'group1',
+  hidden: false,
+  identifier: 1,
+  ignoredInAccounting: false,
+  location: 'ethereum',
+  locationLabel: null,
+  sequenceIndex: 0,
+  states: [],
+  timestamp: 1000000,
+};
+
+function createEvmEvent(overrides: Partial<Omit<EvmHistoryEvent, 'entryType'>> = {}): HistoryEventEntry {
+  return { ...commonFields, address: null, counterparty: null, extraData: null, txRef: 'tx1', entryType: HistoryEventEntryType.EVM_EVENT, ...overrides };
+}
+
+function createEvmSwapEvent(overrides: Partial<Omit<EvmSwapEvent, 'entryType'>> = {}): HistoryEventEntry {
+  return { ...commonFields, address: null, counterparty: null, extraData: null, txRef: 'tx1', entryType: HistoryEventEntryType.EVM_SWAP_EVENT, ...overrides };
+}
+
+function createSolanaSwapEvent(overrides: Partial<Omit<SolanaSwapEvent, 'entryType'>> = {}): HistoryEventEntry {
+  return { ...commonFields, address: null, counterparty: null, extraData: null, txRef: 'tx1', entryType: HistoryEventEntryType.SOLANA_SWAP_EVENT, ...overrides };
+}
+
+function createSwapEvent(overrides: Partial<Omit<SwapEvent, 'entryType'>> = {}): HistoryEventEntry {
+  return { ...commonFields, extraData: null, entryType: HistoryEventEntryType.SWAP_EVENT, ...overrides };
+}
+
+function createAssetMovementEvent(overrides: Partial<Omit<AssetMovementEvent, 'entryType'>> = {}): HistoryEventEntry {
+  return { ...commonFields, extraData: null, entryType: HistoryEventEntryType.ASSET_MOVEMENT_EVENT, ...overrides };
+}
+
+function createHistoryEvent(overrides: Partial<Omit<OnlineHistoryEvent, 'entryType'>> = {}): HistoryEventEntry {
+  return { ...commonFields, entryType: HistoryEventEntryType.HISTORY_EVENT, ...overrides };
+}
+
+describe('eventActionVisibility', () => {
+  describe('hideEditAction', () => {
+    it('should show edit for swap primary event (index 0)', () => {
+      const item = createEvmSwapEvent();
+      expect(hideEditAction(item, 0)).toBe(false);
+    });
+
+    it('should hide edit for swap sub-events (index > 0)', () => {
+      const item = createEvmSwapEvent();
+      expect(hideEditAction(item, 1)).toBe(true);
+      expect(hideEditAction(item, 2)).toBe(true);
+    });
+
+    it('should hide edit for solana swap sub-events', () => {
+      const item = createSolanaSwapEvent();
+      expect(hideEditAction(item, 1)).toBe(true);
+    });
+
+    it('should hide edit for online swap sub-events', () => {
+      const item = createSwapEvent();
+      expect(hideEditAction(item, 1)).toBe(true);
+    });
+
+    it('should hide edit for asset movement fee events', () => {
+      const item = createAssetMovementEvent({ eventSubtype: 'fee' });
+      expect(hideEditAction(item, 0)).toBe(true);
+    });
+
+    it('should show edit for regular events', () => {
+      const item = createEvmEvent();
+      expect(hideEditAction(item, 0)).toBe(false);
+    });
+  });
+
+  describe('hideDeleteAction', () => {
+    it('should hide delete for asset movement fee events', () => {
+      const item = createAssetMovementEvent({ eventSubtype: 'fee' });
+      expect(hideDeleteAction(item, 0, [])).toBe(true);
+    });
+
+    it('should show delete for swap fee sub-events', () => {
+      const item = createEvmSwapEvent({ eventSubtype: 'fee' });
+      expect(hideDeleteAction(item, 1, [])).toBe(false);
+    });
+
+    it('should hide delete for swap spend sub-event when only one spend exists', () => {
+      const spend = createEvmSwapEvent({ eventSubtype: 'spend', identifier: 1 });
+      const receive = createEvmSwapEvent({ eventSubtype: 'receive', identifier: 2 });
+      expect(hideDeleteAction(spend, 1, [spend, receive])).toBe(true);
+    });
+
+    it('should show delete for swap spend sub-event when multiple spends exist', () => {
+      const spend1 = createEvmSwapEvent({ eventSubtype: 'spend', identifier: 1 });
+      const spend2 = createEvmSwapEvent({ eventSubtype: 'spend', identifier: 2 });
+      const receive = createEvmSwapEvent({ eventSubtype: 'receive', identifier: 3 });
+      expect(hideDeleteAction(spend2, 2, [spend1, spend2, receive])).toBe(false);
+    });
+
+    it('should hide delete for swap receive sub-event when only one receive exists', () => {
+      const spend = createEvmSwapEvent({ eventSubtype: 'spend', identifier: 1 });
+      const receive = createEvmSwapEvent({ eventSubtype: 'receive', identifier: 2 });
+      expect(hideDeleteAction(receive, 1, [spend, receive])).toBe(true);
+    });
+
+    it('should show delete for swap receive sub-event when multiple receives exist', () => {
+      const spend = createEvmSwapEvent({ eventSubtype: 'spend', identifier: 1 });
+      const receive1 = createEvmSwapEvent({ eventSubtype: 'receive', identifier: 2 });
+      const receive2 = createEvmSwapEvent({ eventSubtype: 'receive', identifier: 3 });
+      expect(hideDeleteAction(receive2, 2, [spend, receive1, receive2])).toBe(false);
+    });
+
+    it('should not hide delete for swap primary event (index 0)', () => {
+      const item = createEvmSwapEvent({ eventSubtype: 'spend' });
+      expect(hideDeleteAction(item, 0, [item])).toBe(false);
+    });
+
+    it('should not hide delete for regular events', () => {
+      const item = createEvmEvent();
+      expect(hideDeleteAction(item, 0, [item])).toBe(false);
+    });
+
+    it('should work with solana swap events', () => {
+      const spend = createSolanaSwapEvent({ eventSubtype: 'spend', identifier: 1 });
+      const receive = createSolanaSwapEvent({ eventSubtype: 'receive', identifier: 2 });
+      expect(hideDeleteAction(spend, 1, [spend, receive])).toBe(true);
+    });
+
+    it('should work with online swap events', () => {
+      const spend1 = createSwapEvent({ eventSubtype: 'spend', identifier: 1 });
+      const spend2 = createSwapEvent({ eventSubtype: 'spend', identifier: 2 });
+      const receive = createSwapEvent({ eventSubtype: 'receive', identifier: 3 });
+      expect(hideDeleteAction(spend2, 2, [spend1, spend2, receive])).toBe(false);
+    });
+  });
+
+  describe('shouldDeleteGroup', () => {
+    it('should delete group for asset movement events', () => {
+      const item = createAssetMovementEvent({ eventSubtype: 'deposit' });
+      expect(shouldDeleteGroup(item, 0)).toBe(true);
+    });
+
+    it('should delete group for online swap events (isGroupEditableHistoryEvent)', () => {
+      const item = createSwapEvent();
+      expect(shouldDeleteGroup(item, 0)).toBe(true);
+    });
+
+    it('should delete group for evm swap at index 0', () => {
+      const item = createEvmSwapEvent();
+      expect(shouldDeleteGroup(item, 0)).toBe(true);
+    });
+
+    it('should not delete group for evm swap sub-events (index > 0)', () => {
+      const item = createEvmSwapEvent();
+      expect(shouldDeleteGroup(item, 1)).toBe(false);
+      expect(shouldDeleteGroup(item, 2)).toBe(false);
+    });
+
+    it('should delete group for solana swap at index 0', () => {
+      const item = createSolanaSwapEvent();
+      expect(shouldDeleteGroup(item, 0)).toBe(true);
+    });
+
+    it('should not delete group for solana swap sub-events', () => {
+      const item = createSolanaSwapEvent();
+      expect(shouldDeleteGroup(item, 1)).toBe(false);
+    });
+
+    it('should not delete group for regular events', () => {
+      const item = createEvmEvent();
+      expect(shouldDeleteGroup(item, 0)).toBe(false);
+    });
+
+    it('should not delete group for history events', () => {
+      const item = createHistoryEvent();
+      expect(shouldDeleteGroup(item, 0)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/event-action-visibility.ts
+++ b/frontend/app/src/modules/history/events/event-action-visibility.ts
@@ -1,0 +1,40 @@
+import type { HistoryEventEntry } from '@/types/history/events/schemas';
+import {
+  isGroupEditableHistoryEvent,
+  isSwapTypeEvent,
+} from '@/modules/history/management/forms/form-guards';
+import { isAssetMovementEvent } from '@/utils/history/events';
+
+export function hideEditAction(item: HistoryEventEntry, index: number): boolean {
+  const isSwapSubEvent = isSwapTypeEvent(item.entryType) && index !== 0;
+  const isAssetMovementFee = isAssetMovementEvent(item) && item.eventSubtype === 'fee';
+  return isAssetMovementFee || isSwapSubEvent;
+}
+
+export function hideDeleteAction(item: HistoryEventEntry, index: number, completeGroupEvents: HistoryEventEntry[]): boolean {
+  const isAssetMovementFee = isAssetMovementEvent(item) && item.eventSubtype === 'fee';
+  if (isAssetMovementFee)
+    return true;
+
+  if (isSwapTypeEvent(item.entryType) && index !== 0) {
+    const subtype = item.eventSubtype;
+    if (subtype === 'fee')
+      return false;
+
+    const count = completeGroupEvents.filter(
+      e => isSwapTypeEvent(e.entryType) && e.eventSubtype === subtype,
+    ).length;
+
+    return count <= 1;
+  }
+
+  return false;
+}
+
+export function shouldDeleteGroup(item: HistoryEventEntry, index: number): boolean {
+  if (isGroupEditableHistoryEvent(item))
+    return true;
+
+  // For EVM/Solana swap primary events (index 0), delete the whole group
+  return isSwapTypeEvent(item.entryType) && index === 0;
+}

--- a/frontend/app/tests/e2e/pages/history-events-page.ts
+++ b/frontend/app/tests/e2e/pages/history-events-page.ts
@@ -304,6 +304,25 @@ export class HistoryEventsPage {
     }
   }
 
+  async expandSwap(index: number): Promise<void> {
+    const swapRow = this.page.locator('[data-cy=history-event-swap]').nth(index);
+    await swapRow.hover();
+    await swapRow.locator('[data-cy=swap-expand]').click();
+  }
+
+  async getExpandedEventRows(): Promise<number> {
+    return this.page.locator('[data-cy=history-event-row]').count();
+  }
+
+  async deleteSubEvent(index: number): Promise<void> {
+    const row = this.page.locator('[data-cy=history-event-row]').nth(index);
+    await row.hover();
+    await row.locator('[data-cy=row-delete]').click();
+    const dialog = this.page.locator('[data-cy=confirm-dialog]');
+    await dialog.locator('[data-cy=button-confirm]').click();
+    await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+  }
+
   async fillEvmMultiSwapEventForm(data: EvmMultiSwapEventFixture): Promise<void> {
     await this.fillDatetime();
     await this.selectLocation('ethereum');

--- a/frontend/app/tests/e2e/specs/history/history-events.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/history-events.spec.ts
@@ -423,6 +423,39 @@ test.describe.serial('evm history events', () => {
     }).toPass({ timeout: 10000 });
   });
 
+  test('delete extra sub-event from multi-asset swap', async () => {
+    // The multi-asset swap has 2 spend + 2 receive + 2 fee = 6 sub-events.
+    // It was added last so it has the most recent timestamp.
+    // With descending sort it appears first (index 0).
+    const rowsBeforeExpand = await page.getExpandedEventRows();
+    await page.expandSwap(0);
+
+    // Wait for the 6 sub-event rows to appear (on top of any existing event-rows)
+    await expect(async () => {
+      const rows = await page.getExpandedEventRows();
+      expect(rows).toBeGreaterThanOrEqual(rowsBeforeExpand + 6);
+    }).toPass({ timeout: 10000 });
+
+    const rowsBefore = await page.getExpandedEventRows();
+
+    // Delete the last fee sub-event (index 5 within the swap — the 6th expanded row).
+    // The swap sub-events are the first event-rows on the page since this group is first.
+    await page.deleteSubEvent(5);
+
+    await expect(async () => {
+      const rowsAfter = await page.getExpandedEventRows();
+      expect(rowsAfter).toBe(rowsBefore - 1);
+    }).toPass({ timeout: 10000 });
+
+    // The swap group should still exist
+    await expect(async () => {
+      const swaps = await page.getSwapRows();
+      // Swap rows are hidden when expanded, so check sub-events remain
+      const expandedRows = await page.getExpandedEventRows();
+      expect(swaps + expandedRows).toBeGreaterThanOrEqual(1);
+    }).toPass({ timeout: 10000 });
+  });
+
   test('add eth deposit event', async () => {
     await page.openAddDialog();
     await page.selectEntryType('eth deposit event');


### PR DESCRIPTION
## Summary
- Split `hideEditDeleteActions` into separate `hideEditAction` and `hideDeleteAction` so that extra swap sub-events (spend, receive, fee) can be individually deleted while preserving the minimum 1-spend + 1-receive swap structure
- Fix a bug where deleting the primary event (index 0) of an EVM/Solana swap would only delete that single event instead of the whole group
- Extract visibility logic into `event-action-visibility.ts` under `modules/history/events/`

## Test plan
- [x] 24 unit tests for `hideEditAction`, `hideDeleteAction`, and `shouldDeleteGroup` covering all swap types (EVM, Solana, online), asset movements, and regular events
- [x] E2E test: expand a multi-asset swap, delete an extra fee sub-event, verify the swap group persists with one fewer event
- [x] Lint and typecheck pass

Closes #11784