### PR TITLE
perf: skip JOIN in internal tx query during decoding

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -211,6 +211,7 @@ class SushiswapDecoder(EvmDecoderInterface):
             internal_txs = DBEvmTx(self.node_inquirer.database).get_evm_internal_transactions(
                 parent_tx_hash=transaction.tx_hash,
                 blockchain=self.node_inquirer.blockchain,
+                parent_tx_id=transaction.db_id,
             )
             if len(internal_txs) == 0:
                 return fee, fee_event

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -558,7 +558,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
 
         self.base.reset_sequence_counter(tx_receipt)
         # check if any eth transfer happened in the transaction, including in internal transactions
-        events = self._maybe_decode_simple_transactions(transaction, tx_receipt)
+        events = self._maybe_decode_simple_transactions(transaction, tx_receipt, tx_id=tx_id)
         action_items: list[ActionItem] = []
         counterparties = set()
         refresh_balances = False
@@ -792,6 +792,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             tx: EvmTransaction,
             tx_receipt: EvmTxReceipt,
             events: list['EvmEvent'],
+            tx_id: int,
     ) -> None:
         """
         check for internal transactions if the transaction is not canceled. This function mutates
@@ -803,6 +804,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
         internal_txs = self.dbtx.get_evm_internal_transactions(
             parent_tx_hash=tx.tx_hash,
             blockchain=self.evm_inquirer.blockchain,
+            parent_tx_id=tx_id,
         )
         for internal_tx in internal_txs:
             if internal_tx.to_address is None:
@@ -946,6 +948,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             self,
             tx: EvmTransaction,
             tx_receipt: EvmTxReceipt,
+            tx_id: int,
     ) -> list['EvmEvent']:
         """Decodes normal ETH transfers, internal transactions and gas cost payments"""
         events: list[EvmEvent] = []
@@ -1001,6 +1004,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             tx=tx,
             tx_receipt=tx_receipt,
             events=events,
+            tx_id=tx_id,
         )
 
         if tx_receipt.status is False or direction_result is None:

--- a/rotkehlchen/chain/evm/decoding/sushiswap/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/sushiswap/decoder.py
@@ -228,6 +228,7 @@ class SushiswapCommonDecoder(EvmDecoderInterface):
             internal_txs = DBEvmTx(self.node_inquirer.database).get_evm_internal_transactions(
                 parent_tx_hash=transaction.tx_hash,
                 blockchain=self.node_inquirer.blockchain,
+                parent_tx_id=transaction.db_id,
             )
             if len(internal_txs) == 0:
                 return fee, fee_event

--- a/rotkehlchen/chain/evm/decoding/uniswap/v4/utils.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v4/utils.py
@@ -53,6 +53,7 @@ def decode_uniswap_v4_like_swaps(
     if len(internal_txs := DBEvmTx(base_tools.database).get_evm_internal_transactions(
         parent_tx_hash=transaction.tx_hash,
         blockchain=base_tools.evm_inquirer.blockchain,
+        parent_tx_id=transaction.db_id,
     )) != 0:  # check internal txs for possible fees and use the wrapped native token to represent it.  # noqa: E501
         for internal_tx in internal_txs:
             if (

--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -1160,12 +1160,19 @@ class EvmTransactions(ABC):  # noqa: B024
         - DataIntegrityError if the indexer returns an empty result but the DB already contains
         internal transactions for this tx hash."""
         # check if full internal txs for this parent tx and chain have already been queried.
+        # Also fetch the tx DB id to avoid a JOIN later.
+        chain_id_db = chain_id.serialize_for_db()
         with self.database.conn.read_ctx() as cursor:
+            if (row := cursor.execute(
+                'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+                (tx_hash, chain_id_db),
+            ).fetchone()) is None:
+                return []  # transaction not in DB yet
+
+            parent_tx_id = row[0]
             was_queried = cursor.execute(
-                'SELECT 1 FROM evm_tx_mappings WHERE tx_id IN ('
-                'SELECT identifier FROM evm_transactions '
-                'WHERE tx_hash=? AND chain_id=?) AND value=?',
-                (tx_hash, chain_id.serialize_for_db(), TX_INTERNALS_QUERIED),
+                'SELECT 1 FROM evm_tx_mappings WHERE tx_id=? AND value=?',
+                (parent_tx_id, TX_INTERNALS_QUERIED),
             ).fetchone() is not None
 
         if was_queried is False:
