### PR TITLE
Improve premium sync edge cases

### DIFF
--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -161,6 +161,10 @@ class PremiumSyncManager(LockableQueryMixIn):
         if self.premium is None:
             return False
 
+        if self.premium.get_capabilities()['max_backup_size_mb'] == 0:
+            log.debug('Skipping premium db backup because max size is zero')
+            return False
+
         with self.data.db.conn.read_ctx() as cursor:
             if not self.data.db.get_setting(cursor, 'premium_should_sync') and not force_upload:
                 return False

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -743,6 +743,26 @@ def test_upload_data_error(rotkehlchen_instance: 'Rotkehlchen') -> None:
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('premium_limits_override', [{'max_backup_size_mb': 0}])
+def test_upload_skipped_when_backup_limit_is_zero(rotkehlchen_instance: 'Rotkehlchen') -> None:
+    """Test that upload is disabled when the premium tier does not allow backups."""
+    assert rotkehlchen_instance.task_manager is not None
+    with patch.object(
+        rotkehlchen_instance.premium_sync_manager,
+        'maybe_upload_data_to_server',
+    ) as upload_mock:
+        assert rotkehlchen_instance.task_manager._maybe_schedule_db_upload() is None
+        success, message = rotkehlchen_instance.premium_sync_manager.sync_data(
+            action='upload',
+            perform_migrations=False,
+        )
+
+    assert success is False
+    assert message == 'Upload failed.'
+    upload_mock.assert_not_called()
+
+
+@pytest.mark.parametrize('start_with_valid_premium', [True])
 @pytest.mark.parametrize('device_limit', [1, 2])
 def test_device_limits(rotkehlchen_instance: 'Rotkehlchen', device_limit: int) -> None:
     """


### PR DESCRIPTION
Avoid syncing db when the tier has a limit of zero MB for backups

