### PR TITLE
fix(frontend): await decoding before stopping sync progress

### DIFF
--- a/frontend/app/src/composables/history/events/tx/use-refresh-transactions.spec.ts
+++ b/frontend/app/src/composables/history/events/tx/use-refresh-transactions.spec.ts
@@ -67,6 +67,7 @@ const mockHistoryStore = {
 
 const mockTransactionSync = {
   syncTransactionsByChains: vi.fn().mockResolvedValue(undefined),
+  waitForDecoding: vi.fn().mockResolvedValue(undefined),
 };
 
 const mockSupportedChains = {
@@ -522,6 +523,24 @@ describe('useRefreshTransactions', () => {
       await refreshTransactions();
 
       expect(callOrder.indexOf('onHistoryStarted')).toBeLessThan(callOrder.indexOf('syncTransactionsByChains'));
+    });
+
+    it('should wait for decoding to complete before stopping decoding sync progress', async () => {
+      const callOrder: string[] = [];
+
+      mockTransactionSync.waitForDecoding.mockImplementation(async () => {
+        callOrder.push('waitForDecoding');
+      });
+      mockHistoryStore.stopDecodingSyncProgress.mockImplementation(() => {
+        callOrder.push('stopDecodingSyncProgress');
+      });
+
+      const { refreshTransactions } = useRefreshTransactions();
+
+      await refreshTransactions();
+
+      expect(mockTransactionSync.waitForDecoding).toHaveBeenCalledTimes(1);
+      expect(callOrder.indexOf('waitForDecoding')).toBeLessThan(callOrder.indexOf('stopDecodingSyncProgress'));
     });
 
     it('should call onHistoryFinished after all operations complete', async () => {

--- a/frontend/app/src/composables/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/composables/history/events/tx/use-refresh-transactions.ts
@@ -34,7 +34,7 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
   const { resetDecodingSyncProgress, resetUndecodedTransactionsStatus, stopDecodingSyncProgress } = useHistoryStore();
   const { isDecodableChains } = useSupportedChains();
 
-  const { syncTransactionsByChains } = useTransactionSync();
+  const { syncTransactionsByChains, waitForDecoding } = useTransactionSync();
   const { queryAllExchangeEvents, queryOnlineEvent } = useRefreshHandlers();
   const { onHistoryFinished, onHistoryStarted } = useSchedulerState();
 
@@ -170,6 +170,10 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
           logger.error(error);
         }
       }
+
+      // Wait for any queued decode tasks to finish before proceeding,
+      // so that WS progress updates are not dropped by stopDecodingSyncProgress()
+      await waitForDecoding();
 
       queue.queue('fetch-undecoded-transactions-breakdown', fetchUndecodedTransactionsBreakdown);
 

--- a/frontend/app/src/composables/history/events/tx/use-transaction-sync.ts
+++ b/frontend/app/src/composables/history/events/tx/use-transaction-sync.ts
@@ -24,6 +24,7 @@ interface UseTransactionSyncReturn {
   syncAndReDecodeEvents: (chain: string, params: TransactionSyncParams) => Promise<void>;
   syncTransactionTask: (account: ChainAddress, type: TransactionChainType, trackProgress?: boolean) => Promise<void>;
   syncTransactionsByChains: (accounts: ChainAddress[], trackProgress?: boolean) => Promise<void>;
+  waitForDecoding: () => Promise<void>;
 }
 
 export function useTransactionSync(): UseTransactionSyncReturn {
@@ -153,9 +154,18 @@ export function useTransactionSync(): UseTransactionSyncReturn {
     );
   };
 
+  const waitForDecoding = async (): Promise<void> => new Promise((resolve) => {
+    if (queue.running === 0 && queue.pending === 0) {
+      resolve();
+      return;
+    }
+    queue.setOnCompletion(() => resolve());
+  });
+
   return {
     syncAndReDecodeEvents,
     syncTransactionsByChains,
     syncTransactionTask,
+    waitForDecoding,
   };
 }

--- a/frontend/app/src/modules/sync-progress/composables/use-sync-progress.spec.ts
+++ b/frontend/app/src/modules/sync-progress/composables/use-sync-progress.spec.ts
@@ -201,6 +201,40 @@ describe('useSyncProgress', () => {
       expect(decodingValue[0].progress).toBe(50);
     });
 
+    it('should not update sync progress after stopDecodingSyncProgress is called', () => {
+      const historyStore = useHistoryStore();
+      historyStore.resetDecodingSyncProgress();
+      historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
+
+      // Stop sync progress (simulates the finally block running)
+      historyStore.stopDecodingSyncProgress();
+
+      // Simulate a late WS update arriving after stop
+      historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 100));
+
+      const { decoding } = useSyncProgress();
+      const decodingValue = get(decoding);
+
+      // The sync progress should still show the old value (50), not the updated one (100)
+      expect(decodingValue).toHaveLength(1);
+      expect(decodingValue[0].processed).toBe(50);
+    });
+
+    it('should continue updating sync progress while decodingSyncing is true', () => {
+      const historyStore = useHistoryStore();
+      historyStore.resetDecodingSyncProgress();
+      historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 0));
+      historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
+      historyStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 100));
+
+      const { decoding } = useSyncProgress();
+      const decodingValue = get(decoding);
+
+      // All updates should have been applied while decodingSyncing was true
+      expect(decodingValue).toHaveLength(1);
+      expect(decodingValue[0].processed).toBe(100);
+    });
+
     it('should filter out chains with total 0', () => {
       const historyStore = useHistoryStore();
       historyStore.resetDecodingSyncProgress();


### PR DESCRIPTION
## Summary
- The sync progress bar could get stuck at `0/N` because `stopDecodingSyncProgress()` ran in the `finally` block before queued decode tasks finished, causing the `decodingSyncing` guard to drop all subsequent WS progress updates
- Added `waitForDecoding()` to `useTransactionSync` that returns a promise resolving when the decode queue drains
- Await `waitForDecoding()` in `useRefreshTransactions` before the `finally` block so `decodingSyncing` stays `true` while decoding is active

## Test plan
- [ ] Verify sync progress bar updates correctly during a full refresh with decodable chains
- [ ] Verify background-initiated decoding does not show progress in the sync bar
- [ ] New unit tests verify ordering (`waitForDecoding` before `stopDecodingSyncProgress`) and guard behavior