### PR TITLE
Prevent data loss in internal transactions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ Changelog
 * :bug:`-` Beefy Finance harvest call rewards will now be properly decoded as part of the beefy side of a transaction.
 * :bug:`-` Beefy Finance staking and unstaking of vault tokens will now be properly decoded by rotki along with any potential rewards.
 * :bug:`-` Depositing via Pendle v3 router should be now properly decoded by rotki.
+* :bug:`-` Repulling wrong data from indexers won't delete local data.
 * :bug:`-` Bridging ETH from mainnet to Optimism will no longer duplicate the event under some weird circumstances.
 * :bug:`-` Historic event values will no longer incorrectly fallback to the current price when the historic price is not available.
 * :bug:`-` Curve deposits with add liquidity + stake will now be properly decoded.

--- a/rotkehlchen/api/services/transactions.py
+++ b/rotkehlchen/api/services/transactions.py
@@ -25,7 +25,7 @@ from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.db.solanatx import DBSolanaTx
 from rotkehlchen.errors.api import PremiumApiError
 from rotkehlchen.errors.asset import WrongAssetType
-from rotkehlchen.errors.misc import AlreadyExists, InputError, RemoteError
+from rotkehlchen.errors.misc import AlreadyExists, DataIntegrityError, InputError, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.externalapis.monerium import init_monerium
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -444,14 +444,14 @@ class TransactionsService:
                 solana_tx_refs = cast('list[Signature]', tx_refs)
                 for solana_tx_ref in solana_tx_refs:
                     self._decode_given_solana_tx(solana_tx_ref, delete_custom)
-        except (RemoteError, DeserializationError, InputError) as e:
+        except (RemoteError, DeserializationError, InputError, DataIntegrityError) as e:
             success = False
             message = (
                 f'Failed to request {chain.name.lower()} transaction decoding due to {e!s}'
             )
             status_code = (
                 HTTPStatus.CONFLICT
-                if isinstance(e, InputError)
+                if isinstance(e, (InputError, DataIntegrityError))
                 else HTTPStatus.BAD_GATEWAY
             )
         finally:
@@ -832,14 +832,16 @@ class TransactionsService:
 
         dbevmtx = DBEvmTx(self.rotkehlchen.data.db)
         parent_hash_internal_txs: list[EvmInternalTransaction] = []
+        indexer_source = 'unknown'
         if transaction.to_address is not None:  # internal transactions only through contracts
-            parent_hash_internal_txs, _ = chain_manager.transactions._query_internal_transactions_for_parent_hash(  # noqa: E501
+            parent_hash_internal_txs, _, indexer_source = (
+                chain_manager.transactions._query_internal_transactions_for_parent_hash(
                 parent_tx_hash=tx_ref,
                 address=None,
                 return_queried_hashes=False,
                 known_parent_timestamps={tx_ref: transaction.timestamp},
                 tx_timestamp=transaction.timestamp,
-            )
+            ))
 
         with self.rotkehlchen.data.db.user_write() as write_cursor:
             write_cursor.execute(
@@ -861,6 +863,7 @@ class TransactionsService:
                     write_cursor=write_cursor,
                     parent_tx_hash=tx_ref,
                     transactions=parent_hash_internal_txs,
+                    indexer_source=indexer_source,
                 )
 
         events = chain_manager.transactions_decoder.decode_and_get_transaction_hashes(

--- a/rotkehlchen/chain/evm/decoding/odos/common.py
+++ b/rotkehlchen/chain/evm/decoding/odos/common.py
@@ -11,7 +11,7 @@ from rotkehlchen.chain.evm.decoding.structures import DecoderContext, EvmDecodin
 from rotkehlchen.chain.evm.transactions import EvmTransactions
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.constants.resolver import evm_address_to_identifier
-from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.errors.misc import DataIntegrityError, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -94,7 +94,7 @@ class OdosCommonDecoderBase(EvmDecoderInterface):
                     to_address=sender,
                     user_address=sender,
                 )
-            except RemoteError as e:
+            except (RemoteError, DataIntegrityError) as e:
                 log.error(f'Failed to get internal transactions for {self.label} swap {context.transaction} due to {e!s}')  # noqa: E501
             else:
                 for internal_native_in in internal_native_ins:

