### PR TITLE
Clean and protect from incorrect cc prices

### DIFF
--- a/rotkehlchen/constants/prices.py
+++ b/rotkehlchen/constants/prices.py
@@ -1,4 +1,8 @@
+from typing import Final
+
 from rotkehlchen.constants import ZERO
-from rotkehlchen.types import Price
+from rotkehlchen.types import Price, Timestamp
 
 ZERO_PRICE = Price(ZERO)
+BITCOIN_GENESIS_BLOCK_TS: Final = Timestamp(1231006505)  # 2009-01-03 18:15:05 UTC
+CRYPTOCOMPARE_INVALID_PRICE_TS_CUTOFF: Final = Timestamp(946684800)  # 2000-01-01 00:00:00 UTC

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -37,7 +37,7 @@ from rotkehlchen.constants.assets import (
     A_YFII,
     A_ZRX,
 )
-from rotkehlchen.constants.prices import ZERO_PRICE
+from rotkehlchen.constants.prices import CRYPTOCOMPARE_INVALID_PRICE_TS_CUTOFF, ZERO_PRICE
 from rotkehlchen.constants.resolver import strethaddress_to_identifier
 from rotkehlchen.constants.timing import HOUR_IN_SECONDS, WEEK_IN_SECONDS
 from rotkehlchen.db.settings import CachedSettings
@@ -52,6 +52,7 @@ from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
 from rotkehlchen.interfaces import HistoricalPriceOracleWithCoinListInterface
 from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.serialization.deserialize import deserialize_timestamp
 from rotkehlchen.types import ExternalService, Price, Timestamp
 from rotkehlchen.utils.misc import set_user_agent, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
@@ -803,6 +804,13 @@ class Cryptocompare(
         prices = []
         for entry in calculated_history:
             try:
+
+                if (
+                    timestamp := deserialize_timestamp(entry['TIMESTAMP'])
+                ) < CRYPTOCOMPARE_INVALID_PRICE_TS_CUTOFF:
+                    log.warning(f'Skipping cc entry with unexpected timestamp {entry=}')
+                    continue
+
                 price = Price((deserialize_price(entry['HIGH']) + deserialize_price(entry['LOW'])) / 2)  # noqa: E501
                 if price == ZERO_PRICE:
                     continue  # don't write zero prices
@@ -810,7 +818,7 @@ class Cryptocompare(
                     from_asset=from_asset,
                     to_asset=to_asset,
                     source=HistoricalPriceOracle.CRYPTOCOMPARE,
-                    timestamp=Timestamp(entry['TIMESTAMP']),
+                    timestamp=timestamp,
                     price=price,
                 ))
             except (DeserializationError, KeyError) as e:

--- a/rotkehlchen/globaldb/upgrades/v15_v16.py
+++ b/rotkehlchen/globaldb/upgrades/v15_v16.py
@@ -1,6 +1,11 @@
 import logging
 from typing import TYPE_CHECKING
 
+from rotkehlchen.constants.prices import (
+    BITCOIN_GENESIS_BLOCK_TS,
+    CRYPTOCOMPARE_INVALID_PRICE_TS_CUTOFF,
+)
+from rotkehlchen.history.types import HistoricalPriceOracle
 from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
 from rotkehlchen.utils.progress import perform_globaldb_upgrade_steps, progress_step
 
@@ -26,5 +31,45 @@ def migrate_to_v16(
             'CREATE INDEX IF NOT EXISTS idx_price_history_timestamp_desc_order '
             'ON price_history (timestamp DESC, from_asset, to_asset, source_type);',
         )
