### PR TITLE
fix(frontend): default unkeyed search to notes on history filter

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`12111` Free-text typed in the History events filter without a key=value prefix is now applied as a notes search on Enter, so you can quickly find events by any word in their notes instead of having to remember the notes= prefix.
+
 * :release:`1.43.0 <2026-05-08>`
 * :bug:`-` Docker users can once again import data, snapshots, and asset icons larger than 1 MiB; the bundled nginx no longer rejects them with a 413 before they reach rotki.
 * :feature:`12143` CSV imports now accept an optional timezone so files whose dates lack timezone information can be interpreted in the correct local time instead of defaulting to UTC.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5432,6 +5432,7 @@
       "example": "start = 26/05/2022"
     },
     "label": "Combined filters",
+    "press_enter_to_apply": "Press enter to apply:",
     "saved_filters": {
       "actions": {
         "add": "Save current filter to list",

--- a/frontend/app/src/modules/core/common/data/search.ts
+++ b/frontend/app/src/modules/core/common/data/search.ts
@@ -1,6 +1,6 @@
 import type { Nullable } from '@rotki/common';
 
-interface SplitResult {
+export interface SplitResult {
   key: string;
   value: string;
   exclude?: boolean;

--- a/frontend/app/src/modules/core/table/FilterDropdown.spec.ts
+++ b/frontend/app/src/modules/core/table/FilterDropdown.spec.ts
@@ -72,6 +72,42 @@ describe('filter-dropdown', () => {
     expect(wrapper.find('div > div:first-child > span:last-child').text()).toBe(props.keyword);
   });
 
+  it('should show the default-matcher hint instead of "unsupported" when defaultMatcherKey is set', () => {
+    wrapper = createWrapper({
+      props: {
+        matches: {},
+        matchers: [],
+        keyword: 'plain text search',
+        selectedSuggestion: 0,
+        defaultMatcherKey: 'notes',
+      },
+    });
+
+    const hint = wrapper.find('div > div:first-child');
+    expect(hint.find('span:first-child').text()).toBe('table_filter.press_enter_to_apply');
+    expect(hint.find('span:last-child').text()).toBe('notes=plain text search');
+    expect(wrapper.text()).not.toContain('table_filter.unsupported_filter');
+  });
+
+  it.each([
+    ['foo=bar'],
+    ['foo:bar'],
+    ['foo!=bar'],
+  ])('should still show "unsupported" when defaultMatcherKey is set but keyword has a key separator: %s', (keyword: string) => {
+    wrapper = createWrapper({
+      props: {
+        matches: {},
+        matchers: [],
+        keyword,
+        selectedSuggestion: 0,
+        defaultMatcherKey: 'notes',
+      },
+    });
+
+    expect(wrapper.find('div > div:first-child > span:first-child').text()).toBe('table_filter.unsupported_filter');
+    expect(wrapper.text()).not.toContain('table_filter.press_enter_to_apply');
+  });
+
   it('should show suggestions', async () => {
     const props = {
       matches: {},

--- a/frontend/app/src/modules/core/table/FilterDropdown.vue
+++ b/frontend/app/src/modules/core/table/FilterDropdown.vue
@@ -1,18 +1,31 @@
 <script setup lang="ts">
-import type { BaseSuggestion, MatchedKeywordWithBehaviour, SearchMatcher, Suggestion } from '@/modules/core/table/filtering';
 import { getTextToken } from '@rotki/common';
-import { splitSearch } from '@/modules/core/common/data/search';
+import { type SplitResult, splitSearch } from '@/modules/core/common/data/search';
 import { compareTextByKeyword } from '@/modules/core/common/display/assets';
 import { logger } from '@/modules/core/common/logging/logging';
 import FilterEntry from '@/modules/core/table/FilterEntry.vue';
+import {
+  type BaseSuggestion,
+  createEmptySuggestion,
+  type MatchedKeywordWithBehaviour,
+  type SearchMatcher,
+  type Suggestion,
+} from '@/modules/core/table/filtering';
 import SuggestedItem from '@/modules/core/table/SuggestedItem.vue';
 
-const { keyword, matchers, selectedMatcher, selectedSuggestion } = defineProps<{
+interface ResolvedSuggestions {
+  items: BaseSuggestion[];
+  exclude: boolean;
+  asset: boolean;
+}
+
+const { keyword, matchers, selectedMatcher, selectedSuggestion, defaultMatcherKey } = defineProps<{
   matches: MatchedKeywordWithBehaviour<any>;
   matchers: SearchMatcher<any>[];
   selectedMatcher?: SearchMatcher<any>;
   keyword: string;
   selectedSuggestion: number;
+  defaultMatcherKey?: string;
 }>();
 
 const emit = defineEmits<{
@@ -21,12 +34,19 @@ const emit = defineEmits<{
   'apply-filter': [item: Suggestion];
 }>();
 
-const keywordSplit = computed(() => splitSearch(keyword));
+const { t } = useI18n({ useScope: 'global' });
+
+const highlightedTextClasses = 'text-subtitle-2 text-rui-text-secondary';
 
 const lastSuggestion = ref<Suggestion | null>(null);
 const suggested = ref<Suggestion[]>([]);
 
-function updateSuggestion(value: Suggestion[], index: number) {
+const keywordSplit = computed<SplitResult>(() => splitSearch(keyword));
+const showDefaultMatcherHint = computed<boolean>(() =>
+  !!defaultMatcherKey && matchers.length === 0 && !!keyword && get(keywordSplit).exclude === undefined,
+);
+
+function updateSuggestion(value: Suggestion[], index: number): void {
   set(lastSuggestion, value[index]);
   emit('suggest', {
     ...value[index],
@@ -35,14 +55,80 @@ function updateSuggestion(value: Suggestion[], index: number) {
   });
 }
 
-function click(matcher: SearchMatcher<any>) {
+function click(matcher: SearchMatcher<any>): void {
   emit('click', matcher);
 }
 
-function applyFilter(item: Suggestion) {
+function applyFilter(item: Suggestion): void {
   const value = typeof item.value === 'string' ? item.value : item.value.symbol;
   if (value)
     emit('apply-filter', item);
+}
+
+function buildStringSuggestions(matcher: SearchMatcher<any>, searchString: string, allowExclude: boolean): ResolvedSuggestions {
+  if (!('string' in matcher))
+    return { asset: false, exclude: false, items: [] };
+
+  const exclude = !!matcher.allowExclusion && allowExclude;
+  let suggestions = matcher.suggestions();
+
+  // When strictMatching is enabled, filter suggestions to only include those containing the keyword.
+  if (matcher.strictMatching && searchString) {
+    const tokenizedSearch = getTextToken(searchString);
+    suggestions = suggestions.filter(item => getTextToken(item).includes(tokenizedSearch));
+  }
+
+  return {
+    asset: false,
+    exclude,
+    items: suggestions.map(item => ({ exclude, key: matcher.key, value: item })),
+  };
+}
+
+async function buildAssetSuggestions(matcher: SearchMatcher<any>, searchString: string): Promise<ResolvedSuggestions> {
+  if (!('asset' in matcher) || !searchString)
+    return { asset: false, exclude: false, items: [] };
+
+  try {
+    const suggestions = await matcher.suggestions(searchString);
+    return {
+      asset: true,
+      exclude: false,
+      items: (suggestions ?? []).map(value => ({ exclude: false, key: matcher.key, value })),
+    };
+  }
+  catch (error) {
+    logger.error(error);
+    return { asset: true, exclude: false, items: [] };
+  }
+}
+
+function buildBooleanSuggestions(matcher: SearchMatcher<any>): ResolvedSuggestions {
+  return {
+    asset: false,
+    exclude: false,
+    items: [{ exclude: false, key: matcher.key, value: true }],
+  };
+}
+
+async function resolveSuggestions(matcher: SearchMatcher<any>, search: SplitResult): Promise<ResolvedSuggestions> {
+  const searchString = search.value ?? '';
+
+  if ('string' in matcher)
+    return buildStringSuggestions(matcher, searchString, !!search.exclude);
+
+  if ('asset' in matcher)
+    return buildAssetSuggestions(matcher, searchString);
+
+  if ('boolean' in matcher)
+    return buildBooleanSuggestions(matcher);
+
+  logger.debug('Matcher doesn\'t have asset=true, string=true, or boolean=true.', matcher);
+  return { asset: false, exclude: false, items: [] };
+}
+
+function getSuggestionText(item: BaseSuggestion): string {
+  return typeof item.value === 'string' ? item.value : `${item.value.symbol} ${item.value.evmChain}`;
 }
 
 watch(() => selectedSuggestion, (index) => {
@@ -56,98 +142,37 @@ watch(suggested, (value) => {
   }
   else {
     set(lastSuggestion, null);
-    emit('suggest', { index: 0, key: '', total: 0 } as Suggestion);
+    emit('suggest', createEmptySuggestion());
   }
 });
 
 watch([() => keyword, () => selectedMatcher], async ([keyword, selectedMatcher]) => {
   if (!keyword || !selectedMatcher)
-    return [];
+    return;
 
   const search = splitSearch(keyword);
-  const suggestedFilter = selectedMatcher.key;
-
   const searchString = search.value ?? '';
-
-  let suggestedItems: BaseSuggestion[] = [];
-
-  let exclude = false;
-  let asset = false;
-  if ('string' in selectedMatcher) {
-    exclude = !!selectedMatcher.allowExclusion && !!search.exclude;
-    let suggestions = selectedMatcher.suggestions();
-
-    // When strictMatching is enabled, filter suggestions to only include those containing the keyword
-    if (selectedMatcher.strictMatching && searchString) {
-      const tokenizedSearch = getTextToken(searchString);
-      suggestions = suggestions.filter(item => getTextToken(item).includes(tokenizedSearch));
-    }
-
-    suggestedItems = suggestions.map(item => ({
-      exclude,
-      key: suggestedFilter,
-      value: item,
-    }));
-  }
-  else if ('asset' in selectedMatcher) {
-    if (searchString) {
-      asset = true;
-      try {
-        const suggestions = await selectedMatcher.suggestions(searchString);
-        if (suggestions) {
-          suggestedItems = suggestions.map(asset => ({
-            exclude,
-            key: suggestedFilter,
-            value: asset,
-          }));
-        }
-      }
-      catch (error) {
-        logger.error(error);
-        suggestedItems = [];
-      }
-    }
-  }
-  else if ('boolean' in selectedMatcher) {
-    suggestedItems = [
-      {
-        exclude: false,
-        key: suggestedFilter,
-        value: true,
-      },
-    ];
-  }
-  else {
-    logger.debug('Matcher doesn\'t have asset=true, string=true, or boolean=true.', selectedMatcher);
-  }
-
-  const getItemText = (item: BaseSuggestion) =>
-    typeof item.value === 'string' ? item.value : `${item.value.symbol} ${item.value.evmChain}`;
+  const { asset, exclude, items } = await resolveSuggestions(selectedMatcher, search);
 
   const limit = selectedMatcher.suggestionsToShow ?? (asset ? 10 : 5);
-  const sorted = suggestedItems.sort((a, b) => compareTextByKeyword(getItemText(a), getItemText(b), searchString));
+  const sorted = items.sort((a, b) => compareTextByKeyword(getSuggestionText(a), getSuggestionText(b), searchString));
   const limited = limit < 0 ? sorted : sorted.slice(0, limit);
 
-  set(suggested, limited
-    .map((a, index) => ({
-      asset: typeof a.value !== 'string',
-      exclude,
-      index,
-      key: a.key,
-      total: suggestedItems.length,
-      value: a.value,
-    })));
+  set(suggested, limited.map((a, index) => ({
+    asset: typeof a.value !== 'string',
+    exclude,
+    index,
+    key: a.key,
+    total: items.length,
+    value: a.value,
+  })));
 }, { immediate: true });
-
-const { t } = useI18n({ useScope: 'global' });
 
 watch(() => selectedSuggestion, async () => {
   await nextTick(() => {
     document.getElementsByClassName('highlightedMatcher')[0]?.scrollIntoView?.({ block: 'nearest' });
   });
 });
-
-const highlightedTextClasses = 'text-subtitle-2 text-rui-text-secondary';
 </script>
 
 <template>
@@ -214,6 +239,12 @@ const highlightedTextClasses = 'text-subtitle-2 text-rui-text-secondary';
       >
         {{ selectedMatcher.hint }}
       </div>
+    </div>
+    <div
+      v-else-if="showDefaultMatcherHint"
+    >
+      <span>{{ t('table_filter.press_enter_to_apply') }}</span>
+      <span class="font-medium ms-2">{{ defaultMatcherKey }}={{ keyword }}</span>
     </div>
     <div
       v-else-if="keyword && matchers.length === 0"

--- a/frontend/app/src/modules/core/table/TableFilter.spec.ts
+++ b/frontend/app/src/modules/core/table/TableFilter.spec.ts
@@ -294,6 +294,105 @@ describe('table-filter', () => {
     expect(wrapper.emitted('update:matches')?.at(-1)).toEqual([{ start: 'valid' }]);
   });
 
+  describe('defaultMatcherKey', () => {
+    it('should apply unkeyed free-text as the default matcher when set', async () => {
+      wrapper = createWrapper({
+        props: {
+          defaultMatcherKey: FilterKeys.START,
+          matchers,
+          matches: {},
+        },
+      });
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('plain text search');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').trigger('keydown.enter');
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(wrapper.emitted('update:matches')?.at(-1)).toEqual([{ start: 'plain text search' }]);
+      expect(wrapper.find<HTMLInputElement>('input').element.value).toBe('');
+    });
+
+    it('should leave key=value input untouched when defaultMatcherKey is set', async () => {
+      wrapper = createWrapper({
+        props: {
+          defaultMatcherKey: FilterKeys.START,
+          matchers,
+          matches: {},
+        },
+      });
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('type=type 1');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').trigger('keydown.enter');
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(wrapper.emitted('update:matches')?.at(-1)).toEqual([{ type: ['type 1'] }]);
+    });
+
+    it('should not apply unkeyed free-text as a filter when defaultMatcherKey is not set', async () => {
+      wrapper = createWrapper({
+        props: {
+          matchers,
+          matches: {},
+        },
+      });
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('plain text search');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').trigger('keydown.enter');
+      await vi.advanceTimersToNextTimerAsync();
+
+      // Without defaultMatcherKey, free text must never be implicitly committed
+      // as a filter value for any matcher.
+      const emissions = wrapper.emitted<[Record<string, unknown>]>('update:matches') ?? [];
+      const appliedAsFilter = emissions.some(([m]) =>
+        Object.values(m).some(v => v === 'plain text search' || (Array.isArray(v) && v.includes('plain text search'))),
+      );
+      expect(appliedAsFilter).toBe(false);
+    });
+
+    it('should skip default matcher when validation fails', async () => {
+      const matchersWithValidation = createMatchers(value => value === 'valid');
+      wrapper = createWrapper({
+        props: {
+          defaultMatcherKey: FilterKeys.START,
+          matchers: matchersWithValidation,
+          matches: {},
+        },
+      });
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('not valid');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').trigger('keydown.enter');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const emissions = wrapper.emitted('update:matches') ?? [];
+      const hasStart = emissions.some(([m]) => Object.prototype.hasOwnProperty.call(m, 'start'));
+      expect(hasStart).toBe(false);
+    });
+  });
+
   describe('strictMatching', () => {
     const createStrictMatchingMatchers = (): StringSuggestionMatcher<FilterKeys, FilterKeyValues>[] => [
       {

--- a/frontend/app/src/modules/core/table/TableFilter.vue
+++ b/frontend/app/src/modules/core/table/TableFilter.vue
@@ -1,10 +1,4 @@
 <script setup lang="ts">
-import type {
-  MatchedKeywordWithBehaviour,
-  SavedFilterLocation,
-  SearchMatcher,
-  Suggestion,
-} from '@/modules/core/table/filtering';
 import { type AssetInfo, getTextToken } from '@rotki/common';
 import { splitSearch } from '@/modules/core/common/data/search';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -13,8 +7,21 @@ import { useFilterMatchers } from '@/modules/core/table/composables/use-filter-m
 import { useFilterSelection } from '@/modules/core/table/composables/use-filter-selection';
 import { useMatcherUtils } from '@/modules/core/table/composables/use-matcher-utils';
 import FilterDropdown from '@/modules/core/table/FilterDropdown.vue';
+import {
+  createEmptySuggestion,
+  type MatchedKeywordWithBehaviour,
+  type SavedFilterLocation,
+  type SearchMatcher,
+  type Suggestion,
+} from '@/modules/core/table/filtering';
 import SavedFilterManagement from '@/modules/core/table/SavedFilterManagement.vue';
 import SelectionChip from '@/modules/core/table/SelectionChip.vue';
+
+interface MatcherItems {
+  items: (AssetInfo | string)[];
+  asset: boolean;
+  strictMatching: boolean;
+}
 
 defineOptions({
   inheritAttrs: false,
@@ -36,16 +43,12 @@ defineSlots<{
   tooltip: () => any;
 }>();
 
+const { t } = useI18n({ useScope: 'global' });
+
 const input = useTemplateRef<any>('input');
 const search = ref<string>('');
 const selectedSuggestion = ref<number>(0);
-const suggestedFilter = ref<Suggestion>({
-  asset: false,
-  index: 0,
-  key: '',
-  total: 0,
-  value: '',
-});
+const suggestedFilter = ref<Suggestion>(createEmptySuggestion());
 const shaking = ref<boolean>(false);
 
 // Matcher utilities
@@ -126,7 +129,7 @@ async function tryApplyDefaultMatcher(): Promise<boolean> {
     return false;
 
   const searchVal = get(search).trim();
-  if (!searchVal || searchVal.includes('='))
+  if (!searchVal || splitSearch(searchVal).exclude !== undefined)
     return false;
 
   const matcher = matcherForKey(defaultMatcherKey);
@@ -147,102 +150,115 @@ async function tryApplyDefaultMatcher(): Promise<boolean> {
   return true;
 }
 
-async function applySuggestion(): Promise<void> {
+function resetSearchState(): void {
+  set(selectedSuggestion, 0);
+  set(search, '');
+}
+
+async function applySelectedSuggestion(): Promise<void> {
+  await nextTick(() => applyFilter(get(suggestedFilter)));
+  resetSearchState();
+}
+
+function autocompleteFirstMatcher(): void {
+  const filteredMatchersVal = get(filteredMatchers);
   const selectedIndex = get(selectedSuggestion);
-  if (!get(selectedMatcher)) {
-    if (await tryApplyDefaultMatcher())
-      return;
+  if (filteredMatchersVal.length > selectedIndex)
+    setSearchToMatcherKey(filteredMatchersVal[selectedIndex]);
+}
 
-    const filteredMatchersVal = get(filteredMatchers);
-    if (filteredMatchersVal.length > selectedIndex)
-      setSearchToMatcherKey(filteredMatchersVal[selectedIndex]);
+async function collectMatcherItems(matcher: SearchMatcher<any, any>, keyword: string): Promise<MatcherItems> {
+  if ('string' in matcher) {
+    const strictMatching = !!matcher.strictMatching;
+    let items: (AssetInfo | string)[] = matcher.suggestions();
+    if (strictMatching && keyword) {
+      const tokenizedKeyword = getTextToken(keyword);
+      items = items.filter(item => typeof item === 'string' && getTextToken(item).includes(tokenizedKeyword));
+    }
+    return { asset: false, items, strictMatching };
+  }
+  if ('asset' in matcher)
+    return { asset: true, items: await matcher.suggestions(keyword), strictMatching: false };
 
+  if (!('boolean' in matcher))
+    logger.debug('Matcher doesn\'t have asset=true, string=true, or boolean=true.', matcher);
+
+  return { asset: false, items: [], strictMatching: false };
+}
+
+async function handleValidationFailure(key: string, exclude: boolean, searchVal: string): Promise<void> {
+  triggerShake();
+  const valueStart = key.length + (exclude ? 2 : 1);
+  await nextTick(async () => {
+    set(search, searchVal);
+    await nextTick(() => {
+      const inputEl = get(input)?.$el?.querySelector('input');
+      inputEl?.setSelectionRange(valueStart, searchVal.length);
+    });
+  });
+}
+
+async function commitFreeFormValue(
+  matcher: SearchMatcher<any, any>,
+  key: string,
+  keyword: string,
+  exclude: boolean,
+  asset: boolean,
+  strictMatching: boolean,
+  searchVal: string,
+): Promise<void> {
+  if (!('validate' in matcher))
+    return;
+
+  if (!strictMatching && matcher.validate(keyword)) {
+    await nextTick(() => applyFilter({ asset, exclude, index: 0, key, total: 1, value: keyword }));
+    resetSearchState();
     return;
   }
+  await handleValidationFailure(key, exclude, searchVal);
+}
 
-  const filter = get(suggestedFilter);
-  if (filter.value) {
-    await nextTick(() => applyFilter(filter));
-    set(selectedSuggestion, 0);
-    set(search, '');
-    return;
-  }
-
+async function applyKeyedSearch(): Promise<void> {
   const searchVal = get(search);
   const { exclude, key, value: keyword } = splitSearch(searchVal);
 
   if (!key) {
     get(input).blur();
-    set(selectedSuggestion, 0);
-    set(search, '');
+    resetSearchState();
     return;
   }
 
   const matcher = matcherForKey(key);
   if (!matcher) {
-    set(selectedSuggestion, 0);
-    set(search, '');
+    resetSearchState();
     return;
   }
 
-  let asset = false;
-  let suggestedItems: (AssetInfo | string)[] = [];
-  let strictMatching = false;
-  if ('string' in matcher) {
-    suggestedItems = matcher.suggestions();
-    strictMatching = !!matcher.strictMatching;
+  const { asset, items, strictMatching } = await collectMatcherItems(matcher, keyword);
 
-    // When strictMatching is enabled, filter suggestions to only include those containing the keyword
-    if (strictMatching && keyword) {
-      const tokenizedKeyword = getTextToken(keyword);
-      suggestedItems = suggestedItems.filter(item =>
-        typeof item === 'string' && getTextToken(item).includes(tokenizedKeyword),
-      );
-    }
-  }
-  else if ('asset' in matcher) {
-    suggestedItems = await matcher.suggestions(keyword);
-    asset = true;
-  }
-  else if (!('boolean' in matcher)) {
-    logger.debug('Matcher doesn\'t have asset=true, string=true, or boolean=true.', selectedMatcher);
-  }
-
-  // If there are no suggestions and the matcher has a validate function
-  // For strictMatching, validation fails when no matching suggestions exist
-  if (suggestedItems.length === 0 && 'validate' in matcher) {
-    if (!strictMatching && matcher.validate(keyword)) {
-      await nextTick(() =>
-        applyFilter({
-          asset,
-          exclude,
-          index: 0,
-          key,
-          total: 1,
-          value: keyword,
-        }),
-      );
-      set(selectedSuggestion, 0);
-      set(search, '');
-    }
-    else {
-      // Validation failed - keep search and shake
-      triggerShake();
-      const valueStart = key.length + (exclude ? 2 : 1);
-      await nextTick(async () => {
-        set(search, searchVal);
-        await nextTick(() => {
-          const inputEl = get(input)?.$el?.querySelector('input');
-          inputEl?.setSelectionRange(valueStart, searchVal.length);
-        });
-      });
-    }
+  if (items.length === 0) {
+    await commitFreeFormValue(matcher, key, keyword, !!exclude, asset, strictMatching, searchVal);
     return;
   }
 
   cancelEditSuggestion();
-  set(selectedSuggestion, 0);
-  set(search, '');
+  resetSearchState();
+}
+
+async function applySuggestion(): Promise<void> {
+  if (!get(selectedMatcher)) {
+    if (await tryApplyDefaultMatcher())
+      return;
+    autocompleteFirstMatcher();
+    return;
+  }
+
+  if (get(suggestedFilter).value) {
+    await applySelectedSuggestion();
+    return;
+  }
+
+  await applyKeyedSearch();
 }
 
 function moveSuggestion(up: boolean): void {
@@ -259,20 +275,6 @@ function moveSuggestion(up: boolean): void {
     set(selectedSuggestion, total - 1);
   else set(selectedSuggestion, position);
 }
-
-onMounted(() => {
-  get(input).onTabDown = function (e: KeyboardEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    moveSuggestion(false);
-  };
-  get(input).onEnterDown = function (e: KeyboardEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-  };
-
-  restoreSelection(matches);
-});
 
 watch(search, () => {
   set(selectedSuggestion, 0);
@@ -291,7 +293,19 @@ watch(suggestionBeingEdited, (value, old) => {
   });
 });
 
-const { t } = useI18n({ useScope: 'global' });
+onMounted(() => {
+  get(input).onTabDown = function (e: KeyboardEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    moveSuggestion(false);
+  };
+  get(input).onEnterDown = function (e: KeyboardEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  restoreSelection(matches);
+});
 </script>
 
 <template>
@@ -358,6 +372,7 @@ const { t } = useI18n({ useScope: 'global' });
               :keyword="search"
               :selected-matcher="selectedMatcher"
               :selected-suggestion="selectedSuggestion"
+              :default-matcher-key="defaultMatcherKey"
               @apply-filter="applyFilter($event)"
               @suggest="suggestedFilter = $event"
               @click="setSearchToMatcherKey($event)"

--- a/frontend/app/src/modules/core/table/TableFilter.vue
+++ b/frontend/app/src/modules/core/table/TableFilter.vue
@@ -20,11 +20,12 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const { matches, matchers, location, disabled } = defineProps<{
+const { matches, matchers, location, disabled, defaultMatcherKey } = defineProps<{
   matches: MatchedKeywordWithBehaviour<any>;
   matchers: SearchMatcher<any, any>[];
   location?: SavedFilterLocation;
   disabled?: boolean;
+  defaultMatcherKey?: string;
 }>();
 
 const emit = defineEmits<{
@@ -117,11 +118,42 @@ function setSearchToMatcherKey(matcher: SearchMatcher<any>): void {
   });
 }
 
+// Treat unkeyed free-text as the consumer's default matcher (e.g. notes search
+// on the History table). Only fires when the input has no `key=value` separator,
+// so explicit `key=value` autocomplete is unchanged.
+async function tryApplyDefaultMatcher(): Promise<boolean> {
+  if (!defaultMatcherKey)
+    return false;
+
+  const searchVal = get(search).trim();
+  if (!searchVal || searchVal.includes('='))
+    return false;
+
+  const matcher = matcherForKey(defaultMatcherKey);
+  if (!matcher || !('string' in matcher) || !matcher.validate(searchVal))
+    return false;
+
+  await nextTick(() =>
+    applyFilter({
+      asset: false,
+      index: 0,
+      key: defaultMatcherKey,
+      total: 1,
+      value: searchVal,
+    }),
+  );
+  set(selectedSuggestion, 0);
+  set(search, '');
+  return true;
+}
+
 async function applySuggestion(): Promise<void> {
   const selectedIndex = get(selectedSuggestion);
   if (!get(selectedMatcher)) {
-    const filteredMatchersVal = get(filteredMatchers);
+    if (await tryApplyDefaultMatcher())
+      return;
 
+    const filteredMatchersVal = get(filteredMatchers);
     if (filteredMatchersVal.length > selectedIndex)
       setSearchToMatcherKey(filteredMatchersVal[selectedIndex]);
 

--- a/frontend/app/src/modules/core/table/filtering.ts
+++ b/frontend/app/src/modules/core/table/filtering.ts
@@ -82,6 +82,16 @@ export const Suggestion = BaseSuggestion.extend({
 
 export type Suggestion = z.infer<typeof Suggestion>;
 
+export function createEmptySuggestion(): Suggestion {
+  return {
+    asset: false,
+    index: 0,
+    key: '',
+    total: 0,
+    value: '',
+  };
+}
+
 export enum SavedFilterLocation {
   HISTORY_EVENTS = 'historyEvents',
   BLOCKCHAIN_ACCOUNTS = 'blockchainAccounts',

--- a/frontend/app/src/modules/core/table/filters/use-events-filter.ts
+++ b/frontend/app/src/modules/core/table/filters/use-events-filter.ts
@@ -29,7 +29,7 @@ import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-hi
 import { useHistoryStore } from '@/modules/history/use-history-store';
 import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
 
-enum HistoryEventFilterKeys {
+export enum HistoryEventFilterKeys {
   START = 'start',
   END = 'end',
   ASSET = 'asset',

--- a/frontend/app/src/modules/history/events/HistoryEventsTableActions.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsTableActions.vue
@@ -4,6 +4,7 @@ import type { HistoryEventRequestPayload } from '@/modules/history/events/reques
 import type { IgnoreStatus } from '@/modules/history/events/use-history-events-selection-actions';
 import type { SelectionState } from '@/modules/history/events/use-selection-mode';
 import { type MatchedKeywordWithBehaviour, SavedFilterLocation, type SearchMatcher } from '@/modules/core/table/filtering';
+import { HistoryEventFilterKeys } from '@/modules/core/table/filters/use-events-filter';
 import TableFilter from '@/modules/core/table/TableFilter.vue';
 import HistoryEventsExport from '@/modules/history/events/HistoryEventsExport.vue';
 import HistoryEventsStateFilter from '@/modules/history/events/HistoryEventsStateFilter.vue';
@@ -85,6 +86,7 @@ function handleToggleSelectAllMatching(): void {
         v-model:matches="filters"
         class="min-w-[12rem] md:min-w-[24rem]"
         :matchers="matchers"
+        :default-matcher-key="HistoryEventFilterKeys.NOTES"
         :location="SavedFilterLocation.HISTORY_EVENTS"
       />
     </template>


### PR DESCRIPTION
Closes #12111.

- Adds an opt-in `defaultMatcherKey` prop to `TableFilter`; when set, Enter on free-text without `key=value` applies it through that matcher.
- Wires `HistoryEventFilterKeys.NOTES` on the History events `TableFilter` so `gas refund` + Enter is equivalent to `notes=gas refund`. Other consumers unaffected.