### PR TITLE
fix(frontend): delete swap sub-event only

### DIFF
--- a/frontend/app/src/modules/history/events/event-action-visibility.spec.ts
+++ b/frontend/app/src/modules/history/events/event-action-visibility.spec.ts
@@ -154,9 +154,15 @@ describe('eventActionVisibility', () => {
       expect(shouldDeleteGroup(item, 0)).toBe(true);
     });
 
-    it('should delete group for online swap events (isGroupEditableHistoryEvent)', () => {
+    it('should delete group for online swap events at index 0', () => {
       const item = createSwapEvent();
       expect(shouldDeleteGroup(item, 0)).toBe(true);
+    });
+
+    it('should not delete group for online swap sub-events (index > 0)', () => {
+      const item = createSwapEvent();
+      expect(shouldDeleteGroup(item, 1)).toBe(false);
+      expect(shouldDeleteGroup(item, 2)).toBe(false);
     });
 
     it('should delete group for evm swap at index 0', () => {

--- a/frontend/app/src/modules/history/events/event-action-visibility.ts
+++ b/frontend/app/src/modules/history/events/event-action-visibility.ts
@@ -32,9 +32,8 @@ export function hideDeleteAction(item: HistoryEventEntry, index: number, complet
 }
 
 export function shouldDeleteGroup(item: HistoryEventEntry, index: number): boolean {
-  if (isGroupEditableHistoryEvent(item))
-    return true;
+  if (isSwapTypeEvent(item.entryType))
+    return index === 0;
 
-  // For EVM/Solana swap primary events (index 0), delete the whole group
-  return isSwapTypeEvent(item.entryType) && index === 0;
+  return isGroupEditableHistoryEvent(item);
 }

--- a/frontend/app/tests/e2e/specs/history/history-events.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/history-events.spec.ts
@@ -104,6 +104,35 @@ test.describe.serial('history events', () => {
     }).toPass({ timeout: 10000 });
   });
 
+  test('delete fee sub-event from online swap', async () => {
+    // The swap created earlier has 3 sub-events: spend, receive, fee.
+    // Expand it, delete the fee, and verify the swap group survives.
+    const rowsBeforeExpand = await page.getExpandedEventRows();
+    await page.expandSwap(0);
+
+    await expect(async () => {
+      const rows = await page.getExpandedEventRows();
+      expect(rows).toBeGreaterThanOrEqual(rowsBeforeExpand + 3);
+    }).toPass({ timeout: 10000 });
+
+    const rowsBefore = await page.getExpandedEventRows();
+
+    // The fee is the 3rd sub-event (index 2) within the expanded swap rows.
+    await page.deleteSubEvent(2);
+
+    await expect(async () => {
+      const rowsAfter = await page.getExpandedEventRows();
+      expect(rowsAfter).toBe(rowsBefore - 1);
+    }).toPass({ timeout: 10000 });
+
+    // The swap group should still exist (spend + receive remain)
+    await expect(async () => {
+      const swaps = await page.getSwapRows();
+      const expandedRows = await page.getExpandedEventRows();
+      expect(swaps + expandedRows).toBeGreaterThanOrEqual(1);
+    }).toPass({ timeout: 10000 });
+  });
+
   test('add asset movement event', async () => {
     await page.openAddDialog();
     await page.selectEntryType('asset movement event');


### PR DESCRIPTION
## Summary
- Fix `shouldDeleteGroup()` deleting the entire event group when removing a fee or other sub-event from an expanded online swap (`SWAP_EVENT` type)
- The root cause was `isGroupEditableHistoryEvent()` matching `SWAP_EVENT` and returning `true` before the `index === 0` check was reached
- Reorder checks so `isSwapTypeEvent` is evaluated first, ensuring only the primary event (index 0) triggers group deletion

## Test plan
- [x] Unit tests updated and new case added for online swap sub-events
- [x] E2e test added: expand an online swap with a fee, delete the fee sub-event, verify the swap group survives
- [ ] Manual: create an online swap with fee, expand it, click delete on the fee row — only the fee should be removed