### PR TITLE
feat(frontend): add UI for internal tx conflict repull settings

### DIFF
--- a/frontend/app/src/components/settings/HistoryEventSettingsCategory.vue
+++ b/frontend/app/src/components/settings/HistoryEventSettingsCategory.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import AutoCreateProfitEventsSetting from '@/components/settings/general/AutoCreateProfitEventsSetting.vue';
+import InternalTxConflictRepullSettings from '@/components/settings/general/InternalTxConflictRepullSettings.vue';
 import SettingCategory from '@/components/settings/SettingCategory.vue';
 
 const HistoryEventsSkippedExternalEvents = defineAsyncComponent(
@@ -18,6 +19,7 @@ const { t } = useI18n({ useScope: 'global' });
       {{ t('general_settings.history_event.subtitle') }}
     </template>
     <AutoCreateProfitEventsSetting />
+    <InternalTxConflictRepullSettings />
     <HistoryEventsSkippedExternalEvents />
   </SettingCategory>
 </template>

--- a/frontend/app/src/components/settings/general/InternalTxConflictRepullSettings.vue
+++ b/frontend/app/src/components/settings/general/InternalTxConflictRepullSettings.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import SettingsOption from '@/components/settings/controls/SettingsOption.vue';
+import { Defaults } from '@/data/defaults';
+import { useGeneralSettingsStore } from '@/store/settings/general';
+
+const { compact = false } = defineProps<{
+  compact?: boolean;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const store = useGeneralSettingsStore();
+const { internalTxConflictRepullFrequency: storedFrequency, internalTxsToRepull: storedBatchSize } = storeToRefs(store);
+
+const batchSize = ref<string>(Defaults.DEFAULT_INTERNAL_TXS_TO_REPULL.toString());
+const SECONDS_PER_MINUTE = 60;
+const frequency = ref<string>((Defaults.DEFAULT_INTERNAL_TX_CONFLICT_REPULL_FREQUENCY / SECONDS_PER_MINUTE).toString());
+
+function resetBatchSize(update: (value: number) => void): void {
+  const defaultVal = Defaults.DEFAULT_INTERNAL_TXS_TO_REPULL;
+  update(defaultVal);
+  set(batchSize, defaultVal.toString());
+}
+
+function resetFrequency(update: (value: number) => void): void {
+  const defaultVal = Defaults.DEFAULT_INTERNAL_TX_CONFLICT_REPULL_FREQUENCY;
+  update(defaultVal);
+  set(frequency, (defaultVal / SECONDS_PER_MINUTE).toString());
+}
+
+onMounted(() => {
+  set(batchSize, get(storedBatchSize).toString());
+  set(frequency, (get(storedFrequency) / SECONDS_PER_MINUTE).toString());
+});
+</script>
+
+<template>
+  <div :class="compact ? 'flex flex-col gap-3 pt-4' : undefined">
+    <SettingsOption
+      setting="internalTxsToRepull"
+      :error-message="t('general_settings.history_event.internal_tx_conflicts.batch_size.error')"
+    >
+      <template
+        v-if="!compact"
+        #title
+      >
+        {{ t('general_settings.history_event.internal_tx_conflicts.batch_size.title') }}
+      </template>
+      <template
+        v-if="!compact"
+        #subtitle
+      >
+        {{ t('general_settings.history_event.internal_tx_conflicts.batch_size.subtitle') }}
+      </template>
+      <template #default="{ error, success, update, updateImmediate }">
+        <div class="flex items-start w-full">
+          <RuiTextField
+            v-model.number="batchSize"
+            variant="outlined"
+            color="primary"
+            class="w-full"
+            :dense="compact"
+            :label="t('general_settings.history_event.internal_tx_conflicts.batch_size.label')"
+            type="number"
+            :min="1"
+            :success-messages="success"
+            :error-messages="error"
+            @update:model-value="update($event ? parseInt($event) : $event)"
+          />
+          <RuiButton
+            :class="compact ? 'ml-1' : 'mt-1 ml-2'"
+            variant="text"
+            icon
+            :size="compact ? 'sm' : undefined"
+            @click="resetBatchSize(updateImmediate)"
+          >
+            <RuiIcon name="lu-history" />
+          </RuiButton>
+        </div>
+      </template>
+    </SettingsOption>
+    <SettingsOption
+      setting="internalTxConflictRepullFrequency"
+      :error-message="t('general_settings.history_event.internal_tx_conflicts.frequency.error')"
+    >
+      <template
+        v-if="!compact"
+        #title
+      >
+        {{ t('general_settings.history_event.internal_tx_conflicts.frequency.title') }}
+      </template>
+      <template
+        v-if="!compact"
+        #subtitle
+      >
+        {{ t('general_settings.history_event.internal_tx_conflicts.frequency.subtitle') }}
+      </template>
+      <template #default="{ error, success, update, updateImmediate }">
+        <div class="flex items-start w-full">
+          <RuiTextField
+            v-model.number="frequency"
+            variant="outlined"
+            color="primary"
+            class="w-full"
+            :dense="compact"
+            :label="t('general_settings.history_event.internal_tx_conflicts.frequency.label')"
+            type="number"
+            :min="0.5"
+            :step="0.5"
+            :success-messages="success"
+            :error-messages="error"
+            @update:model-value="update($event ? Number.parseFloat($event) * SECONDS_PER_MINUTE : $event)"
+          />
+          <RuiButton
+            :class="compact ? 'ml-1' : 'mt-1 ml-2'"
+            variant="text"
+            icon
+            :size="compact ? 'sm' : undefined"
+            @click="resetFrequency(updateImmediate)"
+          >
+            <RuiIcon name="lu-history" />
+          </RuiButton>
+        </div>
+      </template>
+    </SettingsOption>
+  </div>
+</template>

--- a/frontend/app/src/data/defaults.ts
+++ b/frontend/app/src/data/defaults.ts
@@ -42,6 +42,8 @@ export const Defaults = {
   DISPLAY_DATE_IN_LOCALTIME: true,
   DOT_RPC_ENDPOINT: '', // same as Kusama, must be set by user
   FLOATING_PRECISION: 2,
+  DEFAULT_INTERNAL_TX_CONFLICT_REPULL_FREQUENCY: 3600,
+  DEFAULT_INTERNAL_TXS_TO_REPULL: 20,
   KSM_RPC_ENDPOINT: 'http://localhost:9933',
 } as const;
 

--- a/frontend/app/src/data/factories.ts
+++ b/frontend/app/src/data/factories.ts
@@ -28,6 +28,8 @@ export function defaultGeneralSettings(mainCurrency: Currency): GeneralSettings 
     evmIndexersOrder: {},
     historicalPriceOracles: [],
     inferZeroTimedBalances: false,
+    internalTxConflictRepullFrequency: Defaults.DEFAULT_INTERNAL_TX_CONFLICT_REPULL_FREQUENCY,
+    internalTxsToRepull: Defaults.DEFAULT_INTERNAL_TXS_TO_REPULL,
     ksmRpcEndpoint: Defaults.KSM_RPC_ENDPOINT,
     mainCurrency,
     nonSyncingExchanges: [],

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3149,6 +3149,20 @@
           "error": "Error setting auto create profit events"
         }
       },
