### PR TITLE
Add UNIQUE constraint to manual balance labels in v51->52 DB upgrade

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -1598,7 +1598,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
         if action == 'txlist':
             for tx_batch in transactions_iterator:
                 for tx in tx_batch:
-                    self.block_to_timestamp_cache.add(key=tx.block_number, value=tx.timestamp)
+                    self.block_to_timestamp_cache.add(key=tx.block_number, value=tx.timestamp)    # type: ignore[union-attr]
 
                 yield tx_batch
         else:

--- a/rotkehlchen/db/minimized_schema.py
+++ b/rotkehlchen/db/minimized_schema.py
@@ -12,7 +12,7 @@ MINIMIZED_USER_DB_SCHEMA = {
     "blockchain_accounts": "blockchainvarchar[24]notnull,accounttextnotnull,primarykey(blockchain,account)",
     "evm_accounts_details": "accountvarchar[42]notnull,chain_idintegernotnull,keytextnotnull,valuetextnotnull,primarykey(account,chain_id,key,value)",
     "multisettings": "namevarchar[24]notnull,valuetext,unique(name,value)",
-    "manually_tracked_balances": "idintegerprimarykey,assettextnotnull,labeltextnotnull,amounttext,locationchar(1)notnulldefault('a')referenceslocation(location),categorychar(1)notnulldefault('a')referencesbalance_category(category),foreignkey(asset)referencesassets(identifier)onupdatecascade",
+    "manually_tracked_balances": "idintegerprimarykey,assettextnotnull,labeltextnotnullunique,amounttext,locationchar(1)notnulldefault('a')referenceslocation(location),categorychar(1)notnulldefault('a')referencesbalance_category(category),foreignkey(asset)referencesassets(identifier)onupdatecascade",
     "evm_transactions": "identifierintegernotnullprimarykey,tx_hashblobnotnull,chain_idintegernotnull,timestampintegernotnull,block_numberintegernotnull,from_addresstextnotnull,to_addresstext,valuetextnotnull,gastextnotnull,gas_pricetextnotnull,gas_usedtextnotnull,input_datablobnotnull,nonceintegernotnull,unique(tx_hash,chain_id)",
     "evm_transactions_authorizations": "tx_idintegernotnullprimarykey,nonceintegernotnull,delegated_addresstextnotnull,foreignkey(tx_id)referencesevm_transactions(identifier)ondeletecascade",
     "optimism_transactions": "tx_idintegernotnullprimarykey,l1_feetext,foreignkey(tx_id)referencesevm_transactions(identifier)ondeletecascadeonupdatecascade",

--- a/rotkehlchen/db/schema.py
+++ b/rotkehlchen/db/schema.py
@@ -260,7 +260,7 @@ DB_CREATE_MANUALLY_TRACKED_BALANCES = """
 CREATE TABLE IF NOT EXISTS manually_tracked_balances (
     id INTEGER PRIMARY KEY,
     asset TEXT NOT NULL,
-    label TEXT NOT NULL,
+    label TEXT NOT NULL UNIQUE,
     amount TEXT,
     location CHAR(1) NOT NULL DEFAULT('A') REFERENCES location(location),
     category CHAR(1) NOT NULL DEFAULT('A') REFERENCES balance_category(category),

--- a/rotkehlchen/db/upgrades/v51_v52.py
+++ b/rotkehlchen/db/upgrades/v51_v52.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.bitcoin.bch.validation import is_valid_bitcoin_cash_address
 from rotkehlchen.chain.bitcoin.validation import is_valid_btc_address
+from rotkehlchen.db.utils import update_table_schema
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.types import HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
@@ -97,5 +98,42 @@ def upgrade_v51_to_v52(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             f'Inserted {len(mappings)} bitcoin event address mappings '
             'during v51->v52 upgrade',
         )
+
+    @progress_step(description='Adding UNIQUE constraint to manually_tracked_balances label column.')  # noqa: E501
+    def _add_unique_label_constraint(write_cursor: 'DBCursor') -> None:
+        """Add UNIQUE constraint to the label column of manually_tracked_balances.
+        First deduplicate any existing entries by appending a suffix.
+        """
+        duplicates = write_cursor.execute(
+            'SELECT label FROM manually_tracked_balances '
+            'GROUP BY label HAVING COUNT(*) > 1',
+        ).fetchall()
+
+        for (label,) in duplicates:
+            rows = write_cursor.execute(
+                'SELECT id FROM manually_tracked_balances WHERE label=? ORDER BY id',
+                (label,),
+            ).fetchall()
+            for idx, (row_id,) in enumerate(rows[1:], start=2):
+                write_cursor.execute(
+                    'UPDATE manually_tracked_balances SET label=? WHERE id=?',
+                    (f'{label} ({idx})', row_id),
+                )
+
+        write_cursor.switch_foreign_keys('OFF')
+        update_table_schema(
+            write_cursor=write_cursor,
+            table_name='manually_tracked_balances',
+            schema="""id INTEGER PRIMARY KEY,
+            asset TEXT NOT NULL,
+            label TEXT NOT NULL UNIQUE,
+            amount TEXT,
+            location CHAR(1) NOT NULL DEFAULT('A') REFERENCES location(location),
+            category CHAR(1) NOT NULL DEFAULT('A') REFERENCES balance_category(category),
+            FOREIGN KEY(asset) REFERENCES assets(identifier) ON UPDATE CASCADE""",
+            insert_columns='asset, label, amount, location, category',
+            insert_order='(asset, label, amount, location, category)',
+        )
+        write_cursor.switch_foreign_keys('ON')
 
     perform_userdb_upgrade_steps(db=db, progress_handler=progress_handler, should_vacuum=True)

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -4015,6 +4015,19 @@ def test_upgrade_db_51_to_52(user_data_dir, messages_aggregator):
             ),
         )
 
+    # Insert manually tracked balances with duplicate labels to test dedup
+    with db_v51.conn.write_ctx() as write_cursor:
+        write_cursor.executemany(
+            'INSERT INTO manually_tracked_balances(asset, label, amount, location, category) '
+            'VALUES(?, ?, ?, ?, ?)',
+            [
+                ('BTC', 'My wallet', '1.5', 'A', 'A'),
+                ('ETH', 'My wallet', '10', 'A', 'A'),  # duplicate label
+                ('ETH', 'My wallet', '20', 'A', 'A'),  # another duplicate
+                ('BTC', 'Unique balance', '0.5', 'A', 'A'),
+            ],
+        )
+
     db_v51.logout()
     db = _init_db_with_target_version(
         target_version=52,
@@ -4050,5 +4063,38 @@ def test_upgrade_db_51_to_52(user_data_dir, messages_aggregator):
             ')',
             ('BTC_NOTE_TEST_2',),
         ).fetchone()[0] == 0
+
+        # Verify duplicate labels were deduplicated
+        labels = cursor.execute(
+            'SELECT label FROM manually_tracked_balances ORDER BY id',
+        ).fetchall()
+        assert labels == [
+            ('My wallet',),
+            ('My wallet (2)',),
+            ('My wallet (3)',),
+            ('Unique balance',),
+        ]
+
+        # Verify UNIQUE constraint is enforced — inserting a duplicate label should fail
+        with pytest.raises(sqlcipher.IntegrityError):  # pylint: disable=no-member
+            cursor.execute(
+                'INSERT INTO manually_tracked_balances(asset, label, amount, location, category) '
+                'VALUES(?, ?, ?, ?, ?)',
+                ('BTC', 'Unique balance', '1', 'A', 'A'),
+            )
+
+        # Verify the upgraded table has the correct schema with id column
+        columns = [
+            row[1] for row in cursor.execute(
+                'PRAGMA table_info(manually_tracked_balances)',
+            ).fetchall()
+        ]
+        assert columns == ['id', 'asset', 'label', 'amount', 'location', 'category']
+        # Verify id column auto-populated and data survived the migration
+        rows = cursor.execute(
+            'SELECT id, asset, label, amount FROM manually_tracked_balances ORDER BY id',
+        ).fetchall()
+        assert len(rows) == 4
+        assert all(row[0] is not None for row in rows)  # all have an id
 
     db.logout()

--- a/rotkehlchen/tests/unit/test_evm_misc.py
+++ b/rotkehlchen/tests/unit/test_evm_misc.py
@@ -207,7 +207,7 @@ def test_get_transactions_populates_block_timestamp_cache(
         input_data=b'',
         nonce=1,
     )
-    with patch.object(ethereum_inquirer, '_try_indexers_iterable', return_value=iter([[tx]])):
+    with patch.object(ethereum_inquirer, '_try_indexers_iterable_with_source', return_value=(iter([[tx]]), 'mock')):  # noqa: E501
         result = list(ethereum_inquirer.get_transactions(
             account=make_evm_address(),
             action='txlist',


### PR DESCRIPTION
This is the develop part of the fix for
https://github.com/rotki/rotki/issues/11935 which contains a DB schema change and a deduplication of already existing duplicated manually tracked balance labels

