### PR TITLE
Fix decoders after merging bugfixes

### DIFF
--- a/rotkehlchen/tests/unit/decoders/test_balancer.py
+++ b/rotkehlchen/tests/unit/decoders/test_balancer.py
@@ -1200,7 +1200,7 @@ def test_balancer_v2_swap_repeated_pair_netted_transfers(gnosis_inquirer, gnosis
             asset=Asset('eip155:100/erc20:0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'),
             amount=FVal(spend_amount := '57.062317629971433046'),
             location_label=user_address,
-            notes=f'Swap {spend_amount} WXDAI via Balancer v2',
+            notes=f'Swap {spend_amount} WXDAI in Balancer v2',
             counterparty=CPT_BALANCER_V2,
             address=VAULT_ADDRESS,
         ), EvmSwapEvent(
@@ -1212,7 +1212,7 @@ def test_balancer_v2_swap_repeated_pair_netted_transfers(gnosis_inquirer, gnosis
             asset=Asset('eip155:100/erc20:0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1'),
             amount=FVal(receive_amount := '0.028538349974533588'),
             location_label=user_address,
-            notes=f'Receive {receive_amount} WETH as the result of a swap via Balancer v2',
+            notes=f'Receive {receive_amount} WETH as the result of a swap in Balancer v2',
             counterparty=CPT_BALANCER_V2,
             address=VAULT_ADDRESS,
         ),

--- a/rotkehlchen/tests/unit/decoders/test_weth.py
+++ b/rotkehlchen/tests/unit/decoders/test_weth.py
@@ -5,6 +5,7 @@ from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V3
 from rotkehlchen.chain.evm.decoding.weth.constants import CPT_WETH
+from rotkehlchen.chain.evm.decoding.woo_fi.constants import CPT_WOO_FI
 from rotkehlchen.chain.evm.types import (
     EvmIndexer,
     SerializableChainIndexerOrder,
@@ -884,26 +885,13 @@ def test_weth_withdraw_base_without_transfer_log(
         sequence_index=1,
         timestamp=timestamp,
         location=Location.BASE,
-        event_type=HistoryEventType.SPEND,
-        event_subtype=HistoryEventSubType.RETURN_WRAPPED,
-        asset=A_WETH_BASE,
-        amount=(amount := FVal('0.747282755150069211')),
-        location_label=user,
-        notes=f'Unwrap {amount} WETH',
-        counterparty=CPT_WETH,
-        address=WETH_OP_BASE_ADDRESS,
-    ), EvmEvent(
-        tx_ref=tx_hash,
-        sequence_index=2,
-        timestamp=timestamp,
-        location=Location.BASE,
         event_type=HistoryEventType.WITHDRAWAL,
         event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
         asset=A_ETH,
-        amount=amount,
+        amount=(amount := FVal('0.747282755150069211')),
         location_label=user,
-        notes=f'Receive {amount} ETH',
-        counterparty=CPT_WETH,
+        notes=f'Withdraw {amount} ETH from WOOFi supercharger vault',
+        counterparty=CPT_WOO_FI,
         address=string_to_evm_address('0xe61Acb121a2B538dF495A85C4E50dD8581de4ed0'),
     )]
 


### PR DESCRIPTION
- Balancer needed its notes adjusted
- The weth transaction in the test is a woofi event that gets decoded properly in develop since we have a decoder for it

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
