### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    ":dependencyDashboard",
     ":dependencyDashboardApproval",
     ":pinAllExceptPeerDependencies",
     ":separateMultipleMajorReleases"

--- a/.github/workflows/rotki_cassette_merge.yml
+++ b/.github/workflows/rotki_cassette_merge.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.repository == 'rotki/rotki' }}
     environment: cassette-merge
     steps:
-      - uses: rotki/action-cassette-deck@v4
+      - uses: rotki/action-cassette-deck@56ee180ca0d2c8db88e61d7e68a0613e9407278e  # v4.0.0
         with:
           token: ${{ secrets.MERGE_TOKEN }}
           cassette_repo: test-caching

--- a/.github/workflows/rotki_cassette_merge.yml
+++ b/.github/workflows/rotki_cassette_merge.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.repository == 'rotki/rotki' }}
     environment: cassette-merge
     steps:
-      - uses: rotki/action-cassette-deck@v3
+      - uses: rotki/action-cassette-deck@v4
         with:
           token: ${{ secrets.MERGE_TOKEN }}
           cassette_repo: test-caching

--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -35,12 +35,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Run check action
-        uses: rotki/action-job-checker@v5
+        uses: rotki/action-job-checker@7e0e1933df593a14ee57c51d2be1f0014d4191d0  # v5.0.0
         id: checker
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,12 +62,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Run typos checker
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d  # v1.45.0
 
   code-analyze-frontend:
     name: 'Code analyze frontend'
@@ -80,20 +80,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
         with:
           languages: 'javascript'
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
         with:
           category: "/language:javascript"
 
@@ -106,23 +106,23 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 2
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: 'pnpm'
@@ -162,23 +162,23 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           version: ${{ env.UV_VERSION }}
@@ -201,20 +201,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
         with:
           languages: 'python'
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
         with:
           category: "/language:python"
 
@@ -226,15 +226,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@clippy
+      - uses: dtolnay/rust-toolchain@e7a32da269276b4d9cb3a0343133a168355ab751  # clippy
         with:
           toolchain: 1.91
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           cache-on-failure: true
           workspaces: colibri
@@ -258,23 +258,23 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           version: ${{ env.UV_VERSION }}
@@ -282,20 +282,20 @@ jobs:
 
       - name: Cache find-duplicate-constants binary
         id: fdc-cache
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: tools/find-duplicate-constants/target/release/find-duplicate-constants
           key: ${{ runner.os }}-find-duplicate-constants-${{ hashFiles('tools/find-duplicate-constants/Cargo.lock', 'tools/find-duplicate-constants/Cargo.toml', 'tools/find-duplicate-constants/src/**') }}
 
       - name: Setup Rust
         if: steps.fdc-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: 1.91
 
       - name: Cache Rust dependencies
         if: steps.fdc-cache.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           cache-on-failure: true
           workspaces: tools/find-duplicate-constants

--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Run check action
-        uses: rotki/action-job-checker@v4
+        uses: rotki/action-job-checker@v5
         id: checker
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -112,7 +112,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 
@@ -167,7 +167,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 
@@ -263,7 +263,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -29,35 +29,35 @@ jobs:
       actions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: false
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
 
@@ -70,7 +70,7 @@ jobs:
           uv run package.py --build full
 
       - name: Upload files
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: linux-app
           path: |
@@ -107,13 +107,13 @@ jobs:
       actions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
@@ -122,7 +122,7 @@ jobs:
         run: rustup target add aarch64-apple-darwin
 
       - name: Cache python pkg
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: ~/python*.pkg
           key: ${{ runner.os }}-python-${{ env.PYTHON_VERSION }}-${{ env.PYTHON_MACOS }}-${{ matrix.os.arch }}
@@ -131,19 +131,19 @@ jobs:
         run: packaging/setup-macos-python.sh "${PYTHON_VERSION}" "${PYTHON_MACOS}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: false
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
 
@@ -162,7 +162,7 @@ jobs:
           APPLEIDPASS: ${{ secrets.APPLEIDPASS }}
 
       - name: Upload files (${{ matrix.os.arch }})
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: macos-app-${{ matrix.os.arch }}
           path: |
