### PR TITLE
fix(build): patch electron-builder for pnpm catalog:

### DIFF
--- a/frontend/patches/app-builder-lib.patch
+++ b/frontend/patches/app-builder-lib.patch
@@ -1,0 +1,15 @@
+diff --git a/out/util/packageMetadata.js b/out/util/packageMetadata.js
+index 2f74568906659672295ca1f3f20f9b9c1195a110..42e27aac062fc79cf992eca3f21fe9b263b52c36 100644
+--- a/out/util/packageMetadata.js
++++ b/out/util/packageMetadata.js
+@@ -90,6 +90,10 @@ function checkDependencies(dependencies, errors) {
+                 updaterVersion = match[1];
+             }
+         }
++        // pnpm catalog: protocol - version is resolved by pnpm, skip validation
++        if (updaterVersion === "catalog:" || updaterVersion.startsWith("catalog:")) {
++            return;
++        }
+         // for testing auto-update using workspace electron-updater
+         const prefixes = ["link:", "file:"];
+         for (const prefix of prefixes) {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -300,6 +300,9 @@ overrides:
   yaml-eslint-parser: 1.3.2
 
 patchedDependencies:
+  app-builder-lib:
+    hash: 74f87c34f13b5c0d45e0c56b221cf7c77dac257298868081bdacddaa543aa97f
+    path: patches/app-builder-lib.patch
   bignumber.js@9.3.1:
     hash: 61396dd0164598dffc80190e90a8d2bd4ec88d03f7ec9956ab22182f63c0cb1d
     path: patches/bignumber.js@9.3.1.patch
@@ -10167,7 +10170,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.12: {}
 
-  app-builder-lib@26.8.2(dmg-builder@26.8.2)(electron-builder-squirrel-windows@26.8.2):
+  app-builder-lib@26.8.2(patch_hash=74f87c34f13b5c0d45e0c56b221cf7c77dac257298868081bdacddaa543aa97f)(dmg-builder@26.8.2)(electron-builder-squirrel-windows@26.8.2):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.4.1
@@ -10812,7 +10815,7 @@ snapshots:
 
   dmg-builder@26.8.2(electron-builder-squirrel-windows@26.8.2):
     dependencies:
-      app-builder-lib: 26.8.2(dmg-builder@26.8.2)(electron-builder-squirrel-windows@26.8.2)
+      app-builder-lib: 26.8.2(patch_hash=74f87c34f13b5c0d45e0c56b221cf7c77dac257298868081bdacddaa543aa97f)(dmg-builder@26.8.2)(electron-builder-squirrel-windows@26.8.2)
       builder-util: 26.8.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
@@ -10903,7 +10906,7 @@ snapshots:
 
   electron-builder-squirrel-windows@26.8.2(dmg-builder@26.8.2):
     dependencies:
-      app-builder-lib: 26.8.2(dmg-builder@26.8.2)(electron-builder-squirrel-windows@26.8.2)
+      app-builder-lib: 26.8.2(patch_hash=74f87c34f13b5c0d45e0c56b221cf7c77dac257298868081bdacddaa543aa97f)(dmg-builder@26.8.2)(electron-builder-squirrel-windows@26.8.2)
       builder-util: 26.8.1
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
@@ -10912,7 +10915,7 @@ snapshots:
 
   electron-builder@26.8.2(electron-builder-squirrel-windows@26.8.2):
     dependencies:
-      app-builder-lib: 26.8.2(dmg-builder@26.8.2)(electron-builder-squirrel-windows@26.8.2)
+      app-builder-lib: 26.8.2(patch_hash=74f87c34f13b5c0d45e0c56b221cf7c77dac257298868081bdacddaa543aa97f)(dmg-builder@26.8.2)(electron-builder-squirrel-windows@26.8.2)
       builder-util: 26.8.1
       builder-util-runtime: 9.5.1
       chalk: 4.1.2

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ overrides:
   chokidar: 5.0.0
   yaml-eslint-parser: 1.3.2
 patchedDependencies:
+  app-builder-lib: patches/app-builder-lib.patch
   bignumber.js@9.3.1: patches/bignumber.js@9.3.1.patch
 catalog:
   '@clack/prompts': 1.1.0


### PR DESCRIPTION
## Summary
- Patches `app-builder-lib` to handle pnpm's `catalog:` protocol in the `electron-updater` version check
- electron-builder doesn't recognize `catalog:` and fails with _"At least electron-updater 4.0.0 is recommended"_ since it sees the literal string `"catalog:"` instead of a resolved version

## Test plan
- [x] Verified local build succeeds with the patch
- [x] Linter passes without reverting `catalog:` back to an explicit version