--- a/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/paraswap/decoder.py
@@ -14,7 +14,7 @@ from rotkehlchen.chain.evm.decoding.structures import (
     EvmDecodingOutput,
 )
 from rotkehlchen.chain.evm.transactions import EvmTransactions
-from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.errors.misc import DataIntegrityError, RemoteError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
@@ -131,7 +131,7 @@ class ParaswapCommonDecoder(EvmDecoderInterface, ABC):
                     to_address=self.fee_receiver_address,
                     user_address=sender,
                 )
-            except RemoteError as e:
+            except (RemoteError, DataIntegrityError) as e:
                 log.error(f'Failed to get internal transactions for paraswap {self.node_inquirer.chain_name} swap {context.transaction.tx_hash!s} due to {e!s}')  # noqa: E501
             else:
                 if len(internal_fee_txs) > 0:

--- a/rotkehlchen/chain/evm/decoding/rainbow/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/rainbow/decoder.py
@@ -15,6 +15,7 @@ from rotkehlchen.chain.evm.decoding.structures import (
 )
 from rotkehlchen.chain.evm.transactions import EvmTransactions
 from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.errors.misc import DataIntegrityError, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -148,12 +149,18 @@ class RainbowDecoder(EvmDecoderInterface):
         # if we are dealing with eth swaps check the internal transfers of eth from/to
         # the rainbow router
         if self.node_inquirer.native_token in {out_event.asset, in_event.asset}:
