### PR TITLE
fix(frontend): clear Vue warnings and tidy asset icon check

### DIFF
--- a/frontend/app/src/modules/assets/use-asset-icon-check.ts
+++ b/frontend/app/src/modules/assets/use-asset-icon-check.ts
@@ -17,57 +17,61 @@ export function useAssetIconCheck(): UseAssetIconCheckReturn {
   const { assetExistsCache, pendingIconRequests } = storeToRefs(useAssetsStore());
   const { checkAsset } = useAssetIconApi();
 
-  const checkIfAssetExists = async (identifier: string, options: AssetCheckOptions): Promise<boolean> => {
+  const MAX_ATTEMPTS = 4;
+  const RETRY_DELAY_MS = 1500;
+
+  async function resolveExists(identifier: string, options: AssetCheckOptions): Promise<boolean> {
     const cache = get(assetExistsCache);
     const pending = get(pendingIconRequests);
-    const now = Date.now();
+
+    try {
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        if (options.abortController?.signal.aborted) {
+          logger.info('Aborted asset check');
+          return false;
+        }
+
+        const status = await checkAsset(identifier, options);
+        if (status === 200 || status === 404) {
+          const exists = status === 200;
+          cache.set(identifier, { exists, timestamp: Date.now() });
+          return exists;
+        }
+
+        if (status !== 202)
+          logger.debug(`Asset ${identifier} check failed with status ${status} (${attempt}), waiting`);
+
+        await wait(RETRY_DELAY_MS);
+      }
+
+      cache.set(identifier, { exists: false, timestamp: Date.now() });
+      return false;
+    }
+    catch (error: unknown) {
+      logger.error(error);
+      return false;
+    }
+    finally {
+      pending.delete(identifier);
+    }
+  }
+
+  async function checkIfAssetExists(identifier: string, options: AssetCheckOptions): Promise<boolean> {
+    const cache = get(assetExistsCache);
+    const pending = get(pendingIconRequests);
 
     const cached = cache.get(identifier);
-    if (cached && (now - cached.timestamp) < CACHE_TTL) {
+    if (cached && (Date.now() - cached.timestamp) < CACHE_TTL)
       return cached.exists;
-    }
 
     const existingRequest = pending.get(identifier);
-    if (existingRequest) {
+    if (existingRequest)
       return existingRequest;
-    }
 
-    const request = (async (): Promise<boolean> => {
-      let tries = 0;
-      try {
-        while (tries < 4) {
-          const status = await checkAsset(identifier, options);
-          if (status === 200 || status === 404) {
-            const exists = status === 200;
-            cache.set(identifier, { exists, timestamp: Date.now() });
-            return exists;
-          }
-
-          logger.debug(`Asset ${identifier} check failed with status ${status} (${tries + 1}), waiting`);
-          await wait(1500);
-
-          if (options.abortController?.signal.aborted) {
-            logger.info('Aborted asset check');
-            return false;
-          }
-
-          tries++;
-        }
-        cache.set(identifier, { exists: false, timestamp: Date.now() });
-        return false;
-      }
-      catch (error: unknown) {
-        logger.error(error);
-        return false;
-      }
-      finally {
-        pending.delete(identifier);
-      }
-    })();
-
+    const request = resolveExists(identifier, options);
     pending.set(identifier, request);
     return request;
-  };
+  }
 
   return {
     checkIfAssetExists,

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -312,7 +312,6 @@ watchDebounced(route, async () => {
             :highlighted-identifiers="highlightedIdentifiers"
             :highlight-types="highlightTypes"
             :selection="selectionMode"
-            :match-exact-events="toggles.matchExactEvents"
             :duplicate-handling-status="duplicateHandlingStatus"
             @clear-filters="clearFilters()"
             @show:dialog="dialogContainer?.show($event)"

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleSetting.vue
@@ -63,7 +63,6 @@ const {
   isLoading,
   matchers,
   pagination,
-  setPage,
   state,
   updateFilter,
 } = usePaginationFilters<
@@ -448,7 +447,6 @@ const importFileDialog = ref<boolean>(false);
         :state="state"
         :is-loading="isLoading"
         :is-custom="customRuleHandling === CustomRuleHandling.ONLY"
-        @set-page="setPage($event)"
         @delete-click="showDeleteConfirmation($event)"
         @edit-click="edit($event)"
       />

--- a/frontend/app/src/modules/shell/components/AssetIcon.vue
+++ b/frontend/app/src/modules/shell/components/AssetIcon.vue
@@ -159,6 +159,12 @@ watchImmediate(mappedIdentifier, async (identifier) => {
   set(pending, true);
   set(error, false);
 
+  // Fiat currencies render via their unicode symbol — no icon fetch needed.
+  if (isDefined(currency)) {
+    set(pending, false);
+    return;
+  }
+
   if (isDefined(abortController)) {
     get(abortController).abort();
   }

--- a/frontend/app/src/router/index.ts
+++ b/frontend/app/src/router/index.ts
@@ -56,23 +56,22 @@ export const router = createRouter({
 
 const userRoutes: RouteLocationRaw[] = ['/user/create', '/user/login', '/user'];
 
-router.beforeEach((to, from, next) => {
+router.beforeEach((to) => {
   document.title = to.meta?.title ? to.meta.title.toString() : 'rotki';
 
   const store = useSessionAuthStore();
   const logged = store.logged;
   if (logged) {
     if (userRoutes.includes(to.path))
-      return next('/dashboard');
+      return '/dashboard';
 
-    next();
+    return true;
   }
-  else if (to.path.startsWith('/user') || to.path === '/wallet-bridge') {
-    next();
-  }
-  else {
-    next('/user/login');
-  }
+
+  if (to.path.startsWith('/user') || to.path === '/wallet-bridge')
+    return true;
+
+  return '/user/login';
 });
 
 if (import.meta.hot)


### PR DESCRIPTION
## Summary

- Return values from the router \`beforeEach\` guard instead of calling the deprecated \`next()\` callback (Vue Router 4 API).
- Drop a stale \`:match-exact-events\` binding on \`HistoryEventsVirtualTable\` — the component doesn't declare that prop; its sibling \`HistoryEventsTableActions\` is the legitimate consumer.
- Drop a stale \`@set-page\` listener on \`AccountingRuleTable\` — the table no longer emits \`set-page\` since migrating to \`v-model:pagination\`.
- Refactor \`useAssetIconCheck\`: extract the polling loop into a named \`resolveExists\` helper (removing a typed async IIFE that Volar misparsed as a bare expression statement), pull magic numbers into constants, and move the abort-signal check ahead of the first request.
- Skip the asset-existence fetch for fiat currencies in \`AssetIcon\` — they render via their unicode symbol, so the HTTP check is redundant.

## Test plan

- [ ] Navigate between \`/user/login\`, \`/dashboard\` and other routes — no \`[Vue Router warn]\` about \`next()\` in the console.
- [ ] Open a history events page — no \`[Vue warn]\` about extraneous \`match-exact-events\` attribute.
- [ ] Open \`Settings → Accounting → Rules\` — no \`[Vue warn]\` about extraneous \`setPage\` listener.
- [ ] Display an asset icon for a fiat currency (EUR / USD) — renders the unicode symbol without firing a network request to \`/assets/icon\`.
- [ ] Display an asset icon for a crypto asset — existence check still runs and the icon loads as before.