### PR TITLE
feat(frontend): expose timezone option for csv import

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`12143` CSV imports now accept an optional timezone so files whose dates lack timezone information can be interpreted in the correct local time instead of defaulting to UTC.
 * :feature:`-` After a rotki update, a friendly prompt will walk you through any new recommended settings. You can accept the ones you like, keep what you have for the rest.
 * :feature:`12102` New giveth donation events will now be properly decoded on all supported chains.
 * :feature:`10654` HyperEVM and Hyperliquid Core are now supported in rotki.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2947,6 +2947,11 @@
     "replace_file": "Replace file",
     "task": {
       "title": "Importing csv for source: {source}"
+    },
+    "timezone": {
+      "hint": "Used for dates in the file that do not include timezone information. Defaults to UTC.",
+      "label": "Timezone",
+      "switch_label": "Use a specific timezone for dates without timezone info"
     }
   },
   "frontend_settings": {

--- a/frontend/app/src/modules/user-data/ImportSource.vue
+++ b/frontend/app/src/modules/user-data/ImportSource.vue
@@ -28,6 +28,8 @@ defineSlots<{
 }>();
 
 const dateInputFormat = ref<string>();
+const useCustomTimezone = ref<boolean>(false);
+const timezone = ref<string>();
 const uploaded = ref(false);
 const errorMessage = ref('');
 const formatHelp = ref<boolean>(false);
@@ -74,7 +76,12 @@ const { importDataFrom, importFile } = useImportDataApi();
 
 async function uploadPackaged(file: string): Promise<void> {
   const outcome = await runTask<boolean, ImportTaskMeta>(
-    () => importDataFrom(source, file, get(dateInputFormat) || null),
+    () => importDataFrom({
+      file,
+      source,
+      timestampFormat: get(dateInputFormat) || null,
+      timezone: get(timezone) || null,
+    }),
     {
       type: taskType,
       meta: { source, title: t('file_upload.task.title', { source }) },
@@ -106,6 +113,9 @@ async function uploadFile(): Promise<void> {
       const dateInputFormatVal = get(dateInputFormat);
       if (dateInputFormatVal)
         formData.append('timestamp_format', dateInputFormatVal);
+      const timezoneVal = get(timezone);
+      if (timezoneVal)
+        formData.append('timezone', timezoneVal);
 
       const outcome = await runTask<boolean, ImportTaskMeta>(
         () => importFile(formData),
@@ -130,6 +140,12 @@ function changeShouldCustomDateFormat() {
   if (!isDefined(dateInputFormat))
     set(dateInputFormat, DateFormat.DateMonthYearHourMinuteSecond);
   else set(dateInputFormat, undefined);
+}
+
+function toggleCustomTimezone(enabled: boolean): void {
+  set(useCustomTimezone, enabled);
+  if (!enabled)
+    set(timezone, undefined);
 }
 
 const isRotkiCustomImport = computed<boolean>(() => source.startsWith('rotki_'));
@@ -186,6 +202,33 @@ const isRotkiCustomImport = computed<boolean>(() => source.startsWith('rotki_'))
           </RuiButton>
         </template>
       </RuiTextField>
+
+      <div
+        v-if="!isRotkiCustomImport"
+        data-testid="import-timezone-switch"
+      >
+        <RuiSwitch
+          color="primary"
+          class="mt-4"
+          :model-value="useCustomTimezone"
+          @update:model-value="toggleCustomTimezone($event)"
+        >
+          {{ t('file_upload.timezone.switch_label') }}
+        </RuiSwitch>
+      </div>
+      <div
+        v-if="useCustomTimezone"
+        data-testid="import-timezone-select"
+        class="mt-2"
+      >
+        <RuiTimezoneSelect
+          v-model="timezone"
+          variant="outlined"
+          clearable
+          :label="t('file_upload.timezone.label')"
+          :hint="t('file_upload.timezone.hint')"
+        />
+      </div>
 
       <div class="mt-4 text-sm leading-7 text-rui-text-secondary">
         <slot />

--- a/frontend/app/src/modules/user-data/use-import-data-api.spec.ts
+++ b/frontend/app/src/modules/user-data/use-import-data-api.spec.ts
@@ -25,13 +25,19 @@ describe('composables/api/import/index', () => {
       );
 
       const { importDataFrom } = useImportDataApi();
-      const result = await importDataFrom('cointracking', '/path/to/file.csv', '%Y-%m-%d');
+      const result = await importDataFrom({
+        file: '/path/to/file.csv',
+        source: 'cointracking',
+        timestampFormat: '%Y-%m-%d',
+        timezone: 'Europe/Madrid',
+      });
 
       expect(capturedBody).toEqual({
         async_query: true,
         file: '/path/to/file.csv',
         source: 'cointracking',
         timestamp_format: '%Y-%m-%d',
+        timezone: 'Europe/Madrid',
       });
       expect(result.taskId).toBe(123);
     });
@@ -50,13 +56,19 @@ describe('composables/api/import/index', () => {
       );
 
       const { importDataFrom } = useImportDataApi();
-      await importDataFrom('rotki', '/path/to/export.json', null);
+      await importDataFrom({
+        file: '/path/to/export.json',
+        source: 'rotki',
+        timestampFormat: null,
+        timezone: null,
+      });
 
       expect(capturedBody).toEqual({
         async_query: true,
         file: '/path/to/export.json',
         source: 'rotki',
         timestamp_format: null,
+        timezone: null,
       });
     });
 
@@ -74,7 +86,12 @@ describe('composables/api/import/index', () => {
       );
 
       const { importDataFrom } = useImportDataApi();
-      await importDataFrom('cryptocom', '/data/crypto.csv', '%d/%m/%Y');
+      await importDataFrom({
+        file: '/data/crypto.csv',
+        source: 'cryptocom',
+        timestampFormat: '%d/%m/%Y',
+        timezone: null,
+      });
 
       expect(capturedBody).toHaveProperty('source', 'cryptocom');
       expect(capturedBody).toHaveProperty('timestamp_format', '%d/%m/%Y');
@@ -91,7 +108,12 @@ describe('composables/api/import/index', () => {
 
       const { importDataFrom } = useImportDataApi();
 
-      await expect(importDataFrom('cointracking', '/invalid.txt', null))
+      await expect(importDataFrom({
+        file: '/invalid.txt',
+        source: 'cointracking',
+        timestampFormat: null,
+        timezone: null,
+      }))
         .rejects
         .toThrow('Invalid file format');
     });

--- a/frontend/app/src/modules/user-data/use-import-data-api.ts
+++ b/frontend/app/src/modules/user-data/use-import-data-api.ts
@@ -1,20 +1,25 @@
 import { api } from '@/modules/core/api/rotki-api';
 import { type PendingTask, PendingTaskSchema } from '@/modules/core/tasks/types';
 
+interface ImportDataFromPayload {
+  source: string;
+  file: string;
+  timestampFormat: string | null;
+  timezone: string | null;
+}
+
 interface UseImportDataApiReturn {
-  importDataFrom: (source: string, file: string, timestampFormat: string | null) => Promise<PendingTask>;
+  importDataFrom: (payload: ImportDataFromPayload) => Promise<PendingTask>;
   importFile: (data: FormData) => Promise<PendingTask>;
 }
 
 export function useImportDataApi(): UseImportDataApiReturn {
-  const importDataFrom = async (source: string, file: string, timestampFormat: string | null): Promise<PendingTask> => {
+  const importDataFrom = async (payload: ImportDataFromPayload): Promise<PendingTask> => {
     const response = await api.put<PendingTask>(
       '/import',
       {
         asyncQuery: true,
-        file,
-        source,
-        timestampFormat,
+        ...payload,
       },
     );
 

--- a/frontend/app/tests/e2e/pages/import-page.ts
+++ b/frontend/app/tests/e2e/pages/import-page.ts
@@ -34,6 +34,20 @@ export class ImportPage {
     await fileInput.setInputFiles(filePath);
   }
 
+  async selectTimezone(sourceKey: string, timezone: string): Promise<void> {
+    const container = this.page.locator(`[data-cy="import-source-${sourceKey}"]`);
+    await container.getByTestId('import-timezone-switch').locator('input').click();
+    const select = container.getByTestId('import-timezone-select');
+    await select.waitFor({ state: 'visible' });
+    await select.locator('[data-id=activator]').click();
+    const menu = this.page.locator('[role=menu]').last();
+    await menu.waitFor({ state: 'visible' });
+    await select.locator('input').fill(timezone);
+    const option = menu.getByText(timezone, { exact: true }).first();
+    await option.waitFor({ state: 'visible' });
+    await option.click();
+  }
+
   async submitImport(sourceKey: string): Promise<void> {
     const container = this.page.locator(`[data-cy="import-source-${sourceKey}"]`);
     await container.locator('[data-cy=button-import]').click();

--- a/frontend/app/tests/e2e/specs/import/csv-import.spec.ts
+++ b/frontend/app/tests/e2e/specs/import/csv-import.spec.ts
@@ -69,7 +69,11 @@ test.describe.serial('csv import', () => {
   test('import cointracking csv', async () => {
     await importPage.visit();
     await importPage.selectSource('Cointracking');
-    await importPage.importCsv('cointracking', 'cointracking_trades_list.csv');
+    await importPage.uploadFile('cointracking', 'cointracking_trades_list.csv');
+    await importPage.selectTimezone('cointracking', 'Europe/Madrid');
+    await importPage.submitImport('cointracking');
+    await importPage.waitForImportComplete('cointracking');
+    await importPage.dismissNotifications();
 
     // Navigate to history and filter by poloniex (unique: 5 XMR deposit from cointracking)
     await historyPage.visit();


### PR DESCRIPTION
## Summary
- Adds a `RuiTimezoneSelect` (ui-library 2.20) to the CSV import dialog so users can pick an IANA timezone, wiring it through to the new backend `timezone` field added in #12152.
- Default is empty so existing imports keep their UTC behavior; the field is hidden for rotki-native imports which don't accept the option.
- Refactors `importDataFrom` to take an options object since positional args were getting unwieldy with the new parameter.
- Adds a changelog entry.

Closes #12143.

## Test plan
- [x] `pnpm run test:unit src/modules/user-data/use-import-data-api.spec.ts`
- [x] `pnpm run test:e2e tests/e2e/specs/import/csv-import.spec.ts` (cointracking test now selects `Europe/Madrid`)
- [x] `pnpm run typecheck`