+
+    @progress_step('Remove invalid old Cryptocompare prices.')
+    def _remove_invalid_old_cryptocompare_prices(write_cursor: 'DBCursor') -> None:
+        """
+        With the introduction of the new price handling we identified some incorrect
+        entries in the price cache coming from Cryptocompare. We checked that these
+        entries are old, dating back to at least 2024, and they have not reappeared
+        since.
+
+        Since rotki accepted any timestamp returned by Cryptocompare, the most likely
+        source is invalid price data from the hourly candle endpoint used by the
+        background cache task.
+
+        This step uses an old enough arbitrary cutoff date to find affected assets, then
+        removes Cryptocompare prices older than the asset start timestamp. If an asset has
+        no start timestamp, the Bitcoin genesis block timestamp is used as the crypto
+        price floor.
+        """
+        cryptocompare_source = HistoricalPriceOracle.CRYPTOCOMPARE.serialize_for_db()
+        deleted_rows = 0
+        affected_assets = write_cursor.execute(
+            'SELECT DISTINCT P.from_asset, C.started FROM price_history AS P '
+            'LEFT JOIN common_asset_details AS C ON C.identifier=P.from_asset '
+            'WHERE P.source_type=? AND P.timestamp<?',
+            (cryptocompare_source, CRYPTOCOMPARE_INVALID_PRICE_TS_CUTOFF),
+        ).fetchall()
+        if len(affected_assets) != 0:
+            write_cursor.executemany(
+                'DELETE FROM price_history WHERE source_type=? AND from_asset=? AND timestamp<?',
+                [
+                    (
+                        cryptocompare_source,
+                        asset_id,
+                        started if started is not None else BITCOIN_GENESIS_BLOCK_TS,
+                    ) for asset_id, started in affected_assets
+                ],
+            )
+            deleted_rows = write_cursor.rowcount
+
+        log.info(f'Removed {deleted_rows} invalid old Cryptocompare price entries.')
 
     perform_globaldb_upgrade_steps(connection, progress_handler)

--- a/rotkehlchen/tests/unit/globaldb/test_upgrades.py
+++ b/rotkehlchen/tests/unit/globaldb/test_upgrades.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import shutil
 from contextlib import ExitStack
 from pathlib import Path
@@ -12,8 +13,12 @@ from rsqlite import IntegrityError
 
 from rotkehlchen.assets.types import AssetType
 from rotkehlchen.chain.ethereum.utils import should_update_protocol_cache
-from rotkehlchen.constants.assets import A_PAX, A_USDT
+from rotkehlchen.constants.assets import A_PAX, A_SOL, A_USD, A_USDT
 from rotkehlchen.constants.misc import GLOBALDB_NAME, GLOBALDIR_NAME
+from rotkehlchen.constants.prices import (
+    BITCOIN_GENESIS_BLOCK_TS,
+    CRYPTOCOMPARE_INVALID_PRICE_TS_CUTOFF,
+)
 from rotkehlchen.db.drivers.gevent import DBConnection, DBConnectionType
 from rotkehlchen.db.utils import table_exists
 from rotkehlchen.errors.misc import DBUpgradeError
@@ -40,6 +45,7 @@ from rotkehlchen.globaldb.upgrades.v3_v4 import (
 )
 from rotkehlchen.globaldb.upgrades.v5_v6 import V5_V6_UPGRADE_UNIQUE_CACHE_KEYS
 from rotkehlchen.globaldb.utils import GLOBAL_DB_VERSION
+from rotkehlchen.history.types import HistoricalPriceOracle
 from rotkehlchen.tests.conftest import TestEnvironment, requires_env
 from rotkehlchen.tests.fixtures.globaldb import create_globaldb
 from rotkehlchen.tests.utils.database import column_exists, index_exists
