### PR TITLE
fix(frontend): align DbActivityProgress circles and refine typography

### DIFF
--- a/frontend/app/src/modules/auth/upgrade/DbActivityProgress.vue
+++ b/frontend/app/src/modules/auth/upgrade/DbActivityProgress.vue
@@ -33,49 +33,47 @@ const multipleUpgrades = computed<boolean>(() => {
     class="max-w-[29rem] mx-auto !bg-transparent"
   >
     <template #header>
-      <span v-if="dataMigration">{{ t('login.migrating_data.title') }} </span>
-      <span v-else> {{ t('login.upgrading_db.title') }}</span>
+      <span class="text-h6">
+        {{ dataMigration ? t('login.migrating_data.title') : t('login.upgrading_db.title') }}
+      </span>
     </template>
-    <div class="flex space-x-4 break-all">
-      <div class="flex flex-col">
-        <div class="relative inline-flex rotate-90">
-          <RuiProgress
-            :value="progress.percentage"
-            color="primary"
-            size="45"
-            circular
-            :variant="progress.totalSteps === 0 ? 'indeterminate' : 'determinate'"
-          />
-          <RuiProgress
-            v-if="multipleUpgrades"
-            :value="progress.totalPercentage"
-            class="top-[0.40625rem] left-[0.40625rem] absolute"
-            color="primary"
-            circular
-          />
-        </div>
+    <div class="flex items-start gap-4">
+      <div class="relative inline-flex rotate-90 size-[45px] shrink-0">
+        <RuiProgress
+          :value="progress.percentage"
+          color="primary"
+          size="45"
+          circular
+          :variant="progress.totalSteps === 0 ? 'indeterminate' : 'determinate'"
+        />
+        <RuiProgress
+          v-if="multipleUpgrades"
+          :value="progress.totalPercentage"
+          class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+          color="primary"
+          size="32"
+          circular
+        />
       </div>
-      <div class="text-body-1">
+      <div class="min-w-0 flex-1">
         <DefineProgress #default="{ updateProgress, warning, current }">
-          <div>
+          <div class="text-body-1 font-medium break-words">
             {{ warning }}
           </div>
           <RuiDivider class="my-2" />
           <!-- hide the progress message when the reset signal is received from the backend -->
           <div
             v-if="updateProgress.totalSteps > 0"
-            class="break-words"
+            class="text-body-2 text-rui-text-secondary break-words"
           >
             {{ current }}
           </div>
-          <ul
+          <p
             v-if="updateProgress.description"
-            class="-ml-2 mt-2 list-disc"
+            class="text-caption text-rui-text-secondary mt-2 break-words"
           >
-            <li class="break-words">
-              {{ updateProgress.description }}
-            </li>
-          </ul>
+            {{ updateProgress.description }}
+          </p>
         </DefineProgress>
         <ReuseProgress
           v-if="!dataMigration"

--- a/frontend/app/tests/e2e/helpers/utils.ts
+++ b/frontend/app/tests/e2e/helpers/utils.ts
@@ -28,7 +28,11 @@ export async function selectAsset(page: Page, element: string, value: string, id
   await page.locator(`${element} [data-id="activator"]`).click();
   await page.locator(`${element} input`).fill(value);
   const identifier = getValidSelectorFromEvmAddress((id ?? value).toLocaleLowerCase());
-  await page.locator(`#asset-${identifier}`).click();
+  const option = page.locator(`#asset-${identifier}`);
+  await option.click();
+  // Wait for the dropdown menu to close so subsequent activator clicks
+  // are not intercepted by the still-visible menu overlay.
+  await option.waitFor({ state: 'hidden', timeout: TIMEOUT_MEDIUM });
 }
 
 /**

--- a/frontend/app/tests/e2e/pages/history-events-page.ts
+++ b/frontend/app/tests/e2e/pages/history-events-page.ts
@@ -70,6 +70,11 @@ export class HistoryEventsPage {
     for (const digit of digits)
       await input.press(digit);
     await input.press('Tab');
+    // The datetime input opens a calendar popover on click; Tab does not
+    // always close it. Press Escape and wait for the popover to detach so
+    // the next form click is not intercepted by the calendar overlay.
+    await input.press('Escape');
+    await this.page.locator('[role=menu] h3').waitFor({ state: 'hidden', timeout: TIMEOUT_MEDIUM });
   }
 
   private async selectAutocompleteOption(dataCy: string, value: string): Promise<void> {
@@ -81,6 +86,9 @@ export class HistoryEventsPage {
     const option = menu.getByText(value, { exact: false }).first();
     await option.waitFor({ state: 'visible' });
     await option.click();
+    // Wait for the menu to close so the next activator click is not
+    // intercepted by the still-visible menu overlay.
+    await menu.waitFor({ state: 'hidden', timeout: TIMEOUT_MEDIUM });
   }
 
   private async selectLocation(location: string): Promise<void> {
@@ -323,7 +331,11 @@ export class HistoryEventsPage {
     await container.locator('[data-id=activator]').click();
     await container.locator('input').fill(value);
     const identifier = getValidSelectorFromEvmAddress((id ?? value).toLocaleLowerCase());
-    await this.page.locator(`#asset-${identifier}`).click();
+    const option = this.page.locator(`#asset-${identifier}`);
+    await option.click();
+    // Wait for the dropdown menu to close so subsequent activator clicks
+    // are not intercepted by the still-visible menu overlay.
+    await option.waitFor({ state: 'hidden', timeout: TIMEOUT_MEDIUM });
   }
 
   private async fillSubEventList(


### PR DESCRIPTION
## Summary
- The inner progress ring in the DB upgrade / data migration screen was no longer concentric with the outer one — the previous markup used fixed `0.40625rem` offsets that assumed a 32px inner inside a 45px outer, which broke when the default circular size changed. Now the wrapper has an explicit size and the inner ring is centered with `translate`.
- Refined the typography in the same component: header is now `text-h6`, body has a clear hierarchy (medium warning → muted body-2 current step → caption description), `break-all` replaced with `break-words`, and the single-item `<ul><li>` collapsed into a paragraph.
- Tightened the row layout: `gap-4`, `items-start`, `shrink-0` on the progress, `min-w-0 flex-1` on the text column so long strings actually break.

## Test plan
- [ ] Visual check on the login screen during a DB upgrade / data migration (single step + multi-step)
- [ ] CI green