@@ -1175,9 +1182,8 @@ class EvmTransactions(ABC):  # noqa: B024
             )
             with self.database.user_write() as write_cursor:
                 write_cursor.execute(
-                    'INSERT OR IGNORE INTO evm_tx_mappings(tx_id, value) '
-                    'SELECT identifier, ? FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
-                    (TX_INTERNALS_QUERIED, tx_hash, chain_id.serialize_for_db()),
+                    'INSERT OR IGNORE INTO evm_tx_mappings(tx_id, value) VALUES (?, ?)',
+                    (parent_tx_id, TX_INTERNALS_QUERIED),
                 )
             log.debug(
                 f'Queried full internal txs for {tx_hash!s} on {chain_id.to_name()} '
@@ -1189,6 +1195,7 @@ class EvmTransactions(ABC):  # noqa: B024
             blockchain=CHAINID_TO_SUPPORTED_BLOCKCHAIN[chain_id],
             from_address=from_address,
             to_address=to_address,
+            parent_tx_id=parent_tx_id,
         )
 
     def get_or_create_transaction(

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -188,26 +188,28 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
             self,
             parent_tx_hash: EVMTxHash,
             blockchain: SupportedBlockchain,
+            parent_tx_id: int,
             from_address: ChecksumEvmAddress | None = None,
             to_address: ChecksumEvmAddress | None = None,
     ) -> list[EvmInternalTransaction]:
-        """Get all internal transactions under a parent tx_hash for a given chain"""
+        """Get all internal transactions under a parent tx for a given chain.
+        Uses parent_tx_id to query directly by foreign key without joining."""
         chain_id = blockchain.to_chain_id()
-        address_filter, bindings = '', [parent_tx_hash, chain_id.serialize_for_db()]
+        address_filter: str = ''
+        bindings: list = [parent_tx_id]
         if from_address is not None:
-            address_filter += ' AND ITX.from_address=?'
+            address_filter += ' AND from_address=?'
             bindings.append(from_address)
         if to_address is not None:
-            address_filter += ' AND ITX.to_address=?'
+            address_filter += ' AND to_address=?'
             bindings.append(to_address)
 
+        query = (
+            'SELECT trace_id, from_address, to_address, value, gas, gas_used '
+            f'FROM evm_internal_transactions WHERE parent_tx=?{address_filter}'
+        )
         with self.db.conn.read_ctx() as cursor:
