### PR TITLE
fix(frontend): gate cloud sync behind plan capabilities

### DIFF
--- a/frontend/app/src/components/status/sync/AutomaticSyncSetting.vue
+++ b/frontend/app/src/components/status/sync/AutomaticSyncSetting.vue
@@ -6,16 +6,10 @@ defineOptions({
   inheritAttrs: false,
 });
 
-withDefaults(
-  defineProps<{
-    disabled?: boolean;
-    dense?: boolean;
-  }>(),
-  {
-    dense: false,
-    disabled: false,
-  },
-);
+const { disabled = false, dense = false } = defineProps<{
+  disabled?: boolean;
+  dense?: boolean;
+}>();
 
 const sync = ref(false);
 const { premiumSync } = storeToRefs(usePremiumStore());

--- a/frontend/app/src/components/status/sync/SyncButtons.vue
+++ b/frontend/app/src/components/status/sync/SyncButtons.vue
@@ -4,7 +4,10 @@ import { usePremium } from '@/composables/premium';
 import { useSync } from '@/composables/session/sync';
 import { SYNC_DOWNLOAD, SYNC_UPLOAD, type SyncAction } from '@/types/session/sync';
 
-defineProps<{ pending: boolean }>();
+const { pending, disabled = false } = defineProps<{
+  pending: boolean;
+  disabled?: boolean;
+}>();
 
 const emit = defineEmits<{
   action: [action: SyncAction];
@@ -35,7 +38,7 @@ const { loadingBalancesAndDetection: loading } = useBalancesLoading();
           :variant="uploadStatus ? 'default' : 'outlined'"
           color="primary"
           class="w-full"
-          :disabled="!premium || pending || loading"
+          :disabled="!premium || pending || loading || disabled"
           @click="action(UPLOAD)"
         >
           <template #prepend>
@@ -56,7 +59,7 @@ const { loadingBalancesAndDetection: loading } = useBalancesLoading();
           variant="outlined"
           color="primary"
           class="w-full"
-          :disabled="!premium || pending || !!uploadStatus || loading"
+          :disabled="!premium || pending || !!uploadStatus || loading || disabled"
           @click="action(DOWNLOAD)"
         >
           <template #prepend>

--- a/frontend/app/src/components/status/sync/SyncIndicator.vue
+++ b/frontend/app/src/components/status/sync/SyncIndicator.vue
@@ -8,6 +8,7 @@ import SyncSettings from '@/components/status/sync/SyncSettings.vue';
 import { useLinks } from '@/composables/links';
 import { useSync } from '@/composables/session/sync';
 import { useLogout } from '@/modules/account/use-logout';
+import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { usePeriodicStore } from '@/store/session/periodic';
 import { usePremiumStore } from '@/store/session/premium';
 import { useTaskStore } from '@/store/tasks';
@@ -22,6 +23,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const { premium, premiumSync } = storeToRefs(usePremiumStore());
 const { lastDataUpload } = storeToRefs(usePeriodicStore());
+const { allowed: cloudBackupAllowed } = useFeatureAccess(PremiumFeature.CLOUD_BACKUP);
 
 const {
   cancelSync,
@@ -84,6 +86,9 @@ const uploadProgressIcon = computed<string>(() => {
 });
 
 const tooltip = computed<string>(() => {
+  if (!get(cloudBackupAllowed))
+    return t('sync_indicator.cloud_backup_unavailable');
+
   if (get(uploadStatus)) {
     const title = t('sync_indicator.db_upload_result.title');
     const message = t('sync_indicator.db_upload_result.message', {
@@ -169,14 +174,24 @@ watchImmediate(runCounter, (runCounter) => {
           v-bind="attrs"
         >
           <RuiBadge
-            :model-value="!!uploadStatus"
-            color="warning"
-            dot
+            :model-value="!!uploadStatus || !cloudBackupAllowed"
+            :color="!cloudBackupAllowed ? undefined : 'warning'"
+            :dot="cloudBackupAllowed"
             placement="top"
-            offset-y="4"
-            size="lg"
+            :offset-y="cloudBackupAllowed ? 4 : 12"
+            :offset-x="cloudBackupAllowed ? undefined : -6"
+            :size="cloudBackupAllowed ? 'lg' : 'sm'"
             class="flex items-center"
           >
+            <template
+              v-if="!cloudBackupAllowed"
+              #icon
+            >
+              <RuiIcon
+                name="lu-lock-keyhole"
+                size="10"
+              />
+            </template>
             <RuiIcon
               v-if="uploadStatus"
               name="lu-cloud-off-fill"
@@ -219,10 +234,34 @@ watchImmediate(runCounter, (runCounter) => {
               </span>
             </div>
           </div>
-          <SyncSettings v-model="syncSettingMenuOpen" />
+          <SyncSettings
+            v-model="syncSettingMenuOpen"
+            :disabled="!cloudBackupAllowed"
+          />
         </div>
         <RuiAlert
-          v-if="uploadProgress"
+          v-if="!cloudBackupAllowed"
+          type="info"
+          outlined
+          class="border border-rui-info"
+        >
+          <div class="text-sm">
+            {{ t('sync_indicator.cloud_backup_unavailable') }}
+          </div>
+          <div class="flex flex-row-reverse -mb-1">
+            <RuiButton
+              variant="text"
+              color="primary"
+              size="sm"
+              :href="href"
+              @click="onLinkClick()"
+            >
+              {{ t('sync_indicator.cloud_backup_upgrade') }}
+            </RuiButton>
+          </div>
+        </RuiAlert>
+        <RuiAlert
+          v-else-if="uploadProgress"
           type="info"
           outlined
           class="border border-rui-info"
@@ -300,6 +339,7 @@ watchImmediate(runCounter, (runCounter) => {
         </RuiAlert>
         <SyncButtons
           :pending="pending"
+          :disabled="!cloudBackupAllowed"
           @action="showConfirmation($event)"
         />
       </div>
@@ -309,7 +349,7 @@ watchImmediate(runCounter, (runCounter) => {
     <RuiBadge
       placement="top"
       offset-y="12"
-      offset-x="-10"
+      offset-x="-6"
       size="sm"
     >
       <template #icon>

--- a/frontend/app/src/components/status/sync/SyncSettings.vue
+++ b/frontend/app/src/components/status/sync/SyncSettings.vue
@@ -4,6 +4,10 @@ import AutomaticSyncSetting from '@/components/status/sync/AutomaticSyncSetting.
 
 const model = defineModel<boolean>({ required: true });
 
+const { disabled = false } = defineProps<{
+  disabled?: boolean;
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 const { isMdAndUp } = useBreakpoint();
 </script>
@@ -38,6 +42,7 @@ const { isMdAndUp } = useBreakpoint();
           class="mt-2"
           size="sm"
           dense
+          :disabled="disabled"
         />
       </div>
 

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -4638,6 +4638,8 @@
       "statistic": "The statistics view is not available",
       "title": "Graphs are not available"
     },
+    "cloud_backup_unavailable": "Cloud backup is not available for your current plan. {link} to enable cloud sync.",
+    "cloud_backup_upgrade_link": "Upgrade your subscription",
     "current_plan_label": "Current plan:",
     "delete_confirmation": {
       "message": "Are you sure you want to delete the rotki premium keys for your account? If you want to re-enable premium you will have to enter your keys again.",
@@ -5096,6 +5098,8 @@
     "upload_tooltip": "Push your local database to the server and replace all data there"
   },
   "sync_indicator": {
+    "cloud_backup_unavailable": "Cloud backup is not available for your current plan. Upgrade to enable cloud sync.",
+    "cloud_backup_upgrade": "Upgrade plan",
     "db_upload_result": {
       "message": "We could not complete the upload because {reason}",
       "title": "Database sync attempt unsuccessful"

--- a/frontend/app/src/modules/premium/use-feature-access.spec.ts
+++ b/frontend/app/src/modules/premium/use-feature-access.spec.ts
@@ -149,6 +149,56 @@ describe('modules/premium/use-feature-access', () => {
       expect(get(allowed)).toBe(false);
     });
 
+    it('should return allowed=true for CLOUD_BACKUP when maxBackupSizeMb > 0', () => {
+      const store = usePremiumStore();
+      const { capabilities, premium } = storeToRefs(store);
+      set(premium, true);
+      set(capabilities, {
+        maxBackupSizeMb: 100,
+      });
+
+      const { allowed } = useFeatureAccess(PremiumFeature.CLOUD_BACKUP);
+
+      expect(get(allowed)).toBe(true);
+    });
+
+    it('should return allowed=false for CLOUD_BACKUP when maxBackupSizeMb is 0', () => {
+      const store = usePremiumStore();
+      const { capabilities, premium } = storeToRefs(store);
+      set(premium, true);
+      set(capabilities, {
+        maxBackupSizeMb: 0,
+      });
+
+      const { allowed } = useFeatureAccess(PremiumFeature.CLOUD_BACKUP);
+
+      expect(get(allowed)).toBe(false);
+    });
+
+    it('should return allowed=false for CLOUD_BACKUP when maxBackupSizeMb is not set', () => {
+      const store = usePremiumStore();
+      const { capabilities, premium } = storeToRefs(store);
+      set(premium, true);
+      set(capabilities, {});
+
+      const { allowed } = useFeatureAccess(PremiumFeature.CLOUD_BACKUP);
+
+      expect(get(allowed)).toBe(false);
+    });
+
+    it('should return null minimumTier for CLOUD_BACKUP', () => {
+      const store = usePremiumStore();
+      const { capabilities, premium } = storeToRefs(store);
+      set(premium, true);
+      set(capabilities, {
+        maxBackupSizeMb: 100,
+      });
+
+      const { minimumTier } = useFeatureAccess(PremiumFeature.CLOUD_BACKUP);
+
+      expect(get(minimumTier)).toBeNull();
+    });
+
     it('should work with reactive feature parameter', async () => {
       const store = usePremiumStore();
       const { capabilities, premium } = storeToRefs(store);

--- a/frontend/app/src/modules/premium/use-feature-access.ts
+++ b/frontend/app/src/modules/premium/use-feature-access.ts
@@ -28,12 +28,20 @@ export function useFeatureAccess(feature: MaybeRefOrGetter<PremiumFeature>): Use
       return false;
 
     const caps = get(capabilities);
-    return caps?.[toValue(feature)]?.enabled ?? false;
+    const featureValue = toValue(feature);
+    if (featureValue === PremiumFeature.CLOUD_BACKUP)
+      return (caps?.maxBackupSizeMb ?? 0) > 0;
+
+    return caps?.[featureValue]?.enabled ?? false;
   });
 
   const minimumTier = computed<string | null>(() => {
     const caps = get(capabilities);
-    return caps?.[toValue(feature)]?.minimumTier ?? null;
+    const featureValue = toValue(feature);
+    if (featureValue === PremiumFeature.CLOUD_BACKUP)
+      return null;
+
+    return caps?.[featureValue]?.minimumTier ?? null;
   });
 
   const currentTier = computed<string>(() => get(capabilities)?.currentTier ?? '');

--- a/frontend/app/src/pages/api-keys/premium/index.vue
+++ b/frontend/app/src/pages/api-keys/premium/index.vue
@@ -9,6 +9,7 @@ import AutomaticSyncSetting from '@/components/status/sync/AutomaticSyncSetting.
 import { useInterop } from '@/composables/electron-interop';
 import { usePremiumHelper } from '@/composables/premium';
 import PremiumDeviceList from '@/modules/premium/devices/components/PremiumDeviceList.vue';
+import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { useConfirmStore } from '@/store/confirm';
 import { useMessageStore } from '@/store/message';
 import { useSessionAuthStore } from '@/store/session/auth';
@@ -35,6 +36,7 @@ const { setMessage } = useMessageStore();
 
 const { currentTier } = usePremiumHelper();
 const { openUrl, premiumUserLoggedIn } = useInterop();
+const { allowed: cloudBackupAllowed } = useFeatureAccess(PremiumFeature.CLOUD_BACKUP);
 
 const mainActionText = computed<string>(() => {
   if (!get(premium))
@@ -231,8 +233,28 @@ onMounted(() => {
 
       <AutomaticSyncSetting
         class="mt-6"
-        :disabled="!premium || edit"
+        :disabled="!premium || edit || !cloudBackupAllowed"
       />
+
+      <RuiAlert
+        v-if="premium && !cloudBackupAllowed"
+        type="info"
+        class="mt-4"
+      >
+        <i18n-t
+          scope="global"
+          tag="span"
+          keypath="premium_settings.cloud_backup_unavailable"
+        >
+          <template #link>
+            <ExternalLink
+              :url="externalLinks.manageSubscriptions"
+              :text="t('premium_settings.cloud_backup_upgrade_link')"
+              color="primary"
+            />
+          </template>
+        </i18n-t>
+      </RuiAlert>
 
       <template #footer>
         <div class="flex flex-row gap-2">

--- a/frontend/app/src/types/session/index.ts
+++ b/frontend/app/src/types/session/index.ts
@@ -55,6 +55,7 @@ export interface QueriedAddressPayload {
 }
 
 export enum PremiumFeature {
+  CLOUD_BACKUP = 'cloudBackup',
   ETH_STAKING_VIEW = 'ethStakingView',
   EVENT_ANALYSIS_VIEW = 'eventAnalysisView',
   GRAPHS_VIEW = 'graphsView',


### PR DESCRIPTION
## Summary
- Add `CLOUD_BACKUP` premium feature check based on `maxBackupSizeMb` from capabilities
- Disable sync controls (buttons, auto-sync toggle, settings) when cloud backup is not available for the user's plan
- Show a lock badge on the cloud icon in the status bar when cloud backup is unavailable
- Display upgrade prompts with links in both the sync indicator dropdown and the premium API keys page

## Test plan
- [ ] Verify sync buttons and auto-sync toggle are disabled when the plan doesn't support cloud backup
- [ ] Verify the lock badge appears on the cloud icon for users without cloud backup access
- [ ] Verify the upgrade link in the sync indicator menu navigates to the premium page
- [ ] Verify the upgrade alert appears on the premium API keys page when cloud backup is not available
- [ ] Verify all controls work normally when cloud backup is available
- [ ] Run `pnpm run test:unit` to confirm tests pass