### PR TITLE
feat(frontend): use POST endpoint for conflict count

### DIFF
--- a/frontend/app/src/modules/history/internal-tx-conflicts/internal-tx-conflicts-api.spec.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/internal-tx-conflicts-api.spec.ts
@@ -140,5 +140,49 @@ describe('modules/history/internal-tx-conflicts/internal-tx-conflicts-api', () =
           .toThrow();
       });
     });
+
+    describe('fetchInternalTxConflictsCount', () => {
+      it('sends POST with correct payload and returns counts', async () => {
+        let capturedBody: Record<string, unknown> | undefined;
+
+        server.use(
+          http.post(`${backendUrl}/api/1/blockchains/transactions/internal/conflicts`, async ({ request }) => {
+            capturedBody = await request.json() as Record<string, unknown>;
+            return HttpResponse.json({
+              result: {
+                entries_found: 178,
+                entries_total: 237,
+              },
+              message: '',
+            });
+          }),
+        );
+
+        const { fetchInternalTxConflictsCount } = useInternalTxConflictsApi();
+        const result = await fetchInternalTxConflictsCount({ failed: false, fixed: false });
+
+        expect(capturedBody).toBeDefined();
+        expect(capturedBody!.fixed).toBe(false);
+        expect(capturedBody!.failed).toBe(false);
+        expect(result.entriesFound).toBe(178);
+        expect(result.entriesTotal).toBe(237);
+      });
+
+      it('throws on HTTP error response', async () => {
+        server.use(
+          http.post(`${backendUrl}/api/1/blockchains/transactions/internal/conflicts`, () =>
+            HttpResponse.json({
+              result: null,
+              message: 'Server error',
+            }, { status: HTTPStatus.INTERNAL_SERVER_ERROR })),
+        );
+
+        const { fetchInternalTxConflictsCount } = useInternalTxConflictsApi();
+
+        await expect(fetchInternalTxConflictsCount({ failed: false, fixed: false }))
+          .rejects
+          .toThrow();
+      });
+    });
   });
 });

--- a/frontend/app/src/modules/history/internal-tx-conflicts/internal-tx-conflicts-api.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/internal-tx-conflicts-api.ts
@@ -1,5 +1,5 @@
 import type { MaybeRef } from 'vue';
-import type { InternalTxConflict, InternalTxConflictsRequestPayload } from './types';
+import type { InternalTxConflict, InternalTxConflictsCountPayload, InternalTxConflictsCountResponse, InternalTxConflictsRequestPayload } from './types';
 import type { Collection, CollectionResponse } from '@/types/collection';
 import { api } from '@/modules/api/rotki-api';
 import { mapCollectionResponse } from '@/utils/collection';
@@ -7,6 +7,7 @@ import { nonEmptyProperties } from '@/utils/data';
 
 interface UseInternalTxConflictsApiReturn {
   fetchInternalTxConflicts: (payload: MaybeRef<InternalTxConflictsRequestPayload>) => Promise<Collection<InternalTxConflict>>;
+  fetchInternalTxConflictsCount: (payload: InternalTxConflictsCountPayload) => Promise<InternalTxConflictsCountResponse>;
 }
 
 export function useInternalTxConflictsApi(): UseInternalTxConflictsApiReturn {
@@ -20,5 +21,15 @@ export function useInternalTxConflictsApi(): UseInternalTxConflictsApiReturn {
     return mapCollectionResponse(response);
   };
 
-  return { fetchInternalTxConflicts };
+  const fetchInternalTxConflictsCount = async (
+    payload: InternalTxConflictsCountPayload,
+  ): Promise<InternalTxConflictsCountResponse> => {
+    const response = await api.post<InternalTxConflictsCountResponse>(
+      '/blockchains/transactions/internal/conflicts',
+      nonEmptyProperties(payload),
+    );
+    return response;
+  };
+
+  return { fetchInternalTxConflicts, fetchInternalTxConflictsCount };
 }

--- a/frontend/app/src/modules/history/internal-tx-conflicts/types.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/types.ts
@@ -50,3 +50,17 @@ export interface InternalTxConflictsRequestPayload extends PaginationRequestPayl
   fromTimestamp?: number;
   toTimestamp?: number;
 }
