### PR TITLE
fix(frontend): guard monerium status with tier check

### DIFF
--- a/frontend/app/src/modules/external-services/monerium/use-monerium-auth.ts
+++ b/frontend/app/src/modules/external-services/monerium/use-monerium-auth.ts
@@ -1,5 +1,6 @@
 import type { ComputedRef, Ref } from 'vue';
 import type { MoneriumOAuthResult, MoneriumStatus } from './types';
+import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { useSessionAuthStore } from '@/store/session/auth';
 import { logger } from '@/utils/logging';
 import { useMoneriumOAuthApi } from './use-monerium-api';
@@ -23,10 +24,11 @@ export const useMoneriumOAuth = createSharedComposable((): UseMoneriumOAuthRetur
   const api = useMoneriumOAuthApi();
 
   const { logged } = storeToRefs(useSessionAuthStore());
+  const { allowed } = useFeatureAccess(PremiumFeature.MONERIUM);
 
   const status: Ref<MoneriumStatus | undefined> = asyncComputed<MoneriumStatus | undefined>(
     async () => {
-      if (get(logged)) {
+      if (get(logged) && get(allowed)) {
         try {
           return await api.getStatus();
         }


### PR DESCRIPTION
## Summary

- Guard the Monerium status API call with `useFeatureAccess(PremiumFeature.MONERIUM)` so it only fires when the user's subscription tier includes the Monerium integration
- Prevents a 403 error on login for users without the required tier

## Test plan
- [x] Lint passes
- [ ] Login with a non-Monerium tier account — no 403 error in console
- [ ] Login with a Monerium-enabled tier — status fetched as expected