### PR TITLE
Avoid extra query for timestamp in block

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -57,6 +57,7 @@ from rotkehlchen.externalapis.blockscout import Blockscout
 from rotkehlchen.externalapis.etherscan import Etherscan
 from rotkehlchen.externalapis.etherscan_like import EtherscanLikeApi, HasChainActivity
 from rotkehlchen.externalapis.routescan import Routescan
+from rotkehlchen.externalapis.utils import read_integer
 from rotkehlchen.fval import FVal
 from rotkehlchen.greenlets.manager import GreenletManager
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -250,6 +251,9 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
         # the same information. Remove from here with
         # https://github.com/rotki/rotki/issues/9998
         self.timestamp_to_block_cache: dict[ChainID, LRUCacheWithRemove[Timestamp, int]] = defaultdict(lambda: LRUCacheWithRemove(maxsize=32))  # noqa: E501
+        # Cache block_number -> timestamp to avoid extra block header calls when transaction
+        # lists from indexers already include the timestamp.
+        self.block_to_timestamp_cache: LRUCacheWithRemove[int, Timestamp] = LRUCacheWithRemove(maxsize=2048)  # noqa: E501
 
         # A cache for erc20 and erc721 contract info to not requery the info
         self.contract_info_erc20_cache: LRUCacheWithRemove[ChecksumEvmAddress, dict[str, Any]] = LRUCacheWithRemove(maxsize=1024)  # noqa: E501
@@ -1420,6 +1424,16 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
             log.error(f'Failed to get L1 fees for {account=} {tx_hash=} {block_number=} due to {e!s}')  # noqa: E501
             return None
 
+    def get_block_timestamp(self, block_number: int) -> Timestamp:
+        """Return block timestamp using cache first and falling back to block query."""
+        if (cached_timestamp := self.block_to_timestamp_cache.get(block_number)) is not None:
+            return cached_timestamp
+
+        block_data = self.get_block_by_number(num=block_number)
+        timestamp = Timestamp(read_integer(block_data, 'timestamp', 'web3'))
+        self.block_to_timestamp_cache.add(key=block_number, value=timestamp)
+        return timestamp
+
     # -- methods to be optionally implemented by child classes --
 
     def logquery_block_range(
@@ -1557,15 +1571,33 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
             action: Literal['txlist', 'txlistinternal'],
             period_or_hash: TimestampOrBlockRange | EVMTxHash | None = None,
     ) -> Iterator[list[EvmTransaction]] | Iterator[list[EvmInternalTransaction]]:
