### PR TITLE
Collapse action column in internal tx conflicts dialog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` The internal transaction conflicts dialog now shows the action type (re-pull or re-decode) in the resolve button's tooltip instead of a separate column.
 * :bug:`-` Quickswap v2 swaps for native token (ETH, POL etc.) will now be decoded properly.
 * :bug:`-` External swap events (manual trades) can now be deleted from the history events view.
 * :feature:`12028` "Ignore/Unignore in accounting" labels are now "Exclude/Include from accounting (PnL)" for clarity.

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
@@ -79,7 +79,6 @@ const headers = computed<DataTableColumn<InternalTxConflict>[]>(() => {
       { key: 'selection', label: '', sortable: false },
       { key: 'chain', label: '', sortable: true, cellClass: '!p-1', class: '!p-1' },
       { key: 'txHash', label: t('internal_tx_conflicts.columns.tx_hash'), sortable: true },
-      { key: 'action', label: '', sortable: true, cellClass: '!p-1', class: '!p-1' },
       { key: 'timestamp', label: t('internal_tx_conflicts.columns.timestamp'), sortable: true },
       { key: 'actions', label: '' },
     ];
@@ -89,7 +88,6 @@ const headers = computed<DataTableColumn<InternalTxConflict>[]>(() => {
     { key: 'selection', label: '', sortable: false },
     { key: 'chain', label: '', sortable: true, cellClass: '!p-1', class: '!p-1' },
     { key: 'txHash', label: t('internal_tx_conflicts.columns.tx_hash'), sortable: true },
-    { key: 'action', label: '', sortable: true, cellClass: '!p-1', class: '!p-1' },
     { key: 'timestamp', label: t('internal_tx_conflicts.columns.timestamp'), sortable: true },
     { key: 'reason', label: t('internal_tx_conflicts.columns.reason') },
     { key: 'lastRetryTs', label: t('internal_tx_conflicts.columns.last_retry'), sortable: true },
@@ -287,21 +285,6 @@ defineExpose({
             type="transaction"
           />
         </template>
-        <template #item.action="{ row }">
-          <RuiTooltip
-            :popper="{ placement: 'top' }"
-            :open-delay="400"
-          >
-            <template #activator>
-              <RuiIcon
-                :name="row.action === InternalTxConflictActions.REPULL ? 'lu-refresh-cw' : 'lu-wrench'"
-                :color="row.action === InternalTxConflictActions.REPULL ? 'primary' : 'warning'"
-                size="18"
-              />
-            </template>
-            {{ getActionLabel(row.action) }}
-          </RuiTooltip>
-        </template>
         <template #item.timestamp="{ row }">
           <div :class="compact && 'text-xs'">
             <DateDisplay
@@ -365,17 +348,18 @@ defineExpose({
                   variant="text"
                   icon
                   size="sm"
+                  :color="row.action === InternalTxConflictActions.REPULL ? 'primary' : 'warning'"
                   :loading="isResolving(row)"
                   :disabled="isRunning || isResolving(row)"
                   @click="onResolveOne(row)"
                 >
                   <RuiIcon
-                    name="lu-refresh-cw"
+                    :name="row.action === InternalTxConflictActions.REPULL ? 'lu-refresh-cw' : 'lu-wrench'"
                     size="16"
                   />
                 </RuiButton>
               </template>
-              {{ t('internal_tx_conflicts.resolution.resolve') }}
+              {{ t('internal_tx_conflicts.resolution.resolve') }} ({{ getActionLabel(row.action) }})
             </RuiTooltip>
             <RuiTooltip
               :popper="{ placement: 'top' }"


### PR DESCRIPTION
## Summary
- Removed the untitled `action` column from the internal transaction conflicts dialog.
- The resolve button now carries the visual cue: its icon (`lu-refresh-cw` / `lu-wrench`) and color (primary / warning) reflect the action type, and the tooltip reads e.g. "Resolve (Re-pull)".
- Added a changelog entry.

## Test plan
- [ ] Open the internal transaction conflicts dialog and verify the untitled column is gone.
- [ ] Hover the resolve button on a re-pull row — tooltip reads "Resolve (Re-pull)", icon is `refresh-cw` in primary.
- [ ] Hover the resolve button on a re-decode row — tooltip reads "Resolve (Fix & Re-decode)", icon is `wrench` in warning.
- [ ] Confirm both compact and full table variants still render correctly.