### PR TITLE
fix(frontend): clear stale unmatched-movements toast when count is zero

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` After a rotki update, a friendly prompt will walk you through any new recommended settings. You can accept the ones you like, keep what you have for the rest.
 * :feature:`12102` New giveth donation events will now be properly decoded on all supported chains.
 * :feature:`10654` HyperEVM and Hyperliquid Core are now supported in rotki.
 * :feature:`11812` Monad is now supported in rotki.

--- a/frontend/app/src/modules/history/events/use-unmatched-asset-movements.spec.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-asset-movements.spec.ts
@@ -1,0 +1,131 @@
+import { NotificationGroup } from '@rotki/common';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUnmatchedAssetMovements } from '@/modules/history/events/use-unmatched-asset-movements';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    getUnmatchedAssetMovements: vi.fn<(onlyIgnored?: boolean) => Promise<string[]>>(),
+    fetchHistoryEvents: vi.fn(),
+    matchAssetMovements: vi.fn(),
+    triggerAssetMovementMatching: vi.fn(),
+    getAssetMovementMatches: vi.fn(),
+    unlinkAssetMovement: vi.fn(),
+    removeMatching: vi.fn(),
+    showErrorMessage: vi.fn(),
+    showSuccessMessage: vi.fn(),
+    runTask: vi.fn(),
+    useIsTaskRunning: vi.fn(() => ref(false)),
+    signalEventsModified: vi.fn(),
+    getAssetInfo: vi.fn(() => ({ assetType: 'crypto' })),
+  },
+}));
+
+vi.mock('@/modules/history/api/events/use-asset-movement-matching-api', () => ({
+  useAssetMovementMatchingApi: (): object => ({
+    getAssetMovementMatches: spies.getAssetMovementMatches,
+    getUnmatchedAssetMovements: spies.getUnmatchedAssetMovements,
+    matchAssetMovements: spies.matchAssetMovements,
+    triggerAssetMovementMatching: spies.triggerAssetMovementMatching,
+    unlinkAssetMovement: spies.unlinkAssetMovement,
+  }),
+}));
+
+vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
+  useHistoryEventsApi: (): object => ({
+    fetchHistoryEvents: spies.fetchHistoryEvents,
+  }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>(
+    '@/modules/core/notifications/use-notifications',
+  );
+  return {
+    ...actual,
+    useNotifications: (): object => ({
+      removeMatching: spies.removeMatching,
+      showErrorMessage: spies.showErrorMessage,
+      showSuccessMessage: spies.showSuccessMessage,
+    }),
+  };
+});
+
+vi.mock('@/modules/core/tasks/use-task-handler', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/tasks/use-task-handler')>(
+    '@/modules/core/tasks/use-task-handler',
+  );
+  return {
+    ...actual,
+    useTaskHandler: (): object => ({ runTask: spies.runTask }),
+  };
+});
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: (): object => ({ useIsTaskRunning: spies.useIsTaskRunning }),
+}));
+
+vi.mock('@/modules/history/use-history-store', () => ({
+  useHistoryStore: (): object => ({ signalEventsModified: spies.signalEventsModified }),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: (): object => ({ getAssetInfo: spies.getAssetInfo }),
+}));
+
+vi.mock('@/modules/premium/use-feature-access', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/premium/use-feature-access')>(
+    '@/modules/premium/use-feature-access',
+  );
+  return {
+    ...actual,
+    useFeatureAccess: (): object => ({
+      allowed: ref(true),
+      minimumTier: ref(null),
+    }),
+  };
+});
+
+describe('use-unmatched-asset-movements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('fetchUnmatchedAssetMovements clears stale notification', () => {
+    it('should clear the unmatched-movements notification when the unmatched list becomes empty', async () => {
+      spies.getUnmatchedAssetMovements.mockResolvedValueOnce([]);
+      const { fetchUnmatchedAssetMovements } = useUnmatchedAssetMovements();
+
+      await fetchUnmatchedAssetMovements(false);
+
+      expect(spies.removeMatching).toHaveBeenCalledTimes(1);
+      const predicate = spies.removeMatching.mock.calls[0][0] as (n: { group?: string }) => boolean;
+      expect(predicate({ group: NotificationGroup.UNMATCHED_ASSET_MOVEMENTS })).toBe(true);
+      expect(predicate({ group: 'OTHER' })).toBe(false);
+    });
+
+    it('should not clear the notification when fetching the ignored list', async () => {
+      spies.getUnmatchedAssetMovements.mockResolvedValueOnce([]);
+      const { fetchUnmatchedAssetMovements } = useUnmatchedAssetMovements();
+
+      await fetchUnmatchedAssetMovements(true);
+
+      expect(spies.removeMatching).not.toHaveBeenCalled();
+    });
+
+    it('should not clear the notification when there are still unmatched movements', async () => {
+      spies.getUnmatchedAssetMovements.mockResolvedValueOnce(['group-a']);
+      spies.fetchHistoryEvents.mockResolvedValueOnce({
+        entries: [{ entry: { asset: 'ETH', groupIdentifier: 'group-a' } }],
+      });
+      const { fetchUnmatchedAssetMovements } = useUnmatchedAssetMovements();
+
+      await fetchUnmatchedAssetMovements(false);
+
+      expect(spies.removeMatching).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-unmatched-asset-movements.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-asset-movements.ts
@@ -3,6 +3,7 @@ import type { ActionStatus } from '@/modules/core/common/action';
 import type { TaskMeta } from '@/modules/core/tasks/types';
 import type { LinkedMovementMatch } from '@/modules/history/events/event-payloads';
 import type { HistoryEventCollectionRow, HistoryEventEntry } from '@/modules/history/events/schemas';
+import { NotificationGroup } from '@rotki/common';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { arrayify } from '@/modules/core/common/data/array';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -56,7 +57,7 @@ const triggerAutoMatchLoading = ref<boolean>(false);
 
 export const useUnmatchedAssetMovements = createSharedComposable((): UseUnmatchedAssetMovementsReturn => {
   const { t } = useI18n({ useScope: 'global' });
-  const { showErrorMessage, showSuccessMessage } = useNotifications();
+  const { removeMatching, showErrorMessage, showSuccessMessage } = useNotifications();
   const { getAssetInfo } = useAssetInfoRetrieval();
   const { runTask } = useTaskHandler();
   const { useIsTaskRunning } = useTaskStore();
@@ -87,6 +88,10 @@ export const useUnmatchedAssetMovements = createSharedComposable((): UseUnmatche
   const unmatchedCount = computed<number>(() => get(unmatchedMovements).length);
   const ignoredCount = computed<number>(() => get(ignoredMovements).length);
 
+  function clearUnmatchedAssetMovementsNotification(): void {
+    removeMatching(notification => notification.group === NotificationGroup.UNMATCHED_ASSET_MOVEMENTS);
+  }
+
   const fetchUnmatchedAssetMovements = async (onlyIgnored?: boolean): Promise<void> => {
     const isIgnored = onlyIgnored === true;
     const loadingRef = isIgnored ? ignoredLoading : loading;
@@ -98,6 +103,8 @@ export const useUnmatchedAssetMovements = createSharedComposable((): UseUnmatche
 
       if (groupIdentifiers.length === 0) {
         set(movementsRef, []);
+        if (!isIgnored)
+          clearUnmatchedAssetMovementsNotification();
         return;
       }
 


### PR DESCRIPTION
## Summary
- The unmatched-asset-movements warning toast was created from a websocket message that the backend only emits when the unmatched count is greater than zero. After a subsequent auto-match drained the count to zero (e.g. the auto-match watcher in `use-history-watchers.ts` re-runs matching once history processing finishes and resolves the remaining items), no message was sent and the stale toast persisted. Clicking it then opened an empty dialog.
- `fetchUnmatchedAssetMovements` now clears any `UNMATCHED_ASSET_MOVEMENTS` notification when the non-ignored fetch resolves with an empty list. The auto-match flow already calls `refreshUnmatchedAssetMovements` after the task completes, so the stale toast is removed before the user has a chance to click it.
- Added a changelog entry for the existing "new default settings on update" prompt that wasn't documented yet.

## Test plan
- [x] `pnpm run test:unit src/modules/history/events/use-unmatched-asset-movements.spec.ts` — 3 new tests passing (clears when empty, doesn't clear when fetching ignored list, doesn't clear while non-empty)
- [x] `pnpm run typecheck`
- [x] `CI=true pnpm run lint` (no new errors)
- [ ] Manual: trigger asset-movement matching with no unmatched movements after a previous toast — confirm it disappears without needing to navigate to the events page