@@ -170,7 +170,7 @@ jobs:
             dist/rotki-darwin_*.dmg.sha512
 
       - name: Upload colibri files
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: macos-colibri-${{ matrix.os.arch }}
           path: |
@@ -189,35 +189,35 @@ jobs:
       actions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Set up python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: false
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
 
@@ -234,7 +234,7 @@ jobs:
         shell: powershell
 
       - name: Upload files
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: windows-app
           path: |
@@ -259,7 +259,7 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -272,19 +272,19 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: |
             ${{ github.repository }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Rotki Version
         id: rotki_version
@@ -296,7 +296,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./Dockerfile
@@ -319,7 +319,7 @@ jobs:
           touch "${TEMP}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -333,24 +333,24 @@ jobs:
     environment: docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: |
             ${{ github.repository }}
@@ -381,7 +381,7 @@ jobs:
     environment: nightly_notify
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 
@@ -113,7 +113,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 
@@ -195,7 +195,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/rotki_docker_publish.yaml
+++ b/.github/workflows/rotki_docker_publish.yaml
@@ -19,7 +19,7 @@ jobs:
       REGCTL_SUM: 'df25ceaadf190ec73804023657673128a62d909cca12ccd7a9a727a0b6df84b846b00a89ae581bf179528d74dce6a12fb8b7f5e55e546615b75e0a5e5c56c227'
     steps:
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -29,7 +29,7 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
 
       - name: Cache regctl
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: regctl-linux-amd64
           key: ${{ runner.os }}-regctl-${{ env.REGCTL }}

--- a/.github/workflows/rotki_nightly.yml
+++ b/.github/workflows/rotki_nightly.yml
@@ -65,24 +65,24 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           version: ${{ env.UV_VERSION }}
@@ -92,7 +92,7 @@ jobs:
         run: uv sync --group dev --group lint --group ci
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: coverage-ubuntu-22.04-*
           merge-multiple: true
@@ -104,7 +104,7 @@ jobs:
           uv run coverage xml -o coverage.xml
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5.5.4
         with:
           flags: backend-nightly
           files: coverage.xml
@@ -134,7 +134,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/rotki_nightly.yml
+++ b/.github/workflows/rotki_nightly.yml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v2
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -153,6 +153,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
+          package-manager-cache: false
 
       - name: Package
         id: packaging
@@ -252,6 +253,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
+          package-manager-cache: false
 
       - name: Package
         id: packaging
@@ -309,6 +311,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
+          package-manager-cache: false
 
       - name: download latest-mac.yml artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -378,6 +381,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
+          package-manager-cache: false
 
       - name: Build rotki
         id: packaging

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -24,7 +24,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -119,13 +119,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 
@@ -133,24 +133,24 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
 
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'frontend/.nvmrc'
 
@@ -173,7 +173,7 @@ jobs:
             dist/*.sha512
             dist/rotki-core-*-linux.zip
 
-      - uses: actions/attest-build-provenance@v1
+      - uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             dist/rotki-core-*-linux.zip
@@ -213,13 +213,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 
@@ -228,7 +228,7 @@ jobs:
         run: rustup target add aarch64-apple-darwin
 
       - name: Cache python pkg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/python*.pkg
           key: ${{ runner.os }}-python-${{ env.PYTHON_VERSION }}-${{ env.PYTHON_MACOS }}-${{ matrix.os.arch }}
@@ -237,19 +237,19 @@ jobs:
         run: packaging/setup-macos-python.sh "${PYTHON_VERSION}" "${PYTHON_MACOS}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'frontend/.nvmrc'
 
@@ -271,7 +271,7 @@ jobs:
         run: mv dist/latest-mac.yml dist/latest-mac-${{ matrix.os.arch }}.yml
 
       - name: upload latest-mac.yml
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: latest-mac-${{ matrix.os.arch }}
           path: dist/latest-mac-*.yml
@@ -286,7 +286,7 @@ jobs:
             dist/*.sha512
             dist/rotki-core-*-macos-*.zip
 
-      - uses: actions/attest-build-provenance@v1
+      - uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             dist/*.zip
@@ -300,18 +300,18 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'frontend/.nvmrc'
 
       - name: download latest-mac.yml artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: latest-mac
           pattern: latest-mac-*
@@ -344,13 +344,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 
@@ -358,24 +358,24 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
 
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: 'frontend/.nvmrc'
 
@@ -401,7 +401,7 @@ jobs:
             dist/*.sha512
             dist/rotki-core-*-windows.zip
 
-      - uses: actions/attest-build-provenance@v1
+      - uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             dist/*.exe
@@ -425,7 +425,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -437,19 +437,19 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ github.repository }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Rotki Version
         id: rotki_version
@@ -457,7 +457,7 @@ jobs:
 
       - name: Build and push by digest
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -480,7 +480,7 @@ jobs:
           touch "${TEMP}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -494,24 +494,24 @@ jobs:
     environment: docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ github.repository }}

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -24,7 +24,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: rotki/action-gh-release@v2
+        uses: rotki/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
@@ -119,13 +119,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
@@ -133,24 +133,24 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
 
       - name: Set up python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: false
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
 
@@ -164,7 +164,7 @@ jobs:
           uv run ./package.py --build full
 
       - name: Upload to release
-        uses: rotki/action-gh-release@v2
+        uses: rotki/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           name: Rotki ${{ env.RELEASE_VERSION }} -
@@ -173,7 +173,7 @@ jobs:
             dist/*.sha512
             dist/rotki-core-*-linux.zip
 
-      - uses: actions/attest-build-provenance@v4
+      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           subject-path: |
             dist/rotki-core-*-linux.zip
@@ -213,13 +213,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
@@ -228,7 +228,7 @@ jobs:
         run: rustup target add aarch64-apple-darwin
 
       - name: Cache python pkg
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: ~/python*.pkg
           key: ${{ runner.os }}-python-${{ env.PYTHON_VERSION }}-${{ env.PYTHON_MACOS }}-${{ matrix.os.arch }}
@@ -237,19 +237,19 @@ jobs:
         run: packaging/setup-macos-python.sh "${PYTHON_VERSION}" "${PYTHON_MACOS}"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: false
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
 
@@ -271,13 +271,13 @@ jobs:
         run: mv dist/latest-mac.yml dist/latest-mac-${{ matrix.os.arch }}.yml
 
       - name: upload latest-mac.yml
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: latest-mac-${{ matrix.os.arch }}
           path: dist/latest-mac-*.yml
 
       - name: Upload to release
-        uses: rotki/action-gh-release@v2
+        uses: rotki/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           name: Rotki ${{ env.RELEASE_VERSION }} -
@@ -286,7 +286,7 @@ jobs:
             dist/*.sha512
             dist/rotki-core-*-macos-*.zip
 
-      - uses: actions/attest-build-provenance@v4
+      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           subject-path: |
             dist/*.zip
@@ -300,18 +300,18 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
 
       - name: download latest-mac.yml artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: latest-mac
           pattern: latest-mac-*
@@ -323,7 +323,7 @@ jobs:
           node ./.github/scripts/merge-latest.mjs latest-mac/latest-mac-x86_64.yml latest-mac/latest-mac-arm64.yml latest-mac.yml
 
       - name: Upload to release
-        uses: rotki/action-gh-release@v2
+        uses: rotki/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           name: Rotki ${{ env.RELEASE_VERSION }} -
@@ -344,13 +344,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
@@ -358,24 +358,24 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
 
       - name: Set up python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: false
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
 
@@ -392,7 +392,7 @@ jobs:
         shell: powershell
 
       - name: Upload to release
-        uses: rotki/action-gh-release@v2
+        uses: rotki/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           name: Rotki ${{ env.RELEASE_VERSION }} -
@@ -401,7 +401,7 @@ jobs:
             dist/*.sha512
             dist/rotki-core-*-windows.zip
 
-      - uses: actions/attest-build-provenance@v4
+      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           subject-path: |
             dist/*.exe
@@ -425,7 +425,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -437,19 +437,19 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: |
             ${{ github.repository }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Rotki Version
         id: rotki_version
@@ -457,7 +457,7 @@ jobs:
 
       - name: Build and push by digest
         id: docker_build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: ./Dockerfile
@@ -480,7 +480,7 @@ jobs:
           touch "${TEMP}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -494,24 +494,24 @@ jobs:
     environment: docker
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
           images: |
             ${{ github.repository }}

--- a/.github/workflows/rotki_sqldiff.yml
+++ b/.github/workflows/rotki_sqldiff.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: SQLDiff action
         id: sql-diff
-        uses: rotki/action-sqldiff@v2
+        uses: rotki/action-sqldiff@v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           files: '*.db'

--- a/.github/workflows/rotki_sqldiff.yml
+++ b/.github/workflows/rotki_sqldiff.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: SQLDiff action
         id: sql-diff
-        uses: rotki/action-sqldiff@v3
+        uses: rotki/action-sqldiff@f993660c46af62ec07baebe149014e170ac03f9d  # v3.0.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           files: '*.db'

--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -83,7 +83,7 @@ jobs:
           echo "VCR setup: $SOURCE_BRANCH not fully rebased on $TARGET_BRANCH" && exit 1
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -38,13 +38,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 2
           persist-credentials: false
 
       - name: Checkout test caching
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: rotki/test-caching
           path: test-caching
@@ -83,24 +83,24 @@ jobs:
           echo "VCR setup: $SOURCE_BRANCH not fully rebased on $TARGET_BRANCH" && exit 1
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
       - name: Cache rotkehlchen test directory
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: ~/.cache/.rotkehlchen-test-dir
           key: ${{ runner.os }}-testdir
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: ${{ inputs.collect_coverage }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: coverage-${{ inputs.os }}-${{ matrix.test-group }}
           path: .coverage.${{ matrix.test-group }}

--- a/.github/workflows/task_docs_event_types_check.yml
+++ b/.github/workflows/task_docs_event_types_check.yml
@@ -30,22 +30,22 @@ jobs:
       contents: read
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           version: ${{ env.UV_VERSION }}
@@ -55,7 +55,7 @@ jobs:
         run: uv sync --no-dev --group lint
 
       - name: Checkout docs repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: rotki/docs
           ref: main

--- a/.github/workflows/task_docs_event_types_check.yml
+++ b/.github/workflows/task_docs_event_types_check.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -18,23 +18,23 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 2
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: 'pnpm'
@@ -53,7 +53,7 @@ jobs:
         run: pnpm run build:app --mode e2e
 
       - name: Upload frontend build
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: frontend-dist
           path: frontend/app/dist
@@ -66,21 +66,21 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 2
           persist-credentials: false
 
       - name: Cache Colibri binary
         id: colibri-cache
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: colibri/target/release/colibri
           key: ${{ runner.os }}-colibri-${{ hashFiles('colibri/Cargo.lock', 'colibri/Cargo.toml', 'colibri/build.rs', 'colibri/src/**') }}
 
       - name: Setup Rust
         if: steps.colibri-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: 1.91
 
@@ -90,7 +90,7 @@ jobs:
         run: cargo build --release
 
       - name: Upload Colibri binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: colibri-binary
           path: colibri/target/release/colibri
@@ -112,36 +112,36 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 2
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: 'frontend/pnpm-lock.yaml'
 
       - name: Store test data
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: |
             ./frontend/app/.e2e/data/icons
@@ -149,7 +149,7 @@ jobs:
           key: ${{ runner.os }}-e2e-data-${{ hashFiles('rotkehlchen/data/global.db') }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           version: ${{ env.UV_VERSION }}
@@ -163,13 +163,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download frontend build
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: frontend-dist
           path: frontend/app/dist
 
       - name: Download Colibri binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: colibri-binary
           path: colibri/target/release
@@ -179,7 +179,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/pnpm-lock.yaml') }}
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: success()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./frontend/app/tests/e2e/coverage/lcov.info
@@ -218,14 +218,14 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         if: failure()
         with:
           name: test-artifacts-${{ runner.os }}-${{ matrix.group }}
           path: ./frontend/app/tests/e2e/test-results
 
       - name: Upload backend logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         if: always()
         with:
           name: backend-logs-${{ runner.os }}-${{ matrix.group }}

--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 
@@ -118,7 +118,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/task_fe_external_links_verification.yml
+++ b/.github/workflows/task_fe_external_links_verification.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 

--- a/.github/workflows/task_fe_external_links_verification.yml
+++ b/.github/workflows/task_fe_external_links_verification.yml
@@ -15,23 +15,23 @@ jobs:
       CYPRESS_INSTALL_BINARY: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 2
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: 'pnpm'

--- a/.github/workflows/task_fe_unit_tests.yml
+++ b/.github/workflows/task_fe_unit_tests.yml
@@ -16,23 +16,23 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 2
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v4
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
         with:
           env_file: .github/.env.ci
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5.0.0
         with:
           package_json_file: frontend/package.json
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: 'frontend/.nvmrc'
           cache: 'pnpm'
@@ -47,7 +47,7 @@ jobs:
         run: pnpm run --filter rotki test:unit
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5.5.4
         with:
           flags: frontend_unit
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/task_fe_unit_tests.yml
+++ b/.github/workflows/task_fe_unit_tests.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Load env
-        uses: rotki/action-env@v3
+        uses: rotki/action-env@v4
         with:
           env_file: .github/.env.ci
 

--- a/tools/pin_github_actions.py
+++ b/tools/pin_github_actions.py
@@ -1,0 +1,161 @@
+"""Resolve GitHub Actions tags to commit SHAs for hash pinning.
+
+Usage:
+    python tools/pin_github_actions.py actions/checkout@v6 [owner/repo@ref ...]
+    python tools/pin_github_actions.py --file .github/workflows/rotki_ci.yml
+
+Prints one line per input in the form:
+    owner/repo@<full-sha>  # <resolved-tag>
+
+Set GITHUB_TOKEN in the environment to avoid the unauthenticated rate limit.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Final
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+API_ROOT: Final = 'https://api.github.com'
+USES_RE: Final = re.compile(r'^\s*(?:-\s*)?uses:\s*([^\s#]+)', re.MULTILINE)
+
+
+def _request(url: str) -> dict | list:
+    headers = {
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'rotki-pin-github-actions',
+    }
+    if (token := os.environ.get('GITHUB_TOKEN')):
+        headers['Authorization'] = f'Bearer {token}'
+    with urlopen(Request(url, headers=headers)) as response:  # noqa: S310
+        return json.load(response)
+
+
+def _split_action(action: str) -> tuple[str, str, str]:
+    """Split 'owner/repo[/subpath]@ref' into (owner/repo, subpath, ref)."""
+    if '@' not in action:
+        raise ValueError(f'missing @ref in {action!r}')
+    path, ref = action.rsplit('@', 1)
+    parts = path.split('/', 2)
+    if len(parts) < 2:
+        raise ValueError(f'expected owner/repo in {action!r}')
+    repo = f'{parts[0]}/{parts[1]}'
+    subpath = f'/{parts[2]}' if len(parts) == 3 else ''
+    return repo, subpath, ref
+
+
+def resolve(action: str) -> tuple[str, str]:
+    """Return (full_sha, resolved_ref) for an ``owner/repo[/sub]@ref`` spec.
+
+    ``resolved_ref`` is the most specific tag pointing at the SHA when the
+    input was a branch or short tag (e.g. ``v6`` → ``v6.0.1``); otherwise it
+    is the original ref.
+    """
+    repo, _, ref = _split_action(action)
+    # Try tag first, then branch, then raw commit.
+    for endpoint in (f'git/ref/tags/{quote(ref)}', f'git/ref/heads/{quote(ref)}'):
+        try:
+            data = _request(f'{API_ROOT}/repos/{repo}/{endpoint}')
+            break
+        except HTTPError as exc:
+            if exc.code != 404:
+                raise
+    else:
+        data = _request(f'{API_ROOT}/repos/{repo}/commits/{quote(ref)}')
+
+    if isinstance(data, dict) and 'object' in data:
+        obj = data['object']
+        sha = obj['sha']
+        if obj.get('type') == 'tag':
+            # Annotated tag — dereference to the commit it points at.
+            tag_obj = _request(f'{API_ROOT}/repos/{repo}/git/tags/{sha}')
+            if isinstance(tag_obj, dict):
+                sha = tag_obj['object']['sha']
+    elif isinstance(data, dict) and 'sha' in data:
+        sha = data['sha']
+    else:
+        raise RuntimeError(f'unexpected response shape for {action!r}')
+
+    resolved_ref = _most_specific_tag(repo, sha, ref)
+    return sha, resolved_ref
+
+
+def _most_specific_tag(repo: str, sha: str, fallback: str) -> str:
+    """Find the longest tag name pointing at ``sha`` (e.g. v6 → v6.0.1)."""
+    try:
+        tags = _request(f'{API_ROOT}/repos/{repo}/tags?per_page=100')
+    except HTTPError:
+        return fallback
+    if not isinstance(tags, list):
+        return fallback
+    matches = [
+        t['name'] for t in tags
+        if isinstance(t, dict) and t.get('commit', {}).get('sha') == sha
+    ]
+    if not matches:
+        return fallback
+    # Prefer the longest (most specific) name — semver-like tags sort naturally.
+    matches.sort(key=len, reverse=True)
+    return matches[0]
+
+
+def format_pinned(action: str, sha: str, resolved_ref: str) -> str:
+    repo, subpath, _ = _split_action(action)
+    return f'{repo}{subpath}@{sha}  # {resolved_ref}'
+
+
+def _actions_in_file(path: str) -> list[str]:
+    content = Path(path).read_text(encoding='utf-8')
+    seen: dict[str, None] = {}
+    for match in USES_RE.finditer(content):
+        action = match.group(1)
+        if action.startswith(('./', '.\\')):
+            continue  # local reusable workflow
+        if '@' not in action:
+            continue
+        seen.setdefault(action, None)
+    return list(seen)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('actions', nargs='*', help='owner/repo@ref specs to resolve')
+    parser.add_argument(
+        '--file', '-f',
+        action='append',
+        default=[],
+        help='workflow file to scan for uses: entries',
+    )
+    args = parser.parse_args()
+
+    targets: list[str] = list(args.actions)
+    for file_path in args.file:
+        targets.extend(_actions_in_file(file_path))
+
+    if len(targets) == 0:
+        parser.error('provide at least one action spec or --file')
+
+    exit_code = 0
+    for action in targets:
+        try:
+            sha, resolved_ref = resolve(action)
+        except (HTTPError, ValueError, RuntimeError) as exc:
+            print(f'{action}\tERROR: {exc}', file=sys.stderr)
+            exit_code = 1
+            continue
+        print(format_pinned(action, sha, resolved_ref))
+    return exit_code
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add `tools/pin_github_actions.py` helper that resolves `owner/repo@ref` specs (and whole workflow files via `--file`) to commit SHAs with a trailing version comment, so hash pinning stays Renovate-friendly.
- Bring every workflow action to its latest major. `rotki_release.yaml` and `rotki_nightly.yml` were skipped by Renovate and lagged behind the rest of the workflows; first-party `rotki/action-*` actions are also bumped (except `rotki/action-gh-release` which is pinned to our `v2` fork).
- Pin every `uses:` entry in `.github/workflows/` to a commit SHA, with a `# vX.Y.Z` (or branch name) comment preserved for Renovate.
- Add `package-manager-cache: false` to every `actions/setup-node` in `rotki_release.yaml` so the pnpm project does not pick up the npm-only auto-cache default on tag-triggered publishes.
- Enable Renovate's `:dependencyDashboard` preset so the current state of pending updates is tracked as an issue alongside the existing approval gate.

## Breaking-change audit

All third-party major bumps were cross-checked against upstream release notes. No `with:` blocks need to change. Noted caveats:

- Most actions move to the Node 24 runtime — self-hosted runners (if any) must be ≥ v2.327.1. GitHub-hosted runners are fine.
- `actions/download-artifact@v8` now errors on digest mismatch instead of warning.
- `actions/attest-build-provenance@v2+` emits one combined attestation for multi-subject `subject-path:` instead of per-file attestations. Three release-workflow call sites are affected; no downstream consumer in the repo expects per-file attestations.
- `docker/build-push-action@v7` removes `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` — neither is set anywhere in `.github/`.
- `docker/metadata-action@v6` tightened `#` parsing in list inputs — no literal `#` in our `tags:` / `flavor:` blocks.

## Test plan

- [ ] CI green on this branch (lint, backend, frontend, e2e, docs)
- [ ] Nightly workflow dispatch succeeds
- [ ] Release dry-run on a test tag verifies the Docker buildx publish path still works with the pinned docker/* actions