-            results = cursor.execute(
-                'SELECT ITX.trace_id, ITX.from_address, ITX.to_address, ITX.value, ITX.gas, '
-                'ITX.gas_used FROM evm_internal_transactions ITX INNER JOIN evm_transactions TX '
-                'ON ITX.parent_tx=TX.identifier WHERE TX.tx_hash=? AND TX.chain_id=?'
-                f'{address_filter}', bindings,
-            )
+            results = cursor.execute(query, bindings)
             transactions = []
             for result in results:
                 tx = EvmInternalTransaction(

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1551,9 +1551,14 @@ def test_repulling_transaction_fetch_error_does_not_drop_existing_data(
     with rotki.data.db.conn.read_ctx() as cursor:
         tx_count_before = len(dbevmtx.get_transactions(cursor=cursor, filter_=tx_filter))
         receipt_before = dbevmtx.get_receipt(cursor=cursor, tx_hash=tx_hash, chain_id=ChainID.ETHEREUM)  # noqa: E501
+        parent_tx_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (tx_hash, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
     internal_before = dbevmtx.get_evm_internal_transactions(
         parent_tx_hash=tx_hash,
         blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id,
     )
     assert tx_count_before == 1
     assert receipt_before is not None
@@ -1580,6 +1585,7 @@ def test_repulling_transaction_fetch_error_does_not_drop_existing_data(
     internal_after = dbevmtx.get_evm_internal_transactions(
         parent_tx_hash=tx_hash,
         blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id,
     )
 
     assert tx_count_after == tx_count_before
@@ -1597,9 +1603,15 @@ def test_repulling_transaction_internal_fetch_error_restores_previous_internal_t
     dbevmtx, transaction = _prepare_repull_test_transaction(rotki.data.db)
     tx_hash = transaction.tx_hash
 
+    with rotki.data.db.conn.read_ctx() as cursor:
+        parent_tx_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (tx_hash, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
     internal_before = dbevmtx.get_evm_internal_transactions(
         parent_tx_hash=tx_hash,
         blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id,
     )
     assert len(internal_before) > 0
     fresh_transaction = make_ethereum_transaction(
@@ -1639,6 +1651,7 @@ def test_repulling_transaction_internal_fetch_error_restores_previous_internal_t
     internal_after = dbevmtx.get_evm_internal_transactions(
         parent_tx_hash=tx_hash,
         blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id,
     )
     assert internal_after == internal_before
 
@@ -1657,9 +1670,14 @@ def test_repulling_transaction_internal_replace_failure_rolls_back_tx_data(
     with rotki.data.db.conn.read_ctx() as cursor:
         tx_before = dbevmtx.get_transactions(cursor=cursor, filter_=tx_filter)[0]
         receipt_before = dbevmtx.get_receipt(cursor=cursor, tx_hash=tx_hash, chain_id=ChainID.ETHEREUM)  # noqa: E501
+        parent_tx_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (tx_hash, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
     internal_before = dbevmtx.get_evm_internal_transactions(
         parent_tx_hash=tx_hash,
         blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id,
     )
     assert receipt_before is not None
     fresh_transaction = make_ethereum_transaction(
@@ -1707,6 +1725,7 @@ def test_repulling_transaction_internal_replace_failure_rolls_back_tx_data(
     internal_after = dbevmtx.get_evm_internal_transactions(
         parent_tx_hash=tx_hash,
         blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id,
     )
     assert tx_after == tx_before
     assert receipt_after == receipt_before

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -156,22 +156,30 @@ def test_etherscan_get_transactions_genesis_block(eth_transactions):
             cursor=cursor,
             filter_=EvmTransactionsFilterQuery.make(),
         )
+        parent_tx_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (GENESIS_HASH, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
         internal_tx_in_db = dbtx.get_evm_internal_transactions(
             parent_tx_hash=GENESIS_HASH,
             blockchain=SupportedBlockchain.ETHEREUM,
+            parent_tx_id=parent_tx_id,
         )
 
         assert dbtx.get_evm_internal_transactions(  # filter using from_address
             parent_tx_hash=GENESIS_HASH,
             blockchain=SupportedBlockchain.ETHEREUM,
+            parent_tx_id=parent_tx_id,
             from_address=ZERO_ADDRESS,
         ) == dbtx.get_evm_internal_transactions(  # filter using to_address
             parent_tx_hash=GENESIS_HASH,
             blockchain=SupportedBlockchain.ETHEREUM,
+            parent_tx_id=parent_tx_id,
             to_address=string_to_evm_address('0xC951900c341aBbb3BAfbf7ee2029377071Dbc36A'),
         ) == dbtx.get_evm_internal_transactions(  # filter using both from_address and to_address
             parent_tx_hash=GENESIS_HASH,
             blockchain=SupportedBlockchain.ETHEREUM,
+            parent_tx_id=parent_tx_id,
             from_address=ZERO_ADDRESS,
             to_address=string_to_evm_address('0xC951900c341aBbb3BAfbf7ee2029377071Dbc36A'),
         ) == internal_tx_in_db  # filter using none of from_address and to_address
@@ -179,10 +187,12 @@ def test_etherscan_get_transactions_genesis_block(eth_transactions):
         assert dbtx.get_evm_internal_transactions(  # filter using different from_address
             parent_tx_hash=GENESIS_HASH,
             blockchain=SupportedBlockchain.ETHEREUM,
+            parent_tx_id=parent_tx_id,
             from_address=string_to_evm_address('0xC951900c341aBbb3BAfbf7ee2029377071Dbc36A'),
         ) == dbtx.get_evm_internal_transactions(  # filter using different to_address
             parent_tx_hash=GENESIS_HASH,
             blockchain=SupportedBlockchain.ETHEREUM,
+            parent_tx_id=parent_tx_id,
             to_address=ZERO_ADDRESS,
         ) == []
 

--- a/rotkehlchen/tests/unit/test_evm_transactions.py
+++ b/rotkehlchen/tests/unit/test_evm_transactions.py
@@ -343,9 +343,15 @@ def test_empty_repull_blocked_when_db_has_internals(
         )
 
     # DB must remain untouched
+    with database.conn.read_ctx() as cursor:
+        parent_tx_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (parent_tx.tx_hash, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
     stored = dbevmtx.get_evm_internal_transactions(
         parent_tx_hash=parent_tx.tx_hash,
         blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id,
     )
     assert stored == [existing_internal_tx]
 
@@ -379,9 +385,15 @@ def test_empty_repull_allowed_when_db_has_no_internals(
             parent_tx_hash=parent_tx.tx_hash,
         )
 
+    with database.conn.read_ctx() as cursor:
+        parent_tx_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (parent_tx.tx_hash, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
     stored = dbevmtx.get_evm_internal_transactions(
         parent_tx_hash=parent_tx.tx_hash,
         blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id,
     )
     assert stored == []
 
@@ -439,9 +451,15 @@ def test_nonempty_repull_replaces_existing_internals(
             parent_tx_hash=parent_tx.tx_hash,
         )
 
+    with database.conn.read_ctx() as cursor:
+        parent_tx_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (parent_tx.tx_hash, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
     stored = dbevmtx.get_evm_internal_transactions(
         parent_tx_hash=parent_tx.tx_hash,
         blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id,
     )
     assert stored == [updated_internal_tx]
 
@@ -694,9 +712,14 @@ def test_indexers_fall_back_properly(
         }
 
         # Check that an internal tx (always queried via an indexer) was properly retrieved.
+        parent_tx_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (tx_hash1, ChainID.OPTIMISM.serialize_for_db()),
+        ).fetchone()[0]
         internal_txs = dbevmtx.get_evm_internal_transactions(
             parent_tx_hash=tx_hash1,
             blockchain=SupportedBlockchain.OPTIMISM,
+            parent_tx_id=parent_tx_id,
         )
         assert len(internal_txs) == 1  # tx has two internal txs but only one involves the tracked address.  # noqa: E501
 


### PR DESCRIPTION
When decoding transactions the parent tx DB id is already known. Pass it through to get_evm_internal_transactions so it can query evm_internal_transactions directly by foreign key instead of joining with evm_transactions to resolve the tx_hash.

Also optimizes get_and_ensure_internal_txns_of_parent_in_db to fetch the tx id once and reuse it for both the mapping check and the final internal tx query.


----

Some benchmarks

```
  ┌──────────────────┬───────────────────────────┬──────────────────────────────────────────────┐                                                                                                                                                                                
  │      Query       │          Speedup          │                    Notes                     │                                                                                                                                                                              
  ├──────────────────┼───────────────────────────┼──────────────────────────────────────────────┤                                                                                                                                                                                
  │ get_internal_txs │ ~1.2x faster (12-20%)     │ JOIN elimination → direct FK scan            │                                                                                                                                                                              
  ├──────────────────┼───────────────────────────┼──────────────────────────────────────────────┤
  │ check_mapping    │ ~3.4x faster (70%)        │ Subquery → direct PK lookup, biggest win     │                                                                                                                                                                                
  ├──────────────────┼───────────────────────────┼──────────────────────────────────────────────┤                                                                                                                                                                                
  │ full_pipeline    │ ~1.2-1.3x faster (17-22%) │ Combined effect across the whole decode path │                                                                                                                                                                                
  └──────────────────┴───────────────────────────┴──────────────────────────────────────────────┘                                                                                                                                                                                
```                                                                                                                                                                                                                                                                               
  
The mapping check sees the largest improvement (3.4x) since it goes from a subquery-with-join to a direct primary key lookup. The internal tx query itself gains ~20% by avoiding the JOIN. The full pipeline (which includes a one-time tx_hash → identifier resolution in the
   new approach) nets about 20-22% overall.                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                 
  Note these are per-transaction savings. During a full decode of, say, 50,000 transactions, that ~3µs saving per tx compounds to ~150ms total. The real-world impact is more meaningful when considering disk-backed SQLite (these benchmarks use :memory:) where the JOIN has  
  to do additional I/O.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
   



