### PR TITLE
fix(frontend): allow null userEmail in calendar schema

### DIFF
--- a/frontend/app/src/types/settings/google-calendar.ts
+++ b/frontend/app/src/types/settings/google-calendar.ts
@@ -2,7 +2,7 @@ import { z } from 'zod/v4';
 
 export const GoogleCalendarStatusSchema = z.object({
   authenticated: z.boolean(),
-  userEmail: z.string().optional(),
+  userEmail: z.string().nullish(),
 });
 
 export type GoogleCalendarStatus = z.infer<typeof GoogleCalendarStatusSchema>;
@@ -10,7 +10,7 @@ export type GoogleCalendarStatus = z.infer<typeof GoogleCalendarStatusSchema>;
 export const GoogleCalendarAuthResultSchema = z.object({
   success: z.boolean(),
   message: z.string(),
-  userEmail: z.string().optional(),
+  userEmail: z.string().nullish(),
 });
 
 export type GoogleCalendarAuthResult = z.infer<typeof GoogleCalendarAuthResultSchema>;


### PR DESCRIPTION
## Summary

- Use `nullish()` instead of `optional()` for `userEmail` fields in Google Calendar Zod schemas since the backend may return `null`
- Fixes a ZodError when checking Google Calendar status

## Test plan
- [x] Lint passes
- [ ] Open calendar settings — no Zod validation error in console