### PR TITLE
periodic task now also processes fix_redecode internal tx conflicts

### DIFF
--- a/rotkehlchen/data_migrations/migrations/migration_24.py
+++ b/rotkehlchen/data_migrations/migrations/migration_24.py
@@ -40,7 +40,7 @@ def data_migration_24(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgress
     @progress_step(description='Fixing non-customized internal tx conflicts')
     def _fix_non_customized(rotki: 'Rotkehlchen') -> None:
         with rotki.data.db.conn.write_ctx() as write_cursor:
-            for chain_id, tx_hash in get_internal_tx_conflicts(
+            for chain_id, tx_hash, _ in get_internal_tx_conflicts(
                 cursor=write_cursor,
                 action=INTERNAL_TX_CONFLICT_ACTION_FIX_REDECODE,
                 fixed=False,

--- a/rotkehlchen/db/internal_tx_conflicts.py
+++ b/rotkehlchen/db/internal_tx_conflicts.py
@@ -175,29 +175,35 @@ def clean_internal_tx_conflict(
 
 def get_internal_tx_conflicts(
         cursor: 'DBCursor',
-        action: str,
         fixed: bool,
+        action: str | None = None,
         limit: int | None = None,
-) -> list[tuple[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE, EVMTxHash]]:
-    """Get internal tx conflict entries."""
+) -> list[tuple[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE, EVMTxHash, str]]:
+    """Get internal tx conflict entries. When action is None, returns all action types."""
     query = (
-        'SELECT chain, transaction_hash FROM evm_internal_tx_conflicts '
-        'WHERE action=? AND fixed=? '
+        'SELECT chain, transaction_hash, action FROM evm_internal_tx_conflicts '
+        'WHERE fixed=? '
+    )
+    bindings: tuple[object, ...] = (int(fixed),)
+    if action is not None:
+        query += 'AND action=? '
+        bindings = (*bindings, action)
+
+    query += (
         'ORDER BY '
         'CASE WHEN last_retry_ts IS NULL THEN 0 ELSE 1 END, '
         'last_retry_ts ASC, '
         'chain, transaction_hash'
     )
-    bindings: tuple[object, ...] = (action, int(fixed))
     if limit is not None:
         query += ' LIMIT ?'
         bindings = (*bindings, limit)
 
-    entries: list[tuple[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE, EVMTxHash]] = []
-    for chain, tx_hash in cursor.execute(query, bindings):
+    entries: list[tuple[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE, EVMTxHash, str]] = []
+    for chain, tx_hash, row_action in cursor.execute(query, bindings):
         chain_id = ChainID.deserialize_from_db(chain)
         assert chain_id in EVM_CHAIN_IDS_WITH_TRANSACTIONS
-        entries.append((cast('EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE', chain_id), deserialize_evm_tx_hash(tx_hash)))  # noqa: E501
+        entries.append((cast('EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE', chain_id), deserialize_evm_tx_hash(tx_hash), row_action))  # noqa: E501
 
     return entries
 

--- a/rotkehlchen/tasks/internal_tx_conflicts.py
+++ b/rotkehlchen/tasks/internal_tx_conflicts.py
@@ -7,6 +7,7 @@ from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.internal_tx_conflicts import (
     INTERNAL_TX_CONFLICT_ACTION_REPULL,
+    clean_internal_tx_conflict,
     get_internal_tx_conflicts,
     is_tx_customized,
     set_internal_tx_conflict_fixed,
@@ -107,40 +108,55 @@ def repull_internal_tx_conflicts(
         chains_aggregator: 'ChainsAggregator',
         limit: int,
 ) -> None:
-    """Process a batch of repull internal tx conflicts."""
+    """Process a batch of internal tx conflicts (both repull and fix_redecode)."""
     with database.conn.read_ctx() as read_cursor:
         entries = get_internal_tx_conflicts(
             cursor=read_cursor,
-            action=INTERNAL_TX_CONFLICT_ACTION_REPULL,
             fixed=False,
             limit=limit,
         )
 
-    for chain_id, tx_hash in entries:
-        try:
-            _repull_and_redecode_tx(
-                database=database,
-                chains_aggregator=chains_aggregator,
-                chain_id=chain_id,
-                tx_hash=tx_hash,
-            )
-        except (InputError, RemoteError, DeserializationError, DataIntegrityError) as e:
-            error_msg = str(e)
-            if isinstance(e, DataIntegrityError):
-                error_msg = f'Indexer did not provide valid data: {e!s}'
-            log.error(
-                f'Failed to repull internal tx conflict {tx_hash!s} on {chain_id.to_name()} '
-                f'due to {error_msg}',
-            )
+    for chain_id, tx_hash, action in entries:
+        if action == INTERNAL_TX_CONFLICT_ACTION_REPULL:
+            try:
+                _repull_and_redecode_tx(
+                    database=database,
+                    chains_aggregator=chains_aggregator,
+                    chain_id=chain_id,
+                    tx_hash=tx_hash,
+                )
+            except (InputError, RemoteError, DeserializationError, DataIntegrityError) as e:
+                error_msg = str(e)
+                if isinstance(e, DataIntegrityError):
+                    error_msg = f'Indexer did not provide valid data: {e!s}'
+                log.error(
+                    f'Failed to repull internal tx conflict {tx_hash!s} on '
+                    f'{chain_id.to_name()} due to {error_msg}',
+                )
+                with database.user_write() as write_cursor:
+                    set_internal_tx_conflict_repull_error(
+                        write_cursor=write_cursor,
+                        tx_hash=tx_hash,
+                        chain_id=chain_id,
+                        retry_ts=ts_now(),
+                        error=error_msg,
+                    )
+                continue
+        else:  # fix_redecode
             with database.user_write() as write_cursor:
-                set_internal_tx_conflict_repull_error(
+                clean_internal_tx_conflict(
                     write_cursor=write_cursor,
                     tx_hash=tx_hash,
                     chain_id=chain_id,
-                    retry_ts=ts_now(),
-                    error=error_msg,
                 )
-            continue
+            chain = chain_id.to_blockchain()
+            chain_manager = chains_aggregator.get_chain_manager(blockchain=chain)  # type: ignore[call-overload]
+            chain_manager.transactions_decoder.decode_and_get_transaction_hashes(
+                tx_hashes=[tx_hash],
+                send_ws_notifications=True,
+                ignore_cache=True,
+                delete_customized=False,
+            )
 
         with database.user_write() as write_cursor:
             set_internal_tx_conflict_fixed(

--- a/rotkehlchen/tests/unit/test_internal_tx_conflicts.py
+++ b/rotkehlchen/tests/unit/test_internal_tx_conflicts.py
@@ -486,7 +486,7 @@ def test_fix_conflict_with_specific_internal_tx_dataset(database) -> None:
             cursor=write_cursor,
             action=INTERNAL_TX_CONFLICT_ACTION_FIX_REDECODE,
             fixed=False,
-        ) == [(ChainID.ARBITRUM_ONE, tx_hash)]
+        ) == [(ChainID.ARBITRUM_ONE, tx_hash, INTERNAL_TX_CONFLICT_ACTION_FIX_REDECODE)]
 
         clean_internal_tx_conflict(
             write_cursor=write_cursor,


### PR DESCRIPTION
The periodic task (repull_internal_tx_conflicts) only processed repull action conflicts, completely ignoring fix_redecode entries. Added a second loop that fetches unfixed fix_redecode conflicts, calls clean_internal_tx_conflict to remove bad/duplicate internal tx rows, redecodes the transaction (respecting customized events via delete_customized=False), and marks the conflict as fixed.
