### PR TITLE
fix: prevent duplicate labels when editing manual balances via API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`11935` Editing a manual balance to have duplicate names should no longer be possible.
 * :feature:`-` Added an accounting rule to transfer cost basis between assets and applied it as a default for actions such as wrapping/unwrapping ETH, depositing to DeFi etc.
 * :bug:`11908` Individual pending task items now show a static icon instead of an indeterminate spinner, reducing visual noise when many tasks are running.
 * :bug:`11902` The redecode option is now available for exchange withdrawals with a linked on-chain transaction.

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1834,8 +1834,19 @@ class DBHandler:
 
         May raise:
         - InputError if any of the manually tracked balance labels to edit do not
-        exist in the DB
+        exist in the DB or if any of the new labels already exist for a different entry
         """
+        # Check that the new labels don't conflict with existing entries
+        for entry in data:
+            write_cursor.execute(
+                'SELECT id FROM manually_tracked_balances WHERE label=? AND id!=?',
+                (entry.label, entry.identifier),
+            )
+            if write_cursor.fetchone() is not None:
+                raise InputError(
+                    f'A manually tracked balance entry with label "{entry.label}" already exists',
+                )
+
         # Update the manually tracked balance entries in the DB
         tuples = [(
             entry.asset.identifier,

--- a/rotkehlchen/tests/api/test_manually_tracked_balances.py
+++ b/rotkehlchen/tests/api/test_manually_tracked_balances.py
@@ -837,3 +837,55 @@ def test_update_manual_balance_label(rotkehlchen_api_server: 'APIServer') -> Non
         expected_balances=expected_balances,
         returned_balances=result['balances'],
     )
+
+
+def test_edit_manual_balance_duplicate_label(rotkehlchen_api_server: 'APIServer') -> None:
+    """Test that editing a manually tracked balance to use a label that already
+    exists for a different entry is prevented"""
+    _populate_tags(rotkehlchen_api_server)
+    balances = _populate_initial_balances(rotkehlchen_api_server)
+    balances.sort(key=itemgetter('identifier'))
+
+    # Try to edit the second balance to have the same label as the first
+    balance_to_edit = balances[1].copy()
+    balance_to_edit['label'] = balances[0]['label']
+    response = requests.patch(
+        api_url_for(
+            rotkehlchen_api_server,
+            'manuallytrackedbalancesresource',
+        ), json={'balances': [balance_to_edit]},
+    )
+    assert_error_response(
+        response=response,
+        contained_in_msg=f'A manually tracked balance entry with label "{balances[0]["label"]}" already exists',  # noqa: E501
+        status_code=HTTPStatus.BAD_REQUEST,
+    )
+
+    # Verify balances are unchanged
+    response = requests.get(
+        api_url_for(
+            rotkehlchen_api_server,
+            'manuallytrackedbalancesresource',
+        ),
+    )
+    result = assert_proper_sync_response_with_result(response)
+    assert_balances_match(
+        expected_balances=balances,
+        returned_balances=result['balances'],
+    )
+
+    # Verify that editing a balance to keep its own label works fine
+    balance_to_edit = balances[0].copy()
+    balance_to_edit['amount'] = '999'
+    response = requests.patch(
+        api_url_for(
+            rotkehlchen_api_server,
+            'manuallytrackedbalancesresource',
+        ), json={'balances': [balance_to_edit]},
+    )
+    result = assert_proper_sync_response_with_result(response)
+    balances[0]['amount'] = '999'
+    assert_balances_match(
+        expected_balances=balances,
+        returned_balances=result['balances'],
+    )


### PR DESCRIPTION
Fix https://github.com/rotki/rotki/issues/11935

