### PR TITLE
feat(frontend): color oracle source chips by brand

### DIFF
--- a/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceContent.vue
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceContent.vue
@@ -78,8 +78,34 @@ const sourceLabels: Record<string, string> = {
   [PriceOracle.UNISWAP3]: 'Uniswap V3',
 };
 
+const sourceBrandColors: Record<string, string> = {
+  [PriceOracle.ALCHEMY]: '#363ff9',
+  [PriceOracle.COINGECKO]: '#8dc63f',
+  [PriceOracle.CRYPTOCOMPARE]: '#f37021',
+  [PriceOracle.DEFILLAMA]: '#2172e5',
+  [PriceOracle.FIAT]: '#85bb65',
+  [PriceOracle.UNISWAP2]: '#ff007a',
+  [PriceOracle.UNISWAP3]: '#e50887',
+};
+
+type ChipColor = 'grey' | 'primary' | 'secondary' | 'error' | 'warning' | 'info' | 'success';
+
+const sourceContextColors: Record<string, ChipColor> = {
+  [PriceOracle.BLOCKCHAIN]: 'secondary',
+  [PriceOracle.MANUAL]: 'warning',
+  [PriceOracle.MANUALCURRENT]: 'warning',
+};
+
 function getSourceLabel(source: string): string {
   return sourceLabels[source] ?? source;
+}
+
+function getSourceBgColor(source: string): string | undefined {
+  return sourceBrandColors[source];
+}
+
+function getSourceColor(source: string): ChipColor {
+  return sourceContextColors[source] ?? 'grey';
 }
 
 const editingItem = ref<OraclePriceEntry>();
@@ -161,7 +187,10 @@ onMounted(async () => {
         <template #item.sourceType="{ row }">
           <RuiChip
             size="sm"
-            variant="outlined"
+            :bg-color="getSourceBgColor(row.sourceType)"
+            :text-color="getSourceBgColor(row.sourceType) ? '#ffffff' : undefined"
+            :variant="getSourceBgColor(row.sourceType) ? 'filled' : 'outlined'"
+            :color="getSourceColor(row.sourceType)"
           >
             {{ getSourceLabel(row.sourceType) }}
           </RuiChip>


### PR DESCRIPTION
## Summary
- Oracle source chips in the historical oracle prices table now use per-oracle brand colors (Alchemy, CoinGecko, CryptoCompare, DefiLlama, Fiat/dollar green, Uniswap V2/V3) rendered as filled chips with white text.
- Blockchain and Manual/ManualCurrent remain outlined but use distinct context colors (secondary / warning) so they are visually separable from unknown sources, which still fall back to grey outlined.

## Test plan
- [ ] Open the historical oracle prices page and verify each oracle source chip renders with the expected color.
- [ ] Verify non-brand sources (Blockchain, Manual) remain outlined and visually distinct from each other.