### PR TITLE
fix(frontend): don't mask blockchain balances during refresh

### DIFF
--- a/frontend/app/src/pages/balances/blockchain/index.vue
+++ b/frontend/app/src/pages/balances/blockchain/index.vue
@@ -5,7 +5,6 @@ import {
   type AccountManageState,
   createNewBlockchainAccount,
 } from '@/modules/accounts/blockchain/use-account-manage';
-import { useAccountLoading } from '@/modules/accounts/use-account-loading';
 import { useBlockchainAccountLoading } from '@/modules/accounts/use-blockchain-account-loading';
 import PriceRefresh from '@/modules/assets/prices/PriceRefresh.vue';
 import AssetBalances from '@/modules/balances/AssetBalances.vue';
@@ -14,6 +13,7 @@ import BlockchainBalanceStalenessIndicator from '@/modules/balances/BlockchainBa
 import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
 import { useBalanceRefresh } from '@/modules/balances/use-balance-refresh';
 import { NoteLocation } from '@/modules/core/common/notes';
+import { Section } from '@/modules/core/common/status';
 import SummaryCardRefreshMenu from '@/modules/dashboard/summary/SummaryCardRefreshMenu.vue';
 import VisibleColumnsSelector from '@/modules/dashboard/VisibleColumnsSelector.vue';
 import HideSmallBalances from '@/modules/settings/HideSmallBalances.vue';
@@ -21,6 +21,7 @@ import { BalanceSource, DashboardTableType } from '@/modules/settings/types/fron
 import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
+import { useSectionStatus } from '@/modules/shell/sync-progress/use-section-status';
 
 definePage({
   meta: {
@@ -42,7 +43,8 @@ const route = useRoute('balances-blockchain');
 const tableType = DashboardTableType.BLOCKCHAIN_ASSET_BALANCES;
 
 const { useBlockchainBalances } = useAggregatedBalances();
-const { isBlockchainLoading } = useAccountLoading();
+const { isInitialLoading, isLoading } = useSectionStatus(Section.BLOCKCHAIN);
+const isRefreshing = computed<boolean>(() => get(isLoading) && !get(isInitialLoading));
 const { dashboardTablesVisibleColumns } = storeToRefs(useFrontendSettingsStore());
 const { isDetectingTokens, refreshDisabled } = useBlockchainAccountLoading();
 const { handleBlockchainRefresh } = useBalanceRefresh();
@@ -81,7 +83,7 @@ onMounted(() => {
             <SummaryCardRefreshMenu
               data-cy="blockchain-balances-refresh-menu"
               :disabled="refreshDisabled"
-              :loading="isDetectingTokens"
+              :loading="isDetectingTokens || isRefreshing"
               :tooltip="t('account_balances.refresh_tooltip')"
               @refresh="handleBlockchainRefresh()"
             >
@@ -128,7 +130,7 @@ onMounted(() => {
 
         <AssetBalances
           data-cy="blockchain-asset-balances"
-          :loading="isBlockchainLoading"
+          :loading="isInitialLoading"
           :balances="aggregatedBalances"
           :search="search"
           :details="{


### PR DESCRIPTION
## Summary

The blockchain balances page showed an empty loading state until the *full refresh* completed, even when a prior cached GET had already populated the store. This matched a user-visible symptom of \"GET comes back but nothing renders — data only shows after the POST finishes\".

### Root cause

`pages/balances/blockchain/index.vue` was binding \`<AssetBalances :loading>\` to \`isBlockchainLoading\`, which is simply \`useIsTaskRunning(TaskType.QUERY_BLOCKCHAIN_BALANCES)\`. Both the cached GET and the follow-up refresh POST run under the **same task type**, so the flag stays \`true\` across the whole GET→POST window and the loading overlay covers the table the entire time. The store write from the cached GET never becomes visible to the user.

### Fix

The balance processing service already sets \`Status.LOADING\` vs \`Status.REFRESHING\` on \`Section.BLOCKCHAIN\` via \`useStatusUpdater\` (see \`use-balance-processing-service.ts\`). The section status store exposes these as \`isInitialLoading\` and \`isLoading\`. The UI just needed to ask the right source.

- Table \`:loading\` now uses \`isInitialLoading\` (true only during the first load with no data in store).
- Refresh-menu spinner ORs in \`isRefreshing = isLoading && !isInitialLoading\`, so the user sees a subtle \"refreshing\" indicator on the refresh button while the background refresh runs without the table being masked.

No changes to the processing service, store, or task wiring — just a 6-line change in one file that reads the richer status the service already tracks.

## Test plan

- [x] \`pnpm run typecheck\`
- [x] \`pnpm run lint\` — 0 errors
- [x] \`pnpm run test:unit\` — 3210 passing
- [ ] Manual: on blockchain balances page, observe cached rows appear as soon as the GET returns; refresh menu spinner spins while the POST is in flight; rows do not disappear during refresh.