### PR TITLE
Add spam subtype

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,7 @@ Changelog
 * :bug:`-` Claiming AAVE rewards and immediately restaking them will now be properly decoded.
 * :bug:`-` Kyberswap swaps containing refunds will now be processed properly and deduct refund from original swap amount.
 * :bug:`-` Specific cases of rainbow swaps with fees will now also be properly decoded.
+* :feature:`-` Added a spam subtype event so you can manually tag and differentiate spam / phishing / address poisoning transactions.
 * :bug:`-` WETH Unwrapping in base will now be properly decoded.
 * :bug:`-` The rare case of balancer v2 swaps with repeated swap logs for a single events is now decoded properly.
 * :feature:`-` ERC4337 fee payments will now be properly understood by rotki

--- a/frontend/app/backend-icons.generated.ts
+++ b/frontend/app/backend-icons.generated.ts
@@ -57,6 +57,7 @@ export const backendIcons: string[] = [
   'lu-rocket',
   'lu-scale',
   'lu-send-to-back',
+  'lu-shield-alert',
   'lu-skull',
   'lu-sprout',
   'lu-square-pen',

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1515,6 +1515,7 @@
         "remove_asset": "Remove Asset",
         "return_wrapped": "Return Wrapped",
         "reward": "Reward",
+        "spam": "Spam",
         "spend": "Spend"
       },
       "history_event_type": {

--- a/rotkehlchen/accounting/constants.py
+++ b/rotkehlchen/accounting/constants.py
@@ -46,6 +46,7 @@ EVENT_CATEGORY_MAPPINGS = {  # possible combinations of types and subtypes mappe
         HistoryEventSubType.INTEREST: {DEFAULT: EventCategory.INTEREST},
         HistoryEventSubType.CASHBACK: {DEFAULT: EventCategory.CASHBACK},
         HistoryEventSubType.REFUND: {DEFAULT: EventCategory.REFUND},
+        HistoryEventSubType.SPAM: {DEFAULT: EventCategory.SPAM},
     },
     HistoryEventType.DEPOSIT: {
         HistoryEventSubType.DEPOSIT_ASSET: {
@@ -184,9 +185,10 @@ EVENT_GROUPING_ORDER = {  # Determines how to group events when serializing for 
 # possible color values
 # success=green, error=red, warning=yellow/orangish, info=blue,
 # primary=our primary blue color, secondary=somewhat gray
-# Icons are taken from here: https://remixicon.com/
-# IMPORTANT: All icons added here need to also be packaged in the frontend
-# here frontend/app/src/plugins/rui/index.ts
+# Icons are taken from here: https://lucide.dev/icons/
+# IMPORTANT: All icons added here need to also be packaged in the frontend.
+# Run `pnpm run --filter rotki generate:backend-icons` to regenerate
+# and `pnpm run --filter rotki check:icons` to verify.
 EVENT_CATEGORY_DETAILS = {
     EventCategory.SEND: {DEFAULT: EventCategoryDetails(
         label='send',
@@ -387,6 +389,10 @@ EVENT_CATEGORY_DETAILS = {
     )}, EventCategory.PROTOCOL_WITHDRAWAL: {DEFAULT: EventCategoryDetails(
         label='protocol withdrawal',
         icon='lu-download',
+    )}, EventCategory.SPAM: {DEFAULT: EventCategoryDetails(
+        label='spam',
+        icon='lu-shield-alert',
+        color='error',
     )},
 }
 

--- a/rotkehlchen/history/events/structures/types.py
+++ b/rotkehlchen/history/events/structures/types.py
@@ -107,6 +107,7 @@ class HistoryEventSubType(SerializableEnumNameMixin):
     LOSS = auto()
     DEPOSIT_TO_PROTOCOL = auto()
     WITHDRAW_FROM_PROTOCOL = auto()
+    SPAM = auto()  # for spam/phishing transactions
 
     def serialize_or_none(self) -> str | None:
         return self.serialize()
@@ -202,6 +203,7 @@ class EventCategory(Enum):
     SELF_TRANSACTION = 60, EventDirection.NEUTRAL
     PROTOCOL_DEPOSIT = 61, EventDirection.NEUTRAL
     PROTOCOL_WITHDRAWAL = 62, EventDirection.NEUTRAL
+    SPAM = 63, EventDirection.IN
 
     @property
     def direction(self) -> EventDirection:


### PR DESCRIPTION
Added a spam subtype event so you can manually tag and differentiate spam / phishing / address poisoning transactions.
