### PR TITLE
Preserve customized events in periodic internal tx conflict path

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :release:`1.42.1 <2025-03-25>`
+* :release:`1.42.1 <2025-03-26>`
 * :bug:`-` Asset icons in the Docker deployment will no longer fail to load due to an invalid base URL when constructing icon URLs.
 * :bug:`11935` Editing a manual balance to have duplicate names should no longer be possible.
 * :feature:`-` Added an accounting rule to transfer cost basis between assets and applied it as a default for actions such as wrapping/unwrapping ETH, depositing to DeFi etc.

--- a/rotkehlchen/db/internal_tx_conflicts.py
+++ b/rotkehlchen/db/internal_tx_conflicts.py
@@ -114,19 +114,15 @@ def is_tx_customized(
     ).fetchone()[0] > 0
 
 
-def clean_internal_tx_conflict(
+def clean_internal_tx_rows(
         write_cursor: 'DBCursor',
         tx_hash: EVMTxHash,
         chain_id: EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE,
 ) -> None:
-    """Delete invalid/duplicate internals and queue decode-only refresh.
+    """Delete only invalid/duplicate internal tx rows without touching events or TX_DECODED.
 
-    TX_INTERNALS_QUERIED is intentionally not cleared for fix_redecode actions because
-    these transactions are repaired in-place and do not need an internal repull.
-
-    For non-customized transactions we also remove decoded history events linked to this tx
-    so the next decode recreates them from the repaired internals.
-    """
+    Used for customized transactions where we want to repair the internal tx data
+    but preserve user-edited events."""
     write_cursor.execute("""
     WITH fix_txs AS (
       SELECT identifier AS parent_tx
@@ -154,6 +150,22 @@ def clean_internal_tx_conflict(
       WHERE gas = '0' OR rn > 1
     )
     """, (tx_hash, chain_id.serialize_for_db()))
+
+
+def clean_internal_tx_conflict(
+        write_cursor: 'DBCursor',
+        tx_hash: EVMTxHash,
+        chain_id: EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE,
+) -> None:
+    """Delete invalid/duplicate internals and queue decode-only refresh.
+
+    TX_INTERNALS_QUERIED is intentionally not cleared for fix_redecode actions because
+    these transactions are repaired in-place and do not need an internal repull.
+
+    For non-customized transactions we also remove decoded history events linked to this tx
+    so the next decode recreates them from the repaired internals.
+    """
+    clean_internal_tx_rows(write_cursor, tx_hash, chain_id)
 
     write_cursor.execute(
         'DELETE FROM history_events WHERE identifier IN ('

--- a/rotkehlchen/tasks/internal_tx_conflicts.py
+++ b/rotkehlchen/tasks/internal_tx_conflicts.py
@@ -9,6 +9,7 @@ from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.internal_tx_conflicts import (
     INTERNAL_TX_CONFLICT_ACTION_REPULL,
     clean_internal_tx_conflict,
+    clean_internal_tx_rows,
     get_internal_tx_conflicts,
     is_tx_customized,
     set_internal_tx_conflict_fixed,
@@ -384,13 +385,29 @@ def repull_internal_tx_conflicts(
         if action == INTERNAL_TX_CONFLICT_ACTION_REPULL:
             repull_entries.append((chain_id, tx_hash))
         else:  # fix_redecode
-            with database.user_write() as write_cursor:
-                clean_internal_tx_conflict(
-                    write_cursor=write_cursor,
-                    tx_hash=tx_hash,
+            with database.conn.read_ctx() as cursor:
+                tx_is_customized = is_tx_customized(cursor=cursor, tx_hash=tx_hash, chain_id=chain_id)  # noqa: E501
+            if tx_is_customized:
+                # Only repair internal tx rows; preserve customized events
+                with database.user_write() as write_cursor:
+                    clean_internal_tx_rows(
+                        write_cursor=write_cursor,
+                        tx_hash=tx_hash,
+                        chain_id=chain_id,
+                    )
+                _mark_internal_tx_conflict_fixed(
+                    database=database,
                     chain_id=chain_id,
+                    tx_hash=tx_hash,
                 )
-            to_decode_by_chain[chain_id].append(tx_hash)
+            else:
+                with database.user_write() as write_cursor:
+                    clean_internal_tx_conflict(
+                        write_cursor=write_cursor,
+                        tx_hash=tx_hash,
+                        chain_id=chain_id,
+                    )
+                to_decode_by_chain[chain_id].append(tx_hash)
 
     for chain_id, tx_hashes in _process_repull_conflicts(
         database=database,

--- a/rotkehlchen/tests/unit/test_internal_tx_conflicts.py
+++ b/rotkehlchen/tests/unit/test_internal_tx_conflicts.py
@@ -1115,3 +1115,89 @@ def test_repull_skips_previously_failed_entries(database) -> None:
             'SELECT COUNT(*) FROM key_value_cache WHERE name=?',
             (DBCacheStatic.LAST_INTERNAL_TX_CONFLICTS_REPULL_TS.value,),
         ).fetchone()[0] == 1
+
+
+def test_fix_redecode_preserves_customized_events(database) -> None:
+    """Regression: fix_redecode must not delete customized events.
+
+    Previously clean_internal_tx_conflict unconditionally deleted all events
+    and TX_DECODED for a transaction, even when some events were customized by
+    the user.  The fix checks is_tx_customized before cleaning; for customized
+    txs only the bad internal tx rows are repaired and the conflict is marked
+    fixed without touching events."""
+    tx_hash = make_evm_tx_hash()
+    tx = EvmTransaction(
+        tx_hash=tx_hash,
+        chain_id=ChainID.ETHEREUM,
+        timestamp=Timestamp(1700000000),
+        block_number=1,
+        from_address=(sender := make_evm_address()),
+        to_address=make_evm_address(),
+        value=0,
+        gas=1,
+        gas_price=1,
+        gas_used=1,
+        input_data=b'',
+        nonce=1,
+    )
+    with database.user_write() as write_cursor:
+        DBEvmTx(database).add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[tx],
+            relevant_address=sender,
+        )
+        write_cursor.execute(
+            'INSERT INTO evm_internal_tx_conflicts'
+            '(transaction_hash, chain, action, fixed) VALUES(?, ?, ?, ?)',
+            (tx_hash, ChainID.ETHEREUM.serialize_for_db(), INTERNAL_TX_CONFLICT_ACTION_FIX_REDECODE, 0),  # noqa: E501
+        )
+        # Insert a customized event linked to this tx
+        write_cursor.execute(
+            'INSERT INTO history_events('
+            'identifier, entry_type, group_identifier, sequence_index, timestamp, '
+            'location, location_label, asset, amount, notes, type, subtype, extra_data, ignored) '
+            'VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            (
+                888_001,
+                HistoryBaseEntryType.EVM_EVENT.serialize_for_db(),
+                f'10{tx_hash!s}',
+                0,
+                1700000000,
+                Location.ETHEREUM.serialize_for_db(),
+                sender,
+                A_ETH.identifier,
+                '1',
+                'user edited receive',
+                HistoryEventType.TRADE.serialize(),
+                HistoryEventSubType.RECEIVE.serialize(),
+                None,
+                0,
+            ),
+        )
+        write_cursor.execute(
+            'INSERT INTO chain_events_info(identifier, tx_ref, counterparty, address) '
+            'VALUES(?, ?, ?, ?)',
+            (888_001, tx_hash, None, None),
+        )
+        write_cursor.execute(
+            'INSERT INTO history_events_mappings(parent_identifier, name, value) VALUES(?, ?, ?)',
+            (888_001, HISTORY_MAPPING_KEY_STATE, HistoryMappingState.CUSTOMIZED.serialize_for_db()),  # noqa: E501
+        )
+
+    repull_internal_tx_conflicts(
+        database=database,
+        chains_aggregator=make_dummy_chains_aggregator(),
+        limit=DEFAULT_INTERNAL_TXS_TO_REPULL,
+    )
+
+    with database.conn.read_ctx() as cursor:
+        # Conflict is marked fixed
+        assert cursor.execute(
+            'SELECT fixed FROM evm_internal_tx_conflicts WHERE transaction_hash=? AND chain=?',
+            (tx_hash, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0] == 1
+        # Customized event is preserved
+        assert cursor.execute(
+            'SELECT notes FROM history_events WHERE identifier=?',
+            (888_001,),
+        ).fetchone()[0] == 'user edited receive'


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
