### PR TITLE
Fresh account doesnt use RPC nodes to query tokens

### DIFF
--- a/rotkehlchen/chain/arbitrum_one/modules/thegraph/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/thegraph/balances.py
@@ -13,7 +13,7 @@ from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, Pr
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.thegraph.constants import CPT_THEGRAPH
-from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order
+from rotkehlchen.chain.evm.tokens import get_rpc_first_chunk_size_call_order
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_GRT_ARB
 from rotkehlchen.constants.misc import ZERO
@@ -118,7 +118,7 @@ class ThegraphBalances(ProtocolWithBalance):
         if len(delegations := self._get_delegations()) == 0:  # user had no delegation events
             return balances
 
-        chunk_size, call_order = get_chunk_size_call_order(self.evm_inquirer)
+        chunk_size, call_order = get_rpc_first_chunk_size_call_order(self.evm_inquirer)
         staking_contract = EvmContract(
             address=CONTRACT_STAKING,
             abi=HORIZON_STAKING_ABI,

--- a/rotkehlchen/chain/arbitrum_one/node_inquirer.py
+++ b/rotkehlchen/chain/arbitrum_one/node_inquirer.py
@@ -2,7 +2,10 @@ import logging
 from typing import TYPE_CHECKING, Literal
 
 from rotkehlchen.chain.constants import DEFAULT_RPC_TIMEOUT
-from rotkehlchen.chain.evm.constants import BALANCE_SCANNER_ADDRESS
+from rotkehlchen.chain.evm.constants import (
+    ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT,
+    BALANCE_SCANNER_ADDRESS,
+)
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -30,6 +33,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 class ArbitrumOneInquirer(EvmNodeInquirer):
+    INDEXER_CHUNK_SIZE = ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT
 
     def __init__(
             self,

--- a/rotkehlchen/chain/arbitrum_one/tokens.py
+++ b/rotkehlchen/chain/arbitrum_one/tokens.py
@@ -1,5 +1,5 @@
-from rotkehlchen.chain.evm.tokens import EvmTokens
+from rotkehlchen.chain.evm.tokens import ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT, EvmTokens
 
 
 class ArbitrumOneTokens(EvmTokens):
-    ...
+    INDEXER_CHUNK_SIZE = ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT

--- a/rotkehlchen/chain/arbitrum_one/tokens.py
+++ b/rotkehlchen/chain/arbitrum_one/tokens.py
@@ -1,5 +1,5 @@
-from rotkehlchen.chain.evm.tokens import ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT, EvmTokens
+from rotkehlchen.chain.evm.tokens import EvmTokens
 
 
 class ArbitrumOneTokens(EvmTokens):
-    INDEXER_CHUNK_SIZE = ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT
+    ...

--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -8,7 +8,7 @@ from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.api.v1.types import IncludeExcludeFilterData
 from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.assets.utils import token_normalized_value
-from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order
+from rotkehlchen.chain.evm.tokens import get_rpc_first_chunk_size_call_order
 from rotkehlchen.chain.evm.types import WeightedNode, string_to_evm_address
 from rotkehlchen.db.filtering import EvmEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
@@ -238,7 +238,7 @@ class ProtocolWithGauges(ProtocolWithBalance):
         balances: BalancesSheetType = defaultdict(BalanceSheet)
         gauges_to_token: dict[ChecksumEvmAddress, EvmToken] = {}
         # query addresses and gauges where they interacted
-        chunk_size, call_order = get_chunk_size_call_order(self.evm_inquirer)
+        chunk_size, call_order = get_rpc_first_chunk_size_call_order(self.evm_inquirer)
         for address, events in self.addresses_with_gauge_deposits().items():
             # Create a mapping of a gauge to its token
             for event in events:

--- a/rotkehlchen/chain/ethereum/modules/aave/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/balances.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, Pr
 from rotkehlchen.chain.ethereum.modules.aave.constants import STK_AAVE_ADDR
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE
-from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order
+from rotkehlchen.chain.evm.tokens import get_rpc_first_chunk_size_call_order
 from rotkehlchen.constants.assets import A_AAVE
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.db.settings import CachedSettings
@@ -49,7 +49,7 @@ class AaveBalances(ProtocolWithBalance):
             return balances
 
         staking_contract = self.evm_inquirer.contracts.contract(address=STK_AAVE_ADDR)
-        chunk_size, call_order = get_chunk_size_call_order(self.evm_inquirer)
+        chunk_size, call_order = get_rpc_first_chunk_size_call_order(self.evm_inquirer)
         if len(staked_rewards := self.evm_inquirer.multicall(
             calls=[(
                 staking_contract.address,

--- a/rotkehlchen/chain/ethereum/modules/pendle/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/pendle/balances.py
@@ -8,7 +8,7 @@ from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, Pr
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.pendle.constants import CPT_PENDLE
-from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order
+from rotkehlchen.chain.evm.tokens import get_rpc_first_chunk_size_call_order
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -51,7 +51,7 @@ class PendleBalances(ProtocolWithBalance):
         if len(addresses_with_deposits := list(self.addresses_with_deposits())) == 0:
             return balances
 
-        _, call_order = get_chunk_size_call_order(self.evm_inquirer)
+        call_order = get_rpc_first_chunk_size_call_order(self.evm_inquirer)[1]
         try:
             results = self.evm_inquirer.multicall(
                 calls=[

--- a/rotkehlchen/chain/evm/constants.py
+++ b/rotkehlchen/chain/evm/constants.py
@@ -7,6 +7,10 @@ from .types import string_to_evm_address
 
 DEFAULT_TOKEN_DECIMALS: Final = 18
 
+# maximum 32-byte arguments in one call to tokensBalance/multicall via indexers
+ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT: Final = 110
+ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT: Final = 25
+
 EIP7702_DELEGATION_PREFIX: Final = '0xef0100'
 EIP7702_DELEGATION_CODE_LENGTH: Final = 48  # 0x + prefix + delegation address
 

--- a/rotkehlchen/chain/evm/decoding/hop/balances.py
+++ b/rotkehlchen/chain/evm/decoding/hop/balances.py
@@ -8,7 +8,7 @@ from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.hop.constants import CPT_HOP
-from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order
+from rotkehlchen.chain.evm.tokens import get_rpc_first_chunk_size_call_order
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
@@ -67,7 +67,7 @@ class HopBalances(ProtocolWithBalance):
                 abi=hop_abi,
                 deployed_block=0,  # not used here since logs are not queried
             )
-            chunk_size, call_order = get_chunk_size_call_order(self.evm_inquirer)
+            chunk_size, call_order = get_rpc_first_chunk_size_call_order(self.evm_inquirer)
 
             if len(staked_lps := self.evm_inquirer.multicall(
                 calls=[(

--- a/rotkehlchen/chain/evm/decoding/velodrome/balances.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/balances.py
@@ -11,7 +11,7 @@ from rotkehlchen.chain.ethereum.interfaces.balances import (
 from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.velodrome.constants import VOTING_ESCROW_ABI
-from rotkehlchen.chain.evm.tokens import get_chunk_size_call_order
+from rotkehlchen.chain.evm.tokens import get_rpc_first_chunk_size_call_order
 from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -75,7 +75,7 @@ class VelodromeLikeBalances(ProtocolWithGauges):
             abi=VOTING_ESCROW_ABI,
             deployed_block=0,
         )
-        chunk_size, call_order = get_chunk_size_call_order(self.evm_inquirer)
+        chunk_size, call_order = get_rpc_first_chunk_size_call_order(self.evm_inquirer)
         if (price := Inquirer.find_price(
                 from_asset=self.protocol_token,
                 to_asset=CachedSettings().main_currency,

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -30,6 +30,7 @@ from rotkehlchen.chain.evm.constants import (
     EIP7702_DELEGATION_PREFIX,
     ERC20_PROPERTIES,
     ERC721_PROPERTIES,
+    ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT,
     FAKE_GENESIS_TX_RECEIPT,
     GENESIS_HASH,
 )
@@ -210,6 +211,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
         '_get_transaction_by_hash',
         '_get_logs',
     )
+    INDEXER_CHUNK_SIZE = ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT
 
     def __init__(
             self,

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -2,6 +2,7 @@ import logging
 from abc import ABC
 from collections import defaultdict, deque
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeVar, cast
 
 from rotkehlchen.assets.asset import Asset, EvmToken, Nft
@@ -53,6 +54,20 @@ DetectedTokensType = dict[
     ChecksumEvmAddress,
     tuple[list[EvmToken] | None, Timestamp | None],
 ]
+
+
+@dataclass
+class TokenChunkQueryResult:
+    """Result of querying token balances for one address across chunked requests.
+
+    Attributes:
+    - balances: accumulated detected balances across successful chunk queries.
+    - had_failures: True when at least one chunk could not be queried even after
+      retry/split/indexer fallback handling. In that case results are considered
+      unreliable for cache persistence.
+    """
+    balances: dict[Asset, FVal]
+    had_failures: bool
 
 # 27/11/2024
 # Etherscan has by far the fastest responding server if you use an API key
@@ -147,6 +162,8 @@ def get_chunk_size_call_order(
 
 
 class EvmTokens(ABC):  # noqa: B024
+    INDEXER_CHUNK_SIZE = ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT
+
     def __init__(
             self,
             database: 'DBHandler',
@@ -273,30 +290,50 @@ class EvmTokens(ABC):  # noqa: B024
             tokens: list[EvmTokenDetectionData],
             chunk_size: int,
             call_order: list[WeightedNode],
-    ) -> dict[Asset, FVal]:
+    ) -> TokenChunkQueryResult:
         """Processes token balance queries in batches of chunk_size to avoid hitting gas limits.
         Uses Asset objects directly instead of EvmToken to minimize database queries.
+
+        Starts with the given `call_order` and chunk size. If a chunk is too large, it retries
+        smaller chunks first using the same call order (preserving RPC-first behavior). Once a
+        chunk is at or below `INDEXER_CHUNK_SIZE`, request-size failures are retried with
+        indexer-only calls chunked by `INDEXER_CHUNK_SIZE`.
         """
         total_token_balances: dict[Asset, FVal] = defaultdict(FVal)
-        chunks_to_process = deque(get_chunks(tokens, n=chunk_size))
+        had_failures = False
+        chunks_to_process: deque[tuple[list[EvmTokenDetectionData], bool]] = deque(
+            (chunk, False) for chunk in get_chunks(tokens, n=chunk_size)
+        )
         while len(chunks_to_process) > 0:
-            chunk = chunks_to_process.popleft()
+            chunk, use_indexer_only = chunks_to_process.popleft()
             try:
                 new_token_balances = self.get_token_balances(
                     address=address,
                     tokens=chunk,
-                    call_order=call_order,
+                    call_order=[self.evm_inquirer.indexers_node] if use_indexer_only else call_order,  # noqa: E501
                 )
             except RequestTooLargeError:
-                if len(chunk) == 1:
+                if use_indexer_only is False and len(chunk) <= self.INDEXER_CHUNK_SIZE:
+                    log.warning(
+                        f'{self.evm_inquirer.chain_name} tokensBalance chunk too large '
+                        f'for address {address}. Retrying with indexer-only calls in '
+                        f'chunks of {self.INDEXER_CHUNK_SIZE}.',
+                    )
+                    indexer_chunks = list(get_chunks(chunk, n=self.INDEXER_CHUNK_SIZE))
+                    for item in reversed(indexer_chunks):
+                        chunks_to_process.appendleft((item, True))
+                    continue
+
+                if use_indexer_only is True and len(chunk) <= self.INDEXER_CHUNK_SIZE:
+                    had_failures = True
                     log.error(
                         f'{self.evm_inquirer.chain_name} tokensBalance call failed '
-                        f'for address {address}. Could not query a single token '
-                        f'{chunk[0].address} due to request size limits.',
+                        f'for address {address} even with indexer-only chunk size '
+                        f'{self.INDEXER_CHUNK_SIZE}.',
                     )
                     continue
 
-                smaller_chunk_size = max(1, len(chunk) // 2)
+                smaller_chunk_size = max(self.INDEXER_CHUNK_SIZE, len(chunk) // 2)
                 log.warning(
                     f'{self.evm_inquirer.chain_name} tokensBalance chunk too large '
                     f'for address {address}. Retrying by splitting {len(chunk)} '
@@ -304,11 +341,12 @@ class EvmTokens(ABC):  # noqa: B024
                 )
                 smaller_chunks = list(get_chunks(chunk, n=smaller_chunk_size))
                 for item in reversed(smaller_chunks):
-                    chunks_to_process.appendleft(item)
+                    chunks_to_process.appendleft((item, use_indexer_only))
                 continue
 
             total_token_balances = combine_dicts(total_token_balances, new_token_balances)
-        return total_token_balances
+
+        return TokenChunkQueryResult(balances=total_token_balances, had_failures=had_failures)
 
     def _compute_detected_tokens_info(self, addresses: Sequence[ChecksumEvmAddress]) -> DetectedTokensType:  # noqa: E501
         """
@@ -330,21 +368,43 @@ class EvmTokens(ABC):  # noqa: B024
         return addresses_info
 
     def _query_new_tokens(self, addresses: Sequence[ChecksumEvmAddress]) -> None:
+        """Run token detection and persist results for the given addresses.
+
+        Cache-safety behavior:
+        - ERC20 detection returns both detected tokens and addresses with failed detection.
+        - Any address in the failed set is considered unreliable for this run and is not
+          persisted to the token cache (even if partial tokens were detected).
+        - ERC721 detection is executed only for addresses that did not fail ERC20 detection.
+
+        This avoids destructive cache overwrites (e.g. replacing previously cached tokens with
+        an empty/partial list after a failed detection query).
+        """
         erc20_tokens, erc721_tokens = GlobalDBHandler.get_token_detection_data(
             chain_id=self.evm_inquirer.chain_id,
             exceptions=self._get_token_exceptions(),
         )
-        detected_erc20_tokens = self._detect_tokens(
+        detected_erc20_tokens, failed_detection_addresses = self._detect_tokens(
             addresses=addresses,
             tokens_to_check=erc20_tokens,
         )
         all_detected_tokens = self._detect_erc721_tokens(
-            addresses=addresses,
+            addresses=[
+                address for address in addresses
+                if address not in failed_detection_addresses
+            ],
             tokens_to_check=erc721_tokens,
             detected_tokens=detected_erc20_tokens,
         )
         with self.db.user_write() as write_cursor:
             for address, detected_tokens in all_detected_tokens.items():
+                if address in failed_detection_addresses:
+                    log.warning(
+                        f'{self.evm_inquirer.chain_name} token detection failed '
+                        f'for address {address}. '
+                        'Skipping cache update to avoid persisting incomplete token results.',
+                    )
+                    continue
+
                 self.db.save_tokens_for_address(
                     write_cursor=write_cursor,
                     address=address,
@@ -438,13 +498,36 @@ class EvmTokens(ABC):  # noqa: B024
 
         return self._compute_detected_tokens_info(addresses)
 
+    def _get_token_detection_chunk_size_call_order(self) -> tuple[int, list[WeightedNode]]:
+        """Return chunk size and call order used by token detection queries.
+
+        We always start with RPC nodes. If there is no connected node yet, we still build
+        an RPC-first order (lazy connect in `_query`) and append indexers only as a final
+        fallback.
+        """
+        rpc_call_order = self.evm_inquirer.default_call_order(skip_indexers=True)
+        if self.evm_inquirer.connected_to_any_node():
+            return OTHER_MAX_TOKEN_CHUNK_LENGTH, rpc_call_order
+
+        if len(rpc_call_order) == 0:
+            return self.INDEXER_CHUNK_SIZE, [self.evm_inquirer.indexers_node]
+
+        return OTHER_MAX_TOKEN_CHUNK_LENGTH, [*rpc_call_order, self.evm_inquirer.indexers_node]
+
     def _detect_tokens(
             self,
             addresses: Sequence[ChecksumEvmAddress],
             tokens_to_check: list[EvmTokenDetectionData],
-    ) -> dict[ChecksumEvmAddress, list[Asset]]:
-        """
-        Detect tokens for the given addresses.
+    ) -> tuple[dict[ChecksumEvmAddress, list[Asset]], set[ChecksumEvmAddress]]:
+        """Detect ERC20 tokens per address and track unreliable detection runs.
+
+        Returns:
+        - detected_tokens: address -> detected token list for successful detection runs.
+        - failed_addresses: addresses where token querying had failures (see
+          ``TokenChunkQueryResult.had_failures``).
+
+        For failed addresses, this method intentionally does not return partial token results,
+        because callers treat failures as non-cacheable and must avoid destructive overwrites.
 
         May raise:
         - RemoteError if an external service such as Etherscan is queried and
@@ -452,19 +535,27 @@ class EvmTokens(ABC):  # noqa: B024
         - BadFunctionCallOutput if a local node is used and the contract for the
           token has no code. That means the chain is not synced
         """
-        chunk_size, call_order = get_chunk_size_call_order(self.evm_inquirer)
+        chunk_size, call_order = self._get_token_detection_chunk_size_call_order()
         tokens_per_address = defaultdict(list)
+        failed_addresses: set[ChecksumEvmAddress] = set()
         for address in addresses:
-            token_balances = self._query_chunks(
+            query_result = self._query_chunks(
                 address=address,
                 tokens=tokens_to_check,
                 chunk_size=chunk_size,
                 call_order=call_order,
             )
-            detected_tokens = list(token_balances.keys())
-            tokens_per_address[address] = detected_tokens
+            if query_result.had_failures is True:
+                failed_addresses.add(address)
+                log.warning(
+                    f'{self.evm_inquirer.chain_name} token detection encountered query failures '
+                    f'for address {address}. Skipping token-cache update for this address.',
+                )
+                continue
 
-        return tokens_per_address
+            tokens_per_address[address] = list(query_result.balances.keys())
+
+        return tokens_per_address, failed_addresses
 
     def query_tokens_for_addresses(
             self,
@@ -482,7 +573,7 @@ class EvmTokens(ABC):  # noqa: B024
         addresses_to_balances: dict[ChecksumEvmAddress, dict[EvmToken, FVal]] = defaultdict(dict)
         all_tokens: set[EvmToken] = set()
         addresses_to_tokens: dict[ChecksumEvmAddress, list[EvmToken]] = {}
-        chunk_size, call_order = get_chunk_size_call_order(self.evm_inquirer)
+        chunk_size, call_order = self._get_token_detection_chunk_size_call_order()
 
         with self.db.conn.read_ctx() as cursor:
             for address in addresses:

--- a/rotkehlchen/chain/evm/tokens.py
+++ b/rotkehlchen/chain/evm/tokens.py
@@ -24,7 +24,6 @@ from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import (
-    ChainID,
     ChecksumEvmAddress,
     Price,
     SupportedBlockchain,
@@ -33,7 +32,7 @@ from rotkehlchen.types import (
 )
 from rotkehlchen.utils.misc import combine_dicts, get_chunks
 
-from .constants import ZERO_ADDRESS
+from .constants import ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT, ZERO_ADDRESS
 from .contracts import EvmContract
 
 if TYPE_CHECKING:
@@ -100,10 +99,6 @@ class TokenChunkQueryResult:
 
 OTHER_MAX_TOKEN_CHUNK_LENGTH = 460
 
-# maximum 32-bytes arguments in one call to a contract (either tokensBalance or multicall)
-ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT = 110
-ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT = 25
-
 # this is a number of arguments that a pure tokensBalance contract occupies when is added
 # to multicall. In total, it occupies (7 + number of tokens passed) arguments.
 PURE_TOKENS_BALANCE_ARGUMENTS = 7
@@ -139,26 +134,26 @@ def generate_multicall_chunks(
     return multicall_chunks
 
 
-def get_chunk_size_call_order(
+def get_rpc_first_chunk_size_call_order(
         evm_inquirer: 'EvmNodeInquirer',
         web3_node_chunk_size: int = OTHER_MAX_TOKEN_CHUNK_LENGTH,
-        etherscan_chunk_size: int = ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT,
-        arbiscan_chunksize: int = ARBISCAN_MAX_ARGUMENTS_TO_CONTRACT,
 ) -> tuple[int, list[WeightedNode]]:
-    """
-    Return the max number of tokens that can be queried in a single call depending on whether we
-    have a web3 node connected or we are going to use etherscan.
-    We also return the nodes call order. In the case of having web3 nodes available we
-    skip etherscan because chunk size is too big for etherscan.
-    """
-    if evm_inquirer.connected_to_any_node():
-        chunk_size = web3_node_chunk_size
-        call_order = evm_inquirer.default_call_order(skip_indexers=True)
-    else:
-        chunk_size = etherscan_chunk_size if evm_inquirer.chain_id != ChainID.ARBITRUM_ONE else arbiscan_chunksize  # noqa: E501
-        call_order = [evm_inquirer.indexers_node]
+    """Return chunk size and RPC-first call order with indexer fallback.
 
-    return chunk_size, call_order
+    Behavior:
+    - if any RPC node is connected, use RPC-only order with the web3 chunk size.
+    - if no RPC node is connected but RPC nodes are configured, keep RPC nodes first and append
+      the indexer as fallback, still using the web3 chunk size (lazy connect in `_query`).
+    - if no RPC nodes are configured, use indexer-only order and inquirer indexer chunk size.
+    """
+    rpc_call_order = evm_inquirer.default_call_order(skip_indexers=True)
+    if evm_inquirer.connected_to_any_node():
+        return web3_node_chunk_size, rpc_call_order
+
+    if len(rpc_call_order) == 0:
+        return evm_inquirer.INDEXER_CHUNK_SIZE, [evm_inquirer.indexers_node]
+
+    return web3_node_chunk_size, [*rpc_call_order, evm_inquirer.indexers_node]
 
 
 class EvmTokens(ABC):  # noqa: B024
@@ -173,6 +168,7 @@ class EvmTokens(ABC):  # noqa: B024
         self.db = database
         self.evm_inquirer = evm_inquirer
         self.token_exceptions = token_exceptions if token_exceptions is not None else set()
+        self.INDEXER_CHUNK_SIZE = evm_inquirer.INDEXER_CHUNK_SIZE
 
     def get_token_balances(
             self,
@@ -505,14 +501,10 @@ class EvmTokens(ABC):  # noqa: B024
         an RPC-first order (lazy connect in `_query`) and append indexers only as a final
         fallback.
         """
-        rpc_call_order = self.evm_inquirer.default_call_order(skip_indexers=True)
-        if self.evm_inquirer.connected_to_any_node():
-            return OTHER_MAX_TOKEN_CHUNK_LENGTH, rpc_call_order
-
-        if len(rpc_call_order) == 0:
-            return self.INDEXER_CHUNK_SIZE, [self.evm_inquirer.indexers_node]
-
-        return OTHER_MAX_TOKEN_CHUNK_LENGTH, [*rpc_call_order, self.evm_inquirer.indexers_node]
+        return get_rpc_first_chunk_size_call_order(
+            evm_inquirer=self.evm_inquirer,
+            web3_node_chunk_size=OTHER_MAX_TOKEN_CHUNK_LENGTH,
+        )
 
     def _detect_tokens(
             self,

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -574,7 +574,7 @@ def test_uniswap_v3_v4_balances(
     with patch.object(  # patch the erc20 token detection
             target=rotki.chains_aggregator.arbitrum_one.tokens,
             attribute='_detect_tokens',
-            return_value={(user_address := arbitrum_one_accounts[0]): []},
+            return_value=({(user_address := arbitrum_one_accounts[0]): []}, set()),
     ):
         response = requests.post(
             api_url_for(

--- a/rotkehlchen/tests/unit/test_tokens.py
+++ b/rotkehlchen/tests/unit/test_tokens.py
@@ -10,7 +10,12 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.utils import _query_or_get_given_token_info, get_or_create_evm_token
 from rotkehlchen.chain.ethereum.tokens import EthereumTokens
 from rotkehlchen.chain.evm.decoding.summer_fi.constants import CPT_SUMMER_FI
-from rotkehlchen.chain.evm.tokens import EvmTokensWithProxies, generate_multicall_chunks
+from rotkehlchen.chain.evm.tokens import (
+    ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT,
+    EvmTokensWithProxies,
+    generate_multicall_chunks,
+    get_chunk_size_call_order,
+)
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.structures import EvmTokenDetectionData
 from rotkehlchen.constants import ONE, ZERO
@@ -220,6 +225,58 @@ def test_generate_chunks():
     assert generated_chunks == expected_chunks
 
 
+def test_get_chunk_size_call_order_uses_rpc_only_order_when_connected() -> None:
+    call_order = [MagicMock()]
+    evm_inquirer = MagicMock()
+    evm_inquirer.connected_to_any_node.return_value = True
+    evm_inquirer.default_call_order.return_value = call_order
+
+    chunk_size, returned_call_order = get_chunk_size_call_order(
+        evm_inquirer=evm_inquirer,
+        web3_node_chunk_size=999,
+    )
+
+    evm_inquirer.default_call_order.assert_called_once_with(skip_indexers=True)
+    assert chunk_size == 999
+    assert returned_call_order == call_order
+
+
+def test_get_chunk_size_call_order_uses_indexer_fallback_when_disconnected() -> None:
+    evm_inquirer = MagicMock()
+    evm_inquirer.connected_to_any_node.return_value = False
+    evm_inquirer.chain_id = ChainID.HYPERLIQUID
+    evm_inquirer.indexers_node = MagicMock()
+
+    chunk_size, returned_call_order = get_chunk_size_call_order(
+        evm_inquirer=evm_inquirer,
+        web3_node_chunk_size=999,
+        etherscan_chunk_size=111,
+        arbiscan_chunksize=222,
+    )
+
+    assert evm_inquirer.default_call_order.call_count == 0
+    assert chunk_size == 111
+    assert returned_call_order == [evm_inquirer.indexers_node]
+
+
+def test_get_chunk_size_call_order_uses_arbiscan_chunk_on_arbitrum_fallback() -> None:
+    evm_inquirer = MagicMock()
+    evm_inquirer.connected_to_any_node.return_value = False
+    evm_inquirer.chain_id = ChainID.ARBITRUM_ONE
+    evm_inquirer.indexers_node = MagicMock()
+
+    chunk_size, returned_call_order = get_chunk_size_call_order(
+        evm_inquirer=evm_inquirer,
+        web3_node_chunk_size=999,
+        etherscan_chunk_size=111,
+        arbiscan_chunksize=222,
+    )
+
+    assert evm_inquirer.default_call_order.call_count == 0
+    assert chunk_size == 222
+    assert returned_call_order == [evm_inquirer.indexers_node]
+
+
 def test_get_token_balances_propagates_request_too_large(tokens: EthereumTokens) -> None:
     detection_data = EvmTokenDetectionData(
         identifier='eip155:1/erc20:0x0000000000000000000000000000000000000001',
@@ -246,6 +303,7 @@ def test_query_chunks_retries_with_smaller_chunks(tokens: EthereumTokens) -> Non
         ) for i in range(1, 6)
     ]
     queried_chunk_sizes: list[int] = []
+    tokens.INDEXER_CHUNK_SIZE = 2
 
     def mocked_get_token_balances(
             address: ChecksumEvmAddress,
@@ -266,8 +324,204 @@ def test_query_chunks_retries_with_smaller_chunks(tokens: EthereumTokens) -> Non
             call_order=[],
         )
 
-    assert result == {}
+    assert result.balances == {}
+    assert result.had_failures is False
     assert queried_chunk_sizes == [4, 2, 2, 1]
+
+
+def test_query_chunks_retries_with_reduced_rpc_chunks(tokens: EthereumTokens) -> None:
+    """Ensure oversized RPC chunks are retried with smaller RPC-sized chunks first.
+
+    This test does not assert indexer-only fallback. It verifies the split sequence keeps the
+    original RPC-first call order while reducing chunk size (150 -> 110 -> 40).
+    """
+    token_data = [
+        EvmTokenDetectionData(
+            identifier=f'eip155:1/erc20:{(address := make_evm_address())}',
+            address=address,
+            decimals=18,
+        ) for _ in range(150)
+    ]
+    rpc_call_order = [MagicMock(name='rpc_node'), tokens.evm_inquirer.indexers_node]
+    queried_calls: list[tuple[int, list[Any]]] = []
+
+    def mocked_get_token_balances(
+            address: ChecksumEvmAddress,
+            tokens: list[EvmTokenDetectionData],
+            call_order: list[Any],
+    ) -> dict[Asset, FVal]:
+        queried_calls.append((len(tokens), call_order))
+        if call_order == rpc_call_order and len(tokens) > ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT:
+            raise RequestTooLargeError('chunk too big for fallback indexer')
+
+        return {}
+
+    with patch.object(tokens, 'get_token_balances', side_effect=mocked_get_token_balances):
+        result = tokens._query_chunks(
+            address=make_evm_address(),
+            tokens=token_data,
+            chunk_size=460,
+            call_order=rpc_call_order,  # type: ignore
+        )
+
+    assert result.balances == {}
+    assert result.had_failures is False
+    assert queried_calls[0] == (150, rpc_call_order)
+    assert queried_calls[1] == (110, rpc_call_order)
+    assert queried_calls[2] == (40, rpc_call_order)
+
+
+def test_query_chunks_prefers_rpc_split(tokens: EthereumTokens) -> None:
+    """Ensure RequestTooLargeError triggers RPC-path splitting before any indexer-only fallback.
+
+    The test forces an oversize failure for RPC-sized chunks and verifies follow-up retries
+    continue using the original RPC-first call order (not `[indexers_node]`).
+    """
+    token_data = [
+        EvmTokenDetectionData(
+            identifier=f'eip155:1/erc20:{(address := make_evm_address())}',
+            address=address,
+            decimals=18,
+        ) for _ in range(150)
+    ]
+    rpc_node = MagicMock(name='rpc_node')
+    call_order = [rpc_node, tokens.evm_inquirer.indexers_node]
+    queried_call_orders: list[list[Any]] = []
+
+    def mocked_get_token_balances(
+            address: ChecksumEvmAddress,
+            tokens: list[EvmTokenDetectionData],
+            call_order: list[Any],
+    ) -> dict[Asset, FVal]:
+        queried_call_orders.append(call_order)
+        if len(tokens) > ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT:
+            raise RequestTooLargeError('too large on first pass')
+
+        return {Asset(tokens[0].identifier): ONE}
+
+    with patch.object(tokens, 'get_token_balances', side_effect=mocked_get_token_balances):
+        result = tokens._query_chunks(
+            address=make_evm_address(),
+            tokens=token_data,
+            chunk_size=460,
+            call_order=call_order,  # type: ignore
+        )
+
+    assert len(result.balances) >= 1
+    assert result.had_failures is False
+    assert all(x != [tokens.evm_inquirer.indexers_node] for x in queried_call_orders)
+
+
+def test_query_chunks_uses_indexer_chunk_size_before_single_token_fallback(tokens: EthereumTokens) -> None:  # noqa: E501
+    token_data = [
+        EvmTokenDetectionData(
+            identifier=f'eip155:1/erc20:{(address := make_evm_address())}',
+            address=address,
+            decimals=18,
+        ) for _ in range(120)
+    ]
+    rpc_call_order = [MagicMock(name='rpc_node'), tokens.evm_inquirer.indexers_node]
+    queried_calls: list[tuple[int, list[Any]]] = []
+
+    def mocked_get_token_balances(
+            address: ChecksumEvmAddress,
+            tokens: list[EvmTokenDetectionData],
+            call_order: list[Any],
+    ) -> dict[Asset, FVal]:
+        queried_calls.append((len(tokens), call_order))
+        if call_order == rpc_call_order:
+            raise RequestTooLargeError('rpc too large')
+
+        return {}
+
+    with patch.object(tokens, 'get_token_balances', side_effect=mocked_get_token_balances):
+        result = tokens._query_chunks(
+            address=make_evm_address(),
+            tokens=token_data,
+            chunk_size=460,
+            call_order=rpc_call_order,  # type: ignore
+        )
+
+    assert result.balances == {}
+    assert result.had_failures is False
+    indexer_calls = [
+        size for size, used_call_order in queried_calls
+        if used_call_order == [tokens.evm_inquirer.indexers_node]
+    ]
+    assert indexer_calls == [tokens.INDEXER_CHUNK_SIZE, 120 - tokens.INDEXER_CHUNK_SIZE]
+    assert all(size <= tokens.INDEXER_CHUNK_SIZE for size in indexer_calls)
+    assert all(size > 1 for size in indexer_calls)
+
+
+def test_query_new_tokens_keeps_cache_on_failures(tokens: EthereumTokens) -> None:
+    tracked_address = make_evm_address()
+    existing_token = A_DAI
+
+    with tokens.db.user_write() as write_cursor:
+        tokens.db.save_tokens_for_address(
+            write_cursor=write_cursor,
+            address=tracked_address,
+            blockchain=tokens.evm_inquirer.blockchain,
+            tokens=[existing_token],
+        )
+
+    with (
+        patch.object(GlobalDBHandler, 'get_token_detection_data', return_value=([], [])),
+        patch.object(
+            tokens,
+            '_detect_tokens',
+            return_value=({tracked_address: []}, {tracked_address}),
+        ),
+        patch.object(tokens, 'maybe_detect_proxies_tokens', return_value=None),
+    ):
+        tokens._query_new_tokens(addresses=[tracked_address])
+
+    with tokens.db.conn.read_ctx() as cursor:
+        saved_tokens, _ = tokens.db.get_tokens_for_address(
+            cursor=cursor,
+            address=tracked_address,
+            blockchain=tokens.evm_inquirer.blockchain,
+            token_exceptions=tokens._per_chain_token_exceptions(),
+        )
+
+    assert saved_tokens is not None
+    assert saved_tokens == [existing_token]
+
+
+def test_query_new_tokens_skips_save_on_partial_failures(tokens: EthereumTokens) -> None:
+    tracked_address = make_evm_address()
+    existing_token = A_DAI
+    partial_token = A_WETH
+
+    with tokens.db.user_write() as write_cursor:
+        tokens.db.save_tokens_for_address(
+            write_cursor=write_cursor,
+            address=tracked_address,
+            blockchain=tokens.evm_inquirer.blockchain,
+            tokens=[existing_token],
+        )
+
+    with (
+        patch.object(GlobalDBHandler, 'get_token_detection_data', return_value=([], [])),
+        patch.object(
+            tokens,
+            '_detect_tokens',
+            return_value=({tracked_address: [partial_token]}, {tracked_address}),
+        ),
+        patch.object(tokens, 'maybe_detect_proxies_tokens', return_value=None),
+    ):
+        tokens._query_new_tokens(addresses=[tracked_address])
+
+    with tokens.db.conn.read_ctx() as cursor:
+        saved_tokens, _ = tokens.db.get_tokens_for_address(
+            cursor=cursor,
+            address=tracked_address,
+            blockchain=tokens.evm_inquirer.blockchain,
+            token_exceptions=tokens._per_chain_token_exceptions(),
+        )
+
+    assert saved_tokens is not None
+    assert saved_tokens == [existing_token]
 
 
 def test_last_queried_ts(tokens, freezer):
@@ -698,7 +952,10 @@ def test_erc721_token_ownership_verification(
     # regression test: dai token added here to ensure detected erc20 tokens
     # aren't removed when erc721 tokens are detected
     # see https://github.com/orgs/rotki/projects/11/views/2?pane=issue&itemId=112828923
-    with patch('rotkehlchen.chain.ethereum.tokens.EthereumTokens._detect_tokens', return_value={ethereum_accounts[0]: [A_DAI]}):  # noqa: E501
+    with patch(
+            'rotkehlchen.chain.ethereum.tokens.EthereumTokens._detect_tokens',
+            return_value=({ethereum_accounts[0]: [A_DAI]}, set()),
+    ):
         user_tokens = EthereumTokens(database, ethereum_inquirer).detect_tokens(
             only_cache=False,
             addresses=ethereum_accounts,

--- a/rotkehlchen/tests/unit/test_tokens.py
+++ b/rotkehlchen/tests/unit/test_tokens.py
@@ -14,7 +14,7 @@ from rotkehlchen.chain.evm.tokens import (
     ETHERSCAN_MAX_ARGUMENTS_TO_CONTRACT,
     EvmTokensWithProxies,
     generate_multicall_chunks,
-    get_chunk_size_call_order,
+    get_rpc_first_chunk_size_call_order,
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.structures import EvmTokenDetectionData
@@ -225,55 +225,39 @@ def test_generate_chunks():
     assert generated_chunks == expected_chunks
 
 
-def test_get_chunk_size_call_order_uses_rpc_only_order_when_connected() -> None:
-    call_order = [MagicMock()]
+def test_get_rpc_first_chunk_size_call_order_uses_rpc_order_when_disconnected() -> None:
+    rpc_node_1 = MagicMock(name='rpc_node_1')
+    rpc_node_2 = MagicMock(name='rpc_node_2')
     evm_inquirer = MagicMock()
-    evm_inquirer.connected_to_any_node.return_value = True
-    evm_inquirer.default_call_order.return_value = call_order
+    evm_inquirer.connected_to_any_node.return_value = False
+    evm_inquirer.default_call_order.return_value = [rpc_node_1, rpc_node_2]
+    evm_inquirer.indexers_node = MagicMock(name='indexer_node')
 
-    chunk_size, returned_call_order = get_chunk_size_call_order(
+    chunk_size, returned_call_order = get_rpc_first_chunk_size_call_order(
         evm_inquirer=evm_inquirer,
         web3_node_chunk_size=999,
     )
 
     evm_inquirer.default_call_order.assert_called_once_with(skip_indexers=True)
     assert chunk_size == 999
-    assert returned_call_order == call_order
+    assert returned_call_order == [rpc_node_1, rpc_node_2, evm_inquirer.indexers_node]
 
 
-def test_get_chunk_size_call_order_uses_indexer_fallback_when_disconnected() -> None:
+def test_get_rpc_first_chunk_size_call_order_uses_indexer_when_no_rpc_nodes() -> None:
     evm_inquirer = MagicMock()
     evm_inquirer.connected_to_any_node.return_value = False
+    evm_inquirer.default_call_order.return_value = []
+    evm_inquirer.INDEXER_CHUNK_SIZE = 111
     evm_inquirer.chain_id = ChainID.HYPERLIQUID
     evm_inquirer.indexers_node = MagicMock()
 
-    chunk_size, returned_call_order = get_chunk_size_call_order(
+    chunk_size, returned_call_order = get_rpc_first_chunk_size_call_order(
         evm_inquirer=evm_inquirer,
         web3_node_chunk_size=999,
-        etherscan_chunk_size=111,
-        arbiscan_chunksize=222,
     )
 
-    assert evm_inquirer.default_call_order.call_count == 0
+    evm_inquirer.default_call_order.assert_called_once_with(skip_indexers=True)
     assert chunk_size == 111
-    assert returned_call_order == [evm_inquirer.indexers_node]
-
-
-def test_get_chunk_size_call_order_uses_arbiscan_chunk_on_arbitrum_fallback() -> None:
-    evm_inquirer = MagicMock()
-    evm_inquirer.connected_to_any_node.return_value = False
-    evm_inquirer.chain_id = ChainID.ARBITRUM_ONE
-    evm_inquirer.indexers_node = MagicMock()
-
-    chunk_size, returned_call_order = get_chunk_size_call_order(
-        evm_inquirer=evm_inquirer,
-        web3_node_chunk_size=999,
-        etherscan_chunk_size=111,
-        arbiscan_chunksize=222,
-    )
-
-    assert evm_inquirer.default_call_order.call_count == 0
-    assert chunk_size == 222
     assert returned_call_order == [evm_inquirer.indexers_node]
 
 


### PR DESCRIPTION
A new account that didn´t query the chain before would have no connected nodes and the logic for token detection would use the indexer only to query tokens. This caused premature Etherscan/indexer usage instead of lazy RPC-first behavior.

Closes https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=177288968