-        """Returns an iterator of transaction lists for a given account, action, and period/hash.
-        Tries etherscan first, then blockscout. Raises RemoteError if both fail.
+        """Return transaction batches from indexers in configured order.
+
+        For `action='txlist'`, this also stores each tx's block->timestamp mapping in
+        `self.block_to_timestamp_cache` so later RPC timestamp lookups can be skipped.
         """
-        yield from self._try_indexers_iterable(func=lambda indexer: indexer.get_transactions(  # type: ignore[misc]
-            chain_id=self.chain_id,
-            account=account,
-            period_or_hash=period_or_hash,
-            action=action,
-        ))
+        if action == 'txlist':
+            for tx_batch in self._try_indexers_iterable(
+                func=lambda indexer: indexer.get_transactions(
+                    chain_id=self.chain_id,
+                    account=account,
+                    period_or_hash=period_or_hash,
+                    action='txlist',
+                ),
+            ):
+                for tx in tx_batch:
+                    self.block_to_timestamp_cache.add(key=tx.block_number, value=tx.timestamp)
+
+                yield tx_batch
+        else:
+            yield from self._try_indexers_iterable(
+                func=lambda indexer: indexer.get_transactions(
+                    chain_id=self.chain_id,
+                    account=account,
+                    period_or_hash=period_or_hash,
+                    action='txlistinternal',
+                ),
+            )
 
     def get_token_transaction_hashes(
             self,
@@ -1573,12 +1605,21 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
             from_block: int | None = None,
             to_block: int | None = None,
     ) -> Iterator[list[EVMTxHash]]:
-        yield from self._try_indexers_iterable(func=lambda indexer: indexer.get_token_transaction_hashes(  # noqa: E501
-            chain_id=self.chain_id,
-            account=account,
-            from_block=from_block,
-            to_block=to_block,
-        ))
+        """Return ERC20/721 token transaction hash batches for an account.
+
+        The underlying indexer response also contains timestamps and block numbers, those are
+        cached in `self.block_to_timestamp_cache` while only transaction hashes are yielded.
+        """
+        for tx_data_batch in self._try_indexers_iterable(func=lambda indexer: indexer.get_token_transaction_data(  # noqa: E501
+                chain_id=self.chain_id,
+                account=account,
+                from_block=from_block,
+                to_block=to_block,
+        )):
+            for _, timestamp, block_number in tx_data_batch:
+                self.block_to_timestamp_cache.add(key=block_number, value=timestamp)
+
+            yield [tx_hash for tx_hash, _, _ in tx_data_batch]
 
     def has_activity(
             self,

--- a/rotkehlchen/externalapis/etherscan_like.py
+++ b/rotkehlchen/externalapis/etherscan_like.py
@@ -44,7 +44,7 @@ from rotkehlchen.types import (
     Timestamp,
     deserialize_evm_tx_hash,
 )
-from rotkehlchen.utils.misc import hexstr_to_int, set_user_agent
+from rotkehlchen.utils.misc import convert_to_int, hexstr_to_int, set_user_agent
 from rotkehlchen.utils.network import create_session
 from rotkehlchen.utils.serialization import jsonloads_dict
 
@@ -631,6 +631,26 @@ class EtherscanLikeApi(ABC):
             from_block: int | None = None,
             to_block: int | None = None,
     ) -> Iterator[list[EVMTxHash]]:
+        for tx_data_batch in self.get_token_transaction_data(
+            chain_id=chain_id,
+            account=account,
+            from_block=from_block,
+            to_block=to_block,
+        ):
+            yield [tx_hash for tx_hash, _, _ in tx_data_batch]
+
+    def get_token_transaction_data(
+            self,
+            chain_id: SUPPORTED_CHAIN_IDS,
+            account: ChecksumEvmAddress,
+            from_block: int | None = None,
+            to_block: int | None = None,
+    ) -> Iterator[list[tuple[EVMTxHash, Timestamp, int]]]:
+        """Return token tx data batches as ``(tx_hash, timestamp, block_number)``.
+
+        A set is used to deduplicate results across paginated responses, so we sort each yielded
+        batch by tuple index ``1`` (timestamp) to keep chronological ordering.
+        """
         options = {'address': str(account), 'sort': 'asc'}
         if (pagination_options := self._get_account_pagination_options(
             action='tokentx',
@@ -642,7 +662,7 @@ class EtherscanLikeApi(ABC):
         if to_block is not None:
             options['endblock'] = str(to_block)
 
-        hashes: set[tuple[EVMTxHash, Timestamp]] = set()
+        tx_data: set[tuple[EVMTxHash, Timestamp, int]] = set()
         while True:
             result = self._query(
                 chain_id=chain_id,
@@ -661,16 +681,23 @@ class EtherscanLikeApi(ABC):
                     )
                     continue
 
-                if timestamp > last_ts and len(hashes) >= TRANSACTIONS_BATCH_NUM:  # type: ignore
-                    yield _hashes_tuple_to_list(hashes)
-                    hashes = set()
+                if timestamp > last_ts and len(tx_data) >= TRANSACTIONS_BATCH_NUM:  # type: ignore
+                    # Keep deterministic chronological order after set deduplication.
+                    # item 1 is timestamp in (tx_hash, timestamp, block_number).
+                    yield sorted(tx_data, key=operator.itemgetter(1))
+                    tx_data = set()
                     last_ts = timestamp
                 try:
-                    hashes.add((deserialize_evm_tx_hash(entry['hash']), timestamp))
+                    tx_data.add((
+                        deserialize_evm_tx_hash(entry['hash']),
+                        timestamp,
+                        convert_to_int(entry['blockNumber']),
+                    ))
                 except DeserializationError as e:
                     log.error(
-                        f"Failed to read transaction hash {entry['hash']} from {chain_id} "
-                        f'{self.name} for {account} in the range {from_block} to {to_block}. {e!s}',  # noqa: E501
+                        f"Failed to read transaction hash or block number for {entry['hash']} "
+                        f'from {chain_id} {self.name} for {account} in the range '
+                        f'{from_block} to {to_block}. {e!s}',
                     )
                     continue
 
@@ -678,7 +705,9 @@ class EtherscanLikeApi(ABC):
                 break  # no need to paginate further
             options = new_options
 
-        yield _hashes_tuple_to_list(hashes)
+        # Keep deterministic chronological order after set deduplication.
+        # item 1 is timestamp in (tx_hash, timestamp, block_number).
+        yield sorted(tx_data, key=operator.itemgetter(1))
 
     def get_blocknumber_by_time(
             self,

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -607,13 +607,11 @@ def deserialize_evm_transaction(
             tx_hash = deserialize_evm_tx_hash(data['transactionHash'])
 
         block_number = read_integer(data, 'blockNumber', source)
-        block_data = None
         if 'timeStamp' not in data:
             if evm_inquirer is None:
                 raise DeserializationError('Got in deserialize evm transaction without timestamp and without evm inquirer')  # noqa: E501
 
-            block_data = evm_inquirer.get_block_by_number(block_number)
-            timestamp = Timestamp(read_integer(block_data, 'timestamp', source))
+            timestamp = evm_inquirer.get_block_timestamp(block_number=block_number)
         else:
             timestamp = deserialize_timestamp(data['timeStamp'])
 

--- a/rotkehlchen/tests/unit/test_evm_misc.py
+++ b/rotkehlchen/tests/unit/test_evm_misc.py
@@ -19,12 +19,19 @@ from rotkehlchen.chain.evm.types import (
 )
 from rotkehlchen.constants import ONE
 from rotkehlchen.errors.misc import RemoteError, RequestTooLargeError
+from rotkehlchen.serialization.deserialize import deserialize_evm_transaction
 from rotkehlchen.tests.utils.ethereum import (
     ETHEREUM_WEB3_AND_ETHERSCAN_TEST_PARAMETERS,
     wait_until_all_nodes_connected,
 )
-from rotkehlchen.tests.utils.factories import make_evm_address
-from rotkehlchen.types import SUPPORTED_CHAIN_IDS, ChainID, SupportedBlockchain
+from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
+from rotkehlchen.types import (
+    SUPPORTED_CHAIN_IDS,
+    ChainID,
+    EvmTransaction,
+    SupportedBlockchain,
+    Timestamp,
+)
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
@@ -181,3 +188,78 @@ def test_query_raises_request_too_large_when_gas_limit_seen(
         ethereum_inquirer._query(method=mock_method, call_order=call_order)
 
     assert call_count == len(call_order)
+
+
+def test_get_transactions_populates_block_timestamp_cache(
+        ethereum_inquirer: 'EthereumInquirer',
+) -> None:
+    tx = EvmTransaction(
+        tx_hash=make_evm_tx_hash(),
+        chain_id=ChainID.ETHEREUM,
+        timestamp=Timestamp(1710000000),
+        block_number=123456,
+        from_address=make_evm_address(),
+        to_address=make_evm_address(),
+        value=0,
+        gas=21000,
+        gas_price=100,
+        gas_used=21000,
+        input_data=b'',
+        nonce=1,
+    )
+    with patch.object(ethereum_inquirer, '_try_indexers_iterable', return_value=iter([[tx]])):
+        result = list(ethereum_inquirer.get_transactions(
+            account=make_evm_address(),
+            action='txlist',
+        ))
+
+    assert result == [[tx]]
+    assert ethereum_inquirer.block_to_timestamp_cache.get(tx.block_number) == tx.timestamp
+
+
+def test_get_token_transaction_hashes_populates_block_timestamp_cache(
+        ethereum_inquirer: 'EthereumInquirer',
+) -> None:
+    tx_hash = make_evm_tx_hash()
+    block_number = 654321
+    timestamp = Timestamp(1712222222)
+    with patch.object(
+            ethereum_inquirer,
+            '_try_indexers_iterable',
+            return_value=iter([[(tx_hash, timestamp, block_number)]]),
+    ):
+        result = list(ethereum_inquirer.get_token_transaction_hashes(
+            account=make_evm_address(),
+        ))
+
+    assert result == [[tx_hash]]
+    assert ethereum_inquirer.block_to_timestamp_cache.get(block_number) == timestamp
+
+
+def test_deserialize_evm_transaction_uses_cached_block_timestamp(
+        ethereum_inquirer: 'EthereumInquirer',
+) -> None:
+    block_number = 999
+    expected_timestamp = Timestamp(1711111111)
+    ethereum_inquirer.block_to_timestamp_cache.add(key=block_number, value=expected_timestamp)
+    tx_data = {
+        'hash': str(make_evm_tx_hash()),
+        'blockNumber': str(block_number),
+        'from': make_evm_address(),
+        'to': make_evm_address(),
+        'value': '0',
+        'gas': '21000',
+        'gasPrice': '100',
+        'gasUsed': '21000',
+        'input': '0x',
+        'nonce': '1',
+    }
+    with patch.object(ethereum_inquirer, 'get_block_by_number', side_effect=AssertionError):
+        tx, _ = deserialize_evm_transaction(
+            data=tx_data,
+            internal=False,
+            chain_id=ChainID.ETHEREUM,
+            evm_inquirer=ethereum_inquirer,
+        )
+
+    assert tx.timestamp == expected_timestamp

--- a/rotkehlchen/tests/unit/test_evm_transactions.py
+++ b/rotkehlchen/tests/unit/test_evm_transactions.py
@@ -118,7 +118,7 @@ def test_erc20_transfers_range_not_updated_on_remote_error(database: 'DBHandler'
         ):
             stack.enter_context(patch.object(
                 target=indexer,
-                attribute='get_token_transaction_hashes',
+                attribute='get_token_transaction_data',
                 side_effect=RemoteError('FAIL')),
             )
 
@@ -496,11 +496,11 @@ def test_indexers_fall_back_properly(
             ))
             hashes_mock = stack.enter_context(patch.object(
                 target=indexer,
-                attribute='get_token_transaction_hashes',
-                wraps=indexer.get_token_transaction_hashes,
+                attribute='get_token_transaction_data',
+                wraps=indexer.get_token_transaction_data,
             ) if name == tested_indexer else patch.object(
                 target=indexer,
-                attribute='get_token_transaction_hashes',
+                attribute='get_token_transaction_data',
                 side_effect=RemoteError('FAIL'),
             ))
 


### PR DESCRIPTION
this PR removes an extra query to the RPC of blockbynumber that we were using only to get the timestamp. Since we get the transactions of the user from the indexer and it returns the blocknumber and the timestamp we can cache it and then avoid this extra call to the RPC.

The reduction in time to pull the history of this PR is meaningful