### PR TITLE
fix(frontend): clear highlights on user interaction

### DIFF
--- a/frontend/app/src/components/history/events/MatchAssetMovementsPinned.vue
+++ b/frontend/app/src/components/history/events/MatchAssetMovementsPinned.vue
@@ -28,7 +28,13 @@ const potentialMatchMovement = ref<UnmatchedAssetMovement>();
 const showPotentialMatchesDrawer = ref<boolean>(false);
 
 const { pinned, showPinned } = storeToRefs(useAreaVisibilityStore());
-const { clearAllHighlightTargets, clearHighlightTarget, requestNavigation, setHighlightTarget } = useHistoryEventNavigation();
+const {
+  clearAllHighlightTargets,
+  clearHighlightTarget,
+  highlightTargets,
+  requestNavigation,
+  setHighlightTarget,
+} = useHistoryEventNavigation();
 
 const {
   ignoredMovements,
@@ -180,6 +186,14 @@ watch(() => props.highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
   // Update local ref and navigate to the new highlight
   set(activeGroupIdentifier, newHighlight);
   navigateToHighlightedMovement(newHighlight);
+});
+
+watch(highlightTargets, (targets) => {
+  if (Object.keys(targets).length > 0) {
+    return;
+  }
+  set(activeGroupIdentifier, undefined);
+  set(activePotentialMatchIdentifier, undefined);
 });
 
 onUnmounted(() => {

--- a/frontend/app/src/composables/history/events/use-history-events-filters.spec.ts
+++ b/frontend/app/src/composables/history/events/use-history-events-filters.spec.ts
@@ -6,10 +6,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHistoryEventsFilters } from './use-history-events-filters';
 
 let capturedRequestParams: ComputedRef<Partial<HistoryEventRequestPayload>> | undefined;
+let capturedQueryParamsOnly: ComputedRef<Record<string, unknown>> | undefined;
+
+interface PaginationMockOptions {
+  requestParams?: ComputedRef<Partial<HistoryEventRequestPayload>>;
+  queryParamsOnly?: ComputedRef<Record<string, unknown>>;
+}
 
 vi.mock('@/composables/use-pagination-filter', () => ({
-  usePaginationFilters: vi.fn((_requestFn: unknown, options: { requestParams?: ComputedRef<Partial<HistoryEventRequestPayload>> }) => {
+  usePaginationFilters: vi.fn((_requestFn: unknown, options: PaginationMockOptions) => {
     capturedRequestParams = options.requestParams;
+    capturedQueryParamsOnly = options.queryParamsOnly;
     return {
       fetchData: vi.fn(),
       filters: computed(() => ({})),
@@ -32,12 +39,16 @@ vi.mock('@/composables/history/events', () => ({
   })),
 }));
 
+const mockIsNavigating = ref<boolean>(false);
+const mockClearAllHighlightTargets = vi.fn();
+
 vi.mock('@/composables/history/events/use-history-event-navigation', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/composables/history/events/use-history-event-navigation')>();
   return {
     ...actual,
     useHistoryEventNavigation: vi.fn(() => ({
-      findHighlightPage: vi.fn().mockResolvedValue(-1),
+      clearAllHighlightTargets: mockClearAllHighlightTargets,
+      isNavigating: mockIsNavigating,
     })),
   };
 });
@@ -91,9 +102,13 @@ function createDefaultOptions(locationValue?: string): DefaultOptions {
 describe('useHistoryEventsFilters', () => {
   beforeEach(() => {
     capturedRequestParams = undefined;
+    capturedQueryParamsOnly = undefined;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const router = useRouter();
+    await router.push({ query: {} });
+    set(mockIsNavigating, false);
     vi.clearAllMocks();
   });
 
@@ -139,6 +154,81 @@ describe('useHistoryEventsFilters', () => {
       expect(capturedRequestParams).toBeDefined();
       const params = get(capturedRequestParams!);
       expect(params.location).toBe('binanceus');
+    });
+  });
+
+  describe('highlight preservation', () => {
+    it('should include highlight params in queryParamsOnly when route has highlights', async () => {
+      const router = useRouter();
+      await router.push({ query: { highlightedAssetMovement: '123' } });
+
+      const { options, toggles } = createDefaultOptions();
+      useHistoryEventsFilters(options, toggles);
+
+      expect(capturedQueryParamsOnly).toBeDefined();
+      const params = get(capturedQueryParamsOnly!);
+      expect(params.highlightedAssetMovement).toBe('123');
+    });
+
+    it('should return highlighted identifiers from route query', async () => {
+      const router = useRouter();
+      await router.push({ query: { highlightedAssetMovement: '42', highlightedPotentialMatch: '99' } });
+
+      const { options, toggles } = createDefaultOptions();
+      const { highlightedIdentifiers } = useHistoryEventsFilters(options, toggles);
+
+      expect(get(highlightedIdentifiers)).toEqual(['42', '99']);
+    });
+
+    it('should return correct highlight types from route query', async () => {
+      const router = useRouter();
+      await router.push({ query: { highlightedAssetMovement: '10', highlightedNegativeBalanceEvent: '20' } });
+
+      const { options, toggles } = createDefaultOptions();
+      const { highlightTypes } = useHistoryEventsFilters(options, toggles);
+
+      const types = get(highlightTypes);
+      expect(types['10']).toBe('warning');
+      expect(types['20']).toBe('error');
+    });
+
+    it('should return highlighted group identifier for internal tx conflicts', async () => {
+      const router = useRouter();
+      await router.push({ query: { highlightedInternalTxConflict: '0xabc' } });
+
+      const { options, toggles } = createDefaultOptions();
+      const { highlightedGroupIdentifier, highlightTypes } = useHistoryEventsFilters(options, toggles);
+
+      expect(get(highlightedGroupIdentifier)).toBe('0xabc');
+      expect(get(highlightTypes)['group:0xabc']).toBe('warning');
+    });
+
+    it('should preserve highlights when navigation system is active', async () => {
+      const router = useRouter();
+
+      // Simulate navigation system pushing route with highlights (isNavigating is true)
+      set(mockIsNavigating, true);
+      await router.push({ query: { highlightedAssetMovement: '123', page: '5' } });
+
+      const { options, toggles } = createDefaultOptions();
+      useHistoryEventsFilters(options, toggles);
+      await nextTick();
+
+      // Highlights should be preserved because isNavigating is true
+      expect(get(capturedQueryParamsOnly!)?.highlightedAssetMovement).toBe('123');
+      expect(mockClearAllHighlightTargets).not.toHaveBeenCalled();
+    });
+
+    it('should not include highlight keys in queryParamsOnly when no highlights are active', () => {
+      const { options, toggles } = createDefaultOptions();
+      useHistoryEventsFilters(options, toggles);
+
+      expect(capturedQueryParamsOnly).toBeDefined();
+      const params = get(capturedQueryParamsOnly!);
+      expect(params).not.toHaveProperty('highlightedAssetMovement');
+      expect(params).not.toHaveProperty('highlightedInternalTxConflict');
+      expect(params).not.toHaveProperty('highlightedPotentialMatch');
+      expect(params).not.toHaveProperty('highlightedNegativeBalanceEvent');
     });
   });
 });

--- a/frontend/app/src/composables/history/events/use-history-events-filters.ts
+++ b/frontend/app/src/composables/history/events/use-history-events-filters.ts
@@ -5,14 +5,13 @@ import type { HistoryEventRequestPayload } from '@/modules/history/events/reques
 import type { Collection } from '@/types/collection';
 import type { HistoryEventRow } from '@/types/history/events/schemas';
 import { type Account, type HistoryEventEntryType, toSnakeCase, type Writeable } from '@rotki/common';
-import { startPromise } from '@shared/utils';
 import { objectOmit } from '@vueuse/shared';
 import { isEqual } from 'es-toolkit';
 import { type Filters, type Matcher, useHistoryEventFilter } from '@/composables/filters/events';
 import { useHistoryEvents } from '@/composables/history/events';
 import { isValidHistoryEventState } from '@/composables/history/events/mapping/state';
 import { DuplicateHandlingStatus, type HighlightType } from '@/composables/history/events/types';
-import { HIGHLIGHT_FETCH_DEBOUNCE, HIGHLIGHT_FILTER_DEBOUNCE, useHistoryEventNavigation } from '@/composables/history/events/use-history-event-navigation';
+import { HIGHLIGHT_FETCH_DEBOUNCE, useHistoryEventNavigation } from '@/composables/history/events/use-history-event-navigation';
 import { useRefWithDebounce } from '@/composables/ref';
 import { usePaginationFilters } from '@/composables/use-pagination-filter';
 import { TableId } from '@/modules/table/use-remember-table-sorting';
@@ -97,7 +96,10 @@ export function useHistoryEventsFilters(
 
   const route = useRoute();
   const { fetchHistoryEvents } = useHistoryEvents();
-  const { findHighlightPage } = useHistoryEventNavigation();
+  const { clearAllHighlightTargets, isNavigating } = useHistoryEventNavigation();
+
+  const highlightKeys = ['highlightedAssetMovement', 'highlightedInternalTxConflict', 'highlightedPotentialMatch', 'highlightedNegativeBalanceEvent'] as const;
+  const shouldPreserveHighlights = ref<boolean>(highlightKeys.some(key => !!get(route).query[key]));
 
   const fetchHistoryEventsTagged = async (
     payload: MaybeRef<HistoryEventRequestPayload>,
@@ -221,6 +223,7 @@ export function useHistoryEventsFilters(
     queryParamsOnly: computed(() => {
       const duplicateHandlingStatusValue = get(duplicateHandlingStatusFromQuery);
       const groupIdentifiersValue = get(groupIdentifiersFromQuery);
+      const preserve = get(shouldPreserveHighlights);
       const { highlightedAssetMovement, highlightedInternalTxConflict, highlightedPotentialMatch, highlightedNegativeBalanceEvent } = get(route).query;
 
       const missingAcquisitionValue = get(missingAcquisitionFromQuery);
@@ -228,10 +231,14 @@ export function useHistoryEventsFilters(
       return {
         duplicateHandlingStatus: duplicateHandlingStatusValue,
         groupIdentifiers: groupIdentifiersValue?.join(','),
-        highlightedAssetMovement,
-        highlightedInternalTxConflict,
-        highlightedNegativeBalanceEvent,
-        highlightedPotentialMatch,
+        ...(preserve
+          ? {
+              highlightedAssetMovement,
+              highlightedInternalTxConflict,
+              highlightedNegativeBalanceEvent,
+              highlightedPotentialMatch,
+            }
+          : {}),
         locationLabels: get(usedLocationLabels),
         missingAcquisitionIdentifier: missingAcquisitionValue?.join(','),
         ...(stateMarkersValue.length > 0 ? { stateMarkers: stateMarkersValue.join(',') } : {}),
@@ -339,37 +346,30 @@ export function useHistoryEventsFilters(
     set(locationLabels, labels);
   }
 
-  // Calculate position of highlighted event and set the page directly to avoid a duplicate fetch.
-  let navigationGeneration = 0;
-
-  async function navigateToHighlightPosition(): Promise<void> {
-    const generation = ++navigationGeneration;
-    const page = await findHighlightPage(get(pageParams), get(pagination).limit);
-
-    if (generation !== navigationGeneration)
-      return;
-
-    if (page >= 1)
-      setPage(page);
-  }
-
   /**
-   * Re-navigate highlights when any parameter affecting the result set changes.
-   * Watches the aggregated pageParams (filters, toggles, limit, etc.) but ignores
-   * offset changes since those are just page navigation.
+   * Clear highlights when the user changes page or filters.
+   * Sort changes (orderByAttributes, ascending) are excluded so highlights
+   * persist through reordering.
    */
-  watchDebounced(pageParams, (params, oldParams) => {
-    if (!oldParams)
+  watch(pageParams, (params, oldParams) => {
+    if (!oldParams || !get(shouldPreserveHighlights) || get(isNavigating))
       return;
 
-    const current = objectOmit(params, ['offset']);
-    const previous = objectOmit(oldParams, ['offset']);
+    const current = objectOmit(params, ['orderByAttributes', 'ascending']);
+    const previous = objectOmit(oldParams, ['orderByAttributes', 'ascending']);
 
     if (isEqual(current, previous))
       return;
 
-    startPromise(navigateToHighlightPosition());
-  }, { debounce: HIGHLIGHT_FILTER_DEBOUNCE, deep: true });
+    set(shouldPreserveHighlights, false);
+    clearAllHighlightTargets();
+  }, { deep: true });
+
+  /** Re-enable highlight preservation when new highlight params arrive via navigation. */
+  watch(() => get(route).query, (query, oldQuery) => {
+    if (highlightKeys.some(key => query[key] && query[key] !== oldQuery?.[key]))
+      set(shouldPreserveHighlights, true);
+  });
 
   return {
     clearFilters,

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsPinned.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsPinned.vue
@@ -18,7 +18,7 @@ const router = useRouter();
 const route = useRoute();
 
 const { pinned, showPinned } = storeToRefs(useAreaVisibilityStore());
-const { clearAllHighlightTargets, requestNavigation, setHighlightTarget } = useHistoryEventNavigation();
+const { clearAllHighlightTargets, highlightTargets, requestNavigation, setHighlightTarget } = useHistoryEventNavigation();
 const { cancelResolution, progress } = useInternalTxConflictResolution();
 
 const activeTxHash = ref<string | undefined>(highlightedTxHash);
@@ -75,6 +75,11 @@ onBeforeMount(() => {
 watch([() => highlightedGroupIdentifier, () => highlightedTxHash], ([newGroupId, newHash], [oldGroupId]) => {
   if (newGroupId && newHash && newGroupId !== oldGroupId)
     navigateToHighlight(newGroupId, newHash);
+});
+
+watch(highlightTargets, (targets) => {
+  if (Object.keys(targets).length === 0)
+    set(activeTxHash, undefined);
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
## Summary
- Replace debounced highlight page navigation with a `shouldPreserveHighlights` gate that clears highlight query params when the user changes page or filters
- Sort changes are excluded — highlights persist through reordering
- Pinned sidebars (conflicts + asset movements) now watch `highlightTargets` and sync their local highlight state when targets are cleared

## Test plan
- [ ] Pin conflict sidebar → click "Show in Events" → verify highlight appears → change page → verify highlight clears in both table and sidebar
- [ ] Same flow but change filters instead of page → verify highlight clears
- [ ] Same flow but change sort → verify highlight **persists**
- [ ] After clearing, click "Show in Events" again → verify highlight reappears
- [ ] Repeat above for asset movement matching pinned sidebar