### PR TITLE
fix(frontend): reopen filter suggestions on chip edit

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Clicking an applied table filter chip to edit it now reliably reopens the suggestions dropdown, instead of showing nothing after the first edit.
 * :bug:`12079` Log level changes now take effect immediately without restarting rotki — including switching to debug on packaged builds after resetting to defaults.
 * :bug:`-` The PnL report's Custom range quick-options (Last 12 hours, Last 7 days, etc.) no longer leave a stale "Date cannot be after …" error on the Start field when switching from a past year/quarter to Custom.
 * :feature:`-` You can now update the historical price of an asset for a specific event directly from the event row's asset menu, either by patching the existing oracle entry or saving a manual override.

--- a/frontend/app/src/modules/core/table/TableFilter.spec.ts
+++ b/frontend/app/src/modules/core/table/TableFilter.spec.ts
@@ -523,4 +523,60 @@ describe('table-filter', () => {
       expect(wrapper.emitted('update:matches')?.at(-1)).toEqual([{ type: ['type 2', 'type 3', 'type 4'] }]);
     });
   });
+
+  describe('chip edit reopens suggestions', () => {
+    // Regression test for a bug where editing a chip (clicking an applied
+    // filter) did not re-open the RuiAutoComplete menu, so `FilterDropdown`
+    // (rendered inside `<template #no-data>`) stayed unmounted and the user
+    // saw no suggestions despite the underlying data being populated.
+    // See https://github.com/rotki/ui-library/issues/517 for the follow-up
+    // that will replace the synthetic-input workaround with a public API.
+    it('should show suggestions when clicking a chip to edit it', async () => {
+      wrapper = createWrapper({
+        props: {
+          matchers,
+          matches: { type: ['type 1'] },
+        },
+      });
+      await vi.advanceTimersToNextTimerAsync();
+
+      // The chip for `type=type 1` should be present
+      const chip = wrapper.find('[data-id="activator"] .contents:nth-child(1) > [role=button]');
+      expect(chip.exists()).toBe(true);
+
+      // Click the chip to enter edit mode
+      await chip.trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      // The autocomplete's native input should reflect the chip key
+      expect(wrapper.find<HTMLInputElement>('input:not(.edit-input)').element.value).toBe('type=');
+
+      // The suggestions dropdown should be visible with all type suggestions
+      const suggestionButtons = wrapper.findAll('[data-cy=suggestions] > button');
+      expect(suggestionButtons).toHaveLength(matchers[1].suggestions().length);
+    });
+
+    it('should show filtered suggestions when typing in the chip edit input', async () => {
+      wrapper = createWrapper({
+        props: {
+          matchers,
+          matches: { type: ['type 1'] },
+        },
+      });
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('[data-id="activator"] .contents:nth-child(1) > [role=button]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      // Type into the chip's inline edit input — the TableFilter should
+      // propagate this to `search` and keep the autocomplete menu open.
+      const editInput = wrapper.find<HTMLInputElement>('input.edit-input');
+      await editInput.setValue('type 2');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const suggestionButtons = wrapper.findAll('[data-cy=suggestions] > button');
+      expect(suggestionButtons.length).toBeGreaterThan(0);
+      expect(suggestionButtons[0].text()).toContain('type 2');
+    });
+  });
 });

--- a/frontend/app/src/modules/core/table/TableFilter.vue
+++ b/frontend/app/src/modules/core/table/TableFilter.vue
@@ -250,6 +250,24 @@ watch(() => matches, (matchesData) => {
   restoreSelection(matchesData);
 });
 
