### PR TITLE
Avoid lossing relevant address when repulling

### DIFF
--- a/rotkehlchen/api/services/transactions.py
+++ b/rotkehlchen/api/services/transactions.py
@@ -10,7 +10,7 @@ from sqlcipher3 import dbapi2 as sqlcipher
 from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.evm.constants import GENESIS_HASH
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
-from rotkehlchen.chain.evm.types import NodeName
+from rotkehlchen.chain.evm.types import NodeName, string_to_evm_address
 from rotkehlchen.chain.gnosis.modules.gnosis_pay.constants import CPT_GNOSIS_PAY
 from rotkehlchen.chain.zksync_lite.constants import ZKL_IDENTIFIER
 from rotkehlchen.db.cache import DBCacheDynamic
@@ -917,7 +917,7 @@ class TransactionsService:
         except DeserializationError as e:
             raise InputError(str(e)) from e
 
-        dbevmtx = DBEvmTx(self.rotkehlchen.data.db)
+        dbevmtx = chain_manager.transactions.dbevmtx  # either DBL2WithL1FeesTx or DBEvmTx
         parent_hash_internal_txs: list[EvmInternalTransaction] = []
         indexer_source = 'unknown'
         if transaction.to_address is not None:  # internal transactions only through contracts
@@ -930,49 +930,29 @@ class TransactionsService:
                 tx_timestamp=transaction.timestamp,
             ))
 
+        db_tuple = (tx_ref, chain_manager.node_inquirer.chain_id.serialize_for_db())
         with self.rotkehlchen.data.db.conn.read_ctx() as cursor:
             tx_is_customized = is_tx_customized(cursor, tx_ref, chain_manager.node_inquirer.chain_id)  # noqa: E501
+            raw_relevant_address = cursor.execute(
+                'SELECT m.address FROM evm_transactions AS t '
+                'JOIN evmtx_address_mappings AS m ON m.tx_id = t.identifier '
+                'WHERE t.tx_hash = ? AND t.chain_id = ?',
+                db_tuple,
+            ).fetchone()
+            relevant_address = None if raw_relevant_address is None else string_to_evm_address(raw_relevant_address[0])  # noqa: E501
 
         if not delete_custom and tx_is_customized:
-            with self.rotkehlchen.data.db.user_write() as write_cursor:
-                write_cursor.execute(
-                    'DELETE FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
-                    (tx_ref, chain_manager.node_inquirer.chain_id.serialize_for_db()),
-                )
-                dbevmtx.add_transactions(
-                    write_cursor=write_cursor,
-                    evm_transactions=[transaction],
-                    relevant_address=None,
-                )
-                dbevmtx.add_or_ignore_receipt_data(
-                    write_cursor=write_cursor,
-                    chain_id=chain_manager.node_inquirer.chain_id,
-                    data=raw_receipt_data,
-                )
-                if transaction.to_address is not None:
-                    chain_manager.transactions._replace_internal_transactions_for_parent_hash(
-                        write_cursor=write_cursor,
-                        parent_tx_hash=tx_ref,
-                        transactions=parent_hash_internal_txs,
-                        indexer_source=indexer_source,
-                    )
-                if table_exists(write_cursor, 'evm_internal_tx_conflicts'):  # temporary table, to be removed in a future release  # noqa: E501
-                    set_internal_tx_conflict_fixed(
-                        write_cursor=write_cursor,
-                        tx_hash=tx_ref,
-                        chain_id=chain_manager.node_inquirer.chain_id,
-                    )
-            return
+            raise InputError(f'Tried to delete customized transaction {tx_ref} while delete custom is False')  # noqa: E501
 
         with self.rotkehlchen.data.db.user_write() as write_cursor:
             write_cursor.execute(
                 'DELETE FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
-                (tx_ref, chain_manager.node_inquirer.chain_id.serialize_for_db()),
+                db_tuple,
             )
