### PR TITLE
feat(frontend): show failed count on internal tx conflicts tab

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventsAlerts.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsAlerts.vue
@@ -45,7 +45,7 @@ const {
   manualReviewGroupIds,
 } = useCustomizedEventDuplicates();
 
-const { fetchPendingCount, pendingCount: internalConflictsCount } = useInternalTxConflicts();
+const { fetchCounts, pendingCount: internalConflictsCount } = useInternalTxConflicts();
 
 const showUnmatchedMovements = computed<boolean>(() => !get(autoMatchLoading) && get(unmatchedCount) > 0);
 const showAutoFixDuplicates = computed<boolean>(() => get(autoFixCount) > 0);
@@ -88,7 +88,7 @@ watchImmediate(loading, async (isLoading) => {
     await Promise.all([
       refreshUnmatchedAssetMovements(),
       fetchCustomizedEventDuplicates(),
-      fetchPendingCount(),
+      fetchCounts(),
     ]);
   }
 });

--- a/frontend/app/src/components/history/events/HistoryEventsViewButtons.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsViewButtons.vue
@@ -30,7 +30,7 @@ const noIssuesFeedback = ref<IssueCheckType>();
 
 const { refreshUnmatchedAssetMovements, unmatchedCount, ignoredCount } = useUnmatchedAssetMovements();
 const { fetchCustomizedEventDuplicates, totalCount: duplicatesCount } = useCustomizedEventDuplicates();
