### PR TITLE
fix(docker): asset icon URL construction failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN sed "s/fallback_version.*/fallback_version = \"$PACKAGE_FALLBACK_VERSION\"/"
     uv run python -c "import sys;from rotkehlchen.db.misc import detect_sqlcipher_version; version = detect_sqlcipher_version();sys.exit(0) if version == 4 else sys.exit(1)" && \
     PYTHONOPTIMIZE=2 uv run pyinstaller --noconfirm --clean --distpath /tmp/dist rotkehlchen.spec
 
-FROM nginx:1.26 AS runtime
+FROM nginx:1.28 AS runtime
 
 LABEL maintainer="Rotki Solutions GmbH <info@rotki.com>"
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :release:`1.42.1 <2025-03-25>`
+* :bug:`-` Asset icons in the Docker deployment will no longer fail to load due to an invalid base URL when constructing icon URLs.
 * :bug:`11935` Editing a manual balance to have duplicate names should no longer be possible.
 * :feature:`-` Added an accounting rule to transfer cost basis between assets and applied it as a default for actions such as wrapping/unwrapping ETH, depositing to DeFi etc.
 * :bug:`-` Upgrading an older rotki database won't cause data migration 20 to fail.

--- a/frontend/app/src/composables/api/assets/icon.ts
+++ b/frontend/app/src/composables/api/assets/icon.ts
@@ -17,13 +17,13 @@ interface UseAssetIconApiReturn {
 
 export function useAssetIconApi(): UseAssetIconApiReturn {
   const assetImageUrl = (identifier: string, randomString?: string | number): string => {
-    const url = new URL('/assets/icon', defaultApiUrls.colibriApiUrl);
-    url.searchParams.set('asset_id', identifier);
+    const params = new URLSearchParams();
+    params.set('asset_id', identifier);
 
     if (randomString)
-      url.searchParams.set('t', String(randomString));
+      params.set('t', String(randomString));
 
-    return url.toString();
+    return `${defaultApiUrls.colibriApiUrl}/assets/icon?${params.toString()}`;
   };
 
   const checkAsset = async (identifier: string, options: CheckAssetOptions): Promise<number> => {


### PR DESCRIPTION
## Summary
- Fix `TypeError: Failed to construct 'URL': Invalid base URL` in Docker deployments by replacing `new URL()` with `URLSearchParams` + string interpolation for asset icon URLs. The `URL` constructor requires an absolute base URL, but in Docker behind nginx `colibriApiUrl` resolves to a relative path (`/colibri`).
- Bump Docker nginx base image from 1.26 to 1.28 (latest stable).

## Test plan
- [ ] Build and run the Docker image
- [ ] Verify asset icons load without console errors
- [ ] Verify Solana token icons still load correctly (special character encoding)