### PR TITLE
Modify sleep time for write context lock

### DIFF
--- a/rotkehlchen/db/drivers/gevent.py
+++ b/rotkehlchen/db/drivers/gevent.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 UnderlyingCursor: TypeAlias = rsqlite.Cursor | sqlcipher.Cursor  # pylint: disable=no-member
 UnderlyingConnection: TypeAlias = rsqlite.Connection | sqlcipher.Connection  # pylint: disable=no-member
 
-CONTEXT_SWITCH_WAIT = 1  # seconds to wait for a status change in a DB context switch
+CONTEXT_SWITCH_WAIT = 0.025  # seconds to wait for a status change in a DB context switch
 import logging
 
 logger: 'RotkehlchenLogger' = logging.getLogger(__name__)  # type: ignore


### PR DESCRIPTION
I checked syncing transactions on my big EVM account (all chains) and my public ENS. This only on my ENS takes around 20min last time I mreasured it in develop. This run syncing both started around 17:55 and finished by 16:14. Includes querying transaction + decoding.

The explanation I find is that the different greenlets that run in parallel don´t need to wait that much when they hit the lock and can resume to writing to the db the transactions much faster.

In the logs you can see clearly how there are more calls per second to the RPCs

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
