### PR TITLE
fix(frontend): toggle highlight in pinned conflicts

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3708,6 +3708,7 @@
   },
   "internal_tx_conflicts": {
     "actions": {
+      "clear_highlight": "Clear highlight",
       "fix_redecode": "Fix & Redecode",
       "pin": "Pin to sidebar",
       "repull": "Repull",

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
@@ -373,16 +373,19 @@ defineExpose({
                   icon
                   size="sm"
                   :disabled="!row.groupIdentifier"
-                  :color="highlightedTxHash === row.txHash ? 'primary' : undefined"
+                  :color="highlightedTxHash === row.txHash ? 'warning' : undefined"
                   @click="emit('show-in-events', row)"
                 >
                   <RuiIcon
-                    name="lu-external-link"
+                    :name="highlightedTxHash === row.txHash ? 'lu-eye-off' : 'lu-external-link'"
                     size="16"
                   />
                 </RuiButton>
               </template>
-              {{ t('internal_tx_conflicts.actions.show_in_events') }}
+              {{ highlightedTxHash === row.txHash
+                ? t('internal_tx_conflicts.actions.clear_highlight')
+                : t('internal_tx_conflicts.actions.show_in_events')
+              }}
             </RuiTooltip>
           </div>
         </template>

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsPinned.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsPinned.vue
@@ -59,6 +59,11 @@ function showInHistoryEvents(conflict: InternalTxConflict): void {
   if (!conflict.groupIdentifier)
     return;
 
+  if (get(activeTxHash) === conflict.txHash) {
+    startPromise(clearHighlight());
+    return;
+  }
+
   navigateToHighlight(conflict.groupIdentifier, conflict.txHash);
 }
 


### PR DESCRIPTION
## Summary
- Clicking the "Show in Events" button on an already-highlighted conflict now clears the highlight instead of re-navigating
- The button visually indicates the active state with a warning color and eye-off icon
- Tooltip updates to "Clear highlight" when the conflict is currently highlighted

## Test plan
- [ ] Pin the internal tx conflicts sidebar
- [ ] Click "Show in Events" on a conflict — verify highlight appears on the events table
- [ ] Click the same button again — verify highlight is cleared and button returns to default state
- [ ] Click a different conflict — verify highlight switches to the new one