### PR TITLE
Prevent failing connection after keep alive finishes with kraken

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`11976` Bybit deposits and withdrawals older than 30 days will now be correctly imported.
 * :bug:`11964` Resolving many internal transaction conflicts at once will no longer flood the frontend with duplicate refresh requests, reducing unnecessary network calls and improving responsiveness.
 * :bug:`-` rotki no longer gets stuck when querying Routescan transactions with more than 100 internal transactions.
+* :bug:`-` rotki will now recover more reliably when an exchange closes idle API connections, reducing failed requests after the app has been left open for a while.
 
 * :release:`1.42.1 <2025-03-26>`
 * :bug:`-` Asset icons in the Docker deployment will no longer fail to load due to an invalid base URL when constructing icon URLs.

--- a/rotkehlchen/exchanges/exchange.py
+++ b/rotkehlchen/exchanges/exchange.py
@@ -1,7 +1,12 @@
 import logging
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
+from http.client import RemoteDisconnected
 from typing import TYPE_CHECKING, Any
+
+import requests
+from gevent.event import Event
+from gevent.lock import RLock, Semaphore
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.api.websockets.typedefs import (
@@ -43,6 +48,108 @@ ExchangeQueryBalances = tuple[dict[AssetWithOracles, Balance] | None, str]
 
 ExchangeHistoryFailCallback = Callable[[str], None]
 ExchangeHistoryNewStepCallback = Callable[[str], None]
+
+
+class RecoveringExchangeSession(requests.Session):
+    """Session wrapper that retries once after recoverable keep-alive disconnects."""
+
+    def __init__(self, exchange: 'ExchangeWithoutApiSecret') -> None:
+        super().__init__()
+        self.exchange = exchange
+        self._recovery_lock = Semaphore()
+        self._session_state_lock = RLock()
+        self._session_reset_gate = RLock()
+        self._session_reset_ready = Event()
+        self._session_reset_ready.set()
+        self._session_inflight_requests = 0
+
+    def _register_request_start(self) -> None:
+        """Mark request start and update reset-readiness state.
+
+        A reset is only safe once there are no other in-flight requests using
+        this session. As soon as concurrency appears (`inflight > 1`), clear
+        `_session_reset_ready` so the resetter waits before closing session.
+        """
+        with self._session_state_lock:
+            self._session_inflight_requests += 1
+            if self._session_inflight_requests > 1:
+                self._session_reset_ready.clear()
+
+    def _register_request_end(self) -> None:
+        """Mark request end and signal when reset becomes safe again."""
+        with self._session_state_lock:
+            self._session_inflight_requests -= 1
+            if self._session_inflight_requests <= 1:
+                self._session_reset_ready.set()
+
+    def _reset_exchange_session(self) -> None:
+        """Reset exchange session once no other request uses this session.
+
+        We acquire `_session_reset_gate` to block new request registration,
+        wait for `_session_reset_ready` if another request is still in flight,
+        and then swap the exchange session.
+        """
+        with self._session_reset_gate:
+            with self._session_state_lock:
+                should_wait = self._session_inflight_requests > 1
+            if should_wait:
+                self._session_reset_ready.wait()
+
+            old_headers = dict(self.exchange.session.headers)
+            self.exchange.session.close()
+            self.exchange.session = self.exchange._create_session(headers=old_headers)
+
+    @staticmethod
+    def _is_recoverable_connection_error(error: requests.RequestException) -> bool:
+        """Return whether a connection error comes from `RemoteDisconnected`.
+
+        We only retry `requests.ConnectionError` failures caused by the remote end
+        closing a keep-alive socket without sending a response.
+
+        In requests/urllib3 this can appear either directly in `error.args` or
+        wrapped one level deeper (for example inside `urllib3.ProtocolError`).
+        """
+        if not isinstance(error, requests.ConnectionError):
+            return False
+
+        for arg in error.args:
+            if isinstance(arg, RemoteDisconnected):
+                return True
+            if isinstance(arg, BaseException) and any(
+                isinstance(inner, RemoteDisconnected) for inner in arg.args
+            ):
+                return True
+
+        return False
+
+    def request(self, *args: Any, **kwargs: Any) -> requests.Response:
+        with self._session_reset_gate:
+            self._register_request_start()
+        try:
+            return super().request(*args, **kwargs)
+        except requests.RequestException as e:
+            if not self._is_recoverable_connection_error(e):
+                raise
+
+            # Use the semaphore to ensure only one greenlet performs recovery.
+            # If another greenlet is already recovering, wait for it to finish
+            # and then retry with the new session.
+            if not self._recovery_lock.acquire(blocking=False):
+                # Another greenlet is recovering; wait for it to finish
+                self._recovery_lock.acquire(blocking=True)
+                self._recovery_lock.release()
+                # Retry with the session that was reset by the other greenlet
+                return self.exchange.session.request(*args, **kwargs)
+
+            try:
+                # Retry once with a fresh session after stale keep-alive disconnects.
+                # Subsequent failures in this chain bubble up.
+                self._reset_exchange_session()
+                return self.exchange.session.request(*args, **kwargs)
+            finally:
+                self._recovery_lock.release()
+        finally:
+            self._register_request_end()
 
 
 class ExchangeWithExtras:
@@ -87,9 +194,18 @@ class ExchangeWithoutApiSecret(CacheableMixIn, LockableQueryMixIn):
         self.api_key = api_key
         self.msg_aggregator = msg_aggregator
         self.first_connection_made = False
-        self.session = create_session()
-        set_user_agent(self.session)
+        self.session = self._create_session()
         log.info(f'Initialized {location!s} exchange {name}')
+
+    def _create_session(self, headers: dict[str, str | bytes] | None = None) -> requests.Session:
+        """Special create session that uses RecoveringExchangeSession to recover
+        on RemoteDisconnected errors
+        """
+        session = create_session(session=RecoveringExchangeSession(self))
+        set_user_agent(session)
+        if headers is not None:
+            session.headers.update(headers)
+        return session
 
     def reset_to_db_credentials(self) -> None:
         """Resets the exchange credentials to the ones saved in the DB"""

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -3,6 +3,7 @@ import warnings as test_warnings
 from collections import defaultdict
 from contextlib import ExitStack
 from http import HTTPStatus
+from http.client import RemoteDisconnected
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import _patch, patch
@@ -11,6 +12,8 @@ from uuid import uuid4
 import gevent
 import pytest
 import requests
+from gevent.event import Event
+from urllib3.exceptions import ProtocolError
 
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.structures.balance import Balance
@@ -38,6 +41,7 @@ from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.kraken import Kraken
 from rotkehlchen.fval import FVal
@@ -225,11 +229,13 @@ def test_querying_rate_limit_exhaustion(kraken, database):
     patch_kraken = patch.object(kraken.session, 'post', side_effect=mock_response)
     patch_retries = patch('rotkehlchen.exchanges.kraken.KRAKEN_QUERY_TRIES', new=2)
     patch_dividend = patch('rotkehlchen.exchanges.kraken.KRAKEN_BACKOFF_DIVIDEND', new=1)
+    patch_sleep = patch('rotkehlchen.exchanges.kraken.gevent.sleep')
 
     with ExitStack() as stack:
         stack.enter_context(gevent.Timeout(8))
         stack.enter_context(patch_retries)
         stack.enter_context(patch_dividend)
+        stack.enter_context(patch_sleep)
         stack.enter_context(patch_kraken)
         kraken.query_history_events()
 
@@ -242,6 +248,152 @@ def test_querying_rate_limit_exhaustion(kraken, database):
 
     assert from_ts == 0
     assert to_ts == 1609950165, 'should have saved only until the last trades timestamp'
+
+
+def test_kraken_retries_after_remote_disconnect(kraken) -> None:
+    kraken.use_original_kraken = True
+
+    initial_session = kraken.session
+    response_text = (
+        '{"error":[],"result":{"ledger":{"L1":{"refid":"AOEXXV-61T63-AKPSJ0",'
+        '"time":1609950165.4497,"type":"trade","subtype":"","aclass":"currency",'
+        '"asset":"KFEE","amount":"0.00","fee":"1.145","balance":"0.00"}},"count":1}}'
+    )
+
+    with (
+        patch(
+            'requests.sessions.Session.send',
+            side_effect=[
+                requests.ConnectionError(
+                    'Connection aborted.',
+                    RemoteDisconnected('Remote end closed connection without response'),
+                ),
+                MockResponse(200, response_text),
+            ],
+        ) as post_patch,
+        patch('rotkehlchen.exchanges.kraken.gevent.sleep') as sleep_patch,
+    ):
+        response = kraken.api_query('Ledgers', {'start': 1, 'end': 2})
+
+    assert response['count'] == 1
+    assert len(response['ledger']) == 1
+    assert post_patch.call_count == 2
+    assert kraken.session is not initial_session
+    sleep_patch.assert_not_called()
+
+
+def test_kraken_does_not_retry_other_request_exceptions(kraken) -> None:
+    kraken.use_original_kraken = True
+
+    initial_session = kraken.session
+
+    with (
+        patch(
+            'requests.sessions.Session.post',
+            side_effect=requests.exceptions.ReadTimeout('timed out'),
+        ) as post_patch,
+        patch.object(kraken.session, 'close') as close_patch,
+        pytest.raises(RemoteError, match='timed out'),
+    ):
+        kraken.api_query('Ledgers', {'start': 1, 'end': 2})
+
+    assert post_patch.call_count == 1
+    assert kraken.session is initial_session
+    close_patch.assert_not_called()
+
+
+def test_kraken_retries_after_wrapped_remote_disconnect(kraken) -> None:
+    kraken.use_original_kraken = True
+
+    response_text = (
+        '{"error":[],"result":{"ledger":{"L1":{"refid":"AOEXXV-61T63-AKPSJ0",'
+        '"time":1609950165.4497,"type":"trade","subtype":"","aclass":"currency",'
+        '"asset":"KFEE","amount":"0.00","fee":"1.145","balance":"0.00"}},"count":1}}'
+    )
+
+    with patch(
+        'requests.sessions.Session.send',
+        side_effect=[
+            requests.exceptions.ConnectionError(ProtocolError(
+                'Connection aborted.',
+                RemoteDisconnected('Remote end closed connection without response'),
+            )),
+            MockResponse(200, response_text),
+        ],
+    ) as post_patch, patch('rotkehlchen.exchanges.kraken.gevent.sleep') as sleep_patch:
+        response = kraken.api_query('Ledgers', {'start': 1, 'end': 2})
+
+    assert response['count'] == 1
+    assert len(response['ledger']) == 1
+    assert post_patch.call_count == 2
+    sleep_patch.assert_not_called()
+
+
+def test_kraken_waits_before_resetting_session_if_another_request_is_in_flight(kraken) -> None:
+    """Ensure reset waits until other in-flight session requests complete.
+
+    Strategy:
+    1. Start a "slow" request on the exchange session and block it in `send()`.
+    2. While it is still in flight, start a second request that raises a recoverable
+       connection error (`ConnectionError` wrapping `RemoteDisconnected`).
+    3. Instrument `initial_session.close()` and verify close is *not* performed
+       before the slow request completes.
+    """
+    kraken.use_original_kraken = True
+
+    slow_started = Event()
+    allow_slow_finish = Event()
+    slow_finished = Event()
+    close_while_slow = False
+    recover_attempt = 0
+    initial_session = kraken.session
+
+    def mock_send(*args, **kwargs):  # pylint: disable=unused-argument
+        nonlocal recover_attempt
+        request = kwargs.get('request') or args[0]
+        if request.url.endswith('/slow'):
+            slow_started.set()
+            assert allow_slow_finish.wait(timeout=2) is True
+            slow_finished.set()
+            return MockResponse(200, '{}')
+
+        if request.url.endswith('/recover'):
+            if recover_attempt == 0:
+                recover_attempt += 1
+                # First recover request fails with the wrapped disconnect variant.
+                # Recovery code should catch this and reset the session.
+                raise requests.exceptions.ConnectionError(ProtocolError(
+                    'Connection aborted.',
+                    RemoteDisconnected('Remote end closed connection without response'),
+                ))
+
+            return MockResponse(200, '{}')
+
+        raise AssertionError(f'Unexpected request url: {request.url}')
+
+    original_close = initial_session.close
+
+    def tracked_close() -> None:
+        nonlocal close_while_slow
+        if slow_started.is_set() and not slow_finished.is_set():
+            close_while_slow = True
+        original_close()
+
+    with (
+        patch('requests.sessions.Session.send', side_effect=mock_send),
+        patch.object(initial_session, 'close', side_effect=tracked_close),
+    ):
+        slow_greenlet = gevent.spawn(kraken.session.get, 'https://rotki.test/slow')
+        assert slow_started.wait(timeout=2) is True
+
+        recover_greenlet = gevent.spawn(kraken.session.get, 'https://rotki.test/recover')
+        gevent.sleep(0)
+
+        allow_slow_finish.set()
+        gevent.joinall([slow_greenlet, recover_greenlet], timeout=2, raise_error=True)
+
+    assert recover_attempt == 1
+    assert close_while_slow is False
 
 
 def test_querying_deposits_withdrawals(kraken):

--- a/rotkehlchen/utils/network.py
+++ b/rotkehlchen/utils/network.py
@@ -18,7 +18,10 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-def create_session(max_backoff_secs: float = 30) -> requests.Session:
+def create_session(
+        max_backoff_secs: float = 30,
+        session: requests.Session | None = None,
+) -> requests.Session:
     """Create a requests session configured to retry on connection, read, and
     specific server errors.
 
@@ -32,7 +35,7 @@ def create_session(max_backoff_secs: float = 30) -> requests.Session:
     to failed DNS lookups, socket connections and connection timeouts, never to requests
     where data has made it to the server.
     """
-    session = requests.Session()
+    session = session or requests.Session()
     # we don't use total in the adapter because it seems to trigger on certain bad status codes
     # like too many requests even when status_forcelist is set to an empty list. This
     # configuration worked fine for what we could test in real scenarios in the e2e tests.


### PR DESCRIPTION
This hits me all the time when I leave the app open. The reason is that for kraken the calls are POST and they don't get retried but the keep alive finishes and the session doesn't recover in requests