### PR TITLE
fix(frontend): track resolution failures properly

### DIFF
--- a/frontend/app/src/composables/history/events/tx/decoding.ts
+++ b/frontend/app/src/composables/history/events/tx/decoding.ts
@@ -32,7 +32,7 @@ export const useHistoryTransactionDecoding = createSharedComposable(() => {
     pullAndRecodeTransactionRequest,
   } = useHistoryEventsApi();
 
-  const { awaitTask, isTaskRunning } = useTaskStore();
+  const { awaitTask, cancelTaskByTaskType, isTaskRunning } = useTaskStore();
   const {
     markDecodingCancelled,
     resetUndecodedTransactionsStatus,
@@ -185,53 +185,62 @@ export const useHistoryTransactionDecoding = createSharedComposable(() => {
     );
   };
 
-  const pullAndDecodeTransactions = async (payload: PullTransactionPayload): Promise<void> => {
-    const notifyUser = (error: string): void => notify({
-      display: true,
-      message: t('actions.transactions_redecode.error.description', {
-        error,
+  /**
+   * Core decode function that throws on failure instead of notifying.
+   * Used by callers that need to handle errors themselves (e.g. conflict resolution).
+   */
+  const pullAndDecodeTransactionsRaw = async (payload: PullTransactionPayload): Promise<void> => {
+    const taskType = TaskType.TRANSACTIONS_DECODING;
+    const { taskId } = await pullAndRecodeTransactionRequest(payload);
+
+    let taskMeta = {
+      description: t('actions.transactions_redecode.task.single_description', {
+        chain: get(getChainName(payload.chain)),
+        number: payload.txRefs.length,
       }),
-      title: t('actions.transactions_redecode.error.title'),
-    });
+      title: t('actions.transactions_redecode.task.title'),
+    };
 
-    try {
-      const taskType = TaskType.TRANSACTIONS_DECODING;
-      const { taskId } = await pullAndRecodeTransactionRequest(payload);
-
-      let taskMeta = {
-        description: t('actions.transactions_redecode.task.single_description', {
-          chain: get(getChainName(payload.chain)),
-          number: payload.txRefs.length,
+    if (payload.txRefs.length === 1) {
+      taskMeta = {
+        description: t('actions.transactions_redecode.task.description', {
+          chain: payload.chain,
+          tx: payload.txRefs[0],
         }),
         title: t('actions.transactions_redecode.task.title'),
       };
+    }
 
-      if (payload.txRefs.length === 1) {
-        taskMeta = {
-          description: t('actions.transactions_redecode.task.description', {
-            chain: payload.chain,
-            tx: payload.txRefs[0],
-          }),
-          title: t('actions.transactions_redecode.task.title'),
-        };
-      }
+    const { message, result } = await awaitTask<boolean, TaskMeta>(taskId, taskType, taskMeta, true);
 
-      const { message, result } = await awaitTask<boolean, TaskMeta>(taskId, taskType, taskMeta, true);
+    if (result) {
+      clearDependedSection();
+    }
+    else {
+      throw new Error(message ?? t('actions.transactions_redecode.error.title'));
+    }
+  };
 
-      if (result) {
-        clearDependedSection();
-      }
-      else {
-        notifyUser(message ?? '');
-      }
+  /**
+   * Notifying wrapper — catches errors and shows notifications to the user.
+   * Used by the UI redecode flow where errors are displayed as toast messages.
+   */
+  const pullAndDecodeTransactions = async (payload: PullTransactionPayload): Promise<void> => {
+    try {
+      await pullAndDecodeTransactionsRaw(payload);
     }
     catch (error: any) {
-      if (isTaskCancelled(error)) {
+      if (isTaskCancelled(error))
         return;
-      }
 
       logger.error(error);
-      notifyUser(error);
+      notify({
+        display: true,
+        message: t('actions.transactions_redecode.error.description', {
+          error: error.message ?? error,
+        }),
+        title: t('actions.transactions_redecode.error.title'),
+      });
     }
   };
 
@@ -341,11 +350,17 @@ export const useHistoryTransactionDecoding = createSharedComposable(() => {
     }
   };
 
+  async function cancelDecoding(): Promise<void> {
+    await cancelTaskByTaskType(TaskType.TRANSACTIONS_DECODING);
+  }
+
   return {
+    cancelDecoding,
     checkMissingEventsAndRedecode,
     decodeTransactionsTask,
     fetchUndecodedTransactionsBreakdown,
     fetchUndecodedTransactionsStatus,
+    pullAndDecodeTransactionsRaw,
     pullAndRecodeEthBlockEvents,
     pullAndRedecodeTransactions,
     redecodeTransactions,

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.spec.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.spec.ts
@@ -5,8 +5,8 @@ import { type ResolutionCallbacks, useInternalTxConflictResolution } from './use
 
 const { spies } = vi.hoisted(() => ({
   spies: {
-    cancelTaskByTaskType: vi.fn<() => Promise<void>>(),
-    pullAndRedecodeTransactions: vi.fn<() => Promise<void>>(),
+    cancelDecoding: vi.fn<() => Promise<void>>(),
+    pullAndDecodeTransactionsRaw: vi.fn<() => Promise<void>>(),
     removeKeys: vi.fn(),
   },
 }));
@@ -22,7 +22,8 @@ vi.mock('@/composables/info/chains', () => ({
 
 vi.mock('@/composables/history/events/tx/decoding', () => ({
   useHistoryTransactionDecoding: (): object => ({
-    pullAndRedecodeTransactions: spies.pullAndRedecodeTransactions,
+    cancelDecoding: spies.cancelDecoding,
+    pullAndDecodeTransactionsRaw: spies.pullAndDecodeTransactionsRaw,
   }),
 }));
 
@@ -35,12 +36,6 @@ vi.mock('./use-internal-tx-conflict-selection', () => ({
 vi.mock('@/store/notifications', () => ({
   useNotificationsStore: (): object => ({
     notify: vi.fn(),
-  }),
-}));
-
-vi.mock('@/store/tasks', () => ({
-  useTaskStore: (): object => ({
-    cancelTaskByTaskType: spies.cancelTaskByTaskType,
   }),
 }));
 
@@ -66,8 +61,8 @@ describe('use-internal-tx-conflict-resolution', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    spies.pullAndRedecodeTransactions.mockResolvedValue(undefined);
-    spies.cancelTaskByTaskType.mockResolvedValue(undefined);
+    spies.pullAndDecodeTransactionsRaw.mockResolvedValue(undefined);
+    spies.cancelDecoding.mockResolvedValue(undefined);
     scope = effectScope();
     scope.run(() => {
       composable = useInternalTxConflictResolution();
@@ -81,18 +76,19 @@ describe('use-internal-tx-conflict-resolution', () => {
   });
 
   describe('resolveOne', () => {
-    it('calls pullAndRedecodeTransactions for repull action', async () => {
+    it('calls pullAndDecodeTransactionsRaw for repull action', async () => {
       const conflict = createMockConflict({ action: InternalTxConflictActions.REPULL, chain: 'ethereum' });
       await composable.resolveOne(conflict, callbacks);
 
-      expect(spies.pullAndRedecodeTransactions).toHaveBeenCalledWith({
-        transactions: [{ location: 'eth', txRef: '0xabc' }],
+      expect(spies.pullAndDecodeTransactionsRaw).toHaveBeenCalledWith({
+        chain: 'eth',
+        txRefs: ['0xabc'],
       });
       expect(spies.removeKeys).toHaveBeenCalledWith(['ethereum:0xabc']);
       expect(callbacks.onComplete).toHaveBeenCalled();
     });
 
-    it('calls pullAndRedecodeTransactions for fix_redecode action', async () => {
+    it('calls pullAndDecodeTransactionsRaw for fix_redecode action', async () => {
       const conflict = createMockConflict({
         action: InternalTxConflictActions.FIX_REDECODE,
         chain: 'ethereum',
@@ -102,15 +98,16 @@ describe('use-internal-tx-conflict-resolution', () => {
       });
       await composable.resolveOne(conflict, callbacks);
 
-      expect(spies.pullAndRedecodeTransactions).toHaveBeenCalledWith({
-        transactions: [{ location: 'eth', txRef: '0xdef' }],
+      expect(spies.pullAndDecodeTransactionsRaw).toHaveBeenCalledWith({
+        chain: 'eth',
+        txRefs: ['0xdef'],
       });
       expect(spies.removeKeys).toHaveBeenCalledWith(['ethereum:0xdef']);
       expect(callbacks.onComplete).toHaveBeenCalled();
     });
 
     it('handles errors without removing keys', async () => {
-      spies.pullAndRedecodeTransactions.mockRejectedValue(new Error('Network error'));
+      spies.pullAndDecodeTransactionsRaw.mockRejectedValue(new Error('Network error'));
       const conflict = createMockConflict();
       await composable.resolveOne(conflict, callbacks);
 
@@ -120,7 +117,7 @@ describe('use-internal-tx-conflict-resolution', () => {
 
     it('tracks resolving state per conflict', async () => {
       let resolveCall: (() => void) | undefined;
-      spies.pullAndRedecodeTransactions.mockImplementationOnce(
+      spies.pullAndDecodeTransactionsRaw.mockImplementationOnce(
         async (): Promise<void> => new Promise<void>((resolve) => {
           resolveCall = resolve;
         }),
@@ -148,15 +145,18 @@ describe('use-internal-tx-conflict-resolution', () => {
 
       await composable.resolveMany(conflicts, callbacks);
 
-      expect(spies.pullAndRedecodeTransactions).toHaveBeenCalledTimes(3);
-      expect(spies.pullAndRedecodeTransactions).toHaveBeenCalledWith({
-        transactions: [{ location: 'eth', txRef: '0x111' }],
+      expect(spies.pullAndDecodeTransactionsRaw).toHaveBeenCalledTimes(3);
+      expect(spies.pullAndDecodeTransactionsRaw).toHaveBeenCalledWith({
+        chain: 'eth',
+        txRefs: ['0x111'],
       });
-      expect(spies.pullAndRedecodeTransactions).toHaveBeenCalledWith({
-        transactions: [{ location: 'eth', txRef: '0x222' }],
+      expect(spies.pullAndDecodeTransactionsRaw).toHaveBeenCalledWith({
+        chain: 'eth',
+        txRefs: ['0x222'],
       });
-      expect(spies.pullAndRedecodeTransactions).toHaveBeenCalledWith({
-        transactions: [{ location: 'opt', txRef: '0x333' }],
+      expect(spies.pullAndDecodeTransactionsRaw).toHaveBeenCalledWith({
+        chain: 'opt',
+        txRefs: ['0x333'],
       });
       expect(spies.removeKeys).toHaveBeenCalledTimes(3);
       expect(callbacks.onComplete).toHaveBeenCalledTimes(3);
@@ -176,12 +176,12 @@ describe('use-internal-tx-conflict-resolution', () => {
 
       await composable.resolveMany(conflicts, callbacks);
 
-      expect(spies.pullAndRedecodeTransactions).toHaveBeenCalledTimes(2);
+      expect(spies.pullAndDecodeTransactionsRaw).toHaveBeenCalledTimes(2);
     });
 
     it('increments failed counter on error and continues', async () => {
-      spies.pullAndRedecodeTransactions.mockRejectedValueOnce(new Error('fail'));
-      spies.pullAndRedecodeTransactions.mockResolvedValueOnce(undefined);
+      spies.pullAndDecodeTransactionsRaw.mockRejectedValueOnce(new Error('fail'));
+      spies.pullAndDecodeTransactionsRaw.mockResolvedValueOnce(undefined);
 
       const conflicts = [
         createMockConflict({ chain: 'ethereum', txHash: '0x111' }),
@@ -190,19 +190,19 @@ describe('use-internal-tx-conflict-resolution', () => {
 
       await composable.resolveMany(conflicts, callbacks);
 
-      expect(spies.pullAndRedecodeTransactions).toHaveBeenCalledTimes(2);
+      expect(spies.pullAndDecodeTransactionsRaw).toHaveBeenCalledTimes(2);
       expect(spies.removeKeys).toHaveBeenCalledWith(['optimism:0x222']);
       expect(callbacks.onComplete).toHaveBeenCalledTimes(2);
     });
 
     it('stops processing when cancel is requested', async () => {
       let resolveFirst: (() => void) | undefined;
-      spies.pullAndRedecodeTransactions.mockImplementationOnce(
+      spies.pullAndDecodeTransactionsRaw.mockImplementationOnce(
         async (): Promise<void> => new Promise<void>((resolve) => {
           resolveFirst = resolve;
         }),
       );
-      spies.pullAndRedecodeTransactions.mockResolvedValueOnce(undefined);
+      spies.pullAndDecodeTransactionsRaw.mockResolvedValueOnce(undefined);
 
       const conflicts = [
         createMockConflict({ chain: 'ethereum', txHash: '0x111' }),
@@ -214,7 +214,7 @@ describe('use-internal-tx-conflict-resolution', () => {
       resolveFirst?.();
       await promise;
 
-      expect(spies.pullAndRedecodeTransactions).toHaveBeenCalledTimes(1);
+      expect(spies.pullAndDecodeTransactionsRaw).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.ts
@@ -6,8 +6,6 @@ import { useHistoryTransactionDecoding } from '@/composables/history/events/tx/d
 import { useSupportedChains } from '@/composables/info/chains';
 import { createPersistentSharedComposable } from '@/modules/common/use-persistent-shared-composable';
 import { useNotificationsStore } from '@/store/notifications';
-import { useTaskStore } from '@/store/tasks';
-import { TaskType } from '@/types/task-type';
 import { logger } from '@/utils/logging';
 import { useInternalTxConflictSelection } from './use-internal-tx-conflict-selection';
 import { getConflictKey } from './use-internal-tx-conflicts';
@@ -45,10 +43,9 @@ export interface ResolutionCallbacks {
 export const useInternalTxConflictResolution = createPersistentSharedComposable(({ acquireBusy, releaseBusy }): UseInternalTxConflictResolutionReturn => {
   const { t } = useI18n({ useScope: 'global' });
   const { getChain } = useSupportedChains();
-  const { pullAndRedecodeTransactions } = useHistoryTransactionDecoding();
+  const { cancelDecoding, pullAndDecodeTransactionsRaw } = useHistoryTransactionDecoding();
   const { removeKeys } = useInternalTxConflictSelection();
   const { notify } = useNotificationsStore();
-  const { cancelTaskByTaskType } = useTaskStore();
 
   const progress = ref<ResolutionProgress>(defaultProgress());
   const cancelRequested = ref<boolean>(false);
@@ -61,11 +58,14 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
   // Both REPULL and FIX_REDECODE resolve via the same backend API (pull + redecode).
   // The action type distinction is visual — it categorizes the problem for the user,
   // not the resolution strategy.
+  // Uses pullAndDecodeTransactionsRaw which throws on failure,
+  // so errors are properly tracked by the resolution progress.
   async function executeResolution(conflict: InternalTxConflict): Promise<void> {
-    const chainId = getChain(conflict.chain);
+    const chain = getChain(conflict.chain);
 
-    await pullAndRedecodeTransactions({
-      transactions: [{ location: chainId, txRef: conflict.txHash }],
+    await pullAndDecodeTransactionsRaw({
+      chain,
+      txRefs: [conflict.txHash],
     });
   }
 
@@ -189,7 +189,7 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
 
   function cancelResolution(): void {
     set(cancelRequested, true);
-    startPromise(cancelTaskByTaskType(TaskType.TRANSACTIONS_DECODING));
+    startPromise(cancelDecoding());
   }
 
   return {


### PR DESCRIPTION
## Summary
- Split `pullAndDecodeTransactions` into a raw (throwing) version and a notifying wrapper
- Conflict resolution now uses the raw version so errors propagate correctly and are counted as failures
- Moved `cancelDecoding` into `useHistoryTransactionDecoding` to keep task/store concerns contained

## Test plan
- [x] Lint passes
- [x] Unit tests pass (250 files, 2780 tests)
- [ ] Resolve a conflict that succeeds — verify it's counted as completed
- [ ] Resolve a conflict that fails (e.g., indexer error) — verify it's counted as failed
- [ ] Batch resolve mixed success/failure — verify the final notification shows correct counts