### PR TITLE
fix(frontend): remove spurious success field from sync schema

### DIFF
--- a/frontend/app/src/composables/api/settings/google-calendar.spec.ts
+++ b/frontend/app/src/composables/api/settings/google-calendar.spec.ts
@@ -124,7 +124,6 @@ describe('composables/api/settings/google-calendar', () => {
           requestMethod = request.method;
           return HttpResponse.json({
             result: {
-              success: true,
               calendar_id: 'calendar-id-abc',
               events_processed: 100,
               events_created: 25,
@@ -139,7 +138,6 @@ describe('composables/api/settings/google-calendar', () => {
       const result = await syncCalendar();
 
       expect(requestMethod).toBe('POST');
-      expect(result.success).toBe(true);
       expect(result.calendarId).toBe('calendar-id-abc');
       expect(result.eventsProcessed).toBe(100);
       expect(result.eventsCreated).toBe(25);

--- a/frontend/app/src/types/settings/google-calendar.ts
+++ b/frontend/app/src/types/settings/google-calendar.ts
@@ -16,7 +16,6 @@ export const GoogleCalendarAuthResultSchema = z.object({
 export type GoogleCalendarAuthResult = z.infer<typeof GoogleCalendarAuthResultSchema>;
 
 export const GoogleCalendarSyncResultSchema = z.object({
-  success: z.boolean(),
   calendarId: z.string(),
   eventsProcessed: z.number(),
   eventsCreated: z.number(),


### PR DESCRIPTION
## Summary
- Remove `success` field from `GoogleCalendarSyncResultSchema` — the backend `sync_events` endpoint never returns it. The `success` field only exists in auth/disconnect responses.

## Test plan
- [ ] Verify Google Calendar sync still parses correctly without the extra field