### PR TITLE
fix(frontend): refresh seeded prices alongside aggregated assets

### DIFF
--- a/frontend/app/src/modules/assets/prices/PriceRefresh.vue
+++ b/frontend/app/src/modules/assets/prices/PriceRefresh.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { usePriceRefresh } from '@/modules/assets/prices/use-price-refresh';
-import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
 import { useBalancesLoading } from '@/modules/balances/use-balance-loading';
 import { Section } from '@/modules/core/common/status';
 import { useSectionStatus } from '@/modules/shell/sync-progress/use-section-status';
@@ -14,12 +13,11 @@ const { t } = useI18n({ useScope: 'global' });
 const { refreshPrices } = usePriceRefresh();
 const { isLoading: refreshing } = useSectionStatus(Section.PRICES);
 const { loadingBalances } = useBalancesLoading();
-const { assets } = useAggregatedBalances();
 const disabled = computed<boolean>(() => get(refreshing) || get(loadingBalances));
 
 async function refresh() {
   emit('click');
-  await refreshPrices(true, get(assets));
+  await refreshPrices(true);
 }
 </script>
 

--- a/frontend/app/src/modules/assets/prices/use-price-refresh.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-price-refresh.spec.ts
@@ -185,6 +185,77 @@ describe('usePriceRefresh', () => {
     });
   });
 
+  // Regression: the price seed populates `prices` for assets the user holds, but
+  // before chain balances finish loading `useAggregatedBalances.assets` can be
+  // empty. The refresh button and currency switch must still re-fetch the seeded
+  // entries (otherwise they stay stale / in the old currency).
+  // These tests reset modules so the shared composable is re-instantiated with
+  // a fresh pinia, instead of retaining state from the suite above.
+  describe('refreshPrices — seeded assets', () => {
+    beforeEach(async () => {
+      vi.resetModules();
+      setActivePinia(createPinia());
+      mockFetchExchangeRates.mockClear().mockResolvedValue({});
+      mockFetchPrices.mockClear().mockResolvedValue({});
+    });
+
+    async function loadFreshRefresh(): Promise<{ refreshPrices: (ignoreCache?: boolean, selectedAssets?: string[] | null) => Promise<void> }> {
+      const mod = await import('@/modules/assets/prices/use-price-refresh');
+      return mod.usePriceRefresh();
+    }
+
+    it('should refresh seeded assets even when aggregated balances are empty', async () => {
+      const { prices } = storeToRefs(useBalancePricesStore());
+      set(prices, {
+        BTC: createTestPriceInfo(40000),
+        ETH: createTestPriceInfo(3000),
+      });
+
+      const { refreshPrices } = await loadFreshRefresh();
+      await refreshPrices(true);
+
+      expect(mockFetchExchangeRates).toHaveBeenCalled();
+      expect(mockFetchPrices).toHaveBeenCalledTimes(1);
+      const { ignoreCache, selectedAssets } = mockFetchPrices.mock.calls[0][0];
+      expect(ignoreCache).toBe(true);
+      expect([...selectedAssets].sort()).toEqual(['BTC', 'ETH']);
+    });
+
+    it('should union aggregated assets with seeded prices when no selection is passed', async () => {
+      const { prices } = storeToRefs(useBalancePricesStore());
+      const { manualBalances } = storeToRefs(useBalancesStore());
+
+      set(manualBalances, [
+        createTestManualBalance('DAI', 50, 50, TRADE_LOCATION_BANKS),
+      ]);
+      set(prices, {
+        BTC: createTestPriceInfo(40000),
+      });
+
+      const { refreshPrices } = await loadFreshRefresh();
+      await refreshPrices(true);
+
+      expect(mockFetchPrices).toHaveBeenCalledTimes(1);
+      const { selectedAssets } = mockFetchPrices.mock.calls[0][0];
+      expect([...selectedAssets].sort()).toEqual(['BTC', 'DAI']);
+    });
+
+    it('should respect an explicit selectedAssets list and not union with priced assets', async () => {
+      const { prices } = storeToRefs(useBalancePricesStore());
+      set(prices, {
+        BTC: createTestPriceInfo(40000),
+        ETH: createTestPriceInfo(3000),
+      });
+
+      const { refreshPrices } = await loadFreshRefresh();
+      await refreshPrices(true, ['DAI']);
+
+      expect(mockFetchPrices).toHaveBeenCalledTimes(1);
+      const { selectedAssets } = mockFetchPrices.mock.calls[0][0];
+      expect([...selectedAssets]).toEqual(['DAI']);
+    });
+  });
+
   describe('queue fifo', () => {
     let executionOrder: string[];
     let callCount: number;

--- a/frontend/app/src/modules/assets/prices/use-price-refresh.ts
+++ b/frontend/app/src/modules/assets/prices/use-price-refresh.ts
@@ -121,7 +121,8 @@ export const usePriceRefresh = createSharedComposable((): UsePriceRefreshReturn 
     });
 
   const refreshPrices = async (ignoreCache = false, selectedAssets: string[] | null = null): Promise<void> => {
-    const assetsToRefresh = selectedAssets?.filter(uniqueStrings) ?? get(assets);
+    const assetsToRefresh = selectedAssets?.filter(uniqueStrings)
+      ?? [...get(assets), ...Object.keys(get(prices))].filter(uniqueStrings);
     await enqueueTask(ignoreCache, assetsToRefresh);
   };
 


### PR DESCRIPTION
## Summary
- The price seed populates the `prices` store for assets the user holds, but the global refresh button and currency switch only iterated `useAggregatedBalances.assets`. Before chain balances finished loading that set could be smaller than what was seeded, so seeded entries were never re-fetched and stayed stale (or in the previous currency after a switch).
- `refreshPrices` now defaults to the union of aggregated assets and the keys already in the `prices` store when no explicit selection is passed.
- `PriceRefresh.vue` drops its explicit `get(assets)` argument so the global button picks up that default.
- Callers that pass an explicit list (manual price manager, the internal `fetchNoPriceAssets` watcher) are unchanged — explicit selection still wins.

## Test plan
- [x] `pnpm run test:unit src/modules/assets/prices/use-price-refresh.spec.ts` — 13 tests pass
- [x] Three new regression tests cover: seeded-only refresh, union with aggregated balances, and that explicit selection is preserved (verified to fail without the fix)
- [x] `pnpm run typecheck`