### PR TITLE
fix(frontend): refresh premium capabilities after setup

### DIFF
--- a/frontend/app/src/modules/premium/use-fetch-premium-capabilities.ts
+++ b/frontend/app/src/modules/premium/use-fetch-premium-capabilities.ts
@@ -1,0 +1,24 @@
+import { logger } from '@/modules/core/common/logging/logging';
+import { usePremiumCredentialsApi } from '@/modules/premium/use-premium-credentials-api';
+import { usePremiumStore } from '@/modules/premium/use-premium-store';
+
+interface UseFetchPremiumCapabilitiesReturn {
+  fetchCapabilities: () => Promise<void>;
+}
+
+export function useFetchPremiumCapabilities(): UseFetchPremiumCapabilitiesReturn {
+  const api = usePremiumCredentialsApi();
+  const { capabilities } = storeToRefs(usePremiumStore());
+
+  async function fetchCapabilities(): Promise<void> {
+    try {
+      const result = await api.getPremiumCapabilities();
+      set(capabilities, result);
+    }
+    catch (error: unknown) {
+      logger.error('Failed to fetch premium capabilities:', error);
+    }
+  }
+
+  return { fetchCapabilities };
+}

--- a/frontend/app/src/modules/premium/use-premium-operations.spec.ts
+++ b/frontend/app/src/modules/premium/use-premium-operations.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePremiumOperations } from '@/modules/premium/use-premium-operations';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    setPremiumCredentials: vi.fn<(username: string, apiKey: string, apiSecret: string) => Promise<boolean>>(),
+    deletePremiumCredentials: vi.fn<() => Promise<boolean>>(),
+    fetchCapabilities: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@/modules/premium/use-premium-credentials-api', () => ({
+  usePremiumCredentialsApi: (): object => ({
+    deletePremiumCredentials: spies.deletePremiumCredentials,
+    setPremiumCredentials: spies.setPremiumCredentials,
+  }),
+}));
+
+vi.mock('@/modules/premium/use-fetch-premium-capabilities', () => ({
+  useFetchPremiumCapabilities: (): object => ({
+    fetchCapabilities: spies.fetchCapabilities,
+  }),
+}));
+
+describe('use-premium-operations', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('setup', () => {
+    const payload = { apiKey: 'k', apiSecret: 's', username: 'me' };
+
+    it('should refresh capabilities after a successful setup', async () => {
+      spies.setPremiumCredentials.mockResolvedValueOnce(true);
+      const { setup } = usePremiumOperations();
+
+      const result = await setup(payload);
+
+      expect(result.success).toBe(true);
+      expect(spies.setPremiumCredentials).toHaveBeenCalledWith('me', 'k', 's');
+      expect(spies.fetchCapabilities).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not refresh capabilities when the API reports failure', async () => {
+      spies.setPremiumCredentials.mockResolvedValueOnce(false);
+      const { setup } = usePremiumOperations();
+
+      const result = await setup(payload);
+
+      expect(result.success).toBe(false);
+      expect(spies.fetchCapabilities).not.toHaveBeenCalled();
+    });
+
+    it('should not refresh capabilities when setup throws', async () => {
+      spies.setPremiumCredentials.mockRejectedValueOnce(new Error('boom'));
+      const { setup } = usePremiumOperations();
+
+      const result = await setup(payload);
+
+      expect(result.success).toBe(false);
+      expect(spies.fetchCapabilities).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/premium/use-premium-operations.ts
+++ b/frontend/app/src/modules/premium/use-premium-operations.ts
@@ -2,6 +2,7 @@ import type { ActionStatus } from '@/modules/core/common/action';
 import type { PremiumCredentialsPayload } from '@/modules/session/types';
 import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useFetchPremiumCapabilities } from '@/modules/premium/use-fetch-premium-capabilities';
 import { usePremiumCredentialsApi } from '@/modules/premium/use-premium-credentials-api';
 import { usePremiumStore } from '@/modules/premium/use-premium-store';
 
@@ -13,6 +14,7 @@ interface UsePremiumOperationsReturn {
 export function usePremiumOperations(): UsePremiumOperationsReturn {
   const api = usePremiumCredentialsApi();
   const { capabilities, premium } = storeToRefs(usePremiumStore());
+  const { fetchCapabilities } = useFetchPremiumCapabilities();
 
   async function setup({
     apiKey,
@@ -22,8 +24,10 @@ export function usePremiumOperations(): UsePremiumOperationsReturn {
     try {
       const success = await api.setPremiumCredentials(username, apiKey, apiSecret);
 
-      if (success)
+      if (success) {
         set(premium, true);
+        await fetchCapabilities();
+      }
 
       return { success };
     }

--- a/frontend/app/src/modules/premium/use-premium-watchers.ts
+++ b/frontend/app/src/modules/premium/use-premium-watchers.ts
@@ -1,6 +1,5 @@
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
-import { logger } from '@/modules/core/common/logging/logging';
-import { usePremiumCredentialsApi } from '@/modules/premium/use-premium-credentials-api';
+import { useFetchPremiumCapabilities } from '@/modules/premium/use-fetch-premium-capabilities';
 import { usePremiumStore } from '@/modules/premium/use-premium-store';
 
 interface UsePremiumWatchersReturn {
@@ -8,19 +7,9 @@ interface UsePremiumWatchersReturn {
 }
 
 export function usePremiumWatchers(): UsePremiumWatchersReturn {
-  const api = usePremiumCredentialsApi();
   const { capabilities } = storeToRefs(usePremiumStore());
   const { logged } = storeToRefs(useSessionAuthStore());
-
-  async function fetchCapabilities(): Promise<void> {
-    try {
-      const result = await api.getPremiumCapabilities();
-      set(capabilities, result);
-    }
-    catch (error: unknown) {
-      logger.error('Failed to fetch premium capabilities:', error);
-    }
-  }
+  const { fetchCapabilities } = useFetchPremiumCapabilities();
 
   watch(logged, (isLogged) => {
     if (!isLogged) {


### PR DESCRIPTION
## Summary
- After saving new premium API keys on the Premium API Keys page, `usePremiumOperations.setup` toggled the `premium` flag but never refreshed the capabilities cache. The current-tier label, cloud-backup availability, and other capability-gated UI stayed at their previous (often `undefined`) value until the page was refreshed.
- Extracted the capabilities fetch into its own `useFetchPremiumCapabilities` composable and call it from `setup` after a successful credential write. `usePremiumWatchers` now delegates to the same helper, so there is a single source of truth for fetching/storing capabilities.

## Test plan
- [x] `pnpm run test:unit src/modules/premium/use-premium-operations.spec.ts` — 3 new tests: refresh on success, no refresh on API false, no refresh on throw
- [x] `pnpm run test:unit src/modules/premium/use-feature-access.spec.ts` — 21 existing tests still passing
- [x] `pnpm run typecheck`
- [x] `CI=true pnpm run lint` (no new errors)
- [x] Manual: save new premium keys → confirmed current tier and cloud-backup gated UI update without refresh