### PR TITLE
fix: debounce internal tx conflict count refresh

### DIFF
--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
@@ -112,9 +112,9 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
     await Promise.all([fetchCounts(), fetchConflicts()]);
   }
 
-  watch(internalTxFixedSignal, () => {
+  watchDebounced(internalTxFixedSignal, () => {
     startPromise(handleConflictFixed());
-  });
+  }, { debounce: 800 });
 
   return {
     activeFilter,


### PR DESCRIPTION
## Summary
- Fixes #11964 — internal tx conflict refresh was firing N*2 API calls for N WebSocket messages
- Replaced `watch` with `watchDebounced` (800ms) on `internalTxFixedSignal` to collapse rapid successive messages into a single refresh
- `watchDebounced` is already auto-imported from VueUse and used throughout the codebase

## Changes
- `frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts` — swapped `watch` for `watchDebounced` with 800ms debounce

## Test plan
- [x] Rapid `internal_tx_fixed` WebSocket messages now trigger a single batched refresh
- [x] No new dependencies — `watchDebounced` already available via VueUse auto-import