### PR TITLE
Bump dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dev = [
     "pytest-deadfixtures @ git+https://github.com/rotki/pytest-deadfixtures@87d2be8#egg=pytest-deadfixtures", # temporarily due to false positive
     "pytest-socket==0.7.0",
     "pytest-vcr==1.0.2",
-    "vcrpy==7.0.0",
+    "vcrpy==8.1.1",
     "freezegun==1.5.5",
     # To test google spreadsheet uploading
     "google-auth-httplib2==0.2.0",
@@ -138,7 +138,7 @@ docs = [
 
 packaging = [
     "setuptools-scm==7.1.0",
-    "wheel==0.40.0",
+    "wheel==0.46.2",
 ]
 
 crossbuild = [
@@ -153,11 +153,6 @@ profiling = [
 
 ci = [
     "pytest-github-actions-annotate-failures",
-]
-
-[tool.uv]
-override-dependencies = [
-    "urllib3==2.4.0",  # Override vcrpy's urllib3<2 requirement
 ]
 
 [tool.setuptools.packages.find]

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -14,7 +14,7 @@ from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.aggregator import CHAIN_TO_BALANCE_PROTOCOLS
 from rotkehlchen.chain.ethereum.modules.liquity.constants import CPT_LIQUITY
 from rotkehlchen.chain.ethereum.modules.makerdao.vaults import MakerdaoVault
-from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.chain.evm.types import NodeName, WeightedNode, string_to_evm_address
 from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ONE, ZERO
 from rotkehlchen.constants.assets import (
     A_AVAX,
@@ -1277,13 +1277,24 @@ def test_balance_snapshot_saves_manual_prices_as_historical(
 
 
 @pytest.mark.freeze_time('2026-01-01 00:00:00 GMT')
-@pytest.mark.vcr
+@pytest.mark.vcr(match_on=['solana_rpc_matcher'])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
+@pytest.mark.parametrize('solana_nodes_connect_at_start', [(
+    WeightedNode(
+        node_info=NodeName(
+            name='publicnode',
+            endpoint='https://solana-rpc.publicnode.com/',
+            blockchain=SupportedBlockchain.SOLANA,
+            owned=False,
+        ),
+        weight=ONE,
+        active=True,
+    ),
+)])
 @pytest.mark.parametrize('solana_accounts', [[
-    '8comvKwUxq6x2KV6bqZeU695a1d4R2UFuVJZxH2raTYf',
-    '9oAgKbKmrQ6t1MSn5mNgYwhogeXkAqtzAuFdtBtwf7xr',
-    'Bt26YqVLJJ233frMxvvo9uL1mPu7YdBFgFPe6Rwh3AqB',
+    'FkzRQKW8Mzip4xXHamibLZB28sjqN9ZLFacQdbuVEYxa',
+    '5DxRG8hTcBfeCL7pz7NVMZSeqrQAiDJ5pv5RR9pM84ey',
 ]])
 def test_solana_balances_multiple_accounts(
         rotkehlchen_api_server: 'APIServer',
@@ -1295,9 +1306,9 @@ def test_solana_balances_multiple_accounts(
     result = assert_proper_sync_response_with_result(requests.get(
         api_url_for(rotkehlchen_api_server, 'allbalancesresource'),
     ))
-    assert result['assets']['solana/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v']['amount'] == '160556.002808'  # USDC  # noqa: E501
-    assert result['assets']['solana/token:2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv']['amount'] == '370905.247021'  # PENGU  # noqa: E501
-    assert result['assets']['solana/token:Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB']['amount'] == '21787'  # USDT  # noqa: E501
+    assert result['assets']['SOL']['amount'] == '0.575169256'
+    assert result['assets']['solana/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v']['amount'] == '0.006302'  # USDC  # noqa: E501
+    assert result['assets']['solana/token:2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo']['amount'] == '0.338918'  # Paypal USD  # noqa: E501
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -280,6 +280,28 @@ def vcr_fixture(vcr: 'VCR') -> 'VCR':
 
         return r1.uri == r2.uri and b1 == b2
 
+    def solana_rpc_matcher(r1, r2):
+        """Match Solana JSON-RPC calls by method/params while ignoring request id."""
+        if 'solana' not in r1.uri and 'solana' not in r2.uri:
+            return etherscan_matcher(r1, r2)
+        if r1.uri != r2.uri or r1.method != r2.method:
+            return False
+
+        def strip_jsonrpc_id(payload: Any) -> Any:
+            if isinstance(payload, dict):
+                return {k: strip_jsonrpc_id(v) for k, v in payload.items() if k != 'id'}
+            if isinstance(payload, list):
+                return [strip_jsonrpc_id(item) for item in payload]
+            return payload
+
+        try:
+            b1 = strip_jsonrpc_id(json.loads(r1.body))
+            b2 = strip_jsonrpc_id(json.loads(r2.body))
+        except (TypeError, json.JSONDecodeError):
+            return r1.body == r2.body
+
+        return b1 == b2
+
     def etherscan_matcher(r1, r2):
         """Match Etherscan API calls with case-insensitive query parameters.
         This allows old VCR cassettes to still work after refactoring some of the etherscan
@@ -310,6 +332,7 @@ def vcr_fixture(vcr: 'VCR') -> 'VCR':
     vcr.register_matcher('beaconchain_matcher', beaconchain_matcher)
     vcr.register_matcher('github_branch_matcher', github_branch_matcher)
     vcr.register_matcher('match_rpc_calls', match_rpc_calls)
+    vcr.register_matcher('solana_rpc_matcher', solana_rpc_matcher)
     vcr.register_matcher('etherscan_matcher', etherscan_matcher)
     return vcr
 

--- a/rotkehlchen/tests/unit/test_solana.py
+++ b/rotkehlchen/tests/unit/test_solana.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from contextlib import suppress
 from functools import partial
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
@@ -35,15 +36,15 @@ def identifier_to_address(identifier: str) -> SolanaAddress:
 @pytest.mark.vcr
 @pytest.mark.parametrize('solana_accounts', [[
     SolanaAddress('updtkJ8HAhh3rSkBCd3p9Z1Q74yJW4rMhSbScRskDPM'),
-    SolanaAddress('EfxpFpET4tvP4jjFEbWLCfkzQ6LozJjsPQD4FbpRk6KX'),
+    SolanaAddress('FkzRQKW8Mzip4xXHamibLZB28sjqN9ZLFacQdbuVEYxa'),
 ]])
 def test_solana_balances(
         solana_manager: 'SolanaManager',
         solana_accounts: list['SolanaAddress'],
 ) -> None:
     assert solana_manager.get_multi_balance(accounts=solana_accounts) == {
-        solana_accounts[0]: FVal('3.432027149'),
-        solana_accounts[1]: FVal('1.437765205'),
+        solana_accounts[0]: FVal('3.063908962'),
+        solana_accounts[1]: FVal('0.564503502'),
     }
 
 
@@ -133,7 +134,7 @@ def test_is_nft_via_offchain_metadata() -> None:
     """
     for uri, is_nft in (
         ('https://gateway.pinit.io/ipfs/QmSTAhtdaqJmm9FTxWEdjQwKqvvjf99uGvN3vQaxzhRGqP/1089.json', True),  # Pixie Willie NFT  # noqa: E501
-        ('https://bafkreib5jykd5ehlvmi7f253jdjzzknj6eqlnqhzenfmdc6okrwksqfu6a.ipfs.nftstorage.link', False),  # catwifhat token  # noqa: E501
+        ('https://bafkreib5jykd5ehlvmi7f253jdjzzknj6eqlnqhzenfmdc6okrwksqfu6a.ipfs.dweb.link/', False),  # catwifhat token  # noqa: E501
     ):
         assert is_solana_token_nft(
             token_address=SolanaAddress('Cg4noWpzmDHhPZZXDwmCLJns43PJpLmd6E8aYL1pRcRJ'),
@@ -203,15 +204,14 @@ def test_query_signatures_for_address(solana_inquirer: 'SolanaInquirer') -> None
     signatures = solana_inquirer.query_tx_signatures_for_address(
         address=SolanaAddress('7T8ckKtdc5DH7ACS5AnCny7rVXYJPEsaAbdBri1FhPxY'),
     )
-    assert len(signatures) == 64
-    assert signatures[0] == deserialize_tx_signature('4awgHCjCD2Da2UbaKitSfUWExW2eVSA1x5PBrdHBi61NdCpWWxG1JbCDRbKUsQYSPZfPzMKLGrJw2XhajUUvz2Tc')  # noqa: E501
-    assert signatures[63] == deserialize_tx_signature('Ars2bdNxYNVRDmWsGCwr9j8jHgRkb6gq7giaritpLw9yj6kiefwEUZpqz4Hr6SxRnJLTLtNnQaVNjuX6jjMAL7T')  # noqa: E501
+    assert len(signatures) == 312
+    assert signatures[0] == deserialize_tx_signature('5gJFZweW8EsTQCNWH2EyjJA3vm2VcT91vQtrNAcx7YXeq4zHmqXzSqxxnhb9GxiLvecWJJZv8xxW6opHSnJME643')  # noqa: E501
+    assert signatures[63] == deserialize_tx_signature('63u9VxkLKDSBs2nH7Knv4MwX7dU9BKx8WEMGXquWkzVkCm9McGrDcbhhfw8TRm7LgRzXDvutdX74pNMRmo7L2TbL')  # noqa: E501
 
 
-@pytest.mark.vcr
 @pytest.mark.parametrize('solana_accounts', [[SolanaAddress('7T8ckKtdc5DH7ACS5AnCny7rVXYJPEsaAbdBri1FhPxY')]])  # noqa: E501
 @pytest.mark.parametrize('solana_nodes_connect_at_start', [(
-    WeightedNode(node_info=NodeName(name='therpc', endpoint='https://solana.therpc.io', blockchain=SupportedBlockchain.SOLANA, owned=False), weight=ONE, active=True),  # noqa: E501
+    WeightedNode(node_info=NodeName(name='therpc', endpoint='https://solana-rpc.publicnode.com/', blockchain=SupportedBlockchain.SOLANA, owned=False), weight=ONE, active=True),  # noqa: E501
     WeightedNode(node_info=NodeName(name='solana.com', endpoint='https://api.mainnet-beta.solana.com', blockchain=SupportedBlockchain.SOLANA, owned=False), weight=ONE, active=True),  # noqa: E501
 )])
 def test_only_archive_nodes(
@@ -222,28 +222,40 @@ def test_only_archive_nodes(
     solana_nodes_connect_at_start sets the call order to be first a non-archive node and then an
     archive node, so it always tries the non-archive node first unless explicitly skipped.
     """
-    client_to_endpoint = {}
+    client_to_endpoint: dict[int, str] = {}
     original_query = solana_manager.node_inquirer.query
 
     def mock_client_creation(endpoint: str, timeout: int) -> Client:
-        client_to_endpoint[client := Client(endpoint=endpoint, timeout=timeout)] = endpoint
+        client = MagicMock(spec=Client)
+        client.is_connected.return_value = True
+        client.get_signatures_for_address.return_value = SimpleNamespace(value=[SimpleNamespace(
+            signature=deserialize_tx_signature('5gJFZweW8EsTQCNWH2EyjJA3vm2VcT91vQtrNAcx7YXeq4zHmqXzSqxxnhb9GxiLvecWJJZv8xxW6opHSnJME643'),
+        )])
+        client.get_multiple_accounts.return_value = SimpleNamespace(
+            value=[SimpleNamespace(lamports=1_000_000_000)],
+        )
+        client_to_endpoint[id(client)] = endpoint
         return client
 
     def check_client(client: Client, method: Callable, expected_endpoint: str) -> Any:
-        assert client_to_endpoint[client] == expected_endpoint
+        assert client_to_endpoint[id(client)] == expected_endpoint
         return method(client)
 
     for query_func, expected_endpoint, expected_result_len in ((
         lambda: solana_manager.node_inquirer.query_tx_signatures_for_address(address=solana_accounts[0]),  # noqa: E501
         'https://api.mainnet-beta.solana.com',  # archive node
-        64,
+        1,
     ), (
         lambda: solana_manager.get_multi_balance(accounts=solana_accounts),
-        'https://solana.therpc.io',  # non-archive node
+        'https://solana-rpc.publicnode.com/',  # non-archive node
         1,
     )):
         with (
             patch('rotkehlchen.chain.mixins.rpc_nodes.Client', side_effect=mock_client_creation),
+            patch(
+                'rotkehlchen.chain.mixins.rpc_nodes.SolanaRPCMixin._is_archive',
+                side_effect=lambda client: client_to_endpoint[id(client)] == 'https://api.mainnet-beta.solana.com',
+            ),
             patch.object(
                 target=solana_manager.node_inquirer,
                 attribute='query',

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = "==3.11.*"
 
-[manifest]
-overrides = [{ name = "urllib3", specifier = "==2.4.0" }]
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -2186,7 +2183,7 @@ dev = [
     { name = "pytest-socket", specifier = "==0.7.0" },
     { name = "pytest-vcr", specifier = "==1.0.2" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
-    { name = "vcrpy", specifier = "==7.0.0" },
+    { name = "vcrpy", specifier = "==8.1.1" },
 ]
 docs = [
     { name = "rotki-releases" },
@@ -2217,7 +2214,7 @@ lint = [
 ]
 packaging = [
     { name = "setuptools-scm", specifier = "==7.1.0" },
-    { name = "wheel", specifier = "==0.40.0" },
+    { name = "wheel", specifier = "==0.46.2" },
 ]
 profiling = [{ name = "objgraph", specifier = "==3.5.0" }]
 
@@ -2832,26 +2829,24 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload-time = "2025-04-10T15:23:39.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload-time = "2025-04-10T15:23:37.377Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]
 name = "vcrpy"
-version = "7.0.0"
+version = "8.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
-    { name = "urllib3" },
     { name = "wrapt" },
-    { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/d3/856e06184d4572aada1dd559ddec3bedc46df1f2edc5ab2c91121a2cccdb/vcrpy-7.0.0.tar.gz", hash = "sha256:176391ad0425edde1680c5b20738ea3dc7fb942520a48d2993448050986b3a50", size = 85502, upload-time = "2024-12-31T00:07:57.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/07/bcfd5ebd7cb308026ab78a353e091bd699593358be49197d39d004e5ad83/vcrpy-8.1.1.tar.gz", hash = "sha256:58e3053e33b423f3594031cb758c3f4d1df931307f1e67928e30cf352df7709f", size = 85770, upload-time = "2026-01-04T19:22:03.886Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/5d/1f15b252890c968d42b348d1e9b0aa12d5bf3e776704178ec37cceccdb63/vcrpy-7.0.0-py2.py3-none-any.whl", hash = "sha256:55791e26c18daa363435054d8b35bd41a4ac441b6676167635d1b37a71dbe124", size = 42321, upload-time = "2024-12-31T00:07:55.277Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d7/f79b05a5d728f8786876a7d75dfb0c5cae27e428081b2d60152fb52f155f/vcrpy-8.1.1-py3-none-any.whl", hash = "sha256:2d16f31ad56493efb6165182dd99767207031b0da3f68b18f975545ede8ac4b9", size = 42445, upload-time = "2026-01-04T19:22:02.532Z" },
 ]
 
 [[package]]
@@ -2935,11 +2930,14 @@ wheels = [
 
 [[package]]
 name = "wheel"
-version = "0.40.0"
+version = "0.46.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/ef/0335f7217dd1e8096a9e8383e1d472aa14717878ffe07c4772e68b6e8735/wheel-0.40.0.tar.gz", hash = "sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873", size = 96226, upload-time = "2023-03-14T15:10:02.873Z" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/92/3a64fa9639b8e290fe8630d8067a66f7c5510845c6d73686ad880c9b04d9/wheel-0.46.2.tar.gz", hash = "sha256:3d79e48fde9847618a5a181f3cc35764c349c752e2fe911e65fa17faab9809b0", size = 60274, upload-time = "2026-01-21T23:55:25.838Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/86/cc8d1ff2ca31a312a25a708c891cf9facbad4eae493b3872638db6785eb5/wheel-0.40.0-py3-none-any.whl", hash = "sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247", size = 64545, upload-time = "2023-03-14T15:10:00.828Z" },
+    { url = "https://files.pythonhosted.org/packages/13/2c/5e079cefe955ae58e5a052fe037c850ce493eb7269dedeb960237e78fb0f/wheel-0.46.2-py3-none-any.whl", hash = "sha256:33ae60725d69eaa249bc1982e739943c23b34b58d51f1cb6253453773aca6e65", size = 29971, upload-time = "2026-01-21T23:55:24.447Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
main reason to bump is to unpin urrllib3.

vcrpy changed how httpx is mocked and I needed to redecode the solana tests