### PR TITLE
fix(frontend): preserve event_subtype filter on navigation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`11896` Indexer limitation warnings are now shown in the EVM Indexer Order settings for Optimism (Blockscout pre-Bedrock gaps) and Base (Blockscout as only free indexer).
+* :bug:`11901` The event_subtype filter (e.g. subtype=None) is no longer lost when navigating away from the history events page and back.
 * :bug:`-` Assets in the same collection now share cost basis, preventing false missing acquisition errors when the same asset is tracked under different identifiers.
 * :feature:`-` Sushiswap swaps should now be decoded on all EVM chains
 * :bug:`11854` Users can now unmark assets as spam or unignore them directly from the history events context menu, instead of having to navigate to the asset manager.

--- a/frontend/app/src/composables/filters/events.spec.ts
+++ b/frontend/app/src/composables/filters/events.spec.ts
@@ -1,0 +1,155 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, type Ref } from 'vue';
+import { useHistoryEventFilter } from './events';
+
+const globalMappingData = ref<Record<string, Record<string, { default: string; exchange?: string }>>>({});
+
+vi.mock('@/composables/history/events/mapping', () => ({
+  useHistoryEventMappings: (): {
+    historyEventTypeGlobalMapping: Ref<Record<string, Record<string, { default: string; exchange?: string }>>>;
+    historyEventTypes: Ref<string[]>;
+  } => ({
+    historyEventTypeGlobalMapping: globalMappingData,
+    historyEventTypes: computed<string[]>(() => Object.keys(get(globalMappingData))),
+  }),
+}));
+
+vi.mock('@/composables/history/events/mapping/counterparty', () => ({
+  useHistoryEventCounterpartyMappings: (): { counterparties: Ref<string[]> } => ({
+    counterparties: ref<string[]>([]),
+  }),
+}));
+
+vi.mock('@/composables/assets/retrieval', () => ({
+  useAssetInfoRetrieval: (): { assetInfo: Ref<undefined>; assetSearch: Ref<() => never[]> } => ({
+    assetInfo: ref<undefined>(undefined),
+    assetSearch: ref<() => never[]>(() => []),
+  }),
+}));
+
+vi.mock('@/store/history', () => ({
+  useHistoryStore: (): { associatedLocations: Ref<string[]> } => ({
+    associatedLocations: ref<string[]>([]),
+  }),
+}));
+
+vi.mock('@/store/settings/frontend', () => ({
+  useFrontendSettingsStore: (): Record<string, unknown> => ({
+    dateInputFormat: ref<string>(''),
+    $id: 'frontend-settings',
+  }),
+}));
+
+function getMockGlobalMapping(): Record<string, Record<string, { default: string }>> {
+  return {
+    receive: {
+      none: { default: 'receive' },
+      reward: { default: 'claim_reward' },
+      airdrop: { default: 'airdrop' },
+    },
+    spend: {
+      none: { default: 'send' },
+      fee: { default: 'fee' },
+    },
+    trade: {
+      spend: { default: 'swap_out' },
+      receive: { default: 'swap_in' },
+      fee: { default: 'fee' },
+    },
+  };
+}
+
+describe('composables/filters/events', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    set(globalMappingData, {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('useHistoryEventFilter', () => {
+    it('does not strip event subtypes when mapping is not yet loaded', async () => {
+      set(globalMappingData, {});
+
+      const { filters } = useHistoryEventFilter({});
+
+      set(filters, { eventTypes: ['receive'], eventSubtypes: ['none'] });
+      await nextTick();
+
+      expect(get(filters).eventSubtypes).toEqual(['none']);
+    });
+
+    it('preserves valid event subtypes once mapping loads', async () => {
+      set(globalMappingData, {});
+
+      const { filters } = useHistoryEventFilter({});
+
+      set(filters, { eventTypes: ['receive'], eventSubtypes: ['none'] });
+      await nextTick();
+
+      set(globalMappingData, getMockGlobalMapping());
+      await nextTick();
+
+      expect(get(filters).eventSubtypes).toEqual(['none']);
+    });
+
+    it('strips invalid event subtypes once mapping loads', async () => {
+      set(globalMappingData, {});
+
+      const { filters } = useHistoryEventFilter({});
+
+      set(filters, { eventTypes: ['receive'], eventSubtypes: ['invalid_subtype'] });
+      await nextTick();
+
+      set(globalMappingData, getMockGlobalMapping());
+      await nextTick();
+
+      expect(get(filters).eventSubtypes).toBeUndefined();
+    });
+
+    it('keeps valid subtypes and strips invalid ones from a mixed set', async () => {
+      set(globalMappingData, getMockGlobalMapping());
+
+      const { filters } = useHistoryEventFilter({});
+
+      set(filters, { eventTypes: ['receive'], eventSubtypes: ['none', 'invalid_subtype'] });
+      await nextTick();
+
+      expect(get(filters).eventSubtypes).toEqual(['none']);
+    });
+
+    it('strips subtypes not valid for the selected event type', async () => {
+      set(globalMappingData, getMockGlobalMapping());
+
+      const { filters } = useHistoryEventFilter({});
+
+      // 'spend' is a valid subtype of 'trade' but not of 'receive'
+      set(filters, { eventTypes: ['receive'], eventSubtypes: ['spend'] });
+      await nextTick();
+
+      expect(get(filters).eventSubtypes).toBeUndefined();
+    });
+
+    it('provides event_subtype matcher with correct suggestions', async () => {
+      set(globalMappingData, getMockGlobalMapping());
+
+      const { filters, matchers } = useHistoryEventFilter({ period: true });
+
+      set(filters, { eventTypes: ['receive'] });
+      await nextTick();
+
+      const subtypeMatcher = get(matchers).find(m => m.key === 'event_subtype');
+      expect(subtypeMatcher).toBeDefined();
+      assert('string' in subtypeMatcher!);
+
+      const suggestions = subtypeMatcher.suggestions();
+      expect(suggestions).toContain('none');
+      expect(suggestions).toContain('reward');
+      expect(suggestions).toContain('airdrop');
+      expect(suggestions).not.toContain('fee');
+    });
+  });
+});

--- a/frontend/app/src/composables/filters/events.ts
+++ b/frontend/app/src/composables/filters/events.ts
@@ -3,7 +3,6 @@ import type { FilterSchema } from '@/composables/use-pagination-filter/types';
 import type {
   MatchedKeywordWithBehaviour,
   SearchMatcher,
-
 } from '@/types/filtering';
 import {
   HistoryEventEntryType,
@@ -83,6 +82,55 @@ export function useHistoryEventFilter(
   const { assetInfo, assetSearch } = useAssetInfoRetrieval();
   const { associatedLocations } = storeToRefs(useHistoryStore());
   const { t } = useI18n({ useScope: 'global' });
+
+  const validSubtypeKeys = computed<string[]>(() => {
+    if (disabled.eventSubtypes)
+      return [];
+
+    const globalMapping = get(historyEventTypeGlobalMapping);
+    if (Object.keys(globalMapping).length === 0)
+      return [];
+
+    let selectedEventTypes = get(filters)?.eventTypes || [];
+    if (!Array.isArray(selectedEventTypes))
+      selectedEventTypes = [selectedEventTypes.toString()];
+
+    const keys: string[] = [];
+    if (selectedEventTypes.length > 0) {
+      selectedEventTypes.forEach((selectedEventType) => {
+        const globalMappingFound = globalMapping[selectedEventType];
+        if (globalMappingFound)
+          keys.push(...Object.keys(globalMappingFound));
+      });
+    }
+    else {
+      for (const key in globalMapping)
+        keys.push(...Object.keys(globalMapping[key]));
+    }
+
+    return keys;
+  });
+
+  watch(validSubtypeKeys, (keys) => {
+    if (keys.length === 0)
+      return;
+
+    let selectedEventSubtypes = get(filters)?.eventSubtypes || [];
+    if (!Array.isArray(selectedEventSubtypes))
+      selectedEventSubtypes = [selectedEventSubtypes.toString()];
+
+    if (selectedEventSubtypes.length === 0)
+      return;
+
+    const filteredEventSubtypes = selectedEventSubtypes.filter(item => keys.includes(item));
+
+    if (!isEqual(filteredEventSubtypes, selectedEventSubtypes)) {
+      set(filters, {
+        ...get(filters),
+        eventSubtypes: filteredEventSubtypes.length > 0 ? filteredEventSubtypes : undefined,
+      });
+    }
+  });
 
   const matchers = computed<Matcher[]>(() => {
     const selectedLocation = get(filters)?.location;
@@ -202,50 +250,17 @@ export function useHistoryEventFilter(
         });
       }
 
-      let selectedEventTypes = get(filters)?.eventTypes || [];
-      if (!Array.isArray(selectedEventTypes))
-        selectedEventTypes = [selectedEventTypes.toString()];
-
       if (!disabled.eventSubtypes) {
-        const globalMapping = get(historyEventTypeGlobalMapping);
-
-        const globalMappingKeys: string[] = [];
-        if (selectedEventTypes.length > 0) {
-          selectedEventTypes.forEach((selectedEventType) => {
-            const globalMappingFound = globalMapping[selectedEventType];
-            if (globalMappingFound)
-              globalMappingKeys.push(...Object.keys(globalMappingFound));
-          });
-        }
-        else {
-          for (const key in globalMapping)
-            globalMappingKeys.push(...Object.keys(globalMapping[key]));
-        }
-
-        let selectedEventSubtypes = get(filters)?.eventSubtypes || [];
-        if (!Array.isArray(selectedEventSubtypes))
-          selectedEventSubtypes = [selectedEventSubtypes.toString()];
-
-        if (selectedEventSubtypes.length > 0) {
-          const filteredEventSubtypes = selectedEventSubtypes.filter(item => globalMappingKeys.includes(item));
-
-          if (!isEqual(filteredEventSubtypes, selectedEventSubtypes)) {
-            set(filters, {
-              ...get(filters),
-              eventSubtypes: filteredEventSubtypes.length > 0 ? filteredEventSubtypes : undefined,
-            });
-          }
-        }
-
+        const subtypeKeys = get(validSubtypeKeys);
         data.push({
           description: t('transactions.filter.event_subtype'),
           key: HistoryEventFilterKeys.EVENT_SUBTYPE,
           keyValue: HistoryEventFilterValueKeys.EVENT_SUBTYPE,
           multiple: true,
           string: true,
-          suggestions: () => globalMappingKeys.filter(uniqueStrings),
+          suggestions: () => subtypeKeys.filter(uniqueStrings),
           suggestionsToShow: -1,
-          validate: (type: string) => globalMappingKeys.includes(type),
+          validate: (type: string) => subtypeKeys.includes(type),
         });
       }
     }

--- a/frontend/app/tests/e2e/specs/history/history-events.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/history-events.spec.ts
@@ -504,3 +504,51 @@ test.describe.serial('evm history events', () => {
     }).toPass({ timeout: 10000 });
   });
 });
