### PR TITLE
fix(frontend): avoid writing to readonly saveError ref in AccountDialog

### DIFF
--- a/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
@@ -150,6 +150,7 @@ interface UseAccountManageReturn {
   saveError: Readonly<Ref<string>>;
   saveErrorIsPremium: Readonly<Ref<boolean>>;
   save: (state: AccountManageState) => Promise<boolean>;
+  resetSaveError: () => void;
 }
 
 export function useAccountManage(): UseAccountManageReturn {
@@ -290,6 +291,11 @@ export function useAccountManage(): UseAccountManageReturn {
     return result.success;
   }
 
+  function resetSaveError(): void {
+    set(saveError, '');
+    set(saveErrorIsPremium, false);
+  }
+
   const save = async (state: AccountManageState): Promise<boolean> => {
     switch (state.type) {
       case 'account':
@@ -307,6 +313,7 @@ export function useAccountManage(): UseAccountManageReturn {
     // eslint-disable-next-line @rotki/composable-return-readonly
     errorMessages,
     pending: readonly(pending),
+    resetSaveError,
     save,
     saveError: readonly(saveError),
     saveErrorIsPremium: readonly(saveErrorIsPremium),

--- a/frontend/app/src/modules/accounts/management/AccountDialog.vue
+++ b/frontend/app/src/modules/accounts/management/AccountDialog.vue
@@ -37,7 +37,7 @@ const subtitle = computed<string>(() =>
   get(model)?.mode === 'edit' ? t('blockchain_balances.form_dialog.edit_subtitle') : '',
 );
 
-const { errorMessages, pending, save, saveError, saveErrorIsPremium } = useAccountManage();
+const { errorMessages, pending, resetSaveError, save, saveError, saveErrorIsPremium } = useAccountManage();
 const { loading } = useAccountLoading();
 const { getApiKey } = useExternalApiKeys();
 const { beaconRpcEndpoint } = storeToRefs(useGeneralSettingsStore());
@@ -74,17 +74,16 @@ const isSaveDisabled = computed<boolean>(() => {
   return state.type === 'validator' && !(getApiKey('beaconchain') || get(beaconRpcEndpoint));
 });
 
-function dismiss() {
-  set(saveError, '');
-  set(saveErrorIsPremium, false);
+function dismiss(): void {
+  resetSaveError();
   set(model, undefined);
 }
 
-async function confirm() {
+async function confirm(): Promise<void> {
   assert(isDefined(form));
   const accountForm = get(form);
   set(errorMessages, {});
-  set(saveError, '');
+  resetSaveError();
   const valid = await accountForm.validate();
   if (!valid)
     return;


### PR DESCRIPTION
## Summary
- `AccountDialog.vue` was calling `set(saveError, '')` and `set(saveErrorIsPremium, false)` on refs that `useAccountManage` exposes via `readonly(...)`, triggering a `[Vue warn] Set operation on key "value" failed: target is readonly` whenever the dialog confirmed or dismissed.
- Add a `resetSaveError()` helper to `useAccountManage` and call it from the dialog so mutations stay inside the composable that owns the state.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run --filter rotki test:unit src/modules/accounts/blockchain/use-account-manage.spec.ts`
- [ ] Manually open the add/edit account dialog and confirm the warning is gone