### PR TITLE
refactor(frontend): move plan chip to user dropdown

### DIFF
--- a/frontend/app/src/components/UserDropdown.vue
+++ b/frontend/app/src/components/UserDropdown.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { externalLinks } from '@shared/external-links';
+import ExternalLink from '@/components/helper/ExternalLink.vue';
 import MenuTooltipButton from '@/components/helper/MenuTooltipButton.vue';
 import { useInterop } from '@/composables/electron-interop';
+import { usePremiumHelper } from '@/composables/premium';
 import { usePrivacyMode } from '@/composables/privacy';
 import { useRememberSettings } from '@/composables/user/use-remember-settings';
 import { useLogout } from '@/modules/account/use-logout';
@@ -17,6 +20,12 @@ const { privacyModeIcon, togglePrivacyMode } = usePrivacyMode();
 const { isXs } = useBreakpoint();
 
 const { savedRememberPassword } = useRememberSettings();
+const { currentTier, premium } = usePremiumHelper();
+
+const tierLabel = computed<string>(() => {
+  const tier = get(currentTier);
+  return tier ? t('premium_placeholder.current_plan', { tier }) : '';
+});
 
 const { show } = useConfirmStore();
 
@@ -59,11 +68,27 @@ const { isDark } = useRotkiTheme();
         data-cy="user-dropdown"
         class="py-2"
       >
-        <div
-          data-cy="username"
-          class="py-3 font-bold text-center"
-        >
-          {{ username }}
+        <div class="py-3 flex flex-col items-center gap-1">
+          <div
+            data-cy="username"
+            class="font-bold"
+          >
+            {{ username }}
+          </div>
+          <ExternalLink
+            v-if="premium && tierLabel"
+            custom
+            :url="externalLinks.manageSubscriptions"
+          >
+            <RuiChip
+              size="sm"
+              variant="outlined"
+              color="primary"
+              class="!cursor-pointer"
+            >
+              {{ tierLabel }}
+            </RuiChip>
+          </ExternalLink>
         </div>
         <RuiDivider />
         <RouterLink :to="{ path: '/settings' }">

--- a/frontend/app/src/components/premium/GetPremiumButton.vue
+++ b/frontend/app/src/components/premium/GetPremiumButton.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { externalLinks } from '@shared/external-links';
 import ExternalLink from '@/components/helper/ExternalLink.vue';
 import { usePremiumHelper } from '@/composables/premium';
 
@@ -8,17 +7,15 @@ const { hideOnSmallScreen = false } = defineProps<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const { currentTier, premium } = usePremiumHelper();
+const { premium } = usePremiumHelper();
 const { isLgAndDown } = useBreakpoint();
-
-const tierLabel = computed<string>(() => {
-  const tier = get(currentTier);
-  return tier ? t('premium_placeholder.current_plan', { tier }) : t('premium_placeholder.upgrade_plan');
-});
 </script>
 
 <template>
-  <div class="mr-2">
+  <div
+    v-if="!premium"
+    class="mr-2"
+  >
     <RuiTooltip
       :popper="{ placement: 'bottom' }"
       :disabled="!(isLgAndDown && hideOnSmallScreen)"
@@ -26,7 +23,6 @@ const tierLabel = computed<string>(() => {
     >
       <template #activator>
         <ExternalLink
-          v-if="!premium"
           custom
           premium
         >
@@ -43,23 +39,8 @@ const tierLabel = computed<string>(() => {
             {{ t('premium_settings.get') }}
           </RuiButton>
         </ExternalLink>
-        <ExternalLink
-          v-else
-          custom
-          :url="externalLinks.manageSubscriptions"
-        >
-          <RuiChip
-            size="sm"
-            variant="outlined"
-            color="primary"
-            data-cy="get-premium-button"
-            class="!cursor-pointer"
-          >
-            {{ tierLabel }}
-          </RuiChip>
-        </ExternalLink>
       </template>
-      <span>{{ premium ? tierLabel : t('premium_settings.get') }}</span>
+      <span>{{ t('premium_settings.get') }}</span>
     </RuiTooltip>
   </div>
 </template>

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -4698,8 +4698,7 @@
   "premium_placeholder": {
     "current_plan": "{tier} plan",
     "free_description": "This feature requires a minimum of {tier} tier.",
-    "premium_description": "This feature requires a minimum of {tier} tier. Your current tier is {currentTier}.",
-    "upgrade_plan": "Upgrade plan"
+    "premium_description": "This feature requires a minimum of {tier} tier. Your current tier is {currentTier}."
   },
   "premium_settings": {
     "actions": {

--- a/frontend/app/tests/unit/specs/components/premium/get-premium-button.spec.ts
+++ b/frontend/app/tests/unit/specs/components/premium/get-premium-button.spec.ts
@@ -33,7 +33,7 @@ describe('getPremiumButton.vue', () => {
     expect(button.text()).toContain('premium_settings.get');
   });
 
-  it('should show upgrade plan button for premium users', () => {
+  it('should not render for premium users', () => {
     store = usePremiumStore();
     const { premium } = storeToRefs(store);
     set(premium, true);
@@ -41,7 +41,6 @@ describe('getPremiumButton.vue', () => {
     wrapper = createWrapper();
 
     const button = wrapper.find('[data-cy=get-premium-button]');
-    expect(button.exists()).toBeTruthy();
-    expect(button.text()).toContain('premium_placeholder.current_plan');
+    expect(button.exists()).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary
- Move the subscription tier chip from the top bar into the user dropdown menu under the username
- The "Get Premium" button remains visible in the top bar for non-premium users
- Simplify `GetPremiumButton` component — only renders for non-premium users
- Remove unused `upgrade_plan` locale key

## Test plan
- [ ] Verify non-premium users still see "Get Premium" button in the top bar
- [ ] Verify premium users see the tier chip (e.g., "P1 plan") under their username in the dropdown
- [ ] Verify clicking the tier chip opens the manage subscriptions page