### PR TITLE
Fix internal transaction deletion case

### DIFF
--- a/rotkehlchen/api/services/transactions.py
+++ b/rotkehlchen/api/services/transactions.py
@@ -986,6 +986,22 @@ class TransactionsService:
             raise InputError(f'Tried to delete customized transaction {tx_ref} while delete custom is False')  # noqa: E501
 
         with self.rotkehlchen.data.db.user_write() as write_cursor:
+            if (
+                (internal_txs_count := len(parent_hash_internal_txs)) == 0 and
+                transaction.to_address is not None
+            ):
+                # Guard against deleting pre-existing internals due to an empty indexer payload.
+                # This check must run before deleting the parent tx row, since deleting that row
+                # cascades to evm_internal_transactions.
+                # If internals exist and should not be removed, this call raises DataIntegrityError
+                # and prevents the parent row delete from executing.
+                chain_manager.transactions._replace_internal_transactions_for_parent_hash(
+                    write_cursor=write_cursor,
+                    parent_tx_hash=tx_ref,
+                    transactions=parent_hash_internal_txs,
+                    indexer_source=indexer_source,
+                )
+
             write_cursor.execute(
                 'DELETE FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
                 db_tuple,
@@ -1000,7 +1016,7 @@ class TransactionsService:
                 chain_id=chain_manager.node_inquirer.chain_id,
                 data=raw_receipt_data,
             )
-            if transaction.to_address is not None:  # internal transactions only through contracts
+            if internal_txs_count != 0:  # parent_hash_internal_txs != 0 when transaction.to_address is not None  # noqa: E501
                 chain_manager.transactions._replace_internal_transactions_for_parent_hash(
                     write_cursor=write_cursor,
                     parent_tx_hash=tx_ref,

--- a/rotkehlchen/tests/api/test_ethereum_transactions.py
+++ b/rotkehlchen/tests/api/test_ethereum_transactions.py
@@ -1611,6 +1611,78 @@ def test_repulling_transaction_fetch_error_does_not_drop_existing_data(
 
 @pytest.mark.parametrize('have_decoders', [True])
 @pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
+def test_repull_empty_internals_preserves_db(
+        rotkehlchen_api_server: 'APIServer',
+) -> None:
+    """When redecode gets an empty internal-tx payload from the indexer for a tx that already
+    has internal txs in DB, the API should reject the redecode (conflict) and keep the existing
+    internal tx rows untouched.
+    """
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    dbevmtx, transaction = _prepare_repull_test_transaction(rotki.data.db)
+    tx_hash = transaction.tx_hash
+
+    with rotki.data.db.conn.read_ctx() as cursor:
+        parent_tx_id = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (tx_hash, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
+    internal_before = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id,
+    )
+    assert len(internal_before) > 0
+    fresh_transaction = make_ethereum_transaction(
+        tx_hash=tx_hash,
+        timestamp=Timestamp(transaction.timestamp + 1),
+    )
+
+    with (
+        patch.object(
+            rotki.chains_aggregator.ethereum.node_inquirer,
+            'get_transaction_by_hash',
+            return_value=(fresh_transaction, txreceipt_to_data(EvmTxReceipt(
+                tx_hash=tx_hash,
+                chain_id=ChainID.ETHEREUM,
+                contract_address=None,
+                status=True,
+                tx_type=2,
+                logs=[],
+            ))),
+        ),
+        patch.object(
+            rotki.chains_aggregator.ethereum.node_inquirer,
+            'get_transactions_with_source',
+            return_value=(iter([[]]), 'blockscout'),
+        ),
+    ):
+        response = requests.put(
+            api_url_for(rotkehlchen_api_server, 'transactionsdecodingresource'),
+            json={'async_query': False, 'chain': 'eth', 'tx_refs': [str(tx_hash)]},
+        )
+
+    assert_error_response(
+        response=response,
+        contained_in_msg='empty result',
+        status_code=HTTPStatus.CONFLICT,
+    )
+
+    with rotki.data.db.conn.read_ctx() as cursor:
+        parent_tx_id_after = cursor.execute(
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?',
+            (tx_hash, ChainID.ETHEREUM.serialize_for_db()),
+        ).fetchone()[0]
+    internal_after = dbevmtx.get_evm_internal_transactions(
+        parent_tx_hash=tx_hash,
+        blockchain=SupportedBlockchain.ETHEREUM,
+        parent_tx_id=parent_tx_id_after,
+    )
+    assert internal_after == internal_before
+
+
+@pytest.mark.parametrize('have_decoders', [True])
+@pytest.mark.parametrize('ethereum_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_repulling_transaction_internal_fetch_error_restores_previous_internal_txs(
         rotkehlchen_api_server: 'APIServer',
 ) -> None:


### PR DESCRIPTION
Fix redecode data loss for internal transactions when an indexer returns an empty internals payload. Previously, the API deleted and reinserted the parent transaction before validating the empty internals result, so foreign-key cascade could remove existing internals and bypass the safety check. The fix runs the empty-result guard first, so a DataIntegrityError is raised before any parent delete, preserving existing internal transaction rows.