### PR TITLE
Fix BASIS_TRANSFER to preserve receive-side acquisition when source lots are missing

### DIFF
--- a/rotkehlchen/accounting/cost_basis/base.py
+++ b/rotkehlchen/accounting/cost_basis/base.py
@@ -637,13 +637,20 @@ class CostBasisCalculator(CustomizableDateMixin):
             out_amount: FVal,
             in_amount: FVal,
             timestamp: Timestamp,
-    ) -> None:
+    ) -> FVal:
         """Transfer cost basis lots from out_asset to in_asset preserving original prices.
 
         Used for deposit/withdraw-wrapped events where no taxable event should occur
         and cost basis should carry over from the source to the destination asset.
-        For same-bucket assets (e.g. ETH/WETH) this is a no-op since get_events()
-        resolves both to the same CostBasisEvents object.
+
+        Returns the amount of `in_asset` that was actually created from transferred
+        source lots. Callers use this to add a fallback acquisition for any remainder.
+        This is needed because BASIS_TRANSFER consumes the paired in-event at the
+        iterator level, so if source lots are missing, the in-event would otherwise
+        never create an acquisition.
+
+        For same-bucket assets (e.g. ETH/WETH), we return the full `in_amount` so
+        callers know nothing else needs to be added.
         """
         if ZERO in (out_amount, in_amount):
             log.error(
@@ -653,13 +660,15 @@ class CostBasisCalculator(CustomizableDateMixin):
                 out_amount=out_amount,
                 in_amount=in_amount,
             )
-            return
+            return ZERO
 
         source_events = self.get_events(out_asset)
         dest_events = self.get_events(in_asset)
 
         if source_events is dest_events:
-            return  # same cost basis bucket (e.g. ETH/WETH), nothing to do
+            # Same cost-basis bucket (e.g. ETH/WETH): no lot movement needed.
+            # Returning full in_amount tells caller there is no remainder/fallback.
+            return in_amount
 
         # Scaling factors to preserve total cost when amounts differ (e.g. 100 DAI → 95 aDAI)
         # new_amount = old_amount * amount_ratio, new_rate = old_rate * rate_ratio
@@ -701,13 +710,18 @@ class CostBasisCalculator(CustomizableDateMixin):
                 ),
             )
 
+        transferred_in_amount = ZERO
         for lot_amount, lot_rate, lot_timestamp, lot_index in lots_to_transfer:
+            new_amount = lot_amount * amount_ratio
             dest_events.acquisitions_manager.add_in_event(AssetAcquisitionEvent(
-                amount=lot_amount * amount_ratio,
+                amount=new_amount,
                 timestamp=lot_timestamp,
                 rate=Price(lot_rate * rate_ratio),
                 index=lot_index,
             ))
