### PR TITLE
fix(frontend): gate gnosis pay and monerium behind plan capabilities

### DIFF
--- a/frontend/app/src/components/settings/api-keys/ServiceKeyCard.vue
+++ b/frontend/app/src/components/settings/api-keys/ServiceKeyCard.vue
@@ -2,33 +2,39 @@
 import AppImage from '@/components/common/AppImage.vue';
 import BigDialog from '@/components/dialogs/BigDialog.vue';
 import PremiumLock from '@/components/premium/PremiumLock.vue';
-import { usePremium } from '@/composables/premium';
 
-const props = withDefaults(
-  defineProps<{
-    name?: string;
-    title: string;
-    subtitle?: string;
-    imageSrc: string;
-    needPremium?: boolean;
-    roundedIcon?: boolean;
-    keySet?: boolean;
-    hideAction?: boolean;
-    primaryAction?: string;
-    actionDisabled?: boolean;
-    addButtonText?: string;
-    editButtonText?: string;
-  }>(),
-  {
-    actionDisabled: false,
-    hideAction: false,
-    keySet: false,
-    needPremium: false,
-    primaryAction: '',
-    roundedIcon: false,
-    subtitle: '',
-  },
-);
+export interface FeatureGate {
+  allowed: boolean;
+  message: string;
+}
+
+const {
+  name,
+  title,
+  subtitle = '',
+  imageSrc,
+  featureGate,
+  roundedIcon = false,
+  keySet = false,
+  hideAction = false,
+  primaryAction = '',
+  actionDisabled = false,
+  addButtonText,
+  editButtonText,
+} = defineProps<{
+  name?: string;
+  title: string;
+  subtitle?: string;
+  imageSrc: string;
+  featureGate?: FeatureGate;
+  roundedIcon?: boolean;
+  keySet?: boolean;
+  hideAction?: boolean;
+  primaryAction?: string;
+  actionDisabled?: boolean;
+  addButtonText?: string;
+  editButtonText?: string;
+}>();
 
 const emit = defineEmits<{
   confirm: [];
@@ -43,9 +49,9 @@ const { t } = useI18n({ useScope: 'global' });
 
 const openDialog = ref<boolean>(false);
 
-const premium = usePremium();
+const featureBlocked = computed<boolean>(() => !!featureGate && !featureGate.allowed);
 
-function setOpen(value: boolean) {
+function setOpen(value: boolean): void {
   set(openDialog, value);
 }
 
@@ -53,7 +59,7 @@ const route = useRoute();
 const router = useRouter();
 
 watch(route, async (route) => {
-  if (!props.name)
+  if (!name)
     return;
 
   const { query } = route;
@@ -62,7 +68,7 @@ watch(route, async (route) => {
   }
   const { service, ...restQuery } = query;
 
-  if (service === props.name) {
+  if (service === name) {
     nextTick(() => {
       setOpen(true);
     });
@@ -70,11 +76,11 @@ watch(route, async (route) => {
   }
 }, { immediate: true });
 
-const addButtonTextComputed = computed<string>(() => props.addButtonText || t('external_services.actions.enter_api_key'));
+const addButtonTextComputed = computed<string>(() => addButtonText || t('external_services.actions.enter_api_key'));
 
-const editButtonTextComputed = computed<string>(() => props.editButtonText || t('external_services.actions.replace_key'));
+const editButtonTextComputed = computed<string>(() => editButtonText || t('external_services.actions.replace_key'));
 
-const primaryActionTextComputed = computed<string>(() => props.primaryAction || (props.keySet
+const primaryActionTextComputed = computed<string>(() => primaryAction || (keySet
   ? t('external_services.actions.replace_key')
   : t('external_services.actions.save_key')));
 
@@ -109,11 +115,11 @@ defineExpose({
       </RuiCardHeader>
     </div>
     <div
-      v-if="needPremium && !premium"
+      v-if="featureBlocked"
       class="py-2.5 px-6 -ml-4 flex items-center gap-2 text-body-2 border-t border-default text-rui-text-secondary"
     >
       <PremiumLock />
-      {{ t('external_services.need_premium') }}
+      {{ featureGate?.message }}
     </div>
     <div
       v-else

--- a/frontend/app/src/composables/history/events/tx/refresh-handlers.ts
+++ b/frontend/app/src/composables/history/events/tx/refresh-handlers.ts
@@ -4,6 +4,7 @@ import { useHistoryEventsApi } from '@/composables/api/history/events';
 import { useModules } from '@/composables/session/modules';
 import { useExternalApiKeys } from '@/composables/settings/api-keys/external';
 import { useMoneriumOAuth } from '@/modules/external-services/monerium/use-monerium-auth';
+import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { useEventsQueryStatusStore } from '@/store/history/query-status/events-query-status';
 import { useNotificationsStore } from '@/store/notifications';
 import { useTaskStore } from '@/store/tasks';
@@ -30,6 +31,8 @@ export function useRefreshHandlers(): UseRefreshHandlersReturn {
   const isEth2Enabled = isModuleEnabled(Module.ETH2);
   const { apiKey } = useExternalApiKeys(t);
   const { authenticated: moneriumAuthenticated, refreshStatus } = useMoneriumOAuth();
+  const { allowed: gnosisPayAllowed } = useFeatureAccess(PremiumFeature.GNOSIS_PAY);
+  const { allowed: moneriumAllowed } = useFeatureAccess(PremiumFeature.MONERIUM);
 
   const queryOnlineEvent = async (queryType: OnlineHistoryEventsQueryType): Promise<void> => {
     const eth2QueryTypes: OnlineHistoryEventsQueryType[] = [
@@ -40,11 +43,14 @@ export function useRefreshHandlers(): UseRefreshHandlersReturn {
     if (!get(isEth2Enabled) && eth2QueryTypes.includes(queryType))
       return;
 
-    if (!get(apiKey('gnosis_pay')) && queryType === OnlineHistoryEventsQueryType.GNOSIS_PAY) {
+    if (queryType === OnlineHistoryEventsQueryType.GNOSIS_PAY && (!get(gnosisPayAllowed) || !get(apiKey('gnosis_pay')))) {
       return;
     }
 
     if (queryType === OnlineHistoryEventsQueryType.MONERIUM) {
+      if (!get(moneriumAllowed))
+        return;
+
       await refreshStatus();
       if (!get(moneriumAuthenticated)) {
         return;

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2841,6 +2841,7 @@
       "website_url_missing": "Monerium OAuth website URL is not configured."
     },
     "need_premium": "Upgrade to premium to use this feature.",
+    "need_tier": "Requires {tier} tier or higher.",
     "no_services_found": "No services found",
     "opensea": {
       "description": "Used to query NFT information and balances from OpenSea.",

--- a/frontend/app/src/modules/external-services/gnosis-pay/components/GnosisPayAuth.vue
+++ b/frontend/app/src/modules/external-services/gnosis-pay/components/GnosisPayAuth.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { gnosis } from '@reown/appkit/networks';
-import ServiceKeyCard from '@/components/settings/api-keys/ServiceKeyCard.vue';
+import ServiceKeyCard, { type FeatureGate } from '@/components/settings/api-keys/ServiceKeyCard.vue';
 import ProviderSelectionDialog from '@/components/wallets/ProviderSelectionDialog.vue';
 import { useExternalApiKeys } from '@/composables/settings/api-keys/external';
 import { useWalletStore } from '@/modules/onchain/use-wallet-store';
 import { useUnifiedProviders } from '@/modules/onchain/wallet-providers/use-unified-providers';
+import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { useMessageStore } from '@/store/message';
 import { getPublicServiceImagePath } from '@/utils/file';
 import { logger } from '@/utils/logging';
@@ -22,6 +23,16 @@ const { t } = useI18n({ useScope: 'global' });
 const name = 'gnosis_pay';
 const { apiKey, confirmDelete, load, loading } = useExternalApiKeys(t);
 const key = apiKey(name);
+
+const { allowed, minimumTier, premium } = useFeatureAccess(PremiumFeature.GNOSIS_PAY);
+const featureGate = computed<FeatureGate>(() => {
+  const tier = get(minimumTier);
+  const message = !get(premium)
+    ? t('external_services.need_premium')
+    : t('external_services.need_tier', { tier });
+
+  return { allowed: get(allowed), message };
+});
 
 const serviceKeyCard = useTemplateRef<InstanceType<typeof ServiceKeyCard>>('serviceKeyCard');
 
@@ -238,7 +249,7 @@ watch(() => isStepComplete(AuthStep.SIGN_MESSAGE), (complete) => {
   <div>
     <ServiceKeyCard
       ref="serviceKeyCard"
-      need-premium
+      :feature-gate="featureGate"
       rounded-icon
       :name="name"
       :add-button-text="t('external_services.actions.authenticate')"

--- a/frontend/app/src/modules/external-services/monerium/MoneriumAuth.vue
+++ b/frontend/app/src/modules/external-services/monerium/MoneriumAuth.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { OAuthResult } from '@shared/ipc';
 import { Severity } from '@rotki/common';
-import ServiceKeyCard from '@/components/settings/api-keys/ServiceKeyCard.vue';
+import ServiceKeyCard, { type FeatureGate } from '@/components/settings/api-keys/ServiceKeyCard.vue';
 import { useInterop } from '@/composables/electron-interop';
+import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { useBackendMessagesStore } from '@/store/backend-messages';
 import { useNotificationsStore } from '@/store/notifications';
 import { getPublicServiceImagePath } from '@/utils/file';
@@ -11,6 +12,16 @@ import { useMoneriumOAuth } from './use-monerium-auth';
 
 const { t } = useI18n({ useScope: 'global' });
 const name = 'monerium';
+
+const { allowed, minimumTier, premium } = useFeatureAccess(PremiumFeature.MONERIUM);
+const featureGate = computed<FeatureGate>(() => {
+  const tier = get(minimumTier);
+  const message = !get(premium)
+    ? t('external_services.need_premium')
+    : t('external_services.need_tier', { tier });
+
+  return { allowed: get(allowed), message };
+});
 
 const websiteUrl = import.meta.env.VITE_ROTKI_WEBSITE_URL as string | undefined;
 
@@ -167,7 +178,7 @@ onUnmounted(() => {
 <template>
   <ServiceKeyCard
     :name="name"
-    need-premium
+    :feature-gate="featureGate"
     :key-set="authenticated"
     :title="t('external_services.monerium.title')"
     :subtitle="t('external_services.monerium.description')"

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshProtocolEvents.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshProtocolEvents.vue
@@ -4,6 +4,7 @@ import { get, set } from '@vueuse/core';
 import { isEqual } from 'es-toolkit';
 import { useExternalApiKeys } from '@/composables/settings/api-keys/external';
 import { useMoneriumOAuth } from '@/modules/external-services/monerium/use-monerium-auth';
+import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { OnlineHistoryEventsQueryType } from '@/types/history/events/schemas';
 
 const modelValue = defineModel<OnlineHistoryEventsQueryType[]>({ required: true });
@@ -24,6 +25,8 @@ const { t } = useI18n({ useScope: 'global' });
 
 const { apiKey } = useExternalApiKeys(t);
 const { authenticated: moneriumAuthenticated } = useMoneriumOAuth();
+const { allowed: gnosisPayAllowed } = useFeatureAccess(PremiumFeature.GNOSIS_PAY);
+const { allowed: moneriumAllowed } = useFeatureAccess(PremiumFeature.MONERIUM);
 
 interface QueryConfig {
   enabled: boolean;
@@ -31,8 +34,8 @@ interface QueryConfig {
 }
 
 const queryConfigs = computed<Record<OnlineHistoryEventsQueryType, QueryConfig>>(() => {
-  const gnosisPayEnabled = !!get(apiKey('gnosis_pay'));
-  const moneriumEnabled = get(moneriumAuthenticated);
+  const gnosisPayEnabled = get(gnosisPayAllowed) && !!get(apiKey('gnosis_pay'));
+  const moneriumEnabled = get(moneriumAllowed) && get(moneriumAuthenticated);
 
   return {
     [OnlineHistoryEventsQueryType.GNOSIS_PAY]: {

--- a/frontend/app/src/modules/premium/use-feature-access.spec.ts
+++ b/frontend/app/src/modules/premium/use-feature-access.spec.ts
@@ -350,5 +350,32 @@ describe('modules/premium/use-feature-access', () => {
         expect(get(eventAnalysisAllowed)).toBe(false);
       });
     });
+
+    it('should handle gnosis pay and monerium capabilities', async () => {
+      const mockCapabilities: PremiumCapabilities = {
+        [PremiumFeature.GNOSIS_PAY]: cap(true, 'Advanced'),
+        [PremiumFeature.MONERIUM]: cap(false, 'Advanced'),
+      };
+
+      server.use(mockPremiumCapabilities(mockCapabilities));
+
+      const store = usePremiumStore();
+      const { premium } = storeToRefs(store);
+
+      const { allowed: gnosisPayAllowed, minimumTier: gnosisPayTier } = useFeatureAccess(PremiumFeature.GNOSIS_PAY);
+      const { allowed: moneriumAllowed, minimumTier: moneriumTier } = useFeatureAccess(PremiumFeature.MONERIUM);
+
+      expect(get(gnosisPayAllowed)).toBe(false);
+      expect(get(moneriumAllowed)).toBe(false);
+
+      set(premium, true);
+
+      await vi.waitFor(() => {
+        expect(get(gnosisPayAllowed)).toBe(true);
+        expect(get(moneriumAllowed)).toBe(false);
+        expect(get(gnosisPayTier)).toBe('Advanced');
+        expect(get(moneriumTier)).toBe('Advanced');
+      });
+    });
   });
 });

--- a/frontend/app/src/modules/statistics/wrapped/composables/use-wrapped-gnosis-pay.ts
+++ b/frontend/app/src/modules/statistics/wrapped/composables/use-wrapped-gnosis-pay.ts
@@ -2,9 +2,10 @@ import type { BigNumber } from '@rotki/common';
 import type { ComputedRef, Ref } from 'vue';
 import type { WrapStatisticsResult } from '@/composables/api/statistics/wrap';
 import { get } from '@vueuse/shared';
-import { usePremium } from '@/composables/premium';
 import { useExternalApiKeys } from '@/composables/settings/api-keys/external';
+import { useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { useCurrencies } from '@/types/currencies';
+import { PremiumFeature } from '@/types/session';
 
 interface GnosisPayResult {
   amount: BigNumber;
@@ -21,12 +22,12 @@ interface UseWrappedGnosisPayReturn {
 
 export function useWrappedGnosisPay(summary: Ref<WrapStatisticsResult | null | undefined>): UseWrappedGnosisPayReturn {
   const { t } = useI18n({ useScope: 'global' });
-  const premium = usePremium();
+  const { allowed } = useFeatureAccess(PremiumFeature.GNOSIS_PAY);
   const { apiKey } = useExternalApiKeys(t);
   const { findCurrency } = useCurrencies();
 
   const gnosisPayKey = computed<string | null>(() => get(apiKey('gnosis_pay')));
-  const showGnosisData = computed<boolean>(() => get(premium) && !!get(gnosisPayKey));
+  const showGnosisData = computed<boolean>(() => get(allowed) && !!get(gnosisPayKey));
 
   const gnosisPayResult = computed<GnosisPayResult[]>(() => {
     const gnosisMaxPaymentsByCurrency = get(summary)?.gnosisMaxPaymentsByCurrency;

--- a/frontend/app/src/types/session/index.ts
+++ b/frontend/app/src/types/session/index.ts
@@ -59,6 +59,8 @@ export enum PremiumFeature {
   EVENT_ANALYSIS_VIEW = 'eventAnalysisView',
   GRAPHS_VIEW = 'graphsView',
   ASSET_MOVEMENT_MATCHING = 'assetMovementMatching',
+  GNOSIS_PAY = 'gnosispay',
+  MONERIUM = 'monerium',
 }
 
 export const PremiumFeatureCapability = z.object({
@@ -74,10 +76,12 @@ export const PremiumCapabilities = z.object({
   ethStakedLimit: z.number().optional(),
   ethStakingView: PremiumFeatureCapability.optional(),
   eventAnalysisView: PremiumFeatureCapability.optional(),
+  gnosispay: PremiumFeatureCapability.optional(),
   graphsView: PremiumFeatureCapability.optional(),
   historyEventsLimit: z.number().optional(),
   limitOfDevices: z.number().optional(),
   maxBackupSizeMb: z.number().optional(),
+  monerium: PremiumFeatureCapability.optional(),
   pnlEventsLimit: z.number().optional(),
   reportsLookupLimit: z.number().optional(),
 });


### PR DESCRIPTION
## Summary
- Add `gnosispay` and `monerium` to `PremiumFeature` enum and `PremiumCapabilities` schema to match the backend capabilities added in 6cc020f76e
- Replace the `needPremium` boolean prop on `ServiceKeyCard` with a `featureGate` prop (`{ allowed, message }`) so the parent controls the gating logic and the card stays presentational
- Gate Gnosis Pay and Monerium auth flows, history refresh, and wrapped statistics behind the new capabilities
- Show "Upgrade to premium" for non-premium users and "Requires {tier} tier or higher" for premium users on a lower tier

## Test plan
- [x] Lint passes
- [x] Unit tests pass (2696 tests, including new capability test)
- [ ] Verify Gnosis Pay card shows lock with tier message for users without the capability
- [ ] Verify Monerium card shows lock with tier message for users without the capability
- [ ] Verify both cards unlock for users with the correct tier
- [ ] Verify history refresh skips Gnosis Pay/Monerium when capability is missing