### PR TITLE
chore(frontend): bump @rotki/ui-library to 2.20.0

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.3.2
       version: 1.3.2
     '@rotki/ui-library':
-      specifier: 2.19.3
-      version: 2.19.3
+      specifier: 2.20.0
+      version: 2.20.0
     '@tsconfig/node24':
       specifier: 24.0.4
       version: 24.0.4
@@ -370,7 +370,7 @@ importers:
         version: link:../common
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.19.3(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 2.20.0(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
@@ -1908,8 +1908,8 @@ packages:
     peerDependencies:
       eslint: ^9.20.0
 
-  '@rotki/ui-library@2.19.3':
-    resolution: {integrity: sha512-LnyFUOE4dMyAJPdqBiyKb7Y/T+z23jRml3aq02aMC5WGqM+fC5IzOBxQf2VZK94ZtzpOJZc6KLNtOupVrDhw/w==}
+  '@rotki/ui-library@2.20.0':
+    resolution: {integrity: sha512-p0w5+Aiyb0gQOGWTxoM/CK/5Wha7IT2qk18sedT3FV5L01s7QLmhnlnLCwpfa5K05ieNFdQuTmFC7qpTcIsNCw==}
     engines: {node: '>=24 <25', pnpm: '>=10 <11'}
     peerDependencies:
       dayjs: '>=1.11.13 <12'
@@ -8557,7 +8557,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rotki/ui-library@2.19.3(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+  '@rotki/ui-library@2.20.0(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@vueuse/core': 14.2.1(vue@3.5.32(typescript@5.9.3))

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   '@reown/appkit-adapter-ethers': 1.8.19
   '@rotki/eslint-config': 5.0.1
   '@rotki/eslint-plugin': 1.3.2
-  '@rotki/ui-library': 2.19.3
+  '@rotki/ui-library': 2.20.0
   '@tsconfig/node24': 24.0.4
   '@types/body-parser': 1.19.6
   '@types/express': 5.0.6


### PR DESCRIPTION
## Summary
- Bumps `@rotki/ui-library` from 2.19.3 to 2.20.0 in the workspace catalog.

## Test plan
- [x] `pnpm install` succeeds
- [x] `pnpm run typecheck` passes
- [x] `CI=true pnpm run lint` passes (no new errors)