+      "internal_tx_conflicts": {
+        "batch_size": {
+          "error": "Error setting internal transactions to repull",
+          "label": "Transactions per batch",
+          "subtitle": "Number of internal transaction conflicts to process per periodic task run.",
+          "title": "Internal transactions to repull"
+        },
+        "frequency": {
+          "error": "Error setting internal tx conflict repull frequency",
+          "label": "Repull frequency (minutes)",
+          "subtitle": "How often (in minutes) the system automatically attempts to repull conflicting internal transactions.",
+          "title": "Conflict repull frequency"
+        }
+      },
       "skipped_events": {
         "subtitle": "View and manage skipped external events",
         "title": "Skipped External Events"
@@ -3713,6 +3727,7 @@
       "fix_redecode": "Fix & Redecode",
       "pin": "Pin to sidebar",
       "repull": "Repull",
+      "settings": "Toggle settings",
       "show_in_events": "Show in history events",
       "unpin": "Unpin section"
     },

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsDialog.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { InternalTxConflict } from './types';
+import InternalTxConflictRepullSettings from '@/components/settings/general/InternalTxConflictRepullSettings.vue';
 import CardTitle from '@/components/typography/CardTitle.vue';
 import { useAreaVisibilityStore } from '@/store/session/visibility';
 import { PinnedNames } from '@/types/session';
