### PR TITLE
Seed prices from cached historic rates on session load

### DIFF
--- a/frontend/app/src/modules/assets/prices/use-price-seed.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-price-seed.spec.ts
@@ -1,0 +1,193 @@
+import type { Balances } from '@/modules/accounts/blockchain-accounts';
+import { bigNumberify } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePriceSeed } from '@/modules/assets/prices/use-price-seed';
+import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
+import { useBalancesStore } from '@/modules/balances/use-balances-store';
+import { useBlockchainRefreshTimestampsStore } from '@/modules/balances/use-blockchain-refresh-timestamps-store';
+import '@test/i18n';
+
+const adjustPricesMock = vi.fn();
+const queryOnlyCacheHistoricalRatesMock = vi.fn();
+
+vi.mock('@/modules/balances/api/use-price-api', () => ({
+  usePriceApi: vi.fn(() => ({
+    queryOnlyCacheHistoricalRates: queryOnlyCacheHistoricalRatesMock,
+  })),
+}));
+
+vi.mock('@/modules/assets/prices/use-price-refresh', () => ({
+  usePriceRefresh: vi.fn(() => ({
+    adjustPrices: adjustPricesMock,
+  })),
+}));
+
+function seedBalances(balances: Balances): void {
+  const balancesStore = useBalancesStore();
+  const { balances: blockchainBalances } = storeToRefs(balancesStore);
+  set(blockchainBalances, balances);
+}
+
+function seedTimestamps(timestamps: Record<string, number>): void {
+  const { updateTimestamps } = useBlockchainRefreshTimestampsStore();
+  updateTimestamps(timestamps);
+}
+
+describe('usePriceSeed', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    queryOnlyCacheHistoricalRatesMock.mockReset();
+    adjustPricesMock.mockReset();
+  });
+
+  it('should not call the api when no chain timestamps are present', async () => {
+    const { seedFromHistoric } = usePriceSeed();
+    await seedFromHistoric();
+
+    expect(queryOnlyCacheHistoricalRatesMock).not.toHaveBeenCalled();
+    expect(adjustPricesMock).not.toHaveBeenCalled();
+  });
+
+  it('should not call the api when timestamps exist but no balances are loaded', async () => {
+    seedTimestamps({ eth: 1700000000 });
+
+    const { seedFromHistoric } = usePriceSeed();
+    await seedFromHistoric();
+
+    expect(queryOnlyCacheHistoricalRatesMock).not.toHaveBeenCalled();
+  });
+
+  it('should query and seed prices for assets held on a single chain', async () => {
+    seedBalances({
+      eth: {
+        '0xaccount': {
+          assets: {
+            ETH: { amount: bigNumberify(1), value: bigNumberify(1500) },
+            DAI: { amount: bigNumberify(100), value: bigNumberify(100) },
+          } as any,
+          liabilities: {} as any,
+        },
+      },
+    });
+    seedTimestamps({ eth: 1700000000 });
+
+    queryOnlyCacheHistoricalRatesMock.mockResolvedValue({
+      assets: {
+        ETH: { 1700000000: '1500.00' },
+        DAI: { 1700000000: '1.00' },
+      },
+      targetAsset: 'USD',
+    });
+
+    const { seedFromHistoric } = usePriceSeed();
+    await seedFromHistoric();
+
+    expect(queryOnlyCacheHistoricalRatesMock).toHaveBeenCalledTimes(1);
+    const payload = queryOnlyCacheHistoricalRatesMock.mock.calls[0][0];
+    expect(payload.targetAsset).toBe('USD');
+    expect(payload.onlyCachePeriod).toBe(6 * 60 * 60);
+    expect(payload.assetsTimestamp).toEqual(expect.arrayContaining([
+      ['ETH', '1700000000'],
+      ['DAI', '1700000000'],
+    ]));
+
+    const { prices } = storeToRefs(useBalancePricesStore());
+    expect(get(prices)).toEqual({
+      ETH: { isManualPrice: false, oracle: '', value: '1500.00' },
+      DAI: { isManualPrice: false, oracle: '', value: '1.00' },
+    });
+    expect(adjustPricesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pick the newest timestamp for assets held on multiple chains', async () => {
+    seedBalances({
+      eth: {
+        '0xa': {
+          assets: { USDC: { amount: bigNumberify(10), value: bigNumberify(10) } } as any,
+          liabilities: {} as any,
+        },
+      },
+      optimism: {
+        '0xb': {
+          assets: { USDC: { amount: bigNumberify(20), value: bigNumberify(20) } } as any,
+          liabilities: {} as any,
+        },
+      },
+    });
+    seedTimestamps({ eth: 1700000000, optimism: 1700100000 });
+
+    queryOnlyCacheHistoricalRatesMock.mockResolvedValue({
+      assets: { USDC: { 1700100000: '1.00' } },
+      targetAsset: 'USD',
+    });
+
+    const { seedFromHistoric } = usePriceSeed();
+    await seedFromHistoric();
+
+    const payload = queryOnlyCacheHistoricalRatesMock.mock.calls[0][0];
+    expect(payload.assetsTimestamp).toEqual([['USDC', '1700100000']]);
+  });
+
+  it('should include liability assets in the seed query', async () => {
+    seedBalances({
+      eth: {
+        '0xa': {
+          assets: {} as any,
+          liabilities: { DAI: { amount: bigNumberify(50), value: bigNumberify(50) } } as any,
+        },
+      },
+    });
+    seedTimestamps({ eth: 1700000000 });
+
+    queryOnlyCacheHistoricalRatesMock.mockResolvedValue({
+      assets: { DAI: { 1700000000: '1.00' } },
+      targetAsset: 'USD',
+    });
+
+    const { seedFromHistoric } = usePriceSeed();
+    await seedFromHistoric();
+
+    const payload = queryOnlyCacheHistoricalRatesMock.mock.calls[0][0];
+    expect(payload.assetsTimestamp).toEqual([['DAI', '1700000000']]);
+  });
+
+  it('should swallow api errors without throwing or mutating the store', async () => {
+    seedBalances({
+      eth: {
+        '0xa': {
+          assets: { ETH: { amount: bigNumberify(1), value: bigNumberify(1500) } } as any,
+          liabilities: {} as any,
+        },
+      },
+    });
+    seedTimestamps({ eth: 1700000000 });
+
+    queryOnlyCacheHistoricalRatesMock.mockRejectedValue(new Error('boom'));
+
+    const { seedFromHistoric } = usePriceSeed();
+    await expect(seedFromHistoric()).resolves.toBeUndefined();
+
+    expect(adjustPricesMock).not.toHaveBeenCalled();
+    const { prices } = storeToRefs(useBalancePricesStore());
+    expect(get(prices)).toEqual({});
+  });
+
+  it('should not update the store when the api returns no prices', async () => {
+    seedBalances({
+      eth: {
+        '0xa': {
+          assets: { ETH: { amount: bigNumberify(1), value: bigNumberify(1500) } } as any,
+          liabilities: {} as any,
+        },
+      },
+    });
+    seedTimestamps({ eth: 1700000000 });
+
+    queryOnlyCacheHistoricalRatesMock.mockResolvedValue({ assets: {}, targetAsset: 'USD' });
+
+    const { seedFromHistoric } = usePriceSeed();
+    await seedFromHistoric();
+
+    expect(adjustPricesMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/assets/prices/use-price-seed.ts
+++ b/frontend/app/src/modules/assets/prices/use-price-seed.ts
@@ -1,0 +1,93 @@
+import type { AssetPrices } from '@/modules/assets/prices/price-types';
+import { usePriceRefresh } from '@/modules/assets/prices/use-price-refresh';
+import { usePriceApi } from '@/modules/balances/api/use-price-api';
+import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
+import { useBalancesStore } from '@/modules/balances/use-balances-store';
+import { useBlockchainRefreshTimestampsStore } from '@/modules/balances/use-blockchain-refresh-timestamps-store';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
+
+const SEED_CACHE_WINDOW_SECONDS = 6 * 60 * 60;
+
+interface UsePriceSeedReturn {
+  seedFromHistoric: () => Promise<void>;
+}
+
+export function usePriceSeed(): UsePriceSeedReturn {
+  const { queryOnlyCacheHistoricalRates } = usePriceApi();
+  const { prices } = storeToRefs(useBalancePricesStore());
+  const { balances } = storeToRefs(useBalancesStore());
+  const { refreshTimestamps } = storeToRefs(useBlockchainRefreshTimestampsStore());
+  const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
+  const { adjustPrices } = usePriceRefresh();
+
+  const collectAssetsByNewestTimestamp = (): Map<string, number> => {
+    const newestPerAsset = new Map<string, number>();
+    const tsMap = get(refreshTimestamps);
+    const blockchainBalances = get(balances);
+
+    for (const [chain, ts] of Object.entries(tsMap)) {
+      const accounts = blockchainBalances[chain];
+      if (!accounts || ts <= 0)
+        continue;
+
+      for (const account in accounts) {
+        const { assets, liabilities } = accounts[account];
+        const assetIds = [...Object.keys(assets ?? {}), ...Object.keys(liabilities ?? {})];
+        for (const asset of assetIds) {
+          const previous = newestPerAsset.get(asset) ?? 0;
+          if (ts > previous)
+            newestPerAsset.set(asset, ts);
+        }
+      }
+    }
+
+    return newestPerAsset;
+  };
+
+  const seedFromHistoric = async (): Promise<void> => {
+    const start = performance.now();
+    const newestPerAsset = collectAssetsByNewestTimestamp();
+
+    if (newestPerAsset.size === 0) {
+      logger.debug('[price-seed] skipped — no chain timestamps or balances available');
+      return;
+    }
+
+    const requested = newestPerAsset.size;
+    logger.debug(`[price-seed] querying cached historic prices for ${requested} asset(s) (window ±${SEED_CACHE_WINDOW_SECONDS}s, target=${get(currencySymbol)})`);
+
+    try {
+      const result = await queryOnlyCacheHistoricalRates({
+        assetsTimestamp: [...newestPerAsset.entries()].map(([asset, ts]) => [asset, String(ts)]),
+        onlyCachePeriod: SEED_CACHE_WINDOW_SECONDS,
+        targetAsset: get(currencySymbol),
+      });
+
+      const seeded: AssetPrices = {};
+      for (const [asset, byTs] of Object.entries(result.assets ?? {})) {
+        const value = Object.values(byTs ?? {})[0];
+        if (value)
+          seeded[asset] = { isManualPrice: false, oracle: '', value };
+      }
+
+      const seededCount = Object.keys(seeded).length;
+      const elapsed = Math.round(performance.now() - start);
+
+      if (seededCount === 0) {
+        logger.debug(`[price-seed] no cached prices found for ${requested} asset(s) in ${elapsed}ms`);
+        return;
+      }
+
+      set(prices, { ...get(prices), ...seeded });
+      adjustPrices(seeded);
+      logger.info(`[price-seed] seeded ${seededCount}/${requested} asset prices from cache in ${elapsed}ms`);
+    }
+    catch (error) {
+      const elapsed = Math.round(performance.now() - start);
+      logger.warn(`[price-seed] failed after ${elapsed}ms`, error);
+    }
+  };
+
+  return { seedFromHistoric };
+}

--- a/frontend/app/src/modules/auth/use-session-load.spec.ts
+++ b/frontend/app/src/modules/auth/use-session-load.spec.ts
@@ -3,11 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDataLoader } from '@/modules/auth/use-session-load';
 
 const mockOnBalancesLoaded = vi.fn();
-const mockFetch = vi.fn();
+const mockFetchCached = vi.fn();
+const mockRefreshFromChain = vi.fn();
 const mockFetchIgnoredAssets = vi.fn();
 const mockFetchWhitelistedAssets = vi.fn();
 const mockFetchNetValue = vi.fn();
 const mockRefreshPrices = vi.fn();
+const mockSeedFromHistoric = vi.fn();
 const mockFetchTags = vi.fn();
 const mockFetchAllLocations = vi.fn();
 const mockSetStatus = vi.fn();
@@ -21,7 +23,14 @@ vi.mock('@/modules/session/use-scheduler-state', () => ({
 
 vi.mock('@/modules/balances/use-balance-fetching', () => ({
   useBalanceFetching: vi.fn(() => ({
-    fetch: mockFetch,
+    fetchCached: mockFetchCached,
+    refreshFromChain: mockRefreshFromChain,
+  })),
+}));
+
+vi.mock('@/modules/assets/prices/use-price-seed', () => ({
+  usePriceSeed: vi.fn(() => ({
+    seedFromHistoric: mockSeedFromHistoric,
   })),
 }));
 
@@ -92,11 +101,13 @@ describe('composables::session::load', () => {
 
     set(mockShouldFetchData, true);
 
-    mockFetch.mockResolvedValue(undefined);
+    mockFetchCached.mockResolvedValue(undefined);
+    mockRefreshFromChain.mockReturnValue(undefined);
     mockFetchIgnoredAssets.mockResolvedValue(undefined);
     mockFetchWhitelistedAssets.mockResolvedValue(undefined);
     mockFetchNetValue.mockResolvedValue(undefined);
     mockRefreshPrices.mockResolvedValue(undefined);
+    mockSeedFromHistoric.mockResolvedValue(undefined);
     mockFetchTags.mockResolvedValue(undefined);
     mockFetchAllLocations.mockResolvedValue({ locations: {} });
   });
@@ -122,12 +133,21 @@ describe('composables::session::load', () => {
       await flushPromises();
 
       // Verify data fetching happened before onBalancesLoaded
-      expect(mockFetch).toHaveBeenCalled();
+      expect(mockFetchCached).toHaveBeenCalled();
       expect(mockFetchIgnoredAssets).toHaveBeenCalled();
       expect(mockFetchWhitelistedAssets).toHaveBeenCalled();
       expect(mockFetchNetValue).toHaveBeenCalled();
+      expect(mockSeedFromHistoric).toHaveBeenCalled();
       expect(mockRefreshPrices).toHaveBeenCalled();
+      expect(mockRefreshFromChain).toHaveBeenCalled();
       expect(mockOnBalancesLoaded).toHaveBeenCalled();
+
+      // Seed must run before live refresh and chain refetch
+      const seedOrder = mockSeedFromHistoric.mock.invocationCallOrder[0];
+      const refreshOrder = mockRefreshPrices.mock.invocationCallOrder[0];
+      const chainOrder = mockRefreshFromChain.mock.invocationCallOrder[0];
+      expect(seedOrder).toBeLessThan(refreshOrder);
+      expect(seedOrder).toBeLessThan(chainOrder);
     });
 
     it('should not call onBalancesLoaded when shouldFetchData is false', async () => {
@@ -142,7 +162,7 @@ describe('composables::session::load', () => {
     });
 
     it('should call onBalancesLoaded even if some fetches fail', async () => {
-      mockFetch.mockRejectedValue(new Error('Fetch failed'));
+      mockFetchCached.mockRejectedValue(new Error('Fetch failed'));
 
       const { load } = useDataLoader();
 

--- a/frontend/app/src/modules/auth/use-session-load.ts
+++ b/frontend/app/src/modules/auth/use-session-load.ts
@@ -1,6 +1,7 @@
 import { Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { usePriceRefresh } from '@/modules/assets/prices/use-price-refresh';
+import { usePriceSeed } from '@/modules/assets/prices/use-price-seed';
 import { useIgnoredAssetOperations } from '@/modules/assets/use-ignored-asset-operations';
 import { useWhitelistedAssetOperations } from '@/modules/assets/use-whitelisted-asset-operations';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
@@ -27,8 +28,9 @@ export function useDataLoader(): UseDataLoaderReturn {
   const { fetchNetValue } = useStatisticsDataFetching();
   const { allLocations } = storeToRefs(useLocationStore());
   const { fetchAllLocations } = useHistoryApi();
-  const { fetch } = useBalanceFetching();
+  const { fetchCached, refreshFromChain } = useBalanceFetching();
   const { refreshPrices } = usePriceRefresh();
+  const { seedFromHistoric } = usePriceSeed();
   const { setStatus } = useStatusUpdater(Section.BLOCKCHAIN);
 
   const { onBalancesLoaded } = useSchedulerState();
@@ -39,10 +41,12 @@ export function useDataLoader(): UseDataLoaderReturn {
     await Promise.allSettled([
       fetchIgnoredAssets(),
       fetchWhitelistedAssets(),
-      fetch(),
+      fetchCached(),
       fetchNetValue(),
     ]);
-    await refreshPrices();
+    await seedFromHistoric();
+    startPromise(refreshPrices());
+    refreshFromChain();
     onBalancesLoaded();
     sigilBus.emit('balances:loaded');
   };

--- a/frontend/app/src/modules/balances/use-balance-fetching.ts
+++ b/frontend/app/src/modules/balances/use-balance-fetching.ts
@@ -41,12 +41,19 @@ export const useBalanceFetching = createSharedComposable(() => {
     }
   };
 
-  const fetch = async (): Promise<void> => {
+  const fetchCached = async (): Promise<void> => {
     await fetchExchangeRates();
     await Promise.allSettled([fetchManualBalances(), refreshAccounts(), fetchConnectedExchangeBalances()]);
+  };
 
+  const refreshFromChain = (): void => {
     startPromise(refreshBlockchainBalances());
     startPromise(fetchBalances());
+  };
+
+  const fetch = async (): Promise<void> => {
+    await fetchCached();
+    refreshFromChain();
   };
 
   const autoRefresh = async (): Promise<void> => {
@@ -64,5 +71,7 @@ export const useBalanceFetching = createSharedComposable(() => {
     autoRefresh,
     fetch,
     fetchBalances,
+    fetchCached,
+    refreshFromChain,
   };
 });


### PR DESCRIPTION
## Summary

- Add `usePriceSeed`: queries the only-cache historic rates endpoint for assets currently held, using the newest per-chain refresh timestamp per asset.
- Session loader now seeds prices between the cached balance fetch and the live refresh — dashboard renders populated values immediately while fresh data streams in.
- Splits `useBalanceFetching` into `fetchCached` + `refreshFromChain` so the loader can sequence cached reads, seed prices, then run live refresh and chain refetch in parallel.

## Test plan

- [ ] `pnpm run test:unit` passes (new spec covers seed flow: empty timestamps, single chain, multi-chain newest-wins, liabilities, API error swallow, empty response)
- [ ] `pnpm run typecheck` clean
- [ ] `pnpm run lint` clean
- [ ] Log in to an existing account: dashboard balances appear with values immediately instead of flashing 0.00 while prices load
- [ ] Confirm live refresh still runs after seed (network tab shows the live price endpoint hit after the only-cache one)