### PR TITLE
test: cover snapshot edit + export flow (vitest + e2e)

### DIFF
--- a/frontend/app/src/modules/dashboard/ExportSnapshotDialog.vue
+++ b/frontend/app/src/modules/dashboard/ExportSnapshotDialog.vue
@@ -139,7 +139,7 @@ function showDeleteConfirmation() {
     v-model="display"
     max-width="600"
   >
-    <RuiCard>
+    <RuiCard data-testid="export-snapshot-dialog">
       <template #header>
         {{ t('dashboard.snapshot.export_database_snapshot') }}
       </template>
@@ -168,6 +168,7 @@ function showDeleteConfirmation() {
       <template #footer>
         <RuiButton
           color="primary"
+          data-testid="export-snapshot-edit"
           @click="editMode = true"
         >
           <template #prepend>
@@ -177,6 +178,7 @@ function showDeleteConfirmation() {
         </RuiButton>
         <RuiButton
           color="error"
+          data-testid="export-snapshot-delete"
           @click="showDeleteConfirmation()"
         >
           <template #prepend>
@@ -187,6 +189,7 @@ function showDeleteConfirmation() {
         <div class="grow" />
         <RuiButton
           color="primary"
+          data-testid="export-snapshot-download"
           @click="exportSnapshot()"
         >
           <template #prepend>

--- a/frontend/app/src/modules/dashboard/SnapshotActionButton.vue
+++ b/frontend/app/src/modules/dashboard/SnapshotActionButton.vue
@@ -120,6 +120,7 @@ watchImmediate(ignoreSnapshotError, (ignoreSnapshotError) => {
         custom-color
         v-bind="attrs"
         class="!p-2"
+        data-testid="snapshot-action"
       >
         <RuiIcon name="lu-git-commit-vertical" />
       </MenuTooltipButton>

--- a/frontend/app/src/modules/dashboard/SnapshotImportDialog.vue
+++ b/frontend/app/src/modules/dashboard/SnapshotImportDialog.vue
@@ -44,7 +44,7 @@ const complete = logicAnd(balanceFile, locationFile);
       </RuiButton>
     </template>
 
-    <RuiCard>
+    <RuiCard data-testid="snapshot-import-dialog">
       <template #header>
         {{ t('snapshot_import_dialog.title') }}
       </template>
@@ -54,7 +54,10 @@ const complete = logicAnd(balanceFile, locationFile);
           <div class="font-bold">
             {{ t('snapshot_import_dialog.balance_snapshot_file') }}
           </div>
-          <div class="py-2">
+          <div
+            class="py-2"
+            data-testid="snapshot-import-balance-file"
+          >
             <FileUpload
               v-model="balanceFile"
               source="csv"
@@ -68,7 +71,10 @@ const complete = logicAnd(balanceFile, locationFile);
           <div class="font-bold">
             {{ t('snapshot_import_dialog.location_data_snapshot_file') }}
           </div>
-          <div class="py-2">
+          <div
+            class="py-2"
+            data-testid="snapshot-import-location-file"
+          >
             <FileUpload
               v-model="locationFile"
               source="csv"
@@ -93,6 +99,7 @@ const complete = logicAnd(balanceFile, locationFile);
           color="primary"
           :disabled="!complete"
           :loading="loading"
+          data-testid="snapshot-import-submit"
           @click="emit('import')"
         >
           {{ t('common.actions.import') }}

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.spec.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.spec.ts
@@ -1,0 +1,159 @@
+import type { BalanceSnapshotPayload } from '@/modules/dashboard/snapshots';
+import { bigNumberify } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, ref } from 'vue';
+import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
+import { BalanceType } from '@/modules/balances/types/balances';
+import EditBalancesSnapshotAssetPriceForm from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue';
+import EditBalancesSnapshotForm from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue';
+
+vi.mock('@/modules/assets/prices/use-price-task-manager', () => ({
+  usePriceTaskManager: vi.fn().mockReturnValue({
+    getHistoricPrice: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: vi.fn().mockReturnValue({
+    addHistoricalPrice: vi.fn(),
+  }),
+}));
+
+interface BalanceSnapshotPayloadAndLocation extends BalanceSnapshotPayload {
+  location: string;
+}
+
+type FormInstance = InstanceType<typeof EditBalancesSnapshotForm>;
+
+describe('edit-snapshot/EditBalancesSnapshotForm.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<FormInstance>;
+
+  const timestamp = 1700000000;
+
+  const baseModel = (): BalanceSnapshotPayloadAndLocation => ({
+    amount: '1.5',
+    assetIdentifier: 'ETH',
+    category: BalanceType.ASSET,
+    location: 'blockchain',
+    timestamp,
+    usdValue: '3000',
+  });
+
+  beforeAll(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(usePriceTaskManager().getHistoricPrice).mockResolvedValue(bigNumberify(2000));
+    vi.mocked(useAssetPricesApi().addHistoricalPrice).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(modelValue: BalanceSnapshotPayloadAndLocation = baseModel()): VueWrapper<FormInstance> {
+    const model = ref<BalanceSnapshotPayloadAndLocation>(modelValue);
+    return mount(EditBalancesSnapshotForm, {
+      global: {
+        plugins: [pinia],
+      },
+      props: {
+        'locations': ['blockchain', 'kraken'],
+        'modelValue': model.value,
+        timestamp,
+        'onUpdate:modelValue': (value: BalanceSnapshotPayloadAndLocation) => {
+          model.value = value;
+        },
+      },
+    });
+  }
+
+  it('should pre-populate fields from the v-model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const amountInput = wrapper.find<HTMLInputElement>('[data-cy=amount] input');
+    expect(amountInput.element.value).toBe('1.5');
+
+    const assetInput = wrapper.find<HTMLInputElement>('[data-cy=asset] input');
+    expect(assetInput.element.value).toBe('ETH');
+  });
+
+  it('should fail validation when category is missing', async () => {
+    const model = baseModel();
+    // @ts-expect-error category is required by type but we simulate invalid state
+    model.category = undefined;
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    const valid = await wrapper.vm.validate();
+    expect(valid).toBe(false);
+  });
+
+  it('should pass validation when category is set', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const valid = await wrapper.vm.validate();
+    expect(valid).toBe(true);
+  });
+
+  it('should forward update:asset emitted by the inner price form', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const priceForm = wrapper.findComponent(EditBalancesSnapshotAssetPriceForm);
+    expect(priceForm.exists()).toBe(true);
+
+    priceForm.vm.$emit('update:asset', 'BTC');
+
+    expect(wrapper.emitted('update:asset')).toBeTruthy();
+    expect(wrapper.emitted('update:asset')?.[0]).toEqual(['BTC']);
+  });
+
+  it('should propagate amount edits through v-model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.find('[data-cy=amount] input').setValue('5');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const updates = wrapper.emitted<[BalanceSnapshotPayloadAndLocation]>('update:modelValue');
+    expect(updates).toBeTruthy();
+    const last = updates![updates!.length - 1][0];
+    expect(last.amount).toBe('5');
+    expect(last.assetIdentifier).toBe('ETH');
+  });
+
+  it('should expose submitPrice without throwing', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(typeof wrapper.vm.submitPrice).toBe('function');
+    expect(() => wrapper.vm.submitPrice()).not.toThrow();
+  });
+
+  it('should force amount to 1 when the model carries an NFT identifier', async () => {
+    vi.useRealTimers();
+    const model = baseModel();
+    model.assetIdentifier = '_nft_0xabc/123';
+    model.amount = '42';
+    wrapper = createWrapper(model);
+    await flushPromises();
+    await nextTick();
+
+    const updates = wrapper.emitted<[BalanceSnapshotPayloadAndLocation]>('update:modelValue');
+    const nftUpdate = updates?.find(([payload]) => payload.amount === '1');
+    expect(nftUpdate).toBeDefined();
+    expect(nftUpdate?.[0].assetIdentifier).toBe('_nft_0xabc/123');
+  });
+});

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotTable.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotTable.vue
@@ -458,6 +458,7 @@ function confirmDelete(): void {
         </RuiButton>
         <RuiButton
           color="primary"
+          data-testid="edit-snapshot-next"
           @click="updateStep(2)"
         >
           {{ t('common.actions.next') }}

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.spec.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.spec.ts
@@ -1,0 +1,95 @@
+import type { LocationDataSnapshotPayload } from '@/modules/dashboard/snapshots';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import EditLocationDataSnapshotForm from '@/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue';
+import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
+
+type FormInstance = InstanceType<typeof EditLocationDataSnapshotForm>;
+
+describe('edit-snapshot/EditLocationDataSnapshotForm.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<FormInstance>;
+
+  const baseModel = (): LocationDataSnapshotPayload => ({
+    location: 'blockchain',
+    timestamp: 1700000000,
+    usdValue: '5000',
+  });
+
+  beforeAll(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(modelValue: LocationDataSnapshotPayload = baseModel()): VueWrapper<FormInstance> {
+    return mount(EditLocationDataSnapshotForm, {
+      global: {
+        plugins: [pinia],
+      },
+      props: {
+        modelValue,
+      },
+    });
+  }
+
+  it('should pre-populate value from the v-model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const amount = wrapper.findComponent(AmountInput);
+    expect(amount.props('modelValue')).toBe('5000');
+  });
+
+  it('should pass validation with valid model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const valid = await wrapper.vm.validate();
+    expect(valid).toBe(true);
+  });
+
+  it('should fail validation when location is missing', async () => {
+    const model = baseModel();
+    model.location = '';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    const valid = await wrapper.vm.validate();
+    expect(valid).toBe(false);
+  });
+
+  it('should fail validation when usdValue is missing', async () => {
+    const model = baseModel();
+    model.usdValue = '';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    const valid = await wrapper.vm.validate();
+    expect(valid).toBe(false);
+  });
+
+  it('should emit update:modelValue when the value field changes', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const amount = wrapper.findComponent(AmountInput);
+    amount.vm.$emit('update:modelValue', '6000');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const updates = wrapper.emitted<[LocationDataSnapshotPayload]>('update:modelValue');
+    expect(updates).toBeTruthy();
+    const last = updates![updates!.length - 1][0];
+    expect(last.usdValue).toBe('6000');
+    expect(last.location).toBe('blockchain');
+  });
+});

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue
@@ -60,6 +60,7 @@ defineExpose({
     <AmountInput
       v-model="value"
       variant="outlined"
+      data-testid="edit-location-value"
       :label="
         t('common.value_in_symbol', {
           symbol: currencySymbol,

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotTable.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotTable.vue
@@ -255,6 +255,7 @@ function showDeleteConfirmation(item: IndexedLocationDataSnapshot) {
         </RuiButton>
         <RuiButton
           variant="text"
+          data-testid="edit-snapshot-prev"
           @click="updateStep(1)"
         >
           <template #prepend>
@@ -264,6 +265,7 @@ function showDeleteConfirmation(item: IndexedLocationDataSnapshot) {
         </RuiButton>
         <RuiButton
           color="primary"
+          data-testid="edit-snapshot-next"
           @click="updateStep(3)"
         >
           {{ t('common.actions.next') }}

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditSnapshotDialog.spec.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditSnapshotDialog.spec.ts
@@ -1,0 +1,313 @@
+import type { LocationDataSnapshot, Snapshot } from '@/modules/dashboard/snapshots';
+import { bigNumberify } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { BalanceType } from '@/modules/balances/types/balances';
+import { useNotifications } from '@/modules/core/notifications/use-notifications';
+import EditSnapshotDialog from '@/modules/dashboard/edit-snapshot/EditSnapshotDialog.vue';
+import { useSnapshotApi } from '@/modules/settings/api/use-snapshot-api';
+import { useStatisticsDataFetching } from '@/modules/statistics/use-statistics-data-fetching';
+
+vi.mock('@/modules/settings/api/use-snapshot-api', () => ({
+  useSnapshotApi: vi.fn(),
+}));
+
+vi.mock('@/modules/statistics/use-statistics-data-fetching', () => ({
+  useStatisticsDataFetching: vi.fn().mockReturnValue({
+    fetchNetValue: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>(
+    '@/modules/core/notifications/use-notifications',
+  );
+  return {
+    ...actual,
+    useNotifications: vi.fn(),
+  };
+});
+
+const BalancesTableStub = defineComponent({
+  emits: ['update:model-value', 'update:step'],
+  name: 'EditBalancesSnapshotTable',
+  props: ['modelValue', 'timestamp'],
+  render() {
+    return h('div', { class: 'balances-stub' });
+  },
+});
+
+const LocationTableStub = defineComponent({
+  emits: ['update:model-value', 'update:step'],
+  name: 'EditLocationDataSnapshotTable',
+  props: ['modelValue', 'timestamp'],
+  render() {
+    return h('div', { class: 'location-stub' });
+  },
+});
+
+const TotalStub = defineComponent({
+  emits: ['update:model-value', 'update:step'],
+  name: 'EditSnapshotTotal',
+  props: ['modelValue', 'balancesSnapshot', 'timestamp'],
+  render() {
+    return h('div', { class: 'total-stub' });
+  },
+});
+
+type DialogInstance = InstanceType<typeof EditSnapshotDialog>;
+
+describe('edit-snapshot/EditSnapshotDialog.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<DialogInstance>;
+
+  let getSnapshotData: ReturnType<typeof vi.fn<ReturnType<typeof useSnapshotApi>['getSnapshotData']>>;
+  let updateSnapshotData: ReturnType<typeof vi.fn<ReturnType<typeof useSnapshotApi>['updateSnapshotData']>>;
+  let fetchNetValue: ReturnType<typeof vi.fn<ReturnType<typeof useStatisticsDataFetching>['fetchNetValue']>>;
+  let notifyError: ReturnType<typeof vi.fn<ReturnType<typeof useNotifications>['notifyError']>>;
+  let showSuccessMessage: ReturnType<typeof vi.fn<ReturnType<typeof useNotifications>['showSuccessMessage']>>;
+
+  const timestamp = 1700000000;
+
+  function fixtureSnapshot(): Snapshot {
+    return {
+      balancesSnapshot: [
+        {
+          amount: bigNumberify('1.5'),
+          assetIdentifier: 'ETH',
+          category: BalanceType.ASSET,
+          timestamp,
+          usdValue: bigNumberify('3000'),
+        },
+        {
+          amount: bigNumberify('0.1'),
+          assetIdentifier: 'BTC',
+          category: BalanceType.ASSET,
+          timestamp,
+          usdValue: bigNumberify('4000'),
+        },
+      ],
+      locationDataSnapshot: [
+        { location: 'blockchain', timestamp, usdValue: bigNumberify('5000') },
+        { location: 'total', timestamp, usdValue: bigNumberify('7000') },
+      ],
+    };
+  }
+
+  beforeAll(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  beforeEach(() => {
+    getSnapshotData = vi.fn<ReturnType<typeof useSnapshotApi>['getSnapshotData']>().mockResolvedValue(fixtureSnapshot());
+    updateSnapshotData = vi.fn<ReturnType<typeof useSnapshotApi>['updateSnapshotData']>().mockResolvedValue(true);
+    fetchNetValue = vi.fn<ReturnType<typeof useStatisticsDataFetching>['fetchNetValue']>().mockResolvedValue(undefined);
+    notifyError = vi.fn<ReturnType<typeof useNotifications>['notifyError']>();
+    showSuccessMessage = vi.fn<ReturnType<typeof useNotifications>['showSuccessMessage']>();
+
+    vi.mocked(useSnapshotApi).mockReturnValue({
+      deleteSnapshot: vi.fn(),
+      downloadSnapshot: vi.fn(),
+      exportSnapshotCSV: vi.fn(),
+      getSnapshotData,
+      importBalancesSnapshot: vi.fn(),
+      updateSnapshotData,
+      uploadBalancesSnapshot: vi.fn(),
+    });
+
+    vi.mocked(useStatisticsDataFetching).mockReturnValue({
+      fetchNetValue,
+    });
+
+    vi.mocked(useNotifications).mockReturnValue({
+      notify: vi.fn(),
+      notifyError,
+      notifyInfo: vi.fn(),
+      notifyWarning: vi.fn(),
+      removeMatching: vi.fn(),
+      showErrorMessage: vi.fn(),
+      showSuccessMessage,
+    });
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function createWrapper(): VueWrapper<DialogInstance> {
+    return mount(EditSnapshotDialog, {
+      attachTo: document.body,
+      global: {
+        plugins: [pinia],
+        stubs: {
+          EditBalancesSnapshotTable: BalancesTableStub,
+          EditLocationDataSnapshotTable: LocationTableStub,
+          EditSnapshotTotal: TotalStub,
+        },
+      },
+      props: { timestamp },
+    });
+  }
+
+  it('should fetch the snapshot on mount', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+
+    expect(getSnapshotData).toHaveBeenCalledWith(timestamp);
+    expect(wrapper.findComponent(BalancesTableStub).exists()).toBe(true);
+  });
+
+  it('should sort balances and locations descending by usdValue', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+
+    const passed: Snapshot = wrapper.findComponent(BalancesTableStub).props('modelValue');
+    expect(passed.balancesSnapshot.map(b => b.assetIdentifier)).toEqual(['BTC', 'ETH']);
+    expect(passed.locationDataSnapshot.map(l => l.location)).toEqual(['total', 'blockchain']);
+  });
+
+  it('should call updateSnapshotData with both arrays when balances stub emits update:model-value', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+
+    const next: Snapshot = {
+      balancesSnapshot: [{
+        amount: bigNumberify('2'),
+        assetIdentifier: 'ETH',
+        category: BalanceType.ASSET,
+        timestamp,
+        usdValue: bigNumberify('4000'),
+      }],
+      locationDataSnapshot: [
+        { location: 'blockchain', timestamp, usdValue: bigNumberify('5000') },
+      ],
+    };
+
+    const balances = wrapper.findComponent(BalancesTableStub);
+    balances.vm.$emit('update:model-value', next);
+    await flushPromises();
+
+    expect(updateSnapshotData).toHaveBeenCalledTimes(1);
+    expect(updateSnapshotData).toHaveBeenCalledWith(timestamp, {
+      balancesSnapshot: [{
+        amount: '2',
+        assetIdentifier: 'ETH',
+        category: BalanceType.ASSET,
+        timestamp,
+        usdValue: '4000',
+      }],
+      locationDataSnapshot: [
+        { location: 'blockchain', timestamp, usdValue: '5000' },
+      ],
+    });
+  });
+
+  it('should call updateSnapshotData once per balances stub emit', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+
+    const next: Snapshot = {
+      balancesSnapshot: [{
+        amount: bigNumberify('2'),
+        assetIdentifier: 'ETH',
+        category: BalanceType.ASSET,
+        timestamp,
+        usdValue: bigNumberify('4000'),
+      }],
+      locationDataSnapshot: [
+        { location: 'blockchain', timestamp, usdValue: bigNumberify('5000') },
+      ],
+    };
+
+    const balances = wrapper.findComponent(BalancesTableStub);
+    balances.vm.$emit('update:model-value', next);
+    balances.vm.$emit('update:model-value', next);
+    await flushPromises();
+
+    expect(updateSnapshotData).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call updateSnapshotData with merged payload when location stub emits', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+
+    wrapper.findComponent(BalancesTableStub).vm.$emit('update:step', 2);
+    await flushPromises();
+
+    const newLocations: LocationDataSnapshot[] = [
+      { location: 'blockchain', timestamp, usdValue: bigNumberify('9000') },
+    ];
+
+    const location = wrapper.findComponent(LocationTableStub);
+    location.vm.$emit('update:model-value', newLocations);
+    await flushPromises();
+
+    expect(updateSnapshotData).toHaveBeenCalledTimes(1);
+    const [, payload] = updateSnapshotData.mock.calls[0];
+    expect(payload.balancesSnapshot.map((b: { assetIdentifier: string }) => b.assetIdentifier)).toEqual(['BTC', 'ETH']);
+    expect(payload.locationDataSnapshot).toEqual([
+      { location: 'blockchain', timestamp, usdValue: '9000' },
+    ]);
+  });
+
+  it('should call updateSnapshotData and emit finish when total stub completes', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+
+    wrapper.findComponent(BalancesTableStub).vm.$emit('update:step', 3);
+    await flushPromises();
+
+    const total = wrapper.findComponent(TotalStub);
+    total.vm.$emit('update:model-value', [
+      { location: 'total', timestamp, usdValue: bigNumberify('7000') },
+    ]);
+    await flushPromises();
+
+    expect(updateSnapshotData).toHaveBeenCalledTimes(1);
+    expect(showSuccessMessage).toHaveBeenCalled();
+    expect(fetchNetValue).toHaveBeenCalled();
+    expect(wrapper.emitted('finish')).toBeTruthy();
+  });
+
+  it('should notify when updateSnapshotData resolves false on completion', async () => {
+    updateSnapshotData.mockResolvedValueOnce(false);
+    wrapper = createWrapper();
+    await flushPromises();
+
+    wrapper.findComponent(BalancesTableStub).vm.$emit('update:step', 3);
+    await flushPromises();
+
+    const total = wrapper.findComponent(TotalStub);
+    total.vm.$emit('update:model-value', [
+      { location: 'total', timestamp, usdValue: bigNumberify('7000') },
+    ]);
+    await flushPromises();
+
+    expect(notifyError).toHaveBeenCalled();
+    expect(showSuccessMessage).not.toHaveBeenCalled();
+    expect(wrapper.emitted('finish')).toBeFalsy();
+  });
+
+  it('should notify and not emit finish when updateSnapshotData throws on completion', async () => {
+    updateSnapshotData.mockRejectedValueOnce(new Error('boom'));
+    wrapper = createWrapper();
+    await flushPromises();
+
+    wrapper.findComponent(BalancesTableStub).vm.$emit('update:step', 3);
+    await flushPromises();
+
+    const total = wrapper.findComponent(TotalStub);
+    total.vm.$emit('update:model-value', [
+      { location: 'total', timestamp, usdValue: bigNumberify('7000') },
+    ]);
+    await flushPromises();
+
+    expect(notifyError).toHaveBeenCalled();
+    expect(showSuccessMessage).not.toHaveBeenCalled();
+    expect(wrapper.emitted('finish')).toBeFalsy();
+  });
+});

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditSnapshotDialog.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditSnapshotDialog.vue
@@ -162,6 +162,7 @@ const steps = computed<{ title: string }[]>(() => [
       no-padding
       variant="flat"
       class="overflow-hidden"
+      data-testid="edit-snapshot-dialog"
     >
       <div class="flex bg-rui-primary text-white p-2">
         <RuiButton

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditSnapshotTotal.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditSnapshotTotal.vue
@@ -245,6 +245,7 @@ async function save(): Promise<void> {
     <div class="border-t-2 border-rui-grey-300 dark:border-rui-grey-800 relative z-[2] flex justify-end p-2 gap-2">
       <RuiButton
         variant="text"
+        data-testid="edit-snapshot-prev"
         @click="updateStep(2)"
       >
         <template #prepend>
@@ -254,6 +255,7 @@ async function save(): Promise<void> {
       </RuiButton>
       <RuiButton
         color="primary"
+        data-testid="edit-snapshot-complete"
         @click="save()"
       >
         {{ t('common.actions.finish') }}

--- a/frontend/app/src/modules/dashboard/graph/NetWorthChart.vue
+++ b/frontend/app/src/modules/dashboard/graph/NetWorthChart.vue
@@ -49,6 +49,7 @@ watchImmediate(chartOption, () => {
   <div
     ref="chartContainer"
     class="relative w-full h-full"
+    data-testid="net-worth-chart"
   >
     <VChart
       ref="chartInstance"

--- a/frontend/app/tests/e2e/helpers/snapshot-api.ts
+++ b/frontend/app/tests/e2e/helpers/snapshot-api.ts
@@ -1,0 +1,43 @@
+import type { APIRequestContext } from '@playwright/test';
+import { backendUrl } from '../../../playwright.config';
+
+export interface ApiBalanceSnapshot {
+  amount: string;
+  asset_identifier: string;
+  category: string;
+  timestamp: number;
+  usd_value: string;
+}
+
+export interface ApiLocationDataSnapshot {
+  location: string;
+  timestamp: number;
+  usd_value: string;
+}
+
+export interface ApiSnapshot {
+  balances_snapshot: ApiBalanceSnapshot[];
+  location_data_snapshot: ApiLocationDataSnapshot[];
+}
+
+/**
+ * Reads a snapshot directly from the backend for assertion purposes. Keys are
+ * snake_case (the raw backend shape) — the frontend's camelCase is applied by
+ * its own API wrapper, which we deliberately bypass here.
+ */
+export async function apiGetSnapshot(
+  request: APIRequestContext,
+  timestamp: number,
+): Promise<ApiSnapshot> {
+  const response = await request.get(`${backendUrl}/api/1/snapshots/${timestamp}`);
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to fetch snapshot at ${timestamp}: ${response.status()} ${await response.text()}`,
+    );
+  }
+  const body: { result: ApiSnapshot | null; message: string } = await response.json();
+  if (!body.result) {
+    throw new Error(`No snapshot at ${timestamp}: ${body.message}`);
+  }
+  return body.result;
+}

--- a/frontend/app/tests/e2e/helpers/snapshot-csv.ts
+++ b/frontend/app/tests/e2e/helpers/snapshot-csv.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Snapshot CSV shape mirrors the backend's `_for_import` serializer in
+ * `rotkehlchen/db/utils.py`; headers are validated by `validate_import_data`
+ * in `rotkehlchen/utils/snapshots.py`. All rows must share the same int
+ * (seconds) timestamp and the headers must appear in the exact order below
+ * or the import is rejected with `'csv file has invalid headers'`.
+ */
+
+export interface BalanceRow {
+  category: 'asset' | 'liability';
+  assetIdentifier: string;
+  amount: string;
+  usdValue: string;
+}
+
+export interface LocationRow {
+  location: string;
+  usdValue: string;
+}
+
+const BALANCE_HEADERS = ['timestamp', 'category', 'asset_identifier', 'amount', 'usd_value'] as const;
+const LOCATION_HEADERS = ['timestamp', 'location', 'usd_value'] as const;
+
+export function generateBalancesCsv(timestamp: number, rows: BalanceRow[]): string {
+  const body = rows.map(row => [
+    timestamp,
+    row.category,
+    row.assetIdentifier,
+    row.amount,
+    row.usdValue,
+  ].join(','));
+  return [BALANCE_HEADERS.join(','), ...body].join('\n');
+}
+
+export function generateLocationDataCsv(timestamp: number, rows: LocationRow[]): string {
+  const body = rows.map(row => [timestamp, row.location, row.usdValue].join(','));
+  return [LOCATION_HEADERS.join(','), ...body].join('\n');
+}
+
+export interface SnapshotFixturePaths {
+  balancesPath: string;
+  locationsPath: string;
+  cleanup: () => void;
+}
+
+/**
+ * Writes the two CSVs to a unique tmp directory and returns the paths plus a
+ * cleanup hook. The caller must invoke `cleanup()` from `afterAll` to remove
+ * the temp dir.
+ */
+export function writeFixturesToTmp(
+  timestamp: number,
+  balanceRows: BalanceRow[],
+  locationRows: LocationRow[],
+): SnapshotFixturePaths {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rotki-snapshot-'));
+  const balancesPath = path.join(dir, 'balances_snapshot_import.csv');
+  const locationsPath = path.join(dir, 'location_data_snapshot.csv');
+  fs.writeFileSync(balancesPath, generateBalancesCsv(timestamp, balanceRows));
+  fs.writeFileSync(locationsPath, generateLocationDataCsv(timestamp, locationRows));
+  return {
+    balancesPath,
+    locationsPath,
+    cleanup: (): void => {
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}

--- a/frontend/app/tests/e2e/pages/dashboard-page.ts
+++ b/frontend/app/tests/e2e/pages/dashboard-page.ts
@@ -1,7 +1,9 @@
 import { expect, type Page } from '@playwright/test';
 import { type BigNumber, Zero } from '@rotki/common';
 import { parseBigNumber, updateLocationBalance } from '../helpers/utils';
+import { ExportSnapshotDialog } from './export-snapshot-dialog';
 import { RotkiApp } from './rotki-app';
+import { SnapshotImportDialog } from './snapshot-import-dialog';
 
 export class DashboardPage {
   constructor(private readonly page: Page) {}
@@ -94,5 +96,51 @@ export class DashboardPage {
 
   async percentageDisplayIsNotBlurred(): Promise<void> {
     await expect(this.page.locator('[data-cy=percentage-display]').first()).not.toHaveClass(/blur/);
+  }
+
+  async openSnapshotMenu(): Promise<void> {
+    await this.page.locator('[data-testid=snapshot-action]').click();
+  }
+
+  async openImportSnapshotDialog(): Promise<SnapshotImportDialog> {
+    // The snapshot menu must already be open; the Import button lives inside it.
+    await this.page.getByRole('button', { name: 'Import', exact: true }).click();
+    const dialog = new SnapshotImportDialog(this.page);
+    await dialog.waitForVisible();
+    return dialog;
+  }
+
+  /**
+   * Clicks the rendered data point on the net-worth chart to open the export
+   * snapshot dialog. With a single seeded snapshot 7 days back the chart
+   * draws a marker at the left edge (the snapshot) and a synthetic "current
+   * balance" point on the right. The click sweeps a few x positions near the
+   * left edge to handle small layout shifts (axis label widths, padding).
+   */
+  async openSnapshotDialogAt(): Promise<ExportSnapshotDialog> {
+    const chart = this.page.locator('[data-testid=net-worth-chart]');
+    await chart.waitFor({ state: 'visible' });
+    const canvas = chart.locator('canvas').first();
+    const box = await canvas.boundingBox();
+    if (!box) {
+      throw new Error('net-worth chart canvas has no bounding box');
+    }
+    const dialog = new ExportSnapshotDialog(this.page);
+    const dialogLocator = this.page.locator('[data-testid=export-snapshot-dialog]');
+    // Echarts plots the leftmost data point a bit inside the axis margin;
+    // sweep through a handful of x positions until the dialog appears.
+    for (const xRatio of [0.06, 0.08, 0.04, 0.1, 0.02]) {
+      await canvas.click({
+        position: { x: box.width * xRatio, y: box.height * 0.4 },
+      });
+      try {
+        await dialogLocator.waitFor({ state: 'visible', timeout: 2_000 });
+        return dialog;
+      }
+      catch {
+        // Try the next x offset.
+      }
+    }
+    throw new Error('Failed to open export snapshot dialog by clicking the chart');
   }
 }

--- a/frontend/app/tests/e2e/pages/edit-snapshot-dialog.ts
+++ b/frontend/app/tests/e2e/pages/edit-snapshot-dialog.ts
@@ -1,0 +1,66 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class EditSnapshotDialog {
+  constructor(private readonly page: Page) {}
+
+  private get root(): Locator {
+    return this.page.locator('[data-testid=edit-snapshot-dialog]');
+  }
+
+  private get bigDialog(): Locator {
+    // BigDialog (`data-cy=bottom-dialog`) is the inline edit form opened from a
+    // table row's edit button. It overlays the snapshot dialog itself.
+    return this.page.locator('[data-cy=bottom-dialog]');
+  }
+
+  async waitForVisible(): Promise<void> {
+    await this.root.waitFor({ state: 'visible' });
+  }
+
+  async editBalanceRow(asset: string, newAmount: string): Promise<void> {
+    const row = this.root.locator('tr', { hasText: asset }).first();
+    await row.locator('[data-cy=row-edit]').click();
+    const dialog = this.bigDialog;
+    await dialog.waitFor({ state: 'visible' });
+    const amountInput = dialog.locator('[data-cy=amount] input');
+    await amountInput.fill(newAmount);
+    await this.page.locator('[data-cy=confirm]').click();
+    await dialog.waitFor({ state: 'hidden' });
+  }
+
+  async editLocationRow(location: string, newUsd: string): Promise<void> {
+    const row = this.root.locator('tr', { hasText: location }).first();
+    await row.locator('[data-cy=row-edit]').click();
+    const dialog = this.bigDialog;
+    await dialog.waitFor({ state: 'visible' });
+    const valueInput = dialog.locator('[data-testid=edit-location-value] input');
+    await valueInput.fill(newUsd);
+    await this.page.locator('[data-cy=confirm]').click();
+    await dialog.waitFor({ state: 'hidden' });
+  }
+
+  async next(): Promise<void> {
+    await this.page.locator('[data-testid=edit-snapshot-next]').click();
+  }
+
+  async prev(): Promise<void> {
+    await this.page.locator('[data-testid=edit-snapshot-prev]').click();
+  }
+
+  async complete(): Promise<void> {
+    await this.page.locator('[data-testid=edit-snapshot-complete]').click();
+    await this.root.waitFor({ state: 'hidden' });
+    // A "Data was successfully updated" confirmation dialog appears after a
+    // successful save and otherwise sits over the dashboard, blocking the
+    // next test's chart click.
+    const okButton = this.page.getByRole('button', { name: 'OK', exact: true });
+    try {
+      await okButton.waitFor({ state: 'visible', timeout: 5_000 });
+      await okButton.click();
+      await okButton.waitFor({ state: 'hidden' });
+    }
+    catch {
+      // No confirmation popped up — fine.
+    }
+  }
+}

--- a/frontend/app/tests/e2e/pages/export-snapshot-dialog.ts
+++ b/frontend/app/tests/e2e/pages/export-snapshot-dialog.ts
@@ -1,0 +1,27 @@
+import type { Download, Page } from '@playwright/test';
+import { EditSnapshotDialog } from './edit-snapshot-dialog';
+
+export class ExportSnapshotDialog {
+  constructor(private readonly page: Page) {}
+
+  private get root() {
+    return this.page.locator('[data-testid=export-snapshot-dialog]');
+  }
+
+  async waitForVisible(): Promise<void> {
+    await this.root.waitFor({ state: 'visible' });
+  }
+
+  async openEdit(): Promise<EditSnapshotDialog> {
+    await this.page.locator('[data-testid=export-snapshot-edit]').click();
+    const dialog = new EditSnapshotDialog(this.page);
+    await dialog.waitForVisible();
+    return dialog;
+  }
+
+  async download(): Promise<Download> {
+    const downloadPromise = this.page.waitForEvent('download');
+    await this.page.locator('[data-testid=export-snapshot-download]').click();
+    return downloadPromise;
+  }
+}

--- a/frontend/app/tests/e2e/pages/snapshot-import-dialog.ts
+++ b/frontend/app/tests/e2e/pages/snapshot-import-dialog.ts
@@ -1,0 +1,29 @@
+import type { Page } from '@playwright/test';
+
+export class SnapshotImportDialog {
+  constructor(private readonly page: Page) {}
+
+  private get root() {
+    return this.page.locator('[data-testid=snapshot-import-dialog]');
+  }
+
+  async waitForVisible(): Promise<void> {
+    await this.root.waitFor({ state: 'visible' });
+  }
+
+  async uploadBalanceCsv(filePath: string): Promise<void> {
+    await this.root
+      .locator('[data-testid=snapshot-import-balance-file] input[type=file]')
+      .setInputFiles(filePath);
+  }
+
+  async uploadLocationCsv(filePath: string): Promise<void> {
+    await this.root
+      .locator('[data-testid=snapshot-import-location-file] input[type=file]')
+      .setInputFiles(filePath);
+  }
+
+  async import(): Promise<void> {
+    await this.page.locator('[data-testid=snapshot-import-submit]').click();
+  }
+}

--- a/frontend/app/tests/e2e/specs/app/snapshot-edit.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/snapshot-edit.spec.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import { expect, test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { apiGetSnapshot } from '../../helpers/snapshot-api';
+import { type SnapshotFixturePaths, writeFixturesToTmp } from '../../helpers/snapshot-csv';
+import { DashboardPage } from '../../pages/dashboard-page';
+
+// Fixed snapshot timestamp seven days back, snapped to midnight UTC. Stable
+// enough to be deterministic, far enough in the past to render inside the
+// chart's default range, and unlikely to collide with anything else seeded by
+// the e2e suite (which uses now-based timestamps).
+const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
+const SNAPSHOT_TIMESTAMP = Math.floor(Date.now() / 1000 / 86400) * 86400 - SEVEN_DAYS_SECONDS;
+
+test.describe.serial('snapshot edit', () => {
+  let ctx: SharedTestContext;
+  let fixtures: SnapshotFixturePaths;
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request, { disableModules: true });
+    fixtures = writeFixturesToTmp(
+      SNAPSHOT_TIMESTAMP,
+      [
+        { amount: '10', assetIdentifier: 'ETH', category: 'asset', usdValue: '20000' },
+        { amount: '0.5', assetIdentifier: 'BTC', category: 'asset', usdValue: '30000' },
+        { amount: '500', assetIdentifier: 'USD', category: 'asset', usdValue: '500' },
+      ],
+      [
+        { location: 'blockchain', usdValue: '50000' },
+        { location: 'total', usdValue: '50500' },
+      ],
+    );
+  });
+
+  test.afterAll(async () => {
+    fixtures?.cleanup();
+    await cleanupContext(ctx);
+  });
+
+  test('imports a snapshot via the UI and re-logs in', async () => {
+    const dashboard = new DashboardPage(ctx.sharedPage);
+    await dashboard.visit();
+    await dashboard.openSnapshotMenu();
+    const importDialog = await dashboard.openImportSnapshotDialog();
+    await importDialog.uploadBalanceCsv(fixtures.balancesPath);
+    await importDialog.uploadLocationCsv(fixtures.locationsPath);
+    await importDialog.import();
+
+    // Auto-logout fires ~3s after a successful import; the most reliable
+    // signal that we're back at the login screen is the username field.
+    // We call `login()` directly rather than `relogin()` because the auto-
+    // logout has already detached the session — `relogin()` would try to
+    // click a logout button that no longer exists.
+    await ctx.sharedPage.locator('[data-cy=username-input]').waitFor({ state: 'visible', timeout: 10_000 });
+    await ctx.app.login(ctx.username);
+
+    await ctx.sharedPage.locator('[data-testid=net-worth-chart]').waitFor({ state: 'visible' });
+  });
+
+  test('edits a balance row and a location row', async () => {
+    const dashboard = new DashboardPage(ctx.sharedPage);
+    const exportDialog = await dashboard.openSnapshotDialogAt();
+    const editDialog = await exportDialog.openEdit();
+
+    await editDialog.editBalanceRow('ETH', '12.5');
+    await editDialog.next();
+
+    await editDialog.editLocationRow('blockchain', '40000');
+    await editDialog.next();
+
+    await editDialog.complete();
+
+    // Use the page's request context so the GET shares the browser session
+    // (the test-level `request` fixture lost its cookies during the re-login).
+    const snapshot = await apiGetSnapshot(ctx.sharedPage.request, SNAPSHOT_TIMESTAMP);
+    const eth = snapshot.balances_snapshot.find(b => b.asset_identifier === 'ETH');
+    const blockchain = snapshot.location_data_snapshot.find(l => l.location === 'blockchain');
+    expect(eth?.amount).toBe('12.5');
+    expect(blockchain?.usd_value).toBe('40000');
+  });
+
+  test('exports the snapshot zip', async () => {
+    const dashboard = new DashboardPage(ctx.sharedPage);
+    const exportDialog = await dashboard.openSnapshotDialogAt();
+    const download = await exportDialog.download();
+    const downloadPath = await download.path();
+    expect(downloadPath).toBeTruthy();
+    const stats = fs.statSync(downloadPath);
+    expect(stats.size).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Vitest specs for the inner snapshot-edit forms (`EditBalancesSnapshotForm`, `EditLocationDataSnapshotForm`) and the 3-step `EditSnapshotDialog`, covering merged-payload save, success/error notifications, and the `finish` emit.
- Playwright spec that drives the full UI roundtrip: imports two CSVs through the dashboard menu, re-logs in after the import-triggered auto-logout, edits a balance row + a location row through the stepper, and verifies the download produces a non-empty file. Persistence is checked by reading the snapshot back from the API.
- Minimal `data-testid` additions on the snapshot menu, import dialog, chart, export dialog, and edit dialog so the page objects have stable selectors. No broader \`data-cy\` migration.

## Test plan

- [x] \`pnpm run test:unit src/modules/dashboard/edit-snapshot/\` (20 tests passing)
- [x] \`pnpm run typecheck\`
- [x] \`pnpm run lint-staged\`
- [x] \`pnpm run test:e2e snapshot-edit\` — 3/3 passing across 3 consecutive local runs (no flake; ~32s per run)

Refs #11252