### PR TITLE
fix(electron): harden Windows shutdown flow

### DIFF
--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -195,20 +195,37 @@ export class Application {
     app.removeAllListeners('before-quit');
   }
 
+  private static readonly quitTimeoutMs = 30_000;
+
   private async quit() {
+    this.logger.info('Quit initiated, starting cleanup...');
     this.cleanup();
     this.menu.cleanup();
     this.window.cleanup();
+    this.logger.info('Window destroyed');
     this.tray.cleanup();
-    this.ipc.cleanup();
+
+    const gracefulShutdown = async (): Promise<void> => {
+      await this.ipc.cleanup();
+      this.logger.info('IPC cleanup complete, terminating subprocesses...');
+      await this.processHandler.terminateProcesses(false, false);
+      this.logger.info('Subprocess termination complete');
+    };
+
+    const timeout = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error('Quit timeout exceeded')), Application.quitTimeoutMs);
+    });
+
     try {
-      await this.processHandler.terminateProcesses();
+      await Promise.race([gracefulShutdown(), timeout]);
+    }
+    catch (error: any) {
+      this.logger.warn(`Quit error: ${error.message}`);
     }
     finally {
-      // In some cases the app object might be already disposed
+      this.logger.info('Calling app.exit()');
       try {
-        if (process.platform !== 'win32')
-          app.exit();
+        app.exit();
       }
       catch (error: any) {
         if (error.message !== 'Object has been destroyed')

--- a/frontend/app/electron/main/ipc-setup.ts
+++ b/frontend/app/electron/main/ipc-setup.ts
@@ -176,14 +176,66 @@ export class IpcManager {
     startPromise(this.oauthHandlers.clearOAuthCookies('startup'));
   }
 
-  cleanup(): void {
+  async cleanup(): Promise<void> {
     this.logger.info('Cleaning up IPC manager resources...');
 
-    // Stop WebSocket server
-    this.walletBridgeWebSocketServer.stop();
+    // Remove all ipcMain.on() listeners registered in initialize()
+    const onChannels = [
+      IpcCommands.SYNC_GET_DEBUG,
+      IpcCommands.SYNC_API_URL,
+      IpcCommands.PREMIUM_LOGIN,
+      IpcCommands.LOG_TO_FILE,
+      IpcCommands.TRAY_UPDATE,
+      IpcCommands.USER_LOGOUT,
+    ] as const;
+
+    for (const channel of onChannels) {
+      ipcMain.removeAllListeners(channel);
+    }
+
+    // Remove all ipcMain.handle() handlers registered in initialize()
+    const handleChannels = [
+      IpcCommands.INVOKE_CLOSE_APP,
+      IpcCommands.INVOKE_OPEN_URL,
+      IpcCommands.INVOKE_OPEN_DIRECTORY,
+      IpcCommands.INVOKE_OPEN_PATH,
+      IpcCommands.INVOKE_CONFIG,
+      IpcCommands.INVOKE_VERSION,
+      IpcCommands.INVOKE_IS_MAC,
+      IpcCommands.INVOKE_THEME,
+      IpcCommands.INVOKE_SUBPROCESS_START,
+      IpcCommands.INVOKE_UPDATE_CHECK,
+      IpcCommands.INVOKE_DOWNLOAD_UPDATE,
+      IpcCommands.INVOKE_INSTALL_UPDATE,
+      IpcCommands.INVOKE_STORE_PASSWORD,
+      IpcCommands.INVOKE_GET_PASSWORD,
+      IpcCommands.INVOKE_CLEAR_PASSWORD,
+      IpcCommands.INVOKE_WALLET_IMPORT,
+      IpcCommands.OPEN_WALLET_CONNECT_BRIDGE,
+      IpcCommands.WALLET_BRIDGE_HTTP_LISTENING,
+      IpcCommands.WALLET_BRIDGE_WS_LISTENING,
+      IpcCommands.WALLET_BRIDGE_CLIENT_READY,
+      IpcCommands.WALLET_BRIDGE_REQUEST,
+      IpcCommands.WALLET_BRIDGE_IS_CLIENT_CONNECTED,
+      IpcCommands.WALLET_BRIDGE_STOP_SERVERS,
+      IpcCommands.WALLET_BRIDGE_GET_PROVIDERS,
+      IpcCommands.WALLET_BRIDGE_SELECT_PROVIDER,
+      IpcCommands.WALLET_BRIDGE_GET_SELECTED_PROVIDER,
+    ] as const;
+
+    for (const channel of handleChannels) {
+      ipcMain.removeHandler(channel);
+    }
+
+    this.callbacks = null;
+    this.logger.info('IPC handlers removed');
+
+    // Stop WebSocket server and wait for connections to close
+    await this.walletBridgeWebSocketServer.stop();
 
     // Cleanup wallet import handlers (they manage their own servers)
     this.walletImportHandlers.cleanup();
+    this.logger.info('IPC cleanup complete');
   }
 
   private readonly handleBridgeDisconnected = (): void => {

--- a/frontend/app/electron/main/process-manager.ts
+++ b/frontend/app/electron/main/process-manager.ts
@@ -162,13 +162,19 @@ export class ProcessManager {
     this.log(`Currently running: ${tasks.length} tasks`);
 
     const pids = tasks.filter(task => task.name === this.command).map(task => task.pid);
+
+    if (pids.length === 0) {
+      this.log(`No running ${this.processName} processes found, skipping taskkill`);
+      return;
+    }
+
     this.log(`Detected the following running rotki-core processes: ${pids.join(', ')}`);
 
     const args = ['/f', '/t'];
 
     for (const pid of pids) args.push('/PID', pid.toString());
 
-    this.log(`Preparing to call "taskill ${args.join(' ')}" on the rotki-core processes`);
+    this.log(`Preparing to call "taskkill ${args.join(' ')}" on the rotki-core processes`);
 
     try {
       spawnSync('taskkill', args);
@@ -209,25 +215,28 @@ export class ProcessManager {
   }
 
   private async waitForTermination(processes: ProcessDescriptor[], processIds: number[]) {
-    function stillRunning(process: ProcessDescriptor[]): number {
-      return process.filter(({ pid }) => processIds.includes(pid)).length;
+    function stillRunning(procs: ProcessDescriptor[]): number {
+      return procs.filter(({ pid }) => processIds.includes(pid)).length;
     }
 
-    const running = stillRunning(processes);
-    if (running === 0) {
+    let remaining = stillRunning(processes);
+    if (remaining === 0) {
       this.log('The process killed successfully');
       return;
     }
 
     for (let i = 0; i < 10; i++) {
-      this.log(`The ${running} processes are still running. Waiting for 2 seconds`);
+      this.log(`${remaining} processes still running. Waiting for 2 seconds`);
       await wait(2000);
       processes = await psList();
-      if (stillRunning(processes) === 0) {
+      remaining = stillRunning(processes);
+      if (remaining === 0) {
         this.log('The process killed successfully');
-        break;
+        return;
       }
     }
+
+    this.log(`Failed to kill ${remaining} processes after 20 seconds of waiting`);
   }
 
   private cleanup() {

--- a/frontend/app/electron/main/window-manager.ts
+++ b/frontend/app/electron/main/window-manager.ts
@@ -219,13 +219,19 @@ export class WindowManager {
     // Reset startup error state
     this.startupError = null;
     this.rendererReady = false;
-    // Clean up window listeners
-    this.window?.removeAllListeners('show');
-    this.window?.removeAllListeners('hide');
-    this.window?.removeAllListeners('close');
-    this.window?.removeAllListeners('closed');
-    this.listener = null;
+    // Clean up window listeners and destroy the window
+    const win = this.window;
     this.window = null;
+    this.listener = null;
+    if (win) {
+      win.removeAllListeners('show');
+      win.removeAllListeners('hide');
+      win.removeAllListeners('close');
+      win.removeAllListeners('closed');
+      if (!win.isDestroyed()) {
+        win.destroy();
+      }
+    }
   }
 
   private setupEventListeners(window: BrowserWindow) {

--- a/frontend/app/electron/main/ws.ts
+++ b/frontend/app/electron/main/ws.ts
@@ -104,7 +104,9 @@ export class WalletBridgeWebSocketServer {
 
     this.idleTimer = setTimeout(() => {
       this.logger.info('WebSocket connection idle timeout reached, closing connection');
-      this.disconnect();
+      this.disconnect().catch((error) => {
+        this.logger.error('Failed to disconnect on idle timeout:', error);
+      });
     }, IDLE_TIMEOUT_MS);
   }
 
@@ -219,7 +221,7 @@ export class WalletBridgeWebSocketServer {
   }
 
   /** Disconnect all connections and stop the server */
-  public disconnect(): void {
+  public async disconnect(): Promise<void> {
     // Clear idle timer
     this.clearIdleTimer();
 
@@ -232,21 +234,26 @@ export class WalletBridgeWebSocketServer {
     // Clear all connection mappings
     this.connectionManager.clearAll();
 
-    if (this.wsServer) {
-      this.wsServer.close();
-      this.wsServer = undefined;
-    }
-
     // Reject all pending requests
     this.pendingRequests.forEach(({ reject }) => {
       reject(new Error('Wallet bridge disconnected'));
     });
     this.pendingRequests.clear();
+
+    // Await server close to ensure all connections are terminated
+    if (this.wsServer) {
+      const server = this.wsServer;
+      this.wsServer = undefined;
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      this.logger.info('Wallet bridge WebSocket server stopped');
+    }
   }
 
   /** Stop the server (alias for disconnect) */
-  public stop(): void {
-    this.disconnect();
+  public async stop(): Promise<void> {
+    await this.disconnect();
   }
 
   public setOnBridgeDisconnected(callback: () => void): void {


### PR DESCRIPTION
## Summary
- Add 30s timeout on the quit flow with unconditional `app.exit()` fallback on all platforms
- Destroy `BrowserWindow` explicitly in `WindowManager.cleanup()` to prevent lingering process
- Remove all ~25 IPC handlers during `IpcManager.cleanup()` to release references
- Await WebSocket server close to ensure connections are terminated before exit
- Guard `taskkill` against empty PID list (invalid call when no processes matched)
- Pass `quitApp=false` from `Application.quit()` to avoid redundant `app.quit()` into removed listeners
- Fix `waitForTermination` logging stale process count and add warning when timeout is exhausted
- Add info/warn logging throughout the quit flow for diagnostics

Closes #12000

## Test plan
- [ ] Build Windows binary and verify app closes cleanly
- [ ] Verify no "app cannot be closed" OS popup on Windows
- [ ] Verify macOS quit flow still works (dock quit, Cmd+Q)
- [ ] Verify Linux close works
- [ ] Verify restart-backend flow still works (subprocess restart)