### PR TITLE
fix: renovate dependency dashboard config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,16 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard"
+    ":dependencyDashboardApproval",
+    ":pinAllExceptPeerDependencies",
+    ":separateMultipleMajorReleases"
   ],
   "dependencyDashboardAutoclose": false,
-  "prCreation": "not-pending",
   "minimumReleaseAge": "7 days",
   "packageRules": [
-    {
-      "matchPackageNames": ["*"],
-      "enabled": false
-    },
     {
       "allowedVersions": "/^(24)\\./",
       "groupName": "Node.js",


### PR DESCRIPTION
## Summary
- Remove catch-all `enabled: false` rule that prevented Renovate from scanning dependencies, which meant the dashboard issue was never created
- Replace `:dependencyDashboard` with `:dependencyDashboardApproval` so PRs require manual approval
- Add `:pinAllExceptPeerDependencies` and `:separateMultipleMajorReleases` presets
- Remove unnecessary `prCreation: not-pending`

## Test plan
- [ ] Verify Renovate creates a "Dependency Dashboard" issue after merge
- [ ] Confirm no PRs are auto-created without dashboard approval