### PR TITLE
Bump version: 1.42.1 → 1.43.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.42.1
+current_version = 1.43.0
 commit = True
 tag = False
 

--- a/colibri/Cargo.lock
+++ b/colibri/Cargo.lock
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "colibri"
-version = "1.42.1"
+version = "1.43.0"
 dependencies = [
  "alloy",
  "async-sqlite",

--- a/colibri/Cargo.toml
+++ b/colibri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "colibri"
-version = "1.42.1"
+version = "1.43.0"
 edition = "2021"
 
 [dependencies]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :release:`1.43.0 <2026-05-06>`
 * :feature:`12143` CSV imports now accept an optional timezone so files whose dates lack timezone information can be interpreted in the correct local time instead of defaulting to UTC.
 * :feature:`-` After a rotki update, a friendly prompt will walk you through any new recommended settings. You can accept the ones you like, keep what you have for the rest.
 * :feature:`12102` New giveth donation events will now be properly decoded on all supported chains.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,9 +23,9 @@ project_copyright = '2018-2020, Eleftherios Karapetsas. 2020-2025, Rotki Solutio
 author = 'The rotki team'
 
 # The short X.Y version
-version = '1.42.1'
+version = '1.43.0'
 # The full version, including alpha/beta/rc tags
-release = '1.42.1'
+release = '1.43.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotki",
-  "version": "1.42.1",
+  "version": "1.43.0",
   "description": "A portfolio tracking, asset analytics and tax reporting application specializing in Cryptoassets that protects your privacy",
   "type": "module",
   "license": "AGPL-3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ rotkehlchen_mock = "rotkehlchen_mock.__main__:main"
 # dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools_scm]
-fallback_version = "1.42.1"
+fallback_version = "1.43.0"
 
 [tool.setuptools.package-data]
 "rotkehlchen.data" = ["*"]


### PR DESCRIPTION
## Summary
- Bump version to 1.43.0
- Add 1.43.0 release entry to changelog (dated 2026-05-06)

## Test plan
- [ ] Verify version strings updated in all config files
- [ ] Verify changelog renders correctly