@@ -9,6 +10,7 @@ const modelValue = defineModel<boolean>({ default: false });
 
 const { t } = useI18n({ useScope: 'global' });
 
+const showSettings = ref<boolean>(false);
 const { pinned } = storeToRefs(useAreaVisibilityStore());
 
 function closeDialog(): void {
@@ -63,6 +65,21 @@ function showInEvents(conflict: InternalTxConflict): void {
                 <RuiButton
                   variant="text"
                   icon
+                  @click="showSettings = !showSettings"
+                >
+                  <RuiIcon name="lu-settings" />
+                </RuiButton>
+              </template>
+              {{ t('internal_tx_conflicts.actions.settings') }}
+            </RuiTooltip>
+            <RuiTooltip
+              :popper="{ placement: 'bottom' }"
+              :open-delay="400"
+            >
+              <template #activator>
+                <RuiButton
+                  variant="text"
+                  icon
                   @click="pinSection()"
                 >
                   <RuiIcon name="lu-pin" />
@@ -80,6 +97,13 @@ function showInEvents(conflict: InternalTxConflict): void {
           </div>
         </div>
       </template>
+
+      <div
+        v-if="showSettings"
+        class="px-4 pt-4 border-b border-default"
+      >
+        <InternalTxConflictRepullSettings compact />
+      </div>
 
       <InternalTxConflictsContent
         class="my-4"

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsPinned.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsPinned.vue
@@ -3,6 +3,7 @@ import type { Nullable } from '@rotki/common';
 import type { InternalTxConflict } from './types';
 import type { Pinned } from '@/types/session';
 import { startPromise } from '@shared/utils';
+import InternalTxConflictRepullSettings from '@/components/settings/general/InternalTxConflictRepullSettings.vue';
 import { HighlightTargetTypes, useHistoryEventNavigation } from '@/composables/history/events/use-history-event-navigation';
 import { useAreaVisibilityStore } from '@/store/session/visibility';
 import InternalTxConflictsContent from './InternalTxConflictsContent.vue';
@@ -22,6 +23,7 @@ const { clearAllHighlightTargets, highlightTargets, requestNavigation, setHighli
 const { cancelResolution, progress } = useInternalTxConflictResolution();
 
 const activeTxHash = ref<string | undefined>(highlightedTxHash);
+const showSettings = ref<boolean>(false);
 const isRunning = computed<boolean>(() => get(progress).isRunning);
 
 function setPinned(pin: Nullable<Pinned>): void {
@@ -140,6 +142,26 @@ onUnmounted(() => {
               variant="text"
               icon
               size="sm"
+              @click="showSettings = !showSettings"
+            >
+              <RuiIcon
+                size="20"
+                class="text-white"
+                name="lu-settings"
+              />
+            </RuiButton>
+          </template>
+          {{ t('internal_tx_conflicts.actions.settings') }}
+        </RuiTooltip>
+        <RuiTooltip
+          :popper="{ placement: 'bottom' }"
+          :open-delay="400"
+        >
+          <template #activator>
+            <RuiButton
+              variant="text"
+              icon
+              size="sm"
               @click="unpin()"
             >
               <RuiIcon
@@ -152,6 +174,13 @@ onUnmounted(() => {
           {{ t('internal_tx_conflicts.actions.unpin') }}
         </RuiTooltip>
       </template>
+    </div>
+
+    <div
+      v-if="showSettings"
+      class="px-2 pt-2 border-b border-default"
+    >
+      <InternalTxConflictRepullSettings compact />
     </div>
 
     <InternalTxConflictsContent

--- a/frontend/app/src/store/settings/general.ts
+++ b/frontend/app/src/store/settings/general.ts
@@ -25,6 +25,8 @@ export const useGeneralSettingsStore = defineStore('settings/general', () => {
   const historicalPriceOracles = useComputedRef(settings, 'historicalPriceOracles');
   const ssfGraphMultiplier = useComputedRef(settings, 'ssfGraphMultiplier');
   const inferZeroTimedBalances = useComputedRef(settings, 'inferZeroTimedBalances');
+  const internalTxConflictRepullFrequency = useComputedRef(settings, 'internalTxConflictRepullFrequency');
+  const internalTxsToRepull = useComputedRef(settings, 'internalTxsToRepull');
   const nonSyncingExchanges = useComputedRef(settings, 'nonSyncingExchanges');
   const evmchainsToSkipDetection = useComputedRef(settings, 'evmchainsToSkipDetection');
   const evmIndexersOrder = useComputedRef(settings, 'evmIndexersOrder');
@@ -84,6 +86,8 @@ export const useGeneralSettingsStore = defineStore('settings/general', () => {
     floatingPrecision: uiFloatingPrecision,
     historicalPriceOracles,
     inferZeroTimedBalances,
+    internalTxConflictRepullFrequency,
+    internalTxsToRepull,
     ksmRpcEndpoint,
     nonSyncingExchanges,
     oraclePenaltyDuration,

--- a/frontend/app/src/types/user.ts
+++ b/frontend/app/src/types/user.ts
@@ -66,6 +66,8 @@ const GeneralSettings = z.object({
   evmIndexersOrder: z.record(z.string(), z.array(EvmIndexerEnum)),
   historicalPriceOracles: z.array(PriceOracleEnum),
   inferZeroTimedBalances: z.boolean(),
+  internalTxConflictRepullFrequency: z.number().int().min(30).default(Defaults.DEFAULT_INTERNAL_TX_CONFLICT_REPULL_FREQUENCY),
+  internalTxsToRepull: z.number().int().min(1).default(Defaults.DEFAULT_INTERNAL_TXS_TO_REPULL),
   ksmRpcEndpoint: z.string(),
   mainCurrency: z.string().transform((currency) => {
     const { findCurrency } = useCurrencies();
@@ -188,6 +190,8 @@ function getGeneralSettings(settings: UserSettings): GeneralSettings {
     evmIndexersOrder: settings.evmIndexersOrder,
     historicalPriceOracles: settings.historicalPriceOracles,
     inferZeroTimedBalances: settings.inferZeroTimedBalances,
+    internalTxConflictRepullFrequency: settings.internalTxConflictRepullFrequency,
+    internalTxsToRepull: settings.internalTxsToRepull,
     ksmRpcEndpoint: settings.ksmRpcEndpoint,
     mainCurrency: settings.mainCurrency,
     nonSyncingExchanges: settings.nonSyncingExchanges,


### PR DESCRIPTION
## Summary
- Expose `internal_txs_to_repull` and `internal_tx_conflict_repull_frequency` settings in the frontend UI
- Add a reusable `InternalTxConflictRepullSettings` component with compact mode for embedding in different contexts
- Settings accessible from: General Settings > History Events section, Internal Tx Conflicts dialog, and pinned sidebar view
- Frequency displayed in minutes for user friendliness, converted to seconds for the API

## Test plan
- [ ] Open General Settings > History Events and verify both new settings appear with title/subtitle
- [ ] Change batch size and frequency values, verify they persist after page reload
- [ ] Test reset buttons restore default values (20 transactions, 60 minutes)
- [ ] Open Internal Tx Conflicts dialog, toggle settings gear icon, verify compact settings panel appears
- [ ] Pin Internal Tx Conflicts to sidebar, toggle settings gear icon, verify compact settings panel appears
- [ ] Verify min constraints: batch size >= 1, frequency >= 0.5 minutes