### PR TITLE
chore: add Renovate config for dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard"
+  ],
+  "dependencyDashboardAutoclose": false,
+  "prCreation": "not-pending",
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "matchPackageNames": ["*"],
+      "enabled": false
+    },
+    {
+      "allowedVersions": "/^(24)\\./",
+      "groupName": "Node.js",
+      "matchPackageNames": ["@types/node", "node"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.github/renovate.json5` for dependency tracking via the Renovate dashboard
- Dashboard-only: all PR creation is disabled, this is purely for visibility into outdated deps across npm, cargo, and uv
- 7-day minimum release age for stability
- Node.js constrained to v24.x

## Test plan
- [x] Config validated with `renovate-config-validator` (no warnings)