### PR TITLE
test(e2e): cover exchange data purge by category

### DIFF
--- a/frontend/app/src/modules/settings/data-security/data-management/PurgeData.vue
+++ b/frontend/app/src/modules/settings/data-security/data-management/PurgeData.vue
@@ -174,6 +174,7 @@ const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
         key-attr="id"
         hide-details
         :disabled="pending"
+        data-testid="purge-source"
       />
       <ChainSelect
         v-if="source === Purgeable.TRANSACTIONS"
@@ -192,6 +193,7 @@ const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
         :items="allExchanges"
         :label="t('purge_selector.centralized_exchange_to_clear.label')"
         :hint="t('purge_selector.centralized_exchange_to_clear.hint')"
+        data-testid="purge-cex-location"
       />
       <RuiAutoComplete
         v-if="source === Purgeable.CENTRALIZED_EXCHANGES"
@@ -203,6 +205,7 @@ const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
         key-attr="id"
         hide-details
         :disabled="pending"
+        data-testid="purge-cex-data-type"
       />
       <LocationSelector
         v-else-if="source === Purgeable.DECENTRALIZED_EXCHANGES"
@@ -231,6 +234,7 @@ const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
           :disabled="!source || pending"
           :loading="pending"
           color="error"
+          data-testid="purge-submit"
           @click="showConfirmation(source)"
         >
           <template #prepend>

--- a/frontend/app/tests/e2e/helpers/exchange-api.ts
+++ b/frontend/app/tests/e2e/helpers/exchange-api.ts
@@ -1,0 +1,142 @@
+import type { APIRequestContext } from '@playwright/test';
+import { backendUrl } from '../../../playwright.config';
+
+export type ExchangePurgeDataType = 'all' | 'trades' | 'asset_movements' | 'other';
+
+/**
+ * Purges history events for a single exchange via the public API. Pass a
+ * `dataType` to scope the purge to one bucket (trades, asset movements, or
+ * everything else); the default `'all'` is the same call the UI makes when no
+ * category is chosen.
+ *
+ * Useful in `beforeEach` to reset state between purge-by-category tests
+ * without recreating the user/context.
+ */
+export async function apiPurgeExchangeData(
+  request: APIRequestContext,
+  location: string,
+  dataType: ExchangePurgeDataType = 'all',
+): Promise<void> {
+  const response = await request.delete(`${backendUrl}/api/1/exchanges/data/${location}`, {
+    params: { data_type: dataType },
+  });
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to purge ${dataType} data for ${location}: ${response.status()} ${await response.text()}`,
+    );
+  }
+}
+
+interface SeedOptions {
+  location: string;
+  /** Unix timestamp in milliseconds. Each event needs a unique value. */
+  timestampMs: number;
+  /** Position within the parent group; needs to be unique per group. */
+  sequenceIndex: number;
+}
+
+/**
+ * Adds a single non-trade, non-movement history event (`entry_type=history event`)
+ * tagged with the given location. Falls into the `OTHER` purge bucket.
+ */
+export async function apiSeedHistoryEvent(
+  request: APIRequestContext,
+  options: SeedOptions,
+): Promise<void> {
+  const payload = {
+    entry_type: 'history event',
+    timestamp: options.timestampMs,
+    location: options.location,
+    sequence_index: options.sequenceIndex,
+    event_type: 'staking',
+    event_subtype: 'reward',
+    asset: 'ETH',
+    amount: '0.1',
+    group_identifier: `e2e-other-${options.timestampMs}`,
+  };
+  await putHistoryEvent(request, payload, 'history event');
+}
+
+/**
+ * Adds a single asset movement event (`entry_type=asset movement event`) tagged
+ * with the given location. Falls into the `ASSET_MOVEMENTS` purge bucket.
+ */
+export async function apiSeedAssetMovement(
+  request: APIRequestContext,
+  options: SeedOptions,
+): Promise<void> {
+  const payload = {
+    entry_type: 'asset movement event',
+    timestamp: options.timestampMs,
+    location: options.location,
+    event_subtype: 'receive',
+    amount: '0.5',
+    asset: 'ETH',
+    unique_id: `e2e-movement-${options.timestampMs}-${options.sequenceIndex}`,
+  };
+  await putHistoryEvent(request, payload, 'asset movement event');
+}
+
+/**
+ * Adds a single swap/trade event (`entry_type=swap event`) tagged with the
+ * given location. Falls into the `TRADES` purge bucket.
+ */
+export async function apiSeedSwap(
+  request: APIRequestContext,
+  options: SeedOptions,
+): Promise<void> {
+  const payload = {
+    entry_type: 'swap event',
+    timestamp: options.timestampMs,
+    location: options.location,
+    spend_amount: '1',
+    spend_asset: 'ETH',
+    receive_amount: '3000',
+    receive_asset: 'USD',
+    unique_id: `e2e-trade-${options.timestampMs}-${options.sequenceIndex}`,
+  };
+  await putHistoryEvent(request, payload, 'swap event');
+}
+
+/**
+ * Counts existing history events at a given location, bucketed by the
+ * `entry_type` values that map to the three purge categories the UI exposes.
+ */
+export async function apiCountExchangeEventsByCategory(
+  request: APIRequestContext,
+  location: string,
+): Promise<{ trades: number; assetMovements: number; other: number }> {
+  const response = await request.post(`${backendUrl}/api/1/history/events`, {
+    data: { location, exclude_ignored_assets: false },
+  });
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to query history events for ${location}: ${response.status()} ${await response.text()}`,
+    );
+  }
+  const body = await response.json();
+  const entries: Array<{ entry: { entry_type: string } }> = body.result?.entries ?? [];
+  return {
+    trades: entries.filter(e => e.entry.entry_type === 'swap event').length,
+    assetMovements: entries.filter(e => e.entry.entry_type === 'asset movement event').length,
+    other: entries.filter(e => e.entry.entry_type === 'history event').length,
+  };
+}
+
+async function putHistoryEvent(
+  request: APIRequestContext,
+  payload: Record<string, unknown>,
+  kind: string,
+): Promise<void> {
+  const response = await request.put(`${backendUrl}/api/1/history/events`, { data: payload });
+  const body = await response.json().catch(() => null);
+  // Rotki's API often returns HTTP 200 with `result: false` and a non-empty
+  // `message` on validation errors, so check both transport status and the
+  // body envelope.
+  const apiOk = body && body.result !== false && body.result !== null && body.result !== undefined;
+  if (!response.ok() || !apiOk) {
+    throw new Error(
+      `Failed to seed ${kind} (${response.status()}): ${JSON.stringify(body) || await response.text()}`,
+    );
+  }
+}

