### PR TITLE
Optimize transaction fetch paths: batch DB operations and remove pre-read checks

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -466,7 +466,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
             save_query=False,
         ) == expected_balance
 
-    def _query(self, method: Callable, call_order: Sequence[WeightedNode], **kwargs: Any) -> Any:
+    def _query(self, method: Callable, call_order: Sequence[WeightedNode] | None = None, **kwargs: Any) -> Any:  # noqa: E501
         """Queries evm related data by performing a query of the provided method to all given nodes
 
         The first node in the call order that gets a successful response returns.
@@ -475,6 +475,8 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
         - RequestTooLargeError if we encounter a 414 error from etherscan-like
           indexers or gas limit errors from RPC nodes.
         """
+        if call_order is None:
+            call_order = self.default_call_order()
         gas_limit_error_seen = False
         for node_idx, weighted_node in enumerate(call_order):
             node_info = weighted_node.node_info
@@ -577,7 +579,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
     def get_latest_block_number(self, call_order: Sequence[WeightedNode] | None = None) -> int:
         return self._query(
             method=self._get_latest_block_number,
-            call_order=call_order if call_order is not None else self.default_call_order(),
+            call_order=call_order,
         )
 
     def get_block_by_number(
@@ -587,7 +589,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
     ) -> dict[str, Any]:
         return self._query(
             method=self._get_block_by_number,
-            call_order=call_order if call_order is not None else self.default_call_order(),
+            call_order=call_order,
             num=num,
         )
 
@@ -617,7 +619,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
     ) -> str:
         return self._query(
             method=self._get_code,
-            call_order=call_order if call_order is not None else self.default_call_order(),
+            call_order=call_order,
             account=account,
         )
 
@@ -686,7 +688,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
     ) -> Any:
         return self._query(
             method=self._call_contract,
-            call_order=call_order if call_order is not None else self.default_call_order(),
+            call_order=call_order,
             contract_address=contract_address,
             abi=abi,
             method_name=method_name,
@@ -798,7 +800,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
     ) -> dict[str, Any] | None:
         return self._query(
             method=self._get_transaction_receipt,
-            call_order=call_order if call_order is not None else self.default_call_order(),
+            call_order=call_order,
             tx_hash=tx_hash,
             must_exist=must_exist,
         )
@@ -814,7 +816,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
         and we are connected to at least one node that can retrieve it.
         """
         tx_receipt = self.maybe_get_transaction_receipt(
-            call_order=call_order if call_order is not None else self.default_call_order(),
+            call_order=call_order,
             tx_hash=tx_hash,
             must_exist=True,
         )
@@ -866,7 +868,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
         """Gets transaction by hash and raw receipt data"""
         return self._query(
             method=self._get_transaction_by_hash,
-            call_order=call_order if call_order is not None else self.default_call_order(),
+            call_order=call_order,
             tx_hash=tx_hash,
             must_exist=must_exist,
         )
@@ -882,7 +884,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
         and we are connected to at least 1 node that can retrieve it.
         """
         result = self.maybe_get_transaction_by_hash(
-            call_order=call_order if call_order is not None else self.default_call_order(),
+            call_order=call_order,
             tx_hash=tx_hash,
             must_exist=True,
         )

--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -123,32 +123,75 @@ class EvmTransactions(ABC):  # noqa: B024
         self.msg_aggregator = database.msg_aggregator
         self.dbevmtx = DBEvmTx(database)
 