-            dbevmtx.add_transactions(
+            dbevmtx.add_transactions(  # for chains with L2 fees it also saves the l1fee
                 write_cursor=write_cursor,
                 evm_transactions=[transaction],
-                relevant_address=None,
+                relevant_address=relevant_address,
             )
             dbevmtx.add_or_ignore_receipt_data(
                 write_cursor=write_cursor,

--- a/rotkehlchen/tests/api/test_history_base_entry.py
+++ b/rotkehlchen/tests/api/test_history_base_entry.py
@@ -95,6 +95,7 @@ def assert_editing_works(
         sequence_index: int,
         autoedited: dict[str, Any] | None = None,
         also_redecode: bool = False,
+        delete_custom: bool = False,
 ) -> None:
     """A function to assert editing works per entry type. If autoedited is given
     then we check that some fields, given in autoedited, were automatically edited
@@ -157,7 +158,7 @@ def assert_editing_works(
     # are still correctly shown and not deleted
     response = requests.put(
         api_url_for(rotkehlchen_api_server, 'transactionsdecodingresource'),
-        json={'chain': 'eth', 'tx_refs': [str(entry.tx_ref)], 'delete_custom': False},
+        json={'chain': 'eth', 'tx_refs': [str(entry.tx_ref)], 'delete_custom': delete_custom},
     )
     assert_simple_ok_response(response)
     assert_event_got_edited(entry)
@@ -321,7 +322,7 @@ def test_add_edit_delete_entries(
             status_code=HTTPStatus.BAD_REQUEST,
         )
     # Test that editing works for the various event types
-    assert_editing_works(entry, rotkehlchen_api_server, db, 4, also_redecode=True)  # evm event
+    assert_editing_works(entry, rotkehlchen_api_server, db, 4, also_redecode=False, delete_custom=True)  # evm event. We set also_redecode=False because with True the related events get deleted since the event is customized  # noqa: E501
     assert_editing_works(entries[5], rotkehlchen_api_server, db, 5)  # history event
     assert_editing_works(entries[6], rotkehlchen_api_server, db, 6, {'notes': 'Exit validator 1001 with 1500.1 ETH', 'group_identifier': 'EW_1001_19460'})  # eth withdrawal event  # noqa: E501
     assert_editing_works(entries[7], rotkehlchen_api_server, db, 7, {'notes': 'Deposit 1500.1 ETH to validator 1001'})  # eth deposit event  # noqa: E501

--- a/rotkehlchen/tests/api/test_internal_tx_conflicts.py
+++ b/rotkehlchen/tests/api/test_internal_tx_conflicts.py
@@ -1,7 +1,13 @@
 from typing import TYPE_CHECKING, Any, cast
 
+import pytest
 import requests
 
+from rotkehlchen.chain.evm.types import (
+    EvmIndexer,
+    SerializableChainIndexerOrder,
+    string_to_evm_address,
+)
 from rotkehlchen.db.internal_tx_conflicts import (
     INTERNAL_TX_CONFLICT_ACTION_FIX_REDECODE,
     INTERNAL_TX_CONFLICT_ACTION_REPULL,
@@ -11,8 +17,9 @@ from rotkehlchen.db.internal_tx_conflicts import (
 from rotkehlchen.history.events.structures.base import HistoryBaseEntryType
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response_with_result
+from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
-from rotkehlchen.types import ChainID, Location, Timestamp
+from rotkehlchen.types import ChainID, Location, Timestamp, deserialize_evm_tx_hash
 
 if TYPE_CHECKING:
     from rotkehlchen.api.server import APIServer
@@ -335,3 +342,70 @@ def test_post_pending_internal_tx_conflicts_count_endpoint(
         async_query=False,
     ))
     assert result == {'pending': 1, 'failed': 2}
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('db_settings', [{'evm_indexers_order': SerializableChainIndexerOrder(order={ChainID.OPTIMISM: [EvmIndexer.BLOCKSCOUT]})}])  # noqa: E501
+@pytest.mark.parametrize('have_decoders', [True])
+@pytest.mark.parametrize('optimism_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
+def test_redecode_keeps_optimism_l1_fee_and_relevant_address(
+        rotkehlchen_api_server: 'APIServer',
+        optimism_accounts: list[str],
+) -> None:
+    """Decode an Optimism tx, assert L1 fee + address mapping in DB, then redecode and
+    ensure both remain unchanged.
+    """
+    tx_hash = deserialize_evm_tx_hash('0x1b3ace2628e40a360c8420ba7ff16bc10dce7a54f4a28dfcce97986eae62c0ed')  # noqa: E501
+    expected_l1_fee = 716831161
+    relevant_address = string_to_evm_address(optimism_accounts[0])
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+
+    get_decoded_events_of_transaction(
+        evm_inquirer=rotki.chains_aggregator.optimism.node_inquirer,
+        tx_hash=tx_hash,
+        relevant_address=relevant_address,
+    )
+
+    with rotki.data.db.conn.read_ctx() as cursor:
+        l1_fee_before = cursor.execute(
+            'SELECT optimism_transactions.l1_fee FROM optimism_transactions '
+            'JOIN evm_transactions tx ON tx.identifier=optimism_transactions.tx_id '
+            'WHERE tx.tx_hash=? AND tx.chain_id=?',
+            (tx_hash, ChainID.OPTIMISM.serialize_for_db()),
+        ).fetchone()
+        relevant_mappings_before = cursor.execute(
+            'SELECT COUNT(*) FROM evmtx_address_mappings map '
+            'JOIN evm_transactions tx ON tx.identifier=map.tx_id '
+            'WHERE tx.tx_hash=? AND tx.chain_id=? AND map.address=?',
+            (tx_hash, ChainID.OPTIMISM.serialize_for_db(), relevant_address),
+        ).fetchone()
+    assert l1_fee_before is not None
+    assert int(l1_fee_before[0]) == expected_l1_fee
+    assert relevant_mappings_before is not None
+    assert relevant_mappings_before[0] == 1
+
+    assert assert_proper_response_with_result(
+        response=requests.put(
+            api_url_for(rotkehlchen_api_server, 'transactionsdecodingresource'),
+            json={'async_query': False, 'chain': 'optimism', 'tx_refs': [str(tx_hash)]},
+        ),
+        rotkehlchen_api_server=rotkehlchen_api_server,
+        async_query=False,
+    ) is True
+    with rotki.data.db.conn.read_ctx() as cursor:
+        l1_fee_after = cursor.execute(
+            'SELECT optimism_transactions.l1_fee FROM optimism_transactions '
+            'JOIN evm_transactions tx ON tx.identifier=optimism_transactions.tx_id '
+            'WHERE tx.tx_hash=? AND tx.chain_id=?',
+            (tx_hash, ChainID.OPTIMISM.serialize_for_db()),
+        ).fetchone()
+        relevant_mappings_after = cursor.execute(
+            'SELECT COUNT(*) FROM evmtx_address_mappings map '
+            'JOIN evm_transactions tx ON tx.identifier=map.tx_id '
+            'WHERE tx.tx_hash=? AND tx.chain_id=? AND map.address=?',
+            (tx_hash, ChainID.OPTIMISM.serialize_for_db(), relevant_address),
+        ).fetchone()
+    assert l1_fee_after is not None
+    assert int(l1_fee_after[0]) == expected_l1_fee
+    assert relevant_mappings_after is not None
+    assert relevant_mappings_after[0] == 1


### PR DESCRIPTION
- This commit ensures that the relevant address is kept and not dropped
when deleting on cascade.
- Also ensures that the L1 fee is inserted along the data queried
- also raises inputError when trying to preserve customized events during redecoding 
