### PR TITLE
fix(frontend): clear progress notification on batch end

### DIFF
--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.spec.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.spec.ts
@@ -36,6 +36,7 @@ vi.mock('./use-internal-tx-conflict-selection', () => ({
 vi.mock('@/store/notifications', () => ({
   useNotificationsStore: (): object => ({
     notify: vi.fn(),
+    removeMatching: vi.fn(),
   }),
 }));
 

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.ts
@@ -45,7 +45,7 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
   const { getChain } = useSupportedChains();
   const { cancelDecoding, pullAndDecodeTransactionsRaw } = useHistoryTransactionDecoding();
   const { removeKeys } = useInternalTxConflictSelection();
-  const { notify } = useNotificationsStore();
+  const { notify, removeMatching } = useNotificationsStore();
 
   const progress = ref<ResolutionProgress>(defaultProgress());
   const cancelRequested = ref<boolean>(false);
@@ -154,10 +154,10 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
       set(progress, { ...get(progress), current: undefined, isRunning: false });
       set(progress, defaultProgress());
 
+      removeMatching(({ group }) => group === NotificationGroup.INTERNAL_TX_CONFLICT_RESOLUTION);
+
       if (cancelled) {
         notify({
-          display: true,
-          group: NotificationGroup.INTERNAL_TX_CONFLICT_RESOLUTION,
           message: t('internal_tx_conflicts.notifications.cancelled', { completed, total }),
           severity: Severity.WARNING,
           title: t('internal_tx_conflicts.notifications.title'),
@@ -165,8 +165,6 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
       }
       else if (failed > 0) {
         notify({
-          display: true,
-          group: NotificationGroup.INTERNAL_TX_CONFLICT_RESOLUTION,
           message: t('internal_tx_conflicts.notifications.completed_with_errors', { completed, failed, total }),
           severity: Severity.WARNING,
           title: t('internal_tx_conflicts.notifications.title'),
@@ -174,8 +172,6 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
       }
       else {
         notify({
-          display: true,
-          group: NotificationGroup.INTERNAL_TX_CONFLICT_RESOLUTION,
           message: t('internal_tx_conflicts.notifications.completed', { total }),
           severity: Severity.INFO,
           title: t('internal_tx_conflicts.notifications.title'),


### PR DESCRIPTION
## Summary
- Remove the grouped progress notification when conflict resolution finishes
- Emit the final summary (completed/failed/cancelled) as an ungrouped silent notification
- Prevents the next batch from overwriting the previous batch's summary

## Test plan
- [x] Lint passes
- [x] Unit tests pass (8/8 resolution tests)
- [ ] Resolve a batch of conflicts — verify progress notifications update in place
- [ ] After completion, verify the summary notification persists in the notification panel
- [ ] Start a second batch — verify the first summary is not overwritten