### PR TITLE
Split blockchain balance cache/refresh signals

### DIFF
--- a/frontend/app/src/modules/accounts/table/AccountBalancesTable.vue
+++ b/frontend/app/src/modules/accounts/table/AccountBalancesTable.vue
@@ -58,7 +58,7 @@ const {
   totalValue,
 } = useAccountTableData<T>(() => accounts, expandedIds, chainFilter);
 
-const { accountOperation, isAnyLoading, isRowLoading, isSectionLoading } = useAccountLoadingStates<T>(() => category);
+const { accountOperation, isInitialLoading, isRowLoading, isSectionLoading } = useAccountLoadingStates<T>(() => category);
 
 const { confirmDelete, edit } = useAccountOperations<T>({
   onEdit: account => emit('edit', account),
@@ -85,7 +85,7 @@ defineExpose({
     v-model:collapsed="collapsed"
     :cols="cols"
     :rows="rows"
-    :loading="group && isAnyLoading"
+    :loading="group && isInitialLoading"
     row-attr="id"
     :empty="{ description: t('data_table.no_data') }"
     :loading-text="t('account_balances.data_table.loading')"

--- a/frontend/app/src/modules/accounts/table/use-account-loading-states.ts
+++ b/frontend/app/src/modules/accounts/table/use-account-loading-states.ts
@@ -1,7 +1,10 @@
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { AccountDataRow } from './types';
 import type { BlockchainAccountBalance } from '@/modules/accounts/blockchain-accounts';
+import { useAccountCategoryHelper } from '@/modules/accounts/use-account-category-helper';
 import { useBlockchainAccountLoading } from '@/modules/accounts/use-blockchain-account-loading';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
+import { isCacheInitialLoading } from '@/modules/balances/use-balance-status';
 import { Section } from '@/modules/core/common/status';
 import { useStatusStore } from '@/modules/core/common/use-status-store';
 import { TaskType } from '@/modules/core/tasks/task-type';
@@ -9,7 +12,7 @@ import { useTaskStore } from '@/modules/core/tasks/use-task-store';
 
 interface UseAccountLoadingStates<T extends BlockchainAccountBalance> {
   accountOperation: ComputedRef<boolean>;
-  isAnyLoading: ComputedRef<boolean>;
+  isInitialLoading: ComputedRef<boolean>;
   isRowLoading: (row: AccountDataRow<T>) => boolean;
   isSectionLoading: ComputedRef<boolean>;
 }
@@ -18,8 +21,11 @@ export function useAccountLoadingStates<T extends BlockchainAccountBalance>(
   category: MaybeRefOrGetter<string>,
 ): UseAccountLoadingStates<T> {
   const { useIsTaskRunning } = useTaskStore();
-  const { getIsLoading } = useStatusStore();
+  const statusStore = useStatusStore();
+  const { status } = storeToRefs(statusStore);
+  const { refreshingChains } = storeToRefs(useBalanceRefreshState());
   const { isSectionLoading } = useBlockchainAccountLoading(category);
+  const { chainIds } = useAccountCategoryHelper(category);
 
   const accountOperation = logicOr(
     useIsTaskRunning(TaskType.ADD_ACCOUNT),
@@ -27,18 +33,30 @@ export function useAccountLoadingStates<T extends BlockchainAccountBalance>(
     isSectionLoading,
   );
 
-  const isAnyLoading = logicOr(accountOperation, isSectionLoading);
+  const isInitialLoading = computed<boolean>(() => {
+    const chains = get(status)[Section.BLOCKCHAIN];
+    if (!chains)
+      return false;
+    const categoryChains = get(chainIds);
+    const candidates = categoryChains.length > 0
+      ? categoryChains.filter(chain => chain in chains)
+      : Object.keys(chains);
+    if (candidates.length === 0)
+      return false;
+    return candidates.some(chain => isCacheInitialLoading(chains[chain]));
+  });
 
   function isRowLoading(row: AccountDataRow<T>): boolean {
+    const refreshing = get(refreshingChains);
     if (row.type === 'account')
-      return getIsLoading(Section.BLOCKCHAIN, row.chain);
+      return refreshing.has(row.chain);
     else
-      return row.chains.some(chain => getIsLoading(Section.BLOCKCHAIN, chain));
+      return row.chains.some(chain => refreshing.has(chain));
   }
 
   return {
     accountOperation,
-    isAnyLoading,
+    isInitialLoading,
     isRowLoading,
     isSectionLoading,
   };

--- a/frontend/app/src/modules/accounts/use-account-loading.ts
+++ b/frontend/app/src/modules/accounts/use-account-loading.ts
@@ -1,12 +1,11 @@
 import type { ComputedRef, Ref } from 'vue';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { TaskType } from '@/modules/core/tasks/task-type';
 import { useTaskStore } from '@/modules/core/tasks/use-task-store';
 
 interface UseAccountLoadingReturn {
   pending: Ref<boolean>;
   loading: ComputedRef<boolean>;
-  isQueryingBlockchain: ComputedRef<boolean>;
-  isBlockchainLoading: ComputedRef<boolean>;
   isAccountOperationRunning: (blockchain?: string) => ComputedRef<boolean>;
 }
 
@@ -14,11 +13,7 @@ export const useAccountLoading = createSharedComposable((): UseAccountLoadingRet
   const pending = ref<boolean>(false);
 
   const { useIsTaskRunning } = useTaskStore();
-
-  const isQueryingBlockchain = useIsTaskRunning(TaskType.QUERY_BLOCKCHAIN_BALANCES);
-  const isLoopringLoading = useIsTaskRunning(TaskType.L2_LOOPRING);
-
-  const isBlockchainLoading = computed<boolean>(() => get(isQueryingBlockchain) || get(isLoopringLoading));
+  const { isRefreshing } = storeToRefs(useBalanceRefreshState());
 
   const isAccountOperationRunning = (blockchain?: string): ComputedRef<boolean> =>
     logicOr(
@@ -26,12 +21,10 @@ export const useAccountLoading = createSharedComposable((): UseAccountLoadingRet
       useIsTaskRunning(TaskType.REMOVE_ACCOUNT, blockchain ? { blockchain } : {}),
     );
 
-  const loading: ComputedRef<boolean> = logicOr(isAccountOperationRunning(), pending, isQueryingBlockchain);
+  const loading: ComputedRef<boolean> = logicOr(isAccountOperationRunning(), pending, isRefreshing);
 
   return {
     isAccountOperationRunning,
-    isBlockchainLoading,
-    isQueryingBlockchain,
     loading,
     pending,
   };

--- a/frontend/app/src/modules/accounts/use-blockchain-account-loading.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-account-loading.ts
@@ -1,6 +1,7 @@
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import { useAccountCategoryHelper } from '@/modules/accounts/use-account-category-helper';
 import { useTokenDetectionStore } from '@/modules/balances/blockchain/use-token-detection-store';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { Section } from '@/modules/core/common/status';
 import { useStatusStore } from '@/modules/core/common/use-status-store';
 import { TaskType } from '@/modules/core/tasks/task-type';
@@ -19,6 +20,7 @@ export function useBlockchainAccountLoading(category: MaybeRefOrGetter<string> =
   const { isTaskRunning, useIsTaskRunning } = useTaskStore();
   const { massDetecting } = storeToRefs(useTokenDetectionStore());
   const { getIsLoading } = useStatusStore();
+  const { refreshingChains } = storeToRefs(useBalanceRefreshState());
 
   const { chainIds, isEvm } = useAccountCategoryHelper(category);
 
@@ -35,10 +37,11 @@ export function useBlockchainAccountLoading(category: MaybeRefOrGetter<string> =
   });
 
   const isSectionLoading = computed<boolean>(() => {
+    const refreshing = get(refreshingChains);
     if (!toValue(category))
-      return getIsLoading(Section.BLOCKCHAIN);
+      return getIsLoading(Section.BLOCKCHAIN) || refreshing.size > 0;
 
-    return get(chainIds).some(chain => getIsLoading(Section.BLOCKCHAIN, chain));
+    return get(chainIds).some(chain => getIsLoading(Section.BLOCKCHAIN, chain) || refreshing.has(chain));
   });
 
   const isDetectingTokens = computed<boolean>(() => get(isEvm) && isDefined(massDetecting));

--- a/frontend/app/src/modules/balances/services/use-balance-processing-service.spec.ts
+++ b/frontend/app/src/modules/balances/services/use-balance-processing-service.spec.ts
@@ -1,0 +1,154 @@
+import { Blockchain } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAccount } from '@/modules/accounts/create-account';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
+import { useBalanceStatus } from '@/modules/balances/use-balance-status';
+
+vi.mock('@/modules/core/notifications/use-notifications-store', () => ({
+  useNotificationsStore: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@/modules/balances/use-balances-store', () => ({
+  useBalancesStore: vi.fn().mockReturnValue({
+    updateBalances: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const { computed } = await import('vue');
+  return {
+    useSupportedChains: vi.fn().mockReturnValue({
+      getChainName: vi.fn((chain: string) => computed(() => chain)),
+    }),
+  };
+});
+
+const mockQueryBlockchainBalances = vi.fn();
+const mockRefreshBlockchainBalances = vi.fn();
+
+vi.mock('@/modules/balances/api/use-blockchain-balances-api', () => ({
+  useBlockchainBalancesApi: vi.fn().mockReturnValue({
+    queryBlockchainBalances: (...args: unknown[]) => mockQueryBlockchainBalances(...args),
+    refreshBlockchainBalances: (...args: unknown[]) => mockRefreshBlockchainBalances(...args),
+    queryXpubBalances: vi.fn(),
+  }),
+}));
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const pendingTasks = new Map<number, Deferred<{ success: true; result: unknown }>>();
+let nextTaskId = 1;
+
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useTaskHandler: vi.fn().mockReturnValue({
+    runTask: vi.fn().mockImplementation(async (taskFn: () => Promise<{ taskId: number }>) => {
+      const { taskId } = await taskFn();
+      const d = deferred<{ success: true; result: unknown }>();
+      pendingTasks.set(taskId, d);
+      return d.promise;
+    }),
+  }),
+}));
+
+const { useBalanceProcessingService } = await import('@/modules/balances/services/use-balance-processing-service');
+
+function emptyBalances(blockchain: string): unknown {
+  return {
+    perAccount: { [blockchain]: {} },
+    totals: { assets: {}, liabilities: {} },
+  };
+}
+
+describe('useBalanceProcessingService', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    pendingTasks.clear();
+    nextTaskId = 1;
+    mockQueryBlockchainBalances.mockReset();
+    mockRefreshBlockchainBalances.mockReset();
+
+    const { updateAccounts } = useBlockchainAccountsStore();
+    updateAccounts(Blockchain.ETH, [
+      createAccount({ address: '0x1', label: null, tags: null }, { chain: Blockchain.ETH, nativeAsset: 'ETH' }),
+    ]);
+  });
+
+  it('should flip hasCachedData when the cached GET resolves, before refresh POST completes', async () => {
+    mockQueryBlockchainBalances.mockImplementation(async () => ({ taskId: nextTaskId++ }));
+    mockRefreshBlockchainBalances.mockImplementation(async () => ({ taskId: nextTaskId++ }));
+
+    const service = useBalanceProcessingService();
+    const { hasCachedData, isRefreshing } = useBalanceStatus(Blockchain.ETH);
+
+    const cachedPromise = service.handleCachedFetch(
+      { addresses: undefined, blockchain: Blockchain.ETH, isXpub: false },
+      undefined,
+    );
+    const refreshPromise = service.handleRefresh(
+      { addresses: undefined, blockchain: Blockchain.ETH, isXpub: false },
+    );
+
+    // wait for both api calls to have registered their tasks
+    await vi.waitFor(() => {
+      expect(pendingTasks.size).toBe(2);
+    });
+
+    expect(get(hasCachedData)).toBe(false);
+    expect(get(isRefreshing)).toBe(true);
+
+    // resolve the cached GET task first (taskId 1)
+    pendingTasks.get(1)!.resolve({ success: true, result: emptyBalances(Blockchain.ETH) });
+    await cachedPromise;
+
+    expect(get(hasCachedData)).toBe(true);
+    expect(get(isRefreshing)).toBe(true); // refresh POST still in flight
+
+    // resolve the refresh POST task
+    pendingTasks.get(2)!.resolve({ success: true, result: emptyBalances(Blockchain.ETH) });
+    await refreshPromise;
+
+    expect(get(hasCachedData)).toBe(true);
+    expect(get(isRefreshing)).toBe(false);
+  });
+
+  it('should clear isRefreshing even when the refresh POST fails', async () => {
+    mockRefreshBlockchainBalances.mockImplementation(async () => ({ taskId: nextTaskId++ }));
+
+    const service = useBalanceProcessingService();
+    const refreshState = useBalanceRefreshState();
+    const isEthRefreshing = refreshState.useIsRefreshing(Blockchain.ETH);
+
+    const refreshPromise = service.handleRefresh(
+      { addresses: undefined, blockchain: Blockchain.ETH, isXpub: false },
+    );
+
+    await vi.waitFor(() => {
+      expect(pendingTasks.size).toBe(1);
+    });
+    expect(get(isEthRefreshing)).toBe(true);
+
+    pendingTasks.get(1)!.resolve({
+      success: false,
+      message: 'cancelled',
+      cancelled: true,
+      backendCancelled: false,
+      skipped: false,
+    } as never);
+    await refreshPromise;
+
+    expect(get(isEthRefreshing)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
+++ b/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
@@ -7,6 +7,7 @@ import {
   type BtcBalances,
   type FetchBlockchainBalancePayload,
 } from '@/modules/balances/types/blockchain-balances';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { useBlockchainRefreshTimestampsStore } from '@/modules/balances/use-blockchain-refresh-timestamps-store';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -35,7 +36,8 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
   const { updateTimestamps } = useBlockchainRefreshTimestampsStore();
   const { getChainName } = useSupportedChains();
   const { t } = useI18n({ useScope: 'global' });
-  const { isFirstLoad, resetStatus, setStatus } = useStatusUpdater(Section.BLOCKCHAIN);
+  const { getStatus, resetStatus, setStatus } = useStatusUpdater(Section.BLOCKCHAIN);
+  const refreshState = useBalanceRefreshState();
 
   const processBalanceResult = (blockchain: string, result: unknown): void => {
     const parsedBalances: BlockchainBalances = BlockchainBalances.parse(result);
@@ -101,17 +103,23 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
 
   const handleCachedFetch = async (payload: FetchBlockchainBalancePayload, threshold: string | undefined): Promise<void> => {
     const { blockchain } = payload;
-    setStatus(isFirstLoad() ? Status.LOADING : Status.REFRESHING, { subsection: blockchain });
+    if (getStatus({ subsection: blockchain }) !== Status.LOADED)
+      setStatus(Status.LOADING, { subsection: blockchain });
     await executeBalanceQuery(blockchain, async () => queryBlockchainBalances(payload, threshold));
   };
 
   const handleRefresh = async (payload: FetchBlockchainBalancePayload): Promise<void> => {
     const { blockchain, isXpub } = payload;
-    setStatus(Status.REFRESHING, { subsection: blockchain });
-    await executeBalanceQuery(
-      blockchain,
-      async () => !isXpub ? refreshBlockchainBalances(payload) : queryXpubBalances(payload),
-    );
+    refreshState.start(blockchain);
+    try {
+      await executeBalanceQuery(
+        blockchain,
+        async () => !isXpub ? refreshBlockchainBalances(payload) : queryXpubBalances(payload),
+      );
+    }
+    finally {
+      refreshState.stop(blockchain);
+    }
   };
 
   return {

--- a/frontend/app/src/modules/balances/use-balance-refresh-state.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-refresh-state.spec.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
+
+describe('useBalanceRefreshState', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should start empty', () => {
+    const store = useBalanceRefreshState();
+    const { isRefreshing, refreshingChains } = storeToRefs(store);
+    expect(get(refreshingChains).size).toBe(0);
+    expect(get(isRefreshing)).toBe(false);
+  });
+
+  it('should flip isRefreshing when any chain is active', () => {
+    const store = useBalanceRefreshState();
+    const { isRefreshing } = storeToRefs(store);
+    store.start('eth');
+    expect(get(isRefreshing)).toBe(true);
+    store.stop('eth');
+    expect(get(isRefreshing)).toBe(false);
+  });
+
+  it('should track per-chain refresh state via useIsRefreshing', () => {
+    const { start, stop, useIsRefreshing } = useBalanceRefreshState();
+
+    const eth = useIsRefreshing('eth');
+    const optimism = useIsRefreshing('optimism');
+
+    start('eth');
+    expect(get(eth)).toBe(true);
+    expect(get(optimism)).toBe(false);
+
+    start('optimism');
+    expect(get(eth)).toBe(true);
+    expect(get(optimism)).toBe(true);
+
+    stop('eth');
+    expect(get(eth)).toBe(false);
+    expect(get(optimism)).toBe(true);
+  });
+
+  it('should be a no-op when stopping a chain that is not refreshing', () => {
+    const store = useBalanceRefreshState();
+    const { isRefreshing, refreshingChains } = storeToRefs(store);
+    const before = get(refreshingChains);
+    store.stop('eth');
+    expect(get(refreshingChains)).toBe(before);
+    expect(get(isRefreshing)).toBe(false);
+  });
+
+  it('should dedupe repeated starts for the same chain', () => {
+    const store = useBalanceRefreshState();
+    const { refreshingChains } = storeToRefs(store);
+    store.start('eth');
+    store.start('eth');
+    expect(get(refreshingChains).size).toBe(1);
+    store.stop('eth');
+    expect(get(refreshingChains).size).toBe(0);
+  });
+
+  it('should reset all refreshing chains', () => {
+    const store = useBalanceRefreshState();
+    const { isRefreshing } = storeToRefs(store);
+    store.start('eth');
+    store.start('optimism');
+    store.reset();
+    expect(get(isRefreshing)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/balances/use-balance-refresh-state.ts
+++ b/frontend/app/src/modules/balances/use-balance-refresh-state.ts
@@ -1,0 +1,37 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+
+export const useBalanceRefreshState = defineStore('balances/refresh-state', () => {
+  const refreshingChains = ref<Set<string>>(new Set());
+
+  const start = (chain: string): void => {
+    const current = get(refreshingChains);
+    if (current.has(chain))
+      return;
+    const next = new Set(current);
+    next.add(chain);
+    set(refreshingChains, next);
+  };
+
+  const stop = (chain: string): void => {
+    const current = get(refreshingChains);
+    if (!current.has(chain))
+      return;
+    const next = new Set(current);
+    next.delete(chain);
+    set(refreshingChains, next);
+  };
+
+  const isRefreshing = computed<boolean>(() => get(refreshingChains).size > 0);
+
+  const useIsRefreshing = (chain: MaybeRefOrGetter<string>): ComputedRef<boolean> =>
+    computed<boolean>(() => get(refreshingChains).has(toValue(chain)));
+
+  const reset = (): void => {
+    set(refreshingChains, new Set());
+  };
+
+  return { isRefreshing, refreshingChains, reset, start, stop, useIsRefreshing };
+});
+
+if (import.meta.hot)
+  import.meta.hot.accept(acceptHMRUpdate(useBalanceRefreshState, import.meta.hot));

--- a/frontend/app/src/modules/balances/use-balance-status.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-status.spec.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ref } from 'vue';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
+import { useBalanceStatus } from '@/modules/balances/use-balance-status';
+import { Section, Status } from '@/modules/core/common/status';
+import { useStatusStore } from '@/modules/core/common/use-status-store';
+
+describe('useBalanceStatus', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('per-chain', () => {
+    it('should report initial loading when no status has been set', () => {
+      const { hasCachedData, isInitialLoading, isRefreshing } = useBalanceStatus('eth');
+      expect(get(hasCachedData)).toBe(false);
+      expect(get(isInitialLoading)).toBe(true);
+      expect(get(isRefreshing)).toBe(false);
+    });
+
+    it('should flip hasCachedData when the cache reaches LOADED', () => {
+      const { setStatus } = useStatusStore();
+      const { hasCachedData, isInitialLoading } = useBalanceStatus('eth');
+
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADING, subsection: 'eth' });
+      expect(get(hasCachedData)).toBe(false);
+      expect(get(isInitialLoading)).toBe(true);
+
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADED, subsection: 'eth' });
+      expect(get(hasCachedData)).toBe(true);
+      expect(get(isInitialLoading)).toBe(false);
+    });
+
+    it('should track refresh independently of cache status', () => {
+      const { setStatus } = useStatusStore();
+      const refreshState = useBalanceRefreshState();
+      const { hasCachedData, isRefreshing } = useBalanceStatus('eth');
+
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADED, subsection: 'eth' });
+      refreshState.start('eth');
+
+      expect(get(hasCachedData)).toBe(true);
+      expect(get(isRefreshing)).toBe(true);
+
+      refreshState.stop('eth');
+      expect(get(hasCachedData)).toBe(true);
+      expect(get(isRefreshing)).toBe(false);
+    });
+
+    it('should react to a reactive chain argument', () => {
+      const { setStatus } = useStatusStore();
+      const chain = ref<string>('eth');
+      const { hasCachedData } = useBalanceStatus(chain);
+
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADED, subsection: 'eth' });
+      expect(get(hasCachedData)).toBe(true);
+
+      set(chain, 'optimism');
+      expect(get(hasCachedData)).toBe(false);
+
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADED, subsection: 'optimism' });
+      expect(get(hasCachedData)).toBe(true);
+    });
+  });
+
+  describe('aggregate', () => {
+    it('should be false/false when no chain has been touched', () => {
+      const { hasCachedData, isInitialLoading, isRefreshing } = useBalanceStatus();
+      expect(get(hasCachedData)).toBe(false);
+      expect(get(isInitialLoading)).toBe(false);
+      expect(get(isRefreshing)).toBe(false);
+    });
+
+    it('should report hasCachedData when at least one chain is LOADED', () => {
+      const { setStatus } = useStatusStore();
+      const { hasCachedData } = useBalanceStatus();
+
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADING, subsection: 'eth' });
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADING, subsection: 'optimism' });
+      expect(get(hasCachedData)).toBe(false);
+
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADED, subsection: 'eth' });
+      expect(get(hasCachedData)).toBe(true);
+    });
+
+    it('should report isInitialLoading while any chain is still LOADING', () => {
+      const { setStatus } = useStatusStore();
+      const { isInitialLoading } = useBalanceStatus();
+
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADING, subsection: 'eth' });
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADING, subsection: 'optimism' });
+      expect(get(isInitialLoading)).toBe(true);
+
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADED, subsection: 'eth' });
+      expect(get(isInitialLoading)).toBe(true);
+
+      setStatus({ section: Section.BLOCKCHAIN, status: Status.LOADED, subsection: 'optimism' });
+      expect(get(isInitialLoading)).toBe(false);
+    });
+
+    it('should report isRefreshing when any chain has a refresh in flight', () => {
+      const refreshState = useBalanceRefreshState();
+      const { isRefreshing } = useBalanceStatus();
+
+      refreshState.start('eth');
+      expect(get(isRefreshing)).toBe(true);
+
+      refreshState.start('optimism');
+      refreshState.stop('eth');
+      expect(get(isRefreshing)).toBe(true);
+
+      refreshState.stop('optimism');
+      expect(get(isRefreshing)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/balances/use-balance-status.ts
+++ b/frontend/app/src/modules/balances/use-balance-status.ts
@@ -1,0 +1,62 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
+import { Section, Status } from '@/modules/core/common/status';
+import { useStatusStore } from '@/modules/core/common/use-status-store';
+
+interface UseBalanceStatusReturn {
+  hasCachedData: ComputedRef<boolean>;
+  isInitialLoading: ComputedRef<boolean>;
+  isRefreshing: ComputedRef<boolean>;
+}
+
+export function isCacheInitialLoading(status: Status | undefined): boolean {
+  return status === undefined || status === Status.NONE || status === Status.LOADING;
+}
+
+/**
+ * Per-chain or aggregate view of blockchain balance loading.
+ *
+ * Aggregate semantics (no chain arg):
+ * - hasCachedData: at least one touched chain has reached LOADED
+ * - isInitialLoading: at least one touched chain is still LOADING/NONE
+ * - isRefreshing: at least one chain has an in-flight refresh POST
+ */
+export function useBalanceStatus(chain?: MaybeRefOrGetter<string>): UseBalanceStatusReturn {
+  const statusStore = useStatusStore();
+  const { status } = storeToRefs(statusStore);
+  const { getStatus } = statusStore;
+  const refreshState = useBalanceRefreshState();
+
+  const hasCachedData = computed<boolean>(() => {
+    const target = toValue(chain);
+    if (target !== undefined)
+      return getStatus(Section.BLOCKCHAIN, target) === Status.LOADED;
+
+    const chains = get(status)[Section.BLOCKCHAIN];
+    if (!chains)
+      return false;
+    return Object.values(chains).includes(Status.LOADED);
+  });
+
+  const isInitialLoading = computed<boolean>(() => {
+    const target = toValue(chain);
+    if (target !== undefined)
+      return isCacheInitialLoading(getStatus(Section.BLOCKCHAIN, target));
+
+    const chains = get(status)[Section.BLOCKCHAIN];
+    if (!chains)
+      return false;
+    return Object.values(chains).some(isCacheInitialLoading);
+  });
+
+  const { isRefreshing: anyIsRefreshing } = storeToRefs(refreshState);
+  const isRefreshing = chain === undefined
+    ? anyIsRefreshing
+    : refreshState.useIsRefreshing(chain);
+
+  return {
+    hasCachedData,
+    isInitialLoading,
+    isRefreshing,
+  };
+}

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -6,10 +6,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAccount } from '@/modules/accounts/create-account';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useBlockchainBalancesApi } from '@/modules/balances/api/use-blockchain-balances-api';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
-import { Section } from '@/modules/core/common/status';
-import { useStatusStore } from '@/modules/core/common/use-status-store';
 import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
 
 vi.mock('@/modules/settings/use-general-settings-store', async () => {
@@ -198,8 +197,8 @@ describe('useBlockchainBalances', () => {
         });
       };
 
-      const { useIsLoading } = useStatusStore();
-      const loading = useIsLoading(Section.BLOCKCHAIN, Blockchain.ETH);
+      const refreshState = useBalanceRefreshState();
+      const loading = refreshState.useIsRefreshing(Blockchain.ETH);
 
       startPromise(call());
       assert(1);
@@ -230,8 +229,8 @@ describe('useBlockchainBalances', () => {
         });
       };
 
-      const { useIsLoading } = useStatusStore();
-      const loading = useIsLoading(Section.BLOCKCHAIN, Blockchain.ETH);
+      const refreshState = useBalanceRefreshState();
+      const loading = refreshState.useIsRefreshing(Blockchain.ETH);
 
       startPromise(call());
       assert(1);

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -1,12 +1,12 @@
 import type { BlockchainBalancePayload } from '@/modules/balances/types/blockchain-balances';
 import { useValueThreshold } from '@/modules/assets/amount-display/use-usd-value-threshold';
 import { useBalanceQueue } from '@/modules/balances/use-balance-queue';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { arrayify } from '@/modules/core/common/data/array';
 import { Section } from '@/modules/core/common/status';
 import { useStatusStore } from '@/modules/core/common/use-status-store';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { BalanceSource } from '@/modules/settings/types/frontend-settings';
-import { waitUntilIdle } from '@/modules/shell/sync-progress/use-section-status';
 import { useBalanceProcessingService } from './services/use-balance-processing-service';
 import { useLoopringBalanceService } from './services/use-loopring-balance-service';
 
@@ -24,6 +24,10 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
   const { handleCachedFetch, handleRefresh } = useBalanceProcessingService();
   const { fetchLoopringBalances } = useLoopringBalanceService();
   const { queueBalanceQueries } = useBalanceQueue();
+  const refreshState = useBalanceRefreshState();
+
+  const isChainBusy = (chain: string): boolean =>
+    getIsLoading(Section.BLOCKCHAIN, chain) || get(refreshState.refreshingChains).has(chain);
 
   // Cached DB read — always fires immediately, no loading checks needed
   const fetchBlockchainBalances = async (
@@ -46,10 +50,10 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
     const { addresses, blockchain, isXpub = false } = payload;
     const chains = blockchain ? arrayify(blockchain) : get(supportedChains).map(chain => chain.id);
     await queueBalanceQueries(chains, async (chain) => {
-      if (getIsLoading(Section.BLOCKCHAIN, chain)) {
+      if (isChainBusy(chain)) {
         if (periodic)
           return;
-        await waitUntilIdle(Section.BLOCKCHAIN, chain);
+        await until(() => isChainBusy(chain)).toBe(false);
       }
       await handleRefresh({ addresses, blockchain: chain, isXpub });
     });

--- a/frontend/app/src/modules/core/common/use-status-store.ts
+++ b/frontend/app/src/modules/core/common/use-status-store.ts
@@ -9,6 +9,8 @@ type StatusState = Partial<Record<Section, SectionStatus>>;
 
 const defaultSection = 'default';
 
+// Balance sections no longer write REFRESHING (refresh activity lives in useBalanceRefreshState);
+// this fallthrough keeps behavior correct for history/staking/nft/liquity which still use it.
 function isInitialLoadingStatus(status: Status): boolean {
   return status !== Status.LOADED && status !== Status.PARTIALLY_LOADED && status !== Status.REFRESHING;
 }

--- a/frontend/app/src/modules/dashboard/Dashboard.vue
+++ b/frontend/app/src/modules/dashboard/Dashboard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import PriceRefresh from '@/modules/assets/prices/PriceRefresh.vue';
 import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
-import { useBalancesLoading } from '@/modules/balances/use-balance-loading';
+import { useBalanceStatus } from '@/modules/balances/use-balance-status';
 import { useDynamicMessages } from '@/modules/core/messaging/use-dynamic-messages';
 import DashboardAssetTable from '@/modules/dashboard/DashboardAssetTable.vue';
 import DynamicMessageDisplay from '@/modules/dashboard/DynamicMessageDisplay.vue';
@@ -31,7 +31,7 @@ const { enabled: nftEnabled } = useModuleEnabled(Module.NFTS);
 const { width } = useElementSize(dashboardRef);
 const { height: floatingHeight } = useElementBounding(floatingRef);
 
-const { loadingBalancesAndDetection: isAnyLoading } = useBalancesLoading();
+const { isInitialLoading: isAnyLoading } = useBalanceStatus();
 const dismissedMessage = useSessionStorage('rotki.messages.dash.dismissed', false);
 
 const paddingTop = computed<number>(() => get(floatingHeight) || 0);

--- a/frontend/app/src/modules/dashboard/summary/BlockchainSummary.vue
+++ b/frontend/app/src/modules/dashboard/summary/BlockchainSummary.vue
@@ -4,6 +4,7 @@ import BlockchainBalanceRefreshBehaviourMenu
   from '@/modules/balances/BlockchainBalanceRefreshBehaviourMenu.vue';
 import BlockchainBalanceStalenessIndicator from '@/modules/balances/BlockchainBalanceStalenessIndicator.vue';
 import { useBalanceRefresh } from '@/modules/balances/use-balance-refresh';
+import { useBalanceStatus } from '@/modules/balances/use-balance-status';
 import { TaskType } from '@/modules/core/tasks/task-type';
 import { useTaskStore } from '@/modules/core/tasks/use-task-store';
 import SummaryCard from '@/modules/dashboard/summary/SummaryCard.vue';
@@ -14,13 +15,12 @@ import BlockchainSummaryCardCreateButton from './BlockchainSummaryCardCreateButt
 const { blockchainTotals } = useBlockchainTotalSummary();
 const { useIsTaskRunning } = useTaskStore();
 const { refreshBalance } = useBalanceRefresh();
+const { isRefreshing } = useBalanceStatus();
 const { t } = useI18n({ useScope: 'global' });
 
 const isTokenDetecting = useIsTaskRunning(TaskType.FETCH_DETECTED_TOKENS);
-const isQueryingBlockchain = useIsTaskRunning(TaskType.QUERY_BLOCKCHAIN_BALANCES);
 const isLoopringLoading = useIsTaskRunning(TaskType.L2_LOOPRING);
-const isBlockchainLoading = logicOr(isQueryingBlockchain, isLoopringLoading);
-const isLoading = logicOr(isBlockchainLoading, isTokenDetecting);
+const isLoading = logicOr(isRefreshing, isLoopringLoading, isTokenDetecting);
 </script>
 
 <template>

--- a/frontend/app/src/pages/balances/blockchain/index.vue
+++ b/frontend/app/src/pages/balances/blockchain/index.vue
@@ -12,8 +12,8 @@ import BlockchainBalanceRefreshBehaviourMenu from '@/modules/balances/Blockchain
 import BlockchainBalanceStalenessIndicator from '@/modules/balances/BlockchainBalanceStalenessIndicator.vue';
 import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
 import { useBalanceRefresh } from '@/modules/balances/use-balance-refresh';
+import { useBalanceStatus } from '@/modules/balances/use-balance-status';
 import { NoteLocation } from '@/modules/core/common/notes';
-import { Section } from '@/modules/core/common/status';
 import SummaryCardRefreshMenu from '@/modules/dashboard/summary/SummaryCardRefreshMenu.vue';
 import VisibleColumnsSelector from '@/modules/dashboard/VisibleColumnsSelector.vue';
 import HideSmallBalances from '@/modules/settings/HideSmallBalances.vue';
@@ -21,7 +21,6 @@ import { BalanceSource, DashboardTableType } from '@/modules/settings/types/fron
 import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
-import { useSectionStatus } from '@/modules/shell/sync-progress/use-section-status';
 
 definePage({
   meta: {
@@ -43,8 +42,7 @@ const route = useRoute('balances-blockchain');
 const tableType = DashboardTableType.BLOCKCHAIN_ASSET_BALANCES;
 
 const { useBlockchainBalances } = useAggregatedBalances();
-const { isInitialLoading, isLoading } = useSectionStatus(Section.BLOCKCHAIN);
-const isRefreshing = computed<boolean>(() => get(isLoading) && !get(isInitialLoading));
+const { isInitialLoading, isRefreshing } = useBalanceStatus();
 const { dashboardTablesVisibleColumns } = storeToRefs(useFrontendSettingsStore());
 const { isDetectingTokens, refreshDisabled } = useBlockchainAccountLoading();
 const { handleBlockchainRefresh } = useBalanceRefresh();


### PR DESCRIPTION
## Summary
- Cached GET and refresh POST were writing to the same per-chain status, so consumers gated on `QUERY_BLOCKCHAIN_BALANCES` hid cached balances until the refresh finished.
- Adds `useBalanceRefreshState` (per-chain in-flight set) and `useBalanceStatus` (`hasCachedData` / `isInitialLoading` / `isRefreshing`). `handleRefresh` toggles the refresh set and no longer writes `Status.REFRESHING`; `handleCachedFetch` keeps the cache status monotonic.
- Migrates the blockchain balances page, `BlockchainSummary`, `AccountBalancesTable`, `useBlockchainAccountLoading`, `useAccountLoading`, and the dashboard assets table to the new signals.

## Test plan
- [x] Unit tests for the new store, composable, and balance processing service
- [ ] Verify cached balances render before the refresh POST completes
- [ ] Verify refresh spinners track refresh-only, initial overlays track cache-only