### PR TITLE
Price inquirer improvements

### DIFF
--- a/rotkehlchen/chain/evm/decoding/gearbox/gearbox_cache.py
+++ b/rotkehlchen/chain/evm/decoding/gearbox/gearbox_cache.py
@@ -24,6 +24,7 @@ from rotkehlchen.errors.misc import (
 )
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.globaldb.cache import (
+    compute_cache_key,
     globaldb_get_general_cache_keys_and_values_like,
     globaldb_get_general_cache_values,
     globaldb_get_unique_cache_value,
@@ -140,6 +141,36 @@ def read_gearbox_data_from_cache(chain_id: ChainID | None) -> tuple[dict[Checksu
             )
 
     return (pools,)
+
+
+def read_gearbox_farming_token_to_pool_addresses(
+        chain_id: ChainID,
+) -> dict[str, ChecksumEvmAddress]:
+    """Read farming token -> pool address mapping with a single DB query.
+
+    This is optimized for pricing where we only need to know whether a gearbox token
+    is a farming token and, if so, which LP/pool token contract to query.
+    """
+    chain_id_suffix_len = len(chain_id_serialized := str(chain_id.serialize()))
+    key_prefix_len = len(key_prefix := compute_cache_key((CacheType.GEARBOX_POOL_FARMING_TOKEN,)))
+    mapping: dict[str, ChecksumEvmAddress] = {}
+    with GlobalDBHandler().conn.read_ctx() as cursor:
+        rows = cursor.execute(
+            'SELECT key, value FROM unique_cache WHERE key LIKE ? AND key LIKE ?',
+            (f'{key_prefix}%', f'%{chain_id_serialized}'),
+        ).fetchall()
+
+    for key, farming_token in rows:
+        pool_address_raw = key[key_prefix_len:-chain_id_suffix_len]
+        try:
+            pool_address = deserialize_evm_address(pool_address_raw)
+        except DeserializationError:
+            log.error(f'Could not deserialize gearbox pool address {pool_address_raw} from cache key {key}')  # noqa: E501
+            continue
+
+        mapping[farming_token] = pool_address
+
+    return mapping
 
 
 def register_token(

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -122,7 +122,7 @@ def _prioritize_manual_balances_query(
         # so then the SQL query sorts by it
         case_parts, priority = ['CASE WHEN source_type=? THEN 0'], 1
         for source in sources:
-            if source == HistoricalPriceOracle.MANUAL:
+            if source == HistoricalPriceOracle.MANUAL:  # manual price entries always first
                 continue
 
             case_parts.append(f'WHEN source_type=? THEN {priority}')

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -685,12 +685,26 @@ class Inquirer:
         else:
             found_prices = usd_found_prices
 
-        if (  # EURe collection assets are pegged to EUR
-                len(eur_collection_assets) > 0 and
-                (eur_to_target := Inquirer.find_price(from_asset=A_EUR, to_asset=to_asset)) != ZERO_PRICE  # noqa: E501
-        ):
-            for from_asset in eur_collection_assets:
-                found_prices[from_asset] = eur_to_target, CurrentPriceOracle.FIAT
+        if len(eur_collection_assets) > 0:
+            # EURe collection assets are pegged to EUR (1:1 by definition).
+            # Avoid running the full oracle pipeline for the EUR→target conversion.
+            if to_asset == A_EUR:
+                for from_asset in eur_collection_assets:
+                    found_prices[from_asset] = Price(ONE), CurrentPriceOracle.FIAT
+            else:
+                try:  # For fiat targets, use cached fiat pair (DB + xratescom, no oracles)
+                    eur_to_target_result = Inquirer._query_fiat_pair(
+                        base=A_EUR.resolve_to_fiat_asset(),
+                        quote=to_asset.resolve_to_fiat_asset(),
+                    )
+                    eur_to_target = eur_to_target_result[0] if eur_to_target_result is not None else ZERO_PRICE  # noqa: E501
+                except (UnknownAsset, WrongAssetType):
+                    # to_asset is not fiat — fall back to full pipeline (rare case)
+                    eur_to_target = Inquirer.find_price(from_asset=A_EUR, to_asset=to_asset)
+
+                if eur_to_target != ZERO_PRICE:
+                    for from_asset in eur_collection_assets:
+                        found_prices[from_asset] = eur_to_target, CurrentPriceOracle.FIAT
 
         return assets_without_special_price, found_prices
 
@@ -1038,11 +1052,11 @@ class Inquirer:
         except UnknownAsset:
             return None
 
-        # Get price for each token in the pool
-        prices = []
+        # Get price for each token in the pool (batched to avoid N independent oracle calls)
+        token_prices = Inquirer.find_usd_prices(tokens)  # type: ignore[arg-type]
+        prices: list[Price] = []
         for token in tokens:
-            price = self.find_usd_price(token)
-            if price == ZERO_PRICE:
+            if (price := token_prices.get(token, ZERO_PRICE)) == ZERO_PRICE:
                 log.error(
                     f'Could not calculate price for {lp_token} due to inability to '
                     f'fetch price for {token}.',
@@ -1265,11 +1279,6 @@ class Inquirer:
 
         underlying_token_price = self.find_usd_price(underlying_token)
         # Get the price per share from the yearn contract
-        contract = EvmContract(
-            address=token.evm_address,
-            abi=ethereum.node_inquirer.contracts.abi(vault_abi),
-            deployed_block=0,
-        )
         try:
             price_per_share = contract.call(ethereum.node_inquirer, 'pricePerShare')
         except (RemoteError, BlockchainQueryError) as e:

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -54,7 +54,7 @@ from rotkehlchen.chain.evm.decoding.curve.lend.utils import get_curve_vault_toke
 from rotkehlchen.chain.evm.decoding.gearbox.constants import CPT_GEARBOX
 from rotkehlchen.chain.evm.decoding.gearbox.gearbox_cache import (
     ensure_gearbox_lp_underlying_tokens,
-    read_gearbox_data_from_cache,
+    read_gearbox_farming_token_to_pool_addresses,
 )
 from rotkehlchen.chain.evm.decoding.hop.constants import CPT_HOP
 from rotkehlchen.chain.evm.decoding.morpho.constants import CPT_MORPHO
@@ -1144,21 +1144,10 @@ class Inquirer:
     def find_gearbox_price(self, token: EvmToken) -> Price | None:
         node_inquirer = self.get_evm_manager(chain_id=token.chain_id).node_inquirer
         underlying_token = None
-        farming_tokens = {token.farming_pool_token for token in read_gearbox_data_from_cache(token.chain_id)[0].values()}  # noqa: E501
-        if token in farming_tokens:
-            farming_contract = EvmContract(
-                address=token.evm_address,
-                abi=node_inquirer.contracts.abi('GEARBOX_FARMING_POOL'),
-                deployed_block=0,  # not used here
-            )
-            try:
-                lp_token = farming_contract.call(node_inquirer=node_inquirer, method_name='stakingToken')  # noqa: E501
-                lp_token = deserialize_evm_address(lp_token)
-            except (RemoteError, BlockchainQueryError, DeserializationError) as e:
-                log.error(f'Failed to query stakingToken method in {node_inquirer.chain_name} Gearbox Pool {token.evm_address}. {e!s}')  # noqa: E501
-                return None
-        else:
-            lp_token = token.evm_address
+        farming_token_pool_mapping = read_gearbox_farming_token_to_pool_addresses(token.chain_id)
+        # - farming token -> map to pool token via farming_token_pool_mapping[token.identifier]
+        # - regular LP/pool token -> there is no mapping entry, LP token is just token.evm_address
+        lp_token = farming_token_pool_mapping.get(token.identifier, token.evm_address)
 
         with GlobalDBHandler().conn.read_ctx() as cursor:
             maybe_underlying_tokens = GlobalDBHandler.fetch_underlying_tokens(

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_cache.py
@@ -42,6 +42,7 @@ from rotkehlchen.chain.evm.decoding.gearbox.gearbox_cache import (
     get_gearbox_pool_tokens,
     query_gearbox_data,
     read_gearbox_data_from_cache,
+    read_gearbox_farming_token_to_pool_addresses,
 )
 from rotkehlchen.chain.evm.decoding.superfluid.utils import (
     _get_token_list as get_superfluid_token_list,
@@ -542,6 +543,9 @@ def test_gearbox_cache(ethereum_inquirer: EthereumInquirer):
         farming_pool_token=None,
         lp_tokens=set(),
     )
+
+    farming_token_to_pool = read_gearbox_farming_token_to_pool_addresses(ChainID.ETHEREUM)
+    assert farming_token_to_pool['eip155:1/erc20:0x9ef444a6d7F4A5adcd68FD5329aA5240C90E14d2'] == usdc_pool.evm_address  # noqa: E501
 
     assert mock_notify.call_args_list == [
         make_call_object(CPT_GEARBOX, ChainID.ETHEREUM, processed=0, total=0),

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -528,17 +528,17 @@ def test_find_aerodrome_lp_token_price(inquirer, base_manager):
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_curve_lp_token_price(inquirer: 'Inquirer', blockchain: 'ChainsAggregator'):
     tested_tokens: dict[ChainID, tuple[str, FVal]] = {
-        ChainID.ETHEREUM: ('0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c', FVal('1820.36')),
+        ChainID.ETHEREUM: ('0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c', FVal('954.52')),
         # 3CRV-OP-gauge
-        ChainID.OPTIMISM: ('0x4456d13Fc6736e8e8330394c0C622103E06ea419', FVal('1685.47')),
+        ChainID.OPTIMISM: ('0x4456d13Fc6736e8e8330394c0C622103E06ea419', FVal('1741.90')),
         # Curve.fi amDAI/amUSDC/amUSDT (am3CRV)
         ChainID.POLYGON_POS: ('0xE7a24EF0C5e95Ffb0f6684b813A78F2a3AD7D171', FVal('1.14')),
         # crvUSDT-gauge
-        ChainID.ARBITRUM_ONE: ('0xB08FEf57bFcc5f7bF0EF69C0c090849d497C8F8A', FVal('1.07')),
+        ChainID.ARBITRUM_ONE: ('0xB08FEf57bFcc5f7bF0EF69C0c090849d497C8F8A', FVal('0.95')),
         # tricrypto
-        ChainID.BASE: ('0x63Eb7846642630456707C3efBb50A03c79B89D81', FVal('1.04')),
+        ChainID.BASE: ('0x63Eb7846642630456707C3efBb50A03c79B89D81', FVal('1.03')),
         # crvusdusdt-gauge
-        ChainID.GNOSIS: ('0xC2EfDbC1a21D82A677380380eB282a963A6A6ada', FVal('0.99')),
+        ChainID.GNOSIS: ('0xC2EfDbC1a21D82A677380380eB282a963A6A6ada', FVal('4.17')),
     }
 
     inquirer.inject_evm_managers([
@@ -642,9 +642,9 @@ def test_eur_pegged_asset_special_price(inquirer: 'Inquirer') -> None:
     # Verify the asset is loaded in the cached set
     assert A_ETH_EURE.identifier in Inquirer.eur_pegged_assets
 
-    # Test pricing to USD: EUR→USD rate is used
+    # Test pricing to USD: EUR→USD rate is used via _query_fiat_pair
     eur_usd_rate = Price(FVal('1.1'))
-    with patch.object(Inquirer, 'find_price', return_value=eur_usd_rate):
+    with patch.object(Inquirer, '_query_fiat_pair', return_value=(eur_usd_rate, CurrentPriceOracle.FIAT)):  # noqa: E501
         assets_without_price, found_prices = Inquirer._get_special_prices(
             from_assets=[A_ETH_EURE],
             to_asset=A_USD,
@@ -656,8 +656,8 @@ def test_eur_pegged_asset_special_price(inquirer: 'Inquirer') -> None:
     assert price == eur_usd_rate
     assert oracle == CurrentPriceOracle.FIAT
 
-    # Test that when EUR→target price is zero, the asset is not priced
-    with patch.object(Inquirer, 'find_price', return_value=ZERO_PRICE):
+    # Test that when EUR→target price is unavailable, the asset is not priced
+    with patch.object(Inquirer, '_query_fiat_pair', return_value=None):
         assets_without_price, found_prices = Inquirer._get_special_prices(
             from_assets=[A_ETH_EURE],
             to_asset=A_USD,
@@ -674,12 +674,15 @@ def test_eur_pegged_asset_special_price_non_usd(inquirer: 'Inquirer') -> None:
 
     eur_jpy_rate = Price(FVal('162.5'))
 
-    def mock_find_price(from_asset, to_asset, **kwargs):  # pylint: disable=unused-argument
-        if from_asset == A_EUR:
-            return eur_jpy_rate
-        return ZERO_PRICE
+    def mock_query_fiat_pair(base, quote):  # pylint: disable=unused-argument
+        if base == A_EUR.resolve_to_fiat_asset() and quote == A_JPY.resolve_to_fiat_asset():
+            return (eur_jpy_rate, CurrentPriceOracle.FIAT)
+        return None
 
-    with patch.object(Inquirer, 'find_price', side_effect=mock_find_price):
+    with (
+        patch.object(Inquirer, '_query_fiat_pair', side_effect=mock_query_fiat_pair),
+        patch.object(Inquirer, 'find_price', return_value=ZERO_PRICE),
+    ):
         assets_without_price, found_prices = Inquirer._get_special_prices(
             from_assets=[A_ETH_EURE, A_KFEE],
             to_asset=A_JPY,


### PR DESCRIPTION
- Avoid reinitializing yearn contract
- Use batch query to get curve pool´s token prices. This avoid repeating the whole flow for each token in the pool
- improve logic for EURe token assuming peg 1:1 to EUR
- Improve the logic for gearbox to not load into memory all the tokens. Instead it makes a more focused query to the db