### PR TITLE
fix(frontend): drop redundant menu padding wrappers

### DIFF
--- a/frontend/app/src/modules/accounts/AccountBalancesExportImport.vue
+++ b/frontend/app/src/modules/accounts/AccountBalancesExportImport.vue
@@ -44,26 +44,24 @@ async function doImport() {
           <RuiIcon name="lu-ellipsis-vertical" />
         </RuiButton>
       </template>
-      <div class="py-2">
-        <RuiButton
-          variant="list"
-          @click="exportAccounts()"
-        >
-          <template #prepend>
-            <RuiIcon name="lu-file-down" />
-          </template>
-          {{ t('blockchain_balances.export_blockchain_accounts') }}
-        </RuiButton>
-        <RuiButton
-          variant="list"
-          @click="importDialogOpen = true;"
-        >
-          <template #prepend>
-            <RuiIcon name="lu-file-up" />
-          </template>
-          {{ t('blockchain_balances.import_blockchain_accounts') }}
-        </RuiButton>
-      </div>
+      <RuiButton
+        variant="list"
+        @click="exportAccounts()"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-file-down" />
+        </template>
+        {{ t('blockchain_balances.export_blockchain_accounts') }}
+      </RuiButton>
+      <RuiButton
+        variant="list"
+        @click="importDialogOpen = true;"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-file-up" />
+        </template>
+        {{ t('blockchain_balances.import_blockchain_accounts') }}
+      </RuiButton>
     </RuiMenu>
     <RuiDialog
       v-model="importDialogOpen"

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
@@ -62,17 +62,15 @@ async function doImport() {
           <RuiIcon name="lu-ellipsis-vertical" />
         </RuiButton>
       </template>
-      <div class="py-2">
-        <RuiButton
-          variant="list"
-          @click="importDialogOpen = true;"
-        >
-          <template #prepend>
-            <RuiIcon name="lu-file-up" />
-          </template>
-          {{ t('address_book.import.title') }}
-        </RuiButton>
-      </div>
+      <RuiButton
+        variant="list"
+        @click="importDialogOpen = true;"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-file-up" />
+        </template>
+        {{ t('address_book.import.title') }}
+      </RuiButton>
     </RuiMenu>
     <RuiDialog
       v-model="importDialogOpen"

--- a/frontend/app/src/modules/assets/admin/RestoreAssetDbButton.vue
+++ b/frontend/app/src/modules/assets/admin/RestoreAssetDbButton.vue
@@ -121,18 +121,16 @@ function showDoneConfirmation() {
         </template>
       </RuiButton>
     </template>
-    <div class="py-2">
-      <ListItem
-        :title="t('asset_update.restore.soft_reset')"
-        :subtitle="t('asset_update.restore.soft_reset_hint')"
-        @click="showRestoreConfirmation('soft')"
-      />
-      <ListItem
-        :title="t('asset_update.restore.hard_reset')"
-        :subtitle="t('asset_update.restore.hard_reset_hint')"
-        @click="showRestoreConfirmation('hard')"
-      />
-    </div>
+    <ListItem
+      :title="t('asset_update.restore.soft_reset')"
+      :subtitle="t('asset_update.restore.soft_reset_hint')"
+      @click="showRestoreConfirmation('soft')"
+    />
+    <ListItem
+      :title="t('asset_update.restore.hard_reset')"
+      :subtitle="t('asset_update.restore.hard_reset_hint')"
+      @click="showRestoreConfirmation('hard')"
+    />
   </RuiMenu>
   <div
     v-else

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
@@ -252,28 +252,26 @@ onBeforeMount(async () => {
             <RuiIcon name="lu-ellipsis-vertical" />
           </RuiButton>
         </template>
-        <div class="py-2">
-          <RestoreAssetDbButton dropdown />
-          <RuiTooltip
-            :open-delay="400"
-            class="w-full"
-            :popper="{ placement: 'left' }"
-            tooltip-class="max-w-[200px]"
-          >
-            <template #activator>
-              <RuiButton
-                variant="list"
-                @click="mergeTool = true; openAction = false"
-              >
-                <template #prepend>
-                  <RuiIcon name="lu-combine" />
-                </template>
-                {{ t('asset_management.merge_assets') }}
-              </RuiButton>
-            </template>
-            {{ t('asset_management.merge_assets_tooltip') }}
-          </RuiTooltip>
-        </div>
+        <RestoreAssetDbButton dropdown />
+        <RuiTooltip
+          :open-delay="400"
+          class="w-full"
+          :popper="{ placement: 'left' }"
+          tooltip-class="max-w-[200px]"
+        >
+          <template #activator>
+            <RuiButton
+              variant="list"
+              @click="mergeTool = true; openAction = false"
+            >
+              <template #prepend>
+                <RuiIcon name="lu-combine" />
+              </template>
+              {{ t('asset_management.merge_assets') }}
+            </RuiButton>
+          </template>
+          {{ t('asset_management.merge_assets_tooltip') }}
+        </RuiTooltip>
       </RuiMenu>
     </template>
 

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetIgnoreSwitch.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetIgnoreSwitch.vue
@@ -91,7 +91,7 @@ const tooltipMessage = computed<string>(() =>
           </RuiButton>
         </RuiBadge>
       </template>
-      <div class="py-2 text-rui-text-secondary">
+      <div class="text-rui-text-secondary">
         <RuiButton
           variant="list"
           size="sm"

--- a/frontend/app/src/modules/dashboard/VisibleColumnsSelector.vue
+++ b/frontend/app/src/modules/dashboard/VisibleColumnsSelector.vue
@@ -70,29 +70,27 @@ function update(value: TableColumn) {
         <RuiIcon name="lu-ellipsis-vertical" />
       </MenuTooltipButton>
     </template>
-    <div class="py-2">
-      <template
-        v-for="item in availableColumns"
-        :key="item.value"
+    <template
+      v-for="item in availableColumns"
+      :key="item.value"
+    >
+      <RuiButton
+        variant="list"
+        size="sm"
+        :model-value="item.value"
+        @click="update(item.value)"
       >
-        <RuiButton
-          variant="list"
-          size="sm"
-          :model-value="item.value"
-          @click="update(item.value)"
-        >
-          <template #prepend>
-            <RuiCheckbox
-              class="-mr-2"
-              color="primary"
-              hide-details
-              :model-value="active(item.value)"
-              @update:model-value="update(item.value)"
-            />
-          </template>
-          {{ item.text }}
-        </RuiButton>
-      </template>
-    </div>
+        <template #prepend>
+          <RuiCheckbox
+            class="-mr-2"
+            color="primary"
+            hide-details
+            :model-value="active(item.value)"
+            @update:model-value="update(item.value)"
+          />
+        </template>
+        {{ item.text }}
+      </RuiButton>
+    </template>
   </RuiMenu>
 </template>

--- a/frontend/app/src/modules/dashboard/summary/BlockchainSummaryCardCreateButton.vue
+++ b/frontend/app/src/modules/dashboard/summary/BlockchainSummaryCardCreateButton.vue
@@ -41,19 +41,17 @@ function addBlockchainAccount(path: string) {
       </SummaryCardCreateButton>
     </template>
 
-    <div class="py-2">
-      <RuiButton
-        v-for="blockchainCategory in blockchainCategories"
-        :key="blockchainCategory.path"
-        variant="list"
-        @click="addBlockchainAccount(blockchainCategory.path)"
-      >
-        <template #prepend>
-          <RuiIcon :name="blockchainCategory.icon" />
-        </template>
+    <RuiButton
+      v-for="blockchainCategory in blockchainCategories"
+      :key="blockchainCategory.path"
+      variant="list"
+      @click="addBlockchainAccount(blockchainCategory.path)"
+    >
+      <template #prepend>
+        <RuiIcon :name="blockchainCategory.icon" />
+      </template>
 
-        {{ blockchainCategory.label }}
-      </RuiButton>
-    </div>
+      {{ blockchainCategory.label }}
+    </RuiButton>
   </RuiMenu>
 </template>

--- a/frontend/app/src/modules/history/events/HistoryEventAction.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventAction.vue
@@ -54,33 +54,31 @@ function onEditRule(): void {
           />
         </RuiButton>
       </template>
-      <div class="py-2">
-        <RuiButton
-          variant="list"
-          @click="onEditRule()"
-        >
-          <template #prepend>
-            <RuiIcon
-              class="text-rui-text-secondary"
-              name="lu-pencil"
-            />
-          </template>
-          {{ t('accounting_settings.rule.edit') }}
-        </RuiButton>
-        <RuiButton
-          v-if="canUnlink"
-          variant="list"
-          @click="emit('unlink')"
-        >
-          <template #prepend>
-            <RuiIcon
-              class="text-rui-text-secondary"
-              name="lu-unlink"
-            />
-          </template>
-          {{ t('transactions.events.actions.unlink') }}
-        </RuiButton>
-      </div>
+      <RuiButton
+        variant="list"
+        @click="onEditRule()"
+      >
+        <template #prepend>
+          <RuiIcon
+            class="text-rui-text-secondary"
+            name="lu-pencil"
+          />
+        </template>
+        {{ t('accounting_settings.rule.edit') }}
+      </RuiButton>
+      <RuiButton
+        v-if="canUnlink"
+        variant="list"
+        @click="emit('unlink')"
+      >
+        <template #prepend>
+          <RuiIcon
+            class="text-rui-text-secondary"
+            name="lu-unlink"
+          />
+        </template>
+        {{ t('transactions.events.actions.unlink') }}
+      </RuiButton>
     </RuiMenu>
   </div>
 </template>

--- a/frontend/app/src/modules/history/events/HistoryEventsAction.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsAction.vue
@@ -270,113 +270,107 @@ function confirmIgnoreDuplicate(): void {
           />
         </RuiButton>
       </template>
-      <div class="py-2">
-        <RuiButton
-          v-if="!hideAddAction(event)"
-          variant="list"
-          @click="addEvent(event)"
-        >
-          <template #prepend>
-            <RuiIcon name="lu-plus" />
-          </template>
-          {{ t('transactions.actions.add_event_here') }}
-        </RuiButton>
-        <RuiButton
-          variant="list"
-          @click="toggleIgnore(event)"
-        >
-          <template #prepend>
-            <RuiIcon :name="event.ignoredInAccounting ? 'lu-eye' : 'lu-eye-off'" />
-          </template>
-          {{ event.ignoredInAccounting ? t('transactions.unignore') : t('transactions.ignore') }}
-        </RuiButton>
-        <template v-if="blockEvent">
-          <RuiButton
-            variant="list"
-            :disabled="loading || ethBlockEventsDecoding"
-            @click="redecode(blockEvent)"
-          >
-            <template #prepend>
-              <RuiIcon name="lu-rotate-ccw" />
-            </template>
-            {{ t('transactions.actions.redecode_events') }}
-          </RuiButton>
+      <RuiButton
+        v-if="!hideAddAction(event)"
+        variant="list"
+        @click="addEvent(event)"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-plus" />
         </template>
-        <template v-else-if="eventWithDecoding">
-          <RuiButton
-            variant="list"
-            :class="{ '!py-2': decodableEvmEvent }"
-            :disabled="loading || txEventsDecoding"
-            @click="redecode(eventWithDecoding)"
-          >
-            <template #prepend>
-              <RuiIcon
-                name="lu-rotate-ccw"
-                class="min-w-[1.375rem]"
-                size="20"
-              />
-            </template>
-            {{ t('transactions.actions.redecode_events') }}
-            <template #append>
-              <RuiTooltip
-                v-if="decodableEvmEvent"
-                :popper="{ placement: 'top', scroll: false, resize: false }"
-              >
-                <template #activator>
-                  <RuiButton
-                    icon
-                    variant="text"
-                    size="sm"
-                    class="!p-2"
-                    :disabled="loading || txEventsDecoding"
-                    @click.stop="redecodeWithOptions(decodableEvmEvent)"
-                  >
-                    <RuiIcon
-                      name="lu-settings-2"
-                      size="16"
-                    />
-                  </RuiButton>
-                </template>
-                {{ t('transactions.actions.redecode_with_options') }}
-              </RuiTooltip>
-            </template>
-          </RuiButton>
+        {{ t('transactions.actions.add_event_here') }}
+      </RuiButton>
+      <RuiButton
+        variant="list"
+        @click="toggleIgnore(event)"
+      >
+        <template #prepend>
+          <RuiIcon :name="event.ignoredInAccounting ? 'lu-eye' : 'lu-eye-off'" />
         </template>
-        <RuiButton
-          v-if="eventWithTxRef"
-          variant="list"
-          color="error"
-          :disabled="loading"
-          @click="deleteTxAndEvents(eventWithTxRef)"
-        >
-          <template #prepend>
-            <RuiIcon name="lu-trash-2" />
-          </template>
-          {{ t('transactions.actions.delete_transaction') }}
-        </RuiButton>
-        <RuiButton
-          v-else-if="canDeleteEvents"
-          variant="list"
-          color="error"
-          :disabled="loading"
-          @click="deleteEvents()"
-        >
-          <template #prepend>
-            <RuiIcon name="lu-trash-2" />
-          </template>
-          {{ t('transactions.actions.delete_event') }}
-        </RuiButton>
-        <RuiDivider class="my-2" />
+        {{ event.ignoredInAccounting ? t('transactions.unignore') : t('transactions.ignore') }}
+      </RuiButton>
+      <template v-if="blockEvent">
         <RuiButton
           variant="list"
-          @click="openReportDialog()"
+          :disabled="loading || ethBlockEventsDecoding"
+          @click="redecode(blockEvent)"
         >
           <template #prepend>
-            <RuiIcon name="lu-bug" />
+            <RuiIcon name="lu-rotate-ccw" />
           </template>
-          {{ t('actions.history_events.report_issue.action') }}
+          {{ t('transactions.actions.redecode_events') }}
         </RuiButton>
-      </div>
+      </template>
+      <template v-else-if="eventWithDecoding">
+        <RuiButton
+          variant="list"
+          :class="{ '!py-2': decodableEvmEvent }"
+          :disabled="loading || txEventsDecoding"
+          @click="redecode(eventWithDecoding)"
+        >
+          <template #prepend>
+            <RuiIcon name="lu-rotate-ccw" />
+          </template>
+          {{ t('transactions.actions.redecode_events') }}
+          <template #append>
+            <RuiTooltip
+              v-if="decodableEvmEvent"
+              :popper="{ placement: 'top', scroll: false, resize: false }"
+            >
+              <template #activator>
+                <RuiButton
+                  icon
+                  variant="text"
+                  size="sm"
+                  class="!p-2"
+                  :disabled="loading || txEventsDecoding"
+                  @click.stop="redecodeWithOptions(decodableEvmEvent)"
+                >
+                  <RuiIcon
+                    name="lu-settings-2"
+                    size="16"
+                  />
+                </RuiButton>
+              </template>
+              {{ t('transactions.actions.redecode_with_options') }}
+            </RuiTooltip>
+          </template>
+        </RuiButton>
+      </template>
+      <RuiButton
+        v-if="eventWithTxRef"
+        variant="list"
+        color="error"
+        :disabled="loading"
+        @click="deleteTxAndEvents(eventWithTxRef)"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-trash-2" />
+        </template>
+        {{ t('transactions.actions.delete_transaction') }}
+      </RuiButton>
+      <RuiButton
+        v-else-if="canDeleteEvents"
+        variant="list"
+        color="error"
+        :disabled="loading"
+        @click="deleteEvents()"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-trash-2" />
+        </template>
+        {{ t('transactions.actions.delete_event') }}
+      </RuiButton>
+      <RuiDivider class="my-2" />
+      <RuiButton
+        variant="list"
+        @click="openReportDialog()"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-bug" />
+        </template>
+        {{ t('actions.history_events.report_issue.action') }}
+      </RuiButton>
     </RuiMenu>
   </div>
 </template>

--- a/frontend/app/src/modules/history/events/HistoryEventsViewButtons.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsViewButtons.vue
@@ -132,100 +132,98 @@ function checkInternalConflicts(): void {
       </RuiBadge>
     </template>
 
-    <div class="py-2">
-      <template v-if="includeEvmEvents">
-        <RuiButton
-          variant="list"
-          @click="emit('show:dialog', { type: DIALOG_TYPES.DECODING_STATUS })"
-        >
-          <template #prepend>
-            <RuiBadge
-              :model-value="loading"
-              color="primary"
-              dot
-              placement="top"
-              offset-y="4"
-              offset-x="-4"
-            >
-              <RuiIcon name="lu-scroll-text" />
-            </RuiBadge>
-          </template>
-
-          {{ t('transactions.events_decoding.title') }}
-        </RuiButton>
-      </template>
-
+    <template v-if="includeEvmEvents">
       <RuiButton
         variant="list"
-        data-cy="history-events__add_by_tx_hash"
-        :disabled="loading"
-        @click="emit('show:dialog', { type: DIALOG_TYPES.ADD_TRANSACTION })"
-      >
-        <template #prepend>
-          <RuiIcon name="lu-plus" />
-        </template>
-        {{ t('transactions.dialog.add_tx') }}
-      </RuiButton>
-
-      <RuiButton
-        variant="list"
-        data-cy="history-events__repulling-transactions"
-        :disabled="loading"
-        @click="emit('show:dialog', { type: DIALOG_TYPES.REPULLING_TRANSACTION })"
-      >
-        <template #prepend>
-          <RuiIcon name="lu-clock-arrow-up" />
-        </template>
-        {{ t('transactions.repulling.action') }}
-      </RuiButton>
-
-      <RuiDivider class="my-1" />
-
-      <RuiButton
-        variant="list"
-        :disabled="processing || !!checkingType"
-        :loading="checkingType === 'unmatched'"
-        :color="noIssuesFeedback === 'unmatched' ? 'success' : undefined"
-        @click.stop="checkUnmatched()"
-      >
-        <template #prepend>
-          <RuiIcon :name="noIssuesFeedback === 'unmatched' ? 'lu-circle-check' : 'lu-git-compare-arrows'" />
-        </template>
-        {{ noIssuesFeedback === 'unmatched' ? t('transactions.alerts.no_issues_found') : t('transactions.alerts.check_unmatched_movements') }}
-      </RuiButton>
-
-      <RuiButton
-        variant="list"
-        :disabled="processing || !!checkingType"
-        :loading="checkingType === 'duplicates'"
-        :color="noIssuesFeedback === 'duplicates' ? 'success' : undefined"
-        @click.stop="checkDuplicates()"
-      >
-        <template #prepend>
-          <RuiIcon :name="noIssuesFeedback === 'duplicates' ? 'lu-circle-check' : 'lu-copy'" />
-        </template>
-        {{ noIssuesFeedback === 'duplicates' ? t('transactions.alerts.no_issues_found') : t('transactions.alerts.check_duplicate_events') }}
-      </RuiButton>
-
-      <RuiButton
-        variant="list"
-        :disabled="processing || !!checkingType"
-        @click.stop="checkInternalConflicts()"
+        @click="emit('show:dialog', { type: DIALOG_TYPES.DECODING_STATUS })"
       >
         <template #prepend>
           <RuiBadge
-            :model-value="internalConflictsCount > 0"
-            color="warning"
+            :model-value="loading"
+            color="primary"
             dot
             placement="top"
             offset-y="4"
             offset-x="-4"
           >
-            <RuiIcon name="lu-git-merge" />
+            <RuiIcon name="lu-scroll-text" />
           </RuiBadge>
         </template>
-        {{ t('transactions.alerts.check_internal_conflicts') }}
+
+        {{ t('transactions.events_decoding.title') }}
       </RuiButton>
-    </div>
+    </template>
+
+    <RuiButton
+      variant="list"
+      data-cy="history-events__add_by_tx_hash"
+      :disabled="loading"
+      @click="emit('show:dialog', { type: DIALOG_TYPES.ADD_TRANSACTION })"
+    >
+      <template #prepend>
+        <RuiIcon name="lu-plus" />
+      </template>
+      {{ t('transactions.dialog.add_tx') }}
+    </RuiButton>
+
+    <RuiButton
+      variant="list"
+      data-cy="history-events__repulling-transactions"
+      :disabled="loading"
+      @click="emit('show:dialog', { type: DIALOG_TYPES.REPULLING_TRANSACTION })"
+    >
+      <template #prepend>
+        <RuiIcon name="lu-clock-arrow-up" />
+      </template>
+      {{ t('transactions.repulling.action') }}
+    </RuiButton>
+
+    <RuiDivider class="my-1" />
+
+    <RuiButton
+      variant="list"
+      :disabled="processing || !!checkingType"
+      :loading="checkingType === 'unmatched'"
+      :color="noIssuesFeedback === 'unmatched' ? 'success' : undefined"
+      @click.stop="checkUnmatched()"
+    >
+      <template #prepend>
+        <RuiIcon :name="noIssuesFeedback === 'unmatched' ? 'lu-circle-check' : 'lu-git-compare-arrows'" />
+      </template>
+      {{ noIssuesFeedback === 'unmatched' ? t('transactions.alerts.no_issues_found') : t('transactions.alerts.check_unmatched_movements') }}
+    </RuiButton>
+
+    <RuiButton
+      variant="list"
+      :disabled="processing || !!checkingType"
+      :loading="checkingType === 'duplicates'"
+      :color="noIssuesFeedback === 'duplicates' ? 'success' : undefined"
+      @click.stop="checkDuplicates()"
+    >
+      <template #prepend>
+        <RuiIcon :name="noIssuesFeedback === 'duplicates' ? 'lu-circle-check' : 'lu-copy'" />
+      </template>
+      {{ noIssuesFeedback === 'duplicates' ? t('transactions.alerts.no_issues_found') : t('transactions.alerts.check_duplicate_events') }}
+    </RuiButton>
+
+    <RuiButton
+      variant="list"
+      :disabled="processing || !!checkingType"
+      @click.stop="checkInternalConflicts()"
+    >
+      <template #prepend>
+        <RuiBadge
+          :model-value="internalConflictsCount > 0"
+          color="warning"
+          dot
+          placement="top"
+          offset-y="4"
+          offset-x="-4"
+        >
+          <RuiIcon name="lu-git-merge" />
+        </RuiBadge>
+      </template>
+      {{ t('transactions.alerts.check_internal_conflicts') }}
+    </RuiButton>
   </RuiMenu>
 </template>

--- a/frontend/app/src/modules/reports/ReportGenerator.vue
+++ b/frontend/app/src/modules/reports/ReportGenerator.vue
@@ -180,26 +180,24 @@ onMounted(async () => {
                 {{ t('profit_loss_reports.debug.title') }}
               </RuiButton>
             </template>
-            <div class="py-2">
-              <RuiButton
-                variant="list"
-                @click="exportReportData()"
-              >
-                <template #prepend>
-                  <RuiIcon name="lu-file-down" />
-                </template>
-                {{ t('profit_loss_reports.debug.export_data') }}
-              </RuiButton>
-              <RuiButton
-                variant="list"
-                @click="importReportData()"
-              >
-                <template #prepend>
-                  <RuiIcon name="lu-file-up" />
-                </template>
-                {{ t('profit_loss_reports.debug.import_data') }}
-              </RuiButton>
-            </div>
+            <RuiButton
+              variant="list"
+              @click="exportReportData()"
+            >
+              <template #prepend>
+                <RuiIcon name="lu-file-down" />
+              </template>
+              {{ t('profit_loss_reports.debug.export_data') }}
+            </RuiButton>
+            <RuiButton
+              variant="list"
+              @click="importReportData()"
+            >
+              <template #prepend>
+                <RuiIcon name="lu-file-up" />
+              </template>
+              {{ t('profit_loss_reports.debug.import_data') }}
+            </RuiButton>
           </RuiMenu>
         </div>
       </div>

--- a/frontend/app/src/modules/reports/ReportMissingAcquisitions.vue
+++ b/frontend/app/src/modules/reports/ReportMissingAcquisitions.vue
@@ -213,17 +213,15 @@ async function showInHistoryEvent(identifier: number) {
                 />
               </RuiButton>
             </template>
-            <div class="py-2">
-              <RuiButton
-                variant="list"
-                @click="ignoreAsset(row.asset)"
-              >
-                <template #prepend>
-                  <RuiIcon name="lu-eye-off" />
-                  {{ t('assets.action.ignore') }}
-                </template>
-              </RuiButton>
-            </div>
+            <RuiButton
+              variant="list"
+              @click="ignoreAsset(row.asset)"
+            >
+              <template #prepend>
+                <RuiIcon name="lu-eye-off" />
+                {{ t('assets.action.ignore') }}
+              </template>
+            </RuiButton>
           </RuiMenu>
 
           <RuiTooltip

--- a/frontend/app/src/modules/reports/ReportPeriodSelector.vue
+++ b/frontend/app/src/modules/reports/ReportPeriodSelector.vue
@@ -201,7 +201,7 @@ const quarterModel = computed({
             </RuiButton>
           </template>
 
-          <div class="flex flex-col py-2">
+          <div class="flex flex-col">
             <RuiButton
               v-for="period in olderPeriods"
               :key="period"

--- a/frontend/app/src/modules/reports/ReportProfitLossEventAction.vue
+++ b/frontend/app/src/modules/reports/ReportProfitLossEventAction.vue
@@ -102,17 +102,15 @@ async function updatePrice() {
           <RuiIcon name="lu-ellipsis-vertical" />
         </RuiButton>
       </template>
-      <div class="py-2">
-        <RuiButton
-          variant="list"
-          @click="openEditHistoricPriceDialog()"
-        >
-          <template #prepend>
-            <RuiIcon name="lu-pencil-line" />
-          </template>
-          {{ t('profit_loss_events.edit_historic_price') }}
-        </RuiButton>
-      </div>
+      <RuiButton
+        variant="list"
+        @click="openEditHistoricPriceDialog()"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-pencil-line" />
+        </template>
+        {{ t('profit_loss_events.edit_historic_price') }}
+      </RuiButton>
     </RuiMenu>
 
     <RuiDialog

--- a/frontend/app/src/modules/reports/ReportsTableMoreAction.vue
+++ b/frontend/app/src/modules/reports/ReportsTableMoreAction.vue
@@ -31,25 +31,23 @@ const { t } = useI18n({ useScope: 'global' });
         />
       </RuiButton>
     </template>
-    <div class="py-2">
-      <ExportReportCsv
-        :report-id="reportId"
-        list
-      />
-      <RuiButton
-        variant="list"
-        color="error"
-        @click="emit('delete')"
-      >
-        <template #prepend>
-          <RuiIcon
-            size="20"
-            name="lu-trash-2"
-          />
-        </template>
+    <ExportReportCsv
+      :report-id="reportId"
+      list
+    />
+    <RuiButton
+      variant="list"
+      color="error"
+      @click="emit('delete')"
+    >
+      <template #prepend>
+        <RuiIcon
+          size="20"
+          name="lu-trash-2"
+        />
+      </template>
 
-        {{ t('reports_table.delete') }}
-      </RuiButton>
-    </div>
+      {{ t('reports_table.delete') }}
+    </RuiButton>
   </RuiMenu>
 </template>

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleSetting.vue
@@ -361,28 +361,26 @@ const importFileDialog = ref<boolean>(false);
               />
             </RuiButton>
           </template>
-          <div class="py-2">
-            <RuiButton
-              variant="list"
-              :loading="exportFileLoading"
-              @click="exportJSON()"
-            >
-              <template #prepend>
-                <RuiIcon name="lu-file-down" />
-              </template>
-              {{ t('accounting_settings.rule.export') }}
-            </RuiButton>
-            <RuiButton
-              variant="list"
-              :loading="importFileLoading"
-              @click="importFileDialog = true"
-            >
-              <template #prepend>
-                <RuiIcon name="lu-file-up" />
-              </template>
-              {{ t('accounting_settings.rule.import') }}
-            </RuiButton>
-          </div>
+          <RuiButton
+            variant="list"
+            :loading="exportFileLoading"
+            @click="exportJSON()"
+          >
+            <template #prepend>
+              <RuiIcon name="lu-file-down" />
+            </template>
+            {{ t('accounting_settings.rule.export') }}
+          </RuiButton>
+          <RuiButton
+            variant="list"
+            :loading="importFileLoading"
+            @click="importFileDialog = true"
+          >
+            <template #prepend>
+              <RuiIcon name="lu-file-up" />
+            </template>
+            {{ t('accounting_settings.rule.import') }}
+          </RuiButton>
         </RuiMenu>
       </div>
     </div>

--- a/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
+++ b/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
@@ -202,27 +202,25 @@ onMounted(() => {
                     <RuiIcon name="lu-chevron-down" />
                   </RuiButton>
                 </template>
-                <div class="py-2">
-                  <RuiButton
-                    variant="list"
-                    @click="copyEmail()"
-                  >
-                    <template #prepend>
-                      <RuiIcon name="lu-copy" />
-                    </template>
-                    {{ t('help_sidebar.report_issue.dialog.submit_options.copy_email', { email: SUPPORT_EMAIL }) }}
-                  </RuiButton>
-                  <RuiButton
-                    variant="list"
-                    :disabled="!isFormValid"
-                    @click="openGmail()"
-                  >
-                    <template #prepend>
-                      <RuiIcon name="lu-mail" />
-                    </template>
-                    {{ t('help_sidebar.report_issue.dialog.submit_options.open_gmail') }}
-                  </RuiButton>
-                </div>
+                <RuiButton
+                  variant="list"
+                  @click="copyEmail()"
+                >
+                  <template #prepend>
+                    <RuiIcon name="lu-copy" />
+                  </template>
+                  {{ t('help_sidebar.report_issue.dialog.submit_options.copy_email', { email: SUPPORT_EMAIL }) }}
+                </RuiButton>
+                <RuiButton
+                  variant="list"
+                  :disabled="!isFormValid"
+                  @click="openGmail()"
+                >
+                  <template #prepend>
+                    <RuiIcon name="lu-mail" />
+                  </template>
+                  {{ t('help_sidebar.report_issue.dialog.submit_options.open_gmail') }}
+                </RuiButton>
               </RuiMenu>
             </div>
           </div>

--- a/frontend/app/src/modules/shell/components/UserDropdown.vue
+++ b/frontend/app/src/modules/shell/components/UserDropdown.vue
@@ -64,10 +64,7 @@ const { isDark } = useRotkiTheme();
           <RuiIcon name="lu-circle-user" />
         </MenuTooltipButton>
       </template>
-      <div
-        data-cy="user-dropdown"
-        class="py-2"
-      >
+      <div data-cy="user-dropdown">
         <div class="py-3 flex flex-col items-center gap-1">
           <div
             data-cy="username"


### PR DESCRIPTION
## Summary
- @rotki/ui-library 2.16.x added `py-2` to `RuiMenu`'s content container as part of the Material Design 3 spacing pass. Consumer-side `<div class="py-2">` wrappers around menu content now stack on top of the library's gutter, visibly doubling the vertical padding (e.g., 16 px above "morpho" + 16 px below "Logout" in the user dropdown).
- This PR removes the redundant `py-2` consumer wrappers from 18 `RuiMenu` callsites. Where the wrapper carried no other state, it's unwrapped entirely (children dedented). Where it carries other state, only the `py-2` class is stripped:
  - `UserDropdown.vue` keeps the wrapper for `data-cy="user-dropdown"`.
  - `ManagedAssetIgnoreSwitch.vue` keeps the wrapper for `text-rui-text-secondary`.
  - `ReportPeriodSelector.vue` keeps the wrapper for `flex flex-col`.
- Also drops nonstandard `class="min-w-[1.375rem]" size="20"` overrides on the evm-event redecode icon in `HistoryEventsAction.vue`, so every prepend icon in that menu inherits the same `--rui-icon-size` from the parent button instead of one row being off-aspect.

Out of scope, tracked separately: mixed `p-N` consumer wrappers (where the wrapper provides intentional horizontal padding too) — those need a per-site visual call, not a blanket strip. And the `lu-eye-off` "renders small" anomaly in the same menu — looks like an icon-data issue in the library, will dig in there.

## Test plan
- [ ] Open the user dropdown — gap above the username and below "Logout" should look like a single 8 px gutter, not stacked 16 + 16.
- [ ] Open menus on: any per-event "..." menu (HistoryEventsAction), the Reports table more-action menu, the dashboard "Visible columns" selector, the Settings reset confirm menu, the assets restore-DB dropdown.
- [ ] Confirm the redecode-events row in `HistoryEventsAction.vue` lines up with siblings (icon size, row height).
- [ ] `pnpm typecheck` clean.