### PR TITLE
Remove unused model utils

### DIFF
--- a/frontend/app/src/utils/model.spec.ts
+++ b/frontend/app/src/utils/model.spec.ts
@@ -1,65 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
-import { usePropVModel, useRefPropVModel, useSimplePropVModel } from '@/utils/model';
+import { describe, expect, it } from 'vitest';
+import { useRefPropVModel } from '@/utils/model';
 
 describe('model-utils', () => {
-  describe('useSimplePropVModel', () => {
-    it('should emit proper event and update value property', () => {
-      const props = {
-        modelValue: {
-          counter: 1,
-          name: 'test',
-        },
-      };
-      const emit = vi.fn();
-      const model = useSimplePropVModel(props, 'counter', emit);
-      expect(get(model)).toBe(1);
-      set(model, 12);
-
-      expect(emit).toHaveBeenCalledWith('update:modelValue', {
-        counter: 12,
-        name: 'test',
-      });
-    });
-  });
-
-  describe('usePropVModel', () => {
-    it('should emit proper event and update only the specified value property', () => {
-      const props = {
-        model: {
-          name: 'model',
-          counter: 1,
-        },
-      };
-      const emit = vi.fn();
-      const model = usePropVModel(props, 'model', 'counter', emit);
-      expect(get(model)).toBe(1);
-      set(model, 12);
-
-      expect(emit).toHaveBeenCalledWith('update:model', {
-        name: 'model',
-        counter: 12,
-      });
-    });
-
-    it('should emit kebab case event on camel case prop', () => {
-      const props = {
-        testModel: {
-          name: 'model',
-          counter: 1,
-        },
-      };
-      const emit = vi.fn();
-      const model = usePropVModel(props, 'testModel', 'counter', emit);
-      expect(get(model)).toBe(1);
-      set(model, 12);
-
-      expect(emit).toHaveBeenCalledWith('update:test-model', {
-        name: 'model',
-        counter: 12,
-      });
-    });
-  });
-
   it('should properly map computed property to parent ref', () => {
     const objRef = ref({
       title: 'title',

--- a/frontend/app/src/utils/model/index.ts
+++ b/frontend/app/src/utils/model/index.ts
@@ -1,6 +1,5 @@
 import type { Ref, WritableComputedRef } from 'vue';
 import { type BigNumber, bigNumberify } from '@rotki/common';
-import { kebabCase } from 'es-toolkit';
 
 export function useBigNumberModel(model: WritableComputedRef<BigNumber | null | undefined>): WritableComputedRef<string> {
   return computed<string>({
@@ -14,33 +13,6 @@ export function useBigNumberModel(model: WritableComputedRef<BigNumber | null | 
       set(model, value ? bigNumberify(value) : null);
     },
   });
-}
-
-export function usePropVModel<
-  P extends object,
-  K extends keyof P,
-  S extends P[K] extends object ? keyof P[K] : never,
-  Name extends string,
->(props: P, key: K, subKey: S, emit?: (name: Name, ...args: any[]) => void): WritableComputedRef<P[K][S]> {
-  const keyStr = key.toString();
-  const eventName = `update:${keyStr === 'modelValue' ? keyStr : kebabCase(keyStr)}` as Name;
-  return computed({
-    get() {
-      return props[key][subKey];
-    },
-    set(value: P[K][S]) {
-      emit?.(eventName, { ...props[key], [subKey]: value });
-    },
-  });
-}
-
-export function useSimplePropVModel<
-  T,
-  P extends { modelValue: T },
-  S extends P['modelValue'] extends object ? keyof P['modelValue'] : never,
-  Name extends string,
->(props: P, subKey: S, emit?: (name: Name, ...args: any[]) => void): WritableComputedRef<P['modelValue'][S]> {
-  return usePropVModel(props, 'modelValue', subKey, emit);
 }
 
 export function nullDefined<T>(comp: WritableComputedRef<T | null>): WritableComputedRef<T | undefined> {


### PR DESCRIPTION
## Summary
- Remove `usePropVModel` and `useSimplePropVModel` from `frontend/app/src/utils/model/index.ts` — neither had any production consumers (only referenced by their own tests)
- Remove corresponding tests from `model.spec.ts`
- Drop unused `kebabCase` import from `es-toolkit`

## Test plan
- [x] `pnpm run test:unit src/utils/model.spec.ts` passes
- [x] `CI=true pnpm run lint` has no errors