### PR TITLE
chore(frontend): adopt @rotki/ui-library 2.18 button sizing + toolbar polish

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The PnL report's Custom range quick-options (Last 12 hours, Last 7 days, etc.) no longer leave a stale "Date cannot be after …" error on the Start field when switching from a past year/quarter to Custom.
 * :feature:`-` You can now update the historical price of an asset for a specific event directly from the event row's asset menu, either by patching the existing oracle entry or saving a manual override.
 * :feature:`12032` Added a dedicated oracle prices management page with paginated filtering, inline editing, and deletion of cached oracle price entries, plus CryptoCompare cache management in the same place.
 * :feature:`-` The address selector in EVM history event forms now shows resolved address-book and ENS names, and lets you filter by either name or address.

--- a/frontend/app/src/modules/accounts/AccountAssetSelectionActions.vue
+++ b/frontend/app/src/modules/accounts/AccountAssetSelectionActions.vue
@@ -33,15 +33,12 @@ const { t } = useI18n({ useScope: 'global' });
       <template #activator>
         <RuiButton
           variant="text"
-          class="!h-10"
+          size="xl"
           :disabled="disabled"
           @click="emit('toggle-mode')"
         >
           <template #prepend>
-            <RuiIcon
-              name="lu-copy-check"
-              size="24"
-            />
+            <RuiIcon name="lu-copy-check" />
           </template>
         </RuiButton>
       </template>

--- a/frontend/app/src/modules/accounts/AccountAssetSelectionActions.vue
+++ b/frontend/app/src/modules/accounts/AccountAssetSelectionActions.vue
@@ -52,7 +52,7 @@ const { t } = useI18n({ useScope: 'global' });
       >
         <template #activator>
           <RuiButton
-            class="h-10"
+            size="xl"
             variant="outlined"
             color="error"
             :disabled="selectedCount === 0"
@@ -61,7 +61,6 @@ const { t } = useI18n({ useScope: 'global' });
             <template #prepend>
               <RuiIcon
                 name="lu-eye-off"
-                size="16"
               />
             </template>
             {{ t('ignore_buttons.ignore') }}
@@ -76,16 +75,15 @@ const { t } = useI18n({ useScope: 'global' });
         >
           <template #activator>
             <RuiButton
-              class="h-10"
               variant="outlined"
               color="error"
+              size="xl"
               :disabled="selectedCount === 0"
               @click="emit('mark-spam')"
             >
               <template #prepend>
                 <RuiIcon
                   name="lu-trash-2"
-                  size="16"
                 />
               </template>
               {{ t('asset_table.mark_spam') }}

