### PR TITLE
fix: allow deletion of external swap events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` External swap events (manual trades) can now be deleted from the history events view.
 * :feature:`12028` "Ignore/Unignore in accounting" labels are now "Exclude/Include from accounting (PnL)" for clarity.
 * :feature:`11068` rotki now also counts staked solana balances.
 * :feature:`11982` Blockscout users can add their PRO API key.

--- a/frontend/app/src/components/history/events/HistoryEventsAction.vue
+++ b/frontend/app/src/components/history/events/HistoryEventsAction.vue
@@ -45,6 +45,7 @@ const emit = defineEmits<{
   'redecode': [event: PullEventPayload];
   'redecode-with-options': [event: PullEventPayload];
   'delete-tx': [data: LocationAndTxRef];
+  'delete-events': [ids: number[]];
   'fix-duplicate': [];
   'ignore-duplicate': [];
 }>();
@@ -163,9 +164,16 @@ function redecodeWithOptions(event: DecodableEventType): void {
   });
 }
 
-function deleteTxAndEvents(params: LocationAndTxRef) {
-  return emit('delete-tx', params);
+function deleteTxAndEvents(params: LocationAndTxRef): void {
+  emit('delete-tx', params);
 }
+
+function deleteEvents(): void {
+  const ids = groupEvents?.map(e => e.identifier) ?? [event.identifier];
+  emit('delete-events', ids);
+}
+
+const canDeleteEvents = computed<boolean>(() => !get(eventWithTxRef) && !get(blockEvent));
 
 function hideAddAction(item: HistoryEvent): boolean {
   return isGroupEditableHistoryEvent(item);
@@ -345,6 +353,18 @@ function confirmIgnoreDuplicate(): void {
             <RuiIcon name="lu-trash-2" />
           </template>
           {{ t('transactions.actions.delete_transaction') }}
+        </RuiButton>
+        <RuiButton
+          v-else-if="canDeleteEvents"
+          variant="list"
+          color="error"
+          :disabled="loading"
+          @click="deleteEvents()"
+        >
+          <template #prepend>
+            <RuiIcon name="lu-trash-2" />
+          </template>
+          {{ t('transactions.actions.delete_event') }}
         </RuiButton>
         <RuiDivider class="my-2" />
         <RuiButton

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5460,6 +5460,7 @@
     "actions": {
       "add_event": "Add new event",
       "add_event_here": "Add new event here",
+      "delete_event": "Delete event",
       "delete_transaction": "Delete transaction & events",
       "redecode_events": "Redecode events",
       "redecode_page": "Redecode page",

--- a/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
@@ -38,6 +38,7 @@ const emit = defineEmits<{
   'redecode': [event: PullEventPayload];
   'redecode-with-options': [event: PullEventPayload];
   'delete-tx': [data: LocationAndTxRef];
+  'delete-events': [ids: number[]];
   'fix-duplicate': [];
   'ignore-duplicate': [];
 }>();
@@ -120,6 +121,7 @@ const isCard = computed<boolean>(() => variant === 'card');
         @redecode="emit('redecode', $event)"
         @redecode-with-options="emit('redecode-with-options', $event)"
         @delete-tx="emit('delete-tx', $event)"
+        @delete-events="emit('delete-events', $event)"
         @fix-duplicate="emit('fix-duplicate')"
         @ignore-duplicate="emit('ignore-duplicate')"
       />
@@ -227,6 +229,7 @@ const isCard = computed<boolean>(() => variant === 'card');
       @redecode="emit('redecode', $event)"
       @redecode-with-options="emit('redecode-with-options', $event)"
       @delete-tx="emit('delete-tx', $event)"
+      @delete-events="emit('delete-events', $event)"
       @fix-duplicate="emit('fix-duplicate')"
       @ignore-duplicate="emit('ignore-duplicate')"
     />

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -299,6 +299,7 @@ function isShowingIgnoredAssets(groupId: string): boolean {
             @redecode="redecode($event, row.data.groupIdentifier)"
             @redecode-with-options="redecodeWithOptions($event, row.data.groupIdentifier)"
             @delete-tx="confirmTxAndEventsDelete($event)"
+            @delete-events="confirmDelete({ type: 'delete', ids: $event })"
             @fix-duplicate="emit('refresh')"
             @ignore-duplicate="emit('refresh')"
           />

--- a/frontend/app/tests/e2e/pages/history-events-page.ts
+++ b/frontend/app/tests/e2e/pages/history-events-page.ts
@@ -206,6 +206,7 @@ export class HistoryEventsPage {
 
   async fillSolanaSwapEventForm(data: SolanaSwapEventFixture): Promise<void> {
     await this.fillDatetime();
+    await this.page.locator('[data-cy=tx-ref] input').click();
     await this.page.locator('[data-cy=tx-ref] input').fill(data.txRef);
     await selectAsset(this.page, '[data-cy=spend-asset]', data.spendAsset, data.spendAssetId);
     await this.page.locator('[data-cy=spend-amount] input').clear();


### PR DESCRIPTION
## Summary

- External swap events (manual trades on "External" location) could not be deleted because the delete button only appeared for events with a transaction reference (`txRef`)
- Adds a "Delete event" action for non-blockchain events that deletes all events in the group by their identifiers
- The existing "Delete transaction & events" button remains for blockchain events with a `txRef`

## Test plan

- [ ] Create an external swap event via the API:
  ```bash
  curl -X PUT http://localhost:4242/api/1/history/events \
    -H "Content-Type: application/json" \
    -d '{
      "entry_type": "swap event",
      "location": "external",
      "timestamp": 1475464212000,
      "spend_amount": "0.12",
      "spend_asset": "EUR",
      "receive_amount": "0.01",
      "receive_asset": "ETH",
      "user_notes": ["Test spend", "Test receive"]
    }'
  ```
- [ ] Navigate to History Events, find the "Swap on External" event
- [ ] Click the three-dot menu — verify "Delete event" option appears
- [ ] Click "Delete event" — confirm dialog appears, confirm deletion
- [ ] Verify the event is removed from the list
- [ ] Verify blockchain swap events still show "Delete transaction & events" (not "Delete event")