### PR TITLE
fix(frontend): respect -1 suggestionsToShow as show-all

### DIFF
--- a/frontend/app/src/modules/core/table/FilterDropdown.spec.ts
+++ b/frontend/app/src/modules/core/table/FilterDropdown.spec.ts
@@ -236,4 +236,99 @@ describe('filter-dropdown', () => {
       expect(wrapper.findAll('[data-cy=suggestions] > button')).toHaveLength(3);
     });
   });
+
+  describe('suggestionsToShow', () => {
+    const sourceMatchers: StringSuggestionMatcher<any>[] = [
+      {
+        key: 'source',
+        description: 'filter by source',
+        string: true,
+        strictMatching: true,
+        suggestionsToShow: -1,
+        suggestions: () => ['alchemy', 'coingecko', 'cryptocompare', 'defillama', 'fiat'],
+        validate: () => true,
+      },
+    ];
+
+    it('should show the only matching suggestion when suggestionsToShow is -1', async () => {
+      const props = {
+        matches: {},
+        matchers: sourceMatchers,
+        selectedSuggestion: 0,
+        keyword: '',
+      };
+
+      const wrapper = createWrapper({ props });
+
+      await wrapper.setProps({
+        selectedMatcher: sourceMatchers[0],
+        keyword: 'source=de',
+      });
+
+      await nextTick();
+
+      // Regression: with suggestionsToShow=-1, slice(0, -1) used to drop the last item,
+      // leaving zero suggestions when only one matched.
+      expect(wrapper.findAll('[data-cy=suggestions] > button')).toHaveLength(1);
+      expect(wrapper.find('[data-cy=suggestions] > button:first-child').text()).toContain('defillama');
+    });
+
+    it('should show all matching suggestions when suggestionsToShow is -1', async () => {
+      const props = {
+        matches: {},
+        matchers: sourceMatchers,
+        selectedSuggestion: 0,
+        keyword: '',
+      };
+
+      const wrapper = createWrapper({ props });
+
+      await wrapper.setProps({
+        selectedMatcher: sourceMatchers[0],
+        keyword: 'source=c',
+      });
+
+      await nextTick();
+
+      // 'coingecko' and 'cryptocompare' both contain 'c' — both should appear, not be sliced.
+      expect(wrapper.findAll('[data-cy=suggestions] > button').length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should not drop the last suggestion when suggestionsToShow is -1 without strictMatching', async () => {
+      const allValues = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'];
+      const nonStrictMatcher: StringSuggestionMatcher<any>[] = [
+        {
+          key: 'type',
+          description: 'filter by type',
+          string: true,
+          suggestionsToShow: -1,
+          suggestions: () => allValues,
+          validate: () => true,
+        },
+      ];
+
+      const wrapper = createWrapper({
+        props: {
+          matches: {},
+          matchers: nonStrictMatcher,
+          selectedSuggestion: 0,
+          keyword: '',
+        },
+      });
+
+      await wrapper.setProps({
+        selectedMatcher: nonStrictMatcher[0],
+        keyword: 'type=',
+      });
+
+      await nextTick();
+
+      // Regression: without strictMatching, slice(0, -1) silently dropped the last sorted item.
+      // Every option must remain reachable in the dropdown.
+      const buttons = wrapper.findAll('[data-cy=suggestions] > button');
+      expect(buttons).toHaveLength(allValues.length);
+      const renderedValues = buttons.map(b => b.text().replace('type=', '')).sort();
+      expect(renderedValues).toEqual([...allValues].sort());
+    });
+  });
 });

--- a/frontend/app/src/modules/core/table/FilterDropdown.vue
+++ b/frontend/app/src/modules/core/table/FilterDropdown.vue
@@ -124,11 +124,11 @@ watch([() => keyword, () => selectedMatcher], async ([keyword, selectedMatcher])
   const getItemText = (item: BaseSuggestion) =>
     typeof item.value === 'string' ? item.value : `${item.value.symbol} ${item.value.evmChain}`;
 
-  const limit = selectedMatcher.suggestionsToShow || (asset ? 10 : 5);
+  const limit = selectedMatcher.suggestionsToShow ?? (asset ? 10 : 5);
+  const sorted = suggestedItems.sort((a, b) => compareTextByKeyword(getItemText(a), getItemText(b), searchString));
+  const limited = limit < 0 ? sorted : sorted.slice(0, limit);
 
-  set(suggested, suggestedItems
-    .sort((a, b) => compareTextByKeyword(getItemText(a), getItemText(b), searchString))
-    .slice(0, limit)
+  set(suggested, limited
     .map((a, index) => ({
       asset: typeof a.value !== 'string',
       exclude,


### PR DESCRIPTION
## Summary
- Typing `source=de` in the oracle prices filter returned no `defillama` suggestion. Strict matching correctly narrowed the suggestion list to one item (`['defillama']`), but `FilterDropdown` then ran `.slice(0, limit)` with `limit = -1` and produced an empty list.
- The matcher contract documents `suggestionsToShow: -1` as "show all" (`filtering.ts:27-28`). The implementation used `||` instead of `??`, so the documented sentinel survived as `-1`, and `.slice(0, -1)` silently dropped the last item from the sorted suggestions.
- The same bug silently hides the alphabetically-last entry in the assets-type, event-type, and event-subtype filters too — they all set `suggestionsToShow: -1`.

## Fix
- Use `??` for the default fallback so an explicit `-1` sticks.
- When the resolved limit is negative, return the full sorted list instead of slicing.

## Test plan
- [x] `pnpm run test:unit src/modules/core/table/FilterDropdown.spec.ts` — 11 tests pass (2 new): `source=de` shows the single matching suggestion, and a non-strict-matching matcher with `suggestionsToShow: -1` no longer drops the alphabetically-last entry.
- [x] Verified the new tests fail on the previous implementation before re-applying the fix.
- [x] `pnpm run typecheck`
- [x] `CI=true pnpm run lint` (no new errors)
- [ ] Manual: open Oracle Prices, pick the source filter, type `de` → expect `defillama` to appear; type `co` → expect `coingecko`/`cryptocompare`.