### PR TITLE
test(e2e): add address book manager spec

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/AddressBookForm.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookForm.vue
@@ -112,12 +112,14 @@ defineExpose({
       key-attr="key"
       text-attr="label"
       variant="outlined"
+      data-testid="address-book-form-location"
     />
     <ChainSelect
       v-model="blockchainModel"
       :disabled="editMode"
       :items="chainOptions"
       :error-messages="toMessages(v$.blockchain)"
+      data-testid="address-book-form-chain"
     />
     <div class="flex gap-2">
       <div class="m-3 rounded-full overflow-hidden w-8 h-8 bg-rui-grey-300 dark:bg-rui-grey-600">
@@ -136,6 +138,7 @@ defineExpose({
         :disabled="editMode"
         :error-messages="toMessages(v$.address)"
         clearable
+        data-testid="address-book-form-address"
       >
         <template #item.prepend="{ item }">
           <div
@@ -158,6 +161,7 @@ defineExpose({
       color="primary"
       :label="t('common.name')"
       :error-messages="toMessages(v$.name)"
+      data-testid="address-book-form-name"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/accounts/address-book/AddressBookFormDialog.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookFormDialog.vue
@@ -101,6 +101,7 @@ async function save(): Promise<boolean> {
   set(loading, false);
   if (success) {
     set(modelValue, undefined);
+    set(open, false);
     emit('update:tab', location === 'global' ? 0 : 1);
     emit('refresh');
   }

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagement.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagement.vue
@@ -85,6 +85,7 @@ watchImmediate(location, async () => {
       <RuiButton
         color="primary"
         size="lg"
+        data-testid="address-book-add"
         @click="add()"
       >
         <template #prepend>
@@ -116,6 +117,7 @@ watchImmediate(location, async () => {
             clearable
             dense
             exclude-eth-staking
+            data-testid="address-book-chain-filter"
           />
         </div>
 
@@ -132,11 +134,13 @@ watchImmediate(location, async () => {
           v-model="tab"
           color="primary"
           class="border border-default rounded bg-white dark:bg-rui-grey-900 flex max-w-min"
+          data-testid="address-book-scope-tabs"
         >
           <RuiTab
             v-for="loc in locations"
             :key="loc"
             class="capitalize"
+            :data-testid="`address-book-scope-${loc}`"
           >
             {{ loc }}
           </RuiTab>
@@ -168,6 +172,7 @@ watchImmediate(location, async () => {
     <AddressBookFormDialog
       v-model:open="openDialog"
       :editable-item="editableItem"
+      :edit-mode="!!editableItem"
       :selected-chain="selectedChain"
       :location="location"
       @update-tab="tab = $event"

--- a/frontend/app/src/modules/accounts/address-book/AddressBookTable.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookTable.vue
@@ -64,6 +64,7 @@ const { showDeleteConfirmation } = useAddressBookDeletion(location, refresh);
     row-attr="address"
     outlined
     dense
+    data-testid="address-book-table"
   >
     <template #item.address="{ row }">
       <AccountDisplay

--- a/frontend/app/tests/e2e/pages/address-book-page.ts
+++ b/frontend/app/tests/e2e/pages/address-book-page.ts
@@ -1,0 +1,172 @@
+import { expect, type Page } from '@playwright/test';
+import { TIMEOUT_MEDIUM, TIMEOUT_SHORT } from '../helpers/constants';
+import { RotkiApp } from './rotki-app';
+
+type Scope = 'global' | 'private';
+
+async function dismissErrorIfShown(page: Page): Promise<void> {
+  const okBtn = page.locator('[data-cy=message-dialog__ok]');
+  // Wait briefly for a delayed popup to appear; if none, move on.
+  try {
+    await okBtn.waitFor({ state: 'visible', timeout: 500 });
+  }
+  catch {
+    return;
+  }
+  await okBtn.click();
+  await okBtn.waitFor({ state: 'detached', timeout: TIMEOUT_SHORT }).catch(() => undefined);
+}
+
+async function confirmDialog(page: Page): Promise<void> {
+  const dialog = page.locator('[data-cy=bottom-dialog]');
+  await dialog.locator('[data-cy=confirm]').click();
+  await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+  await dismissErrorIfShown(page);
+}
+
+async function confirmDelete(page: Page): Promise<void> {
+  const confirmDialogEl = page.locator('[data-cy=confirm-dialog]');
+  await confirmDialogEl.locator('[data-cy=button-confirm]').click();
+  await confirmDialogEl.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+}
+
+async function pickMenuOption(page: Page, value: string): Promise<void> {
+  const menu = page.locator('[role="menu"], [role="listbox"]').last();
+  await menu.waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
+  await menu.locator('button[type="button"]').filter({ hasText: new RegExp(`^${value}$`, 'i') }).first().click();
+  await menu.waitFor({ state: 'hidden', timeout: TIMEOUT_SHORT });
+}
+
+export class AddressBookPage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await RotkiApp.navigateTo(this.page, 'address-book-manager');
+  }
+
+  private table() {
+    return this.page.getByTestId('address-book-table');
+  }
+
+  private rows() {
+    return this.table().locator('tbody tr[data-id="row"]');
+  }
+
+  rowFor(addressOrName: string) {
+    // For 0x... addresses match by the leading hex, otherwise match the full text.
+    const needle = addressOrName.startsWith('0x') ? addressOrName.slice(0, 12) : addressOrName;
+    return this.rows().filter({ hasText: needle });
+  }
+
+  rowByName(name: string) {
+    return this.rows().filter({ hasText: name });
+  }
+
+  async selectScope(scope: Scope): Promise<void> {
+    await this.page.getByTestId(`address-book-scope-${scope}`).click();
+    // Wait for any in-flight fetch to settle by checking row attachment.
+    await this.page.waitForTimeout(200);
+  }
+
+  async expectScopeActive(scope: Scope): Promise<void> {
+    const tab = this.page.getByTestId(`address-book-scope-${scope}`);
+    await expect(tab).toHaveAttribute('aria-selected', 'true');
+  }
+
+  async openAddDialog(): Promise<void> {
+    await dismissErrorIfShown(this.page);
+    await this.page.getByTestId('address-book-add').click();
+    await this.page.locator('[data-cy=bottom-dialog]').waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+  }
+
+  async submitDialog(): Promise<void> {
+    await this.page.locator('[data-cy=bottom-dialog] [data-cy=confirm]').click();
+  }
+
+  async cancelDialog(): Promise<void> {
+    const dialog = this.page.locator('[data-cy=bottom-dialog]');
+    await dialog.locator('[data-cy=cancel]').click();
+    await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+  }
+
+  async expectRequiredErrors(): Promise<void> {
+    const dialog = this.page.locator('[data-cy=bottom-dialog]');
+    await expect(dialog.getByText('The address field cannot be empty')).toBeVisible();
+    await expect(dialog.getByText('The name field cannot be empty')).toBeVisible();
+  }
+
+  async addEntry(opts: { address: string; name: string }): Promise<void> {
+    await dismissErrorIfShown(this.page);
+    await this.page.getByTestId('address-book-add').click();
+    const dialog = this.page.locator('[data-cy=bottom-dialog]');
+    await dialog.waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+    await this.page.getByTestId('address-book-form-address').locator('input').first().fill(opts.address);
+    await this.page.getByTestId('address-book-form-name').locator('input').fill(opts.name);
+    await confirmDialog(this.page);
+  }
+
+  async editEntry(address: string, newName: string): Promise<void> {
+    await dismissErrorIfShown(this.page);
+    await this.rowFor(address).first().locator('[data-cy=row-edit]').click();
+    const dialog = this.page.locator('[data-cy=bottom-dialog]');
+    await dialog.waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+    // Wait for the dialog to bind to the editable row's data; the title flips
+    // from the empty "Add" form to "Edit address book entry" once that lands.
+    await expect(dialog.locator('h5').filter({ hasText: /edit/i })).toBeVisible({ timeout: TIMEOUT_MEDIUM });
+    const nameInput = this.page.getByTestId('address-book-form-name').locator('input');
+    await nameInput.fill(newName);
+    await confirmDialog(this.page);
+  }
+
+  async deleteEntry(address: string): Promise<void> {
+    await this.rowFor(address).first().locator('[data-cy=row-delete]').click();
+    await confirmDelete(this.page);
+    await expect(this.rowFor(address)).toHaveCount(0);
+  }
+
+  async filterByChain(chain: string): Promise<void> {
+    const filter = this.page.getByTestId('address-book-chain-filter');
+    await filter.click();
+    await pickMenuOption(this.page, chain);
+  }
+
+  async clearChainFilter(): Promise<void> {
+    const filter = this.page.getByTestId('address-book-chain-filter');
+    // Look for the clear button rendered when an option is selected.
+    const clear = filter.locator('button').filter({ hasNot: this.page.locator('text=/.+/') }).first();
+    if (await clear.isVisible().catch(() => false)) {
+      await clear.click();
+    }
+  }
+
+  async expectRow(address: string, name?: string): Promise<void> {
+    const row = this.rowFor(address).first();
+    await expect(row).toBeVisible();
+    if (name)
+      await expect(row).toContainText(name);
+  }
+
+  async expectRowByName(name: string): Promise<void> {
+    await expect(this.rowByName(name).first()).toBeVisible();
+  }
+
+  async expectNoRow(address: string): Promise<void> {
+    await expect(this.rowFor(address)).toHaveCount(0);
+  }
+
+  async visibleRowCount(): Promise<number> {
+    return this.rows().count();
+  }
+
+  async goToNextPage(): Promise<void> {
+    await this.table().locator('[data-id=table-pagination-next]').first().click();
+  }
+
+  async expectNextPageEnabled(enabled: boolean): Promise<void> {
+    const next = this.table().locator('[data-id=table-pagination-next]').first();
+    if (enabled)
+      await expect(next).toBeEnabled();
+    else
+      await expect(next).toBeDisabled();
+  }
+}

--- a/frontend/app/tests/e2e/specs/app/address-book.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/address-book.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { AddressBookPage } from '../../pages/address-book-page';
+
+const ADDR_PRIVATE = '0x1111111111111111111111111111111111111111';
+
+test.describe.serial('address book', () => {
+  let ctx: SharedTestContext;
+  let page: AddressBookPage;
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request, { disableModules: true });
+    page = new AddressBookPage(ctx.sharedPage);
+    await page.visit();
+    // The global address book is seeded by rotki's global DB (~500+ entries
+    // shared across users). Tests stay in the private scope which is per-user
+    // and starts empty.
+    await page.selectScope('private');
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('switches between global and private scopes', async () => {
+    await page.selectScope('global');
+    await page.expectScopeActive('global');
+    await page.selectScope('private');
+    await page.expectScopeActive('private');
+  });
+
+  test('creates a private entry', async () => {
+    await page.addEntry({ address: ADDR_PRIVATE, name: 'private one' });
+    await page.expectRow(ADDR_PRIVATE, 'private one');
+  });
+
+  test('edits an entry', async () => {
+    await page.editEntry(ADDR_PRIVATE, 'private renamed');
+    await page.expectRow(ADDR_PRIVATE, 'private renamed');
+  });
+
+  test('deletes an entry', async () => {
+    await page.deleteEntry(ADDR_PRIVATE);
+    await page.expectNoRow(ADDR_PRIVATE);
+  });
+
+  test('shows validation errors when required fields are empty', async () => {
+    await page.openAddDialog();
+    await page.submitDialog();
+    await page.expectRequiredErrors();
+    await page.cancelDialog();
+  });
+
+  test('cancel button closes the dialog', async () => {
+    await page.openAddDialog();
+    await page.cancelDialog();
+  });
+
+  test('paginates when more than 10 entries exist', async () => {
+    // Default page size is 10, so 11 entries guarantees a second page.
+    for (let i = 0; i < 11; i++) {
+      // Encode i in the address prefix so each entry has a unique value.
+      const addr = `0x${i.toString(16).padStart(2, '0')}${'b'.repeat(38)}`;
+      const name = `entry-${i.toString().padStart(2, '0')}`;
+      await page.addEntry({ address: addr, name });
+    }
+
+    expect(await page.visibleRowCount()).toBe(10);
+    await page.expectNextPageEnabled(true);
+
+    await page.goToNextPage();
+    expect(await page.visibleRowCount()).toBeGreaterThan(0);
+    await page.expectNextPageEnabled(false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds e2e coverage for the address book manager page. Previously zero coverage — only stores/composables had unit tests.

Tests (all in the private scope; the global address book is shared via the global DB and seeded with ~500 entries, so it's not safe to assert on):

- switch between global and private scopes
- create a private entry
- edit an entry
- delete an entry
- empty-form validation (address + name required)
- cancel button closes the dialog
- pagination — add 11 entries, assert page-1 has 10 + next enabled, navigate, assert page-2 has rows + next disabled

Adds \`data-testid\` attributes to the management page (add button, chain filter, scope tabs and individual tab buttons), the address book table, and the four form inputs (location, chain, address, name).

### Drive-by fixes
- \`AddressBookFormDialog\`: on successful save, also \`set(open, false)\`. Previously only \`modelValue\` was reset; \`openDialog\` stayed true in the parent, so the next \`add()\` call wouldn't re-trigger the open watch and the dialog would silently fail to re-open. Reproducible by clicking \"Add\" twice in succession.
- \`AddressBookManagement\`: explicitly pass \`:edit-mode=\"!!editableItem\"\` to the form dialog so the add/update branch reflects the current state, instead of relying on an implicit \`editMode ?? !!editableItem\` fallback inside the dialog.

Refs #11252 — addresses the address-book gap.

## Test plan
- [x] \`pnpm run test:e2e tests/e2e/specs/app/address-book.spec.ts\` — 7/7 passing locally
- [x] \`pnpm run typecheck\`