### PR TITLE
fix(frontend): fetch capabilities during login

### DIFF
--- a/frontend/app/src/composables/session/settings.ts
+++ b/frontend/app/src/composables/session/settings.ts
@@ -3,6 +3,7 @@ import type { UserSettingsModel } from '@/types/user';
 import { BigNumber, TimeFramePersist } from '@rotki/common';
 import { useThemeMigration } from '@/composables/settings/theme';
 import { getBnFormat } from '@/data/amount-formatter';
+import { usePremiumWatchers } from '@/modules/premium/use-premium-watchers';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
 import { usePremiumStore } from '@/store/session/premium';
 import { useAccountingSettingsStore } from '@/store/settings/accounting';
@@ -17,6 +18,7 @@ interface UseSessionSettingsReturn {
 
 export function useSessionSettings(): UseSessionSettingsReturn {
   const { premium, premiumSync } = storeToRefs(usePremiumStore());
+  const { fetchCapabilities } = usePremiumWatchers();
   const { update: updateFrontendSettings } = useFrontendSettingsStore();
   const { updateFrontendSetting } = useSettingsOperations();
   const { update: updateAccountingSettings } = useAccountingSettingsStore();
@@ -53,6 +55,7 @@ export function useSessionSettings(): UseSessionSettingsReturn {
     set(premiumSync, premiumShouldSync);
     updateGeneralSettings(general);
     updateAccountingSettings(accounting);
+    await fetchCapabilities();
   };
 
   return {

--- a/frontend/app/src/modules/premium/use-feature-access.spec.ts
+++ b/frontend/app/src/modules/premium/use-feature-access.spec.ts
@@ -224,7 +224,7 @@ describe('modules/premium/use-feature-access', () => {
   });
 
   describe('usePremiumStore - API Integration', () => {
-    it('should fetch and parse capabilities when premium status becomes true', async () => {
+    it('should fetch and parse capabilities via fetchCapabilities', async () => {
       const mockCapabilities: PremiumCapabilities = {
         [PremiumFeature.ASSET_MOVEMENT_MATCHING]: cap(false, 'Advanced'),
         [PremiumFeature.ETH_STAKING_VIEW]: cap(true),
@@ -233,16 +233,15 @@ describe('modules/premium/use-feature-access', () => {
       };
 
       server.use(mockPremiumCapabilities(mockCapabilities));
-      usePremiumWatchers();
+      const { fetchCapabilities } = usePremiumWatchers();
 
       const store = usePremiumStore();
       const { capabilities, premium } = storeToRefs(store);
 
       set(premium, true);
+      await fetchCapabilities();
 
-      await vi.waitFor(() => {
-        expect(get(capabilities)).toEqual(mockCapabilities);
-      });
+      expect(get(capabilities)).toEqual(mockCapabilities);
     });
 
     it('should handle API response with missing capabilities', async () => {
@@ -251,22 +250,21 @@ describe('modules/premium/use-feature-access', () => {
       };
 
       server.use(mockPremiumCapabilities<Partial<PremiumCapabilities>>(partialCapabilities));
-      usePremiumWatchers();
+      const { fetchCapabilities } = usePremiumWatchers();
 
       const store = usePremiumStore();
       const { premium } = storeToRefs(store);
 
       set(premium, true);
+      await fetchCapabilities();
 
       const { allowed: ethStakingAllowed } = useFeatureAccess(PremiumFeature.ETH_STAKING_VIEW);
       const { allowed: eventAnalysisAllowed } = useFeatureAccess(PremiumFeature.EVENT_ANALYSIS_VIEW);
       const { allowed: graphsAllowed } = useFeatureAccess(PremiumFeature.GRAPHS_VIEW);
 
-      await vi.waitFor(() => {
-        expect(get(ethStakingAllowed)).toBe(true);
-        expect(get(eventAnalysisAllowed)).toBe(false);
-        expect(get(graphsAllowed)).toBe(false);
-      });
+      expect(get(ethStakingAllowed)).toBe(true);
+      expect(get(eventAnalysisAllowed)).toBe(false);
+      expect(get(graphsAllowed)).toBe(false);
     });
 
     it('should handle all capabilities set to false', async () => {
@@ -278,16 +276,15 @@ describe('modules/premium/use-feature-access', () => {
       };
 
       server.use(mockPremiumCapabilities(allFalseCapabilities));
-      usePremiumWatchers();
+      const { fetchCapabilities } = usePremiumWatchers();
 
       const store = usePremiumStore();
       const { capabilities, premium } = storeToRefs(store);
 
       set(premium, true);
+      await fetchCapabilities();
 
-      await vi.waitFor(() => {
-        expect(get(capabilities)).toEqual(allFalseCapabilities);
-      });
+      expect(get(capabilities)).toEqual(allFalseCapabilities);
 
       const { allowed: ethStakingAllowed } = useFeatureAccess(PremiumFeature.ETH_STAKING_VIEW);
       const { allowed: graphsAllowed } = useFeatureAccess(PremiumFeature.GRAPHS_VIEW);
@@ -304,21 +301,19 @@ describe('modules/premium/use-feature-access', () => {
       server.use(
         http.get(`${backendUrl}/api/1/premium/capabilities`, apiCallSpy),
       );
-      usePremiumWatchers();
+      const { fetchCapabilities } = usePremiumWatchers();
 
       const store = usePremiumStore();
       const { capabilities, premium } = storeToRefs(store);
 
       set(premium, true);
+      await fetchCapabilities();
 
-      await vi.waitFor(() => {
-        expect(apiCallSpy).toHaveBeenCalled();
-      });
-
+      expect(apiCallSpy).toHaveBeenCalled();
       expect(get(capabilities)).toBeUndefined();
     });
 
-    it('should refetch capabilities when premium status becomes false', async () => {
+    it('should clear capabilities on logout', async () => {
       const mockCapabilities: PremiumCapabilities = {
         [PremiumFeature.ASSET_MOVEMENT_MATCHING]: cap(true),
         [PremiumFeature.ETH_STAKING_VIEW]: cap(true),
@@ -327,58 +322,24 @@ describe('modules/premium/use-feature-access', () => {
       };
 
       server.use(mockPremiumCapabilities(mockCapabilities));
-      usePremiumWatchers();
+      const { fetchCapabilities } = usePremiumWatchers();
 
       const store = usePremiumStore();
       const { capabilities, premium } = storeToRefs(store);
+      const { logged } = storeToRefs(useSessionAuthStore());
 
       set(premium, true);
-      await vi.waitFor(() => {
-        expect(get(capabilities)).toEqual(mockCapabilities);
-      });
+      await fetchCapabilities();
 
-      set(premium, false);
-      await vi.waitFor(() => {
-        expect(get(capabilities)).toEqual(mockCapabilities);
-      });
-    });
+      expect(get(capabilities)).toEqual(mockCapabilities);
 
-    it('should not fetch capabilities if premium was already true', async () => {
-      const mockCapabilities: PremiumCapabilities = {
-        [PremiumFeature.ASSET_MOVEMENT_MATCHING]: cap(true),
-        [PremiumFeature.ETH_STAKING_VIEW]: cap(true),
-        [PremiumFeature.EVENT_ANALYSIS_VIEW]: cap(true),
-        [PremiumFeature.GRAPHS_VIEW]: cap(true),
-      };
-
-      const apiCallSpy = vi.fn(() => HttpResponse.json<ActionResult<PremiumCapabilities>>({
-        message: '',
-        result: mockCapabilities,
-      }, { status: 200 }));
-
-      server.use(
-        http.get(`${backendUrl}/api/1/premium/capabilities`, apiCallSpy),
-      );
-      usePremiumWatchers();
-
-      const store = usePremiumStore();
-      const { capabilities, premium } = storeToRefs(store);
-
-      set(premium, true);
-
-      await vi.waitFor(() => {
-        expect(get(capabilities)).toEqual(mockCapabilities);
-      });
-
-      const callCount = apiCallSpy.mock.calls.length;
-
-      set(premium, true);
+      set(logged, false);
       await nextTick();
 
-      expect(apiCallSpy).toHaveBeenCalledTimes(callCount);
+      expect(get(capabilities)).toBeUndefined();
     });
 
-    it('should integrate with useFeatureAccess after API call', async () => {
+    it('should integrate with useFeatureAccess after fetchCapabilities', async () => {
       const mockCapabilities: PremiumCapabilities = {
         [PremiumFeature.ASSET_MOVEMENT_MATCHING]: cap(false),
         [PremiumFeature.ETH_STAKING_VIEW]: cap(true),
@@ -387,7 +348,7 @@ describe('modules/premium/use-feature-access', () => {
       };
 
       server.use(mockPremiumCapabilities(mockCapabilities));
-      usePremiumWatchers();
+      const { fetchCapabilities } = usePremiumWatchers();
 
       const store = usePremiumStore();
       const { premium } = storeToRefs(store);
@@ -401,12 +362,11 @@ describe('modules/premium/use-feature-access', () => {
       expect(get(eventAnalysisAllowed)).toBe(false);
 
       set(premium, true);
+      await fetchCapabilities();
 
-      await vi.waitFor(() => {
-        expect(get(ethStakingAllowed)).toBe(true);
-        expect(get(graphsAllowed)).toBe(true);
-        expect(get(eventAnalysisAllowed)).toBe(false);
-      });
+      expect(get(ethStakingAllowed)).toBe(true);
+      expect(get(graphsAllowed)).toBe(true);
+      expect(get(eventAnalysisAllowed)).toBe(false);
     });
 
     it('should handle gnosis pay and monerium capabilities', async () => {
@@ -416,7 +376,7 @@ describe('modules/premium/use-feature-access', () => {
       };
 
       server.use(mockPremiumCapabilities(mockCapabilities));
-      usePremiumWatchers();
+      const { fetchCapabilities } = usePremiumWatchers();
 
       const store = usePremiumStore();
       const { premium } = storeToRefs(store);
@@ -428,13 +388,12 @@ describe('modules/premium/use-feature-access', () => {
       expect(get(moneriumAllowed)).toBe(false);
 
       set(premium, true);
+      await fetchCapabilities();
 
-      await vi.waitFor(() => {
-        expect(get(gnosisPayAllowed)).toBe(true);
-        expect(get(moneriumAllowed)).toBe(false);
-        expect(get(gnosisPayTier)).toBe('Advanced');
-        expect(get(moneriumTier)).toBe('Advanced');
-      });
+      expect(get(gnosisPayAllowed)).toBe(true);
+      expect(get(moneriumAllowed)).toBe(false);
+      expect(get(gnosisPayTier)).toBe('Advanced');
+      expect(get(moneriumTier)).toBe('Advanced');
     });
   });
 });

--- a/frontend/app/src/modules/premium/use-premium-watchers.ts
+++ b/frontend/app/src/modules/premium/use-premium-watchers.ts
@@ -3,17 +3,16 @@ import { useSessionAuthStore } from '@/store/session/auth';
 import { usePremiumStore } from '@/store/session/premium';
 import { logger } from '@/utils/logging';
 
-export function usePremiumWatchers(): void {
+interface UsePremiumWatchersReturn {
+  fetchCapabilities: () => Promise<void>;
+}
+
+export function usePremiumWatchers(): UsePremiumWatchersReturn {
   const api = usePremiumCredentialsApi();
-  const { capabilities, premium } = storeToRefs(usePremiumStore());
+  const { capabilities } = storeToRefs(usePremiumStore());
   const { logged } = storeToRefs(useSessionAuthStore());
 
-  watchImmediate([premium, logged], async ([, isLogged]) => {
-    if (!isLogged) {
-      set(capabilities, undefined);
-      return;
-    }
-
+  async function fetchCapabilities(): Promise<void> {
     try {
       const result = await api.getPremiumCapabilities();
       set(capabilities, result);
@@ -21,5 +20,13 @@ export function usePremiumWatchers(): void {
     catch (error: unknown) {
       logger.error('Failed to fetch premium capabilities:', error);
     }
+  }
+
+  watch(logged, (isLogged) => {
+    if (!isLogged) {
+      set(capabilities, undefined);
+    }
   });
+
+  return { fetchCapabilities };
 }

--- a/frontend/app/src/modules/sigil/use-sigil.ts
+++ b/frontend/app/src/modules/sigil/use-sigil.ts
@@ -10,7 +10,6 @@ import { enqueue, startQueue, stopQueue, WEBSITE_ID } from '@/modules/sigil/use-
 import { router } from '@/router';
 import { useMainStore } from '@/store/main';
 import { useSessionAuthStore } from '@/store/session/auth';
-import { usePremiumStore } from '@/store/session/premium';
 import { useGeneralSettingsStore } from '@/store/settings/general';
 import { logger } from '@/utils/logging';
 
@@ -49,7 +48,6 @@ export const useSigil = createPersistentSharedComposable(({ acquireBusy, release
   const { logged } = storeToRefs(useSessionAuthStore());
   const { submitUsageAnalytics } = storeToRefs(useGeneralSettingsStore());
   const { isDevelop } = storeToRefs(useMainStore());
-  const { capabilities } = storeToRefs(usePremiumStore());
 
   // Initialize handlers in Vue context so they can resolve stores/composables.
   const collectSessionConfig = useSessionConfigHandler();
@@ -86,10 +84,6 @@ export const useSigil = createPersistentSharedComposable(({ acquireBusy, release
     if (sessionReadyHandled)
       return;
     sessionReadyHandled = true;
-
-    // Wait for premium capabilities to load so plan/tier is accurate.
-    if (!get(capabilities))
-      await until(capabilities).not.toBeUndefined({ timeout: 5000 }).catch(() => {});
 
     chronicle('session_config', collectSessionConfig());
     chronicle('exchanges_summary', collectExchangesSummary());


### PR DESCRIPTION
## Summary
- Fetch premium capabilities explicitly during session initialization instead of relying on a `watchImmediate` that raced with the `session:ready` event
- Remove the 5-second timeout workaround in sigil that waited for capabilities to load
- Extract `fetchCapabilities()` from `usePremiumWatchers` so it can be called deterministically during login

## Test plan
- [x] Sigil tests pass (18/18)
- [x] Premium feature access tests pass (21/21)
- [ ] Manual: log in with premium account, verify capabilities load without delay
- [ ] Manual: log in without premium, verify no errors