### PR TITLE
perf: use frozenset for non_syncing_exchanges O(1) lookups

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -214,7 +214,7 @@ class DBHandler:
             'main_currency': (Asset, A_USD),
             'ongoing_upgrade_from_version': (int, None),
             'last_data_migration': (int, DEFAULT_LAST_DATA_MIGRATION),
-            'non_syncing_exchanges': (lambda data: [ExchangeLocationID.deserialize(x) for x in json.loads(data)], []),  # noqa: E501
+            'non_syncing_exchanges': (lambda data: frozenset(ExchangeLocationID.deserialize(x) for x in json.loads(data)), frozenset()),  # noqa: E501
             'beacon_rpc_endpoint': (str, None),
             'btc_mempool_api': (str, None),
             'ask_user_upon_size_discrepancy': (str_to_bool, DEFAULT_ASK_USER_UPON_SIZE_DISCREPANCY),  # noqa: E501
@@ -412,7 +412,7 @@ class DBHandler:
         ...
 
     @overload
-    def get_setting(self, cursor: 'DBCursor', name: Literal['non_syncing_exchanges']) -> list['ExchangeLocationID']:  # noqa: E501
+    def get_setting(self, cursor: 'DBCursor', name: Literal['non_syncing_exchanges']) -> frozenset['ExchangeLocationID']:  # noqa: E501
         ...
 
     @overload
@@ -438,7 +438,7 @@ class DBHandler:
                 'btc_mempool_api',
                 'ask_user_upon_size_discrepancy',
             ],
-    ) -> int | Timestamp | bool | Asset | list['ExchangeLocationID'] | str | None:
+    ) -> int | Timestamp | bool | Asset | frozenset['ExchangeLocationID'] | str | None:
         deserializer, default_value = self.setting_to_default_type[name]
         if (result := cursor.execute('SELECT value FROM settings WHERE name=?;', (name,)).fetchone()) is not None:  # noqa: E501
             return deserializer(result[0])  # type: ignore

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -242,7 +242,7 @@ class DBSettings:
     pnl_csv_have_summary: bool = DEFAULT_PNL_CSV_HAVE_SUMMARY
     ssf_graph_multiplier: int = DEFAULT_SSF_GRAPH_MULTIPLIER
     last_data_migration: int = DEFAULT_LAST_DATA_MIGRATION
-    non_syncing_exchanges: Sequence[ExchangeLocationID] = field(default_factory=list)
+    non_syncing_exchanges: frozenset[ExchangeLocationID] = field(default_factory=frozenset)
     evmchains_to_skip_detection: Sequence[SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE] = field(default_factory=list)  # Both EVM and EVMLike chains # noqa: E501
     cost_basis_method: CostBasisMethod = DEFAULT_COST_BASIS_METHOD
     treat_eth2_as_eth: bool = DEFAULT_TREAT_ETH2_AS_ETH
@@ -428,7 +428,7 @@ def db_settings_from_dict(
             specified_args[key] = [EvmIndexer.deserialize(entry) for entry in json.loads(value)]
         elif key == 'non_syncing_exchanges':
             values = json.loads(value)
-            specified_args[key] = [ExchangeLocationID.deserialize(x) for x in values]
+            specified_args[key] = frozenset(ExchangeLocationID.deserialize(x) for x in values)
         elif key == 'evmchains_to_skip_detection':
             values = json.loads(value)
             specified_args[key] = [SupportedBlockchain.deserialize(x) for x in values]

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -1,6 +1,7 @@
 import dataclasses
 from dataclasses import fields
 from http import HTTPStatus
+from operator import itemgetter
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
@@ -779,7 +780,7 @@ def test_excluded_exchanges_settings(rotkehlchen_api_server: 'APIServer') -> Non
         json=exchanges_input,
     )
     response = requests.get(api_url_for(rotkehlchen_api_server, 'settingsresource')).json()
-    assert response['result']['non_syncing_exchanges'] == exchanges_expected
+    assert sorted(response['result']['non_syncing_exchanges'], key=itemgetter('name')) == sorted(exchanges_expected, key=itemgetter('name'))  # noqa: E501
 
     response = requests.put(
         api_url_for(rotkehlchen_api_server, 'settingsresource'),

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -255,7 +255,7 @@ def test_add_remove_exchange(database: DBHandler) -> None:
 
         # check that we have the coinbase exchange in the list of exchanges to not sync
         settings = database.get_settings(cursor=cursor)
-        assert settings.non_syncing_exchanges[0].location == Location.COINBASE
+        assert next(iter(settings.non_syncing_exchanges)).location == Location.COINBASE
 
     assert len(credentials) == 2
     assert len(credentials[Location.KRAKEN]) == 2
@@ -529,7 +529,7 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
         'pnl_csv_have_summary': DEFAULT_PNL_CSV_HAVE_SUMMARY,
         'ssf_graph_multiplier': DEFAULT_SSF_GRAPH_MULTIPLIER,
         'last_data_migration': DEFAULT_LAST_DATA_MIGRATION,
-        'non_syncing_exchanges': [],
+        'non_syncing_exchanges': frozenset(),
         'evmchains_to_skip_detection': [],
         'cost_basis_method': CostBasisMethod.FIFO,
         'treat_eth2_as_eth': DEFAULT_TREAT_ETH2_AS_ETH,
@@ -1906,9 +1906,9 @@ def test_startup_check_settings(database: 'DBHandler') -> None:
     with database.conn.read_ctx() as cursor:
         settings: DBSettings = database.get_settings(cursor)
 
-    assert settings.non_syncing_exchanges == [
+    assert settings.non_syncing_exchanges == frozenset({
         ExchangeLocationID(name='Coinbase', location=Location.COINBASE),
-    ]
+    })
 
 
 def test_address_book_primary_key(database: DBHandler):


### PR DESCRIPTION
 Change non_syncing_exchanges from Sequence (list) to frozenset in
 DBSettings, matching the recent frozenset optimization for tracked
 addresses. The in operator on a list is O(n) per check and this field
 is tested in iterate_exchanges() for every connected exchange during
 history sync and balance queries. frozenset gives O(1) membership tests.
