### PR TITLE
refactor(frontend): reload cached balances after token detection

### DIFF
--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.spec.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.spec.ts
@@ -31,10 +31,10 @@ vi.mock('@/modules/core/common/use-supported-chains', () => ({
   }),
 }));
 
-const mockRefreshBlockchainBalances = vi.fn().mockResolvedValue(undefined);
+const mockFetchBlockchainBalances = vi.fn().mockResolvedValue(undefined);
 vi.mock('@/modules/balances/use-blockchain-balances', () => ({
   useBlockchainBalances: vi.fn().mockReturnValue({
-    refreshBlockchainBalances: mockRefreshBlockchainBalances,
+    fetchBlockchainBalances: mockFetchBlockchainBalances,
   }),
 }));
 
@@ -71,7 +71,7 @@ describe('useTokenDetectionOrchestrator', () => {
   });
 
   describe('detectTokens', () => {
-    it('should queue detection and refresh balances for a single chain', async () => {
+    it('should queue detection and reload cached balances for a single chain', async () => {
       const { useTokenDetectionOrchestrator } = await loadOrchestrator();
       const { detectTokens } = useTokenDetectionOrchestrator();
 
@@ -81,7 +81,7 @@ describe('useTokenDetectionOrchestrator', () => {
       expect(mockQueueTokenDetection).toHaveBeenCalledWith('eth', ['0xaddr1', '0xaddr2'], expect.any(Function));
       expect(mockFetchDetectedTokens).toHaveBeenCalledWith('eth', '0xaddr1');
       expect(mockFetchDetectedTokens).toHaveBeenCalledWith('eth', '0xaddr2');
-      expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({
+      expect(mockFetchBlockchainBalances).toHaveBeenCalledWith({
         blockchain: 'eth',
       });
     });
@@ -93,17 +93,7 @@ describe('useTokenDetectionOrchestrator', () => {
       await detectTokens(['eth', 'optimism'], ['0xaddr1']);
 
       expect(mockQueueTokenDetection).toHaveBeenCalledTimes(2);
-      expect(mockRefreshBlockchainBalances).toHaveBeenCalledTimes(2);
-    });
-
-    it('should skip balance refresh when option is false', async () => {
-      const { useTokenDetectionOrchestrator } = await loadOrchestrator();
-      const { detectTokens } = useTokenDetectionOrchestrator();
-
-      await detectTokens('eth', ['0xaddr1'], { refreshBalancesAfter: false });
-
-      expect(mockQueueTokenDetection).toHaveBeenCalledOnce();
-      expect(mockRefreshBlockchainBalances).not.toHaveBeenCalled();
+      expect(mockFetchBlockchainBalances).toHaveBeenCalledTimes(2);
     });
 
     it('should filter out addresses already being detected', async () => {
@@ -128,9 +118,9 @@ describe('useTokenDetectionOrchestrator', () => {
 
       await detectTokens('eth', ['0xaddr1']);
 
-      // No addresses left to queue, but balance refresh still happens
+      // No addresses left to queue, but cached balance reload still happens
       expect(mockQueueTokenDetection).not.toHaveBeenCalled();
-      expect(mockRefreshBlockchainBalances).toHaveBeenCalledOnce();
+      expect(mockFetchBlockchainBalances).toHaveBeenCalledOnce();
     });
   });
 
@@ -147,7 +137,7 @@ describe('useTokenDetectionOrchestrator', () => {
       await detectAllTokens();
 
       expect(mockQueueTokenDetection).toHaveBeenCalledTimes(2);
-      expect(mockRefreshBlockchainBalances).toHaveBeenCalledTimes(2);
+      expect(mockFetchBlockchainBalances).toHaveBeenCalledTimes(2);
     });
 
     it('should detect tokens only for specified chains', async () => {

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
@@ -11,13 +11,9 @@ import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { TaskType } from '@/modules/core/tasks/task-type';
 import { useTaskStore } from '@/modules/core/tasks/use-task-store';
 
-interface DetectOptions {
-  refreshBalancesAfter?: boolean;
-}
-
 interface UseTokenDetectionOrchestratorReturn {
-  detectTokens: (chain: string | string[], addresses: string[], options?: DetectOptions) => Promise<void>;
-  detectAllTokens: (chains?: string | string[], options?: DetectOptions) => Promise<void>;
+  detectTokens: (chain: string | string[], addresses: string[]) => Promise<void>;
+  detectAllTokens: (chains?: string | string[]) => Promise<void>;
   useIsDetecting: (chain: MaybeRefOrGetter<string | string[]>, address?: MaybeRefOrGetter<string | null>) => ComputedRef<boolean>;
 }
 
@@ -26,7 +22,7 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
   const { setMassDetecting } = useTokenDetectionStore();
   const { addresses } = useAccountAddresses();
   const { supportsTransactions, txEvmChains } = useSupportedChains();
-  const { refreshBlockchainBalances } = useBlockchainBalances();
+  const { fetchBlockchainBalances } = useBlockchainBalances();
   const { queueTokenDetection } = useBalanceQueue();
   const { isTaskRunning } = useTaskStore();
 
@@ -44,9 +40,9 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
       await queueTokenDetection(chain, filteredAddresses, async addr => fetchDetectedTokens(chain, addr));
   };
 
-  const refreshBalancesForChains = async (chains: string[]): Promise<void> => {
+  const reloadBalancesForChains = async (chains: string[]): Promise<void> => {
     await Promise.allSettled(chains.map(async chain =>
-      refreshBlockchainBalances({
+      fetchBlockchainBalances({
         blockchain: chain,
       }),
     ));
@@ -55,22 +51,15 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
   const detectTokens = async (
     chain: string | string[],
     addrs: string[],
-    options: DetectOptions = {},
   ): Promise<void> => {
-    const { refreshBalancesAfter = true } = options;
     const chains = arrayify(chain);
-
     await Promise.all(chains.map(async c => queueDetectionForChain(c, addrs)));
-
-    if (refreshBalancesAfter)
-      await refreshBalancesForChains(chains);
+    await reloadBalancesForChains(chains);
   };
 
   const detectAllTokens = async (
     chain?: string | string[],
-    options: DetectOptions = {},
   ): Promise<void> => {
-    const { refreshBalancesAfter = true } = options;
     const chains = chain ? arrayify(chain) : get(txEvmChains).map(c => c.id);
 
     setMassDetecting(chains.join(',') || 'all');
@@ -86,8 +75,7 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
           await queueDetectionForChain(c, tokenAddresses);
       }));
 
-      if (refreshBalancesAfter)
-        await refreshBalancesForChains(chains);
+      await reloadBalancesForChains(chains);
     }
     finally {
       setMassDetecting(undefined);


### PR DESCRIPTION
## Summary

- Token detection already writes ERC-20 balances to `blockchain_balances_cache` (see `set_blockchain_detected_token_balances_cache` in `dbhandler.py`), so the post-detection `refreshBlockchainBalances` (POST → spawns `QUERY_BLOCKCHAIN_BALANCES` task) re-queries the chain unnecessarily.
- Switch the orchestrator to call `fetchBlockchainBalances` (GET, cache read) so the frontend store picks up the freshly-written token balances without a second round-trip to the node.
- Drop the unused `refreshBalancesAfter` option — no caller passed it, and the cached fetch is cheap enough to always run.

Biggest win is `detectAllTokens`, which previously fanned out one network refresh task per EVM chain.

## Test plan

- [x] `pnpm run test:unit src/modules/balances/blockchain/use-token-detection-orchestrator.spec.ts` (12/12)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint:fix`
- [ ] Manual: detect tokens on a single account → newly-detected token balance appears without a network refresh
- [ ] Manual: "detect all" across multiple chains → no `QUERY_BLOCKCHAIN_BALANCES` tasks spawned