+            transferred_in_amount += new_amount
+
+        return transferred_in_amount
 
     def reduce_asset_amount(
             self,

--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.rules import AccountingRulesManager
 from rotkehlchen.chain.evm.accounting.structures import BaseEventSettings, TxAccountingTreatment
-from rotkehlchen.constants import ONE
+from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.solana_event import SolanaEvent
@@ -116,13 +116,30 @@ class EventsAccountant:
 
             # event_direction is OUT (first event is always the deposit/spend)
             # paired_direction is IN (second event is always the receive/withdraw)
-            self.pot.cost_basis.transfer_basis(
+            transferred_in_amount = self.pot.cost_basis.transfer_basis(
                 out_asset=event.asset,
                 in_asset=in_event.asset,
                 out_amount=event.amount,
                 in_amount=in_event.amount,
                 timestamp=timestamp,
             )
+            # Why this fallback exists:
+            # BASIS_TRANSFER consumes the paired in_event (see next(events_iterator) above),
+            # so if transfer_basis() cannot map all incoming amount from source lots
+            # (e.g. missing prior acquisitions), that remainder would be silently lost.
+            # We explicitly create an acquisition for the unmatched part to preserve
+            # balances and avoid dropping the receive-side lot.
+            if (remaining_in_amount := in_event.amount - transferred_in_amount) > ZERO:
+                self.pot.add_in_event(
+                    event_type=AccountingEventType.TRANSACTION_EVENT,
+                    notes=in_event.notes or '',
+                    location=in_event.location,
+                    timestamp=in_event.get_timestamp_in_sec(),
+                    asset=in_event.asset,
+                    amount=remaining_in_amount,
+                    taxable=event_settings.taxable,
+                    extra_data=general_extra_data,
+                )
             return 2
 
         if event_settings.accounting_treatment == TxAccountingTreatment.SWAP:

--- a/rotkehlchen/tests/unit/accounting/test_default_settings.py
+++ b/rotkehlchen/tests/unit/accounting/test_default_settings.py
@@ -437,7 +437,7 @@ MOCKED_PRICES_WITH_WETH = {
 
 def _setup_basis_transfer_rules(
         accounting_pot: 'AccountingPot',
-        counterparty: str = CPT_WETH,
+        counterparty: str | None = CPT_WETH,
 ) -> None:
     """Insert basis_transfer rules for both wrap and unwrap, then re-reset the pot."""
     rules_db = DBAccountingRules(accounting_pot.database)
@@ -724,6 +724,59 @@ def test_basis_transfer_different_bucket(accounting_pot: 'AccountingPot'):
     )
     # Original acquisition timestamp is preserved, not the deposit timestamp
     assert adai_acquisitions[0].timestamp == TIMESTAMP_1_SECS
+
+
+@pytest.mark.parametrize('mocked_price_queries', [{
+    Asset('eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48').identifier: {
+        'EUR': {TIMESTAMP_2_SECS: Price(ONE)},
+    },
+    Asset('eip155:1/erc20:0xc3d688B66703497DAA19211EEdff47f25384cdc3').identifier: {
+        'EUR': {TIMESTAMP_2_SECS: Price(ONE)},
+    },
+}])
+def test_basis_transfer_missing_out_lots(accounting_pot: 'AccountingPot'):
+    """Regression: BASIS_TRANSFER consumes the in-event.
+
+    If out-asset lots are missing, the in-asset acquisition must still be recorded.
+    """
+    usdc = Asset('eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')
+    c_usdc_v3 = Asset('eip155:1/erc20:0xc3d688B66703497DAA19211EEdff47f25384cdc3')
+    _setup_basis_transfer_rules(accounting_pot, counterparty=None)
+
+    deposit_out = EvmEvent(
+        tx_ref=(dep_hash := make_evm_tx_hash()),
+        sequence_index=0,
+        timestamp=TIMESTAMP_2_MS,
+        location=Location.ETHEREUM,
+        location_label=EXAMPLE_ADDRESS,
+        asset=usdc,
+        amount=FVal(25),
+        notes='Deposit 25 USDC',
+        event_type=HistoryEventType.DEPOSIT,
+        event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
+    )
+    deposit_in = EvmEvent(
+        tx_ref=dep_hash,
+        sequence_index=1,
+        timestamp=TIMESTAMP_2_MS,
+        location=Location.ETHEREUM,
+        location_label=EXAMPLE_ADDRESS,
+        asset=c_usdc_v3,
+        amount=FVal(25),
+        notes='Receive 25 cUSDCv3',
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
+    )
+
+    assert accounting_pot.events_accountant.process(
+        event=deposit_out,
+        events_iterator=peekable([deposit_in]),
+    ) == 2
+
+    c_usdc_events = accounting_pot.cost_basis.get_events(c_usdc_v3)
+    acquisitions = c_usdc_events.acquisitions_manager.get_acquisitions()
+    assert len(acquisitions) == 1, 'in-event acquisition should not be dropped by basis_transfer'
+    assert acquisitions[0].remaining_amount == FVal(25)
 
 
 @pytest.mark.parametrize('mocked_price_queries', [MOCKED_PRICES])


### PR DESCRIPTION
### What was broken

- BASIS_TRANSFER consumes the paired receive/withdraw event.
- If there were no usable source lots on the out-asset side, transfer_basis moved 0 lots.
- Because the in-event was already consumed, no fallback acquisition was created.
- Result: the receive-side acquisition could disappear (missing acquisition in accounting).

### What this commit changes

1) Make cost-basis transfer report how much was actually transferred
- transfer_basis() now returns transferred_in_amount.
- Same-bucket case (for example ETH/WETH) returns full in_amount.

2) Add fallback acquisition for any remainder
- After transfer, compute: remaining_in_amount = in_event.amount - transferred_in_amount
- If remainder > 0, create a normal in-acquisition for the remainder.
- This prevents silent loss when source lots are missing or partial.

3) Add regression coverage
- Added regression test for missing out lots scenario: test_basis_transfer_missing_out_lots
- Verifies receive-side lot is still recorded.

### Some notes:

- No double counting: only the unmatched remainder is added.
- Normal transfer behavior is preserved when source lots exist.
- Same-bucket wrappers remain a no-op from a cost-basis movement perspective.

https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=177288027