### PR TITLE
Bump version: 1.42.0 → 1.42.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.42.0
+current_version = 1.42.1
 commit = True
 tag = False
 

--- a/colibri/Cargo.lock
+++ b/colibri/Cargo.lock
@@ -1204,7 +1204,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colibri"
-version = "1.42.0"
+version = "1.42.1"
 dependencies = [
  "alloy",
  "async-sqlite",

--- a/colibri/Cargo.toml
+++ b/colibri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "colibri"
-version = "1.42.0"
+version = "1.42.1"
 edition = "2021"
 
 [dependencies]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :release:`1.42.1 <2025-03-25>`
 * :bug:`11935` Editing a manual balance to have duplicate names should no longer be possible.
 * :feature:`-` Added an accounting rule to transfer cost basis between assets and applied it as a default for actions such as wrapping/unwrapping ETH, depositing to DeFi etc.
 * :bug:`-` Upgrading an older rotki database won't cause data migration 20 to fail.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,9 +23,9 @@ project_copyright = '2018-2020, Eleftherios Karapetsas. 2020-2025, Rotki Solutio
 author = 'The rotki team'
 
 # The short X.Y version
-version = '1.42.0'
+version = '1.42.1'
 # The full version, including alpha/beta/rc tags
-release = '1.42.0'
+release = '1.42.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotki",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "description": "A portfolio tracking, asset analytics and tax reporting application specializing in Cryptoassets that protects your privacy",
   "type": "module",
   "license": "AGPL-3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,7 @@ rotkehlchen_mock = "rotkehlchen_mock.__main__:main"
 # dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools_scm]
-fallback_version = "1.42.0"
+fallback_version = "1.42.1"
 
 [tool.setuptools.package-data]
 "rotkehlchen.data" = ["*"]


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
