### PR TITLE
Fix kyber refund swap decoding

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,7 @@ Changelog
 * :feature:`11702` Zerox Base Swaps through the latest settler  will now be properly decoded.
 * :bug:`-` ZKSynclite batch withdrawal on the ethereum side should now be properly decoded.
 * :bug:`-` Claiming AAVE rewards and immediately restaking them will now be properly decoded.
+* :bug:`-` Kyberswap swaps containing refunds will now be processed properly and deduct refund from original swap amount.
 * :bug:`-` WETH Unwrapping in base will now be properly decoded.
 * :bug:`-` The rare case of balancer v2 swaps with repeated swap logs for a single events is now decoded properly.
 * :feature:`-` ERC4337 fee payments will now be properly understood by rotki

--- a/rotkehlchen/chain/evm/decoding/kyber/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/kyber/decoder.py
@@ -47,25 +47,53 @@ class KyberCommonDecoder(EvmDecoderInterface):
         Use the information from a trade transaction to modify the HistoryEvents from receive/send
         to trade if the conditions are correct.
         """
-        in_event = out_event = None
+        in_event = out_event = refund_event = None
         for event in decoded_events:
+            if event.location_label != sender:
+                continue
+
             crypto_asset = event.asset.symbol_or_name()
             # it can happen that a spend event get decoded first by an amm decoder. To make sure
             # that the event matches we check both event type and subtype
-            if (event.event_type == HistoryEventType.SPEND or event.event_subtype == HistoryEventSubType.SPEND) and event.location_label == sender and event.asset == source_asset and event.amount == spent_amount:  # noqa: E501
+            if (
+                    (event.event_type == HistoryEventType.SPEND or event.event_subtype == HistoryEventSubType.SPEND) and  # noqa: E501
+                    event.asset == source_asset and
+                    event.amount == spent_amount
+            ):
                 event.event_type = HistoryEventType.TRADE
                 event.event_subtype = HistoryEventSubType.SPEND
                 event.counterparty = counterparty
-                event.notes = f'Swap {event.amount} {crypto_asset} in kyber'
                 out_event = event
-            elif (event.event_type == HistoryEventType.RECEIVE or event.event_subtype == HistoryEventSubType.RECEIVE) and event.location_label == sender and event.amount == return_amount and destination_asset == event.asset:  # noqa: E501
+            elif (
+                    (event.event_type == HistoryEventType.RECEIVE or event.event_subtype == HistoryEventSubType.RECEIVE) and  # noqa: E501
+                    event.amount == return_amount and
+                    destination_asset == event.asset
+            ):
                 event.event_type = HistoryEventType.TRADE
                 event.event_subtype = HistoryEventSubType.RECEIVE
                 event.notes = f'Receive {event.amount} {crypto_asset} from kyber swap'
                 in_event = event
+            elif (
+                    source_asset != destination_asset and
+                    refund_event is None and
+                    (event.event_type == HistoryEventType.RECEIVE or event.event_subtype == HistoryEventSubType.RECEIVE) and  # noqa: E501
+                    event.asset == source_asset and
+                    event.amount < spent_amount
+            ):
+                refund_event = event
 
-            if out_event is not None and in_event is not None:
-                maybe_reshuffle_events(ordered_events=[out_event, in_event], events_list=decoded_events)  # noqa: E501
+        if refund_event is not None and out_event is not None:
+            out_event.amount -= refund_event.amount
+            decoded_events.remove(refund_event)
+
+        if out_event is not None and in_event is not None:
+            out_event.notes = (
+                f'Swap {out_event.amount} {out_event.asset.symbol_or_name()} in kyber'
+            )
+            maybe_reshuffle_events(
+                ordered_events=[out_event, in_event],
+                events_list=decoded_events,
+            )
 
     def _decode_aggregator_trade(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decodes a kyber aggregator swap, updating the events with proper metadata"""

--- a/rotkehlchen/tests/unit/decoders/test_kyber.py
+++ b/rotkehlchen/tests/unit/decoders/test_kyber.py
@@ -185,6 +185,71 @@ def test_kyber_aggregator_swap_ethereum(ethereum_inquirer, ethereum_accounts):
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0xc2E8fdd6638e8ef469f39E3024D96eEF7FCf7DdC']])
+def test_kyber_aggregator_swap_ethereum_with_refund(ethereum_inquirer, ethereum_accounts):
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe29c8695ba05e994e2890fe920147b5d4dbc21dcd9355681844b625c1ecb52a0')),  # noqa: E501
+    )
+    expected_events = [
+        EvmEvent(
+            tx_ref=tx_hash,
+            sequence_index=0,
+            timestamp=(timestamp := TimestampMS(1757449319000)),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_ETH,
+            amount=FVal(gas := '0.000256338161229945'),
+            location_label=ethereum_accounts[0],
+            notes=f'Burn {gas} ETH for gas',
+            counterparty=CPT_GAS,
+        ), EvmEvent(
+            tx_ref=tx_hash,
+            sequence_index=383,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.INFORMATIONAL,
+            event_subtype=HistoryEventSubType.APPROVE,
+            asset=(a_eeth := Asset('eip155:1/erc20:0x35fA164735182de50811E8e2E824cFb9B6118ac2')),
+            amount=ZERO,
+            location_label=ethereum_accounts[0],
+            notes=f'Revoke eETH spending approval of {ethereum_accounts[0]} by {KYBER_AGGREGATOR_CONTRACT}',  # noqa: E501
+            address=KYBER_AGGREGATOR_CONTRACT,
+        ), EvmSwapEvent(
+            tx_ref=tx_hash,
+            sequence_index=384,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=a_eeth,
+            amount=FVal(spend_amount := '1.985158248360464351'),
+            location_label=ethereum_accounts[0],
+            notes=f'Swap {spend_amount} eETH in kyber',
+            counterparty=CPT_KYBER,
+            address=(
+                pool_address := string_to_evm_address(
+                    '0x6E4141d33021b52C91c28608403db4A0FFB50Ec6',
+                )
+            ),
+        ), EvmSwapEvent(
+            tx_ref=tx_hash,
+            sequence_index=385,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            asset=Asset('eip155:1/erc20:0xF0Bb20865277aBd641a307EcE5Ee04E79073416C'),
+            amount=FVal(receive_amount := '1.872813330450180743'),
+            location_label=ethereum_accounts[0],
+            notes=f'Receive {receive_amount} liquidETH from kyber swap',
+            counterparty=CPT_KYBER,
+            address=pool_address,
+        ),
+    ]
+    assert events == expected_events
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D']])
 def test_kyber_aggregator_swap_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0xbcc690fb11b0a6b0f3b1e5bed6abb5c3e93d5b4855472f94adea824bfa2be6ed')  # noqa: E501


### PR DESCRIPTION
Kyberswap swaps can in some cases refund you a tiny bit. rotki was seeing those as extra receives, unrelated to the swap. We now fix this by deducting from the original swap amount.
