### PR TITLE
Use ONEDIR when packaging for windows and linux

### DIFF
--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -61,7 +61,7 @@ jobs:
               - [AppImage](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x86_64-${{ env.RELEASE_VERSION }}.AppImage)
               - [Tar with executable](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x64-${{ env.RELEASE_VERSION }}.tar.xz)
               - [deb package](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_amd64-${{ env.RELEASE_VERSION }}.deb)
-              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-core-${{ steps.change_log.outputs.version }}-linux)
+              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-core-${{ steps.change_log.outputs.version }}-linux.zip)
             - **OSX**
               - arm64
                 - [DMG](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-darwin_arm64-${{ env.RELEASE_VERSION }}.dmg)
@@ -72,7 +72,7 @@ jobs:
               - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-core-${{ steps.change_log.outputs.version }}-macos.zip)
             - **Windows**
               - [Windows executable](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-win32_x64-${{ env.RELEASE_VERSION }}.exe)
-              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-core-${{ steps.change_log.outputs.version }}-windows.exe)
+              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-core-${{ steps.change_log.outputs.version }}-windows.zip)
             
             Optionally, you can also [verify the integrity](https://docs.rotki.com/requirement-and-installation/packaged-binaries.html#verifying-integrity) of the aforementioned binaries using the following checksums:
             
@@ -80,7 +80,7 @@ jobs:
               - [AppImage checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x86_64-${{ env.RELEASE_VERSION }}.AppImage.sha512)
               - [Tar with executable checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_x64-${{ env.RELEASE_VERSION }}.tar.xz.sha512)
               - [deb package](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-linux_amd64-${{ env.RELEASE_VERSION }}.deb.sha512)
-              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-core-${{ steps.change_log.outputs.version }}-linux.sha512)
+              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-core-${{ steps.change_log.outputs.version }}-linux.zip.sha512)
             - **OSX**
               - arm64
                 - [DMG checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-darwin_arm64-${{ env.RELEASE_VERSION }}.dmg.sha512)
@@ -91,7 +91,7 @@ jobs:
               - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-core-backend-${{ steps.change_log.outputs.version }}-macos.zip.sha512)
             - **Windows**
               - [Windows executable checksum](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-win32_x64-${{ env.RELEASE_VERSION }}.exe.sha512)
