### PR TITLE
test(e2e): add standalone tag manager spec

### DIFF
--- a/frontend/app/src/modules/tags/TagManager.vue
+++ b/frontend/app/src/modules/tags/TagManager.vue
@@ -114,6 +114,7 @@ onMounted(async () => {
         prepend-icon="lu-search"
         :label="t('common.actions.search')"
         hide-details
+        data-testid="tag-manager-search"
       />
       <RuiDataTable
         v-model:sort="sort"
@@ -123,6 +124,7 @@ onMounted(async () => {
         row-attr="name"
         :cols="headers"
         :search="search"
+        data-testid="tag-manager-table"
       >
         <template #item.tagView="{ row }">
           <TagIcon

--- a/frontend/app/tests/e2e/pages/tag-manager.ts
+++ b/frontend/app/tests/e2e/pages/tag-manager.ts
@@ -1,5 +1,41 @@
 import { expect, type Page } from '@playwright/test';
 import { hexToRgbPoints } from '@rotki/common';
+import { RotkiApp } from './rotki-app';
+
+async function fillTagDialog(
+  page: Page,
+  name: string,
+  description: string,
+  background?: string,
+  foreground?: string,
+): Promise<void> {
+  await page.locator('[data-cy=tag-creator-name] input').fill(name);
+  await page.locator('[data-cy=tag-creator-description] input').fill(description);
+
+  if (background && foreground) {
+    const bgInput = page.locator('[data-cy=tag-creator__color-picker__background] input');
+    await bgInput.clear();
+    await bgInput.fill(background);
+    await bgInput.press('Tab');
+
+    const bgDisplay = page.locator('[data-cy=tag-creator__color-picker__background] [data-id=color-display]');
+    await expect(bgDisplay).toHaveCSS('background-color', `rgb(${hexToRgbPoints(background).join(', ')})`);
+
+    const fgInput = page.locator('[data-cy=tag-creator__color-picker__foreground] input');
+    await fgInput.clear();
+    await fgInput.fill(foreground);
+    await fgInput.press('Tab');
+
+    const fgDisplay = page.locator('[data-cy=tag-creator__color-picker__foreground] [data-id=color-display]');
+    await expect(fgDisplay).toHaveCSS('background-color', `rgb(${hexToRgbPoints(foreground).join(', ')})`);
+  }
+}
+
+async function confirmTagDialog(page: Page, dialogTitle: 'Create Tag' | 'Edit Tag'): Promise<void> {
+  const dialog = page.locator('[data-cy=bottom-dialog]').filter({ hasText: dialogTitle });
+  await dialog.locator('[data-cy=confirm]').click();
+  await dialog.waitFor({ state: 'detached' });
+}
 
 export class TagManager {
   constructor(private readonly page: Page) {}
@@ -12,33 +48,80 @@ export class TagManager {
     foreground?: string,
   ): Promise<void> {
     await this.page.locator(`${parent} [data-cy=add-tag-button]`).click();
-    await this.page.locator('[data-cy=tag-creator-name] input').fill(name);
-    await this.page.locator('[data-cy=tag-creator-description] input').fill(description);
+    await fillTagDialog(this.page, name, description, background, foreground);
+    await confirmTagDialog(this.page, 'Create Tag');
+  }
+}
 
-    if (background && foreground) {
-      const bgInput = this.page.locator('[data-cy=tag-creator__color-picker__background] input');
-      await bgInput.clear();
-      await bgInput.fill(background);
-      // Trigger update by pressing Tab to blur
-      await bgInput.press('Tab');
+export class TagManagerPage {
+  constructor(private readonly page: Page) {}
 
-      const bgDisplay = this.page.locator('[data-cy=tag-creator__color-picker__background] [data-id=color-display]');
-      await expect(bgDisplay).toHaveCSS('background-color', `rgb(${hexToRgbPoints(background).join(', ')})`);
+  async visit(): Promise<void> {
+    await RotkiApp.navigateTo(this.page, 'tag-manager');
+  }
 
-      const fgInput = this.page.locator('[data-cy=tag-creator__color-picker__foreground] input');
-      await fgInput.clear();
-      await fgInput.fill(foreground);
-      // Trigger update by pressing Tab to blur
-      await fgInput.press('Tab');
+  private table() {
+    return this.page.getByTestId('tag-manager-table');
+  }
 
-      const fgDisplay = this.page.locator('[data-cy=tag-creator__color-picker__foreground] [data-id=color-display]');
-      await expect(fgDisplay).toHaveCSS('background-color', `rgb(${hexToRgbPoints(foreground).join(', ')})`);
-    }
+  private rows() {
+    return this.table().locator('tbody tr[data-id="row"]');
+  }
 
-    // Use filter to get the Create Tag dialog's confirm button specifically
-    const tagCreatorDialog = this.page.locator('[data-cy=bottom-dialog]').filter({ hasText: 'Create Tag' });
-    await tagCreatorDialog.locator('[data-cy=confirm]').click();
-    // Wait for the tag creation dialog to close
-    await tagCreatorDialog.waitFor({ state: 'detached' });
+  private rowFor(name: string) {
+    return this.rows().filter({ hasText: name });
+  }
+
+  async createTag(
+    name: string,
+    description: string,
+    background?: string,
+    foreground?: string,
+  ): Promise<void> {
+    await this.page.locator('[data-cy=add-tags]').click();
+    await fillTagDialog(this.page, name, description, background, foreground);
+    await confirmTagDialog(this.page, 'Create Tag');
+  }
+
+  async expectTagVisible(name: string): Promise<void> {
+    await expect(this.rowFor(name)).toBeVisible();
+  }
+
+  async editTag(name: string, newDescription: string): Promise<void> {
+    await this.rowFor(name).locator('[data-cy=row-edit]').click();
+    await this.page.locator('[data-cy=tag-creator-description] input').fill(newDescription);
+    await confirmTagDialog(this.page, 'Edit Tag');
+    await expect(this.rowFor(name)).toContainText(newDescription);
+  }
+
+  async deleteTag(name: string): Promise<void> {
+    await this.rowFor(name).locator('[data-cy=row-delete]').click();
+    const confirm = this.page.locator('[data-cy=confirm-dialog]');
+    await confirm.locator('[data-cy=button-confirm]').click();
+    await expect(this.rowFor(name)).toHaveCount(0);
+  }
+
+  async search(query: string): Promise<void> {
+    await this.page.getByTestId('tag-manager-search').locator('input').fill(query);
+  }
+
+  async clearSearch(): Promise<void> {
+    await this.search('');
+  }
+
+  async visibleRowCount(): Promise<number> {
+    return this.rows().count();
+  }
+
+  async goToNextPage(): Promise<void> {
+    await this.table().locator('[data-id=table-pagination-next]').first().click();
+  }
+
+  async expectNextPageEnabled(enabled: boolean): Promise<void> {
+    const next = this.table().locator('[data-id=table-pagination-next]').first();
+    if (enabled)
+      await expect(next).toBeEnabled();
+    else
+      await expect(next).toBeDisabled();
   }
 }

--- a/frontend/app/tests/e2e/specs/app/tag-manager.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/tag-manager.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { TagManagerPage } from '../../pages/tag-manager';
+
+test.describe.serial('tag manager', () => {
+  let ctx: SharedTestContext;
+  let page: TagManagerPage;
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request, { disableModules: true });
+    page = new TagManagerPage(ctx.sharedPage);
+    await page.visit();
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('creates a tag', async () => {
+    await page.createTag('alpha', 'first tag', 'EF703C', 'FFFFF8');
+    await page.expectTagVisible('alpha');
+  });
+
+  test('edits an existing tag', async () => {
+    await page.editTag('alpha', 'first tag updated');
+  });
+
+  test('filters tags via search', async () => {
+    await page.createTag('beta', 'second tag');
+    await page.createTag('gamma', 'third tag');
+
+    await page.search('beta');
+    expect(await page.visibleRowCount()).toBe(1);
+    await page.expectTagVisible('beta');
+
+    await page.clearSearch();
+    expect(await page.visibleRowCount()).toBeGreaterThanOrEqual(3);
+  });
+
+  test('paginates when more than 10 tags exist', async () => {
+    // After previous tests there are 4 tags (Contract reserved + alpha + beta + gamma).
+    // Add 9 more to push total to 13 and force a second page (default page size is 10).
+    for (let i = 0; i < 9; i++)
+      await page.createTag(`tag-${i.toString().padStart(2, '0')}`, `tag ${i}`);
+
+    expect(await page.visibleRowCount()).toBe(10);
+    await page.expectNextPageEnabled(true);
+
+    await page.goToNextPage();
+    expect(await page.visibleRowCount()).toBeGreaterThan(0);
+    await page.expectNextPageEnabled(false);
+  });
+
+  test('deletes a tag', async () => {
+    await page.search('alpha');
+    await page.deleteTag('alpha');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an e2e spec covering the standalone tag manager page. Previously the page was only exercised indirectly through the inline tag creator in the account dialog, so the page-level CRUD/search/pagination flow had no coverage.
- Spec covers: create (with custom colors), edit, search filter, pagination (forces > 10 rows so the second page is reachable), and delete.
- Adds two `data-testid` attributes to `TagManager.vue` (search field, data table) so the spec can target them via Playwright's default `getByTestId` selector. Existing `data-cy` selectors are untouched.
- Extends `tests/e2e/pages/tag-manager.ts` with a new `TagManagerPage` page object alongside the existing inline `TagManager`. Shared dialog-fill logic is extracted into a private helper.

Refs #11252 — addresses the "Tag managements" item in the integration-test punch list.

## Test plan
- [x] `pnpm run test:e2e tests/e2e/specs/app/tag-manager.spec.ts` — 5/5 passing locally
- [x] `pnpm run typecheck`