### PR TITLE
Adjust address provider for curve pools

### DIFF
--- a/rotkehlchen/chain/evm/decoding/curve/constants.py
+++ b/rotkehlchen/chain/evm/decoding/curve/constants.py
@@ -112,9 +112,13 @@ CURVE_METAREGISTRY_METHODS = [
     'get_coins',
     'get_underlying_coins',
 ]
-# The address provider address is same for all the supported chains
-# https://docs.curve.finance/deployments/contract-deployments/#address-provider
+# Curve address provider is the same for many chains but changes in some specific cases.
+# https://docs.curve.finance/developer/deployments?search=address-provider
 CURVE_ADDRESS_PROVIDER: Final = string_to_evm_address('0x5ffe7FB82894076ECB99A30D6A32e969e6e35E98')
+CURVE_ADDRESS_PROVIDER_BY_CHAIN: Final = {
+    ChainID.HYPERLIQUID: string_to_evm_address('0x1764ee18e8B3ccA4787249Ceb249356192594585'),
+    ChainID.MONAD: string_to_evm_address('0x4574921eb950d3Fd5B01562162EC566Cb8bc3648'),
+}
 # This is used in these evm chains(ethereum, optimism, gnosis, polygon, arbitrum)
 # https://github.com/curvefi/curve-router-ng/blob/1014d3691bd9df935dc06fc5988484b0614d1fd5/v1.0/README.md
 CURVE_SWAP_ROUTER_V1: Final = string_to_evm_address('0xF0d4c12A5768D806021F80a262B4d39d26C58b8D')

--- a/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
+++ b/rotkehlchen/chain/evm/decoding/curve/curve_cache.py
@@ -7,6 +7,7 @@ from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.curve.constants import (
     CPT_CURVE,
     CURVE_ADDRESS_PROVIDER,
+    CURVE_ADDRESS_PROVIDER_BY_CHAIN,
     CURVE_API_URL,
     CURVE_CHAIN_ID,
     CURVE_METAREGISTRY_METHODS,
@@ -227,7 +228,20 @@ def _query_curve_data_from_chain(
     """Query all curve information(lp tokens, pools, gauges, pool coins) from the metaregistry.
     `reload_all` controls whether to refresh all pools or only query new pools.
     """
-    address_provider = evm_inquirer.contracts.contract(CURVE_ADDRESS_PROVIDER)
+    address_provider_address = CURVE_ADDRESS_PROVIDER_BY_CHAIN.get(
+        evm_inquirer.chain_id,
+        CURVE_ADDRESS_PROVIDER,
+    )
+
+    if (address_provider := evm_inquirer.contracts.contract_by_address(
+        address=address_provider_address,
+    )) is None:
+        log.error(
+            f'Failed to retrieve Curve address provider contract {address_provider_address} '
+            f'on {evm_inquirer.chain_name}. Skipping Curve cache update.',
+        )
+        return []
+
     try:
         metaregistry_address = deserialize_evm_address(address_provider.call(
             node_inquirer=evm_inquirer,


### PR DESCRIPTION
Addresses this error that we saw in develop

```
[09/04/2026 18:32:28 CEST] ERROR rotkehlchen.greenlets.manager Greenlet with id 5502051648: decode 9 monad transactions died with exception: 'NoneType' object has no attribute 'call'.
Exception Name: <class 'AttributeError'>
Exception Info: 'NoneType' object has no attribute 'call'
Traceback:
   File "src/gevent/greenlet.py", line 912, in gevent._gevent_cgreenlet.Greenlet.run
  File "rotkehlchen/chain/decoding/decoder.py", line 220, in get_and_decode_undecoded_transactions
  File "rotkehlchen/chain/decoding/decoder.py", line 269, in decode_transaction_hashes
  File "rotkehlchen/chain/evm/decoding/decoder.py", line 751, in _decode_transaction_hashes
  File "rotkehlchen/chain/decoding/decoder.py", line 378, in _decode_transaction_hashes
  File "rotkehlchen/chain/decoding/decoder.py", line 399, in _do_decode_transaction_hashes
  File "rotkehlchen/chain/decoding/decoder.py", line 183, in reload_data
  File "rotkehlchen/chain/evm/decoding/decoder.py", line 402, in _reload_single_decoder
  File "rotkehlchen/chain/evm/decoding/interfaces.py", line 470, in reload_data
  File "rotkehlchen/utils/mixins/lockable.py", line 73, in wrapper
  File "rotkehlchen/chain/evm/node_inquirer.py", line 1460, in ensure_cache_data_is_updated
  File "rotkehlchen/chain/evm/decoding/curve/curve_cache.py", line 390, in query_curve_data
  File "rotkehlchen/chain/evm/decoding/curve/curve_cache.py", line 232, in _query_curve_data_from_chain
``` 