-              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-core-${{ steps.change_log.outputs.version }}-windows.exe.sha512)
+              - [Standalone Backend](https://github.com/rotki/rotki/releases/download/${{ env.RELEASE_VERSION }}/rotki-core-${{ steps.change_log.outputs.version }}-windows.zip.sha512)
 
             # Release Highlights
             ----
@@ -171,12 +171,12 @@ jobs:
           draft: true
           files: |
             dist/*.sha512
-            dist/rotki-core-*-linux
+            dist/rotki-core-*-linux.zip
 
       - uses: actions/attest-build-provenance@v1
         with:
           subject-path: |
-            dist/rotki-core-*-linux
+            dist/rotki-core-*-linux.zip
             dist/*.deb
             dist/*.AppImage
             dist/*.tar.xz
@@ -399,11 +399,13 @@ jobs:
           draft: true
           files: |
             dist/*.sha512
-            dist/rotki-core-*-windows.exe
+            dist/rotki-core-*-windows.zip
 
       - uses: actions/attest-build-provenance@v1
         with:
-          subject-path: dist/*.exe
+          subject-path: |
+            dist/*.exe
+            dist/rotki-core-*-windows.zip
 
   docker:
     name: 'Build docker images'

--- a/frontend/app/electron/main/core-args.ts
+++ b/frontend/app/electron/main/core-args.ts
@@ -1,6 +1,5 @@
 import type { BackendOptions } from '@shared/ipc';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { assert } from '@rotki/common';
@@ -108,9 +107,23 @@ export const RotkiCoreConfig = {
     }
     else {
       const resources = process.resourcesPath ? process.resourcesPath : import.meta.dirname;
-      const binaryDirectory = os.platform() === 'darwin'
-        ? path.join(resources, BACKEND_DIRECTORY, 'rotki-core')
-        : path.join(resources, BACKEND_DIRECTORY);
+      const backendDirectory = path.join(resources, BACKEND_DIRECTORY);
+      const candidateBinaryDirectories: string[] = [
+        path.join(backendDirectory, 'rotki-core'),
+        backendDirectory,
+      ];
+
+      const binaryDirectory = candidateBinaryDirectories.find((directory: string) => {
+        if (!fs.existsSync(directory))
+          return false;
+
+        return fs.statSync(directory).isDirectory();
+      });
+
+      if (!binaryDirectory) {
+        const searched = candidateBinaryDirectories.join(', ');
+        throw new RotkiConfigError(`No backend directory found. Searched: ${searched}`, false);
+      }
 
       const files = fs.readdirSync(binaryDirectory);
 

--- a/package.py
+++ b/package.py
@@ -84,9 +84,6 @@ class Environment:
         self.os = platform.system()
         self.target_arch = os.environ.get('MACOS_BUILD_ARCH', self.arch)
 
-        if self.is_mac():
-            os.environ.setdefault('ONEFILE', '0')
-
         self.rotki_version = rotki_version
         if os.environ.get('ROTKI_VERSION') is None:
             os.environ.setdefault('ROTKI_VERSION', self.rotki_version)
@@ -505,27 +502,6 @@ class MacPackaging:
                 sys.exit(1)
         self.cleanup_keychain()
 
-    @log_group('zip')
-    def perform_zip(self) -> None:
-        """
-        Creates a zip from the directory that contains the backend, checksums it
-        and moves them to the dist/ directory.
-        """
-        backend_directory = self.__storage.backend_directory
-        os.chdir(backend_directory)
-        zip_filename = f'{BACKEND_PREFIX}-{self.__environment.rotki_version}-{self.__environment.backend_suffix()}.zip'  # noqa: E501
-        ret_code = subprocess.call(
-            f'zip -vr "{zip_filename}" {BACKEND_PREFIX}/ -x "*.DS_Store"',
-            shell=True,
-        )
-        if ret_code != 0:
-            logger.error('zip failed')
-            sys.exit(1)
-        zip_file = backend_directory / zip_filename
-        checksum_file = Checksum.generate(self.__environment, zip_file)
-        self.__storage.move_to_dist(zip_file)
-        self.__storage.move_to_dist(checksum_file)
-
 
 class BackendBuilder:
     def __init__(
@@ -643,16 +619,20 @@ class BackendBuilder:
 
     def __move_to_dist(self) -> None:
         """
-        Generates a checksum for the backend and moves it along with a copy of the backend
-        to the dist/ directory. The backend file is copied instead of moved because the original
-        will be needed for electron-builder.
+        Generates a zipped backend artifact from the onedir output,
+        creates its checksum and moves both to the dist/ directory.
         """
         backend_directory = self.__storage.backend_directory
-        os.chdir(backend_directory)
-        filename = f'{BACKEND_PREFIX}-{self.__env.rotki_version}-{self.__env.backend_suffix()}'
-        file = backend_directory / filename
-        checksum_file = Checksum.generate(self.__env, file)
-        self.__storage.copy_to_dist(file)
+        backend_bundle_dir = backend_directory / BACKEND_PREFIX
+        if not backend_bundle_dir.exists():
+            logger.error(f'missing backend bundle directory: {backend_bundle_dir}')
+            sys.exit(1)
+
+        suffix = self.__env.backend_suffix().removesuffix('.exe')
+        archive_basename = backend_directory / f'{BACKEND_PREFIX}-{self.__env.rotki_version}-{suffix}'  # noqa: E501
+        archive_path = Path(shutil.make_archive(str(archive_basename), 'zip', backend_directory, BACKEND_PREFIX))  # noqa: E501
+        checksum_file = Checksum.generate(self.__env, archive_path)
+        self.__storage.move_to_dist(archive_path)
         self.__storage.move_to_dist(checksum_file)
 
     def _move_colibri_to_dist(self) -> None:
@@ -691,15 +671,11 @@ class BackendBuilder:
         self.__sanity_check()
         self.__package()
 
-        # When building for mac perform_zip() is
-        # responsible for moving the packaged backend to dist
         if mac is not None:
             backend_directory = self.__storage.backend_directory / BACKEND_PREFIX
             mac.sign(paths=backend_directory.glob('**/*'))
-            mac.perform_zip()
-        else:
-            self.__move_to_dist()
 
+        self.__move_to_dist()
         self._move_colibri_to_dist()
 
     @staticmethod
@@ -785,12 +761,8 @@ class BackendBuilder:
         """
         Packages the rotki backend using PyInstaller with Python optimizations.
 
-        In Linux, Windows the method will create an one-file bundled executable.
-
-        In macOS it will create an one-folder bundle containing an executable.
-        The reason we use the one-folder approach for macOS is due to signing.
-        All the bundled files have to be individually signed with a valid key
-        otherwise the backend will not start and will give cryptic errors instead.
+        The backend is built in one-folder mode on all platforms.
+        On macOS, bundled files are signed before creating the archive artifact.
         """
         self.__storage.prepare_backend()
         backend_directory = self.__storage.backend_directory

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -13,11 +13,9 @@ from rotkehlchen.types import CHAINS_WITH_TRANSACTION_DECODERS, Location
 from rotkehlchen.utils.misc import get_system_spec
 
 """
-PyInstaller spec file to build single file or dir distributions
+PyInstaller spec file to build one-folder distributions.
 """
 
-# Set to false to produce an exploded single-dir
-ONEFILE = int(os.environ.get('ONEFILE', True))
 MACOS_IDENTITY = os.environ.get('IDENTITY', None)
 
 
@@ -97,49 +95,33 @@ a = Entrypoint(
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)
 
-if ONEFILE:
-    exe = EXE(
-        pyz,
-        a.scripts,
-        a.binaries,
-        a.zipfiles,
-        a.datas,
-        name=executable_name,
-        debug=False,
-        strip=False,
-        upx=False,
-        runtime_tmpdir=None,
-        console=True,
-    )
-else:
+identity = None
+entitlements = None
+if MACOS_IDENTITY is not None:
+    identity = MACOS_IDENTITY
+    entitlements = 'packaging/entitlements.plist'
 
-    identity = None
-    entitlements = None
-    if MACOS_IDENTITY is not None:
-        identity = MACOS_IDENTITY
-        entitlements = 'packaging/entitlements.plist'
+exe = EXE(
+    pyz,
+    a.scripts,
+    exclude_binaries=True,
+    name=executable_name,
+    debug=False,
+    strip=False,
+    upx=False,
+    console=True,
+    codesign_identity=identity,
+    entitlements_file=entitlements,
+)
 
-    exe = EXE(
-        pyz,
-        a.scripts,
-        exclude_binaries=True,
-        name=executable_name,
-        debug=False,
-        strip=False,
-        upx=False,
-        console=True,
-        codesign_identity=identity,
-        entitlements_file=entitlements,
-    )
-
-    coll = COLLECT(
-        exe,
-        a.binaries,
-        a.zipfiles,
-        a.datas,
-        strip=False,
-        upx=False,
-        name='rotki-core',
-        codesign_identity=identity,
-        entitlements_file=entitlements,
-    )
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    name='rotki-core',
+    codesign_identity=identity,
+    entitlements_file=entitlements,
+)


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
