### PR TITLE
test(e2e): add calendar spec

### DIFF
--- a/frontend/app/src/modules/calendar/CalendarDateNavigator.vue
+++ b/frontend/app/src/modules/calendar/CalendarDateNavigator.vue
@@ -63,6 +63,7 @@ watch(
       size="xl"
       class="!rounded-r-none"
       :disabled="alreadyOnToday"
+      data-testid="calendar-today"
       @click="emit('set-today')"
     >
       {{ t('calendar.today') }}

--- a/frontend/app/src/modules/calendar/CalendarEventList.vue
+++ b/frontend/app/src/modules/calendar/CalendarEventList.vue
@@ -49,7 +49,11 @@ function onEventClicked(calendarEvent: CalendarEvent) {
 </script>
 
 <template>
-  <div class="flex items-center gap-4">
+  <div
+    class="flex items-center gap-4"
+    :data-testid="`calendar-event-${event.identifier}`"
+    :data-event-name="event.name"
+  >
     <div
       class="min-w-5 min-h-5 rounded-full"
       :style="{

--- a/frontend/app/src/modules/calendar/CalendarForm.vue
+++ b/frontend/app/src/modules/calendar/CalendarForm.vue
@@ -140,6 +140,7 @@ defineExpose({
         variant="outlined"
         color="primary"
         :error-messages="toMessages(v$.name)"
+        data-testid="calendar-form-name"
         @blur="v$.name.$touch()"
       />
 
@@ -156,6 +157,7 @@ defineExpose({
       min-rows="5"
       :error-messages="toMessages(v$.description)"
       :hint="t('common.optional')"
+      data-testid="calendar-form-description"
       @blur="v$.description.$touch()"
     />
 

--- a/frontend/app/src/modules/calendar/CalendarFormDialog.vue
+++ b/frontend/app/src/modules/calendar/CalendarFormDialog.vue
@@ -117,6 +117,7 @@ const dialogTitle = computed<string>(() =>
       <RuiButton
         v-if="editMode"
         color="error"
+        data-testid="calendar-form-delete"
         @click="emit('delete')"
       >
         {{ t('calendar.delete_event') }}

--- a/frontend/app/src/modules/calendar/CalendarMonthNavigator.vue
+++ b/frontend/app/src/modules/calendar/CalendarMonthNavigator.vue
@@ -22,6 +22,7 @@ const readableMonthAndYear = computed(() => get(model).format('MMMM YYYY'));
       variant="text"
       icon
       class="!p-2"
+      data-testid="calendar-prev-month"
       @click="prevMonth()"
     >
       <RuiIcon name="lu-chevron-left" />
@@ -30,6 +31,7 @@ const readableMonthAndYear = computed(() => get(model).format('MMMM YYYY'));
       variant="text"
       icon
       class="!p-2"
+      data-testid="calendar-next-month"
       @click="nextMonth()"
     >
       <RuiIcon name="lu-chevron-right" />
@@ -44,6 +46,7 @@ const readableMonthAndYear = computed(() => get(model).format('MMMM YYYY'));
         dense
         hide-details
         append-icon="lu-calendar-days"
+        data-testid="calendar-month-label"
       />
     </div>
   </div>

--- a/frontend/app/src/modules/calendar/CalendarSelectedEventsPanel.vue
+++ b/frontend/app/src/modules/calendar/CalendarSelectedEventsPanel.vue
@@ -24,7 +24,10 @@ function edit(event: CalendarEvent): void {
 </script>
 
 <template>
-  <RuiCard class="[&>div:last-child]:!pt-2">
+  <RuiCard
+    class="[&>div:last-child]:!pt-2"
+    data-testid="calendar-selected-list"
+  >
     <template #header>
       <div v-if="today.isSame(selectedDate, 'day')">
         {{ t('calendar.today_events') }}

--- a/frontend/app/src/modules/calendar/CalendarUpcomingEventsPanel.vue
+++ b/frontend/app/src/modules/calendar/CalendarUpcomingEventsPanel.vue
@@ -22,7 +22,10 @@ function edit(event: CalendarEvent): void {
 </script>
 
 <template>
-  <RuiCard class="[&>div:last-child]:!pt-2">
+  <RuiCard
+    class="[&>div:last-child]:!pt-2"
+    data-testid="calendar-upcoming-list"
+  >
     <template #header>
       {{ t('calendar.upcoming_events') }}
     </template>

--- a/frontend/app/src/modules/calendar/CalendarView.vue
+++ b/frontend/app/src/modules/calendar/CalendarView.vue
@@ -66,6 +66,7 @@ onMounted(async () => {
       <RuiButton
         color="primary"
         size="lg"
+        data-testid="calendar-add-event"
         @click="add()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/shell/components/navigation/NavigationMenu.vue
+++ b/frontend/app/src/modules/shell/components/navigation/NavigationMenu.vue
@@ -242,6 +242,7 @@ const navItems = computed<MenuItem[]>(() => {
       type: 'divider',
     },
     {
+      class: 'calendar',
       type: 'item',
       ...Routes.CALENDAR,
     },

--- a/frontend/app/tests/e2e/pages/calendar-page.ts
+++ b/frontend/app/tests/e2e/pages/calendar-page.ts
@@ -1,0 +1,129 @@
+import { expect, type Page } from '@playwright/test';
+import { TIMEOUT_MEDIUM, TIMEOUT_SHORT } from '../helpers/constants';
+import { RotkiApp } from './rotki-app';
+
+async function confirmDialog(page: Page): Promise<void> {
+  const dialog = page.locator('[data-cy=bottom-dialog]');
+  await dialog.locator('[data-cy=confirm]').click();
+  await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+}
+
+async function confirmDelete(page: Page): Promise<void> {
+  const confirmDialogEl = page.locator('[data-cy=confirm-dialog]');
+  await confirmDialogEl.locator('[data-cy=button-confirm]').click();
+  await confirmDialogEl.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+}
+
+export class CalendarPage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await RotkiApp.navigateTo(this.page, 'calendar');
+  }
+
+  selectedPanel() {
+    return this.page.getByTestId('calendar-selected-list');
+  }
+
+  upcomingPanel() {
+    return this.page.getByTestId('calendar-upcoming-list');
+  }
+
+  private eventInPanel(panel: ReturnType<CalendarPage['selectedPanel']>, name: string) {
+    return panel.locator('[data-event-name]').filter({ hasText: name });
+  }
+
+  async openAddDialog(): Promise<void> {
+    await this.page.getByTestId('calendar-add-event').click();
+    await this.page.locator('[data-cy=bottom-dialog]').waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+  }
+
+  async cancelDialog(): Promise<void> {
+    const dialog = this.page.locator('[data-cy=bottom-dialog]');
+    await dialog.locator('[data-cy=cancel]').click();
+    await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+  }
+
+  async clickToday(): Promise<void> {
+    await this.page.getByTestId('calendar-today').click();
+    await this.page.waitForTimeout(150);
+  }
+
+  async expectTodayDisabled(): Promise<void> {
+    await expect(this.page.getByTestId('calendar-today')).toBeDisabled();
+  }
+
+  async expectTodayEnabled(): Promise<void> {
+    await expect(this.page.getByTestId('calendar-today')).toBeEnabled();
+  }
+
+  async createEvent(opts: { name: string; description?: string }): Promise<void> {
+    await this.openAddDialog();
+    await this.page.getByTestId('calendar-form-name').locator('input').fill(opts.name);
+    if (opts.description !== undefined) {
+      await this.page.getByTestId('calendar-form-description').locator('textarea').first().fill(opts.description);
+    }
+    await confirmDialog(this.page);
+  }
+
+  async openEventByName(name: string): Promise<void> {
+    // Click "View details" on the matching event in the selected-events panel.
+    const event = this.eventInPanel(this.selectedPanel(), name).first();
+    await event.getByRole('button', { name: /view details/i }).click();
+    await this.page.locator('[data-cy=bottom-dialog]').waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+  }
+
+  async editEvent(name: string, opts: { newName?: string; newDescription?: string }): Promise<void> {
+    await this.openEventByName(name);
+    if (opts.newName !== undefined) {
+      const input = this.page.getByTestId('calendar-form-name').locator('input');
+      await input.fill(opts.newName);
+    }
+    if (opts.newDescription !== undefined) {
+      const textarea = this.page.getByTestId('calendar-form-description').locator('textarea').first();
+      await textarea.fill(opts.newDescription);
+    }
+    await confirmDialog(this.page);
+  }
+
+  async deleteEvent(name: string): Promise<void> {
+    await this.openEventByName(name);
+    await this.page.getByTestId('calendar-form-delete').click();
+    await confirmDelete(this.page);
+  }
+
+  async expectEventInSelected(name: string): Promise<void> {
+    await expect(this.eventInPanel(this.selectedPanel(), name).first()).toBeVisible();
+  }
+
+  async expectNoEventInSelected(name: string): Promise<void> {
+    await expect(this.eventInPanel(this.selectedPanel(), name)).toHaveCount(0);
+  }
+
+  async expectEventInUpcoming(name: string): Promise<void> {
+    await expect(this.eventInPanel(this.upcomingPanel(), name).first()).toBeVisible();
+  }
+
+  async expectNoEventInUpcoming(name: string): Promise<void> {
+    await expect(this.eventInPanel(this.upcomingPanel(), name)).toHaveCount(0);
+  }
+
+  async goToNextMonth(): Promise<void> {
+    await this.page.getByTestId('calendar-next-month').click();
+    await this.page.waitForTimeout(150);
+  }
+
+  async goToPrevMonth(): Promise<void> {
+    await this.page.getByTestId('calendar-prev-month').click();
+    await this.page.waitForTimeout(150);
+  }
+
+  async currentMonthLabel(): Promise<string> {
+    const value = await this.page.getByTestId('calendar-month-label').locator('input').inputValue();
+    return value;
+  }
+
+  async expectMonthLabel(label: string): Promise<void> {
+    await expect(this.page.getByTestId('calendar-month-label').locator('input')).toHaveValue(label, { timeout: TIMEOUT_SHORT });
+  }
+}

--- a/frontend/app/tests/e2e/specs/app/calendar.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/calendar.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test';
+import dayjs from 'dayjs';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { CalendarPage } from '../../pages/calendar-page';
+
+test.describe.serial('calendar', () => {
+  let ctx: SharedTestContext;
+  let page: CalendarPage;
+  const today = dayjs();
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request, { disableModules: true });
+    page = new CalendarPage(ctx.sharedPage);
+    await page.visit();
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('creates an event on the selected day', async () => {
+    await page.createEvent({ name: 'team standup', description: 'morning sync' });
+    await page.expectEventInSelected('team standup');
+  });
+
+  test('edits an event', async () => {
+    await page.editEvent('team standup', {
+      newName: 'team standup renamed',
+      newDescription: 'updated description',
+    });
+    await page.expectEventInSelected('team standup renamed');
+  });
+
+  test('navigates to next and previous month', async () => {
+    const startLabel = today.format('MMMM YYYY');
+    const nextLabel = today.add(1, 'month').format('MMMM YYYY');
+
+    await page.expectMonthLabel(startLabel);
+    await page.goToNextMonth();
+    await page.expectMonthLabel(nextLabel);
+    await page.goToPrevMonth();
+    await page.expectMonthLabel(startLabel);
+  });
+
+  test('deletes an event', async () => {
+    await page.deleteEvent('team standup renamed');
+    await page.expectNoEventInSelected('team standup renamed');
+  });
+
+  test('shows validation error when name is empty', async () => {
+    await page.openAddDialog();
+    await ctx.sharedPage.locator('[data-cy=bottom-dialog] [data-cy=confirm]').click();
+    await expect(
+      ctx.sharedPage.locator('[data-cy=bottom-dialog]').getByText('The name field cannot be empty'),
+    ).toBeVisible();
+    await page.cancelDialog();
+  });
+
+  test('cancel button closes the add dialog', async () => {
+    await page.openAddDialog();
+    await page.cancelDialog();
+  });
+
+  test('Today button returns to current month when on a different month', async () => {
+    await page.expectTodayDisabled();
+    await page.goToNextMonth();
+    await page.expectMonthLabel(today.add(1, 'month').format('MMMM YYYY'));
+    await page.expectTodayEnabled();
+    await page.clickToday();
+    await page.expectMonthLabel(today.format('MMMM YYYY'));
+    await page.expectTodayDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
Adds e2e coverage for the calendar page. Previously zero coverage — only the operations composable had unit tests.

Tests:
- create an event on the selected day
- edit an event (rename + change description)
- next / previous month navigation
- delete an event via the form's Delete button
- empty-name validation error
- cancel button closes the add dialog
- Today button: disabled on today, enabled after navigating away, returns to today's month when clicked

Adds \`data-testid\` attributes to:
- the top-level Add Event button (\`CalendarView\`)
- prev/next month buttons and the month label (\`CalendarMonthNavigator\`)
- the Today button (\`CalendarDateNavigator\`)
- each rendered event's wrapper plus its name as a data attribute (\`CalendarEventList\`)
- the upcoming-events and selected-events panel cards
- the form's name input, description textarea, and the Delete button

### Drive-by
Add a \`class: 'calendar'\` to the calendar nav menu entry so \`RotkiApp.navigateTo\` can target it via \`[data-cy=navigation__calendar]\`. Without this the entry was rendering as \`navigation__undefined\`.

### Out of scope
Reminders, recurring events, color picker exact-RGB assertions, settings menu.

Refs #11252.

## Test plan
- [x] \`pnpm run test:e2e tests/e2e/specs/app/calendar.spec.ts\` — 7/7 passing locally
- [x] \`pnpm run typecheck\`