-    def _get_existing_evm_tx_hashes(
+    def _batch_ensure_evm_txns_in_db(
             self,
-            cursor: 'DBCursor',
-            tx_hashes: Sequence[EVMTxHash],
-    ) -> set[EVMTxHash]:
-        """Return tx hashes already stored for this chain to filter return_queried_hashes.
+            tx_hashes: list[EVMTxHash],
+            relevant_address: ChecksumEvmAddress | None,
+    ) -> tuple[dict[EVMTxHash, Timestamp], list[EVMTxHash]]:
+        """Ensure all tx hashes exist in DB with receipts.
 
-        We need this because add_transactions uses INSERT OR IGNORE, so we must pre-check
-        to avoid reporting hashes that were not newly saved.
+        Bulk-reads pairs that already have both tx + receipt; fetches+persists missing
+        ones serially from the chain. Handles GENESIS_HASH via the dedicated helper.
+
+        Returns (hash→timestamp mapping for all hashes, list of newly-inserted tx hashes).
+
+        May raise:
+        - RemoteError if a missing transaction cannot be fetched from the data source.
         """
-        existing_hashes: set[EVMTxHash] = set()
-        if len(tx_hashes) == 0:
-            return existing_hashes
+        if not tx_hashes:
+            return {}, []
 
-        serialized_chain_id = self.evm_inquirer.chain_id.serialize_for_db()
-        for tx_hash_chunk, placeholders in get_query_chunks(tx_hashes):
-            cursor.execute(
-                f'SELECT tx_hash FROM evm_transactions '
-                f'WHERE chain_id=? AND tx_hash IN ({placeholders})',
-                (serialized_chain_id, *tx_hash_chunk),
-            )
-            existing_hashes.update(
-                deserialize_evm_tx_hash(entry[0]) for entry in cursor
-            )
+        unique_hashes: set[EVMTxHash] = set(tx_hashes)
+        timestamps: dict[EVMTxHash, Timestamp] = {}
 
-        return existing_hashes
+        has_genesis = GENESIS_HASH in unique_hashes
+        non_genesis = unique_hashes - {GENESIS_HASH} if has_genesis else unique_hashes
+
+        if has_genesis:
+            genesis_tx, _ = self.ensure_genesis_tx_data_exists()
+            timestamps[GENESIS_HASH] = genesis_tx.timestamp
+
+        if len(non_genesis) == 0:
+            return timestamps, []
+
+        chain_id_db = self.evm_inquirer.chain_id.serialize_for_db()
+        with self.database.conn.read_ctx() as cursor:
+            for chunk, placeholders in get_query_chunks(list(non_genesis)):
+                for row in cursor.execute(
+                    f'SELECT et.tx_hash, et.timestamp FROM evm_transactions et '
+                    f'JOIN evmtx_receipts etr ON et.identifier = etr.tx_id '
+                    f'WHERE et.chain_id=? AND et.tx_hash IN ({placeholders})',
+                    (chain_id_db, *chunk),
+                ):
+                    timestamps[deserialize_evm_tx_hash(row[0])] = Timestamp(row[1])
+
+        missing: set[EVMTxHash] = non_genesis - timestamps.keys()
+        if not missing:
+            return timestamps, []
+
+        new_txs: list[Any] = []
+        receipt_data_list: list[dict[str, Any]] = []
+        for tx_hash in missing:
+            transaction, raw_receipt = self.evm_inquirer.get_transaction_by_hash(tx_hash)
+            new_txs.append(transaction)
+            receipt_data_list.append(raw_receipt)
+            timestamps[tx_hash] = transaction.timestamp
+
+        newly_inserted: list[EVMTxHash] = []
+        with self.database.user_write() as write_cursor:
+            newly_inserted = self.dbevmtx.add_transactions(
+                write_cursor=write_cursor,
+                evm_transactions=new_txs,
+                relevant_address=relevant_address,
+            )
+            for receipt_data in receipt_data_list:
+                self.dbevmtx.add_or_ignore_receipt_data(
+                    write_cursor=write_cursor,
+                    chain_id=self.evm_inquirer.chain_id,
+                    data=receipt_data,
+                )
+
+        return timestamps, newly_inserted
 
     @contextmanager
     def wait_until_no_query_for(self, addresses: list[ChecksumEvmAddress]) -> Iterator[None]:
@@ -276,25 +319,12 @@ class EvmTransactions(ABC):  # noqa: B024
             if len(new_transactions) == 0:
                 continue
 
-            if queried_hashes is not None:
-                with self.database.conn.read_ctx() as cursor:
-                    existing_hashes = self._get_existing_evm_tx_hashes(
-                        cursor=cursor,
-                        tx_hashes=[tx.tx_hash for tx in new_transactions],
-                    )
-
-                for tx in new_transactions:
-                    if tx.tx_hash not in existing_hashes:
-                        queried_hashes.append(tx.tx_hash)
-                        existing_hashes.add(tx.tx_hash)
-
             with self.database.user_write() as write_cursor:
-                self.dbevmtx.add_transactions(
+                new_hashes = self.dbevmtx.add_transactions(
                     write_cursor=write_cursor,
                     evm_transactions=new_transactions,
                     relevant_address=address,
                 )
-
                 if period.range_type == 'timestamps':
                     assert location_string, 'should always be given for timestamps'
                     queried_to_ts = Timestamp(max(queried_from_ts, new_transactions[-1].timestamp))
@@ -306,6 +336,9 @@ class EvmTransactions(ABC):  # noqa: B024
                             queried_ranges=[(queried_from_ts, queried_to_ts)],
                         )
                     queried_from_ts = queried_to_ts
+
+            if queried_hashes is not None:
+                queried_hashes.extend(new_hashes)
 
             self.msg_aggregator.add_message(
                 message_type=WSMessageType.TRANSACTION_STATUS,
@@ -610,44 +643,26 @@ class EvmTransactions(ABC):  # noqa: B024
         if len(new_internal_txs) == 0:
             return []
 
-        existing_hashes: set[EVMTxHash] = set()
-        if queried_hashes is not None and len(parent_hashes := [
-            internal_tx.parent_tx_hash
-            for internal_tx in new_internal_txs
-            if internal_tx.value != 0
-        ]) != 0:
-            with self.database.conn.read_ctx() as cursor:
-                existing_hashes = self._get_existing_evm_tx_hashes(
-                    cursor=cursor,
-                    tx_hashes=parent_hashes,
-                )
+        # Collect unresolved parent hashes in one pass (skip zero-value and already-known)
+        unresolved: list[EVMTxHash] = [
+            tx.parent_tx_hash
+            for tx in new_internal_txs
+            if tx.value != 0 and tx.parent_tx_hash not in parent_tx_timestamps
+        ]
+        if unresolved:
+            new_timestamps, new_hashes = self._batch_ensure_evm_txns_in_db(
+                tx_hashes=unresolved,
+                relevant_address=address,
+            )
+            parent_tx_timestamps.update(new_timestamps)
+            if queried_hashes is not None:
+                queried_hashes.extend(new_hashes)
 
-        internal_txs_with_timestamps: list[tuple[EvmInternalTransaction, Timestamp]] = []
-        for internal_tx in new_internal_txs:
-            if internal_tx.value == 0:
-                continue  # Only reason we need internal is for ether transfer. Ignore 0
-
-            # make sure internal transaction parent transactions are in the DB.
-            # new_internal_txs potentially contains internal txs of different parents.
-            if internal_tx.parent_tx_hash not in parent_tx_timestamps:
-                with self.database.conn.read_ctx() as cursor:
-                    tx, _ = self.get_or_create_transaction(
-                        cursor=cursor,
-                        tx_hash=internal_tx.parent_tx_hash,
-                        relevant_address=address,
-                    )
-                if queried_hashes is not None and tx.tx_hash not in existing_hashes:
-                    queried_hashes.append(tx.tx_hash)
-                    existing_hashes.add(tx.tx_hash)
-
-                timestamp = tx.timestamp
-                parent_tx_timestamps[internal_tx.parent_tx_hash] = timestamp
-            else:
-                timestamp = parent_tx_timestamps[internal_tx.parent_tx_hash]
-
-            internal_txs_with_timestamps.append((internal_tx, timestamp))
-
-        return internal_txs_with_timestamps
+        return [
+            (tx, parent_tx_timestamps[tx.parent_tx_hash])
+            for tx in new_internal_txs
+            if tx.value != 0  # Only reason we need internals is for ether transfers
+        ]
 
     @overload
     def _query_internal_transactions_for_parent_hash(
@@ -926,50 +941,39 @@ class EvmTransactions(ABC):  # noqa: B024
             from_block=from_block,
             to_block=to_block,
         ):
-            existing_hashes: set[EVMTxHash] = set()
-            if queried_hashes is not None and len(erc20_tx_hashes) != 0:
-                with self.database.conn.read_ctx() as cursor:
-                    existing_hashes = self._get_existing_evm_tx_hashes(
-                        cursor=cursor,
-                        tx_hashes=erc20_tx_hashes,
-                    )
+            if not erc20_tx_hashes:
+                continue
 
-            queried_to_ts = queried_from_ts
-            for tx_hash in erc20_tx_hashes:
-                with self.database.conn.read_ctx() as cursor:
-                    tx, _ = self.get_or_create_transaction(
-                        cursor=cursor,
-                        tx_hash=tx_hash,
-                        relevant_address=address,
-                    )
-                if queried_hashes is not None and tx.tx_hash not in existing_hashes:
-                    queried_hashes.append(tx.tx_hash)
-                    existing_hashes.add(tx.tx_hash)
+            batch_timestamps, new_hashes = self._batch_ensure_evm_txns_in_db(
+                tx_hashes=erc20_tx_hashes,
+                relevant_address=address,
+            )
+            if queried_hashes is not None:
+                queried_hashes.extend(new_hashes)
 
-                if period.range_type == 'timestamps':
-                    queried_to_ts = Timestamp(max(queried_to_ts, tx.timestamp))
-                    self.msg_aggregator.add_message(
-                        message_type=WSMessageType.TRANSACTION_STATUS,
-                        data={
-                            'address': address,
-                            'chain': self.evm_inquirer.blockchain.value,
-                            'subtype': str(TransactionStatusSubType.EVM),
-                            'period': [period.from_value, tx.timestamp],
-                            'status': str(TransactionStatusStep.QUERYING_EVM_TOKENS_TRANSACTIONS),
-                        },
-                    )
+            if period.range_type != 'timestamps':
+                continue
 
-            # Update the query range once per batch
-            if period.range_type == 'timestamps' and len(erc20_tx_hashes) > 0:
-                log.debug(f'{self.evm_inquirer.chain_name} ERC20 Transfers for {address} -> update range {queried_from_ts} - {queried_to_ts}')  # noqa: E501
-                if update_ranges:
-                    with self.database.user_write() as write_cursor:
-                        self.dbranges.update_used_query_range(
-                            write_cursor=write_cursor,
-                            location_string=location_string,
-                            queried_ranges=[(queried_from_ts, queried_to_ts)],
-                        )
-                queried_from_ts = queried_to_ts
+            queried_to_ts = Timestamp(max(queried_from_ts, *batch_timestamps.values()))
+            log.debug(f'{self.evm_inquirer.chain_name} ERC20 Transfers for {address} -> update range {queried_from_ts} - {queried_to_ts}')  # noqa: E501
+            self.msg_aggregator.add_message(
+                message_type=WSMessageType.TRANSACTION_STATUS,
+                data={
+                    'address': address,
+                    'chain': self.evm_inquirer.blockchain.value,
+                    'subtype': str(TransactionStatusSubType.EVM),
+                    'period': [period.from_value, queried_to_ts],
+                    'status': str(TransactionStatusStep.QUERYING_EVM_TOKENS_TRANSACTIONS),
+                },
+            )
+            if update_ranges:
+                with self.database.user_write() as write_cursor:
+                    self.dbranges.update_used_query_range(
+                        write_cursor=write_cursor,
+                        location_string=location_string,
+                        queried_ranges=[(queried_from_ts, queried_to_ts)],
+                    )
+            queried_from_ts = queried_to_ts
         return queried_hashes
 
     def address_has_been_spammed(self, address: ChecksumEvmAddress) -> bool:

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -2393,27 +2393,35 @@ class DBHandler:
             query: str,
             entry: tuple[Any, ...],
             relevant_address: SolanaAddress | ChecksumEvmAddress | None,
-    ) -> int | None:
-        """Helper to write an entry of a tuple type and handle address mapping"""
+    ) -> tuple[int | None, bool]:
+        """Helper to write an entry of a tuple type and handle address mapping.
+
+        Returns (row_id, is_new) where is_new is True if the row was freshly inserted.
+        row_id is None only when a non-UNIQUE constraint error (or InterfaceError) occurs.
+        """
         tx_id = None
+        is_new = False
         try:
             write_cursor.execute(query, entry)
             if tuple_type == 'evm_transaction':
+                is_new = write_cursor.rowcount == 1  # capture before SELECT resets rowcount
                 tx_id = write_cursor.execute(
                     'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
                     (entry[0], entry[1]),
                 ).fetchone()[0]
                 mapping_table = 'evmtx_address_mappings'
             elif tuple_type == 'solana_transaction':
+                is_new = write_cursor.rowcount == 1
                 tx_id = write_cursor.execute(
                     'SELECT identifier FROM solana_transactions WHERE signature=?',
                     (entry[4],),  # signature is the 5th element (index 4) in the entry tuple
                 ).fetchone()[0]
                 mapping_table = 'solanatx_address_mappings'
             elif tuple_type == 'solana_instruction':
-                return write_cursor.lastrowid  # return the auto-generated instruction ID
+                is_new = write_cursor.rowcount == 1
+                return write_cursor.lastrowid if is_new else None, is_new
             else:
-                return tx_id
+                return tx_id, is_new
 
             # add address mapping if relevant_address is provided and transaction exists
             if relevant_address is not None and tx_id is not None:
@@ -2430,7 +2438,7 @@ class DBHandler:
         except sqlcipher.InterfaceError:  # pylint: disable=no-member
             log.critical(f'Interface error with tuple: {entry}')
 
-        return tx_id  # return the transaction id (new or existing or None)
+        return tx_id, is_new  # row_id (new or existing or None on error), and is_new flag
 
     def add_margin_positions(self, write_cursor: 'DBCursor', margin_positions: list[MarginPosition]) -> None:  # noqa: E501
         margin_tuples: list[tuple[Any, ...]] = []

--- a/rotkehlchen/db/dbtx.py
+++ b/rotkehlchen/db/dbtx.py
@@ -35,8 +35,8 @@ class DBCommonTx(ABC, Generic[T_Address, T_Transaction, T_TxHash, T_TxFilterQuer
             write_cursor: 'DBCursor',
             solana_transactions: list[T_Transaction],
             relevant_address: T_Address | None,
-    ) -> None:
-        """Add transactions to the database."""
+    ) -> list[T_TxHash]:
+        """Add transactions to the database. Returns list of newly-inserted tx hashes."""
 
     @abstractmethod
     def get_transactions(

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -70,8 +70,8 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
             write_cursor: 'DBCursor',
             evm_transactions: list[EvmTransaction],
             relevant_address: ChecksumEvmAddress | None,
-    ) -> None:
-        """Adds evm transactions to the database"""
+    ) -> list[EVMTxHash]:
+        """Adds evm transactions to the database. Returns list of newly-inserted tx hashes."""
         query = """
             INSERT OR IGNORE INTO evm_transactions(
               tx_hash,
@@ -88,8 +88,9 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
               nonce)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
+        newly_inserted: list[EVMTxHash] = []
         for tx in evm_transactions:
-            if (row_id := self.db.write_single_tuple(
+            row_id, is_new = self.db.write_single_tuple(
                 write_cursor=write_cursor,
                 tuple_type='evm_transaction',
                 query=query,
@@ -108,16 +109,20 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
                     tx.nonce,
                 ),
                 relevant_address=relevant_address,
-            )) is not None and tx.authorization_list is not None:
+            )
+            if is_new:
+                newly_inserted.append(tx.tx_hash)
+            if row_id is not None and tx.authorization_list is not None:
                 self.db.write_tuples(
                     write_cursor=write_cursor,
                     tuple_type='evm_transactions_authorization',
                     query='INSERT OR IGNORE INTO evm_transactions_authorizations(tx_id, nonce, delegated_address) VALUES (?, ?, ?)',  # noqa: E501
                     tuples=[
-                        (row_id, entry.nonce, entry.delegated_address)
-                        for entry in tx.authorization_list
+                        (row_id, auth.nonce, auth.delegated_address)
+                        for auth in tx.authorization_list
                     ],
                 )