--- a/frontend/app/src/modules/accounts/AccountBalancesDefaultPage.vue
+++ b/frontend/app/src/modules/accounts/AccountBalancesDefaultPage.vue
@@ -69,6 +69,7 @@ onMounted(async () => {
         data-cy="blockchain-account-refresh"
         variant="outlined"
         color="primary"
+        size="lg"
         :disabled="refreshDisabled"
         :loading="isSectionLoading"
         @click="table?.refreshClick()"
@@ -81,6 +82,7 @@ onMounted(async () => {
       <RuiButton
         data-cy="add-blockchain-account"
         color="primary"
+        size="lg"
         @click="createNewBlockchainAccount()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/accounts/AccountBalancesExportImport.vue
+++ b/frontend/app/src/modules/accounts/AccountBalancesExportImport.vue
@@ -38,8 +38,7 @@ async function doImport() {
         <RuiButton
           variant="text"
           icon
-          size="sm"
-          class="!p-2"
+          size="lg"
           v-bind="attrs"
         >
           <RuiIcon name="lu-ellipsis-vertical" />

--- a/frontend/app/src/modules/accounts/AccountTokenDetectionControls.vue
+++ b/frontend/app/src/modules/accounts/AccountTokenDetectionControls.vue
@@ -37,9 +37,10 @@ function redetectAllClicked(): void {
       >
         <template #activator>
           <RuiButton
-            class="py-2 !outline-0 rounded-none"
+            class="!outline-0 rounded-none"
             variant="outlined"
             color="primary"
+            size="xl"
             :loading="isDetectingTokens"
             :disabled="refreshDisabled"
             @click="redetectAllClicked()"

--- a/frontend/app/src/modules/accounts/EvmAccountPageButtons.vue
+++ b/frontend/app/src/modules/accounts/EvmAccountPageButtons.vue
@@ -37,6 +37,7 @@ const isEth2Loading = logicOr(
     v-if="isAccountsTabSelected"
     variant="outlined"
     color="primary"
+    size="lg"
   >
     <RuiButton
       :disabled="refreshDisabled"
@@ -55,6 +56,7 @@ const isEth2Loading = logicOr(
             ...attrs,
             'data-cy': 'blockchain-account-refresh',
           }"
+          size="lg"
           color="primary"
           variant="outlined"
           class="!outline-0 px-2"
@@ -71,6 +73,7 @@ const isEth2Loading = logicOr(
     v-else
     color="primary"
     variant="outlined"
+    size="lg"
     :loading="isEth2Loading"
     @click="emit('refresh')"
   >
@@ -88,6 +91,7 @@ const isEth2Loading = logicOr(
       <RuiButton
         data-cy="add-blockchain-account"
         color="primary"
+        size="lg"
         :disabled="addDisabled"
         @click="emit('add-account')"
       >

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagement.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagement.vue
@@ -84,6 +84,7 @@ watchImmediate(location, async () => {
     <template #buttons>
       <RuiButton
         color="primary"
+        size="lg"
         @click="add()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
@@ -56,8 +56,7 @@ async function doImport() {
         <RuiButton
           variant="text"
           icon
-          size="sm"
-          class="!p-2"
+          size="lg"
           v-bind="attrs"
         >
           <RuiIcon name="lu-ellipsis-vertical" />

--- a/frontend/app/src/modules/accounts/balances/DetectEvmAccounts.vue
+++ b/frontend/app/src/modules/accounts/balances/DetectEvmAccounts.vue
@@ -18,12 +18,15 @@ const { detectEvmAccounts } = useBlockchainAccountManagement();
   >
     <template #activator>
       <RuiButton
-        class="py-2"
         color="primary"
+        size="xl"
         :loading="isEvmAccountsDetecting"
         :disabled="isEvmAccountsDetecting"
         @click="detectEvmAccounts()"
       >
+        <template #prepend>
+          <RuiIcon name="lu-radar" />
+        </template>
         {{ t('blockchain_balances.evm_detection.title') }}
       </RuiButton>
     </template>

--- a/frontend/app/src/modules/accounts/balances/DetectTokenChainsSelection.vue
+++ b/frontend/app/src/modules/accounts/balances/DetectTokenChainsSelection.vue
@@ -51,13 +51,14 @@ watch(open, (isOpen) => {
     <template #activator="{ attrs }">
       <RuiButton
         variant="outlined"
-        class="px-3 py-3 !outline-none rounded-none"
+        icon
+        size="xl"
+        class="!outline-none rounded-none"
         v-bind="attrs"
       >
         <RuiIcon
           name="lu-chevrons-up-down"
           color="primary"
-          class="size-4"
         />
       </RuiButton>
     </template>

--- a/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingContent.vue
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingContent.vue
@@ -116,6 +116,7 @@ function showDeleteConfirmation(item: CexMapping) {
       <RuiButton
         color="primary"
         variant="outlined"
+        size="lg"
         :loading="loading"
         @click="fetchData()"
       >
@@ -128,6 +129,7 @@ function showDeleteConfirmation(item: CexMapping) {
       <RuiButton
         data-cy="managed-cex-mapping-add-btn"
         color="primary"
+        size="lg"
         @click="add()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMapping.vue
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMapping.vue
@@ -117,6 +117,7 @@ function showDeleteConfirmation(item: CounterpartyMapping) {
       <RuiButton
         color="primary"
         variant="outlined"
+        size="lg"
         :loading="loading"
         @click="fetchData()"
       >
@@ -129,6 +130,7 @@ function showDeleteConfirmation(item: CounterpartyMapping) {
       <RuiButton
         data-cy="managed-counterparty-mapping-add-btn"
         color="primary"
+        size="lg"
         @click="add()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetContent.vue
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetContent.vue
@@ -128,6 +128,7 @@ watch(() => identifier, (assetId) => {
       <RuiButton
         color="primary"
         variant="outlined"
+        size="lg"
         :loading="loading"
         @click="refresh()"
       >
@@ -140,6 +141,7 @@ watch(() => identifier, (assetId) => {
       <RuiButton
         data-cy="managed-asset-add-btn"
         color="primary"
+        size="lg"
         @click="add()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
@@ -217,6 +217,7 @@ onBeforeMount(async () => {
       <RuiButton
         color="primary"
         variant="outlined"
+        size="lg"
         :loading="loading"
         @click="fetchData()"
       >
@@ -229,6 +230,7 @@ onBeforeMount(async () => {
       <RuiButton
         data-cy="managed-asset-add-btn"
         color="primary"
+        size="lg"
         @click="add()"
       >
         <template #prepend>
@@ -244,8 +246,7 @@ onBeforeMount(async () => {
           <RuiButton
             variant="text"
             icon
-            size="sm"
-            class="!p-2"
+            size="lg"
             v-bind="attrs"
           >
             <RuiIcon name="lu-ellipsis-vertical" />

--- a/frontend/app/src/modules/assets/prices/PriceRefresh.vue
+++ b/frontend/app/src/modules/assets/prices/PriceRefresh.vue
@@ -27,6 +27,7 @@ async function refresh() {
   <RuiButton
     variant="outlined"
     color="primary"
+    size="lg"
     :loading="refreshing"
     data-cy="price-refresh"
     :disabled="disabled"

--- a/frontend/app/src/modules/assets/prices/historic/HistoricPriceContent.vue
+++ b/frontend/app/src/modules/assets/prices/historic/HistoricPriceContent.vue
@@ -135,6 +135,7 @@ onMounted(async () => {
           <RuiButton
             variant="outlined"
             color="primary"
+            size="lg"
             :loading="loading"
             @click="refresh()"
           >
@@ -148,6 +149,7 @@ onMounted(async () => {
       </RuiTooltip>
       <RuiButton
         color="primary"
+        size="lg"
         @click="add()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceContent.vue
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceContent.vue
@@ -111,6 +111,7 @@ onMounted(async () => {
           <RuiButton
             color="primary"
             variant="outlined"
+            size="lg"
             :loading="loading || refreshing"
             @click="refreshCurrentPrices()"
           >
@@ -125,6 +126,7 @@ onMounted(async () => {
 
       <RuiButton
         color="primary"
+        size="lg"
         @click="add()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/balances/non-fungible/components/NonFungibleBalancesActions.vue
+++ b/frontend/app/src/modules/balances/non-fungible/components/NonFungibleBalancesActions.vue
@@ -26,6 +26,7 @@ function onRefresh(): void {
         <RuiButton
           variant="outlined"
           color="primary"
+          size="lg"
           :loading="sectionLoading"
           @click="onRefresh()"
         >

--- a/frontend/app/src/modules/calendar/CalendarDateNavigator.vue
+++ b/frontend/app/src/modules/calendar/CalendarDateNavigator.vue
@@ -1,13 +1,10 @@
 <script setup lang="ts">
-import type { RuiButton } from '@rotki/ui-library';
 import dayjs, { type Dayjs } from 'dayjs';
-import { useTemplateRef } from 'vue';
-import { useRefWithDebounce } from '@/modules/core/common/use-ref-debounce';
 import DateTimePicker from '@/modules/shell/components/inputs/DateTimePicker.vue';
 
 const model = defineModel<Dayjs>({ required: true });
 
-defineProps<{
+const { visibleDate, today } = defineProps<{
   visibleDate: Dayjs;
   today: Dayjs;
 }>();
@@ -19,18 +16,14 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 const datetime = ref<number>(0);
-const open = ref(false);
+const open = ref<boolean>(false);
 
-const activatorRef = useTemplateRef<any>('activatorRef');
-const menuContainerRef = useTemplateRef<InstanceType<typeof HTMLDivElement>>('menuContainerRef');
+// Both the Today label and the chevron reflect the same "already on today"
+// state so the pair reads as a single control — the chevron used to stay
+// primary-outlined while Today greyed out, breaking the visual group.
+const alreadyOnToday = computed<boolean>(() => visibleDate.isSame(today, 'day'));
 
-const { focused: menuFocusedWithin } = useFocusWithin(menuContainerRef);
-const { focused: activatorFocusedWithin } = useFocusWithin(activatorRef);
-
-const anyFocused = logicOr(activatorFocusedWithin, menuFocusedWithin);
-const usedAnyFocused = useRefWithDebounce(anyFocused, 100);
-
-function goToSelectedDate() {
+function goToSelectedDate(): void {
   set(model, dayjs(get(datetime) * 1000));
   set(open, false);
 }
@@ -44,21 +37,32 @@ watch(
     immediate: true,
   },
 );
-
-watch(usedAnyFocused, (curr, prev) => {
-  if (prev && !curr) {
-    set(open, false);
-  }
-});
 </script>
 
 <template>
-  <RuiButtonGroup
-    color="primary"
-    variant="outlined"
-  >
+  <!--
+    Today + chevron are rendered as adjacent siblings in a plain flex wrapper
+    rather than inside a RuiButtonGroup. Nesting a RuiMenu as a group child
+    was causing the menu to flicker open/close on Today clicks — the group
+    intercepts each child's `update:model-value` as a button-selection event
+    and injects `active`/`color`/`size` props into the menu's VNode, which
+    destabilised its open state. Here the two buttons share a visual seam
+    via `!rounded-r-none` / `!rounded-l-none` + `-ml-px`.
+
+    The menu stays `persistent` so that interacting with the nested
+    DateTimePicker (which teleports its own time/date overlays outside this
+    component's DOM subtree) doesn't count as an outside click and dismiss
+    the Go-to-date popup. Close paths: pick a date and hit the corner-down
+    submit button, press Enter/Escape inside the popup, or click the
+    chevron again to toggle.
+  -->
+  <div class="flex">
     <RuiButton
-      :disabled="visibleDate.isSame(today, 'day')"
+      color="primary"
+      variant="outlined"
+      size="xl"
+      class="!rounded-r-none"
+      :disabled="alreadyOnToday"
       @click="emit('set-today')"
     >
       {{ t('calendar.today') }}
@@ -66,27 +70,23 @@ watch(usedAnyFocused, (curr, prev) => {
     <RuiMenu
       v-model="open"
       persistent
-      wrapper-class="h-full"
     >
       <template #activator="{ attrs }">
         <RuiButton
-          ref="activatorRef"
-          size="sm"
-          class="!p-2 !outline-none h-full"
           color="primary"
           variant="outlined"
+          icon
+          size="xl"
+          class="!rounded-l-none -ml-px !rounded"
           v-bind="attrs"
         >
-          <RuiIcon
-            size="20"
-            name="lu-chevron-down"
-          />
+          <RuiIcon name="lu-chevron-down" />
         </RuiButton>
       </template>
       <div
-        ref="menuContainerRef"
         class="p-4 flex items-start"
         tabindex="-1"
+        @keydown.esc="open = false"
       >
         <DateTimePicker
           v-model="datetime"
@@ -109,5 +109,5 @@ watch(usedAnyFocused, (curr, prev) => {
         </RuiButton>
       </div>
     </RuiMenu>
-  </RuiButtonGroup>
+  </div>
 </template>

--- a/frontend/app/src/modules/calendar/CalendarSettingsMenu.vue
+++ b/frontend/app/src/modules/calendar/CalendarSettingsMenu.vue
@@ -269,6 +269,7 @@ onUnmounted(() => {
           <RuiButton
             variant="text"
             icon
+            size="lg"
             v-bind="attrs"
           >
             <RuiIcon name="lu-settings" />

--- a/frontend/app/src/modules/calendar/CalendarSettingsMenu.vue
+++ b/frontend/app/src/modules/calendar/CalendarSettingsMenu.vue
@@ -269,6 +269,7 @@ onUnmounted(() => {
           <RuiButton
             variant="text"
             icon
+            color="primary"
             size="lg"
             v-bind="attrs"
           >

--- a/frontend/app/src/modules/calendar/CalendarView.vue
+++ b/frontend/app/src/modules/calendar/CalendarView.vue
@@ -63,7 +63,6 @@ onMounted(async () => {
 <template>
   <TablePageLayout :title="[t('navigation_menu.calendar')]">
     <template #buttons>
-      <CalendarSettingsMenu />
       <RuiButton
         color="primary"
         size="lg"
@@ -74,6 +73,7 @@ onMounted(async () => {
         </template>
         {{ t('calendar.add_event') }}
       </RuiButton>
+      <CalendarSettingsMenu />
     </template>
 
     <div class="grid items-start grid-cols-[minmax(0,1fr)_14rem] gap-4">

--- a/frontend/app/src/modules/calendar/CalendarView.vue
+++ b/frontend/app/src/modules/calendar/CalendarView.vue
@@ -66,6 +66,7 @@ onMounted(async () => {
       <CalendarSettingsMenu />
       <RuiButton
         color="primary"
+        size="lg"
         @click="add()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/history/events/AssetMovementMatchingSettingsMenu.vue
+++ b/frontend/app/src/modules/history/events/AssetMovementMatchingSettingsMenu.vue
@@ -88,13 +88,12 @@ onMounted(() => {
             color="primary"
             v-bind="attrs"
             :disabled="disabled"
-            class="!rounded-l-none !px-2"
-            :class="isPinned ? 'h-[30px]' : 'h-9'"
+            icon
+            :size="isPinned ? 'sm' : 'lg'"
+            class="!rounded-l-none"
+            :class="{ 'h-[30px]': isPinned }"
           >
-            <RuiIcon
-              name="lu-settings"
-              size="20"
-            />
+            <RuiIcon name="lu-settings" />
           </RuiButton>
         </template>
         <span>{{ t('asset_movement_matching.settings.tooltip') }}</span>

--- a/frontend/app/src/modules/history/events/HistoryEventsExport.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsExport.vue
@@ -118,7 +118,9 @@ const taskRunning = useIsTaskRunning(TaskType.EXPORT_HISTORY_EVENTS);
       <RuiButton
         color="primary"
         variant="outlined"
-        class="!p-2"
+        icon
+        size="xl"
+        class="!rounded"
         :disabled="taskRunning"
         @click="showConfirmation()"
       >

--- a/frontend/app/src/modules/history/events/HistoryEventsIssueCheckButton.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsIssueCheckButton.vue
@@ -58,14 +58,12 @@ watch(hasIssues, (value) => {
     <RuiButton
       variant="outlined"
       color="warning"
-      class="h-9 [&>span]:!hidden lg:[&>span]:!inline"
+      size="lg"
+      class="[&>span]:!hidden lg:[&>span]:!inline"
       @click="toggleAlerts()"
     >
       <template #prepend>
-        <RuiIcon
-          name="lu-triangle-alert"
-          size="18"
-        />
+        <RuiIcon name="lu-triangle-alert" />
       </template>
       {{ t('transactions.alerts.button') }}
       <template #append>

--- a/frontend/app/src/modules/history/events/HistoryEventsTableActions.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsTableActions.vue
@@ -218,15 +218,12 @@ function handleToggleSelectAllMatching(): void {
         <template #activator>
           <RuiButton
             variant="text"
-            class="!h-10"
+            size="xl"
             :disabled="!selection.hasAvailableEvents"
             @click="handleToggleMode()"
           >
             <template #prepend>
-              <RuiIcon
-                name="lu-copy-check"
-                size="24"
-              />
+              <RuiIcon name="lu-copy-check" />
             </template>
           </RuiButton>
         </template>

--- a/frontend/app/src/modules/history/events/HistoryEventsViewButtons.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsViewButtons.vue
@@ -124,8 +124,7 @@ function checkInternalConflicts(): void {
         <RuiButton
           variant="text"
           icon
-          size="sm"
-          class="!p-2"
+          size="lg"
           v-bind="attrs"
         >
           <RuiIcon name="lu-ellipsis-vertical" />

--- a/frontend/app/src/modules/history/events/HistoryEventsViewButtons.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsViewButtons.vue
@@ -95,15 +95,13 @@ function checkInternalConflicts(): void {
 
   <RuiButton
     color="primary"
-    class="h-9 [&>span]:!hidden lg:[&>span]:!inline"
+    size="lg"
+    class="[&>span]:!hidden lg:[&>span]:!inline"
     data-cy="history-events__add"
     @click="emit('show:dialog', { type: DIALOG_TYPES.EVENT_FORM, data: { type: 'add', nextSequenceId: '0' } })"
   >
     <template #prepend>
-      <RuiIcon
-        name="lu-plus"
-        size="18"
-      />
+      <RuiIcon name="lu-plus" />
     </template>
     {{ t('transactions.actions.add_event') }}
   </RuiButton>

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
@@ -45,7 +45,7 @@ const {
   selectedUnmatched,
 } = useAssetMovementActions({ onActionComplete });
 
-const buttonSize = computed<'sm' | undefined>(() => isPinned ? 'sm' : undefined);
+const buttonSize = computed<'sm' | 'lg'>(() => isPinned ? 'sm' : 'lg');
 
 onBeforeMount(async () => {
   await refreshUnmatchedAssetMovements();
@@ -183,7 +183,7 @@ onBeforeMount(async () => {
               color="primary"
               class="!rounded-r-none"
               :size="buttonSize"
-              :class="isPinned ? 'h-[30px] !px-3' : 'h-9'"
+              :class="{ 'h-[30px] !px-3': isPinned }"
               :disabled="!isAutoMatchAllowed || unmatchedMovements.length === 0 || autoMatchLoading"
               :loading="autoMatchLoading"
               @click="triggerAssetMovementAutoMatching()"

--- a/frontend/app/src/modules/history/events/PotentialMatchesList.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesList.vue
@@ -339,17 +339,14 @@ watchDebounced(onlyExpectedAssets, () => {
         >
           <template #activator>
             <RuiButton
-              class="!h-10 ml-3"
+              class="ml-3"
               :loading="loading"
-              :size="isPinned ? 'sm' : undefined"
+              :size="isPinned ? 'sm' : 'xl'"
               :class="isPinned ? '[&>span]:!hidden !px-2.5' : '[&>span]:!inline'"
               @click="emit('search')"
             >
               <template #prepend>
-                <RuiIcon
-                  name="lu-search"
-                  size="18"
-                />
+                <RuiIcon name="lu-search" />
               </template>
               {{ t('common.actions.search') }}
             </RuiButton>

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshButton.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshButton.vue
@@ -27,7 +27,7 @@ function confirmRefresh() {
   <RuiButtonGroup
     variant="outlined"
     color="primary"
-    class="h-9"
+    size="lg"
     :class="{ '!outline-rui-text-disabled': processing }"
   >
     <RuiTooltip :open-delay="400">
@@ -40,10 +40,7 @@ function confirmRefresh() {
           @click="confirmRefresh()"
         >
           <template #prepend>
-            <RuiIcon
-              name="lu-refresh-ccw"
-              size="18"
-            />
+            <RuiIcon name="lu-refresh-ccw" />
           </template>
           {{ t('common.refresh') }}
         </RuiButton>

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshSelection.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshSelection.vue
@@ -194,14 +194,12 @@ onMounted(() => {
       <RuiButton
         variant="outlined"
         color="primary"
-        class="px-3 rounded-l-none h-9 !outline-none"
+        size="lg"
+        class="px-3 rounded-l-none !outline-none"
         :disabled="disabled"
         v-bind="attrs"
       >
-        <RuiIcon
-          name="lu-chevrons-up-down"
-          size="16"
-        />
+        <RuiIcon name="lu-chevrons-up-down" />
       </RuiButton>
     </template>
 

--- a/frontend/app/src/modules/reports/RangeSelector.vue
+++ b/frontend/app/src/modules/reports/RangeSelector.vue
@@ -37,20 +37,28 @@ function updateValid(valid: boolean): void {
 }
 
 async function onChanged(event: SelectionChangedEvent): Promise<void> {
+  // Reset the range before the persisted-setting API call so quick-option
+  // clicks inside the Custom picker land on a sane `end=now, start=undefined`
+  // baseline. Doing it after `await updateFrontendSetting` opens a race where
+  // a fast click on a preset gets the old year/quarter's end as the
+  // max-date constraint — see DateTimeRangePicker.applyQuickOption.
+  if (event.year === 'custom') {
+    input({ end: dayjs().unix(), start: undefined });
+  }
+
   await updateFrontendSetting({
     profitLossReportPeriod: event,
   });
-
-  if (event.year === 'custom') {
-    await nextTick();
-    input({ end: dayjs().unix(), start: undefined });
-  }
 }
 
 function onPeriodChange(period: PeriodChangedEvent | null): void {
   const now = dayjs().unix();
   if (period === null) {
-    input({ end: now, start: 0 });
+    // Custom period — leave start undefined so the picker renders empty
+    // instead of defaulting the field to 1970-01-01 (epoch). The
+    // `requiredIf(custom)` rule in v$ catches this as a validation error
+    // until the user picks a date or hits a quick-option preset.
+    input({ end: now, start: undefined });
     return;
   }
 

--- a/frontend/app/src/modules/reports/ReportGenerator.vue
+++ b/frontend/app/src/modules/reports/ReportGenerator.vue
@@ -153,7 +153,7 @@ onMounted(async () => {
           <RuiButton
             class="w-full"
             color="primary"
-            size="lg"
+            size="xl"
             :disabled="!canGenerate"
             @click="generate()"
           >
@@ -170,8 +170,8 @@ onMounted(async () => {
           >
             <template #activator="{ attrs }">
               <RuiButton
-                class="h-[2.625rem]"
-                size="lg"
+                variant="outlined"
+                size="xl"
                 v-bind="attrs"
               >
                 <template #prepend>

--- a/frontend/app/src/modules/reports/ReportGenerator.vue
+++ b/frontend/app/src/modules/reports/ReportGenerator.vue
@@ -19,7 +19,7 @@ const { isOutOfSync, navigateToHistory, processing } = useTransactionStatusCheck
 const { queryBinanceUserMarkets } = useExchangeApi();
 const { connectedExchanges } = storeToRefs(useSessionSettingsStore());
 
-const range = ref<{ start: number | undefined; end: number }>({ end: 0, start: 0 });
+const range = ref<{ start: number | undefined; end: number }>({ end: 0, start: undefined });
 const valid = ref<boolean>(false);
 const binanceExchangesWithoutMarkets = ref<string[]>([]);
 

--- a/frontend/app/src/modules/reports/ReportPeriodSelector.vue
+++ b/frontend/app/src/modules/reports/ReportPeriodSelector.vue
@@ -159,7 +159,7 @@ const quarterModel = computed({
 <template>
   <div class="flex flex-col gap-4">
     <div>
-      <div class="text-subtitle-1 font-bold mb-2">
+      <div class="text-subtitle-1 font-medium mb-2">
         {{ t('generate.period') }}
       </div>
       <div class="flex gap-4">
@@ -168,15 +168,15 @@ const quarterModel = computed({
             <RuiButtonGroup
               v-model="yearModel"
               required
-              class="flex-wrap justify-center"
+              variant="outlined"
               active-color="primary"
+              class="flex-wrap justify-center"
               data-cy="button-group-report-period-year"
             >
               <RuiButton
                 v-for="period in periods"
                 :key="period"
-                :color="year === period ? 'primary' : undefined"
-                class="px-4 [&:last-child]:!rounded-r-none"
+                class="[&:last-child]:!rounded-r-none"
                 :model-value="period"
               >
                 {{ period }}
@@ -184,8 +184,9 @@ const quarterModel = computed({
             </RuiButtonGroup>
             <RuiButton
               v-bind="attrs"
-              class="!rounded-l-none border-l border-rui-grey-400"
+              variant="outlined"
               :color="isOlderYearSelected ? 'primary' : undefined"
+              class="!rounded-l-none -ml-px"
               data-cy="button-older-years"
             >
               <div class="flex items-center gap-2">
@@ -214,7 +215,7 @@ const quarterModel = computed({
         </RuiMenu>
 
         <RuiButton
-          class="px-4"
+          variant="outlined"
           :color="isAllTime ? 'primary' : undefined"
           data-cy="button-all-time"
           @click="selectAllTime()"
@@ -223,7 +224,7 @@ const quarterModel = computed({
         </RuiButton>
 
         <RuiButton
-          class="px-4"
+          variant="outlined"
           :color="isCustom ? 'primary' : undefined"
           data-cy="button-custom"
           @click="yearModel = 'custom'"
@@ -232,24 +233,21 @@ const quarterModel = computed({
         </RuiButton>
       </div>
     </div>
-    <div
-      v-if="year !== 'custom' && year !== 'all-time'"
-      class="pt-3.5"
-    >
-      <div class="text-subtitle-1 font-bold mb-2">
+    <div v-if="year !== 'custom' && year !== 'all-time'">
+      <div class="text-subtitle-1 font-medium mb-2">
         {{ t('generate.sub_period_label') }}
       </div>
       <RuiButtonGroup
         v-model="quarterModel"
         required
-        class="flex-wrap justify-center"
+        variant="outlined"
         active-color="primary"
+        class="flex-wrap justify-center"
         data-cy="button-group-quarter"
       >
         <RuiButton
           v-for="subPeriod in subPeriods"
           :key="subPeriod.id"
-          :color="quarter === subPeriod.id ? 'primary' : undefined"
           :model-value="subPeriod.id"
           :disabled="isStartAfterNow(subPeriod.id)"
         >

--- a/frontend/app/src/modules/settings/HideSmallBalances.vue
+++ b/frontend/app/src/modules/settings/HideSmallBalances.vue
@@ -123,6 +123,7 @@ watch(hide, (hide) => {
         v-bind="attrs"
         icon
         variant="text"
+        size="lg"
       >
         <RuiIcon
           color="primary"

--- a/frontend/app/src/modules/settings/general/nft/NftImageRenderingSettingMenu.vue
+++ b/frontend/app/src/modules/settings/general/nft/NftImageRenderingSettingMenu.vue
@@ -18,7 +18,7 @@ const dialogOpen = ref(false);
       <RuiButton
         variant="text"
         icon
-        class="!p-2"
+        size="lg"
         v-bind="attrs"
       >
         <RuiIcon name="lu-file-cog" />

--- a/frontend/app/src/modules/shell/app/AppCore.vue
+++ b/frontend/app/src/modules/shell/app/AppCore.vue
@@ -124,6 +124,7 @@ onBeforeMount(() => {
           color="primary"
           class="fixed bottom-4 right-4 z-[6]"
           variant="fab"
+          size="lg"
           icon
           @click="scrollToTop()"
         >

--- a/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
+++ b/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
@@ -177,6 +177,7 @@ onMounted(() => {
               <RuiButton
                 variant="outlined"
                 color="primary"
+                size="lg"
                 class="!rounded-r-none !border-r-0"
                 :disabled="!isFormValid"
                 @click="submitViaEmail()"
@@ -194,14 +195,11 @@ onMounted(() => {
                   <RuiButton
                     variant="outlined"
                     color="primary"
-
-                    class="!rounded-l-none !px-2 h-9 -ml-[1px]"
+                    size="lg"
+                    class="!rounded-l-none !px-2 -ml-[1px]"
                     v-bind="attrs"
                   >
-                    <RuiIcon
-                      name="lu-chevron-down"
-                      size="16"
-                    />
+                    <RuiIcon name="lu-chevron-down" />
                   </RuiButton>
                 </template>
                 <div class="py-2">

--- a/frontend/app/src/modules/shell/components/UserDropdown.vue
+++ b/frontend/app/src/modules/shell/components/UserDropdown.vue
@@ -91,10 +91,17 @@ const { isDark } = useRotkiTheme();
           </ExternalLink>
         </div>
         <RuiDivider />
-        <RouterLink :to="{ path: '/settings' }">
+        <RouterLink
+          #default="{ navigate }"
+          :to="{ path: '/settings' }"
+          custom
+        >
+          <!-- TODO: drop the `[&_[data-id=btn-label]]:leading-[1.125rem]` class once rotki/ui-library#515 lands — tightens the list-variant label line-box (20px) to match the md icon box (18px) so the text visually centers with the icon instead of sitting in the upper portion. -->
           <RuiButton
             variant="list"
             data-cy="settings-button"
+            class="[&_[data-id=btn-label]]:leading-[1.125rem]"
+            @click="navigate()"
           >
             <template #prepend>
               <RuiIcon
@@ -110,6 +117,7 @@ const { isDark } = useRotkiTheme();
           v-if="isXs"
           data-cy="privacy-mode-button"
           variant="list"
+          class="[&_[data-id=btn-label]]:leading-[1.125rem]"
           @click="togglePrivacyMode()"
         >
           <template #prepend>
@@ -132,6 +140,7 @@ const { isDark } = useRotkiTheme();
         <RuiButton
           variant="list"
           data-cy="logout-button"
+          class="[&_[data-id=btn-label]]:leading-[1.125rem]"
           @click="showConfirmation()"
         >
           <template #prepend>

--- a/frontend/app/src/modules/shell/components/inputs/DateTimeRangePicker.spec.ts
+++ b/frontend/app/src/modules/shell/components/inputs/DateTimeRangePicker.spec.ts
@@ -1,0 +1,175 @@
+import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
+import dayjs from 'dayjs';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, type VNode } from 'vue';
+import { setupDayjs } from '@/modules/core/common/data/date';
+import DateTimeRangePicker from '@/modules/shell/components/inputs/DateTimeRangePicker.vue';
+
+// Stub RuiDateTimePicker so we can render the `menu-content` slot (where
+// the quick-option buttons live) without pulling in the full picker.
+const RuiDateTimePickerStub = defineComponent({
+  emits: ['update:modelValue'],
+  name: 'RuiDateTimePicker',
+  props: {
+    modelValue: {
+      default: undefined,
+      required: false,
+      type: Number,
+    },
+  },
+  setup(_, { slots }): () => VNode {
+    return (): VNode => h('div', { class: 'rui-date-time-picker' }, [
+      slots['menu-content']?.(),
+    ]);
+  },
+});
+
+// Vue Test Utils types `emitted()` as `unknown[][] | undefined`. Narrow it
+// to the `[number]`-per-call shape our picker emits before touching values.
+function isSingleNumberCall(value: unknown[]): value is [number] {
+  return value.length === 1 && typeof value[0] === 'number';
+}
+
+function firstNumberArg(calls: unknown[][] | undefined, callIndex: number): number {
+  expect(calls).toBeDefined();
+  if (calls === undefined) {
+    throw new Error('emitted() returned undefined');
+  }
+  const call = calls[callIndex];
+  expect(call).toBeDefined();
+  expect(isSingleNumberCall(call)).toBe(true);
+  if (!isSingleNumberCall(call)) {
+    throw new Error(`emitted call ${callIndex} has unexpected shape`);
+  }
+  return call[0];
+}
+
+describe('components/inputs/DateTimeRangePicker.vue', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DateTimeRangePicker>>;
+  let pinia: Pinia;
+
+  beforeAll((): void => {
+    setupDayjs();
+  });
+
+  beforeEach((): void => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.useFakeTimers();
+  });
+
+  afterEach((): void => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    options: ComponentMountingOptions<typeof DateTimeRangePicker> = {
+      props: {
+        end: dayjs().unix(),
+        start: undefined,
+      },
+    },
+  ): VueWrapper<InstanceType<typeof DateTimeRangePicker>> {
+    return mount(DateTimeRangePicker, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          RuiButton: {
+            template: '<button class="quick-option" @click="$emit(\'click\')"><slot /></button>',
+          },
+          RuiDateTimePicker: RuiDateTimePickerStub,
+          RuiIcon: true,
+        },
+      },
+      ...options,
+    });
+  }
+
+  describe('quick options', (): void => {
+    it('should render all seven quick-option buttons inside both pickers', (): void => {
+      wrapper = createWrapper();
+
+      // Each picker renders the same DefineQuickOptions template, so the
+      // button count is 2 × 7 = 14. The component re-uses the template to
+      // keep start/end menus in sync without duplicating the button list.
+      const quickOptionButtons = wrapper.findAll('button.quick-option');
+      expect(quickOptionButtons).toHaveLength(14);
+    });
+
+    it('should update end before start (regression: stale max-date error)', async (): Promise<void> => {
+      // Regression for the bug where clicking a quick-option right after
+      // switching to Custom (from a past year/quarter) left the start
+      // picker latched on the old max-date error ("Date cannot be after
+      // 6/30/2024" or similar). The fix sets `end` first so the max-date
+      // constraint on start widens before start is written.
+      const now = dayjs('2026-04-23T14:58:00');
+      vi.setSystemTime(now.toDate());
+
+      wrapper = createWrapper({
+        props: {
+          // Mirror the "arrived at Custom from a past year/quarter" state —
+          // end is stuck at the previous period's end until onChanged
+          // clears it. In the buggy path, setting start first would
+          // trigger start > end validation.
+          end: dayjs('2024-06-30T23:59:59').unix(),
+          start: undefined,
+        },
+      });
+
+      // Click the first quick option ("Last 12 hours") in the start picker.
+      const buttons = wrapper.findAll('button.quick-option');
+      await buttons[0].trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      // Both update events should have fired exactly once each.
+      const endEmits = wrapper.emitted('update:end');
+      const startEmits = wrapper.emitted('update:start');
+      expect(endEmits).toHaveLength(1);
+      expect(startEmits).toHaveLength(1);
+
+      // End must be emitted first — that's what protects the start picker
+      // from validating against a stale max-date.
+      expect(firstNumberArg(endEmits, 0)).toBe(now.unix());
+      expect(firstNumberArg(startEmits, 0)).toBe(now.subtract(12, 'hour').unix());
+    });
+
+    it('should compute each preset from the current timestamp', async (): Promise<void> => {
+      const now = dayjs('2026-04-23T14:58:00');
+      vi.setSystemTime(now.toDate());
+
+      wrapper = createWrapper({
+        props: {
+          end: now.unix(),
+          start: undefined,
+        },
+      });
+
+      const buttons = wrapper.findAll('button.quick-option');
+
+      // Button layout (order matches `quickOptions`): 12h, 24h, 7d, 1m,
+      // 90d, 6m, 1y — then the same seven repeated for the end picker.
+      const cases: Array<{ index: number; expectedStart: number }> = [
+        { expectedStart: now.subtract(12, 'hour').unix(), index: 0 },
+        { expectedStart: now.subtract(24, 'hour').unix(), index: 1 },
+        { expectedStart: now.subtract(7, 'day').unix(), index: 2 },
+        { expectedStart: now.subtract(1, 'month').unix(), index: 3 },
+        { expectedStart: now.subtract(90, 'day').unix(), index: 4 },
+        { expectedStart: now.subtract(180, 'day').unix(), index: 5 },
+        { expectedStart: now.subtract(1, 'year').unix(), index: 6 },
+      ];
+
+      for (const { index } of cases) {
+        await buttons[index].trigger('click');
+        await vi.advanceTimersToNextTimerAsync();
+      }
+
+      const startEmits = wrapper.emitted('update:start');
+      expect(startEmits).toHaveLength(cases.length);
+      cases.forEach(({ expectedStart }, index: number): void => {
+        expect(firstNumberArg(startEmits, index)).toBe(expectedStart);
+      });
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/components/inputs/DateTimeRangePicker.vue
+++ b/frontend/app/src/modules/shell/components/inputs/DateTimeRangePicker.vue
@@ -60,10 +60,16 @@ const endErrorMessagesComputed = computed<string[]>(() => {
 });
 
 function applyQuickOption(option: QuickOption): void {
+  // Update `end` before `start` so the start picker's max-date constraint
+  // (bound to `end`) widens before the new start is written. Otherwise a
+  // transient state where start > end can latch a validation error in the
+  // start picker that won't clear until the user changes modelValue again —
+  // see RuiDateTimePicker's isDateValid, which only re-runs on modelValue
+  // changes, not on min/max-date prop changes.
   const now = dayjs();
-  set(start, now.subtract(option.value, option.unit).unix());
+  set(end, now.unix());
   nextTick(() => {
-    set(end, now.unix());
+    set(start, now.subtract(option.value, option.unit).unix());
   });
 }
 </script>

--- a/frontend/app/src/modules/staking/eth/components/EthStakingHeaderActions.vue
+++ b/frontend/app/src/modules/staking/eth/components/EthStakingHeaderActions.vue
@@ -24,6 +24,7 @@ const { t } = useI18n({ useScope: 'global' });
         <RuiButton
           variant="outlined"
           color="primary"
+          size="lg"
           :loading="refreshing"
           @click="emit('refresh')"
         >

--- a/frontend/app/src/modules/staking/lido-csm/LidoCsmPage.vue
+++ b/frontend/app/src/modules/staking/lido-csm/LidoCsmPage.vue
@@ -79,14 +79,12 @@ onMounted(async () => {
     <template #buttons>
       <RuiButton
         color="primary"
+        size="lg"
         :disabled="loading"
         @click="openAddDialog()"
       >
         <template #prepend>
-          <RuiIcon
-            name="lu-plus"
-            size="18"
-          />
+          <RuiIcon name="lu-plus" />
         </template>
         {{ t('staking_page.lido_csm.form.submit') }}
       </RuiButton>
@@ -95,14 +93,12 @@ onMounted(async () => {
           <RuiButton
             color="primary"
             variant="outlined"
+            size="lg"
             :loading="loading"
             @click="refresh(true)"
           >
             <template #prepend>
-              <RuiIcon
-                name="lu-refresh-ccw"
-                size="20"
-              />
+              <RuiIcon name="lu-refresh-ccw" />
             </template>
             {{ t('common.refresh') }}
           </RuiButton>

--- a/frontend/app/src/modules/staking/liquity/LiquityStakingDetails.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityStakingDetails.vue
@@ -241,6 +241,7 @@ function refresh() {
             <RuiButton
               variant="outlined"
               color="primary"
+              size="lg"
               :loading="loading"
               @click="refresh()"
             >

--- a/frontend/app/src/modules/tags/TagManager.vue
+++ b/frontend/app/src/modules/tags/TagManager.vue
@@ -93,6 +93,7 @@ onMounted(async () => {
     <template #buttons>
       <RuiButton
         color="primary"
+        size="lg"
         data-cy="add-tags"
         @click="handleCreateTagClick()"
       >

--- a/frontend/app/src/modules/user-data/GroupedImport.vue
+++ b/frontend/app/src/modules/user-data/GroupedImport.vue
@@ -115,7 +115,7 @@ const [DefineDisplay, ReuseDisplay] = createReusableTemplate<{
 </script>
 
 <template>
-  <RuiCard content-class="p-1 pt-2">
+  <RuiCard content-class="p-4">
     <DefineDisplay #default="{ logo, icon, label }">
       <div class="flex items-center gap-3">
         <AppImage

--- a/frontend/app/src/pages/airdrops/index.vue
+++ b/frontend/app/src/pages/airdrops/index.vue
@@ -198,6 +198,7 @@ watch([status, selectedAccounts], () => {
           <RuiButton
             variant="outlined"
             color="primary"
+            size="lg"
             :loading="loading"
             @click="fetchAirdrops()"
           >

--- a/frontend/app/src/pages/api-keys/exchanges/index.vue
+++ b/frontend/app/src/pages/api-keys/exchanges/index.vue
@@ -190,6 +190,7 @@ watch(route, async (route) => {
     <template #buttons>
       <RuiButton
         color="primary"
+        size="lg"
         data-cy="add-exchange"
         @click="addExchange()"
       >

--- a/frontend/app/src/pages/balances/exchange/[[exchange]].vue
+++ b/frontend/app/src/pages/balances/exchange/[[exchange]].vue
@@ -130,6 +130,7 @@ function isBinance(exchange?: string): exchange is 'binance' | 'binanceus' {
           <RuiButton
             color="primary"
             variant="outlined"
+            size="lg"
             class="exchange-balances__refresh"
             :disabled="exchangeDetailTabs !== 0"
             :loading="isExchangeLoading"
@@ -145,6 +146,7 @@ function isBinance(exchange?: string): exchange is 'binance' | 'binanceus' {
       </RuiTooltip>
       <RuiButton
         color="primary"
+        size="lg"
         @click="navigate()"
       >
         <template #prepend>

--- a/frontend/app/src/pages/balances/manual/[[tab]].vue
+++ b/frontend/app/src/pages/balances/manual/[[tab]].vue
@@ -85,6 +85,7 @@ onBeforeMount(async () => {
       <PriceRefresh />
       <RuiButton
         color="primary"
+        size="lg"
         data-cy="manual-balances-add-button"
         :disabled="loading"
         @click="add()"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.3.2
       version: 1.3.2
     '@rotki/ui-library':
-      specifier: 2.17.1
-      version: 2.17.1
+      specifier: 2.18.0
+      version: 2.18.0
     '@tsconfig/node24':
       specifier: 24.0.4
       version: 24.0.4
@@ -370,7 +370,7 @@ importers:
         version: link:../common
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.17.1(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 2.18.0(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
@@ -1908,8 +1908,8 @@ packages:
     peerDependencies:
       eslint: ^9.20.0
 
-  '@rotki/ui-library@2.17.1':
-    resolution: {integrity: sha512-blp1ZGbuO3A6UaiU4Wwun5u7sjyxAnK0vcX6cCvSXG4Az9af0tamWJyRScI/87Z+tpQ1to8a3kMB6n7ttcY8Cw==}
+  '@rotki/ui-library@2.18.0':
+    resolution: {integrity: sha512-PLo4F9wuNmKvT3SGiiHkMEd0qvA2Zi37d3hBiDjt5rXG7hOFR87x6iMqt2O2SZn2EjtoITpBBS6EpgkrsH7wmg==}
     engines: {node: '>=24 <25', pnpm: '>=10 <11'}
     peerDependencies:
       dayjs: '>=1.11.13 <12'
@@ -8557,7 +8557,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rotki/ui-library@2.17.1(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+  '@rotki/ui-library@2.18.0(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@vueuse/core': 14.2.1(vue@3.5.32(typescript@5.9.3))

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   '@reown/appkit-adapter-ethers': 1.8.19
   '@rotki/eslint-config': 5.0.1
   '@rotki/eslint-plugin': 1.3.2
-  '@rotki/ui-library': 2.17.1
+  '@rotki/ui-library': 2.18.0
   '@tsconfig/node24': 24.0.4
   '@types/body-parser': 1.19.6
   '@types/express': 5.0.6


### PR DESCRIPTION
## Summary

- Bump the catalog to `@rotki/ui-library 2.18.0` and migrate the app to the cleaner size presets. `xl` is now 40px (input-row height) so the long tail of `class=\"!h-10\"` / `h-9` / `!p-2` workarounds collapses into `size=\"xl\"` / `size=\"lg\"`.
- Polish the PnL ReportGenerator header for dark mode (outlined buttons, less chroma clash, consistent 40px row heights).
- Fix two bugs uncovered during the cleanup: the Custom range's quick-option buttons latched a stale max-date error, and the Calendar's Today / chevron button group flickered on click.

## Commits
- `384fa19a66` — 2.17 button sizing groundwork (pre-existing).
- `e935bf5294` — **2.18 adoption**: catalog bump + 38 files (height hacks → size presets, export/detect/redetect/GroupedImport/UserDropdown fixes, rotki/ui-library#515 label-leading workaround).
- `0befb0576a` — **ReportGenerator header audit**: outlined year/quarter/AllTime/Custom buttons, Generate and Debug both at 40px, section headings drop to `font-medium`.
- `508c5a8be1` — **Custom-range bug fix**: `DateTimeRangePicker.applyQuickOption` sets `end` before `start` so the start picker's max-date constraint widens first; `RangeSelector.onChanged` resets the range before awaiting the persisted-settings API; Custom start initializes as `undefined` instead of epoch. New unit spec covers emit order + per-preset start values. Changelog entry included.
- `5ef02507ea` — **Calendar toolbar fix**: pull RuiMenu out of RuiButtonGroup in `CalendarDateNavigator` (the group was intercepting the menu's `update:model-value`); drop the focus-within + debounce hack; keep `persistent` + ESC; Add-event button first, settings-menu last.

## Related ui-library issues (filed while doing the cleanup)

- **rotki/ui-library#515** — list-variant label text sits in the upper portion of the icon because the label's line-box (20px) is taller than the md icon box (18px). Temporary workaround in `UserDropdown.vue` pending the library fix.
- **rotki/ui-library#516** — `RuiDateTimePicker` should expose its sub-menu open state (currently internal-only) so parent overlays can do dynamic click-outside handling. Workaround: `persistent` + ESC.

## Test plan

- [x] `pnpm lint` — 0 errors (915 pre-existing warnings).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test:unit` — 3227/3227 pass (includes a new `DateTimeRangePicker.spec.ts` with the quick-option regression).
- [ ] Manual smoke test on dev build (dark mode) for: PnL ReportGenerator header, Custom range quick-options from a past year/quarter, Calendar Today/chevron + Go-to-date.
- [ ] E2E once merged — the frontend E2E audit from the original plan was deferred until the whole restructure lands.

## Follow-ups (not this PR)

- Remove the `[&_[data-id=btn-label]]:leading-[1.125rem]` class in UserDropdown once rotki/ui-library#515 ships.
- Drop the `persistent` + manual ESC handling in `CalendarDateNavigator` once rotki/ui-library#516 ships — swap to `v-model:menu-open`.
- Broader toolbar audit (47 files) surfaced earlier — land PR narrow first, then walk the rest toolbar-by-toolbar.
