### PR TITLE
fix(frontend): guard multiplications against NoPrice sentinel

### DIFF
--- a/frontend/app/src/modules/assets/amount-display/use-asset-value.spec.ts
+++ b/frontend/app/src/modules/assets/amount-display/use-asset-value.spec.ts
@@ -13,6 +13,8 @@ vi.mock('@/modules/assets/prices/use-price-utils', () => ({
         return bigNumberify(2000);
       if (asset === 'BTC')
         return bigNumberify(50000);
+      if (asset === 'NOPRICE')
+        return bigNumberify(-1);
       return fallback;
     },
   }),
@@ -67,6 +69,26 @@ describe('modules/amount-display/composables/use-asset-value', () => {
       expect(get(value).toNumber()).toBe(25000);
     });
 
+    it('should return zero when cached price is negative (NoPrice sentinel)', () => {
+      const { value } = useAssetValue({
+        amount: bigNumberify(10),
+        asset: 'NOPRICE',
+      });
+
+      // Price is -1 in cache → value must not become negative
+      expect(get(value).toNumber()).toBe(0);
+    });
+
+    it('should return zero when knownPrice is negative', () => {
+      const { value } = useAssetValue({
+        amount: bigNumberify(10),
+        asset: 'ETH',
+        knownPrice: bigNumberify(-1),
+      });
+
+      expect(get(value).toNumber()).toBe(0);
+    });
+
     it('should return zero when amount is zero', () => {
       const { value } = useAssetValue({
         amount: bigNumberify(0),
@@ -101,6 +123,15 @@ describe('modules/amount-display/composables/use-asset-value', () => {
       const { price } = useAssetValue({
         amount: bigNumberify(1),
         asset: 'UNKNOWN',
+      });
+
+      expect(get(price).toNumber()).toBe(0);
+    });
+
+    it('should return zero when cached price is negative (NoPrice sentinel)', () => {
+      const { price } = useAssetValue({
+        amount: bigNumberify(1),
+        asset: 'NOPRICE',
       });
 
       expect(get(price).toNumber()).toBe(0);

--- a/frontend/app/src/modules/assets/amount-display/use-asset-value.ts
+++ b/frontend/app/src/modules/assets/amount-display/use-asset-value.ts
@@ -86,18 +86,19 @@ export function useAssetValue(options: UseAssetValueOptions): UseAssetValueRetur
 
     // If known price is provided, use it directly
     if (known !== undefined && known !== null) {
-      return known;
+      return known.gt(0) ? known : Zero;
     }
 
     // Fall back to looking up the price (already in current currency)
-    return getAssetPrice(toValue(asset), Zero);
+    const current = getAssetPrice(assetVal, Zero);
+    return current.gt(0) ? current : Zero;
   });
 
   const value = computed<BigNumber>(() => {
     const amountVal = toValue(amount);
     const priceVal = get(price);
 
-    if (amountVal.isZero() || priceVal.isZero()) {
+    if (amountVal.isZero() || priceVal.lte(0)) {
       return Zero;
     }
 

--- a/frontend/app/src/modules/assets/prices/price-utils.ts
+++ b/frontend/app/src/modules/assets/prices/price-utils.ts
@@ -39,7 +39,7 @@ export function updateBalancesPrices(
       const balance = protocols[protocol];
       const newBalance: Balance = {
         amount: balance.amount,
-        value: assetPrice.value ? balance.amount.times(assetPrice.value) : balance.value,
+        value: assetPrice.value && assetPrice.value.gt(0) ? balance.amount.times(assetPrice.value) : balance.value,
       };
       protocolResult[protocol] = newBalance;
     }
@@ -70,7 +70,7 @@ export function updateExchangeBalancesPrices(
 
     result[asset] = {
       amount: assetInfo.amount,
-      value: assetPrice.value ? assetInfo.amount.times(assetPrice.value) : assetInfo.value,
+      value: assetPrice.value && assetPrice.value.gt(0) ? assetInfo.amount.times(assetPrice.value) : assetInfo.value,
     };
   }
   return result;
@@ -118,7 +118,7 @@ export function updateManualBalancePrices(data: ManualBalanceWithValue[], prices
 
     return {
       ...item,
-      value: assetPrice.value ? item.amount.times(assetPrice.value) : item.value,
+      value: assetPrice.value && assetPrice.value.gt(0) ? item.amount.times(assetPrice.value) : item.value,
     };
   });
 }

--- a/frontend/app/src/modules/assets/prices/use-currency-update.ts
+++ b/frontend/app/src/modules/assets/prices/use-currency-update.ts
@@ -47,7 +47,7 @@ export function useCurrencyUpdate(): UseCurrencyUpdateReturn {
         for (const [asset, priceData] of Object.entries(currentPrices)) {
           scaledPrices[asset] = {
             ...priceData,
-            value: priceData.value.multipliedBy(ratio),
+            value: priceData.value.gt(0) ? priceData.value.multipliedBy(ratio) : priceData.value,
           };
         }
 

--- a/frontend/app/src/modules/assets/prices/use-latest-price-manager.ts
+++ b/frontend/app/src/modules/assets/prices/use-latest-price-manager.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { ManualPrice, ManualPriceFormPayload, ManualPriceWithUsd } from '@/modules/assets/prices/price-types';
-import { Zero } from '@rotki/common';
+import { type BigNumber, Zero } from '@rotki/common';
 import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
 import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
 import { isNft } from '@/modules/assets/nft-utils';
@@ -51,9 +51,17 @@ export function useLatestPrices(
 
     return filteredItems.map((item, index) => {
       const { fromAsset, toAsset, price } = item;
-      const priceInCurrency = isNft(fromAsset)
-        ? getAssetPrice(toAsset)?.multipliedBy(price)
-        : getAssetPrice(fromAsset);
+      let priceInCurrency: BigNumber | undefined;
+      if (isNft(fromAsset)) {
+        const toPrice = getAssetPrice(toAsset);
+        if (toPrice && toPrice.gt(0))
+          priceInCurrency = toPrice.multipliedBy(price);
+      }
+      else {
+        const fromPrice = getAssetPrice(fromAsset);
+        if (fromPrice && fromPrice.gt(0))
+          priceInCurrency = fromPrice;
+      }
 
       return {
         id: index + 1,

--- a/frontend/app/src/modules/balances/manual-balances.ts
+++ b/frontend/app/src/modules/balances/manual-balances.ts
@@ -86,7 +86,7 @@ export function sortAndFilterManualBalance(
 
   const total = filtered.reduce((acc, item) => {
     const price = resolvers.resolveAssetPrice(item.asset);
-    if (price)
+    if (price && price.gt(0))
       return acc.plus(price.times(item.amount));
 
     return acc;

--- a/frontend/app/src/modules/shell/components/display/BalanceDisplay.vue
+++ b/frontend/app/src/modules/shell/components/display/BalanceDisplay.vue
@@ -44,7 +44,8 @@ const valueInCurrency = computed<BigNumber>(() => {
   if (!calculateValue)
     return get(balanceValue);
 
-  return getAssetPrice(asset, Zero).multipliedBy(get(amount));
+  const price = getAssetPrice(asset, Zero);
+  return price.gt(0) ? price.multipliedBy(get(amount)) : Zero;
 });
 </script>
 

--- a/frontend/app/src/modules/staking/kraken/KrakenStaking.vue
+++ b/frontend/app/src/modules/staking/kraken/KrakenStaking.vue
@@ -36,7 +36,7 @@ const earnedAssetsData = computed<[boolean, AssetBalance[]]>(() => {
 
   const earnedWithPrice = earned.map((item) => {
     const price = getAssetPrice(item.asset);
-    if (!price) {
+    if (!price || price.lte(0)) {
       loading = true;
 
       return item;

--- a/frontend/app/src/modules/staking/liquity/LiquityStatistics.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityStatistics.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type AssetBalance, type Balance, type BigNumber, type LiquityPoolDetailEntry, type LiquityStatisticDetails, One } from '@rotki/common';
+import { type AssetBalance, type Balance, type BigNumber, type LiquityPoolDetailEntry, type LiquityStatisticDetails, One, Zero } from '@rotki/common';
 import { FiatDisplay } from '@/modules/assets/amount-display/components';
 import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
 import { bigNumberSum } from '@/modules/core/common/data/calculation';
@@ -19,6 +19,16 @@ const { getAssetPrice, useAssetPrice } = usePriceUtils();
 const LUSD_ID = 'eip155:1/erc20:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0';
 const lusdPrice = useAssetPrice(LUSD_ID);
 
+function priceOrOne(asset: string): BigNumber {
+  const price = getAssetPrice(asset);
+  return price && price.gt(0) ? price : One;
+}
+
+const lusdPriceOrOne = computed<BigNumber>(() => {
+  const price = get(lusdPrice);
+  return price && price.gt(0) ? price : One;
+});
+
 const { isLoading: loading } = useSectionStatus(Section.DEFI_LIQUITY_STATISTICS);
 
 const statisticWithAdjustedPrice = computed<LiquityStatisticDetails | null>(() => {
@@ -33,7 +43,7 @@ const statisticWithAdjustedPrice = computed<LiquityStatisticDetails | null>(() =
 
     return {
       ...stakingGain,
-      value: stakingGain.amount.multipliedBy(price),
+      value: price.gt(0) ? stakingGain.amount.multipliedBy(price) : Zero,
     };
   });
 
@@ -42,7 +52,7 @@ const statisticWithAdjustedPrice = computed<LiquityStatisticDetails | null>(() =
 
     return {
       ...stabilityPoolGain,
-      value: stabilityPoolGain.amount.multipliedBy(price),
+      value: price.gt(0) ? stabilityPoolGain.amount.multipliedBy(price) : Zero,
     };
   });
 
@@ -54,10 +64,10 @@ const statisticWithAdjustedPrice = computed<LiquityStatisticDetails | null>(() =
     ...statistic,
     stabilityPoolGains,
     stakingGains,
-    totalDepositedStabilityPoolValue: statistic.totalDepositedStabilityPool.multipliedBy(get(lusdPrice) ?? One),
+    totalDepositedStabilityPoolValue: statistic.totalDepositedStabilityPool.multipliedBy(get(lusdPriceOrOne)),
     totalValueGainsStabilityPool,
     totalValueGainsStaking,
-    totalWithdrawnStabilityPoolValue: statistic.totalWithdrawnStabilityPool.multipliedBy(get(lusdPrice) ?? One),
+    totalWithdrawnStabilityPoolValue: statistic.totalWithdrawnStabilityPool.multipliedBy(get(lusdPriceOrOne)),
   };
 });
 
@@ -115,9 +125,9 @@ function calculatePnl(
   return computed(() => {
     const expectedAmount = totalDepositedStabilityPool.minus(totalWithdrawnStabilityPool);
 
-    const liquidationGainsInCurrentPrice = poolGains.amount.multipliedBy(getAssetPrice(poolGains.asset, One));
+    const liquidationGainsInCurrentPrice = poolGains.amount.multipliedBy(priceOrOne(poolGains.asset));
 
-    const rewardsInCurrentPrice = poolRewards.amount.multipliedBy(getAssetPrice(poolRewards.asset, One));
+    const rewardsInCurrentPrice = poolRewards.amount.multipliedBy(priceOrOne(poolRewards.asset));
 
     const totalWithdrawals = totalValueGainsStabilityPool
       .plus(liquidationGainsInCurrentPrice)
@@ -125,7 +135,7 @@ function calculatePnl(
 
     const diffDeposited = expectedAmount.minus(poolDeposited.amount);
 
-    const diffDepositedInCurrentUsdPrice = diffDeposited.multipliedBy(get(lusdPrice) ?? One);
+    const diffDepositedInCurrentUsdPrice = diffDeposited.multipliedBy(get(lusdPriceOrOne));
 
     return totalWithdrawals.minus(diffDepositedInCurrentUsdPrice);
   });

--- a/frontend/app/src/modules/wallet/use-tradable-asset.ts
+++ b/frontend/app/src/modules/wallet/use-tradable-asset.ts
@@ -58,9 +58,12 @@ export function useTradableAsset(address: MaybeRefOrGetter<string | undefined>):
   function enhanceWithPrices(assets: TradableAssetWithoutValue[]): TradableAsset[] {
     return assets.map((item) => {
       const price = getAssetPrice(item.asset);
+      if (!price || price.lte(0)) {
+        return { ...item, fiatValue: undefined, price: undefined };
+      }
       return {
         ...item,
-        fiatValue: price?.multipliedBy(item.amount),
+        fiatValue: price.multipliedBy(item.amount),
         price,
       };
     }).sort((a, b) => {


### PR DESCRIPTION
## Summary
- Prices missing from the cache surface as the `NoPrice` sentinel (`-1`). Several sites multiplied `amount × price` without checking, producing negative display values (e.g. FiatDisplay rendering `-amount` instead of `0`).
- This PR adds `price > 0` guards at every multiplication site that reads from the price cache, and stops the currency-switch path from warping the `-1` sentinel.

### Sites fixed
- `useAssetValue` — both current-price and `knownPrice` branches (mirrors the existing historic-price guard).
- `price-utils.ts` — `updateBalancesPrices`, `updateExchangeBalancesPrices`, `updateManualBalancePrices` (core price-refresh pipeline).
- `useCurrencyUpdate` — preserves the `-1` sentinel instead of scaling it by the FX ratio.
- `useLatestPrices` — NFT pricing no longer multiplies by a negative `toPrice`.
- `BalanceDisplay` calculated value.
- `sortAndFilterManualBalance` totals.
- `useTradableAsset` — emits `undefined` for `price`/`fiatValue` when the price is non-positive (templates already use `v-if="data.price"`).
- Kraken staking — treats NoPrice as loading.
- Liquity statistics — gains, LUSD-based totals, and PnL all fall back to `Zero` / `One` appropriately.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `CI=true pnpm run lint` — no new warnings introduced
- [x] `pnpm run test:unit` — 287 passing, including 3 new `useAssetValue` specs covering negative cached price, negative `knownPrice`, and the NoPrice sentinel returning `Zero` from the `price` computed
- [ ] Manually verify: asset with missing price in dashboard / manual balances / wallet send / staking pages no longer shows a negative fiat value