+        return newly_inserted
 
     def add_evm_internal_transactions(
             self,

--- a/rotkehlchen/db/l2withl1feestx.py
+++ b/rotkehlchen/db/l2withl1feestx.py
@@ -11,6 +11,7 @@ from rotkehlchen.types import (
     ChainID,
     ChecksumEvmAddress,
     EvmTransactionAuthorization,
+    EVMTxHash,
     deserialize_evm_tx_hash,
 )
 
@@ -30,12 +31,12 @@ class DBL2WithL1FeesTx(DBEvmTx):
             write_cursor: 'DBCursor',
             evm_transactions: list[L2WithL1FeesTransaction],  # type: ignore[override]
             relevant_address: ChecksumEvmAddress | None,
-    ) -> None:
-        """Adds L2WithL1Fees transactions to the database
+    ) -> list[EVMTxHash]:
+        """Adds L2WithL1Fees transactions to the database. Returns newly-inserted tx hashes.
 
         These transactions are used by all L2 chains with an extra L1 fee structure
         """
-        super().add_transactions(
+        newly_inserted = super().add_transactions(
             write_cursor,
             evm_transactions,  # type: ignore[arg-type]
             relevant_address,
@@ -48,6 +49,7 @@ class DBL2WithL1FeesTx(DBEvmTx):
             evm_transactions WHERE tx_hash=? and chain_id=?
         """
         write_cursor.executemany(query, tx_tuples)
