### PR TITLE
fix(tests): resolve vitest warnings and Vue scope issues

### DIFF
--- a/frontend/app/src/components/settings/OnboardingSettings.spec.ts
+++ b/frontend/app/src/components/settings/OnboardingSettings.spec.ts
@@ -81,7 +81,9 @@ describe('onboarding-settings', () => {
   async function createWrapper(): Promise<VueWrapper<InstanceType<typeof OnboardingSettings>>> {
     const pinia = createPinia();
     setActivePinia(pinia);
-    await useBackendConnection().getInfo();
+    const scope = effectScope();
+    await scope.run(async () => useBackendConnection().getInfo())!;
+    scope.stop();
 
     return mount(OnboardingSettings, {
       global: {

--- a/frontend/app/src/composables/history/events/tx/index.spec.ts
+++ b/frontend/app/src/composables/history/events/tx/index.spec.ts
@@ -41,6 +41,7 @@ vi.mock('@/composables/api/history/events', async () => {
       fetchTransactionsTask: vi.fn().mockResolvedValue({}),
       deleteHistoryEvent: vi.fn(),
       decodeTransactions: vi.fn().mockResolvedValue({}),
+      getUndecodedTransactionsBreakdown: vi.fn().mockResolvedValue({}),
       redecodeMissingEvents: vi.fn(),
       addHistoryEvent: vi.fn(),
       editHistoryEvent: vi.fn(),

--- a/frontend/app/src/composables/history/events/tx/use-refresh-transactions.spec.ts
+++ b/frontend/app/src/composables/history/events/tx/use-refresh-transactions.spec.ts
@@ -1,7 +1,7 @@
 import type { RefreshTransactionsParams } from './types';
 import type { Exchange } from '@/types/exchanges';
 import type { ChainAddress } from '@/types/history/events';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHistoryRefreshStateStore } from '@/store/history/refresh-state';
 import { OnlineHistoryEventsQueryType } from '@/types/history/events/schemas';
 import { Status } from '@/types/status';
@@ -131,9 +131,12 @@ vi.mock('@/store/history/query-status/events-query-status', () => ({
 }));
 
 describe('useRefreshTransactions', () => {
+  let scope: ReturnType<typeof effectScope>;
+
   beforeEach(() => {
     const pinia = createPinia();
     setActivePinia(pinia);
+    scope = effectScope();
 
     // Reset the refresh state store
     const refreshStateStore = useHistoryRefreshStateStore();
@@ -148,9 +151,13 @@ describe('useRefreshTransactions', () => {
     set(mockExchangeData.syncingExchanges, mockExchanges);
   });
 
+  afterEach(() => {
+    scope.stop();
+  });
+
   describe('basic refresh flow', () => {
     it('should perform full refresh when called without parameters', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -166,7 +173,7 @@ describe('useRefreshTransactions', () => {
       mockStatusUpdater.fetchDisabled.mockReturnValue(true);
 
       // First, perform a refresh to mark all accounts/exchanges as refreshed
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
       mockStatusUpdater.fetchDisabled.mockReturnValue(false);
       await refreshTransactions();
 
@@ -183,7 +190,7 @@ describe('useRefreshTransactions', () => {
 
     it('should set LOADING status on first load', async () => {
       mockStatusUpdater.isFirstLoad.mockReturnValue(true);
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -192,7 +199,7 @@ describe('useRefreshTransactions', () => {
 
     it('should set REFRESHING status on subsequent loads', async () => {
       mockStatusUpdater.isFirstLoad.mockReturnValue(false);
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -202,7 +209,7 @@ describe('useRefreshTransactions', () => {
 
   describe('account-specific refresh', () => {
     it('should refresh only specified accounts', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
       const specificAccounts = [mockEvmAccounts[0]];
 
       await refreshTransactions({
@@ -217,7 +224,7 @@ describe('useRefreshTransactions', () => {
     });
 
     it('should not query exchanges when only accounts are specified', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions({
         payload: { accounts: mockEvmAccounts },
@@ -230,7 +237,7 @@ describe('useRefreshTransactions', () => {
 
   describe('exchange refresh', () => {
     it('should refresh exchanges when exchanges are specified', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions({
         payload: { exchanges: mockExchanges },
@@ -241,7 +248,7 @@ describe('useRefreshTransactions', () => {
     });
 
     it('should refresh all connected exchanges in full refresh', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -253,7 +260,7 @@ describe('useRefreshTransactions', () => {
   describe('new account detection', () => {
     it('should bypass fetchDisabled when new accounts are detected', async () => {
       mockStatusUpdater.fetchDisabled.mockReturnValue(true);
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -265,7 +272,7 @@ describe('useRefreshTransactions', () => {
   describe('new exchange detection', () => {
     it('should bypass fetchDisabled when new exchanges are detected', async () => {
       mockStatusUpdater.fetchDisabled.mockReturnValue(true);
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -278,7 +285,7 @@ describe('useRefreshTransactions', () => {
     it('should add new accounts to pending when refresh is running', async () => {
       vi.useFakeTimers();
 
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
       const firstRefresh = refreshTransactions();
 
       // Trigger another refresh while first is running
@@ -299,7 +306,7 @@ describe('useRefreshTransactions', () => {
 
   describe('chain filtering', () => {
     it('should filter accounts by specified chains', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions({
         chains: ['eth'],
@@ -311,7 +318,7 @@ describe('useRefreshTransactions', () => {
 
   describe('disableEvmEvents parameter', () => {
     it('should execute only ETH_WITHDRAWALS and BLOCK_PRODUCTIONS queries when disableEvmEvents is true', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions({
         disableEvmEvents: true,
@@ -330,7 +337,7 @@ describe('useRefreshTransactions', () => {
     });
 
     it('should execute custom queries when disableEvmEvents is false', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions({
         disableEvmEvents: false,
@@ -349,7 +356,7 @@ describe('useRefreshTransactions', () => {
 
   describe('online queries', () => {
     it('should execute ETH_WITHDRAWALS and BLOCK_PRODUCTIONS queries on full refresh', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -362,7 +369,7 @@ describe('useRefreshTransactions', () => {
     });
 
     it('should execute custom queries when specified', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions({
         payload: {
@@ -380,7 +387,7 @@ describe('useRefreshTransactions', () => {
   describe('error handling', () => {
     it('should handle errors gracefully and reset status', async () => {
       mockTransactionSync.syncTransactionsByChains.mockRejectedValue(new Error('Sync failed'));
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -389,7 +396,7 @@ describe('useRefreshTransactions', () => {
 
     it('should continue with other operations when one fails', async () => {
       mockTransactionSync.syncTransactionsByChains.mockRejectedValue(new Error('Sync failed'));
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -400,7 +407,7 @@ describe('useRefreshTransactions', () => {
       mockHistoryTransactionDecoding.fetchUndecodedTransactionsStatus.mockRejectedValueOnce(
         new Error('Fatal error'),
       );
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -411,7 +418,7 @@ describe('useRefreshTransactions', () => {
       mockHistoryTransactionDecoding.fetchUndecodedTransactionsStatus.mockRejectedValueOnce(
         new Error('Fatal error'),
       );
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -423,7 +430,7 @@ describe('useRefreshTransactions', () => {
 
   describe('transaction chain type sync', () => {
     it('should sync EVM transactions', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -437,7 +444,7 @@ describe('useRefreshTransactions', () => {
     });
 
     it('should sync Bitcoin transactions', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -452,7 +459,7 @@ describe('useRefreshTransactions', () => {
     it('should not sync transactions for empty account types', async () => {
       mockHistoryTransactionAccounts.getAllAccounts.mockReturnValue([]);
 
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -462,7 +469,7 @@ describe('useRefreshTransactions', () => {
 
   describe('query status management', () => {
     it('should initialize query status for EVM accounts', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -472,7 +479,7 @@ describe('useRefreshTransactions', () => {
     it('should reset query status when no accounts to refresh', async () => {
       mockHistoryTransactionAccounts.getAllAccounts.mockReturnValue([]);
 
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions({
         payload: { accounts: [], exchanges: [] },
@@ -484,7 +491,7 @@ describe('useRefreshTransactions', () => {
 
   describe('userInitiated parameter', () => {
     it('should pass userInitiated to fetchDisabled check', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions({ userInitiated: true });
 
@@ -492,7 +499,7 @@ describe('useRefreshTransactions', () => {
     });
 
     it('should default userInitiated to false', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -502,7 +509,7 @@ describe('useRefreshTransactions', () => {
 
   describe('scheduler state hooks', () => {
     it('should call onHistoryStarted when refresh starts with accounts', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -510,7 +517,7 @@ describe('useRefreshTransactions', () => {
     });
 
     it('should call onHistoryFinished when refresh completes', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -519,7 +526,7 @@ describe('useRefreshTransactions', () => {
 
     it('should call onHistoryFinished even when errors occur', async () => {
       mockTransactionSync.syncTransactionsByChains.mockRejectedValue(new Error('Sync failed'));
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -530,7 +537,7 @@ describe('useRefreshTransactions', () => {
       mockHistoryTransactionAccounts.getAllAccounts.mockReturnValue([]);
       set(mockExchangeData.syncingExchanges, []);
 
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions({
         payload: { accounts: [], exchanges: [] },
@@ -549,7 +556,7 @@ describe('useRefreshTransactions', () => {
         callOrder.push('syncTransactionsByChains');
       });
 
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -566,7 +573,7 @@ describe('useRefreshTransactions', () => {
         callOrder.push('onHistoryFinished');
       });
 
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -577,7 +584,7 @@ describe('useRefreshTransactions', () => {
   describe('exchange filtering', () => {
     it('should filter out exchanges not in syncingExchanges', async () => {
       const unknownExchange: Exchange = { location: 'unknown_exchange', name: 'Unknown' };
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions({
         payload: { exchanges: [mockExchanges[0], unknownExchange] },
@@ -592,7 +599,7 @@ describe('useRefreshTransactions', () => {
     it('should drain pending exchanges after refresh completes', async () => {
       vi.useFakeTimers();
 
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
       const firstRefresh = refreshTransactions();
 
       // Queue pending exchanges while first refresh is running
@@ -616,7 +623,7 @@ describe('useRefreshTransactions', () => {
       mockStatusUpdater.isFirstLoad.mockReturnValue(false);
 
       // First refresh to mark all accounts as known
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
       await refreshTransactions({ userInitiated: true });
 
       vi.clearAllMocks();
@@ -633,7 +640,7 @@ describe('useRefreshTransactions', () => {
   describe('full refresh with no new accounts', () => {
     it('should not refresh accounts when all accounts are already known and not user initiated', async () => {
       // First refresh to mark all accounts as known
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
       await refreshTransactions();
 
       vi.clearAllMocks();
@@ -650,7 +657,7 @@ describe('useRefreshTransactions', () => {
 
   describe('undecoded transactions', () => {
     it('should queue fetchUndecodedTransactionsBreakdown after operations complete', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -658,7 +665,7 @@ describe('useRefreshTransactions', () => {
     });
 
     it('should queue fetchUndecodedTransactionsStatus for decodable accounts', async () => {
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -670,7 +677,7 @@ describe('useRefreshTransactions', () => {
       // Return only non-decodable accounts
       mockHistoryTransactionAccounts.getAllAccounts.mockReturnValue(mockBitcoinAccounts);
 
-      const { refreshTransactions } = useRefreshTransactions();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
@@ -688,7 +695,7 @@ describe('useRefreshTransactions', () => {
       let refreshFn: ((params?: RefreshTransactionsParams) => Promise<void>) | undefined;
 
       scope.run(() => {
-        const { refreshTransactions } = useRefreshTransactions();
+        const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
         refreshFn = refreshTransactions;
       });
 

--- a/frontend/app/src/composables/random-stepper.spec.ts
+++ b/frontend/app/src/composables/random-stepper.spec.ts
@@ -1,40 +1,49 @@
-import type * as Vue from 'vue';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useRandomStepper } from '@/composables/random-stepper';
 
 describe('useRandomStepper', () => {
   beforeAll(() => {
-    const pinia = createPinia();
     vi.useFakeTimers();
-    setActivePinia(pinia);
+  });
 
-    vi.mock('vue', async () => {
-      const mod = await vi.importActual<typeof Vue>('vue');
+  function mountStepper(steps: number, interval: number = 1000): { wrapper: VueWrapper; result: ReturnType<typeof useRandomStepper> } {
+    let result!: ReturnType<typeof useRandomStepper>;
+    const wrapper = mount(defineComponent({
+      setup() {
+        result = useRandomStepper(steps, interval);
+        return {};
+      },
+      render: () => null,
+    }));
+    return { wrapper, result };
+  }
 
-      return {
-        ...mod,
-        onMounted: vi.fn().mockImplementation((fn: () => void) => fn()),
-      };
-    });
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    wrapper?.unmount();
   });
 
   it('should not randomise when it is a single message', () => {
-    const { step, steps } = useRandomStepper(1, 1000);
+    const { wrapper: w, result: { step, steps } } = mountStepper(1);
+    wrapper = w;
 
     expect(get(step)).toBe(1);
-    expect(get(steps)).toBe(1);
+    expect(steps).toBe(1);
 
     vi.advanceTimersByTime(1000);
 
     expect(get(step)).toBe(1);
-    expect(get(steps)).toBe(1);
+    expect(steps).toBe(1);
   });
 
   it('should randomise when there are multiple messages', () => {
-    const { step, steps } = useRandomStepper(5, 1000);
+    const { wrapper: w, result: { step, steps } } = mountStepper(5);
+    wrapper = w;
 
     expect(get(step)).toBe(1);
-    expect(get(steps)).toBe(5);
+    expect(steps).toBe(5);
 
     vi.advanceTimersByTime(1000);
 
@@ -52,10 +61,11 @@ describe('useRandomStepper', () => {
   });
 
   it('should not randomise when timer is paused', () => {
-    const { step, steps, onPause, onResume } = useRandomStepper(5, 1000);
+    const { wrapper: w, result: { step, steps, onPause, onResume } } = mountStepper(5);
+    wrapper = w;
 
     expect(get(step)).toBe(1);
-    expect(get(steps)).toBe(5);
+    expect(steps).toBe(5);
 
     onPause();
     vi.advanceTimersByTime(1000);
@@ -79,10 +89,11 @@ describe('useRandomStepper', () => {
   });
 
   it('should reset random timer when user navigates', async () => {
-    const { step, steps, onNavigate } = useRandomStepper(5, 1000);
+    const { wrapper: w, result: { step, steps, onNavigate } } = mountStepper(5);
+    wrapper = w;
 
     expect(get(step)).toBe(1);
-    expect(get(steps)).toBe(5);
+    expect(steps).toBe(5);
 
     vi.advanceTimersByTime(900);
     await onNavigate(2);

--- a/frontend/app/src/modules/accounts/import-export/use-account-import.spec.ts
+++ b/frontend/app/src/modules/accounts/import-export/use-account-import.spec.ts
@@ -2,7 +2,7 @@ import type { AccountPayload, XpubAccountPayload } from '@/types/blockchain/acco
 import type { Tag } from '@/types/tags';
 import { Blockchain } from '@rotki/common';
 import { createMockCSV } from '@test/mocks/file';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccountManage } from '@/composables/accounts/blockchain/use-account-manage';
 import { useTagsApi } from '@/composables/api/tags';
 import { useAccountImport } from '@/modules/accounts/import-export/use-account-import';
@@ -108,9 +108,16 @@ vi.mock('@/composables/info/chains', async () => {
 });
 
 describe('useAccountImport', () => {
+  let scope: ReturnType<typeof effectScope>;
+
   beforeEach(() => {
     setActivePinia(createPinia());
+    scope = effectScope();
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    scope.stop();
   });
 
   it('should import valid accounts from csv', async () => {
@@ -123,7 +130,7 @@ describe('useAccountImport', () => {
       '0x124,,eth,Name2,tag1;tag2',
     ]);
 
-    const { importAccounts } = useAccountImport();
+    const { importAccounts } = scope.run(() => useAccountImport())!;
     await importAccounts(mockFile);
 
     expect(addAccount).toHaveBeenCalledTimes(1);
@@ -156,7 +163,7 @@ describe('useAccountImport', () => {
       '0x125,,gnosis,Name3,tag1;tag2',
     ]);
 
-    const { importAccounts } = useAccountImport();
+    const { importAccounts } = scope.run(() => useAccountImport())!;
     await importAccounts(mockFile);
 
     expect(addAccount).toHaveBeenCalledTimes(2);
@@ -183,7 +190,7 @@ describe('useAccountImport', () => {
       'Name2,tag1;tag2',
     ]);
 
-    const { importAccounts } = useAccountImport();
+    const { importAccounts } = scope.run(() => useAccountImport())!;
 
     await expect(importAccounts(mockFile)).resolves.toBeUndefined();
     expect(mockNotifyError).toHaveBeenCalledWith(
@@ -201,7 +208,7 @@ describe('useAccountImport', () => {
       `${XPUB},derivationPath=${DERIVATION_PATH},btc,Test Pub,tag1`,
     ]);
 
-    const { importAccounts } = useAccountImport();
+    const { importAccounts } = scope.run(() => useAccountImport())!;
     await importAccounts(mockFile);
 
     expect(addAccount).toHaveBeenCalledTimes(1);
@@ -227,7 +234,7 @@ describe('useAccountImport', () => {
       `${VALIDATOR_1},ownershipPercentage=80,eth2,,`,
     ]);
 
-    const { importAccounts } = useAccountImport();
+    const { importAccounts } = scope.run(() => useAccountImport())!;
     await importAccounts(mockFile);
 
     expect(save).toHaveBeenCalledTimes(1);
@@ -263,7 +270,7 @@ describe('useAccountImport', () => {
       `${VALIDATOR_2},ownershipPercentage=99,eth2,,`,
     ]);
 
-    const { importAccounts } = useAccountImport();
+    const { importAccounts } = scope.run(() => useAccountImport())!;
     await importAccounts(mockFile);
 
     expect(save).toHaveBeenCalledTimes(1);

--- a/frontend/app/src/modules/app/schedulers/use-interval-scheduler.spec.ts
+++ b/frontend/app/src/modules/app/schedulers/use-interval-scheduler.spec.ts
@@ -1,18 +1,23 @@
+import type { EffectScope } from 'vue';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useIntervalScheduler } from './use-interval-scheduler';
 
 describe('useIntervalScheduler', () => {
+  let scope: EffectScope;
+
   beforeEach(() => {
+    scope = effectScope();
     vi.useFakeTimers();
   });
 
   afterEach(() => {
+    scope.stop();
     vi.useRealTimers();
   });
 
   it('should call callback on each interval tick', async () => {
     const callback = vi.fn().mockResolvedValue(undefined);
-    const scheduler = useIntervalScheduler({ callback, intervalMs: 1000 });
+    const scheduler = scope.run(() => useIntervalScheduler({ callback, intervalMs: 1000 }))!;
 
     scheduler.start();
 
@@ -29,7 +34,7 @@ describe('useIntervalScheduler', () => {
 
   it('should call callback immediately when start is called with immediate=true', async () => {
     const callback = vi.fn().mockResolvedValue(undefined);
-    const scheduler = useIntervalScheduler({ callback, intervalMs: 5000 });
+    const scheduler = scope.run(() => useIntervalScheduler({ callback, intervalMs: 5000 }))!;
 
     scheduler.start(true);
     await vi.advanceTimersByTimeAsync(0);
@@ -41,7 +46,7 @@ describe('useIntervalScheduler', () => {
 
   it('should not call callback immediately when start is called with immediate=false', async () => {
     const callback = vi.fn().mockResolvedValue(undefined);
-    const scheduler = useIntervalScheduler({ callback, intervalMs: 5000 });
+    const scheduler = scope.run(() => useIntervalScheduler({ callback, intervalMs: 5000 }))!;
 
     scheduler.start(false);
     await vi.advanceTimersByTimeAsync(0);
@@ -53,7 +58,7 @@ describe('useIntervalScheduler', () => {
 
   it('should prevent double-start', async () => {
     const callback = vi.fn().mockResolvedValue(undefined);
-    const scheduler = useIntervalScheduler({ callback, intervalMs: 1000 });
+    const scheduler = scope.run(() => useIntervalScheduler({ callback, intervalMs: 1000 }))!;
 
     scheduler.start();
     scheduler.start();
@@ -67,7 +72,7 @@ describe('useIntervalScheduler', () => {
 
   it('should stop the interval on stop', async () => {
     const callback = vi.fn().mockResolvedValue(undefined);
-    const scheduler = useIntervalScheduler({ callback, intervalMs: 1000 });
+    const scheduler = scope.run(() => useIntervalScheduler({ callback, intervalMs: 1000 }))!;
 
     scheduler.start();
     await vi.advanceTimersByTimeAsync(1000);
@@ -82,7 +87,7 @@ describe('useIntervalScheduler', () => {
 
   it('should allow restart after stop', async () => {
     const callback = vi.fn().mockResolvedValue(undefined);
-    const scheduler = useIntervalScheduler({ callback, intervalMs: 1000 });
+    const scheduler = scope.run(() => useIntervalScheduler({ callback, intervalMs: 1000 }))!;
 
     scheduler.start();
     scheduler.stop();
@@ -97,7 +102,7 @@ describe('useIntervalScheduler', () => {
 
   it('should handle stop when not started', () => {
     const callback = vi.fn();
-    const scheduler = useIntervalScheduler({ callback, intervalMs: 1000 });
+    const scheduler = scope.run(() => useIntervalScheduler({ callback, intervalMs: 1000 }))!;
 
     expect(() => scheduler.stop()).not.toThrow();
   });

--- a/frontend/app/src/modules/app/use-backend-connection.spec.ts
+++ b/frontend/app/src/modules/app/use-backend-connection.spec.ts
@@ -39,13 +39,17 @@ vi.mock('@shared/utils', () => ({
 }));
 
 describe('useBackendConnection', () => {
+  let scope: ReturnType<typeof effectScope>;
+
   beforeEach(() => {
     setActivePinia(createPinia());
+    scope = effectScope();
     vi.useFakeTimers();
     vi.clearAllMocks();
   });
 
   afterEach(() => {
+    scope.stop();
     vi.useRealTimers();
     vi.clearAllMocks();
   });
@@ -65,7 +69,7 @@ describe('useBackendConnection', () => {
       });
 
       const { useBackendConnection } = await importModule();
-      const { getVersion } = useBackendConnection();
+      const { getVersion } = scope.run(() => useBackendConnection())!;
       await getVersion();
 
       const store = useMainStore();
@@ -80,7 +84,7 @@ describe('useBackendConnection', () => {
       mockInfo.mockResolvedValue({});
 
       const { useBackendConnection } = await importModule();
-      const { getVersion } = useBackendConnection();
+      const { getVersion } = scope.run(() => useBackendConnection())!;
       await getVersion();
 
       const store = useMainStore();
@@ -98,7 +102,7 @@ describe('useBackendConnection', () => {
       });
 
       const { useBackendConnection } = await importModule();
-      const { getInfo } = useBackendConnection();
+      const { getInfo } = scope.run(() => useBackendConnection())!;
       await getInfo();
 
       const store = useMainStore();
@@ -115,7 +119,7 @@ describe('useBackendConnection', () => {
       set(connectionEnabled, false);
 
       const { useBackendConnection } = await importModule();
-      const { connect } = useBackendConnection();
+      const { connect } = scope.run(() => useBackendConnection())!;
       connect();
 
       vi.advanceTimersByTime(5000);
@@ -127,7 +131,7 @@ describe('useBackendConnection', () => {
       mockPing.mockRejectedValue(new Error('timeout'));
 
       const { useBackendConnection } = await importModule();
-      const { connect } = useBackendConnection();
+      const { connect } = scope.run(() => useBackendConnection())!;
       connect();
 
       for (let i = 0; i <= 20; i++) {
@@ -144,7 +148,7 @@ describe('useBackendConnection', () => {
       mockPing.mockRejectedValue(new Error('timeout'));
 
       const { useBackendConnection } = await importModule();
-      const { cancelConnectionAttempts, connect } = useBackendConnection();
+      const { cancelConnectionAttempts, connect } = scope.run(() => useBackendConnection())!;
       connect();
 
       vi.advanceTimersByTime(2000);
@@ -164,7 +168,7 @@ describe('useBackendConnection', () => {
       const store = useMainStore();
 
       const { useBackendConnection } = await importModule();
-      const { stopConnectionAttempts } = useBackendConnection();
+      const { stopConnectionAttempts } = scope.run(() => useBackendConnection())!;
       stopConnectionAttempts();
 
       expect(get(store.connectionEnabled)).toBe(false);

--- a/frontend/app/src/modules/balances/use-balance-queue.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-queue.spec.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ComputedRef, nextTick, ref } from 'vue';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ComputedRef, type EffectScope, nextTick, ref } from 'vue';
 import { BalanceQueueService } from '@/modules/balances/services/balance-queue';
 
 const mockAnyEventsDecoding = ref<boolean>(false);
@@ -13,14 +13,21 @@ vi.mock('@/modules/history/events/use-history-events-status', () => ({
 const { useBalanceQueue } = await import('@/modules/balances/use-balance-queue');
 
 describe('useBalanceQueue', () => {
+  let scope: EffectScope;
+
   beforeEach(() => {
+    scope = effectScope();
     vi.useFakeTimers();
     BalanceQueueService.resetInstance();
     set(mockAnyEventsDecoding, false);
   });
 
+  afterEach(() => {
+    scope.stop();
+  });
+
   it('should process token detection items', async () => {
-    const { queueTokenDetection, stats } = useBalanceQueue();
+    const { queueTokenDetection, stats } = scope.run(() => useBalanceQueue())!;
 
     const fetchFn = vi.fn().mockResolvedValue(undefined);
     await queueTokenDetection('eth', ['0x123'], fetchFn);
@@ -31,7 +38,7 @@ describe('useBalanceQueue', () => {
   });
 
   it('should process balance query items', async () => {
-    const { queueBalanceQueries, stats } = useBalanceQueue();
+    const { queueBalanceQueries, stats } = scope.run(() => useBalanceQueue())!;
 
     const fetchFn = vi.fn().mockResolvedValue(undefined);
     await queueBalanceQueries(['eth', 'btc'], fetchFn);
@@ -43,7 +50,7 @@ describe('useBalanceQueue', () => {
   });
 
   it('should reset state when singleton is reset between sessions', async () => {
-    const { queueBalanceQueries, stats } = useBalanceQueue();
+    const { queueBalanceQueries, stats } = scope.run(() => useBalanceQueue())!;
 
     // Session 1: process some items
     const fetchFn = vi.fn().mockResolvedValue(undefined);
@@ -56,7 +63,7 @@ describe('useBalanceQueue', () => {
     BalanceQueueService.resetInstance();
 
     // Session 2: get a fresh composable (simulates re-login)
-    const session2 = useBalanceQueue();
+    const session2 = scope.run(() => useBalanceQueue())!;
 
     // Stats should be clean — no stale data from session 1
     expect(get(session2.stats).completed).toBe(0);
@@ -76,7 +83,7 @@ describe('useBalanceQueue', () => {
   it('should block processing while events are decoding', async () => {
     set(mockAnyEventsDecoding, true);
 
-    const { queueTokenDetection, stats } = useBalanceQueue();
+    const { queueTokenDetection, stats } = scope.run(() => useBalanceQueue())!;
 
     const fetchFn = vi.fn().mockResolvedValue(undefined);
     const promise = queueTokenDetection('eth', ['0x123'], fetchFn);

--- a/frontend/app/src/modules/data/use-database.spec.ts
+++ b/frontend/app/src/modules/data/use-database.spec.ts
@@ -27,8 +27,10 @@ describe('useDatabase', () => {
 
   let mockUserIdentifier: ReturnType<typeof ref<string | undefined>>;
   let mockDataDirectory: ReturnType<typeof ref<string | undefined>>;
+  let scope: ReturnType<typeof effectScope>;
 
   beforeEach(async () => {
+    scope = effectScope();
     vi.resetModules();
 
     // Create fresh refs for each test
@@ -75,13 +77,14 @@ describe('useDatabase', () => {
     // Clean up localStorage
     localStorage.removeItem(localStorageKey);
 
+    scope.stop();
     vi.clearAllMocks();
   });
 
   describe('database initialization', () => {
     it('should not be ready when user is not set', async () => {
       const { useDatabase } = await import('./use-database');
-      const { isReady } = useDatabase();
+      const { isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
 
@@ -92,7 +95,7 @@ describe('useDatabase', () => {
       set(mockUserIdentifier, testUsername);
 
       const { useDatabase } = await import('./use-database');
-      const { isReady } = useDatabase();
+      const { isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
 
@@ -104,7 +107,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { isReady } = useDatabase();
+      const { isReady } = scope.run(() => useDatabase())!;
 
       // Wait for watch to execute
       await nextTick();
@@ -118,7 +121,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(50);
@@ -132,7 +135,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(50);
@@ -152,7 +155,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(100);
@@ -183,7 +186,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(100);
@@ -210,7 +213,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(100);
@@ -234,7 +237,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(100);
@@ -264,7 +267,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(100);
@@ -281,7 +284,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(100);
@@ -305,7 +308,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(100);
@@ -334,7 +337,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(100);
@@ -356,7 +359,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(100);
@@ -393,7 +396,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { db, isReady } = useDatabase();
+      const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(100);
@@ -419,7 +422,7 @@ describe('useDatabase', () => {
 
       const { useDatabase } = await import('./use-database');
       // Don't destructure db - we need to access the getter each time to get updated value
-      const database = useDatabase();
+      const database = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(50);
@@ -454,7 +457,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, testDataDirectory);
 
       const { useDatabase } = await import('./use-database');
-      const { isReady } = useDatabase();
+      const { isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(50);
@@ -478,7 +481,7 @@ describe('useDatabase', () => {
 
       const { useDatabase } = await import('./use-database');
       // Don't destructure db - we need to access the getter each time to get updated value
-      const database = useDatabase();
+      const database = scope.run(() => useDatabase())!;
 
       await nextTick();
       await wait(50);

--- a/frontend/app/src/modules/history/events/composables/use-history-events-data.spec.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-events-data.spec.ts
@@ -38,6 +38,7 @@ vi.mock('@/modules/history/events/use-history-events-status', () => ({
 vi.mock('@/modules/assets/use-assets-store', () => ({
   useAssetsStore: vi.fn(() => ({
     isAssetIgnored: mockIsAssetIgnored,
+    ignoredAssets: ref<string[]>([]),
   })),
 }));
 
@@ -61,6 +62,8 @@ vi.mock('@/utils/collection', () => ({
 }));
 
 describe('use-history-events-data', () => {
+  let scope: ReturnType<typeof effectScope>;
+
   function createMockEvent(overrides: Omit<Partial<HistoryEventEntry>, 'entryType'> = {}): HistoryEventEntry {
     const event: HistoryEventEntry = {
       address: '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c',
@@ -97,11 +100,13 @@ describe('use-history-events-data', () => {
 
   beforeEach(() => {
     setActivePinia(createPinia());
+    scope = effectScope();
     mockFetchHistoryEvents.mockResolvedValue({ data: [] });
     mockIsAssetIgnored.mockReturnValue(false);
   });
 
   afterEach(() => {
+    scope.stop();
     vi.clearAllMocks();
   });
 
@@ -121,7 +126,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       expect(get(result.groups)).toHaveLength(2);
       expect(get(result.groups)[0]).toEqual(event1);
@@ -144,7 +149,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       expect(get(result.groups)).toHaveLength(2);
     });
@@ -164,7 +169,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       expect(get(result.loading)).toBe(true);
 
@@ -186,7 +191,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       expect(result.eventsLoading).toBeDefined();
     });
@@ -205,7 +210,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await nextTick();
 
@@ -225,7 +230,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       expect(get(result.groups)).toEqual([]);
       expect(get(result.events)).toEqual([]);
@@ -253,7 +258,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       expect(get(result.found)).toBe(100);
       expect(get(result.limit)).toBe(10);
@@ -296,7 +301,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      useHistoryEventsData(options, emit);
+      scope.run(() => useHistoryEventsData(options, emit));
 
       await waitForFetchEvents();
 
@@ -330,7 +335,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -356,7 +361,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -381,7 +386,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -406,7 +411,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -432,7 +437,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -461,7 +466,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -495,7 +500,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -535,7 +540,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      useHistoryEventsData(options, emit);
+      scope.run(() => useHistoryEventsData(options, emit));
 
       await waitForFetchEvents();
 
@@ -567,7 +572,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       // Let the first (immediate) fetch start
       await nextTick();
@@ -606,7 +611,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
       expect(get(result.rawEvents)).toHaveLength(1);
@@ -643,7 +648,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       // After immediate watch fires, eventsLoading should be true
       await nextTick();
@@ -686,7 +691,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       // Let first fetch start
       await nextTick();
@@ -730,7 +735,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      useHistoryEventsData(options, emit);
+      scope.run(() => useHistoryEventsData(options, emit));
 
       await waitForFetchEvents();
       mockCancelByTag.mockClear();
@@ -758,7 +763,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      useHistoryEventsData(options, emit);
+      scope.run(() => useHistoryEventsData(options, emit));
 
       await waitForFetchEvents();
       mockCancelByTag.mockClear();
@@ -786,7 +791,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
       expect(get(result.rawEvents)).toHaveLength(1);
@@ -856,7 +861,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -885,7 +890,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -912,7 +917,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -960,7 +965,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -989,7 +994,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       await waitForFetchEvents();
 
@@ -1012,7 +1017,7 @@ describe('use-history-events-data', () => {
       };
 
       const emit = vi.fn();
-      const result = useHistoryEventsData(options, emit);
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       expect(result.isSubgroupIncomplete([])).toBe(false);
     });

--- a/frontend/app/src/modules/reports/use-report-generation.spec.ts
+++ b/frontend/app/src/modules/reports/use-report-generation.spec.ts
@@ -40,13 +40,17 @@ vi.mock('@/modules/tasks/use-task-handler', () => ({
 }));
 
 describe('useReportGeneration', () => {
+  let scope: ReturnType<typeof effectScope>;
+
   beforeEach(() => {
     setActivePinia(createPinia());
+    scope = effectScope();
     vi.clearAllMocks();
     vi.useFakeTimers();
   });
 
   afterEach(() => {
+    scope.stop();
     vi.useRealTimers();
   });
 
@@ -58,7 +62,7 @@ describe('useReportGeneration', () => {
       });
       mockFetchReports.mockResolvedValue(undefined);
 
-      const { generateReport } = useReportGeneration();
+      const { generateReport } = scope.run(() => useReportGeneration())!;
       const result = await generateReport({ end: 2000, start: 1000 });
 
       expect(result).toBe(42);
@@ -76,7 +80,7 @@ describe('useReportGeneration', () => {
         success: false,
       });
 
-      const { generateReport } = useReportGeneration();
+      const { generateReport } = scope.run(() => useReportGeneration())!;
       const result = await generateReport({ end: 2000, start: 1000 });
 
       expect(result).toBe(-1);
@@ -89,7 +93,7 @@ describe('useReportGeneration', () => {
         success: true,
       });
 
-      const { generateReport } = useReportGeneration();
+      const { generateReport } = scope.run(() => useReportGeneration())!;
       const result = await generateReport({ end: 2000, start: 1000 });
 
       expect(result).toBe(0);
@@ -105,7 +109,7 @@ describe('useReportGeneration', () => {
         success: true,
       });
 
-      const { exportReportData } = useReportGeneration();
+      const { exportReportData } = scope.run(() => useReportGeneration())!;
       const result = await exportReportData({ fromTimestamp: 1000, toTimestamp: 2000 });
 
       expect(result).toEqual(mockData);
@@ -121,7 +125,7 @@ describe('useReportGeneration', () => {
         success: false,
       });
 
-      const { exportReportData } = useReportGeneration();
+      const { exportReportData } = scope.run(() => useReportGeneration())!;
       const result = await exportReportData({ fromTimestamp: 1000, toTimestamp: 2000 });
 
       expect(result).toEqual({});

--- a/frontend/app/src/modules/staking/kraken/use-kraken-staking-operations.spec.ts
+++ b/frontend/app/src/modules/staking/kraken/use-kraken-staking-operations.spec.ts
@@ -51,9 +51,7 @@ vi.mock('@/modules/tasks/use-task-store', () => ({
 }));
 
 vi.mock('@/store/settings/frontend', () => ({
-  useFrontendSettingsStore: vi.fn(() => ({
-    itemsPerPage: 10,
-  })),
+  useFrontendSettingsStore: vi.fn(() => reactive({ itemsPerPage: 10 })),
 }));
 
 function defaultEvents(): KrakenStakingEvents {
@@ -68,13 +66,17 @@ function defaultEvents(): KrakenStakingEvents {
 }
 
 describe('useKrakenStakingOperations', () => {
+  let scope: ReturnType<typeof effectScope>;
+
   beforeEach(() => {
     setActivePinia(createPinia());
+    scope = effectScope();
     vi.clearAllMocks();
     mockIsTaskRunning.mockReturnValue(false);
   });
 
   afterEach(() => {
+    scope.stop();
     vi.clearAllMocks();
   });
 
@@ -84,7 +86,7 @@ describe('useKrakenStakingOperations', () => {
 
       mockFetchKrakenStakingEvents.mockRejectedValueOnce(new Error('Request timeout'));
 
-      const { fetchEvents } = useKrakenStakingOperations();
+      const { fetchEvents } = scope.run(() => useKrakenStakingOperations())!;
       const statusStore = useStatusStore();
 
       await fetchEvents();
@@ -106,7 +108,7 @@ describe('useKrakenStakingOperations', () => {
       mockFetchKrakenStakingEvents.mockResolvedValue(eventsData);
       mockRefreshKrakenStaking.mockResolvedValue({ taskId: 1 });
 
-      const { fetchEvents } = useKrakenStakingOperations();
+      const { fetchEvents } = scope.run(() => useKrakenStakingOperations())!;
       const statusStore = useStatusStore();
 
       await fetchEvents();
@@ -122,7 +124,7 @@ describe('useKrakenStakingOperations', () => {
       mockFetchKrakenStakingEvents.mockResolvedValueOnce(defaultEvents());
       mockRefreshKrakenStaking.mockRejectedValueOnce(new Error('Backend unresponsive'));
 
-      const { fetchEvents } = useKrakenStakingOperations();
+      const { fetchEvents } = scope.run(() => useKrakenStakingOperations())!;
       const statusStore = useStatusStore();
 
       await fetchEvents();
@@ -135,7 +137,7 @@ describe('useKrakenStakingOperations', () => {
     it('should skip when task is already running', async () => {
       mockIsTaskRunning.mockReturnValue(true);
 
-      const { fetchEvents } = useKrakenStakingOperations();
+      const { fetchEvents } = scope.run(() => useKrakenStakingOperations())!;
       await fetchEvents();
 
       expect(mockFetchKrakenStakingEvents).not.toHaveBeenCalled();
@@ -145,7 +147,7 @@ describe('useKrakenStakingOperations', () => {
       mockFetchKrakenStakingEvents.mockResolvedValue(defaultEvents());
       mockRefreshKrakenStaking.mockResolvedValue({ taskId: 1 });
 
-      const { fetchEvents } = useKrakenStakingOperations();
+      const { fetchEvents } = scope.run(() => useKrakenStakingOperations())!;
       const dateFilter = { fromTimestamp: 1000, toTimestamp: 2000 };
 
       await fetchEvents(false, dateFilter);
@@ -164,7 +166,7 @@ describe('useKrakenStakingOperations', () => {
       mockFetchKrakenStakingEvents.mockResolvedValue(defaultEvents());
       mockRefreshKrakenStaking.mockResolvedValue({ taskId: 1 });
 
-      const { fetchEvents } = useKrakenStakingOperations();
+      const { fetchEvents } = scope.run(() => useKrakenStakingOperations())!;
       await fetchEvents(true);
 
       expect(mockRefreshKrakenStaking).toHaveBeenCalledOnce();
@@ -176,7 +178,7 @@ describe('useKrakenStakingOperations', () => {
       mockFetchKrakenStakingEvents.mockResolvedValue(defaultEvents());
       mockRefreshKrakenStaking.mockResolvedValue({ taskId: 1 });
 
-      const { updatePagination } = useKrakenStakingOperations();
+      const { updatePagination } = scope.run(() => useKrakenStakingOperations())!;
 
       await updatePagination({
         ascending: [true],

--- a/frontend/app/src/modules/sync-progress/test-utils.ts
+++ b/frontend/app/src/modules/sync-progress/test-utils.ts
@@ -1,31 +1,25 @@
 /**
  * Shared test utilities for sync-progress module tests.
- * These helpers reduce boilerplate in component and composable tests.
+ * These mocks are hoisted to the top level by vitest.
+ *
+ * Import this file (or call setupSyncProgressMocks) at the top of test files
+ * before other imports.
  */
 import { type Mock, vi } from 'vitest';
 
-/**
- * Sets up common mocks used across sync-progress component tests.
- * Call this at the top of test files before other imports.
- *
- * @example
- * ```ts
- * import { setupSyncProgressMocks } from '../test-utils';
- *
- * setupSyncProgressMocks();
- *
- * // Rest of your test file...
- * ```
- */
-export function setupSyncProgressMocks(): void {
-  vi.mock('@/composables/api/assets/icon', () => ({
-    useAssetIconApi: vi.fn().mockReturnValue({
-      assetImageUrl: vi.fn(),
-    }),
-  }));
+vi.mock('@/composables/api/assets/icon', () => ({
+  useAssetIconApi: vi.fn().mockReturnValue({
+    assetImageUrl: vi.fn(),
+  }),
+}));
 
-  vi.mock('@/services/websocket/websocket-service');
-}
+vi.mock('@/services/websocket/websocket-service');
+
+/**
+ * No-op kept for backward compatibility with existing test files.
+ * The mocks above are already hoisted and applied at import time.
+ */
+export function setupSyncProgressMocks(): void {}
 
 /**
  * Creates a hoisted mock function with a default return value.

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -9,137 +9,137 @@ import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 import { server } from './server';
 import 'fake-indexeddb/auto';
 
+vi.mock('@/composables/api/assets/info', () => ({
+  useAssetInfoApi: vi.fn().mockReturnValue({
+    assetMapping: vi.fn().mockResolvedValue({ assets: {}, assetCollections: {} }),
+  }),
+}));
+
+vi.mock('@/composables/api/balances/price', () => ({
+  usePriceApi: vi.fn().mockReturnValue({
+    getPriceCache: vi.fn().mockResolvedValue([]),
+    createPriceCache: vi.fn().mockResolvedValue({ taskId: 1 }),
+    deletePriceCache: vi.fn().mockResolvedValue(true),
+    queryHistoricalRate: vi.fn().mockResolvedValue({ taskId: 1 }),
+    queryHistoricalRates: vi.fn().mockResolvedValue({ taskId: 1 }),
+    queryFiatExchangeRates: vi.fn().mockResolvedValue({ taskId: 1 }),
+    queryPrices: vi.fn().mockResolvedValue({ taskId: 1 }),
+    queryCachedPrices: vi.fn().mockResolvedValue({}),
+  }),
+}));
+
+vi.mock('@/composables/api/session/queried-addresses', () => ({
+  useQueriedAddressApi: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@/composables/api/backup', () => ({
+  useBackupApi: vi.fn().mockReturnValue({
+    info: vi.fn().mockReturnValue({
+      userdb: {
+        info: {
+          filepath: '/dev/db.db',
+          size: 1234,
+          version: 5,
+        },
+        backups: [],
+      },
+      globaldb: {
+        globaldbAssetsVersion: 1,
+        globaldbSchemaVersion: 1,
+      },
+    } satisfies DatabaseInfo),
+  }),
+}));
+
+vi.mock('@vueuse/core', async () => {
+  const mod = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
+
+  return {
+    ...mod,
+    useElementBounding: vi.fn().mockReturnValue({ left: 0, right: 0, top: 0, bottom: 0 }),
+    useFocus: vi.fn().mockReturnValue({ focused: ref(false) }),
+    useResizeObserver: vi.fn(),
+    useVirtualList: vi.fn().mockImplementation((options: []) => ({
+      containerProps: {
+        ref: ref(),
+        onScroll: vi.fn(),
+      },
+      list: computed(() => get(options).map((data, index) => ({ data, index }))),
+      wrapperProps: {},
+      scrollTo: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: mockT,
+    te: mockT,
+    locale: ref(''),
+  }),
+  createI18n: () => ({}),
+}));
+
+vi.mock('vue-router', () => {
+  const route = ref({
+    query: {},
+  });
+
+  return {
+    useRoute: vi.fn().mockReturnValue(route),
+    useRouter: vi.fn().mockImplementation(() => ({
+      currentRoute: route,
+      push: vi.fn(({ query }) => {
+        set(route, { ...get(route), query });
+        return true;
+      }),
+    })),
+    createRouter: vi.fn().mockImplementation(() => ({
+      beforeEach: vi.fn(),
+    })),
+    createWebHashHistory: vi.fn(),
+  };
+});
+
+vi.mock('@/modules/app/use-websocket-connection', () => ({
+  useWebsocketConnection: () => ({
+    connected: ref(false),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    setConnectionEnabled: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/app/use-monitor-service', () => ({
+  useMonitorService: () => ({
+    restart: vi.fn(),
+    start: vi.fn(),
+    startTaskMonitoring: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/app/use-backend-messages', () => ({
+  useBackendMessages: () => ({
+    isMacOsVersionUnsupported: ref(false),
+    isWinVersionUnsupported: ref(false),
+    registerOAuthCallbackHandler: vi.fn(),
+    startupErrorMessage: ref(''),
+    unregisterOAuthCallbackHandler: vi.fn(),
+  }),
+}));
+
+vi.mock('@rotki/ui-library', async () => {
+  const actual = await vi.importActual<typeof import('@rotki/ui-library')>('@rotki/ui-library');
+  return {
+    ...actual,
+    createBlockie: vi.fn().mockImplementation(({ seed }) => `${seed.toLowerCase()}face`),
+  };
+});
+
 beforeAll(() => {
   server.listen({
     onUnhandledRequest: 'warn',
-  });
-
-  vi.mock('@/composables/api/assets/info', () => ({
-    useAssetInfoApi: vi.fn().mockReturnValue({
-      assetMapping: vi.fn().mockResolvedValue({ assets: {}, assetCollections: {} }),
-    }),
-  }));
-
-  vi.mock('@/composables/api/balances/price', () => ({
-    usePriceApi: vi.fn().mockReturnValue({
-      getPriceCache: vi.fn().mockResolvedValue([]),
-      createPriceCache: vi.fn().mockResolvedValue({ taskId: 1 }),
-      deletePriceCache: vi.fn().mockResolvedValue(true),
-      queryHistoricalRate: vi.fn().mockResolvedValue({ taskId: 1 }),
-      queryHistoricalRates: vi.fn().mockResolvedValue({ taskId: 1 }),
-      queryFiatExchangeRates: vi.fn().mockResolvedValue({ taskId: 1 }),
-      queryPrices: vi.fn().mockResolvedValue({ taskId: 1 }),
-      queryCachedPrices: vi.fn().mockResolvedValue({}),
-    }),
-  }));
-
-  vi.mock('@/composables/api/session/queried-addresses', () => ({
-    useQueriedAddressApi: vi.fn().mockReturnValue({}),
-  }));
-
-  vi.mock('@/composables/api/backup', () => ({
-    useBackupApi: vi.fn().mockReturnValue({
-      info: vi.fn().mockReturnValue({
-        userdb: {
-          info: {
-            filepath: '/dev/db.db',
-            size: 1234,
-            version: 5,
-          },
-          backups: [],
-        },
-        globaldb: {
-          globaldbAssetsVersion: 1,
-          globaldbSchemaVersion: 1,
-        },
-      } satisfies DatabaseInfo),
-    }),
-  }));
-
-  vi.mock('@vueuse/core', async () => {
-    const mod = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
-
-    return {
-      ...mod,
-      useElementBounding: vi.fn().mockReturnValue({ left: 0, right: 0, top: 0, bottom: 0 }),
-      useFocus: vi.fn().mockReturnValue({ focused: ref(false) }),
-      useResizeObserver: vi.fn(),
-      useVirtualList: vi.fn().mockImplementation((options: []) => ({
-        containerProps: {
-          ref: ref(),
-          onScroll: vi.fn(),
-        },
-        list: computed(() => get(options).map((data, index) => ({ data, index }))),
-        wrapperProps: {},
-        scrollTo: vi.fn(),
-      })),
-    };
-  });
-
-  vi.mock('vue-i18n', () => ({
-    useI18n: () => ({
-      t: mockT,
-      te: mockT,
-      locale: ref(''),
-    }),
-    createI18n: () => ({}),
-  }));
-
-  vi.mock('vue-router', () => {
-    const route = ref({
-      query: {},
-    });
-
-    return {
-      useRoute: vi.fn().mockReturnValue(route),
-      useRouter: vi.fn().mockImplementation(() => ({
-        currentRoute: route,
-        push: vi.fn(({ query }) => {
-          set(route, { ...get(route), query });
-          return true;
-        }),
-      })),
-      createRouter: vi.fn().mockImplementation(() => ({
-        beforeEach: vi.fn(),
-      })),
-      createWebHashHistory: vi.fn(),
-    };
-  });
-
-  vi.mock('@/modules/app/use-websocket-connection', () => ({
-    useWebsocketConnection: () => ({
-      connected: ref(false),
-      connect: vi.fn(),
-      disconnect: vi.fn(),
-      setConnectionEnabled: vi.fn(),
-    }),
-  }));
-
-  vi.mock('@/modules/app/use-monitor-service', () => ({
-    useMonitorService: () => ({
-      restart: vi.fn(),
-      start: vi.fn(),
-      startTaskMonitoring: vi.fn(),
-      stop: vi.fn(),
-    }),
-  }));
-
-  vi.mock('@/modules/app/use-backend-messages', () => ({
-    useBackendMessages: () => ({
-      isMacOsVersionUnsupported: ref(false),
-      isWinVersionUnsupported: ref(false),
-      registerOAuthCallbackHandler: vi.fn(),
-      startupErrorMessage: ref(''),
-      unregisterOAuthCallbackHandler: vi.fn(),
-    }),
-  }));
-
-  vi.mock('@rotki/ui-library', async () => {
-    const actual = await vi.importActual<typeof import('@rotki/ui-library')>('@rotki/ui-library');
-    return {
-      ...actual,
-      createBlockie: vi.fn().mockImplementation(({ seed }) => `${seed.toLowerCase()}face`),
-    };
   });
 
   class ResizeObserverMock {


### PR DESCRIPTION
## Summary
- Move `vi.mock()` calls to module top level to fix vitest hoisting warnings that will become errors in future versions
- Replace `vi.mock('vue')` with proper `mount()` wrapper in `random-stepper.spec.ts`
- Wrap composable calls in `effectScope()` to fix `[Vue warn] onScopeDispose()` warnings in 10 test files
- Fix incomplete mocks causing `Invalid watch source: undefined` and runtime errors

## Test plan
- [x] All 286 test files pass (3126 tests)
- [x] Zero `[Vue warn]` messages in test output
- [x] Zero `vi.mock()` hoisting warnings
- [x] No `getUndecodedTransactionsBreakdown is not a function` errors