### PR TITLE
Optimize internal tx conflicts query

### DIFF
--- a/rotkehlchen/data_migrations/migrations/migration_24.py
+++ b/rotkehlchen/data_migrations/migrations/migration_24.py
@@ -19,14 +19,18 @@ if TYPE_CHECKING:
 
 @enter_exit_debug_log()
 def data_migration_24(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressHandler') -> None:
-    """Introduced at v1.43.0
+    """Introduced at v1.42.1
     - Create and populate internal tx conflict queue
     - Locally fix non-customized fix_redecode conflicts and queue txs for redecoding
     """
-    @progress_step(description='Creating internal tx conflict table')
+    @progress_step(description='Creating internal tx conflict table and indexes')
     def _create_table(rotki: 'Rotkehlchen') -> None:
         with rotki.data.db.conn.write_ctx() as write_cursor:
             write_cursor.execute(DB_CREATE_EVM_INTERNAL_TX_CONFLICTS)
+            write_cursor.execute(
+                'CREATE INDEX IF NOT EXISTS idx_chain_events_info_tx_ref '
+                'ON chain_events_info(tx_ref)',
+            )
 
     @progress_step(description='Populating internal tx conflicts')
     def _populate_conflicts(rotki: 'Rotkehlchen') -> None:

--- a/rotkehlchen/db/internal_tx_conflicts.py
+++ b/rotkehlchen/db/internal_tx_conflicts.py
@@ -209,33 +209,58 @@ def get_pending_internal_tx_repull_conflicts(
     """Return internal tx conflicts with action and metadata, including the transaction timestamp."""  # noqa: E501
     base_query = (
         'SELECT c.chain, c.transaction_hash, et.timestamp, c.action, '
-        'c.repull_reason, c.redecode_reason, c.last_retry_ts, c.last_error, ('
-        'SELECT DISTINCT h.group_identifier '
-        'FROM history_events h '
-        'INNER JOIN chain_events_info ce ON h.identifier = ce.identifier '
-        'WHERE ce.tx_ref = c.transaction_hash '
-        'ORDER BY h.group_identifier'
-        ' LIMIT 1) '
+        'c.repull_reason, c.redecode_reason, c.last_retry_ts, c.last_error '
         f'FROM evm_internal_tx_conflicts c {INTERNAL_TX_CONFLICTS_JOIN}'
     )
     filter_str, bindings = filter_query.prepare()
-    entries: list[tuple[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE, EVMTxHash, int | None, str, str | None, str | None, int | None, str | None, str | None]] = []  # noqa: E501
-    for row_chain, row_tx_hash, tx_timestamp, action, repull_reason, redecode_reason, last_retry_ts, last_error, group_identifier in cursor.execute(  # noqa: E501
+    # First pass: collect rows and compute default group identifiers
+    rows: list[tuple[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE, EVMTxHash, int | None, str, str | None, str | None, int | None, str | None]] = []  # noqa: E501
+    tx_hashes: list[bytes] = []
+    for row_chain, row_tx_hash, tx_timestamp, action, repull_reason, redecode_reason, last_retry_ts, last_error in cursor.execute(  # noqa: E501
             base_query + filter_str,
             bindings,
     ):
         chain_id = ChainID.deserialize_from_db(row_chain)
         assert chain_id in EVM_CHAIN_IDS_WITH_TRANSACTIONS
-        entries.append((
+        tx_hash = deserialize_evm_tx_hash(row_tx_hash)
+        rows.append((
             cast('EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE', chain_id),
-            deserialize_evm_tx_hash(row_tx_hash),
+            tx_hash,
             tx_timestamp,
             action,
             repull_reason,
             redecode_reason,
             last_retry_ts,
             last_error,
-            group_identifier,
+        ))
+        tx_hashes.append(bytes(tx_hash))
+
+    # Single batch query to get group identifiers for all tx hashes at once.
+    group_id_map: dict[bytes, str] = {}
+    if tx_hashes:
+        placeholders = ','.join(['?'] * len(tx_hashes))
+        for tx_ref, group_id in cursor.execute(
+                'SELECT ce.tx_ref, MIN(h.group_identifier) '
+                'FROM history_events h '
+                'INNER JOIN chain_events_info ce ON h.identifier = ce.identifier '
+                f'WHERE ce.tx_ref IN ({placeholders}) '
+                'GROUP BY ce.tx_ref',
+                tx_hashes,
+        ):
+            group_id_map[bytes(tx_ref)] = group_id
+
+    entries: list[tuple[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE, EVMTxHash, int | None, str, str | None, str | None, int | None, str | None, str | None]] = []  # noqa: E501
+    for chain_id, tx_hash, tx_timestamp, action, repull_reason, redecode_reason, last_retry_ts, last_error in rows:  # noqa: E501
+        entries.append((
+            chain_id,
+            tx_hash,
+            tx_timestamp,
+            action,
+            repull_reason,
+            redecode_reason,
+            last_retry_ts,
+            last_error,
+            group_id_map.get(bytes(tx_hash)),
         ))
 
     return entries

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -968,6 +968,7 @@ CREATE INDEX IF NOT EXISTS idx_history_events_ignored ON history_events(ignored)
 CREATE INDEX IF NOT EXISTS idx_history_event_links_right ON history_event_links(right_event_id);
 CREATE INDEX IF NOT EXISTS idx_history_event_links_composite ON history_event_links(link_type, left_event_id, right_event_id);
 CREATE INDEX IF NOT EXISTS idx_history_event_link_ignores_type ON history_event_link_ignores(link_type);
+CREATE INDEX IF NOT EXISTS idx_chain_events_info_tx_ref ON chain_events_info(tx_ref);
 CREATE UNIQUE INDEX IF NOT EXISTS unique_generic_accounting_rules ON accounting_rules(type, subtype, counterparty) WHERE is_event_specific = 0;
 """  # noqa: E501
 

--- a/rotkehlchen/externalapis/etherscan_like.py
+++ b/rotkehlchen/externalapis/etherscan_like.py
@@ -561,6 +561,9 @@ class EtherscanLikeApi(ABC):
             for entry in result:
                 try:  # Handle normal transactions. Internal dict does not contain a hash sometimes
                     if is_internal or entry['hash'].startswith('GENESIS') is False:
+                        if is_internal and entry.get('callType') == 'delegatecall':
+                            log.debug(f'Skipping delegatecall internal tx {entry.get("hash")} on {chain_id.to_name()}')  # noqa: E501
+                            continue
                         tx, _ = deserialize_evm_transaction(  # type: ignore
                             data=entry,
                             internal=is_internal,

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -638,7 +638,10 @@ def deserialize_evm_transaction(
 
         if internal:
             if data.get('callType') == 'delegatecall':
-                raise DeserializationError('Skipping delegatecall internal transaction since no value transfer occurs')  # noqa: E501
+                # Should never reach here — all callers must filter delegatecall entries
+                # before calling this function. If it does, log and skip silently.
+                log.error(f'delegatecall internal tx reached deserialization. Caller should have filtered it. Data: {data}')  # noqa: E501
+                raise DeserializationError('Unexpected delegatecall internal transaction reached deserialization')  # noqa: E501
 
             return EvmInternalTransaction(
                 parent_tx_hash=tx_hash,


### PR DESCRIPTION
- Replace per-row correlated subquery in get_pending_internal_tx_repull_conflicts with a single batch query
- Add missing index on chain_events_info.tx_ref
- Silently skip delegatecall internal transactions at the caller instead of showing a warning to users via DeserializationError