### PR TITLE
feat(frontend): add indexer limitation warnings in EVM settings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`11896` Indexer limitation warnings are now shown in the EVM Indexer Order settings for Optimism (Blockscout pre-Bedrock gaps) and Base (Blockscout as only free indexer).
 * :bug:`-` Assets in the same collection now share cost basis, preventing false missing acquisition errors when the same asset is tracked under different identifiers.
 * :feature:`-` Sushiswap swaps should now be decoded on all EVM chains
 * :bug:`11854` Users can now unmark assets as spam or unignore them directly from the history events context menu, instead of having to navigate to the asset manager.

--- a/frontend/app/src/components/settings/evm/IndexerOrderSetting.vue
+++ b/frontend/app/src/components/settings/evm/IndexerOrderSetting.vue
@@ -167,6 +167,23 @@ const currentOrder = computed<PrioritizedListId[]>(() => {
   return get(localChainOrders)[tab] ?? [];
 });
 
+const chainWarnings = computed<string[]>(() => {
+  const tab = get(activeTab);
+  if (tab === DEFAULT_TAB)
+    return [];
+
+  const warnings: string[] = [];
+  const order = get(currentOrder);
+
+  if (tab === 'optimism' && order.includes(EvmIndexer.BLOCKSCOUT))
+    warnings.push(t('evm_settings.indexer.chain_warnings.optimism_blockscout'));
+
+  if (tab === 'base' && (order.length === 0 || order[0] !== EvmIndexer.BLOCKSCOUT))
+    warnings.push(t('evm_settings.indexer.chain_warnings.base_limited_indexers'));
+
+  return warnings;
+});
+
 const missingApiKeyIndexer = computed<string | null>(() => {
   const order = get(currentOrder);
   if (order.length === 0)
@@ -364,6 +381,16 @@ watchImmediate([evmIndexersOrder, defaultEvmIndexerOrder], () => {
             {{ t('evm_settings.indexer.enter_api_key') }}
           </RuiButton>
         </div>
+      </RuiAlert>
+
+      <RuiAlert
+        v-for="(warning, index) in chainWarnings"
+        :key="index"
+        type="warning"
+        class="mb-4"
+        data-cy="chain-warning-alert"
+      >
+        {{ warning }}
       </RuiAlert>
 
       <RuiTabItems v-model="activeTab">

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2585,6 +2585,10 @@
       "api_key_missing_alert": "{indexer} is your first priority indexer but you don't have an API key configured. Queries may be slower or fail. Consider adding an API key for better performance.",
       "chain_order": "{chain} Indexer Order",
       "chain_updated": "{chain} indexer order updated",
+      "chain_warnings": {
+        "base_limited_indexers": "Blockscout is the only freely available indexer for Base. Consider setting it as your first priority. Blockscout is currently reindexing Base, so data may be temporarily incomplete.",
+        "optimism_blockscout": "Blockscout does not have properly indexed transactions for Optimism before the Bedrock upgrade. Pre-Bedrock transaction history may be incomplete when using Blockscout."
+      },
       "data_name": "indexer",
       "default_order": "Default Indexer Order",
       "default_tab": "Default",


### PR DESCRIPTION
## Summary
- Show a warning on the Optimism tab when Blockscout is in the indexer order, since it lacks properly indexed pre-Bedrock transactions
- Show a warning on the Base tab when Blockscout is not configured or not the first priority, since it is the only freely available indexer with full support

Closes #11896

## Test plan
- [ ] Navigate to Settings → EVM → Indexer Order
- [ ] Select Optimism tab with Blockscout in the order → warning appears
- [ ] Select Optimism tab without Blockscout → no warning
- [ ] Select Base tab with Blockscout as first priority → no warning
- [ ] Select Base tab with Blockscout missing or not first → warning appears
- [ ] Select Default tab → no warnings shown