### PR TITLE
feat(frontend): add confirmation popover to setting reset buttons

### DIFF
--- a/frontend/app/src/components/settings/general/BalanceSaveFrequencySetting.vue
+++ b/frontend/app/src/components/settings/general/BalanceSaveFrequencySetting.vue
@@ -5,6 +5,7 @@ import SettingsOption from '@/components/settings/controls/SettingsOption.vue';
 import { useValidation } from '@/composables/validation';
 import { Constraints } from '@/data/constraints';
 import { Defaults } from '@/data/defaults';
+import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { toMessages } from '@/utils/validation';
 
@@ -84,14 +85,7 @@ onMounted(() => {
           @update:model-value="callIfValid($event, update)"
         />
 
-        <RuiButton
-          class="mt-1 ml-2"
-          variant="text"
-          icon
-          @click="reset(updateImmediate)"
-        >
-          <RuiIcon name="lu-history" />
-        </RuiButton>
+        <SettingResetConfirmButton @confirm="reset(updateImmediate)" />
       </div>
     </template>
   </SettingsOption>

--- a/frontend/app/src/components/settings/general/BtcDerivationGapLimitSetting.vue
+++ b/frontend/app/src/components/settings/general/BtcDerivationGapLimitSetting.vue
@@ -2,6 +2,7 @@
 import SettingsItem from '@/components/settings/controls/SettingsItem.vue';
 import SettingsOption from '@/components/settings/controls/SettingsOption.vue';
 import { Defaults } from '@/data/defaults';
+import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 
 const DEFAULT = Defaults.BTC_DERIVATION_GAP_LIMIT;
@@ -49,14 +50,7 @@ onMounted(() => {
           :error-messages="error"
           @update:model-value="update($event ? parseInt($event) : $event)"
         />
-        <RuiButton
-          class="mt-1 ml-2"
-          variant="text"
-          icon
-          @click="reset(updateImmediate)"
-        >
-          <RuiIcon name="lu-history" />
-        </RuiButton>
+        <SettingResetConfirmButton @confirm="reset(updateImmediate)" />
       </div>
     </SettingsOption>
   </SettingsItem>

--- a/frontend/app/src/components/settings/general/CsvExportDelimiterSetting.vue
+++ b/frontend/app/src/components/settings/general/CsvExportDelimiterSetting.vue
@@ -4,6 +4,7 @@ import { helpers, maxLength, required } from '@vuelidate/validators';
 import SettingsOption from '@/components/settings/controls/SettingsOption.vue';
 import { useValidation } from '@/composables/validation';
 import { Defaults } from '@/data/defaults';
+import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { toMessages } from '@/utils/validation';
 
@@ -67,14 +68,7 @@ onMounted(() => {
         @update:model-value="callIfCsvExportDelimiterValid($event, updateImmediate)"
       />
 
-      <RuiButton
-        class="mt-1 ml-2"
-        variant="text"
-        icon
-        @click="reset(updateImmediate)"
-      >
-        <RuiIcon name="lu-history" />
-      </RuiButton>
+      <SettingResetConfirmButton @confirm="reset(updateImmediate)" />
     </div>
   </SettingsOption>
 </template>

--- a/frontend/app/src/components/settings/general/DateDisplayFormatSetting.vue
+++ b/frontend/app/src/components/settings/general/DateDisplayFormatSetting.vue
@@ -6,6 +6,7 @@ import SettingsOption from '@/components/settings/controls/SettingsOption.vue';
 import { useValidation } from '@/composables/validation';
 import { displayDateFormatter } from '@/data/date-formatter';
 import { Defaults } from '@/data/defaults';
+import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { toMessages } from '@/utils/validation';
 
@@ -89,23 +90,10 @@ onMounted(() => {
             </RuiButton>
           </template>
         </RuiTextField>
-        <RuiTooltip
-          :popper="{ placement: 'top' }"
-          :open-delay="400"
-          class="ml-2"
-        >
-          <template #activator>
-            <RuiButton
-              class="mt-1"
-              variant="text"
-              icon
-              @click="updateImmediate(defaultDateDisplayFormat)"
-            >
-              <RuiIcon name="lu-history" />
-            </RuiButton>
-          </template>
-          {{ t('general_settings.date_display_tooltip') }}
-        </RuiTooltip>
+        <SettingResetConfirmButton
+          :tooltip="t('general_settings.date_display_tooltip')"
+          @confirm="updateImmediate(defaultDateDisplayFormat)"
+        />
       </div>
     </SettingsOption>
   </div>

--- a/frontend/app/src/components/settings/general/InternalTxConflictRepullSettings.vue
+++ b/frontend/app/src/components/settings/general/InternalTxConflictRepullSettings.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import SettingsOption from '@/components/settings/controls/SettingsOption.vue';
 import { Defaults } from '@/data/defaults';
+import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 
 const { compact = false } = defineProps<{
@@ -67,15 +68,10 @@ onMounted(() => {
             :error-messages="error"
             @update:model-value="update($event ? parseInt($event) : $event)"
           />
-          <RuiButton
-            :class="compact ? 'ml-1' : 'mt-1 ml-2'"
-            variant="text"
-            icon
-            :size="compact ? 'sm' : undefined"
-            @click="resetBatchSize(updateImmediate)"
-          >
-            <RuiIcon name="lu-history" />
-          </RuiButton>
+          <SettingResetConfirmButton
+            :compact="compact"
+            @confirm="resetBatchSize(updateImmediate)"
+          />
         </div>
       </template>
     </SettingsOption>
@@ -111,15 +107,10 @@ onMounted(() => {
             :error-messages="error"
             @update:model-value="update($event ? Number.parseFloat($event) * SECONDS_PER_MINUTE : $event)"
           />
-          <RuiButton
-            :class="compact ? 'ml-1' : 'mt-1 ml-2'"
-            variant="text"
-            icon
-            :size="compact ? 'sm' : undefined"
-            @click="resetFrequency(updateImmediate)"
-          >
-            <RuiIcon name="lu-history" />
-          </RuiButton>
+          <SettingResetConfirmButton
+            :compact="compact"
+            @confirm="resetFrequency(updateImmediate)"
+          />
         </div>
       </template>
     </SettingsOption>

--- a/frontend/app/src/components/settings/general/external-services/CommonExternalServiceSetting.vue
+++ b/frontend/app/src/components/settings/general/external-services/CommonExternalServiceSetting.vue
@@ -3,6 +3,7 @@ import useVuelidate from '@vuelidate/core';
 import { helpers, minValue, required } from '@vuelidate/validators';
 import SettingsOption from '@/components/settings/controls/SettingsOption.vue';
 import { useValidation } from '@/composables/validation';
+import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
 import { useMonitorStore } from '@/store/monitor';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { toMessages } from '@/utils/validation';
@@ -85,14 +86,7 @@ onMounted(() => {
             :error-messages="error || toMessages(v$.inputValue)"
             @update:model-value="callIfValid($event, update)"
           />
-          <RuiButton
-            class="mt-1 ml-2"
-            variant="text"
-            icon
-            @click="reset(updateImmediate)"
-          >
-            <RuiIcon name="lu-history" />
-          </RuiButton>
+          <SettingResetConfirmButton @confirm="reset(updateImmediate)" />
         </div>
       </template>
     </SettingsOption>

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5052,6 +5052,12 @@
   "settings": {
     "go_to_section": "Go to section",
     "not_saved": "Setting not saved",
+    "reset_confirm": {
+      "cancel": "Cancel",
+      "confirm": "Reset",
+      "message": "Reset to default?",
+      "tooltip": "Reset to default"
+    },
     "saved": "Setting saved",
     "security_settings": {
       "subtitle": "Manage your account security",

--- a/frontend/app/src/modules/settings/SettingResetConfirmButton.spec.ts
+++ b/frontend/app/src/modules/settings/SettingResetConfirmButton.spec.ts
@@ -1,0 +1,148 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import SettingResetConfirmButton from './SettingResetConfirmButton.vue';
+
+vi.mock('@/services/websocket/websocket-service');
+
+const menuModel = ref<boolean>(false);
+
+const RuiMenuStub = defineComponent({
+  props: { modelValue: { type: Boolean, default: false } },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    watch(() => props.modelValue, val => set(menuModel, val));
+    watch(menuModel, val => emit('update:modelValue', val));
+    return { menuModel };
+  },
+  template: `
+    <div data-testid="menu">
+      <div data-testid="menu-activator"><slot name="activator" :attrs="{}" /></div>
+      <div v-if="modelValue" data-testid="menu-content"><slot /></div>
+    </div>
+  `,
+});
+
+describe('modules/settings/SettingResetConfirmButton', () => {
+  let wrapper: VueWrapper<InstanceType<typeof SettingResetConfirmButton>>;
+  let pinia: Pinia;
+
+  function createWrapper(props: Record<string, unknown> = {}): VueWrapper<InstanceType<typeof SettingResetConfirmButton>> {
+    set(menuModel, false);
+    return mount(SettingResetConfirmButton, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          RuiButton: {
+            template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
+            inheritAttrs: false,
+          },
+          RuiIcon: {
+            template: '<span data-testid="icon">{{ name }}</span>',
+            props: ['name'],
+          },
+          RuiMenu: RuiMenuStub,
+          RuiTooltip: {
+            template: '<div data-testid="tooltip"><slot name="activator" /><span data-testid="tooltip-text"><slot /></span></div>',
+          },
+        },
+      },
+      props,
+    });
+  }
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should render the reset button with history icon', () => {
+    wrapper = createWrapper();
+    const icon = wrapper.find('[data-testid="icon"]');
+    expect(icon.exists()).toBe(true);
+    expect(icon.text()).toBe('lu-history');
+  });
+
+  it('should show tooltip text as i18n key', () => {
+    wrapper = createWrapper();
+    const tooltipText = wrapper.find('[data-testid="tooltip-text"]');
+    expect(tooltipText.text()).toBe('settings.reset_confirm.tooltip');
+  });
+
+  it('should show custom tooltip when provided', () => {
+    wrapper = createWrapper({ tooltip: 'Custom tooltip' });
+    const tooltipText = wrapper.find('[data-testid="tooltip-text"]');
+    expect(tooltipText.text()).toBe('Custom tooltip');
+  });
+
+  it('should apply compact classes when compact is true', () => {
+    wrapper = createWrapper({ compact: true });
+    const button = wrapper.find('[data-testid="menu-activator"] button');
+    expect(button.classes()).toContain('ml-1');
+    expect(button.classes()).not.toContain('mt-1');
+  });
+
+  it('should apply default classes when compact is false', () => {
+    wrapper = createWrapper();
+    const button = wrapper.find('[data-testid="menu-activator"] button');
+    expect(button.classes()).toContain('mt-1');
+    expect(button.classes()).toContain('ml-2');
+  });
+
+  it('should not show menu content initially', () => {
+    wrapper = createWrapper();
+    expect(wrapper.find('[data-testid="menu-content"]').exists()).toBe(false);
+  });
+
+  it('should disable the button when disabled prop is true', () => {
+    wrapper = createWrapper({ disabled: true });
+    const button = wrapper.find('[data-testid="menu-activator"] button');
+    expect(button.attributes('disabled')).toBeDefined();
+  });
+
+  describe('when menu is open', () => {
+    async function openMenu(): Promise<void> {
+      set(menuModel, true);
+      await wrapper.vm.$nextTick();
+    }
+
+    it('should show confirmation message and action buttons', async () => {
+      wrapper = createWrapper();
+      await openMenu();
+
+      const content = wrapper.find('[data-testid="menu-content"]');
+      expect(content.exists()).toBe(true);
+      expect(content.text()).toContain('settings.reset_confirm.message');
+      expect(content.text()).toContain('settings.reset_confirm.cancel');
+      expect(content.text()).toContain('settings.reset_confirm.confirm');
+    });
+
+    it('should emit confirm when confirm button is clicked', async () => {
+      wrapper = createWrapper();
+      await openMenu();
+
+      const buttons = wrapper.findAll('[data-testid="menu-content"] button');
+      const confirmButton = buttons.find(btn => btn.text() === 'settings.reset_confirm.confirm');
+      expect(confirmButton).toBeDefined();
+      await confirmButton!.trigger('click');
+
+      expect(wrapper.emitted('confirm')).toBeDefined();
+    });
+
+    it('should not emit confirm when cancel button is clicked', async () => {
+      wrapper = createWrapper();
+      await openMenu();
+
+      const buttons = wrapper.findAll('[data-testid="menu-content"] button');
+      const cancelButton = buttons.find(btn => btn.text() === 'settings.reset_confirm.cancel');
+      expect(cancelButton).toBeDefined();
+      await cancelButton!.trigger('click');
+
+      expect(wrapper.emitted('confirm')).toBeUndefined();
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/SettingResetConfirmButton.vue
+++ b/frontend/app/src/modules/settings/SettingResetConfirmButton.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+const { tooltip, compact = false, disabled = false } = defineProps<{
+  tooltip?: string;
+  compact?: boolean;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  confirm: [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const open = ref<boolean>(false);
+
+const tooltipText = computed<string>(() => tooltip || t('settings.reset_confirm.tooltip'));
+
+function confirm(): void {
+  set(open, false);
+  emit('confirm');
+}
+
+function cancel(): void {
+  set(open, false);
+}
+</script>
+
+<template>
+  <RuiMenu
+    v-model="open"
+    menu-class="max-w-[14rem]"
+    :popper="{ placement: 'top' }"
+  >
+    <template #activator="{ attrs }">
+      <RuiTooltip
+        :popper="{ placement: 'top' }"
+        :open-delay="400"
+        :disabled="open"
+      >
+        <template #activator>
+          <RuiButton
+            :class="compact ? 'ml-1' : 'mt-1 ml-2'"
+            variant="text"
+            icon
+            :size="compact ? 'sm' : undefined"
+            :disabled="disabled"
+            v-bind="attrs"
+          >
+            <RuiIcon name="lu-history" />
+          </RuiButton>
+        </template>
+        {{ tooltipText }}
+      </RuiTooltip>
+    </template>
+    <div class="p-3">
+      <p class="text-body-2 mb-3">
+        {{ t('settings.reset_confirm.message') }}
+      </p>
+      <div class="flex justify-end gap-2">
+        <RuiButton
+          size="sm"
+          variant="text"
+          @click="cancel()"
+        >
+          {{ t('settings.reset_confirm.cancel') }}
+        </RuiButton>
+        <RuiButton
+          size="sm"
+          color="primary"
+          @click="confirm()"
+        >
+          {{ t('settings.reset_confirm.confirm') }}
+        </RuiButton>
+      </div>
+    </div>
+  </RuiMenu>
+</template>


### PR DESCRIPTION
## Summary
- New `SettingResetConfirmButton` component that wraps the reset icon button with a tooltip (on hover) and a confirmation popover (on click)
- Replaces all 7 inline reset buttons across 6 settings components with the new component
- Prevents accidental resets by requiring a confirmation step

## Affected settings
- Balance save frequency
- BTC derivation gap limit
- CSV export delimiter
- Date display format
- Internal tx conflict repull (batch size + frequency)
- External service settings (query retry limit, connect timeout, read timeout)

## Test plan
- [ ] New co-located unit tests (10 tests) for the component
- [ ] Each setting's reset button should show tooltip on hover
- [ ] Clicking the reset icon opens a popover with "Reset to default?" and Cancel/Reset buttons
- [ ] Only resets when clicking Reset, not Cancel