### PR TITLE
fix(frontend): show redecode for linked movements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`11908` Individual pending task items now show a static icon instead of an indeterminate spinner, reducing visual noise when many tasks are running.
+* :bug:`11902` The redecode option is now available for exchange withdrawals with a linked on-chain transaction.
 * :feature:`11896` Indexer limitation warnings are now shown in the EVM Indexer Order settings for Optimism (Blockscout pre-Bedrock gaps) and Base (Blockscout as only free indexer).
 * :bug:`11901` The event_subtype filter (e.g. subtype=None) is no longer lost when navigating away from the history events page and back.
 * :bug:`-` Assets in the same collection now share cost basis, preventing false missing acquisition errors when the same asset is tracked under different identifiers.

--- a/frontend/app/src/components/history/events/HistoryEventsAction.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsAction.vue
@@ -34,6 +34,7 @@ import {
 
 const props = defineProps<{
   event: HistoryEventEntry;
+  groupEvents?: HistoryEventEntry[];
   loading: boolean;
   duplicateHandlingStatus?: DuplicateHandlingStatus;
 }>();
@@ -80,7 +81,29 @@ const solanaEvent = computed<SolanaEvent | SolanaSwapEvent | undefined>(() => {
   return undefined;
 });
 
-const eventWithDecoding = computed<DecodableEventType | undefined>(() => get(evmEvent) || get(solanaEvent));
+const eventWithDecoding = computed<DecodableEventType | undefined>(() => {
+  const direct = get(evmEvent) || get(solanaEvent);
+  if (direct)
+    return direct;
+
+  if (!props.groupEvents)
+    return undefined;
+
+  for (const child of props.groupEvents) {
+    if (isEvmEvent(child) || isEvmSwapEvent(child) || isSolanaEvent(child) || isSolanaSwapEvent(child))
+      return child;
+  }
+
+  return undefined;
+});
+
+const decodableEvmEvent = computed<EvmHistoryEvent | EvmSwapEvent | undefined>(() => {
+  const decoded = get(eventWithDecoding);
+  if (decoded && (isEvmEvent(decoded) || isEvmSwapEvent(decoded)))
+    return decoded;
+
+  return undefined;
+});
 
 const eventWithTxRef = computed<{ location: string; txRef: string } | undefined>(() => {
   const currentEvent = get(event);
@@ -279,7 +302,7 @@ function confirmIgnoreDuplicate(): void {
         <template v-else-if="eventWithDecoding">
           <RuiButton
             variant="list"
-            :class="{ '!py-2': evmEvent }"
+            :class="{ '!py-2': decodableEvmEvent }"
             :disabled="loading || txEventsDecoding"
             @click="redecode(eventWithDecoding)"
           >
@@ -293,7 +316,7 @@ function confirmIgnoreDuplicate(): void {
             {{ t('transactions.actions.redecode_events') }}
             <template #append>
               <RuiTooltip
-                v-if="evmEvent"
+                v-if="decodableEvmEvent"
                 :popper="{ placement: 'top', scroll: false, resize: false }"
               >
                 <template #activator>
@@ -303,7 +326,7 @@ function confirmIgnoreDuplicate(): void {
                     size="sm"
                     class="!p-2"
                     :disabled="loading || txEventsDecoding"
-                    @click.stop="redecodeWithOptions(evmEvent)"
+                    @click.stop="redecodeWithOptions(decodableEvmEvent)"
                   >
                     <RuiIcon
                       name="lu-settings-2"

--- a/frontend/app/src/components/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Account, Blockchain, HistoryEventEntryType } from '@rotki/common';
+import type { PullLocationTransactionPayload } from '@/types/history/events';
 import type { HistoryEventEntry, HistoryEventRow } from '@/types/history/events/schemas';
 import RefreshButton from '@/components/helper/RefreshButton.vue';
 import { DIALOG_TYPES, type DialogShowOptions, type HistoryEventsToggles } from '@/components/history/events/dialog-types';
@@ -18,7 +19,6 @@ import { useHistoryEventsDeletion } from '@/modules/history/events/composables/u
 import { useHistoryEventsSelectionActions } from '@/modules/history/events/composables/use-history-events-selection-actions';
 import { useHistoryEventsSelectionMode } from '@/modules/history/events/composables/use-selection-mode';
 import { useHistoryEventsStatus } from '@/modules/history/events/use-history-events-status';
-import { useHistoryStore } from '@/store/history';
 
 defineOptions({ inheritAttrs: false });
 
@@ -143,6 +143,7 @@ const actions = useHistoryEventsActions({
   entryTypes,
   fetchData,
   groups,
+  mainPage,
   onlyChains,
   shouldFetchEventsRegularly,
 });
@@ -176,9 +177,7 @@ const {
 });
 
 const debouncedProcessing = refDebounced(processing, 200);
-const { autoMatchLoading, refreshUnmatchedAssetMovements } = useUnmatchedAssetMovements();
-
-const { eventsModificationCounter } = storeToRefs(useHistoryStore());
+const { autoMatchLoading, autoMatchMovement, refreshUnmatchedAssetMovements } = useUnmatchedAssetMovements();
 useHistoryEventNavigationConsumer(pagination, pageParams, groupLoading);
 const backgroundLoading = logicOr(debouncedProcessing, autoMatchLoading);
 
@@ -194,8 +193,13 @@ function handleUpdateEventIds({ eventIds, groupedEvents, rawEvents }: { eventIds
   set(originalGroups, rawEvents || get(groups).data);
 }
 
-function openMatchAssetMovementsDialog(): void {
-  get(dialogContainer)?.show({ type: DIALOG_TYPES.MATCH_ASSET_MOVEMENTS });
+async function handleRedecode(event?: PullLocationTransactionPayload): Promise<void> {
+  await actions.fetch.dataAndRedecode(event);
+  if (event?.linkedMovement) {
+    const matched = await autoMatchMovement(event.linkedMovement);
+    if (matched)
+      await actions.fetch.dataAndLocations();
+  }
 }
 
 async function handleMovementChanged(): Promise<void> {
@@ -225,12 +229,6 @@ watchImmediate(route, async ({ query }) => {
 
 watch(backgroundLoading, async (isLoading, wasLoading) => {
   if (!isLoading && wasLoading)
-    await actions.fetch.dataAndLocations();
-});
-
-// Refresh when events are modified (e.g., from pinned sidebar matching)
-watch(eventsModificationCounter, async (current, previous) => {
-  if (props.mainPage && current > previous)
     await actions.fetch.dataAndLocations();
 });
 
@@ -269,7 +267,7 @@ watchDebounced(route, async () => {
           v-model:show="showAlerts"
           :processing="processing"
           :main-page="mainPage"
-          @open:match-asset-movements="openMatchAssetMovementsDialog()"
+          @open:match-asset-movements="dialogContainer?.show({ type: DIALOG_TYPES.MATCH_ASSET_MOVEMENTS })"
           @open:internal-tx-conflicts="dialogContainer?.show({ type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS })"
         />
 
@@ -330,7 +328,7 @@ watchDebounced(route, async () => {
             :duplicate-handling-status="duplicateHandlingStatus"
             @clear-filters="clearFilters()"
             @show:dialog="dialogContainer?.show($event)"
-            @refresh="actions.fetch.dataAndRedecode($event)"
+            @refresh="handleRedecode($event)"
             @refresh:block-event="actions.redecode.blocks($event)"
             @set-page="setPage($event)"
             @update-event-ids="handleUpdateEventIds($event)"

--- a/frontend/app/src/composables/history/events/use-history-events-actions.ts
+++ b/frontend/app/src/composables/history/events/use-history-events-actions.ts
@@ -35,6 +35,7 @@ interface UseHistoryEventsActionsOptions {
   currentAction: Ref<HistoryEventAction>;
   fetchData: () => Promise<void>;
   groups: Ref<Collection<HistoryEventRow>>;
+  mainPage?: Ref<boolean>;
   shouldFetchEventsRegularly?: Ref<boolean>;
   showDialog?: (options: { type: 'decodingStatus'; persistent?: boolean }) => Promise<void>;
 }
@@ -66,6 +67,7 @@ export function useHistoryEventsActions(options: UseHistoryEventsActionsOptions)
     entryTypes,
     fetchData: fetchEventsData,
     groups,
+    mainPage,
     onlyChains,
     shouldFetchEventsRegularly,
     showDialog,
@@ -84,11 +86,13 @@ export function useHistoryEventsActions(options: UseHistoryEventsActionsOptions)
 
   const { show } = useConfirmStore();
   const { notify } = useNotificationsStore();
+  const historyStore = useHistoryStore();
   const {
     fetchAssociatedLocations,
     fetchLocationLabels,
     resetUndecodedTransactionsStatus,
-  } = useHistoryStore();
+  } = historyStore;
+  const { eventsModificationCounter } = storeToRefs(historyStore);
   const { refreshTransactions } = useHistoryTransactions();
   const {
     fetchUndecodedTransactionsStatus,
@@ -197,6 +201,14 @@ export function useHistoryEventsActions(options: UseHistoryEventsActionsOptions)
   // Set up auto-fetch functionality if shouldFetchEventsRegularly is provided
   if (shouldFetchEventsRegularly) {
     useHistoryEventsAutoFetch(shouldFetchEventsRegularly, fetchDataAndLocations);
+  }
+
+  // Refresh when events are modified (e.g., from pinned sidebar matching)
+  if (mainPage) {
+    watch(eventsModificationCounter, async (current, previous) => {
+      if (get(mainPage) && current > previous)
+        await fetchDataAndLocations();
+    });
   }
 
   // Dialog handlers

--- a/frontend/app/src/composables/history/events/use-unmatched-asset-movements.ts
+++ b/frontend/app/src/composables/history/events/use-unmatched-asset-movements.ts
@@ -1,5 +1,6 @@
 import type { ComputedRef, Ref } from 'vue';
 import type { ActionStatus } from '@/types/action';
+import type { LinkedMovementMatch } from '@/types/history/events';
 import type { HistoryEventCollectionRow, HistoryEventEntry } from '@/types/history/events/schemas';
 import type { TaskMeta } from '@/types/task';
 import { useHistoryEventsApi } from '@/composables/api/history/events';
@@ -39,6 +40,7 @@ interface UseUnmatchedAssetMovementsReturn {
   autoMatchLoading: ComputedRef<boolean>;
   autoMatchMinimumTier: ComputedRef<string | null>;
   isAutoMatchAllowed: ComputedRef<boolean>;
+  autoMatchMovement: (linkedMovement: LinkedMovementMatch) => Promise<boolean>;
   fetchUnmatchedAssetMovements: (onlyIgnored?: boolean) => Promise<void>;
   matchAssetMovement: (assetMovementId: number, matchedEventIds: number[]) => Promise<ActionStatus>;
   refreshUnmatchedAssetMovements: (skipIgnored?: boolean) => Promise<void>;
@@ -59,6 +61,7 @@ export const useUnmatchedAssetMovements = createSharedComposable((): UseUnmatche
 
   const { fetchHistoryEvents } = useHistoryEventsApi();
   const {
+    getAssetMovementMatches,
     getUnmatchedAssetMovements,
     matchAssetMovements: matchAssetMovementsApi,
     triggerAssetMovementMatching,
@@ -207,8 +210,19 @@ export const useUnmatchedAssetMovements = createSharedComposable((): UseUnmatche
     }
   };
 
+  async function autoMatchMovement(linkedMovement: LinkedMovementMatch): Promise<boolean> {
+    const { groupIdentifier, identifier, timeRange, tolerance } = linkedMovement;
+    const suggestions = await getAssetMovementMatches(groupIdentifier, timeRange, false, tolerance);
+    if (suggestions.closeMatches.length > 0) {
+      await matchAssetMovementsApi(identifier, suggestions.closeMatches);
+      return true;
+    }
+    return false;
+  }
+
   return {
     autoMatchLoading,
+    autoMatchMovement,
     autoMatchMinimumTier: assetMovementMatchingMinimumTier,
     fetchUnmatchedAssetMovements,
     isAutoMatchAllowed: isAssetMovementMatchingAllowed,

--- a/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
@@ -109,6 +109,7 @@ const isCard = computed<boolean>(() => props.variant === 'card');
       <HistoryEventsAction
         v-if="!hideActions"
         :event="group"
+        :group-events="groupEvents"
         :loading="loading"
         :duplicate-handling-status="duplicateHandlingStatus"
         class="shrink-0"
@@ -215,6 +216,7 @@ const isCard = computed<boolean>(() => props.variant === 'card');
     <HistoryEventsAction
       v-if="!hideActions"
       :event="group"
+      :group-events="groupEvents"
       :loading="loading"
       :duplicate-handling-status="duplicateHandlingStatus"
       class="shrink-0"

--- a/frontend/app/src/modules/history/events/composables/use-history-events-operations.ts
+++ b/frontend/app/src/modules/history/events/composables/use-history-events-operations.ts
@@ -1,6 +1,7 @@
 import type { ComputedRef, Ref } from 'vue';
 import type { HistoryEventDeletePayload, HistoryEventsTableEmitFn, HistoryEventUnlinkPayload } from '@/modules/history/events/types';
 import type {
+  LinkedMovementMatch,
   LocationAndTxRef,
   PullEventPayload,
 } from '@/types/history/events';
@@ -15,6 +16,7 @@ import { useIgnore } from '@/composables/history';
 import { useHistoryEvents } from '@/composables/history/events';
 import { useUnmatchedAssetMovements } from '@/composables/history/events/use-unmatched-asset-movements';
 import { useSupportedChains } from '@/composables/info/chains';
+import { Defaults } from '@/data/defaults';
 import { useCompleteEvents } from '@/modules/history/events/composables/use-complete-events';
 import { useConfirmStore } from '@/store/confirm';
 import { useNotificationsStore } from '@/store/notifications';
@@ -58,6 +60,7 @@ export function useHistoryEventsOperations(
   const redecodePayload = ref<PullEventPayload>();
   const hasCustomEvents = ref<boolean>(false);
   const showIndexerOptions = ref<boolean>(false);
+  const pendingLinkedMovement = ref<LinkedMovementMatch>();
 
   const { t } = useI18n({ useScope: 'global' });
 
@@ -74,6 +77,40 @@ export function useHistoryEventsOperations(
   }, selected, () => {
     emit('refresh');
   });
+
+  function buildLinkedMovement(movementEvent: HistoryEventEntry, groupEvents: HistoryEventEntry[]): LinkedMovementMatch {
+    const nonMovementEvents = groupEvents.filter(item => !isAssetMovementEvent(item) && item.eventSubtype !== 'fee');
+    const movementTimestamp = movementEvent.timestamp;
+    const movementAmount = movementEvent.amount;
+
+    const defaultTimeRange = Defaults.ASSET_MOVEMENT_TIME_RANGE;
+    const defaultTolerance = Defaults.ASSET_MOVEMENT_AMOUNT_TOLERANCE;
+
+    let timeRange: number = defaultTimeRange;
+    let tolerance: string = defaultTolerance;
+
+    if (nonMovementEvents.length > 0) {
+      const timeDiffs = nonMovementEvents.map(e => Math.abs(e.timestamp - movementTimestamp));
+      timeRange = Math.max(Math.max(...timeDiffs, 60) * 2, defaultTimeRange);
+
+      const amountDiffs = nonMovementEvents
+        .map(e => movementAmount.minus(e.amount).abs().div(movementAmount))
+        .filter(d => d.isFinite());
+
+      if (amountDiffs.length > 0) {
+        const maxDiff = amountDiffs.reduce((a, b) => (a.gt(b) ? a : b));
+        const computed = maxDiff.multipliedBy(2).toFixed(6);
+        tolerance = computed > defaultTolerance ? computed : defaultTolerance;
+      }
+    }
+
+    return {
+      groupIdentifier: movementEvent.actualGroupIdentifier || movementEvent.groupIdentifier,
+      identifier: movementEvent.identifier,
+      timeRange,
+      tolerance,
+    };
+  }
 
   function getItemClass(item: HistoryEventEntry): '' | 'opacity-50' {
     return item.ignoredInAccounting ? 'opacity-50' : '';
@@ -195,7 +232,9 @@ export function useHistoryEventsOperations(
       return;
     }
 
-    const isAnyCustom = getGroupEvents(groupIdentifier).some(item => isCustomizedEvent(item));
+    const groupEvents = getGroupEvents(groupIdentifier);
+    const isAnyCustom = groupEvents.some(item => isCustomizedEvent(item));
+    const movementEvent = groupEvents.find(item => isAssetMovementEvent(item));
 
     // If there are custom events, show dialog to ask about custom event handling
     if (isAnyCustom) {
@@ -209,6 +248,7 @@ export function useHistoryEventsOperations(
     // No custom events - just redecode directly without dialog
     emit('refresh', {
       deleteCustom: false,
+      linkedMovement: movementEvent ? buildLinkedMovement(movementEvent, groupEvents) : undefined,
       transactions: [payload.data],
     });
   }
@@ -219,7 +259,10 @@ export function useHistoryEventsOperations(
       return;
     }
 
-    const isAnyCustom = getGroupEvents(eventIdentifier).some(item => isCustomizedEvent(item));
+    const groupEvents = getGroupEvents(eventIdentifier);
+    const isAnyCustom = groupEvents.some(item => isCustomizedEvent(item));
+    const movementEvent = groupEvents.find(item => isAssetMovementEvent(item));
+    set(pendingLinkedMovement, movementEvent ? buildLinkedMovement(movementEvent, groupEvents) : undefined);
 
     // Show dialog with indexer options (only for EVM events)
     set(hasCustomEvents, isAnyCustom);
@@ -239,10 +282,12 @@ export function useHistoryEventsOperations(
       emit('refresh', {
         customIndexersOrder,
         deleteCustom,
+        linkedMovement: get(pendingLinkedMovement),
         transactions: [payload.data],
       });
     }
     set(redecodePayload, undefined);
+    set(pendingLinkedMovement, undefined);
   }
 
   return {

--- a/frontend/app/src/types/history/events/index.ts
+++ b/frontend/app/src/types/history/events/index.ts
@@ -23,10 +23,18 @@ export interface TransactionRequestPayload {
   readonly accounts: BlockchainAddress[];
 }
 
+export interface LinkedMovementMatch {
+  readonly identifier: number;
+  readonly groupIdentifier: string;
+  readonly timeRange: number;
+  readonly tolerance: string;
+}
+
 export interface PullLocationTransactionPayload {
   readonly transactions: LocationAndTxRef[];
   readonly deleteCustom?: boolean;
   readonly customIndexersOrder?: string[];
+  readonly linkedMovement?: LinkedMovementMatch;
 }
 
 export interface PullEthBlockEventPayload {


### PR DESCRIPTION
## Summary
- Show the redecode (and redecode with options) menu item for exchange withdrawals/deposits that have a linked on-chain transaction
- The fix scans group child events for a decodable event (EVM/Solana) when the header event itself is not decodable (e.g. `AssetMovementEvent`)
- Pass `groupEvents` to `HistoryEventsAction` in both card and row layouts of `HistoryEventsGroupItem`

Closes #11902

## Test plan
- [ ] Find a withdraw from an exchange that has been matched with an on-chain transaction
- [ ] Click the three-dot menu on the group header
- [ ] Verify "Redecode" option appears with the settings (redecode with options) button
- [ ] Verify redecoding works correctly