### PR TITLE
fix(frontend): round percentage shown above ProgressScreen bar

### DIFF
--- a/frontend/app/src/modules/shell/components/ProgressScreen.vue
+++ b/frontend/app/src/modules/shell/components/ProgressScreen.vue
@@ -29,7 +29,7 @@ const { t } = useI18n({ useScope: 'global' });
     <div class="flex flex-col items-center justify-center mb-10 w-full md:w-5/6">
       <template v-if="progress">
         <div class="text-4xl mb-8">
-          {{ t('progress_screen.progress', { progress }) }}
+          {{ t('progress_screen.progress', { progress: progressValue }) }}
         </div>
         <RuiProgress
           thickness="16"


### PR DESCRIPTION
## Summary
- The label above the progress bar in `ProgressScreen.vue` rendered the raw `progress` string straight from the backend, e.g. `34.210526315789475 %`. The progress bar itself already used a `toFixed(2)` value (`progressValue`); now the label uses the same rounded value.
- Affects the report progress screen (most visible) plus other consumers of `ProgressScreen` (NFT gallery loader, Kraken staking page, single report page).
- Other progress percentages in the app (`SyncProgressHeader`, `AddressProgressItem`) already round via `Math.round` upstream, so no other display has the same issue.

## Test plan
- [x] `pnpm run typecheck`
- [ ] Generate a profit/loss report and confirm the percentage above the bar is rendered with at most 2 decimals