### PR TITLE
inline test variables with walrus operator across decoder tests

### DIFF
--- a/rotkehlchen/tests/unit/decoders/test_1inch.py
+++ b/rotkehlchen/tests/unit/decoders/test_1inch.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.types import ChecksumEvmAddress
 
-
 ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 
@@ -56,12 +55,11 @@ def test_1inchv1_swap(ethereum_inquirer):
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     chispender_addy = string_to_evm_address('0xed04A060050cc289d91779A8BB3942C3A6589254')
     oneinch_contract = string_to_evm_address('0x11111254369792b2Ca5d084aB5eEA397cA8fa48B')
-    timestamp = TimestampMS(1594500575000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1594500575000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -108,7 +106,6 @@ def test_1inchv1_swap(ethereum_inquirer):
             address=oneinch_contract,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -122,12 +119,11 @@ def test_1inchv2_swap_for_eth(ethereum_inquirer):
     """
     tx_hash = deserialize_evm_tx_hash('0x5edc23d5a05e347afc60e64a4d5831ed2551985c21dceb85d267926ca2e2c13e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1608498702000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1608498702000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -174,7 +170,6 @@ def test_1inchv2_swap_for_eth(ethereum_inquirer):
             address=ONEINCH_V2_MAINNET_ROUTER,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -184,12 +179,11 @@ def test_1inchv3_swap_for_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc9403f8010c78cec3036fd502103b78566f9b50eae57068538735527b59435ae')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1618011137000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1618011137000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -224,7 +218,6 @@ def test_1inchv3_swap_for_eth(ethereum_inquirer, ethereum_accounts):
             address=ONEINCH_V3_MAINNET_ROUTER,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -238,13 +231,12 @@ def test_1inchv4_swap_on_uniswapv3(ethereum_inquirer):
     """
     tx_hash = deserialize_evm_tx_hash('0xd02bbee01f92d778af8c2d159fb269ad31425b32703da568abb427ac14547e6d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1687361999000)
     user_address = '0x312419eEC9C4632155904D9440dc1EeeafFBb280'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1687361999000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -279,28 +271,26 @@ def test_1inchv4_swap_on_uniswapv3(ethereum_inquirer):
             counterparty=CPT_ONEINCH_V4,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x456325F2AC7067234dD71E01bebe032B0255e039']])
 def test_1inchv4_orderfilledrfq(ethereum_inquirer, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x7e98fc61cdec43a7b886a9d045264bcc9292b2a34f8c466e4270ee6671684b69')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x7e98fc61cdec43a7b886a9d045264bcc9292b2a34f8c466e4270ee6671684b69')),  # noqa: E501
     )
-    timestamp, user_address, gas, amount_out, amount_in = TimestampMS(1683201803000), ethereum_accounts[0], '0.010777074', '1457.408044', '634.912997630527012864'  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1683201803000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.010777074'),
             location_label=user_address,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -311,7 +301,7 @@ def test_1inchv4_orderfilledrfq(ethereum_inquirer, ethereum_accounts):
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_USDT,
-            amount=FVal(amount_out),
+            amount=FVal(amount_out := '1457.408044'),
             location_label=user_address,
             notes=f'Swap {amount_out} USDT in {CPT_ONEINCH_V4}',
             address=ONEINCH_V4_ROUTER,
@@ -323,14 +313,13 @@ def test_1inchv4_orderfilledrfq(ethereum_inquirer, ethereum_accounts):
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=EvmToken('eip155:1/erc20:0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24'),
-            amount=FVal(amount_in),
+            amount=FVal(amount_in := '634.912997630527012864'),
             location_label=user_address,
             notes=f'Receive {amount_in} RNDR as a result of a {CPT_ONEINCH_V4} swap',
             address=ONEINCH_V4_ROUTER,
             counterparty=CPT_ONEINCH_V4,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -342,18 +331,16 @@ def test_1inchv4_swap_on_sushiswap(ethereum_inquirer):
     Data taken from
     https://etherscan.io/tx/0x396f57534e5deff9b530357bda8dcd31b80892ba7ce3de6f6593b0225bba3d0f
     """
-    tx_hash = deserialize_evm_tx_hash('0x396f57534e5deff9b530357bda8dcd31b80892ba7ce3de6f6593b0225bba3d0f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x396f57534e5deff9b530357bda8dcd31b80892ba7ce3de6f6593b0225bba3d0f')),  # noqa: E501
     )
-    timestamp = TimestampMS(1687551611000)
     user_address = '0xF92940216a808378bfFD05f444B7bF71d5A193Cd'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1687551611000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -388,7 +375,6 @@ def test_1inchv4_swap_on_sushiswap(ethereum_inquirer):
             counterparty=CPT_ONEINCH_V4,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -400,18 +386,16 @@ def test_1inchv4_multiple_swaps(ethereum_inquirer):
     Data taken from
     https://etherscan.io/tx/0xeeefe25741462f0832183925ac4b1b840b819fbacd95cfc635496d853b7022bd
     """
-    tx_hash = deserialize_evm_tx_hash('0xeeefe25741462f0832183925ac4b1b840b819fbacd95cfc635496d853b7022bd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xeeefe25741462f0832183925ac4b1b840b819fbacd95cfc635496d853b7022bd')),  # noqa: E501
     )
-    timestamp = TimestampMS(1687762727000)
     user_address = '0x201b5Abfd44A8F9b75F0fE1BaE74CDaC7675E54B'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1687762727000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -458,7 +442,6 @@ def test_1inchv4_multiple_swaps(ethereum_inquirer):
             counterparty=CPT_ONEINCH_V4,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -470,18 +453,16 @@ def test_1inchv4_weth_eth_swap(ethereum_inquirer):
     Data taken from
     https://etherscan.io/tx/0x7097e7e9ef2b8bb096ed98950875b4512a833d41ceb3246903e06b61665cd5cd
     """
-    tx_hash = deserialize_evm_tx_hash('0x7097e7e9ef2b8bb096ed98950875b4512a833d41ceb3246903e06b61665cd5cd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x7097e7e9ef2b8bb096ed98950875b4512a833d41ceb3246903e06b61665cd5cd')),  # noqa: E501
     )
-    timestamp = TimestampMS(1687870007000)
     user_address = '0xcA74F404E0C7bfA35B13B511097df966D5a65597'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1687870007000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -516,7 +497,6 @@ def test_1inchv4_weth_eth_swap(ethereum_inquirer):
             counterparty=CPT_ONEINCH_V4,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -528,18 +508,16 @@ def test_1inchv4_eth_weth_swap(ethereum_inquirer):
     Data taken from
     https://etherscan.io/tx/0x6446f928148dc9f7e1ad719730d661d6d3409a9c62293ca8e8c259d06c6bd004
     """
-    tx_hash = deserialize_evm_tx_hash('0x6446f928148dc9f7e1ad719730d661d6d3409a9c62293ca8e8c259d06c6bd004')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6446f928148dc9f7e1ad719730d661d6d3409a9c62293ca8e8c259d06c6bd004')),  # noqa: E501
     )
-    timestamp = TimestampMS(1688039855000)
     user_address = '0xdCB02829F91533Ab757b1B0e8B595D7c950AfBb8'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1688039855000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -574,7 +552,6 @@ def test_1inchv4_eth_weth_swap(ethereum_inquirer):
             counterparty=CPT_ONEINCH_V4,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -583,20 +560,18 @@ def test_1inch_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
     """Data taken from
     https://polygonscan.com/tx/0xe13e0ebab7a6abc0c0a22fcf0766b9a585a430415c88f3f90328b310119a85af
     """
-    tx_hash = deserialize_evm_tx_hash('0xe13e0ebab7a6abc0c0a22fcf0766b9a585a430415c88f3f90328b310119a85af')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe13e0ebab7a6abc0c0a22fcf0766b9a585a430415c88f3f90328b310119a85af')),  # noqa: E501
     )
     user_addy = polygon_pos_accounts[0]
     pos_usdt = Asset('eip155:137/erc20:0xc2132D05D31c914a87C6611C10748AEb04B58e8F')
     pos_yfi = Asset('eip155:137/erc20:0xDA537104D6A5edd53c6fBba9A898708E465260b6')
-    timestamp = TimestampMS(1641040985000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1641040985000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -643,24 +618,21 @@ def test_1inch_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
             address=ONEINCH_V4_ROUTER,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_1inch_gnosis_v5_swap(gnosis_inquirer, gnosis_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x4b1fcb8836d7cc323015c0d019f595273d176bd6024f7b59b4b15d3f7071ef71')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x4b1fcb8836d7cc323015c0d019f595273d176bd6024f7b59b4b15d3f7071ef71')),  # noqa: E501
     )
     user_addy = gnosis_accounts[0]
-    timestamp = TimestampMS(1693293950000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1693293950000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -695,25 +667,22 @@ def test_1inch_gnosis_v5_swap(gnosis_inquirer, gnosis_accounts):
             address=ONEINCH_V5_ROUTER,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('optimism_accounts', [['0x3Ba6eB0e4327B96aDe6D4f3b578724208a590CEF']])
 def test_1inch_velodrome(optimism_inquirer, optimism_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x3cb68ee7dae76c0ca6466e3a593b32144d25eabb27c1ba416c83f154627d84d8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x3cb68ee7dae76c0ca6466e3a593b32144d25eabb27c1ba416c83f154627d84d8')),  # noqa: E501
     )
     user_addy = optimism_accounts[0]
-    timestamp = TimestampMS(1698055881000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1698055881000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -748,18 +717,16 @@ def test_1inch_velodrome(optimism_inquirer, optimism_accounts):
             address=ONEINCH_V5_ROUTER,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('optimism_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
 def test_1inch_wombatv2_swap(optimism_inquirer, optimism_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xb3f70f0eb6208572e30542304ba5513482b7ff095abd2beb2d22101a705770f2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb3f70f0eb6208572e30542304ba5513482b7ff095abd2beb2d22101a705770f2')),  # noqa: E501
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -798,7 +765,6 @@ def test_1inch_wombatv2_swap(optimism_inquirer, optimism_accounts):
             address=ONEINCH_V5_ROUTER,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -808,18 +774,16 @@ def test_half_decoded_1inch_v5_swap(ethereum_inquirer, ethereum_accounts):
     Test that if a swap using 1inch v5 has been  half decoded by other decoder (uniswap) first
     then the two legs of the swap are properly handled by the 1inch decoder.
     """
-    tx_hash = deserialize_evm_tx_hash('0x0a86fef1df2e7f186cf7239083f67c424c735f91461388c5b23e01c4d6a4e7d8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x0a86fef1df2e7f186cf7239083f67c424c735f91461388c5b23e01c4d6a4e7d8')),  # noqa: E501
     )
-    timestamp = TimestampMS(1701001727000)
     user_address = ethereum_accounts[0]
     expetec_events = [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1701001727000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -874,22 +838,20 @@ def test_half_decoded_1inch_v5_swap(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('base_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_1inch_base_v6_swap(base_inquirer, base_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x5b41c094c49462cd97fc19dc898ef23c24f859b46dbd38ecf5d34d3d0fd291f5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5b41c094c49462cd97fc19dc898ef23c24f859b46dbd38ecf5d34d3d0fd291f5')),  # noqa: E501
     )
-    timestamp, gas, swap_amount, receive_amount = TimestampMS(1716833467000), '0.000019908608867869', '311804', '0.002362174980374604'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716833467000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000019908608867869'),
             location_label=base_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -912,7 +874,7 @@ def test_1inch_base_v6_swap(base_inquirer, base_accounts):
             location=Location.BASE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:8453/erc20:0xAd1C24dE53fAD18270D5C99026302E989D212b41'),
-            amount=FVal(swap_amount),
+            amount=FVal(swap_amount := '311804'),
             location_label=base_accounts[0],
             notes=f'Swap {swap_amount} BERD in 1inch-v6',
             counterparty=CPT_ONEINCH_V6,
@@ -924,35 +886,33 @@ def test_1inch_base_v6_swap(base_inquirer, base_accounts):
             location=Location.BASE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=A_ETH,
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '0.002362174980374604'),
             location_label=base_accounts[0],
             notes=f'Receive {receive_amount} ETH as a result of a 1inch-v6 swap',
             counterparty=CPT_ONEINCH_V6,
             address=ONEINCH_V6_ROUTER,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_1inchv4_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x4c1fcbc20fdd397229d9e3e88411fea589e7ceb901e770f6af2e70e89008d5fa')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x4c1fcbc20fdd397229d9e3e88411fea589e7ceb901e770f6af2e70e89008d5fa')),  # noqa: E501
     )
-    timestamp, user, gas, amount_in, amount_out = TimestampMS(1653476213000), polygon_pos_accounts[0], '0.015694020167926014', '174.218999', '174.206'  # noqa: E501
-    expected_events = [
+    user = polygon_pos_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1653476213000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_POL,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.015694020167926014'),
             location_label=user,
             notes=f'Burn {gas} POL for gas',
             counterparty=CPT_GAS,
@@ -975,7 +935,7 @@ def test_1inchv4_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
             location=Location.POLYGON_POS,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:137/erc20:0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063'),  # DAI
-            amount=FVal(amount_out),
+            amount=FVal(amount_out := '174.206'),
             location_label=user,
             notes=f'Swap {amount_out} DAI in {CPT_ONEINCH_V4}',
             address=ONEINCH_V4_ROUTER,
@@ -987,14 +947,13 @@ def test_1inchv4_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
             location=Location.POLYGON_POS,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:137/erc20:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'),  # USDC
-            amount=FVal(amount_in),
+            amount=FVal(amount_in := '174.218999'),
             location_label=user,
             notes=f'Receive {amount_in} USDC as a result of a {CPT_ONEINCH_V4} swap',
             address=ONEINCH_V4_ROUTER,
             counterparty=CPT_ONEINCH_V4,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1002,16 +961,16 @@ def test_1inchv4_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
 def test_1inch4_swap_via_defi_plaza(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa99ce12e628620861215c88ee2c51f6c0468442dfe0504c9e5f2c918cf63fc8c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user, gas, amount_in, amount_out = TimestampMS(1657035153000), ethereum_accounts[0], '0.01345755735660528', '790.785045156438592337', '710.921537'  # noqa: E501
+    user = ethereum_accounts[0]
     assert events == [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1657035153000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas),
+        amount=FVal(gas := '0.01345755735660528'),
         location_label=user,
         notes=f'Burn {gas} ETH for gas',
         counterparty=CPT_GAS,
@@ -1022,7 +981,7 @@ def test_1inch4_swap_via_defi_plaza(ethereum_inquirer, ethereum_accounts):
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_USDT,
-        amount=FVal(amount_out),
+        amount=FVal(amount_out := '710.921537'),
         location_label=user,
         notes=f'Swap {amount_out} USDT in {CPT_ONEINCH_V4}',
         address=ONEINCH_V4_ROUTER,
@@ -1034,7 +993,7 @@ def test_1inch4_swap_via_defi_plaza(ethereum_inquirer, ethereum_accounts):
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_CRV,
-        amount=FVal(amount_in),
+        amount=FVal(amount_in := '790.785045156438592337'),
         location_label=user,
         notes=f'Receive {amount_in} CRV as a result of a {CPT_ONEINCH_V4} swap',
         address=ONEINCH_V4_ROUTER,
@@ -1045,10 +1004,9 @@ def test_1inch4_swap_via_defi_plaza(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xAc305b47BB34AD6BB566288050920e9307fd23A7']])
 def test_1inch_swap_via_pancake(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x5a092c4d40f2f6a090ec00c38c5b6266bd07f4e6ab3ff87f18c575749a4e60ec')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5a092c4d40f2f6a090ec00c38c5b6266bd07f4e6ab3ff87f18c575749a4e60ec')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -1104,10 +1062,9 @@ def test_1inch_swap_via_pancake(arbitrum_one_inquirer, arbitrum_one_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x3Ba6eB0e4327B96aDe6D4f3b578724208a590CEF']])
 def test_1inch_limit_order_swap_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xd4b65b099928142f9ad8dad41f8de1e8c2ca4cd6551b930828eda5a8b72392db')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd4b65b099928142f9ad8dad41f8de1e8c2ca4cd6551b930828eda5a8b72392db')),  # noqa: E501
     )
     spend_address, pendle, cbbtc = string_to_evm_address('0xde9e4FE32B049f821c7f3e9802381aa470FFCA73'), Asset('eip155:42161/erc20:0x0c880f6761F1af8d9Aa9C466984b80DAb9a8c9e8'), Asset('eip155:42161/erc20:0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf')  # noqa: E501
     expected_events = [EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_aave_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave_v2.py
@@ -49,7 +49,6 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.polygon_pos.node_inquirer import PolygonPOSInquirer
 
-
 A_ADAI_V1 = Asset('eip155:1/erc20:0xfC1E690f61EFd961294b3e1Ce3313fBD8aa4f85d')
 ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 ADDY2 = '0x5727c0481b90a129554395937612d8b9301D6c7b'
@@ -62,14 +61,13 @@ def test_aave_deposit_v1(ethereum_inquirer):
     https://etherscan.io/tx/0x930879d66d13c37edf25cdbb2d2e85b65c3b2a026529ff4085146bb7a5398410
     """
     tx_hash = deserialize_evm_tx_hash('0x930879d66d13c37edf25cdbb2d2e85b65c3b2a026529ff4085146bb7a5398410')  # noqa: E501
-    timestamp = TimestampMS(1595376667000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     amount = '2507.675873220870275072'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1595376667000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -119,7 +117,6 @@ def test_aave_deposit_v1(ethereum_inquirer):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -129,15 +126,13 @@ def test_aave_withdraw_v1(ethereum_inquirer):
     https://etherscan.io/tx/0x4fed67963375a3f90916f0cf7cb9e4d12644629e36233025b36060494ffba486
     """
     tx_hash = deserialize_evm_tx_hash('0x4fed67963375a3f90916f0cf7cb9e4d12644629e36233025b36060494ffba486')  # noqa: E501
-    timestamp = TimestampMS(1598217272000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     amount = '7968.408929477087756071'
-    interest = '88.663672238882760399'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1598217272000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -180,14 +175,13 @@ def test_aave_withdraw_v1(ethereum_inquirer):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_ADAI_V1,
-            amount=FVal(interest),
+            amount=FVal(interest := '88.663672238882760399'),
             location_label=ADDY,
             notes=f'Gain {interest} aDAI from aave-v1 as interest',
             counterparty=CPT_AAVE_V1,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -199,8 +193,7 @@ def test_aave_eth_withdraw_v1(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xbd333bdd5784c10630aac5683e63f703e660a78d06f95b2ff2a8788a8dade787')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     amount = '1.000240847792940067'
-    interest = '0.000240847792940067'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -247,14 +240,13 @@ def test_aave_eth_withdraw_v1(ethereum_inquirer):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_AETH_V1,
-            amount=FVal(interest),
+            amount=FVal(interest := '0.000240847792940067'),
             location_label=ADDY2,
             notes=f'Gain {interest} aETH from aave-v1 as interest',
             counterparty=CPT_AAVE_V1,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x2715273613632226985186221669179813245119')]])  # noqa: E501
@@ -263,10 +255,9 @@ def test_aave_v2_enable_collateral(database, ethereum_inquirer, eth_transactions
     Data taken from
     https://etherscan.io/tx/0xc97b35f42c64a69c01d0e0e4106a655e385c8fa21c812c59a6172199e99cdb7e
     """
-    tx_hash = deserialize_evm_tx_hash('0xc97b35f42c64a69c01d0e0e4106a655e385c8fa21c812c59a6172199e99cdb7e')  # noqa: E501
     user_address = string_to_evm_address('0x2715273613632226985186221669179813245119')
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc97b35f42c64a69c01d0e0e4106a655e385c8fa21c812c59a6172199e99cdb7e')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -307,7 +298,7 @@ def test_aave_v2_enable_collateral(database, ethereum_inquirer, eth_transactions
         transactions=eth_transactions,
     )
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -339,7 +330,6 @@ def test_aave_v2_enable_collateral(database, ethereum_inquirer, eth_transactions
             address=string_to_evm_address('0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x2715273613632226985186221669179813245119')]])  # noqa: E501
@@ -348,10 +338,9 @@ def test_aave_v2_disable_collateral(database, ethereum_inquirer, eth_transaction
     Data taken from
     https://etherscan.io/tx/0x8fe440f37fd0fa1467067a195ea862db1f96c40634ea7bb3782cc3c3431e9b5c
     """
-    tx_hash = deserialize_evm_tx_hash('0x8fe440f37fd0fa1467067a195ea862db1f96c40634ea7bb3782cc3c3431e9b5c')  # noqa: E501
     user_address = string_to_evm_address('0x2715273613632226985186221669179813245119')
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8fe440f37fd0fa1467067a195ea862db1f96c40634ea7bb3782cc3c3431e9b5c')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -392,7 +381,7 @@ def test_aave_v2_disable_collateral(database, ethereum_inquirer, eth_transaction
         transactions=eth_transactions,
     )
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -424,7 +413,6 @@ def test_aave_v2_disable_collateral(database, ethereum_inquirer, eth_transaction
             address=string_to_evm_address('0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x2715273613632226985186221669179813245119')]])  # noqa: E501
@@ -433,10 +421,9 @@ def test_aave_v2_deposit(database, ethereum_inquirer, eth_transactions):
     Data taken from
     https://etherscan.io/tx/0xf79939503543d76942e076a117ee8467565925f8c6efef973a8e2a6baed4616a
     """
-    tx_hash = deserialize_evm_tx_hash('0xf79939503543d76942e076a117ee8467565925f8c6efef973a8e2a6baed4616a')  # noqa: E501
     user_address = string_to_evm_address('0x2715273613632226985186221669179813245119')
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf79939503543d76942e076a117ee8467565925f8c6efef973a8e2a6baed4616a')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -497,7 +484,7 @@ def test_aave_v2_deposit(database, ethereum_inquirer, eth_transactions):
         dbevmtx.add_transactions(cursor, [transaction], relevant_address=None)
         decoder.reload_data(cursor)
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -544,7 +531,6 @@ def test_aave_v2_deposit(database, ethereum_inquirer, eth_transactions):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -555,17 +541,17 @@ def test_aave_v2_deposit(database, ethereum_inquirer, eth_transactions):
 def test_aave_v2_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8fe440f37fd0fa1467067a195ea862db1f96c40634ea7bb3782cc3c3431e9b5c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, user_address = TimestampMS(1660809759000), '0.0217873', ethereum_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1660809759000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.0217873'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -616,7 +602,6 @@ def test_aave_v2_withdraw(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x030bA81f1c18d280636F32af80b9AAd02Cf0854e'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -624,19 +609,17 @@ def test_aave_v2_withdraw(ethereum_inquirer, ethereum_accounts):
 def test_aave_v2_borrow(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6c8af2a4157632e33fac9d94a03619f54d318ce1254998aabc5384053eb98ffb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1622302530000)
-    gas_amount = '0.014311845'
     user_address = ethereum_accounts[0]
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1622302530000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.014311845'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -673,7 +656,6 @@ def test_aave_v2_borrow(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0xCC12AbE4ff81c9378D670De1b57F8e0Dd228D77a'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x00000000000Cd56832cE5dfBcBFf02e7eC639BC9')]])  # noqa: E501
@@ -682,10 +664,9 @@ def test_aave_v2_repay(database, ethereum_inquirer, eth_transactions):
     Data taken from
     https://etherscan.io/tx/0x2d43c327482127821603555b00e9feb67e8de1c412a57f55e0fc8ae6bbb32d11
     """
-    tx_hash = deserialize_evm_tx_hash('0x2d43c327482127821603555b00e9feb67e8de1c412a57f55e0fc8ae6bbb32d11')  # noqa: E501
     user_address = string_to_evm_address('0x00000000000Cd56832cE5dfBcBFf02e7eC639BC9')
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x2d43c327482127821603555b00e9feb67e8de1c412a57f55e0fc8ae6bbb32d11')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -745,7 +726,7 @@ def test_aave_v2_repay(database, ethereum_inquirer, eth_transactions):
         transactions=eth_transactions,
     )
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -792,7 +773,6 @@ def test_aave_v2_repay(database, ethereum_inquirer, eth_transactions):
             address=string_to_evm_address('0x35f6B052C598d933D69A4EEC4D04c73A191fE6c2'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -806,13 +786,12 @@ def test_aave_v2_liquidation(
     """
     tx_hash = deserialize_evm_tx_hash('0x2077a54ecae4a06c553f96c120acc0237887fdd1fc2596aab103f6681712974d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1684738775000)
     user_address = ethereum_accounts[0]
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=6,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1684738775000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.PAYBACK_DEBT,
@@ -838,7 +817,6 @@ def test_aave_v2_liquidation(
             address=string_to_evm_address('0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9'),
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -852,13 +830,12 @@ def test_aave_v1_liquidation(
     """
     tx_hash = deserialize_evm_tx_hash('0x75ef28b5593efd3f0f9eff338e234f59b2bd34a7148a90ce020122900722a832')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1659244817000)
     user_address = ethereum_accounts[0]
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=187,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1659244817000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.GENERATE_DEBT,
@@ -885,7 +862,6 @@ def test_aave_v1_liquidation(
             extra_data={'is_liquidation': True},
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -897,7 +873,7 @@ def test_aave_v2_supply_ether(ethereum_inquirer, ethereum_accounts):
     """
     tx_hash = deserialize_evm_tx_hash('0xefc9040c100829a391a636f02eb96a9361bd0bc2ca5e8e5f97bbc4a1831cdec9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -959,24 +935,21 @@ def test_aave_v2_supply_ether(ethereum_inquirer, ethereum_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x572f60c0b887203324149D9C308574BcF2dfaD82']])
 def test_aave_v2_borrow_polygon(polygon_pos_inquirer, polygon_pos_accounts) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x2c2777e24bc8a59171e33d54c2a87d846fc23e7f21a32b99d22397e64429b39c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x2c2777e24bc8a59171e33d54c2a87d846fc23e7f21a32b99d22397e64429b39c')),  # noqa: E501
     )
-    timestamp = TimestampMS(1711437462000)
     borrowed_amount, gas_fees = '5060', '0.033400048613703322'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711437462000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -1013,7 +986,6 @@ def test_aave_v2_borrow_polygon(polygon_pos_inquirer, polygon_pos_accounts) -> N
             address=string_to_evm_address('0x27F8D03b3a2196956ED754baDc28D73be8830A6e'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1022,16 +994,15 @@ def test_aave_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: li
     """Test that the decoder can decode the stake event from Aave"""
     tx_hash = deserialize_evm_tx_hash('0xfaf96358784483a96a61db6aa4ecf4ac87294b841671ca208de6b5d8f83edf17')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, staked, gas_fees, approval_amount = TimestampMS(1716118019000), '5.126267078394001645', '0.000367527', '115792089237316195423570985008687907853269984665640564038985.825837738726184306'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716118019000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000367527'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             tx_ref=tx_hash,
@@ -1043,7 +1014,7 @@ def test_aave_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: li
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=A_AAVE,
-            amount=FVal(approval_amount),
+            amount=FVal(approval_amount := '115792089237316195423570985008687907853269984665640564038985.825837738726184306'),  # noqa: E501
             location_label=ethereum_accounts[0],
             notes=f'Set AAVE spending approval of {ethereum_accounts[0]} by {STK_AAVE_ADDR} to {approval_amount}',  # noqa: E501
             tx_ref=tx_hash,
@@ -1055,7 +1026,7 @@ def test_aave_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: li
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=A_AAVE,
-            amount=FVal(staked),
+            amount=FVal(staked := '5.126267078394001645'),
             location_label=ethereum_accounts[0],
             notes=f'Stake {staked} AAVE',
             tx_ref=tx_hash,
@@ -1076,7 +1047,6 @@ def test_aave_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: li
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1086,16 +1056,15 @@ def test_aave_stake_behalfof(ethereum_inquirer: 'EthereumInquirer', ethereum_acc
     The implementation of the proxy contract was different back then."""
     tx_hash = deserialize_evm_tx_hash('0x5532a19bdd4aa26656dc5099d80862a5218cbaf7c96f30cae4a8bb0d19803bfc')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, staked, gas_fees, approval_amount = TimestampMS(1684566515000), '58.469937', '0.011340746321963024', '115792089237316195423570985008687907853269984665640564039399.114070913129639935'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1684566515000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.011340746321963024'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             tx_ref=tx_hash,
@@ -1107,7 +1076,7 @@ def test_aave_stake_behalfof(ethereum_inquirer: 'EthereumInquirer', ethereum_acc
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=A_AAVE,
-            amount=FVal(approval_amount),
+            amount=FVal(approval_amount := '115792089237316195423570985008687907853269984665640564039399.114070913129639935'),  # noqa: E501
             location_label=ethereum_accounts[0],
             notes=f'Set AAVE spending approval of {ethereum_accounts[0]} by {STK_AAVE_ADDR} to {approval_amount}',  # noqa: E501
             tx_ref=tx_hash,
@@ -1119,7 +1088,7 @@ def test_aave_stake_behalfof(ethereum_inquirer: 'EthereumInquirer', ethereum_acc
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=A_AAVE,
-            amount=FVal(staked),
+            amount=FVal(staked := '58.469937'),
             location_label=ethereum_accounts[0],
             notes=f'Stake {staked} AAVE',
             tx_ref=tx_hash,
@@ -1140,7 +1109,6 @@ def test_aave_stake_behalfof(ethereum_inquirer: 'EthereumInquirer', ethereum_acc
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1149,16 +1117,15 @@ def test_aave_unstake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: 
     """Test that the decoder can decode the unstake/redeem event from Aave"""
     tx_hash = deserialize_evm_tx_hash('0xaaef5990d08a0f4cb83b0f98b995f734c96ab6dca41bf7de54c3719fe463ce24')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, unstaked, gas_fees = TimestampMS(1716216731000), '2.71357', '0.001456740929488432'
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716216731000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.001456740929488432'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             tx_ref=tx_hash,
@@ -1170,7 +1137,7 @@ def test_aave_unstake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: 
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset(STKAAVE_IDENTIFIER),
-            amount=FVal(unstaked),
+            amount=FVal(unstaked := '2.71357'),
             location_label=ethereum_accounts[0],
             notes=f'Unstake {unstaked} stkAAVE',
             tx_ref=tx_hash,
@@ -1191,7 +1158,6 @@ def test_aave_unstake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: 
             counterparty=CPT_AAVE,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1200,16 +1166,15 @@ def test_aave_unstake_old(ethereum_inquirer: 'EthereumInquirer', ethereum_accoun
     """Test that the decoder can decode the unstake/redeem event from Aave back in 2022"""
     tx_hash = deserialize_evm_tx_hash('0x4d28e34be9ccc8a64d0fe9bc30982700b042cd0bdbe7c3bc3968107dce6471e3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, unstaked, gas_fees = TimestampMS(1648296289000), '31.703464134297535778', '0.006477313887656742'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1648296289000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.006477313887656742'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             tx_ref=tx_hash,
@@ -1221,7 +1186,7 @@ def test_aave_unstake_old(ethereum_inquirer: 'EthereumInquirer', ethereum_accoun
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset(STKAAVE_IDENTIFIER),
-            amount=FVal(unstaked),
+            amount=FVal(unstaked := '31.703464134297535778'),
             location_label=ethereum_accounts[0],
             notes=f'Unstake {unstaked} stkAAVE',
             tx_ref=tx_hash,
@@ -1242,7 +1207,6 @@ def test_aave_unstake_old(ethereum_inquirer: 'EthereumInquirer', ethereum_accoun
             counterparty=CPT_AAVE,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1251,16 +1215,16 @@ def test_stake_reward(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: 
     """Test that the decoder can decode aave reward claiming"""
     tx_hash = deserialize_evm_tx_hash('0xc8ed217572a15a81891ad6480a56150d5b2721c9e517564c3e8ead4439cdcb62')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_fees, amount = TimestampMS(1712099315000), '0.002299167729873168', '0.724507060516081735'  # noqa: E501
-    expected_events = [
+    amount = '0.724507060516081735'
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712099315000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.002299167729873168'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             tx_ref=tx_hash,
@@ -1280,7 +1244,6 @@ def test_stake_reward(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: 
             counterparty=CPT_AAVE,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1292,7 +1255,7 @@ def test_stake_reward_and_restake(ethereum_inquirer: 'EthereumInquirer', ethereu
         tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd140498b2fd93004f21125a4e4ad0d902f34b69b00759e0e8234d4ea0c83199d')),  # noqa: E501
         relevant_address=ethereum_accounts[0],
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
             timestamp=(timestamp := TimestampMS(1712957855000)),
@@ -1346,7 +1309,6 @@ def test_stake_reward_and_restake(ethereum_inquirer: 'EthereumInquirer', ethereu
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1356,16 +1318,16 @@ def test_stake_reward_from_incentives(ethereum_inquirer: 'EthereumInquirer', eth
     which takes it from the aave incentives"""
     tx_hash = deserialize_evm_tx_hash('0x376c51a492f3f309c408b00278fbb77e54adcbb883f9e0fc190c5478fc153bbf')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_fees, amount = TimestampMS(1649141661000), '0.03959433', '14.159467670600490614'
-    expected_events = [
+    amount = '14.159467670600490614'
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1649141661000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.03959433'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             tx_ref=tx_hash,
@@ -1411,27 +1373,26 @@ def test_stake_reward_from_incentives(ethereum_inquirer: 'EthereumInquirer', eth
             counterparty=CPT_AAVE,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9131C96c791A5aAd3dF4F8C85Acc755a8dD487Ed']])
 def test_polygon_incentives(polygon_pos_inquirer: 'PolygonPOSInquirer', polygon_pos_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0x6ebaa1502335caa7aa9b6589169885d0361e96bab9ed3b1264308a716d6524c3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6ebaa1502335caa7aa9b6589169885d0361e96bab9ed3b1264308a716d6524c3')),  # noqa: E501
     )
-    timestamp, user, gas_fees, amount = TimestampMS(1677815446000), polygon_pos_accounts[0], '0.010600028218383051', '2.703388364402691276'  # noqa: E501
-    expected_events = [
+    user = polygon_pos_accounts[0]
+    amount = '2.703388364402691276'
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1677815446000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_POL,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.010600028218383051'),
             location_label=user,
             notes=f'Burn {gas_fees} POL for gas',
             tx_ref=tx_hash,
@@ -1451,7 +1412,6 @@ def test_polygon_incentives(polygon_pos_inquirer: 'PolygonPOSInquirer', polygon_
             counterparty=CPT_AAVE_V2,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1461,7 +1421,7 @@ def test_mainnet_aave_v2_migrate_to_v3_(ethereum_inquirer, ethereum_accounts) ->
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
 
     amount_out, amount_in, approval_amount, gas_fees, timestamp, user = '84.521918902842181053', '76.326951198340166536', '115792089237316195423570985008687907853269984665640564039373.062089010287458882', '0.010769376235131354', TimestampMS(1675004267000), ethereum_accounts[0]  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1539,4 +1499,3 @@ def test_mainnet_aave_v2_migrate_to_v3_(ethereum_inquirer, ethereum_accounts) ->
             counterparty=CPT_AAVE_V3,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_aave_v3.py
+++ b/rotkehlchen/tests/unit/decoders/test_aave_v3.py
@@ -54,13 +54,12 @@ if TYPE_CHECKING:
 def test_aave_v3_enable_collateral(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x867d09a777ca7c5cbccd281d197ffbed327b5a8f07153483e94f75d4e1d04413')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1711029839000)
     deposit_amount, gas_fees = '99503', '0.007154122119159412'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711029839000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -110,7 +109,6 @@ def test_aave_v3_enable_collateral(ethereum_inquirer, ethereum_accounts) -> None
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -118,13 +116,12 @@ def test_aave_v3_enable_collateral(ethereum_inquirer, ethereum_accounts) -> None
 def test_aave_v3_disable_collateral(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x1f7614ba2425f3345d02bf1518c81ab3aa46e888553b409f3c9a360259bc7988')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1711028735000)
     returned_amount, interest_amount, gas_fees = '0.3', '0.00005421', '0.005234272941346752'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711028735000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -186,7 +183,6 @@ def test_aave_v3_disable_collateral(ethereum_inquirer, ethereum_accounts) -> Non
             counterparty=CPT_AAVE_V3,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -194,13 +190,12 @@ def test_aave_v3_disable_collateral(ethereum_inquirer, ethereum_accounts) -> Non
 def test_aave_v3_deposit(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x062bb6b01d4ac5fabd7b7783965d22589d289e44bb0227bb2fc0adaad7eb563b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1711030499000)
     deposit_amount, gas_fees = '71657.177259074315114745', '0.009902467860617334'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711030499000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -237,7 +232,6 @@ def test_aave_v3_deposit(ethereum_inquirer, ethereum_accounts) -> None:
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -245,13 +239,12 @@ def test_aave_v3_deposit(ethereum_inquirer, ethereum_accounts) -> None:
 def test_aave_v3_deposit_with_interest(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0xd5dc3d24da9a97957743c09b8655154ffedb3cb40325b698b1159aa2fe9cf166')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1723640027000)
     deposit_amount, interest_amount, gas_fees = '0.21191208', '0.00000083', '0.000975505588598266'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1723640027000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -300,7 +293,6 @@ def test_aave_v3_deposit_with_interest(ethereum_inquirer, ethereum_accounts) -> 
             counterparty=CPT_AAVE_V3,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -308,13 +300,12 @@ def test_aave_v3_deposit_with_interest(ethereum_inquirer, ethereum_accounts) -> 
 def test_aave_v3_withdraw(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0xf184c285dab9ea6c72d18025c65202e3d9e5ec3181209a6cbedf88dfd4c8283f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1711030631000)
     return_amount, interest_amount, gas_fees = '6770.796829', '9.053171', '0.00692900756596481'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711030631000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -363,7 +354,6 @@ def test_aave_v3_withdraw(ethereum_inquirer, ethereum_accounts) -> None:
             counterparty=CPT_AAVE_V3,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -376,17 +366,16 @@ def test_aave_v3_monerium_order(gnosis_inquirer, gnosis_accounts) -> None:
     """
     tx_hash = deserialize_evm_tx_hash('0x4a8e7cde236b18a4f07e1cd0dbba9e46d3fff75d608a30d6c1db8a5a2b328284')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, return_amount, interest_amount, gas_fees = TimestampMS(1758276410000), '154.130057505168834584', '0.000037471160600675', '0.0000406106'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1758276410000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.0000406106'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas_fees} XDAI for gas',
             counterparty=CPT_GAS,
@@ -398,7 +387,7 @@ def test_aave_v3_monerium_order(gnosis_inquirer, gnosis_accounts) -> None:
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=EvmToken('eip155:100/erc20:0xEdBC7449a9b594CA4E053D9737EC5Dc4CbCcBfb2'),
-            amount=FVal(return_amount),
+            amount=FVal(return_amount := '154.130057505168834584'),
             location_label=gnosis_accounts[0],
             notes=f'Return {return_amount} aGnoEURe to AAVE v3',
             counterparty=CPT_AAVE_V3,
@@ -424,13 +413,12 @@ def test_aave_v3_monerium_order(gnosis_inquirer, gnosis_accounts) -> None:
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.INTEREST,
             asset=EvmToken('eip155:100/erc20:0xcB444e90D8198415266c6a2724b7900fb12FC56E'),
-            amount=FVal(interest_amount),
+            amount=FVal(interest_amount := '0.000037471160600675'),
             location_label=gnosis_accounts[0],
             notes=f'Receive {interest_amount} EURe as interest earned from AAVE v3',
             counterparty=CPT_AAVE_V3,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -438,13 +426,12 @@ def test_aave_v3_monerium_order(gnosis_inquirer, gnosis_accounts) -> None:
 def test_aave_v3_withdraw_with_bigger_interest(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x8ed7c1ed348212c6b9aa615a2c13857dd801dfac103f01852a303e62cc58b24f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1723591427000)
     return_amount, interest_amount, gas_fees = '20000', '33086.007538', '0.000395645857253556'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1723591427000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -493,7 +480,6 @@ def test_aave_v3_withdraw_with_bigger_interest(ethereum_inquirer, ethereum_accou
             counterparty=CPT_AAVE_V3,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -501,13 +487,12 @@ def test_aave_v3_withdraw_with_bigger_interest(ethereum_inquirer, ethereum_accou
 def test_aave_v3_borrow(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x44367976e841cde459d84aec984d5fae4466b2978b1d71c9cd916bb79792ee20')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1711030571000)
     borrowed_amount, gas_fees = '79931.500229', '0.011111128567338506'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711030571000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -544,7 +529,6 @@ def test_aave_v3_borrow(ethereum_inquirer, ethereum_accounts) -> None:
             address=string_to_evm_address('0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -552,13 +536,12 @@ def test_aave_v3_borrow(ethereum_inquirer, ethereum_accounts) -> None:
 def test_aave_v3_repay(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x440dddaad9f8d9c6d99777494640520854cca8dd102fb557f1654f5746da5f7e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1711030643000)
     return_amount, repay_amount, gas_fees = '123942.602894', '123961.452987', '0.00646693553105336'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711030643000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -595,7 +578,6 @@ def test_aave_v3_repay(ethereum_inquirer, ethereum_accounts) -> None:
             address=string_to_evm_address('0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -603,13 +585,12 @@ def test_aave_v3_repay(ethereum_inquirer, ethereum_accounts) -> None:
 def test_aave_v3_liquidation(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0xc1a03e87f1c0446ddd5a77f7eb906831c72618a921a1f6f9f430f612edca0531')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1692320627000)
     payback_amount, liquidation_amount, fee_amount = '23.378156', '0.01887243880551005', '0.000090391508992915'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=242,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1692320627000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.NONE,
@@ -661,24 +642,21 @@ def test_aave_v3_liquidation(ethereum_inquirer, ethereum_accounts) -> None:
             address=string_to_evm_address('0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xA55EaD17fa903b1218dc6a79c47b54C9370E20AB']])
 def test_aave_v3_enable_collateral_polygon(polygon_pos_inquirer, polygon_pos_accounts) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x8002f1a3044bcdec645d512713724f09551c18a14c67509417c83961b230294b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8002f1a3044bcdec645d512713724f09551c18a14c67509417c83961b230294b')),  # noqa: E501
     )
-    timestamp = TimestampMS(1711448176000)
     deposit_amount, gas_fees = '1245.829008', '0.010974492076211867'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711448176000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -728,24 +706,21 @@ def test_aave_v3_enable_collateral_polygon(polygon_pos_inquirer, polygon_pos_acc
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x645C22593c232Ae78a7eCbaC93b38cbaC535ef12']])
 def test_aave_v3_withdraw_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x09d5e6da511fb88e8a7db6f1209542610a9d3873048e405b88c7a766d7210d6f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x09d5e6da511fb88e8a7db6f1209542610a9d3873048e405b88c7a766d7210d6f')),  # noqa: E501
     )
-    timestamp = TimestampMS(1711450245000)
     interest_amount, withdraw_amount, gas_fees = '0.094251900832430913', '11.905748099167569087', '0.00000490517'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711450245000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -794,7 +769,6 @@ def test_aave_v3_withdraw_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accou
             counterparty=CPT_AAVE_V3,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -803,13 +777,12 @@ def test_aave_v3_withdraw_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accou
 def test_aave_v3_borrow_base(base_inquirer, base_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x92b6fef0623a3f56daa651968819f2e5b7a982037c19fed2166e4c00ba4d6350')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1711452273000)
     borrowed_amount, gas_fees = '0.181', '0.000090985761072991'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711452273000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -846,7 +819,6 @@ def test_aave_v3_borrow_base(base_inquirer, base_accounts) -> None:
             address=string_to_evm_address('0x99CBC45ea5bb7eF3a5BC08FB1B7E56bB2442Ef0D'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -854,13 +826,12 @@ def test_aave_v3_borrow_base(base_inquirer, base_accounts) -> None:
 def test_aave_v3_withdraw_gnosis(gnosis_inquirer, gnosis_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x1f3cae37be928563d154c534c98f41eefe9201eb3d0129c99c1ecb51f83e5596')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1711453785000)
     withdraw_amount, gas_fees = '4300', '0.000876816'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711453785000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -897,7 +868,6 @@ def test_aave_v3_withdraw_gnosis(gnosis_inquirer, gnosis_accounts) -> None:
             address=string_to_evm_address('0x7a5c3860a77a8DC1b225BD46d0fb2ac1C6D191BC'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -906,13 +876,12 @@ def test_aave_v3_withdraw_gnosis(gnosis_inquirer, gnosis_accounts) -> None:
 def test_aave_v3_borrow_optimism(optimism_inquirer, optimism_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0xb043a7f28cccd6cb0392db47cea4607f8cf3b91b6510669a0a62588b66eb7fcf')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1711455941000)
     borrowed_amount, gas_fees = '2000', '0.000018093759776472'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711455941000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -949,7 +918,6 @@ def test_aave_v3_borrow_optimism(optimism_inquirer, optimism_accounts) -> None:
             address=string_to_evm_address('0x6ab707Aca953eDAeFBc4fD23bA73294241490620'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(allow_playback_repeats=True, filter_query_parameters=['apikey'])
@@ -957,13 +925,12 @@ def test_aave_v3_borrow_optimism(optimism_inquirer, optimism_accounts) -> None:
 def test_aave_v3_repay_scroll(scroll_inquirer, scroll_accounts, allow_scroll_etherscan) -> None:
     tx_hash = deserialize_evm_tx_hash('0x66010f353be60adaa004f839d37cecd22c35c580060eeaffb9a28ebe169e1692')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1711456958000)
     return_amount, repay_amount, gas_fees = '14459.999417', '14460.008663', '0.000386215421959661'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711456958000)),
             location=Location.SCROLL,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -1000,7 +967,6 @@ def test_aave_v3_repay_scroll(scroll_inquirer, scroll_accounts, allow_scroll_eth
             address=string_to_evm_address('0x1D738a3436A8C49CefFbaB7fbF04B660fb528CbD'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1010,17 +976,17 @@ def test_non_aave_tx(ethereum_inquirer, ethereum_accounts) -> None:
     as aave events."""
     tx_hash = deserialize_evm_tx_hash('0xf5b4c6f3b4e5bce1f91f7e7eab6185b6d1518e63dea637c79d7f1bbb97edda67')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, multisig, gas_fees = TimestampMS(1713496487000), '0x35542F2c7D18716401A38cc7f08Bf5Bf61f371cc', '0.018530645755598298'  # noqa: E501
-    expected_events = [
+    multisig = '0x35542F2c7D18716401A38cc7f08Bf5Bf61f371cc'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1713496487000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.018530645755598298'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -1039,7 +1005,6 @@ def test_non_aave_tx(ethereum_inquirer, ethereum_accounts) -> None:
             address=string_to_evm_address(multisig),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1052,17 +1017,18 @@ def test_safe_interaction_interest(ethereum_inquirer, ethereum_accounts) -> None
     Regression test for aave post decoding not firing."""
     tx_hash = deserialize_evm_tx_hash('0x01ac87a1fe87913f54153a85f9657359387b82f374cb81132f5ccb30b3bddfbb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, signer, multisig, gas_fees, deposit_amount, interest_amount = TimestampMS(1736015087000), ethereum_accounts[0], ethereum_accounts[1], '0.00184223005590466', '8000', '0.534728'  # noqa: E501
-    expected_events = [
+    signer = ethereum_accounts[0]
+    multisig = ethereum_accounts[1]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1736015087000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.00184223005590466'),
             location_label=signer,
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -1087,7 +1053,7 @@ def test_safe_interaction_interest(ethereum_inquirer, ethereum_accounts) -> None
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_USDC,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '8000'),
             location_label=multisig,
             notes=f'Deposit {deposit_amount} USDC into AAVE v3',
             counterparty=CPT_AAVE_V3,
@@ -1113,13 +1079,12 @@ def test_safe_interaction_interest(ethereum_inquirer, ethereum_accounts) -> None
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.INTEREST,
             asset=EvmToken('eip155:1/erc20:0x98C23E9d8f34FEFb1B7BD6a91B7FF122F4e16F5c'),  # aEthUSDC  # noqa: E501
-            amount=FVal(interest_amount),
+            amount=FVal(interest_amount := '0.534728'),
             location_label=multisig,
             notes=f'Receive {interest_amount} aEthUSDC as interest earned from AAVE v3',
             counterparty=CPT_AAVE_V3,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1129,17 +1094,18 @@ def test_claim_incentives_reward(optimism_inquirer, optimism_accounts) -> None:
     """Test that claim rewards for incentives works"""
     tx_hash = deserialize_evm_tx_hash('0xa2860ca34ea7558240c44f3d0895a9cf832bd0dd952b2b27d3ae34ba6d45697c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, gas, user, amount = TimestampMS(1666883965000), '0.000198192753532852', optimism_accounts[0], '558.228460248737908186'  # noqa: E501
-    expected_events = [
+    user = optimism_accounts[0]
+    amount = '558.228460248737908186'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1666883965000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000198192753532852'),
             location_label=user,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -1158,28 +1124,25 @@ def test_claim_incentives_reward(optimism_inquirer, optimism_accounts) -> None:
             address=string_to_evm_address('0x929EC64c34a17401F460460D4B9390518E5B473e'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xfe46dCeb5d586DA13aBAA571613e20f5a61fa62e']])
 def test_aave_v3_events_with_approval(polygon_pos_inquirer, polygon_pos_accounts) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x0aaca18a7e0ee29a247bd9bfab3b081acf469833105a9204251c5a4969a5fc29')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x0aaca18a7e0ee29a247bd9bfab3b081acf469833105a9204251c5a4969a5fc29')),  # noqa: E501
     )
-    timestamp, deposit_amount, approval_amount, gas_fees = TimestampMS(1718134876000), '72.227367', '115792089237316195423570985008687907853269984665640564039457584007903019.443007', '0.006703085584530904'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1718134876000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_POL,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.006703085584530904'),
             location_label=polygon_pos_accounts[0],
             notes=f'Burn {gas_fees} POL for gas',
             counterparty=CPT_GAS,
@@ -1190,7 +1153,7 @@ def test_aave_v3_events_with_approval(polygon_pos_inquirer, polygon_pos_accounts
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=A_POLYGON_POS_USDT,
-            amount=FVal(approval_amount),
+            amount=FVal(approval_amount := '115792089237316195423570985008687907853269984665640564039457584007903019.443007'),  # noqa: E501
             location_label=polygon_pos_accounts[0],
             notes=f'Set USDT spending approval of {polygon_pos_accounts[0]} by 0x794a61358D6845594F94dc1DB02A252b5b4814aD to {approval_amount}',  # noqa: E501
             tx_ref=tx_hash,
@@ -1216,7 +1179,7 @@ def test_aave_v3_events_with_approval(polygon_pos_inquirer, polygon_pos_accounts
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_POLYGON_POS_USDT,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '72.227367'),
             location_label=polygon_pos_accounts[0],
             notes=f'Deposit {deposit_amount} USDT into AAVE v3',
             counterparty=CPT_AAVE_V3,
@@ -1236,7 +1199,6 @@ def test_aave_v3_events_with_approval(polygon_pos_inquirer, polygon_pos_accounts
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(allow_playback_repeats=True, filter_query_parameters=['apikey'])
@@ -1245,18 +1207,17 @@ def test_aave_v3_withdraw_eth(scroll_inquirer, scroll_accounts, allow_scroll_eth
     """Test that withdrawing ETH from Aave gets decoded properly"""
     tx_hash = deserialize_evm_tx_hash('0x65cd06fd54a10052c3d9084d14d28c06e2bb328b1ec39730fab9284cb529d068')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
-    timestamp, gained_amount, withdrawn_amount, gas_fees = TimestampMS(1716738746000), '0.000000021776581852', '0.010000021776581852', '0.000058164147479909'  # noqa: E501
     weth_gateway = string_to_evm_address('0xFF75A4B698E3Ec95E608ac0f22A03B8368E05F5D')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716738746000)),
             location=Location.SCROLL,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000058164147479909'),
             location_label=scroll_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -1294,7 +1255,7 @@ def test_aave_v3_withdraw_eth(scroll_inquirer, scroll_accounts, allow_scroll_eth
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=EvmToken('eip155:534352/erc20:0xf301805bE1Df81102C957f6d4Ce29d2B8c056B2a'),
-            amount=FVal(withdrawn_amount),
+            amount=FVal(withdrawn_amount := '0.010000021776581852'),
             location_label=scroll_accounts[0],
             notes=f'Return {withdrawn_amount} aScrWETH to AAVE v3',
             counterparty=CPT_AAVE_V3,
@@ -1320,14 +1281,13 @@ def test_aave_v3_withdraw_eth(scroll_inquirer, scroll_accounts, allow_scroll_eth
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.INTEREST,
             asset=EvmToken('eip155:534352/erc20:0xf301805bE1Df81102C957f6d4Ce29d2B8c056B2a'),
-            amount=FVal(gained_amount),
+            amount=FVal(gained_amount := '0.000000021776581852'),
             location_label=scroll_accounts[0],
             notes=f'Receive {gained_amount} aScrWETH as interest earned from AAVE v3',
             counterparty=CPT_AAVE_V3,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1336,7 +1296,7 @@ def test_arbitrum_deposit_eth_gatewayv3(arbitrum_one_inquirer, arbitrum_one_acco
     """Test that deposit ETH in Aave in Arbitrum gets decoded properly when using gateway v3"""
     tx_hash = deserialize_evm_tx_hash('0xc951183a146d91b996d36632fc8dbe994378da8af88d3c63631a14fcf2f16ca4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1390,28 +1350,27 @@ def test_arbitrum_deposit_eth_gatewayv3(arbitrum_one_inquirer, arbitrum_one_acco
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x2013b74bdbd2Adf3eBF39E5112a9f794144Aeb15']])
 def test_aave_v3_withdraw_matic(polygon_pos_inquirer, polygon_pos_accounts) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x301885bdc8998d0e6d5c0064b3b92f5ee34f81ebbd14ca2b796579981ff8df31')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x301885bdc8998d0e6d5c0064b3b92f5ee34f81ebbd14ca2b796579981ff8df31')),  # noqa: E501
     )
-    timestamp, gained_amount, withdrawn_amount, gas_fees, gateway_address, approval_amount = TimestampMS(1720447017000), '0.94342753415979831', '4000', '0.013616476612010713', string_to_evm_address('0xC1E320966c485ebF2A0A2A6d3c0Dc860A156eB1B'), FVal('115792089237316195423570985008687907853269984665640564032456.584007913129639935')  # noqa: E501
-    expected_events = [
+    gateway_address = string_to_evm_address('0xC1E320966c485ebF2A0A2A6d3c0Dc860A156eB1B')
+    approval_amount = FVal('115792089237316195423570985008687907853269984665640564032456.584007913129639935')  # noqa: E501
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1720447017000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_POL,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.013616476612010713'),
             location_label=polygon_pos_accounts[0],
             notes=f'Burn {gas_fees} POL for gas',
             counterparty=CPT_GAS,
@@ -1435,7 +1394,7 @@ def test_aave_v3_withdraw_matic(polygon_pos_inquirer, polygon_pos_accounts) -> N
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset('eip155:137/erc20:0x6d80113e533a2C0fe82EaBD35f1875DcEA89Ea97'),
-            amount=FVal(withdrawn_amount),
+            amount=FVal(withdrawn_amount := '4000'),
             location_label=polygon_pos_accounts[0],
             notes=f'Return {withdrawn_amount} aPolWMATIC to AAVE v3',
             counterparty=CPT_AAVE_V3,
@@ -1461,14 +1420,13 @@ def test_aave_v3_withdraw_matic(polygon_pos_inquirer, polygon_pos_accounts) -> N
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.INTEREST,
             asset=Asset('eip155:137/erc20:0x6d80113e533a2C0fe82EaBD35f1875DcEA89Ea97'),
-            amount=FVal(gained_amount),
+            amount=FVal(gained_amount := '0.94342753415979831'),
             location_label=polygon_pos_accounts[0],
             notes=f'Receive {gained_amount} aPolWMATIC as interest earned from AAVE v3',
             counterparty=CPT_AAVE_V3,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1476,17 +1434,18 @@ def test_aave_v3_withdraw_matic(polygon_pos_inquirer, polygon_pos_accounts) -> N
 def test_aave_v3_withdraw_xdai(gnosis_inquirer, gnosis_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x0154ef3042e93a632d654c86bff99f7d452681dba72f4f773806c9c26470f678')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, gained_amount, withdrawn_amount, gas_fees, gateway_address, approval_amount = TimestampMS(1720459795000), '0.076355892637370336', '5.076355892637370336', '0.0008300288', string_to_evm_address('0xfE76366A986B72c3f2923e05E6ba07b7de5401e4'), FVal('115792089237316195423570985008687907853269984665640564039452.507652020492269599')  # noqa: E501
-    expected_events = [
+    gateway_address = string_to_evm_address('0xfE76366A986B72c3f2923e05E6ba07b7de5401e4')
+    approval_amount = FVal('115792089237316195423570985008687907853269984665640564039452.507652020492269599')  # noqa: E501
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1720459795000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.0008300288'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas_fees} XDAI for gas',
             counterparty=CPT_GAS,
@@ -1523,7 +1482,7 @@ def test_aave_v3_withdraw_xdai(gnosis_inquirer, gnosis_accounts) -> None:
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset('eip155:100/erc20:0xd0Dd6cEF72143E22cCED4867eb0d5F2328715533'),
-            amount=FVal(withdrawn_amount),
+            amount=FVal(withdrawn_amount := '5.076355892637370336'),
             location_label=gnosis_accounts[0],
             notes=f'Return {withdrawn_amount} aGnoWXDAI to AAVE v3',
             counterparty=CPT_AAVE_V3,
@@ -1549,14 +1508,13 @@ def test_aave_v3_withdraw_xdai(gnosis_inquirer, gnosis_accounts) -> None:
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.INTEREST,
             asset=Asset('eip155:100/erc20:0xd0Dd6cEF72143E22cCED4867eb0d5F2328715533'),
-            amount=FVal(gained_amount),
+            amount=FVal(gained_amount := '0.076355892637370336'),
             location_label=gnosis_accounts[0],
             notes=f'Receive {gained_amount} aGnoWXDAI as interest earned from AAVE v3',
             counterparty=CPT_AAVE_V3,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1564,13 +1522,12 @@ def test_aave_v3_withdraw_xdai(gnosis_inquirer, gnosis_accounts) -> None:
 def test_aave_v3_interest_on_transfer(ethereum_inquirer, ethereum_accounts) -> None:
     tx_hash = deserialize_evm_tx_hash('0x84a70d14ef53987e1ee267435492100f07a4480b7d8022a8d3508e3a4ee70fbf')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1723481603000)
     transfer_amount, interest_amount, gas_fees = '50000', '2447.464003', '0.001366713726208557'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1723481603000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -1606,7 +1563,6 @@ def test_aave_v3_interest_on_transfer(ethereum_inquirer, ethereum_accounts) -> N
             address=string_to_evm_address('0x9C9EF79aae8996c72eA8C374011D7ac1eB42c4Fc'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1636,7 +1592,7 @@ def test_aave_v3_lido_pool(
 
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     borrow_amount, gas_fees, timestamp = '59000', '0.00170195956638183', TimestampMS(1734912023000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1677,7 +1633,6 @@ def test_aave_v3_lido_pool(
             address=string_to_evm_address('0x18eFE565A5373f430e2F809b97De30335B3ad96A'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1746,23 +1701,25 @@ def test_aave_v3_deposit_bnb(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x57D4bEb0fD4438b8910fEf03a961131742D845E2', '0x1cdC859a9685103A0791075B6c365e2D583BC236']])   # noqa: E501
 def test_aave_v3_close_position_with_safe(arbitrum_one_inquirer, arbitrum_one_accounts) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x56c57b83508f46d45af6b3230ee882f99df315c089af3250fbe5494ea59e5624')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x56c57b83508f46d45af6b3230ee882f99df315c089af3250fbe5494ea59e5624')),  # noqa: E501
     )
-    timestamp, user_eoa_account, user_safe_proxy, eth_interest_amount, eth_withdraw_amount, usd_paid_back_amount, gas_fees = TimestampMS(1736028280000), arbitrum_one_accounts[0], arbitrum_one_accounts[1], '0.031127570161941882', '3.007038496271076913', '2353.18136', '0.00000658667'  # noqa: E501
+    user_eoa_account = arbitrum_one_accounts[0]
+    user_safe_proxy = arbitrum_one_accounts[1]
+    eth_interest_amount = '0.031127570161941882'
+    eth_withdraw_amount = '3.007038496271076913'
 
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1736028280000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.00000658667'),
             location_label=user_eoa_account,
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -1787,7 +1744,7 @@ def test_aave_v3_close_position_with_safe(arbitrum_one_inquirer, arbitrum_one_ac
             event_type=HistoryEventType.TRANSFER,
             event_subtype=HistoryEventSubType.NONE,
             asset=Asset('eip155:42161/erc20:0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9'),
-            amount=FVal(usd_paid_back_amount),
+            amount=FVal(usd_paid_back_amount := '2353.18136'),
             location_label=user_eoa_account,
             notes=f'Transfer {usd_paid_back_amount} USDT from {user_eoa_account} to {user_safe_proxy}',  # noqa: E501
             address=user_safe_proxy,
@@ -1956,7 +1913,6 @@ def test_aave_v3_close_position_with_safe(arbitrum_one_inquirer, arbitrum_one_ac
             counterparty=CPT_AAVE_V3,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_aerodrome.py
+++ b/rotkehlchen/tests/unit/decoders/test_aerodrome.py
@@ -87,20 +87,18 @@ def test_add_liquidity(
     GlobalDBHandler.delete_asset_by_identifier(
         identifier=evm_address_to_identifier(address=pool, chain_id=ChainID.BASE),
     )
-    tx_hash = deserialize_evm_tx_hash('0xb71a1339c700a110d61655387d422bb982252a3b55de7f571ced3b9f00d9beee')  # noqa: E501
     user_address = base_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb71a1339c700a110d61655387d422bb982252a3b55de7f571ced3b9f00d9beee')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1706708913000)
     gas_amount, deposited_wsteth, deposited_weth, received_amount = '0.000071386738065118', '2.595314266724358628', '2.99450075155017638', '2.787544746858080184'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706708913000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -162,7 +160,6 @@ def test_add_liquidity(
             notes=f'Receive {received_amount} vAMM-WETH/wstETH after depositing in aerodrome pool {WSTETH_POOL_ADDRESS}',  # noqa: E501
         ),
     ]
-    assert events == expected_events
     assert EvmToken(pool_token.identifier).protocol == CPT_AERODROME
 
 
@@ -184,20 +181,18 @@ def test_stake_lp_token_to_gauge(base_accounts, base_transaction_decoder, load_g
     GlobalDBHandler.delete_asset_by_identifier(
         identifier=evm_address_to_identifier(address=pool, chain_id=ChainID.BASE),
     )
-    tx_hash = deserialize_evm_tx_hash('0x9a0cd1ab0b8e5dbf2718b1c87dad239f7f3a9ed8ff2e07643922b190f80ae898 ')  # noqa: E501
     user_address = base_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x9a0cd1ab0b8e5dbf2718b1c87dad239f7f3a9ed8ff2e07643922b190f80ae898 ')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1706708947000)
     gas_amount, deposited_amount = '0.000038383457555312', '2.787544746858080184'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706708947000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -233,7 +228,6 @@ def test_stake_lp_token_to_gauge(base_accounts, base_transaction_decoder, load_g
             notes=f'Deposit {deposited_amount} vAMM-WETH/wstETH into {WSTETH_GAUGE_ADDRESS} aerodrome gauge',  # noqa: E501
         ),
     ]
-    assert events == expected_events
     assert EvmToken(pool_token.identifier).protocol == CPT_AERODROME
 
 
@@ -255,25 +249,23 @@ def test_remove_liquidity(base_accounts, base_transaction_decoder, load_global_c
     GlobalDBHandler.delete_asset_by_identifier(
         identifier=evm_address_to_identifier(address=pool_address, chain_id=ChainID.BASE),
     )
-    tx_hash = deserialize_evm_tx_hash('0x847ed0b6bd3f1b030cc84eee74c2c238dd93e0b689c87d44bce7f3591173ef0d')  # noqa: E501
     user_address = base_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x847ed0b6bd3f1b030cc84eee74c2c238dd93e0b689c87d44bce7f3591173ef0d')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1706789989000)
     gas_amount, lp_amount, aero_amount, usdbc_amount = '0.000088467182445046', '0.000053130643452706', '190.426331639958037231', '15.035115'  # noqa: E501
     pool_token = Asset(evm_address_to_identifier(
         address=pool_address,
         chain_id=ChainID.BASE,
         token_type=TokenKind.ERC20,
     ))
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706789989000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -335,7 +327,6 @@ def test_remove_liquidity(base_accounts, base_transaction_decoder, load_global_c
             notes=f'Remove {usdbc_amount} USDbC from aerodrome pool {pool_address}',
         ),
     ]
-    assert events == expected_events
     assert EvmToken(pool_token.identifier).protocol == CPT_AERODROME
 
 
@@ -348,7 +339,7 @@ def test_unlock_aero(base_accounts, base_transaction_decoder):
         evm_inquirer=base_transaction_decoder.evm_inquirer,
         tx_hash=tx_hash,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -389,7 +380,6 @@ def test_unlock_aero(base_accounts, base_transaction_decoder):
             notes=f'Receive {withdrawn_amt} AERO from vote escrow after burning veNFT-71294',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -401,7 +391,7 @@ def test_lock_aero(base_accounts, base_transaction_decoder):
         evm_inquirer=base_transaction_decoder.evm_inquirer,
         tx_hash=tx_hash,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -455,7 +445,6 @@ def test_lock_aero(base_accounts, base_transaction_decoder):
             notes=f'Receive veNFT-71991 for locking {lock_amount} AERO in vote escrow',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -467,7 +456,7 @@ def test_increase_locked_amount(base_accounts, base_transaction_decoder):
         evm_inquirer=base_transaction_decoder.evm_inquirer,
         tx_hash=tx_hash,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -508,7 +497,6 @@ def test_increase_locked_amount(base_accounts, base_transaction_decoder):
             extra_data={'token_id': 3334},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -520,7 +508,7 @@ def test_increase_unlock_time(base_accounts, base_transaction_decoder):
         evm_inquirer=base_transaction_decoder.evm_inquirer,
         tx_hash=tx_hash,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -549,7 +537,6 @@ def test_increase_unlock_time(base_accounts, base_transaction_decoder):
             notes='Increase unlock time to 10/04/2025 for AERO veNFT-16247',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -561,7 +548,7 @@ def test_vote(base_accounts, base_transaction_decoder):
         evm_inquirer=base_transaction_decoder.evm_inquirer,
         tx_hash=tx_hash,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -589,7 +576,6 @@ def test_vote(base_accounts, base_transaction_decoder):
             notes='Cast 1805.00657141664811293 votes for pool 0xDbdfAc0F9268EF02c34Ed58c9Fab3517a98444dc',  # noqa: E501
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -602,10 +588,9 @@ def test_swap(base_transaction_decoder, base_accounts, load_global_caches):
     https://basescan.org/address/0x266c8f8cda4360506b8d32dc5c4102350a069acd#code#F1#L95
     """  # noqa: E501
     _add_aerodrome_pool(string_to_evm_address('0x4F9Dc2229f2357B27C22db56cB39582c854Ad6d5'))
-    tx_hash = deserialize_evm_tx_hash('0x260538961f3f2e17a43d26732f1105f739f9cf79622a3df8986c279c6d69a450')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x260538961f3f2e17a43d26732f1105f739f9cf79622a3df8986c279c6d69a450')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [EvmEvent(
@@ -680,10 +665,9 @@ def test_swap_via_settler_router_on_base(
         base_accounts: list['ChecksumEvmAddress'],
         allow_base_routescan: None,
 ) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x3a02a2df62ec9d633e73771b48806c2fc8a47f64bf97058cc561e20c6fe037c4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x3a02a2df62ec9d633e73771b48806c2fc8a47f64bf97058cc561e20c6fe037c4')),  # noqa: E501
     )
     expected_events = [EvmEvent(
         tx_ref=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_arbitrum_one.py
+++ b/rotkehlchen/tests/unit/decoders/test_arbitrum_one.py
@@ -19,17 +19,16 @@ def test_arbitrum_airdrop_claim(arbitrum_one_inquirer, arbitrum_one_accounts):
     """Data taken from
     https://arbiscan.io/tx/0xa230fc4d5e61db1d9be044215b00cb6ad1775b413a240ea23a98117153f6264e
     """
-    tx_hash = deserialize_evm_tx_hash('0xa230fc4d5e61db1d9be044215b00cb6ad1775b413a240ea23a98117153f6264e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xa230fc4d5e61db1d9be044215b00cb6ad1775b413a240ea23a98117153f6264e')),  # noqa: E501
     )
-    timestamp, user_address = TimestampMS(1689935876000), arbitrum_one_accounts[0]
-    expected_events = [
+    user_address = arbitrum_one_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1689935876000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -52,23 +51,21 @@ def test_arbitrum_airdrop_claim(arbitrum_one_inquirer, arbitrum_one_accounts):
             counterparty=CPT_ARBITRUM_ONE,
             address=ARBITRUM_ONE_AIRDROP,
         )]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_vote_cast(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x10b9c5adb845151365bf6977d76b728fad60b64372ce0bde6ae52602b01c282b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x10b9c5adb845151365bf6977d76b728fad60b64372ce0bde6ae52602b01c282b')),  # noqa: E501
     )
-    timestamp, user_address = TimestampMS(1707677598000), arbitrum_one_accounts[0]
-    expected_events = [
+    user_address = arbitrum_one_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1707677598000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -91,27 +88,24 @@ def test_vote_cast(arbitrum_one_inquirer, arbitrum_one_accounts):
             counterparty=CPT_ARBITRUM_ONE,
             address=GOVERNOR_ADDRESSES[0],
         )]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_vote_cast_2(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xf58c9b1ee6643d6af1fd3b5edbfb311bd86eb3417da561fd1650f12be775d71a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf58c9b1ee6643d6af1fd3b5edbfb311bd86eb3417da561fd1650f12be775d71a')),  # noqa: E501
     )
-    timestamp, gas = TimestampMS(1713188011000), '0.00000252921'
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1713188011000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000252921'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -131,27 +125,24 @@ def test_vote_cast_2(arbitrum_one_inquirer, arbitrum_one_accounts):
             address=GOVERNOR_ADDRESSES[3],
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_vote_cast_treasury(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x8f5eed6ec89eeccbdfa141b91129118a8294d35a1b44f9e7d570945d17f42765')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8f5eed6ec89eeccbdfa141b91129118a8294d35a1b44f9e7d570945d17f42765')),  # noqa: E501
     )
-    timestamp, gas = TimestampMS(1717152106000), '0.00000270109'
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1717152106000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000270109'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -171,4 +162,3 @@ def test_vote_cast_treasury(arbitrum_one_inquirer, arbitrum_one_accounts):
             address=GOVERNOR_ADDRESSES[1],
         ),
     ]
-    assert expected_events == events

--- a/rotkehlchen/tests/unit/decoders/test_arbitrum_one_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_arbitrum_one_bridge.py
@@ -57,10 +57,9 @@ def test_deposit_eth_from_ethereum_to_arbitrum_one(ethereum_inquirer, ethereum_a
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x4e7DF0FDa2d203f5DFbaa34b9FB64DDe5133196e']])
 def test_receive_eth_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x30505174f2f82a6513f21eb5177e59935a6da95d057e4c1972e65da90ea1c547')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x30505174f2f82a6513f21eb5177e59935a6da95d057e4c1972e65da90ea1c547')),  # noqa: E501
     )
     user_address = arbitrum_one_accounts[0]
     assert events == [
@@ -84,10 +83,9 @@ def test_receive_eth_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_account
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x5EA45c8E36704d7F4053Bb0e23cDd96E4d8b80F7']])
 def test_withdraw_eth_from_arbitrum_one_to_ethereum(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xdb8e29f27a7b7b416f168e8135347703268a142b6776503e26419dbfc43bcabf')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xdb8e29f27a7b7b416f168e8135347703268a142b6776503e26419dbfc43bcabf')),  # noqa: E501
     )
     user_address = arbitrum_one_accounts[0]
     assert events == [
@@ -209,10 +207,9 @@ def test_deposit_erc20_from_ethereum_to_arbitrum_one(ethereum_inquirer, ethereum
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x78C13393Aee675DD7ED07ce992210750D1F5dB88']])
 def test_receive_erc20_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x80e6c0835c3ead90dde524c3dfe49a067fd5b5cda93d5a223707e686d910d8a2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x80e6c0835c3ead90dde524c3dfe49a067fd5b5cda93d5a223707e686d910d8a2')),  # noqa: E501
     )
     user_address = arbitrum_one_accounts[0]
     assert events == [
@@ -237,10 +234,9 @@ def test_receive_erc20_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accou
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xbD91C9DF3C30F0e43B19b1dd05888CF9b647b781']])
 def test_withdraw_erc20_from_arbitrum_one_to_ethereum(arbitrum_one_inquirer, arbitrum_one_accounts, caplog):  # noqa: E501
     """Test that LPT withdrawals from arbitrum to L1 work fine"""
-    tx_hash = deserialize_evm_tx_hash('0x90ca8a767118c27aa4f6370bc06d9f952ab88a9219431f68d8e2d33b4a15b395')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x90ca8a767118c27aa4f6370bc06d9f952ab88a9219431f68d8e2d33b4a15b395')),  # noqa: E501
     )
     gateway_address = '0x6D2457a4ad276000A615295f7A80F79E48CcD318'
     user_address = arbitrum_one_accounts[0]
@@ -295,10 +291,9 @@ def test_withdraw_dai_from_arbitrum_one_to_ethereum(arbitrum_one_inquirer, arbit
     """
     Test that DAI withdrawals from arbitrum to L1 work fine. This is just to test that
     our code is not token/gateway specific"""
-    tx_hash = deserialize_evm_tx_hash('0xb425d3f1bfeb5438930115345ad2e3a4fb415db76f845e652d9b5ba945a484e2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb425d3f1bfeb5438930115345ad2e3a4fb415db76f845e652d9b5ba945a484e2')),  # noqa: E501
     )
 
     user_address = arbitrum_one_accounts[0]

--- a/rotkehlchen/tests/unit/decoders/test_aura_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_aura_finance.py
@@ -21,7 +21,7 @@ def test_aura_finance_deposit_arb(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x9c3b996891eb0ffb5261486ff77c69c20a332499b9cf4196df7fab2c2123ea5f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
     user_address, timestamp, gas_str, deposit_amount, receive_amount, approve_amount = arbitrum_one_accounts[0], TimestampMS(1732504225000), '0.00000372964', '2.862546191448752712', '2.054508357973208982', '115792089237316195423570985008687907853269984665640564039448.345378216051229581'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -74,7 +74,6 @@ def test_aura_finance_deposit_arb(arbitrum_one_inquirer, arbitrum_one_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -84,7 +83,7 @@ def test_aura_finance_claim_rewards_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0xffbc4716efdb4dbd7671c969599827313166fc507e2564ff1222a317d47e7a70')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str, claim_amount_1, claim_amount_2 = base_accounts[0], TimestampMS(1721018721000), '0.000001321340972471', '8.383663297617516524', '6.566591452101315364'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -125,7 +124,6 @@ def test_aura_finance_claim_rewards_base(base_inquirer, base_accounts):
             address=string_to_evm_address('0x8b2970c237656d3895588B99a8bFe977D5618201'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -135,7 +133,7 @@ def test_aura_finance_lock_aura_from_base_to_ethereum(base_inquirer, base_accoun
     tx_hash = deserialize_evm_tx_hash('0xe0a6fd1bd40451d4b42c520b41a39ab569bf4aae43b741efbe228da40fed91ad')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str, bridge_fee_amount, locked_amount = base_accounts[0], TimestampMS(1732631175000), '0.000007432156846576', '0.011914017676630994', '90'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -176,7 +174,6 @@ def test_aura_finance_lock_aura_from_base_to_ethereum(base_inquirer, base_accoun
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -185,7 +182,7 @@ def test_aura_finance_lock_aura_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x69a2c2e3e7c80f7ca3207041f09bb2799b760b937ba985af65fd69faa7487336')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str, approval_amount, locked_amount = ethereum_accounts[0], TimestampMS(1732623719000), '0.002081603016233576', '115792089237316195423570985008687907853269984665640563943628.250490697661436953', '4675.24673564105539589'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -225,7 +222,6 @@ def test_aura_finance_lock_aura_ethereum(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -246,7 +242,7 @@ def test_aura_finance_booster_deposit_ethereum(ethereum_inquirer, ethereum_accou
     assert len(pool_token.underlying_tokens) == 1
     assert pool_token.underlying_tokens[0].address == string_to_evm_address('0xfbfaD5fa9E99081da6461F36f229B5cC88A64c63')  # noqa: E501
     user_address, timestamp, gas_str, approval_amount, deposit_amount, receive_amount = ethereum_accounts[0], TimestampMS(1732603247000), '0.004522784347764904', '3046599999999999952014.290938920480356746', '17520.54161498940427181', '17520.54161498940427181'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -299,7 +295,6 @@ def test_aura_finance_booster_deposit_ethereum(ethereum_inquirer, ethereum_accou
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -308,7 +303,7 @@ def test_aura_finance_claim_rewards_arb(arbitrum_one_inquirer, arbitrum_one_acco
     tx_hash = deserialize_evm_tx_hash('0x3ee95df7dfb12a183ef7ccb408e320a6a909561fe8da5408b3897ebd336b5420')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
     user_address, timestamp, gas_str, claim_amount_1, claim_amount_2, claim_amount_3 = arbitrum_one_accounts[0], TimestampMS(1735459868000), '0.00000266091', '0.096740702346661316', '0.097900452506457258', '0.14964073351979476'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -362,7 +357,6 @@ def test_aura_finance_claim_rewards_arb(arbitrum_one_inquirer, arbitrum_one_acco
             address=string_to_evm_address('0xE26200262c84444F7fFf83443B3Cf956Ec680325'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -372,7 +366,7 @@ def test_aura_finance_get_rewards_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc54f5bc1b45b151dd7e106a45fea82a0bbb0dd1a48b5e71be2d8b9f36fbcb704')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str, claim_amount_1, claim_amount_2, claim_amount_3 = base_accounts[0], TimestampMS(1733666205000), '0.000003758872604736', '0.016918933596764049', '0.018407669504926201', '0.018747704109670571'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -426,7 +420,6 @@ def test_aura_finance_get_rewards_base(base_inquirer, base_accounts):
             address=string_to_evm_address('0xB8d8674a6a7BaA9D2aEE2dfE4b50Da5095Ee1ed4'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -435,7 +428,7 @@ def test_aura_finance_claim_rewards_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xefc4dac1c3cf3b7058ae35427edeb984286ade8097717479294999992c508aee')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str, claim_amount_1, claim_amount_2, claim_amount_3, claim_amount_4, claim_amount_5, claim_amount_6, claim_amount_7, claim_amount_8 = ethereum_accounts[0], TimestampMS(1735498547000), '0.002203275422715936', '112.627896656336279713', '114.159636050862453116', '77.020600939024296766', '8.274820603749552408', '184.126157708212142242', '186.630273453043827374', '170.528893362154769237', '216.7944203094842023'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -554,16 +547,14 @@ def test_aura_finance_claim_rewards_eth(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0xAc16927429c5c7Af63dD75BC9d8a58c63FfD0147'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x1A02715cf60f0544dEfDB676A3ffeeE710b04115']])
 def test_claim_and_withdraw(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xfd54629dda6c8a533a0a8019ccdd9dded867cba1bc623d91a75527b571c66ac9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xfd54629dda6c8a533a0a8019ccdd9dded867cba1bc623d91a75527b571c66ac9')),  # noqa: E501
     )
     assert events == [EvmEvent(
             tx_ref=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_balancer.py
+++ b/rotkehlchen/tests/unit/decoders/test_balancer.py
@@ -38,10 +38,9 @@ A_BPT = Asset('eip155:1/erc20:0x59A19D8c652FA0284f44113D0ff9aBa70bd46fB4')
 @pytest.mark.parametrize('load_global_caches', [[CPT_BALANCER_V2]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x20A1CF262Cd3A42a50D226fD728104119e6fD0a1']])
 def test_balancer_v2_swap(ethereum_inquirer, ethereum_accounts, load_global_caches):
-    tx_hash = deserialize_evm_tx_hash('0x35dd639ba80940cb14d79c965002a11ea2aef17bbf1f1b85cc03c336da1ddebe')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x35dd639ba80940cb14d79c965002a11ea2aef17bbf1f1b85cc03c336da1ddebe')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     user_address, timestamp, gas_str = ethereum_accounts[0], TimestampMS(1669622603000), '0.001085530186197622'  # noqa: E501
@@ -90,10 +89,9 @@ def test_balancer_v2_swap(ethereum_inquirer, ethereum_accounts, load_global_cach
 @pytest.mark.parametrize('load_global_caches', [[CPT_BALANCER_V1]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x7716a99194d758c8537F056825b75Dd0C8FDD89f']])
 def test_balancer_v1_join(ethereum_inquirer, ethereum_accounts, load_global_caches):
-    tx_hash = deserialize_evm_tx_hash('0xb9dff9df4e3838c75d354d62c4596d94e5eb8904e07cee07a3b7ffa611c05544')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb9dff9df4e3838c75d354d62c4596d94e5eb8904e07cee07a3b7ffa611c05544')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     user_address, timestamp, gas_str = ethereum_accounts[0], TimestampMS(1597144247000), '0.0141724'  # noqa: E501
@@ -144,14 +142,13 @@ def test_balancer_v1_join(ethereum_inquirer, ethereum_accounts, load_global_cach
 @pytest.mark.parametrize('load_global_caches', [[CPT_BALANCER_V1]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x7716a99194d758c8537F056825b75Dd0C8FDD89f']])
 def test_balancer_v1_exit(ethereum_inquirer, ethereum_accounts, load_global_caches):
-    tx_hash = deserialize_evm_tx_hash('0xfa1dfeb83480e51a15137a93cb0eba9ac92c1b6b0ee0bd8551a422c1ed83695b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xfa1dfeb83480e51a15137a93cb0eba9ac92c1b6b0ee0bd8551a422c1ed83695b')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     user_address, timestamp, gas_str = ethereum_accounts[0], TimestampMS(1597243001000), '0.03071222'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -206,7 +203,6 @@ def test_balancer_v1_exit(ethereum_inquirer, ethereum_accounts, load_global_cach
             address=string_to_evm_address('0x59A19D8c652FA0284f44113D0ff9aBa70bd46fB4'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -214,14 +210,13 @@ def test_balancer_v1_exit(ethereum_inquirer, ethereum_accounts, load_global_cach
 @pytest.mark.parametrize('ethereum_accounts', [['0x549C0421c69Be943A2A60e76B19b4A801682cBD3']])
 def test_deposit_with_excess_tokens(ethereum_inquirer, ethereum_accounts, load_global_caches):
     """Verify that when a refund is made for a deposit in balancer v1 this is properly decoded"""
-    tx_hash = deserialize_evm_tx_hash('0x22162f5c71261421db82a03ba4ad13725ef4fe9639c62bf6702538f980fbe7ba')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x22162f5c71261421db82a03ba4ad13725ef4fe9639c62bf6702538f980fbe7ba')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     user_address, timestamp = ethereum_accounts[0], TimestampMS(1593186380000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -313,7 +308,6 @@ def test_deposit_with_excess_tokens(ethereum_inquirer, ethereum_accounts, load_g
             address=string_to_evm_address('0x9ED47950144e51925166192Bf0aE95553939030a'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -321,10 +315,9 @@ def test_deposit_with_excess_tokens(ethereum_inquirer, ethereum_accounts, load_g
 @pytest.mark.parametrize('ethereum_accounts', [['0xAB12253171A0d73df64B115cD43Fe0A32Feb9dAA']])
 def test_balancer_trade(ethereum_inquirer, ethereum_accounts, load_global_caches):
     """Test a balancer trade of token to token"""
-    tx_hash = deserialize_evm_tx_hash('0xc9e8094d4435c3786bbb28b64546ecdf8a1f384057319e715eab7f28cfb01e4f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc9e8094d4435c3786bbb28b64546ecdf8a1f384057319e715eab7f28cfb01e4f')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     user_address, timestamp, gas_str = ethereum_accounts[0], TimestampMS(1643362575000), '0.01196446449981698'  # noqa: E501
@@ -385,7 +378,6 @@ def test_balancer_v1_non_proxy_join(
             values=['0x0ce69A796aBe0c0451585aA88F6F45ebaC9E12dc'],
         )
 
-    tx_hash = deserialize_evm_tx_hash('0xbba2e9e46c773b91b1528e48af1ed479132353473726d75e7a0f74bfb687613e')  # noqa: E501
     balancer_qqq_weth_pool_token = get_or_create_evm_token(
         userdb=ethereum_inquirer.database,
         evm_address=string_to_evm_address('0x0ce69A796aBe0c0451585aA88F6F45ebaC9E12dc'),
@@ -405,11 +397,11 @@ def test_balancer_v1_non_proxy_join(
     )
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xbba2e9e46c773b91b1528e48af1ed479132353473726d75e7a0f74bfb687613e')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     user_address, timestamp, gas_str, approve_amt, receive_amt, deposit_qqq_amt, deposit_weth_amt = ethereum_accounts[0], TimestampMS(1730837051000), '0.002106711205202376', '0.000000001', '4152.559258169060848717', '3545739.463723403', '0.726672467956343618'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -475,21 +467,19 @@ def test_balancer_v1_non_proxy_join(
             address=balancer_qqq_weth_pool_token.evm_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('load_global_caches', [[CPT_BALANCER_V1]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x6D3B90747dbf5883bF88fF7Eb5fCC86f408b5409']])
 def test_balancer_v1_non_proxy_exit(ethereum_inquirer, ethereum_accounts, load_global_caches):
-    tx_hash = deserialize_evm_tx_hash('0x2a1b671429d1a2c797ba0b46735f029e69a85ba514a4d1132eab6b22c7052540')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x2a1b671429d1a2c797ba0b46735f029e69a85ba514a4d1132eab6b22c7052540')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     user_address, pool_address, timestamp, gas_str, return_amt, withdrawn_sfrx_eth_amt, withdrawn_fxs_amt = ethereum_accounts[0], string_to_evm_address('0x11F2A400de0a2FC93a32F88D8779d8199152c6a4'), TimestampMS(1730953079000), '0.001983415737154446', '224630.905650719593790621', '11.361467105948316099', '18310.050732769125107569'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -543,21 +533,19 @@ def test_balancer_v1_non_proxy_exit(ethereum_inquirer, ethereum_accounts, load_g
             address=pool_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('load_global_caches', [[CPT_BALANCER_V1]])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xE3B73F6f37F782128Ebe11e058B23BA0bA6c03C3']])
 def test_balancer_v1_exit_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts, load_global_caches):  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0xf674623c5877257dbb9e8d328ff56e5dfda4f5a650ea51be3100261a1f8aae65')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf674623c5877257dbb9e8d328ff56e5dfda4f5a650ea51be3100261a1f8aae65')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     user_address, pool_address, timestamp, gas_str, return_amt, withdrawn_usdc_amt, withdrawn_wsteth_amt = arbitrum_one_accounts[0], string_to_evm_address('0xFEa755D5523F3A78c0945141AD396d4E970D2fab'), TimestampMS(1728651192000), '0.00000317535', '1.822676898893300983', '11.664549', '0.004234826018688223'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -611,7 +599,6 @@ def test_balancer_v1_exit_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts,
             address=pool_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -654,7 +641,7 @@ def test_balancer_v1_join_gnosis(gnosis_inquirer, gnosis_accounts, load_global_c
         load_global_caches=load_global_caches,
     )
     user_address, timestamp, gas_str, receive_amt, deposit_gno_amt, deposit_cow_amt = gnosis_accounts[0], TimestampMS(1731355510000), '0.0002310674', '68.63749617341156454', '0.048302073768085864', '30.933559190570998685'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -708,7 +695,6 @@ def test_balancer_v1_join_gnosis(gnosis_inquirer, gnosis_accounts, load_global_c
             address=balancer_gno_cow_pool_token.evm_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -717,7 +703,7 @@ def test_balancer_v2_exit_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xcc1636487bd419892133c0e1245e2f427819193fbaef68270111580291c0b285')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str, return_amt, withdrawn_rsweth_amt = ethereum_accounts[0], TimestampMS(1731642119000), '0.003934656379000305', '14.957821596922618203', '14.953427656474271108'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -758,7 +744,6 @@ def test_balancer_v2_exit_ethereum(ethereum_inquirer, ethereum_accounts):
             address=VAULT_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -767,7 +752,7 @@ def test_balancer_v2_exit_gnosis(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x1a9e201fcec608a49dd6b106c46818f2f898401f6439dc5e619869ad48167a3a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str, return_amt, withdrawn_sdai_amt = gnosis_accounts[0], TimestampMS(1731923340000), '0.0003807456', '2403.555042425564723735', '2215.645258238073851336'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -808,7 +793,6 @@ def test_balancer_v2_exit_gnosis(gnosis_inquirer, gnosis_accounts):
             address=VAULT_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -817,7 +801,7 @@ def test_balancer_v2_join_gnosis(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x1915189b0ad23d6c8e6f23df298e92504ec7537dfa8d52571c60193bc598a8b8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_str, receive_amt, deposit_sdai_amt = gnosis_accounts[0], TimestampMS(1729441770000), '0.0003671558', '2403.555042425564723735', '2229.291979360811376949'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -858,7 +842,6 @@ def test_balancer_v2_join_gnosis(gnosis_inquirer, gnosis_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -871,7 +854,7 @@ def test_reth_arb(
     tx_hash = deserialize_evm_tx_hash('0x6b380e483cb301cb060434e31bf053c0b55cd357e8c18f01d3573d850273954e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
     user_address, timestamp, gas_str, receive_amt, deposit_reth_amt = arbitrum_one_accounts[0], TimestampMS(1733867520000), '0.00000838391546', '0.027783312185816836', '0.025'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -924,7 +907,6 @@ def test_reth_arb(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -948,14 +930,13 @@ def test_balancer_v2_join_with_gauge_deposit(
             key_parts=(CacheType.BALANCER_V2_GAUGES, str(optimism_inquirer.chain_id.value)),
             values=['0xCc2E1CB5d8DeA77F08D19f875F381f34f997d96c'],
         )
-    tx_hash = deserialize_evm_tx_hash('0x1e8d94f4d4bb05b8d868bc558293782f4e7ce2eaa87f3f1f6d1377a15ab1a6f0')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x1e8d94f4d4bb05b8d868bc558293782f4e7ce2eaa87f3f1f6d1377a15ab1a6f0')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     user_address, timestamp, gas_amount, approval_amount, receive_amount, deposit_usdce_amount, deposit_usdt_amount = optimism_accounts[0], TimestampMS(1706002351000), '0.000273096837250597', '115792089237316195423570985008687907853269984665640564039457584007912319.640092', '1753.970737231540926176', '809.999843', '957.891739'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1047,7 +1028,6 @@ def test_balancer_v2_join_with_gauge_deposit(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1070,14 +1050,13 @@ def test_balancer_gauge_withdrawal(
             key_parts=(CacheType.BALANCER_V2_GAUGES, str(ethereum_inquirer.chain_id.value)),
             values=['0xdf54d2Dd06F8Be3B0c4FfC157bE54EC9cca91F3C'],
         )
-    tx_hash = deserialize_evm_tx_hash('0xcbb4179ac94618cd419d4185b5137ce02f5ffaef810a1c209dedab79e837b3af')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xcbb4179ac94618cd419d4185b5137ce02f5ffaef810a1c209dedab79e837b3af')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     user_address, timestamp, gas_amount, withdrawn_amount = ethereum_accounts[0], TimestampMS(1719060983000), '0.001454091177763647', '0.426822578640463022'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1118,7 +1097,6 @@ def test_balancer_gauge_withdrawal(
             address=string_to_evm_address('0xdf54d2Dd06F8Be3B0c4FfC157bE54EC9cca91F3C'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1178,7 +1156,7 @@ def test_balancer_v2_swap_repeated_pair_netted_transfers(gnosis_inquirer, gnosis
         tx_hash=(tx_hash := deserialize_evm_tx_hash('0x47321dcb43441dfb6295a9e34a2591fba26a15e557977e4d92460a3205f71459')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1217,4 +1195,3 @@ def test_balancer_v2_swap_repeated_pair_netted_transfers(gnosis_inquirer, gnosis
             address=VAULT_ADDRESS,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_balancer_v3.py
+++ b/rotkehlchen/tests/unit/decoders/test_balancer_v3.py
@@ -475,10 +475,9 @@ def test_gauge_deposit(
             key_parts=(CacheType.BALANCER_V3_GAUGES, str(ethereum_inquirer.chain_id.value)),
             values=['0x70A1c01902DAb7a45dcA1098Ca76A8314dd8aDbA'],
         )
-    tx_hash = deserialize_evm_tx_hash('0x50ce5d69c6856fe4501b537b81cddea6327d3082a908e587775a6356a31ab6c8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x50ce5d69c6856fe4501b537b81cddea6327d3082a908e587775a6356a31ab6c8')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [EvmEvent(
@@ -543,10 +542,9 @@ def test_gauge_withdrawal(
             key_parts=(CacheType.BALANCER_V3_GAUGES, str(base_inquirer.chain_id.value)),
             values=['0x70DB188E5953f67a4B16979a2ceA26248b315401'],
         )
-    tx_hash = deserialize_evm_tx_hash('0xd00e99e4e26704e5207b7b322424fb7ee625b850726f599ddd4100a86844ecfb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd00e99e4e26704e5207b7b322424fb7ee625b850726f599ddd4100a86844ecfb')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_basenames.py
+++ b/rotkehlchen/tests/unit/decoders/test_basenames.py
@@ -45,17 +45,18 @@ def test_basenames_register(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x20280b43dbcfa86cdf0703d2e9f8f2ef200839b2ee0e819d895515d3adb74eff')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, token_id = TimestampMS(1726738619000), base_accounts[0], '0.000001963384627852', 26612040215479394739615825115912800930061094786769410446114278812336794170041  # noqa: E501
+    user_address = base_accounts[0]
+    token_id = 26612040215479394739615825115912800930061094786769410446114278812336794170041
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1726738619000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000001963384627852'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -162,17 +163,18 @@ def test_basenames_register_with_discount(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x9a7021f26ecabdd0d3a3781cec24a452851d97849defa9862a18230a9e72fbd9')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, token_id = TimestampMS(1730993703000), base_accounts[0], '0.000005269375874545', 7069226722341729763252382492637378743849472286311622838562285205711946962668  # noqa: E501
+    user_address = base_accounts[0]
+    token_id = 7069226722341729763252382492637378743849472286311622838562285205711946962668
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1730993703000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000005269375874545'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -279,17 +281,17 @@ def test_basenames_set_attribute(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xb46d5e9cedf468d6c1cd9c5a07f7147448cfd5a0d591b6f57a8216edc2475cc4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount = TimestampMS(1730993863000), base_accounts[0], '0.000000860174471941'  # noqa: E501
+    user_address = base_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1730993863000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000000860174471941'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -319,17 +321,17 @@ def test_basenames_content_hash_changed(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x1803ee8ecced1de613a331de58d7091e9fa0f4f98ec78bb9882b20b27b357aa7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount = TimestampMS(1725571165000), base_accounts[0], '0.000000178301347708'  # noqa: E501
+    user_address = base_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1725571165000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000000178301347708'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -386,11 +388,11 @@ def test_basenames_transfer_name(database, base_inquirer, action, base_accounts,
         to_address = '0x2B97eb170a57fa2B5ea499b9f0176Ef587c6F54d'
 
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, token_id = TimestampMS(1731055033000), 112426549028048856546593988202926666418642845280196262619695088491431122056723  # noqa: E501
+    token_id = 112426549028048856546593988202926666418642845280196262619695088491431122056723
     gas_event = EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1731055033000)),
         location=Location.BASE,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -430,17 +432,17 @@ def test_basenames_new_owner(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x9c107455c41ac041b274d0c9f4a792e2cdccf3fb3abd31a117fb14570461b429')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount = TimestampMS(1730924307000), base_accounts[0], '0.000001274267527917'  # noqa: E501
+    user_address = base_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1730924307000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000001274267527917'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -494,12 +496,12 @@ def test_basenames_ignore_untracked_events(
     """Regression test for https://github.com/rotki/rotki/issues/11551"""
     tx_hash = deserialize_evm_tx_hash('0x2cb9dcf83b3fd1bbbec4cd5f8d0b688bfc3f6aadd99081f28eaccafcd26c4243')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, user_address = TimestampMS(1770188169000), base_accounts[0]
+    user_address = base_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=812,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1770188169000),
             location=Location.BASE,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.NONE,

--- a/rotkehlchen/tests/unit/decoders/test_beefy_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_beefy_finance.py
@@ -114,10 +114,9 @@ def _set_beefy_cache(chain_id: ChainID, entries: list[tuple[str, str, bool]]) ->
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x71b278042bFf0537CbAc1d5cF2197Bd8f4f79EeF']])
 def test_zap_deposit_to_beefy(ethereum_inquirer, ethereum_accounts, beefy_cache):
-    tx_hash = deserialize_evm_tx_hash('0xab6fab1441b7f6843109eb1c903e93c7d24536d09a81aced724302e1c8002c71')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xab6fab1441b7f6843109eb1c903e93c7d24536d09a81aced724302e1c8002c71')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -163,10 +162,9 @@ def test_zap_deposit_to_beefy(ethereum_inquirer, ethereum_accounts, beefy_cache)
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xfaC2F11ba2577D5122DC1EC5301d35B16688251E']])
 def test_zap_withdrawal_from_beefy(ethereum_inquirer, ethereum_accounts, beefy_cache):
-    tx_hash = deserialize_evm_tx_hash('0x3dab2b65117b4c3953a20e6d850a7aa1b15351de30382cea31a4dba795ec3101')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x3dab2b65117b4c3953a20e6d850a7aa1b15351de30382cea31a4dba795ec3101')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -224,10 +222,9 @@ def test_zap_withdrawal_from_beefy(ethereum_inquirer, ethereum_accounts, beefy_c
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x7B8e047dFa4B27314C6A7EA5067e356F38666089']])
 def test_deposit_to_beefy(ethereum_inquirer, ethereum_accounts, beefy_cache):
-    tx_hash = deserialize_evm_tx_hash('0x5d11116ca9ff5edc826394f93c7ee81057119899daa0a9a77d384909584d816e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5d11116ca9ff5edc826394f93c7ee81057119899daa0a9a77d384909584d816e')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -285,10 +282,9 @@ def test_deposit_to_beefy(ethereum_inquirer, ethereum_accounts, beefy_cache):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xA2d238002Bf1A91fed3C218fA770C4933d833ead']])
 def test_withdrawal_from_beefy(ethereum_inquirer, ethereum_accounts, beefy_cache):
-    tx_hash = deserialize_evm_tx_hash('0xda0a5066e573451465447a0d84d2b62b14dd980b3df7421c639b1beea9f9ec4a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xda0a5066e573451465447a0d84d2b62b14dd980b3df7421c639b1beea9f9ec4a')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -369,10 +365,9 @@ def test_deposit_to_beefy_morpho_vault(
         chain_id=ChainID.BASE,
         entries=[(beefy_vault.evm_address, base_inquirer.wrapped_native_token.evm_address, False)],
     )
-    tx_hash = deserialize_evm_tx_hash('0x9ec67f14375ce96036b23f4b13c38dcee6d74973d4be0ba81c775674450da340')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x9ec67f14375ce96036b23f4b13c38dcee6d74973d4be0ba81c775674450da340')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -549,10 +544,9 @@ def test_withdrawal_from_beefy_clm_vault(
         chain_id=ChainID.ARBITRUM_ONE,
         entries=[(rcow_token.evm_address, cow_token.evm_address, False)],
     )
-    tx_hash = deserialize_evm_tx_hash('0xc964a5c62d7ce489e8d21d5a222bebbb11fccd802fe250cf66118a17f06e9ee5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc964a5c62d7ce489e8d21d5a222bebbb11fccd802fe250cf66118a17f06e9ee5')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -626,10 +620,9 @@ def test_deposit_eth_to_beefy_vault_with_harvest_call_reward(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x9ade23d1ea48257b13e983d0a542fafbfa1dd195975a94b8d3505ef767527167')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x9ade23d1ea48257b13e983d0a542fafbfa1dd195975a94b8d3505ef767527167')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -694,10 +687,9 @@ def test_deposit_usdc_to_beefy_vault_with_harvest_call_reward(
     """This test differs from the deposit-eth one above in that the charged_fees tx log event
     has the values in the data instead of as log topics.
     """
-    tx_hash = deserialize_evm_tx_hash('0x6dc43b963357b6a40adea87129030430d145deb4463d43bec8be324a4e2190e0')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6dc43b963357b6a40adea87129030430d145deb4463d43bec8be324a4e2190e0')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -789,10 +781,9 @@ def test_withdrawal_from_beefy_receiving_eth(
         chain_id=ChainID.OPTIMISM,
         entries=[(cow_token.evm_address, optimism_inquirer.wrapped_native_token.evm_address, False)],  # noqa: E501
     )
-    tx_hash = deserialize_evm_tx_hash('0x1fb86d2bcbccde112422984862ac5ed4f88a2414b86a740ed64ea082b099ee2a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x1fb86d2bcbccde112422984862ac5ed4f88a2414b86a740ed64ea082b099ee2a')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -1232,10 +1223,9 @@ def test_unstake_beefy_reward_pool_with_reward(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x356a14285c8D2d351682D6E6fEF0213ddEd8Abad']])
 def test_legacy_boost_exit(ethereum_inquirer, ethereum_accounts, beefy_cache):
-    tx_hash = deserialize_evm_tx_hash('0x79be37675ed545796804fcb146cb7ba08915d6c032fe99cb8005a877dc9974b4')  # noqa: E501
     get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=deserialize_evm_tx_hash('0x79be37675ed545796804fcb146cb7ba08915d6c032fe99cb8005a877dc9974b4'),
     )
     # TODO @yabirgb(#11317): Fix the beefy decoder to process correctly boost exits
     legacy_vault = EvmToken('eip155:1/erc20:0xbd313b13ed794B86Bd161885F8e170769E0e68b2')

--- a/rotkehlchen/tests/unit/decoders/test_blur.py
+++ b/rotkehlchen/tests/unit/decoders/test_blur.py
@@ -26,17 +26,16 @@ if TYPE_CHECKING:
 def test_blur_claim_and_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list[ChecksumEvmAddress]):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x09b9d311c62dadc69a06f39daa5206760f38ef48d9e8473f27a9cf2d599133c9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, stake_amount, gas_fees = TimestampMS(1702156943000), '6350.3577325406', '0.005302886935404245'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1702156943000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.005302886935404245'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -48,7 +47,7 @@ def test_blur_claim_and_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_ac
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=Asset(BLUR_IDENTIFIER),
-            amount=FVal(stake_amount),
+            amount=FVal(stake_amount := '6350.3577325406'),
             location_label=ethereum_accounts[0],
             notes=f'Claim {stake_amount} BLUR from Blur airdrop',
             counterparty=CPT_BLUR,
@@ -68,7 +67,6 @@ def test_blur_claim_and_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_ac
             address=BLUR_STAKING_CONTRACT,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -76,17 +74,16 @@ def test_blur_claim_and_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_ac
 def test_blur_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list[ChecksumEvmAddress]):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0xdae4c4cc02aea1a4063295aabf75c7fd30618a4fb364209270d215d2d33b7221')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, stake_amount, gas_fees = TimestampMS(1715478947000), '903.93', '0.000533750631510369'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1715478947000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000533750631510369'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -98,14 +95,13 @@ def test_blur_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: li
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=Asset(BLUR_IDENTIFIER),
-            amount=FVal(stake_amount),
+            amount=FVal(stake_amount := '903.93'),
             location_label=ethereum_accounts[0],
             notes=f'Stake {stake_amount} BLUR',
             counterparty=CPT_BLUR,
             address=BLUR_STAKING_CONTRACT,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -113,16 +109,15 @@ def test_blur_stake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: li
 def test_blur_unstake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: list[ChecksumEvmAddress]):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x494259cae7bf1d68c185f5d35ad5991e28a20089b44f30453da6967dd5a5270a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, unstake_amount, gas_fees = TimestampMS(1716377543000), '2333.05', '0.000802495016237112'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716377543000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000802495016237112'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             tx_ref=tx_hash,
@@ -134,7 +129,7 @@ def test_blur_unstake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: 
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REMOVE_ASSET,
             asset=Asset(BLUR_IDENTIFIER),
-            amount=FVal(unstake_amount),
+            amount=FVal(unstake_amount := '2333.05'),
             location_label=ethereum_accounts[0],
             notes=f'Unstake {unstake_amount} BLUR',
             tx_ref=tx_hash,
@@ -142,4 +137,3 @@ def test_blur_unstake(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts: 
             counterparty=CPT_BLUR,
         ),
     ]
-    assert expected_events == events

--- a/rotkehlchen/tests/unit/decoders/test_cctp.py
+++ b/rotkehlchen/tests/unit/decoders/test_cctp.py
@@ -30,16 +30,15 @@ def test_deposit_usdc_from_ethereum_to_arbitrum_one(
 ):
     tx_hash = deserialize_evm_tx_hash('0xac7bb45701a4311a2c662377a4764ac694a8f6438270c1ee8a4100d4a000a511')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, deposit_amount = TimestampMS(1716588659000), '0.000649402467435812', '1839.726596'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716588659000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000649402467435812'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -51,7 +50,7 @@ def test_deposit_usdc_from_ethereum_to_arbitrum_one(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_USDC,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '1839.726596'),
             location_label=ethereum_accounts[0],
             notes=f'Bridge {deposit_amount} USDC from Ethereum to Arbitrum One via CCTP',
             tx_ref=tx_hash,
@@ -59,7 +58,6 @@ def test_deposit_usdc_from_ethereum_to_arbitrum_one(
             address=string_to_evm_address('0xc4922d64a24675E16e1586e3e3Aa56C06fABe907'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -68,21 +66,19 @@ def test_receive_usdc_on_arbitrum_one_from_ethereum(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list[ChecksumEvmAddress],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x9da8beb8e9ad2428ad2de132d920d27c2d6c7e0604d2977669aab219e51fd323')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x9da8beb8e9ad2428ad2de132d920d27c2d6c7e0604d2977669aab219e51fd323')),  # noqa: E501
     )
-    timestamp, gas, deposit_amount = TimestampMS(1716589968000), '0.00000196702', '1839.726596'
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716589968000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000196702'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -94,7 +90,7 @@ def test_receive_usdc_on_arbitrum_one_from_ethereum(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset(USDC_IDENTIFIER_ARB),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '1839.726596'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Bridge {deposit_amount} USDC from Ethereum to Arbitrum One via CCTP',
             tx_ref=tx_hash,
@@ -102,7 +98,6 @@ def test_receive_usdc_on_arbitrum_one_from_ethereum(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -111,21 +106,19 @@ def test_deposit_usdc_from_polygon_to_arbitrum_one(
         polygon_pos_inquirer: 'PolygonPOSInquirer',
         polygon_pos_accounts: list[ChecksumEvmAddress],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x90128b2988d709e7719dc157aaf08ea76792934cac4e47fa01e93c80d21d30fd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x90128b2988d709e7719dc157aaf08ea76792934cac4e47fa01e93c80d21d30fd')),  # noqa: E501
     )
-    timestamp, gas, deposit_amount = TimestampMS(1716970880000), '0.00404958204', '4253.283606'
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716970880000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_POL,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00404958204'),
             location_label=polygon_pos_accounts[0],
             notes=f'Burn {gas} POL for gas',
             tx_ref=tx_hash,
@@ -137,7 +130,7 @@ def test_deposit_usdc_from_polygon_to_arbitrum_one(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset(USDC_IDENTIFIER_POLYGON),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '4253.283606'),
             location_label=polygon_pos_accounts[0],
             notes=f'Bridge {deposit_amount} USDC from Polygon POS to Arbitrum One via CCTP',
             tx_ref=tx_hash,
@@ -145,7 +138,6 @@ def test_deposit_usdc_from_polygon_to_arbitrum_one(
             address=string_to_evm_address('0x10f7835F827D6Cf035115E10c50A853d7FB2D2EC'),
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -154,21 +146,19 @@ def test_receive_usdc_on_arbitrum_one_from_polygon(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list[ChecksumEvmAddress],
 ):
-    tx_hash = deserialize_evm_tx_hash('0xad6aa5691bde79c4c97be04871d92e1cc2fa8e43984834716d09001da309dce0')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xad6aa5691bde79c4c97be04871d92e1cc2fa8e43984834716d09001da309dce0')),  # noqa: E501
     )
-    timestamp, gas, deposit_amount = TimestampMS(1716971722000), '0.00000345289', '4253.283606'
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716971722000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000345289'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -180,7 +170,7 @@ def test_receive_usdc_on_arbitrum_one_from_polygon(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset(USDC_IDENTIFIER_ARB),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '4253.283606'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Bridge {deposit_amount} USDC from Polygon POS to Arbitrum One via CCTP',
             tx_ref=tx_hash,
@@ -188,7 +178,6 @@ def test_receive_usdc_on_arbitrum_one_from_polygon(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -197,21 +186,19 @@ def test_receive_usdc_on_arbitrum_one_from_polygon_2(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list[ChecksumEvmAddress],
 ):
-    tx_hash = deserialize_evm_tx_hash('0xd067d3d8ed104af374b7cf101b8dea72ee4d9cf11a3b18dea9b2de4bb4d1e362')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd067d3d8ed104af374b7cf101b8dea72ee4d9cf11a3b18dea9b2de4bb4d1e362')),  # noqa: E501
     )
-    timestamp, deposit_amount = TimestampMS(1716978796000), '1.541124'
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=1,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1716978796000),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset(USDC_IDENTIFIER_ARB),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '1.541124'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Bridge {deposit_amount} USDC from Polygon POS to Arbitrum One via CCTP',
             tx_ref=tx_hash,
@@ -219,4 +206,3 @@ def test_receive_usdc_on_arbitrum_one_from_polygon_2(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_clrfund.py
+++ b/rotkehlchen/tests/unit/decoders/test_clrfund.py
@@ -17,41 +17,38 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_ethstaker_matching_claim(arbitrum_one_inquirer, arbitrum_one_accounts):
     """Whats interesting here is that someone else claimed funds and not the recipient address"""
-    tx_hash = deserialize_evm_tx_hash('0x5236f217873582446398c9b427a80a669be90b8a17fb5ed842f8d5d2925f3e7f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5236f217873582446398c9b427a80a669be90b8a17fb5ed842f8d5d2925f3e7f')),  # noqa: E501
     )
-    timestamp, user, amount = TimestampMS(1654833348000), arbitrum_one_accounts[0], '39566.332611058195231384'  # noqa: E501
-    expected_events = [
+    user = arbitrum_one_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1654833348000),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.DONATE,
             asset=EvmToken('eip155:42161/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1'),
-            amount=FVal(amount),
+            amount=FVal(amount := '39566.332611058195231384'),
             location_label=user,
             notes=f'Claim {amount} DAI as matching funds payout of clrfund Ethstaker round for {user}',  # noqa: E501
             counterparty=CPT_CLRFUND,
             address=string_to_evm_address('0xeD67d6682DC88E06c66e188027cA883455AfdADa'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_add_recipient(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x52f8b96df94af89566fb6048026d10411928f8cf1518788b2d3d0ef6623bafe2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x52f8b96df94af89566fb6048026d10411928f8cf1518788b2d3d0ef6623bafe2')),  # noqa: E501
     )
     gas, timestamp, user, amount = '0.00483736114768445', TimestampMS(1650384723000), arbitrum_one_accounts[0], '0.005'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -79,19 +76,17 @@ def test_add_recipient(arbitrum_one_inquirer, arbitrum_one_accounts):
             address=string_to_evm_address('0xD2020926C0f1f8990DE806eBbAd510fa4b9b6f45'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x506498abf98C157eFE8B226E5EcAa0093aB77F04']])
 def test_voted(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xf2fa4e67b28a20e49fe69fe83c0848557141b852bf84367f260f285e38bef5c5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf2fa4e67b28a20e49fe69fe83c0848557141b852bf84367f260f285e38bef5c5')),  # noqa: E501
     )
     gas, timestamp, user = '0.003010415219175718', TimestampMS(1653433014000), arbitrum_one_accounts[0]  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -119,19 +114,17 @@ def test_voted(arbitrum_one_inquirer, arbitrum_one_accounts):
             address=string_to_evm_address('0xeD67d6682DC88E06c66e188027cA883455AfdADa'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x017dc108b35495f627B9F991AA34C982Ae1047Fb']])
 def test_contribution(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x527e008a0fd9f0e0146eb842dfe7c47e2830e9cc05f07ca9908b23be1f8a18b8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x527e008a0fd9f0e0146eb842dfe7c47e2830e9cc05f07ca9908b23be1f8a18b8')),  # noqa: E501
     )
     gas, timestamp, amount, user = '0.000313841956638943', TimestampMS(1653433994000), '8', arbitrum_one_accounts[0]  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -159,4 +152,3 @@ def test_contribution(arbitrum_one_inquirer, arbitrum_one_accounts):
             address=string_to_evm_address('0xeD67d6682DC88E06c66e188027cA883455AfdADa'),
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_compound_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_compound_v2.py
@@ -45,12 +45,11 @@ def test_compound_ether_deposit(ethereum_inquirer):
     """
     tx_hash = deserialize_evm_tx_hash('0x06a8b9f758b0471886186c2a48dea189b3044916c7f94ee7f559026fefd91c39')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1598639099000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1598639099000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -86,7 +85,6 @@ def test_compound_ether_deposit(ethereum_inquirer):
             counterparty=CPT_COMPOUND,
             address=string_to_evm_address('0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -97,12 +95,11 @@ def test_compound_ether_withdraw(ethereum_inquirer):
     """
     tx_hash = deserialize_evm_tx_hash('0x024bd402420c3ba2f95b875f55ce2a762338d2a14dac4887b78174254c9ab807')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1598813490000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1598813490000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -138,7 +135,6 @@ def test_compound_ether_withdraw(ethereum_inquirer):
             counterparty=CPT_COMPOUND,
             address=string_to_evm_address('0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -149,15 +145,14 @@ def test_compound_deposit_with_comp_claim(ethereum_inquirer):
     """
     tx_hash = deserialize_evm_tx_hash('0xfdbfe6e9ce822bd988054945c86f2dff1fac6a12b4acb0b68c8805b5aa3b30ba')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1607572696000)
     amount = FVal('14309.930911242041089052')
     wrapped_amount = FVal('687371.5068874')
     interest = FVal('0.076123031460129653')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1607572696000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -206,7 +201,6 @@ def test_compound_deposit_with_comp_claim(ethereum_inquirer):
             counterparty=CPT_COMPOUND,
             address=string_to_evm_address('0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -217,13 +211,12 @@ def test_compound_multiple_comp_claim(ethereum_inquirer):
     as a simple receive.
     """
     tx_hash = deserialize_evm_tx_hash('0x25d341421044fa27006c0ec8df11067d80f69b2d2135065828f1992fa6868a49')  # noqa: E501
-    timestamp = TimestampMS(1622430975000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1622430975000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -298,7 +291,6 @@ def test_compound_multiple_comp_claim(ethereum_inquirer):
             counterparty=CPT_COMPOUND,
             address=string_to_evm_address('0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -309,18 +301,17 @@ def test_compound_comp_claim_last_transfer(ethereum_inquirer, ethereum_accounts)
     the transfer being last the last event
     """
     tx_hash = deserialize_evm_tx_hash('0xbd2dcb1121bf230a855788a77aa054dc1aae7a898cb4a7d7c45c5866f3f887ac')  # noqa: E501
-    timestamp = TimestampMS(1622430975000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, amount = TimestampMS(1672433507000), '0.0041468661739364', '12.817402848098541218'  # noqa: E501
+    amount = '12.817402848098541218'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1672433507000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.0041468661739364'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -349,7 +340,7 @@ def test_compound_borrow(ethereum_inquirer: 'EthereumInquirer') -> None:
     """
     tx_hash = deserialize_evm_tx_hash('0x036338316a076590a496791a729d3459934a89d6eb512f765cf0e28f9eb8b50c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -377,7 +368,6 @@ def test_compound_borrow(ethereum_inquirer: 'EthereumInquirer') -> None:
             address=string_to_evm_address('0x39AA39c021dfbaE8faC545936693aC917d5E7563'),
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -388,7 +378,7 @@ def test_compound_payback(ethereum_inquirer: 'EthereumInquirer') -> None:
     """
     tx_hash = deserialize_evm_tx_hash('0x000da925508a1a2f322f6fb74592baf9a75bb9f971cb3a72a5deb0526d39757d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -429,7 +419,6 @@ def test_compound_payback(ethereum_inquirer: 'EthereumInquirer') -> None:
             address=string_to_evm_address('0x39AA39c021dfbaE8faC545936693aC917d5E7563'),
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -440,7 +429,7 @@ def test_compound_borrow_eth(ethereum_inquirer: 'EthereumInquirer') -> None:
     """
     tx_hash = deserialize_evm_tx_hash('0x00035065f364453ca4585ab5d4ee7dacc59a3f7acc305644c334fdfff3a2527f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -468,7 +457,6 @@ def test_compound_borrow_eth(ethereum_inquirer: 'EthereumInquirer') -> None:
             address=string_to_evm_address('0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5'),
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -479,7 +467,7 @@ def test_compound_repays_eth(ethereum_inquirer: 'EthereumInquirer') -> None:
     """
     tx_hash = deserialize_evm_tx_hash('0x0007416c8caa441ce07c61dbf2455b3068d21d9bffbfbbfca9f1016d7c3ca33f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -507,7 +495,6 @@ def test_compound_repays_eth(ethereum_inquirer: 'EthereumInquirer') -> None:
             address=string_to_evm_address('0xf859A1AD94BcF445A406B892eF0d3082f4174088'),
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_compound_v3.py
+++ b/rotkehlchen/tests/unit/decoders/test_compound_v3.py
@@ -40,19 +40,16 @@ def test_compound_v3_claim_comp(
     tx_hash = deserialize_evm_tx_hash('0x89b189f36989aba504c77e686cb52691fdb147873f72ef9c64c31f39bf355fc8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1700653367000)
-    gas_str = '0.002927949668742244'
-    amount_str = '2.368215'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1700653367000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.002927949668742244'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -64,14 +61,13 @@ def test_compound_v3_claim_comp(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_COMP,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '2.368215'),
             location_label=user_address,
             notes=f'Collect {amount_str} COMP from compound',
             counterparty=CPT_COMPOUND_V3,
             address=COMPOUND_REWARDS_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -79,13 +75,12 @@ def test_compound_v3_claim_comp(
 def test_compound_v3_supply(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xcac67d0ca139b9418673f04dcc18fe7805b1242566489bf2e9c99a2fea4ee01c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1712239823000)
     gas_fees, supply_amount, position_amount = '0.003305489949685846', '15000', '14999.999998'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712239823000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -121,7 +116,6 @@ def test_compound_v3_supply(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_COMPOUND_V3,
             address=ZERO_ADDRESS,
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -129,13 +123,12 @@ def test_compound_v3_supply(ethereum_inquirer, ethereum_accounts):
 def test_compound_v3_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd8ba70d3e993cae4b89a68d5b991d0a85dd9888c0e6a07814c9ddd2ff4ba93d2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1712239703000)
     gas_fees, withdraw_amount = '0.002760840922152728', '8158.266856'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712239703000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -171,7 +164,6 @@ def test_compound_v3_withdraw(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_COMPOUND_V3,
             address=string_to_evm_address('0xc3d688B66703497DAA19211EEdff47f25384cdc3'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -179,13 +171,12 @@ def test_compound_v3_withdraw(ethereum_inquirer, ethereum_accounts):
 def test_compound_v3_withdraw_collateral(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x70aca19e6ac5285a586ad9e6a6d38bb4e4a682386901e987c7f7a30ea8c2431c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1712235011000)
     gas_fees, collateral_amount = '0.003503372063979697', '30'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712235011000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -221,7 +212,6 @@ def test_compound_v3_withdraw_collateral(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_COMPOUND_V3,
             address=string_to_evm_address('0xc3d688B66703497DAA19211EEdff47f25384cdc3'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -229,13 +219,12 @@ def test_compound_v3_withdraw_collateral(ethereum_inquirer, ethereum_accounts):
 def test_compound_v3_deposit_collateral(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2e362252c9c96669eb0801cd431d6b36bdea63968e5781d33ea58efc528ac205')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1712238731000)
     gas_fees, collateral_amount = '0.00267689111806624', '15'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712238731000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -271,24 +260,21 @@ def test_compound_v3_deposit_collateral(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_COMPOUND_V3,
             address=string_to_evm_address('0xc3d688B66703497DAA19211EEdff47f25384cdc3'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xD350663eB2615FF8aDa1Db2A2c810129003142f1']])
 def test_polygon_pos_withdraw(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xb747e7075a5f4d1b4b60da150da7fb0bce7759e36d2753fed47f0f6ecbda780c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb747e7075a5f4d1b4b60da150da7fb0bce7759e36d2753fed47f0f6ecbda780c')),  # noqa: E501
     )
-    timestamp = TimestampMS(1712676523000)
     gas_fees, withdraw_amount, return_amount = '0.025730978971038568', '417.093804', '417.093805'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712676523000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -324,24 +310,21 @@ def test_polygon_pos_withdraw(polygon_pos_inquirer, polygon_pos_accounts):
             counterparty=CPT_COMPOUND_V3,
             address=string_to_evm_address('0xF25212E676D1F7F89Cd72fFEe66158f541246445'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xb453dE1360cEcf95bD9717CB9DEB6Fb961b7010D']])
 def test_arbitrum_one_borrow(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xaabe8666d515f5fa97cf31a5ac43c3f56af062ff3a077ef79dbc2480b33b7802')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xaabe8666d515f5fa97cf31a5ac43c3f56af062ff3a077ef79dbc2480b33b7802')),  # noqa: E501
     )
-    timestamp = TimestampMS(1714561431000)
     gas_fees, borrow_amount = '0.0000019956', '600'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714561431000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -364,25 +347,22 @@ def test_arbitrum_one_borrow(arbitrum_one_inquirer, arbitrum_one_accounts):
             counterparty=CPT_COMPOUND_V3,
             address=string_to_evm_address('0xA5EDBDD9646f8dFF606d7448e414884C7d905dCA'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('base_accounts', [['0xBD1eefb658C2B80c297493A0D4298B16941eff85']])
 def test_base_repay(base_inquirer, base_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x455761ce3e1076eb03a3af1a90b935b42a703336e08aacf218afe76102d8d171')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x455761ce3e1076eb03a3af1a90b935b42a703336e08aacf218afe76102d8d171')),  # noqa: E501
     )
-    timestamp = TimestampMS(1714564377000)
     gas_fees, repay_amount = '0.00000528542843901', '100.000919'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714564377000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -406,24 +386,21 @@ def test_base_repay(base_inquirer, base_accounts):
             address=string_to_evm_address('0xb125E6687d4313864e53df431d5425969c15Eb2F'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(allow_playback_repeats=True, filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('scroll_accounts', [['0xe53Ca0bB4E6F22514Aa1c1ABFd9634d52A808546']])
 def test_scroll_withdraw(scroll_inquirer, scroll_accounts, allow_scroll_etherscan):
-    tx_hash = deserialize_evm_tx_hash('0x0ec09157328bba439e276c83a2c3364c390d430b5bc0bddf3169d475b6fbfdee')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=scroll_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x0ec09157328bba439e276c83a2c3364c390d430b5bc0bddf3169d475b6fbfdee')),  # noqa: E501
     )
-    timestamp = TimestampMS(1712739257000)
     gas_fees, withdraw_amount = '0.000179933419363529', '5001.003801'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712739257000)),
             location=Location.SCROLL,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -459,20 +436,18 @@ def test_scroll_withdraw(scroll_inquirer, scroll_accounts, allow_scroll_ethersca
             counterparty=CPT_COMPOUND_V3,
             address=string_to_evm_address('0xB2f97c1Bd3bf02f5e74d13f02E3e26F93D77CE44'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('optimism_accounts', [['0xBf02910A77281F3c279ee45dA17c3BE8163b108f']])
 def test_optimism_supply_eth_with_wrapping(optimism_inquirer, optimism_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x6b4320c7965cfeb3263cdeb13469e49881ae66c2cfef68c94af1c210d7da8be7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6b4320c7965cfeb3263cdeb13469e49881ae66c2cfef68c94af1c210d7da8be7')),  # noqa: E501
     )
     user, timestamp, gas_fees, deposit_amount, withdraw_amount = optimism_accounts[0], TimestampMS(1739077677000), '0.00000002224085855', '0.025', '0.024999999999999999'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -512,19 +487,17 @@ def test_optimism_supply_eth_with_wrapping(optimism_inquirer, optimism_accounts)
             counterparty=CPT_COMPOUND_V3,
             address=ZERO_ADDRESS,
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xd3c41C883A0B04c9d4f5b6002693d436AB87F67A']])
 def test_arbitrum_one_withdraw_eth_with_unwrapping(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xd12c93b2dfc8009b345549dcf14258300d04d78850960334c816f343770ab63a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd12c93b2dfc8009b345549dcf14258300d04d78850960334c816f343770ab63a')),  # noqa: E501
     )
     user, timestamp, gas_fees, amount = arbitrum_one_accounts[0], TimestampMS(1739094648000), '0.00000128289', '0.409005868637616281'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -564,7 +537,6 @@ def test_arbitrum_one_withdraw_eth_with_unwrapping(arbitrum_one_inquirer, arbitr
             counterparty=CPT_COMPOUND_V3,
             address=ARBITRUM_BULKER_ADDRESS,
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_convex.py
+++ b/rotkehlchen/tests/unit/decoders/test_convex.py
@@ -40,13 +40,11 @@ def test_booster_deposit(
         database,
         ethereum_inquirer: 'EthereumInquirer',
 ) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x8f643dc245ce64085197692ed98309a94fd176a1e7394e8967ae7bfa10ad1f8f')  # noqa: E501
 
-    timestamp = TimestampMS(1655810357000)
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8f643dc245ce64085197692ed98309a94fd176a1e7394e8967ae7bfa10ad1f8f')),  # noqa: E501
     )
     mocked_notifier = database.msg_aggregator.rotki_notifier
     assert mocked_notifier.pop_message() == MockedWsMessage(
@@ -64,11 +62,11 @@ def test_booster_deposit(
             'blockchain': 'eth',
         },
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1655810357000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -96,7 +94,6 @@ def test_booster_deposit(
             extra_data={'gauge_address': '0x008aEa5036b819B4FEAEd10b2190FBb3954981E8'},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -104,13 +101,12 @@ def test_booster_deposit(
 def test_booster_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x79fcbafa4367e0563d3e614f774c5e4257c4e41f124ae8288980a310e2b2b547')  # noqa: E501
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1655877898000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1655877898000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -153,15 +149,13 @@ def test_booster_withdraw(ethereum_inquirer, ethereum_accounts):
             extra_data=None,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0xFb305A40Dac406BdCF3b85F6311e5430770f44bA')]])  # noqa: E501
 def test_cvxcrv_get_reward(database, ethereum_inquirer, eth_transactions):
-    tx_hash = deserialize_evm_tx_hash('0x5e62ce39159fcdf528905d044e5387c8f21a1eca015d08cebc652bfb9c183611')  # noqa: E501
     user_address = string_to_evm_address('0xFb305A40Dac406BdCF3b85F6311e5430770f44bA')
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5e62ce39159fcdf528905d044e5387c8f21a1eca015d08cebc652bfb9c183611')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=1655675488,
         block_number=14998088,
@@ -238,12 +232,11 @@ def test_cvxcrv_get_reward(database, ethereum_inquirer, eth_transactions):
         decoder.reload_data(cursor)
 
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    timestamp = TimestampMS(1655675488000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1655675488000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -301,7 +294,6 @@ def test_cvxcrv_get_reward(database, ethereum_inquirer, eth_transactions):
             extra_data=None,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -309,13 +301,12 @@ def test_cvxcrv_get_reward(database, ethereum_inquirer, eth_transactions):
 def test_cvxcrv_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0a804804cc62f615b72dff55e8c245d9b69aa8f8ed3de549101ae128a4ae432b')  # noqa: E501
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1655747494000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1655747494000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -343,7 +334,6 @@ def test_cvxcrv_withdraw(ethereum_inquirer, ethereum_accounts):
             extra_data=None,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -351,13 +341,12 @@ def test_cvxcrv_withdraw(ethereum_inquirer, ethereum_accounts):
 def test_cvxcrv_stake(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x3cc0b25887e2f0dac7f86fabd81aaafb1e041e84dbe8167885073c443320ad5f')  # noqa: E501
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1655750059000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1655750059000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -399,15 +388,13 @@ def test_cvxcrv_stake(ethereum_inquirer, ethereum_accounts):
             extra_data=None,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x5B186c93A50D3CB435fE2933427d36E6Dc688e4b')]])  # noqa: E501
 def test_cvx_stake(database, ethereum_inquirer, eth_transactions):
-    tx_hash = deserialize_evm_tx_hash('0xc33246acb86798b81fe650061061d32751c53879d46ece6991fb4a3eda808103')  # noqa: E501
     user_address = string_to_evm_address('0x5B186c93A50D3CB435fE2933427d36E6Dc688e4b')
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc33246acb86798b81fe650061061d32751c53879d46ece6991fb4a3eda808103')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -467,7 +454,7 @@ def test_cvx_stake(database, ethereum_inquirer, eth_transactions):
         decoder.reload_data(cursor)
 
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -513,15 +500,13 @@ def test_cvx_stake(database, ethereum_inquirer, eth_transactions):
             extra_data=None,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x95c5582D781d507A084c9E5f885C77BabACf8EeA')]])  # noqa: E501
 def test_cvx_get_reward(database, ethereum_inquirer, eth_transactions):
-    tx_hash = deserialize_evm_tx_hash('0xdaead2f96859462b5800584ecdcf30f2b83a1ca2c36c49a838b23e43c61d803f')  # noqa: E501
     user_address = '0x95c5582D781d507A084c9E5f885C77BabACf8EeA'
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xdaead2f96859462b5800584ecdcf30f2b83a1ca2c36c49a838b23e43c61d803f')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -608,7 +593,7 @@ def test_cvx_get_reward(database, ethereum_inquirer, eth_transactions):
         decoder.reload_data(cursor)
 
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -640,15 +625,13 @@ def test_cvx_get_reward(database, ethereum_inquirer, eth_transactions):
             extra_data=None,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x84BCE169c271e1c1777715bb0dd38Ad9e6381BAa')]])  # noqa: E501
 def test_cvx_withdraw(database, ethereum_inquirer, eth_transactions):
-    tx_hash = deserialize_evm_tx_hash('0xe725bd6e00b840f4fb8f73cd7286bfa18b04a24ca9278cac7249218ee9f420a8')  # noqa: E501
     user_address = string_to_evm_address('0x84BCE169c271e1c1777715bb0dd38Ad9e6381BAa')
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe725bd6e00b840f4fb8f73cd7286bfa18b04a24ca9278cac7249218ee9f420a8')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -699,7 +682,7 @@ def test_cvx_withdraw(database, ethereum_inquirer, eth_transactions):
         decoder.reload_data(cursor)
 
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -731,15 +714,13 @@ def test_cvx_withdraw(database, ethereum_inquirer, eth_transactions):
             extra_data=None,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x999EcCEa3C4f9219B1B1B42b4830e62c26004B40')]])  # noqa: E501
 def test_claimzap_abracadabras(database, ethereum_inquirer, eth_transactions):
-    tx_hash = deserialize_evm_tx_hash('0xe03d27127fda879144ea4cc587470bd37040be9921ff6a90f48d4efd0cb4fe13')  # noqa: E501
     user_address = string_to_evm_address('0x999EcCEa3C4f9219B1B1B42b4830e62c26004B40')
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe03d27127fda879144ea4cc587470bd37040be9921ff6a90f48d4efd0cb4fe13')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -782,7 +763,7 @@ def test_claimzap_abracadabras(database, ethereum_inquirer, eth_transactions):
         decoder.reload_data(cursor)
 
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -814,15 +795,13 @@ def test_claimzap_abracadabras(database, ethereum_inquirer, eth_transactions):
             extra_data=None,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[string_to_evm_address('0x0C3Cc503EaE928Ed6B5b01B8a9EE8de2855d03Ac')]])  # noqa: E501
 def test_claimzap_cvx_locker(database, ethereum_inquirer, eth_transactions):
-    tx_hash = deserialize_evm_tx_hash('0x53e092e6f25e540d6323af851a1e889276096d58ec25495aef4500467ef2753c')  # noqa: E501
     user_address = string_to_evm_address('0x0C3Cc503EaE928Ed6B5b01B8a9EE8de2855d03Ac')
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x53e092e6f25e540d6323af851a1e889276096d58ec25495aef4500467ef2753c')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -874,7 +853,7 @@ def test_claimzap_cvx_locker(database, ethereum_inquirer, eth_transactions):
         decoder.reload_data(cursor)
 
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -906,7 +885,6 @@ def test_claimzap_cvx_locker(database, ethereum_inquirer, eth_transactions):
             extra_data=None,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -918,18 +896,16 @@ def test_convex_claim_pending_rewards(ethereum_inquirer, ethereum_accounts, load
     in the pool. In this case the user is rewarded for performing this action.
     """
     user_address = ethereum_accounts[0]
-    tx_hash = deserialize_evm_tx_hash('0xf3b8bbb2996515bc276626378ad85bc241051cac5d09c709ae9447665a3babd6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf3b8bbb2996515bc276626378ad85bc241051cac5d09c709ae9447665a3babd6')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1683871727000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1683871727000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -954,7 +930,6 @@ def test_convex_claim_pending_rewards(ethereum_inquirer, ethereum_accounts, load
             address=string_to_evm_address('0xF403C135812408BFbE8713b5A23a04b3D48AAE31'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -967,13 +942,12 @@ def test_convex_withdraw_expired_lock(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x4b707540ec6eebf5e787c88df149e8141d2c295cda8a514da6d6111cf2deca40')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1704839507000)
     gas_str, amount_str = '0.008929295372796715', '26633.698252368450151266'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1704839507000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -998,4 +972,3 @@ def test_convex_withdraw_expired_lock(ethereum_inquirer, ethereum_accounts):
             address=CVX_LOCKER_V2,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_cowswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_cowswap.py
@@ -45,16 +45,15 @@ def test_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd4d16ea74bbf806715f5f0e799fd5e8befbf369a9e5461fa9c0ed88d72bd06e4')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1676976635000)
     full_amount = FVal('0.15463537')
     raw_amount = '0.15395918'
     fee_amount = '0.00067619'
     assert full_amount == FVal(raw_amount) + FVal(fee_amount)
-    expected_events = [
+    assert events == [
         EvmSwapEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1676976635000)),
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_WBTC,
@@ -89,7 +88,6 @@ def test_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
             address=GPV2_SETTLEMENT_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -98,12 +96,12 @@ def test_swap_token_to_token_limit_order(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x7674d6e3b8905cc4c6bc525d6cfa12dbb52de3093be0fe68038dfa7dafbdd849')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, spend_amount, receive_amount, fee_amount, a_pendle = TimestampMS(1726757699000), '295.166018766331437412', '1145.856590417709400049', '4.833981233668562588', Asset('eip155:1/erc20:0x808507121B80c02388fAd14726482e061B8da827')  # noqa: E501
+    a_pendle = Asset('eip155:1/erc20:0x808507121B80c02388fAd14726482e061B8da827')
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=222,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1726757699000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
@@ -119,7 +117,7 @@ def test_swap_token_to_token_limit_order(ethereum_inquirer, ethereum_accounts):
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=a_pendle,
-            amount=FVal(spend_amount),
+            amount=FVal(spend_amount := '295.166018766331437412'),
             location_label=user_address,
             notes=f'Swap {spend_amount} PENDLE in a cowswap limit order',
             counterparty=CPT_COWSWAP,
@@ -131,7 +129,7 @@ def test_swap_token_to_token_limit_order(ethereum_inquirer, ethereum_accounts):
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:1/erc20:0x22Fc5A29bd3d6CCe19a06f844019fd506fCe4455'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '1145.856590417709400049'),
             location_label=user_address,
             notes=f'Receive {receive_amount} ePendle as the result of a cowswap limit order',
             counterparty=CPT_COWSWAP,
@@ -143,7 +141,7 @@ def test_swap_token_to_token_limit_order(ethereum_inquirer, ethereum_accounts):
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.FEE,
             asset=a_pendle,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '4.833981233668562588'),
             location_label=user_address,
             notes=f'Spend {fee_amount} PENDLE as a cowswap fee',
             counterparty=CPT_COWSWAP,
@@ -158,16 +156,15 @@ def test_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd4d16ea74bbf806715f5f0e799fd5e8befbf369a9e5461fa9c0ed88d72bd06e4')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1676976635000)
     full_amount = FVal('99.99')
     raw_amount = '89.682951'
     fee_amount = '10.307049'
     assert full_amount == FVal(raw_amount) + FVal(fee_amount)
-    expected_events = [
+    assert events == [
         EvmSwapEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1676976635000)),
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_USDT,
@@ -202,7 +199,6 @@ def test_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
             address=GPV2_SETTLEMENT_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -213,17 +209,16 @@ def test_swap_token_to_eth_with_other_trade(ethereum_inquirer, ethereum_accounts
     tx_hash = deserialize_evm_tx_hash('0x31051b28d2b0a0365c2b518778af91180355f130f1fcf2b199faecd256093cc9')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, approval, amount_out, amount_in, fee_amount = TimestampMS(1718357603000), '115792089237316195423570985008687907853269984665640564039457.584007913129639935', '4987.831513391671511611', '0.861165556733956932', '12.168486608328488389'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=1,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1718357603000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=EvmToken('eip155:1/erc20:0x236501327e701692a281934230AF0b6BE8Df3353'),
-            amount=FVal(approval),
+            amount=FVal(approval := '115792089237316195423570985008687907853269984665640564039457.584007913129639935'),  # noqa: E501
             location_label=user_address,
             notes=f'Set FLT spending approval of {user_address} by 0xC92E8bdf79f0507f65a392b0ab4667716BFE0110 to {approval}',  # noqa: E501
             address=string_to_evm_address('0xC92E8bdf79f0507f65a392b0ab4667716BFE0110'),
@@ -234,7 +229,7 @@ def test_swap_token_to_eth_with_other_trade(ethereum_inquirer, ethereum_accounts
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=EvmToken('eip155:1/erc20:0x236501327e701692a281934230AF0b6BE8Df3353'),
-            amount=FVal(amount_out),
+            amount=FVal(amount_out := '4987.831513391671511611'),
             location_label=user_address,
             notes=f'Swap {amount_out} FLT in a cowswap market order',
             counterparty=CPT_COWSWAP,
@@ -246,7 +241,7 @@ def test_swap_token_to_eth_with_other_trade(ethereum_inquirer, ethereum_accounts
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=A_ETH,
-            amount=FVal(amount_in),
+            amount=FVal(amount_in := '0.861165556733956932'),
             location_label=user_address,
             notes=f'Receive {amount_in} ETH as the result of a cowswap market order',
             counterparty=CPT_COWSWAP,
@@ -258,14 +253,13 @@ def test_swap_token_to_eth_with_other_trade(ethereum_inquirer, ethereum_accounts
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.FEE,
             asset=EvmToken('eip155:1/erc20:0x236501327e701692a281934230AF0b6BE8Df3353'),
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '12.168486608328488389'),
             location_label=user_address,
             notes=f'Spend {fee_amount} FLT as a cowswap fee',
             counterparty=CPT_COWSWAP,
             address=GPV2_SETTLEMENT_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -274,16 +268,15 @@ def test_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xe2d6aa636623989061f1d762b19ca6fe6bc0edb5a890cf5a934a8fc6d42dcaca')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1676987243000)
     full_amount = FVal('24.311042505395616962')
     raw_amount = '24.304521595868826446'
     fee_amount = '0.006520909526790516'
     assert full_amount == FVal(raw_amount) + FVal(fee_amount)
-    expected_events = [
+    assert events == [
         EvmSwapEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1676987243000)),
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
@@ -318,7 +311,6 @@ def test_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
             address=GPV2_SETTLEMENT_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -335,7 +327,6 @@ def test_2_decoded_swaps(ethereum_inquirer, ethereum_accounts):
     user_address_1, user_address_2 = ethereum_accounts
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
 
-    timestamp = TimestampMS(1676976635000)
     asset_fund = Asset('eip155:1/erc20:0xe9B076B476D8865cDF79D1Cf7DF420EE397a7f75')
     full_amount1 = FVal('16000')
     raw_amount1 = '15977.954584364'
@@ -346,11 +337,11 @@ def test_2_decoded_swaps(ethereum_inquirer, ethereum_accounts):
     fee_amount2 = '10.307049'
     assert full_amount2 == FVal(raw_amount2) + FVal(fee_amount2)
 
-    expected_events = [
+    assert events == [
         EvmEvent(  # approval
             tx_ref=tx_hash,
             sequence_index=9,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1676976635000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
@@ -434,7 +425,6 @@ def test_2_decoded_swaps(ethereum_inquirer, ethereum_accounts):
             address=GPV2_SETTLEMENT_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -443,7 +433,7 @@ def test_place_eth_order(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x3619cc8d8f60541df0ea7d96d923efa4c783f53491af0d3ed1ed31de9fe15bcf')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -471,7 +461,6 @@ def test_place_eth_order(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x40A50cf069e992AA4536211B23F286eF88752187'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -480,7 +469,7 @@ def test_place_xdai_order(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0fa7c5936310a7fefa2b62597aea88fd152f73e736eee805d26e9337f461bc4f')  # noqa: E501
     user_address = gnosis_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -508,7 +497,6 @@ def test_place_xdai_order(gnosis_inquirer, gnosis_accounts):
             address=string_to_evm_address('0x40A50cf069e992AA4536211B23F286eF88752187'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -520,7 +508,7 @@ def test_swap_bnb_to_aave(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x2ef3e17313340294f80b2ac03f6e6d602da2f6617fdf9bb0aeda9d29f6a4960e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=binance_sc_inquirer, tx_hash=tx_hash)  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmSwapEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -559,7 +547,6 @@ def test_swap_bnb_to_aave(
             address=GPV2_SETTLEMENT_ADDRESS,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -571,7 +558,7 @@ def test_bnb_create_order(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xd1bd1b511948bcbef89304a4a6004eed3e99bb36b90b19a814ab3b3719cc98ad')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=binance_sc_inquirer, tx_hash=tx_hash)  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -599,7 +586,6 @@ def test_bnb_create_order(
             address=string_to_evm_address('0xbA3cB449bD2B4ADddBc894D8697F5170800EAdeC'),
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -608,7 +594,7 @@ def test_invalidate_eth_order(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5769b4634ae26ec93aebc80a50e0676b0793af485041b249652bd7ee6703a9f5')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -636,7 +622,6 @@ def test_invalidate_eth_order(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x40A50cf069e992AA4536211B23F286eF88752187'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -645,7 +630,7 @@ def test_invalidate_gnosis_order(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x68927e822317242ac1c0a0c71f2303725fc998164f1bb812f61b3053ef2a9a02')  # noqa: E501
     user_address = gnosis_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -673,7 +658,6 @@ def test_invalidate_gnosis_order(gnosis_inquirer, gnosis_accounts):
             address=string_to_evm_address('0x40A50cf069e992AA4536211B23F286eF88752187'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -682,7 +666,7 @@ def test_refund_eth_order(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x424f29ad7b865d764d89fe28767a7f34d177cad71cc123a2a8c0209aa0b70fda')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -698,7 +682,6 @@ def test_refund_eth_order(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x40A50cf069e992AA4536211B23F286eF88752187'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -707,7 +690,7 @@ def test_refund_gnosis_order(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0xb37be7c154ef4fb0fd291c647c21013abb10428181e64ba1c6305b77df929d0e')  # noqa: E501
     user_address = gnosis_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -723,7 +706,6 @@ def test_refund_gnosis_order(gnosis_inquirer, gnosis_accounts):
             address=string_to_evm_address('0x40A50cf069e992AA4536211B23F286eF88752187'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -732,16 +714,15 @@ def test_swap_gnosis_tokens(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x024e1da9dc2bf7ff88dd22643857979fcd954103860698203257b6db27778482')  # noqa: E501
     user_address = gnosis_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1691567755000)
     full_amount = FVal('59.848803')
     raw_amount = '59.847255'
     fee_amount = '0.001548'
     assert full_amount == FVal(raw_amount) + FVal(fee_amount)
-    expected_events = [
+    assert events == [
         EvmSwapEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1691567755000)),
             location=Location.GNOSIS,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:100/erc20:0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83'),
@@ -776,7 +757,6 @@ def test_swap_gnosis_tokens(gnosis_inquirer, gnosis_accounts):
             address=GPV2_SETTLEMENT_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -784,7 +764,7 @@ def test_swap_gnosis_tokens(gnosis_inquirer, gnosis_accounts):
 def test_swap_gnosis_monerium(gnosis_inquirer, gnosis_accounts):
     """The annoying problem with monerium's multiple versions messing with the decoder matching"""
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=(tx_hash := deserialize_evm_tx_hash('0x4f34125588875b708faae04c0711473171982b48f7c0f2de8ca33bc5dcc974a3')))  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmSwapEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -811,7 +791,6 @@ def test_swap_gnosis_monerium(gnosis_inquirer, gnosis_accounts):
             address=GPV2_SETTLEMENT_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -820,12 +799,11 @@ def test_ethereum_claim_airdrop(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8d33a6f1c37da1e2b77a4595425360361b6db79ec8811ff2eef810ebb9942044')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1644614818000)
     amount = FVal('15922.558465644366037906')
     assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1644614818000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -859,12 +837,11 @@ def test_gnosis_claim_airdrop(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x85540c0cb716efa6027ff9415c700ecb36d382aafa18749b9e66c67e66f47b8d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1644617690000)
     amount = FVal('34.73918333042108124')
     assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1644617690000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -898,12 +875,11 @@ def test_ethereum_vested_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xb6b58ea77542bfeec311c2df5707fe002b62c5a5d648aa17892d680f4e0d6e07')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704960791000)
     gas, amount = '0.001562177312628784', '4278.42414719412947787'
     assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1704960791000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -949,12 +925,11 @@ def test_gnosis_vested_claim(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x57ecb8f87eed5548cb375ea695531d6849843d6217771a5c25c957058a460243')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     user_address = gnosis_accounts[0]
-    timestamp = TimestampMS(1707738405000)
     gas, amount = '0.000520287498374868', '99.807039723201809834'
     assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1707738405000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -1000,16 +975,15 @@ def test_gnosis_claim_airdrop_with_xdai_payment(gnosis_inquirer, gnosis_accounts
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x1b82f080f70f00d63be3da2bed93834c254517640406aec949126020f7deb4c4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, payment_amount, claim_amount = TimestampMS(1644614725000), '0.00012231000065232', '864.055299539170506912', '5760.36866359447004608'  # noqa: E501
     assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1644614725000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.00012231000065232'),
             location_label=user_address,
             notes=f'Burn {gas_amount} XDAI for gas',
             tx_ref=tx_hash,
@@ -1020,7 +994,7 @@ def test_gnosis_claim_airdrop_with_xdai_payment(gnosis_inquirer, gnosis_accounts
             location=Location.GNOSIS,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_XDAI,
-            amount=FVal(payment_amount),
+            amount=FVal(payment_amount := '864.055299539170506912'),
             location_label=user_address,
             notes=f'Pay {payment_amount} XDAI to claim vCOW',
             tx_ref=tx_hash,
@@ -1032,7 +1006,7 @@ def test_gnosis_claim_airdrop_with_xdai_payment(gnosis_inquirer, gnosis_accounts
             location=Location.GNOSIS,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=A_GNOSIS_VCOW,
-            amount=FVal(claim_amount),
+            amount=FVal(claim_amount := '5760.36866359447004608'),
             location_label=user_address,
             notes=f'Claim {claim_amount} vCOW from cowswap airdrop',
             tx_ref=tx_hash,
@@ -1049,16 +1023,15 @@ def test_gnosis_claim_airdrop_with_gno_payment(gnosis_inquirer, gnosis_accounts)
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0xdae21fd2a64756326ba0bf119b8ee33cf41480fb758d0d7f17168fcc01622da1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, claim1_amount, payment_amount, claim2_amount = TimestampMS(1645776935000), '0.000259548002076384', '3559.387459031416241036', '2.085578589276220452', '3559.387459031416239786'  # noqa: E501
     assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1645776935000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000259548002076384'),
             location_label=user_address,
             notes=f'Burn {gas_amount} XDAI for gas',
             tx_ref=tx_hash,
@@ -1070,7 +1043,7 @@ def test_gnosis_claim_airdrop_with_gno_payment(gnosis_inquirer, gnosis_accounts)
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=A_GNOSIS_VCOW,
-            amount=FVal(claim1_amount),
+            amount=FVal(claim1_amount := '3559.387459031416241036'),
             location_label=user_address,
             notes=f'Claim {claim1_amount} vCOW from cowswap airdrop',
             tx_ref=tx_hash,
@@ -1083,7 +1056,7 @@ def test_gnosis_claim_airdrop_with_gno_payment(gnosis_inquirer, gnosis_accounts)
             location=Location.GNOSIS,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:100/erc20:0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb'),
-            amount=FVal(payment_amount),
+            amount=FVal(payment_amount := '2.085578589276220452'),
             location_label=user_address,
             notes=f'Pay {payment_amount} GNO to claim vCOW',
             tx_ref=tx_hash,
@@ -1095,7 +1068,7 @@ def test_gnosis_claim_airdrop_with_gno_payment(gnosis_inquirer, gnosis_accounts)
             location=Location.GNOSIS,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=A_GNOSIS_VCOW,
-            amount=FVal(claim2_amount),
+            amount=FVal(claim2_amount := '3559.387459031416239786'),
             location_label=user_address,
             notes=f'Claim {claim2_amount} vCOW from cowswap airdrop',
             tx_ref=tx_hash,
@@ -1109,14 +1082,13 @@ def test_gnosis_claim_airdrop_with_gno_payment(gnosis_inquirer, gnosis_accounts)
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_swap_token_to_token_arb(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xd1b5ca7b7616f827216d4fd541f87b5c4571e568754f1d05ad87370975d4c69a')  # noqa: E501
     user_address = arbitrum_one_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd1b5ca7b7616f827216d4fd541f87b5c4571e568754f1d05ad87370975d4c69a')),  # noqa: E501
     )
     swapped_amount, received_amount, fee_amount, timestamp = '0.208028640823960926', '0.228831', '0.011665366552986548', TimestampMS(1717523107000)  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(  # approval
             tx_ref=tx_hash,
             sequence_index=6,
@@ -1167,7 +1139,6 @@ def test_swap_token_to_token_arb(arbitrum_one_inquirer, arbitrum_one_accounts):
             address=GPV2_SETTLEMENT_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1178,14 +1149,14 @@ def test_gnosis_eure_v2(
 ):
     tx_hash = deserialize_evm_tx_hash('0xf751e1aa988888ab9edfa14ac98022c7d8241664f481fde40a418723b0fed009')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount, received_amount, fee_amount, user_address = TimestampMS(1725445370000), '0.00009974865514625', '0.254038701346779266', '0.00000025134485375', gnosis_accounts[0]  # noqa: E501
+    user_address = gnosis_accounts[0]
     assert events == [EvmSwapEvent(
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1725445370000)),
         location=Location.GNOSIS,
         event_subtype=HistoryEventSubType.SPEND,
         asset=Asset('eip155:100/erc20:0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6'),
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '0.00009974865514625'),
         location_label=user_address,
         notes=f'Swap {swap_amount} wstETH in a cowswap market order',
         tx_ref=tx_hash,
@@ -1197,7 +1168,7 @@ def test_gnosis_eure_v2(
         location=Location.GNOSIS,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '0.254038701346779266'),
         location_label=user_address,
         notes=f'Receive {received_amount} EURe as the result of a cowswap market order',
         tx_ref=tx_hash,
@@ -1210,7 +1181,7 @@ def test_gnosis_eure_v2(
         location=Location.GNOSIS,
         event_subtype=HistoryEventSubType.FEE,
         asset=Asset('eip155:100/erc20:0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6'),
-        amount=FVal(fee_amount),
+        amount=FVal(fee_amount := '0.00000025134485375'),
         location_label=user_address,
         notes=f'Spend {fee_amount} wstETH as a cowswap fee',
         counterparty=CPT_COWSWAP,
@@ -1336,10 +1307,9 @@ def test_cowswap_gnosis_token_to_native_via_curve(gnosis_inquirer, gnosis_accoun
     """Test that swapping a token for native XDAI on gnosis via cowswap is decoded
     correctly when the cowswap solver routes through a Curve pool. The Curve decoder
     must not claim the native XDAI transfer from the settlement to the user."""
-    tx_hash = deserialize_evm_tx_hash('0xa251a5069f7bddf590381ed6716f122f09df18ac89a6479ca6086b7981539a7e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xa251a5069f7bddf590381ed6716f122f09df18ac89a6479ca6086b7981539a7e')),  # noqa: E501
         load_global_caches=[CPT_CURVE],
     )
     user_address = gnosis_accounts[0]

--- a/rotkehlchen/tests/unit/decoders/test_crosscurve.py
+++ b/rotkehlchen/tests/unit/decoders/test_crosscurve.py
@@ -44,17 +44,16 @@ def test_crosscurve_bridge_send(optimism_inquirer: 'OptimismInquirer', optimism_
     """
     tx_hash = deserialize_evm_tx_hash('0xa2f971ba5af848948e0930ab0f86b70751d595e7c79111aa863681a117924e71')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, gas, fee_amount, bridge_amount = TimestampMS(1757661563000), '0.000000012981416497', '0.000009019739891817', '119.844544'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1757661563000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000000012981416497'),
             location_label=(user_address := optimism_accounts[0]),
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -66,7 +65,7 @@ def test_crosscurve_bridge_send(optimism_inquirer: 'OptimismInquirer', optimism_
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000009019739891817'),
             location_label=user_address,
             notes=f'Pay {fee_amount} ETH as CrossCurve bridge fee',
             counterparty=CPT_CROSSCURVE,
@@ -79,7 +78,7 @@ def test_crosscurve_bridge_send(optimism_inquirer: 'OptimismInquirer', optimism_
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:10/erc20:0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'),
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '119.844544'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} USDC via CrossCurve',
             counterparty=CPT_CROSSCURVE,
@@ -93,17 +92,16 @@ def test_crosscurve_bridge_send(optimism_inquirer: 'OptimismInquirer', optimism_
 def test_crosscurve_bridge_send_arbitrum(arbitrum_one_inquirer: 'ArbitrumOneInquirer', arbitrum_one_accounts: list[ChecksumEvmAddress]) -> None:  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x03177504cf5ed18c8cc29bc19a08c9f3ffb23d7f66b62ca43cdcba92346d621c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, gas, fee_amount, bridge_amount = TimestampMS(1741867858000), '0.00001096576', '0.000001467792495776', '12.694988'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1741867858000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00001096576'),
             location_label=(user_address := arbitrum_one_accounts[0]),
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -115,7 +113,7 @@ def test_crosscurve_bridge_send_arbitrum(arbitrum_one_inquirer: 'ArbitrumOneInqu
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000001467792495776'),
             location_label=user_address,
             notes=f'Pay {fee_amount} ETH as CrossCurve bridge fee',
             counterparty=CPT_CROSSCURVE,
@@ -128,7 +126,7 @@ def test_crosscurve_bridge_send_arbitrum(arbitrum_one_inquirer: 'ArbitrumOneInqu
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831'),
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '12.694988'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} USDC via CrossCurve',
             counterparty=CPT_CROSSCURVE,
@@ -145,17 +143,16 @@ def test_crosscurve_bridge_receive_via_curve(arbitrum_one_inquirer: 'ArbitrumOne
     """
     tx_hash = deserialize_evm_tx_hash('0x6d7d84478fe237e905ebfa831d2abe107d8cf5b0969cf8eaa5306f992ad85c24')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, receive_amount = TimestampMS(1729787659000), '452.673538'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=49,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1729787659000),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:42161/erc20:0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '452.673538'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Bridge {receive_amount} USDC.e via CrossCurve',
             counterparty=CPT_CROSSCURVE,
@@ -169,17 +166,16 @@ def test_crosscurve_bridge_receive_via_curve(arbitrum_one_inquirer: 'ArbitrumOne
 def test_crosscurve_bridge_receive(gnosis_inquirer: 'GnosisInquirer', gnosis_accounts: list[ChecksumEvmAddress]) -> None:  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0xd2c1698e07e82e0d0b61c5d22fb2c5f993f21a515322ba890678e772a13d0e08')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, receive_amount = TimestampMS(1757661890000), '101.714686532017583041'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=50,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1757661890000),
             location=Location.GNOSIS,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '101.714686532017583041'),
             location_label=(gnosis_accounts[0]),
             notes=f'Bridge {receive_amount} EURe via CrossCurve',
             counterparty=CPT_CROSSCURVE,

--- a/rotkehlchen/tests/unit/decoders/test_curve.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve.py
@@ -74,7 +74,6 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.types import ChecksumEvmAddress
 
-
 EXP18: Final = FVal(1e18)
 CURVE_SWAP_ROUTER_NG: Final = string_to_evm_address('0xd6681e74eEA20d196c15038C580f721EF2aB6320')
 
@@ -117,11 +116,10 @@ def test_curve_deposit(database, ethereum_transaction_decoder):
     https://etherscan.io/tx/0x523b7df8e168315e97a836a3d516d639908814785d7df1ef1745de3e55501982
     tests that a deposit for the aave pool in curve works correctly
     """
-    tx_hash = deserialize_evm_tx_hash('0x523b7df8e168315e97a836a3d516d639908814785d7df1ef1745de3e55501982')  # noqa: E501
     location_label = '0x57bF3B0f29E37619623994071C9e12091919675c'
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x523b7df8e168315e97a836a3d516d639908814785d7df1ef1745de3e55501982')),  # noqa: E501
         timestamp=1650276061,
         block_number=14608535,
         from_address=string_to_evm_address('0x57bF3B0f29E37619623994071C9e12091919675c'),
@@ -187,12 +185,11 @@ def test_curve_deposit(database, ethereum_transaction_decoder):
         transaction=transaction,
         tx_receipt=receipt,
     )
-    timestamp = TimestampMS(1650276061000)
     expected_events = [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1650276061000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -253,10 +250,9 @@ def test_curve_deposit_eth(database, ethereum_transaction_decoder):
     This tests uses the steth/eth pool to verify that deposits including transfer of ETH work
     properly
     """
-    tx_hash = deserialize_evm_tx_hash('0x51c052c8fb60f092f98ffc3cab6340c7c5348ee3b339582feba1c17cbd97ea56')  # noqa: E501
     location_label = '0x767B35b9F06F6e28e5ed05eE7C27bDf992eba5d2'
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x51c052c8fb60f092f98ffc3cab6340c7c5348ee3b339582feba1c17cbd97ea56')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=1650276061,
         block_number=14608535,
@@ -323,12 +319,11 @@ def test_curve_deposit_eth(database, ethereum_transaction_decoder):
         transaction=transaction,
         tx_receipt=receipt,
     )
-    timestamp = TimestampMS(1650276061000)
     expected_events = [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1650276061000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -408,7 +403,7 @@ def test_curve_deposit_add_liquidity_in_deposit_and_stake_topic(
         relevant_address=(user_address := ethereum_accounts[0]),
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -474,7 +469,6 @@ def test_curve_deposit_add_liquidity_in_deposit_and_stake_topic(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
@@ -488,10 +482,9 @@ def test_curve_remove_liquidity(
     https://etherscan.io/tx/0xd63dccdbebeede3a1f50b97c0a8592255203a0559880b80377daa39f915741b0
     This tests uses the link pool to verify that withdrawals are correctly decoded
     """
-    tx_hash = deserialize_evm_tx_hash('0xd63dccdbebeede3a1f50b97c0a8592255203a0559880b80377daa39f915741b0')  # noqa: E501
     location_label = string_to_evm_address('0xDf9f0AE722A3919fE7f9cC8805773ef142007Ca6')
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd63dccdbebeede3a1f50b97c0a8592255203a0559880b80377daa39f915741b0')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=Timestamp(1650276061),
         block_number=14608535,
@@ -559,12 +552,11 @@ def test_curve_remove_liquidity(
     )
     mocked_notifier = database.msg_aggregator.rotki_notifier
     assert len(mocked_notifier.messages) == 0, 'There is no gauge action, so there should be no message to refresh balances'  # noqa: E501
-    timestamp = TimestampMS(1650276061000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1650276061000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -600,7 +592,6 @@ def test_curve_remove_liquidity(
             counterparty=CPT_CURVE,
             address=string_to_evm_address('0xF178C0b5Bb7e7aBF4e12A4838C7b7c5bA2C623c0'),
         )]
-    assert expected_events == events
 
 
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
@@ -611,10 +602,9 @@ def test_curve_remove_liquidity_with_internal(database, ethereum_transaction_dec
     This tests uses the steth pool to verify that withdrawals are correctly decoded when an
     internal transaction is made for eth transfers
     """
-    tx_hash = deserialize_evm_tx_hash('0x30bb99f3e34fb1fbcf009320af7e290caf18b04b207319e15aa8ffbf645f4ad9')  # noqa: E501
     location_label = '0xa8005630caE7b7d2AFADD38FD3B3040d13cbE2BC'
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x30bb99f3e34fb1fbcf009320af7e290caf18b04b207319e15aa8ffbf645f4ad9')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=1650276061,
         block_number=14647221,
@@ -673,12 +663,11 @@ def test_curve_remove_liquidity_with_internal(database, ethereum_transaction_dec
         transaction=transaction,
         tx_receipt=receipt,
     )
-    timestamp = TimestampMS(1650276061000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1650276061000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -714,7 +703,6 @@ def test_curve_remove_liquidity_with_internal(database, ethereum_transaction_dec
             counterparty=CPT_CURVE,
             address=string_to_evm_address('0xDC24316b9AE028F1497c275EB9192a3Ea0f67022'),
         )]
-    assert expected_events == events
 
 
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
@@ -725,10 +713,9 @@ def test_curve_remove_imbalanced(database, ethereum_transaction_decoder):
     This tests uses the steth pool to verify that withdrawals are correctly decoded when an
     internal transaction is made for eth transfers
     """
-    tx_hash = deserialize_evm_tx_hash('0xd8832abcf4773abe24d8cda5581fb53bfb3850c535c1956d1d120a72a4ebcbd8')  # noqa: E501
     location_label = '0x2fac74A3a04B031F240923621a578724C40678af'
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd8832abcf4773abe24d8cda5581fb53bfb3850c535c1956d1d120a72a4ebcbd8')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=1650276061,
         block_number=14647221,
@@ -831,12 +818,11 @@ def test_curve_remove_imbalanced(database, ethereum_transaction_decoder):
         transaction=transaction,
         tx_receipt=receipt,
     )
-    timestamp = TimestampMS(1650276061000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1650276061000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -872,7 +858,6 @@ def test_curve_remove_imbalanced(database, ethereum_transaction_decoder):
             counterparty=CPT_CURVE,
             address=string_to_evm_address('0xbBC81d23Ea2c3ec7e56D39296F0cbB648873a5d3'),
         )]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -880,14 +865,13 @@ def test_curve_remove_imbalanced(database, ethereum_transaction_decoder):
 @pytest.mark.parametrize('ethereum_accounts', [['0x6Bb553FFC5716782051f51b564Bb149D9946f0d2']])
 def test_deposit_multiple_tokens(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
     """Check the case for a pool where multiple deposit events appear in the transaction"""
-    tx_hash = deserialize_evm_tx_hash('0xe954a396a02ebbea45a1d206c9918f717c55509c8138fccc63155d0262ef4dc4 ')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe954a396a02ebbea45a1d206c9918f717c55509c8138fccc63155d0262ef4dc4 ')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -928,24 +912,21 @@ def test_deposit_multiple_tokens(ethereum_transaction_decoder, ethereum_accounts
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x66215D23B8A247C80c2D1B7beF4BefC2AB384bCE']])
 def test_gauge_vote(ethereum_accounts, ethereum_transaction_decoder) -> None:
-    tx_hash = deserialize_evm_tx_hash('0xf67308b01613b3f75a71f2a3cea198acc063c987f17be4aaf5505a1ad70751ef')  # noqa: E501
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1685562071000)
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=cast('EthereumInquirer', ethereum_transaction_decoder.evm_inquirer),
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf67308b01613b3f75a71f2a3cea198acc063c987f17be4aaf5505a1ad70751ef')),  # noqa: E501
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1685562071000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -969,7 +950,6 @@ def test_gauge_vote(ethereum_accounts, ethereum_transaction_decoder) -> None:
             address=string_to_evm_address('0x740BA8aa0052E07b925908B380248cb03f3DE5cB'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -982,11 +962,10 @@ def test_gauge_deposit(
         ethereum_transaction_decoder,
         load_global_caches,
 ) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x5ae70d68241d85feac65c90e4546154e232dba9fecad9036bcec10082acc9d46')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=cast('EthereumInquirer', ethereum_transaction_decoder.evm_inquirer),
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5ae70d68241d85feac65c90e4546154e232dba9fecad9036bcec10082acc9d46')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     mocked_notifier = database.msg_aggregator.rotki_notifier
@@ -1000,7 +979,7 @@ def test_gauge_deposit(
             'blockchain': 'eth',
         },
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1028,21 +1007,19 @@ def test_gauge_deposit(
             address=string_to_evm_address('0xA90996896660DEcC6E997655E065b23788857849'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd80DF837766C8Edb6f11Bf7fD35703f87F2a31fB']])
 def test_gauge_withdraw(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):
-    tx_hash = deserialize_evm_tx_hash('0x055fc6cafcdae6b367d934e9385816f89153314c5abc5d3659a65778c90342d2')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x055fc6cafcdae6b367d934e9385816f89153314c5abc5d3659a65778c90342d2')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1071,21 +1048,19 @@ def test_gauge_withdraw(ethereum_transaction_decoder, ethereum_accounts, load_gl
             address=string_to_evm_address('0xA90996896660DEcC6E997655E065b23788857849'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('ethereum_accounts', [['0x0E9Fed33f6a202146a615De0FA1985adFb461467']])
 def test_gauge_claim_rewards(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):
-    tx_hash = deserialize_evm_tx_hash('0xe01bc48ddb3df6eb721c122c5ddaea705b771bfb8db407e3a96ae9bab6584453')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe01bc48ddb3df6eb721c122c5ddaea705b771bfb8db407e3a96ae9bab6584453')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1114,7 +1089,6 @@ def test_gauge_claim_rewards(ethereum_transaction_decoder, ethereum_accounts, lo
             address=string_to_evm_address('0xA90996896660DEcC6E997655E065b23788857849'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1122,14 +1096,13 @@ def test_gauge_claim_rewards(ethereum_transaction_decoder, ethereum_accounts, lo
 @pytest.mark.parametrize('ethereum_accounts', [['0xA8d7Fb04877C3FBf175DE76FA3D2fa66c770537F']])
 def test_curve_trade_token_to_token(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
     """Test that trading token to token in curve is decoded correctly"""
-    tx_hash = deserialize_evm_tx_hash('0xaa176ce742d62b663656572f8cc53d63d6c00cd2c3adde32293e4028a5e0693c ')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xaa176ce742d62b663656572f8cc53d63d6c00cd2c3adde32293e4028a5e0693c ')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1169,7 +1142,6 @@ def test_curve_trade_token_to_token(ethereum_transaction_decoder, ethereum_accou
             address=string_to_evm_address('0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1177,14 +1149,13 @@ def test_curve_trade_token_to_token(ethereum_transaction_decoder, ethereum_accou
 @pytest.mark.parametrize('ethereum_accounts', [['0x8a1B73A88E1854Dd3EeBEe4354Bd4DbA23861E3A']])
 def test_curve_trade_eth_to_token(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
     """Test that trading eth to token in curve is decoded correctly"""
-    tx_hash = deserialize_evm_tx_hash('0x34d6674d8d46b8a6c546b04b4c748b82d42a688f562fe80a8d02e9180a684d09')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x34d6674d8d46b8a6c546b04b4c748b82d42a688f562fe80a8d02e9180a684d09')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1224,7 +1195,6 @@ def test_curve_trade_eth_to_token(ethereum_transaction_decoder, ethereum_account
             address=string_to_evm_address('0xA96A65c051bF88B4095Ee1f2451C2A9d43F53Ae2'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1232,14 +1202,13 @@ def test_curve_trade_eth_to_token(ethereum_transaction_decoder, ethereum_account
 @pytest.mark.parametrize('ethereum_accounts', [['0x38abab9766e0b27d2912718a884292b8E7eb2803']])
 def test_curve_trade_exchange_underlying(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
     """Test that if exchange_underlying is happening the trade is decoded correctly"""
-    tx_hash = deserialize_evm_tx_hash('0xed73e8717c9b2571a9cd7c0563e013c569e757920a050b1120ff1e6f5f3d3b8f ')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xed73e8717c9b2571a9cd7c0563e013c569e757920a050b1120ff1e6f5f3d3b8f ')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1279,20 +1248,18 @@ def test_curve_trade_exchange_underlying(ethereum_transaction_decoder, ethereum_
             address=string_to_evm_address('0x8038C01A0390a8c547446a0b2c18fc9aEFEcc10c'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0x3Da232a0c0A5C59918D7B5fF77bf1c8Fc93aeE1B']])
 def test_curve_swap_router(ethereum_transaction_decoder, ethereum_accounts):
     """Test that transactions made via curve swap router are decoded correctly"""
-    tx_hash = deserialize_evm_tx_hash('0xd561728d989c4d8a25ca6708051cdb265dbc455927bb8c355083b790101487e9 ')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd561728d989c4d8a25ca6708051cdb265dbc455927bb8c355083b790101487e9 ')),  # noqa: E501
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1332,7 +1299,6 @@ def test_curve_swap_router(ethereum_transaction_decoder, ethereum_accounts):
             address=string_to_evm_address('0x99a58482BD75cbab83b27EC03CA68fF489b5788f'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1340,15 +1306,14 @@ def test_curve_swap_router(ethereum_transaction_decoder, ethereum_accounts):
 @pytest.mark.parametrize('ethereum_accounts', [['0xdE206bC0Fde2eF5C8BB6A1d552a64F82A2407Be4']])
 def test_curve_usdn_add_liquidity(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
     """Check that adding liquidity to a curve pool using the USDN contract is properly decoded."""
-    tx_hash = deserialize_evm_tx_hash('0x6c28df56ae4a7f784577273f72402a9b6640024327ee952fdde72c9cfdf08da5')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6c28df56ae4a7f784577273f72402a9b6640024327ee952fdde72c9cfdf08da5')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     timestamp = TimestampMS(Timestamp(1674470159000))
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1389,7 +1354,6 @@ def test_curve_usdn_add_liquidity(ethereum_transaction_decoder, ethereum_account
             address=string_to_evm_address('0x094d12e5b541784701FD8d65F11fc0598FBC6332'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1397,15 +1361,14 @@ def test_curve_usdn_add_liquidity(ethereum_transaction_decoder, ethereum_account
 @pytest.mark.parametrize('ethereum_accounts', [['0x6d84264A7bD2Cffa4A117BA2350403b3A9866949']])
 def test_curve_usdn_remove_liquidity(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
     """Check that removing liquidity from a curve pool using the USDN contract is properly decoded."""  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0x4d77fba437b9dee6679dbb0f238b123f01b7b1bdd41bf46e35b00ce016cf8ab2')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x4d77fba437b9dee6679dbb0f238b123f01b7b1bdd41bf46e35b00ce016cf8ab2')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     timestamp = TimestampMS(Timestamp(1676708639000))
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1485,7 +1448,6 @@ def test_curve_usdn_remove_liquidity(ethereum_transaction_decoder, ethereum_acco
             address=string_to_evm_address('0x094d12e5b541784701FD8d65F11fc0598FBC6332'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1493,19 +1455,17 @@ def test_curve_usdn_remove_liquidity(ethereum_transaction_decoder, ethereum_acco
 @pytest.mark.parametrize('ethereum_accounts', [['0xcbE942516AE7687d80a5fF94F8f9A203Be800713']])
 def test_3pool_add_liquidity(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):
     """Check that adding liquidity to a curve pool using the 3Pool zap contract is properly decoded."""  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0xf7c6764b832069785eeee22a078f4cb3c92149c25eb0bdc6bba36ebd1598c255')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf7c6764b832069785eeee22a078f4cb3c92149c25eb0bdc6bba36ebd1598c255')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1680503171000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1680503171000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -1542,7 +1502,6 @@ def test_3pool_add_liquidity(ethereum_transaction_decoder, ethereum_accounts, lo
             address=string_to_evm_address('0x0000000000000000000000000000000000000000'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1550,19 +1509,17 @@ def test_3pool_add_liquidity(ethereum_transaction_decoder, ethereum_accounts, lo
 @pytest.mark.parametrize('ethereum_accounts', [['0xC7BFb2ED20D14407C78cc1FC4a4Abe39f1964964']])
 def test_3pool_remove_liquidity(ethereum_transaction_decoder, ethereum_accounts, load_global_caches):  # noqa: E501
     """Check that removing liquidity from a curve pool using the 3Pool zap contract is properly decoded."""  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0xbf4a445d0452e2f1e046c3ab3d10018c801e2acae89051c98332e9264f36d7f7')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xbf4a445d0452e2f1e046c3ab3d10018c801e2acae89051c98332e9264f36d7f7')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1680390095000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1680390095000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -1638,7 +1595,6 @@ def test_3pool_remove_liquidity(ethereum_transaction_decoder, ethereum_accounts,
             address=string_to_evm_address('0xA79828DF1850E8a3A3064576f380D90aECDD3359'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1649,14 +1605,13 @@ def test_remove_from_aave_pool(ethereum_transaction_decoder, ethereum_accounts, 
     Test that if liquidity is removed from a pool with a(aave) tokens,
     the events are decoded correctly.
     """
-    tx_hash = deserialize_evm_tx_hash('0xb0a45bc41a83b2bdf2e06b9913a2e4c8b0d7f3080030807a0a06f301287424e9')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb0a45bc41a83b2bdf2e06b9913a2e4c8b0d7f3080030807a0a06f301287424e9')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1698,7 +1653,6 @@ def test_remove_from_aave_pool(ethereum_transaction_decoder, ethereum_accounts, 
             address=string_to_evm_address('0x028171bCA77440897B824Ca71D1c56caC55b68A3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1709,14 +1663,13 @@ def test_deposit_via_zap_in_metapool(ethereum_transaction_decoder, ethereum_acco
     Test that deposits via a zap to a metapool (when there are 2 AddLiquidity events emitted)
     are decoded correctly.
     """
-    tx_hash = deserialize_evm_tx_hash('0x3e39ef142826b80da629023bdbdbee77fcc7402d5845f92507c60c404f4441b8')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x3e39ef142826b80da629023bdbdbee77fcc7402d5845f92507c60c404f4441b8')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1771,7 +1724,6 @@ def test_deposit_via_zap_in_metapool(ethereum_transaction_decoder, ethereum_acco
             address=string_to_evm_address('0x0000000000000000000000000000000000000000'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1782,14 +1734,13 @@ def test_no_zap_event(ethereum_transaction_decoder, ethereum_accounts, load_glob
     Checks that if a curve zap is used, but there is no zap-specific event emitted (only event from
     the used pool is emitted), transaction is still decoded correctly.
     """
-    tx_hash = deserialize_evm_tx_hash('0xc8617f0adcd6273c522359a244bb6908f8ea9232879884d572fd64d5b33e5e83 ')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc8617f0adcd6273c522359a244bb6908f8ea9232879884d572fd64d5b33e5e83 ')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1831,19 +1782,17 @@ def test_no_zap_event(ethereum_transaction_decoder, ethereum_accounts, load_glob
             address=string_to_evm_address('0x5a6A4D54456819380173272A5E8E9B9904BdF41B'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x1d5E65a087eBc3d03a294412E46CE5D6882969f4']])
 def test_gauge_bribe_v2(ethereum_transaction_decoder, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x5ac0cf3073b0c6c722b17d08d56cc1d9064717405d7e23b1f92e5a8c88e647e1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5ac0cf3073b0c6c722b17d08d56cc1d9064717405d7e23b1f92e5a8c88e647e1')),  # noqa: E501
     )
     user_address, timestamp, gas, amount = ethereum_accounts[0], TimestampMS(1680736307000), '0.007331605001682333', '14.752122471808652238'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1871,30 +1820,28 @@ def test_gauge_bribe_v2(ethereum_transaction_decoder, ethereum_accounts):
             address=GAUGE_BRIBE_V2,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x1c362DFE864a4c4b3311eC97bf0b8320CB0a4952']])
 def test_curve_deposit_polygon(polygon_pos_inquirer, polygon_pos_accounts, load_global_caches):
-    tx_hash = deserialize_evm_tx_hash('0x6cb9d7ceb55a1063c17b58cb643e699525ca6037e711c34283cf0f3d6e81716e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6cb9d7ceb55a1063c17b58cb643e699525ca6037e711c34283cf0f3d6e81716e')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, pool_address, deposit_amount, approve_amount, received_amount, gas_fees = TimestampMS(1718015936000), string_to_evm_address('0x445FE580eF8d70FF569aB36e80c647af338db351'), '2.12', '0.88', '1.87538744644899407', '0.0127938000149261'  # noqa: E501
-    expected_events = [
+    pool_address = string_to_evm_address('0x445FE580eF8d70FF569aB36e80c647af338db351')
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1718015936000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_POL,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.0127938000149261'),
             location_label=polygon_pos_accounts[0],
             notes=f'Burn {gas_fees} POL for gas',
             counterparty=CPT_GAS,
@@ -1906,7 +1853,7 @@ def test_curve_deposit_polygon(polygon_pos_inquirer, polygon_pos_accounts, load_
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=A_POLYGON_POS_USDT,
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '0.88'),
             location_label=polygon_pos_accounts[0],
             notes=f'Set USDT spending approval of {polygon_pos_accounts[0]} by {pool_address} to {approve_amount}',  # noqa: E501
             address=pool_address,
@@ -1918,7 +1865,7 @@ def test_curve_deposit_polygon(polygon_pos_inquirer, polygon_pos_accounts, load_
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_POLYGON_POS_USDT,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '2.12'),
             location_label=polygon_pos_accounts[0],
             notes=f'Deposit {deposit_amount} USDT in curve pool {pool_address}',
             counterparty=CPT_CURVE,
@@ -1931,14 +1878,13 @@ def test_curve_deposit_polygon(polygon_pos_inquirer, polygon_pos_accounts, load_
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=EvmToken('eip155:137/erc20:0xE7a24EF0C5e95Ffb0f6684b813A78F2a3AD7D171'),
-            amount=FVal(received_amount),
+            amount=FVal(received_amount := '1.87538744644899407'),
             location_label=polygon_pos_accounts[0],
             notes=f'Receive {received_amount} am3CRV after depositing in curve pool {pool_address}',  # noqa: E501
             counterparty=CPT_CURVE,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1946,8 +1892,7 @@ def test_curve_deposit_polygon(polygon_pos_inquirer, polygon_pos_accounts, load_
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('optimism_accounts', [['0x1CD90D091C5c13Bb7e7612a90485C6F38B826Fdd']])
 def test_gauge_deposit_optimism(database, optimism_inquirer, optimism_accounts, load_global_caches):  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0x271f5ee9fddc8e2a2df4187f70b6192acb42661a7d35e934fa68d8778b196c71')  # noqa: E501
-    timestamp, gauge_address, deposit_amount, gas_fees = TimestampMS(1718022201000), string_to_evm_address('0xB280fab4817C54796F9E6147aa1ad0198CFEfb41'), '218.705051991330164886', '0.000020026564634882'  # noqa: E501
+    gauge_address = string_to_evm_address('0xB280fab4817C54796F9E6147aa1ad0198CFEfb41')
     get_or_create_evm_token(  # gauge token should already exist in db by reloading cache tokens
         userdb=database,
         evm_address=gauge_address,
@@ -1958,19 +1903,19 @@ def test_gauge_deposit_optimism(database, optimism_inquirer, optimism_accounts, 
     )
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x271f5ee9fddc8e2a2df4187f70b6192acb42661a7d35e934fa68d8778b196c71')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1718022201000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000020026564634882'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -1982,7 +1927,7 @@ def test_gauge_deposit_optimism(database, optimism_inquirer, optimism_accounts, 
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:10/erc20:0xd8dD9a8b2AcA88E68c46aF9008259d0EC04b7751'),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '218.705051991330164886'),
             location_label=optimism_accounts[0],
             notes=f'Deposit {deposit_amount} 3CRV-OP into {gauge_address} curve gauge',
             counterparty=CPT_CURVE,
@@ -2002,15 +1947,13 @@ def test_gauge_deposit_optimism(database, optimism_inquirer, optimism_accounts, 
             address=ZERO_ADDRESS,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('gnosis_accounts', [['0xD4f9FE0039Da59e6DDb21bbb6E84e0C9e83D73eD']])
 def test_gauge_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts, load_global_caches):
-    tx_hash = deserialize_evm_tx_hash('0x29d1b4a219dfb19562a3915191e6bcc64652ff072daf56216e40267408860474')  # noqa: E501
-    timestamp, gauge_address, withdraw_amount, gas_fees = TimestampMS(1717896445000), string_to_evm_address('0x05cd911eE9B60C28FCEE4ea03Cc5670637D955B1'), '19576.247352101772081083', '0.000196106001764954'  # noqa: E501
+    gauge_address = string_to_evm_address('0x05cd911eE9B60C28FCEE4ea03Cc5670637D955B1')
     get_or_create_evm_token(  # gauge token should already exist in db by reloading cache tokens
         userdb=database,
         evm_address=gauge_address,
@@ -2021,19 +1964,19 @@ def test_gauge_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts, load_
     )
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x29d1b4a219dfb19562a3915191e6bcc64652ff072daf56216e40267408860474')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1717896445000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000196106001764954'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas_fees} XDAI for gas',
             counterparty=CPT_GAS,
@@ -2045,7 +1988,7 @@ def test_gauge_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts, load_
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset(f'eip155:100/erc20:{gauge_address}'),
-            amount=FVal(withdraw_amount),
+            amount=FVal(withdraw_amount := '19576.247352101772081083'),
             location_label=gnosis_accounts[0],
             notes=f'Return {withdraw_amount} crvUSDsDAI-gauge to withdraw from {gauge_address} curve gauge',  # noqa: E501
             counterparty=CPT_CURVE,
@@ -2065,7 +2008,6 @@ def test_gauge_withdraw_gnosis(database, gnosis_inquirer, gnosis_accounts, load_
             address=string_to_evm_address(gauge_address),
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -2075,17 +2017,16 @@ def test_curve_swap_router_base(base_inquirer, base_accounts):
     """Test that transactions made via the new curve swap router are decoded correctly"""
     tx_hash = deserialize_evm_tx_hash('0x6fee2438337aefe297a69d4361ff4d743865ef7fce6637e9e3e544af0c19184f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount, receive_amount, gas_fees = TimestampMS(1718096041000), '0.01702', '59.996794', '0.000001665983350053'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1718096041000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000001665983350053'),
             location_label=base_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -2096,7 +2037,7 @@ def test_curve_swap_router_base(base_inquirer, base_accounts):
             location=Location.BASE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
-            amount=FVal(swap_amount),
+            amount=FVal(swap_amount := '0.01702'),
             location_label=base_accounts[0],
             notes=f'Swap {swap_amount} ETH in curve',
             counterparty=CPT_CURVE,
@@ -2108,38 +2049,36 @@ def test_curve_swap_router_base(base_inquirer, base_accounts):
             location=Location.BASE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '59.996794'),
             location_label=base_accounts[0],
             notes=f'Receive {receive_amount} USDC as the result of a swap in curve',
             counterparty=CPT_CURVE,
             address=CURVE_SWAP_ROUTER_NG,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x8800AcEDF5571F35675CF8Aa1E3C16C7A8da0088']])
 def test_deposit_via_zap_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts, load_global_caches):  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0x5a72b9be1302cc4b9e1d79e61134b0b7f225b3a4aa723c27c557a672c29791ce')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5a72b9be1302cc4b9e1d79e61134b0b7f225b3a4aa723c27c557a672c29791ce')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, pool_address, approve_amount, deposit_amount, receive_amount, gas_fees = TimestampMS(1718104329000), string_to_evm_address('0x73aF1150F265419Ef8a5DB41908B700C32D49135'), '115792089237316195423570985008687907853269984665640564039457584007877854.731259', '10000', '10003.6614101799549838', '0.0000058597'  # noqa: E501
+    pool_address = string_to_evm_address('0x73aF1150F265419Ef8a5DB41908B700C32D49135')
     arbitrum_usdt = Asset('eip155:42161/erc20:0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1718104329000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.0000058597'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -2151,7 +2090,7 @@ def test_deposit_via_zap_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts, 
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=arbitrum_usdt,
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '115792089237316195423570985008687907853269984665640564039457584007877854.731259'),  # noqa: E501
             location_label=arbitrum_one_accounts[0],
             notes=f'Set USDT spending approval of {arbitrum_one_accounts[0]} by {DEPOSIT_AND_STAKE_ZAP} to {approve_amount}',  # noqa: E501
             address=DEPOSIT_AND_STAKE_ZAP,
@@ -2163,7 +2102,7 @@ def test_deposit_via_zap_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts, 
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=arbitrum_usdt,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '10000'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Deposit {deposit_amount} USDT in curve pool {pool_address}',
             counterparty=CPT_CURVE,
@@ -2176,26 +2115,24 @@ def test_deposit_via_zap_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts, 
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:42161/erc20:0x030786336Bc7833D4325404A25FE451e4fde9807'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '10003.6614101799549838'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Receive {receive_amount} crvUSDT-gauge after depositing in a curve pool',
             counterparty=CPT_CURVE,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x5e216ceCB65E1E1B86fE8C46c730af287c4492Dc']])
 def test_fee_distributor_3crv(ethereum_transaction_decoder, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xae8a3781fc8f8b032f4e14db7745f9e4297f61e58a3deebc93d55ef4ed99d728')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xae8a3781fc8f8b032f4e14db7745f9e4297f61e58a3deebc93d55ef4ed99d728')),  # noqa: E501
     )
     user_address, timestamp, gas, amount = ethereum_accounts[0], TimestampMS(1697289611000), '0.002010414684866136', '112.875618618497828084'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -2223,19 +2160,17 @@ def test_fee_distributor_3crv(ethereum_transaction_decoder, ethereum_accounts):
             address=FEE_DISTRIBUTOR_3CRV,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x6544df975cF58A0b2C9a361a8db2e00D338e10c1']])
 def test_fee_distributor_crvusd(ethereum_transaction_decoder, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x200c154d4206ece5b7c4075064991d10afdcc488da29c88b366409b0d7e348c1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x200c154d4206ece5b7c4075064991d10afdcc488da29c88b366409b0d7e348c1')),  # noqa: E501
     )
     user_address, timestamp, gas, amount = ethereum_accounts[0], TimestampMS(1746466763000), '0.000382962892805733', '13.357652880447616117'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -2263,19 +2198,17 @@ def test_fee_distributor_crvusd(ethereum_transaction_decoder, ethereum_accounts)
             address=FEE_DISTRIBUTOR_CRVUSD,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x510B0068C0756bBEFCBaffB6567e467d661291FE']])
 def test_vote_escrow_deposit(ethereum_transaction_decoder, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x2675807cf1950b8a8fbd64e1a0fe0ec3b894ba88fbb8e544ddf279aff12c6d55')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x2675807cf1950b8a8fbd64e1a0fe0ec3b894ba88fbb8e544ddf279aff12c6d55')),  # noqa: E501
     )
     user_address, timestamp, gas, amount, locktime = ethereum_accounts[0], TimestampMS(1671946199000), '0.002774219663106188', '128.808146476393839874', Timestamp(1778112000)  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -2304,19 +2237,17 @@ def test_vote_escrow_deposit(ethereum_transaction_decoder, ethereum_accounts):
             extra_data={'locktime': locktime},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x3142A7Cb03dB13419884b275f61f8542C8850174']])
 def test_vote_escrow_withdraw(ethereum_transaction_decoder, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x5bae0df2aeedc70f82488e8b19030c39d782cd5f58ca66155a5347320c4349a5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5bae0df2aeedc70f82488e8b19030c39d782cd5f58ca66155a5347320c4349a5')),  # noqa: E501
     )
     user_address, timestamp, gas, amount = ethereum_accounts[0], TimestampMS(1671887987000), '0.002702199385335098', '1.872144205854855426'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -2344,19 +2275,17 @@ def test_vote_escrow_withdraw(ethereum_transaction_decoder, ethereum_accounts):
             address=VOTING_ESCROW,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x5bfF1A68663ff91b0650327D83D4230Cd00023Ad']])
 def test_vote_escrow_extend(ethereum_transaction_decoder, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xa5e0ac08412a932f9f8547834bc8c0bce26eff1b78442367716e4a2ea8951c87')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xa5e0ac08412a932f9f8547834bc8c0bce26eff1b78442367716e4a2ea8951c87')),  # noqa: E501
     )
     user_address, timestamp, gas, locktime = ethereum_accounts[0], TimestampMS(1764169943000), '0.000019398914753065', Timestamp(1879718400)  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -2385,19 +2314,17 @@ def test_vote_escrow_extend(ethereum_transaction_decoder, ethereum_accounts):
             extra_data={'locktime': locktime},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x98C5adD2e63C02beB8CCAA0156E4FefD480C3267']])
 def test_crv_minter(ethereum_transaction_decoder, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x05b5da4f6f0def6075c2cb51b8c46553144424368c69b9ad9f986cf925ac0fae')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x05b5da4f6f0def6075c2cb51b8c46553144424368c69b9ad9f986cf925ac0fae')),  # noqa: E501
     )
     user_address, timestamp, gas, amount = ethereum_accounts[0], TimestampMS(1746419195000), '0.000161308740471675', '86.51016103664373998'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -2425,30 +2352,28 @@ def test_crv_minter(ethereum_transaction_decoder, ethereum_accounts):
             address=CURVE_MINTER,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_gauge_deposit_and_stake(gnosis_inquirer, gnosis_accounts, load_global_caches):
-    tx_hash = deserialize_evm_tx_hash('0x52141e28c55744cdfddaa1ab5614642f61459d7624a51981e21ec06176c8f65c')  # noqa: E501
-    timestamp, gauge_address, deposited_amount, gas_fees, received_amount = TimestampMS(1717744880000), string_to_evm_address('0xd91770E868c7471a9585d1819143063A40c54D00'), '834.517942394847767492', '0.0023483922', '431.905365995549947348'  # noqa: E501
+    gauge_address = string_to_evm_address('0xd91770E868c7471a9585d1819143063A40c54D00')
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x52141e28c55744cdfddaa1ab5614642f61459d7624a51981e21ec06176c8f65c')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1717744880000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.0023483922'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas_fees} XDAI for gas',
             counterparty=CPT_GAS,
@@ -2460,7 +2385,7 @@ def test_gauge_deposit_and_stake(gnosis_inquirer, gnosis_accounts, load_global_c
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:100/erc20:0xcB444e90D8198415266c6a2724b7900fb12FC56E'),
-            amount=FVal(deposited_amount),
+            amount=FVal(deposited_amount := '834.517942394847767492'),
             location_label=gnosis_accounts[0],
             notes=f'Deposit {deposited_amount} EURe into {gauge_address} curve gauge',
             counterparty=CPT_CURVE,
@@ -2473,7 +2398,7 @@ def test_gauge_deposit_and_stake(gnosis_inquirer, gnosis_accounts, load_global_c
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset(f'eip155:100/erc20:{gauge_address}'),
-            amount=FVal(received_amount),
+            amount=FVal(received_amount := '431.905365995549947348'),
             location_label=gnosis_accounts[0],
             notes=f'Receive {received_amount} crvEUReUSD-gauge after depositing in {gauge_address} curve gauge',  # noqa: E501
             counterparty=CPT_CURVE,
@@ -2486,24 +2411,23 @@ def test_gauge_deposit_and_stake(gnosis_inquirer, gnosis_accounts, load_global_c
 @pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
 @pytest.mark.parametrize('gnosis_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_gauge_deposit_and_stake_multiple(gnosis_inquirer, gnosis_accounts, load_global_caches):
-    tx_hash = deserialize_evm_tx_hash('0xcbeaaee59405d5f7fd456dc510f1b841cc1329cd9624255ce64c894ac6643bd7')  # noqa: E501
-    timestamp, gauge_address, gas_fees, received_amount = TimestampMS(1719684750000), string_to_evm_address('0xd91770E868c7471a9585d1819143063A40c54D00'), '0.0023626991', '0.567442277824060065'  # noqa: E501
+    gauge_address = string_to_evm_address('0xd91770E868c7471a9585d1819143063A40c54D00')
     deposited_eur, deposited_usdc = '0.551864219634212696', '0.593161'
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xcbeaaee59405d5f7fd456dc510f1b841cc1329cd9624255ce64c894ac6643bd7')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1719684750000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.0023626991'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas_fees} XDAI for gas',
             counterparty=CPT_GAS,
@@ -2541,7 +2465,7 @@ def test_gauge_deposit_and_stake_multiple(gnosis_inquirer, gnosis_accounts, load
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset(f'eip155:100/erc20:{gauge_address}'),
-            amount=FVal(received_amount),
+            amount=FVal(received_amount := '0.567442277824060065'),
             location_label=gnosis_accounts[0],
             notes=f'Receive {received_amount} crvEUReUSD-gauge after depositing in {gauge_address} curve gauge',  # noqa: E501
             counterparty=CPT_CURVE,
@@ -2556,23 +2480,22 @@ def test_gauge_deposit_and_stake_multiple(gnosis_inquirer, gnosis_accounts, load
 def test_liquidity_withdrawal(gnosis_inquirer, gnosis_accounts, load_global_caches):
     """Test that a withdrawal in the case of pools that have underlying pools
     is correctly decoded"""
-    tx_hash = deserialize_evm_tx_hash('0x7645bfeb43a1ccacd3f8eb29c496823bd73586498ff7b79be5a3a48145f1c4b4')  # noqa: E501
-    timestamp, pool_address, gas_fees, removed_amount, returned_amount = TimestampMS(1719046465000), string_to_evm_address('0x0CA1C1eC4EBf3CC67a9f545fF90a3795b318cA4a'), '0.000813878', '1656.600276747801451581', '850'  # noqa: E501
+    pool_address = string_to_evm_address('0x0CA1C1eC4EBf3CC67a9f545fF90a3795b318cA4a')
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x7645bfeb43a1ccacd3f8eb29c496823bd73586498ff7b79be5a3a48145f1c4b4')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1719046465000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000813878'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas_fees} XDAI for gas',
             counterparty=CPT_GAS,
@@ -2584,7 +2507,7 @@ def test_liquidity_withdrawal(gnosis_inquirer, gnosis_accounts, load_global_cach
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset(f'eip155:100/erc20:{pool_address}'),
-            amount=FVal(returned_amount),
+            amount=FVal(returned_amount := '850'),
             location_label=gnosis_accounts[0],
             notes=f'Return {returned_amount} crvEUReUSD',
             counterparty=CPT_CURVE,
@@ -2597,14 +2520,13 @@ def test_liquidity_withdrawal(gnosis_inquirer, gnosis_accounts, load_global_cach
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=Asset('eip155:100/erc20:0xcB444e90D8198415266c6a2724b7900fb12FC56E'),
-            amount=FVal(removed_amount),
+            amount=FVal(removed_amount := '1656.600276747801451581'),
             location_label=gnosis_accounts[0],
             notes=f'Remove {removed_amount} EURe from 0x056C6C5e684CeC248635eD86033378Cc444459B0 curve pool',  # noqa: E501
             counterparty=CPT_CURVE,
             address=string_to_evm_address('0xE3FFF29d4DC930EBb787FeCd49Ee5963DADf60b6'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -2615,23 +2537,22 @@ def test_monerium_eure_v2(gnosis_inquirer, gnosis_accounts, load_global_caches):
     This test pulls a transaction after the deployment of the monerium v2 contracts
     and checks that we ignore correctly the log events emitted by the v1 contract.
     """
-    tx_hash = deserialize_evm_tx_hash('0x1a2f03a1d89bb9ac019e6445c6d30ab32d85ca8e45ecbdf33d026700de5f7103')  # noqa: E501
-    timestamp, pool_address, gas_fees, removed_amount, returned_amount = TimestampMS(1724679110000), string_to_evm_address('0x0CA1C1eC4EBf3CC67a9f545fF90a3795b318cA4a'), '0.0004379778', '0.019043275513941527', '0.01'  # noqa: E501
+    pool_address = string_to_evm_address('0x0CA1C1eC4EBf3CC67a9f545fF90a3795b318cA4a')
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x1a2f03a1d89bb9ac019e6445c6d30ab32d85ca8e45ecbdf33d026700de5f7103')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1724679110000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.0004379778'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas_fees} XDAI for gas',
             counterparty=CPT_GAS,
@@ -2643,7 +2564,7 @@ def test_monerium_eure_v2(gnosis_inquirer, gnosis_accounts, load_global_caches):
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset(f'eip155:100/erc20:{pool_address}'),
-            amount=FVal(returned_amount),
+            amount=FVal(returned_amount := '0.01'),
             location_label=gnosis_accounts[0],
             notes=f'Return {returned_amount} crvEUReUSD',
             counterparty=CPT_CURVE,
@@ -2656,7 +2577,7 @@ def test_monerium_eure_v2(gnosis_inquirer, gnosis_accounts, load_global_caches):
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
-            amount=FVal(removed_amount),
+            amount=FVal(removed_amount := '0.019043275513941527'),
             location_label=gnosis_accounts[0],
             notes=f'Remove {removed_amount} EURe from 0x056C6C5e684CeC248635eD86033378Cc444459B0 curve pool',  # noqa: E501
             counterparty=CPT_CURVE,
@@ -2743,12 +2664,12 @@ def test_deposit_order(gnosis_inquirer, gnosis_accounts, load_global_caches):
     """Ensure that multiple deposits when depositing and staking keep the correct order.
     This is a regression test for an issue where the approval was in between the other deposits.
     """
-    tx_hash = deserialize_evm_tx_hash('0x2b2999cee4447d27e27abe7ad926c12a875e296ddc4ad7af77ff52b13e74d39f')  # noqa: E501
-    timestamp, deposited_eure, deposited_usdc, gas_fees, received_amount, user, contract = TimestampMS(1735459260000), '2.234019807771402726', '1.580616', '0.0011870912', '1.902024272971248158', gnosis_accounts[0], string_to_evm_address('0x37c5ab57AF7100Bdc9B668d766e193CCbF6614FD')  # noqa: E501
+    user = gnosis_accounts[0]
+    contract = string_to_evm_address('0x37c5ab57AF7100Bdc9B668d766e193CCbF6614FD')
     gauge_address = string_to_evm_address('0xd91770E868c7471a9585d1819143063A40c54D00')
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x2b2999cee4447d27e27abe7ad926c12a875e296ddc4ad7af77ff52b13e74d39f')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
 
@@ -2756,12 +2677,12 @@ def test_deposit_order(gnosis_inquirer, gnosis_accounts, load_global_caches):
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1735459260000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.0011870912'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas_fees} XDAI for gas',
             counterparty=CPT_GAS,
@@ -2788,7 +2709,7 @@ def test_deposit_order(gnosis_inquirer, gnosis_accounts, load_global_caches):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
-            amount=FVal(deposited_eure),
+            amount=FVal(deposited_eure := '2.234019807771402726'),
             location_label=gnosis_accounts[0],
             notes=f'Deposit {deposited_eure} EURe into {gauge_address} curve gauge',
             counterparty=CPT_CURVE,
@@ -2801,7 +2722,7 @@ def test_deposit_order(gnosis_inquirer, gnosis_accounts, load_global_caches):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:100/erc20:0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83'),
-            amount=FVal(deposited_usdc),
+            amount=FVal(deposited_usdc := '1.580616'),
             location_label=gnosis_accounts[0],
             notes=f'Deposit {deposited_usdc} USDC into {gauge_address} curve gauge',
             counterparty=CPT_CURVE,
@@ -2814,7 +2735,7 @@ def test_deposit_order(gnosis_inquirer, gnosis_accounts, load_global_caches):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset(f'eip155:100/erc20:{gauge_address}'),
-            amount=FVal(received_amount),
+            amount=FVal(received_amount := '1.902024272971248158'),
             location_label=gnosis_accounts[0],
             notes=f'Receive {received_amount} crvEUReUSD-gauge after depositing in {gauge_address} curve gauge',  # noqa: E501
             counterparty=CPT_CURVE,
@@ -2895,11 +2816,10 @@ def test_deposit_eure_arb(
         populate_curve_pool_cache,
 ):
     """This test checks that we decode properly the optimized curve pools for deposits"""
-    tx_hash = deserialize_evm_tx_hash('0x2f45f0308d2df41155d59bc40564b11cebc661794485727e50f9a99861159512')  # noqa: E501
-    timestamp, gas_fees, pool_addr = TimestampMS(1745307832000), '0.00001019049207', string_to_evm_address('0x590f7e2b211Fa5Ff7840Dd3c425B543363797701')  # noqa: E501
+    pool_addr = string_to_evm_address('0x590f7e2b211Fa5Ff7840Dd3c425B543363797701')
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x2f45f0308d2df41155d59bc40564b11cebc661794485727e50f9a99861159512')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
 
@@ -2907,12 +2827,12 @@ def test_deposit_eure_arb(
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1745307832000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.00001019049207'),
             location_label=(user_address := arbitrum_one_accounts[0]),
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -2970,11 +2890,10 @@ def test_withdraw_eure_arb(
         populate_curve_pool_cache,
 ):
     """This test checks that we decode properly the optimized curve pools for withdrawals"""
-    tx_hash = deserialize_evm_tx_hash('0x601dddf2b0b7557f62ad449e14c06367a501cb2133ed947ea11c0b6cdf8286d2')  # noqa: E501
-    timestamp, gas_fees, pool_addr = TimestampMS(1744700948000), '0.00000114612', string_to_evm_address('0x590f7e2b211Fa5Ff7840Dd3c425B543363797701')  # noqa: E501
+    pool_addr = string_to_evm_address('0x590f7e2b211Fa5Ff7840Dd3c425B543363797701')
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x601dddf2b0b7557f62ad449e14c06367a501cb2133ed947ea11c0b6cdf8286d2')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
 
@@ -2982,12 +2901,12 @@ def test_withdraw_eure_arb(
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1744700948000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.00000114612'),
             location_label=(user_address := arbitrum_one_accounts[0]),
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -3042,10 +2961,9 @@ def test_remove_liquidity_single_token(
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x047c4283007fb778632f75c01984cd9f8a9847b03d9753cb37eb7530bd16615c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x047c4283007fb778632f75c01984cd9f8a9847b03d9753cb37eb7530bd16615c')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [EvmEvent(
@@ -3102,10 +3020,9 @@ def test_remove_liquidity_single_token_2(
     """This test differs from test_remove_liquidity_single_token in that the tx uses a slightly
     different RemoveLiquidityOne method with a different topic0.
     """
-    tx_hash = deserialize_evm_tx_hash('0xb0bb3e348d87978d26c5b790f3417d4212e8b553feb253d097c11f20f3a36e26')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb0bb3e348d87978d26c5b790f3417d4212e8b553feb253d097c11f20f3a36e26')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [EvmEvent(
@@ -3157,10 +3074,9 @@ def test_remove_liquidity_two_assets(
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x48334f00f1c4b34bc3be3a661c4e7f6efcd4d4046aaed5ecdaa99ab57ce3bbbe')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x48334f00f1c4b34bc3be3a661c4e7f6efcd4d4046aaed5ecdaa99ab57ce3bbbe')),  # noqa: E501
         relevant_address=arbitrum_one_accounts[0],
         load_global_caches=load_global_caches,
     )
@@ -3228,21 +3144,21 @@ def test_mint_crv_arb(
     This happens when claiming from gauges since CRV gets minted in the
     ChildLiquidityGaugeFactory contract.
     """
-    tx_hash = deserialize_evm_tx_hash('0xe2a426f58da4ec5221fcdd797377d4d384954dbdeadf28a0fdb840db4357c7d7')  # noqa: E501
-    timestamp, gas_fees, gauge_addr, user_address = TimestampMS(1745598811000), '0.00000377319', string_to_evm_address('0xae0f794Bc4Cad74739354223b167dbD04A3Ac6A5'), arbitrum_one_accounts[0]  # noqa: E501
+    gauge_addr = string_to_evm_address('0xae0f794Bc4Cad74739354223b167dbD04A3Ac6A5')
+    user_address = arbitrum_one_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe2a426f58da4ec5221fcdd797377d4d384954dbdeadf28a0fdb840db4357c7d7')),  # noqa: E501
     )
     assert events == [EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1745598811000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.00000377319'),
             location_label=user_address,
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -3267,10 +3183,9 @@ def test_mint_crv_arb(
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('base_accounts', [['0x77BDF564A1f9cE5A5785a36Fc77cC4fFbEcD3a19']])
 def test_curve_router_v1_2(base_inquirer: 'BaseInquirer', base_accounts: list['ChecksumEvmAddress']) -> None:  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0x72e4c09bd07884df800dea65063b5a2cff22ec697f5644bb17dea14db5cb99e1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x72e4c09bd07884df800dea65063b5a2cff22ec697f5644bb17dea14db5cb99e1')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -3320,10 +3235,9 @@ def test_twocrypto_deposit(
         load_global_caches,
         populate_curve_pool_cache,
 ):
-    tx_hash = deserialize_evm_tx_hash('0x146c01752d19e2b109c36575264150bc39628cfaa1bf8e778ec43938a3282b2b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x146c01752d19e2b109c36575264150bc39628cfaa1bf8e778ec43938a3282b2b')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     expected_events = [EvmEvent(
@@ -3389,10 +3303,9 @@ def test_twocrypto_removal(
         load_global_caches,
         populate_curve_pool_cache,
 ):
-    tx_hash = deserialize_evm_tx_hash('0x31e83874ca81405c66564011963f43e29dabcfe1e7972b8fb70e17e95dfd5773')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x31e83874ca81405c66564011963f43e29dabcfe1e7972b8fb70e17e95dfd5773')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [EvmEvent(
@@ -3445,10 +3358,9 @@ def test_tricrypto_deposit(
         load_global_caches,
 ):
     """We have this pool in the packaged globaldb cache so there is no need to add it."""
-    tx_hash = deserialize_evm_tx_hash('0xa221cd73fe9adbda515338b8642bc5d93c19c6f65acf0f22672cc00b05d6b0e8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xa221cd73fe9adbda515338b8642bc5d93c19c6f65acf0f22672cc00b05d6b0e8')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     pool_address = string_to_evm_address('0x7F86Bf177Dd4F3494b841a37e810A34dD56c829B')

--- a/rotkehlchen/tests/unit/decoders/test_curve_crvusd.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve_crvusd.py
@@ -54,17 +54,17 @@ def test_create_loan(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x164fc91dc34c9107715bbdc9a43f038e5c5e6b578bea535557f66328434f553a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, deposit_amount, receive_amount, approve_amount = TimestampMS(1741679231000), ethereum_accounts[0], '0.000893214862428306', '16', '26000', '115792089237316195423570985008687907853269984665640564039441.584007913129639935'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1741679231000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000893214862428306'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -76,7 +76,7 @@ def test_create_loan(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:1/erc20:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'),
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '115792089237316195423570985008687907853269984665640564039441.584007913129639935'),  # noqa: E501
             location_label=user_address,
             notes=f'Set wstETH spending approval of {user_address} by {crvusd_controller} to {approve_amount}',  # noqa: E501
             address=crvusd_controller,
@@ -88,7 +88,7 @@ def test_create_loan(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=Asset('eip155:1/erc20:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '16'),
             location_label=user_address,
             notes=f'Deposit {deposit_amount} wstETH as collateral on Curve',
             counterparty=CPT_CURVE,
@@ -101,7 +101,7 @@ def test_create_loan(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.GENERATE_DEBT,
             asset=Asset('eip155:1/erc20:0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '26000'),
             location_label=user_address,
             notes=f'Borrow {receive_amount} crvUSD from Curve',
             counterparty=CPT_CURVE,
@@ -121,17 +121,17 @@ def test_borrow_more(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xdb0872be57c7354043b578739c9d2566ec79dddf7ca7f93201b334f9c46cd15a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, receive_amount = TimestampMS(1742385419000), ethereum_accounts[0], '0.001382156244932288', '500'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1742385419000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.001382156244932288'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -143,7 +143,7 @@ def test_borrow_more(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.GENERATE_DEBT,
             asset=Asset('eip155:1/erc20:0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '500'),
             location_label=user_address,
             notes=f'Borrow {receive_amount} crvUSD from Curve',
             counterparty=CPT_CURVE,
@@ -163,17 +163,17 @@ def test_repay(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xe899e752f17209be62d912c24585823df2d53fda0b84d8a16901015b4a947e77')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, repay_amount = TimestampMS(1742391011000), ethereum_accounts[0], '0.00256845168196309', '100931.806980654679668337'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1742391011000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.00256845168196309'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -197,7 +197,7 @@ def test_repay(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.PAYBACK_DEBT,
             asset=Asset('eip155:1/erc20:0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E'),
-            amount=FVal(repay_amount),
+            amount=FVal(repay_amount := '100931.806980654679668337'),
             location_label=user_address,
             notes=f'Repay {repay_amount} crvUSD to Curve',
             counterparty=CPT_CURVE,
@@ -216,17 +216,17 @@ def test_remove_collateral(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xe53f1e91d37d06c9c1408be97dd6c5ed9701ca56fb6dbe46f1567d022e2f8783')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, withdraw_amount = TimestampMS(1742411687000), ethereum_accounts[0], '0.0018137064', '0.3'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1742411687000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.0018137064'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -238,7 +238,7 @@ def test_remove_collateral(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
             asset=Asset('eip155:1/erc20:0x18084fbA666a33d37592fA2633fD49a74DD93a88'),
-            amount=FVal(withdraw_amount),
+            amount=FVal(withdraw_amount := '0.3'),
             location_label=user_address,
             notes=f'Withdraw {withdraw_amount} tBTC from Curve loan collateral',
             counterparty=CPT_CURVE,
@@ -257,16 +257,16 @@ def test_borrow_extended(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xf79aa5972f2233b65f32cfdaa9ea14d7a325ebae85c633be7ebd37677903a032')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, deposit_amount = TimestampMS(1742167583000), ethereum_accounts[0], '0.00154011', '0.30677231'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1742167583000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.00154011'),
         location_label=user_address,
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -278,7 +278,7 @@ def test_borrow_extended(
         event_type=HistoryEventType.DEPOSIT,
         event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
         asset=Asset('eip155:1/erc20:0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'),
-        amount=FVal(deposit_amount),
+        amount=FVal(deposit_amount := '0.30677231'),
         location_label=user_address,
         notes=f'Deposit {deposit_amount} WBTC into a leveraged Curve position',
         counterparty=CPT_CURVE,
@@ -295,16 +295,16 @@ def test_peg_keeper_update_provide(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xb557deee6fcf5fcbb03b539f81413a32e5ac40ccbc4915bcab291136b2049461')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, reward_amount = TimestampMS(1742991251000), ethereum_accounts[0], '0.00040529528116216', '0.263578930549885631'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1742991251000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.00040529528116216'),
         location_label=user_address,
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -316,7 +316,7 @@ def test_peg_keeper_update_provide(
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.REWARD,
         asset=Asset('eip155:1/erc20:0x4DEcE678ceceb27446b35C672dC7d61F30bAD69E'),
-        amount=FVal(reward_amount),
+        amount=FVal(reward_amount := '0.263578930549885631'),
         location_label=user_address,
         notes=f'Receive {reward_amount} crvUSDUSDC-f from Curve peg keeper update',
         counterparty=CPT_CURVE,
@@ -332,16 +332,16 @@ def test_peg_keeper_update_withdraw(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x26ef0b958dcfe3bb3d27232a90cac132d4387e7e5b2f40f48b0e32080c154b32')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, reward_amount = TimestampMS(1742617019000), ethereum_accounts[0], '0.0002972191728', '0.801175881145139442'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1742617019000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.0002972191728'),
         location_label=user_address,
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -353,7 +353,7 @@ def test_peg_keeper_update_withdraw(
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.REWARD,
         asset=Asset('eip155:1/erc20:0x4DEcE678ceceb27446b35C672dC7d61F30bAD69E'),
-        amount=FVal(reward_amount),
+        amount=FVal(reward_amount := '0.801175881145139442'),
         location_label=user_address,
         notes=f'Receive {reward_amount} crvUSDUSDC-f from Curve peg keeper update',
         counterparty=CPT_CURVE,

--- a/rotkehlchen/tests/unit/decoders/test_curve_lend.py
+++ b/rotkehlchen/tests/unit/decoders/test_curve_lend.py
@@ -161,17 +161,17 @@ def test_vault_deposit(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xd7e237db5c10970fd4a5a8bccfc87412fad75680d1358a5d39b4a76ba9ffafa6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, approve_amount, deposit_amount, receive_amount = TimestampMS(1732052219000), arbitrum_one_accounts[0], '0.00000265801', '115792089237316195423570985008687907853269984665640564039400.04103445561341153', '57.542973457516228405', '55862.682306216187960829'  # noqa: E501
+    user_address = arbitrum_one_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732052219000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.00000265801'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -183,7 +183,7 @@ def test_vault_deposit(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=arbitrum_vault_underlying_token,
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '115792089237316195423570985008687907853269984665640564039400.04103445561341153'),  # noqa: E501
             location_label=user_address,
             notes=f'Set crvUSD spending approval of {user_address} by {arbitrum_vault_token.evm_address} to {approve_amount}',  # noqa: E501
             address=arbitrum_vault_token.evm_address,
@@ -195,7 +195,7 @@ def test_vault_deposit(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=arbitrum_vault_underlying_token,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '57.542973457516228405'),
             location_label=user_address,
             notes=f'Deposit {deposit_amount} crvUSD in a Curve lending vault',
             counterparty=CPT_CURVE,
@@ -208,7 +208,7 @@ def test_vault_deposit(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=arbitrum_vault_token,
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '55862.682306216187960829'),
             location_label=user_address,
             notes=f'Receive {receive_amount} cvcrvUSD after deposit in a Curve lending vault',
             counterparty=CPT_CURVE,
@@ -228,17 +228,17 @@ def test_vault_withdraw(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x8f4fe62eebad90a24fd8fb74835dfa3c3cf9d3c38b20ade6425dde54ca98bdd4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, return_amount, withdraw_amount = TimestampMS(1728498363000), optimism_accounts[0], '0.000003575441143222', '99843.76002478005399335', '99.84376024374592538'  # noqa: E501
+    user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1728498363000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000003575441143222'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -250,7 +250,7 @@ def test_vault_withdraw(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=optimism_vault_token,
-            amount=FVal(return_amount),
+            amount=FVal(return_amount := '99843.76002478005399335'),
             location_label=user_address,
             notes=f'Return {return_amount} cvcrvUSD to a Curve lending vault',
             counterparty=CPT_CURVE,
@@ -263,7 +263,7 @@ def test_vault_withdraw(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=optimism_vault_underlying_token,
-            amount=FVal(withdraw_amount),
+            amount=FVal(withdraw_amount := '99.84376024374592538'),
             location_label=user_address,
             notes=f'Withdraw {withdraw_amount} crvUSD from a Curve lending vault',
             counterparty=CPT_CURVE,
@@ -282,17 +282,17 @@ def test_create_loan(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xcaaba5f6206de1a1d3a82a213616548b928397052300057a420ff8083d385b78')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, deposit_amount, receive_amount = TimestampMS(1731831407000), ethereum_accounts[0], '0.004991520607076806', '0.00011219', '6.178023671273738089'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731831407000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.004991520607076806'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -304,7 +304,7 @@ def test_create_loan(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=A_WBTC,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '0.00011219'),
             location_label=user_address,
             notes=f'Deposit {deposit_amount} WBTC as collateral on Curve',
             counterparty=CPT_CURVE,
@@ -317,7 +317,7 @@ def test_create_loan(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.GENERATE_DEBT,
             asset=ethereum_vault_underlying_token,
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '6.178023671273738089'),
             location_label=user_address,
             notes=f'Borrow {receive_amount} crvUSD from Curve',
             counterparty=CPT_CURVE,
@@ -337,17 +337,17 @@ def test_borrow_more(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x6b18af9bf79af5b73a88d6049a4c4e6e67cb6ff43f505b6363e48f3c7aa492ff')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, deposit_amount, receive_amount = TimestampMS(1731312083000), ethereum_accounts[0], '0.005761739463351035', '2', '53000'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731312083000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.005761739463351035'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -359,7 +359,7 @@ def test_borrow_more(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=A_WBTC,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '2'),
             location_label=user_address,
             notes=f'Deposit {deposit_amount} WBTC as collateral on Curve',
             counterparty=CPT_CURVE,
@@ -372,7 +372,7 @@ def test_borrow_more(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.GENERATE_DEBT,
             asset=ethereum_vault_underlying_token,
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '53000'),
             location_label=user_address,
             notes=f'Borrow {receive_amount} crvUSD from Curve',
             counterparty=CPT_CURVE,
@@ -391,17 +391,17 @@ def test_create_leveraged_position_with_collateral_asset(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x94b703880541dd23c4d0d76b3d5bb4ed36e97e5ef7c164fcc8ec081395953699')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, deposit_amount = TimestampMS(1730919179000), ethereum_accounts[0], '0.014631358400811703', '0.72'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1730919179000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.014631358400811703'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -413,7 +413,7 @@ def test_create_leveraged_position_with_collateral_asset(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=A_WBTC,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '0.72'),
             location_label=user_address,
             notes=f'Deposit {deposit_amount} WBTC into a leveraged Curve position',
             counterparty=CPT_CURVE,
@@ -433,17 +433,17 @@ def test_create_leveraged_position_with_borrowed_asset(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x609e8b1b6cf5465441b6d7093b3429b6f8b3c19e0f73c45c8b8f66a47fa9f1bd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, deposit_amount, approve_amount = TimestampMS(1732282256000), arbitrum_one_accounts[0], '0.000812275832834', '3246.108076837089130632', '115792089237316195423570985008687907853269984665640563990215.977712874902778703'  # noqa: E501
+    user_address = arbitrum_one_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732282256000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000812275832834'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -455,7 +455,7 @@ def test_create_leveraged_position_with_borrowed_asset(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=arbitrum_vault_underlying_token,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '3246.108076837089130632'),
             location_label=user_address,
             notes=f'Deposit {deposit_amount} crvUSD into a leveraged Curve position',
             counterparty=CPT_CURVE,
@@ -469,7 +469,7 @@ def test_create_leveraged_position_with_borrowed_asset(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=arbitrum_vault_underlying_token,
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '115792089237316195423570985008687907853269984665640563990215.977712874902778703'),  # noqa: E501
             location_label=user_address,
             notes=f'Set crvUSD spending approval of {user_address} by 0x61C404B60ee9c5fB09F70F9A645DD38fE5b3A956 to {approve_amount}',  # noqa: E501
             address=string_to_evm_address('0x61C404B60ee9c5fB09F70F9A645DD38fE5b3A956'),
@@ -487,17 +487,17 @@ def test_partially_repay_loan(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xec6ea0854141775c7adaf90e5e29c7f34574d3725411f7fe2d354505bb2377ac')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, repay_amount, approve_amount = TimestampMS(1732021665000), arbitrum_one_accounts[0], '0.00000807639', '75.812999322471416588', '115792089237316195423570985008687907853269984665640564038872.139121074632427607'  # noqa: E501
+    user_address = arbitrum_one_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732021665000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.00000807639'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -509,7 +509,7 @@ def test_partially_repay_loan(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.PAYBACK_DEBT,
             asset=arbitrum_vault_underlying_token,
-            amount=FVal(repay_amount),
+            amount=FVal(repay_amount := '75.812999322471416588'),
             location_label=user_address,
             notes=f'Repay {repay_amount} crvUSD to Curve',
             counterparty=CPT_CURVE,
@@ -522,7 +522,7 @@ def test_partially_repay_loan(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=arbitrum_vault_underlying_token,
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '115792089237316195423570985008687907853269984665640564038872.139121074632427607'),  # noqa: E501
             location_label=user_address,
             notes=f'Set crvUSD spending approval of {user_address} by 0xB5c6082d3307088C98dA8D79991501E113e6365d to {approve_amount}',  # noqa: E501
             address=string_to_evm_address('0xB5c6082d3307088C98dA8D79991501E113e6365d'),
@@ -540,17 +540,17 @@ def test_close_loan_using_collateral(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xcca62e6832e2df6f4ff3ca5240069e2d4548dfd23ed8f08c448e4917b916d3df')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, receive1_amount, receive2_amount = TimestampMS(1732139413000), arbitrum_one_accounts[0], '0.00000751744', '0.311352637896780974', '0.009899999999999997'  # noqa: E501
+    user_address = arbitrum_one_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732139413000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.00000751744'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -562,7 +562,7 @@ def test_close_loan_using_collateral(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
             asset=arbitrum_vault_underlying_token,
-            amount=FVal(receive1_amount),
+            amount=FVal(receive1_amount := '0.311352637896780974'),
             location_label=user_address,
             notes=f'Withdraw {receive1_amount} crvUSD from Curve after repaying loan',
             counterparty=CPT_CURVE,
@@ -575,7 +575,7 @@ def test_close_loan_using_collateral(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
             asset=A_WETH_ARB,
-            amount=FVal(receive2_amount),
+            amount=FVal(receive2_amount := '0.009899999999999997'),
             location_label=user_address,
             notes=f'Withdraw {receive2_amount} WETH from Curve after repaying loan',
             counterparty=CPT_CURVE,
@@ -594,17 +594,17 @@ def test_close_loan_using_borrowed(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x34443f7d317affc6bd2c05207f1ff57b29a15039f7bdc0442feb53e279ba81b2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, repay_amount, receive_amount, approve_amount = TimestampMS(1731958927000), arbitrum_one_accounts[0], '0.000008437093425', '0.001195651117770074', '0.450001578098145238', '115792089237316195423570985008687907853269984665640564036198.434455739459094936'  # noqa: E501
+    user_address = arbitrum_one_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731958927000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000008437093425'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -616,7 +616,7 @@ def test_close_loan_using_borrowed(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.PAYBACK_DEBT,
             asset=arbitrum_vault_underlying_token,
-            amount=FVal(repay_amount),
+            amount=FVal(repay_amount := '0.001195651117770074'),
             location_label=user_address,
             notes=f'Repay {repay_amount} crvUSD to Curve',
             counterparty=CPT_CURVE,
@@ -629,7 +629,7 @@ def test_close_loan_using_borrowed(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
             asset=A_WETH_ARB,
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '0.450001578098145238'),
             location_label=user_address,
             notes=f'Withdraw {receive_amount} WETH from Curve after repaying loan',
             counterparty=CPT_CURVE,
@@ -642,7 +642,7 @@ def test_close_loan_using_borrowed(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=arbitrum_vault_underlying_token,
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '115792089237316195423570985008687907853269984665640564036198.434455739459094936'),  # noqa: E501
             location_label=user_address,
             notes=f'Set crvUSD spending approval of {user_address} by 0xB5c6082d3307088C98dA8D79991501E113e6365d to {approve_amount}',  # noqa: E501
             address=string_to_evm_address('0xB5c6082d3307088C98dA8D79991501E113e6365d'),
@@ -659,17 +659,17 @@ def test_remove_collateral(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x9798a5e29c83428b79279202514cc61137c04f3fe2150ab36cf4c767a0fb5aab')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, receive_amount = TimestampMS(1731862176000), arbitrum_one_accounts[0], '0.00000584546', '0.1'  # noqa: E501
+    user_address = arbitrum_one_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731862176000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.00000584546'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -681,7 +681,7 @@ def test_remove_collateral(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
             asset=A_WETH_ARB,
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '0.1'),
             location_label=user_address,
             notes=f'Withdraw {receive_amount} WETH from Curve loan collateral',
             counterparty=CPT_CURVE,
@@ -699,17 +699,17 @@ def test_add_collateral(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x8090a4ac2314e1700ea6e77d480a2cb576722110febb6a9ea321df7ae7a2988d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, deposit_amount, approve_amount = TimestampMS(1731700246000), arbitrum_one_accounts[0], '0.00000464924', '0.022629905446385494', '115792089237316195423570985008687907853269984665640564039456.319129670009705311'  # noqa: E501
+    user_address = arbitrum_one_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731700246000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.00000464924'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -721,7 +721,7 @@ def test_add_collateral(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=A_WETH_ARB,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '0.022629905446385494'),
             location_label=user_address,
             notes=f'Deposit {deposit_amount} WETH as collateral on Curve',
             counterparty=CPT_CURVE,
@@ -734,7 +734,7 @@ def test_add_collateral(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=A_WETH_ARB,
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '115792089237316195423570985008687907853269984665640564039456.319129670009705311'),  # noqa: E501
             location_label=user_address,
             notes=f'Set WETH spending approval of {user_address} by 0xB5c6082d3307088C98dA8D79991501E113e6365d to {approve_amount}',  # noqa: E501
             address=string_to_evm_address('0xB5c6082d3307088C98dA8D79991501E113e6365d'),
@@ -751,17 +751,17 @@ def test_deposit_into_lending_vault_gauge(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x547aa41360bb39e32e14d4d70bf2a2285635d6c9306549f5e62fbaa355500f9e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, deposit_and_receive_amount = TimestampMS(1741528686000), arbitrum_one_accounts[0], '0.000004084593092', '35147690.896605748325841967'  # noqa: E501
-    expected_events = [
+    user_address = arbitrum_one_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1741528686000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000004084593092'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -773,7 +773,7 @@ def test_deposit_into_lending_vault_gauge(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:42161/erc20:0x0E6Ad128D7E217439bEEa90695FE7ec859c7F98C'),
-            amount=FVal(deposit_and_receive_amount),
+            amount=FVal(deposit_and_receive_amount := '35147690.896605748325841967'),
             location_label=user_address,
             notes=f'Deposit {deposit_and_receive_amount} cvcrvUSD into cvcrvUSD-gauge',
             counterparty=CPT_CURVE,
@@ -793,7 +793,6 @@ def test_deposit_into_lending_vault_gauge(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -805,17 +804,17 @@ def test_withdraw_from_lending_vault_gauge(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xe4e6ce22451a1dbadbb72b99123ce4a04d8b56f63be6fd49f0b6493430bdb772')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, return_and_withdrawn_amount = TimestampMS(1741752784000), arbitrum_one_accounts[0], '0.000005044185033', '95369.61296121579592937'  # noqa: E501
-    expected_events = [
+    user_address = arbitrum_one_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1741752784000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000005044185033'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -827,7 +826,7 @@ def test_withdraw_from_lending_vault_gauge(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset('eip155:42161/erc20:0x6ba9bF35158dCB0dC9F71CFe1EED9D5c75cd3836'),
-            amount=FVal(return_and_withdrawn_amount),
+            amount=FVal(return_and_withdrawn_amount := '95369.61296121579592937'),
             location_label=user_address,
             notes=f'Return {return_and_withdrawn_amount} cvcrvUSD-gauge to withdraw from curve lending vault gauge',  # noqa: E501
             counterparty=CPT_CURVE,
@@ -847,7 +846,6 @@ def test_withdraw_from_lending_vault_gauge(
             address=string_to_evm_address('0x6ba9bF35158dCB0dC9F71CFe1EED9D5c75cd3836'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -859,17 +857,17 @@ def test_claim_rewards_from_lending_vault_gauge(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x8ada83b9904451335617d625c9f9ba255af193be786149c2914a1f81468d85fe')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, reward_amount = TimestampMS(1740833839000), arbitrum_one_accounts[0], '0.0000008302', '0.037091751198938204'  # noqa: E501
+    user_address = arbitrum_one_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1740833839000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.0000008302'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -881,7 +879,7 @@ def test_claim_rewards_from_lending_vault_gauge(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_ARB,
-            amount=FVal(reward_amount),
+            amount=FVal(reward_amount := '0.037091751198938204'),
             location_label=user_address,
             notes=f'Receive {reward_amount} ARB rewards from curve lending cvcrvUSD-gauge',
             counterparty=CPT_CURVE,

--- a/rotkehlchen/tests/unit/decoders/test_defisaver.py
+++ b/rotkehlchen/tests/unit/decoders/test_defisaver.py
@@ -14,13 +14,12 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd312551890858CC313Bf1718F502FF9fcDB2e6ff']])
 def test_subscribe(ethereum_inquirer, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x6c9e1aac8818eb5d40761f8c65041a227aec8d4d140b7e1684be80259b0f2138')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6c9e1aac8818eb5d40761f8c65041a227aec8d4d140b7e1684be80259b0f2138')),  # noqa: E501
     )
     user_address, timestamp, gas = ethereum_accounts[0], TimestampMS(1676641271000), '0.02686452'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -49,19 +48,17 @@ def test_subscribe(ethereum_inquirer, ethereum_accounts):
             address=SUB_STORAGE,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xd312551890858CC313Bf1718F502FF9fcDB2e6ff']])
 def test_deactivate_sub(ethereum_inquirer, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x646352346021b3747143dfff704b6b61b736fd86479b5c1bdb0145c92e5d92a0')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x646352346021b3747143dfff704b6b61b736fd86479b5c1bdb0145c92e5d92a0')),  # noqa: E501
     )
     user_address, timestamp, gas = ethereum_accounts[0], TimestampMS(1677329195000), '0.00099726'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -90,4 +87,3 @@ def test_deactivate_sub(ethereum_inquirer, ethereum_accounts):
             address=SUB_STORAGE,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_degen.py
+++ b/rotkehlchen/tests/unit/decoders/test_degen.py
@@ -43,7 +43,7 @@ def test_claim_airdrop_2(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
         tx_hash=(tx_hash := deserialize_evm_tx_hash('0x885722ab252530e687212799080d5d158d767536b62e0d45a700091a5424bcaa ')),  # noqa: E501
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -72,7 +72,6 @@ def test_claim_airdrop_2(
             extra_data={AIRDROP_IDENTIFIER_KEY: 'degen2_season1'},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -139,7 +138,7 @@ def test_claim_airdrop_3(
         evm_inquirer=base_transaction_decoder.evm_inquirer,
         tx_hash=(tx_hash := deserialize_evm_tx_hash('0x40920bf5416e9bd756d1c57f04e1b978e838efb42e7c2b07c4e9aaa8eb0da2ef ')),  # noqa: E501
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -168,4 +167,3 @@ def test_claim_airdrop_3(
             extra_data={AIRDROP_IDENTIFIER_KEY: 'degen2_season3'},
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_diva.py
+++ b/rotkehlchen/tests/unit/decoders/test_diva.py
@@ -17,17 +17,15 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_diva_delegate(ethereum_inquirer, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x806081bcc60a40db22bae2c1729f240f48de4b73e76b673fc4767bcee4f1c704')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x806081bcc60a40db22bae2c1729f240f48de4b73e76b673fc4767bcee4f1c704')),  # noqa: E501
     )
-    timestamp = TimestampMS(1690964039000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1690964039000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -51,7 +49,6 @@ def test_diva_delegate(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_DIVA,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -59,12 +56,11 @@ def test_diva_delegate(ethereum_inquirer, ethereum_accounts):
 def test_diva_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc66dd53da9837e5197f95d32065807706a118dc2ff326a5e3bf8844b8ee261c2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1688847971000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1688847971000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -103,7 +99,6 @@ def test_diva_claim(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_DIVA,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -113,18 +108,16 @@ def test_vote_cast(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x640818700732a7345f085d14377adf285098ae33747da21444e594a64c905d41')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1694557811000)
-    gas_str = '0.00074796777559248'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1694557811000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.00074796777559248'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -144,4 +137,3 @@ def test_vote_cast(ethereum_inquirer, ethereum_accounts):
             address=DIVA_GOVERNOR,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_dripsv1.py
+++ b/rotkehlchen/tests/unit/decoders/test_dripsv1.py
@@ -83,7 +83,7 @@ def test_enduser_collect(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x38b957eaa21ba7a35c8713559680329f4b6b04bd46db00b54217c9d590c1a514')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     gas, amount, timestamp = '0.0003162699', '125.835582561728229714', TimestampMS(1660733511000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -111,7 +111,6 @@ def test_enduser_collect(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x73043143e0A6418cc45d82D4505B096b802FD365'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -212,7 +211,7 @@ def test_give(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x104b65d6b29a133b6eb7950da6abed747c3a806356da5a351a94bbb73ca2271e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     gas, amount, timestamp = '0.001515204384196608', '1', TimestampMS(1660666663000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -240,7 +239,6 @@ def test_give(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x73043143e0A6418cc45d82D4505B096b802FD365'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -249,7 +247,7 @@ def test_set_drips(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x86b8ea87f33cc6ac11286d229840e75f9328380f1b2b2c50ba93f173a97762dc')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)  # noqa: E501
     gas, amount, timestamp, per_sec_amount, end_ts = '0.005778677878564032', '50', TimestampMS(1654597232000), '0.000001929012345679', 1667557232  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -303,4 +301,3 @@ def test_set_drips(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x73043143e0A6418cc45d82D4505B096b802FD365'),
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_eas.py
+++ b/rotkehlchen/tests/unit/decoders/test_eas.py
@@ -21,18 +21,16 @@ def test_attest_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf843f6d09e8dec2ee2d1b5fdeade9a9744857f598cf593b6c259166c32dfd05a')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1700569289000)
-    gas_amount_str = '0.000136427902240075'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1700569289000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount_str),
+            amount=FVal(gas_amount_str := '0.000136427902240075'),
             location_label=user_address,
             notes=f'Burn {gas_amount_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -51,17 +49,15 @@ def test_attest_optimism(optimism_inquirer, optimism_accounts):
             address=string_to_evm_address('0x4200000000000000000000000000000000000021'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
 def test_attest_gitcoin_mint(arbitrum_one_inquirer, arbitrum_one_accounts):
     """A test for minting gitcoin impact donation attestation"""
-    tx_hash = deserialize_evm_tx_hash('0x5e93b5da1e2f22921f2ec0f7efc357f2ad4aafa70d387f87306c11b78f54b2c2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5e93b5da1e2f22921f2ec0f7efc357f2ad4aafa70d387f87306c11b78f54b2c2')),  # noqa: E501
     )
     user_address, timestamp, gas, amount, uid = arbitrum_one_accounts[0], TimestampMS(1744315569000), '0.000010227716042', '0.0007722', '0x07afc8aecb89b381f08f87491901614b55059f2432c21e46681d9f5de2a13ced'  # noqa: E501
     expected_events = [EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_echo.py
+++ b/rotkehlchen/tests/unit/decoders/test_echo.py
@@ -21,12 +21,13 @@ USDC_TOKEN = Asset('eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
 def test_echo_fund(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6f16132d373dbba06259d04bd1e83771343c7ac17ac0a4e74fad645ed9d809de')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, fund_amount, deal_address = TimestampMS(1736535363000), '5887', string_to_evm_address('0xeC14eD2470FaCe0a60a41c945Cc586aFbcc3273C')  # noqa: E501
+    fund_amount = '5887'
+    deal_address = string_to_evm_address('0xeC14eD2470FaCe0a60a41c945Cc586aFbcc3273C')
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=262,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1736535363000)),
             location=Location.BASE,
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
@@ -59,12 +60,12 @@ def test_echo_fund(base_inquirer, base_accounts):
 def test_echo_refund(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0xfaeea0e01cecda7849efb3f27aa216c567366e10237b717a75587ff05ad7a7c6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, deal_address = TimestampMS(1730227259000), string_to_evm_address('0x241F8222D1c80a4FDc25f9FC00181Eec770131A2')  # noqa: E501
+    deal_address = string_to_evm_address('0x241F8222D1c80a4FDc25f9FC00181Eec770131A2')
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=492,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1730227259000),
             location=Location.BASE,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,

--- a/rotkehlchen/tests/unit/decoders/test_efp.py
+++ b/rotkehlchen/tests/unit/decoders/test_efp.py
@@ -32,17 +32,17 @@ def test_efp_list_creation(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x6318183faa985769055925890bea8afd81145a2466c0cfefcc3c42282205749f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount = TimestampMS(1727210173000), base_accounts[0], '0.000001943732883081'  # noqa: E501
+    user_address = base_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1727210173000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000001943732883081'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -84,17 +84,17 @@ def test_efp_list_operations_base(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x73bcb4d09d122edf406da978e8c256de1394050d0f8152db9eb74d79f4d821aa')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount = TimestampMS(1731678515000), base_accounts[0], '0.000007264164076207'  # noqa: E501
+    user_address = base_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731678515000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000007264164076207'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -159,17 +159,17 @@ def test_efp_list_operations_optimism(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x9cdb42b0d1dfa4d61025894721a3a841845eb45fb08bbe619379530d2b67ffff')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount = TimestampMS(1731685871000), optimism_accounts[0], '0.000000746188721518'  # noqa: E501
+    user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731685871000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000000746188721518'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -209,17 +209,17 @@ def test_efp_list_operations_ethereum(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x3cde46b44c8eb9712949ba149ca566c65af5bdbac0d26682b43777b53ab92669')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount = TimestampMS(1728767939000), ethereum_accounts[0], '0.00074678442257622'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1728767939000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.00074678442257622'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,

--- a/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
+++ b/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
@@ -38,19 +38,17 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_deposit_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x716b15f5088ff469d7d31680535d35b085e1c3de25255c7849e5955a59df8d31')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount = TimestampMS(1702926167000), '0.049006058268043653'
-    deposited_amount = '5.740516176725108094'
     strategy_addr = string_to_evm_address('0x0Fe4F44beE93503346A3Ac9EE5A26b130a5796d6')
     a_sweth = Asset('eip155:1/erc20:0xf951E335afb289353dc249e82926178EaC7DEd78')
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1702926167000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.049006058268043653'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -74,7 +72,7 @@ def test_deposit_token(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.STAKING,
         event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
         asset=a_sweth,
-        amount=FVal(deposited_amount),
+        amount=FVal(deposited_amount := '5.740516176725108094'),
         location_label=ethereum_accounts[0],
         notes=f'Deposit {deposited_amount} swETH in EigenLayer',
         counterparty=CPT_EIGENLAYER,
@@ -89,18 +87,16 @@ def test_deposit_token(ethereum_inquirer, ethereum_accounts):
 def test_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x00bdab08d05bd68f8f863e35a8dbe435978481dcbf15faf7276da30a5bfee971')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount = TimestampMS(1707668387000), '0.004606768190817408'
-    withdrawn_amount = '0.407049270448991651'
     strategy_addr = string_to_evm_address('0x0Fe4F44beE93503346A3Ac9EE5A26b130a5796d6')
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1707668387000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.004606768190817408'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -112,7 +108,7 @@ def test_withdraw(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.STAKING,
         event_subtype=HistoryEventSubType.REMOVE_ASSET,
         asset=Asset('eip155:1/erc20:0xf951E335afb289353dc249e82926178EaC7DEd78'),
-        amount=FVal(withdrawn_amount),
+        amount=FVal(withdrawn_amount := '0.407049270448991651'),
         location_label=ethereum_accounts[0],
         notes=f'Unstake {withdrawn_amount} swETH from EigenLayer',
         counterparty=CPT_EIGENLAYER,
@@ -126,16 +122,16 @@ def test_withdraw(ethereum_inquirer, ethereum_accounts):
 def test_airdrop_claim_s1_phase1(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0a72c7bf0fe1808035f8df466a70453f29c6b57d0bec46913d993a19ef72265c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, claim_amount = TimestampMS(1715680739000), '0.00074757962836592', '110'
+    claim_amount = '110'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1715680739000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.00074757962836592'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -162,16 +158,16 @@ def test_airdrop_claim_s1_phase1(ethereum_inquirer, ethereum_accounts):
 def test_airdrop_claim_s1_phase2(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x7896ca761e9e2fd53dbec28c946d5dbc2e0802a3700641d26d61bc79afaac1a5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, claim_amount = TimestampMS(1720527731000), '0.000428532817567424', '110'
+    claim_amount = '110'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1720527731000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.000428532817567424'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -198,17 +194,16 @@ def test_airdrop_claim_s1_phase2(ethereum_inquirer, ethereum_accounts):
 def test_stake_eigen(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4da63226965a8b0584f137efa934106cd0cb7a15b536d6f659945cfd4c260b4e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, staked_amount = TimestampMS(1715684387000), '0.00141296787957222', '110'
     a_eigen, strategy_addr = Asset(EIGEN_TOKEN_ID), '0xaCB55C530Acdb2849e6d4f36992Cd8c9D50ED8F7'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1715684387000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.00141296787957222'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -232,7 +227,7 @@ def test_stake_eigen(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.STAKING,
         event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
         asset=a_eigen,
-        amount=FVal(staked_amount),
+        amount=FVal(staked_amount := '110'),
         location_label=ethereum_accounts[0],
         notes=f'Deposit {staked_amount} EIGEN in EigenLayer',
         counterparty=CPT_EIGENLAYER,
@@ -245,27 +240,26 @@ def test_stake_eigen(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x80B7EDA1Baa2290478205786615F65052c80882f']])
 def test_deploy_eigenpod(ethereum_inquirer, ethereum_accounts, database):
-    tx_hash = deserialize_evm_tx_hash('0x910087fb1be44dbf2d89363579c162e70d5666f16182c9015d635c4f81ac07b6')  # noqa: E501
     ethereum_transactions = EthereumTransactions(ethereum_inquirer=ethereum_inquirer, database=database)  # noqa: E501
     ethereum_tx_decoder = EthereumTransactionDecoder(database=database, ethereum_inquirer=ethereum_inquirer, transactions=ethereum_transactions)  # noqa: E501
     assert ethereum_tx_decoder.decoders['Eigenlayer'].eigenpod_owner_mapping == {}
 
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x910087fb1be44dbf2d89363579c162e70d5666f16182c9015d635c4f81ac07b6')),  # noqa: E501
         transactions=ethereum_transactions,
         evm_decoder=ethereum_tx_decoder,
     )
-    timestamp, gas_amount, eigenpod_address = TimestampMS(1715733143000), '0.00133529055565527', '0x664BFef14A62F316175d39D355809D04D2Cb7a23'  # noqa: E501
+    eigenpod_address = '0x664BFef14A62F316175d39D355809D04D2Cb7a23'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1715733143000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.00133529055565527'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -295,16 +289,18 @@ def test_deploy_eigenpod(ethereum_inquirer, ethereum_accounts, database):
 def test_deploy_eigenpod_via_safe(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x449447b417019f9d8617e41c735c206d94669e91e066bd3cb0dd609fcd8faff7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, eigenpod_address, user_address, safe_address = TimestampMS(1715601779000), '0.002212107522528736', '0x081aC22eb8582eF9f5ae596A5E8Df42b451b28b7', ethereum_accounts[0], ethereum_accounts[1]  # noqa: E501
+    eigenpod_address = '0x081aC22eb8582eF9f5ae596A5E8Df42b451b28b7'
+    user_address = ethereum_accounts[0]
+    safe_address = ethereum_accounts[1]
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1715601779000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.002212107522528736'),
         location_label=user_address,
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -344,16 +340,16 @@ def test_deploy_eigenpod_via_safe(ethereum_inquirer, ethereum_accounts):
 def test_create_delayed_withdrawals(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd054c9f07b880ac8e587c725b0427dde2b4c2633250f6f84a5c803fa665fe307')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, withdrawal_amount = TimestampMS(1715768063000), '0.036853617070145433', '0.021045998'  # noqa: E501
+    withdrawal_amount = '0.021045998'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1715768063000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.036853617070145433'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -377,10 +373,9 @@ def test_create_delayed_withdrawals(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x02855536652F67cB936851D94c793Fb3Ba27F9bb']])
 def test_lst_create_delayed_withdrawals(database, ethereum_inquirer, ethereum_accounts, inquirer):  # pylint: disable=unused-argument
-    tx_hash = deserialize_evm_tx_hash('0x8c006f764e9264cd150b2583ba72205bb4575ace76ed3afa83689227e9fe461b')  # noqa: E501
     events, tx_decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8c006f764e9264cd150b2583ba72205bb4575ace76ed3afa83689227e9fe461b')),  # noqa: E501
     )
     user_address, timestamp, gas_amount, amount = ethereum_accounts[0], TimestampMS(1718731823000), '0.001066996197578511', '0.514712311805302523'  # noqa: E501
     expected_events = [EvmEvent(
@@ -531,16 +526,17 @@ def test_lst_complete_delayed_withdrawals(database, ethereum_inquirer, ethereum_
 def test_claim_delayed_withdrawals(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc5d38c05567f5a4d51e686225dfc461ddf177eefa7c531822656b2ed9560ab12')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, withdrawal_amount, user_address, safe_address = TimestampMS(1716123995000), '0.000369830372847984', '0.004538247', ethereum_accounts[0], ethereum_accounts[1]  # noqa: E501
+    user_address = ethereum_accounts[0]
+    safe_address = ethereum_accounts[1]
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1716123995000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.000369830372847984'),
         location_label=user_address,
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -552,7 +548,7 @@ def test_claim_delayed_withdrawals(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.TRANSFER,
         event_subtype=HistoryEventSubType.NONE,
         asset=A_ETH,
-        amount=FVal(withdrawal_amount),
+        amount=FVal(withdrawal_amount := '0.004538247'),
         location_label=safe_address,
         notes=f'Withdraw {withdrawal_amount} ETH from Eigenlayer delayed withdrawals',
         counterparty=CPT_EIGENLAYER,
@@ -579,12 +575,12 @@ def test_claim_delayed_withdrawals(ethereum_inquirer, ethereum_accounts):
 def test_native_restake_delegate(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd857a09084c1dfc1d2df83cbeed70e99b79b1e3a74c7385df7dc7065a79e184c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, eth_restaked = TimestampMS(1715866679000), '160'
-    expected_events = [
+    eth_restaked = '160'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=373,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1715866679000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.NONE,
@@ -609,7 +605,6 @@ def test_native_restake_delegate(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_EIGENLAYER,
             address=EIGENPOD_MANAGER,
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -627,17 +622,17 @@ def test_eigenpod_start_checkpoint(ethereum_inquirer, ethereum_accounts):
     )
     tx_hash = deserialize_evm_tx_hash('0xc1f4bf3fc591b7bd116fbccff4985425b4823612a052fe6b9553ce664d10f464')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, user_address = TimestampMS(1725469127000), '0.000975571949515495', ethereum_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1725469127000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000975571949515495'),
             location_label=user_address,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -655,7 +650,6 @@ def test_eigenpod_start_checkpoint(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_EIGENLAYER,
             address=eigenpod_address,
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -670,17 +664,17 @@ def test_eigenpod_verify_checkpoint_proofs(ethereum_inquirer, ethereum_accounts)
     )
     tx_hash = deserialize_evm_tx_hash('0xdf949beee9e8b8e56f2ed294251800edc0af3c48cfd8e0662ebf9f0a49f61db0')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, user_address = TimestampMS(1725469151000), '0.001280636519396161', ethereum_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1725469151000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.001280636519396161'),
             location_label=user_address,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -724,7 +718,6 @@ def test_eigenpod_verify_checkpoint_proofs(ethereum_inquirer, ethereum_accounts)
             counterparty=CPT_EIGENLAYER,
             address=eigenpod_address,
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -732,16 +725,16 @@ def test_eigenpod_verify_checkpoint_proofs(ethereum_inquirer, ethereum_accounts)
 def test_avs_rewards_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x652b479994529e11f1331864739312e643e912a78cf1dca05403aa1d33c4ac46')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, rewards_amount, user_address = TimestampMS(1726209683000), '0.000290353368116672', '0.000010159378047479', ethereum_accounts[0]  # noqa: E501
+    user_address = ethereum_accounts[0]
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1726209683000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.000290353368116672'),
         location_label=user_address,
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -753,7 +746,7 @@ def test_avs_rewards_claim(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.REWARD,
         asset=A_WETH,
-        amount=FVal(rewards_amount),
+        amount=FVal(rewards_amount := '0.000010159378047479'),
         location_label=user_address,
         notes=f'Claim {rewards_amount} WETH as AVS restaking reward',
         counterparty=CPT_EIGENLAYER,
@@ -767,16 +760,15 @@ def test_avs_rewards_claim(ethereum_inquirer, ethereum_accounts):
 def test_airdrop_claim_s2(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc939c3ccdb19a4cdc27d00f2010cd45f652e0553efc663ae6050fa2eed74db8a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, claim_amount = TimestampMS(1726667207000), '0.00109526054949798', '4.556109113437771'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1726667207000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.00109526054949798'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -788,7 +780,7 @@ def test_airdrop_claim_s2(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.AIRDROP,
         asset=Asset(EIGEN_TOKEN_ID),
-        amount=FVal(claim_amount),
+        amount=FVal(claim_amount := '4.556109113437771'),
         location_label=ethereum_accounts[0],
         notes=f'Claim {claim_amount} EIGEN from the Eigenlayer airdrop season 2',
         counterparty=CPT_EIGENLAYER,

--- a/rotkehlchen/tests/unit/decoders/test_element_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_element_finance.py
@@ -21,13 +21,12 @@ def test_claim_airdrop(ethereum_inquirer):
     https://etherscan.io/tx/0x1e58aed1baf70b57e6e3e880e1890e7fe607fddc94d62986c38fe70e483e594b
     """
     tx_hash = deserialize_evm_tx_hash('0x1e58aed1baf70b57e6e3e880e1890e7fe607fddc94d62986c38fe70e483e594b')  # noqa: E501
-    timestamp = TimestampMS(1652910214000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1652910214000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -52,4 +51,3 @@ def test_claim_airdrop(ethereum_inquirer):
             extra_data={AIRDROP_IDENTIFIER_KEY: 'elfi'},
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_enriched.py
+++ b/rotkehlchen/tests/unit/decoders/test_enriched.py
@@ -28,9 +28,8 @@ def test_1inch_claim(database, ethereum_inquirer, eth_transactions):
     """Data for claim taken from
     https://etherscan.io/tx/0x0582a0db79de3fa21d3b92a8658e0b1034c51ea54a8e06ea84fbb91d41b8fe17
     """
-    tx_hash = deserialize_evm_tx_hash('0x0582a0db79de3fa21d3b92a8658e0b1034c51ea54a8e06ea84fbb91d41b8fe17')  # noqa: E501
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x0582a0db79de3fa21d3b92a8658e0b1034c51ea54a8e06ea84fbb91d41b8fe17')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=1646375440,
         block_number=14351442,
@@ -81,14 +80,13 @@ def test_1inch_claim(database, ethereum_inquirer, eth_transactions):
         decoder.reload_data(cursor)
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     assert len(events) == 2
-    timestamp = TimestampMS(1646375440000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=deserialize_evm_tx_hash(
                 '0x0582a0db79de3fa21d3b92a8658e0b1034c51ea54a8e06ea84fbb91d41b8fe17',
             ),
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1646375440000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -115,7 +113,6 @@ def test_1inch_claim(database, ethereum_inquirer, eth_transactions):
             extra_data={AIRDROP_IDENTIFIER_KEY: '1inch'},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [['0xdF5CEF8Dc0CEA8DC200F09280915d1CD7a016BDe']])
@@ -123,9 +120,8 @@ def test_gitcoin_claim(database, ethereum_inquirer, eth_transactions):
     """Data for claim taken from
     https://etherscan.io/tx/0x0e22cbdbac56c785f186bec44d715ab0834ceeadd96573c030f2fae1550b64fa
     """
-    tx_hash = deserialize_evm_tx_hash('0x0e22cbdbac56c785f186bec44d715ab0834ceeadd96573c030f2fae1550b64fa')  # noqa: E501
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x0e22cbdbac56c785f186bec44d715ab0834ceeadd96573c030f2fae1550b64fa')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=1646375440,
         block_number=14351442,
@@ -176,7 +172,7 @@ def test_gitcoin_claim(database, ethereum_inquirer, eth_transactions):
         decoder.reload_data(cursor)
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
     assert len(events) == 2
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -205,4 +201,3 @@ def test_gitcoin_claim(database, ethereum_inquirer, eth_transactions):
             extra_data={AIRDROP_IDENTIFIER_KEY: 'gitcoin'},
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_ens.py
+++ b/rotkehlchen/tests/unit/decoders/test_ens.py
@@ -44,27 +44,23 @@ if TYPE_CHECKING:
     from rotkehlchen.globaldb.handler import GlobalDBHandler
     from rotkehlchen.types import ChecksumEvmAddress
 
-
 ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY]])
 def test_mint_ens_name(ethereum_inquirer, add_subgraph_api_key):  # pylint: disable=unused-argument
-    tx_hash = deserialize_evm_tx_hash('0x74e72600c6cd5a1f0170a3ca38ecbf7d59edeb8ceb48adab2ed9b85d12cc2b99')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x74e72600c6cd5a1f0170a3ca38ecbf7d59edeb8ceb48adab2ed9b85d12cc2b99')),  # noqa: E501
     )
     expires_timestamp = 2142055301
-    timestamp = TimestampMS(1637144069000)
-    register_fee_str = '0.019345192039577752'
     token_id = '88045077199635585930173998576189366882372899073811035545363728149974713265418'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1637144069000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -132,7 +128,7 @@ def test_mint_ens_name(ethereum_inquirer, add_subgraph_api_key):  # pylint: disa
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
-            amount=FVal(register_fee_str),
+            amount=FVal(register_fee_str := '0.019345192039577752'),
             location_label=ADDY,
             notes=f'Register ENS name hania.eth for {register_fee_str} ETH until {decoder.decoders["Ens"].timestamp_to_date(expires_timestamp)}',  # noqa: E501
             counterparty=CPT_ENS,
@@ -172,17 +168,15 @@ def test_text_changed_old_name(database, ethereum_inquirer, ethereum_accounts, a
     tx_hash = deserialize_evm_tx_hash('0xaa59cb2029651d2ed2c0d1ee34b9b88f0b90278fc6da5b51446d4abf24d7f598')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1664548859000)
-    gas_str = '0.00655101156241161'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1664548859000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_str),
+        amount=FVal(gas_str := '0.00655101156241161'),
         location_label=user_address,
         notes=f'Burn {gas_str} ETH for gas',
         counterparty=CPT_GAS,
@@ -264,7 +258,7 @@ def test_set_attribute_v2(ethereum_inquirer, ethereum_accounts, add_subgraph_api
     tx_hash = deserialize_evm_tx_hash('0x6b354e4da21cfb06a8eb4cb5b7efd20558ae3be6a7a7c563f318e041fb3bfdd9')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -293,26 +287,23 @@ def test_set_attribute_v2(ethereum_inquirer, ethereum_accounts, add_subgraph_api
             address=string_to_evm_address('0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [['0xA3B9E4b2C18eFB1C767542e8eb9419B840881467']])
 def test_register_v2(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key):  # pylint: disable=unused-argument
     """Test that registering an ens name using eth registar deployed in March 2023 works"""
-    tx_hash = deserialize_evm_tx_hash('0x5150f6e1c76b74fa914e06df9e56577cdeec0faea11f9949ff529daeb16b1c76')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5150f6e1c76b74fa914e06df9e56577cdeec0faea11f9949ff529daeb16b1c76')),  # noqa: E501
     )
-    timestamp = TimestampMS(1681220435000)
     expires_timestamp = Timestamp(1712756435)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1681220435000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -377,7 +368,6 @@ def test_register_v2(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key)
             address=ENS_PUBLIC_RESOLVER_3_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -509,7 +499,7 @@ def test_register_v2_spend_before_refund(ethereum_inquirer, ethereum_accounts):
         evm_inquirer=ethereum_inquirer,
         tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe1a1c33b86b46b37f7581c19500dd55cf6f8d9488d0ecb1cc12ce622ca1d745b')),  # noqa: E501
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=1,
@@ -565,7 +555,6 @@ def test_register_v2_spend_before_refund(ethereum_inquirer, ethereum_accounts):
             address=ENS_REGISTRY_WITH_FALLBACK,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -576,14 +565,13 @@ def test_renewal_with_refund_old_controller(ethereum_inquirer, ethereum_accounts
     spent amount. Check a refund using the old ENS registrar controller. That contract
     logs the net cost (after refund) of a renewal.
     """
-    tx_hash = deserialize_evm_tx_hash('0xd4fd01f50c3c86e7e119311d6830d975cf7d78d6906004d30370ffcbaabdff95')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd4fd01f50c3c86e7e119311d6830d975cf7d78d6906004d30370ffcbaabdff95')),  # noqa: E501
     )
     expires_timestamp = Timestamp(2310615949)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -613,7 +601,6 @@ def test_renewal_with_refund_old_controller(ethereum_inquirer, ethereum_accounts
             extra_data={'name': 'dfern.eth', 'expires': expires_timestamp},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -624,14 +611,13 @@ def test_renewal_with_refund_new_controller(ethereum_inquirer, ethereum_accounts
     spent amount. Check a refund using the new ENS registrar controller. That contract
     logs the brutto cost (msg.value including the refund) of a renewal.
     """
-    tx_hash = deserialize_evm_tx_hash('0x0faef1a1a714d5f2f2e5fb344bd186a745180849bae2c92f9d595d8552ef5c96')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x0faef1a1a714d5f2f2e5fb344bd186a745180849bae2c92f9d595d8552ef5c96')),  # noqa: E501
     )
     expires_timestamp = Timestamp(1849443293)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -661,7 +647,6 @@ def test_renewal_with_refund_new_controller(ethereum_inquirer, ethereum_accounts
             extra_data={'name': 'karapetsas.eth', 'expires': expires_timestamp},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -671,12 +656,11 @@ def test_content_hash_changed(ethereum_inquirer, ethereum_accounts, add_subgraph
     tx_hash = deserialize_evm_tx_hash('0x21fa4ef7a4c20f2548cc010ba00974632cca9e55edea4d50b3fb2c00c7f2080b')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1686304523000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1686304523000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -701,7 +685,6 @@ def test_content_hash_changed(ethereum_inquirer, ethereum_accounts, add_subgraph
             address=ENS_PUBLIC_RESOLVER_2_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -739,12 +722,11 @@ def test_transfer_ens_name(database, ethereum_inquirer, action, ethereum_account
         to_address = '0x4bBa290826C253BD854121346c370a9886d1bC26'
 
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1687771811000)
     token_id = 73552724610198397480670284492690114609730214421511097849210414928326607694469
     gas_event = EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1687771811000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -781,27 +763,23 @@ def test_for_truncated_labelhash(ethereum_inquirer, ethereum_accounts, add_subgr
     """Test for https://github.com/rotki/rotki/issues/6597 where some labelhashes
     had their leading 0s truncated and lead to graph failures
     """
-    tx_hash = deserialize_evm_tx_hash('0x8a809c2286342e04ce74494808c1dee5efd7aeb0af57b600780cb04eb3f83441')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8a809c2286342e04ce74494808c1dee5efd7aeb0af57b600780cb04eb3f83441')),  # noqa: E501
     )
-    timestamp = TimestampMS(1603662139000)
-    gas_str = '0.003424155'
-    register_fee_str = '0.122618417748598345'
     expires_timestamp = Timestamp(1919231659)
     token_id = 520289412805995815014030902380736904960994587318475958708983757899533811755
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1603662139000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.003424155'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -865,7 +843,7 @@ def test_for_truncated_labelhash(ethereum_inquirer, ethereum_accounts, add_subgr
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
-            amount=FVal(register_fee_str),
+            amount=FVal(register_fee_str := '0.122618417748598345'),
             location_label=user_address,
             notes=f'Register ENS name cantillon.eth for {register_fee_str} ETH until {decoder.decoders["Ens"].timestamp_to_date(expires_timestamp)}',  # noqa: E501
             counterparty=CPT_ENS,
@@ -885,7 +863,6 @@ def test_for_truncated_labelhash(ethereum_inquirer, ethereum_accounts, add_subgr
             address=ENS_REGISTRAR_CONTROLLER_1,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -895,18 +872,16 @@ def test_vote_cast(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4677ffa104b011d591ae0c056ba651a978db982c0dfd131520db74c1b46ff564')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1695935903000)
-    gas_str = '0.000916189648966683'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1695935903000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.000916189648966683'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -926,7 +901,6 @@ def test_vote_cast(ethereum_inquirer, ethereum_accounts):
             address=ENS_GOVERNOR,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -936,18 +910,16 @@ def test_vote_cast_abstain(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc16e94a93480fd499373283ee973b34d18525c3b67ea81b248530d8158944ff2')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1720220639000)
-    gas_str = '0.000255411223579504'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1720220639000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.000255411223579504'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -967,7 +939,6 @@ def test_vote_cast_abstain(ethereum_inquirer, ethereum_accounts):
             address=ENS_GOVERNOR,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -978,18 +949,16 @@ def test_set_attribute_for_non_primary_name(ethereum_inquirer, ethereum_accounts
     tx_hash = deserialize_evm_tx_hash('0x07aa7d1ac61fc03f6416a25c0d6cf96f286e2ce84e9b350dd2a9a1bd6426aef2')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    gas_str = '0.00054662131669239'
-    timestamp = TimestampMS(1694558075000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1694558075000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.00054662131669239'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -1008,7 +977,6 @@ def test_set_attribute_for_non_primary_name(ethereum_inquirer, ethereum_accounts
             address=ENS_PUBLIC_RESOLVER_2_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1018,12 +986,11 @@ def test_claim_airdrop(ethereum_inquirer, ethereum_accounts, add_subgraph_api_ke
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     gas_str, claimed_amount = '0.014281582073130576', '88.217476134335168512'
-    timestamp = TimestampMS(1637313773000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1637313773000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -1048,7 +1015,6 @@ def test_claim_airdrop(ethereum_inquirer, ethereum_accounts, add_subgraph_api_ke
             extra_data={AIRDROP_IDENTIFIER_KEY: 'ens'},
         ),
     ]
-    assert events == expected_events
 
 
 def test_invalid_ens_name(globaldb: 'GlobalDBHandler'):
@@ -1073,17 +1039,16 @@ def test_new_owner(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key): 
     tx_hash = deserialize_evm_tx_hash('0x56bb5b09757fadfbb376b207fe5f340df9931f8169b2e852679d57885f9ae1c1')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str = TimestampMS(1669498319000), '0.0004635496'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1669498319000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.0004635496'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -1103,7 +1068,6 @@ def test_new_owner(ethereum_inquirer, ethereum_accounts, add_subgraph_api_key): 
             address=ENS_REGISTRY_WITH_FALLBACK,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -1113,17 +1077,16 @@ def test_address_changed(ethereum_inquirer, ethereum_accounts, add_subgraph_api_
     tx_hash = deserialize_evm_tx_hash('0x67cbfebb9027a004d341b6f57976ba970fae9af8be7f32161a93224cefbb3e83')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str = TimestampMS(1669498439000), '0.000402353718699768'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1669498439000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.000402353718699768'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -1143,4 +1106,3 @@ def test_address_changed(ethereum_inquirer, ethereum_accounts, add_subgraph_api_
             address=ENS_PUBLIC_RESOLVER_2_ADDRESS,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_eth2.py
+++ b/rotkehlchen/tests/unit/decoders/test_eth2.py
@@ -84,7 +84,7 @@ def test_multiple_deposits(database, ethereum_inquirer, ethereum_accounts):
             write_cursor,
             validators=validators,
         )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -121,7 +121,6 @@ def test_multiple_deposits(database, ethereum_inquirer, ethereum_accounts):
             depositor=user_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -144,12 +143,11 @@ def test_deposit_with_anonymous_event(database, ethereum_inquirer, ethereum_acco
     user_address = ethereum_accounts[0]
     proxy_address = ethereum_accounts[1]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1669806275000)
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1669806275000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,

--- a/rotkehlchen/tests/unit/decoders/test_extrafi.py
+++ b/rotkehlchen/tests/unit/decoders/test_extrafi.py
@@ -37,17 +37,16 @@ def test_extrafi_deposit_and_stake(
 ):
     tx_hash = deserialize_evm_tx_hash('0x81a87d2f8a9752ac4889ec92d6ec553417e3b4cc709a240718cf423f362e89b1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, deposited_amount = TimestampMS(1724325113000), '0.000000295568286412', '3259.807132247307892938'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1724325113000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000000295568286412'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -71,7 +70,7 @@ def test_extrafi_deposit_and_stake(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=Asset('eip155:10/erc20:0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db'),
-            amount=FVal(deposited_amount),
+            amount=FVal(deposited_amount := '3259.807132247307892938'),
             location_label=optimism_accounts[0],
             notes=f'Deposit {deposited_amount} VELO into Extrafi lend',
             counterparty=CPT_EXTRAFI,
@@ -90,17 +89,16 @@ def test_extrafi_unstake_and_withdraw(
 ):
     tx_hash = deserialize_evm_tx_hash('0x6acaea14d49f1e27902064251b1656067ed2518f831ae2d75ca6806bb7a21892')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, deposited_amount = TimestampMS(1724414161000), '0.00000029164013947', '28996.716869'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1724414161000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.00000029164013947'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -112,7 +110,7 @@ def test_extrafi_unstake_and_withdraw(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
             asset=Asset('eip155:10/erc20:0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'),
-            amount=FVal(deposited_amount),
+            amount=FVal(deposited_amount := '28996.716869'),
             location_label=optimism_accounts[0],
             notes=f'Withdraw {deposited_amount} USDC from Extrafi lend',
             address=string_to_evm_address('0x85B16A35d310Db338D7bA35b85F83ea44182A396'),
@@ -130,17 +128,16 @@ def test_extrafi_claim_from_pool(
 ):
     tx_hash = deserialize_evm_tx_hash('0x0c14b9d8d9a7dbe9243a29f4ec4d32852456163f80f46de7119c2c9fd8737a0b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, claimed_extra, claimed_op = TimestampMS(1717599275000), '0.000012215355410845', '42.0693742435086256', '0.162673580112061904'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1717599275000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000012215355410845'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -152,7 +149,7 @@ def test_extrafi_claim_from_pool(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=Asset('eip155:10/erc20:0x2dAD3a13ef0C6366220f989157009e501e7938F8'),
-            amount=FVal(claimed_extra),
+            amount=FVal(claimed_extra := '42.0693742435086256'),
             location_label=optimism_accounts[0],
             notes=f'Claim {claimed_extra} EXTRA from Extrafi',
             counterparty=CPT_EXTRAFI,
@@ -165,7 +162,7 @@ def test_extrafi_claim_from_pool(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_OP,
-            amount=FVal(claimed_op),
+            amount=FVal(claimed_op := '0.162673580112061904'),
             location_label=optimism_accounts[0],
             notes=f'Claim {claimed_op} OP from Extrafi',
             counterparty=CPT_EXTRAFI,
@@ -183,17 +180,16 @@ def test_extrafi_lock_token(
 ):
     tx_hash = deserialize_evm_tx_hash('0x10cc6bb6d749e4c42c4d961de69bcd0d3885fe74ecc627e9069b41d000344fa7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, locked_amount = TimestampMS(1724678695000), '0.000002162513212219', '10077.656075837376207314'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1724678695000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000002162513212219'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -217,7 +213,7 @@ def test_extrafi_lock_token(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=Asset('eip155:10/erc20:0x2dAD3a13ef0C6366220f989157009e501e7938F8'),
-            amount=FVal(locked_amount),
+            amount=FVal(locked_amount := '10077.656075837376207314'),
             location_label=optimism_accounts[0],
             notes=f'Lock {locked_amount} EXTRA until 21/08/2025 00:00:00',
             counterparty=CPT_EXTRAFI,
@@ -235,17 +231,16 @@ def test_extrafi_repay(
 ):
     tx_hash = deserialize_evm_tx_hash('0xc1b3c8ac33f3b5d27e48377e59a6a6c384ee425f86c7ac86cec4b903e38c9bca')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, repaid_amount, refund_amount = TimestampMS(1722746575000), '0.000001297692870133', '0.001369169723826962', '0.000000000000000002'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1722746575000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000001297692870133'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -257,7 +252,7 @@ def test_extrafi_repay(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.PAYBACK_DEBT,
             asset=A_ETH,
-            amount=FVal(repaid_amount),
+            amount=FVal(repaid_amount := '0.001369169723826962'),
             location_label=optimism_accounts[0],
             notes=f'Repay {repaid_amount} ETH in Extrafi EXA-WETH farm',
             address=EXTRAFI_FARMING_CONTRACT,
@@ -270,7 +265,7 @@ def test_extrafi_repay(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REFUND,
             asset=A_ETH,
-            amount=FVal(refund_amount),
+            amount=FVal(refund_amount := '0.000000000000000002'),
             location_label=optimism_accounts[0],
             notes=f'Receive {refund_amount} ETH as refund from Extrafi',
             counterparty=CPT_EXTRAFI,
@@ -288,17 +283,16 @@ def test_extrafi_repay_with_token(
 ):
     tx_hash = deserialize_evm_tx_hash('0x5b907d75ec3ba70436385071fc57e31b428b24cb92a05d802a5714273171e697')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, repaid_amount, refund_amount = TimestampMS(1721340039000), '0.000076904200008685', '1589.9698', '0.000002'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1721340039000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000076904200008685'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -322,7 +316,7 @@ def test_extrafi_repay_with_token(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.PAYBACK_DEBT,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-            amount=FVal(repaid_amount),
+            amount=FVal(repaid_amount := '1589.9698'),
             location_label=optimism_accounts[0],
             notes=f'Repay {repaid_amount} USDC.e in Extrafi USDC.e-wUSDR farm',
             address=string_to_evm_address('0x5f88d6f7beD0538Ca825404Baf20C846b4073e5D'),
@@ -335,7 +329,7 @@ def test_extrafi_repay_with_token(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REFUND,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-            amount=FVal(refund_amount),
+            amount=FVal(refund_amount := '0.000002'),
             location_label=optimism_accounts[0],
             notes=f'Receive {refund_amount} USDC.e as refund from Extrafi',
             counterparty=CPT_EXTRAFI,
@@ -353,17 +347,16 @@ def test_close_position(
 ):
     tx_hash = deserialize_evm_tx_hash('0x24c5e37be0340c3713c851cbe849f2f2d7c9fd9c776d889fe065cd5aaaadb49f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, withdrawn_amount = TimestampMS(1722759379000), '0.000001936939279642', '6.195522513842170302'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1722759379000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000001936939279642'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -375,7 +368,7 @@ def test_close_position(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
             asset=Asset('eip155:10/erc20:0x1e925De1c68ef83bD98eE3E130eF14a50309C01B'),
-            amount=FVal(withdrawn_amount),
+            amount=FVal(withdrawn_amount := '6.195522513842170302'),
             location_label=optimism_accounts[0],
             notes=f'Withdraw {withdrawn_amount} EXA from Extrafi EXA-WETH farm',
             counterparty=CPT_EXTRAFI,
@@ -393,17 +386,16 @@ def test_farm_investment(
 ):
     tx_hash = deserialize_evm_tx_hash('0xf1f2de24757b57df7b53090369020a527f9ea54d5a876fe85fe972643c50a7e2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, deposited_amount, borrow_amount = TimestampMS(1722792861000), '0.000027486262250944', '8.230157245731733013', '0.002920375680424896'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1722792861000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000027486262250944'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -427,7 +419,7 @@ def test_farm_investment(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=Asset('eip155:10/erc20:0x1e925De1c68ef83bD98eE3E130eF14a50309C01B'),
-            amount=FVal(deposited_amount),
+            amount=FVal(deposited_amount := '8.230157245731733013'),
             location_label=optimism_accounts[0],
             notes=f'Deposit {deposited_amount} EXA in Extrafi EXA-WETH farm',
             counterparty=CPT_EXTRAFI,
@@ -441,7 +433,7 @@ def test_farm_investment(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.GENERATE_DEBT,
             asset=Asset('eip155:10/erc20:0x4200000000000000000000000000000000000006'),
-            amount=FVal(borrow_amount),
+            amount=FVal(borrow_amount := '0.002920375680424896'),
             location_label=optimism_accounts[0],
             notes=f'Borrow {borrow_amount} WETH in Extrafi EXA-WETH farm',
             counterparty=CPT_EXTRAFI,
@@ -469,17 +461,16 @@ def test_farm_investment(
 def test_new_farm_borrow_position_on_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0xb9479f2e21100ddbba10395d76abb2fb4e151b2142ba90c91151a10fcb5cfbc7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, borrow_amount, gas_fees = TimestampMS(1725972969000), '4025.689364', '0.000006907473477667'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1725972969000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000006907473477667'),
             location_label=base_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -491,7 +482,7 @@ def test_new_farm_borrow_position_on_base(base_inquirer, base_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.GENERATE_DEBT,
             asset=Asset('eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'),
-            amount=FVal(borrow_amount),
+            amount=FVal(borrow_amount := '4025.689364'),
             location_label=base_accounts[0],
             notes=f'Borrow {borrow_amount} USDC in Extrafi USDz-USDC farm',
             counterparty=CPT_EXTRAFI,
@@ -519,17 +510,16 @@ def test_new_farm_borrow_position_on_base(base_inquirer, base_accounts):
 def test_new_farm_position_on_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf0458b2c208fa7362669b6430277808a2bda527fcbe5dd3514a5879c445311cc')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, deposit_amount, gas_fees = TimestampMS(1725309783000), '5042.114438', '0.000003258939143014'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1725309783000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000003258939143014'),
             location_label=base_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -541,7 +531,7 @@ def test_new_farm_position_on_base(base_inquirer, base_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=Asset('eip155:8453/erc20:0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376'),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '5042.114438'),
             location_label=base_accounts[0],
             notes=f'Deposit {deposit_amount} USD+ in Extrafi OVN-USD+ farm',
             counterparty=CPT_EXTRAFI,
@@ -557,17 +547,16 @@ def test_new_farm_position_on_base(base_inquirer, base_accounts):
 def test_vested_extra_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x560a5e279a7f1b9c89dca3d7f93da11c9418037c0362f01b443d50967a719d5d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, locked_amount, gas_fees = TimestampMS(1722581379000), '8.004925206880061111', '0.000002859618316575'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1722581379000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000002859618316575'),
             location_label=base_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -591,7 +580,7 @@ def test_vested_extra_base(base_inquirer, base_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=Asset('eip155:8453/erc20:0x2dAD3a13ef0C6366220f989157009e501e7938F8'),
-            amount=FVal(locked_amount),
+            amount=FVal(locked_amount := '8.004925206880061111'),
             location_label=base_accounts[0],
             notes=f'Lock {locked_amount} EXTRA until 08/08/2024 00:00:00',
             counterparty=CPT_EXTRAFI,
@@ -609,23 +598,21 @@ def test_extrafi_claim_lending(
         optimism_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x6cca377983ebf715d83a3ea566e420d79abf545b8aad61c6bad68cc60fc57c05')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6cca377983ebf715d83a3ea566e420d79abf545b8aad61c6bad68cc60fc57c05')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, fee_amount, claimed_extra, claimed_op = TimestampMS(1727429719000), '0.000000266809434775', '8.888980847307437249', '0.137614520893025687'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1727429719000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000000266809434775'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -637,7 +624,7 @@ def test_extrafi_claim_lending(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=Asset('eip155:10/erc20:0x2dAD3a13ef0C6366220f989157009e501e7938F8'),
-            amount=FVal(claimed_extra),
+            amount=FVal(claimed_extra := '8.888980847307437249'),
             location_label=optimism_accounts[0],
             notes=f'Claim {claimed_extra} EXTRA from Extrafi lending',
             counterparty=CPT_EXTRAFI,
@@ -650,7 +637,7 @@ def test_extrafi_claim_lending(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_OP,
-            amount=FVal(claimed_op),
+            amount=FVal(claimed_op := '0.137614520893025687'),
             location_label=optimism_accounts[0],
             notes=f'Claim {claimed_op} OP from Extrafi lending',
             counterparty=CPT_EXTRAFI,
@@ -668,23 +655,21 @@ def test_extrafi_claim_lending_base(
         base_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0xccefe09c6b3cfc9753494c28f07de309d26ccb5169ed478c93b4169776ac0edc')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xccefe09c6b3cfc9753494c28f07de309d26ccb5169ed478c93b4169776ac0edc')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, fee_amount, claimed_extra = TimestampMS(1721419937000), '0.000001803922832983', '6.970955942301511307'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1721419937000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000001803922832983'),
             location_label=base_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -696,7 +681,7 @@ def test_extrafi_claim_lending_base(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=Asset('eip155:8453/erc20:0x2dAD3a13ef0C6366220f989157009e501e7938F8'),
-            amount=FVal(claimed_extra),
+            amount=FVal(claimed_extra := '6.970955942301511307'),
             location_label=base_accounts[0],
             notes=f'Claim {claimed_extra} EXTRA from Extrafi lending',
             counterparty=CPT_EXTRAFI,
@@ -712,22 +697,20 @@ def test_op_incentive_rewards(
         optimism_inquirer: 'OptimismInquirer',
         optimism_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash('0xb9bb665425a4beeac4afaba637bffcdfc3fe57d2606eee44ec90bba532050a0c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb9bb665425a4beeac4afaba637bffcdfc3fe57d2606eee44ec90bba532050a0c')),  # noqa: E501
     )
-    timestamp, amount = TimestampMS(1737018755000), '0.769886891'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=58,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1737018755000),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_OP,
-            amount=FVal(amount),
+            amount=FVal(amount := '0.769886891'),
             location_label=optimism_accounts[0],
             notes=f'Receive {amount} OP as a reward incentive for participating in an Extrafi pool',  # noqa: E501
             counterparty=CPT_EXTRAFI,

--- a/rotkehlchen/tests/unit/decoders/test_firebird_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_firebird_finance.py
@@ -26,7 +26,7 @@ def test_swap_erc20_tokens(arbitrum_one_inquirer, arbitrum_one_accounts):
     tx_hash = deserialize_evm_tx_hash('0x9e97c7f79e788ebaa815cbee019f1dbb6cb80c4dd5bb0957fd989af130d85445')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
     user_address, timestamp, gas_amount, approval_amount, out_amount, in_amount = arbitrum_one_accounts[0], TimestampMS(1704018154000), '0.0001858737', '999999999999999999999174', '825', '1286.844424'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -77,7 +77,6 @@ def test_swap_erc20_tokens(arbitrum_one_inquirer, arbitrum_one_accounts):
             address=string_to_evm_address('0x1f5A3c42F26b72c917B3625c7a964ca33600Fa25'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -86,7 +85,7 @@ def test_swap_eth_for_erc20_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xe44fe9c5cdd8b1b2d0ab0691fc9633d49146bf665575a83e0c6a3e9e70e70203')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, out_amount, in_amount = ethereum_accounts[0], TimestampMS(1672529231000), '0.004636897380394857', '0.4', '1007.80191074694080899'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -125,7 +124,6 @@ def test_swap_eth_for_erc20_token(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0xe0C38b2a8D09aAD53f1C67734B9A95E43d5981c0'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -135,7 +133,7 @@ def test_swap_erc20_token_for_eth(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc19f8f547c49c3f35dae993b713d95cce79aa425563fd28aeaca2510ebb95059')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, out_amount, in_amount = optimism_accounts[0], TimestampMS(1708454525000), '0.000261272046054672', '24.828647237813394885', '0.03345269400143805'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -174,7 +172,6 @@ def test_swap_erc20_token_for_eth(optimism_inquirer, optimism_accounts):
             address=string_to_evm_address('0xDda1aFE34928450FFf2af5C051E5E0c0853e21C9'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_fluence.py
+++ b/rotkehlchen/tests/unit/decoders/test_fluence.py
@@ -19,13 +19,12 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc04e88de26d3466e64a243c15db181342152d0b771b0e8e224920ea9b28fe7e0')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1712868707000)
     gas_amount_str, claimed_amount = '0.00203104493516988', '5000'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712868707000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -49,7 +48,6 @@ def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
             address=DEV_REWARD_DISTRIBUTOR,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -57,17 +55,16 @@ def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
 def test_airdrop_swap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x1db2028d68fbdc19e770307dd968c24c8fa4211b26eb512a938223f89d11450a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount_str, claimed_amount = TimestampMS(1718357447000), '0.00059501796565782', '5000'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1718357447000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount_str),
+            amount=FVal(gas_amount_str := '0.00059501796565782'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_amount_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -79,7 +76,7 @@ def test_airdrop_swap(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.NONE,
             asset=EvmToken('eip155:1/erc20:0x6081d7F04a8c31e929f25152d4ad37c83638C62b'),
-            amount=FVal(claimed_amount),
+            amount=FVal(claimed_amount := '5000'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {claimed_amount} FLT-DROP',
             counterparty=CPT_FLUENCE,
@@ -99,4 +96,3 @@ def test_airdrop_swap(ethereum_inquirer, ethereum_accounts):
             address=DEV_REWARD_DISTRIBUTOR,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_gearbox.py
+++ b/rotkehlchen/tests/unit/decoders/test_gearbox.py
@@ -109,10 +109,9 @@ def test_gearbox_deposit_non_farming_pool(
             value='Trade DOLA v3',
         )
 
-    tx_hash = deserialize_evm_tx_hash('0x20a0e17d547a76f797bab8c60c2aa65a6cdbceecb1f50f92a4de4408a461c963')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x20a0e17d547a76f797bab8c60c2aa65a6cdbceecb1f50f92a4de4408a461c963')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [EvmEvent(
@@ -164,22 +163,20 @@ def test_gearbox_deposit(
         ethereum_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x04e3bcebf71873a5de1c4d9b40f1c97631a3958ef0d8d743a1a1b4d50361855d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x04e3bcebf71873a5de1c4d9b40f1c97631a3958ef0d8d743a1a1b4d50361855d')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, deposit_amount, lp_token_amount = TimestampMS(1716770963000), '0.0006562535', '156164.834098036387706577', '151038.694912640397702932'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716770963000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.0006562535'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -191,7 +188,7 @@ def test_gearbox_deposit(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_DAI,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '156164.834098036387706577'),
             location_label=ethereum_accounts[0],
             notes=f'Deposit {deposit_amount} DAI to Gearbox',
             tx_ref=tx_hash,
@@ -204,7 +201,7 @@ def test_gearbox_deposit(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:1/erc20:0xC853E4DA38d9Bd1d01675355b8c8f3BBC1451973'),
-            amount=FVal(lp_token_amount),
+            amount=FVal(lp_token_amount := '151038.694912640397702932'),
             location_label=ethereum_accounts[0],
             notes=f'Receive {lp_token_amount} farmdDAIV3 after depositing in Gearbox',
             tx_ref=tx_hash,
@@ -212,7 +209,6 @@ def test_gearbox_deposit(
             address=string_to_evm_address('0x1aD0780a152fE66FAf7c44A7F875A36b1bf790F0'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -223,22 +219,21 @@ def test_gearbox_deposit_usdc(
         ethereum_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x92d178bbe5152cad47029b0c130450848ee46084e72addd09ba955631af1325b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x92d178bbe5152cad47029b0c130450848ee46084e72addd09ba955631af1325b')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, deposit_amount, lp_token_amount = TimestampMS(1716899027000), '0.004946659515956316', '6500000', '6147276.510091'  # noqa: E501
-    expected_events = [
+    deposit_amount = '6500000'
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716899027000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.004946659515956316'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -275,7 +270,7 @@ def test_gearbox_deposit_usdc(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:1/erc20:0x9ef444a6d7F4A5adcd68FD5329aA5240C90E14d2'),
-            amount=FVal(lp_token_amount),
+            amount=FVal(lp_token_amount := '6147276.510091'),
             location_label=ethereum_accounts[0],
             notes=f'Receive {lp_token_amount} farmdUSDCV3 after depositing in Gearbox',
             tx_ref=tx_hash,
@@ -283,7 +278,6 @@ def test_gearbox_deposit_usdc(
             address=string_to_evm_address('0x53D5BD0E7fAa9ee3eafEf7C5572D54DB1b7f5b25'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -294,22 +288,20 @@ def test_gearbox_withdraw(
         ethereum_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0xb286e618ec2e5961c696df1855006dea0343fb635c7f199621f8592db342dfba')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb286e618ec2e5961c696df1855006dea0343fb635c7f199621f8592db342dfba')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, lp_amount, withdrawn = TimestampMS(1716739091000), '0.002506078391975991', '29394.203983328624199078', '30388.281725016794033508'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716739091000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.002506078391975991'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -321,7 +313,7 @@ def test_gearbox_withdraw(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset('eip155:1/erc20:0xC853E4DA38d9Bd1d01675355b8c8f3BBC1451973'),
-            amount=FVal(lp_amount),
+            amount=FVal(lp_amount := '29394.203983328624199078'),
             location_label=ethereum_accounts[0],
             notes=f'Return {lp_amount} farmdDAIV3',
             tx_ref=tx_hash,
@@ -334,7 +326,7 @@ def test_gearbox_withdraw(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=A_DAI,
-            amount=FVal(withdrawn),
+            amount=FVal(withdrawn := '30388.281725016794033508'),
             location_label=ethereum_accounts[0],
             notes=f'Withdraw {withdrawn} DAI from Gearbox',
             tx_ref=tx_hash,
@@ -342,7 +334,6 @@ def test_gearbox_withdraw(
             address=string_to_evm_address('0xe7146F53dBcae9D6Fa3555FE502648deb0B2F823'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -353,22 +344,20 @@ def test_gearbox_deposit_arbitrum(
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x00db27b8c09c9ec4478f27da7e40b90afbb577cfb4822536eab5a52dcae321e6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x00db27b8c09c9ec4478f27da7e40b90afbb577cfb4822536eab5a52dcae321e6')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, deposit_amount, lp_token_amount = TimestampMS(1716815867000), '0.00000249681', '0.001', '0.00098428586189406'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716815867000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000249681'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -380,7 +369,7 @@ def test_gearbox_deposit_arbitrum(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_ETH,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '0.001'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Deposit {deposit_amount} ETH to Gearbox',
             tx_ref=tx_hash,
@@ -393,7 +382,7 @@ def test_gearbox_deposit_arbitrum(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:42161/erc20:0x6773fF780Dd38175247795545Ee37adD6ab6139a'),
-            amount=FVal(lp_token_amount),
+            amount=FVal(lp_token_amount := '0.00098428586189406'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Receive {lp_token_amount} farmdWETHV3 after depositing in Gearbox',
             tx_ref=tx_hash,
@@ -401,7 +390,6 @@ def test_gearbox_deposit_arbitrum(
             address=string_to_evm_address('0x78c1B41b825f89FAE4736878Fa63752F8D789BD6'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -412,22 +400,20 @@ def test_gearbox_deposit_arbitrum_lp(
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x7dbb02839dab23bc87ed6f4f5899fc77986c576e6fedf16cfbd9751fbe09e2eb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x7dbb02839dab23bc87ed6f4f5899fc77986c576e6fedf16cfbd9751fbe09e2eb')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, deposit_amount, lp_token_amount = TimestampMS(1716899425000), '0.0000022431', '0.001', '0.000984005521495659'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716899425000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.0000022431'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -439,7 +425,7 @@ def test_gearbox_deposit_arbitrum_lp(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_ETH,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '0.001'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Deposit {deposit_amount} ETH to Gearbox',
             tx_ref=tx_hash,
@@ -452,7 +438,7 @@ def test_gearbox_deposit_arbitrum_lp(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:42161/erc20:0x04419d3509f13054f60d253E0c79491d9E683399'),
-            amount=FVal(lp_token_amount),
+            amount=FVal(lp_token_amount := '0.000984005521495659'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Receive {lp_token_amount} dWETHV3 after providing liquidity in Gearbox',
             tx_ref=tx_hash,
@@ -460,7 +446,6 @@ def test_gearbox_deposit_arbitrum_lp(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -528,22 +513,20 @@ def test_gearbox_withdraw_arbitrum(
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x9b3f388e53c6b0f2eb12c323aebb05d47e27f6d9f511bd1176ed826a351c6c06')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x9b3f388e53c6b0f2eb12c323aebb05d47e27f6d9f511bd1176ed826a351c6c06')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, lp_amount, withdrawn = TimestampMS(1717435594000), '0.00000250989', '0.7', '0.712544409227268693'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1717435594000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000250989'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -555,7 +538,7 @@ def test_gearbox_withdraw_arbitrum(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset('eip155:42161/erc20:0x6773fF780Dd38175247795545Ee37adD6ab6139a'),
-            amount=FVal(lp_amount),
+            amount=FVal(lp_amount := '0.7'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Return {lp_amount} farmdWETHV3',
             tx_ref=tx_hash,
@@ -568,7 +551,7 @@ def test_gearbox_withdraw_arbitrum(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=A_ETH,
-            amount=FVal(withdrawn),
+            amount=FVal(withdrawn := '0.712544409227268693'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Withdraw {withdrawn} ETH from Gearbox',
             tx_ref=tx_hash,
@@ -576,7 +559,6 @@ def test_gearbox_withdraw_arbitrum(
             address=string_to_evm_address('0x78c1B41b825f89FAE4736878Fa63752F8D789BD6'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -587,22 +569,20 @@ def test_gearbox_deposit_usdc_arbitrum(
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0xc7a3b95862eba49a86b8eefe81837ea141037feda8c0da236d9c3adb370fdfb3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc7a3b95862eba49a86b8eefe81837ea141037feda8c0da236d9c3adb370fdfb3')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, deposit_amount, lp_token_amount, approval_amount = TimestampMS(1717508317000), '0.00000368093', '125.164428', '121.463529', '125.164428'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1717508317000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000368093'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -614,7 +594,7 @@ def test_gearbox_deposit_usdc_arbitrum(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:42161/erc20:0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'),
-            amount=FVal(approval_amount),
+            amount=FVal(approval_amount := '125.164428'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Set USDC.e spending approval of {arbitrum_one_accounts[0]} by 0xD72e1B9A5FC74b35435f71603a81dAE217c2D863 to {approval_amount}',  # noqa: E501
             tx_ref=tx_hash,
@@ -626,7 +606,7 @@ def test_gearbox_deposit_usdc_arbitrum(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:42161/erc20:0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8'),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '125.164428'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Deposit {deposit_amount} USDC.e to Gearbox',
             tx_ref=tx_hash,
@@ -651,7 +631,7 @@ def test_gearbox_deposit_usdc_arbitrum(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:42161/erc20:0x608F9e2E8933Ce6b39A8CddBc34a1e3E8D21cE75'),
-            amount=FVal(lp_token_amount),
+            amount=FVal(lp_token_amount := '121.463529'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Receive {lp_token_amount} farmdUSDCV3 after depositing in Gearbox',
             tx_ref=tx_hash,
@@ -659,7 +639,6 @@ def test_gearbox_deposit_usdc_arbitrum(
             address=string_to_evm_address('0xD72e1B9A5FC74b35435f71603a81dAE217c2D863'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -671,22 +650,20 @@ def test_gearbox_deposit_optimism(
         optimism_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x1dc1803865e909909bf20a82b0d88b476bcac13c7a0efa57c531baa06b0cb27e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x1dc1803865e909909bf20a82b0d88b476bcac13c7a0efa57c531baa06b0cb27e')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, deposit_amount, lp_token_amount = TimestampMS(1714433685000), '0.000010672234173866', '0.1', '0.099957406908026936'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714433685000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000010672234173866'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -698,7 +675,7 @@ def test_gearbox_deposit_optimism(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_ETH,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '0.1'),
             location_label=optimism_accounts[0],
             notes=f'Deposit {deposit_amount} ETH to Gearbox',
             tx_ref=tx_hash,
@@ -711,7 +688,7 @@ def test_gearbox_deposit_optimism(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:10/erc20:0x704c4C9F0d29257E5b0E526b20b48EfFC8f758b2'),
-            amount=FVal(lp_token_amount),
+            amount=FVal(lp_token_amount := '0.099957406908026936'),
             location_label=optimism_accounts[0],
             notes=f'Receive {lp_token_amount} farmdWETHV3 after depositing in Gearbox',
             tx_ref=tx_hash,
@@ -719,7 +696,6 @@ def test_gearbox_deposit_optimism(
             address=string_to_evm_address('0xEa8ca794aEe0f998Ed6AB50F4042c28807E546Eb'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -731,22 +707,20 @@ def test_gearbox_deposit_usdc_optimism(
         optimism_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x25baef6edb2fae8fde18b7ee49dbba94bdaa500db1388cc5b22bdb4ba953d7b4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x25baef6edb2fae8fde18b7ee49dbba94bdaa500db1388cc5b22bdb4ba953d7b4')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, deposit_amount, approval_amount = TimestampMS(1714434001000), '0.000011648221611152', '300', '394.3605'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714434001000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000011648221611152'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -758,7 +732,7 @@ def test_gearbox_deposit_usdc_optimism(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '300'),
             location_label=optimism_accounts[0],
             notes=f'Deposit {deposit_amount} USDC.e to Gearbox',
             tx_ref=tx_hash,
@@ -771,7 +745,7 @@ def test_gearbox_deposit_usdc_optimism(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-            amount=FVal(approval_amount),
+            amount=FVal(approval_amount := '394.3605'),
             location_label=optimism_accounts[0],
             notes=f'Set USDC.e spending approval of {optimism_accounts[0]} by 0x931BC69a32BE7A36f9B00Bf63D17Fa8fB9a8C525 to {approval_amount}',  # noqa: E501
             tx_ref=tx_hash,
@@ -791,7 +765,6 @@ def test_gearbox_deposit_usdc_optimism(
             address=string_to_evm_address('0x931BC69a32BE7A36f9B00Bf63D17Fa8fB9a8C525'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -803,22 +776,20 @@ def test_gearbox_withdraw_optimism_usdc(
         optimism_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x03569fa219dd445c120a38eb294a21feee8da7f0e1d3b6aed1d87a3ca519b16d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x03569fa219dd445c120a38eb294a21feee8da7f0e1d3b6aed1d87a3ca519b16d')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, lp_amount = TimestampMS(1712552439000), '0.000001104938540339', '50'
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712552439000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000001104938540339'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -830,7 +801,7 @@ def test_gearbox_withdraw_optimism_usdc(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset('eip155:10/erc20:0x73302b63Ad4a16C498f26dB89cb27F37a72E4E04'),
-            amount=FVal(lp_amount),
+            amount=FVal(lp_amount := '50'),
             location_label=optimism_accounts[0],
             notes=f'Return {lp_amount} farmdUSDCV3',
             tx_ref=tx_hash,
@@ -851,7 +822,6 @@ def test_gearbox_withdraw_optimism_usdc(
             address=string_to_evm_address('0x5520dAa93A187f4Ec67344e6D2C4FC9B080B6A35'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -862,16 +832,15 @@ def test_gearbox_staking(
 ):
     tx_hash = deserialize_evm_tx_hash('0x5de7647a4c8f8ca1e5434725dd09b27ce05e41954d72c3f1f4d639c8b7019f4a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, stake_amount = TimestampMS(1718177819000), '0.0008970313372218', '260.869836197270890866'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1718177819000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.0008970313372218'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -883,7 +852,7 @@ def test_gearbox_staking(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:1/erc20:0xBa3335588D9403515223F109EdC4eB7269a9Ab5D'),
-            amount=FVal(stake_amount),
+            amount=FVal(stake_amount := '260.869836197270890866'),
             location_label=ethereum_accounts[0],
             notes=f'Set GEAR spending approval of {ethereum_accounts[0]} by {GEAR_STAKING_CONTRACT} to {stake_amount}',  # noqa: E501
             tx_ref=tx_hash,
@@ -915,7 +884,6 @@ def test_gearbox_staking(
             address=GEAR_STAKING_CONTRACT,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -926,16 +894,15 @@ def test_gearbox_unstaking(
 ):
     tx_hash = deserialize_evm_tx_hash('0xb50badadb71b7c8c4ab2d0f9691931396322b2395da2396bee1ed65755e3882a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, stake_amount = TimestampMS(1717241039000), '0.000287410296179888', '1210105.252774990252868034'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1717241039000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000287410296179888'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -947,7 +914,7 @@ def test_gearbox_unstaking(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REMOVE_ASSET,
             asset=Asset('eip155:1/erc20:0xBa3335588D9403515223F109EdC4eB7269a9Ab5D'),
-            amount=FVal(stake_amount),
+            amount=FVal(stake_amount := '1210105.252774990252868034'),
             location_label=ethereum_accounts[0],
             notes=f'Unstake {stake_amount} GEAR',
             tx_ref=tx_hash,
@@ -955,7 +922,6 @@ def test_gearbox_unstaking(
             address=GEAR_STAKING_CONTRACT,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -966,21 +932,19 @@ def test_gearbox_claim_from_angle(
         ethereum_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x6539828c45548f323febc685498457880b0651375ca5077338a162676574048c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6539828c45548f323febc685498457880b0651375ca5077338a162676574048c')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, gear_amount = TimestampMS(1745790011000), '0.00005385590405946', '1412.737469800492924993'  # noqa: E501
     assert events == [EvmEvent(
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1745790011000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas),
+        amount=FVal(gas := '0.00005385590405946'),
         location_label=(user_account := ethereum_accounts[0]),
         notes=f'Burn {gas} ETH for gas',
         tx_ref=tx_hash,
@@ -992,7 +956,7 @@ def test_gearbox_claim_from_angle(
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.REWARD,
         asset=Asset('eip155:1/erc20:0xBa3335588D9403515223F109EdC4eB7269a9Ab5D'),
-        amount=FVal(gear_amount),
+        amount=FVal(gear_amount := '1412.737469800492924993'),
         location_label=user_account,
         notes=f'Claim {gear_amount} GEAR reward from Gearbox',
         tx_ref=tx_hash,
@@ -1010,21 +974,19 @@ def test_gearbox_claim(
         ethereum_accounts: list['ChecksumEvmAddress'],
         load_global_caches: list[str],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x0e0efdf539b2882192958891ff9d0005297e0301ecd594763c87da8a84f1aca8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x0e0efdf539b2882192958891ff9d0005297e0301ecd594763c87da8a84f1aca8')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, gear_amount = TimestampMS(1745790059000), '0.000026898409237966', '46983.327727303683938594'  # noqa: E501
     assert events == [EvmEvent(
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1745790059000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas),
+        amount=FVal(gas := '0.000026898409237966'),
         location_label=(user_account := ethereum_accounts[0]),
         notes=f'Burn {gas} ETH for gas',
         tx_ref=tx_hash,
@@ -1036,7 +998,7 @@ def test_gearbox_claim(
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.REWARD,
         asset=Asset('eip155:1/erc20:0xBa3335588D9403515223F109EdC4eB7269a9Ab5D'),
-        amount=FVal(gear_amount),
+        amount=FVal(gear_amount := '46983.327727303683938594'),
         location_label=user_account,
         notes=f'Claim {gear_amount} GEAR reward from Gearbox',
         tx_ref=tx_hash,
@@ -1055,21 +1017,19 @@ def test_gearbox_claim_farming_token(
         load_global_caches: list[str],
 ):
     """Getting a transfer from a gearbox farming token should be a reward claim"""
-    tx_hash = deserialize_evm_tx_hash('0xaa841ada5e5e30bf1f516b6690b480cbe7e4f5629d93685306ff33b87b6f3f6d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xaa841ada5e5e30bf1f516b6690b480cbe7e4f5629d93685306ff33b87b6f3f6d')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp, gas, gear_amount = TimestampMS(1769851043000), '0.00000905784', '554.695350540591551374'  # noqa: E501
     expected_events = [EvmEvent(
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1769851043000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas),
+        amount=FVal(gas := '0.00000905784'),
         location_label=(user_account := ethereum_accounts[0]),
         notes=f'Burn {gas} ETH for gas',
         tx_ref=tx_hash,
@@ -1081,7 +1041,7 @@ def test_gearbox_claim_farming_token(
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.REWARD,
         asset=Asset('eip155:1/erc20:0xBa3335588D9403515223F109EdC4eB7269a9Ab5D'),
-        amount=FVal(gear_amount),
+        amount=FVal(gear_amount := '554.695350540591551374'),
         location_label=user_account,
         notes=f'Claim {gear_amount} GEAR reward from Gearbox',
         tx_ref=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_gitcoin.py
+++ b/rotkehlchen/tests/unit/decoders/test_gitcoin.py
@@ -20,17 +20,16 @@ ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 def test_gitcoin_old_donation(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x811ba23a10c76111289133ec6f90d3c33a604baa50053739210e870687a456d9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas = TimestampMS(1569924574000), '0.000055118'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1569924574000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000055118'),
             location_label=ADDY,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -62,7 +61,6 @@ def test_gitcoin_old_donation(ethereum_inquirer):
             address=string_to_evm_address('0x00De4B13153673BCAE2616b67bf822500d325Fc3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -70,16 +68,17 @@ def test_gitcoin_old_donation(ethereum_inquirer):
 def test_bulkcheckout_receive_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6ed7d6c156fa3a8e73c3726d9179f139abcf7e7d3845efe9c5b70e6b4222c0be')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, amount, donor = TimestampMS(1670831003000), ethereum_accounts[0], '0.000799', '0xC8CA7F1C1a391CAfE43cf7348a2E54930648a0D4'  # noqa: E501
+    user_address = ethereum_accounts[0]
+    donor = '0xC8CA7F1C1a391CAfE43cf7348a2E54930648a0D4'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=TimestampMS(1670831003000),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.DONATE,
         asset=A_ETH,
-        amount=FVal(amount),
+        amount=FVal(amount := '0.000799'),
         location_label=user_address,
         notes=f'Receive donation of {amount} ETH from {donor} via gitcoin',
         counterparty=CPT_GITCOIN,
@@ -93,17 +92,19 @@ def test_bulkcheckout_receive_eth(ethereum_inquirer, ethereum_accounts):
 def test_bulkcheckout_send_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x89f8f62f7b1a8af0f8de685b676dac94088833442db93a9c4d896817b9f5099d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, user_address, amount1, amount2, dst1, dst2 = TimestampMS(1671869867000), '0.000883451092980928', ethereum_accounts[0], '25', '1.25', '0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3', '0xde21F729137C5Af1b01d73aF1dC21eFfa2B8a0d6'  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    dst1 = '0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3'
+    dst2 = '0xde21F729137C5Af1b01d73aF1dC21eFfa2B8a0d6'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1671869867000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000883451092980928'),
             location_label=user_address,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -115,7 +116,7 @@ def test_bulkcheckout_send_token(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.DONATE,
             asset=A_DAI,
-            amount=FVal(amount1),
+            amount=FVal(amount1 := '25'),
             location_label=user_address,
             notes=f'Donate {amount1} DAI to {dst1} via gitcoin',
             counterparty=CPT_GITCOIN,
@@ -128,34 +129,33 @@ def test_bulkcheckout_send_token(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.DONATE,
             asset=A_DAI,
-            amount=FVal(amount2),
+            amount=FVal(amount2 := '1.25'),
             location_label=user_address,
             notes=f'Donate {amount2} DAI to {dst2} via gitcoin',
             counterparty=CPT_GITCOIN,
             address=dst2,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_polygon_bulkcheckout_receive_matic(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xe2d9464020f45ea2a69c93156976c1323a16e390550e0fe9af749e88e234e06b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe2d9464020f45ea2a69c93156976c1323a16e390550e0fe9af749e88e234e06b')),  # noqa: E501
     )
-    timestamp, user_address, amount, donor = TimestampMS(1667285686000), polygon_pos_accounts[0], '2', '0x6e08E6e2D0deeb294fd53e9708f53b0fBedc06d5'  # noqa: E501
+    user_address = polygon_pos_accounts[0]
+    donor = '0x6e08E6e2D0deeb294fd53e9708f53b0fBedc06d5'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=TimestampMS(1667285686000),
         location=Location.POLYGON_POS,
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.DONATE,
         asset=A_POL,
-        amount=FVal(amount),
+        amount=FVal(amount := '2'),
         location_label=user_address,
         notes=f'Receive donation of {amount} POL from {donor} via gitcoin',
         counterparty=CPT_GITCOIN,
@@ -170,17 +170,16 @@ def test_gitcoin_vote_cast(ethereum_inquirer):
     """Test the old vote cast that gitcoin governor has"""
     tx_hash = deserialize_evm_tx_hash('0x068a954e8c8eda8942e972977d252997bd9de766c7b59230377ebdb9351e0183')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas = TimestampMS(1659375478000), '0.001115205340736039'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1659375478000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.001115205340736039'),
             location_label=ADDY,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -199,7 +198,6 @@ def test_gitcoin_vote_cast(ethereum_inquirer):
             address=GITCOIN_GOVERNOR_ALPHA,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -207,17 +205,18 @@ def test_gitcoin_vote_cast(ethereum_inquirer):
 def test_gitcoin_gr15_matching_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc7ba01598f7fee42bb3923af95355d676ad38ec0aebdcdf49eaf7cb74d2150b2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, user, amount = TimestampMS(1666139015000), '0.00118573107792279', ethereum_accounts[0], '1719.1187865411025'  # noqa: E501
-    expected_events = [
+    user = ethereum_accounts[0]
+    amount = '1719.1187865411025'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1666139015000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00118573107792279'),
             location_label=user,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -236,7 +235,6 @@ def test_gitcoin_gr15_matching_claim(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0xC8AcA0b50F3Ca9A0cBe413d8a110a7aab7d4C1aE'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -244,17 +242,18 @@ def test_gitcoin_gr15_matching_claim(ethereum_inquirer, ethereum_accounts):
 def test_gitcoin_payout_claimed_matching_gr12(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5acb6ddac6b72fc6ff45e6a387cf8316c1478dfbaff513918c4cc8731858b362')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, user, amount = TimestampMS(1643262544000), '0.00327700462232052', ethereum_accounts[0], '793.606553162524960498'  # noqa: E501
-    expected_events = [
+    user = ethereum_accounts[0]
+    amount = '793.606553162524960498'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1643262544000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00327700462232052'),
             location_label=user,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -273,7 +272,6 @@ def test_gitcoin_payout_claimed_matching_gr12(ethereum_inquirer, ethereum_accoun
             address=string_to_evm_address('0xAB8d71d59827dcc90fEDc5DDb97f87eFfB1B1A5B'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -282,17 +280,18 @@ def test_gitcoin_payout_claimed_matching_gr11(ethereum_inquirer, ethereum_accoun
     """Test of the PayoutClaimed event with both recipiend and amount in data (non-indexed args)"""
     tx_hash = deserialize_evm_tx_hash('0x3a069b8cef0d25068fbd2ae4e46ddd552451ed1bbe3737fbaaca05eeb87d9425')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, user, amount = TimestampMS(1648056902000), '0.00206346594437105', ethereum_accounts[0], '2618.692525999999816121'  # noqa: E501
-    expected_events = [
+    user = ethereum_accounts[0]
+    amount = '2618.692525999999816121'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1648056902000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00206346594437105'),
             location_label=user,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -311,4 +310,3 @@ def test_gitcoin_payout_claimed_matching_gr11(ethereum_inquirer, ethereum_accoun
             address=string_to_evm_address('0x0EbD2E2130b73107d0C45fF2E16c93E7e2e10e3a'),
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_gitcoin_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_gitcoin_v2.py
@@ -19,10 +19,9 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('optimism_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_optimism_donation_received(optimism_inquirer, optimism_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x08685669305ee26060a5a78ae70065aec76d9e62a35f0837c291fb1232f33601')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x08685669305ee26060a5a78ae70065aec76d9e62a35f0837c291fb1232f33601')),  # noqa: E501
     )
     user_address, timestamp, amount_str, donator = optimism_accounts[0], TimestampMS(1692176477000), '0.00122', '0xf0C2007aD05a8d66e98be932C698c232292eC8eA'  # noqa: E501
     expected_events = [EvmEvent(
@@ -295,7 +294,6 @@ def test_optimism_many_donations_different_strategies(optimism_inquirer, optimis
 def test_optimism_grant_payout(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x84110136c94ceb71c72afb27ccb517eb33f77a8a419d125101644e2c43294815')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    amount_str = '1228.529999999999934464'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=73,
@@ -304,7 +302,7 @@ def test_optimism_grant_payout(optimism_inquirer, optimism_accounts):
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.DONATE,
         asset=Asset('eip155:10/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1'),  # DAI
-        amount=FVal(amount_str),
+        amount=FVal(amount_str := '1228.529999999999934464'),
         location_label=optimism_accounts[0],
         notes=f'Receive matching payout of {amount_str} DAI for a gitcoin round',
         counterparty=CPT_GITCOIN,
@@ -318,7 +316,6 @@ def test_optimism_grant_payout(optimism_inquirer, optimism_accounts):
 def test_ethereum_grant_payout(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x66ff5be7841f05cc9cb53fd0307460690f91203c52490f5bbfdeabe8462be50b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    amount_str = '20000'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=313,
@@ -327,7 +324,7 @@ def test_ethereum_grant_payout(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.DONATE,
         asset=A_DAI,
-        amount=FVal(amount_str),
+        amount=FVal(amount_str := '20000'),
         location_label=ethereum_accounts[0],
         notes=f'Receive matching payout of {amount_str} DAI for a gitcoin round',
         counterparty=CPT_GITCOIN,
@@ -339,10 +336,9 @@ def test_ethereum_grant_payout(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_polygon_donation_matic_received(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x32837e03ac3e9066f09c1ee0807c533aa1bef5e3119b98dcacdd1ca631bc7ca6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x32837e03ac3e9066f09c1ee0807c533aa1bef5e3119b98dcacdd1ca631bc7ca6')),  # noqa: E501
     )
     user_address, timestamp, amount_str, donator = polygon_pos_accounts[0], TimestampMS(1700595622000), '4', '0x6017B1d17f4D7547dC4aac88fbD0AA1826e7e6CE'  # noqa: E501
     expected_events = [EvmEvent(
@@ -365,10 +361,9 @@ def test_polygon_donation_matic_received(polygon_pos_inquirer, polygon_pos_accou
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_polygon_donation_token_received(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x17601356467af0cfcf3a62f93879b504695b8690545b2b8669da5ec0f3a2a91b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x17601356467af0cfcf3a62f93879b504695b8690545b2b8669da5ec0f3a2a91b')),  # noqa: E501
     )
     user_address, timestamp, amount_str, donator = polygon_pos_accounts[0], TimestampMS(1700593336000), '1.5', '0x3d1f546F05834423Acc7e4CA1169ae320cee9AF0'  # noqa: E501
     expected_events = [EvmEvent(
@@ -391,10 +386,9 @@ def test_polygon_donation_token_received(polygon_pos_inquirer, polygon_pos_accou
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_polygon_apply_to_round(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x51c1909ce9268f453d4b7136b0fecb72d8da567f406c37014dd8ad8ed05c9a1f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x51c1909ce9268f453d4b7136b0fecb72d8da567f406c37014dd8ad8ed05c9a1f')),  # noqa: E501
     )
     user_address, timestamp, gas_str = polygon_pos_accounts[0], TimestampMS(1699442294000), '0.05638388497968273'  # noqa: E501
     expected_events = [EvmEvent(
@@ -430,10 +424,9 @@ def test_polygon_apply_to_round(polygon_pos_inquirer, polygon_pos_accounts):
 @pytest.mark.parametrize('ethereum_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_ethereum_voted_without_application_index(ethereum_inquirer, ethereum_accounts):
     """Test that voted events missing the application index are properly seen as donations"""
-    tx_hash = deserialize_evm_tx_hash('0xdcb6d2282b34a3cb7637ac65d8b7f1d0e8f2bc149379767f0b6f9ba2afa8a359')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xdcb6d2282b34a3cb7637ac65d8b7f1d0e8f2bc149379767f0b6f9ba2afa8a359')),  # noqa: E501
     )
     user_address, timestamp, amount, donator = ethereum_accounts[0], TimestampMS(1673960015000), '0.0035', '0xcD9a4e7C2ad6AAae7Ac25c2139d71739d9Fa2284'  # noqa: E501
     expected_events = [EvmEvent(
@@ -456,10 +449,9 @@ def test_ethereum_voted_without_application_index(ethereum_inquirer, ethereum_ac
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_allocated_receive_token(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x0388c141d93924d4737c4c52956469ecdb2c0a8dd9b3802317994c027d0a38af')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x0388c141d93924d4737c4c52956469ecdb2c0a8dd9b3802317994c027d0a38af')),  # noqa: E501
     )
     user_address, timestamp, amount, donator = arbitrum_one_accounts[0], TimestampMS(1729693571000), '1.77', '0x830862F98399520f351273B12FD3C622a226bDfE'  # noqa: E501
     expected_events = [EvmEvent(
@@ -482,10 +474,9 @@ def test_allocated_receive_token(arbitrum_one_inquirer, arbitrum_one_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x514e84986C09Ca52661eeE5EC8a3E6b645c54388']])
 def test_allocated_donate_token(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x9509a7be197f1926a480f0c02251c5b1f7d4fc4334a77c991efb61f55c243e5f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x9509a7be197f1926a480f0c02251c5b1f7d4fc4334a77c991efb61f55c243e5f')),  # noqa: E501
     )
     user_address, timestamp, gas, amount, approve = arbitrum_one_accounts[0], TimestampMS(1729720900000), '0.00000367783', '2', '4'  # noqa: E501
     expected_events = [EvmEvent(
@@ -557,10 +548,9 @@ def test_allocated_donate_token(arbitrum_one_inquirer, arbitrum_one_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x173a7942Ac9989d8A2203051bF22E673BcDa6e9D']])
 def test_allocated_donate_eth(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x92450a269e9dc36bb78e3c631104eec0e9e190f5672e666bcd6397f310617849')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x92450a269e9dc36bb78e3c631104eec0e9e190f5672e666bcd6397f310617849')),  # noqa: E501
     )
     user_address, timestamp, gas, amount = arbitrum_one_accounts[0], TimestampMS(1729747404000), '0.00000219175', '0.001'  # noqa: E501
     expected_events = [EvmEvent(
@@ -608,10 +598,9 @@ def test_allocated_donate_eth(arbitrum_one_inquirer, arbitrum_one_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_registered(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x75d7138bc9f43954d64120d29be217274e08a6e27a7f3634e5dbc6f1f466e372')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x75d7138bc9f43954d64120d29be217274e08a6e27a7f3634e5dbc6f1f466e372')),  # noqa: E501
     )
     user_address, timestamp, gas, recipient_id = arbitrum_one_accounts[0], TimestampMS(1727784046000), '0.0000047042', '0x73B00B94762f800A244B6a84617Adbf07b9520a8'  # noqa: E501
     expected_events = [EvmEvent(
@@ -724,10 +713,9 @@ def test_update_profile_metadata(optimism_inquirer, optimism_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9531C059098e3d194fF87FebB587aB07B30B1306']])
 def test_registered_retro_strategy(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xaab8dd47ad5c05cb8a2d5aee387b1b3c2c716abdfb7508cf63c0125e7d9752ed')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xaab8dd47ad5c05cb8a2d5aee387b1b3c2c716abdfb7508cf63c0125e7d9752ed')),  # noqa: E501
     )
     user_address, timestamp, gas, recipient_id = arbitrum_one_accounts[0], TimestampMS(1742385330000), '0.000010743737208', '0x73B00B94762f800A244B6a84617Adbf07b9520a8'  # noqa: E501
     expected_events = [EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_giveth.py
+++ b/rotkehlchen/tests/unit/decoders/test_giveth.py
@@ -23,17 +23,18 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_optimism_stake_deposit(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x875d69d471b2c31c5175848b11f68815e197fd609509cee420075685d21feccb')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user, gas, amount = TimestampMS(1733231821000), optimism_accounts[0], '0.00000045219580173', '416.766115409070747461'  # noqa: E501
-    expected_events = [
+    user = optimism_accounts[0]
+    amount = '416.766115409070747461'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1733231821000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000045219580173'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -77,7 +78,6 @@ def test_optimism_stake_deposit(optimism_inquirer, optimism_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -86,17 +86,17 @@ def test_optimism_stake_deposit(optimism_inquirer, optimism_accounts):
 def test_optimism_lock(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x160a78b4ce5001b407db9f5fca3e64fcc0619995d8888c66605f69525eed0270')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user, gas, giv_amount, pow_amount = TimestampMS(1733231841000), optimism_accounts[0], '0.000000453377609571', '416.766115409070747461', '172.630177184494281415'  # noqa: E501
-    expected_events = [
+    user = optimism_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1733231841000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000000453377609571'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -108,7 +108,7 @@ def test_optimism_lock(optimism_inquirer, optimism_accounts):
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=EvmToken(decoder.decoders['Giveth'].giv_token_id),
-            amount=FVal(giv_amount),
+            amount=FVal(giv_amount := '416.766115409070747461'),
             location_label=user,
             notes=f'Lock {giv_amount} GIV for 1 round/s',
             counterparty=CPT_GIVETH,
@@ -121,14 +121,13 @@ def test_optimism_lock(optimism_inquirer, optimism_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=EvmToken(decoder.decoders['Giveth'].pow_token_id),
-            amount=FVal(pow_amount),
+            amount=FVal(pow_amount := '172.630177184494281415'),
             location_label=user,
             notes=f'Receive {pow_amount} POW after locking GIV',
             counterparty=CPT_GIVETH,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -137,17 +136,18 @@ def test_optimism_lock(optimism_inquirer, optimism_accounts):
 def test_optimism_withdraw(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd687dcd65be8a2a9aea83123a9bdae775232af23e5846f01ade70f3f5280d392')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user, gas, amount = TimestampMS(1732744801000), optimism_accounts[0], '0.000000258591448555', '798.24369413782804452'  # noqa: E501
-    expected_events = [
+    user = optimism_accounts[0]
+    amount = '798.24369413782804452'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732744801000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000000258591448555'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -179,7 +179,6 @@ def test_optimism_withdraw(optimism_inquirer, optimism_accounts):
             address=decoder.decoders['Giveth'].givpower_staking_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -188,17 +187,18 @@ def test_optimism_withdraw(optimism_inquirer, optimism_accounts):
 def test_optimism_claim(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2144b2417404977fe2b4b4064b58cdaafc90e416e68a5ad16c04989cc025f3b1')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user, gas, amount = TimestampMS(1732520935000), optimism_accounts[0], '0.000001950934408636', '55.906071953178772758'  # noqa: E501
-    expected_events = [
+    user = optimism_accounts[0]
+    amount = '55.906071953178772758'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732520935000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000001950934408636'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -217,7 +217,6 @@ def test_optimism_claim(optimism_inquirer, optimism_accounts):
             address=decoder.decoders['Giveth'].distro_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -225,17 +224,18 @@ def test_optimism_claim(optimism_inquirer, optimism_accounts):
 def test_gnosis_claim(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8a7edd5f0008f8838664404a2b2aab593b705149044865cbdeb75d2126130949')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user, gas, amount = TimestampMS(1733756450000), gnosis_accounts[0], '0.000142777694803742', '66405.135269385928501434'  # noqa: E501
-    expected_events = [
+    user = gnosis_accounts[0]
+    amount = '66405.135269385928501434'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1733756450000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000142777694803742'),
             location_label=user,
             notes=f'Burn {gas} XDAI for gas',
             counterparty=CPT_GAS,
@@ -254,7 +254,6 @@ def test_gnosis_claim(gnosis_inquirer, gnosis_accounts):
             address=decoder.decoders['Giveth'].distro_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -262,17 +261,17 @@ def test_gnosis_claim(gnosis_inquirer, gnosis_accounts):
 def test_gnosis_lock(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x9a79d704dd637460a17bb3897df522c56deb4848d9d3b5630424c545e47172b5')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user, gas, giv_amount, pow_amount = TimestampMS(1733685985000), gnosis_accounts[0], '0.00026284575126455', '2617.351674315678177796', '10982.806567405488178331'  # noqa: E501
-    expected_events = [
+    user = gnosis_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1733685985000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00026284575126455'),
             location_label=user,
             notes=f'Burn {gas} XDAI for gas',
             counterparty=CPT_GAS,
@@ -284,7 +283,7 @@ def test_gnosis_lock(gnosis_inquirer, gnosis_accounts):
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=EvmToken(decoder.decoders['Giveth'].giv_token_id),
-            amount=FVal(giv_amount),
+            amount=FVal(giv_amount := '2617.351674315678177796'),
             location_label=user,
             notes=f'Lock {giv_amount} GIV for 26 round/s',
             counterparty=CPT_GIVETH,
@@ -297,14 +296,13 @@ def test_gnosis_lock(gnosis_inquirer, gnosis_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=EvmToken(decoder.decoders['Giveth'].pow_token_id),
-            amount=FVal(pow_amount),
+            amount=FVal(pow_amount := '10982.806567405488178331'),
             location_label=user,
             notes=f'Receive {pow_amount} POW after locking GIV',
             counterparty=CPT_GIVETH,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -312,17 +310,18 @@ def test_gnosis_lock(gnosis_inquirer, gnosis_accounts):
 def test_gnosis_stake_deposit(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0xaee26eb3b311b318292d4c29c2ad9b050fc339bfaef6da2f329a43cdb89dcd9b')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user, gas, amount = TimestampMS(1733536070000), gnosis_accounts[0], '0.000391221856613286', '100913.342801097979277274'  # noqa: E501
+    user = gnosis_accounts[0]
+    amount = '100913.342801097979277274'
     expected_events = [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1733536070000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000391221856613286'),
             location_label=user,
             notes=f'Burn {gas} XDAI for gas',
             counterparty=CPT_GAS,
@@ -374,17 +373,18 @@ def test_gnosis_stake_deposit(gnosis_inquirer, gnosis_accounts):
 def test_gnosis_withdraw(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x277949402fb601446f5b8c7e751e72df0f4687b38612935211542b3f4b3f2cf4')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user, gas, amount = TimestampMS(1733322280000), gnosis_accounts[0], '0.00046583297133306', '4927.159556510935243873'  # noqa: E501
-    expected_events = [
+    user = gnosis_accounts[0]
+    amount = '4927.159556510935243873'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1733322280000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00046583297133306'),
             location_label=user,
             notes=f'Burn {gas} XDAI for gas',
             counterparty=CPT_GAS,
@@ -416,7 +416,6 @@ def test_gnosis_withdraw(gnosis_inquirer, gnosis_accounts):
             address=GNOSIS_GIVPOWERSTAKING_WRAPPER,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_gmx.py
+++ b/rotkehlchen/tests/unit/decoders/test_gmx.py
@@ -22,14 +22,12 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x22E798f9440F563B92AAE24E94C75DfA499e3d3E']])
 def test_swap_in_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x5969392c45eaf7e6e3453e2405afb23eb2424e8e4ba2d14e38943fdcdab55d5f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5969392c45eaf7e6e3453e2405afb23eb2424e8e4ba2d14e38943fdcdab55d5f')),  # noqa: E501
     )
     user_address = arbitrum_one_accounts[0]
     gas_amount, swap_amount, received_amount = '0.0001812982', '14964.074104', '947.4907214801'
-    timestamp = TimestampMS(1705481044000)
     a_usdce = Asset('eip155:42161/erc20:0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8')
     a_link = Asset('eip155:42161/erc20:0xf97f4df75117a78c1A5a0DBb814Af92458539FB4')
 
@@ -37,7 +35,7 @@ def test_swap_in_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1705481044000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -89,19 +87,17 @@ def test_swap_in_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0C0e6d63A7933e1C2dE16E1d5E61dB1cA802BF51']])
 def test_long_in_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x99eed649e7845813353b29dba0ac248dc328253051a778ca895a0a6c34092798')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x99eed649e7845813353b29dba0ac248dc328253051a778ca895a0a6c34092798')),  # noqa: E501
     )
     user_address = arbitrum_one_accounts[0]
     gas_amount, amount_deposited, fee_amount = '0.0001744401', '0.000785648767580506', '0.00021'
-    timestamp = TimestampMS(1705487645000)
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1705487645000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -144,20 +140,18 @@ def test_long_in_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x3D4d8A52D5717b09CA1e1980393d244Ac258C6AA']])
 def test_decrease_short_in_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xa3dd437d57689479db67ce685c4b70ee9bdbfbcc53f99fc343f73c89edaafe7a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xa3dd437d57689479db67ce685c4b70ee9bdbfbcc53f99fc343f73c89edaafe7a')),  # noqa: E501
     )
     user_address = arbitrum_one_accounts[0]
     amount_withdrawn, fee_amount = '140.09783', '0.000215'
-    timestamp = TimestampMS(1705498390000)
     a_usdc = Asset('eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831')
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=18,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1705498390000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
@@ -188,21 +182,19 @@ def test_decrease_short_in_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xB5E10681aA81cd65D74912015220999044b9520C']])
 def test_stake_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x682aa15cb8d49021ae5b12c89f6d0138387c4819b1a31b80f67b70aac55d199c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x682aa15cb8d49021ae5b12c89f6d0138387c4819b1a31b80f67b70aac55d199c')),  # noqa: E501
     )
     user_address = arbitrum_one_accounts[0]
     gas_amount, staked_amount = '0.0000631134', '15.9'
     approve_amount = '115792089237316195423570985008687907853269984665640564039169.929301629384984299'  # noqa: E501
-    timestamp = TimestampMS(1707120778000)
     sgmx_address = string_to_evm_address('0x908C4D94D34924765f1eDc22A1DD098397c59dD4')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1707120778000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -303,4 +295,3 @@ def test_stake_gmx(arbitrum_one_inquirer, arbitrum_one_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_gnosis_pay.py
+++ b/rotkehlchen/tests/unit/decoders/test_gnosis_pay.py
@@ -34,12 +34,10 @@ from rotkehlchen.utils.misc import ts_ms_to_sec
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x7EcB43E01425c66a783A3065F782ccF304b39B99']])
 def test_gnosis_pay_cashback(gnosis_inquirer, gnosis_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x1c6f58c55ba2eeef7e08ed4725d16ae479d1b4210b39e647a9b282af6ffb9470')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x1c6f58c55ba2eeef7e08ed4725d16ae479d1b4210b39e647a9b282af6ffb9470')),  # noqa: E501
     )
-    amount = '0.8527869407'
     assert events == [
         EvmEvent(
             sequence_index=8,
@@ -48,7 +46,7 @@ def test_gnosis_pay_cashback(gnosis_inquirer, gnosis_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.CASHBACK,
             asset=Asset('eip155:100/erc20:0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb'),
-            amount=FVal(amount),
+            amount=FVal(amount := '0.8527869407'),
             location_label=gnosis_accounts[0],
             notes=f'Receive cashback of {amount} GNO from Gnosis Pay',
             tx_ref=tx_hash,
@@ -63,12 +61,10 @@ def test_gnosis_pay_cashback(gnosis_inquirer, gnosis_accounts):
     '0xc746598C9dD7FC62EF8775445F2F375aCbaCa7AE',  # user's gnosis pay safe
 ]])
 def test_gnosis_pay_referral(gnosis_inquirer, gnosis_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xc778b8c23b823d6cec199ece516ab68658c7caafb508104f2a0c9de4d0358529')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc778b8c23b823d6cec199ece516ab68658c7caafb508104f2a0c9de4d0358529')),  # noqa: E501
     )
-    amount = '30.23'
     assert events == [
         EvmEvent(
             sequence_index=18,
@@ -77,7 +73,7 @@ def test_gnosis_pay_referral(gnosis_inquirer, gnosis_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
-            amount=FVal(amount),
+            amount=FVal(amount := '30.23'),
             location_label=gnosis_accounts[0],
             notes=f'Receive referral reward of {amount} EURe from Gnosis Pay',
             tx_ref=tx_hash,
@@ -92,14 +88,12 @@ def test_gnosis_pay_referral(gnosis_inquirer, gnosis_accounts):
     '0xF4a1fB1689104479De1EcADfA472A9B866D08B16',  # user's gnosis pay safe
 ]])
 def test_gnosis_pay_spend(gnosis_inquirer, gnosis_accounts, rotki_premium_object):
-    tx_hash = deserialize_evm_tx_hash('0xe8d666d6acf22e5a50dfea7ece1473558a854dfa04441ea9b3d0898843364ad8')  # noqa: E501
     events, gnosis_txs_decoder = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe8d666d6acf22e5a50dfea7ece1473558a854dfa04441ea9b3d0898843364ad8')),  # noqa: E501
     )
     gnosispay_decoder = gnosis_txs_decoder.decoders.get('GnosisPay')
     gnosis_txs_decoder.premium = rotki_premium_object
-    amount = '8.5'
     expected_events = [
         EvmEvent(
             sequence_index=29,
@@ -108,7 +102,7 @@ def test_gnosis_pay_spend(gnosis_inquirer, gnosis_accounts, rotki_premium_object
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.PAYMENT,
             asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
-            amount=FVal(amount),
+            amount=FVal(amount := '8.5'),
             location_label=gnosis_accounts[0],
             notes=f'Spend {amount} EURe via Gnosis Pay',
             tx_ref=tx_hash,
@@ -207,14 +201,12 @@ def test_gnosis_pay_spend(gnosis_inquirer, gnosis_accounts, rotki_premium_object
     '0x49e52a677BD19E50beE3642a8050A5A08a6EC697',  # user's gnosis pay safe
 ]])
 def test_gnosis_pay_refund(gnosis_inquirer, gnosis_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x5f659bbc5214b358ffa5474c4209fad0587b7a9735b5965e7475c2bcb893ad38')  # noqa: E501
     events, gnosis_txs_decoder = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5f659bbc5214b358ffa5474c4209fad0587b7a9735b5965e7475c2bcb893ad38')),  # noqa: E501
     )
     gnosispay_decoder = gnosis_txs_decoder.decoders.get('GnosisPay')
 
-    amount = '2.35'
     expected_events = [
         EvmEvent(
             sequence_index=10,
@@ -223,7 +215,7 @@ def test_gnosis_pay_refund(gnosis_inquirer, gnosis_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REFUND,
             asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
-            amount=FVal(amount),
+            amount=FVal(amount := '2.35'),
             location_label=gnosis_accounts[0],
             notes=f'Receive refund of {amount} EURe from Gnosis Pay',
             tx_ref=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_golem.py
+++ b/rotkehlchen/tests/unit/decoders/test_golem.py
@@ -16,19 +16,16 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_gnt_glm_migration(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x86baa45e4ab48d1db26df82da1a6f654fe96f1254ace5883b6397d7f55eb11a4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1646777828000)
-    gas_str = '0.00560851737819982'
-    amount_str = '5920'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1646777828000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.00560851737819982'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -40,7 +37,7 @@ def test_gnt_glm_migration(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.MIGRATE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:1/erc20:0xa74476443119A942dE498590Fe1f2454d7D4aC0d'),
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '5920'),
             location_label=ethereum_accounts[0],
             notes=f'Migrate {amount_str} GNT to GLM',
             counterparty=CPT_GOLEM,
@@ -60,4 +57,3 @@ def test_gnt_glm_migration(ethereum_inquirer, ethereum_accounts):
             address=GNT_MIGRATION_ADDRESS,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_harvest_finance.py
+++ b/rotkehlchen/tests/unit/decoders/test_harvest_finance.py
@@ -21,17 +21,16 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_claim_grain(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5d0464be1198872d88507a3da2a876fe32c9d4427fb9ba7254c29fef0a94698c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str, amount_str = TimestampMS(1613015691000), '0.007051027', '1373.104541023509385198'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1613015691000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.007051027'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -43,11 +42,10 @@ def test_claim_grain(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=EvmToken(GRAIN_TOKEN_ID),
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '1373.104541023509385198'),
             location_label=ethereum_accounts[0],
             notes=f'Claim {amount_str} GRAIN from the harvest finance hack compensation airdrop',
             counterparty=CPT_HARVEST_FINANCE,
             address=HARVEST_GRAIN_CLAIM,
             extra_data={AIRDROP_IDENTIFIER_KEY: 'grain'},
         )]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_hedgey.py
+++ b/rotkehlchen/tests/unit/decoders/test_hedgey.py
@@ -25,16 +25,16 @@ def test_delegate_vested_tokens_with_vault_creation(
 ):
     tx_hash = deserialize_evm_tx_hash('0x50dc56b705219f9f26e1749d4dabefbac7fae4e60925f4c57cb8a42687adf703')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, user_address = TimestampMS(1738025567000), '0.002012111196478005', ethereum_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1738025567000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.002012111196478005'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -54,7 +54,6 @@ def test_delegate_vested_tokens_with_vault_creation(
             address=ENS_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -65,16 +64,16 @@ def test_delegate_plans(
 ):
     tx_hash = deserialize_evm_tx_hash('0xf5317d7926c5b3f269604ea983a8ed9a6240dfdbabcccd33a12dd135b9b2389a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, user_address = TimestampMS(1738067495000), '0.000156863123427816', ethereum_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1738067495000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000156863123427816'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -94,7 +93,6 @@ def test_delegate_plans(
             address=ENS_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -105,16 +103,17 @@ def test_redeem_plans(
 ):
     tx_hash = deserialize_evm_tx_hash('0xb85eb3fb6496fa51ac3d43d230ea729b52593bd2781b2b9dfab638aab7011719')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, user_address, amount = TimestampMS(1737473963000), '0.000964573778269605', ethereum_accounts[0], '119.425418569253784576'  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    amount = '119.425418569253784576'
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1737473963000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000964573778269605'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -134,4 +133,3 @@ def test_redeem_plans(
             address=VOTING_TOKEN_LOCKUPS,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_hop.py
+++ b/rotkehlchen/tests/unit/decoders/test_hop.py
@@ -53,12 +53,11 @@ ADDY = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12'
 def test_hop_l2_deposit(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xd46640417a686b399b2f2a920b0c58a35095759365cbe7b795bddec34b8c5eee')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1653219722000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1653219722000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -81,7 +80,6 @@ def test_hop_l2_deposit(ethereum_inquirer):
             counterparty=CPT_HOP,
             address=string_to_evm_address('0xb8901acB165ed027E32754E0FFe830802919727f'),
         )]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -89,17 +87,16 @@ def test_hop_l2_deposit(ethereum_inquirer):
 def test_hop_l2_deposit_usdc(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xac42ca2d88194c0ee219f6c71c98fe566667151a1dc235d17d993b6985342062')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_fee, bridge_amount = TimestampMS(1710955643000), '0.005802319111323689', '3700'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1710955643000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fee),
+            amount=FVal(gas_fee := '0.005802319111323689'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_fee} ETH for gas',
             counterparty=CPT_GAS,
@@ -111,14 +108,13 @@ def test_hop_l2_deposit_usdc(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_USDC,
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '3700'),
             location_label=ethereum_accounts[0],
             notes=f'Bridge {bridge_amount} USDC to Arbitrum One via Hop protocol',
             counterparty=CPT_HOP,
             address=string_to_evm_address('0x3666f603Cc164936C1b87e207F36BEBa4AC5f18a'),
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -130,7 +126,7 @@ def test_hop_optimism_eth_receive(optimism_inquirer):
     """
     tx_hash = deserialize_evm_tx_hash('0x8394c39e1f030a04aa8359f0322257632282a7dfa419b3c9ffc8ab61205a815d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -145,7 +141,6 @@ def test_hop_optimism_eth_receive(optimism_inquirer):
             counterparty=CPT_HOP,
             address=string_to_evm_address('0x86cA30bEF97fB651b8d866D45503684b90cb3312'),
         )]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -160,7 +155,7 @@ def test_hop_optimism_eth_receive_no_event(optimism_inquirer, optimism_accounts)
     tx_hash = deserialize_evm_tx_hash('0x3e18e3a0220857ecce91ad79065f10a663128926854b6087161fd0364c7f76f5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     bridge_amount, timestamp, user_address = '0.03958480553397407', TimestampMS(1666977475000), optimism_accounts[0]  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -176,7 +171,6 @@ def test_hop_optimism_eth_receive_no_event(optimism_inquirer, optimism_accounts)
             address=string_to_evm_address('0x86cA30bEF97fB651b8d866D45503684b90cb3312'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -184,24 +178,23 @@ def test_hop_optimism_eth_receive_no_event(optimism_inquirer, optimism_accounts)
 def test_hop_usdc_bridge(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xdca89892d6a738c2ea278d93a5e1757b2f946f4e24c4aa02d59a0abf6a8e5f4b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, bridge_amount, user_address = TimestampMS(1715038763000), '9006.683634', ethereum_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=167,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1715038763000),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_USDC,
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '9006.683634'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} USDC via Hop protocol',
             counterparty=CPT_HOP,
             address=string_to_evm_address('0x3666f603Cc164936C1b87e207F36BEBa4AC5f18a'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -210,24 +203,23 @@ def test_hop_usdc_bridge(ethereum_inquirer, ethereum_accounts):
 def test_hop_eth_bridge_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4f1e95506c10f061ddfe28a7437f3b651959ff17f1e2a7a148c8896147ee357e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, bridge_amount, user_address = TimestampMS(1643122781000), '0.10392672200478311', optimism_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = optimism_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1643122781000),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_ETH,
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '0.10392672200478311'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} ETH via Hop protocol',
             counterparty=CPT_HOP,
             address=string_to_evm_address('0x86cA30bEF97fB651b8d866D45503684b90cb3312'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -235,24 +227,23 @@ def test_hop_eth_bridge_optimism(optimism_inquirer, optimism_accounts):
 def test_hop_eth_bridge_gnosis(gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8765cf6596ff1794679509fcc0ecd5adf921464859f08992944f6d6a7e905d98')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, bridge_amount, user_address = TimestampMS(1715179605000), '0.008909890056139906', gnosis_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = gnosis_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=11,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1715179605000),
             location=Location.GNOSIS,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:100/erc20:0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1'),
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '0.008909890056139906'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} WETH via Hop protocol',
             counterparty=CPT_HOP,
             address=string_to_evm_address('0x03D7f750777eC48d39D080b020D83Eb2CB4e3547'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -260,24 +251,23 @@ def test_hop_eth_bridge_gnosis(gnosis_inquirer: 'GnosisInquirer', gnosis_account
 def test_hop_usdc_bridge_gnosis(gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0xd00e4cd1223d962ef841c16977142856c1f54d4e87fae417c58520270e3a9420')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, bridge_amount, user_address = TimestampMS(1710961255000), '23.482715', gnosis_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = gnosis_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=2021,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1710961255000),
             location=Location.GNOSIS,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:100/erc20:0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83'),
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '23.482715'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} USDC via Hop protocol',
             counterparty=CPT_HOP,
             address=string_to_evm_address('0x76b22b8C1079A44F1211D867D68b1eda76a635A7'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -285,98 +275,91 @@ def test_hop_usdc_bridge_gnosis(gnosis_inquirer: 'GnosisInquirer', gnosis_accoun
 def test_hop_hop_bridge_gnosis(gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x93a644818341e6ac22e499ac1ab73c11b6d8e55ff52ecc529125dc28790d7df1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, bridge_amount, user_address = TimestampMS(1697084045000), '6854.931542581763573457', gnosis_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = gnosis_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=2,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1697084045000),
             location=Location.GNOSIS,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:100/erc20:0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC'),
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '6854.931542581763573457'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} HOP via Hop protocol',
             counterparty=CPT_HOP,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x8f7043fF95c088b5727bF7889b4d868DF92F6a58']])
 def test_hop_eth_bridge_polygon_pos(polygon_pos_inquirer: 'PolygonPOSInquirer', polygon_pos_accounts):  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0xcb26a59c87d41de4d6dd688a9ff8400b4e981f7e38d25787616ec0f81b4dccca')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xcb26a59c87d41de4d6dd688a9ff8400b4e981f7e38d25787616ec0f81b4dccca')),  # noqa: E501
     )
-    timestamp, bridge_amount, user_address = TimestampMS(1715182468000), '0.00371160659018274', polygon_pos_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = polygon_pos_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=30,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1715182468000),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_WETH_POLYGON,
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '0.00371160659018274'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} WETH via Hop protocol',
             counterparty=CPT_HOP,
             address=string_to_evm_address('0xc315239cFb05F1E130E7E28E603CEa4C014c57f0'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('base_accounts', [['0xC0b263b8315FAABC27BC0479a5A547281c049C1c']])
 def test_hop_eth_bridge_base(base_inquirer: 'BaseInquirer', base_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xd78eb0f79fa4af1e140641ef260499a6e138b6398d2c4cdcd2e7c488ee8cb20e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd78eb0f79fa4af1e140641ef260499a6e138b6398d2c4cdcd2e7c488ee8cb20e')),  # noqa: E501
     )
-    timestamp, bridge_amount, user_address = TimestampMS(1715184391000), '0.895370313537560075', base_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = base_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1715184391000),
             location=Location.BASE,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_ETH,
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '0.895370313537560075'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} ETH via Hop protocol',
             counterparty=CPT_HOP,
             address=string_to_evm_address('0x10541b07d8Ad2647Dc6cD67abd4c03575dade261'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x32C885EcE06EBC8F6bEf6C2052E400226C087e08']])
 def test_hop_eth_bridge_l2_to_l1_arbitrum_one(arbitrum_one_inquirer: 'ArbitrumOneInquirer', arbitrum_one_accounts):  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0x4fb91812763e6af24465ee014a306b8322beb612aa51f26b657772447744ae94')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x4fb91812763e6af24465ee014a306b8322beb612aa51f26b657772447744ae94')),  # noqa: E501
     )
-    timestamp = TimestampMS(1715614190000)
     bridge_amount, gas_fee, hop_fee, user_address = '0.194877831029822766', '0.00000323542', '0.004034870881159123', arbitrum_one_accounts[0]  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1715614190000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -413,7 +396,6 @@ def test_hop_eth_bridge_l2_to_l1_arbitrum_one(arbitrum_one_inquirer: 'ArbitrumOn
             address=string_to_evm_address('0x33ceb27b39d2Bb7D2e61F7564d3Df29344020417'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -421,42 +403,39 @@ def test_hop_eth_bridge_l2_to_l1_arbitrum_one(arbitrum_one_inquirer: 'ArbitrumOn
 def test_hop_eth_bridge_l2_to_l1_ethereum(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x15704d966705b423b1f747d9413a474f35647e676a5f7ec2bed5ae83bf4f5e38')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, bridge_amount, user_address = TimestampMS(1715614211000), '0.194877831029822766', ethereum_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1715614211000),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_ETH,
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '0.194877831029822766'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} ETH via Hop protocol',
             counterparty=CPT_HOP,
             address=string_to_evm_address('0xb8901acB165ed027E32754E0FFe830802919727f'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0a6c69327d517568E6308F1E1CD2fD2B2b3cd4BF']])
 def test_hop_magic_bridge_l2_to_l1_arbitrum_one(arbitrum_one_inquirer: 'ArbitrumOneInquirer', arbitrum_one_accounts):  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0x05c2c5f18e9acc193f34c611e176d9e65f34d420ba80c7546e0ba0c124d510e3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x05c2c5f18e9acc193f34c611e176d9e65f34d420ba80c7546e0ba0c124d510e3')),  # noqa: E501
     )
-    timestamp = TimestampMS(1715564239000)
     bridge_amount, gas_fee, bridge_fee, user_address = '690.64074354910030513', '0.00000257294', '5.136762511171047454', arbitrum_one_accounts[0]  # noqa: E501
     approval_amount = '115792089237316195423570985008687907853269984665640563953113.341386879395299329'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1715564239000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -505,7 +484,6 @@ def test_hop_magic_bridge_l2_to_l1_arbitrum_one(arbitrum_one_inquirer: 'Arbitrum
             address=string_to_evm_address('0x50a3a623d00fd8b8a4F3CbC5aa53D0Bc6FA912DD'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -513,24 +491,23 @@ def test_hop_magic_bridge_l2_to_l1_arbitrum_one(arbitrum_one_inquirer: 'Arbitrum
 def test_hop_usdc_bridge_l2_to_l1_ethereum(ethereum_inquirer: 'EthereumInquirer', ethereum_accounts):  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0xc76dbb99825d1e53488426b5cf93f7ff71b5fd1fccd41259537e84824a950cc9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, bridge_amount, user_address = TimestampMS(1715208275000), '60786.713495', ethereum_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = ethereum_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=182,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1715208275000),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_USDC,
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '60786.713495'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} USDC via Hop protocol',
             counterparty=CPT_HOP,
             address=string_to_evm_address('0x3666f603Cc164936C1b87e207F36BEBa4AC5f18a'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -538,17 +515,17 @@ def test_hop_usdc_bridge_l2_to_l1_ethereum(ethereum_inquirer: 'EthereumInquirer'
 def test_hop_usdc_bridge_l2_to_l1_gnosis(gnosis_inquirer: 'GnosisInquirer', gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0c6084399c873b06407f073acec89ffd9693ac0c7df4befd9e45e4178b5ae869')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, bridge_amount, gas_fees, user_address = TimestampMS(1715204760000), '60786.713495', '0.0001299435', gnosis_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = gnosis_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1715204760000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.0001299435'),
             location_label=user_address,
             notes=f'Burn {gas_fees} XDAI for gas',
             counterparty=CPT_GAS,
@@ -560,35 +537,33 @@ def test_hop_usdc_bridge_l2_to_l1_gnosis(gnosis_inquirer: 'GnosisInquirer', gnos
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:100/erc20:0x9ec9551d4A1a1593b0ee8124D98590CC71b3B09D'),
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '60786.713495'),
             location_label=user_address,
             notes=f'Burn {bridge_amount} of Hop hUSDC',
             counterparty=CPT_HOP,
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D', '0xA63734db2c674122EEd383aea7698C68aAbf749e']])  # noqa: E501
 def test_hop_eth_bridge_arbitrum_custom_recipient(arbitrum_one_inquirer: 'ArbitrumOneInquirer', arbitrum_one_accounts):  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0x88b6fce15afacab9fa77caaf8d42d30d7a517f9f5ae6b7d6c37795309ac90383')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x88b6fce15afacab9fa77caaf8d42d30d7a517f9f5ae6b7d6c37795309ac90383')),  # noqa: E501
     )
-    timestamp, gas, bridge_amount, hop_fee, user_address = TimestampMS(1715946201000), '0.00000266018', '0.000880551717232904', '0.000118862618614123', arbitrum_one_accounts[0]  # noqa: E501
-    expected_events = [
+    user_address = arbitrum_one_accounts[0]
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1715946201000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000266018'),
             location_label=user_address,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -600,7 +575,7 @@ def test_hop_eth_bridge_arbitrum_custom_recipient(arbitrum_one_inquirer: 'Arbitr
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_ETH,
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '0.000880551717232904'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} ETH to Base at address {arbitrum_one_accounts[1]} via Hop protocol',  # noqa: E501
             counterparty=CPT_HOP,
@@ -613,14 +588,13 @@ def test_hop_eth_bridge_arbitrum_custom_recipient(arbitrum_one_inquirer: 'Arbitr
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(hop_fee),
+            amount=FVal(hop_fee := '0.000118862618614123'),
             location_label=user_address,
             notes=f'Spend {hop_fee} ETH as a hop fee',
             counterparty=CPT_HOP,
             address=string_to_evm_address('0x33ceb27b39d2Bb7D2e61F7564d3Df29344020417'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -635,16 +609,15 @@ def test_hop_add_liquidity(
 ):
     tx_hash = deserialize_evm_tx_hash('0xa50286f6288ca13452a490d766aaf969d20cce7035b514423a7b1432fd329cc5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, gas, lp_amount, lp_token_amount = TimestampMS(1714582939000), '0.000013783759721971', '0.025', '0.023220146656543904'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714582939000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000013783759721971'),
             location_label=base_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -656,7 +629,7 @@ def test_hop_add_liquidity(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_WETH_BASE,
-            amount=FVal(lp_amount),
+            amount=FVal(lp_amount := '0.025'),
             location_label=base_accounts[0],
             notes=f'Deposit {lp_amount} WETH to Hop',
             tx_ref=tx_hash,
@@ -669,7 +642,7 @@ def test_hop_add_liquidity(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:8453/erc20:0xe9605BEc1c5C3E81F974F80b8dA9fBEFF4845d4D'),
-            amount=FVal(lp_token_amount),
+            amount=FVal(lp_token_amount := '0.023220146656543904'),
             location_label=base_accounts[0],
             notes=f'Receive {lp_token_amount} HOP-LP-ETH after providing liquidity in Hop',
             tx_ref=tx_hash,
@@ -677,7 +650,6 @@ def test_hop_add_liquidity(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
     assert EvmToken('eip155:8453/erc20:0xe9605BEc1c5C3E81F974F80b8dA9fBEFF4845d4D').protocol == CPT_HOP  # noqa: E501
     with GlobalDBHandler().conn.read_ctx() as cursor:
         assert globaldb_get_unique_cache_value(
@@ -699,21 +671,19 @@ def test_hop_add_liquidity_2(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x52ab27e8f15148c0f41df0114429321d2a1e9411f2ea2fe7c8fb9c663bc09ecb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x52ab27e8f15148c0f41df0114429321d2a1e9411f2ea2fe7c8fb9c663bc09ecb')),  # noqa: E501
     )
-    timestamp, gas, lp_amount, lp_amount_2, lp_token_amount, approval_amount_1, approval_amount_2 = TimestampMS(1716391406000), '0.00000298668', '0.001', '0.005129453530970625', '0.005676129314105837', '115792089237316195423570985008687907853269984665640564039457.583007913129639935', '115792089237316195423570985008687907853269984665640564039457.57887845959866931'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716391406000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000298668'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -725,7 +695,7 @@ def test_hop_add_liquidity_2(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=A_WETH_ARB,
-            amount=FVal(approval_amount_1),
+            amount=FVal(approval_amount_1 := '115792089237316195423570985008687907853269984665640564039457.583007913129639935'),  # noqa: E501
             location_label=arbitrum_one_accounts[0],
             notes=f'Set WETH spending approval of {arbitrum_one_accounts[0]} by 0x652d27c0F72771Ce5C76fd400edD61B406Ac6D97 to {approval_amount_1}',  # noqa: E501
             tx_ref=tx_hash,
@@ -737,7 +707,7 @@ def test_hop_add_liquidity_2(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:42161/erc20:0xDa7c0de432a9346bB6e96aC74e3B61A36d8a77eB'),
-            amount=FVal(approval_amount_2),
+            amount=FVal(approval_amount_2 := '115792089237316195423570985008687907853269984665640564039457.57887845959866931'),  # noqa: E501
             location_label=arbitrum_one_accounts[0],
             notes=f'Set hETH spending approval of {arbitrum_one_accounts[0]} by 0x652d27c0F72771Ce5C76fd400edD61B406Ac6D97 to {approval_amount_2}',  # noqa: E501
             tx_ref=tx_hash,
@@ -749,7 +719,7 @@ def test_hop_add_liquidity_2(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_WETH_ARB,
-            amount=FVal(lp_amount),
+            amount=FVal(lp_amount := '0.001'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Deposit {lp_amount} WETH to Hop',
             tx_ref=tx_hash,
@@ -762,7 +732,7 @@ def test_hop_add_liquidity_2(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:42161/erc20:0xDa7c0de432a9346bB6e96aC74e3B61A36d8a77eB'),
-            amount=FVal(lp_amount_2),
+            amount=FVal(lp_amount_2 := '0.005129453530970625'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Deposit {lp_amount_2} hETH to Hop',
             tx_ref=tx_hash,
@@ -775,7 +745,7 @@ def test_hop_add_liquidity_2(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:42161/erc20:0x59745774Ed5EfF903e615F5A2282Cae03484985a'),
-            amount=FVal(lp_token_amount),
+            amount=FVal(lp_token_amount := '0.005676129314105837'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Receive {lp_token_amount} HOP-LP-ETH after providing liquidity in Hop',
             tx_ref=tx_hash,
@@ -783,7 +753,6 @@ def test_hop_add_liquidity_2(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -795,16 +764,15 @@ def test_hop_remove_liquidity(
 ):
     tx_hash = deserialize_evm_tx_hash('0xc3662d3d68f845dd848c9df2aef4efedf9c9a01580872619a2f4eaafdbf98feb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, gas, lp_amount, withdrawn = TimestampMS(1714729295000), '0.000019101983974486', '0.75', '0.807405509354959205'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714729295000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000019101983974486'),
             location_label=base_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -828,7 +796,7 @@ def test_hop_remove_liquidity(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset('eip155:8453/erc20:0xe9605BEc1c5C3E81F974F80b8dA9fBEFF4845d4D'),
-            amount=FVal(lp_amount),
+            amount=FVal(lp_amount := '0.75'),
             location_label=base_accounts[0],
             notes=f'Return {lp_amount} HOP-LP-ETH',
             tx_ref=tx_hash,
@@ -841,7 +809,7 @@ def test_hop_remove_liquidity(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=A_WETH_BASE,
-            amount=FVal(withdrawn),
+            amount=FVal(withdrawn := '0.807405509354959205'),
             location_label=base_accounts[0],
             notes=f'Withdraw {withdrawn} WETH from Hop',
             tx_ref=tx_hash,
@@ -849,7 +817,6 @@ def test_hop_remove_liquidity(
             address=string_to_evm_address('0x0ce6c85cF43553DE10FC56cecA0aef6Ff0DD444d'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -861,16 +828,15 @@ def test_hop_remove_liquidity_2(
 ):
     tx_hash = deserialize_evm_tx_hash('0x4995c8896bb845ab506b759530d35e306d6ef5418630b60bbf26ca0fae90fcaa')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, gas, lp_amount, withdrawn_1, withdrawn_2 = TimestampMS(1716298905000), '0.000020283535960823', '0.014812373943526529', '0.008484007194088721', '0.007520340659511852'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716298905000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000020283535960823'),
             location_label=base_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -894,7 +860,7 @@ def test_hop_remove_liquidity_2(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset('eip155:8453/erc20:0xe9605BEc1c5C3E81F974F80b8dA9fBEFF4845d4D'),
-            amount=FVal(lp_amount),
+            amount=FVal(lp_amount := '0.014812373943526529'),
             location_label=base_accounts[0],
             notes=f'Return {lp_amount} HOP-LP-ETH',
             tx_ref=tx_hash,
@@ -907,7 +873,7 @@ def test_hop_remove_liquidity_2(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=A_WETH_BASE,
-            amount=FVal(withdrawn_1),
+            amount=FVal(withdrawn_1 := '0.008484007194088721'),
             location_label=base_accounts[0],
             notes=f'Withdraw {withdrawn_1} WETH from Hop',
             tx_ref=tx_hash,
@@ -920,7 +886,7 @@ def test_hop_remove_liquidity_2(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=Asset('eip155:8453/erc20:0xC1985d7a3429cDC85E59E2E4Fcc805b857e6Ee2E'),
-            amount=FVal(withdrawn_2),
+            amount=FVal(withdrawn_2 := '0.007520340659511852'),
             location_label=base_accounts[0],
             notes=f'Withdraw {withdrawn_2} hETH from Hop',
             tx_ref=tx_hash,
@@ -928,7 +894,6 @@ def test_hop_remove_liquidity_2(
             address=string_to_evm_address('0x0ce6c85cF43553DE10FC56cecA0aef6Ff0DD444d'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -939,16 +904,15 @@ def test_hop_remove_liquidity_usdc_gnosis(
 ):
     tx_hash = deserialize_evm_tx_hash('0x5833d34d7f20ee4e71b902dac85a025f40739a1d646091553104a3e345a38f81')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, gas, lp_amount, withdrawn, withdrawn_2, approval_amount = TimestampMS(1716258450000), '0.000645488318952488', '2.138240168467212015', '0.258527', '2.026586', '0.861759831532787985'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716258450000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000645488318952488'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas} XDAI for gas',
             tx_ref=tx_hash,
@@ -960,7 +924,7 @@ def test_hop_remove_liquidity_usdc_gnosis(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:100/erc20:0x9D373d22FD091d7f9A6649EB067557cc12Fb1A0A'),
-            amount=FVal(approval_amount),
+            amount=FVal(approval_amount := '0.861759831532787985'),
             location_label=gnosis_accounts[0],
             notes=f'Set HOP-LP-USDC spending approval of {gnosis_accounts[0]} by 0x5C32143C8B198F392d01f8446b754c181224ac26 to {approval_amount}',  # noqa: E501
             tx_ref=tx_hash,
@@ -972,7 +936,7 @@ def test_hop_remove_liquidity_usdc_gnosis(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset('eip155:100/erc20:0x9D373d22FD091d7f9A6649EB067557cc12Fb1A0A'),
-            amount=FVal(lp_amount),
+            amount=FVal(lp_amount := '2.138240168467212015'),
             location_label=gnosis_accounts[0],
             notes=f'Return {lp_amount} HOP-LP-USDC',
             tx_ref=tx_hash,
@@ -985,7 +949,7 @@ def test_hop_remove_liquidity_usdc_gnosis(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=Asset('eip155:100/erc20:0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83'),
-            amount=FVal(withdrawn),
+            amount=FVal(withdrawn := '0.258527'),
             location_label=gnosis_accounts[0],
             notes=f'Withdraw {withdrawn} USDC from Hop',
             tx_ref=tx_hash,
@@ -998,7 +962,7 @@ def test_hop_remove_liquidity_usdc_gnosis(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=Asset('eip155:100/erc20:0x9ec9551d4A1a1593b0ee8124D98590CC71b3B09D'),
-            amount=FVal(withdrawn_2),
+            amount=FVal(withdrawn_2 := '2.026586'),
             location_label=gnosis_accounts[0],
             notes=f'Withdraw {withdrawn_2} hUSDC from Hop',
             tx_ref=tx_hash,
@@ -1006,7 +970,6 @@ def test_hop_remove_liquidity_usdc_gnosis(
             address=string_to_evm_address('0x5C32143C8B198F392d01f8446b754c181224ac26'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1018,25 +981,23 @@ def test_hop_stake(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x6329984b82cb85903fee9fef61fb77cdf848ff6344056156da2e66676ad91473')  # noqa: E501
     get_decoded_events_of_transaction(  # decode the deposit tx to process the LP token
         evm_inquirer=arbitrum_one_inquirer,
         tx_hash=deserialize_evm_tx_hash('0x52ab27e8f15148c0f41df0114429321d2a1e9411f2ea2fe7c8fb9c663bc09ecb'),
     )
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6329984b82cb85903fee9fef61fb77cdf848ff6344056156da2e66676ad91473')),  # noqa: E501
     )
-    timestamp, gas, stake_amount, approval_amount = TimestampMS(1716391575000), '0.00000183398', '0.005676129314105837', '115792089237316195423570985008687907853269984665640564039457.578331783815534098'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716391575000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000183398'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -1048,7 +1009,7 @@ def test_hop_stake(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=Asset('eip155:42161/erc20:0x59745774Ed5EfF903e615F5A2282Cae03484985a'),
-            amount=FVal(stake_amount),
+            amount=FVal(stake_amount := '0.005676129314105837'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Stake {stake_amount} HOP-LP-ETH in Hop',
             tx_ref=tx_hash,
@@ -1061,14 +1022,13 @@ def test_hop_stake(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:42161/erc20:0x59745774Ed5EfF903e615F5A2282Cae03484985a'),
-            amount=FVal(approval_amount),
+            amount=FVal(approval_amount := '115792089237316195423570985008687907853269984665640564039457.578331783815534098'),  # noqa: E501
             location_label=arbitrum_one_accounts[0],
             notes=f'Set HOP-LP-ETH spending approval of {arbitrum_one_accounts[0]} by 0x755569159598f3702bdD7DFF6233A317C156d3Dd to {approval_amount}',  # noqa: E501
             tx_ref=tx_hash,
             address=string_to_evm_address('0x755569159598f3702bdD7DFF6233A317C156d3Dd'),
         ),
     ]
-    assert events == expected_events
     inquirer.inject_evm_managers([(arbitrum_one_inquirer.chain_id, arbitrum_one_manager)])
     assert inquirer.find_usd_price(Asset('eip155:42161/erc20:0x59745774Ed5EfF903e615F5A2282Cae03484985a')).is_close(1995.56814825)  # noqa: E501
 
@@ -1079,21 +1039,19 @@ def test_hop_stake_2(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash('0xe0c1f6f152422784a4e4346d84af7d32fda95eab17da257f3fdc5121f4a6fbc8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe0c1f6f152422784a4e4346d84af7d32fda95eab17da257f3fdc5121f4a6fbc8')),  # noqa: E501
     )
-    timestamp, gas, stake_amount, approval_amount = TimestampMS(1718269403000), '0.00000199918', '0.005676129314105837', '115792089237316195423570985008687907853269984665640564039457.578331783815534098'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1718269403000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000199918'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -1105,7 +1063,7 @@ def test_hop_stake_2(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=Asset('eip155:42161/erc20:0x59745774Ed5EfF903e615F5A2282Cae03484985a'),
-            amount=FVal(stake_amount),
+            amount=FVal(stake_amount := '0.005676129314105837'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Stake {stake_amount} HOP-LP-ETH in Hop',
             tx_ref=tx_hash,
@@ -1118,14 +1076,13 @@ def test_hop_stake_2(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:42161/erc20:0x59745774Ed5EfF903e615F5A2282Cae03484985a'),
-            amount=FVal(approval_amount),
+            amount=FVal(approval_amount := '115792089237316195423570985008687907853269984665640564039457.578331783815534098'),  # noqa: E501
             location_label=arbitrum_one_accounts[0],
             notes=f'Set HOP-LP-ETH spending approval of {arbitrum_one_accounts[0]} by 0x00001fcF29c5Fd7846E4332AfBFaA48701D727f5 to {approval_amount}',  # noqa: E501
             tx_ref=tx_hash,
             address=string_to_evm_address('0x00001fcF29c5Fd7846E4332AfBFaA48701D727f5'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1134,21 +1091,19 @@ def test_hop_claim_rewards(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x905c1f8cf4b94d49b18f14fc7c403df653f731999ef5262b6aa92dbe5ad0423f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x905c1f8cf4b94d49b18f14fc7c403df653f731999ef5262b6aa92dbe5ad0423f')),  # noqa: E501
     )
-    timestamp, gas, reward_amount = TimestampMS(1716445828000), '0.00000098192', '1.556162863261353191'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716445828000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000098192'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -1160,7 +1115,7 @@ def test_hop_claim_rewards(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REWARD,
             asset=Asset('eip155:42161/erc20:0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC'),
-            amount=FVal(reward_amount),
+            amount=FVal(reward_amount := '1.556162863261353191'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Claim {reward_amount} HOP from Hop',
             tx_ref=tx_hash,
@@ -1168,7 +1123,6 @@ def test_hop_claim_rewards(
             address=string_to_evm_address('0x755569159598f3702bdD7DFF6233A317C156d3Dd'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1177,21 +1131,19 @@ def test_hop_claim_rewards_2(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x85b7ca62b27f78f59bcb9fd52ab18c05f3f143ff4df00c70d4f9a3edfa5eea19')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x85b7ca62b27f78f59bcb9fd52ab18c05f3f143ff4df00c70d4f9a3edfa5eea19')),  # noqa: E501
     )
-    timestamp, gas, reward_amount = TimestampMS(1718278937000), '0.00000171746', '1.305947476028639625'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1718278937000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000171746'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -1203,7 +1155,7 @@ def test_hop_claim_rewards_2(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_ARB,
-            amount=FVal(reward_amount),
+            amount=FVal(reward_amount := '1.305947476028639625'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Claim {reward_amount} ARB from Hop',
             tx_ref=tx_hash,
@@ -1211,7 +1163,6 @@ def test_hop_claim_rewards_2(
             address=string_to_evm_address('0x00001fcF29c5Fd7846E4332AfBFaA48701D727f5'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1221,21 +1172,19 @@ def test_hop_claim_merkle_rewards(
         optimism_inquirer: 'OptimismInquirer',
         optimism_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x7f8114d30702cd540154b01a666ef6a7cf4dab8c4d657efa9e0503413243d2f3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x7f8114d30702cd540154b01a666ef6a7cf4dab8c4d657efa9e0503413243d2f3')),  # noqa: E501
     )
-    timestamp, gas, reward_amount = TimestampMS(1747908883000), '0.000000228471368276', '0.18'
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1747908883000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000000228471368276'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -1247,7 +1196,7 @@ def test_hop_claim_merkle_rewards(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_OP,
-            amount=FVal(reward_amount),
+            amount=FVal(reward_amount := '0.18'),
             location_label=optimism_accounts[0],
             notes=f'Claim {reward_amount} OP from Hop',
             tx_ref=tx_hash,
@@ -1255,7 +1204,6 @@ def test_hop_claim_merkle_rewards(
             address=string_to_evm_address('0x45269F59aA76bB491D0Fc4c26F468D8E1EE26b73'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1264,21 +1212,19 @@ def test_hop_unstake(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x4bdf31c7bbe27ccbb9a5d381596b6f4d8cf9583d111af43d5b0b5d76bb8f6751')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x4bdf31c7bbe27ccbb9a5d381596b6f4d8cf9583d111af43d5b0b5d76bb8f6751')),  # noqa: E501
     )
-    timestamp, gas, unstake_amount, reward_amount = TimestampMS(1716446062000), '0.00000160545', '0.000958469117996842', '0.000025838435799823'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1716446062000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00000160545'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -1290,7 +1236,7 @@ def test_hop_unstake(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REMOVE_ASSET,
             asset=Asset('eip155:42161/erc20:0x59745774Ed5EfF903e615F5A2282Cae03484985a'),
-            amount=FVal(unstake_amount),
+            amount=FVal(unstake_amount := '0.000958469117996842'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Unstake {unstake_amount} HOP-LP-ETH from Hop',
             tx_ref=tx_hash,
@@ -1303,7 +1249,7 @@ def test_hop_unstake(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REWARD,
             asset=Asset('eip155:42161/erc20:0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC'),
-            amount=FVal(reward_amount),
+            amount=FVal(reward_amount := '0.000025838435799823'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Claim {reward_amount} HOP from Hop',
             tx_ref=tx_hash,
@@ -1311,7 +1257,6 @@ def test_hop_unstake(
             address=string_to_evm_address('0x755569159598f3702bdD7DFF6233A317C156d3Dd'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1322,16 +1267,15 @@ def test_hop_stake_gnosis(
 ):
     tx_hash = deserialize_evm_tx_hash('0xf3b00cb365594bf9b2894af0edf852d04411db49b5fe9c07708186f75bce5385')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, gas, stake_amount, approval_amount = TimestampMS(1710600070000), '0.00017891077758659', '1.927208027730675426', '115792089237316195423570985008687907853269984665640564039453.729591857668289083'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1710600070000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00017891077758659'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas} XDAI for gas',
             tx_ref=tx_hash,
@@ -1343,7 +1287,7 @@ def test_hop_stake_gnosis(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=Asset('eip155:100/erc20:0x5b10222f2Ada260AAf6C6fC274bd5810AF9d33c0'),
-            amount=FVal(stake_amount),
+            amount=FVal(stake_amount := '1.927208027730675426'),
             location_label=gnosis_accounts[0],
             notes=f'Stake {stake_amount} HOP-LP-USDT in Hop',
             tx_ref=tx_hash,
@@ -1356,14 +1300,13 @@ def test_hop_stake_gnosis(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:100/erc20:0x5b10222f2Ada260AAf6C6fC274bd5810AF9d33c0'),
-            amount=FVal(approval_amount),
+            amount=FVal(approval_amount := '115792089237316195423570985008687907853269984665640564039453.729591857668289083'),  # noqa: E501
             location_label=gnosis_accounts[0],
             notes=f'Set HOP-LP-USDT spending approval of {gnosis_accounts[0]} by 0x2C2Ab81Cf235e86374468b387e241DF22459A265 to {approval_amount}',  # noqa: E501
             tx_ref=tx_hash,
             address=string_to_evm_address('0x2C2Ab81Cf235e86374468b387e241DF22459A265'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1374,16 +1317,15 @@ def test_hop_claim_rewards_gnosis(
 ):
     tx_hash = deserialize_evm_tx_hash('0x5ad3d5050d43ec08883c76116d9328b6bf61dd8478c082bfe21bd97eb237c4b1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, gas, reward_amount = TimestampMS(1710597650000), '0.000149113056096078', '0.001269493516433091'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1710597650000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000149113056096078'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas} XDAI for gas',
             tx_ref=tx_hash,
@@ -1395,7 +1337,7 @@ def test_hop_claim_rewards_gnosis(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REWARD,
             asset=Asset('eip155:100/erc20:0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb'),
-            amount=FVal(reward_amount),
+            amount=FVal(reward_amount := '0.001269493516433091'),
             location_label=gnosis_accounts[0],
             notes=f'Claim {reward_amount} GNO from Hop',
             tx_ref=tx_hash,
@@ -1403,7 +1345,6 @@ def test_hop_claim_rewards_gnosis(
             address=string_to_evm_address('0x2C2Ab81Cf235e86374468b387e241DF22459A265'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1414,16 +1355,15 @@ def test_hop_unstake_gnosis(
 ):
     tx_hash = deserialize_evm_tx_hash('0x10e32923be7fd7beda4551badb4fb3ca1a708268884e540d92c73b88596f3ac4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp, gas, unstake_amount, reward_amount = TimestampMS(1708463325000), '0.000669895628651568', '30000', '0.91583970339645'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1708463325000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_XDAI,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.000669895628651568'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {gas} XDAI for gas',
             tx_ref=tx_hash,
@@ -1435,7 +1375,7 @@ def test_hop_unstake_gnosis(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REMOVE_ASSET,
             asset=Asset('eip155:100/erc20:0x5b10222f2Ada260AAf6C6fC274bd5810AF9d33c0'),
-            amount=FVal(unstake_amount),
+            amount=FVal(unstake_amount := '30000'),
             location_label=gnosis_accounts[0],
             notes=f'Unstake {unstake_amount} HOP-LP-USDT from Hop',
             tx_ref=tx_hash,
@@ -1448,7 +1388,7 @@ def test_hop_unstake_gnosis(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REWARD,
             asset=Asset('eip155:100/erc20:0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb'),
-            amount=FVal(reward_amount),
+            amount=FVal(reward_amount := '0.91583970339645'),
             location_label=gnosis_accounts[0],
             notes=f'Claim {reward_amount} GNO from Hop',
             tx_ref=tx_hash,
@@ -1456,7 +1396,6 @@ def test_hop_unstake_gnosis(
             address=string_to_evm_address('0x2C2Ab81Cf235e86374468b387e241DF22459A265'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1464,17 +1403,16 @@ def test_hop_unstake_gnosis(
 def test_vote_cast(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xc6116ef064b0a713eb50cb55a1e76ef947ebdba9cbfba9a71498dacb6b75ba0e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas = TimestampMS(1671494483000), '0.00186503943913884'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1671494483000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00186503943913884'),
             location_label=ADDY,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -1492,7 +1430,6 @@ def test_vote_cast(ethereum_inquirer):
             counterparty=CPT_HOP,
             address=HOP_GOVERNOR,
         )]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1504,16 +1441,15 @@ def test_hop_add_liquidity_optimism_usdc(
 ):
     tx_hash = deserialize_evm_tx_hash('0x891d2b68a1ecc36b1c14943ddaece1ee50d0d895ca20b9ad61640aa531b8755e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, gas, lp_amount, lp_token_amount, approval_amount = TimestampMS(1670628821000), '0.00006011384375604', '11208.995146', '10843.63570237678072025', '115792089237316195423570985008687907853269984665640564039457584007901920.644789'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1670628821000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00006011384375604'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas} ETH for gas',
             tx_ref=tx_hash,
@@ -1525,7 +1461,7 @@ def test_hop_add_liquidity_optimism_usdc(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-            amount=FVal(approval_amount),
+            amount=FVal(approval_amount := '115792089237316195423570985008687907853269984665640564039457584007901920.644789'),  # noqa: E501
             location_label=optimism_accounts[0],
             notes=f'Set USDC.e spending approval of {optimism_accounts[0]} by 0x3c0FFAca566fCcfD9Cc95139FEF6CBA143795963 to {approval_amount}',  # noqa: E501
             tx_ref=tx_hash,
@@ -1537,7 +1473,7 @@ def test_hop_add_liquidity_optimism_usdc(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-            amount=FVal(lp_amount),
+            amount=FVal(lp_amount := '11208.995146'),
             location_label=optimism_accounts[0],
             notes=f'Deposit {lp_amount} USDC.e to Hop',
             tx_ref=tx_hash,
@@ -1550,7 +1486,7 @@ def test_hop_add_liquidity_optimism_usdc(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:10/erc20:0x2e17b8193566345a2Dd467183526dEdc42d2d5A8'),
-            amount=FVal(lp_token_amount),
+            amount=FVal(lp_token_amount := '10843.63570237678072025'),
             location_label=optimism_accounts[0],
             notes=f'Receive {lp_token_amount} HOP-LP-USDC after providing liquidity in Hop',
             tx_ref=tx_hash,
@@ -1558,4 +1494,3 @@ def test_hop_add_liquidity_optimism_usdc(
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_hyperliquid.py
+++ b/rotkehlchen/tests/unit/decoders/test_hyperliquid.py
@@ -18,10 +18,9 @@ def test_deposit(
         arbitrum_one_inquirer: ArbitrumOneInquirer,
         arbitrum_one_accounts: list[ChecksumEvmAddress],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x2aa0a70af2347ccc4ba3d5f4eddd362c7cd8118c0f2a3617d4b4fcf78c929ea7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x2aa0a70af2347ccc4ba3d5f4eddd362c7cd8118c0f2a3617d4b4fcf78c929ea7')),  # noqa: E501
     )
     assert events == [
         EvmEvent(
@@ -59,10 +58,9 @@ def test_withdrawal(
         arbitrum_one_inquirer: ArbitrumOneInquirer,
         arbitrum_one_accounts: list[ChecksumEvmAddress],
 ):
-    tx_hash = deserialize_evm_tx_hash('0xe57fcce52a6b66fcf1e4435591a43bb65f87141df34756a441a7f816b6f61311')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe57fcce52a6b66fcf1e4435591a43bb65f87141df34756a441a7f816b6f61311')),  # noqa: E501
     )
     assert events == [
         EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_juicebox.py
+++ b/rotkehlchen/tests/unit/decoders/test_juicebox.py
@@ -21,12 +21,11 @@ def test_donation(ethereum_inquirer, ethereum_accounts):
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1706095919000)
     donated_amount, gas_fees = '2', '0.00306450894012447'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1706095919000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -86,12 +85,11 @@ def test_fund_raising(ethereum_inquirer, ethereum_accounts):
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1706711399000)
     paid_amount, gas_fees = '0.4', '0.003792515741532086'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1706711399000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,

--- a/rotkehlchen/tests/unit/decoders/test_kyber.py
+++ b/rotkehlchen/tests/unit/decoders/test_kyber.py
@@ -28,7 +28,7 @@ def test_kyber_legacy_old_contract(ethereum_inquirer, ethereum_accounts):
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
 
     assert len(events) == 3
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -66,7 +66,6 @@ def test_kyber_legacy_old_contract(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_KYBER_LEGACY,
             address=string_to_evm_address('0x65bF64Ff5f51272f729BDcD7AcFB00677ced86Cd'),
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -79,7 +78,7 @@ def test_kyber_legacy_new_contract(ethereum_inquirer):
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
 
     assert len(events) == 3
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -118,7 +117,6 @@ def test_kyber_legacy_new_contract(ethereum_inquirer):
             address=string_to_evm_address('0x7C66550C9c730B6fdd4C03bc2e73c5462c5F7ACC'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -126,15 +124,14 @@ def test_kyber_legacy_new_contract(ethereum_inquirer):
 def test_kyber_aggregator_swap_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x82205817d573da45a2f6da6e5e9623739bd4cdbce5f9b65d48450805bce0bdff')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1714563455000)
     gas, approval_amount = '0.00199568430867988', '20.819823166790499332'
     spend_amount, receive_amount = '20', '21.100486952910759139'
     a_sweth = Asset('eip155:1/erc20:0xf951E335afb289353dc249e82926178EaC7DEd78')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714563455000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -181,7 +178,6 @@ def test_kyber_aggregator_swap_ethereum(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0xf081470f5C6FBCCF48cC4e5B82Dd926409DcdD67'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -191,7 +187,7 @@ def test_kyber_aggregator_swap_ethereum_with_refund(ethereum_inquirer, ethereum_
         evm_inquirer=ethereum_inquirer,
         tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe29c8695ba05e994e2890fe920147b5d4dbc21dcd9355681844b625c1ecb52a0')),  # noqa: E501
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -246,25 +242,22 @@ def test_kyber_aggregator_swap_ethereum_with_refund(ethereum_inquirer, ethereum_
             address=pool_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x0e414c1c4780df6c09c2f1070990768D44B70b1D']])
 def test_kyber_aggregator_swap_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xbcc690fb11b0a6b0f3b1e5bed6abb5c3e93d5b4855472f94adea824bfa2be6ed')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xbcc690fb11b0a6b0f3b1e5bed6abb5c3e93d5b4855472f94adea824bfa2be6ed')),  # noqa: E501
     )
-    timestamp = TimestampMS(1714517062000)
     gas, spend_amount, receive_amount = '0.00001237136', '1', '2693482419.136828'
     a_aidoge = Asset('eip155:42161/erc20:0x09E18590E8f76b6Cf471b3cd75fE1A1a9D2B2c2b')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714517062000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -299,7 +292,6 @@ def test_kyber_aggregator_swap_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_
             address=string_to_evm_address('0x11ddD59C33c73C44733b4123a86Ea5ce57F6e854'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -308,15 +300,14 @@ def test_kyber_aggregator_swap_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_
 def test_kyber_aggregator_swap_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x27b040b725caa995343f98ca16fabebfbd2116063488761cbbdc1f99a2bf8619')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1714588063000)
     gas, spend_amount, receive_amount = '0.000057116139238782', '10076.279107426212183073', '19.725836184026980754'  # noqa: E501
     a_dog = Asset('eip155:8453/erc20:0xAfb89a09D82FBDE58f18Ac6437B3fC81724e4dF6')
     a_uni_base = Asset('eip155:8453/erc20:0xc3De830EA07524a0761646a6a4e4be0e114a3C83')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714588063000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -363,7 +354,6 @@ def test_kyber_aggregator_swap_base(base_inquirer, base_accounts):
             address=string_to_evm_address('0x11ddD59C33c73C44733b4123a86Ea5ce57F6e854'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -372,14 +362,13 @@ def test_kyber_aggregator_swap_base(base_inquirer, base_accounts):
 def test_kyber_aggregator_swap_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc50282f437bacfbeef00baf4dae0785a259f87294089b96f7a6363ad4928570e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1714589233000)
     gas, spend_amount, receive_amount = '0.000018524563536246', '1.404275039033980017', '1.633943151167508706'  # noqa: E501
     a_wsteth_op = Asset('eip155:10/erc20:0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714589233000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -426,26 +415,23 @@ def test_kyber_aggregator_swap_optimism(optimism_inquirer, optimism_accounts):
             address=string_to_evm_address('0x11ddD59C33c73C44733b4123a86Ea5ce57F6e854'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x686e14AFb1AB9eb5aB89593ddE9fCe9389cA8C35']])
 def test_kyber_aggregator_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xfd32220a3dfad3a74b0e172b88f0052670cd60b72f4b0cf19ded4a4145ba4a2b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xfd32220a3dfad3a74b0e172b88f0052670cd60b72f4b0cf19ded4a4145ba4a2b')),  # noqa: E501
     )
-    timestamp = TimestampMS(1714589685000)
     gas, spend_amount, receive_amount = '0.029364910546207', '11.419216', '3.214374219088998048'
     a_bal_poly = Asset('eip155:137/erc20:0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3')
     a_usdc_poly = Asset('eip155:137/erc20:0x3c499c542cef5e3811e1192ce70d8cc03d5c3359')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714589685000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -480,7 +466,6 @@ def test_kyber_aggregator_swap_polygon(polygon_pos_inquirer, polygon_pos_account
             address=string_to_evm_address('0x7bAF833f82BB1971f99A5a5d84bED1d5D0dEDD70'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(allow_playback_repeats=True, filter_query_parameters=['apikey'])
@@ -488,14 +473,13 @@ def test_kyber_aggregator_swap_polygon(polygon_pos_inquirer, polygon_pos_account
 def test_kyber_aggregator_swap_scroll(scroll_inquirer, scroll_accounts, allow_scroll_etherscan):
     tx_hash = deserialize_evm_tx_hash('0xd5c9011e2edd8b724eb3f0a691f5657eb7adb0d943be01b54b52a22b82df7062')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1714590811000)
     gas, spend_amount, receive_amount = '0.00014495886763554', '327.431697', '0.109956490224557286'
     a_usdc_scroll = Asset('eip155:534352/erc20:0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1714590811000)),
             location=Location.SCROLL,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -530,4 +514,3 @@ def test_kyber_aggregator_swap_scroll(scroll_inquirer, scroll_accounts, allow_sc
             address=string_to_evm_address('0xf40442E1Cb0BdFb496E8B7405d0c1c48a81BC897'),
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_lido_eth.py
+++ b/rotkehlchen/tests/unit/decoders/test_lido_eth.py
@@ -23,17 +23,16 @@ if TYPE_CHECKING:
 def test_lido_steth_staking(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x23a3ee601475424e91bdc0999a780afe57bf37cbcce6d1c09a4dfaaae1765451')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str, amount_deposited, amount_minted = TimestampMS(1710486191000), '0.002846110430778206', '1.12137397', '1.121373969999999999'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1710486191000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.002846110430778206'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -45,7 +44,7 @@ def test_lido_steth_staking(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_ETH,
-            amount=FVal(amount_deposited),
+            amount=FVal(amount_deposited := '1.12137397'),
             location_label=ethereum_accounts[0],
             notes=f'Submit {amount_deposited} ETH to Lido',
             counterparty=CPT_LIDO,
@@ -58,7 +57,7 @@ def test_lido_steth_staking(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=A_STETH,
-            amount=FVal(amount_minted),
+            amount=FVal(amount_minted := '1.121373969999999999'),
             location_label=ethereum_accounts[0],
             notes=f'Receive {amount_minted} stETH in exchange for the deposited ETH',
             counterparty=CPT_LIDO,
@@ -66,7 +65,6 @@ def test_lido_steth_staking(ethereum_inquirer, ethereum_accounts):
             extra_data={'staked_eth': str(amount_deposited)},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_liquity.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity.py
@@ -85,12 +85,11 @@ def test_payback_lusd(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x40bb08427a3b99fb9896cf14858d82d361a6e7a8fb7dd6d2000511ac3dca5707')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1650746429000)
     gas_str, amount_str = '0.006264200693494173', '118184.07'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1650746429000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -122,12 +121,11 @@ def test_remove_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6be5312c21855c3cc324b5b6ce9f9f65dbd488e270e84ac5e6fb96c74d83fe4e')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1650998125000)
     gas_str, amount_str = '0.016981969690997082', '32'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1650998125000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -159,12 +157,11 @@ def test_stability_pool_deposit(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x1277cb6c2c8e151fe90118cdd738e46f894e18de04ab6af33d567e91597f322b')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1665994475000)
     gas_str, amount_str, fee_str = '0.003626058925730277', '120', '4.970574827214596312'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1665994475000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -208,16 +205,16 @@ def test_stability_pool_deposit(ethereum_inquirer, ethereum_accounts):
 def test_stability_pool_collect_rewards(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xad077faf7976504615561ac7fd9fdddc934180f3237f216851136d2327d71196')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_str, eth_str, got_lqty_str, fee_lqty_str = TimestampMS(1665913919000), ethereum_accounts[0], '0.00249609940900398', '0.0211265398269', '1308.878062778294406909', '13.810598430718930388'  # noqa: E501
+    user_address = ethereum_accounts[0]
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1665913919000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_str),
+        amount=FVal(gas_str := '0.00249609940900398'),
         location_label=user_address,
         notes=f'Burn {gas_str} ETH for gas',
         counterparty=CPT_GAS,
@@ -229,7 +226,7 @@ def test_stability_pool_collect_rewards(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_LQTY,
-        amount=FVal(fee_lqty_str),
+        amount=FVal(fee_lqty_str := '13.810598430718930388'),
         location_label=user_address,
         notes=f'Paid {fee_lqty_str} LQTY as a frontend fee to 0x03Cd116CABE0747F31A71B3565877717097fc06C',  # noqa: E501
         counterparty=CPT_LIQUITY,
@@ -242,7 +239,7 @@ def test_stability_pool_collect_rewards(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.STAKING,
         event_subtype=HistoryEventSubType.REWARD,
         asset=A_ETH,
-        amount=FVal(eth_str),
+        amount=FVal(eth_str := '0.0211265398269'),
         location_label=user_address,
         notes=f"Collect {eth_str} ETH from liquity's stability pool",
         counterparty=CPT_LIQUITY,
@@ -255,7 +252,7 @@ def test_stability_pool_collect_rewards(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.STAKING,
         event_subtype=HistoryEventSubType.REWARD,
         asset=A_LQTY,
-        amount=FVal(got_lqty_str),
+        amount=FVal(got_lqty_str := '1308.878062778294406909'),
         location_label=user_address,
         notes=f"Collect {got_lqty_str} LQTY from liquity's stability pool",
         counterparty=CPT_LIQUITY,
@@ -457,7 +454,7 @@ def test_ds_proxy_liquity_deposit(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x83e9930bee6a993204ade072ac6753249f9773b0da243b7efdb6cbba1e0bff6c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -497,7 +494,6 @@ def test_ds_proxy_liquity_deposit(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x7815beb98a927565eA43b5854644392F21dA0021'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -508,7 +504,7 @@ def test_ds_proxy_liquity_deposit_and_borrow(ethereum_inquirer, ethereum_account
     comes before borrowing"""
     tx_hash = deserialize_evm_tx_hash('0x48c93d086f9927f0e2aaadf39fa3bfdcf7f5ac80b11024a7055415c6bac5c829')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -562,7 +558,6 @@ def test_ds_proxy_liquity_deposit_and_borrow(ethereum_inquirer, ethereum_account
             address=string_to_evm_address('0x24179CD81c9e782A4096035f7eC97fB8B783e007'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -570,7 +565,7 @@ def test_ds_proxy_liquity_deposit_and_borrow(ethereum_inquirer, ethereum_account
 def test_ds_proxy_liquity_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xdac8d9273a17b00fb81e89839d0c974e393db406a641552051419646b902c4b3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -624,7 +619,6 @@ def test_ds_proxy_liquity_withdraw(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x7815beb98a927565eA43b5854644392F21dA0021'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -632,7 +626,7 @@ def test_ds_proxy_liquity_withdraw(ethereum_inquirer, ethereum_accounts):
 def test_ds_proxy_liquity_staking(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x48aa71f1af847d93601f03777ba960281bc9405bbdcc2fdb8c64f2a3350f354a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -705,7 +699,6 @@ def test_ds_proxy_liquity_staking(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x31E45D87D9549DCc5cc28925238b7e329719C8fB'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -713,16 +706,16 @@ def test_ds_proxy_liquity_staking(ethereum_inquirer, ethereum_accounts):
 def test_ds_proxy_borrow_lusd(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa7404dc759fdef08fde6dbb227d6c55276861853d274c9a739236488a123f794')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_str, debt_str, fee_str = TimestampMS(1704486503000), ethereum_accounts[0], '0.006847541539452045', '50300.21680310311845', '300.21680310311845'  # noqa: E501
+    user_address = ethereum_accounts[0]
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704486503000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_str),
+        amount=FVal(gas_str := '0.006847541539452045'),
         location_label=user_address,
         notes=f'Burn {gas_str} ETH for gas',
         counterparty=CPT_GAS,
@@ -734,7 +727,7 @@ def test_ds_proxy_borrow_lusd(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.WITHDRAWAL,
         event_subtype=HistoryEventSubType.GENERATE_DEBT,
         asset=A_LUSD,
-        amount=FVal(debt_str),
+        amount=FVal(debt_str := '50300.21680310311845'),
         location_label=user_address,
         notes=f'Generate {debt_str} LUSD from liquity',
         counterparty=CPT_LIQUITY,
@@ -747,7 +740,7 @@ def test_ds_proxy_borrow_lusd(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_LUSD,
-        amount=FVal(fee_str),
+        amount=FVal(fee_str := '300.21680310311845'),
         location_label=user_address,
         notes=f'Paid {fee_str} LUSD as a borrowing fee',
         counterparty=CPT_LIQUITY,

--- a/rotkehlchen/tests/unit/decoders/test_liquity_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_liquity_v2.py
@@ -25,12 +25,11 @@ def test_lqty_v2_staking_deposit_with_rewards(ethereum_inquirer, ethereum_accoun
     """Test Liquity V2 staking deposit transaction that also claims previous rewards"""
     tx_hash = deserialize_evm_tx_hash('0x80d85ccacbc3acdbc797ed580044c0d5427d19f70d9d1b67d724bdc7bd4aeff8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1750380179000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1750380179000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -99,7 +98,6 @@ def test_lqty_v2_staking_deposit_with_rewards(ethereum_inquirer, ethereum_accoun
             address='0x807DEf5E7d057DF05C796F4bc75C3Fe82Bd6EeE1',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -108,13 +106,12 @@ def test_lqty_v2_staking_withdraw_with_rewards(ethereum_inquirer, ethereum_accou
     """Test Liquity V2 staking withdraw transaction that also claims previous rewards"""
     tx_hash = deserialize_evm_tx_hash('0xc2288994345ca7c3f7be017c2b3f4e0b32b394b0b7331f6e5fbafafd76daaa8f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1750495547000)
 
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1750495547000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -151,7 +148,6 @@ def test_lqty_v2_staking_withdraw_with_rewards(ethereum_inquirer, ethereum_accou
             address='0x807DEf5E7d057DF05C796F4bc75C3Fe82Bd6EeE1',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_llamazip.py
+++ b/rotkehlchen/tests/unit/decoders/test_llamazip.py
@@ -27,17 +27,16 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_llamazip_optimism_swap_token_to_eth(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa6271df026c97691148b0bcd53096cdbec91394b74f93e6e86ab046852f4a115')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, spend_amount, receive_amount = TimestampMS(1724034205000), '0.000000114027950239', '1.653522515434244221', '0.000626208109106399'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1724034205000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000000114027950239'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -48,7 +47,7 @@ def test_llamazip_optimism_swap_token_to_eth(optimism_inquirer, optimism_account
             location=Location.OPTIMISM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:10/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1'),
-            amount=FVal(spend_amount),
+            amount=FVal(spend_amount := '1.653522515434244221'),
             location_label=optimism_accounts[0],
             notes=f'Swap {spend_amount} DAI in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -60,7 +59,7 @@ def test_llamazip_optimism_swap_token_to_eth(optimism_inquirer, optimism_account
             location=Location.OPTIMISM,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=A_ETH,
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '0.000626208109106399'),
             location_label=optimism_accounts[0],
             notes=f'Receive {receive_amount} ETH as the result of a swap in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -75,17 +74,16 @@ def test_llamazip_optimism_swap_token_to_eth(optimism_inquirer, optimism_account
 def test_llamazip_optimism_swap_eth_to_token(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6caae7d1a32abecf9dcc23c89e11fecfb9fccd2b21e718c0f62c6f001eb7a626')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, spend_amount, receive_amount = TimestampMS(1724081427000), '0.000000754413255739', '0.005', '12.918744'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1724081427000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000000754413255739'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -96,7 +94,7 @@ def test_llamazip_optimism_swap_eth_to_token(optimism_inquirer, optimism_account
             location=Location.OPTIMISM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
-            amount=FVal(spend_amount),
+            amount=FVal(spend_amount := '0.005'),
             location_label=optimism_accounts[0],
             notes=f'Swap {spend_amount} ETH in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -108,7 +106,7 @@ def test_llamazip_optimism_swap_eth_to_token(optimism_inquirer, optimism_account
             location=Location.OPTIMISM,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '12.918744'),
             location_label=optimism_accounts[0],
             notes=f'Receive {receive_amount} USDC.e as the result of a swap in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -123,17 +121,16 @@ def test_llamazip_optimism_swap_eth_to_token(optimism_inquirer, optimism_account
 def test_llamazip_optimism_swap_token_to_token(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x92e9af072a20b74d730037b80a96bf7ab02168679624bc87de8b3427e88882fd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, fee_amount, spend_amount, receive_amount = TimestampMS(1724074841000), '0.000000292773423793', '24.786522600837181987', '24.780601'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1724074841000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.000000292773423793'),
             location_label=optimism_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -144,7 +141,7 @@ def test_llamazip_optimism_swap_token_to_token(optimism_inquirer, optimism_accou
             location=Location.OPTIMISM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:10/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1'),
-            amount=FVal(spend_amount),
+            amount=FVal(spend_amount := '24.786522600837181987'),
             location_label=optimism_accounts[0],
             notes=f'Swap {spend_amount} DAI in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -156,7 +153,7 @@ def test_llamazip_optimism_swap_token_to_token(optimism_inquirer, optimism_accou
             location=Location.OPTIMISM,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '24.780601'),
             location_label=optimism_accounts[0],
             notes=f'Receive {receive_amount} USDC.e as the result of a swap in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -168,22 +165,21 @@ def test_llamazip_optimism_swap_token_to_token(optimism_inquirer, optimism_accou
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x635Cb8149C292Ff96F71a1a49120D04053c7eE7A']])
 def test_llamazip_arbitrum_swap_token_to_eth(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x5a3e6748dd62b943918508a7495df0dc481a054af9dc607a7b85f167a9cc54c2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5a3e6748dd62b943918508a7495df0dc481a054af9dc607a7b85f167a9cc54c2')),  # noqa: E501
     )
-    timestamp, fee_amount, spend_amount, receive_amount, a_usdce = TimestampMS(1679552792000), '0.0000306163', '36', '0.020467522941555658', Asset('eip155:42161/erc20:0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8')  # noqa: E501
+    a_usdce = Asset('eip155:42161/erc20:0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8')
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1679552792000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.0000306163'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -206,7 +202,7 @@ def test_llamazip_arbitrum_swap_token_to_eth(arbitrum_one_inquirer, arbitrum_one
             location=Location.ARBITRUM_ONE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=a_usdce,
-            amount=FVal(spend_amount),
+            amount=FVal(spend_amount := '36'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Swap {spend_amount} USDC.e in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -218,7 +214,7 @@ def test_llamazip_arbitrum_swap_token_to_eth(arbitrum_one_inquirer, arbitrum_one
             location=Location.ARBITRUM_ONE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=A_ETH,
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '0.020467522941555658'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Receive {receive_amount} ETH as the result of a swap in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -230,22 +226,20 @@ def test_llamazip_arbitrum_swap_token_to_eth(arbitrum_one_inquirer, arbitrum_one
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x5Ef3D4F41791f0B9f1CEe6D739d77748f81FCa3A']])
 def test_llamazip_arbitrum_swap_eth_to_token(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xd75a0b795e0748dffdedc80b731710e9596f6af5fbc77274482cc785ed4c1cd3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd75a0b795e0748dffdedc80b731710e9596f6af5fbc77274482cc785ed4c1cd3')),  # noqa: E501
     )
-    timestamp, fee_amount, spend_amount, receive_amount = TimestampMS(1679521589000), '0.0000419029', '0.125', '215.453696'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1679521589000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.0000419029'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -256,7 +250,7 @@ def test_llamazip_arbitrum_swap_eth_to_token(arbitrum_one_inquirer, arbitrum_one
             location=Location.ARBITRUM_ONE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
-            amount=FVal(spend_amount),
+            amount=FVal(spend_amount := '0.125'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Swap {spend_amount} ETH in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -268,7 +262,7 @@ def test_llamazip_arbitrum_swap_eth_to_token(arbitrum_one_inquirer, arbitrum_one
             location=Location.ARBITRUM_ONE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:42161/erc20:0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '215.453696'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Receive {receive_amount} USDT as the result of a swap in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -280,22 +274,21 @@ def test_llamazip_arbitrum_swap_eth_to_token(arbitrum_one_inquirer, arbitrum_one
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x9fAe1b2Be0A8D7e64780fd740F8AD05188E8170A']])
 def test_llamazip_arbitrum_swap_token_to_token(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xb1f65779afe9b92edd791af3b95ea36c46d6a6e8f8cc60f4740bb11b79993a92')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb1f65779afe9b92edd791af3b95ea36c46d6a6e8f8cc60f4740bb11b79993a92')),  # noqa: E501
     )
-    timestamp, fee_amount, spend_amount, receive_amount, a_weth = TimestampMS(1679511150000), '0.0000360038', '0.071985413648931875', '0.00454144', Asset('eip155:42161/erc20:0x82aF49447D8a07e3bd95BD0d56f35241523fBab1')  # noqa: E501
+    a_weth = Asset('eip155:42161/erc20:0x82aF49447D8a07e3bd95BD0d56f35241523fBab1')
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1679511150000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.0000360038'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -318,7 +311,7 @@ def test_llamazip_arbitrum_swap_token_to_token(arbitrum_one_inquirer, arbitrum_o
             location=Location.ARBITRUM_ONE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=a_weth,
-            amount=FVal(spend_amount),
+            amount=FVal(spend_amount := '0.071985413648931875'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Swap {spend_amount} WETH in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -330,7 +323,7 @@ def test_llamazip_arbitrum_swap_token_to_token(arbitrum_one_inquirer, arbitrum_o
             location=Location.ARBITRUM_ONE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:42161/erc20:0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '0.00454144'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Receive {receive_amount} WBTC as the result of a swap in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -342,22 +335,20 @@ def test_llamazip_arbitrum_swap_token_to_token(arbitrum_one_inquirer, arbitrum_o
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xa716c2ef62B60cF82B8119947030ea7E26A39908']])
 def test_llamazip_arbitrum_swap_eth_to_arb(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xf9d2cb0f7593181f3a296647205a184f820dcba36273a4e8486cad545ad1bf39')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf9d2cb0f7593181f3a296647205a184f820dcba36273a4e8486cad545ad1bf39')),  # noqa: E501
     )
-    timestamp, fee_amount, spend_amount, receive_amount = TimestampMS(1724091866000), '0.00000154191', '0.0001', '0.487303878224941508'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1724091866000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(fee_amount),
+            amount=FVal(fee_amount := '0.00000154191'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {fee_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -368,7 +359,7 @@ def test_llamazip_arbitrum_swap_eth_to_arb(arbitrum_one_inquirer, arbitrum_one_a
             location=Location.ARBITRUM_ONE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
-            amount=FVal(spend_amount),
+            amount=FVal(spend_amount := '0.0001'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Swap {spend_amount} ETH in LlamaZip',
             counterparty=CPT_LLAMAZIP,
@@ -380,7 +371,7 @@ def test_llamazip_arbitrum_swap_eth_to_arb(arbitrum_one_inquirer, arbitrum_one_a
             location=Location.ARBITRUM_ONE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:42161/erc20:0x912CE59144191C1204E64559FE8253a0e49E6548'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '0.487303878224941508'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Receive {receive_amount} ARB as the result of a swap in LlamaZip',
             counterparty=CPT_LLAMAZIP,

--- a/rotkehlchen/tests/unit/decoders/test_lockedgno.py
+++ b/rotkehlchen/tests/unit/decoders/test_lockedgno.py
@@ -21,13 +21,11 @@ def test_lock_gno(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xe74bd8d81a057942d734d16303d74b9ae01dcd5659488f7955c36d6be5b107fe')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1643833498000)
-    amount_str = '5.207408513473562376'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1643833498000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -45,7 +43,7 @@ def test_lock_gno(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_GNO,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '5.207408513473562376'),
             location_label=user_address,
             notes=f'Deposit {amount_str} GNO to the locking contract',
             counterparty=CPT_LOCKEDGNO,
@@ -65,7 +63,6 @@ def test_lock_gno(ethereum_inquirer, ethereum_accounts):
             address=LOCKED_GNO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -74,13 +71,11 @@ def test_unlock_gno(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x60b03b2bf3861c68a508f54a233d9ed742ddcd57899e730c57cc10f2939b0df0')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1682246147000)
-    amount_str = '7.232204655685847974'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1682246147000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -98,7 +93,7 @@ def test_unlock_gno(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=A_GNO,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '7.232204655685847974'),
             location_label=user_address,
             notes=f'Receive {amount_str} GNO back from the locking contract',
             counterparty=CPT_LOCKEDGNO,
@@ -118,4 +113,3 @@ def test_unlock_gno(ethereum_inquirer, ethereum_accounts):
             address=LOCKED_GNO_ADDRESS,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_magpie.py
+++ b/rotkehlchen/tests/unit/decoders/test_magpie.py
@@ -42,15 +42,14 @@ def test_magpie_eth_to_token_swap(
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     user_address = base_accounts[0]
-    timestamp = TimestampMS(1747100759000)
     gas_amount = '0.000000857490760886'  # actual gas from test
     spend_amount = '0.00005'  # 50000000000000 / 10^18
     receive_amount = '3.603360047987326035'  # actual amount from test
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1747100759000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -85,7 +84,6 @@ def test_magpie_eth_to_token_swap(
             address=BASE_MAGPIE_V3_ROUTER,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -102,7 +100,6 @@ def test_magpie_token_to_token_swap(
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     user_address = base_accounts[0]
 
-    timestamp = TimestampMS(1747098901000)
     gas_amount = '0.000005597469523105'  # actual gas from output
     rabby_fee_amount = '0.009750330804687233'  # Fee to Rabby
     spend_amount = '3.890381991070206089'  # VIRTUAL swapped (router amount)
@@ -110,11 +107,11 @@ def test_magpie_token_to_token_swap(
     virtual_asset = Asset('eip155:8453/erc20:0x0b3e328455c4059EEb9e3f84b5543F74E24e7E1b')
     usdc_asset = Asset('eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913')  # USDC
 
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1747098901000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -191,7 +188,6 @@ def test_magpie_token_to_token_swap(
             address=BASE_MAGPIE_V3_ROUTER,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -207,18 +203,17 @@ def test_magpie_arbitrum_token_to_token_swap(
     events, _ = get_decoded_events_of_transaction(evm_inquirer=arbitrum_one_inquirer, tx_hash=tx_hash)  # noqa: E501
     user_address = arbitrum_one_accounts[0]
 
-    timestamp = TimestampMS(1747117715000)
     gas_amount = '0.0000023453'  # actual gas from transaction
     rabby_fee_amount = '2.240491123389503579'  # TROVE Fee to Rabby
     spend_amount = '893.955958232411928011'  # TROVE swapped (router amount)
     receive_amount = '0.000813622663851767'  # ETH received
     trove_asset = Asset('eip155:42161/erc20:0x982239D38Af50B0168dA33346d85Fb12929c4c07')
 
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1747117715000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -296,8 +291,6 @@ def test_magpie_arbitrum_token_to_token_swap(
         ),
     ]
 
-    assert expected_events == events
-
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xe4B13d4de7E85E2a763BD440Bc9bf921C69Bc905']])
@@ -312,7 +305,6 @@ def test_magpie_ethereum_usds_to_usdc_swap(
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
 
-    timestamp = TimestampMS(1749670655000)
     gas_amount = '0.000536018493464816'  # actual gas cost
     rabby_fee_amount = '0.015'  # USDS fee to Rabby
     spend_amount = '5.985'  # USDS amount to Magpie
@@ -320,11 +312,11 @@ def test_magpie_ethereum_usds_to_usdc_swap(
     usds_asset = Asset('eip155:1/erc20:0xdC035D45d973E3EC169d2276DDab16f1e407384F')
     usdc_asset = Asset('eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')
 
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1749670655000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -372,8 +364,6 @@ def test_magpie_ethereum_usds_to_usdc_swap(
         ),
     ]
 
-    assert expected_events == events
-
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x6361f989EFf9fE22E8a8C08aCe34f0d30b760a4E']])
@@ -388,18 +378,17 @@ def test_magpie_polygon_pol_to_usdc_swap(
     events, _ = get_decoded_events_of_transaction(evm_inquirer=polygon_pos_inquirer, tx_hash=tx_hash)  # noqa: E501
     user_address = polygon_pos_accounts[0]
 
-    timestamp = TimestampMS(1749654622000)
     gas_amount = '0.022836'  # actual gas from events
     spend_amount = '24.988096505635070242'  # POL sent to Magpie (actual from events)
     receive_amount = '5.809487'  # USDC received (actual from events)
     pol_asset = Asset('eip155:137/erc20:0x0000000000000000000000000000000000001010')  # POL native
     usdc_asset = Asset('eip155:137/erc20:0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359')  # USDC.e
 
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1749654622000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -434,5 +423,3 @@ def test_magpie_polygon_pol_to_usdc_swap(
             address=POLYGON_MAGPIE_V3_1_ROUTER,
         ),
     ]
-
-    assert expected_events == events

--- a/rotkehlchen/tests/unit/decoders/test_main.py
+++ b/rotkehlchen/tests/unit/decoders/test_main.py
@@ -280,11 +280,10 @@ def test_no_logs_and_zero_eth(
     Data taken from
     https://etherscan.io/tx/0x9a95424c48d36bb2f60fb7684a1068c08ec643c64144e7cdfbe5fb3fc820aa7f
     """
-    tx_hash = deserialize_evm_tx_hash('0x9a95424c48d36bb2f60fb7684a1068c08ec643c64144e7cdfbe5fb3fc820aa7f')  # noqa: E501
     user_address = ethereum_accounts[0]
     sender = '0xF99973C9F33793cb83a4590daF15b36F0ab62228'
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x9a95424c48d36bb2f60fb7684a1068c08ec643c64144e7cdfbe5fb3fc820aa7f')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -348,12 +347,11 @@ def test_simple_erc20_transfer(
     Data taken from
     https://etherscan.io/tx/0xbb58b36ddc027a1070131e68b915e5f0dca37767b020ed164eda681725b5ca4e
     """
-    tx_hash = deserialize_evm_tx_hash('0xbb58b36ddc027a1070131e68b915e5f0dca37767b020ed164eda681725b5ca4e')  # noqa: E501
     accounts = ethereum_accounts if chain == ChainID.ETHEREUM else optimism_accounts
     from_address = accounts[0]
     to_address = accounts[1]
     transaction = L2WithL1FeesTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xbb58b36ddc027a1070131e68b915e5f0dca37767b020ed164eda681725b5ca4e')),  # noqa: E501
         chain_id=chain,
         timestamp=0,
         block_number=0,
@@ -443,12 +441,11 @@ def test_eth_transfer(
     Data taken from
     https://etherscan.io/tx/0x8caa7df2ebebfceb98207605e64691202b9e7498c3cccdbccb41c1600cf16e65
     """
-    tx_hash = deserialize_evm_tx_hash('0x8caa7df2ebebfceb98207605e64691202b9e7498c3cccdbccb41c1600cf16e65')  # noqa: E501
     accounts = ethereum_accounts if chain is ChainID.ETHEREUM else optimism_accounts
     from_address = accounts[0]
     to_address = accounts[1]
     transaction = L2WithL1FeesTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8caa7df2ebebfceb98207605e64691202b9e7498c3cccdbccb41c1600cf16e65')),  # noqa: E501
         chain_id=chain,
         timestamp=0,
         block_number=0,
@@ -528,11 +525,10 @@ def test_eth_spend(
     Data taken from
     https://etherscan.io/tx/0x8caa7df2ebebfceb98207605e64691202b9e7498c3cccdbccb41c1600cf16e65
     """
-    tx_hash = deserialize_evm_tx_hash('0x8caa7df2ebebfceb98207605e64691202b9e7498c3cccdbccb41c1600cf16e65')  # noqa: E501
     from_address = ethereum_accounts[0] if chain is ChainID.ETHEREUM else optimism_accounts[0]
     to_address = string_to_evm_address('0x38C3f1Ab36BdCa29133d8AF7A19811D10B6CA3FC')
     transaction = L2WithL1FeesTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8caa7df2ebebfceb98207605e64691202b9e7498c3cccdbccb41c1600cf16e65')),  # noqa: E501
         chain_id=chain,
         timestamp=0,
         block_number=0,
@@ -606,11 +602,10 @@ def test_eth_deposit(
     Data taken from
     https://etherscan.io/tx/0x8f91a9b98a856282cdad74d9b8a683504c13e3c9d810e4e22bd0ca2eb9d71800
     """
-    tx_hash = deserialize_evm_tx_hash('0x8f91a9b98a856282cdad74d9b8a683504c13e3c9d810e4e22bd0ca2eb9d71800')  # noqa: E501
     from_address = ethereum_accounts[0]
     to_address = '0xAe2D4617c862309A3d75A0fFB358c7a5009c673F'  # Kraken 10
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8f91a9b98a856282cdad74d9b8a683504c13e3c9d810e4e22bd0ca2eb9d71800')),  # noqa: E501
         chain_id=ChainID.ETHEREUM,
         timestamp=0,
         block_number=0,
@@ -638,7 +633,7 @@ def test_eth_deposit(
         transaction=transaction,
         tx_receipt=receipt,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -671,7 +666,6 @@ def test_eth_deposit(
             address=string_to_evm_address('0xAe2D4617c862309A3d75A0fFB358c7a5009c673F'),
         ),
     ]
-    assert events == expected_events
 
 
 def test_maybe_reshuffle_events():
@@ -875,7 +869,6 @@ def test_maybe_reshuffle_events():
 def test_genesis_transaction(database, ethereum_inquirer, ethereum_accounts):
     """Test that decoding a genesis transaction is handled correctly"""
     transactions = EthereumTransactions(ethereum_inquirer=ethereum_inquirer, database=database)
-    tx_hash = deserialize_evm_tx_hash(GENESIS_HASH)
     user_address_1, user_address_2 = ethereum_accounts
     transactions._get_transactions_for_range(
         address=user_address_1,
@@ -892,12 +885,12 @@ def test_genesis_transaction(database, ethereum_inquirer, ethereum_accounts):
     with query_patch as query_mock:
         events, _ = get_decoded_events_of_transaction(
             evm_inquirer=ethereum_inquirer,
-            tx_hash=tx_hash,
+            tx_hash=(tx_hash := deserialize_evm_tx_hash(GENESIS_HASH)),
             transactions=transactions,
         )
         assert query_mock.call_count == 1, 'Should have been called only once since one of the addresses already had transactions queried'  # noqa: E501
 
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -924,7 +917,6 @@ def test_genesis_transaction(database, ethereum_inquirer, ethereum_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -935,11 +927,10 @@ def test_genesis_transaction_no_address(ethereum_inquirer):
     Test that decoding a genesis transaction is handled correctly when there is no address tracked
     with a genesis transaction.
     """
-    tx_hash = deserialize_evm_tx_hash(GENESIS_HASH)
     with pytest.raises(InputError):
         get_decoded_events_of_transaction(
             evm_inquirer=ethereum_inquirer,
-            tx_hash=tx_hash,
+            tx_hash=deserialize_evm_tx_hash(GENESIS_HASH),
         )
 
 
@@ -948,10 +939,9 @@ def test_genesis_transaction_no_address(ethereum_inquirer):
 def test_phishing_zero_transfers(database, ethereum_inquirer):
     """Checks that zero transfer phishing transactions are marked as ignored."""
     tx_hex = '0xb45ef1a202a8d9e983cf59129d28f79057969bb822f62e4b7d9f1ac8853d23ed'
-    tx_hash = deserialize_evm_tx_hash(tx_hex)
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash(tx_hex)),
     )
     assert events == []
 
@@ -993,7 +983,6 @@ def test_failed_transaction(ethereum_inquirer, ethereum_accounts):
     """Checks that a failed transaction is understood as failed"""
     tx_hash = deserialize_evm_tx_hash('0xfbfd35db096d0acb26a988895841d786baafe08f6cf55265338e0b5db58350ee')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    gas = '0.00056954114283532'
     assert events == [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
@@ -1002,7 +991,7 @@ def test_failed_transaction(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.FAIL,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas),
+        amount=FVal(gas := '0.00056954114283532'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas} ETH for gas of a failed transaction',
         counterparty=CPT_GAS,
@@ -1101,10 +1090,9 @@ def test_post_decoding_rules_break_on_new_event(
         ethereum_transaction_decoder,
 ):
     """Regression test for https://github.com/rotki/rotki/pull/10982"""
-    tx_hash = deserialize_evm_tx_hash('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef')  # noqa: E501
     user_address = ethereum_accounts[0]
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=deserialize_evm_tx_hash('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'),
         chain_id=ChainID.ETHEREUM,
         timestamp=Timestamp(1000000),
         block_number=1,

--- a/rotkehlchen/tests/unit/decoders/test_makerdao_sai.py
+++ b/rotkehlchen/tests/unit/decoders/test_makerdao_sai.py
@@ -47,10 +47,9 @@ def test_makerdao_sai_new_cdp(ethereum_transaction_decoder):
     Data for cdp creation is taken from
     https://etherscan.io/tx/0xf7049668cb7cbb9c00d80092b2dce7ea59984f4c52c83e5c0940535a93f3d5a0
     """
-    tx_hash = deserialize_evm_tx_hash('0xf7049668cb7cbb9c00d80092b2dce7ea59984f4c52c83e5c0940535a93f3d5a0')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf7049668cb7cbb9c00d80092b2dce7ea59984f4c52c83e5c0940535a93f3d5a0')),  # noqa: E501
         timestamp=1513958719,
         block_number=4777541,
         from_address=ADDY_1,
@@ -99,7 +98,7 @@ def test_makerdao_sai_new_cdp(ethereum_transaction_decoder):
     )
 
     assert len(events) == 2
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -127,7 +126,6 @@ def test_makerdao_sai_new_cdp(ethereum_transaction_decoder):
             address=string_to_evm_address('0x448a5065aeBB8E423F0896E6c5D525C040f59af3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_2]])
@@ -136,10 +134,9 @@ def test_makerdao_sai_borrow_sai(ethereum_transaction_decoder):
     Data for sai borrow is taken from
     https://etherscan.io/tx/0x4aed2d2fe5712a5b65cb6866c51ae672a53e39fa25f343e4c6ebaa8eae21de80
     """
-    tx_hash = deserialize_evm_tx_hash('0x4aed2d2fe5712a5b65cb6866c51ae672a53e39fa25f343e4c6ebaa8eae21de80')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x4aed2d2fe5712a5b65cb6866c51ae672a53e39fa25f343e4c6ebaa8eae21de80')),  # noqa: E501
         timestamp=1513957014,
         block_number=4777443,
         from_address=ADDY_2,
@@ -251,7 +248,7 @@ def test_makerdao_sai_borrow_sai(ethereum_transaction_decoder):
     )
 
     assert len(events) == 2
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -279,7 +276,6 @@ def test_makerdao_sai_borrow_sai(ethereum_transaction_decoder):
             address=string_to_evm_address('0x448a5065aeBB8E423F0896E6c5D525C040f59af3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_3]])
@@ -288,10 +284,9 @@ def test_makerdao_sai_close_cdp(ethereum_transaction_decoder):
     Data for cdp closure is taken from
     https://etherscan.io/tx/0xc851e18df6dec02ac2efff000298001e839dde3d6e99d25d1d98ecb0d390c9a6
     """
-    tx_hash = deserialize_evm_tx_hash('0xc851e18df6dec02ac2efff000298001e839dde3d6e99d25d1d98ecb0d390c9a6')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc851e18df6dec02ac2efff000298001e839dde3d6e99d25d1d98ecb0d390c9a6')),  # noqa: E501
         timestamp=1513954042,
         block_number=4777277,
         from_address=ADDY_3,
@@ -383,12 +378,11 @@ def test_makerdao_sai_close_cdp(ethereum_transaction_decoder):
         transaction=transaction,
         tx_receipt=receipt,
     )
-    timestamp = TimestampMS(1513954042000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1513954042000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -425,7 +419,6 @@ def test_makerdao_sai_close_cdp(ethereum_transaction_decoder):
             address=string_to_evm_address('0x448a5065aeBB8E423F0896E6c5D525C040f59af3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_4]])
@@ -434,10 +427,9 @@ def test_makerdao_sai_repay_sai(ethereum_transaction_decoder):
     Data for repayment of sai loan is taken from
     https://etherscan.io/tx/0xe964cb12f4bbfa1ba4b6db8464eb3f2d4234ceafb0b5ec5f4a2188b0264bab27
     """
-    tx_hash = deserialize_evm_tx_hash('0xe964cb12f4bbfa1ba4b6db8464eb3f2d4234ceafb0b5ec5f4a2188b0264bab27')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe964cb12f4bbfa1ba4b6db8464eb3f2d4234ceafb0b5ec5f4a2188b0264bab27')),  # noqa: E501
         timestamp=1513958625,
         block_number=4777277,
         from_address=ADDY_4,
@@ -554,12 +546,11 @@ def test_makerdao_sai_repay_sai(ethereum_transaction_decoder):
         tx_receipt=receipt,
     )
 
-    timestamp = TimestampMS(1513958625000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1513958625000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -595,7 +586,6 @@ def test_makerdao_sai_repay_sai(ethereum_transaction_decoder):
             address=string_to_evm_address('0x69076e44a9C70a67D5b79d95795Aba299083c275'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -605,7 +595,7 @@ def test_makerdao_sai_deposit_weth(ethereum_inquirer):
         evm_inquirer=ethereum_inquirer,
         tx_hash=(tx_hash := deserialize_evm_tx_hash('0x5a7849ab4b7f7de2b005deddef24a094387c248c3bcb06066109bd7852c1d8af')),  # noqa: E501,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -646,7 +636,6 @@ def test_makerdao_sai_deposit_weth(ethereum_inquirer):
             address=string_to_evm_address('0x448a5065aeBB8E423F0896E6c5D525C040f59af3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -657,7 +646,7 @@ def test_makerdao_sai_deposit_peth(ethereum_inquirer):
         tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc8bd1d3556706e659e907b515185ce7e139777229f257e79a6b0b26e2a536e2c')),  # noqa: E501,
     )
 
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -685,7 +674,6 @@ def test_makerdao_sai_deposit_peth(ethereum_inquirer):
             address=string_to_evm_address('0x448a5065aeBB8E423F0896E6c5D525C040f59af3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_6]])
@@ -694,10 +682,9 @@ def test_makerdao_sai_liquidation(ethereum_transaction_decoder):
     Data for liquidation is taken from
     https://etherscan.io/tx/0x65d53653c584cde22e559cec4667a7278f75966360590b725d87055fb17552ba
     """
-    tx_hash = deserialize_evm_tx_hash('0x65d53653c584cde22e559cec4667a7278f75966360590b725d87055fb17552ba')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x65d53653c584cde22e559cec4667a7278f75966360590b725d87055fb17552ba')),  # noqa: E501
         timestamp=1513952436,
         block_number=4777359,
         from_address=ADDY_6,
@@ -795,7 +782,7 @@ def test_makerdao_sai_liquidation(ethereum_transaction_decoder):
     )
 
     assert len(events) == 2
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -823,7 +810,6 @@ def test_makerdao_sai_liquidation(ethereum_transaction_decoder):
             address=string_to_evm_address('0x448a5065aeBB8E423F0896E6c5D525C040f59af3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_7]])
@@ -832,10 +818,9 @@ def test_makerdao_sai_collateral_removal(ethereum_transaction_decoder):
     Data for abstracted collateral removal is taken from
     https://etherscan.io/tx/0x8c95ecc864db038a42c6cd9d6cab17e12f1f56332b140d903948a69d8b9e4308
     """
-    tx_hash = deserialize_evm_tx_hash('0x8c95ecc864db038a42c6cd9d6cab17e12f1f56332b140d903948a69d8b9e4308')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8c95ecc864db038a42c6cd9d6cab17e12f1f56332b140d903948a69d8b9e4308')),  # noqa: E501
         timestamp=1514047441,
         block_number=4783564,
         from_address=ADDY_7,
@@ -905,12 +890,11 @@ def test_makerdao_sai_collateral_removal(ethereum_transaction_decoder):
         tx_receipt=receipt,
     )
 
-    timestamp = TimestampMS(1514047441000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1514047441000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -934,7 +918,6 @@ def test_makerdao_sai_collateral_removal(ethereum_transaction_decoder):
             address=string_to_evm_address('0x448a5065aeBB8E423F0896E6c5D525C040f59af3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_8]])
@@ -943,10 +926,9 @@ def test_makerdao_sai_underlying_collateral_removal(ethereum_transaction_decoder
     Data for underlying collateral removal is taken from
     https://etherscan.io/tx/0x6467c080d5c0af9756681a368417fb802206d832f51d20b19c08d7c46a4216b0
     """
-    tx_hash = deserialize_evm_tx_hash('0x6467c080d5c0af9756681a368417fb802206d832f51d20b19c08d7c46a4216b0')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x6467c080d5c0af9756681a368417fb802206d832f51d20b19c08d7c46a4216b0')),  # noqa: E501
         timestamp=1663338359,
         block_number=15546757,
         from_address=ADDY_8,
@@ -1004,12 +986,11 @@ def test_makerdao_sai_underlying_collateral_removal(ethereum_transaction_decoder
         tx_receipt=receipt,
     )
 
-    timestamp = TimestampMS(1663338359000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1663338359000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -1033,7 +1014,6 @@ def test_makerdao_sai_underlying_collateral_removal(ethereum_transaction_decoder
             address=string_to_evm_address('0x448a5065aeBB8E423F0896E6c5D525C040f59af3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_9, ADDY_10]])
@@ -1042,10 +1022,9 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
     Data for proxy interaction is taken from
     https://etherscan.io/tx/0xf4203a8b507b0b382903bd8d35dcff29aea98de76b89f745d94705d54b67646f
     """
-    tx_hash = deserialize_evm_tx_hash('0xf4203a8b507b0b382903bd8d35dcff29aea98de76b89f745d94705d54b67646f')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf4203a8b507b0b382903bd8d35dcff29aea98de76b89f745d94705d54b67646f')),  # noqa: E501
         timestamp=1565146195,
         block_number=8300924,
         from_address=ADDY_9,
@@ -1278,12 +1257,11 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
         transaction=transaction,
         tx_receipt=receipt,
     )
-    timestamp = TimestampMS(1565146195000)
     expected_events = [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1565146195000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -1363,10 +1341,9 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
 
     # sai repayment
     # https://etherscan.io/tx/0x96c8d55100427de5edbf33fb41623b42966f7ae7273b55edaf6f7a5178d93594
-    tx_hash = deserialize_evm_tx_hash('0x96c8d55100427de5edbf33fb41623b42966f7ae7273b55edaf6f7a5178d93594')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x96c8d55100427de5edbf33fb41623b42966f7ae7273b55edaf6f7a5178d93594')),  # noqa: E501
         timestamp=1588030530,
         block_number=8300924,
         from_address=ADDY_10,
@@ -1574,10 +1551,9 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
 
     # proxy interaction
     # https://etherscan.io/tx/0x3c85624d0103f946e02c76bf4f801e72e6a753679601611c13ba2d736db1c004
-    tx_hash = deserialize_evm_tx_hash('0x3c85624d0103f946e02c76bf4f801e72e6a753679601611c13ba2d736db1c004')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x3c85624d0103f946e02c76bf4f801e72e6a753679601611c13ba2d736db1c004')),  # noqa: E501
         timestamp=1588035170,
         block_number=8300924,
         from_address=ADDY_10,
@@ -1857,10 +1833,9 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
 
     # another proxy interaction
     # https://etherscan.io/tx/0x4e569aa1f23dc771f1c9ad05ab7cdb0af2607358b166a8137b702f81b88e37b9
-    tx_hash = deserialize_evm_tx_hash('0x4e569aa1f23dc771f1c9ad05ab7cdb0af2607358b166a8137b702f81b88e37b9')  # noqa: E501
     transaction = EvmTransaction(
         chain_id=ChainID.ETHEREUM,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x4e569aa1f23dc771f1c9ad05ab7cdb0af2607358b166a8137b702f81b88e37b9')),  # noqa: E501
         timestamp=1588030595,
         block_number=9957537,
         from_address=ADDY_10,
@@ -2024,7 +1999,7 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
         tx_receipt=receipt,
     )
     assert len(events) == 3
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -2065,20 +2040,18 @@ def test_makerdao_sai_proxy_interaction(ethereum_transaction_decoder):
             address=string_to_evm_address('0x448a5065aeBB8E423F0896E6c5D525C040f59af3'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xca482bCd75A6E0697aD6A1732aa187310b8372Df']])
 def test_makerdao_sai_cdp_migration(ethereum_transaction_decoder, ethereum_accounts):
     """Check that a Sai CDP migration is decoded properly"""
-    tx_hash = deserialize_evm_tx_hash('0x03620c6bf5edb7a7935953337ffcfac70d631cf2012d6c80d36828d636063318 ')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x03620c6bf5edb7a7935953337ffcfac70d631cf2012d6c80d36828d636063318 ')),  # noqa: E501
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -2194,32 +2167,27 @@ def test_makerdao_sai_cdp_migration(ethereum_transaction_decoder, ethereum_accou
             address=string_to_evm_address('0x22953B20aB21eF5b2A28c1bB55734fB2525Ebaf2'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x2D3f907b0cF2C7D3c2BA4Cbc72971081FfCea963']])
 def test_sai_dai_migration(ethereum_transaction_decoder, ethereum_accounts):
     """Check that SAI to DAI migration is decoded properly"""
-    tx_hash = deserialize_evm_tx_hash('0x1f1f65d04c9c0de8b39d574380851c0e2f9b2552c9aedd71ff56459e2b83cf5c')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x1f1f65d04c9c0de8b39d574380851c0e2f9b2552c9aedd71ff56459e2b83cf5c')),  # noqa: E501
     )
-    timestamp = TimestampMS(1575726133000)
-    gas_str = '0.0018393'
-    amount_str = '12.559504275171697953'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1575726133000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.0018393'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -2232,7 +2200,7 @@ def test_sai_dai_migration(ethereum_transaction_decoder, ethereum_accounts):
             event_type=HistoryEventType.MIGRATE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_SAI,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '12.559504275171697953'),
             location_label=user_address,
             notes=f'Migrate {amount_str} SAI to DAI',
             counterparty=CPT_MAKERDAO_MIGRATION,
@@ -2252,4 +2220,3 @@ def test_sai_dai_migration(ethereum_transaction_decoder, ethereum_accounts):
             address=MAKERDAO_MIGRATION_ADDRESS,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_metamask.py
+++ b/rotkehlchen/tests/unit/decoders/test_metamask.py
@@ -59,12 +59,11 @@ def test_metamask_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1696160411000)
     approval_amount, swap_amount, received_amount, gas_fees, metamask_fee = '115792089237316195423570985008687907853269984665640564032906.862642668551001919', '6550.721365244578638016', '0.017595546435556104', '0.001533786820220988', '0.000153961031311116'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1696160411000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -133,12 +132,11 @@ def test_metamask_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1702292675000)
     swap_amount, received_amount, gas_fees, fee_amount = '0.0495625', '2595.147664794130524115', '0.004927174848537517', '0.0004375'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1702292675000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -195,12 +193,11 @@ def test_metamask_swap_usdt_to_token(ethereum_inquirer, ethereum_accounts):
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1702376699000)
     swap_amount, received_amount, gas_fees, fee_amount = '568.614655', '157279690809.103532500734254552', '0.007519637280969888', '5.019297'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1702376699000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -257,12 +254,11 @@ def test_metamask_swap_token_to_usdc(ethereum_inquirer, ethereum_accounts):
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1702376675000)
     swap_amount, received_amount, gas_fees, fee_amount = '52000000000', '2837.148343', '0.01015815871814444', '24.824308'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1702376675000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -319,12 +315,11 @@ def test_metamask_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1702399619000)
     swap_amount, received_amount, gas_fees, fee_amount, approval_amount = '89.301543595802992849', '323.028598123743886055', '0.036588478688486165', '0.788286009042397163', '90071443.400914235154609988'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1702399619000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -396,12 +391,11 @@ def test_metamask_swap_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
         tx_hash=tx_hash,
     )
     user_address = arbitrum_one_accounts[0]
-    timestamp = TimestampMS(1702461343000)
     swap_amount, received_amount, gas_fees, metamask_fee = '44.903625', '0.020630400240849773', '0.0003196843', '0.396375'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1702461343000)),
         location=Location.ARBITRUM_ONE,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -459,12 +453,11 @@ def test_metamask_swap_optimism(optimism_inquirer, optimism_accounts):
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     user_address = optimism_accounts[0]
-    timestamp = TimestampMS(1702469285000)
     swap_amount, received_amount, gas_fees, fee_amount = '148.6875', '148.608467', '0.000354333259086529', '1.3125'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1702469285000)),
         location=Location.OPTIMISM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -524,12 +517,11 @@ def test_metamask_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
         tx_hash=tx_hash,
     )
     user_address = polygon_pos_accounts[0]
-    timestamp = TimestampMS(1702471426000)
     approval_amount, swap_amount, received_amount, gas_fees, fee_amount = '115792089237316195423570985008687907853269984665640564039457584007913105.669754', '18.804192', '22.278327092660803452', '0.079877964587736024', '0.165989'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1702471426000)),
         location=Location.POLYGON_POS,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,

--- a/rotkehlchen/tests/unit/decoders/test_monerium.py
+++ b/rotkehlchen/tests/unit/decoders/test_monerium.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
 
-
 A_POLYGON_EURE = Asset('eip155:137/erc20:0x18ec0A6E18E5bc3784fDd3a3634b31245ab704F6')
 
 
@@ -27,8 +26,7 @@ A_POLYGON_EURE = Asset('eip155:137/erc20:0x18ec0A6E18E5bc3784fDd3a3634b31245ab70
 def test_minting_monerium_on_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(val='0x4ed9db44c5ee4ba6a4cf3e8e9b386f0b857afebad8339a92666e175c747bdd74')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    amount_str = '1500'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=113,
@@ -37,13 +35,12 @@ def test_minting_monerium_on_eth(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.NONE,
             asset=A_ETH_EURE,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '1500'),
             location_label=ethereum_accounts[0],
             notes=f'Mint {amount_str} EURe',
             counterparty=CPT_MONERIUM,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -51,8 +48,7 @@ def test_minting_monerium_on_eth(ethereum_inquirer, ethereum_accounts):
 def test_burning_monerium_on_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash(val='0x10d953610921f39d9d20722082077e03ec8db8d9c75e4b301d0d552119fd0354')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    amount_str = '1161210.84'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=171,
@@ -61,25 +57,22 @@ def test_burning_monerium_on_eth(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.NONE,
             asset=A_ETH_EURE,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '1161210.84'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {amount_str} EURe',
             counterparty=CPT_MONERIUM,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x762e5f511c219823eeC73C743C8245807A53E123']])
 def test_minting_monerium_on_matic(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash(val='0xb240acc158fb2cdcdebc7321ca4a96f71b371379e2a78a9a7f27d0718a2e3735')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash(val='0xb240acc158fb2cdcdebc7321ca4a96f71b371379e2a78a9a7f27d0718a2e3735')),  # noqa: E501
     )
-    amount_str = '95'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=176,
@@ -88,25 +81,22 @@ def test_minting_monerium_on_matic(polygon_pos_inquirer, polygon_pos_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.NONE,
             asset=A_POLYGON_EURE,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '95'),
             location_label=polygon_pos_accounts[0],
             notes=f'Mint {amount_str} EURe',
             counterparty=CPT_MONERIUM,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x0A251dF99A88A20a93876205Fb7f5Faf2E85A481']])
 def test_burning_monerium_on_matic(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash(val='0xeaed8e3e862a9b41189e9039c825ee57fb80385801b8ac5c3ed70339baf243e5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash(val='0xeaed8e3e862a9b41189e9039c825ee57fb80385801b8ac5c3ed70339baf243e5')),  # noqa: E501
     )
-    amount_str = '208.93'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=418,
@@ -115,25 +105,22 @@ def test_burning_monerium_on_matic(polygon_pos_inquirer, polygon_pos_accounts):
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.NONE,
             asset=A_POLYGON_EURE,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '208.93'),
             location_label=polygon_pos_accounts[0],
             notes=f'Burn {amount_str} EURe',
             counterparty=CPT_MONERIUM,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('gnosis_accounts', [['0x9566E3e6F55D4378243E55DE8e037Ee8E6e4de7E']])
 def test_minting_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
-    tx_hash = deserialize_evm_tx_hash(val='0x31183d757f530f799872600e6fe8644e3c20a1f90d02de9e89d0463454b400fa')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash(val='0x31183d757f530f799872600e6fe8644e3c20a1f90d02de9e89d0463454b400fa')),  # noqa: E501
     )
-    amount_str = '66'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=371,
@@ -142,13 +129,12 @@ def test_minting_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.NONE,
             asset=A_GNOSIS_EURE,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '66'),
             location_label=gnosis_accounts[0],
             notes=f'Mint {amount_str} EURe',
             counterparty=CPT_MONERIUM,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -156,8 +142,7 @@ def test_minting_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
 def test_burning_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash(val='0xae087f309231e4dc1fa84927888deb6c56b9980e63f9cc049cbe2d7d2bc503e6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    amount_str = '1'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=500,
@@ -166,13 +151,12 @@ def test_burning_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.NONE,
             asset=A_GNOSIS_EURE,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '1'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {amount_str} EURe',
             counterparty=CPT_MONERIUM,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -180,8 +164,7 @@ def test_burning_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
 def test_burnfrom_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash(val='0xf04a5d84e6749828ff63991fb3323944472346c3b2c421e51d9999283d18f1fd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    amount_str = '501.04'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=497,
@@ -190,13 +173,12 @@ def test_burnfrom_monerium_on_gnosis(gnosis_inquirer, gnosis_accounts):
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.NONE,
             asset=A_GNOSIS_EURE,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '501.04'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {amount_str} EURe',
             counterparty=CPT_MONERIUM,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -205,10 +187,9 @@ def test_mint_v2_eure(
         gnosis_inquirer: 'GnosisInquirer',
         gnosis_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash(val='0x859af3a118c2f2503dca9aba17421cfe46bfe1b9e2585988cded6cc3da0dc0f4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash(val='0x859af3a118c2f2503dca9aba17421cfe46bfe1b9e2585988cded6cc3da0dc0f4')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -231,13 +212,11 @@ def test_burn_v2_eure_gnosis(
         gnosis_inquirer: 'GnosisInquirer',
         gnosis_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash(val='0xeaf8521348335bce75863507c48dd48c36ebbd43e2f774524a0d5b3cfa5d594e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash(val='0xeaf8521348335bce75863507c48dd48c36ebbd43e2f774524a0d5b3cfa5d594e')),  # noqa: E501
     )
-    amount_str = '905.02'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=27,
@@ -246,13 +225,12 @@ def test_burn_v2_eure_gnosis(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.NONE,
             asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '905.02'),
             location_label=gnosis_accounts[0],
             notes=f'Burn {amount_str} EURe',
             counterparty=CPT_MONERIUM,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -261,10 +239,9 @@ def test_mint_eure_on_arbitrum(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash('0x792faaede6cd025d0a630669bf8fde06f51cc16aceebb67a09430536fea25109')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x792faaede6cd025d0a630669bf8fde06f51cc16aceebb67a09430536fea25109')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -287,10 +264,9 @@ def test_burn_eure_on_arbitrum(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ):
-    tx_hash = deserialize_evm_tx_hash('0xd403cb41ddb6ae65fbfea44e1f8be8edb20ac5bc2252d69387b16bae3c5f7694')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd403cb41ddb6ae65fbfea44e1f8be8edb20ac5bc2252d69387b16bae3c5f7694')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_morpho.py
+++ b/rotkehlchen/tests/unit/decoders/test_morpho.py
@@ -79,17 +79,17 @@ def test_morpho_deposit_base(
     assert vault_token.underlying_tokens is not None
     assert len(vault_token.underlying_tokens) == 1
     assert vault_token.underlying_tokens[0].address == underlying_addr
-    timestamp, user_address, gas_amount, deposit_amount, receive_amount = TimestampMS(1731100821000), base_accounts[0], '0.000007106536379632', '51.573591', '51.333358693113784641'  # noqa: E501
+    user_address = base_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731100821000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000007106536379632'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -101,7 +101,7 @@ def test_morpho_deposit_base(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=A_BASE_USDC,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '51.573591'),
             location_label=user_address,
             notes=f'Set USDC spending approval of {user_address} by 0x23055618898e202386e6c13955a58D3C68200BFB to {deposit_amount}',  # noqa: E501
             address=string_to_evm_address('0x23055618898e202386e6c13955a58D3C68200BFB'),
@@ -127,7 +127,7 @@ def test_morpho_deposit_base(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=vault_token,
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '51.333358693113784641'),
             location_label=user_address,
             notes=f'Receive {receive_amount} mwUSDC after deposit in a Morpho vault',
             counterparty=CPT_MORPHO,
@@ -156,17 +156,17 @@ def test_morpho_deposit_base_bundler(
         underlying=string_to_evm_address('0x4200000000000000000000000000000000000006'),
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount = TimestampMS(1731679657000), base_accounts[0], '0.000033559670856685'  # noqa: E501
+    user_address = base_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731679657000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000033559670856685'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -267,17 +267,17 @@ def test_morpho_withdraw_base(
         underlying=string_to_evm_address('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'),
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, return_amount, withdraw_amount = TimestampMS(1731408939000), base_accounts[0], '0.000009372834639654', '9951.725252259523570499', '10000'  # noqa: E501
+    user_address = base_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731408939000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000009372834639654'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -289,7 +289,7 @@ def test_morpho_withdraw_base(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset(f'eip155:8453/erc20:{vault_addr}'),
-            amount=FVal(return_amount),
+            amount=FVal(return_amount := '9951.725252259523570499'),
             location_label=user_address,
             notes=f'Return {return_amount} mwUSDC to a Morpho vault',
             counterparty=CPT_MORPHO,
@@ -302,7 +302,7 @@ def test_morpho_withdraw_base(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=A_BASE_USDC,
-            amount=FVal(withdraw_amount),
+            amount=FVal(withdraw_amount := '10000'),
             location_label=user_address,
             notes=f'Withdraw {withdraw_amount} USDC from a Morpho vault',
             counterparty=CPT_MORPHO,
@@ -320,17 +320,17 @@ def test_morpho_claim_reward_base(
     tx_hash = deserialize_evm_tx_hash('0xf1c08fcee3717217b30cbd5e120a4079837e319064d8c01a28d9fb7f44fcb88b')  # noqa: E501
     _add_morpho_reward_distributor(chain_id=ChainID.BASE, address='0x5400dBb270c956E8985184335A1C62AcA6Ce1333')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, reward_amount = TimestampMS(1731272621000), base_accounts[0], '0.000024248426432951', '0.033158'  # noqa: E501
+    user_address = base_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731272621000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000024248426432951'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -342,7 +342,7 @@ def test_morpho_claim_reward_base(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_BASE_USDC,
-            amount=FVal(reward_amount),
+            amount=FVal(reward_amount := '0.033158'),
             location_label=user_address,
             notes=f'Claim {reward_amount} USDC from Morpho',
             counterparty=CPT_MORPHO,
@@ -365,17 +365,17 @@ def test_morpho_deposit_ethereum(
         underlying=string_to_evm_address('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, deposit_amount, receive_amount = TimestampMS(1731354683000), ethereum_accounts[0], '0.019537376734385857', '200', '194.826292786685129719'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731354683000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.019537376734385857'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -387,7 +387,7 @@ def test_morpho_deposit_ethereum(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=A_USDC,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '200'),
             location_label=user_address,
             notes=f'Set USDC spending approval of {user_address} by 0x4095F064B8d3c3548A3bebfd0Bbfd04750E30077 to {deposit_amount}',  # noqa: E501
             address=string_to_evm_address('0x4095F064B8d3c3548A3bebfd0Bbfd04750E30077'),
@@ -413,7 +413,7 @@ def test_morpho_deposit_ethereum(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset(f'eip155:1/erc20:{vault_addr}'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '194.826292786685129719'),
             location_label=user_address,
             notes=f'Receive {receive_amount} USUALUSDC+ after deposit in a Morpho vault',
             counterparty=CPT_MORPHO,
@@ -436,17 +436,17 @@ def test_morpho_withdraw_ethereum(
         underlying=string_to_evm_address('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, approve_amount, return_amount, withdraw_amount = TimestampMS(1731405887000), ethereum_accounts[0], '0.035931819008110328', '1141398.660779466856241893', '1141393.264141539859656044', '1172000'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1731405887000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.035931819008110328'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -458,7 +458,7 @@ def test_morpho_withdraw_ethereum(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset(f'eip155:1/erc20:{vault_addr}'),
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '1141398.660779466856241893'),
             location_label=user_address,
             notes=f'Set USUALUSDC+ spending approval of {user_address} by 0x4095F064B8d3c3548A3bebfd0Bbfd04750E30077 to {approve_amount}',  # noqa: E501
             address=string_to_evm_address('0x4095F064B8d3c3548A3bebfd0Bbfd04750E30077'),
@@ -470,7 +470,7 @@ def test_morpho_withdraw_ethereum(
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset(f'eip155:1/erc20:{vault_addr}'),
-            amount=FVal(return_amount),
+            amount=FVal(return_amount := '1141393.264141539859656044'),
             location_label=user_address,
             notes=f'Return {return_amount} USUALUSDC+ to a Morpho vault',
             counterparty=CPT_MORPHO,
@@ -483,7 +483,7 @@ def test_morpho_withdraw_ethereum(
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=A_USDC,
-            amount=FVal(withdraw_amount),
+            amount=FVal(withdraw_amount := '1172000'),
             location_label=user_address,
             notes=f'Withdraw {withdraw_amount} USDC from a Morpho vault',
             counterparty=CPT_MORPHO,
@@ -501,17 +501,17 @@ def test_morpho_claim_reward_ethereum(
     tx_hash = deserialize_evm_tx_hash('0x1a6775590dfffdc2da036ec280627a65c57140b921d5afd11cabe913c78edcba')  # noqa: E501
     _add_morpho_reward_distributor(chain_id=ChainID.ETHEREUM, address='0x330eefa8a787552DC5cAd3C3cA644844B1E61Ddb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, reward_amount = TimestampMS(1730476199000), ethereum_accounts[0], '13.56253'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=285,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1730476199000),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_USDT,
-            amount=FVal(reward_amount),
+            amount=FVal(reward_amount := '13.56253'),
             location_label=user_address,
             notes=f'Claim {reward_amount} USDT from Morpho',
             counterparty=CPT_MORPHO,
@@ -534,16 +534,16 @@ def test_morpho_deposit_eth_and_weth_base(
         underlying=string_to_evm_address('0x4200000000000000000000000000000000000006'),
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, deposit1_amount, deposit2_amount, receive_amount = TimestampMS(1737414513000), base_accounts[0], '0.000014687937701214', '0.030990676336768753', '0.000009323663231247', '0.030971714651894301'  # noqa: E501
+    user_address = base_accounts[0]
     assert events == [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1737414513000)),
         location=Location.BASE,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.000014687937701214'),
         location_label=user_address,
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -555,7 +555,7 @@ def test_morpho_deposit_eth_and_weth_base(
         event_type=HistoryEventType.DEPOSIT,
         event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
         asset=A_ETH,
-        amount=FVal(deposit1_amount),
+        amount=FVal(deposit1_amount := '0.030990676336768753'),
         location_label=user_address,
         notes=f'Deposit {deposit1_amount} ETH in a Morpho vault',
         counterparty=CPT_MORPHO,
@@ -569,7 +569,7 @@ def test_morpho_deposit_eth_and_weth_base(
         event_type=HistoryEventType.DEPOSIT,
         event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
         asset=A_WETH_BASE,
-        amount=FVal(deposit2_amount),
+        amount=FVal(deposit2_amount := '0.000009323663231247'),
         location_label=user_address,
         notes=f'Deposit {deposit2_amount} WETH in a Morpho vault',
         counterparty=CPT_MORPHO,
@@ -583,7 +583,7 @@ def test_morpho_deposit_eth_and_weth_base(
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
         asset=Asset(f'eip155:8453/erc20:{vault_addr}'),
-        amount=FVal(receive_amount),
+        amount=FVal(receive_amount := '0.030971714651894301'),
         location_label=user_address,
         notes=f'Receive {receive_amount} exmWETH after deposit in a Morpho vault',
         counterparty=CPT_MORPHO,

--- a/rotkehlchen/tests/unit/decoders/test_octant.py
+++ b/rotkehlchen/tests/unit/decoders/test_octant.py
@@ -21,20 +21,16 @@ def test_lock_glm(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x29944efad254413b5eccdd5f13f14642ab830dbf51d5f2cfc59cf4957f33671a')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1697572739000)
-    gas_str = '0.000721453620442015'
-    approval_str = '199999000'
-    amount_str = '1000'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1697572739000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.000721453620442015'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -46,7 +42,7 @@ def test_lock_glm(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=A_GLM,
-            amount=FVal(approval_str),
+            amount=FVal(approval_str := '199999000'),
             location_label=user_address,
             notes=f'Set GLM spending approval of {user_address} by {OCTANT_DEPOSITS} to {approval_str}',  # noqa: E501
             address=OCTANT_DEPOSITS,
@@ -58,14 +54,13 @@ def test_lock_glm(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
             asset=A_GLM,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '1000'),
             location_label=user_address,
             notes=f'Lock {amount_str} GLM in Octant',
             counterparty=CPT_OCTANT,
             address=OCTANT_DEPOSITS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -74,19 +69,16 @@ def test_unlock_glm(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6705075bef0c3d9167c95a4a6c4911d6cc4055365e12fc445acd1039b157b1ab')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1697527487000)
-    gas_str = '0.000482531053547631'
-    amount_str = '500'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1697527487000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.000482531053547631'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -98,14 +90,13 @@ def test_unlock_glm(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
             asset=A_GLM,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '500'),
             location_label=user_address,
             notes=f'Unlock {amount_str} GLM from Octant',
             counterparty=CPT_OCTANT,
             address=OCTANT_DEPOSITS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -114,19 +105,16 @@ def test_claim_rewards(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xfc9b4ca277dcfd8000830aee13f8785b15516ce55a432c0d68f1bbdc0f599a49')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1706775971000)
-    gas_str = '0.000818835884130552'
-    amount_str = '7.989863001451442888'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706775971000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.000818835884130552'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -138,14 +126,13 @@ def test_claim_rewards(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_ETH,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '7.989863001451442888'),
             location_label=user_address,
             notes=f'Claim {amount_str} ETH as Octant epoch 2 reward',
             counterparty=CPT_OCTANT,
             address=OCTANT_REWARDS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -153,7 +140,7 @@ def test_claim_rewards(ethereum_inquirer, ethereum_accounts):
 def test_lock_glm_v2(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x117d78603f8a20f3c8ce29145d2f485d27688c922e09f532132fe33ecddcfe71')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -193,4 +180,3 @@ def test_lock_glm_v2(ethereum_inquirer, ethereum_accounts):
             address=OCTANT_DEPOSITS_V2,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_odos_v1.py
+++ b/rotkehlchen/tests/unit/decoders/test_odos_v1.py
@@ -37,16 +37,15 @@ if TYPE_CHECKING:
 def test_swap_token_to_token_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xce86cc4bb232af0ede2342b012270b1db4c61082ce2e32d8d274166cc9839143')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, approval_amount, swap_amount, received_amount, odos_fees_eth, gas_fees = TimestampMS(1691645135000), '115792089237316195423570985008687907853269984665640564035457.584007913129639935', '4000', '2.15484532751231104', '0.000151599541198592', '0.00403543'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1691645135000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.00403543'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -58,7 +57,7 @@ def test_swap_token_to_token_ethereum(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.INFORMATIONAL,
         event_subtype=HistoryEventSubType.APPROVE,
         asset=A_LUSD,
-        amount=FVal(approval_amount),
+        amount=FVal(approval_amount := '115792089237316195423570985008687907853269984665640564035457.584007913129639935'),  # noqa: E501
         location_label=ethereum_accounts[0],
         notes=f'Set LUSD spending approval of {ethereum_accounts[0]} by {ETH_ROUTER} to {approval_amount}',  # noqa: E501
         address=ETH_ROUTER,
@@ -69,7 +68,7 @@ def test_swap_token_to_token_ethereum(ethereum_inquirer, ethereum_accounts):
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_LUSD,
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '4000'),
         location_label=ethereum_accounts[0],
         notes=f'Swap {swap_amount} LUSD in Odos v1',
         counterparty=CPT_ODOS_V1,
@@ -81,7 +80,7 @@ def test_swap_token_to_token_ethereum(ethereum_inquirer, ethereum_accounts):
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_WETH,
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '2.15484532751231104'),
         location_label=ethereum_accounts[0],
         notes=f'Receive {received_amount} WETH as the result of a swap in Odos v1',
         counterparty=CPT_ODOS_V1,
@@ -93,7 +92,7 @@ def test_swap_token_to_token_ethereum(ethereum_inquirer, ethereum_accounts):
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_WETH,
-        amount=FVal(odos_fees_eth),
+        amount=FVal(odos_fees_eth := '0.000151599541198592'),
         location_label=ethereum_accounts[0],
         notes=f'Spend {odos_fees_eth} WETH as an Odos v1 fee',
         counterparty=CPT_ODOS_V1,
@@ -105,21 +104,19 @@ def test_swap_token_to_token_ethereum(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xcC91A1Fa81d7c4b10C4ECe01AbEb3EeE55e5373c']])
 def test_swap_token_to_eth_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x98805f922be9de669ddbb7c398db3c1bfb692530ad32fa72b40ac5aba49b895e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x98805f922be9de669ddbb7c398db3c1bfb692530ad32fa72b40ac5aba49b895e')),  # noqa: E501
     )
-    timestamp, approval_amount, swap_amount, received_amount, odos_fees_eth, gas_fees = TimestampMS(1693606715000), '115792089237316195423570985008687907853269984665640564039457.580725740003253015', '0.00328217312638692', '0.003282173126386919', '0.000000000000000001', '0.0000798467'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1693606715000)),
         location=Location.ARBITRUM_ONE,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.0000798467'),
         location_label=arbitrum_one_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -131,7 +128,7 @@ def test_swap_token_to_eth_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts
         event_type=HistoryEventType.INFORMATIONAL,
         event_subtype=HistoryEventSubType.APPROVE,
         asset=A_WETH_ARB,
-        amount=FVal(approval_amount),
+        amount=FVal(approval_amount := '115792089237316195423570985008687907853269984665640564039457.580725740003253015'),  # noqa: E501
         location_label=arbitrum_one_accounts[0],
         notes=f'Set WETH spending approval of {arbitrum_one_accounts[0]} by {ARB_ROUTER} to {approval_amount}',  # noqa: E501
         address=ARB_ROUTER,
@@ -142,7 +139,7 @@ def test_swap_token_to_eth_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts
         location=Location.ARBITRUM_ONE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_WETH_ARB,
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '0.00328217312638692'),
         location_label=arbitrum_one_accounts[0],
         notes=f'Swap {swap_amount} WETH in Odos v1',
         counterparty=CPT_ODOS_V1,
@@ -154,7 +151,7 @@ def test_swap_token_to_eth_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts
         location=Location.ARBITRUM_ONE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_ETH,
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '0.003282173126386919'),
         location_label=arbitrum_one_accounts[0],
         notes=f'Receive {received_amount} ETH as the result of a swap in Odos v1',
         counterparty=CPT_ODOS_V1,
@@ -166,7 +163,7 @@ def test_swap_token_to_eth_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts
         location=Location.ARBITRUM_ONE,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(odos_fees_eth),
+        amount=FVal(odos_fees_eth := '0.000000000000000001'),
         location_label=arbitrum_one_accounts[0],
         notes=f'Spend {odos_fees_eth} ETH as an Odos v1 fee',
         counterparty=CPT_ODOS_V1,
@@ -190,16 +187,15 @@ def test_swap_token_to_eth_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts
 def test_swap_eth_to_token_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x82e41cedb2265288f4475d8c7137bcaa031e5969ecbfa21551a797f5a7a71e8f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1691607223000), '1.347', '2494.738788', '0.000108989578875775'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1691607223000)),
         location=Location.OPTIMISM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.000108989578875775'),
         location_label=optimism_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -210,7 +206,7 @@ def test_swap_eth_to_token_optimism(optimism_inquirer, optimism_accounts):
         location=Location.OPTIMISM,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_ETH,
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '1.347'),
         location_label=optimism_accounts[0],
         notes=f'Swap {swap_amount} ETH in Odos v1',
         counterparty=CPT_ODOS_V1,
@@ -222,7 +218,7 @@ def test_swap_eth_to_token_optimism(optimism_inquirer, optimism_accounts):
         location=Location.OPTIMISM,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '2494.738788'),
         location_label=optimism_accounts[0],
         notes=f'Receive {received_amount} USDC.e as the result of a swap in Odos v1',
         counterparty=CPT_ODOS_V1,
@@ -234,21 +230,19 @@ def test_swap_eth_to_token_optimism(optimism_inquirer, optimism_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x0638df8ce244060e2ce2eEC04484334a99608Fa6']])
 def test_swap_matic_to_token_polygon(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x3802c36346914887b09d65d6ace796ba2549a8947aed9087475b78cef3b089e8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x3802c36346914887b09d65d6ace796ba2549a8947aed9087475b78cef3b089e8')),  # noqa: E501
     )
-    timestamp, swap_amount, received_amount, odos_fees_eth, gas_fees = TimestampMS(1700674099000), '5', '420.01909972952905', '66.153912047014979328', '0.022903685'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1700674099000)),
         location=Location.POLYGON_POS,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_POL,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.022903685'),
         location_label=polygon_pos_accounts[0],
         notes=f'Burn {gas_fees} POL for gas',
         counterparty=CPT_GAS,
@@ -259,7 +253,7 @@ def test_swap_matic_to_token_polygon(polygon_pos_inquirer, polygon_pos_accounts)
         location=Location.POLYGON_POS,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_POL,
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '5'),
         location_label=polygon_pos_accounts[0],
         notes=f'Swap {swap_amount} POL in Odos v1',
         counterparty=CPT_ODOS_V1,
@@ -271,7 +265,7 @@ def test_swap_matic_to_token_polygon(polygon_pos_inquirer, polygon_pos_accounts)
         location=Location.POLYGON_POS,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=Asset('eip155:137/erc20:0x8b1f836491903743fE51ACd13f2CC8Ab95b270f6'),
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '420.01909972952905'),
         location_label=polygon_pos_accounts[0],
         notes=f'Receive {received_amount} ACY as the result of a swap in Odos v1',
         counterparty=CPT_ODOS_V1,
@@ -283,7 +277,7 @@ def test_swap_matic_to_token_polygon(polygon_pos_inquirer, polygon_pos_accounts)
         location=Location.POLYGON_POS,
         event_subtype=HistoryEventSubType.FEE,
         asset=Asset('eip155:137/erc20:0x8b1f836491903743fE51ACd13f2CC8Ab95b270f6'),
-        amount=FVal(odos_fees_eth),
+        amount=FVal(odos_fees_eth := '66.153912047014979328'),
         location_label=polygon_pos_accounts[0],
         notes=f'Spend {odos_fees_eth} ACY as an Odos v1 fee',
         counterparty=CPT_ODOS_V1,

--- a/rotkehlchen/tests/unit/decoders/test_odos_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_odos_v2.py
@@ -48,16 +48,15 @@ if TYPE_CHECKING:
 def test_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0efcdf00cf582b5befb367e4527bcde302c3bb078aa7683c51b3a14df5ae2e1e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1721202275000), '6421.31', '7037.875022', '0.00129060601'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1721202275000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.00129060601'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -68,7 +67,7 @@ def test_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.SPEND,
         asset=Asset('eip155:1/erc20:0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c'),
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '6421.31'),
         location_label=ethereum_accounts[0],
         notes=f'Swap {swap_amount} EURC in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -80,7 +79,7 @@ def test_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_USDC,
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '7037.875022'),
         location_label=ethereum_accounts[0],
         notes=f'Receive {received_amount} USDC as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -94,16 +93,15 @@ def test_swap_token_to_token(ethereum_inquirer, ethereum_accounts):
 def test_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf2e7b37c24428631dad93b436019aa1602dbc4315f06a231a87b75b33f2f3491')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1721210603000), '0.252163033513435945', '0.252169099350692012', '0.00211742541059688'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1721210603000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.00211742541059688'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -114,7 +112,7 @@ def test_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.SPEND,
         asset=Asset('eip155:1/erc20:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'),
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '0.252163033513435945'),
         location_label=ethereum_accounts[0],
         notes=f'Swap {swap_amount} stETH in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -126,7 +124,7 @@ def test_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_ETH,
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '0.252169099350692012'),
         location_label=ethereum_accounts[0],
         notes=f'Receive {received_amount} ETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -149,16 +147,15 @@ def test_swap_token_to_eth(ethereum_inquirer, ethereum_accounts):
 def test_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x3bd3fa946e7da66914bd0c90deccea9ed41fd19e6f7b34e23e7a971eaffa48d8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount, gas_fees = TimestampMS(1721215703000), '0.48', '0.000956250976660625'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1721215703000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.000956250976660625'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -169,7 +166,7 @@ def test_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_ETH,
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '0.48'),
         location_label=ethereum_accounts[0],
         notes=f'Swap {swap_amount} ETH in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -195,16 +192,15 @@ def test_swap_eth_to_token(ethereum_inquirer, ethereum_accounts):
 def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xedc73ef9cec8f60630a509d87038e8826f6ca334443ffc025e03d212ffa9e267')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount_barron, swap_amount_sapo, received_amount, odos_fees, gas_fees = TimestampMS(1721212283000), '21952.133805449', '25347.248642364588152989', '0.008056869560090457', '0.000000805767532763', '0.001959751810319688'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1721212283000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.001959751810319688'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -240,7 +236,7 @@ def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=Asset('eip155:1/erc20:0x1F70300BCe8c2302780BD0a153ebb75B8CA7efCb'),
-        amount=FVal(swap_amount_barron),
+        amount=FVal(swap_amount_barron := '21952.133805449'),
         location_label=ethereum_accounts[0],
         notes=f'Swap {swap_amount_barron} BARRON in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -253,7 +249,7 @@ def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=Asset('eip155:1/erc20:0xb48EF10254C688ca0077f45C84459DC466bC83F6'),
-        amount=FVal(swap_amount_sapo),
+        amount=FVal(swap_amount_sapo := '25347.248642364588152989'),
         location_label=ethereum_accounts[0],
         notes=f'Swap {swap_amount_sapo} SAPO in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -266,7 +262,7 @@ def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_ETH,
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '0.008056869560090457'),
         location_label=ethereum_accounts[0],
         notes=f'Receive {received_amount} ETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -279,7 +275,7 @@ def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(odos_fees),
+        amount=FVal(odos_fees := '0.000000805767532763'),
         location_label=ethereum_accounts[0],
         notes=f'Spend {odos_fees} ETH as an Odos v2 fee',
         counterparty=CPT_ODOS_V2,
@@ -293,16 +289,15 @@ def test_swap_multi_to_single(ethereum_inquirer, ethereum_accounts):
 def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa331b8a62ccf8a62960a6a4edda43f3b835c0a76b5c6365691936077787a5507')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount, received_amount_sfrax, received_amount_rgusd, odos_fees_sfrax, odos_fees_rgusd, gas_fees = TimestampMS(1721103275000), '0.01', '16.393269664059458706', '17.599136295574420014', '0.001639490915497496', '0.001760089638521295', '0.00234938705101066'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1721103275000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.00234938705101066'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -314,7 +309,7 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_ETH,
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '0.01'),
         location_label=ethereum_accounts[0],
         notes=f'Swap {swap_amount} ETH in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -327,7 +322,7 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=Asset('eip155:1/erc20:0xA663B02CF0a4b149d2aD41910CB81e23e1c41c32'),
-        amount=FVal(received_amount_sfrax),
+        amount=FVal(received_amount_sfrax := '16.393269664059458706'),
         location_label=ethereum_accounts[0],
         notes=f'Receive {received_amount_sfrax} sFRAX as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -340,7 +335,7 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=Asset('eip155:1/erc20:0x78da5799CF427Fee11e9996982F4150eCe7a99A7'),
-        amount=FVal(received_amount_rgusd),
+        amount=FVal(received_amount_rgusd := '17.599136295574420014'),
         location_label=ethereum_accounts[0],
         notes=f'Receive {received_amount_rgusd} rgUSD as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -353,7 +348,7 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.FEE,
         asset=Asset('eip155:1/erc20:0xA663B02CF0a4b149d2aD41910CB81e23e1c41c32'),
-        amount=FVal(odos_fees_sfrax),
+        amount=FVal(odos_fees_sfrax := '0.001639490915497496'),
         location_label=ethereum_accounts[0],
         notes=f'Spend {odos_fees_sfrax} sFRAX as an Odos v2 fee',
         counterparty=CPT_ODOS_V2,
@@ -366,7 +361,7 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.FEE,
         asset=Asset('eip155:1/erc20:0x78da5799CF427Fee11e9996982F4150eCe7a99A7'),
-        amount=FVal(odos_fees_rgusd),
+        amount=FVal(odos_fees_rgusd := '0.001760089638521295'),
         location_label=ethereum_accounts[0],
         notes=f'Spend {odos_fees_rgusd} rgUSD as an Odos v2 fee',
         counterparty=CPT_ODOS_V2,
@@ -380,16 +375,15 @@ def test_swap_single_to_multi(ethereum_inquirer, ethereum_accounts):
 def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2ae9298c00c76fc63df4112a7924a5deb908f095cb9d41d284e890aee31ca114')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount_sweth, swap_amount_usdc, received_amount_eth, received_amount_cbeth, odos_fees_eth, odos_fees_cbeth, gas_fees = TimestampMS(1720651511000), '0.300942750197910709', '5.085873', '0.21177820231350276', '0.101348638838421792', '0.000021179938225173', '0.00001013587747159', '0.00194866414'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1720651511000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.00194866414'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -413,7 +407,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=Asset('eip155:1/erc20:0xf951E335afb289353dc249e82926178EaC7DEd78'),
-        amount=FVal(swap_amount_sweth),
+        amount=FVal(swap_amount_sweth := '0.300942750197910709'),
         location_label=ethereum_accounts[0],
         notes=f'Swap {swap_amount_sweth} swETH in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -426,7 +420,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_USDC,
-        amount=FVal(swap_amount_usdc),
+        amount=FVal(swap_amount_usdc := '5.085873'),
         location_label=ethereum_accounts[0],
         notes=f'Swap {swap_amount_usdc} USDC in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -439,7 +433,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_ETH,
-        amount=FVal(received_amount_eth),
+        amount=FVal(received_amount_eth := '0.21177820231350276'),
         location_label=ethereum_accounts[0],
         notes=f'Receive {received_amount_eth} ETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -452,7 +446,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=Asset('eip155:1/erc20:0xBe9895146f7AF43049ca1c1AE358B0541Ea49704'),
-        amount=FVal(received_amount_cbeth),
+        amount=FVal(received_amount_cbeth := '0.101348638838421792'),
         location_label=ethereum_accounts[0],
         notes=f'Receive {received_amount_cbeth} cbETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -465,7 +459,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.FEE,
         asset=Asset('eip155:1/erc20:0xBe9895146f7AF43049ca1c1AE358B0541Ea49704'),
-        amount=FVal(odos_fees_cbeth),
+        amount=FVal(odos_fees_cbeth := '0.00001013587747159'),
         location_label=ethereum_accounts[0],
         notes=f'Spend {odos_fees_cbeth} cbETH as an Odos v2 fee',
         counterparty=CPT_ODOS_V2,
@@ -478,7 +472,7 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(odos_fees_eth),
+        amount=FVal(odos_fees_eth := '0.000021179938225173'),
         location_label=ethereum_accounts[0],
         notes=f'Spend {odos_fees_eth} ETH as an Odos v2 fee',
         counterparty=CPT_ODOS_V2,
@@ -490,21 +484,19 @@ def test_swap_multi_to_multi(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x437AD8a22CeeD33cBC4e661f8ef33D57a390d287']])
 def test_swap_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xab0ca6d2749425e0e45a60dc66daa5059276bf2b97db5939949e24564dff9826')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xab0ca6d2749425e0e45a60dc66daa5059276bf2b97db5939949e24564dff9826')),  # noqa: E501
     )
-    timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1721303364000), '5', '3.797619', '0.000006397028928'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1721303364000)),
         location=Location.ARBITRUM_ONE,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.000006397028928'),
         location_label=arbitrum_one_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -527,7 +519,7 @@ def test_swap_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
         location=Location.ARBITRUM_ONE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_ARB,
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '5'),
         location_label=arbitrum_one_accounts[0],
         notes=f'Swap {swap_amount} ARB in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -539,7 +531,7 @@ def test_swap_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
         location=Location.ARBITRUM_ONE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_ARBITRUM_USDC,
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '3.797619'),
         location_label=arbitrum_one_accounts[0],
         notes=f'Receive {received_amount} USDC as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -554,16 +546,15 @@ def test_swap_on_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
 def test_swap_on_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2029ab1ad9985a21c8a064be8384b531d55864f37f16a1716a00da8577891aab')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, approval_amount, swap_amount, received_amount, gas_fees = TimestampMS(1721303613000), '9007199254724259.054195778508578652', '10.586121519928495085', '0.003163240870272189', '0.00000767513097358'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1721303613000)),
         location=Location.BASE,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.00000767513097358'),
         location_label=base_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -575,7 +566,7 @@ def test_swap_on_base(base_inquirer, base_accounts):
         event_type=HistoryEventType.INFORMATIONAL,
         event_subtype=HistoryEventSubType.APPROVE,
         asset=A_AERO,
-        amount=FVal(approval_amount),
+        amount=FVal(approval_amount := '9007199254724259.054195778508578652'),
         location_label=base_accounts[0],
         notes=f'Set AERO spending approval of {base_accounts[0]} by {BASE_ROUTER} to {approval_amount}',  # noqa: E501
         address=BASE_ROUTER,
@@ -586,7 +577,7 @@ def test_swap_on_base(base_inquirer, base_accounts):
         location=Location.BASE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_AERO,
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '10.586121519928495085'),
         location_label=base_accounts[0],
         notes=f'Swap {swap_amount} AERO in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -598,7 +589,7 @@ def test_swap_on_base(base_inquirer, base_accounts):
         location=Location.BASE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_ETH,
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '0.003163240870272189'),
         location_label=base_accounts[0],
         notes=f'Receive {received_amount} ETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -613,16 +604,15 @@ def test_swap_on_base(base_inquirer, base_accounts):
 def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc7c9b85ba66e6d262a5bf23afd75a49ffb6c079979587d5bbc1dddd647afc906')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, approval_amount, swap_amount_usdc, swap_amount_usdce, received_amount, odos_fees, gas_fees = TimestampMS(1721310953000), '115792089237316195423570985008687907853269984665640564039457584007913129.447868', '1.199279', '0.192067', '0.000401886614321588', '0.000000040192680701', '0.000015691756359161'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1721310953000)),
         location=Location.OPTIMISM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.000015691756359161'),
         location_label=optimism_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -634,7 +624,7 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
         event_type=HistoryEventType.INFORMATIONAL,
         event_subtype=HistoryEventSubType.APPROVE,
         asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-        amount=FVal(approval_amount),
+        amount=FVal(approval_amount := '115792089237316195423570985008687907853269984665640564039457584007913129.447868'),  # noqa: E501
         location_label=optimism_accounts[0],
         notes=f'Set USDC.e spending approval of {optimism_accounts[0]} by {OP_ROUTER} to {approval_amount}',  # noqa: E501
         address=OP_ROUTER,
@@ -646,7 +636,7 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_OPTIMISM_USDC,
-        amount=FVal(swap_amount_usdc),
+        amount=FVal(swap_amount_usdc := '1.199279'),
         location_label=optimism_accounts[0],
         notes=f'Swap {swap_amount_usdc} USDC in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -659,7 +649,7 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-        amount=FVal(swap_amount_usdce),
+        amount=FVal(swap_amount_usdce := '0.192067'),
         location_label=optimism_accounts[0],
         notes=f'Swap {swap_amount_usdce} USDC.e in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -672,7 +662,7 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_ETH,
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '0.000401886614321588'),
         location_label=optimism_accounts[0],
         notes=f'Receive {received_amount} ETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -685,7 +675,7 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
         event_type=HistoryEventType.MULTI_TRADE,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(odos_fees),
+        amount=FVal(odos_fees := '0.000000040192680701'),
         location_label=optimism_accounts[0],
         notes=f'Spend {odos_fees} ETH as an Odos v2 fee',
         counterparty=CPT_ODOS_V2,
@@ -697,21 +687,19 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xB14cF335808931BDED4B232c6d01C65e5E73237F']])
 def test_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x82bd45bcf1faf80f4b2e0d12b3e45c5801d1065a7e6a7daf68cd35a3a33c5fc7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x82bd45bcf1faf80f4b2e0d12b3e45c5801d1065a7e6a7daf68cd35a3a33c5fc7')),  # noqa: E501
     )
-    timestamp, approval_amount, swap_amount, received_amount, gas_fees = TimestampMS(1721305107000), '0.0000001', '0.0000019', '0.217325398483406396', '0.006751666697583186'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1721305107000)),
         location=Location.POLYGON_POS,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_POL,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.006751666697583186'),
         location_label=polygon_pos_accounts[0],
         notes=f'Burn {gas_fees} POL for gas',
         counterparty=CPT_GAS,
@@ -723,7 +711,7 @@ def test_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
         event_type=HistoryEventType.INFORMATIONAL,
         event_subtype=HistoryEventSubType.APPROVE,
         asset=Asset('eip155:137/erc20:0x2297aEbD383787A160DD0d9F71508148769342E3'),
-        amount=FVal(approval_amount),
+        amount=FVal(approval_amount := '0.0000001'),
         location_label=polygon_pos_accounts[0],
         notes=f'Set BTC.b spending approval of {polygon_pos_accounts[0]} by {MATIC_ROUTER} to {approval_amount}',  # noqa: E501
         address=MATIC_ROUTER,
@@ -734,7 +722,7 @@ def test_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
         location=Location.POLYGON_POS,
         event_subtype=HistoryEventSubType.SPEND,
         asset=Asset('eip155:137/erc20:0x2297aEbD383787A160DD0d9F71508148769342E3'),
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '0.0000019'),
         location_label=polygon_pos_accounts[0],
         notes=f'Swap {swap_amount} BTC.b in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -746,7 +734,7 @@ def test_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
         location=Location.POLYGON_POS,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=A_POL,
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '0.217325398483406396'),
         location_label=polygon_pos_accounts[0],
         notes=f'Receive {received_amount} POL as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -760,16 +748,15 @@ def test_swap_on_polygon(polygon_pos_inquirer, polygon_pos_accounts):
 def test_swap_on_scroll(scroll_inquirer, scroll_accounts, allow_scroll_etherscan):
     tx_hash = deserialize_evm_tx_hash('0x442e968d8a5c6adb81bf087041ed3dd19dc2f20725044c7f9c435bf6234d9992')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1721305362000), '0.042810448486080933', '0.049288894534015152', '0.000033784756880726'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1721305362000)),
         location=Location.SCROLL,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.000033784756880726'),
         location_label=scroll_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -780,7 +767,7 @@ def test_swap_on_scroll(scroll_inquirer, scroll_accounts, allow_scroll_etherscan
         location=Location.SCROLL,
         event_subtype=HistoryEventSubType.SPEND,
         asset=Asset('eip155:534352/erc20:0xf610A9dfB7C89644979b4A0f27063E9e7d7Cda32'),
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '0.042810448486080933'),
         location_label=scroll_accounts[0],
         notes=f'Swap {swap_amount} wstETH in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -792,7 +779,7 @@ def test_swap_on_scroll(scroll_inquirer, scroll_accounts, allow_scroll_etherscan
         location=Location.SCROLL,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=Asset('eip155:534352/erc20:0xa25b25548B4C98B0c7d3d27dcA5D5ca743d68b7F'),
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '0.049288894534015152'),
         location_label=scroll_accounts[0],
         notes=f'Receive {received_amount} wrsETH as the result of a swap in Odos v2',
         counterparty=CPT_ODOS_V2,
@@ -871,16 +858,15 @@ def test_airdrop_claim(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x7d78887e1f615d83e95d2fd2cddd72b1042131d8b194bceb9630580ea596a14c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, received_amount, gas_fees = TimestampMS(1734686937000), '1739.7281675210563', '0.000025147925631755'  # noqa: E501
     assert events == [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1734686937000)),
         location=Location.BASE,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.000025147925631755'),
         location_label=base_accounts[0],
         notes=f'Burn {gas_fees} ETH for gas',
         counterparty=CPT_GAS,
@@ -892,7 +878,7 @@ def test_airdrop_claim(
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.AIRDROP,
         asset=Asset(ODOS_ASSET_ID),
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '1739.7281675210563'),
         location_label=base_accounts[0],
         notes=f'Claim {received_amount} ODOS from Odos airdrop',
         address=ODOS_AIRDROP_DISTRIBUTOR,

--- a/rotkehlchen/tests/unit/decoders/test_omni.py
+++ b/rotkehlchen/tests/unit/decoders/test_omni.py
@@ -23,17 +23,16 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc626898273896eb771e9725137849dd104e388aad49687068a7681b5c54893fe')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str = TimestampMS(1713555527000), '0.000567969103578996'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1713555527000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.000567969103578996'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -66,7 +65,6 @@ def test_claim(ethereum_inquirer, ethereum_accounts):
             extra_data={AIRDROP_IDENTIFIER_KEY: 'omni'},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -74,17 +72,16 @@ def test_claim(ethereum_inquirer, ethereum_accounts):
 def test_stake(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x66f47dc448d7371eeccaa500af1aea76a1620de56c621187be83b1cc19bf861c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str, omni_str = TimestampMS(1713604307000), '0.00061736344563685', '5.06213676'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1713604307000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.00061736344563685'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -108,14 +105,13 @@ def test_stake(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=Asset(OMNI_TOKEN_ID),
-            amount=FVal(omni_str),
+            amount=FVal(omni_str := '5.06213676'),
             location_label=ethereum_accounts[0],
             notes=f'Stake {omni_str} OMNI',
             counterparty=CPT_OMNI,
             address=OMNI_STAKING_CONTRACT,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -123,17 +119,16 @@ def test_stake(ethereum_inquirer, ethereum_accounts):
 def test_claim_and_stake(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x630c32c20d75c51ffe7b1db1cb3d82d357a8db4da10c1c5b212e01f8e92f6310')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str, omni_str = TimestampMS(1713602555000), '0.000645708531342875', '15.3275649'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1713602555000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.000645708531342875'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -158,7 +153,7 @@ def test_claim_and_stake(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=Asset(OMNI_TOKEN_ID),
-            amount=FVal(omni_str),
+            amount=FVal(omni_str := '15.3275649'),
             location_label=ethereum_accounts[0],
             notes=f'Claim {omni_str} OMNI from the Omni genesis airdrop',
             counterparty=CPT_OMNI,
@@ -179,4 +174,3 @@ def test_claim_and_stake(ethereum_inquirer, ethereum_accounts):
             address=OMNI_STAKING_CONTRACT,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_optimism.py
+++ b/rotkehlchen/tests/unit/decoders/test_optimism.py
@@ -38,12 +38,11 @@ def test_optimism_airdrop_1_claim(optimism_inquirer):
     """
     tx_hash = deserialize_evm_tx_hash('0xda810d7e1757c6ce7387b437c26472f802eec47404e60d4f1eaa9f23bf8d8b73')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1673337921000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1673337921000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -67,7 +66,6 @@ def test_optimism_airdrop_1_claim(optimism_inquirer):
             address=OPTIMISM_AIRDROP_1,
             extra_data={AIRDROP_IDENTIFIER_KEY: 'optimism_1'},
         )]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -76,17 +74,16 @@ def test_optimism_airdrop_1_claim(optimism_inquirer):
 def test_optimism_airdrop_4_claim(optimism_accounts, optimism_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xb5b478b321a81ae03565dd72bd625fcb203a97f017670b28e306a893414ae83b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, claim_amount = TimestampMS(1712777987000), '0.000007620095114963', '6000'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712777987000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000007620095114963'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -98,14 +95,13 @@ def test_optimism_airdrop_4_claim(optimism_accounts, optimism_inquirer):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=A_OP,
-            amount=FVal(claim_amount),
+            amount=FVal(claim_amount := '6000'),
             location_label=optimism_accounts[0],
             notes=f'Claim {claim_amount} OP from the optimism airdrop 4',
             counterparty=CPT_OPTIMISM,
             address=OPTIMISM_AIRDROP_4,
             extra_data={AIRDROP_IDENTIFIER_KEY: 'optimism_4'},
         )]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -114,17 +110,16 @@ def test_optimism_airdrop_4_claim(optimism_accounts, optimism_inquirer):
 def test_optimism_airdrop_5_claim(optimism_accounts, optimism_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xc017fb7d0a9362f7aa681ed6fa695779d1d8dd22dbabbc4aa77fb40c6bc8bda8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, claim_amount = TimestampMS(1729405689000), '0.00000030058552275', '150'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1729405689000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.00000030058552275'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -136,14 +131,13 @@ def test_optimism_airdrop_5_claim(optimism_accounts, optimism_inquirer):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=A_OP,
-            amount=FVal(claim_amount),
+            amount=FVal(claim_amount := '150'),
             location_label=optimism_accounts[0],
             notes=f'Claim {claim_amount} OP from the optimism airdrop 5',
             counterparty=CPT_OPTIMISM,
             address=OPTIMISM_AIRDROP_5,
             extra_data={AIRDROP_IDENTIFIER_KEY: 'optimism_5'},
         )]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -152,17 +146,16 @@ def test_optimism_airdrop_5_claim(optimism_accounts, optimism_inquirer):
 def test_optimism_airdrop_3_distribution(optimism_accounts, optimism_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x178e96280c38d2b0b40143e3794b89747ee544b2a273b64eb3fb09392c220cfa')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, claim_amount = TimestampMS(1695060701000), '1518.05545398906'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=913,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1695060701000),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=A_OP,
-            amount=FVal(claim_amount),
+            amount=FVal(claim_amount := '1518.05545398906'),
             location_label=optimism_accounts[0],
             notes=f'Receive {claim_amount} OP from the optimism airdrop 3',
             counterparty=CPT_OPTIMISM,
@@ -170,7 +163,6 @@ def test_optimism_airdrop_3_distribution(optimism_accounts, optimism_inquirer):
             extra_data={AIRDROP_IDENTIFIER_KEY: 'optimism_3'},
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -179,17 +171,16 @@ def test_optimism_airdrop_3_distribution(optimism_accounts, optimism_inquirer):
 def test_optimism_airdrop_2_distribution(optimism_accounts, optimism_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xce2215e8d2141d7a0a2e45d9c07ca7599d9b762447e77f0b3e65f3fa2fc49b9f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, claim_amount = TimestampMS(1675972022000), '4.036252419409362'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=308,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1675972022000),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=A_OP,
-            amount=FVal(claim_amount),
+            amount=FVal(claim_amount := '4.036252419409362'),
             location_label=optimism_accounts[0],
             notes=f'Receive {claim_amount} OP from the optimism airdrop 2',
             counterparty=CPT_OPTIMISM,
@@ -197,7 +188,6 @@ def test_optimism_airdrop_2_distribution(optimism_accounts, optimism_inquirer):
             extra_data={AIRDROP_IDENTIFIER_KEY: 'optimism_2'},
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -206,17 +196,16 @@ def test_optimism_airdrop_2_distribution(optimism_accounts, optimism_inquirer):
 def test_optimism_airdrop_1_distribution(optimism_accounts, optimism_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xc0e1ee0ea2f3683c5186a078aea67a84009c42d6cf55002725da1adbe0614ac8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, claim_amount = TimestampMS(1694801257000), '409.426292836590288896'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=117,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1694801257000),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=A_OP,
-            amount=FVal(claim_amount),
+            amount=FVal(claim_amount := '409.426292836590288896'),
             location_label=optimism_accounts[0],
             notes=f'Receive {claim_amount} OP from the optimism airdrop 1',
             counterparty=CPT_OPTIMISM,
@@ -224,7 +213,6 @@ def test_optimism_airdrop_1_distribution(optimism_accounts, optimism_inquirer):
             extra_data={AIRDROP_IDENTIFIER_KEY: 'optimism_1'},
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -236,12 +224,11 @@ def test_optimism_delegate_change(optimism_inquirer):
     """
     tx_hash = deserialize_evm_tx_hash('0xe0b31814f787385ab9f680c2ecf7e20e6dd2f880d979a44487768add26faa594')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1673338011000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1673338011000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -264,4 +251,3 @@ def test_optimism_delegate_change(optimism_inquirer):
             counterparty=CPT_OPTIMISM,
             address=string_to_evm_address('0x4200000000000000000000000000000000000042'),
         )]
-    assert expected_events == events

--- a/rotkehlchen/tests/unit/decoders/test_optimism_governor.py
+++ b/rotkehlchen/tests/unit/decoders/test_optimism_governor.py
@@ -97,18 +97,16 @@ def test_vote_cast_with_reason(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xced69de2a81814554b9f69a19240737f0728f94bd67d94c73f960d24f99343bd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     user_address = optimism_accounts[0]
-    timestamp = TimestampMS(1706051703000)
-    gas_amount = '0.000022621225472652'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706051703000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=Asset('ETH'),
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000022621225472652'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,

--- a/rotkehlchen/tests/unit/decoders/test_paladin.py
+++ b/rotkehlchen/tests/unit/decoders/test_paladin.py
@@ -21,17 +21,18 @@ def test_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8a2bf33211bb1903ee3db7ca5a7bef10b168fdd68701cd3c9dc17c7b0c60a3f7')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, amount, period = TimestampMS(1672197467000), '0.00120340458490378', '1079.056809836717269824', 1671062400  # noqa: E501
-    expected_events = [
+    amount = '1079.056809836717269824'
+    period = 1671062400
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1672197467000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.00120340458490378'),
             location_label=user_address,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -50,4 +51,3 @@ def test_claim(ethereum_inquirer, ethereum_accounts):
             address=PALADIN_MERKLE_DISTRIBUTOR_V2,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_paraswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_paraswap.py
@@ -53,7 +53,6 @@ A_sUSD = Asset('eip155:10/erc20:0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9')
 A_POLYGON_POS_USDC = Asset('eip155:137/erc20:0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359')
 A_POLYGON_POS_DAI = Asset('eip155:137/erc20:0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063')
 
-
 PARASWAP_TOKEN_TRANSFER_PROXY: Final = string_to_evm_address('0x216B4B4Ba9F3e719726886d34a177484278Bfcae')  # noqa: E501
 
 
@@ -63,12 +62,11 @@ def test_simple_swap_no_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xeab04bca5abb6a794fd83e3c336b128824a2d3a72abf565d82a6ecd39d5929ef')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704814775000)
     swap_amount, received_amount, approval_amount, gas_fees = '3860.977240111926214656', '3997.851328', '115792089237316195423570985008687907853269984665640564034996.606767801203425279', '0.003865522700588692'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704814775000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -124,12 +122,11 @@ def test_simple_swap_eth_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xeeea20b39f157fe59fa4904fd4b62f8971188b53d05c6831e0ed67ee157e40c2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704806231000)
     swap_amount, received_amount, gas_fees, paraswap_fee = '3.020129914302378395', '3.019113864780728103', '0.00680806307180382', '0.028681581715416916'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704806231000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -193,12 +190,11 @@ def test_simple_swap_token_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf4d28d1c46dde983fac73db8e651514fe7299edaf40870766462362b1b1a1d83')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704797495000)
     swap_amount, received_amount, gas_fees, paraswap_fee = '138.2851', '1190.359719', '0.0034595', '11.308417'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704797495000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -266,12 +262,11 @@ def test_simple_buy(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x695739b3eab8dc7e6ef7f9b362983cfd4d9b81592b0840bd0ca69b0b2e8e51f9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704888587000)
     swap_amount, received_amount, gas_fees = '223.031074350165285613', '200.000000000000000001', '0.00727228725913224'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704888587000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -314,12 +309,11 @@ def test_multi_swap_no_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6f7313845874cb26cda5d63adcbf9899edf257f2e196a7ace641bdbb179947e7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704815411000)
     swap_amount, received_amount, gas_fees = '400', '30.498415074803766847', '0.007613212553923857'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704815411000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -362,12 +356,11 @@ def test_multi_swap_token_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0c55b3df325d145b82fbe4e135e88eeae9820b035842b2ec5e17ccb1357375c6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704883367000)
     swap_amount, received_amount, gas_fees, paraswap_fee = '24996', '48398.029944956021622964', '0.010829082710902124', '91.956256895416441083'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704883367000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -422,12 +415,11 @@ def test_mega_swap_no_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5c36bcfa67d3306a3fe21203b7279e589d26c9925d055b3174ac259b262345f3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704802211000)
     swap_amount, received_amount, gas_fees = '219410.681102', '4.68800235', '0.019375015240876558'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704802211000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -483,12 +475,11 @@ def test_mega_swap_token_fee(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x9c529e46976ce23d1caf3dc1c062ee3c9ec9c327014f5447761409788e842294')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704881183000)
     swap_amount, received_amount, gas_fees, paraswap_fee = '42226.901446319896728285', '40567.774843', '0.028635611789064984', '0.858994'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704881183000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -543,12 +534,11 @@ def test_swap_on_uniswap_v2_fork(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6fa4a6a9c0d9c5aad831cc1ff149fb7683c0573db93571bc43acb5b4848314ae')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704889739000)
     swap_amount, received_amount, gas_fees = '0.35', '835.81811', '0.00296189763180853'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704889739000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -591,12 +581,11 @@ def test_swap_on_uniswap_v2_fork_with_permit(ethereum_inquirer, ethereum_account
     tx_hash = deserialize_evm_tx_hash('0xaab04d564e1f065b350e6aa6fda9d0ff51082e8810520e691866fdade91ba9c4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704889595000)
     swap_amount, received_amount, approval_amount, gas_fees = '150', '150.152117', '115792089237316195423570985008687907853269984665640564039457584007913129.639935', '0.004565275677196416'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704889595000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -652,12 +641,11 @@ def test_buy_uniswap_v2_fork(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x15df127374a04772df72b94685f60f71200da679e4bc2c334a12889fe2ab046c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1705575743000)
     swap_amount, received_amount, gas_fees = '0.396919294295211225', '40', '0.004393070468277507'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1705575743000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -700,12 +688,11 @@ def test_direct_uniswap_v3_swap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2b6e830d4b32c22b3c4c2a26dbdb9a17c3cc2962fc35d5b4cd5d56c58cbec68a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1704888899000)
     swap_amount, received_amount, gas_fees = '2010000', '3.265498018938813939', '0.005934293486927232'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1704888899000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -748,12 +735,11 @@ def test_direct_curve_v1_swap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5a601f524592627eaf3562e4cb1340880260a1bf627a984392308cdf79a828dc')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1705577795000)
     swap_amount, received_amount, gas_fees = '1175.108', '1343.06000017590196878', '0.008673416651691594'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1705577795000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -809,12 +795,11 @@ def test_direct_curve_v2_swap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2ea92952050e9f5cbf9b46619355a3b34822286443e10a6f5405573330def118')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1705502243000)
     swap_amount, received_amount, gas_fees = '5.48189', '184.099593744496046878', '0.01392159540206184'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1705502243000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -857,12 +842,11 @@ def test_direct_balancer_v2_given_swap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x606413e4074e79e68ee0f79eee96c94cf091e7c061a551d2dd2a27044fb007e7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1705575743000)
     swap_amount, received_amount, gas_fees = '17438.484493735105063894', '0.253269184972671572', '0.006247513881593877'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1705575743000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -928,18 +912,16 @@ def test_direct_balancer_v2_given_swap(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xFee285cf79719FC3552c5F7c540554f09DAdAD21']])
 def test_simple_buy_fee_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x92a422b746cc1ce14b795e5fc2239cdf3146482a5bc3c5278dccb1c3ccccdc17')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x92a422b746cc1ce14b795e5fc2239cdf3146482a5bc3c5278dccb1c3ccccdc17')),  # noqa: E501
     )
     user_address = arbitrum_one_accounts[0]
-    timestamp = TimestampMS(1705593327000)
     swap_amount, received_amount, approval_amount, gas_fees, paraswap_fee = '0.145421', '0.000057531692024488', '15.547876', '0.0002783844', '0.000002'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1705593327000)),
         location=Location.ARBITRUM_ONE,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -1005,18 +987,16 @@ def test_simple_buy_fee_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_account
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('base_accounts', [['0x66CF237A0D3505E80eF083E0F8D4Cad09Fd0BFe4']])
 def test_simple_swap_no_fee_base(base_inquirer, base_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xf93a7211656753e841899b40edf3a9ccfded6b40b6d7b3538a4215362f9bd34f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf93a7211656753e841899b40edf3a9ccfded6b40b6d7b3538a4215362f9bd34f')),  # noqa: E501
     )
     user_address = base_accounts[0]
-    timestamp = TimestampMS(1705604855000)
     swap_amount, received_amount, gas_fees = '0.051094010416535325', '0.048393744103758202', '0.000257848719493097'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1705604855000)),
         location=Location.BASE,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -1057,18 +1037,16 @@ def test_simple_swap_no_fee_base(base_inquirer, base_accounts):
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('optimism_accounts', [['0xDa2181fB19f2Fe365BeF6Ccb84209d6FDb0d1828']])
 def test_direct_curve_v1_swap_optimism(optimism_inquirer, optimism_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x83ac5abc6819fca458f614e4fdbca6fe324bbea8b7ce5fb072bf99407cd8c031')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x83ac5abc6819fca458f614e4fdbca6fe324bbea8b7ce5fb072bf99407cd8c031')),  # noqa: E501
     )
     user_address = optimism_accounts[0]
-    timestamp = TimestampMS(1705666455000)
     swap_amount, received_amount, paraswap_fee, gas_fees = '16000.007289', '16026.407272974863067802', '0.262301326491870034', '0.000098575498010565'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1705666455000)),
         location=Location.OPTIMISM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -1133,18 +1111,16 @@ def test_direct_curve_v1_swap_optimism(optimism_inquirer, optimism_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xe03679B59AC0026036ba4518bc0d5e5F800Bd9c1']])
 def test_direct_uniswap_v3_swap_polygon(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x4f72cff63802c8eed51662e3d1e20bc7e86ac06cdc1aa490c26cfeee075b6018')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x4f72cff63802c8eed51662e3d1e20bc7e86ac06cdc1aa490c26cfeee075b6018')),  # noqa: E501
     )
     user_address = polygon_pos_accounts[0]
-    timestamp = TimestampMS(1705665114000)
     swap_amount, received_amount, paraswap_fee, gas_fees = '4', '3.999618836617901732', '0.000000000000000002', '0.010937453116939734'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1705665114000)),
         location=Location.POLYGON_POS,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -1200,12 +1176,11 @@ def test_paraswap_fork_with_factory(ethereum_inquirer, ethereum_accounts):
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
 
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1646086826000)
     swap_amount, received_amount, gas_fees = '7800', '0.338822187329295101', '0.010252494'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1646086826000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,

--- a/rotkehlchen/tests/unit/decoders/test_paraswap_v6.py
+++ b/rotkehlchen/tests/unit/decoders/test_paraswap_v6.py
@@ -876,10 +876,9 @@ def test_swap_with_unrelated_curve_deposit(
 ) -> None:
     """Regression test for a bug where an unrelated curve deposit was causing the spend half of the
     swap to be incorrectly decoded."""
-    tx_hash = deserialize_evm_tx_hash('0xb65c9b6566bf9d7f6e6313523560e0683f63bfadcadd9e4e8444819f96803401')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb65c9b6566bf9d7f6e6313523560e0683f63bfadcadd9e4e8444819f96803401')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [EvmEvent(
@@ -943,10 +942,9 @@ def test_curve_deposit_interfering_with_paraswap_swap(
 ) -> None:
     """Regression test for a bug where a curve deposit was causing the spend half of the
     paraswap swap to be incorrectly decoded as a curve return wrapped event."""
-    tx_hash = deserialize_evm_tx_hash('0x863e33760f41500e261e8e9a81be18af2dc68f494803c22802e922a4771a91ce')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x863e33760f41500e261e8e9a81be18af2dc68f494803c22802e922a4771a91ce')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
     assert events == [EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_pendle.py
+++ b/rotkehlchen/tests/unit/decoders/test_pendle.py
@@ -48,13 +48,12 @@ def _pendle_cache(globaldb: 'GlobalDBHandler') -> None:
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xFd83CCCecef02a334e6A86e7eA8D0aa0F61f1Faf']])
 def test_lock_pendle(ethereum_inquirer, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xc8b252de1a62daa57d4fe294f371e67550e087fdeffe972261e1acc890d84bd5')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc8b252de1a62daa57d4fe294f371e67550e087fdeffe972261e1acc890d84bd5')),  # noqa: E501
     )
     user_address, timestamp, gas_amount, approval_amount, out_amount, locked_amount, lock_timestamp = ethereum_accounts[0], TimestampMS(1742478515000), '0.00118595784570676', '11.106239093069566243', '0.003254870108208791', '1110.62390930695662426', 1747267200  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -108,7 +107,6 @@ def test_lock_pendle(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x4f30A9D41B80ecC5B94306AB4364951AE3170210'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -117,7 +115,7 @@ def test_unlock_pendle(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5bbfd3175156e347edb917f02311cbc7723d6f61d5bed532e7cfb947fe5b4d72')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, withdrawn_amount = ethereum_accounts[0], TimestampMS(1742472839000), '0.000059142779024945', '4497.51803084'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -145,25 +143,23 @@ def test_unlock_pendle(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x4f30A9D41B80ecC5B94306AB4364951AE3170210'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x4aCAeaD5249770F268F18284Ef7e71039DC127Fb']])
 def test_buy_pt(ethereum_inquirer, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x4374352cb86470cc895b7ad433a5ea6e8c62a7d0016434600fa1446ebaea857b')  # noqa: E501
     assert get_evm_token(
         evm_address=(pt_token_addr := string_to_evm_address('0xeA1180804bDBA8aC04E2a4406B11fb7970c474f1')),  # noqa: E501
         chain_id=ethereum_inquirer.chain_id,
     ) is None
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x4374352cb86470cc895b7ad433a5ea6e8c62a7d0016434600fa1446ebaea857b')),  # noqa: E501
     )
     assert (pt_token := get_evm_token(evm_address=pt_token_addr, chain_id=ethereum_inquirer.chain_id)) is not None  # noqa: E501
     assert pt_token.protocol == CPT_PENDLE
     user_address, timestamp, gas_amount, approval_amount, out_amount, in_amount, interest_amount = ethereum_accounts[0], TimestampMS(1742355155000), '0.00033753258899598', '50.014942', '5001.535682', '5066.377589', '1.535939'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -230,7 +226,6 @@ def test_buy_pt(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x8539B41CA14148d1F7400d399723827a80579414'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -409,13 +404,12 @@ def test_return_pt(ethereum_inquirer, ethereum_accounts, pendle_cache):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xAeF32637DbE2cC1ed4e8b04bE1363bE583724947']])
 def test_buy_yt(ethereum_inquirer, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x08cb3b86393593946047da9fd672278820815e884b199ed913a9f95fa2280cff')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x08cb3b86393593946047da9fd672278820815e884b199ed913a9f95fa2280cff')),  # noqa: E501
     )
     user_address, timestamp, gas_amount, out_amount, in_amount = ethereum_accounts[0], TimestampMS(1741190135000), '0.000361416310494255', '0.016', '0.11143761'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -457,19 +451,17 @@ def test_buy_yt(ethereum_inquirer, ethereum_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xC1466a0a0e2a8BB9304823087643Fec98957a73B']])
 def test_sell_yt(ethereum_inquirer, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xfde90002b389234406d1f3a600166d9023c12263047007ddc7886ca99e23e15e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xfde90002b389234406d1f3a600166d9023c12263047007ddc7886ca99e23e15e')),  # noqa: E501
     )
     user_address, timestamp, gas_amount, revoke_amount, out_amount, in_amount = ethereum_accounts[0], TimestampMS(1742901911000), '0.00024787188908118', '0', '5.98230108', '0.00114182'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -522,7 +514,6 @@ def test_sell_yt(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0xC781c0cC527CB8C351bE3A64c690216c535C6F36'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -533,15 +524,14 @@ def test_add_liquidity(base_inquirer, base_accounts):
         evm_address=(lp_token_addr := string_to_evm_address('0xE15578523937ed7F08E8F7a1Fa8a021E07025a08')),  # noqa: E501
         chain_id=base_inquirer.chain_id,
     ) is None
-    tx_hash = deserialize_evm_tx_hash('0x04ca9cb81658c528c2a026d8aa9df5798b473d3a8be8e0215ed3efd444a89456')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x04ca9cb81658c528c2a026d8aa9df5798b473d3a8be8e0215ed3efd444a89456')),  # noqa: E501
     )
     assert (lp_token := get_evm_token(evm_address=lp_token_addr, chain_id=base_inquirer.chain_id)) is not None  # noqa: E501
     assert lp_token.protocol == CPT_PENDLE
     user_address, timestamp, gas_amount, out_amount, in_amount = base_accounts[0], TimestampMS(1743007437000), '0.000000641175932399', '222', '113.156787685931457114'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -582,20 +572,18 @@ def test_add_liquidity(base_inquirer, base_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xe1685a3D1aE79B7C85829fcCe57D62a02eac61a5']])
 def test_swap_using_kyber(ethereum_inquirer, ethereum_accounts):
     """This checks for swaps where the receive event comes after the swap event."""
-    tx_hash = deserialize_evm_tx_hash('0xf0c60f4d2a87716bb4f3a7a62ed2d196448fe8435da7413edeaf20120b7d618a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf0c60f4d2a87716bb4f3a7a62ed2d196448fe8435da7413edeaf20120b7d618a')),  # noqa: E501
     )
     user_address, timestamp, gas_amount, revoke_amount, out_amount, in_amount = ethereum_accounts[0], TimestampMS(1743012491000), '0.00020274888980646', '0', '6.453525486228687704', '7.457926'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -646,20 +634,18 @@ def test_swap_using_kyber(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x888888888889758F76e7103c6CbF23ABbF58F946'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x21f2a9b5F420245d86E8Faa753022dA01946B13F']])
 def test_swap_using_kyber_2(ethereum_inquirer, ethereum_accounts):
     """This checks for swaps where the receive event comes before the swap event."""
-    tx_hash = deserialize_evm_tx_hash('0xe3e3b9467890b233007917900fb7b9282d2c14c3381e1db0de2850523ba24359')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe3e3b9467890b233007917900fb7b9282d2c14c3381e1db0de2850523ba24359')),  # noqa: E501
     )
     user_address, timestamp, gas_amount, out_amount, in_amount = ethereum_accounts[0], TimestampMS(1743064667000), '0.00010481829185758', '5.634264087233128405', '0.00424279429101785'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -698,19 +684,17 @@ def test_swap_using_kyber_2(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x888888888889758F76e7103c6CbF23ABbF58F946'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xc68Ca8A21AAcF167E234F8d08F5d9d115fae2F8d']])
 def test_swap_using_odos(ethereum_inquirer, ethereum_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x55fdb8d8f9b8968904e022798049f5c56103f06854c5575e9c09cee1aa2314f9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x55fdb8d8f9b8968904e022798049f5c56103f06854c5575e9c09cee1aa2314f9')),  # noqa: E501
     )
     user_address, timestamp, gas_amount, out_amount, in_amount = ethereum_accounts[0], TimestampMS(1743083231000), '0.000421634677180424', '307.491735', '307.738865329882018479'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -749,7 +733,6 @@ def test_swap_using_odos(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x888888888889758F76e7103c6CbF23ABbF58F946'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1086,15 +1069,14 @@ def test_remove_liquidity(base_inquirer, base_accounts, pendle_cache):
         evm_address=(lp_token_addr := string_to_evm_address('0xE15578523937ed7F08E8F7a1Fa8a021E07025a08')),  # noqa: E501
         chain_id=base_inquirer.chain_id,
     ) is None
-    tx_hash = deserialize_evm_tx_hash('0x60ab64b9c8c560ffccd2bfbf5411be2efdd8d241296d3bfe778d905001db663d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=base_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x60ab64b9c8c560ffccd2bfbf5411be2efdd8d241296d3bfe778d905001db663d')),  # noqa: E501
     )
     assert (lp_token := get_evm_token(evm_address=lp_token_addr, chain_id=base_inquirer.chain_id)) is not None  # noqa: E501
     assert lp_token.protocol == CPT_PENDLE
     user_address, timestamp, gas_amount, approve_amount, out_amount, in_amount, reward_amount = base_accounts[0], TimestampMS(1743008107000), '0.000000772529310385', '0.501902187294857254', '51.498097812705142746', '101.027879453122635516', '0.038804848288942801'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1160,19 +1142,17 @@ def test_remove_liquidity(base_inquirer, base_accounts, pendle_cache):
             address=lp_token.evm_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x11B6AA86Cd8EFB8B4452cc7f9c0C6fcc188D92F0']])
 def test_redeem_due_rewards_and_interests(ethereum_inquirer, ethereum_accounts, pendle_cache):
-    tx_hash = deserialize_evm_tx_hash('0xe6a4e6b2df756c4dabc1bb1c275338207e6c1e06f2f7f2ffae566c87f76dbf95')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe6a4e6b2df756c4dabc1bb1c275338207e6c1e06f2f7f2ffae566c87f76dbf95')),  # noqa: E501
     )
     user_address, timestamp, gas_amount, approve_amount, in_amount, reward_amount = ethereum_accounts[0], TimestampMS(1743612395000), '0.00047191725218462', '0.001409507994839191', '0.140950799483919151', '466.678734752621960369'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1225,19 +1205,17 @@ def test_redeem_due_rewards_and_interests(ethereum_inquirer, ethereum_accounts, 
             address=string_to_evm_address('0xfd5Cf95E8b886aCE955057cA4DC69466e793FBBE'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x743D7B30661d65B41960Bf6b5d1bB93CF7972A73']])
 def test_redeem_due_rewards_multiple_tokens(ethereum_inquirer, ethereum_accounts, pendle_cache):
-    tx_hash = deserialize_evm_tx_hash('0xd6307558bb3252cb0b6bd9af91eaf97fcc1423181cd44db7bc187d29440322c1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=ethereum_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd6307558bb3252cb0b6bd9af91eaf97fcc1423181cd44db7bc187d29440322c1')),  # noqa: E501
     )
     user_address, timestamp, gas_amount, sy_weeth_amount, pendle_amount = ethereum_accounts[0], TimestampMS(1713128123000), '0.002537430445956456', '0.010279749482167444', '1.305613281699848198'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1278,4 +1256,3 @@ def test_redeem_due_rewards_multiple_tokens(ethereum_inquirer, ethereum_accounts
             address=string_to_evm_address('0xF32e58F92e60f4b0A37A69b95d642A471365EAe8'),
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_pickle.py
+++ b/rotkehlchen/tests/unit/decoders/test_pickle.py
@@ -24,17 +24,16 @@ PICKLE_JAR = string_to_evm_address('0xb4EBc2C371182DeEa04B2264B9ff5AC4F0159C69')
 def test_pickle_deposit(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xba9a52a144d4e79580a557160e9f8269d3e5373ce44bce00ebd609754034b7bd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str, deposit_str, withdraw_str, approve_str = TimestampMS(1646619202000), '0.00355751579933013', '907.258590539447889901', '560.885632516582380401', '115792089237316195423570985008687907853269984665640564027654.491316674464992473'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1646619202000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.00355751579933013'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -46,7 +45,7 @@ def test_pickle_deposit(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=EvmToken('eip155:1/erc20:0xf4d2888d29D722226FafA5d9B24F9164c092421E'),
-            amount=FVal(deposit_str),
+            amount=FVal(deposit_str := '907.258590539447889901'),
             location_label=ethereum_accounts[0],
             notes=f'Deposit {deposit_str} LOOKS in pickle contract',
             counterparty=CPT_PICKLE,
@@ -59,7 +58,7 @@ def test_pickle_deposit(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=EvmToken('eip155:1/erc20:0xf4d2888d29D722226FafA5d9B24F9164c092421E'),
-            amount=FVal(approve_str),
+            amount=FVal(approve_str := '115792089237316195423570985008687907853269984665640564027654.491316674464992473'),  # noqa: E501
             location_label=ethereum_accounts[0],
             notes=f'Set LOOKS spending approval of {ethereum_accounts[0]} by {PICKLE_JAR} to {approve_str}',  # noqa: E501
             address=PICKLE_JAR,
@@ -71,13 +70,12 @@ def test_pickle_deposit(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=EvmToken('eip155:1/erc20:0xb4EBc2C371182DeEa04B2264B9ff5AC4F0159C69'),
-            amount=FVal(withdraw_str),
+            amount=FVal(withdraw_str := '560.885632516582380401'),
             location_label=ethereum_accounts[0],
             notes=f'Receive {withdraw_str} pLOOKS after depositing in pickle contract',
             counterparty=CPT_PICKLE,
             address=PICKLE_JAR,
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -85,17 +83,16 @@ def test_pickle_deposit(ethereum_inquirer, ethereum_accounts):
 def test_pickle_withdraw(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x91bc102e1cbb0e4542a10a7a13370b5e591d8d284989bdb0ca4ece4e54e61bab')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str, deposit_str, withdraw_str = TimestampMS(1646873135000), '0.00389232626065528', '245.522202162316534411', '403.097099656688209687'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1646873135000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.00389232626065528'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -107,7 +104,7 @@ def test_pickle_withdraw(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=EvmToken('eip155:1/erc20:0xb4EBc2C371182DeEa04B2264B9ff5AC4F0159C69'),
-            amount=FVal(deposit_str),
+            amount=FVal(deposit_str := '245.522202162316534411'),
             location_label=ethereum_accounts[0],
             notes=f'Return {deposit_str} pLOOKS to the pickle contract',
             counterparty=CPT_PICKLE,
@@ -120,13 +117,12 @@ def test_pickle_withdraw(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=EvmToken('eip155:1/erc20:0xf4d2888d29D722226FafA5d9B24F9164c092421E'),
-            amount=FVal(withdraw_str),
+            amount=FVal(withdraw_str := '403.097099656688209687'),
             location_label=ethereum_accounts[0],
             notes=f'Unstake {withdraw_str} LOOKS from the pickle contract',
             counterparty=CPT_PICKLE,
             address=PICKLE_JAR,
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -134,17 +130,16 @@ def test_pickle_withdraw(ethereum_inquirer, ethereum_accounts):
 def test_claim_cornichon(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x23a52632e47eeaf9588972cc3f65a2101745952880be17828d810da3735f333f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str, amount_str = TimestampMS(1606695800000), '0.002380306', '125.214613076726835921'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1606695800000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.002380306'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -156,11 +151,10 @@ def test_claim_cornichon(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=EvmToken(CORN_TOKEN_ID),
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '125.214613076726835921'),
             location_label=ethereum_accounts[0],
             notes=f'Claim {amount_str} CORN from the pickle finance hack compensation airdrop',
             counterparty=CPT_PICKLE,
             address=CORNICHON_CLAIM,
             extra_data={AIRDROP_IDENTIFIER_KEY: 'cornichon'},
         )]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_polygon.py
+++ b/rotkehlchen/tests/unit/decoders/test_polygon.py
@@ -16,19 +16,17 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 @pytest.mark.parametrize('ethereum_accounts', [['0x692C673814eDB9Fe6DB2a6F4227F40524240Cbec']])
 def test_matic_to_pol_migration(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6c30b202e7223ea93b9d1c898d7012b699d14bec5434e8839fc290858718f6a2')  # noqa: E501
-    timestamp = TimestampMS(1698285215000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     amount = '10000.28'
-    gas_str = '0.001792178291324676'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1698285215000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_str),
+        amount=FVal(gas_str := '0.001792178291324676'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_str} ETH for gas',
         counterparty=CPT_GAS,

--- a/rotkehlchen/tests/unit/decoders/test_polygon_pos_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_polygon_pos_bridge.py
@@ -37,17 +37,17 @@ def test_polygon_pos_bridge_l2_deposit(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xa97396d6b61f213ebf194807553c06768fb9d1ca04ba30bfafb1a788357f3c36')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=polygon_pos_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, deposit_amount = TimestampMS(1729861499000), polygon_pos_accounts[0], '0.0016145640090944', '80.675001498474753918'  # noqa: E501
+    user_address = polygon_pos_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1729861499000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_POL,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.0016145640090944'),
             location_label=user_address,
             notes=f'Burn {gas_amount} POL for gas',
             counterparty=CPT_GAS,
@@ -59,7 +59,7 @@ def test_polygon_pos_bridge_l2_deposit(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:137/erc20:0x61299774020dA444Af134c82fa83E3810b309991'),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '80.675001498474753918'),
             location_label=user_address,
             notes=f'Bridge {deposit_amount} RNDR from Polygon POS to Ethereum via Polygon bridge',
             counterparty=CPT_POLYGON,
@@ -76,17 +76,17 @@ def test_polygon_pos_bridge_l2_plasma_deposit(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x8b86c3f67ce0497075fd4d7ffa0c57a0b4c752bace3e0764f6e7a8b8f6a720a9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=polygon_pos_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, deposit_amount = TimestampMS(1729875073000), polygon_pos_accounts[0], '0.00456586488143955', '57008.16996625583804992'  # noqa: E501
+    user_address = polygon_pos_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1729875073000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_POL,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.00456586488143955'),
             location_label=user_address,
             notes=f'Burn {gas_amount} POL for gas',
             counterparty=CPT_GAS,
@@ -98,7 +98,7 @@ def test_polygon_pos_bridge_l2_plasma_deposit(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_POL,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '57008.16996625583804992'),
             location_label=user_address,
             notes=f'Bridge {deposit_amount} POL from Polygon POS to Ethereum via Polygon bridge',
             counterparty=CPT_POLYGON,
@@ -115,17 +115,17 @@ def test_polygon_pos_bridge_l2_withdraw(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x74b36dd98fb9e3a6bf9fa4cd6ba2066cd3fa86797b206bd709cfb097bb0c85a4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=polygon_pos_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, bridge_amount = TimestampMS(1729879355000), polygon_pos_accounts[0], '892014.616138'  # noqa: E501
+    user_address = polygon_pos_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=293,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1729879355000),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:137/erc20:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'),
-            amount=FVal(bridge_amount),
+            amount=FVal(bridge_amount := '892014.616138'),
             location_label=user_address,
             notes=f'Bridge {bridge_amount} USDC from Ethereum to Polygon POS via Polygon bridge',
             counterparty=CPT_POLYGON,

--- a/rotkehlchen/tests/unit/decoders/test_puffer.py
+++ b/rotkehlchen/tests/unit/decoders/test_puffer.py
@@ -23,16 +23,15 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_pufferxeigen_s2_airdrop(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4e42f307effc0dc7fdfbf72d54a9a86b4b0d96cf1a14f1069717e2d637bf5561')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, claim_amount = TimestampMS(1726953011000), '0.001071196143585596', '9.61696139158485'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1726953011000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.001071196143585596'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -44,7 +43,7 @@ def test_pufferxeigen_s2_airdrop(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.AIRDROP,
         asset=Asset(EIGEN_TOKEN_ID),
-        amount=FVal(claim_amount),
+        amount=FVal(claim_amount := '9.61696139158485'),
         location_label=ethereum_accounts[0],
         notes=f'Claim {claim_amount} EIGEN from PufferXEigen S2 airdrop',
         counterparty=CPT_PUFFER,
@@ -58,16 +57,15 @@ def test_pufferxeigen_s2_airdrop(ethereum_inquirer, ethereum_accounts):
 def test_puffer_s1_airdrop_2_campaigns(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5f5111b2ebdc3fa8f7bcf4659d898fafc00fc7df5e727f1edabf246ee89c68f9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, claim_amount1, claim_amount2 = TimestampMS(1728945107000), '0.002975374594297972', '70', '210'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1728945107000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_ETH,
-        amount=FVal(gas_amount),
+        amount=FVal(gas_amount := '0.002975374594297972'),
         location_label=ethereum_accounts[0],
         notes=f'Burn {gas_amount} ETH for gas',
         counterparty=CPT_GAS,
@@ -79,7 +77,7 @@ def test_puffer_s1_airdrop_2_campaigns(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.AIRDROP,
         asset=Asset(PUFFER_TOKEN_ID),
-        amount=FVal(claim_amount1),
+        amount=FVal(claim_amount1 := '70'),
         location_label=ethereum_accounts[0],
         notes=f'Claim {claim_amount1} PUFFER from Puffer S1 airdrop',
         counterparty=CPT_PUFFER,
@@ -92,7 +90,7 @@ def test_puffer_s1_airdrop_2_campaigns(ethereum_inquirer, ethereum_accounts):
         event_type=HistoryEventType.RECEIVE,
         event_subtype=HistoryEventSubType.AIRDROP,
         asset=Asset(PUFFER_TOKEN_ID),
-        amount=FVal(claim_amount2),
+        amount=FVal(claim_amount2 := '210'),
         location_label=ethereum_accounts[0],
         notes=f'Claim {claim_amount2} PUFFER from Puffer S1 airdrop',
         counterparty=CPT_PUFFER,

--- a/rotkehlchen/tests/unit/decoders/test_safe.py
+++ b/rotkehlchen/tests/unit/decoders/test_safe.py
@@ -51,18 +51,16 @@ def test_added_owner(ethereum_inquirer, ethereum_accounts):
     multisig_address = ethereum_accounts[1]
     new_owner = '0xa0DD8E6c5440a424cD19f5Ec30F8fa485E814247'
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1611089364000)
-    gas_amount_str = '0.004625442'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1611089364000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount_str),
+            amount=FVal(gas_amount_str := '0.004625442'),
             location_label=user_address,
             notes=f'Burn {gas_amount_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -81,7 +79,6 @@ def test_added_owner(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -97,18 +94,16 @@ def test_removed_owner(ethereum_inquirer, ethereum_accounts):
     multisig_address = ethereum_accounts[1]
     removed_owner = '0x8a7dbC2824AcaC4d272289a33b255C3F1f3cdf32'
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1623789005000)
-    gas_amount_str = '0.00130834'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1623789005000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount_str),
+            amount=FVal(gas_amount_str := '0.00130834'),
             location_label=user_address,
             notes=f'Burn {gas_amount_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -127,7 +122,6 @@ def test_removed_owner(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -142,18 +136,16 @@ def test_changed_threshold(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     multisig_address = ethereum_accounts[1]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1614713692000)
-    gas_amount_str = '0.005093127'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1614713692000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount_str),
+            amount=FVal(gas_amount_str := '0.005093127'),
             location_label=user_address,
             notes=f'Burn {gas_amount_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -172,7 +164,6 @@ def test_changed_threshold(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -185,18 +176,16 @@ def test_execution_success(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     multisig_address = '0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52'
-    timestamp = TimestampMS(1656087756000)
-    gas_amount_str = '0.006953999441541852'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1656087756000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount_str),
+            amount=FVal(gas_amount_str := '0.006953999441541852'),
             location_label=user_address,
             notes=f'Burn {gas_amount_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -215,7 +204,6 @@ def test_execution_success(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -228,18 +216,16 @@ def test_execution_failure(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     multisig_address = '0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52'
-    timestamp = TimestampMS(1599570321000)
-    gas_amount_str = '0.020435096'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1599570321000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount_str),
+            amount=FVal(gas_amount_str := '0.020435096'),
             location_label=user_address,
             notes=f'Burn {gas_amount_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -258,7 +244,6 @@ def test_execution_failure(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -287,7 +272,7 @@ def test_safe_mastercopy_upgrade_on_base(base_inquirer, base_accounts) -> None:
         end_ts=Timestamp(1756713400),
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -315,7 +300,6 @@ def test_safe_mastercopy_upgrade_on_base(base_inquirer, base_accounts) -> None:
             address=base_accounts[1],
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -325,18 +309,16 @@ def test_safe_creation(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa9e3c581f39403a0a2eb5a3e604be715c0a4ee8aa4bcc9bddece5c268b47e233')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1691846051000)
-    gas_amount_str = '0.004928138478008416'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1691846051000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount_str),
+            amount=FVal(gas_amount_str := '0.004928138478008416'),
             location_label=user_address,
             notes=f'Burn {gas_amount_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -355,38 +337,33 @@ def test_safe_creation(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x2eb2B9300036807A7674997e6c6874601275EDDD'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])  # yabir.eth  # noqa: E501
 def test_safe_spam(polygon_pos_inquirer, polygon_pos_accounts):
     """Test that a safe transaction if from an unrelated account, does not appear in events"""
-    tx_hash = deserialize_evm_tx_hash('0xefb07f4d166d6887eada96e61fd6821bfdf889d5435d75ab44d4ca0fa7627396')  # noqa: E501
     user_address = polygon_pos_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xefb07f4d166d6887eada96e61fd6821bfdf889d5435d75ab44d4ca0fa7627396')),  # noqa: E501
     )
-    timestamp = TimestampMS(1651102781000)
-    amount_str = '0.00637462961483049'
     spam_contract = '0xC63c477465a792537D291ADb32Ed15c0095E106B'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=431,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1651102781000),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.NONE,
             asset=Asset('eip155:137/erc20:0x580A84C73811E1839F75d86d75d88cCa0c241fF4'),
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '0.00637462961483049'),
             location_label=user_address,
             notes=f'Receive {amount_str} QI from {spam_contract} to {user_address}',
             address=spam_contract,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -398,7 +375,7 @@ def test_safe_vesting_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc831d94b43be533e83562da9bc10b38b4bab6ce6046c3a9baf76c5359634625a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, multisig_address, timestamp, gas, amount = ethereum_accounts[0], ethereum_accounts[1], TimestampMS(1717404395000), '0.00123180896602807', '20549.221611721611721612'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -439,7 +416,6 @@ def test_safe_vesting_claim(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -451,7 +427,7 @@ def test_safe_lock(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xad3d976ae02cf82f109cc2d2f3e8f2f10df6a00a4825e3f04cf0e1b7e68a06b8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, multisig_address, timestamp, gas, amount = ethereum_accounts[0], ethereum_accounts[1], TimestampMS(1719926867000), '0.00072087801264352', '5115.763372'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -516,7 +492,6 @@ def test_safe_lock(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -528,7 +503,7 @@ def test_safe_unlock(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x51d4c06ff00be729fe5bc79215253e45e65ce4c8531cd249633c6e76754c89d0')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, multisig_address, timestamp, gas, amount = ethereum_accounts[0], ethereum_accounts[1], TimestampMS(1721101211000), '0.0003433', '1026.126150242296748346'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -569,7 +544,6 @@ def test_safe_unlock(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -581,7 +555,7 @@ def test_safe_withdraw_unlocked(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x9520c7e117225afc930d1092bf35c17e6726c6564ed4e757eeb6a3c29d10304b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, multisig_address, timestamp, gas, amount = ethereum_accounts[0], ethereum_accounts[1], TimestampMS(1721130791000), '0.00095328952396285', '2404.451820314008697626'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -622,7 +596,6 @@ def test_safe_withdraw_unlocked(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -634,7 +607,7 @@ def test_safepass_start_vesting_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xfd07173651763370557d8300a8f5891d26ec7055238d6daf4f53c3f060d0f42d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, multisig_address, timestamp, gas = ethereum_accounts[0], ethereum_accounts[1], TimestampMS(1735818059000), '0.00149046414099075'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -675,7 +648,6 @@ def test_safepass_start_vesting_claim(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -687,7 +659,7 @@ def test_safepass_vesting_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x26eb93c73ca61ab2a8df16ce5ce861142fb21b67e5aa466a13c4a0ca7744fe5c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, multisig_address, timestamp, gas, amount = ethereum_accounts[0], ethereum_accounts[1], TimestampMS(1765106423000), '0.000143501926752041', '829'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -728,7 +700,6 @@ def test_safepass_vesting_claim(ethereum_inquirer, ethereum_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -740,7 +711,7 @@ def test_safe_added_owner_indexed(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x42536687dbc0c93d6b18c451c458def1e9d78476f610c8909be31bf2ffd56a69')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     user_address, multisig_address, timestamp, gas = gnosis_accounts[0], gnosis_accounts[1], TimestampMS(1747908200000), '0.000097393118048512'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -781,7 +752,6 @@ def test_safe_added_owner_indexed(gnosis_inquirer, gnosis_accounts):
             address=multisig_address,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_scroll_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_scroll_bridge.py
@@ -34,13 +34,12 @@ def test_deposit_eth_from_ethereum_to_scroll(ethereum_inquirer, ethereum_account
     tx_hash = deserialize_evm_tx_hash('0x1d924e2f2f63cf5a2d78ceaa6289658cf4743e968d23f78064d55c7428f78b60')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1711626707000)
     gas, amount, bridging_fee = '0.006936488814808056', '0.1179', '0.0002604'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711626707000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -85,18 +84,16 @@ def test_receive_eth_on_scroll(scroll_inquirer, scroll_accounts, allow_scroll_et
     tx_hash = deserialize_evm_tx_hash('0xd47e37dc8acb08b86bd90214d1df15549305e6d5fe126b97ff3b66a1b814b801')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
     user_address = scroll_accounts[0]
-    timestamp = TimestampMS(1711627620000)
-    amount = '0.1179'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1711627620000),
             location=Location.SCROLL,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_ETH,
-            amount=FVal(amount),
+            amount=FVal(amount := '0.1179'),
             location_label=user_address,
             notes=f'Bridge {amount} ETH from Ethereum to Scroll via Scroll bridge',
             counterparty=CPT_SCROLL,
@@ -111,13 +108,12 @@ def test_withdraw_eth_from_scroll_to_ethereum(scroll_inquirer, scroll_accounts, 
     tx_hash = deserialize_evm_tx_hash('0x87c44e16cf62a8aa8e56b9677e6c400041b6731a5c24f9b8ca2deb6e00202a42')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
     user_address = scroll_accounts[0]
-    timestamp = TimestampMS(1708178454000)
     gas, amount = '0.00021234172322581', '0.6'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1708178454000)),
             location=Location.SCROLL,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -149,13 +145,12 @@ def test_receive_eth_on_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xed4d0ddc99b88caa07d5d15faf376abade6cc06eaf6a28dce47eac66695503c4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1708187711000)
     gas, amount = '0.003718494016624992', '0.6'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1708187711000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -187,13 +182,12 @@ def test_deposit_erc20_from_ethereum_to_scroll(ethereum_inquirer, ethereum_accou
     tx_hash = deserialize_evm_tx_hash('0xd80e6894bce182c2976bb9fa64e162f1757a087057b00638b43fe0c5154cf1a6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1711698851000)
     gas, fee, amount = '0.005582179923194343', '0.00012288', '100'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1711698851000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -238,18 +232,16 @@ def test_receive_erc20_on_scroll(scroll_inquirer, scroll_accounts, allow_scroll_
     tx_hash = deserialize_evm_tx_hash('0x630cd85723676d993f4afdd9f182cd2468444748eb7b1c6c0c8cc1db0d925c15')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
     user_address = scroll_accounts[0]
-    timestamp = TimestampMS(1711699803000)
-    amount = '100'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=9,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1711699803000),
             location=Location.SCROLL,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:534352/erc20:0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4'),
-            amount=FVal(amount),
+            amount=FVal(amount := '100'),
             location_label=user_address,
             notes=f'Bridge {amount} USDC from Ethereum to Scroll via Scroll bridge',
             counterparty=CPT_SCROLL,
@@ -265,13 +257,12 @@ def test_withdraw_erc20_from_scroll_to_ethereum(scroll_inquirer, scroll_accounts
     tx_hash = deserialize_evm_tx_hash('0x0ff9e74db99dc2224fac1ab4e20cc8dba1cd1b0d089d657f0f005488b37cc20c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
     user_address = scroll_accounts[0]
-    timestamp = TimestampMS(1708535681000)
     gas, amount = '0.000430578838556533', '1000.001993'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1708535681000)),
             location=Location.SCROLL,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -310,13 +301,12 @@ def test_withdraw_usdc_from_scroll_to_ethereum(scroll_inquirer, scroll_accounts,
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
 
     user_address = scroll_accounts[0]
-    timestamp = TimestampMS(1708534727000)
     gas, amount = '0.000383984852231895', '450'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1708534727000)),
             location=Location.SCROLL,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -348,13 +338,12 @@ def test_receive_erc20_on_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xbe6e98db62ee719922c7d01b0b623e16c8ee162a2bf9143603f11eba3e3dd474')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1708223951000)
     gas, amount = '0.002531473518821568', '1647'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1708223951000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -386,13 +375,12 @@ def test_deposit_send_message_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x7ae1e3ef6e4d87e2e44446a683b9ca624241a24d294b60ddec39af1309aeb37a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1708771043000)
     gas, fee, amount = '0.00353129959117221', '0.000081144', '0.034'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1708771043000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -437,18 +425,16 @@ def test_receive_deposit_message_scroll(scroll_inquirer, scroll_accounts, allow_
     tx_hash = deserialize_evm_tx_hash('0x2844533993f614da06a4a81ee692f10562b4b2d077265a33605ca9415d0dcacb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
     user_address = scroll_accounts[0]
-    timestamp = TimestampMS(1708772190000)
-    amount = '0.034'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1708772190000),
             location=Location.SCROLL,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_ETH,
-            amount=FVal(amount),
+            amount=FVal(amount := '0.034'),
             location_label=user_address,
             notes=f'Bridge {amount} ETH from Ethereum to Scroll via Scroll bridge',
             counterparty=CPT_SCROLL,

--- a/rotkehlchen/tests/unit/decoders/test_shapeshift.py
+++ b/rotkehlchen/tests/unit/decoders/test_shapeshift.py
@@ -16,12 +16,11 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6635d1e12fed1a95019a53e6f6495c586891bf7b41bccfc5838f9b1703a9c20c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1634470709000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=243,
-            timestamp=timestamp,
+            timestamp=TimestampMS(1634470709000),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
@@ -34,4 +33,3 @@ def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
             extra_data={AIRDROP_IDENTIFIER_KEY: 'shapeshift'},
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_shutter.py
+++ b/rotkehlchen/tests/unit/decoders/test_shutter.py
@@ -20,13 +20,12 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x3f20929de51baefdc688997a05bde1e32120cb7d4e0fda5da3963b1a620d0a8b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1706703155000)
     gas_amount_str, claimed_amount = '0.006946508605618104', '1086.95652173913'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706703155000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -51,7 +50,6 @@ def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
             extra_data={AIRDROP_IDENTIFIER_KEY: 'shutter'},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -59,18 +57,16 @@ def test_airdrop_claim(ethereum_inquirer, ethereum_accounts):
 def test_shu_delegation(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x46a476b09c85d2278f1ac889e943d7f47d029d0985719cc2a73d589a73cb2473')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1705596215000)
-    gas_amount_str = '0.00549203889835413'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1705596215000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount_str),
+            amount=FVal(gas_amount_str := '0.00549203889835413'),
             location_label=ethereum_accounts[0],
             notes=f'Burn {gas_amount_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -88,4 +84,3 @@ def test_shu_delegation(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_SHUTTER,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_sky.py
+++ b/rotkehlchen/tests/unit/decoders/test_sky.py
@@ -26,12 +26,11 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_migrate_dai(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xda915701a7634628d8301d44a4e122599f05a1281286ab416f5101c79a24e408')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1726732211000)
     gas_amount, migrated_amount = '0.001933756075256005', '10086.448037727051859359'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1726732211000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -172,12 +171,11 @@ def test_migrate_dai_susds(ethereum_inquirer, ethereum_accounts):
 def test_migrate_maker(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xbfa0b5489a1f4b28c416d0ef8cbcbbc9d7d4fea8c3f1d53830b2cd5f78252b79')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1726760855000)
     gas_amount, migrated_amount, received_amount = '0.00127609766341068', '0.75001216', '18000.29184'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1726760855000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,

--- a/rotkehlchen/tests/unit/decoders/test_socket.py
+++ b/rotkehlchen/tests/unit/decoders/test_socket.py
@@ -20,12 +20,11 @@ def test_optimism_to_arb_bridge(optimism_inquirer, optimism_accounts):
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
     user_address = optimism_accounts[0]
     bridged_amount, gas_amount = '360.791433', '0.000035854553456552'
-    timestamp = TimestampMS(1705844449000)
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1705844449000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -54,19 +53,17 @@ def test_optimism_to_arb_bridge(optimism_inquirer, optimism_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_bridge_eth(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xb1e29bebca0300ff02ee478dfa6c0c2197169761e1c0dcc87418c53a6530d3a5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xb1e29bebca0300ff02ee478dfa6c0c2197169761e1c0dcc87418c53a6530d3a5')),  # noqa: E501
     )
     user_address = arbitrum_one_accounts[0]
     bridged_amount, gas_amount = '0.01', '0.0000464928'
-    timestamp = TimestampMS(1696328657000)
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1696328657000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,

--- a/rotkehlchen/tests/unit/decoders/test_spark.py
+++ b/rotkehlchen/tests/unit/decoders/test_spark.py
@@ -23,7 +23,7 @@ def test_deposit_usdc_into_savings(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc63747c31bc5ac9d62e9217a44681463724bd36c74ea2b6ffe90cbeafbcf91a8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, out_amount, in_amount = base_accounts[0], TimestampMS(1736935243000), '0.000003809323980083', '18.364226', '17.867188'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -64,7 +64,6 @@ def test_deposit_usdc_into_savings(base_inquirer, base_accounts):
             address=string_to_evm_address('0x1601843c5E9bC251A3272907010AFa41Fa18347E'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -74,7 +73,7 @@ def test_withdraw_usdc_from_savings(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x46d434c03ff6721fff43cbc1b1570ee3739dbd32f84d4531c5ca0a556a0dc433')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, out_amount, in_amount = base_accounts[0], TimestampMS(1736937043000), '0.000003506413757861', '16.539774682836928356', '17'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -115,7 +114,6 @@ def test_withdraw_usdc_from_savings(base_inquirer, base_accounts):
             address=string_to_evm_address('0x1601843c5E9bC251A3272907010AFa41Fa18347E'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -142,7 +140,7 @@ def test_deposit_to_spark(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xe7ae42aa6b3815b135c5dfe62222421e43013d30ec132f18d52b396229ce5c6a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, out_amount, in_amount = ethereum_accounts[0], TimestampMS(1737005627000), '0.000511374451566069', '5839855.131490784645058218', '5839855.131490784645058218'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -196,7 +194,6 @@ def test_deposit_to_spark(ethereum_inquirer, ethereum_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -223,7 +220,7 @@ def test_withdraw_from_spark(gnosis_inquirer, gnosis_accounts):
     tx_hash = deserialize_evm_tx_hash('0x783c3199d405cbf9a9f95ac31e6aeeb0c092d405d4abd56ec2cd3c62b760b3e8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
     user_address, timestamp, gas_amount, out_amount, in_amount, interest_amount = gnosis_accounts[0], TimestampMS(1737008645000), '0.0002680834', '0.73523915024913116', '0.73523915024913116', '0.002274206849231879'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -289,7 +286,6 @@ def test_withdraw_from_spark(gnosis_inquirer, gnosis_accounts):
             counterparty=CPT_SPARK,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -395,12 +391,11 @@ def test_susdc_ethereum_redeem(ethereum_inquirer, ethereum_accounts):
 def test_redeem_susds(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2e5bac2cb234a4388d45754656bad35cc03c7dde7745de10b5b605ff28187d52')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1726736615000)
     gas_amount, returned_amount, withdrawn_amount = '0.002553705360907168', '76400.28490997120343213', '76424.11'  # noqa: E501
     assert events == [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1726736615000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -443,12 +438,11 @@ def test_redeem_susds(ethereum_inquirer, ethereum_accounts):
 def test_deposit_susds(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xe9ca86a0ce9c0226d65203805b77d13697ad5e579989505562638095dc45cac4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1726754135000)
     gas_amount, deposited_amount, withdrawn_amount = '0.003750084090503928', '5114.68', '5112.913299374006156278'  # noqa: E501
     assert events == [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1726754135000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -585,10 +579,9 @@ def test_deposit_dai_to_sdai(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x78E87757861185Ec5e8C0EF6BF0C69Fa7832df6C']])
 def test_deposit_xdai_to_sdai(gnosis_inquirer, gnosis_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x1342646cab122d58f0b7dfae404dad5235d42224de881099dc05e59477bb93aa')  # noqa: E501
     actual_events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x1342646cab122d58f0b7dfae404dad5235d42224de881099dc05e59477bb93aa')),  # noqa: E501
     )
     gas_amount, deposit_amount, receive_amount = '0.000367251244452481', '315', '303.052244055946806232'  # noqa: E501
     assert actual_events == [
@@ -637,10 +630,9 @@ def test_deposit_xdai_to_sdai(gnosis_inquirer, gnosis_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0x4fFAD6ac852c0Af0AA301376F4C5Dea3a928b120']])
 def test_withdraw_xdai_from_sdai(gnosis_inquirer, gnosis_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xe23ee1ac52b8981723c737b01781691b965c5819cccccdb98e7c8cb5894dddbb')  # noqa: E501
     actual_events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe23ee1ac52b8981723c737b01781691b965c5819cccccdb98e7c8cb5894dddbb')),  # noqa: E501
     )
     gas_amount, received_amount, sent_amount = '0.0003018867380459', '36546.085557613238621948', '35168.419304792460265156'  # noqa: E501
     assert actual_events == [
@@ -690,17 +682,15 @@ def test_withdraw_xdai_from_sdai(gnosis_inquirer, gnosis_accounts):
 @pytest.mark.parametrize('gnosis_accounts', [['0x5938852FE18Ad6963322FB98D1fDDA5c24DD8a0E']])
 def test_deposit_wxdai_to_sdai(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
-    tx_hash = deserialize_evm_tx_hash('0xd406f40ecd2538d41adb2e645c8fb6d32cec5485510798bfed5d991c258d4b1d')  # noqa: E501
     actual_events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd406f40ecd2538d41adb2e645c8fb6d32cec5485510798bfed5d991c258d4b1d')),  # noqa: E501
     )
-    timestamp = TimestampMS(1706794335000)
     withdraw_amount, deposit_amount, gas_amount = '319.006747127200240848', '331.313258668881367296', '0.0006162151'  # noqa: E501
     assert actual_events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706794335000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -744,17 +734,15 @@ def test_deposit_wxdai_to_sdai(gnosis_inquirer, gnosis_accounts):
 @pytest.mark.parametrize('gnosis_accounts', [['0x23727b54163F63CffdD8B7769e0eCb13Df253b4e']])
 def test_withdraw_wxdai_from_sdai(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
-    tx_hash = deserialize_evm_tx_hash('0xd7e2123adc6c8f4fd8ced74733010cf47dba2bd4e0e5c468d63d53942b9e2dd3')  # noqa: E501
     actual_events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd7e2123adc6c8f4fd8ced74733010cf47dba2bd4e0e5c468d63d53942b9e2dd3')),  # noqa: E501
     )
-    timestamp = TimestampMS(1706699405000)
     gas_amount, redeem_amount, received_amount = '0.0002100203', '66725.257159368617313463', '69285.250334740811647229'  # noqa: E501
     assert actual_events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706699405000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,

--- a/rotkehlchen/tests/unit/decoders/test_spark_airdrop.py
+++ b/rotkehlchen/tests/unit/decoders/test_spark_airdrop.py
@@ -28,7 +28,7 @@ def test_spark_airdrop_claim(ethereum_inquirer, ethereum_accounts):
         tx_hash=tx_hash,
     )
     user_address, timestamp, gas_amount, claimed_amount = ethereum_accounts[0], TimestampMS(1750283303000), '0.000095432422616478', '5400'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -57,7 +57,6 @@ def test_spark_airdrop_claim(ethereum_inquirer, ethereum_accounts):
             extra_data={'airdrop_identifier': 'spark'},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -72,7 +71,7 @@ def test_spark_staking(ethereum_inquirer, ethereum_accounts):
         tx_hash=tx_hash,
     )
     user_address, timestamp, gas_amount, staked_amount = ethereum_accounts[0], TimestampMS(1750212503000), '0.000263240428824864', '2169.948625059716493489'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -113,4 +112,3 @@ def test_spark_staking(ethereum_inquirer, ethereum_accounts):
             address=string_to_evm_address('0x0000000000000000000000000000000000000000'),
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_stakedao.py
+++ b/rotkehlchen/tests/unit/decoders/test_stakedao.py
@@ -31,7 +31,6 @@ if TYPE_CHECKING:
     from rotkehlchen.globaldb.handler import GlobalDBHandler
     from rotkehlchen.types import ChecksumEvmAddress
 
-
 BSC_NODES_TO_CONNECT = [(WeightedNode(node_info=ZAN_BINANCE_SC_NODE, active=True, weight=ONE),)]
 
 
@@ -65,14 +64,12 @@ def test_claim_one(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x3f747b34f1d0a6c59c62b5d6c3aba8f2bd278546cd53daa131327242c7c5b02e')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1684662791000)
-    amount_str = '215.403304465915246838'
     period = 1684368000
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1684662791000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -90,14 +87,13 @@ def test_claim_one(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_CRV,
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '215.403304465915246838'),
             location_label=user_address,
             notes=f'Claim {amount_str} CRV from StakeDAO veCRV bribes for the period starting at {timestamp_to_date(period, formatstr="%d/%m/%Y %H:%M:%S")}',  # noqa: E501
             counterparty=CPT_STAKEDAO,
             address=STAKEDAO_CLAIMER2,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -106,17 +102,17 @@ def test_old_claim(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc76710a3bd4428ae8f462f75b31fcf56bbf40c4cfe2746f62259437526735073')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_str, amount_str, period = TimestampMS(1673676767000), '0.002265930693617121', '1.029361212967421451', 1673481600  # noqa: E501
-    expected_events = [
+    period = 1673481600
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1673676767000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.002265930693617121'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -129,14 +125,13 @@ def test_old_claim(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=Asset('eip155:1/erc20:0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68'),
-            amount=FVal(amount_str),
+            amount=FVal(amount_str := '1.029361212967421451'),
             location_label=user_address,
             notes=f'Claim {amount_str} INV from StakeDAO veCRV bribes for the period starting at {timestamp_to_date(period, formatstr="%d/%m/%Y %H:%M:%S")}',  # noqa: E501
             counterparty=CPT_STAKEDAO,
             address=STAKEDAO_CLAIMER_OLD,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -145,15 +140,12 @@ def test_claim_multiple(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc866db3fcbef6359919c444de324b6f059f299ed155f5bff00abd81537c88627')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1678952351000)
     period = 1678924800
-    amount1_str = '43.57001129039620188'
-    amount2_str = '41.966838515681574848'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1678952351000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -171,7 +163,7 @@ def test_claim_multiple(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_CRV,
-            amount=FVal(amount1_str),
+            amount=FVal(amount1_str := '43.57001129039620188'),
             location_label=user_address,
             notes=f'Claim {amount1_str} CRV from StakeDAO veCRV bribes for the period starting at {timestamp_to_date(period, formatstr="%d/%m/%Y %H:%M:%S")}',  # noqa: E501
             counterparty=CPT_STAKEDAO,
@@ -184,14 +176,13 @@ def test_claim_multiple(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.REWARD,
             asset=A_CRV,
-            amount=FVal(amount2_str),
+            amount=FVal(amount2_str := '41.966838515681574848'),
             location_label=user_address,
             notes=f'Claim {amount2_str} CRV from StakeDAO veCRV bribes for the period starting at {timestamp_to_date(period, formatstr="%d/%m/%Y %H:%M:%S")}',  # noqa: E501
             counterparty=CPT_STAKEDAO,
             address=STAKEDAO_CLAIMER1,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -370,7 +361,6 @@ def test_deposit_arb(arbitrum_one_inquirer, arbitrum_one_accounts, stakedao_gaug
 @pytest.mark.parametrize('binance_sc_accounts', [['0xa99345367044C80D8f01d0618c44B752C4C29Bdb']])
 @pytest.mark.parametrize('binance_sc_manager_connect_at_start', BSC_NODES_TO_CONNECT)
 def test_withdraw_bsc(binance_sc_inquirer, binance_sc_accounts, stakedao_gauges):
-    tx_hash = deserialize_evm_tx_hash('0x0e8556a645758a6747072673fa713f98a5b3dae090b940257e5ef7c86dc73d49')  # noqa: E501
     user_address = binance_sc_accounts[0]
     original_get = binance_sc_inquirer.etherscan.session.get
 
@@ -383,7 +373,7 @@ def test_withdraw_bsc(binance_sc_inquirer, binance_sc_accounts, stakedao_gauges)
     with patch.object(binance_sc_inquirer.etherscan.session, 'get', side_effect=mocked_get):
         events, _ = get_decoded_events_of_transaction(
             evm_inquirer=binance_sc_inquirer,
-            tx_hash=tx_hash,
+            tx_hash=(tx_hash := deserialize_evm_tx_hash('0x0e8556a645758a6747072673fa713f98a5b3dae090b940257e5ef7c86dc73d49')),  # noqa: E501
         )
     gas_amount, cake_reward, received_amount, timestamp = '0.000358695', '1.156230303623121164', '2000', TimestampMS(1743674447000)  # noqa: E501
     assert events == [EvmEvent(

--- a/rotkehlchen/tests/unit/decoders/test_stakedao_v2.py
+++ b/rotkehlchen/tests/unit/decoders/test_stakedao_v2.py
@@ -202,10 +202,9 @@ def test_votemarket_claim(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x3242696cf8a0ec3133f1b9051c72d4276680b463f350eaa2fb78fe35e61d2df1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x3242696cf8a0ec3133f1b9051c72d4276680b463f350eaa2fb78fe35e61d2df1')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -345,10 +344,9 @@ def test_votemarket_bridge_out(
         arbitrum_one_inquirer: 'ArbitrumOneInquirer',
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ) -> None:
-    tx_hash = deserialize_evm_tx_hash('0x64e762b0ce41613885695864d491b34a786e7f72e601df5a56d26b5fd82ecaa5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x64e762b0ce41613885695864d491b34a786e7f72e601df5a56d26b5fd82ecaa5')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_superchain_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_superchain_bridge.py
@@ -379,19 +379,17 @@ def test_prove_withdrawal(ethereum_inquirer, ethereum_accounts):
     """
     tx_hash = deserialize_evm_tx_hash('0xc68e09838d421ea4cdde39a30917579943a29d74e3d93266b52ee8ebdc841f78')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1694198291000)
     user_address = ethereum_accounts[0]
-    gas_str = '0.015525942536120381'
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1694198291000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.015525942536120381'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,

--- a/rotkehlchen/tests/unit/decoders/test_sushiswap.py
+++ b/rotkehlchen/tests/unit/decoders/test_sushiswap.py
@@ -41,17 +41,16 @@ ADDY_3 = string_to_evm_address('0x3D6a724247c4B133C3b279558e90EdD0c5d25751')
 def test_sushiswap_single_swap(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xbfe3c8a13c325a32736beb34ea170053cdbbd1740a9c3ceca52060906b7f87bd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, swap_amount, received_amount, approved_amount = TimestampMS(1622840771000), '0.001815413', '19.157411925828275084', '18.47349725628421943', '115792089237316195423570985008687907853269984665640564039438.426595987301364851'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1622840771000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.001815413'),
             location_label=ADDY_1,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -63,7 +62,7 @@ def test_sushiswap_single_swap(ethereum_inquirer):
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:1/erc20:0x62B9c7356A2Dc64a1969e19C23e4f579F9810Aa7'),
-            amount=FVal(approved_amount),
+            amount=FVal(approved_amount := '115792089237316195423570985008687907853269984665640564039438.426595987301364851'),  # noqa: E501
             location_label=ADDY_1,
             notes=f'Set cvxCRV spending approval of {ADDY_1} by 0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F to {approved_amount}',  # noqa: E501
             counterparty=None,
@@ -75,7 +74,7 @@ def test_sushiswap_single_swap(ethereum_inquirer):
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=EvmToken('eip155:1/erc20:0x62B9c7356A2Dc64a1969e19C23e4f579F9810Aa7'),
-            amount=FVal(swap_amount),
+            amount=FVal(swap_amount := '19.157411925828275084'),
             location_label=ADDY_1,
             notes=f'Swap {swap_amount} cvxCRV in Sushiswap V2 from {ADDY_1}',
             counterparty=CPT_SUSHISWAP_V2,
@@ -87,14 +86,13 @@ def test_sushiswap_single_swap(ethereum_inquirer):
             location=Location.ETHEREUM,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=EvmToken('eip155:1/erc20:0xD533a949740bb3306d119CC777fa900bA034cd52'),
-            amount=FVal(received_amount),
+            amount=FVal(received_amount := '18.47349725628421943'),
             location_label=ADDY_1,
             notes=f'Receive {received_amount} CRV in Sushiswap V2 from {ADDY_1}',
             counterparty=CPT_SUSHISWAP_V2,
             address=string_to_evm_address('0x33F6DDAEa2a8a54062E021873bCaEE006CdF4007'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -103,17 +101,17 @@ def test_sushiswap_v2_remove_liquidity(ethereum_inquirer):
     """This checks that removing liquidity to Sushiswap V2 pool is decoded properly"""
     tx_hash = deserialize_evm_tx_hash('0x4720a52fc768591cb3997da3a2eab76c54b69176f3c3f8d9a817c2d60dd449ac')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, spent_amount, removed_eth, removed_usdt, pool_address = TimestampMS(1672888271000), '0.006668386', '0.0000243611620791', '1.122198589808876532', '1408.739932', string_to_evm_address('0x06da0fd433C1A5d7a4faa01111c044910A184553')  # noqa: E501
-    expected_events = [
+    pool_address = string_to_evm_address('0x06da0fd433C1A5d7a4faa01111c044910A184553')
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1672888271000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.006668386'),
             location_label=ADDY_2,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -125,7 +123,7 @@ def test_sushiswap_v2_remove_liquidity(ethereum_inquirer):
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.RETURN_WRAPPED,
             asset=Asset('eip155:1/erc20:0x06da0fd433C1A5d7a4faa01111c044910A184553'),
-            amount=FVal(spent_amount),
+            amount=FVal(spent_amount := '0.0000243611620791'),
             location_label=ADDY_2,
             notes=f'Send {spent_amount} SLP WETH-USDT to Sushiswap V2 pool',
             counterparty=CPT_SUSHISWAP_V2,
@@ -138,7 +136,7 @@ def test_sushiswap_v2_remove_liquidity(ethereum_inquirer):
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=A_ETH,
-            amount=FVal(removed_eth),
+            amount=FVal(removed_eth := '1.122198589808876532'),
             location_label=ADDY_2,
             notes=f'Remove {removed_eth} ETH from Sushiswap V2 LP {pool_address}',
             counterparty=CPT_SUSHISWAP_V2,
@@ -152,7 +150,7 @@ def test_sushiswap_v2_remove_liquidity(ethereum_inquirer):
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
             asset=A_USDT,
-            amount=FVal(removed_usdt),
+            amount=FVal(removed_usdt := '1408.739932'),
             location_label=ADDY_2,
             notes=f'Remove {removed_usdt} USDT from Sushiswap V2 LP 0x06da0fd433C1A5d7a4faa01111c044910A184553',  # noqa: E501
             counterparty=CPT_SUSHISWAP_V2,
@@ -160,7 +158,6 @@ def test_sushiswap_v2_remove_liquidity(ethereum_inquirer):
             extra_data={'pool_address': pool_address},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -169,22 +166,22 @@ def test_sushiswap_v2_add_liquidity(ethereum_inquirer):
     """This checks that adding liquidity to Sushiswap V2 pool is decoded properly"""
     tx_hash = deserialize_evm_tx_hash('0x2ce6f92f4020fdc4ed69a173b10c1dd2811184fac34d56188270950db1152f3a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas_amount, received_amount, deposited_eth, deposited_usdt, pool_address = TimestampMS(1672893947000), '0.0030789891485573', '0.000000017297304741', '0.000797012710918264', '0.999992', string_to_evm_address('0x06da0fd433C1A5d7a4faa01111c044910A184553')  # noqa: E501
+    pool_address = string_to_evm_address('0x06da0fd433C1A5d7a4faa01111c044910A184553')
     lp_token_identifier = evm_address_to_identifier(
         address=pool_address,
         chain_id=ChainID.ETHEREUM,
         token_type=TokenKind.ERC20,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1672893947000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.0030789891485573'),
             location_label=ADDY_3,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -196,7 +193,7 @@ def test_sushiswap_v2_add_liquidity(ethereum_inquirer):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_ETH,
-            amount=FVal(deposited_eth),
+            amount=FVal(deposited_eth := '0.000797012710918264'),
             location_label=ADDY_3,
             notes=f'Deposit {deposited_eth} ETH to Sushiswap V2 LP {pool_address}',
             counterparty=CPT_SUSHISWAP_V2,
@@ -210,7 +207,7 @@ def test_sushiswap_v2_add_liquidity(ethereum_inquirer):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_USDT,
-            amount=FVal(deposited_usdt),
+            amount=FVal(deposited_usdt := '0.999992'),
             location_label=ADDY_3,
             notes=f'Deposit {deposited_usdt} USDT to Sushiswap V2 LP {pool_address}',
             counterparty=CPT_SUSHISWAP_V2,
@@ -224,14 +221,13 @@ def test_sushiswap_v2_add_liquidity(ethereum_inquirer):
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset(lp_token_identifier),
-            amount=FVal(received_amount),
+            amount=FVal(received_amount := '0.000000017297304741'),
             location_label=ADDY_3,
             notes=f'Receive {received_amount} SLP WETH-USDT from Sushiswap V2 pool',
             counterparty=CPT_SUSHISWAP_V2,
             address=pool_address,
         ),
     ]
-    assert events == expected_events
     assert EvmToken(lp_token_identifier).protocol == CPT_SUSHISWAP_V2
 
 

--- a/rotkehlchen/tests/unit/decoders/test_thegraph.py
+++ b/rotkehlchen/tests/unit/decoders/test_thegraph.py
@@ -42,15 +42,14 @@ ADDY_USER_3_ARB = string_to_evm_address('0xBe79986821637afD1406BF9278DA55cf9085c
 def test_thegraph_delegate(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x6ed3377db652151fb8e4794dd994a921a2d029ad317bd3f2a2916af239490fec')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1690731467000)
     delegate_amount, delegate_tax, gas_fees = '998.98', '5.02', '0.002150596408306665'
     approval_amount = '115792089237316195423570985008687907853269984665640563952473.318503163402575923'  # noqa: E501
     indexer_address = string_to_evm_address('0x6125eA331851367716beE301ECDe7F38A7E429e7')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1690731467000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -101,7 +100,6 @@ def test_thegraph_delegate(ethereum_inquirer):
             address=CONTRACT_STAKING,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -109,13 +107,12 @@ def test_thegraph_delegate(ethereum_inquirer):
 def test_thegraph_contract_deposit_gas(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xf254ac1bbfbf07ca21042edd3ff78dad7c3158c8218598b5359b6e415e0977b7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1706311139000)
     gas, deposit_amount = '0.000626151499903872', '0.001135647343563552'
     indexer = string_to_evm_address('0x7D91717579885BfCFec3Cb4B4C4fe71c1EedD4dE')
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706311139000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -141,7 +138,6 @@ def test_thegraph_contract_deposit_gas(ethereum_inquirer):
             extra_data={'indexer': indexer},
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -149,18 +145,16 @@ def test_thegraph_contract_deposit_gas(ethereum_inquirer):
 def test_thegraph_contract_transfer_approval(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xbb8280cc9ca9de1d33e573a4381d88525a214fc45f84415129face03125ba22f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1706311067000)
-    gas = '0.001243940743655704'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706311067000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.001243940743655704'),
             location_label=ADDY_ROTKI,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -179,7 +173,6 @@ def test_thegraph_contract_transfer_approval(ethereum_inquirer):
             address=string_to_evm_address('0x7D91717579885BfCFec3Cb4B4C4fe71c1EedD4dE'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr
@@ -187,16 +180,15 @@ def test_thegraph_contract_transfer_approval(ethereum_inquirer):
 def test_thegraph_contract_delegation_transferred_to_l2_vested(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x48321bb00e5c5b67f080991864606dbc493051d20712735a579d7ae31eca3d78')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1706316575000)
     gas, delegation_amount = '0.0034549683606123', '199846.719749385820105919'
     indexer = string_to_evm_address('0x5A8904be09625965d9AEc4BFfD30D853438a053e')
     indexer_l2 = string_to_evm_address('0x2f09092aacd80196FC984908c5A9a7aB3ee4f1CE')
     delegator_l2 = string_to_evm_address('0x9F219c3D048967990f675F49C1117B0598331408')
     contract = string_to_evm_address('0x7D91717579885BfCFec3Cb4B4C4fe71c1EedD4dE')
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706316575000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -224,7 +216,6 @@ def test_thegraph_contract_delegation_transferred_to_l2_vested(ethereum_inquirer
             extra_data={'delegator_l2': delegator_l2, 'indexer_l2': indexer_l2, 'beneficiary': ADDY_ROTKI},  # noqa: E501
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -232,15 +223,14 @@ def test_thegraph_contract_delegation_transferred_to_l2_vested(ethereum_inquirer
 def test_thegraph_contract_delegation_transferred_to_l2(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0xed80711e4cb9c428790f0d9b51f79473bf5253d5d03c04d958d411e7fa34a92e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1706317031000)
     eth_amount, gas, delegation_amount = '0.000255709530674816', '0.002540860890653745', '39243.651715794449516669'  # noqa: E501
     indexer = string_to_evm_address('0xb06071394531B63b0bac78f27e12dc2BEaA913E4')
     indexer_l2 = string_to_evm_address('0x0fd8FD1dC8162148cb9413062FE6C6B144335Dbf')
     delegator_l2 = string_to_evm_address('0x9531C059098e3d194fF87FebB587aB07B30B1306')
-    expected_events = [
+    assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1706317031000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -279,22 +269,19 @@ def test_thegraph_contract_delegation_transferred_to_l2(ethereum_inquirer):
         ),
     ]
 
-    assert expected_events == events
-
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('ethereum_accounts', [[ADDY_USER]])
 def test_thegraph_undelegate(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x5ca5244868d9c0d8c30a1cad0feaf137bd28acd9c3f669a09a3a199fd75ad25a')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1691771855000)
     gas_fee, undelegate_amount, lock_time = '0.00307607001551556', '1003.70342593701668535', '983'
     indexer_address = string_to_evm_address('0x6125eA331851367716beE301ECDe7F38A7E429e7')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1691771855000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -318,7 +305,6 @@ def test_thegraph_undelegate(ethereum_inquirer):
             address=CONTRACT_STAKING,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -326,14 +312,13 @@ def test_thegraph_undelegate(ethereum_inquirer):
 def test_thegraph_delegated_withdrawn(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x49307751de5ba4cf98fccbdd1ab8387fd60a7ce120800212c216bf0a6a04acfa')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1694577371000)
     gas_fees, withdrawn_amount = '0.000651667321615926', '1003.70342593701668535'
     indexer_address = string_to_evm_address('0x6125eA331851367716beE301ECDe7F38A7E429e7')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1694577371000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -357,25 +342,22 @@ def test_thegraph_delegated_withdrawn(ethereum_inquirer):
             address=CONTRACT_STAKING,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_USER_1_ARB]])
 def test_thegraph_delegate_arbitrum_one(arbitrum_one_inquirer):
-    tx_hash = deserialize_evm_tx_hash('0x3c846f305330969fb0ddb87c5ae411b4e9692f451a7ff3237b6f71020030c7d1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x3c846f305330969fb0ddb87c5ae411b4e9692f451a7ff3237b6f71020030c7d1')),  # noqa: E501
     )
-    timestamp = TimestampMS(1713366299000)
     gas_fees, approve_amount, delegate_amount, delegate_tax = '0.000003483187128', '1.009574848602990389', '24.9745', '0.1255'  # noqa: E501
     indexer_address = string_to_evm_address('0xE13840A2E92e0Cb17A246609b432D0fA2e418774')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1713366299000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -426,27 +408,24 @@ def test_thegraph_delegate_arbitrum_one(arbitrum_one_inquirer):
             address=CONTRACT_STAKING_ARB,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_USER_2_ARB]])
 def test_thegraph_undelegate_arbitrum_one(arbitrum_one_inquirer):
-    tx_hash = deserialize_evm_tx_hash('0xc66ea685db10809b1765e8381175ada7b021b5a40f57572e220a8b94235c1f72')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc66ea685db10809b1765e8381175ada7b021b5a40f57572e220a8b94235c1f72')),  # noqa: E501
     )
-    timestamp = TimestampMS(1700727276000)
     gas_fees, withdraw_amount, undelegate_amount = '0.0000568994', '49.766469576778571786', '50.576247644221196145'  # noqa: E501
     indexer_address = string_to_evm_address('0xf92f430Dd8567B0d466358c79594ab58d919A6D4')
     lock_time = '390'
 
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1700727276000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -483,25 +462,22 @@ def test_thegraph_undelegate_arbitrum_one(arbitrum_one_inquirer):
             address=CONTRACT_STAKING_ARB,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_USER_3_ARB]])
 def test_thegraph_delegated_withdrawn_arbitrum_one(arbitrum_one_inquirer):
-    tx_hash = deserialize_evm_tx_hash('0xd6847bc02b65891118caaa8a2882cf5db6e0938c909db112e4fa6930929d8c39')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xd6847bc02b65891118caaa8a2882cf5db6e0938c909db112e4fa6930929d8c39')),  # noqa: E501
     )
-    timestamp = TimestampMS(1713445792000)
     gas_fees, withdrawn_amount = '0.00000134642', '9.949999999999999998'
     indexer_address = string_to_evm_address('0xf92f430Dd8567B0d466358c79594ab58d919A6D4')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1713445792000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -525,7 +501,6 @@ def test_thegraph_delegated_withdrawn_arbitrum_one(arbitrum_one_inquirer):
             address=CONTRACT_STAKING_ARB,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -535,10 +510,9 @@ def test_delegate_horizon(
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ) -> None:
     """This checks that delegation post-horizon works correctly"""
-    tx_hash = deserialize_evm_tx_hash('0x7beba0df2eee3a7425ec1dae22b33209c40d37bba73bddd8749a29143ce57f14')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x7beba0df2eee3a7425ec1dae22b33209c40d37bba73bddd8749a29143ce57f14')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,
@@ -631,10 +605,9 @@ def test_thegraph_delegated_withdrawn_horizon(
         arbitrum_one_accounts: list['ChecksumEvmAddress'],
 ) -> None:
     """This checks that delegation withdrawal post-horizon works correctly"""
-    tx_hash = deserialize_evm_tx_hash('0xcaba90e80b65df1d6fc542940d0f8362a16f93c03cfb6f0603dad1eb45b07b0e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xcaba90e80b65df1d6fc542940d0f8362a16f93c03cfb6f0603dad1eb45b07b0e')),  # noqa: E501
     )
     assert events == [EvmEvent(
         tx_ref=tx_hash,

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv2.py
@@ -50,7 +50,7 @@ ADDY_4 = string_to_evm_address('0x43e141534d718D72552De1B606a5FCBc72256cD7')
 def test_uniswap_v2_swap(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x67cf6c4ce5078f9750a14afd2f5070c327caf8c5180bdee2be59644ac59974e1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -89,7 +89,6 @@ def test_uniswap_v2_swap(ethereum_inquirer):
             address=UNISWAP_V2_ROUTER,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -98,12 +97,11 @@ def test_uniswap_v2_swap_eth_returned(ethereum_inquirer):
     """Test a transaction where eth is swapped and some of it is returned due to change in price"""
     tx_hash = deserialize_evm_tx_hash('0x20ecc226c438a8803a6195d8031ae7dd97a27351e6b7429621b36194121b9b76')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1634652419000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1634652419000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -151,7 +149,6 @@ def test_uniswap_v2_swap_eth_returned(ethereum_inquirer):
             address=UNISWAP_V2_ROUTER,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -224,7 +221,7 @@ def test_uniswap_v2_add_liquidity(ethereum_inquirer):
         chain_id=ChainID.ETHEREUM,
         token_type=TokenKind.ERC20,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -280,7 +277,6 @@ def test_uniswap_v2_add_liquidity(ethereum_inquirer):
             address=pool_address,
         ),
     ]
-    assert events == expected_events
     lp_token = EvmToken(lp_token_identifier)
     assert lp_token.protocol == CPT_UNISWAP_V2
     assert lp_token.symbol == 'UNI-V2 DAI-USDC'
@@ -292,7 +288,7 @@ def test_uniswap_v2_remove_liquidity(ethereum_inquirer):
     """This checks that removing liquidity from a Uniswap V2 pool is decoded properly."""
     tx_hash = deserialize_evm_tx_hash('0x0936a16e1d3655e832c60bed52040fd5ac0d99d03865d11225b3183dba318f43')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -360,7 +356,6 @@ def test_uniswap_v2_remove_liquidity(ethereum_inquirer):
             extra_data={'pool_address': '0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc'},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -379,10 +374,9 @@ def test_uniswap_v2_swap_events_order(
     It checks that an approval event does not come between trade events.
     """
     tx_hash = '0xec15324d55274d9ad3181ed2f29d29e9812841e5e79aa9228a0f3ef4d3ce8d2c'
-    tx_hash = deserialize_evm_tx_hash(tx_hash)
     user_address = ethereum_accounts[0]
     transaction = EvmTransaction(
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash(tx_hash)),
         chain_id=ChainID.ETHEREUM,
         timestamp=Timestamp(1672784687),
         block_number=16329226,
@@ -500,7 +494,7 @@ def test_uniswap_v2_swap_events_order(
         decoder.reload_data(cursor)
 
     events, _, _ = decoder._decode_transaction(transaction=transaction, tx_receipt=receipt)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             timestamp=1672784687000,
@@ -552,7 +546,6 @@ def test_uniswap_v2_swap_events_order(
             address=string_to_evm_address('0x0d0d65E7A7dB277d3E0F5E1676325E75f3340455'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -562,7 +555,7 @@ def test_remove_liquidity_with_weth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x00007120e5281e9bdf9a57739e3ecaf736013e4a1a31ecfe44f719c229cc2cbd')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -619,7 +612,6 @@ def test_remove_liquidity_with_weth(ethereum_inquirer, ethereum_accounts):
             extra_data={'pool_address': '0xFfA98A091331Df4600F87C9164cD27e8a5CD2405'},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -628,13 +620,12 @@ def test_claim_airdrop(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0e50e7374e0ffbe0aea82dbe94a04ab0da3981f3bfb1a66927eb250c7aff29e3')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1600446008000)
     gas_amount, claimed_amount = '0.027890731101011885', '408.638074'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1600446008000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -660,7 +651,6 @@ def test_claim_airdrop(ethereum_inquirer, ethereum_accounts):
             extra_data={AIRDROP_IDENTIFIER_KEY: 'uniswap'},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])

--- a/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
+++ b/rotkehlchen/tests/unit/decoders/test_uniswapv3.py
@@ -62,7 +62,7 @@ ADDY_5 = string_to_evm_address('0xa931b486F661540c6D709aE6DfC8BcEF347ea437')
 def test_uniswap_v3_swap(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x1c50c336329a7ee41f722ce5d848ebd066b72bf44a1eaafcaa92e8c0282049d2')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -101,7 +101,6 @@ def test_uniswap_v3_swap(ethereum_inquirer):
             address=string_to_evm_address('0xE592427A0AEce92De3Edee1F18E0157C05861564'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -111,7 +110,7 @@ def test_uniswap_v3_swap_received_token2(ethereum_inquirer):
     the pool."""
     tx_hash = deserialize_evm_tx_hash('0x116b3a9c0b2a4857605e336438c8e4c91897a9ef2af23178f9dbceba85264bd9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -150,7 +149,6 @@ def test_uniswap_v3_swap_received_token2(ethereum_inquirer):
             address=string_to_evm_address('0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -159,7 +157,7 @@ def test_uniswap_v3_swap_by_aggregator(ethereum_inquirer):
     """This checks that swap(s) initiated by an aggregator is decoded properly."""
     tx_hash = deserialize_evm_tx_hash('0x14e73a3bbced025ae22245eae0045972c1664fc01038b2ba6b1153590f536948')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=253,
@@ -210,7 +208,6 @@ def test_uniswap_v3_swap_by_aggregator(ethereum_inquirer):
             counterparty=CPT_COWSWAP,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -360,7 +357,7 @@ def test_swap_tokens_to_tokens_single_receipt(ethereum_inquirer, ethereum_accoun
     tx_hash = deserialize_evm_tx_hash('0x3ae92fa63a9cf672906036beb18ece09592a8a471bd7f15e4385ca5011615e51')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -399,7 +396,6 @@ def test_swap_tokens_to_tokens_single_receipt(ethereum_inquirer, ethereum_accoun
             address=string_to_evm_address('0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -408,7 +404,7 @@ def test_swap_tokens_to_tokens_multiple_receipts(ethereum_inquirer, ethereum_acc
     tx_hash = deserialize_evm_tx_hash('0xa4e0dbf77bf7a9721e1ba4ecf44ed6ea8dcb1c16e9e784b6fefa30749f64e7c0')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -447,7 +443,6 @@ def test_swap_tokens_to_tokens_multiple_receipts(ethereum_inquirer, ethereum_acc
             address=string_to_evm_address('0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -462,7 +457,7 @@ def test_uniswap_v3_remove_liquidity(ethereum_inquirer):
     tx_hash = deserialize_evm_tx_hash('0x76c312fe1c8604de5175c37dcbbb99cc8699336f3e4840e9e29e3383970f6c6d ')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert len(events) == 3
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -503,7 +498,6 @@ def test_uniswap_v3_remove_liquidity(ethereum_inquirer):
             address=string_to_evm_address('0xC36442b4a4522E871399CD717aBDD847Ab11FE88'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -512,7 +506,7 @@ def test_uniswap_v3_add_liquidity(ethereum_inquirer):
     """Check that adding liquidity to a Uniswap V3 LP is decoded properly."""
     tx_hash = deserialize_evm_tx_hash('0x6bf3588f669a784adf5def3c0db149b0cdbcca775e472bb35f00acedee263c4c')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -566,7 +560,6 @@ def test_uniswap_v3_add_liquidity(ethereum_inquirer):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
     # Ensure the position token's name and symbol are set correctly
     position_token = get_evm_token(
@@ -663,10 +656,9 @@ def test_uniswap_v3_swap_by_universal_router(ethereum_inquirer, ethereum_account
     tx_hash = deserialize_evm_tx_hash('0xd2fe13a9727b2ff3f9458154afb8e59216864b57e0aacffeedc3d3d4cff1c43d')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1698949487000)
     assert events == [EvmEvent(
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1698949487000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -709,12 +701,11 @@ def test_uniswap_v3_weth_deposit(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xdb9a489fa0404facc9ee514ce9e08a8dffdd5bbc051ed1fbc8d165cc4dc408f3 ')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1705025555000)
     rai_amount, weth_amount = '5409.802671424102374943', '5.964487282596591371'
     nft_id = '645638'
     assert events == [EvmEvent(
         sequence_index=102,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1705025555000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.INFORMATIONAL,
         event_subtype=HistoryEventSubType.NONE,
@@ -770,22 +761,20 @@ def test_uniswap_v3_weth_deposit(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xEEb775c27a0d476B145d2e3B4dCd10A0A5Bd064F']])
 def test_swap_on_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x8fe6f4f80e34eebc8e61ad638d57fde3ec4a975817ee08ab209562d00a6aa217')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8fe6f4f80e34eebc8e61ad638d57fde3ec4a975817ee08ab209562d00a6aa217')),  # noqa: E501
     )
-    timestamp, swap_amount, receive_amount, gas_fees = TimestampMS(1710224315000), '0.21', '416.708088668961143612', '0.0001952302'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1710224315000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.0001952302'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -796,7 +785,7 @@ def test_swap_on_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
             location=Location.ARBITRUM_ONE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
-            amount=FVal(swap_amount),
+            amount=FVal(swap_amount := '0.21'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Swap {swap_amount} ETH via Uniswap V3 auto router',
             counterparty=CPT_UNISWAP_V3,
@@ -808,14 +797,13 @@ def test_swap_on_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
             location=Location.ARBITRUM_ONE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=A_ARB,
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '416.708088668961143612'),
             location_label=arbitrum_one_accounts[0],
             notes=f'Receive {receive_amount} ARB as the result of a swap via Uniswap V3 auto router',  # noqa: E501
             counterparty=CPT_UNISWAP_V3,
             address=UNISWAP_UNIVERSAL_ROUTER,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -824,17 +812,16 @@ def test_swap_on_arbitrum(arbitrum_one_inquirer, arbitrum_one_accounts):
 def test_swap_on_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x2125ff35709009b9782f8351db3cb5a44a0bf088c3f38de08d92eb3906394635')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount, receive_amount, gas_fees = TimestampMS(1710230035000), '0.005', '10083924.460996717903453391', '0.000189731906791024'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1710230035000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000189731906791024'),
             location_label=base_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -845,7 +832,7 @@ def test_swap_on_base(base_inquirer, base_accounts):
             location=Location.BASE,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_ETH,
-            amount=FVal(swap_amount),
+            amount=FVal(swap_amount := '0.005'),
             location_label=base_accounts[0],
             notes=f'Swap {swap_amount} ETH via Uniswap V3 auto router',
             counterparty=CPT_UNISWAP_V3,
@@ -857,14 +844,13 @@ def test_swap_on_base(base_inquirer, base_accounts):
             location=Location.BASE,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:8453/erc20:0x7299cD731d0712dB09E7dF43fD670D75Db3319Bc'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '10083924.460996717903453391'),
             location_label=base_accounts[0],
             notes=f'Receive {receive_amount} NESSY as the result of a swap via Uniswap V3 auto router',  # noqa: E501
             counterparty=CPT_UNISWAP_V3,
             address=UNISWAP_UNIVERSAL_ROUTER,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -873,17 +859,16 @@ def test_swap_on_base(base_inquirer, base_accounts):
 def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0xfbaacab45a9d788c993f08a65652e7a363a82ee2343152ffa41d07c5456d1fe7')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, swap_amount, receive_amount, gas_fees = TimestampMS(1710230523000), '23.093637251974648887', '23.084554', '0.000335793972468462'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1710230523000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000335793972468462'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -894,7 +879,7 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
             location=Location.OPTIMISM,
             event_subtype=HistoryEventSubType.SPEND,
             asset=Asset('eip155:10/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1'),
-            amount=FVal(swap_amount),
+            amount=FVal(swap_amount := '23.093637251974648887'),
             location_label=optimism_accounts[0],
             notes=f'Swap {swap_amount} DAI via Uniswap V3 auto router',
             counterparty=CPT_UNISWAP_V3,
@@ -906,35 +891,32 @@ def test_swap_on_optimism(optimism_inquirer, optimism_accounts):
             location=Location.OPTIMISM,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:10/erc20:0x7F5c764cBc14f9669B88837ca1490cCa17c31607'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '23.084554'),
             location_label=optimism_accounts[0],
             notes=f'Receive {receive_amount} USDC.e as the result of a swap via Uniswap V3 auto router',  # noqa: E501
             counterparty=CPT_UNISWAP_V3,
             address=UNISWAP_UNIVERSAL_ROUTER,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x9d38bC769b4E88da3f4c31a06b626ef88a21065C']])
 def test_swap_on_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x2004f7b593d4ddf9372d78adb4b89852fa70eafa42418793b142a881b4171974')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x2004f7b593d4ddf9372d78adb4b89852fa70eafa42418793b142a881b4171974')),  # noqa: E501
     )
-    timestamp, swap_amount, receive_amount, gas_fees = TimestampMS(1710231022000), '0.017521626565388156', '0.00097703', '0.025131590391178764'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1710231022000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_POL,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.025131590391178764'),
             location_label=polygon_pos_accounts[0],
             notes=f'Burn {gas_fees} POL for gas',
             counterparty=CPT_GAS,
@@ -945,7 +927,7 @@ def test_swap_on_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
             location=Location.POLYGON_POS,
             event_subtype=HistoryEventSubType.SPEND,
             asset=A_WETH_POLYGON,
-            amount=FVal(swap_amount),
+            amount=FVal(swap_amount := '0.017521626565388156'),
             location_label=polygon_pos_accounts[0],
             notes=f'Swap {swap_amount} WETH via Uniswap V3 auto router',
             counterparty=CPT_UNISWAP_V3,
@@ -957,14 +939,13 @@ def test_swap_on_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
             location=Location.POLYGON_POS,
             event_subtype=HistoryEventSubType.RECEIVE,
             asset=Asset('eip155:137/erc20:0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '0.00097703'),
             location_label=polygon_pos_accounts[0],
             notes=f'Receive {receive_amount} WBTC as the result of a swap via Uniswap V3 auto router',  # noqa: E501
             counterparty=CPT_UNISWAP_V3,
             address=UNISWAP_UNIVERSAL_ROUTER,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -973,17 +954,16 @@ def test_swap_on_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
 def test_add_liquidity_on_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x96bd0e37e1734b5e73f9abdf30b39c4e4a6879667c2d01a7be2d95a85cc0b0cc')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, approval, op_deposit, usdc_deposit, gas_fees = TimestampMS(1713269405000), '0.000129292741769402', '10975.908530657738737186', '32.212735', '0.000027353637451875'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1713269405000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_fees),
+            amount=FVal(gas_fees := '0.000027353637451875'),
             location_label=optimism_accounts[0],
             notes=f'Burn {gas_fees} ETH for gas',
             counterparty=CPT_GAS,
@@ -995,7 +975,7 @@ def test_add_liquidity_on_optimism(optimism_inquirer, optimism_accounts):
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=A_OP,
-            amount=FVal(approval),
+            amount=FVal(approval := '0.000129292741769402'),
             location_label=optimism_accounts[0],
             notes=f'Set OP spending approval of 0x9A539f692cDE873D6B882fc326c8d62D4cEA8048 by 0xC36442b4a4522E871399CD717aBDD847Ab11FE88 to {approval}',  # noqa: E501
             address=string_to_evm_address('0xC36442b4a4522E871399CD717aBDD847Ab11FE88'),
@@ -1007,7 +987,7 @@ def test_add_liquidity_on_optimism(optimism_inquirer, optimism_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:10/erc20:0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'),  # USDC
-            amount=FVal(usdc_deposit),
+            amount=FVal(usdc_deposit := '32.212735'),
             location_label=optimism_accounts[0],
             notes=f'Deposit {usdc_deposit} USDC to Uniswap V3 LP 550709',
             counterparty=CPT_UNISWAP_V3,
@@ -1020,7 +1000,7 @@ def test_add_liquidity_on_optimism(optimism_inquirer, optimism_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_OP,
-            amount=FVal(op_deposit),
+            amount=FVal(op_deposit := '10975.908530657738737186'),
             location_label=optimism_accounts[0],
             notes=f'Deposit {op_deposit} OP to Uniswap V3 LP 550709',
             counterparty=CPT_UNISWAP_V3,
@@ -1040,7 +1020,6 @@ def test_add_liquidity_on_optimism(optimism_inquirer, optimism_accounts):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1165,7 +1144,7 @@ def test_receive_position_token_on_arbitrum(
 def test_uniswap_v3_universal_router_2(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8c1aab138325e03f5bc20e676b8a242d470922003c3be4a76c386a4e67ce7bce')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1204,4 +1183,3 @@ def test_uniswap_v3_universal_router_2(ethereum_inquirer, ethereum_accounts):
             address=UNISWAP_UNIVERSAL_ROUTER_V2,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_velodrome.py
+++ b/rotkehlchen/tests/unit/decoders/test_velodrome.py
@@ -68,19 +68,17 @@ def test_add_liquidity_v2(optimism_transaction_decoder, optimism_accounts, load_
     """Check that adding liquidity to a velodrome v2 pool is properly decoded."""
     _add_velodrome_pool(WETH_OP_POOL_ADDRESS)
     assert GlobalDBHandler.get_evm_token(address=WETH_OP_POOL_ADDRESS, chain_id=ChainID.OPTIMISM) is None  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0xa1cf038ca08b51971314b4f8e006b455f2a82f113899e5eb7818ac1528605bfc')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xa1cf038ca08b51971314b4f8e006b455f2a82f113899e5eb7818ac1528605bfc')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1693573631000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1693573631000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -142,7 +140,6 @@ def test_add_liquidity_v2(optimism_transaction_decoder, optimism_accounts, load_
             notes=f'Receive 0.172627291949741834 vAMMV2-WETH/OP after depositing in velodrome pool {WETH_OP_POOL_ADDRESS}',  # noqa: E501
         ),
     ]
-    assert events == expected_events
     assert EvmToken(WETH_OP_LP_TOKEN).protocol == CPT_VELODROME
 
 
@@ -156,20 +153,18 @@ def test_add_liquidity_v1(optimism_transaction_decoder, optimism_accounts, load_
     """Check that adding liquidity to a velodrome v1 pool is properly decoded."""
     _add_velodrome_pool(pool := string_to_evm_address('0x6fE665F19517Cd6076866dB0548177d0E628156a'))  # noqa: E501
     assert GlobalDBHandler.get_evm_token(address=pool, chain_id=ChainID.OPTIMISM) is None
-    tx_hash = deserialize_evm_tx_hash('0x779c2c762ed7ca5d2236ac548f9e9bdc723a8bc9d6d8feba9e3baea9456bbac9')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x779c2c762ed7ca5d2236ac548f9e9bdc723a8bc9d6d8feba9e3baea9456bbac9')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1685968046000)
     lp_token_identifier = evm_address_to_identifier(pool, ChainID.OPTIMISM, TokenKind.ERC20)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1685968046000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -219,7 +214,6 @@ def test_add_liquidity_v1(optimism_transaction_decoder, optimism_accounts, load_
             notes=f'Receive 21.069827457300304618 vAMM-RED/VELO after depositing in velodrome pool {pool}',  # noqa: E501
         ),
     ]
-    assert events == expected_events
     assert EvmToken(lp_token_identifier).protocol == CPT_VELODROME
 
 
@@ -229,19 +223,17 @@ def test_add_liquidity_v1(optimism_transaction_decoder, optimism_accounts, load_
 def test_remove_liquidity_v2(optimism_transaction_decoder, optimism_accounts, load_global_caches):
     """Check that removing liquidity from a velodrome v2 pool is properly decoded."""
     _add_velodrome_pool(string_to_evm_address('0xd25711EdfBf747efCE181442Cc1D8F5F8fc8a0D3'))
-    tx_hash = deserialize_evm_tx_hash('0x81351bf9ca6d78bff92d2b714d68dd7c785bb70de0e250bc7bc6ab073736d1ce')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x81351bf9ca6d78bff92d2b714d68dd7c785bb70de0e250bc7bc6ab073736d1ce')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1694677251000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1694677251000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -303,7 +295,6 @@ def test_remove_liquidity_v2(optimism_transaction_decoder, optimism_accounts, lo
             notes=f'Remove 2.995474411210852897 OP from velodrome pool {WETH_OP_POOL_ADDRESS}',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -312,19 +303,17 @@ def test_remove_liquidity_v2(optimism_transaction_decoder, optimism_accounts, lo
 def test_remove_liquidity_v1(optimism_transaction_decoder, optimism_accounts, load_global_caches):
     """Check that removing liquidity from a velodrome v1 pool is properly decoded."""
     _add_velodrome_pool(pool := string_to_evm_address('0x47029bc8f5CBe3b464004E87eF9c9419a48018cd'))  # noqa: E501
-    tx_hash = deserialize_evm_tx_hash('0x9b564c266aea871c14fbe120d060d1713f0ba524452906af3592360594b946f6')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x9b564c266aea871c14fbe120d060d1713f0ba524452906af3592360594b946f6')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1695202305000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1695202305000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -386,7 +375,6 @@ def test_remove_liquidity_v1(optimism_transaction_decoder, optimism_accounts, lo
             notes=f'Remove 205.545843 USDC.e from velodrome pool {pool}',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -396,19 +384,17 @@ def test_swap_eth_to_token_v2(optimism_accounts, optimism_transaction_decoder, l
     """Check that swapping eth to token in velodrome v2 is properly decoded."""
     _add_velodrome_pool(string_to_evm_address('0x3f42Dc59DC4dF5cD607163bC620168f7FF7aB970'))
     _add_velodrome_pool(string_to_evm_address('0x2fE304b407c7fAb2a3c10962F14dB751468a4f5b'))
-    tx_hash = deserialize_evm_tx_hash('0x8d65dc5a77aaceabac3b80fd28f8fa3cd45143748c2d31598706580f68d724da')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8d65dc5a77aaceabac3b80fd28f8fa3cd45143748c2d31598706580f68d724da')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1693572877000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1693572877000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -443,7 +429,6 @@ def test_swap_eth_to_token_v2(optimism_accounts, optimism_transaction_decoder, l
             notes=f'Receive 11.895061655417592619 OP as the result of a swap in {CPT_VELODROME}',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -455,19 +440,17 @@ def test_swap_eth_to_token_v2(optimism_accounts, optimism_transaction_decoder, l
 def test_swap_eth_to_token_v1(optimism_accounts, optimism_transaction_decoder, load_global_caches):
     """Check that swapping eth to token in velodrome v1 is properly decoded."""
     _add_velodrome_pool(string_to_evm_address('0x7866C6072B09539fC0FDE82963846b80203d7beb'))
-    tx_hash = deserialize_evm_tx_hash('0xaa6b816c09863eab80f6184ab4112d7fea3a813c194dcebf08b6d4e13df22354')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xaa6b816c09863eab80f6184ab4112d7fea3a813c194dcebf08b6d4e13df22354')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1695194435000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1695194435000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -502,7 +485,6 @@ def test_swap_eth_to_token_v1(optimism_accounts, optimism_transaction_decoder, l
             notes=f'Receive 0.130694520044655821 agEUR as the result of a swap in {CPT_VELODROME}',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -514,19 +496,17 @@ def test_swap_eth_to_token_v1(optimism_accounts, optimism_transaction_decoder, l
 def test_swap_token_to_eth_v2(optimism_accounts, optimism_transaction_decoder, load_global_caches):
     """Check that swapping token to eth in velodrome v2 is properly decoded."""
     _add_velodrome_pool(string_to_evm_address('0xd25711EdfBf747efCE181442Cc1D8F5F8fc8a0D3'))
-    tx_hash = deserialize_evm_tx_hash('0x15c46045b9a4b03d15f0260f6518563f9a050fd693712330d9c05bedef833886')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x15c46045b9a4b03d15f0260f6518563f9a050fd693712330d9c05bedef833886')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1695108881000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1695108881000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -573,7 +553,6 @@ def test_swap_token_to_eth_v2(optimism_accounts, optimism_transaction_decoder, l
             notes=f'Receive 0.0770899907450713 ETH as the result of a swap in {CPT_VELODROME}',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -583,19 +562,17 @@ def test_swap_token_to_eth_v1(optimism_accounts, optimism_transaction_decoder, l
     """Check that swapping token to eth in velodrome v1 is properly decoded."""
     _add_velodrome_pool(string_to_evm_address('0xe8537b6FF1039CB9eD0B71713f697DDbaDBb717d'))
     _add_velodrome_pool(string_to_evm_address('0x79c912FEF520be002c2B6e57EC4324e260f38E50'))
-    tx_hash = deserialize_evm_tx_hash('0x10d52ec5cf06d1b5b48a346334c8f0e6ef83bd281c371d762d3c163e37f629d8')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x10d52ec5cf06d1b5b48a346334c8f0e6ef83bd281c371d762d3c163e37f629d8')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1695155023000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1695155023000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -630,7 +607,6 @@ def test_swap_token_to_eth_v1(optimism_accounts, optimism_transaction_decoder, l
             notes=f'Receive 0.181508840163183003 ETH as the result of a swap in {CPT_VELODROME}',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -643,19 +619,17 @@ def test_swap_tokens_v2(optimism_accounts, optimism_transaction_decoder, load_gl
     """Check that swapping tokens in velodrome v2 is properly decoded."""
     _add_velodrome_pool(string_to_evm_address('0x1f8b46abe1EAbF5A60CbBB5Fb2e4a6A46fA0b6e6'))
     _add_velodrome_pool(string_to_evm_address('0xBf75051F6e6dF9fEcF90d9bebbBB08a85950858C'))
-    tx_hash = deserialize_evm_tx_hash('0x8c36e51bc4d3deec6a4c06a59179083adfd9caa8a5ad7e957e639d5792c9e139')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8c36e51bc4d3deec6a4c06a59179083adfd9caa8a5ad7e957e639d5792c9e139')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1697106165000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1697106165000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -702,7 +676,6 @@ def test_swap_tokens_v2(optimism_accounts, optimism_transaction_decoder, load_gl
             notes=f'Receive 1122.945013439390360367 DUSD as the result of a swap in {CPT_VELODROME}',  # noqa: E501
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -711,19 +684,17 @@ def test_swap_tokens_v2(optimism_accounts, optimism_transaction_decoder, load_gl
 def test_swap_tokens_v1(optimism_accounts, optimism_transaction_decoder, load_global_caches):
     """Check that swapping tokens in velodrome v1 is properly decoded."""
     _add_velodrome_pool(string_to_evm_address('0xcdd41009E74bD1AE4F7B2EeCF892e4bC718b9302'))
-    tx_hash = deserialize_evm_tx_hash('0x398538615367f778e9bb7fd95b3f96ee52e2192880b6f6331f91530ae4c829d9')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x398538615367f778e9bb7fd95b3f96ee52e2192880b6f6331f91530ae4c829d9')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1695193815000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1695193815000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -758,7 +729,6 @@ def test_swap_tokens_v1(optimism_accounts, optimism_transaction_decoder, load_gl
             notes=f'Receive 67.507104801871949085 OP as the result of a swap in {CPT_VELODROME}',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -774,19 +744,17 @@ def test_stake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_deco
         protocol=CPT_VELODROME,
         symbol='vAMMV2-WETH/OP',
     )
-    tx_hash = deserialize_evm_tx_hash('0x1bfa588dc839b13205e80bbfd7b7748a4c599854a03b52bb5476d6edae2e95a9')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x1bfa588dc839b13205e80bbfd7b7748a4c599854a03b52bb5476d6edae2e95a9')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1694639877000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1694639877000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -822,7 +790,6 @@ def test_stake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_deco
             notes=f'Deposit 0.172627291949741834 vAMMV2-WETH/OP into {WETH_OP_GAUGE_ADDRESS} velodrome gauge',  # noqa: E501,
         ),
     ]
-    assert events == expected_events
     assert EvmToken(WETH_OP_LP_TOKEN).protocol == CPT_VELODROME
 
 
@@ -831,19 +798,17 @@ def test_stake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_deco
 @pytest.mark.parametrize('optimism_accounts', [['0x78C13393Aee675DD7ED07ce992210750D1F5dB88']])
 def test_unstake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_decoder, load_global_caches):  # noqa: E501
     """Check that withdrawing lp tokens from a velodrome v2 gauge is properly decoded."""
-    tx_hash = deserialize_evm_tx_hash('0xe774e27053cab2c9cc293d6b1010d024a9a6af57fb6645ca52f0c5a26d117eeb')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe774e27053cab2c9cc293d6b1010d024a9a6af57fb6645ca52f0c5a26d117eeb')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1694676717000)
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1694676717000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -867,7 +832,6 @@ def test_unstake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_de
             notes=f'Withdraw 0.172627291949741834 vAMMV2-WETH/OP from {WETH_OP_GAUGE_ADDRESS} velodrome gauge',  # noqa: E501,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -876,20 +840,18 @@ def test_unstake_lp_token_to_gauge_v2(optimism_accounts, optimism_transaction_de
 @pytest.mark.parametrize('optimism_accounts', [['0xf9AEb52bB4eF74E1987dd295E4Df326d41D0d0fF']])
 def test_get_reward_from_gauge_v2(optimism_accounts, optimism_transaction_decoder, load_global_caches):  # noqa: E501
     """Check claiming rewards from a velodrome v2 gauge is properly decoded."""
-    tx_hash = deserialize_evm_tx_hash('0x9d0eae3c2d2cda853e77a2571a7c702507beb015c08b40406e03baa4b1dde505')  # noqa: E501
     user_address = optimism_accounts[0]
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x9d0eae3c2d2cda853e77a2571a7c702507beb015c08b40406e03baa4b1dde505')),  # noqa: E501
         load_global_caches=load_global_caches,
     )
-    timestamp = TimestampMS(1695116021000)
     gauge_address = string_to_evm_address('0x84195De69B8B131ddAa4Be4F75633fCD7F430b7c')
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1695116021000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -913,7 +875,6 @@ def test_get_reward_from_gauge_v2(optimism_accounts, optimism_transaction_decode
             notes=f'Receive 872.22115188616298484 VELO rewards from {gauge_address} velodrome gauge',  # noqa: E501,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -925,7 +886,7 @@ def test_unlock_velo(optimism_accounts, optimism_transaction_decoder):
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
         tx_hash=tx_hash,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -966,7 +927,6 @@ def test_unlock_velo(optimism_accounts, optimism_transaction_decoder):
             notes=f'Receive {withdrawn_amt} VELO from vote escrow after burning veNFT-27891',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -978,7 +938,7 @@ def test_lock_velo(optimism_accounts, optimism_transaction_decoder):
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
         tx_hash=tx_hash,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1032,7 +992,6 @@ def test_lock_velo(optimism_accounts, optimism_transaction_decoder):
             notes=f'Receive veNFT-30079 for locking {lock_amount} VELO in vote escrow',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1044,7 +1003,7 @@ def test_increase_locked_amount(optimism_accounts, optimism_transaction_decoder)
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
         tx_hash=tx_hash,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1085,7 +1044,6 @@ def test_increase_locked_amount(optimism_accounts, optimism_transaction_decoder)
             extra_data={'token_id': 20820},
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1097,7 +1055,7 @@ def test_increase_unlock_time(optimism_accounts, optimism_transaction_decoder):
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
         tx_hash=tx_hash,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1126,7 +1084,6 @@ def test_increase_unlock_time(optimism_accounts, optimism_transaction_decoder):
             notes='Increase unlock time to 12/06/2025 for VELO veNFT-30064',
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -1150,7 +1107,7 @@ def test_claim_bribes(optimism_accounts, optimism_transaction_decoder, globaldb)
         evm_inquirer=optimism_transaction_decoder.evm_inquirer,
         tx_hash=tx_hash,
     )
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -1217,4 +1174,3 @@ def test_claim_bribes(optimism_accounts, optimism_transaction_decoder, globaldb)
             notes=f'Claim {receive_amount_4} tBTC from velodrome as a fee',
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_votium.py
+++ b/rotkehlchen/tests/unit/decoders/test_votium.py
@@ -19,17 +19,17 @@ def test_votium_claim_1(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x75b81b2edd454a7b564cc55a6b676e2441e155401bde99a38d867028081d2c30')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, amount = TimestampMS(1646375440000), '0.005264399856069432', '12.369108326706528256'  # noqa: E501
-    expected_events = [
+    amount = '12.369108326706528256'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1646375440000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.005264399856069432'),
             location_label=user_address,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -48,7 +48,6 @@ def test_votium_claim_1(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_VOTIUM,
             address=VOTIUM_CONTRACTS[0],
         )]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -58,17 +57,17 @@ def test_votium_claim_2(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x27b48aa8f0f02e8e35f182925e2efb2a299a1410641d96de4de98666d28b36c7')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, gas, amount = TimestampMS(1678972523000), '0.001771703400663612', '0.130390330817010288'  # noqa: E501
-    expected_events = [
+    amount = '0.130390330817010288'
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1678972523000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas),
+            amount=FVal(gas := '0.001771703400663612'),
             location_label=user_address,
             notes=f'Burn {gas} ETH for gas',
             counterparty=CPT_GAS,
@@ -87,4 +86,3 @@ def test_votium_claim_2(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_VOTIUM,
             address=VOTIUM_CONTRACTS[1],
         )]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_walletconnect.py
+++ b/rotkehlchen/tests/unit/decoders/test_walletconnect.py
@@ -35,17 +35,17 @@ def test_airdrop_claim(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x1bf831eb53a09cbd1ed309b938d3a09d0a00c17cd777830e3a47f49422eff3e6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, token_amount = TimestampMS(1732720037000), optimism_accounts[0], '0.000002227023099306', '181.44172120901'  # noqa: E501
+    user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732720037000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000002227023099306'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -57,7 +57,7 @@ def test_airdrop_claim(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.AIRDROP,
             asset=Asset(WCT_TOKEN_ID),
-            amount=FVal(token_amount),
+            amount=FVal(token_amount := '181.44172120901'),
             location_label=user_address,
             notes=f'Claim {token_amount} WCT from walletconnect airdrop',
             counterparty=CPT_WALLETCONNECT,
@@ -76,17 +76,18 @@ def test_stake(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0xcc691ea8eeb56fd5f5ceb98879e3571ee167a2ac4c5bad4c9463127262d096af')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, token_amount, lock_timestamp = TimestampMS(1732726673000), optimism_accounts[0], '0.000000666285515991', '184.286559270201', 1734566400  # noqa: E501
+    user_address = optimism_accounts[0]
+    lock_timestamp = 1734566400
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732726673000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000000666285515991'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -98,7 +99,7 @@ def test_stake(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=Asset(WCT_TOKEN_ID),
-            amount=FVal(token_amount),
+            amount=FVal(token_amount := '184.286559270201'),
             location_label=user_address,
             notes=f'Stake {token_amount} WCT until {decoder.decoders["Walletconnect"].timestamp_to_date(lock_timestamp)}',  # type: ignore  # noqa: E501
             counterparty=CPT_WALLETCONNECT,
@@ -117,17 +118,17 @@ def test_unstake(
 ) -> None:
     tx_hash = deserialize_evm_tx_hash('0x73d20d4ad0af8350fa66e9d8ee5a83b65b5099cde5a9ae51299c440793951b18')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, token_amount = TimestampMS(1732792847000), optimism_accounts[0], '0.000004252055654884', '248'  # noqa: E501
+    user_address = optimism_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732792847000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000004252055654884'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -139,7 +140,7 @@ def test_unstake(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.REMOVE_ASSET,
             asset=Asset(WCT_TOKEN_ID),
-            amount=FVal(token_amount),
+            amount=FVal(token_amount := '248'),
             location_label=user_address,
             notes=f'Unstake {token_amount} WCT',
             counterparty=CPT_WALLETCONNECT,
@@ -164,17 +165,18 @@ def test_increase_lock(
     )
     tx_hash = deserialize_evm_tx_hash('0xbf5de8df32c5faa598b56f0235f51ca779a659ee4686e959d89fc38798c62c54')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, unlock_time = TimestampMS(1732793011000), optimism_accounts[0], '0.000002761170017713', 1736985600  # noqa: E501
+    user_address = optimism_accounts[0]
+    unlock_time = 1736985600
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732793011000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000002761170017713'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -206,17 +208,18 @@ def test_update_lock(
     """Updates an existing staking lock by adding more WCT to it"""
     tx_hash = deserialize_evm_tx_hash('0xf5c75dc26c66075cea2105cae62f31200a2518123b6106876229e661573bada7')  # noqa: E501
     events, decoder = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, user_address, gas_amount, token_amount, unlock_time = TimestampMS(1732792963000), optimism_accounts[0], '0.000003454138559574', '100.003508602839', 1738800000  # noqa: E501
+    user_address = optimism_accounts[0]
+    unlock_time = 1738800000
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1732792963000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000003454138559574'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -228,7 +231,7 @@ def test_update_lock(
             event_type=HistoryEventType.STAKING,
             event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
             asset=Asset(WCT_TOKEN_ID),
-            amount=FVal(token_amount),
+            amount=FVal(token_amount := '100.003508602839'),
             location_label=user_address,
             notes=f'Stake {token_amount} WCT until {decoder.decoders["Walletconnect"].timestamp_to_date(unlock_time)}',  # type: ignore  # noqa: E501
             counterparty=CPT_WALLETCONNECT,

--- a/rotkehlchen/tests/unit/decoders/test_weth.py
+++ b/rotkehlchen/tests/unit/decoders/test_weth.py
@@ -54,14 +54,13 @@ def test_weth_deposit(ethereum_inquirer):
     https://etherscan.io/tx/0x5bb623b365def9650816dcbaf1babde8fd0ebed737db36d3a033d7cf63792daf
     """
     tx_hash = deserialize_evm_tx_hash('0x5bb623b365def9650816dcbaf1babde8fd0ebed737db36d3a033d7cf63792daf')  # noqa: E501
-    timestamp = TimestampMS(1666256147000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert len(events) == 3
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1666256147000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -98,7 +97,6 @@ def test_weth_deposit(ethereum_inquirer):
             address=WETH_MAINNET_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -109,14 +107,13 @@ def test_weth_withdrawal(ethereum_inquirer):
     https://etherscan.io/tx/0x1f3aa6f7d33bfaaaf9cdd92b16fecdf911341601c02ad89b4ec0b80c66c28a07
     """
     tx_hash = deserialize_evm_tx_hash('0x1f3aa6f7d33bfaaaf9cdd92b16fecdf911341601c02ad89b4ec0b80c66c28a07')  # noqa: E501
-    timestamp = TimestampMS(1666256147000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert len(events) == 3
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1666256147000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -153,7 +150,6 @@ def test_weth_withdrawal(ethereum_inquirer):
             address=WETH_MAINNET_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -164,14 +160,13 @@ def test_weth_interaction_with_protocols_deposit(database, ethereum_inquirer):
     https://etherscan.io/tx/0xab0dec3785632c567365c48ea1fd1178f0998773136a555912625d2668ef53e9
     """
     tx_hash = deserialize_evm_tx_hash('0xab0dec3785632c567365c48ea1fd1178f0998773136a555912625d2668ef53e9')  # noqa: E501
-    timestamp = TimestampMS(1666595591000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert len(events) == 4
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1666595591000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -221,7 +216,6 @@ def test_weth_interaction_with_protocols_deposit(database, ethereum_inquirer):
             address=ZERO_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -235,7 +229,7 @@ def test_weth_interaction_with_protocols_withdrawal(ethereum_inquirer):
     timesatmp = TimestampMS(1666284551000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert len(events) == 3
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -276,7 +270,6 @@ def test_weth_interaction_with_protocols_withdrawal(ethereum_inquirer):
             address=string_to_evm_address('0xC36442b4a4522E871399CD717aBDD847Ab11FE88'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -287,14 +280,13 @@ def test_weth_interaction_errors(ethereum_inquirer):
     https://etherscan.io/tx/0x4ca19c97b7533e74f36dff18acf0115055f63f9d8ae078dfc8ab15ceb14d2f2d
     """
     tx_hash = deserialize_evm_tx_hash('0x4ca19c97b7533e74f36dff18acf0115055f63f9d8ae078dfc8ab15ceb14d2f2d')  # noqa: E501
-    timestamp = TimestampMS(1666800983000)
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     assert len(events) == 3
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1666800983000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -329,7 +321,6 @@ def test_weth_interaction_errors(ethereum_inquirer):
             address=string_to_evm_address('0xe66B31678d6C16E9ebf358268a790B763C133750'),
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -338,14 +329,13 @@ def test_wxdai_unwrap(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0xa6af9ea737de26c87a36367fd896a8fe471049f4c18ac909901336aaccbf2369')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1707739650000)
     gas_amount, unwrapped_amount = '0.0000886822502438', '555.374747825771664891'
     wxdai_address = A_WXDAI.resolve_to_evm_token().evm_address
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1707739650000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -383,8 +373,6 @@ def test_wxdai_unwrap(gnosis_inquirer, gnosis_accounts):
         ),
     ]
 
-    assert events == expected_events
-
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('gnosis_accounts', [['0xd6f585378F3232E440B165AD56658bFcA76D1B32']])
@@ -392,14 +380,13 @@ def test_wxdai_wrap(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x8cf8362f36e5a76912bc05ef804c0ea4b4f2de54700afe9ced99aa486f3dd0e8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1707744465000)
     gas_amount, wrapped_amount = '0.0000586761', '103'
     wxdai_address = A_WXDAI.resolve_to_evm_token().evm_address
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1707744465000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -437,24 +424,20 @@ def test_wxdai_wrap(gnosis_inquirer, gnosis_accounts):
         ),
     ]
 
-    assert events == expected_events
-
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xBE6660FBE96B61B72Bf35FFaB40eB2CA886A7f85']])
 def test_weth_withdraw_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xc19c7e1e0af7819b1922a287d034540e8f8dba4e065317d6483d48ac27e727e9')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc19c7e1e0af7819b1922a287d034540e8f8dba4e065317d6483d48ac27e727e9')),  # noqa: E501
     )
-    timestamp = TimestampMS(1712238368000)
     amount, gas_fees = '0.00052', '0.00000108547'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712238368000)),
             location=Location.ARBITRUM_ONE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -491,19 +474,17 @@ def test_weth_withdraw_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts
             address=WETH_ARB_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0x7aBAee8F04EFd689961115f7A28bAA2E73Be6703']])
 def test_weth_deposit_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x57cc837c6f3d84c8fa3db8a7405f7244f11d32152159edf5ba79f5a7c34919b8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x57cc837c6f3d84c8fa3db8a7405f7244f11d32152159edf5ba79f5a7c34919b8')),  # noqa: E501
     )
     user, amount, gas_fees, timestamp = arbitrum_one_accounts[0], '0.007767825959188763', '0.000001382891214', TimestampMS(1712328694000)  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -544,7 +525,6 @@ def test_weth_deposit_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts)
             address=WETH_ARB_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -553,13 +533,12 @@ def test_weth_deposit_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts)
 def test_weth_withdraw_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4a6b47e1f622a8ad059bd0723c53f2c71f12e7b105d2ef2ff4dff07ac1f185c0')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1712240095000)
     amount, gas_fees = '0.000518962654328944', '0.000001897927938075'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712240095000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -596,7 +575,6 @@ def test_weth_withdraw_optimism(optimism_inquirer, optimism_accounts):
             address=WETH_OP_BASE_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -605,13 +583,12 @@ def test_weth_withdraw_optimism(optimism_inquirer, optimism_accounts):
 def test_weth_deposit_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x42074e2228be1716f84888f1993fa62443f591945b21dfbf159a64ae467990c4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1712241853000)
     amount, gas_fees = '0.0345', '0.000002820767318933'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712241853000)),
             location=Location.OPTIMISM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -648,7 +625,6 @@ def test_weth_deposit_optimism(optimism_inquirer, optimism_accounts):
             address=WETH_OP_BASE_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(allow_playback_repeats=True, filter_query_parameters=['apikey'])
@@ -656,13 +632,12 @@ def test_weth_deposit_optimism(optimism_inquirer, optimism_accounts):
 def test_weth_withdraw_scroll(scroll_inquirer, scroll_accounts, allow_scroll_etherscan):
     tx_hash = deserialize_evm_tx_hash('0x88f49633073a7667f93eb888ec2151c26f449cc10afca565a15f8df68ee20f82')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1712239879000)
     amount, gas_fees = '0.00211824', '0.000194659253936861'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712239879000)),
             location=Location.SCROLL,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -699,7 +674,6 @@ def test_weth_withdraw_scroll(scroll_inquirer, scroll_accounts, allow_scroll_eth
             address=WETH_SCROLL_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(allow_playback_repeats=True, filter_query_parameters=['apikey'])
@@ -707,13 +681,12 @@ def test_weth_withdraw_scroll(scroll_inquirer, scroll_accounts, allow_scroll_eth
 def test_weth_deposit_scroll(scroll_inquirer, scroll_accounts, allow_scroll_etherscan):
     tx_hash = deserialize_evm_tx_hash('0x1fa6d87801891fcea66a9be2d4fce1c52569c5ce30579fbe7de37eb05bd247f8')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=scroll_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1712239897000)
     amount, gas_fees = '0.135', '0.000199290832110225'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712239897000)),
             location=Location.SCROLL,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -750,7 +723,6 @@ def test_weth_deposit_scroll(scroll_inquirer, scroll_accounts, allow_scroll_ethe
             address=WETH_SCROLL_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -759,13 +731,12 @@ def test_weth_deposit_scroll(scroll_inquirer, scroll_accounts, allow_scroll_ethe
 def test_weth_withdraw_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x8d54608c2f684d880ad40a16cf9b82525c51520798ae8875d543d3338327ddad')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1712239837000)
     amount, gas_fees = '0.00022448658511341', '0.000000533995613184'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712239837000)),
             location=Location.BASE,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -802,7 +773,6 @@ def test_weth_withdraw_base(base_inquirer, base_accounts):
             address=WETH_OP_BASE_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -810,7 +780,7 @@ def test_weth_withdraw_base(base_inquirer, base_accounts):
 @pytest.mark.parametrize('base_accounts', [['0xf396e7dbb20489D47F2daBfDA013163223B892a0']])
 def test_weth_deposit_base(base_inquirer, base_accounts):
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=(tx_hash := deserialize_evm_tx_hash('0x0d418e4a858ca5faf00c36b685561ca0fdac52ebd10364bf2cb6d7b5969e84e5')))  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
@@ -851,7 +821,6 @@ def test_weth_deposit_base(base_inquirer, base_accounts):
             address=WETH_OP_BASE_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -899,18 +868,16 @@ def test_weth_withdraw_base_without_transfer_log(
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x33C0Aae5b2b6Eae2a6286B3a6621B55DcC02dC9e']])
 def test_wmatic_deposit_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xba581391d417a6dcc31031f1cf7cba6e63b701a8680828445ffdde73777843e1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xba581391d417a6dcc31031f1cf7cba6e63b701a8680828445ffdde73777843e1')),  # noqa: E501
     )
-    timestamp = TimestampMS(1712851902000)
     amount, gas_fees = '119.97566999849747', '0.007112105381183941'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712851902000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -947,24 +914,21 @@ def test_wmatic_deposit_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
             address=WMATIC_ADDRESS,
         ),
     ]
-    assert events == expected_events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xdAA9E3CA7500d7Ba3855dF9d8BCCde229C13919e']])
 def test_wmatic_withdraw_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0xe90ed71875ff44ea45ea960d006ec4c0ccb86506cba494471aba4ba9dc86123f')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xe90ed71875ff44ea45ea960d006ec4c0ccb86506cba494471aba4ba9dc86123f')),  # noqa: E501
     )
-    timestamp = TimestampMS(1712851796000)
     amount, gas_fees = '4.9750995', '0.007687202027240021'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1712851796000)),
             location=Location.POLYGON_POS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -1001,4 +965,3 @@ def test_wmatic_withdraw_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts)
             address=WMATIC_ADDRESS,
         ),
     ]
-    assert events == expected_events

--- a/rotkehlchen/tests/unit/decoders/test_xdai_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_xdai_bridge.py
@@ -29,12 +29,11 @@ def test_bridge_dai_from_ethereum(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xe17f61edb9fe278720679ecfd5498f75082e38bf4779e5e6403a551f5084ee23')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1697470703000)
     amount = FVal('19.997099097418611102')
     assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1697470703000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -104,12 +103,11 @@ def test_bridge_dai_from_ethereum_nolog(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x196e7d687e1e2ce280dbe7f52b6ffe5a61d3a851b38740a37d1d00caffce7562')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address = ethereum_accounts[0]
-    timestamp = TimestampMS(1705093391000)
     gas, amount = '0.00115669008897503', '193.961036565990280733'
     assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1705093391000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -142,12 +140,11 @@ def test_withdraw_dai_to_ethereum(ethereum_inquirer, ethereum_accounts):
     user_address = ethereum_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0xb151a9294e7cdf9b62d5716eff3d69cc96c6fa3f1279b1d36c16896bd9cb3b32')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1697473655000)
     amount = FVal(900)
     assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1697473655000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -180,12 +177,11 @@ def test_withdraw_dai_from_gnosis(gnosis_inquirer, gnosis_accounts):
     user_address = gnosis_accounts[0]
     tx_hash = deserialize_evm_tx_hash('0x1a7014cbc1e6af2558c3a3cafd7fe87d8d67d27242b5abe8af0d4bf51a5230f6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1697473395000)
     amount = FVal(900)
     assert events == [
         EvmEvent(
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1697473395000)),
             location=Location.GNOSIS,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,

--- a/rotkehlchen/tests/unit/decoders/test_yearn.py
+++ b/rotkehlchen/tests/unit/decoders/test_yearn.py
@@ -143,17 +143,16 @@ def test_deposit_yearn_v3(
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
     user_address, vault_address = ethereum_accounts[0], string_to_evm_address('0xBF319dDC2Edc1Eb6FDf9910E39b37Be221C8805F')  # noqa: E501
-    timestamp, gas_amount, deposit_amount, receive_amount, approve_amount = TimestampMS(1722289343000), '0.000357122879546472', '7445', '7336.974656759870797081', '57896044618658097711785492504343953926634992332820282012283.792003956564819967'  # noqa: E501
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1722289343000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.000357122879546472'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -165,7 +164,7 @@ def test_deposit_yearn_v3(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:1/erc20:0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E'),
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '57896044618658097711785492504343953926634992332820282012283.792003956564819967'),  # noqa: E501
             location_label=user_address,
             notes=f'Set crvUSD spending approval of {user_address} by {vault_address} to {approve_amount}',  # noqa: E501
             address=vault_address,
@@ -177,7 +176,7 @@ def test_deposit_yearn_v3(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:1/erc20:0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E'),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '7445'),
             location_label=user_address,
             notes=f'Deposit {deposit_amount} crvUSD in yearn-v3 vault crvUSD-2 yVault',
             counterparty=CPT_YEARN_V3,
@@ -190,7 +189,7 @@ def test_deposit_yearn_v3(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:1/erc20:0xBF319dDC2Edc1Eb6FDf9910E39b37Be221C8805F'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '7336.974656759870797081'),
             location_label=user_address,
             notes=f'Receive {receive_amount} yvcrvUSD-2 after deposit in a yearn-v3 vault',
             counterparty=CPT_YEARN_V3,
@@ -293,17 +292,17 @@ def test_deposit_yearn_v2(
         )],
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, deposit_amount, receive_amount, approve_amount = TimestampMS(1729145687000), ethereum_accounts[0], '0.001446241576196176', '38541.366598671832692528', '38514.207134567395983686', '57896044618658097711785492504343953926634992332820281981187.425405284732127439'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1729145687000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.001446241576196176'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -315,7 +314,7 @@ def test_deposit_yearn_v2(
             event_type=HistoryEventType.INFORMATIONAL,
             event_subtype=HistoryEventSubType.APPROVE,
             asset=Asset('eip155:1/erc20:0xef484de8C07B6e2d732A92B5F78e81B38f99f95E'),
-            amount=FVal(approve_amount),
+            amount=FVal(approve_amount := '57896044618658097711785492504343953926634992332820281981187.425405284732127439'),  # noqa: E501
             location_label=user_address,
             notes=f'Set crvDOLA spending approval of {user_address} by {YEARN_PARTNER_TRACKER} to {approve_amount}',  # noqa: E501
             address=YEARN_PARTNER_TRACKER,
@@ -327,7 +326,7 @@ def test_deposit_yearn_v2(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=Asset('eip155:1/erc20:0xef484de8C07B6e2d732A92B5F78e81B38f99f95E'),
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '38541.366598671832692528'),
             location_label=user_address,
             notes=f'Deposit {deposit_amount} crvDOLA in yearn-v2 vault',
             counterparty=CPT_YEARN_V2,
@@ -340,7 +339,7 @@ def test_deposit_yearn_v2(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:1/erc20:0xcC2EFb8bEdB6eD69ADeE0c3762470c38D4730C50'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '38514.207134567395983686'),
             location_label=user_address,
             notes=f'Receive {receive_amount} yvCurve-crvDOLA-f after deposit in a yearn-v2 vault',
             counterparty=CPT_YEARN_V2,
@@ -374,17 +373,17 @@ def test_increase_deposit_yearn_v2(
         )],
     )
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, user_address, gas_amount, deposit_amount, receive_amount = TimestampMS(1729346255000), ethereum_accounts[0], '0.0020739662607066', '10000', '9035.10865'  # noqa: E501
+    user_address = ethereum_accounts[0]
     assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1729346255000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_amount),
+            amount=FVal(gas_amount := '0.0020739662607066'),
             location_label=user_address,
             notes=f'Burn {gas_amount} ETH for gas',
             counterparty=CPT_GAS,
@@ -396,7 +395,7 @@ def test_increase_deposit_yearn_v2(
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
             asset=A_USDC,
-            amount=FVal(deposit_amount),
+            amount=FVal(deposit_amount := '10000'),
             location_label=user_address,
             notes=f'Deposit {deposit_amount} USDC in yearn-v2 vault',
             counterparty=CPT_YEARN_V2,
@@ -409,7 +408,7 @@ def test_increase_deposit_yearn_v2(
             event_type=HistoryEventType.RECEIVE,
             event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
             asset=Asset('eip155:1/erc20:0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE'),
-            amount=FVal(receive_amount),
+            amount=FVal(receive_amount := '9035.10865'),
             location_label=user_address,
             notes=f'Receive {receive_amount} yvUSDC after deposit in a yearn-v2 vault',
             counterparty=CPT_YEARN_V2,

--- a/rotkehlchen/tests/unit/decoders/test_ygov.py
+++ b/rotkehlchen/tests/unit/decoders/test_ygov.py
@@ -16,14 +16,13 @@ from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
 def test_ygov_stake(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x1c596eb9189d124418d5bd060cb702acf20be8f7b18220fbec9b94a99b95c1d3')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1594992345000)
     addy_user = ethereum_accounts[0]
     gas_amount, deposited_amount = '0.005269935', '1736.929114514645653598'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1594992345000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -48,7 +47,6 @@ def test_ygov_stake(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_YGOV,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -56,14 +54,13 @@ def test_ygov_stake(ethereum_inquirer, ethereum_accounts):
 def test_ygov_get_reward(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x9063899641457daf68518b7017a4df30a79a0630224528aee0f2c483db76fc58')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1623310131000)
     addy_user = ethereum_accounts[0]
     gas_amount, reward_amount = '0.0010707', '0.224594237566776997'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1623310131000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -88,7 +85,6 @@ def test_ygov_get_reward(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_YGOV,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -96,14 +92,13 @@ def test_ygov_get_reward(ethereum_inquirer, ethereum_accounts):
 def test_ygov_exit(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x42787b2b175d7f09401c3fd68c92f78982de2deef2214196261a31258c68006b')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1633109458000)
     addy_user = ethereum_accounts[0]
     gas_amount, reward_amount, withdrawn_amount = '0.012938107', '2.281399151169433806', '665811.174187646507558478'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1633109458000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
@@ -142,4 +137,3 @@ def test_ygov_exit(ethereum_inquirer, ethereum_accounts):
             counterparty=CPT_YGOV,
         ),
     ]
-    assert expected_events == events

--- a/rotkehlchen/tests/unit/decoders/test_zerox.py
+++ b/rotkehlchen/tests/unit/decoders/test_zerox.py
@@ -35,7 +35,6 @@ from rotkehlchen.types import Location, SupportedBlockchain, TimestampMS, deseri
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
 
-
 A_AI: Final = Asset(strethaddress_to_identifier('0x2598c30330D5771AE9F983979209486aE26dE875'))
 A_DRGN: Final = Asset(strethaddress_to_identifier('0x419c4dB4B9e25d6Db2AD9691ccb832C8D9fDA05E'))
 A_MYRIA: Final = Asset(strethaddress_to_identifier('0xA0Ef786Bf476fE0810408CaBA05E536aC800ff86'))
@@ -65,12 +64,11 @@ A_BULL: Final = Asset('eip155:137/erc20:0x9f95e17b2668AFE01F8fbD157068b0a4405Cc0
 def test_sell_to_uniswap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xb9827174e182a1b8df3507d13c5cedccdc974c4edd5d66f59355f7e9758b9006')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709225123000)
     swap_amount, received_amount, gas_fees = '12.425145745058641', '646.553802069266414457', '0.018008266883477871'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709225123000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -112,12 +110,11 @@ def test_sell_to_uniswap(ethereum_inquirer, ethereum_accounts):
 def test_sell_eth_for_token_to_uniswap_v3(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x5b7719016f7d7d3d8ed9d4d86afd0e0079551d0a7795f70f01764ce5eaa44478')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709222447000)
     swap_amount, received_amount, gas_fees = '0.2882978462709', '85192.182824334037015387', '0.007717607607009392'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709222447000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -159,12 +156,11 @@ def test_sell_eth_for_token_to_uniswap_v3(ethereum_inquirer, ethereum_accounts):
 def test_sell_token_for_eth_to_uniswap_v3(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x68416e19252c678cdf67ae9b7adff742d78f95cea3c3f0582d3dc930340e5bdf')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709225147000)
     swap_amount, received_amount, gas_fees = '150000', '1.446309922122136822', '0.013066559749685724'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709225147000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -206,12 +202,11 @@ def test_sell_token_for_eth_to_uniswap_v3(ethereum_inquirer, ethereum_accounts):
 def test_sell_token_for_token_to_uniswap_v3(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6efe8a18de9ca3183bdb319be445f1b0b9041c0e8208fa04a58ee276b54574dd')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709054219000)
     swap_amount, received_amount, gas_fees = '26035459.499107021225491254', '6627.784156933620641174', '0.011785737692958302'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709054219000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -253,12 +248,11 @@ def test_sell_token_for_token_to_uniswap_v3(ethereum_inquirer, ethereum_accounts
 def test_multiplex_batch_sell_eth_for_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa151bc4f1c69591598386eaa65761cefd706cbfe0a1a340d8856dbfe2c3bd8c5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709282363000)
     swap_amount, received_amount, gas_fees = '1.160624381328078', '155577.466855002838240404', '0.0083327194970355'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709282363000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -300,12 +294,11 @@ def test_multiplex_batch_sell_eth_for_token(ethereum_inquirer, ethereum_accounts
 def test_multiplex_batch_sell_token_for_eth(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xf9b40a3bbbd92fe72099cff45564e099782fc9b0b4bd40c2d87484b43735b3b1')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709306375000)
     swap_amount, received_amount, gas_fees = '13438.664993496960137988', '2.669421884825430502', '0.01627396521423088'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709306375000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -347,12 +340,11 @@ def test_multiplex_batch_sell_token_for_eth(ethereum_inquirer, ethereum_accounts
 def test_multiplex_batch_sell_token_for_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x0f422be6e6904700181c3effb0600a8ed7e1616e70e6587d383b29290d6a7c1d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709300411000)
     swap_amount, received_amount, gas_fees = '125.156732374288853661', '43405.98545005', '0.018050672959219548'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709300411000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -394,12 +386,11 @@ def test_multiplex_batch_sell_token_for_token(ethereum_inquirer, ethereum_accoun
 def test_multiplex_multihop_sell_token_for_token(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xceccb105d312df00105eca2560b8da4cd0e791bb0f0da4cebeb17ca46abf2ce4')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709652443000)
     swap_amount, received_amount, gas_fees = '64666', '143469.489576604990799103', '0.03327224673453317'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709652443000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -442,12 +433,11 @@ def test_0x415565b0_eth_to_token(ethereum_inquirer, ethereum_accounts):
     """Test ETH to Token swaps done through 0x415565b0 method ID via the 0x protocol router contract."""  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x56dd5341b27b744e3ef3a2f356a6db48cb811397495a4cb9e8924c8232ef9abc')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709302619000)
     swap_amount, received_amount, gas_fees = '2.9077036701035723', '688264582.664559041869620658', '0.016733414171811015'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709302619000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -490,12 +480,11 @@ def test_0x415565b0_token_to_eth(ethereum_inquirer, ethereum_accounts):
     """Test Token to ETH swaps done through 0x415565b0 method ID via the 0x protocol router contract."""  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0xc4bab35f7499def296e9ccb08eebd8933ad8c37ff2701f2750027600f9050c55')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709302223000)
     swap_amount, received_amount, gas_fees = '5000', '1.450387601635590055', '0.01419246270466794'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709302223000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -538,12 +527,11 @@ def test_0x415565b0_token_to_token(ethereum_inquirer, ethereum_accounts):
     """Test Token to Token swaps done through 0x415565b0 method ID via the 0x protocol router contract."""  # noqa: E501
     tx_hash = deserialize_evm_tx_hash('0x29bd536ecd4cacec3495b02f6375ab7465be64fff015916484746cd18da7a37d')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709301911000)
     swap_amount, received_amount, gas_fees = '1496', '1480.467089', '0.014804818364279386'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709301911000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -586,12 +574,11 @@ def test_execute_meta_transaction_v2(ethereum_inquirer, ethereum_accounts):
     """Test meta transaction swaps done via the 0x protocol router contract."""
     tx_hash = deserialize_evm_tx_hash('0xb77f8e36a86517928f890296a263cafafa48ef01c6cc424a838b59b4401bf314')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709638007000)
     swap_amount, received_amount, meta_tx_fees = '1405.596892', '4910.533168813496285354', '58.171192'  # noqa: E501
     expected_events = [EvmSwapEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709638007000)),
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_USDT,
@@ -634,12 +621,11 @@ def test_execute_meta_transaction_v2_multiplex(ethereum_inquirer, ethereum_accou
     """Test meta transaction multiplex swaps done via the 0x protocol router contract."""
     tx_hash = deserialize_evm_tx_hash('0x48f48d62b9829152c5963716acaed198320595859093cfc8a117742287f5a5eb')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709641247000)
     swap_amount, received_amount, meta_tx_fees = '49934.597014', '352963.071479518181477885', '65.402986'  # noqa: E501
     expected_events = [EvmSwapEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709641247000)),
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_USDT,
@@ -682,12 +668,11 @@ def test_execute_meta_transaction_v2_flash(ethereum_inquirer, ethereum_accounts)
     """Test meta transaction swaps done via the 0x protocol using its flash contract."""
     tx_hash = deserialize_evm_tx_hash('0xf0be288974b275768725e7322c66d4086bd9b70bac4427af394966d333c0c807')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709633675000)
     swap_amount, received_amount, meta_tx_fees = '10659.465069', '25162.301091908076364354', '60.028487'  # noqa: E501
     expected_events = [EvmSwapEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709633675000)),
         location=Location.ETHEREUM,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_USDT,
@@ -727,17 +712,15 @@ def test_execute_meta_transaction_v2_flash(ethereum_inquirer, ethereum_accounts)
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0x701D5a3344C98765b36014A8a71941f499A2Bc75']])
 def test_swap_on_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x8e7c52d519d1ca0d1dfd8c8c21a2d2c34574e2bdada0ae7faafd49c1ddb8e8a6')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x8e7c52d519d1ca0d1dfd8c8c21a2d2c34574e2bdada0ae7faafd49c1ddb8e8a6')),  # noqa: E501
     )
-    timestamp = TimestampMS(1709653684000)
     swap_amount, received_amount, gas_fees = '0.130848158787696777', '0.146129', '0.05669366828688572'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709653684000)),
         location=Location.POLYGON_POS,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -779,16 +762,15 @@ def test_swap_on_polygon_pos(polygon_pos_inquirer, polygon_pos_accounts):
 def test_swap_on_binance_sc(binance_sc_inquirer, binance_sc_accounts):
     tx_hash = deserialize_evm_tx_hash('0xea3ec21b6e96e4972dbe734b10c417f451d5dc2b193aed37d5e9c28b4460a529')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=binance_sc_inquirer, tx_hash=tx_hash)  # noqa: E501
-    timestamp, swap_amount, received_amount, gas_fees = TimestampMS(1742473783000), '1', '1011.063746262162828865', '0.0003771'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1742473783000)),
         location=Location.BINANCE_SC,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_BSC_BNB,
-        amount=FVal(gas_fees),
+        amount=FVal(gas_fees := '0.0003771'),
         location_label=binance_sc_accounts[0],
         notes=f'Burn {gas_fees} BNB for gas',
         counterparty=CPT_GAS,
@@ -799,7 +781,7 @@ def test_swap_on_binance_sc(binance_sc_inquirer, binance_sc_accounts):
         location=Location.BINANCE_SC,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_BSC_BNB,
-        amount=FVal(swap_amount),
+        amount=FVal(swap_amount := '1'),
         location_label=binance_sc_accounts[0],
         notes=f'Swap {swap_amount} BNB via the 0x protocol',
         counterparty=CPT_ZEROX,
@@ -811,7 +793,7 @@ def test_swap_on_binance_sc(binance_sc_inquirer, binance_sc_accounts):
         location=Location.BINANCE_SC,
         event_subtype=HistoryEventSubType.RECEIVE,
         asset=Asset('eip155:56/erc20:0x477bC8d23c634C154061869478bce96BE6045D12'),
-        amount=FVal(received_amount),
+        amount=FVal(received_amount := '1011.063746262162828865'),
         location_label=binance_sc_accounts[0],
         notes=f'Receive {received_amount} SFUND as the result of a swap via the 0x protocol',
         counterparty=CPT_ZEROX,
@@ -823,17 +805,15 @@ def test_swap_on_binance_sc(binance_sc_inquirer, binance_sc_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('arbitrum_one_accounts', [['0xf06cc31757760CC9B8235C868ED90789f9c1E883']])
 def test_swap_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x355c18ab70fb5d17098b6bc8fd527ce00f0b25c8220d6fe29522a1fb64b711bc')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=arbitrum_one_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x355c18ab70fb5d17098b6bc8fd527ce00f0b25c8220d6fe29522a1fb64b711bc')),  # noqa: E501
     )
-    timestamp = TimestampMS(1709664647000)
     swap_amount, received_amount, meta_tx_fees = '49920.273922', '11.88137754443033075', '79.726078'  # noqa: E501
     expected_events = [EvmSwapEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709664647000)),
         location=Location.ARBITRUM_ONE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_ARBITRUM_USDC,
@@ -876,12 +856,11 @@ def test_swap_arbitrum_one(arbitrum_one_inquirer, arbitrum_one_accounts):
 def test_swap_optimism(optimism_inquirer, optimism_accounts):
     tx_hash = deserialize_evm_tx_hash('0x6b2b2d8c0cf2e27bb9e6c8309fd9887a066f9b72139acfe13d7ca5c29ae6c0ff')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=optimism_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1707868177000)
     swap_amount, received_amount, meta_tx_fees = '1.181244', '1.180785', '0.818756'
     expected_events = [EvmSwapEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1707868177000)),
         location=Location.OPTIMISM,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_OPTIMISM_USDC,
@@ -924,12 +903,11 @@ def test_swap_optimism(optimism_inquirer, optimism_accounts):
 def test_swap_base(base_inquirer, base_accounts):
     tx_hash = deserialize_evm_tx_hash('0x4a5eb8fac7ef1d6637ff1d54e67791e4a5a49effb141f30e5af90f5aba5d48a5')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709665909000)
     swap_amount, received_amount, meta_tx_fees = '688.271588', '1726.46678822133419734', '4.288419'
     expected_events = [EvmSwapEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709665909000)),
         location=Location.BASE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_BASE_USDC,
@@ -971,12 +949,11 @@ def test_swap_base(base_inquirer, base_accounts):
 def test_swap_on_pancakeswap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xcfb3b1587bb4d24a06d0f543493098ab285ae3763a489911da5bbea99bcb3499')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709701415000)
     swap_amount, received_amount, gas_fees = '10.414111669423209', '36912.012249', '0.017837784148433769'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709701415000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -1018,12 +995,11 @@ def test_swap_on_pancakeswap(ethereum_inquirer, ethereum_accounts):
 def test_swap_on_curve(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x12d794e7ced93da02978aa9b46b59f27ceab49724fdb1b0c39963792af68fdf0')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1709683307000)
     swap_amount, received_amount, gas_fees = '458480.413', '459177.562744', '0.03000569702410494'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709683307000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -1065,12 +1041,11 @@ def test_swap_on_curve(ethereum_inquirer, ethereum_accounts):
 def test_swap_on_sushiswap(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x802f7d1c4b2f1b7ef48e5c3af92a3a166a91624b89e736f85b90df3dd7ce9d73')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp = TimestampMS(1708569407000)
     swap_amount, received_amount, gas_fees = '50', '68.557872437267381014', '0.007767959110971294'
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1708569407000)),
         location=Location.ETHEREUM,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,
@@ -1110,17 +1085,15 @@ def test_swap_on_sushiswap(ethereum_inquirer, ethereum_accounts):
 @pytest.mark.vcr
 @pytest.mark.parametrize('polygon_pos_accounts', [['0xb3Dd5Cdb7F73acD1177c96409412e0b326E9C457']])
 def test_swap_on_quickswap(polygon_pos_inquirer, polygon_pos_accounts):
-    tx_hash = deserialize_evm_tx_hash('0x7b1bef89b8890e060787924a279e040ce8d50aedd35337747af6d56024ce269e')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=polygon_pos_inquirer,
-        tx_hash=tx_hash,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x7b1bef89b8890e060787924a279e040ce8d50aedd35337747af6d56024ce269e')),  # noqa: E501
     )
-    timestamp = TimestampMS(1709675020000)
     swap_amount, received_amount, gas_fees = '58.6229436575138', '10313.421767180867447506', '0.05297558472'  # noqa: E501
     expected_events = [EvmEvent(
         tx_ref=tx_hash,
         sequence_index=0,
-        timestamp=timestamp,
+        timestamp=(timestamp := TimestampMS(1709675020000)),
         location=Location.POLYGON_POS,
         event_type=HistoryEventType.SPEND,
         event_subtype=HistoryEventSubType.FEE,

--- a/rotkehlchen/tests/unit/decoders/test_zksync.py
+++ b/rotkehlchen/tests/unit/decoders/test_zksync.py
@@ -18,21 +18,18 @@ def test_zksync_lite_legacy_deposit(ethereum_inquirer, ethereum_accounts):
     from the newest implementation of the proxy address
     """
     tx_hash = deserialize_evm_tx_hash('0x6740ba7d674c285ce315b97dffdbf2cf91f74a2b75fba6fd82b3e0e5c8057218')  # noqa: E501
-    timestamp = TimestampMS(1607624823000)
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    gas_str = '0.003633546'
-    dai_str = '9.4361'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1607624823000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.003633546'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -44,14 +41,13 @@ def test_zksync_lite_legacy_deposit(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_DAI,
-            amount=FVal(dai_str),
+            amount=FVal(dai_str := '9.4361'),
             location_label=user_address,
             notes=f'Deposit {dai_str} DAI to zksync',
             counterparty=CPT_ZKSYNC,
             address=ZKSYNC_BRIDGE,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr
@@ -59,21 +55,18 @@ def test_zksync_lite_legacy_deposit(ethereum_inquirer, ethereum_accounts):
 def test_zksync_lite_deposit(ethereum_inquirer, ethereum_accounts):
     """Test a transaction with the Deposit event"""
     tx_hash = deserialize_evm_tx_hash('0x041514c879ae6f4f36c44000270ce482798502be230865911d1013978f4bcb87')  # noqa: E501
-    timestamp = TimestampMS(1639578202000)
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    gas_str = '0.007252433740671543'
-    dai_str = '18.4614'
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1639578202000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.SPEND,
             event_subtype=HistoryEventSubType.FEE,
             asset=A_ETH,
-            amount=FVal(gas_str),
+            amount=FVal(gas_str := '0.007252433740671543'),
             location_label=user_address,
             notes=f'Burn {gas_str} ETH for gas',
             counterparty=CPT_GAS,
@@ -85,14 +78,13 @@ def test_zksync_lite_deposit(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.DEPOSIT,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_DAI,
-            amount=FVal(dai_str),
+            amount=FVal(dai_str := '18.4614'),
             location_label=user_address,
             notes=f'Deposit {dai_str} DAI to zksync',
             counterparty=CPT_ZKSYNC,
             address=ZKSYNC_BRIDGE,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
@@ -102,17 +94,16 @@ def test_zksync_lite_withdrawal(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0x234407968b9a688be3fb37cf7ff8ef3b4168d6cd85ec45b8344bb2a88832f982')  # noqa: E501
     user_address = ethereum_accounts[0]
     events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
-    timestamp, eth_str, dai_str, pan_str, usdc_str, usdt_str = TimestampMS(1604326368000), '1.4437093', '1691.92749999', '1586.6', '57.25', '15.2'  # noqa: E501
-    expected_events = [
+    assert events == [
         EvmEvent(
             tx_ref=tx_hash,
             sequence_index=0,
-            timestamp=timestamp,
+            timestamp=(timestamp := TimestampMS(1604326368000)),
             location=Location.ETHEREUM,
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_ETH,
-            amount=FVal(eth_str),
+            amount=FVal(eth_str := '1.4437093'),
             location_label=user_address,
             notes=f'Withdraw {eth_str} ETH from zksync',
             counterparty=CPT_ZKSYNC,
@@ -125,7 +116,7 @@ def test_zksync_lite_withdrawal(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_DAI,
-            amount=FVal(dai_str),
+            amount=FVal(dai_str := '1691.92749999'),
             location_label=user_address,
             notes=f'Withdraw {dai_str} DAI from zksync',
             counterparty=CPT_ZKSYNC,
@@ -138,7 +129,7 @@ def test_zksync_lite_withdrawal(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=Asset('eip155:1/erc20:0xD56daC73A4d6766464b38ec6D91eB45Ce7457c44'),
-            amount=FVal(pan_str),
+            amount=FVal(pan_str := '1586.6'),
             location_label=user_address,
             notes=f'Withdraw {pan_str} PAN from zksync',
             counterparty=CPT_ZKSYNC,
@@ -151,7 +142,7 @@ def test_zksync_lite_withdrawal(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_USDC,
-            amount=FVal(usdc_str),
+            amount=FVal(usdc_str := '57.25'),
             location_label=user_address,
             notes=f'Withdraw {usdc_str} USDC from zksync',
             counterparty=CPT_ZKSYNC,
@@ -164,14 +155,13 @@ def test_zksync_lite_withdrawal(ethereum_inquirer, ethereum_accounts):
             event_type=HistoryEventType.WITHDRAWAL,
             event_subtype=HistoryEventSubType.BRIDGE,
             asset=A_USDT,
-            amount=FVal(usdt_str),
+            amount=FVal(usdt_str := '15.2'),
             location_label=user_address,
             notes=f'Withdraw {usdt_str} USDT from zksync',
             counterparty=CPT_ZKSYNC,
             address=ZKSYNC_BRIDGE,
         ),
     ]
-    assert expected_events == events
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])


### PR DESCRIPTION
Many times the LLMs copy a random test and sometimes they copy the right approach, using walrus, sometimes not. So hopefully this will make it easier for them to see the pattern