--- a/frontend/app/tests/e2e/pages/purge-data-page.ts
+++ b/frontend/app/tests/e2e/pages/purge-data-page.ts
@@ -1,0 +1,78 @@
+import { expect, type Page } from '@playwright/test';
+import { TIMEOUT_MEDIUM, TIMEOUT_SHORT } from '../helpers/constants';
+
+type PurgeSourceLabel = 'Centralized Exchange' | 'Decentralized Exchange' | 'DeFi Module' | 'Transactions';
+
+type CexCategoryLabel = 'All' | 'Trades' | 'Deposits / Withdrawals' | 'Other events';
+
+export class PurgeDataPage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    // Reuse the same user-menu → settings → tab path the rest of the e2e suite
+    // uses; navigating directly to `/#/settings/database` lands on a blank
+    // shell because the layout's data-bootstrapping never runs.
+    await this.page.locator('[data-cy=user-menu-button]').click();
+    await this.page.locator('[data-cy=user-dropdown]').waitFor({ state: 'visible' });
+    await this.page.locator('[data-cy=settings-button]').click();
+    await this.page.locator('[data-cy=user-dropdown]').waitFor({ state: 'detached' });
+    await this.page.locator('[data-cy=settings__database]').click();
+    await this.page.getByTestId('purge-source').waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+  }
+
+  /**
+   * Picks an option from a `RuiAutoComplete`-backed control identified by its
+   * test id. Selection-by-id (`#item-<key>`) is preferred for stability;
+   * if the option for the typed text isn't rendered yet (debounced search,
+   * lazy lists, etc.) we fall back to typing then clicking the first match.
+   */
+  private async selectOption(testId: string, text: string): Promise<void> {
+    const select = this.page.getByTestId(testId);
+    await select.click();
+    const menu = this.page.locator('[role="listbox"], [role="menu"]').last();
+    await menu.waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
+
+    const byText = menu.getByText(text, { exact: true }).first();
+    try {
+      await byText.waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
+      await byText.click();
+    }
+    catch {
+      await this.page.keyboard.type(text);
+      const firstOption = menu.locator('button[type="button"]').first();
+      await firstOption.waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
+      await firstOption.click();
+    }
+    await menu.waitFor({ state: 'hidden', timeout: TIMEOUT_SHORT });
+  }
+
+  async chooseSource(label: PurgeSourceLabel): Promise<void> {
+    await this.selectOption('purge-source', label);
+  }
+
+  async chooseExchange(location: string): Promise<void> {
+    await this.selectOption('purge-cex-location', location);
+  }
+
+  async chooseCategory(label: CexCategoryLabel): Promise<void> {
+    await this.selectOption('purge-cex-data-type', label);
+  }
+
+  async submitAndConfirm(): Promise<void> {
+    await this.page.getByTestId('purge-submit').click();
+    const dialog = this.page.locator('[data-cy=confirm-dialog]');
+    await dialog.waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+    await dialog.locator('[data-cy=button-confirm]').click();
+    await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+    // The component shows an inline ActionStatusIndicator on success; wait for
+    // the success state so subsequent assertions see the post-purge DB state.
+    await expect(this.page.getByText('Data was successfully deleted')).toBeVisible({ timeout: TIMEOUT_MEDIUM });
+  }
+
+  async purgeExchange(location: string, category: CexCategoryLabel): Promise<void> {
+    await this.chooseSource('Centralized Exchange');
+    await this.chooseExchange(location);
+    await this.chooseCategory(category);
+    await this.submitAndConfirm();
+  }
+}

