### PR TITLE
Add Blockscout API key integration test

### DIFF
--- a/rotkehlchen/tests/api/test_external_services.py
+++ b/rotkehlchen/tests/api/test_external_services.py
@@ -94,6 +94,7 @@ def test_etherscan_re_enabled(rotkehlchen_api_server: 'APIServer') -> None:
 
 @pytest.mark.parametrize('include_etherscan_key', [False])
 @pytest.mark.parametrize('include_beaconchain_key', [False])
+@pytest.mark.parametrize('include_blockscout_key', [False])
 def test_delete_external_service(rotkehlchen_api_server: 'APIServer') -> None:
     """Tests that delete external service credentials works"""
     # Add some data and see that the response shows they are added

--- a/rotkehlchen/tests/api/test_external_services.py
+++ b/rotkehlchen/tests/api/test_external_services.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize('include_etherscan_key', [False])
 @pytest.mark.parametrize('include_cryptocompare_key', [False])
 @pytest.mark.parametrize('include_beaconchain_key', [False])
+@pytest.mark.parametrize('include_blockscout_key', [False])
 def test_add_get_external_service(rotkehlchen_api_server: 'APIServer') -> None:
     """Tests that adding and retrieving external service credentials works"""
     # With no data an empty response should be returned
@@ -33,10 +34,12 @@ def test_add_get_external_service(rotkehlchen_api_server: 'APIServer') -> None:
     expected_result = {
         'etherscan': {'api_key': 'key1'},
         'cryptocompare': {'api_key': 'key2'},
+        'blockscout': {'api_key': 'key3'},
     }
     data = {'services': [
         {'name': 'etherscan', 'api_key': 'key1'},
         {'name': 'cryptocompare', 'api_key': 'key2'},
+        {'name': 'blockscout', 'api_key': 'key3'},
     ]}
     response = requests.put(
         api_url_for(rotkehlchen_api_server, 'externalservicesresource'),

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -38,6 +38,7 @@ from rotkehlchen.tests.utils.database import (
     add_settings_to_test_db,
     add_tags_to_test_db,
     maybe_include_beaconchain_key,
+    maybe_include_blockscout_key,
     maybe_include_cryptocompare_key,
     maybe_include_etherscan_key,
     mock_db_schema_sanity_check,
@@ -323,6 +324,7 @@ def initialize_mock_rotkehlchen_instance(
         include_etherscan_key,
         include_beaconchain_key,
         include_cryptocompare_key,
+        include_blockscout_key,
         should_mock_price_queries,
         mocked_price_queries,
         ethereum_modules,
@@ -385,6 +387,7 @@ def initialize_mock_rotkehlchen_instance(
         maybe_include_etherscan_key(rotki.data.db, include_etherscan_key)
         maybe_include_beaconchain_key(rotki.data.db, include_beaconchain_key)
         maybe_include_cryptocompare_key(rotki.data.db, include_cryptocompare_key)
+        maybe_include_blockscout_key(rotki.data.db, include_blockscout_key)
         if add_accounts_to_db is True:
             add_blockchain_accounts_to_db(rotki.data.db, blockchain_accounts)
         add_tags_to_test_db(rotki.data.db, tags)
@@ -574,6 +577,7 @@ def fixture_rotkehlchen_api_server(
         include_etherscan_key,
         include_beaconchain_key,
         include_cryptocompare_key,
+        include_blockscout_key,
         should_mock_price_queries,
         mocked_price_queries,
         ethereum_modules,
@@ -632,6 +636,7 @@ def fixture_rotkehlchen_api_server(
         include_etherscan_key=include_etherscan_key,
         include_beaconchain_key=include_beaconchain_key,
         include_cryptocompare_key=include_cryptocompare_key,
+        include_blockscout_key=include_blockscout_key,
         should_mock_price_queries=should_mock_price_queries,
         mocked_price_queries=mocked_price_queries,
         ethereum_modules=ethereum_modules,
@@ -724,6 +729,7 @@ def rotkehlchen_instance(
         include_etherscan_key,
         include_beaconchain_key,
         include_cryptocompare_key,
+        include_blockscout_key,
         should_mock_price_queries,
         mocked_price_queries,
         ethereum_modules,
@@ -772,6 +778,7 @@ def rotkehlchen_instance(
         include_etherscan_key=include_etherscan_key,
         include_beaconchain_key=include_beaconchain_key,
         include_cryptocompare_key=include_cryptocompare_key,
+        include_blockscout_key=include_blockscout_key,
         should_mock_price_queries=should_mock_price_queries,
         mocked_price_queries=mocked_price_queries,
         ethereum_modules=ethereum_modules,


### PR DESCRIPTION
Closes #(issue_number)

- Tests the new API key format for blockscout in the GET / PUT API requests

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
