### PR TITLE
Route scramble settings through operations layer

### DIFF
--- a/frontend/app/src/modules/settings/use-scramble-settings.ts
+++ b/frontend/app/src/modules/settings/use-scramble-settings.ts
@@ -21,7 +21,7 @@ export function useScrambleSetting(): UseScrambleSettingReturn {
 
   const frontendStore = useFrontendSettingsStore();
   const { scrambleData: enabled, scrambleMultiplier: multiplier } = storeToRefs(frontendStore);
-  const { updateFrontendSetting } = useSettingsOperations();
+  const { applyFrontendSettingLocal, updateFrontendSetting } = useSettingsOperations();
 
   // Debounced backend update
   const debouncedBackendUpdate = useDebounceFn(async (value: number) => {
@@ -40,11 +40,7 @@ export function useScrambleSetting(): UseScrambleSettingReturn {
 
     const numValue = Number(value);
 
-    // Update store immediately for UI
-    frontendStore.update({
-      ...get(frontendStore.settings),
-      scrambleMultiplier: numValue,
-    });
+    applyFrontendSettingLocal({ scrambleMultiplier: numValue });
 
     // Debounce backend update
     startPromise(debouncedBackendUpdate(numValue));

--- a/frontend/app/src/modules/settings/use-settings-operations.spec.ts
+++ b/frontend/app/src/modules/settings/use-settings-operations.spec.ts
@@ -6,6 +6,7 @@ import { Currency, CURRENCY_USD } from '@/modules/assets/amount-display/currenci
 import { Module } from '@/modules/core/common/modules';
 import { defaultAccountingSettings, defaultGeneralSettings } from '@/modules/settings/factories';
 import { getDefaultFrontendSettings } from '@/modules/settings/types/frontend-settings';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
 import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
 import '@test/i18n';
 
@@ -122,6 +123,35 @@ describe('useSettingsOperations', () => {
       await setKrakenAccountType('starter');
 
       expect(mockShowErrorMessage).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('applyFrontendSettingLocal', () => {
+    it('should patch the frontend store without calling the API', async () => {
+      const frontendStore = useFrontendSettingsStore();
+      const initial = get(frontendStore.settings).scrambleMultiplier;
+
+      const { useSettingsOperations } = await importModule();
+      const { applyFrontendSettingLocal } = useSettingsOperations();
+      applyFrontendSettingLocal({ scrambleMultiplier: 42 });
+
+      expect(get(frontendStore.settings).scrambleMultiplier).toBe(42);
+      expect(get(frontendStore.settings).scrambleMultiplier).not.toBe(initial);
+      expect(mockSetSettings).not.toHaveBeenCalled();
+    });
+
+    it('should merge with existing settings', async () => {
+      const frontendStore = useFrontendSettingsStore();
+      const before = get(frontendStore.settings);
+
+      const { useSettingsOperations } = await importModule();
+      const { applyFrontendSettingLocal } = useSettingsOperations();
+      applyFrontendSettingLocal({ scrambleMultiplier: 7 });
+
+      const after = get(frontendStore.settings);
+      expect(after.scrambleMultiplier).toBe(7);
+      expect(after.selectedTheme).toBe(before.selectedTheme);
+      expect(after.privacyMode).toBe(before.privacyMode);
     });
   });
 

--- a/frontend/app/src/modules/settings/use-settings-operations.ts
+++ b/frontend/app/src/modules/settings/use-settings-operations.ts
@@ -36,6 +36,7 @@ function extractSettingsFieldError(errors: Record<string, string | string[]>, ke
 }
 
 interface UseSettingsOperationsReturn {
+  applyFrontendSettingLocal: (payload: FrontendSettingsPayload) => void;
   enableModule: (payload: { readonly enable: Module[]; readonly addresses: string[] }) => Promise<void>;
   setKrakenAccountType: (krakenAccountType: KrakenAccountType) => Promise<void>;
   update: (update: SettingsUpdate) => Promise<ActionStatus>;
@@ -119,6 +120,11 @@ export function useSettingsOperations(): UseSettingsOperationsReturn {
     }
   };
 
+  function applyFrontendSettingLocal(payload: FrontendSettingsPayload): void {
+    const currentSettings = get(frontendStore.settings);
+    frontendStore.update({ ...currentSettings, ...payload });
+  }
+
   async function updateFrontendSetting(payload: FrontendSettingsPayload): Promise<ActionStatus> {
     const props = Object.keys(payload);
     assert(props.length > 0, 'Payload must be not-empty');
@@ -163,6 +169,7 @@ export function useSettingsOperations(): UseSettingsOperationsReturn {
   }, { debounce: 800, maxWait: 1200 });
 
   return {
+    applyFrontendSettingLocal,
     enableModule,
     setKrakenAccountType,
     update,


### PR DESCRIPTION
## Summary
- `useScrambleSetting` was the only production consumer calling `frontendStore.update()` directly — it did so to patch the store optimistically so scramble effects updated instantly while the backend sync debounced at 500ms.
- Added `applyFrontendSettingLocal(payload)` to `useSettingsOperations`: a no-API, store-patch-only helper. Scramble now uses it for the optimistic step and the existing `updateFrontendSetting` for the debounced backend sync.
- Same UX, one funnel for all settings mutations.
- Phase 0 of a broader settings-exposure refactor — precondition for the facade-composable work planned in later phases.

## Test plan
- [ ] Unit tests pass (added two cases for `applyFrontendSettingLocal` covering patch + merge).
- [ ] Open Settings → Frontend → Scramble data: toggle it on, drag the multiplier slider, confirm amount scrambling updates immediately in the app (e.g. dashboard totals) — no 500 ms lag.
- [ ] Let the slider settle and reload the app; confirm the new multiplier persisted.