-const { pendingCount: internalConflictsCount, fetchPendingCount } = useInternalTxConflicts();
+const { pendingCount: internalConflictsCount, fetchCounts } = useInternalTxConflicts();
 
 const { start: startFeedbackTimeout, stop: stopFeedbackTimeout } = useTimeoutFn(() => {
   set(noIssuesFeedback, undefined);
@@ -79,7 +79,7 @@ async function checkDuplicates(): Promise<void> {
 async function checkInternalConflicts(): Promise<void> {
   set(checkingType, 'internalConflicts');
   try {
-    await fetchPendingCount();
+    await fetchCounts();
     if (get(internalConflictsCount) > 0) {
       set(menuOpen, false);
       emit('show:dialog', { type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS });

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
@@ -33,8 +33,9 @@ const { t } = useI18n({ useScope: 'global' });
 
 const {
   conflicts,
+  failedCount,
   fetchConflicts,
-  fetchPendingCount,
+  fetchCounts,
   filters,
   loading,
   matchers,
@@ -127,7 +128,7 @@ function getReasonLabel(row: InternalTxConflict): string {
 }
 
 async function refreshData(): Promise<void> {
-  await Promise.all([fetchConflicts(), fetchPendingCount()]);
+  await Promise.all([fetchConflicts(), fetchCounts()]);
 }
 
 function onResolveOne(conflict: InternalTxConflict): void {
@@ -144,7 +145,7 @@ watch(activeTab, (tab) => {
 });
 
 onBeforeMount(() => {
-  startPromise(Promise.all([fetchPendingCount(), fetchConflicts()]));
+  startPromise(Promise.all([fetchCounts(), fetchConflicts()]));
 });
 
 defineExpose({
@@ -172,6 +173,14 @@ defineExpose({
       </RuiTab>
       <RuiTab>
         {{ t('internal_tx_conflicts.tabs.failed') }}
+        <RuiChip
+          v-if="failedCount > 0"
+          color="error"
+          size="sm"
+          class="ml-2 !px-0.5 !py-0"
+        >
+          {{ failedCount }}
+        </RuiChip>
       </RuiTab>
       <RuiTab>
         {{ t('internal_tx_conflicts.tabs.fixed') }}

--- a/frontend/app/src/modules/history/internal-tx-conflicts/internal-tx-conflicts-api.spec.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/internal-tx-conflicts-api.spec.ts
@@ -142,30 +142,23 @@ describe('modules/history/internal-tx-conflicts/internal-tx-conflicts-api', () =
     });
 
     describe('fetchInternalTxConflictsCount', () => {
-      it('sends POST with correct payload and returns counts', async () => {
-        let capturedBody: Record<string, unknown> | undefined;
-
+      it('sends POST and returns pending and failed counts', async () => {
         server.use(
-          http.post(`${backendUrl}/api/1/blockchains/transactions/internal/conflicts`, async ({ request }) => {
-            capturedBody = await request.json() as Record<string, unknown>;
-            return HttpResponse.json({
+          http.post(`${backendUrl}/api/1/blockchains/transactions/internal/conflicts`, () =>
+            HttpResponse.json({
               result: {
-                entries_found: 178,
-                entries_total: 237,
+                pending: 178,
+                failed: 12,
               },
               message: '',
-            });
-          }),
+            })),
         );
 
         const { fetchInternalTxConflictsCount } = useInternalTxConflictsApi();
-        const result = await fetchInternalTxConflictsCount({ failed: false, fixed: false });
+        const result = await fetchInternalTxConflictsCount();
 
-        expect(capturedBody).toBeDefined();
-        expect(capturedBody!.fixed).toBe(false);
-        expect(capturedBody!.failed).toBe(false);
-        expect(result.entriesFound).toBe(178);
-        expect(result.entriesTotal).toBe(237);
+        expect(result.pending).toBe(178);
+        expect(result.failed).toBe(12);
       });
 
       it('throws on HTTP error response', async () => {
@@ -179,7 +172,7 @@ describe('modules/history/internal-tx-conflicts/internal-tx-conflicts-api', () =
 
         const { fetchInternalTxConflictsCount } = useInternalTxConflictsApi();
 
-        await expect(fetchInternalTxConflictsCount({ failed: false, fixed: false }))
+        await expect(fetchInternalTxConflictsCount())
           .rejects
           .toThrow();
       });

--- a/frontend/app/src/modules/history/internal-tx-conflicts/internal-tx-conflicts-api.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/internal-tx-conflicts-api.ts
@@ -1,5 +1,5 @@
 import type { MaybeRef } from 'vue';
-import type { InternalTxConflict, InternalTxConflictsCountPayload, InternalTxConflictsCountResponse, InternalTxConflictsRequestPayload } from './types';
+import type { InternalTxConflict, InternalTxConflictsCountResponse, InternalTxConflictsRequestPayload } from './types';
 import type { Collection, CollectionResponse } from '@/types/collection';
 import { api } from '@/modules/api/rotki-api';
 import { mapCollectionResponse } from '@/utils/collection';
@@ -7,7 +7,7 @@ import { nonEmptyProperties } from '@/utils/data';
 
 interface UseInternalTxConflictsApiReturn {
   fetchInternalTxConflicts: (payload: MaybeRef<InternalTxConflictsRequestPayload>) => Promise<Collection<InternalTxConflict>>;
-  fetchInternalTxConflictsCount: (payload: InternalTxConflictsCountPayload) => Promise<InternalTxConflictsCountResponse>;
+  fetchInternalTxConflictsCount: () => Promise<InternalTxConflictsCountResponse>;
 }
 
 export function useInternalTxConflictsApi(): UseInternalTxConflictsApiReturn {
@@ -21,15 +21,8 @@ export function useInternalTxConflictsApi(): UseInternalTxConflictsApiReturn {
     return mapCollectionResponse(response);
   };
 
-  const fetchInternalTxConflictsCount = async (
-    payload: InternalTxConflictsCountPayload,
-  ): Promise<InternalTxConflictsCountResponse> => {
-    const response = await api.post<InternalTxConflictsCountResponse>(
-      '/blockchains/transactions/internal/conflicts',
-      nonEmptyProperties(payload),
-    );
-    return response;
-  };
+  const fetchInternalTxConflictsCount = async (): Promise<InternalTxConflictsCountResponse> =>
+    api.post<InternalTxConflictsCountResponse>('/blockchains/transactions/internal/conflicts');
 
   return { fetchInternalTxConflicts, fetchInternalTxConflictsCount };
 }

--- a/frontend/app/src/modules/history/internal-tx-conflicts/types.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/types.ts
@@ -51,16 +51,7 @@ export interface InternalTxConflictsRequestPayload extends PaginationRequestPayl
   toTimestamp?: number;
 }
 
-export interface InternalTxConflictsCountPayload {
-  txHash?: string;
-  chain?: string;
-  fixed?: boolean;
-  failed?: boolean;
-  fromTimestamp?: number;
-  toTimestamp?: number;
-}
-
 export interface InternalTxConflictsCountResponse {
-  entriesFound: number;
-  entriesTotal: number;
+  pending: number;
+  failed: number;
 }

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.spec.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.spec.ts
@@ -88,7 +88,7 @@ describe('use-internal-tx-conflicts', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     spies.fetchInternalTxConflicts.mockResolvedValue(createMockCollection());
-    spies.fetchInternalTxConflictsCount.mockResolvedValue({ entriesFound: 0, entriesTotal: 0 });
+    spies.fetchInternalTxConflictsCount.mockResolvedValue({ pending: 0, failed: 0 });
     composable = useInternalTxConflicts();
   });
 
@@ -96,17 +96,15 @@ describe('use-internal-tx-conflicts', () => {
     vi.restoreAllMocks();
   });
 
-  describe('fetchPendingCount', () => {
-    it('updates pendingCount from POST count endpoint', async () => {
-      spies.fetchInternalTxConflictsCount.mockResolvedValue({ entriesFound: 4, entriesTotal: 5 });
+  describe('fetchCounts', () => {
+    it('updates pendingCount and failedCount from POST count endpoint', async () => {
+      spies.fetchInternalTxConflictsCount.mockResolvedValue({ pending: 4, failed: 2 });
 
-      await composable.fetchPendingCount();
+      await composable.fetchCounts();
 
       expect(get(composable.pendingCount)).toBe(4);
-      expect(spies.fetchInternalTxConflictsCount).toHaveBeenCalledWith({
-        failed: false,
-        fixed: false,
-      });
+      expect(get(composable.failedCount)).toBe(2);
+      expect(spies.fetchInternalTxConflictsCount).toHaveBeenCalledWith();
     });
   });
 

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
@@ -26,8 +26,9 @@ function getStatusFilter(status: InternalTxConflictStatus): { failed?: boolean; 
 interface UseInternalTxConflictsReturn {
   activeFilter: Ref<InternalTxConflictStatus>;
   conflicts: ComputedRef<InternalTxConflict[]>;
+  failedCount: Ref<number>;
   fetchConflicts: () => Promise<void>;
-  fetchPendingCount: () => Promise<void>;
+  fetchCounts: () => Promise<void>;
   filters: WritableComputedRef<Filters>;
   handleConflictFixed: () => Promise<void>;
   loading: Ref<boolean>;
@@ -45,6 +46,7 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
   const { fetchInternalTxConflicts, fetchInternalTxConflictsCount } = useInternalTxConflictsApi();
 
   const pendingCount = ref<number>(0);
+  const failedCount = ref<number>(0);
   const activeFilter = ref<InternalTxConflictStatus>(InternalTxConflictStatuses.PENDING);
 
   const requestParams = computed<Partial<InternalTxConflictsRequestPayload>>(() => ({
@@ -75,16 +77,14 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
   const conflicts = computed<InternalTxConflict[]>(() => get(state).data);
   const totalFound = computed<number>(() => get(state).found);
 
-  async function fetchPendingCount(): Promise<void> {
+  async function fetchCounts(): Promise<void> {
     try {
-      const result = await fetchInternalTxConflictsCount({
-        failed: false,
-        fixed: false,
-      });
-      set(pendingCount, result.entriesFound);
+      const result = await fetchInternalTxConflictsCount();
+      set(pendingCount, result.pending);
+      set(failedCount, result.failed);
     }
     catch (error: any) {
-      logger.error('Failed to fetch internal tx conflicts pending count:', error);
+      logger.error('Failed to fetch internal tx conflicts counts:', error);
     }
   }
 
@@ -107,7 +107,7 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
   }
 
   async function handleConflictFixed(): Promise<void> {
-    await Promise.all([fetchPendingCount(), fetchConflicts()]);
+    await Promise.all([fetchCounts(), fetchConflicts()]);
   }
 
   watch(internalTxFixedSignal, () => {
@@ -117,8 +117,9 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
   return {
     activeFilter,
     conflicts,
+    failedCount,
     fetchConflicts,
-    fetchPendingCount,
+    fetchCounts,
     filters,
     handleConflictFixed,
     loading,


### PR DESCRIPTION
## Summary
- Simplify POST `/internal/conflicts` to return `{ pending, failed }` counts in a single call (no filter params)
- Add `failedCount` to `useInternalTxConflicts` composable
- Display failed count as error chip on the Failed tab

**Depends on backend changes** to adjust the POST endpoint response format.

## Test plan
- [ ] Verify pending count chip still shows on Pending tab
- [ ] Verify failed count chip shows on Failed tab with error color
- [ ] Counts refresh after conflict resolution