+
+test.describe.serial('history event filter persistence', () => {
+  let ctx: SharedTestContext;
+  let page: HistoryEventsPage;
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request);
+    page = new HistoryEventsPage(ctx.sharedPage);
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('event_subtype=none filter persists after navigation', async () => {
+    await ctx.app.checkGetPremiumButton();
+    await page.visit();
+    await waitForNoRunningTasks(ctx.sharedPage);
+
+    // Apply event_type and event_subtype filters
+    await page.applyTableFilter('event_type', 'receive');
+    await page.applyTableFilter('event_subtype', 'none');
+
+    // Verify filters are in the URL
+    await expect(async () => {
+      const url = ctx.sharedPage.url();
+      expect(url).toContain('eventTypes=receive');
+      expect(url).toContain('eventSubtypes=none');
+    }).toPass({ timeout: 5000 });
+
+    // Navigate to dashboard
+    await RotkiApp.navigateTo(ctx.sharedPage, 'dashboard');
+    await expect(async () => {
+      expect(ctx.sharedPage.url()).toContain('/dashboard');
+    }).toPass({ timeout: 10000 });
+
+    // Navigate back to history events
+    await page.visit();
+    await waitForNoRunningTasks(ctx.sharedPage);
+
+    // Verify both filters are restored in the URL
+    await expect(async () => {
+      const url = ctx.sharedPage.url();
+      expect(url).toContain('eventTypes=receive');
+      expect(url).toContain('eventSubtypes=none');
+    }).toPass({ timeout: 10000 });
+  });
+});