+
+export interface InternalTxConflictsCountPayload {
+  txHash?: string;
+  chain?: string;
+  fixed?: boolean;
+  failed?: boolean;
+  fromTimestamp?: number;
+  toTimestamp?: number;
+}
+
+export interface InternalTxConflictsCountResponse {
+  entriesFound: number;
+  entriesTotal: number;
+}

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.spec.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.spec.ts
@@ -1,18 +1,20 @@
 import type { Ref } from 'vue';
 import type { Collection } from '@/types/collection';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type InternalTxConflict, InternalTxConflictStatuses } from './types';
+import { type InternalTxConflict, type InternalTxConflictsCountResponse, InternalTxConflictStatuses } from './types';
 import { useInternalTxConflicts } from './use-internal-tx-conflicts';
 
 const { spies } = vi.hoisted(() => ({
   spies: {
     fetchInternalTxConflicts: vi.fn<() => Promise<Collection<InternalTxConflict>>>(),
+    fetchInternalTxConflictsCount: vi.fn<() => Promise<InternalTxConflictsCountResponse>>(),
   },
 }));
 
 vi.mock('./internal-tx-conflicts-api', () => ({
   useInternalTxConflictsApi: (): object => ({
     fetchInternalTxConflicts: spies.fetchInternalTxConflicts,
+    fetchInternalTxConflictsCount: spies.fetchInternalTxConflictsCount,
   }),
 }));
 
@@ -86,6 +88,7 @@ describe('use-internal-tx-conflicts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     spies.fetchInternalTxConflicts.mockResolvedValue(createMockCollection());
+    spies.fetchInternalTxConflictsCount.mockResolvedValue({ entriesFound: 0, entriesTotal: 0 });
     composable = useInternalTxConflicts();
   });
 
@@ -94,17 +97,15 @@ describe('use-internal-tx-conflicts', () => {
   });
 
   describe('fetchPendingCount', () => {
-    it('updates pendingCount from API total', async () => {
-      spies.fetchInternalTxConflicts.mockResolvedValue(createMockCollection([], 4, 5));
+    it('updates pendingCount from POST count endpoint', async () => {
+      spies.fetchInternalTxConflictsCount.mockResolvedValue({ entriesFound: 4, entriesTotal: 5 });
 
       await composable.fetchPendingCount();
 
       expect(get(composable.pendingCount)).toBe(4);
-      expect(spies.fetchInternalTxConflicts).toHaveBeenCalledWith({
+      expect(spies.fetchInternalTxConflictsCount).toHaveBeenCalledWith({
         failed: false,
         fixed: false,
-        limit: 0,
-        offset: 0,
       });
     });
   });

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
@@ -42,7 +42,7 @@ interface UseInternalTxConflictsReturn {
 export const useInternalTxConflicts = createSharedComposable((): UseInternalTxConflictsReturn => {
   const { t } = useI18n({ useScope: 'global' });
   const { setMessage } = useMessageStore();
-  const { fetchInternalTxConflicts } = useInternalTxConflictsApi();
+  const { fetchInternalTxConflicts, fetchInternalTxConflictsCount } = useInternalTxConflictsApi();
 
   const pendingCount = ref<number>(0);
   const activeFilter = ref<InternalTxConflictStatus>(InternalTxConflictStatuses.PENDING);
@@ -77,13 +77,11 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
 
   async function fetchPendingCount(): Promise<void> {
     try {
-      const result = await fetchInternalTxConflicts({
+      const result = await fetchInternalTxConflictsCount({
         failed: false,
         fixed: false,
-        limit: 0,
-        offset: 0,
       });
-      set(pendingCount, result.found);
+      set(pendingCount, result.entriesFound);
     }
     catch (error: any) {
       logger.error('Failed to fetch internal tx conflicts pending count:', error);


### PR DESCRIPTION
## Summary
- Add `fetchInternalTxConflictsCount` API call using the new POST `/blockchains/transactions/internal/conflicts` endpoint (from #11942)
- Replace the GET call with `limit: 0, offset: 0` in `fetchPendingCount` with the lighter POST endpoint that returns only counts (`entries_found`, `entries_total`)
- Add `InternalTxConflictsCountPayload` and `InternalTxConflictsCountResponse` types

## Test plan
- [ ] Verify pending conflict count badge updates correctly
- [ ] Updated unit tests for API layer and composable