--- a/frontend/app/tests/e2e/specs/app/exchange-purge.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/exchange-purge.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import {
+  apiCountExchangeEventsByCategory,
+  apiPurgeExchangeData,
+  apiSeedAssetMovement,
+  apiSeedHistoryEvent,
+  apiSeedSwap,
+} from '../../helpers/exchange-api';
+import { PurgeDataPage } from '../../pages/purge-data-page';
+
+const LOCATION = 'kraken';
+
+async function seedAllCategories(request: Parameters<typeof apiSeedSwap>[0]): Promise<void> {
+  // Tests share a backend, so re-seeds run sequentially. The IDs embedded in
+  // each helper's `unique_id`/`group_identifier` are stamped from the
+  // timestamp, so every reseed creates fresh rows even after a prior purge.
+  // Use a base timestamp safely in the past so the default
+  // `to_timestamp = now()` query filter on the events endpoint includes them.
+  const base = Date.now() - 60_000;
+  await apiSeedSwap(request, { location: LOCATION, sequenceIndex: 0, timestampMs: base });
+  await apiSeedAssetMovement(request, { location: LOCATION, sequenceIndex: 0, timestampMs: base + 1 });
+  await apiSeedHistoryEvent(request, { location: LOCATION, sequenceIndex: 0, timestampMs: base + 2 });
+}
+
+test.describe.serial('exchange purge by category', () => {
+  let ctx: SharedTestContext;
+  let page: PurgeDataPage;
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request, { disableModules: true });
+    page = new PurgeDataPage(ctx.sharedPage);
+    await page.visit();
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test.beforeEach(async ({ request }) => {
+    // Wipe-and-seed so each test starts from a known {1 trade, 1 movement, 1 other}.
+    // Using the purge endpoint itself for cleanup keeps setup light and verifies
+    // no test leaves residual state behind.
+    await apiPurgeExchangeData(request, LOCATION, 'all');
+    await seedAllCategories(request);
+  });
+
+  // A single seeded swap expands into spend+receive sub-events (entry_type
+  // `swap event`), so the trade-bucket count is 2 per swap. Asset movements
+  // and `history event` rows stay 1:1 with seeds.
+  const seededCounts = { assetMovements: 1, other: 1, trades: 2 };
+
+  test('purges only trades', async ({ request }) => {
+    expect(await apiCountExchangeEventsByCategory(request, LOCATION)).toEqual(seededCounts);
+    await page.purgeExchange('Kraken', 'Trades');
+    expect(await apiCountExchangeEventsByCategory(request, LOCATION)).toEqual({
+      assetMovements: 1,
+      other: 1,
+      trades: 0,
+    });
+  });
+
+  test('purges only asset movements', async ({ request }) => {
+    expect(await apiCountExchangeEventsByCategory(request, LOCATION)).toEqual(seededCounts);
+    await page.purgeExchange('Kraken', 'Deposits / Withdrawals');
+    expect(await apiCountExchangeEventsByCategory(request, LOCATION)).toEqual({
+      assetMovements: 0,
+      other: 1,
+      trades: 2,
+    });
+  });
+
+  test('purges only other events', async ({ request }) => {
+    expect(await apiCountExchangeEventsByCategory(request, LOCATION)).toEqual(seededCounts);
+    await page.purgeExchange('Kraken', 'Other events');
+    expect(await apiCountExchangeEventsByCategory(request, LOCATION)).toEqual({
+      assetMovements: 1,
+      other: 0,
+      trades: 2,
+    });
+  });
+
+  test('purges everything', async ({ request }) => {
+    expect(await apiCountExchangeEventsByCategory(request, LOCATION)).toEqual(seededCounts);
+    await page.purgeExchange('Kraken', 'All');
+    expect(await apiCountExchangeEventsByCategory(request, LOCATION)).toEqual({
+      assetMovements: 0,
+      other: 0,
+      trades: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Playwright e2e spec exercising **Settings → Database → Manage Data → Purge Data** for centralized exchanges, one test per data-type the dropdown exposes (`Trades`, `Deposits / Withdrawals`, `Other events`, `All`).
- Each test seeds three `location=kraken` history events via the public `PUT /history/events` API (one swap, one asset movement, one online "other" event), asserts the seed landed, drives the purge through the UI, then verifies only the targeted bucket was wiped — so we confirm both presence and absence around the action.
- Reset between tests is the same purge endpoint at `data_type=all`, so cleanup also exercises the same code path.
- Adds a small set of `data-testid` attributes to `PurgeData.vue` so the page object doesn't depend on label text.

## Test plan
- [x] `pnpm --filter rotki run test:e2e tests/e2e/specs/app/exchange-purge.spec.ts` — 4/4 pass locally, ~44s total. Re-ran for stability, still 4/4.
- [x] Repo lint clean (`pnpm run lint:fix` — 0 errors, only pre-existing warnings).
- [x] Repo typecheck clean (`pnpm run typecheck`).

Refs #11252.