### PR TITLE
fix(frontend): clear stale period when switching reports to custom

### DIFF
--- a/frontend/app/src/modules/reports/ReportPeriodSelector.spec.ts
+++ b/frontend/app/src/modules/reports/ReportPeriodSelector.spec.ts
@@ -173,6 +173,37 @@ describe('components/profitloss/ReportPeriodSelector.vue', () => {
       });
     });
 
+    it('should emit null period when custom is clicked from a past year (regression: stale max-date)', async () => {
+      // Regression for the bug where clicking the Custom button while a
+      // past year was selected synchronously re-emitted that year's period.
+      // The parent (RangeSelector) would briefly apply the stale window as
+      // the model, the custom DateTimeRangePicker would mount against it,
+      // and RuiDateTimePicker would latch its max-date validation
+      // ("Date cannot be after 12/31/<past-year>") because
+      // `useDateTimeSelection` captures `maxDate` once at mount.
+      const pastYear = (Number(currentYear) - 4).toString();
+      wrapper = createWrapper({
+        props: {
+          quarter: Quarter.ALL,
+          year: pastYear,
+        },
+      });
+
+      // Drop the mount-time period emit from the assertion window.
+      await vi.advanceTimersToNextTimerAsync();
+
+      const customButton = wrapper.find('[data-cy=button-custom]');
+      await customButton.trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const periodEvents = wrapper.emitted<(PeriodChangedEvent | null)[]>('update:period')!;
+      // The very next period emit after the click must be null — not a
+      // payload reflecting the past year.
+      const eventsAfterMount = periodEvents.slice(1);
+      expect(eventsAfterMount.length).toBeGreaterThan(0);
+      expect(eventsAfterMount[0][0]).toBeNull();
+    });
+
     it('should not show quarter selection when custom is selected', () => {
       wrapper = createWrapper({
         props: {

--- a/frontend/app/src/modules/reports/ReportPeriodSelector.vue
+++ b/frontend/app/src/modules/reports/ReportPeriodSelector.vue
@@ -130,11 +130,20 @@ const subPeriods = [
 ];
 
 function onChange(change: { year?: string; quarter?: Quarter }) {
+  const newYear = change?.year ?? year;
   updateSelection({
     quarter: change?.quarter ?? quarter,
-    year: change?.year ?? year,
+    year: newYear,
   });
-  updatePeriod(year !== 'custom' ? get(periodEventPayload) : null);
+  // Use the incoming `newYear` (not the stale `year` prop) to decide whether
+  // to emit a period. Reading the prop here returns the value before the
+  // parent re-renders, so switching to Custom would synchronously emit the
+  // previous year's period — the parent would briefly apply it as the
+  // model, the custom picker would mount against that stale window, and
+  // RuiDateTimePicker would latch its max-date validation (its
+  // `useDateTimeSelection` captures `maxDate` once at mount and never
+  // reacts to later prop changes). See DateTimeRangePicker.applyQuickOption.
+  updatePeriod(newYear !== 'custom' ? get(periodEventPayload) : null);
 }
 
 const yearModel = computed({
@@ -170,13 +179,12 @@ const quarterModel = computed({
               required
               variant="outlined"
               active-color="primary"
-              class="flex-wrap justify-center"
+              class="flex-wrap justify-center !rounded-r-none [&>*:last-child]:!rounded-r-none"
               data-cy="button-group-report-period-year"
             >
               <RuiButton
                 v-for="period in periods"
                 :key="period"
-                class="[&:last-child]:!rounded-r-none"
                 :model-value="period"
               >
                 {{ period }}


### PR DESCRIPTION
## Summary
- `ReportPeriodSelector.onChange` was reading the stale local `year` prop when deciding whether to emit a period, so clicking **Custom** from a past year (e.g. 2022) synchronously re-emitted that year's window.
- The parent (`RangeSelector`) applied it as the model, the custom `DateTimeRangePicker` mounted against it, and `RuiDateTimePicker.useDateTimeSelection` captured `maxDate=2022-12-31` once at mount — it doesn't react to later prop changes.
- Result: the start picker latched a "Date cannot be after 12/31/2022" validation that nothing else could clear, so clicking *Last 1 year* afterwards still showed the error against the modern dates:

  ![error](https://github.com/user-attachments/assets/placeholder)

  Use the incoming `change.year` (not the stale prop) to drive the emit — switching to Custom now emits `null` immediately, the parent's `{end:now, start:undefined}` reset is what the picker mounts against, and there's no stale max-date to latch onto.
- Drive-by CSS: flatten the right outline + last-button corner of the year `RuiButtonGroup` so it butts cleanly into the older-years chevron (the library's own `last:!rounded-r` was overriding our previous `[&:last-child]:!rounded-r-none` due to higher specificity).

## Test plan
- [x] New regression unit test in `ReportPeriodSelector.spec.ts`: clicking **Custom** while a past year is selected emits `update:period(null)` first (not a payload reflecting the past year).
- [x] Existing `ReportPeriodSelector.spec.ts` (14 tests) and `DateTimeRangePicker.spec.ts` (3 tests) still green.
- [ ] Manual: in Reports → Generate, pick year 2022, click **Custom**, click **Last 1 year** in the start picker. No "Date cannot be after 12/31/2022" error.
- [ ] Manual: visually confirm the right edge of the year button group is flat into the chevron dropdown.