### PR TITLE
fix(frontend): debounce internal tx conflict refresh

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`11964` Resolving many internal transaction conflicts at once will no longer flood the frontend with duplicate refresh requests, reducing unnecessary network calls and improving responsiveness.
+
 * :release:`1.42.1 <2025-03-26>`
 * :bug:`-` Asset icons in the Docker deployment will no longer fail to load due to an invalid base URL when constructing icon URLs.
 * :bug:`11935` Editing a manual balance to have duplicate names should no longer be possible.

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
@@ -48,6 +48,7 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
 
   const pendingCount = ref<number>(0);
   const failedCount = ref<number>(0);
+  const refreshing = ref<boolean>(false);
   const issueCount = computed<number>(() => get(pendingCount) + get(failedCount));
   const activeFilter = ref<InternalTxConflictStatus>(InternalTxConflictStatuses.PENDING);
 
@@ -109,12 +110,21 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
   }
 
   async function handleConflictFixed(): Promise<void> {
-    await Promise.all([fetchCounts(), fetchConflicts()]);
+    if (get(refreshing))
+      return;
+
+    set(refreshing, true);
+    try {
+      await Promise.all([fetchCounts(), fetchConflicts()]);
+    }
+    finally {
+      set(refreshing, false);
+    }
   }
 
-  watch(internalTxFixedSignal, () => {
+  watchDebounced(internalTxFixedSignal, () => {
     startPromise(handleConflictFixed());
-  });
+  }, { debounce: 2000, maxWait: 10000 });
 
   return {
     activeFilter,


### PR DESCRIPTION
## Summary

- Replace `watch` with `watchDebounced` (2s debounce, 10s maxWait) on the `internalTxFixedSignal` to collapse rapid WebSocket messages into a single refresh
- Add a `refreshing` guard to prevent concurrent API calls if a refresh is already in flight

Closes #11964

## Test plan

- [ ] Verify that resolving a single internal tx conflict still refreshes counts and list
- [ ] Verify that resolving many conflicts in quick succession only triggers one refresh after the burst
- [ ] Verify that the UI still updates correctly after the debounced refresh completes