--- a/frontend/app/tests/unit/specs/composables/filters/use-history-event-filter.spec.ts
+++ b/frontend/app/tests/unit/specs/composables/filters/use-history-event-filter.spec.ts
@@ -49,6 +49,8 @@ describe('composables::filter/use-history-event-filter - Additional Tests', () =
       eventTypes: ref([]),
       eventSubTypes: ref([]),
       getEventTypeData: vi.fn().mockReturnValue(computed(() => undefined)),
+      historyEventTypeGlobalMapping: ref({}),
+      historyEventTypes: computed<string[]>(() => []),
     });
     const { connected } = storeToRefs(useMainStore());
     set(connected, true);


### PR DESCRIPTION
## Summary
- Move subtype validation from a side effect inside the `matchers` computed into a dedicated `watch` on `validSubtypeKeys`
- The computed ran before the global mapping was loaded (due to `createSharedComposable` resetting on unmount), stripping valid subtypes like `none` when restoring filters after navigation
- The watch only validates once the mapping data is available, preventing premature removal of valid filter values

Closes #11901

## Test plan
- [x] Unit tests for subtype validation timing (6 tests in `events.spec.ts`)
- [x] E2E test: apply `event_type=receive` + `event_subtype=none`, navigate to dashboard and back, verify both filters persist
- [x] E2E test passes 3/3 runs consistently