-            for internal_tx in self.evm_txns.get_and_ensure_internal_txns_of_parent_in_db(
-                tx_hash=transaction.tx_hash,
-                chain_id=self.base.evm_inquirer.chain_id,
-                tx_timestamp=transaction.timestamp,
-                user_address=string_to_evm_address(out_event.location_label),  # type: ignore[arg-type]  # location_label should always be set
-            ):
+            try:
+                internal_txs = self.evm_txns.get_and_ensure_internal_txns_of_parent_in_db(
+                    tx_hash=transaction.tx_hash,
+                    chain_id=self.base.evm_inquirer.chain_id,
+                    tx_timestamp=transaction.timestamp,
+                    user_address=string_to_evm_address(out_event.location_label),  # type: ignore[arg-type]  # location_label should always be set
+                )
+            except (RemoteError, DataIntegrityError) as e:
+                log.error(f'Failed to get internal transactions for rainbow swap {transaction.tx_hash!s} due to {e!s}')  # noqa: E501
+                internal_txs = []
+
+            for internal_tx in internal_txs:
                 if ((
                     internal_tx.from_address == RAINBOW_ROUTER_CONTRACT and
                     internal_tx.to_address != out_event.location_label

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -1565,13 +1565,62 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
         transaction queries. Passed through to indexers so they can gate queries without
         an extra DB round-trip.
         """
-        yield from self._try_indexers_iterable(func=lambda indexer: indexer.get_transactions(  # type: ignore[misc]
-            chain_id=self.chain_id,
+        transactions_iterator, _ = self.get_transactions_with_source(
             account=account,
             period_or_hash=period_or_hash,
             action=action,
             tx_timestamp=tx_timestamp,
-        ))
+        )
+        yield from transactions_iterator
+
+    @overload
+    def get_transactions_with_source(
+            self,
+            account: ChecksumEvmAddress | None,
+            action: Literal['txlistinternal'],
+            period_or_hash: TimestampOrBlockRange | EVMTxHash | None = None,
+            tx_timestamp: Timestamp | None = None,
+    ) -> tuple[Iterator[list[EvmInternalTransaction]], str]:
+        ...
+
+    @overload
+    def get_transactions_with_source(
+            self,
+            account: ChecksumEvmAddress | None,
+            action: Literal['txlist'],
+            period_or_hash: TimestampOrBlockRange | EVMTxHash | None = None,
+            tx_timestamp: Timestamp | None = None,
+    ) -> tuple[Iterator[list[EvmTransaction]], str]:
+        ...
+
+    def get_transactions_with_source(
+            self,
+            account: ChecksumEvmAddress | None,
+            action: Literal['txlist', 'txlistinternal'],
+            period_or_hash: TimestampOrBlockRange | EVMTxHash | None = None,
+            tx_timestamp: Timestamp | None = None,
+    ) -> tuple[Iterator[list[EvmTransaction]] | Iterator[list[EvmInternalTransaction]], str]:
+        """Like get_transactions(), but also returns the indexer source name used."""
+        if action == 'txlistinternal':
+            return self._try_indexers_iterable_with_source(
+                func=lambda indexer: indexer.get_transactions(
+                    chain_id=self.chain_id,
+                    account=account,
+                    period_or_hash=period_or_hash,
+                    action='txlistinternal',
+                    tx_timestamp=tx_timestamp,
+                ),
+            )
+
+        return self._try_indexers_iterable_with_source(
+            func=lambda indexer: indexer.get_transactions(
+                chain_id=self.chain_id,
+                account=account,
+                period_or_hash=period_or_hash,
+                action='txlist',
+                tx_timestamp=tx_timestamp,
+            ),
+        )
 
     def get_token_transaction_hashes(
             self,
@@ -1631,6 +1680,11 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
         - NoAvailableIndexers if there are no indexers available
         - RequestTooLargeError to allow callers to retry with smaller chunks
         """
+        result, _ = self._try_indexers_with_name(func=func)
+        return result
+
+    def _try_indexers_with_name(self, func: Callable[[EtherscanLikeApi], T]) -> tuple[T, str]:
+        """Like _try_indexers, but also returns the indexer name used for the query."""
         if len(ordered_indexers := self._get_indexers_in_order()) == 0:
             raise NoAvailableIndexers(f'No indexers are available for {self.chain_name}')
 
@@ -1640,7 +1694,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
                 continue  # was removed while looping
 
             try:
-                return func(indexer)
+                result = func(indexer)
             except ChainNotSupported as e:
                 if self.available_indexers.pop(indexer_name, None) is not None:
                     log.warning(  # removed the indexer
@@ -1653,6 +1707,8 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
             except (RemoteError, DeserializationError) as e:
                 log.warning(f'Failed to query {indexer.name} due to {e!s}. Trying next indexer.')
                 errors.append((indexer.name, e))
+            else:
+                return result, indexer.name
 
         raise RemoteError(
             f'Failed to query any indexer. '
@@ -1664,6 +1720,14 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
             func: Callable[[EtherscanLikeApi], Iterator[T]],
     ) -> Iterator[T]:
         """Wrapper for _try_indexers that returns an iterator instead of a single value."""
+        generator, _ = self._try_indexers_iterable_with_source(func=func)
+        yield from generator
+
+    def _try_indexers_iterable_with_source(
+            self,
+            func: Callable[[EtherscanLikeApi], Iterator[T]],
+    ) -> tuple[Iterator[T], str]:
+        """Like _try_indexers_iterable, but also returns the indexer name used."""
         def _query_indexer_iterator(indexer: EtherscanLikeApi) -> Iterator[T]:
             """Consume the first item in the iterator returned by `func` so if it fails the
             exception is raised immediately, and _try_indexers goes to the next indexer.
@@ -1673,7 +1737,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
             first_batch = next(generator)
             return itertools.chain([first_batch], generator)
 
-        yield from self._try_indexers(func=_query_indexer_iterator)
+        return self._try_indexers_with_name(func=_query_indexer_iterator)
 
 
 class EvmNodeInquirerWithProxies(EvmNodeInquirer):

--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -26,7 +26,13 @@ from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
 from rotkehlchen.db.ranges import DBQueryRanges
 from rotkehlchen.db.utils import get_query_chunks
 from rotkehlchen.errors.asset import UnknownAsset
-from rotkehlchen.errors.misc import AlreadyExists, InputError, NoAvailableIndexers, RemoteError
+from rotkehlchen.errors.misc import (
+    AlreadyExists,
+    DataIntegrityError,
+    InputError,
+    NoAvailableIndexers,
+    RemoteError,
+)
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
@@ -536,7 +542,7 @@ class EvmTransactions(ABC):  # noqa: B024
         that already have the transaction object in memory (e.g. after get_or_create_transaction)
         so that indexers can use it to gate their queries without an extra DB round-trip.
         """
-        parent_hash_internal_txs, queried_hashes = (
+        parent_hash_internal_txs, queried_hashes, indexer_source = (
             self._query_internal_transactions_for_parent_hash(
                 parent_tx_hash=parent_tx_hash,
                 address=address,
@@ -549,6 +555,7 @@ class EvmTransactions(ABC):  # noqa: B024
                 write_cursor=write_cursor,
                 parent_tx_hash=parent_tx_hash,
                 transactions=parent_hash_internal_txs,
+                indexer_source=indexer_source,
             )
         return queried_hashes
 
@@ -559,7 +566,7 @@ class EvmTransactions(ABC):  # noqa: B024
             return_queried_hashes: bool,
             known_parent_timestamps: dict[EVMTxHash, Timestamp] | None = None,
             tx_timestamp: Timestamp | None = None,
-    ) -> tuple[list[tuple[EvmInternalTransaction, Timestamp]], list[EVMTxHash] | None]:
+    ) -> tuple[list[tuple[EvmInternalTransaction, Timestamp]], list[EVMTxHash] | None, str]:
         """Query internal transactions and normalize parent-transaction state.
 
         This helper is shared by both range and parent-hash flows and has no
@@ -576,20 +583,21 @@ class EvmTransactions(ABC):  # noqa: B024
             known_parent_timestamps.copy() if known_parent_timestamps is not None else {}
         )
         queried_hashes: list[EVMTxHash] | None = [] if return_queried_hashes else None
-        for new_internal_txs in self.evm_inquirer.get_transactions(
+        internal_txs_iterator, indexer_source = self.evm_inquirer.get_transactions_with_source(
                 account=address,
                 period_or_hash=query_period_or_hash,
                 action='txlistinternal',
                 tx_timestamp=tx_timestamp,
-        ):
+        )
+        for new_internal_txs in internal_txs_iterator:
             internal_txs_with_timestamps.extend(self._process_internal_transactions_batch(
-                new_internal_txs=new_internal_txs,
+                new_internal_txs=[tx._replace(source=indexer_source) for tx in new_internal_txs],
                 address=address,
                 parent_tx_timestamps=parent_tx_timestamps,
                 queried_hashes=queried_hashes,
             ))
 
-        return internal_txs_with_timestamps, queried_hashes
+        return internal_txs_with_timestamps, queried_hashes, indexer_source
 
     def _process_internal_transactions_batch(
             self,
@@ -649,7 +657,7 @@ class EvmTransactions(ABC):  # noqa: B024
             return_queried_hashes: Literal[True] = True,
             known_parent_timestamps: dict[EVMTxHash, Timestamp] | None = None,
             tx_timestamp: Timestamp | None = None,
-    ) -> tuple[list[EvmInternalTransaction], list[EVMTxHash]]:
+    ) -> tuple[list[EvmInternalTransaction], list[EVMTxHash], str]:
         ...
 
     @overload
@@ -660,7 +668,7 @@ class EvmTransactions(ABC):  # noqa: B024
             return_queried_hashes: Literal[False] = False,
             known_parent_timestamps: dict[EVMTxHash, Timestamp] | None = None,
             tx_timestamp: Timestamp | None = None,
-    ) -> tuple[list[EvmInternalTransaction], None]:
+    ) -> tuple[list[EvmInternalTransaction], None, str]:
         ...
 
     @overload
@@ -671,7 +679,7 @@ class EvmTransactions(ABC):  # noqa: B024
             return_queried_hashes: bool = False,
             known_parent_timestamps: dict[EVMTxHash, Timestamp] | None = None,
             tx_timestamp: Timestamp | None = None,
-    ) -> tuple[list[EvmInternalTransaction], list[EVMTxHash] | None]:
+    ) -> tuple[list[EvmInternalTransaction], list[EVMTxHash] | None, str]:
         ...
 
     def _query_internal_transactions_for_parent_hash(
@@ -681,7 +689,7 @@ class EvmTransactions(ABC):  # noqa: B024
             return_queried_hashes: bool = False,
             known_parent_timestamps: dict[EVMTxHash, Timestamp] | None = None,
             tx_timestamp: Timestamp | None = None,
-    ) -> tuple[list[EvmInternalTransaction], list[EVMTxHash] | None]:
+    ) -> tuple[list[EvmInternalTransaction], list[EVMTxHash] | None, str]:
         """Fetch internal txs for a parent hash without replacing DB internals.
 
         This method only performs querying/deserialization and parent-tx
@@ -692,33 +700,65 @@ class EvmTransactions(ABC):  # noqa: B024
         that already have the transaction object in memory so that indexers can use it
         to gate their queries without an extra DB round-trip.
         """
-        internal_txs_with_timestamps, queried_hashes = self._query_internal_transactions(
+        internal_txs_with_timestamps, queried_hashes, indexer_source = self._query_internal_transactions(  # noqa: E501
             query_period_or_hash=parent_tx_hash,
             address=address,
             return_queried_hashes=return_queried_hashes,
             known_parent_timestamps=known_parent_timestamps,
             tx_timestamp=tx_timestamp,
         )
-        return [entry[0] for entry in internal_txs_with_timestamps], queried_hashes
+        return [entry[0] for entry in internal_txs_with_timestamps], queried_hashes, indexer_source
 
     def _replace_internal_transactions_for_parent_hash(
             self,
             write_cursor: 'DBCursor',
             parent_tx_hash: EVMTxHash,
             transactions: list[EvmInternalTransaction],
+            indexer_source: str,
     ) -> None:
-        """Atomically replace all internal tx rows for a single parent tx hash."""
+        """Atomically replace all internal tx rows for a single parent tx hash.
+
+        May raise:
+        - DataIntegrityError if the fetched list is empty but DB already has internals for this
+          tx hash, indicating the indexer returned a bad/incomplete response that would
+          overwrite existing data.
+        """
+        if len(transactions) == 0:
+            with self.database.conn.read_ctx() as cursor:
+                existing_count = cursor.execute(
+                    'SELECT COUNT(*) FROM evm_internal_transactions WHERE parent_tx IN ('
+                    'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?)',
+                    (parent_tx_hash, self.evm_inquirer.chain_id.serialize_for_db()),
+                ).fetchone()[0]
+            if existing_count > 0:
+                msg = (
+                    f'Refusing to replace internal transactions for {parent_tx_hash!s} on '
+                    f'{self.evm_inquirer.chain_name}: indexer "{indexer_source}" returned an '
+                    f'empty result but DB '
+                    f'already contains {existing_count} internal transaction(s) for this '
+                    f'transaction. The indexer may be experiencing issues. Retry later or '
+                    f'switch to a healthy indexer.'
+                )
+                log.error(
+                    'Prevented data loss: blocked empty re-pull of internal transactions',
+                    tx_hash=str(parent_tx_hash),
+                    chain=self.evm_inquirer.chain_name,
+                    indexer=indexer_source,
+                    existing_count=existing_count,
+                )
+                raise DataIntegrityError(msg)
+            return  # empty fetch + no existing data → no-op
+
         self.dbevmtx.delete_evm_internal_transactions_by_parent_tx_hash(
             write_cursor=write_cursor,
             parent_tx_hash=parent_tx_hash,
             chain_id=self.evm_inquirer.chain_id,
         )
-        if len(transactions) != 0:
-            self.dbevmtx.add_evm_internal_transactions(
-                write_cursor=write_cursor,
-                transactions=transactions,
-                relevant_address=None,
-            )
+        self.dbevmtx.add_evm_internal_transactions(
+            write_cursor=write_cursor,
+            transactions=transactions,
+            relevant_address=None,
+        )
 
     def _get_internal_transactions_for_ranges(
             self,
@@ -1116,7 +1156,9 @@ class EvmTransactions(ABC):  # noqa: B024
 
         May raise:
         - RemoteError if there is a problem querying the data sources or transaction hash does
-        not exist."""
+        not exist.
+        - DataIntegrityError if the indexer returns an empty result but the DB already contains
+        internal transactions for this tx hash."""
         # check if full internal txs for this parent tx and chain have already been queried.
         with self.database.conn.read_ctx() as cursor:
             was_queried = cursor.execute(

--- a/rotkehlchen/errors/misc.py
+++ b/rotkehlchen/errors/misc.py
@@ -94,6 +94,10 @@ class DBSchemaError(Exception):
     """May be raised during database sanity check"""
 
 
+class DataIntegrityError(Exception):
+    """Raised when an operation would corrupt or destroy data that is already stored in the DB."""
+
+
 class GreenletKilledError(Exception):
     """Raised when a greenlet is killed"""
 

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1666,7 +1666,7 @@ def test_repulling_transaction_internal_replace_failure_rolls_back_tx_data(
         patch.object(
             rotki.chains_aggregator.ethereum.transactions,
             '_query_internal_transactions_for_parent_hash',
-            return_value=(internal_before, None),
+            return_value=(internal_before, None, 'etherscan'),
         ),
         patch.object(
             rotki.chains_aggregator.ethereum.transactions,

--- a/rotkehlchen/tests/unit/test_evm_transactions.py
+++ b/rotkehlchen/tests/unit/test_evm_transactions.py
@@ -16,7 +16,7 @@ from rotkehlchen.constants.misc import ONE
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmEventFilterQuery, EvmTransactionsFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
-from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.errors.misc import DataIntegrityError, RemoteError
 from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.tests.utils.factories import make_ethereum_transaction, make_evm_address
 from rotkehlchen.types import (
@@ -193,8 +193,8 @@ def test_query_and_save_internal_transactions_returns_only_new_hashes(
 
     with patch.object(
         ethereum_manager.node_inquirer,
-        'get_transactions',
-        return_value=iter([[EvmInternalTransaction(
+        'get_transactions_with_source',
+        return_value=(iter([[EvmInternalTransaction(
             parent_tx_hash=existing_parent_tx.tx_hash,
             chain_id=ChainID.ETHEREUM,
             trace_id=1,
@@ -213,7 +213,7 @@ def test_query_and_save_internal_transactions_returns_only_new_hashes(
             gas=1,
             gas_used=1,
         ),
-    ]])), patch.object(
+    ]]), 'etherscan')), patch.object(
         ethereum_manager.node_inquirer,
         'get_transaction_by_hash',
         side_effect=_mock_get_transaction_by_hash,
@@ -267,8 +267,8 @@ def test_query_single_parent_hash_replaces_existing_internal_transactions(
 
     with patch.object(
         ethereum_manager.node_inquirer,
-        'get_transactions',
-        return_value=iter([[EvmInternalTransaction(
+        'get_transactions_with_source',
+        return_value=(iter([[EvmInternalTransaction(
             parent_tx_hash=parent_tx.tx_hash,
             chain_id=ChainID.ETHEREUM,
             trace_id=1,
@@ -277,7 +277,7 @@ def test_query_single_parent_hash_replaces_existing_internal_transactions(
             value=100,
             gas=30945,
             gas_used=0,
-        )]]),
+        )]]), 'etherscan'),
     ):
         ethereum_manager.transactions._query_and_save_internal_transactions_for_parent_hash(
             parent_tx_hash=parent_tx.tx_hash,
@@ -295,6 +295,155 @@ def test_query_single_parent_hash_replaces_existing_internal_transactions(
         ).fetchall()
 
     assert rows == [(1, sender, receiver, '100', '30945', '0')]
+
+
+def test_empty_repull_blocked_when_db_has_internals(
+        database: 'DBHandler',
+        ethereum_manager: 'EthereumManager',
+) -> None:
+    """Case A: empty re-pull + DB has existing internals => raises RemoteError, DB unchanged."""
+    dbevmtx = DBEvmTx(database)
+    parent_tx = make_ethereum_transaction()
+    sender, receiver = make_evm_address(), make_evm_address()
+    existing_internal_tx = EvmInternalTransaction(
+        parent_tx_hash=parent_tx.tx_hash,
+        chain_id=ChainID.ETHEREUM,
+        trace_id=1,
+        from_address=sender,
+        to_address=receiver,
+        value=100,
+        gas=0,
+        gas_used=0,
+    )
+    with database.user_write() as write_cursor:
+        dbevmtx.add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[parent_tx],
+            relevant_address=None,
+        )
+        dbevmtx.add_or_ignore_receipt_data(
+            write_cursor=write_cursor,
+            chain_id=ChainID.ETHEREUM,
+            data=_make_receipt_data(parent_tx.tx_hash),
+        )
+        dbevmtx.add_evm_internal_transactions(
+            write_cursor=write_cursor,
+            transactions=[existing_internal_tx],
+            relevant_address=None,
+        )
+
+    # Indexer returns empty list (simulating Blockscout indexing issue)
+    with patch.object(
+        ethereum_manager.node_inquirer,
+        'get_transactions_with_source',
+        return_value=(iter([[]]), 'blockscout'),
+    ), pytest.raises(DataIntegrityError, match='empty result'):
+        ethereum_manager.transactions._query_and_save_internal_transactions_for_parent_hash(
+            parent_tx_hash=parent_tx.tx_hash,
+        )
+
+    # DB must remain untouched
+    stored = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=parent_tx.tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    )
+    assert stored == [existing_internal_tx]
+
+
+def test_empty_repull_allowed_when_db_has_no_internals(
+        database: 'DBHandler',
+        ethereum_manager: 'EthereumManager',
+) -> None:
+    """Case B: empty re-pull + DB has no internals => no error, normal empty handling."""
+    dbevmtx = DBEvmTx(database)
+    parent_tx = make_ethereum_transaction()
+    with database.user_write() as write_cursor:
+        dbevmtx.add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[parent_tx],
+            relevant_address=None,
+        )
+        dbevmtx.add_or_ignore_receipt_data(
+            write_cursor=write_cursor,
+            chain_id=ChainID.ETHEREUM,
+            data=_make_receipt_data(parent_tx.tx_hash),
+        )
+
+    # Indexer returns empty list and DB has no existing internals — should be a no-op
+    with patch.object(
+        ethereum_manager.node_inquirer,
+        'get_transactions_with_source',
+        return_value=(iter([[]]), 'blockscout'),
+    ):
+        ethereum_manager.transactions._query_and_save_internal_transactions_for_parent_hash(
+            parent_tx_hash=parent_tx.tx_hash,
+        )
+
+    stored = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=parent_tx.tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    )
+    assert stored == []
+
+
+def test_nonempty_repull_replaces_existing_internals(
+        database: 'DBHandler',
+        ethereum_manager: 'EthereumManager',
+) -> None:
+    """Case C: non-empty re-pull + DB has existing internals => replacement succeeds."""
+    dbevmtx = DBEvmTx(database)
+    parent_tx = make_ethereum_transaction()
+    sender, receiver = make_evm_address(), make_evm_address()
+    with database.user_write() as write_cursor:
+        dbevmtx.add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[parent_tx],
+            relevant_address=None,
+        )
+        dbevmtx.add_or_ignore_receipt_data(
+            write_cursor=write_cursor,
+            chain_id=ChainID.ETHEREUM,
+            data=_make_receipt_data(parent_tx.tx_hash),
+        )
+        dbevmtx.add_evm_internal_transactions(
+            write_cursor=write_cursor,
+            transactions=[EvmInternalTransaction(
+                parent_tx_hash=parent_tx.tx_hash,
+                chain_id=ChainID.ETHEREUM,
+                trace_id=1,
+                from_address=sender,
+                to_address=receiver,
+                value=50,
+                gas=0,
+                gas_used=0,
+            )],
+            relevant_address=None,
+        )
+
+    updated_internal_tx = EvmInternalTransaction(
+        parent_tx_hash=parent_tx.tx_hash,
+        chain_id=ChainID.ETHEREUM,
+        trace_id=1,
+        from_address=sender,
+        to_address=receiver,
+        value=50,
+        gas=21000,  # updated gas
+        gas_used=0,
+    )
+    with patch.object(
+        ethereum_manager.node_inquirer,
+        'get_transactions_with_source',
+        return_value=(iter([[updated_internal_tx]]), 'routescan'),
+    ):
+        ethereum_manager.transactions._query_and_save_internal_transactions_for_parent_hash(
+            parent_tx_hash=parent_tx.tx_hash,
+        )
+
+    stored = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=parent_tx.tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+    )
+    assert stored == [updated_internal_tx]
 
 
 def test_query_range_replaces_internal_transactions_for_address(
@@ -358,8 +507,8 @@ def test_query_range_replaces_internal_transactions_for_address(
 
     with patch.object(
         ethereum_manager.node_inquirer,
-        'get_transactions',
-        return_value=iter([[EvmInternalTransaction(
+        'get_transactions_with_source',
+        return_value=(iter([[EvmInternalTransaction(
             parent_tx_hash=parent_tx.tx_hash,
             chain_id=ChainID.ETHEREUM,
             trace_id=1,
@@ -368,7 +517,7 @@ def test_query_range_replaces_internal_transactions_for_address(
             value=100,
             gas=30945,
             gas_used=0,
-        )]]),
+        )]]), 'etherscan'),
     ):
         ethereum_manager.transactions._query_and_save_internal_transactions_for_range(
             address=queried_address,

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -393,6 +393,7 @@ class EvmInternalTransaction(NamedTuple):
     value: int
     gas: int
     gas_used: int
+    source: str | None = None
 
     def __hash__(self) -> int:
         return hash(self.identifier)


### PR DESCRIPTION
When repulling a transaction it can happen that the indexer says that there isn't internal transactions but we have them from a different indexer or older information.

This PR adds a check to prevent deleting local data before replacing it