+// Re-open the RuiAutoComplete menu when the user clicks an existing chip to
+// edit it. `hide-search-input` makes the native input `display:none`, so
+// neither `.focus()` nor the exposed `focus` setter opens the menu. The
+// menu's `isOpen` flag is only flipped to `true` inside `updateSearchInput`
+// (the native input's `@input` handler), so we dispatch a synthetic input
+// event — it reads the current value (already `key=`) without clobbering it.
+// Follow-up in @rotki/ui-library#517 will replace this with a public API.
+watch(suggestionBeingEdited, (value, old) => {
+  if (!value || old)
+    return;
+
+  nextTick(() => {
+    const inputEl = get(input)?.$el?.querySelector('input[type="text"]');
+    if (inputEl instanceof HTMLInputElement)
+      inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+});
+
 const { t } = useI18n({ useScope: 'global' });
 </script>
 

--- a/frontend/app/tests/e2e/pages/history-events-page.ts
+++ b/frontend/app/tests/e2e/pages/history-events-page.ts
@@ -149,6 +149,27 @@ export class HistoryEventsPage {
     await option.click();
   }
 
+  async clickFilterChipToEdit(key: string, value: string): Promise<void> {
+    const filter = this.page.locator('[data-cy=table-filter]');
+    const chip = filter.locator('[role=button]', { hasText: `${key}=${value}` }).first();
+    await chip.waitFor({ state: 'visible' });
+    await chip.click();
+  }
+
+  async expectFilterSuggestionsVisible(): Promise<void> {
+    const suggestions = this.page.locator('[data-cy=suggestions]');
+    await suggestions.waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+    const buttons = suggestions.locator('> button');
+    expect(await buttons.count()).toBeGreaterThan(0);
+  }
+
+  async dismissFilterDropdown(): Promise<void> {
+    // Click a neutral page region to trigger onClickOutside on the chip's
+    // edit input and close the autocomplete menu.
+    await this.page.locator('body').click({ position: { x: 5, y: 5 } });
+    await this.page.locator('[data-cy=suggestions]').waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+  }
+
   async getEventRows(): Promise<number> {
     const rows = this.page.locator('[data-cy=history-event-row]');
     return rows.count();

--- a/frontend/app/tests/e2e/specs/history/history-events.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/history-events.spec.ts
@@ -580,4 +580,28 @@ test.describe.serial('history event filter persistence', () => {
       expect(url).toContain('eventSubtypes=none');
     }).toPass({ timeout: 10000 });
   });
+
+  // Regression test for a bug where editing an applied filter chip did not
+  // re-open the suggestions dropdown. The RuiAutoComplete menu closed on
+  // apply, which unmounted FilterDropdown, and clicking a chip had no way
+  // to reopen it. Follow-up: https://github.com/rotki/ui-library/issues/517
+  test('clicking a filter chip reopens the suggestions dropdown', async () => {
+    await page.visit();
+    await waitForNoRunningTasks(ctx.sharedPage);
+
+    await page.applyTableFilter('event_type', 'receive');
+
+    // First edit — reproduces the initial chip-edit case.
+    await page.clickFilterChipToEdit('event_type', 'receive');
+    await page.expectFilterSuggestionsVisible();
+
+    // Dismiss the dropdown by clicking elsewhere so the RuiAutoComplete
+    // menu fully closes (and FilterDropdown unmounts) before we re-edit.
+    // This is the condition under which the original bug manifested.
+    await page.dismissFilterDropdown();
+
+    // Second edit on the same chip — must still reopen suggestions.
+    await page.clickFilterChipToEdit('event_type', 'receive');
+    await page.expectFilterSuggestionsVisible();
+  });
 });


### PR DESCRIPTION
## Summary

- Clicking an applied filter chip to re-edit it now reliably re-opens the suggestions dropdown.
- Previously, once the `RuiAutoComplete` menu closed (e.g. on apply), `FilterDropdown` — which is rendered inside `<template #no-data>` — unmounted. Clicking a chip set `suggestionBeingEdited` and updated `search`, but nothing reopened the menu because `hide-search-input` keeps the native input `display: none` (so `.focus()` is a no-op) and the library's exposed `focus()` only toggles an internal flag. Keystrokes flowed into `search` but never rendered.
- Fix: watch `suggestionBeingEdited` in `TableFilter.vue` and dispatch a synthetic `input` event on the hidden autocomplete input when it transitions truthy. That triggers `updateSearchInput` inside `RuiAutoComplete`, flipping `isOpen = true` without clobbering the search value.
- Follow-up tracked in rotki/ui-library#517 — once the library exposes an `openMenu()` / improved `focus()`, this local workaround can be removed.

## Tests

- **Unit**: `TableFilter.spec.ts` gains a `chip edit reopens suggestions` describe block with two regression tests (chip click shows suggestions; typing in the edit input narrows them). Verified they fail without the fix and pass with it.
- **E2E**: `history-events.spec.ts` gains a test that applies an `event_type=receive` filter, clicks the chip, asserts suggestions render, dismisses the dropdown (forcing `FilterDropdown` unmount — the condition where the bug appeared), then clicks the chip again and asserts suggestions render a second time.

## Test plan

- [x] `pnpm run test:unit src/modules/core/table/TableFilter.spec.ts` passes (17/17)
- [x] Unit tests verified to fail without the `TableFilter.vue` workaround
- [x] `pnpm run test:e2e --grep "clicking a filter chip reopens"` passes
- [ ] Manually verify in the app: apply a location filter, click the chip to edit, change to a different location — suggestions should keep appearing across multiple edits