### PR TITLE
fix flaky lido csm test

### DIFF
--- a/rotkehlchen/tests/unit/test_lido_csm_balances.py
+++ b/rotkehlchen/tests/unit/test_lido_csm_balances.py
@@ -90,7 +90,7 @@ def test_lido_csm_balances_skips_on_error():
         side_effect=_raise_remote_error,
     ), patch.object(
         Inquirer,
-        'find_usd_price',
+        'find_price',
         return_value=FVal('2000'),
     ), patch.object(
         LidoCsmMetricsFetcher,


### PR DESCRIPTION
- Before fix: test_lido_csm_balances_skips_on_error mocks Inquirer.find_usd_price, but query_balances()
calls Inquirer.find_price. The unmocked find_price hits the real Inquirer singleton, which blows up with AttributeErr or when oracle/cache state isn't initialized. Depends entirely on what other tests ran before it in CI.

- After fix: Mocking find_price (what the code actually calls) prevents any real Inquirer interaction. Test passes regardless of singleton state
