### PR TITLE
test(e2e): add price manager spec

### DIFF
--- a/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceContent.vue
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceContent.vue
@@ -171,6 +171,7 @@ onMounted(async () => {
         :loading="loading"
         :rows="state.data"
         row-attr="fromAsset"
+        data-testid="oracle-price-table"
       >
         <template #item.fromAsset="{ row }">
           <AssetDetails :asset="row.fromAsset" />

--- a/frontend/app/src/modules/assets/prices/historic/HistoricPriceContent.vue
+++ b/frontend/app/src/modules/assets/prices/historic/HistoricPriceContent.vue
@@ -150,6 +150,7 @@ onMounted(async () => {
       <RuiButton
         color="primary"
         size="lg"
+        data-testid="historic-price-add"
         @click="add()"
       >
         <template #prepend>
@@ -167,6 +168,7 @@ onMounted(async () => {
           clearable
           class="flex-1"
           hide-details
+          data-testid="historic-price-filter-from"
         />
         <AssetSelect
           v-model="toAsset"
@@ -185,6 +187,7 @@ onMounted(async () => {
         :loading="loading"
         :rows="items"
         row-attr="fromAsset"
+        data-testid="historic-price-table"
       >
         <template #item.fromAsset="{ row }">
           <AssetDetails :asset="row.fromAsset" />

--- a/frontend/app/src/modules/assets/prices/historic/HistoricPriceForm.vue
+++ b/frontend/app/src/modules/assets/prices/historic/HistoricPriceForm.vue
@@ -79,6 +79,7 @@ defineExpose({
         outlined
         :disabled="editMode"
         :error-messages="toMessages(v$.fromAsset)"
+        data-testid="historic-price-from-asset"
       />
       <AssetSelect
         v-model="toAsset"
@@ -86,6 +87,7 @@ defineExpose({
         :disabled="editMode"
         outlined
         :error-messages="toMessages(v$.toAsset)"
+        data-testid="historic-price-to-asset"
       />
     </div>
     <DateTimePicker
@@ -95,12 +97,14 @@ defineExpose({
       type="epoch"
       variant="outlined"
       :error-messages="toMessages(v$.timestamp)"
+      data-testid="historic-price-datetime"
     />
     <AmountInput
       v-model="price"
       variant="outlined"
       :error-messages="toMessages(v$.price)"
       :label="t('common.price')"
+      data-testid="historic-price-value"
     />
     <i18n-t
       v-if="price && fromAssetSymbol && toAssetSymbol"

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceContent.vue
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceContent.vue
@@ -127,6 +127,7 @@ onMounted(async () => {
       <RuiButton
         color="primary"
         size="lg"
+        data-testid="latest-price-add"
         @click="add()"
       >
         <template #prepend>
@@ -146,6 +147,7 @@ onMounted(async () => {
           :label="t('price_management.from_asset')"
           clearable
           hide-details
+          data-testid="latest-price-filter-from"
         />
       </div>
       <RuiDataTable
@@ -156,6 +158,7 @@ onMounted(async () => {
         :loading="loading || refreshing"
         :rows="items"
         row-attr="id"
+        data-testid="latest-price-table"
       >
         <template #item.fromAsset="{ row }">
           <NftDetails

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceForm.vue
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceForm.vue
@@ -75,12 +75,14 @@ defineExpose({
         include-nfts
         :disabled="editMode || disableFromAsset"
         :error-messages="toMessages(v$.fromAsset)"
+        data-testid="latest-price-from-asset"
       />
       <AssetSelect
         v-model="toAsset"
         :label="t('price_form.to_asset')"
         outlined
         :error-messages="toMessages(v$.toAsset)"
+        data-testid="latest-price-to-asset"
       />
     </div>
     <AmountInput
@@ -88,6 +90,7 @@ defineExpose({
       variant="outlined"
       :error-messages="toMessages(v$.price)"
       :label="t('common.price')"
+      data-testid="latest-price-value"
     />
     <i18n-t
       v-if="price && fromAssetSymbol && toAssetSymbol"

--- a/frontend/app/tests/e2e/pages/price-manager-page.ts
+++ b/frontend/app/tests/e2e/pages/price-manager-page.ts
@@ -1,0 +1,203 @@
+import { expect, type Page } from '@playwright/test';
+import { TIMEOUT_MEDIUM, TIMEOUT_SHORT } from '../helpers/constants';
+import { RotkiApp } from './rotki-app';
+
+async function selectAsset(testId: string, asset: string, page: Page): Promise<void> {
+  const select = page.getByTestId(testId);
+  // RuiAutoComplete renders a zero-size input behind a clickable wrapper.
+  // Click the wrapper to focus the typeahead, then type via keyboard.
+  await select.click();
+  await page.keyboard.type(asset);
+  // Wait for the option list to populate, then commit via the menu item
+  // matching the typed text exactly (case-insensitive identifier match).
+  const menu = page.locator('[role="listbox"], [role="menu"]').last();
+  await menu.waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
+  const option = menu.locator(`#asset-${asset.toLowerCase()}`);
+  await option.first().waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
+  await option.first().click();
+  await menu.waitFor({ state: 'hidden', timeout: TIMEOUT_SHORT });
+}
+
+async function confirmDialog(page: Page): Promise<void> {
+  const dialog = page.locator('[data-cy=bottom-dialog]');
+  await dialog.locator('[data-cy=confirm]').click();
+  await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+}
+
+async function confirmDelete(page: Page): Promise<void> {
+  const confirmDialogEl = page.locator('[data-cy=confirm-dialog]');
+  await confirmDialogEl.locator('[data-cy=button-confirm]').click();
+  await confirmDialogEl.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+}
+
+async function cancelDialog(page: Page): Promise<void> {
+  const dialog = page.locator('[data-cy=bottom-dialog]');
+  await dialog.locator('[data-cy=cancel]').click();
+  await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+}
+
+export class LatestPricePage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await RotkiApp.navigateTo(this.page, 'price-manager', 'price-manager-latest');
+  }
+
+  private table() {
+    return this.page.getByTestId('latest-price-table');
+  }
+
+  private rows() {
+    return this.table().locator('tbody tr[data-id="row"]');
+  }
+
+  private rowMatching(value: string) {
+    return this.rows().filter({ hasText: value });
+  }
+
+  async addPrice(fromAsset: string, toAsset: string, value: string): Promise<void> {
+    await this.page.getByTestId('latest-price-add').click();
+    await selectAsset('latest-price-from-asset', fromAsset, this.page);
+    await selectAsset('latest-price-to-asset', toAsset, this.page);
+    await this.page.getByTestId('latest-price-value').locator('input').fill(value);
+    await confirmDialog(this.page);
+  }
+
+  async editPrice(currentValue: string, newValue: string): Promise<void> {
+    await this.rowMatching(currentValue).first().locator('[data-cy=row-edit]').click();
+    const valueInput = this.page.getByTestId('latest-price-value').locator('input');
+    await valueInput.fill(newValue);
+    await confirmDialog(this.page);
+  }
+
+  async deletePrice(value: string): Promise<void> {
+    const row = this.rowMatching(value).first();
+    await row.locator('[data-cy=row-delete]').click();
+    await confirmDelete(this.page);
+    await expect(this.rowMatching(value)).toHaveCount(0);
+  }
+
+  async expectRowWithValue(value: string): Promise<void> {
+    await expect(this.rowMatching(value).first()).toBeVisible();
+  }
+
+  async expectVisibleRowCount(count: number): Promise<void> {
+    await expect(this.rows()).toHaveCount(count);
+  }
+
+  async openAddDialog(): Promise<void> {
+    await this.page.getByTestId('latest-price-add').click();
+    await this.page.locator('[data-cy=bottom-dialog]').waitFor({ state: 'visible' });
+  }
+
+  async submitDialog(): Promise<void> {
+    await this.page.locator('[data-cy=bottom-dialog] [data-cy=confirm]').click();
+  }
+
+  async cancelDialog(): Promise<void> {
+    await cancelDialog(this.page);
+  }
+
+  async expectRequiredErrors(): Promise<void> {
+    const dialog = this.page.locator('[data-cy=bottom-dialog]');
+    await expect(dialog.getByText('The from asset cannot be empty')).toBeVisible();
+    await expect(dialog.getByText('The to asset cannot be empty')).toBeVisible();
+    await expect(dialog.getByText('The price cannot be empty')).toBeVisible();
+  }
+
+  async filterByFromAsset(asset: string): Promise<void> {
+    await selectAsset('latest-price-filter-from', asset, this.page);
+  }
+}
+
+export class HistoricPricePage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await RotkiApp.navigateTo(this.page, 'price-manager', 'price-manager-historic');
+  }
+
+  private table() {
+    return this.page.getByTestId('historic-price-table');
+  }
+
+  private rows() {
+    return this.table().locator('tbody tr[data-id="row"]');
+  }
+
+  private rowMatching(value: string) {
+    return this.rows().filter({ hasText: value });
+  }
+
+  async addPrice(fromAsset: string, toAsset: string, value: string, timestamp: string): Promise<void> {
+    await this.page.getByTestId('historic-price-add').click();
+    await selectAsset('historic-price-from-asset', fromAsset, this.page);
+    await selectAsset('historic-price-to-asset', toAsset, this.page);
+    const datetimeInput = this.page.getByTestId('historic-price-datetime').locator('input').first();
+    await datetimeInput.click();
+    await datetimeInput.fill(timestamp);
+    // The datetime input opens a calendar popover on click; press Escape to dismiss
+    // so the next form click is not intercepted by the calendar overlay.
+    await this.page.keyboard.press('Escape');
+    await this.page.getByTestId('historic-price-value').locator('input').fill(value);
+    await confirmDialog(this.page);
+  }
+
+  async editPrice(currentValue: string, newValue: string): Promise<void> {
+    await this.rowMatching(currentValue).first().locator('[data-cy=row-edit]').click();
+    const valueInput = this.page.getByTestId('historic-price-value').locator('input');
+    await valueInput.fill(newValue);
+    await confirmDialog(this.page);
+  }
+
+  async deletePrice(value: string): Promise<void> {
+    const row = this.rowMatching(value).first();
+    await row.locator('[data-cy=row-delete]').click();
+    await confirmDelete(this.page);
+    await expect(this.rowMatching(value)).toHaveCount(0);
+  }
+
+  async expectRowWithValue(value: string): Promise<void> {
+    await expect(this.rowMatching(value).first()).toBeVisible();
+  }
+
+  async expectVisibleRowCount(count: number): Promise<void> {
+    await expect(this.rows()).toHaveCount(count);
+  }
+
+  async openAddDialog(): Promise<void> {
+    await this.page.getByTestId('historic-price-add').click();
+    await this.page.locator('[data-cy=bottom-dialog]').waitFor({ state: 'visible' });
+  }
+
+  async submitDialog(): Promise<void> {
+    await this.page.locator('[data-cy=bottom-dialog] [data-cy=confirm]').click();
+  }
+
+  async cancelDialog(): Promise<void> {
+    await cancelDialog(this.page);
+  }
+
+  async expectRequiredErrors(): Promise<void> {
+    const dialog = this.page.locator('[data-cy=bottom-dialog]');
+    await expect(dialog.getByText('The from asset cannot be empty')).toBeVisible();
+    await expect(dialog.getByText('The to asset cannot be empty')).toBeVisible();
+    await expect(dialog.getByText('The price cannot be empty')).toBeVisible();
+  }
+
+  async filterByFromAsset(asset: string): Promise<void> {
+    await selectAsset('historic-price-filter-from', asset, this.page);
+  }
+}
+
+export class OraclePricePage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await RotkiApp.navigateTo(this.page, 'price-manager', 'price-manager-oracle');
+  }
+
+  async expectTableVisible(): Promise<void> {
+    await expect(this.page.getByTestId('oracle-price-table')).toBeVisible();
+  }
+}

--- a/frontend/app/tests/e2e/specs/app/price-manager.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/price-manager.spec.ts
@@ -1,0 +1,122 @@
+import { test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { HistoricPricePage, LatestPricePage, OraclePricePage } from '../../pages/price-manager-page';
+
+test.describe('price manager', () => {
+  test.describe.serial('latest', () => {
+    let ctx: SharedTestContext;
+    let page: LatestPricePage;
+
+    test.beforeAll(async ({ browser, request }) => {
+      ctx = await createLoggedInContext(browser, request, { disableModules: true });
+      page = new LatestPricePage(ctx.sharedPage);
+      await page.visit();
+    });
+
+    test.afterAll(async () => {
+      await cleanupContext(ctx);
+    });
+
+    test('creates a latest price', async () => {
+      await page.addPrice('EUR', 'USD', '1234');
+      await page.expectRowWithValue('1,234');
+    });
+
+    test('edits the price value', async () => {
+      await page.editPrice('1,234', '5678');
+      await page.expectRowWithValue('5,678');
+    });
+
+    test('deletes the price', async () => {
+      await page.deletePrice('5,678');
+    });
+
+    test('shows validation errors when required fields are empty', async () => {
+      await page.openAddDialog();
+      await page.submitDialog();
+      await page.expectRequiredErrors();
+      await page.cancelDialog();
+    });
+
+    test('filters table by from-asset', async () => {
+      await page.addPrice('EUR', 'USD', '999');
+      await page.expectRowWithValue('999');
+
+      await page.filterByFromAsset('BTC');
+      await page.expectVisibleRowCount(0);
+
+      await page.filterByFromAsset('EUR');
+      await page.expectRowWithValue('999');
+
+      await page.deletePrice('999');
+    });
+  });
+
+  test.describe.serial('historic', () => {
+    let ctx: SharedTestContext;
+    let page: HistoricPricePage;
+
+    test.beforeAll(async ({ browser, request }) => {
+      ctx = await createLoggedInContext(browser, request, { disableModules: true });
+      page = new HistoricPricePage(ctx.sharedPage);
+      await page.visit();
+    });
+
+    test.afterAll(async () => {
+      await cleanupContext(ctx);
+    });
+
+    test('creates a historic price', async () => {
+      await page.addPrice('EUR', 'USD', '1500', '01/06/2024 12:00:00');
+      await page.expectRowWithValue('1,500');
+    });
+
+    test('edits the historic price value', async () => {
+      await page.editPrice('1,500', '1750');
+      await page.expectRowWithValue('1,750');
+    });
+
+    test('deletes the historic price', async () => {
+      await page.deletePrice('1,750');
+    });
+
+    test('shows validation errors when required fields are empty', async () => {
+      await page.openAddDialog();
+      await page.submitDialog();
+      await page.expectRequiredErrors();
+      await page.cancelDialog();
+    });
+
+    test('filters table by from-asset', async () => {
+      await page.addPrice('EUR', 'USD', '888', '01/06/2024 12:00:00');
+      await page.expectRowWithValue('888');
+
+      await page.filterByFromAsset('BTC');
+      await page.expectVisibleRowCount(0);
+
+      await page.filterByFromAsset('EUR');
+      await page.expectRowWithValue('888');
+
+      await page.deletePrice('888');
+    });
+  });
+
+  test.describe.serial('oracle', () => {
+    let ctx: SharedTestContext;
+    let page: OraclePricePage;
+
+    test.beforeAll(async ({ browser, request }) => {
+      ctx = await createLoggedInContext(browser, request, { disableModules: true });
+      page = new OraclePricePage(ctx.sharedPage);
+      await page.visit();
+    });
+
+    test.afterAll(async () => {
+      await cleanupContext(ctx);
+    });
+
+    test('renders the oracle prices table', async () => {
+      await page.expectTableVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds e2e coverage for the price manager — previously zero coverage across all three subroutes (`/price-manager/latest`, `/price-manager/historic`, `/price-manager/oracle`).

- **Latest prices**: create, edit, delete; empty-form validation; filter table by from-asset.
- **Historic prices**: create (with timestamp), edit, delete; empty-form validation; filter table by from-asset.
- **Oracle**: smoke test that the oracle prices table renders.

Adds `data-testid` attributes to the add buttons, tables, asset selectors, form inputs and the page-level from-asset filter on `LatestPrice*` and `HistoricPrice*` components, and to the oracle prices table.

Refs #11252 — addresses the price-manager gap in the integration-test punch list.

## Test plan
- [x] `pnpm run test:e2e tests/e2e/specs/app/price-manager.spec.ts` — 11/11 passing locally
- [x] `pnpm run typecheck`