### PR TITLE
Handle rate limited nodes

### DIFF
--- a/frontend/app/src/components/history/BadgeDisplay.vue
+++ b/frontend/app/src/components/history/BadgeDisplay.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-type Color = 'grey' | 'red' | 'green';
+type Color = 'grey' | 'red' | 'green' | 'orange';
 const {
   color = 'grey',
 } = defineProps<{
@@ -9,6 +9,7 @@ const {
 const colorVariants: Record<Color, string> = {
   green: 'text-rui-green-700 bg-rui-green-100',
   grey: 'text-rui-grey-700 bg-rui-grey-100 dark:text-rui-grey-400 dark:bg-rui-grey-800',
+  orange: 'text-rui-orange-700 bg-rui-orange-100',
   red: 'text-rui-red-700 bg-rui-red-100',
 };
 </script>

--- a/frontend/app/src/components/settings/general/rpc/BlockchainRpcNodeManager.vue
+++ b/frontend/app/src/components/settings/general/rpc/BlockchainRpcNodeManager.vue
@@ -2,6 +2,7 @@
 import type { Blockchain } from '@rotki/common';
 import { camelCase } from 'es-toolkit';
 import SimpleTable from '@/components/common/SimpleTable.vue';
+import DateDisplay from '@/components/display/DateDisplay.vue';
 import RowActions from '@/components/helper/RowActions.vue';
 import BadgeDisplay from '@/components/history/BadgeDisplay.vue';
 import BlockchainRpcNodeFormDialog from '@/components/settings/general/rpc/BlockchainRpcNodeFormDialog.vue';
@@ -32,7 +33,7 @@ const reconnecting = ref<boolean>(false);
 const { notify } = useNotificationDispatcher();
 const { setMessage } = useMessageStore();
 
-const { connectedNodes, failedToConnect } = storeToRefs(useSessionMetadataStore());
+const { connectedNodes, coolingDownNodes, failedToConnect } = storeToRefs(useSessionMetadataStore());
 const { show } = useConfirmStore();
 const { useChainName } = useSupportedChains();
 const api = useEvmNodesApi(() => chain);
@@ -114,6 +115,7 @@ function isNodeInDataset(dataset: Record<string, string[]>, item: BlockchainRpcN
 
 const NODE_STATUS = {
   CONNECTED: 'connected',
+  COOLING_DOWN: 'cooling_down',
   FAILED: 'failed',
   READY: 'ready',
 } as const;
@@ -125,6 +127,10 @@ function isNodeConnected(item: BlockchainRpcNode): boolean {
 }
 
 function getNodeStatus(item: BlockchainRpcNode): NodeStatus {
+  if (isNodeInDataset(get(coolingDownNodes), item)) {
+    return NODE_STATUS.COOLING_DOWN;
+  }
+
   if (isNodeConnected(item)) {
     return NODE_STATUS.CONNECTED;
   }
@@ -315,6 +321,29 @@ defineExpose({
                 {{ t('evm_rpc_node_manager.connected.true') }}
               </span>
             </BadgeDisplay>
+            <RuiTooltip
+              v-else-if="getNodeStatus(item) === NODE_STATUS.COOLING_DOWN"
+              :open-delay="400"
+            >
+              <template #activator>
+                <BadgeDisplay
+                  color="orange"
+                  class="items-center gap-2 !leading-6"
+                >
+                  <RuiIcon
+                    size="16"
+                    name="lu-clock"
+                  />
+                  <span>
+                    {{ t('evm_rpc_node_manager.connected.cooling_down') }}
+                  </span>
+                </BadgeDisplay>
+              </template>
+              <span v-if="item.cooldownUntil">
+                {{ t('evm_rpc_node_manager.cooldown_until') }}
+                <DateDisplay :timestamp="item.cooldownUntil" />
+              </span>
+            </RuiTooltip>
             <BadgeDisplay
               v-else-if="getNodeStatus(item) === NODE_STATUS.FAILED"
               color="red"

--- a/frontend/app/src/composables/api/session/index.spec.ts
+++ b/frontend/app/src/composables/api/session/index.spec.ts
@@ -76,6 +76,9 @@ describe('composables/api/session/index', () => {
                 ethereum: ['node1', 'node2'],
                 optimism: ['op_node1'],
               },
+              cooling_down_nodes: {
+                ethereum: ['node3'],
+              },
               failed_to_connect: {
                 arbitrum: ['arb_node1'],
               },
@@ -91,6 +94,7 @@ describe('composables/api/session/index', () => {
 
       expect(result.connectedNodes.ethereum).toEqual(['node1', 'node2']);
       expect(result.connectedNodes.optimism).toEqual(['op_node1']);
+      expect(result.coolingDownNodes?.ethereum).toEqual(['node3']);
       expect(result.failedToConnect?.arbitrum).toEqual(['arb_node1']);
       expect(result.lastBalanceSave).toBe(1700000000);
       expect(result.lastDataUploadTs).toBe(1700100000);

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2543,11 +2543,13 @@
       "title": "Delete {chain} RPC Node"
     },
     "connected": {
+      "cooling_down": "Rate limited",
       "failure": "Failed",
       "false": "Ready",
       "true": "Connected"
     },
     "connectivity": "Connectivity",
+    "cooldown_until": "Rate limited until:",
     "delete_error": {
       "title": "Deleting {chain} RPC Node"
     },

--- a/frontend/app/src/modules/session/use-periodic-data-fetcher.spec.ts
+++ b/frontend/app/src/modules/session/use-periodic-data-fetcher.spec.ts
@@ -41,6 +41,7 @@ describe('usePeriodicDataFetcher', () => {
   it('should update store with fetched periodic data', async () => {
     const result: PeriodicClientQueryResult = {
       connectedNodes: { eth: ['node1'] },
+      coolingDownNodes: { eth: ['node3'] },
       failedToConnect: { bsc: ['node2'] },
       lastBalanceSave: 1234,
       lastDataUploadTs: 5678,
@@ -55,6 +56,7 @@ describe('usePeriodicDataFetcher', () => {
     expect(get(store.lastBalanceSave)).toBe(1234);
     expect(get(store.lastDataUpload)).toBe(5678);
     expect(get(store.connectedNodes)).toEqual({ eth: ['node1'] });
+    expect(get(store.coolingDownNodes)).toEqual({ eth: ['node3'] });
     expect(get(store.failedToConnect)).toEqual({ bsc: ['node2'] });
   });
 
@@ -70,14 +72,14 @@ describe('usePeriodicDataFetcher', () => {
     expect(get(store.lastDataUpload)).toBe(0);
   });
 
-  it('should only update lastBalanceSave when value changes', async () => {
+  it('should clear optional node state maps when backend omits them', async () => {
     const store = useSessionMetadataStore();
-    const { lastBalanceSave } = storeToRefs(store);
-    set(lastBalanceSave, 1234);
+    const { coolingDownNodes, failedToConnect } = storeToRefs(store);
+    set(coolingDownNodes, { eth: ['cooling'] });
+    set(failedToConnect, { eth: ['failed'] });
 
     const result: PeriodicClientQueryResult = {
       connectedNodes: {},
-      failedToConnect: {},
       lastBalanceSave: 1234,
       lastDataUploadTs: 9999,
     };
@@ -87,8 +89,8 @@ describe('usePeriodicDataFetcher', () => {
     const { check } = usePeriodicDataFetcher();
     await check();
 
-    expect(get(store.lastBalanceSave)).toBe(1234);
-    expect(get(store.lastDataUpload)).toBe(9999);
+    expect(get(store.coolingDownNodes)).toEqual({});
+    expect(get(store.failedToConnect)).toEqual({});
   });
 
   it('should notify error on fetch failure', async () => {
@@ -116,7 +118,6 @@ describe('usePeriodicDataFetcher', () => {
 
     resolveFirst!({
       connectedNodes: {},
-      failedToConnect: {},
       lastBalanceSave: 100,
       lastDataUploadTs: 200,
     });

--- a/frontend/app/src/modules/session/use-periodic-data-fetcher.ts
+++ b/frontend/app/src/modules/session/use-periodic-data-fetcher.ts
@@ -13,7 +13,7 @@ export function usePeriodicDataFetcher(): UsePeriodicDataFetcherReturn {
   const { t } = useI18n({ useScope: 'global' });
 
   const store = useSessionMetadataStore();
-  const { connectedNodes, failedToConnect, lastBalanceSave, lastDataUpload } = storeToRefs(store);
+  const { connectedNodes, coolingDownNodes, failedToConnect, lastBalanceSave, lastDataUpload } = storeToRefs(store);
 
   const { notifyError } = useNotifications();
   const { fetchPeriodicData } = useSessionApi();
@@ -32,6 +32,7 @@ export function usePeriodicDataFetcher(): UsePeriodicDataFetcherReturn {
 
       const {
         connectedNodes: connected,
+        coolingDownNodes: cooling,
         failedToConnect: failed,
         lastBalanceSave: balance,
         lastDataUploadTs: upload,
@@ -44,7 +45,8 @@ export function usePeriodicDataFetcher(): UsePeriodicDataFetcherReturn {
         set(lastDataUpload, upload);
 
       set(connectedNodes, connected);
-      set(failedToConnect, failed);
+      set(coolingDownNodes, cooling ?? {});
+      set(failedToConnect, failed ?? {});
     }
     catch (error: unknown) {
       notifyError(

--- a/frontend/app/src/store/session/metadata.ts
+++ b/frontend/app/src/store/session/metadata.ts
@@ -6,6 +6,7 @@ export const useSessionMetadataStore = defineStore('session/metadata', () => {
   const lastBalanceSave = ref<number>(0);
   const lastDataUpload = ref<number>(0);
   const connectedNodes = shallowRef<Record<string, string[]>>({});
+  const coolingDownNodes = shallowRef<Record<string, string[]>>({});
   const failedToConnect = shallowRef<Record<string, string[]>>({});
 
   // Tags
@@ -18,6 +19,7 @@ export const useSessionMetadataStore = defineStore('session/metadata', () => {
   return {
     allTags,
     connectedNodes,
+    coolingDownNodes,
     failedToConnect,
     lastBalanceSave,
     lastDataUpload,

--- a/frontend/app/src/types/session/index.ts
+++ b/frontend/app/src/types/session/index.ts
@@ -4,6 +4,7 @@ import { z } from 'zod/v4';
 
 export const PeriodicClientQueryResultSchema = z.object({
   connectedNodes: z.record(z.string(), z.array(z.string())),
+  coolingDownNodes: z.record(z.string(), z.array(z.string())).optional(),
   failedToConnect: z.record(z.string(), z.array(z.string())).optional(),
   lastBalanceSave: z.number(),
   lastDataUploadTs: z.number(),

--- a/frontend/app/src/types/settings/rpc.ts
+++ b/frontend/app/src/types/settings/rpc.ts
@@ -4,11 +4,13 @@ import { z } from 'zod/v4';
 const BlockchainRpcNode = z.object({
   active: z.boolean(),
   blockchain: z.string().min(1),
+  cooldownUntil: z.number().nullable().optional(),
   endpoint: z.string(),
   identifier: z.number(),
   isArchive: z.boolean().optional(),
   name: z.string().min(1),
   owned: z.boolean(),
+  runtimeStatus: z.enum(['ready', 'cooling_down']).optional(),
   weight: z.preprocess(weight => Number.parseFloat(weight as string), z.number().nonnegative().max(100)),
 });
 

--- a/rotkehlchen/api/services/transactions.py
+++ b/rotkehlchen/api/services/transactions.py
@@ -12,6 +12,7 @@ from rotkehlchen.chain.evm.constants import GENESIS_HASH
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.chain.evm.types import NodeName
 from rotkehlchen.chain.gnosis.modules.gnosis_pay.constants import CPT_GNOSIS_PAY
+from rotkehlchen.chain.mixins.rpc_nodes import NodeStatus
 from rotkehlchen.chain.zksync_lite.constants import ZKL_IDENTIFIER
 from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.db.eth2 import DBEth2
@@ -122,10 +123,12 @@ class TransactionsService:
     def get_rpc_nodes(self, blockchain: SupportedBlockchain) -> dict[str, Any]:
         nodes = self.rotkehlchen.data.db.get_rpc_nodes(blockchain=blockchain)
 
+        inquirer = None
         archive_status: dict[str, bool] = {}
         if blockchain in CHAINS_WITH_NODES:
             manager = self.rotkehlchen.chains_aggregator.get_chain_manager(blockchain=blockchain)  # type: ignore[call-overload]
-            for node_info, rpc_node in manager.node_inquirer.rpc_mapping.items():
+            inquirer = manager.node_inquirer
+            for node_info, rpc_node in inquirer.rpc_mapping.items():
                 archive_status[node_info.endpoint] = rpc_node.is_archive
 
         result = []
@@ -133,6 +136,19 @@ class TransactionsService:
             serialized = node.serialize()
             if (is_archive := archive_status.get(node.node_info.endpoint)) is not None:
                 serialized['is_archive'] = is_archive
+
+            if inquirer is not None:
+                # is_node_in_cooldown() handles auto-expiry of elapsed windows
+                in_cooldown = inquirer.is_node_in_cooldown(node.node_info)
+                runtime = inquirer.get_runtime_state(node.node_info)
+                runtime_status = NodeStatus.COOLING_DOWN if in_cooldown else NodeStatus.READY
+                serialized['runtime_status'] = runtime_status
+                serialized['ready'] = not in_cooldown
+                serialized['cooldown_until'] = runtime.cooldown_until if runtime else None
+                serialized['last_error'] = runtime.last_error_ts if runtime else None
+                serialized['last_error_kind'] = runtime.last_error_kind if runtime else None
+                serialized['last_success_timestamp'] = runtime.last_success_ts if runtime else None
+
             result.append(serialized)
 
         return {
@@ -146,6 +162,12 @@ class TransactionsService:
             self.rotkehlchen.data.db.add_rpc_node(node)
         except InputError as e:
             return {'result': None, 'message': str(e), 'status_code': HTTPStatus.CONFLICT}
+
+        if node.node_info.blockchain in CHAINS_WITH_NODES:
+            manager = self.rotkehlchen.chains_aggregator.get_chain_manager(
+                blockchain=node.node_info.blockchain,
+            )
+            manager.node_inquirer.invalidate_nodes_cache()  # type: ignore[attr-defined]
 
         return {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
 
@@ -187,10 +209,26 @@ class TransactionsService:
                 f'Failed to find node with endpoint {old_endpoint} in web3 mappings. Skipping',
             )
 
+        manager.node_inquirer.invalidate_nodes_cache()
         manager.node_inquirer.connect_to_multiple_nodes(nodes_to_connect)
         return {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
 
     def delete_rpc_node(self, identifier: int, blockchain: SupportedBlockchain) -> dict[str, Any]:
+        # Fetch the endpoint before deletion so we can clean up runtime state
+        deleted_node_info: NodeName | None = None
+        if blockchain in CHAINS_WITH_NODES:
+            with self.rotkehlchen.data.db.conn.read_ctx() as cursor:
+                if (row := cursor.execute(
+                    'SELECT name, endpoint, owned FROM rpc_nodes WHERE identifier=?',
+                    (identifier,),
+                ).fetchone()) is not None:
+                    deleted_node_info = NodeName(
+                        name=row[0],
+                        endpoint=row[1],
+                        owned=bool(row[2]),
+                        blockchain=blockchain,  # type: ignore[arg-type]
+                    )
+
         try:
             self.rotkehlchen.data.db.delete_rpc_node(
                 identifier=identifier,
@@ -204,6 +242,9 @@ class TransactionsService:
             only_active=True,
         )
         manager = self.rotkehlchen.chains_aggregator.get_chain_manager(blockchain)  # type: ignore
+        if deleted_node_info is not None:
+            manager.node_inquirer.clear_runtime_state(deleted_node_info)
+        manager.node_inquirer.invalidate_nodes_cache()
         manager.node_inquirer.connect_to_multiple_nodes(nodes_to_connect)
         return {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
 

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -38,7 +38,7 @@ from rotkehlchen.chain.evm.contracts import EvmContract, EvmContracts
 from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2_CHAINIDS_WITH_L1_FEES
 from rotkehlchen.chain.evm.proxies_inquirer import EvmProxiesInquirer
 from rotkehlchen.chain.evm.types import EvmIndexer, RemoteDataQueryStatus, WeightedNode
-from rotkehlchen.chain.mixins.rpc_nodes import EVMRPCMixin
+from rotkehlchen.chain.mixins.rpc_nodes import EVMRPCMixin, _is_rate_limit_error
 from rotkehlchen.chain.structures import TimestampOrBlockRange
 from rotkehlchen.constants import ONE
 from rotkehlchen.db.settings import CachedSettings
@@ -524,6 +524,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
                     f'Timed out while querying {node_info.name} for '
                     f'{method.__name__}: {e!s}. Skipping this node in future queries.',
                 )
+                self.mark_node_failure(node_info, str(e))
                 self.failed_to_connect_nodes.add(node_info.name)
                 self.rpc_mapping.pop(node_info, None)
                 continue
@@ -543,9 +544,14 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
                 )
                 if any(x in str(e).lower() for x in ('out of gas', 'exceeds block gas limit')):
                     gas_limit_error_seen = True
+                elif _is_rate_limit_error(e):
+                    self.mark_node_rate_limited(node_info, str(e))
+                else:
+                    self.mark_node_failure(node_info, str(e))
                 # Catch all possible errors here and just try next node call
                 continue
 
+            self.mark_node_success(node_info)
             return result
 
         # no node in the call order list was successfully queried

--- a/rotkehlchen/chain/mixins/rpc_nodes.py
+++ b/rotkehlchen/chain/mixins/rpc_nodes.py
@@ -4,7 +4,9 @@ import random
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Final, Generic, Literal, TypeVar
 from urllib.parse import urlparse
 
 import requests
@@ -26,7 +28,6 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.greenlets.manager import GreenletManager
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.tests.utils.globaldb import Literal
 from rotkehlchen.types import (
     SUPPORTED_CHAIN_IDS,
     SUPPORTED_EVM_CHAINS_TYPE,
@@ -34,7 +35,9 @@ from rotkehlchen.types import (
     ChecksumEvmAddress,
     EVMTxHash,
     SupportedBlockchain,
+    Timestamp,
 )
+from rotkehlchen.utils.misc import ts_now
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -43,6 +46,63 @@ if TYPE_CHECKING:
 WEB3_NODE_TYPE = TypeVar('WEB3_NODE_TYPE', Web3, Client)
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
+
+RATE_LIMIT_COOLDOWN_SECS: Final = 300  # 5 minutes before retrying a rate-limited node
+# Patterns indicating a rate-limit response in a provider's error message
+RATE_LIMIT_PATTERNS: Final = ('rate limit', 'too many requests', 'rate_limit', '429')
+
+
+class NodeStatus(StrEnum):
+    READY = 'ready'
+    COOLING_DOWN = 'cooling_down'
+
+
+def _normalize_endpoint(endpoint: str) -> str:
+    """Normalize an RPC endpoint URL to a stable identity key.
+
+    Two endpoints that differ only by scheme casing, trailing slash, or default port
+    will produce the same key, so they share runtime state.
+
+    TODO: Normalize/canonicalize endpoints before persisting them in DB.
+    We currently store raw endpoint strings, so canonical-equivalent endpoints can be
+    saved as separate rows and need runtime normalization.
+    """
+    if '://' not in endpoint:
+        endpoint = f'http://{endpoint}'
+    parsed = urlparse(endpoint)
+    host = (parsed.hostname or '').lower()
+    port = parsed.port
+    path = parsed.path.rstrip('/')
+    # Omit port when it is the default for the scheme
+    if port and not (
+        (parsed.scheme == 'https' and port == 443) or
+        (parsed.scheme == 'http' and port == 80)
+    ):
+        return f'{parsed.scheme}://{host}:{port}{path}'
+    return f'{parsed.scheme}://{host}{path}'
+
+
+@dataclass
+class NodeRuntimeState:
+    """In-memory runtime health state for a single RPC endpoint.
+
+    This is keyed by normalized endpoint URL and reset on restart.
+    It is separate from DB configuration state (WeightedNode).
+    """
+    status: NodeStatus
+    cooldown_until: Timestamp | None = None
+    last_success_ts: Timestamp | None = None
+    last_error_ts: Timestamp | None = None
+    last_error_kind: str | None = None
+    consecutive_failures: int = 0
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    """Returns True when exc indicates the provider is rate-limiting us."""
+    if isinstance(exc, requests.exceptions.HTTPError) and exc.response is not None:
+        return exc.response.status_code in (429, 403)
+    err = str(exc).lower()
+    return any(p in err for p in RATE_LIMIT_PATTERNS)
 
 
 class RPCNode(NamedTuple, Generic[WEB3_NODE_TYPE]):
@@ -81,6 +141,12 @@ class RPCManagerMixin(ABC, Generic[WEB3_NODE_TYPE]):
         # moment of writing this we don't remove entries from the set after some time.
         # To force the app to retry a node a restart is needed.
         self.failed_to_connect_nodes: set[str] = set()
+        # Per-endpoint runtime health: keyed by _normalize_endpoint(endpoint).
+        # Reset on restart; never persisted.
+        self._node_runtime_state: dict[str, NodeRuntimeState] = {}
+        # Cached list of active configured nodes for this chain.
+        # None means the cache is stale and must be reloaded from DB on next access.
+        self._configured_nodes_cache: list[WeightedNode] | None = None
 
     def connected_to_any_node(self) -> bool:
         """Check if there are any currently connected nodes.
@@ -108,6 +174,97 @@ class RPCManagerMixin(ABC, Generic[WEB3_NODE_TYPE]):
         """Get all currently connected nodes"""
         return list(self.rpc_mapping.keys())
 
+    def _get_configured_nodes(self) -> list['WeightedNode']:
+        """Return the cached list of active configured nodes, loading from DB if needed."""
+        if self._configured_nodes_cache is None:
+            self._configured_nodes_cache = list(
+                self.database.get_rpc_nodes(blockchain=self.blockchain, only_active=True),
+            )
+        return self._configured_nodes_cache
+
+    def invalidate_nodes_cache(self) -> None:
+        """Mark the configured-node cache as stale.
+
+        Must be called after any RPC configuration change (add / edit / delete / enable).
+        """
+        self._configured_nodes_cache = None
+
+    def _endpoint_key(self, node: 'NodeName') -> str:
+        return _normalize_endpoint(node.endpoint)
+
+    def mark_node_success(self, node: 'NodeName') -> None:
+        """Record a successful query."""
+        key = self._endpoint_key(node)
+        now = ts_now()
+        existing = self._node_runtime_state.get(key)
+        if existing is not None:
+            # Mutate in-place — avoids object allocation on the hot path
+            existing.status = NodeStatus.READY
+            existing.cooldown_until = None
+            existing.consecutive_failures = 0
+            existing.last_success_ts = now
+        else:
+            self._node_runtime_state[key] = NodeRuntimeState(
+                status=NodeStatus.READY,
+                last_success_ts=now,
+            )
+
+    def mark_node_rate_limited(self, node: 'NodeName', error: str) -> None:
+        """Put a node into cooldown after a rate-limit response (HTTP 429 / 403 / message)."""
+        key = self._endpoint_key(node)
+        now = ts_now()
+        existing = self._node_runtime_state.get(key)
+        consecutive_failures = (existing.consecutive_failures if existing else 0) + 1
+        self._node_runtime_state[key] = NodeRuntimeState(
+            status=NodeStatus.COOLING_DOWN,
+            cooldown_until=Timestamp(now + RATE_LIMIT_COOLDOWN_SECS),
+            last_success_ts=existing.last_success_ts if existing else None,
+            last_error_ts=now,
+            last_error_kind='rate_limited',
+            consecutive_failures=consecutive_failures,
+        )
+        log.warning(
+            f'Node {node.name} ({key}) is rate-limited. '
+            f'Cooling down for {RATE_LIMIT_COOLDOWN_SECS}s. Error: {error}',
+        )
+
+    def mark_node_failure(self, node: 'NodeName', error: str) -> None:
+        """Record a non-rate-limit failure for a node."""
+        key = self._endpoint_key(node)
+        now = ts_now()
+        existing = self._node_runtime_state.get(key)
+        consecutive_failures = (existing.consecutive_failures if existing else 0) + 1
+        self._node_runtime_state[key] = NodeRuntimeState(
+            # Ordinary failure: stay ready so the node is tried again later.
+            status=NodeStatus.READY,
+            cooldown_until=existing.cooldown_until if existing else None,
+            last_success_ts=existing.last_success_ts if existing else None,
+            last_error_ts=now,
+            last_error_kind='failure',
+            consecutive_failures=consecutive_failures,
+        )
+
+    def is_node_in_cooldown(self, node: 'NodeName') -> bool:
+        """Return True if the node is currently in the rate-limit cooldown window."""
+        key = self._endpoint_key(node)
+        state = self._node_runtime_state.get(key)
+        if state is None or state.status != NodeStatus.COOLING_DOWN:
+            return False
+        if state.cooldown_until is not None and ts_now() >= state.cooldown_until:
+            # Cooldown window has expired — transition back to ready
+            state.status = NodeStatus.READY
+            state.cooldown_until = None
+            return False
+        return True
+
+    def get_runtime_state(self, node: 'NodeName') -> NodeRuntimeState | None:
+        """Return the current runtime state for a node, or None if not yet tracked."""
+        return self._node_runtime_state.get(self._endpoint_key(node))
+
+    def clear_runtime_state(self, node: 'NodeName') -> None:
+        """Remove all runtime state for a node (call when a node is deleted from config)."""
+        self._node_runtime_state.pop(self._endpoint_key(node), None)
+
     def maybe_connect_to_nodes(self, when_tracked_accounts: bool) -> None:
         """Start async connect to the saved nodes for the given blockchain if needed.
 
@@ -130,8 +287,10 @@ class RPCManagerMixin(ABC, Generic[WEB3_NODE_TYPE]):
                 when_tracked_accounts is False or self.blockchain == SupportedBlockchain.ETHEREUM
             ))
         ):
-            rpc_nodes = self.database.get_rpc_nodes(blockchain=self.blockchain, only_active=True)
-            self.connect_to_multiple_nodes(rpc_nodes)
+            # Re-read configured nodes at connect time. This avoids using stale cache
+            # entries when node configuration changed before first connection attempt.
+            self.invalidate_nodes_cache()
+            self.connect_to_multiple_nodes(self._get_configured_nodes())
 
     @abstractmethod
     def attempt_connect(
@@ -154,22 +313,23 @@ class RPCManagerMixin(ABC, Generic[WEB3_NODE_TYPE]):
             )
 
     def default_call_order(self) -> list['WeightedNode']:
-        """Default call order for RPCx nodes
+        """Default call order for RPC nodes.
 
-        Own node always has preference. Then all other node types are randomly queried
-        in sequence depending on a weighted probability.
+        Builds the order from the in-memory configured-node cache (no DB hit).
+        Ready owned nodes always come first. Nodes currently in cooldown are excluded.
+        Remaining public nodes are ordered by weighted random selection.
         """
         selection, owned_nodes = [], []
-        for wnode in self.database.get_rpc_nodes(
-            blockchain=self.blockchain,
-            only_active=True,
-        ):
+        for wnode in self._get_configured_nodes():
+            if self.is_node_in_cooldown(wnode.node_info):
+                continue
+
             if wnode.node_info.owned is False:
                 selection.append(wnode)
             else:
                 owned_nodes.append(wnode.node_info)
 
-        ordered_list = []
+        ordered_list: list[WeightedNode] = []
         while len(selection) != 0:
             weights = [float(entry.weight) for entry in selection]
             node = random.choices(selection, weights, k=1)

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -1446,17 +1446,32 @@ class Rotkehlchen:
         if self.user_is_logged_in:
             with self.data.db.conn.read_ctx() as cursor:
                 result[DBCacheStatic.LAST_BALANCE_SAVE.value] = self.data.db.get_last_balance_save_time(cursor)  # noqa: E501
-                connected_nodes, failed_to_connect = {}, {}
+                connected_nodes: dict[str, list[str]] = {}
+                failed_to_connect: dict[str, list[str]] = {}
+                cooling_down_nodes: dict[str, list[str]] = {}
                 for chain_manager in self.chains_aggregator.iterate_chain_managers_with_nodes():
-                    connected_nodes[serialized_chain := chain_manager.node_inquirer.blockchain.serialize()] = [  # noqa: E501
-                        node.name for node in chain_manager.node_inquirer.get_connected_nodes()
+                    inquirer = chain_manager.node_inquirer
+                    serialized_chain = inquirer.blockchain.serialize()
+                    connected_nodes[serialized_chain] = [
+                        node.name for node in inquirer.get_connected_nodes()
                     ]
-                    if len(chain_manager.node_inquirer.failed_to_connect_nodes) != 0:
-                        failed_to_connect[serialized_chain] = list(chain_manager.node_inquirer.failed_to_connect_nodes)  # noqa: E501
+                    if len(inquirer.failed_to_connect_nodes) != 0:
+                        failed_to_connect[serialized_chain] = list(
+                            inquirer.failed_to_connect_nodes,
+                        )
+                    cooling = [
+                        wnode.node_info.name
+                        for wnode in inquirer._get_configured_nodes()
+                        if inquirer.is_node_in_cooldown(wnode.node_info)
+                    ]
+                    if cooling:
+                        cooling_down_nodes[serialized_chain] = cooling
 
                 result['connected_nodes'] = connected_nodes
                 if len(failed_to_connect) != 0:
                     result['failed_to_connect'] = failed_to_connect
+                if len(cooling_down_nodes) != 0:
+                    result['cooling_down_nodes'] = cooling_down_nodes
 
                 result[DBCacheStatic.LAST_DATA_UPLOAD_TS.value] = Timestamp(self.premium_sync_manager.last_remote_data_upload_ts)  # noqa: E501
         return result

--- a/rotkehlchen/tests/api/test_misc.py
+++ b/rotkehlchen/tests/api/test_misc.py
@@ -456,6 +456,38 @@ def test_rpc_nodes_is_archive_field(rotkehlchen_api_server: 'APIServer') -> None
             assert 'is_archive' not in node
 
 
+def test_rpc_nodes_runtime_status_fields(rotkehlchen_api_server: 'APIServer') -> None:
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    node = WeightedNode(
+        identifier=100,
+        node_info=NodeName(
+            name='rate_limited_node',
+            endpoint='https://rate-limited.example.com',
+            owned=False,
+            blockchain=SupportedBlockchain.ETHEREUM,
+        ),
+        weight=FVal('0.3'),
+        active=True,
+    )
+    rotki.data.db.add_rpc_node(node)
+
+    inquirer = rotki.chains_aggregator.ethereum.node_inquirer
+    inquirer.mark_node_rate_limited(node.node_info, '429')
+
+    result = assert_proper_sync_response_with_result(requests.get(api_url_for(
+        api_server=rotkehlchen_api_server,
+        endpoint='rpcnodesresource',
+        blockchain=SupportedBlockchain.ETHEREUM.serialize(),
+    )))
+    serialized_node = next(entry for entry in result if entry['name'] == node.node_info.name)
+    assert serialized_node['runtime_status'] == 'cooling_down'
+    assert serialized_node['ready'] is False
+    assert serialized_node['cooldown_until'] is not None
+    assert serialized_node['last_error'] is not None
+    assert serialized_node['last_error_kind'] == 'rate_limited'
+    assert 'last_success_timestamp' in serialized_node
+
+
 @pytest.mark.parametrize('max_size_in_mb_all_logs', [659])
 def test_configuration(rotkehlchen_api_server: 'APIServer') -> None:
     """Test that the configuration endpoint returns the expected information"""

--- a/rotkehlchen/tests/api/test_periodic.py
+++ b/rotkehlchen/tests/api/test_periodic.py
@@ -2,14 +2,16 @@ import pytest
 import requests
 
 from rotkehlchen.api.server import APIServer
+from rotkehlchen.chain.evm.types import NodeName, WeightedNode
 from rotkehlchen.db.cache import DBCacheStatic
+from rotkehlchen.fval import FVal
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_proper_response,
     assert_proper_sync_response_with_result,
 )
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
-from rotkehlchen.types import Location
+from rotkehlchen.types import Location, SupportedBlockchain
 from rotkehlchen.utils.misc import ts_now
 
 
@@ -46,7 +48,26 @@ def test_query_periodic(rotkehlchen_api_server_with_exchanges: APIServer) -> Non
     # Non -1 value tests for these exist in test_history.py::test_query_history_timerange
     assert result[DBCacheStatic.LAST_DATA_UPLOAD_TS.value] == 0
 
+    rotki.data.db.add_rpc_node(WeightedNode(
+        identifier=100,
+        node_info=NodeName(
+            name='rate_limited_node',
+            endpoint='https://rate-limited.example.com',
+            owned=False,
+            blockchain=SupportedBlockchain.ETHEREUM,
+        ),
+        weight=FVal('0.3'),
+        active=True,
+    ))
+    rotki.chains_aggregator.ethereum.node_inquirer.invalidate_nodes_cache()
     rotki.chains_aggregator.ethereum.node_inquirer.failed_to_connect_nodes.add('custom node')
+    rotki.chains_aggregator.ethereum.node_inquirer.mark_node_rate_limited(
+        next(
+            iter(rotki.chains_aggregator.ethereum.node_inquirer._get_configured_nodes()),
+        ).node_info,
+        '429',
+    )
     response = requests.get(periodic_url)
     result = assert_proper_sync_response_with_result(response)
     assert result['failed_to_connect'] == {'eth': ['custom node']}
+    assert len(result['cooling_down_nodes']['eth']) == 1

--- a/rotkehlchen/tests/unit/test_rpc_node_runtime.py
+++ b/rotkehlchen/tests/unit/test_rpc_node_runtime.py
@@ -1,0 +1,333 @@
+"""Tests for RPC node runtime state, cooldown, and configured-node cache."""
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rotkehlchen.chain.evm.types import NodeName, WeightedNode
+from rotkehlchen.chain.mixins.rpc_nodes import (
+    RPCManagerMixin,
+    _is_rate_limit_error,
+    _normalize_endpoint,
+)
+from rotkehlchen.fval import FVal
+from rotkehlchen.types import SupportedBlockchain, Timestamp
+
+
+class _ConcreteManager(RPCManagerMixin):
+    """Concrete subclass that provides the required abstract methods."""
+    blockchain = SupportedBlockchain.ETHEREUM
+    chain_name = 'ethereum'
+    rpc_timeout = 10
+
+    def __init__(self, nodes: list[WeightedNode]) -> None:
+        super().__init__()
+        self.database = MagicMock()
+        self.database.get_rpc_nodes.return_value = nodes
+        self._configured_nodes_cache = nodes  # pre-warm to avoid DB calls
+
+    def attempt_connect(self, node: NodeName, connectivity_check: bool = True) -> tuple[bool, str]:
+        return True, ''
+
+
+def _make_node(name: str, endpoint: str, owned: bool = False) -> NodeName:
+    return NodeName(
+        name=name,
+        endpoint=endpoint,
+        owned=owned,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    )
+
+
+def _make_weighted_node(
+        name: str,
+        endpoint: str,
+        weight: float = 0.5,
+        owned: bool = False,
+) -> WeightedNode:
+    return WeightedNode(
+        node_info=_make_node(name, endpoint, owned=owned),
+        active=True,
+        weight=FVal(weight),
+        identifier=1,
+    )
+
+
+def _make_manager(nodes: list[WeightedNode]) -> _ConcreteManager:
+    return _ConcreteManager(nodes)
+
+
+@pytest.mark.parametrize(
+    ('endpoint', 'normalized'),
+    [
+        ('https://RPC.Example.COM/', 'https://rpc.example.com'),
+        ('https://rpc.example.com:443', 'https://rpc.example.com'),
+        ('http://rpc.example.com:80', 'http://rpc.example.com'),
+        ('https://rpc.example.com:8545', 'https://rpc.example.com:8545'),
+        ('localhost:8545', 'http://localhost:8545'),
+    ],
+)
+def test_normalize_endpoint(endpoint: str, normalized: str) -> None:
+    assert _normalize_endpoint(endpoint) == normalized
+
+
+@pytest.mark.parametrize(
+    ('error', 'expected'),
+    [
+        pytest.param(Exception('rate limit exceeded'), True, id='message-rate-limit'),
+        pytest.param(Exception('too many requests'), True, id='message-too-many-requests'),
+        pytest.param(Exception('HTTP Error 429'), True, id='message-429'),
+        pytest.param(Exception('connection refused'), False, id='message-not-rate-limit'),
+    ],
+)
+def test_is_rate_limit_error_messages(error: Exception, expected: bool) -> None:
+    assert _is_rate_limit_error(error) is expected
+
+
+@pytest.mark.parametrize(
+    ('status_code', 'expected'),
+    [
+        (429, True),
+        (403, True),
+        (500, False),
+    ],
+)
+def test_is_rate_limit_error_http_status(status_code: int, expected: bool) -> None:
+    import requests as req
+
+    resp = MagicMock()
+    resp.status_code = status_code
+    assert _is_rate_limit_error(req.exceptions.HTTPError(response=resp)) is expected
+
+
+def test_mark_node_success_clears_cooldown() -> None:
+    node = _make_node('test', 'https://rpc.example.com')
+    manager = _make_manager([])
+    manager.mark_node_rate_limited(node, 'rate limit')
+    assert manager.is_node_in_cooldown(node) is True
+
+    manager.mark_node_success(node)
+    assert manager.is_node_in_cooldown(node) is False
+    state = manager.get_runtime_state(node)
+    assert state is not None
+    assert state.status == 'ready'
+    assert state.consecutive_failures == 0
+    assert state.cooldown_until is None
+
+
+def test_mark_node_rate_limited_sets_cooldown() -> None:
+    node = _make_node('test', 'https://rpc.example.com')
+    manager = _make_manager([])
+    manager.mark_node_rate_limited(node, '429')
+    assert manager.is_node_in_cooldown(node) is True
+    state = manager.get_runtime_state(node)
+    assert state is not None
+    assert state.status == 'cooling_down'
+    assert state.last_error_kind == 'rate_limited'
+    assert state.cooldown_until is not None
+
+
+def test_cooldown_expires_transitions_to_ready() -> None:
+    node = _make_node('test', 'https://rpc.example.com')
+    manager = _make_manager([])
+    manager.mark_node_rate_limited(node, '429')
+
+    state = manager.get_runtime_state(node)
+    assert state is not None
+    state.cooldown_until = Timestamp(int(time.time()) - 1)
+
+    assert manager.is_node_in_cooldown(node) is False
+    assert state.status == 'ready'
+    assert state.cooldown_until is None
+
+
+def test_mark_node_failure_preserves_ready_status() -> None:
+    node = _make_node('test', 'https://rpc.example.com')
+    manager = _make_manager([])
+    manager.mark_node_failure(node, 'connection error')
+    state = manager.get_runtime_state(node)
+    assert state is not None
+    assert state.status == 'ready'
+    assert state.consecutive_failures == 1
+    assert state.last_error_kind == 'failure'
+
+
+def test_consecutive_failures_accumulate() -> None:
+    node = _make_node('test', 'https://rpc.example.com')
+    manager = _make_manager([])
+    for _ in range(3):
+        manager.mark_node_failure(node, 'error')
+    assert manager.get_runtime_state(node).consecutive_failures == 3  # type: ignore[union-attr]
+
+
+def test_mark_node_success_resets_consecutive_failures() -> None:
+    node = _make_node('test', 'https://rpc.example.com')
+    manager = _make_manager([])
+    manager.mark_node_failure(node, 'err')
+    manager.mark_node_failure(node, 'err')
+    manager.mark_node_success(node)
+    assert manager.get_runtime_state(node).consecutive_failures == 0  # type: ignore[union-attr]
+
+
+def test_get_runtime_state_returns_none_for_unknown_node() -> None:
+    node = _make_node('unknown', 'https://new.example.com')
+    manager = _make_manager([])
+    assert manager.get_runtime_state(node) is None
+    assert manager.is_node_in_cooldown(node) is False
+
+
+def test_clear_runtime_state_removes_entry() -> None:
+    node = _make_node('test', 'https://rpc.example.com')
+    manager = _make_manager([])
+    manager.mark_node_rate_limited(node, '429')
+    assert manager.get_runtime_state(node) is not None
+    manager.clear_runtime_state(node)
+    assert manager.get_runtime_state(node) is None
+    assert manager.is_node_in_cooldown(node) is False
+
+
+def test_cooldown_shared_across_endpoint_aliases() -> None:
+    """Two nodes with different names but same endpoint share cooldown state."""
+    node_a = _make_node('flashbots', 'https://rpc.flashbots.net/')
+    node_b = _make_node('Flashbots', 'https://rpc.flashbots.net')
+    manager = _make_manager([])
+    manager.mark_node_rate_limited(node_a, '429')
+    assert manager.is_node_in_cooldown(node_b) is True
+
+
+def test_success_on_alias_clears_cooldown_for_other() -> None:
+    node_a = _make_node('a', 'https://rpc.example.com/')
+    node_b = _make_node('b', 'https://rpc.example.com')
+    manager = _make_manager([])
+    manager.mark_node_rate_limited(node_a, '429')
+    manager.mark_node_success(node_b)
+    assert manager.is_node_in_cooldown(node_a) is False
+
+
+def test_configured_nodes_cache_avoids_db_on_repeated_calls() -> None:
+    node = _make_weighted_node('test', 'https://rpc.example.com')
+    manager = _make_manager([node])
+    db_mock = MagicMock()
+    manager.database = db_mock
+
+    manager._get_configured_nodes()
+    manager._get_configured_nodes()
+    manager._get_configured_nodes()
+
+    db_mock.get_rpc_nodes.assert_not_called()
+
+
+def test_configured_nodes_cache_invalidation_forces_db_reload() -> None:
+    node = _make_weighted_node('test', 'https://rpc.example.com')
+    manager = _make_manager([node])
+    db_mock = MagicMock()
+    db_mock.get_rpc_nodes.return_value = [node]
+    manager.database = db_mock
+    manager.blockchain = SupportedBlockchain.ETHEREUM
+
+    manager.invalidate_nodes_cache()
+    manager._get_configured_nodes()
+
+    db_mock.get_rpc_nodes.assert_called_once()
+
+
+def test_configured_nodes_cache_loads_from_db_when_empty() -> None:
+    manager = _make_manager([])
+    manager._configured_nodes_cache = None
+    db_mock = MagicMock()
+    db_mock.get_rpc_nodes.return_value = []
+    manager.database = db_mock
+    manager.blockchain = SupportedBlockchain.ETHEREUM
+
+    result = manager._get_configured_nodes()
+    assert result == []
+    db_mock.get_rpc_nodes.assert_called_once_with(
+        blockchain=SupportedBlockchain.ETHEREUM,
+        only_active=True,
+    )
+
+
+def test_default_call_order_excludes_cooling_node() -> None:
+    nodes = [
+        _make_weighted_node('good', 'https://good.example.com', weight=0.5),
+        _make_weighted_node('bad', 'https://bad.example.com', weight=0.5),
+    ]
+    manager = _make_manager(nodes)
+    bad_node = _make_node('bad', 'https://bad.example.com')
+    manager.mark_node_rate_limited(bad_node, '429')
+
+    for _ in range(20):  # repeat to rule out random false negatives
+        order = manager.default_call_order()
+        names = [w.node_info.name for w in order]
+        assert 'bad' not in names
+        assert 'good' in names
+
+
+def test_default_call_order_expired_cooldown_node_returns() -> None:
+    nodes = [
+        _make_weighted_node('good', 'https://good.example.com', weight=0.5),
+        _make_weighted_node('bad', 'https://bad.example.com', weight=0.5),
+    ]
+    manager = _make_manager(nodes)
+    bad_node = _make_node('bad', 'https://bad.example.com')
+    manager.mark_node_rate_limited(bad_node, '429')
+
+    state = manager.get_runtime_state(bad_node)
+    assert state is not None
+    state.cooldown_until = Timestamp(int(time.time()) - 1)
+
+    names_seen: set[str] = set()
+    for _ in range(20):
+        names_seen.update(w.node_info.name for w in manager.default_call_order())
+    assert 'bad' in names_seen
+
+
+def test_default_call_order_owned_node_comes_first() -> None:
+    nodes = [
+        _make_weighted_node('mynode', 'https://mine.example.com', weight=1.0, owned=True),
+        _make_weighted_node('public', 'https://pub.example.com', weight=1.0),
+    ]
+    manager = _make_manager(nodes)
+
+    for _ in range(10):
+        assert manager.default_call_order()[0].node_info.name == 'mynode'
+
+
+def test_default_call_order_excludes_cooling_owned_node() -> None:
+    nodes = [
+        _make_weighted_node('mynode', 'https://mine.example.com', weight=1.0, owned=True),
+        _make_weighted_node('public', 'https://pub.example.com', weight=1.0),
+    ]
+    manager = _make_manager(nodes)
+    manager.mark_node_rate_limited(
+        _make_node('mynode', 'https://mine.example.com', owned=True),
+        '429',
+    )
+
+    for _ in range(10):
+        names = [w.node_info.name for w in manager.default_call_order()]
+        assert 'mynode' not in names
+        assert names == ['public']
+
+
+def test_maybe_connect_to_nodes_refreshes_stale_configured_nodes_cache() -> None:
+    stale_node = _make_weighted_node('stale', 'https://stale.example.com', weight=1.0)
+    fresh_node = _make_weighted_node('fresh', 'https://fresh.example.com', weight=1.0)
+    manager = _make_manager([stale_node])
+    manager._configured_nodes_cache = [stale_node]
+
+    db_mock = MagicMock()
+    db_mock.get_rpc_nodes.return_value = [fresh_node]
+    db_mock.get_blockchain_accounts.return_value = {SupportedBlockchain.ETHEREUM: []}
+    ctx_mock = MagicMock()
+    ctx_mock.__enter__.return_value = MagicMock()
+    ctx_mock.__exit__.return_value = None
+    db_mock.conn.read_ctx.return_value = ctx_mock
+    manager.database = db_mock
+
+    manager.greenlet_manager = MagicMock()
+    manager.greenlet_manager.has_task.return_value = False
+
+    with patch.object(manager, 'connect_to_multiple_nodes') as mock_connect:
+        manager.maybe_connect_to_nodes(when_tracked_accounts=False)
+        mock_connect.assert_called_once_with([fresh_node])


### PR DESCRIPTION
This PR was co-authored with claude

What It does is:

- Handle rate limits to avoid querying nodes that we know will fail
- Keep an in memory cache of the nodes so we don't do a trip to the db on each default call order query.
- Adjusted the periodic endpoint to return also the rate limited status
- Adjusted frontend to handle rate limited nodes