@@ -1664,12 +1670,36 @@ def test_upgrade_v14_v15_post_asset_upgrade_missing_velo(
 @pytest.mark.parametrize('target_globaldb_version', [14])
 @pytest.mark.parametrize('reload_user_assets', [False])
 @pytest.mark.parametrize('use_in_memory_globaldb', [False])
-def test_upgrade_v15_v16_creates_price_history_timestamp_order_index(
+def test_upgrade_v15_v16(
         globaldb: GlobalDBHandler,
         messages_aggregator: MessagesAggregator,
+        caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the global DB upgrade path that creates the price history timestamp-order index."""
     assert globaldb.get_setting_value('version', 0) == 14
+    caplog.set_level(logging.INFO)
+    cryptocompare_source_type = HistoricalPriceOracle.CRYPTOCOMPARE.serialize_for_db()
+    aura_identifier = 'eip155:1/erc20:0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF'
+    with globaldb.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT source_type, timestamp, price FROM price_history WHERE from_asset=? AND '
+            'to_asset=? AND timestamp IN (?, ?) ORDER BY source_type, timestamp',
+            (A_SOL.identifier, A_USD.identifier, 4381200, CRYPTOCOMPARE_INVALID_PRICE_TS_CUTOFF),
+        ).fetchall() == [
+            ('B', 4381200, '176.47'),
+            (cryptocompare_source_type, 4381200, '176.47'),
+            (cryptocompare_source_type, CRYPTOCOMPARE_INVALID_PRICE_TS_CUTOFF, '0.95'),
+        ]
+        assert cursor.execute(
+            'SELECT timestamp, price FROM price_history WHERE from_asset=? AND to_asset=? '
+            'AND source_type=? ORDER BY timestamp',
+            (aura_identifier, A_USD.identifier, cryptocompare_source_type),
+        ).fetchall() == [(4381200, '1.1'), (1262304000, '2.2')]
+        assert cursor.execute(
+            'SELECT timestamp, price FROM price_history WHERE from_asset=? AND to_asset=? '
+            'AND source_type=? ORDER BY timestamp',
+            ('AUD', A_USD.identifier, cryptocompare_source_type),
+        ).fetchall() == [(4381200, '0.6'), (1262304000, '0.7')]
 
     with ExitStack() as stack:
         patch_for_globaldb_upgrade_to(stack, 16)
@@ -1681,8 +1711,32 @@ def test_upgrade_v15_v16_creates_price_history_timestamp_order_index(
         )
 
     assert globaldb.get_setting_value('version', 0) == 16
+    assert 'Removed 5 invalid old Cryptocompare price entries.' in caplog.text
     with globaldb.conn.read_ctx() as cursor:
         assert index_exists(cursor=cursor, name='idx_price_history_timestamp_desc_order') is True
+        assert cursor.execute(
+            'SELECT source_type, timestamp, price FROM price_history WHERE from_asset=? AND '
+            'to_asset=? AND timestamp IN (?, ?) ORDER BY source_type, timestamp',
+            (A_SOL.identifier, A_USD.identifier, 4381200, CRYPTOCOMPARE_INVALID_PRICE_TS_CUTOFF),
+        ).fetchall() == [
+            ('B', 4381200, '176.47'),
+        ]
+        assert cursor.execute(
+            'SELECT timestamp, price FROM price_history WHERE from_asset=? AND to_asset=? '
+            'AND source_type=? ORDER BY timestamp',
+            (aura_identifier, A_USD.identifier, cryptocompare_source_type),
+        ).fetchall() == []
+        assert cursor.execute(
+            'SELECT timestamp, price FROM price_history WHERE from_asset=? AND to_asset=? '
+            'AND source_type=? AND timestamp IN (?, ?) ORDER BY timestamp',
+            (
+                'AUD',
+                A_USD.identifier,
+                cryptocompare_source_type,
+                BITCOIN_GENESIS_BLOCK_TS,
+                1262304000,
+            ),
+        ).fetchall() == [(1262304000, '0.7')]
 
 
 @pytest.mark.parametrize('custom_globaldb', ['v2_global.db'])


### PR DESCRIPTION
With the introduction of the new price handling we identified some incorrect
entries in the price cache coming from Cryptocompare. We checked that these
entries are old, dating back to at least 2024, and they have not reappeared
since.

Since rotki accepted any timestamp returned by Cryptocompare, the most likely
source is invalid price data from the hourly candle endpoint used by the
background cache task.