### PR TITLE
fix(frontend): include failed conflicts in issue count

### DIFF
--- a/frontend/app/src/components/history/events/HistoryEventsAlerts.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsAlerts.vue
@@ -45,8 +45,7 @@ const {
   manualReviewGroupIds,
 } = useCustomizedEventDuplicates();
 
-const { fetchCounts, pendingCount: internalConflictsCount } = useInternalTxConflicts();
-
+const { fetchCounts, issueCount: internalConflictsCount } = useInternalTxConflicts();
 const showUnmatchedMovements = computed<boolean>(() => !get(autoMatchLoading) && get(unmatchedCount) > 0);
 const showAutoFixDuplicates = computed<boolean>(() => get(autoFixCount) > 0);
 const showManualReviewDuplicates = computed<boolean>(() => get(manualReviewCount) > 0);

--- a/frontend/app/src/components/history/events/HistoryEventsIssueCheckButton.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsIssueCheckButton.vue
@@ -14,7 +14,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const { autoMatchLoading, unmatchedCount } = useUnmatchedAssetMovements();
 const { actionableCount: duplicatesCount } = useCustomizedEventDuplicates();
-const { pendingCount: internalConflictsCount } = useInternalTxConflicts();
+const { issueCount: internalConflictsCount } = useInternalTxConflicts();
 
 const totalIssuesCount = computed<number>(() => get(unmatchedCount) + get(duplicatesCount) + get(internalConflictsCount));
 const hasIssues = computed<boolean>(() => !get(autoMatchLoading) && get(totalIssuesCount) > 0);

--- a/frontend/app/src/components/history/events/HistoryEventsViewButtons.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsViewButtons.vue
@@ -22,7 +22,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-type IssueCheckType = 'unmatched' | 'duplicates' | 'internalConflicts';
+type IssueCheckType = 'unmatched' | 'duplicates';
 
 const menuOpen = ref<boolean>(false);
 const checkingType = ref<IssueCheckType>();
@@ -30,7 +30,7 @@ const noIssuesFeedback = ref<IssueCheckType>();
 
 const { refreshUnmatchedAssetMovements, unmatchedCount, ignoredCount } = useUnmatchedAssetMovements();
 const { fetchCustomizedEventDuplicates, totalCount: duplicatesCount } = useCustomizedEventDuplicates();
-const { pendingCount: internalConflictsCount, fetchCounts } = useInternalTxConflicts();
+const { issueCount: internalConflictsCount } = useInternalTxConflicts();
 
 const { start: startFeedbackTimeout, stop: stopFeedbackTimeout } = useTimeoutFn(() => {
   set(noIssuesFeedback, undefined);
@@ -76,21 +76,9 @@ async function checkDuplicates(): Promise<void> {
   }
 }
 
-async function checkInternalConflicts(): Promise<void> {
-  set(checkingType, 'internalConflicts');
-  try {
-    await fetchCounts();
-    if (get(internalConflictsCount) > 0) {
-      set(menuOpen, false);
-      emit('show:dialog', { type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS });
-    }
-    else {
-      showNoIssuesFeedback('internalConflicts');
-    }
-  }
-  finally {
-    set(checkingType, undefined);
-  }
+function checkInternalConflicts(): void {
+  set(menuOpen, false);
+  emit('show:dialog', { type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS });
 }
 </script>
 
@@ -225,8 +213,6 @@ async function checkInternalConflicts(): Promise<void> {
       <RuiButton
         variant="list"
         :disabled="processing || !!checkingType"
-        :loading="checkingType === 'internalConflicts'"
-        :color="noIssuesFeedback === 'internalConflicts' ? 'success' : undefined"
         @click.stop="checkInternalConflicts()"
       >
         <template #prepend>
@@ -238,10 +224,10 @@ async function checkInternalConflicts(): Promise<void> {
             offset-y="4"
             offset-x="-4"
           >
-            <RuiIcon :name="noIssuesFeedback === 'internalConflicts' ? 'lu-circle-check' : 'lu-git-merge'" />
+            <RuiIcon name="lu-git-merge" />
           </RuiBadge>
         </template>
-        {{ noIssuesFeedback === 'internalConflicts' ? t('transactions.alerts.no_issues_found') : t('transactions.alerts.check_internal_conflicts') }}
+        {{ t('transactions.alerts.check_internal_conflicts') }}
       </RuiButton>
     </div>
   </RuiMenu>

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
@@ -31,6 +31,7 @@ interface UseInternalTxConflictsReturn {
   fetchCounts: () => Promise<void>;
   filters: WritableComputedRef<Filters>;
   handleConflictFixed: () => Promise<void>;
+  issueCount: ComputedRef<number>;
   loading: Ref<boolean>;
   matchers: ComputedRef<Matcher[]>;
   pagination: WritableComputedRef<TablePaginationData>;
@@ -47,6 +48,7 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
 
   const pendingCount = ref<number>(0);
   const failedCount = ref<number>(0);
+  const issueCount = computed<number>(() => get(pendingCount) + get(failedCount));
   const activeFilter = ref<InternalTxConflictStatus>(InternalTxConflictStatuses.PENDING);
 
   const requestParams = computed<Partial<InternalTxConflictsRequestPayload>>(() => ({
@@ -122,6 +124,7 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
     fetchCounts,
     filters,
     handleConflictFixed,
+    issueCount,
     loading,
     matchers,
     pagination,


### PR DESCRIPTION
## Summary
- Include failed internal tx conflicts in the issue count across all 3 places that were only checking pending:
  - `HistoryEventsIssueCheckButton.vue` — the warning badge button
  - `HistoryEventsAlerts.vue` — the dropdown alerts panel
  - `HistoryEventsViewButtons.vue` — the 3-dot menu "check conflicts" action

## Test plan
- [ ] Have internal tx conflicts in failed state with none pending — verify the warning button appears and shows the correct count
- [ ] Click the 3-dot menu → check internal tx conflicts — should open the dialog when only failed conflicts exist