### PR TITLE
fix(frontend): reduce indeterminate loaders in pending tasks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11908` Individual pending task items now show a static icon instead of an indeterminate spinner, reducing visual noise when many tasks are running.
 * :feature:`11896` Indexer limitation warnings are now shown in the EVM Indexer Order settings for Optimism (Blockscout pre-Bedrock gaps) and Base (Blockscout as only free indexer).
 * :bug:`11901` The event_subtype filter (e.g. subtype=None) is no longer lost when navigating away from the history events page and back.
 * :bug:`-` Assets in the same collection now share cost basis, preventing false missing acquisition errors when the same asset is tracked under different identifiers.

--- a/frontend/app/src/components/status/notifications/PendingTask.vue
+++ b/frontend/app/src/components/status/notifications/PendingTask.vue
@@ -17,7 +17,7 @@ const { progress: taskProgress } = storeToRefs(useReportsStore());
 const { historicalDailyPriceStatus } = storeToRefs(useHistoricCachePriceStore());
 const { t } = useI18n({ useScope: 'global' });
 
-const hasDeterminateProgress = computed(() => {
+const hasDeterminateProgress = computed<boolean>(() => {
   const { type } = get(task);
   return type === TaskType.TRADE_HISTORY || type === TaskType.FETCH_DAILY_HISTORIC_PRICE;
 });
@@ -57,13 +57,20 @@ const progress = computed<number | undefined>(() => {
       </div>
     </div>
     <RuiProgress
+      v-if="hasDeterminateProgress"
       color="primary"
       circular
-      :variant="hasDeterminateProgress ? 'determinate' : 'indeterminate'"
+      variant="determinate"
       :value="progress"
       size="24"
-      :show-label="hasDeterminateProgress"
+      show-label
       thickness="2"
+    />
+    <RuiIcon
+      v-else
+      name="lu-loader"
+      size="20"
+      class="text-rui-text-secondary shrink-0"
     />
     <RuiTooltip
       :popper="{ placement: 'top' }"


### PR DESCRIPTION
## Summary
- Replace indeterminate circular spinners on individual pending task items with a static `lu-loader` icon
- Determinate progress tasks (`TRADE_HISTORY`, `FETCH_DAILY_HISTORIC_PRICE`) keep their circular progress with percentage label unchanged
- The group header in `CollapsedPendingTasks` keeps its indeterminate spinner unchanged

Used `lu-loader` as the static icon since it visually conveys "processing" without adding animation noise.

Closes #11908

## Test plan
- [ ] Open the pending tasks panel while multiple tasks are running
- [ ] Verify indeterminate tasks show a static loader icon instead of a spinning progress
- [ ] Verify determinate tasks (e.g. trade history) still show circular progress with percentage
- [ ] Verify the group header still shows its indeterminate spinner