+        return newly_inserted
 
     def _form_evm_transaction_dbquery(self, query: str, bindings: list[Any]) -> tuple[str, list[tuple]]:  # noqa: E501
         base_select = (

--- a/rotkehlchen/db/solanatx.py
+++ b/rotkehlchen/db/solanatx.py
@@ -58,17 +58,21 @@ class DBSolanaTx(DBCommonTx[SolanaAddress, SolanaTransaction, Signature, SolanaT
             write_cursor: 'DBCursor',
             solana_transactions: list[SolanaTransaction],
             relevant_address: SolanaAddress | None,
-    ) -> None:
-        """Add solana transactions to the database"""
+    ) -> list[Signature]:
+        """Add solana transactions to the database. Returns list of newly-inserted signatures."""
         query = """INSERT OR IGNORE INTO solana_transactions(slot, fee, block_time, success, signature) VALUES (?, ?, ?, ?, ?)"""  # noqa: E501
+        newly_inserted: list[Signature] = []
         for tx in solana_transactions:
-            if (tx_id := self.db.write_single_tuple(
+            tx_id, is_new = self.db.write_single_tuple(
                 write_cursor=write_cursor,
                 tuple_type='solana_transaction',
                 query=query,
                 entry=(tx.slot, tx.fee, tx.block_time, int(tx.success), tx.signature.to_bytes()),
                 relevant_address=relevant_address,
-            )) is None:
+            )
+            if is_new:
+                newly_inserted.append(tx.signature)
+            if tx_id is None:
                 continue
 
             self.db.write_tuples(
@@ -81,7 +85,7 @@ class DBSolanaTx(DBCommonTx[SolanaAddress, SolanaTransaction, Signature, SolanaT
                 ],
             )
             for instruction in tx.instructions:  # insert instructions
-                if (instruction_id := self.db.write_single_tuple(
+                instruction_id, _ = self.db.write_single_tuple(
                     write_cursor=write_cursor,
                     tuple_type='solana_instruction',
                     query='INSERT OR IGNORE INTO solana_tx_instructions(tx_id, execution_index, parent_execution_index, program_id_index, data) VALUES (?, ?, ?, ?, ?)',  # noqa: E501
@@ -93,7 +97,8 @@ class DBSolanaTx(DBCommonTx[SolanaAddress, SolanaTransaction, Signature, SolanaT
                         instruction.data,
                     ),
                     relevant_address=None,
-                )) is not None:
+                )
+                if instruction_id is not None:
                     self.db.write_tuples(
                         write_cursor=write_cursor,
                         tuple_type='solana_instruction_account',
@@ -103,6 +108,8 @@ class DBSolanaTx(DBCommonTx[SolanaAddress, SolanaTransaction, Signature, SolanaT
                             for order, account_address in enumerate(instruction.accounts)
                         ],
                     )
+
+        return newly_inserted
 
     @staticmethod
     def add_token_account_mappings(


### PR DESCRIPTION
- Batch parent transaction resolution in internal tx processing
- Batch ERC20 tx hash resolution instead of serial get_or_create calls
- Extend add_transactions to return newly-inserted hashes across EVM, L2, and Solana
- Simplify _query call_order defaulting in node_inquirer

THis while syncing yabir.eth across the different chains saves ~5 mins
