### PR TITLE
fix(frontend): zoom-aware net worth percentage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`12112` The dashboard's net worth percentage and trend indicator now follow the chart's data-zoom selection.
 * :feature:`12111` Free-text typed in the History events filter without a key=value prefix is now applied as a notes search on Enter, so you can quickly find events by any word in their notes instead of having to remember the notes= prefix.
 
 * :release:`1.43.0 <2026-05-08>`

--- a/frontend/app/src/modules/dashboard/OverallBalances.vue
+++ b/frontend/app/src/modules/dashboard/OverallBalances.vue
@@ -3,6 +3,7 @@ import { assert, TimeFramePeriod, TimeFramePersist, timeframes, type TimeFrameSe
 import dayjs from 'dayjs';
 import { FiatDisplay } from '@/modules/assets/amount-display/components';
 import { Section } from '@/modules/core/common/status';
+import { computeNetValueDelta, type NetValueZoomRange } from '@/modules/dashboard/graph/net-value-stats';
 import NetWorthChart from '@/modules/dashboard/graph/NetWorthChart.vue';
 import SnapshotActionButton from '@/modules/dashboard/SnapshotActionButton.vue';
 import { usePremium } from '@/modules/premium/use-premium';
@@ -31,6 +32,8 @@ const { isInitialLoading, isLoading: sectionLoading } = useSectionStatus(Section
 
 const isLoading = logicOr(isInitialLoading, sectionLoading);
 
+const zoomRange = ref<NetValueZoomRange>();
+
 const allTimeframes = computed(() =>
   timeframes((unit, amount) => dayjs().subtract(amount, unit).startOf(TimeUnit.DAY).unix()),
 );
@@ -42,21 +45,13 @@ const timeframeData = computed(() => {
   return getNetValue(startingDate);
 });
 
-const startingValue = computed(() => {
-  const data = get(timeframeData).data;
-  let start = data[0];
-  if (start.isZero()) {
-    for (let i = 1; i < data.length; i++) {
-      if (data[i].gt(0)) {
-        start = data[i];
-        break;
-      }
-    }
-  }
-  return start;
+const stats = computed(() => {
+  const { data, times } = get(timeframeData);
+  return computeNetValueDelta(data, times, get(totalNetWorth), get(zoomRange));
 });
 
-const balanceDelta = computed(() => get(totalNetWorth).minus(get(startingValue)));
+const startingValue = computed(() => get(stats).startingValue);
+const balanceDelta = computed(() => get(stats).balanceDelta);
 
 const percentage = computed(() => {
   const bigNumber = get(balanceDelta).div(get(startingValue)).multipliedBy(100);
@@ -90,6 +85,13 @@ async function setTimeframe(value: TimeFrameSetting) {
   sessionStore.update({ timeframe: value });
   await updateFrontendSetting({ lastKnownTimeframe: value });
 }
+
+// Resetting on timeframe change keeps the header on the full-range numbers
+// after the user switches buttons, without clobbering an active zoom on routine
+// balance refreshes.
+watch(timeframe, () => {
+  set(zoomRange, undefined);
+});
 
 onMounted(() => {
   const isPremium = get(premium);
@@ -160,7 +162,10 @@ onMounted(() => {
         <SnapshotActionButton />
       </div>
       <div class="relative">
-        <NetWorthChart :chart-data="timeframeData" />
+        <NetWorthChart
+          v-model:zoom-range="zoomRange"
+          :chart-data="timeframeData"
+        />
         <div
           v-if="isLoading"
           class="absolute top-0 h-full w-full flex flex-col gap-3 items-center justify-center text-caption text-rui-text-secondary bg-white/[0.8] dark:bg-dark-elevated/[0.9] z-[6]"

--- a/frontend/app/src/modules/dashboard/graph/NetWorthChart.vue
+++ b/frontend/app/src/modules/dashboard/graph/NetWorthChart.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { NetValueZoomRange } from '@/modules/dashboard/graph/net-value-stats';
 import type { NetValueChartData } from '@/modules/dashboard/graph/types';
 import { type BigNumber, Zero } from '@rotki/common';
 import VChart from 'vue-echarts';
@@ -8,6 +9,8 @@ import { useNetValueChartConfig } from '@/modules/dashboard/graph/use-net-value-
 import { useNetValueEventHandlers } from '@/modules/dashboard/graph/use-net-value-event-handlers';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import NewGraphTooltipWrapper from '@/modules/statistics/NewGraphTooltipWrapper.vue';
+
+const zoomRange = defineModel<NetValueZoomRange | undefined>('zoomRange');
 
 const { chartData } = defineProps<{
   chartData: NetValueChartData;
@@ -24,7 +27,14 @@ const showExportSnapshotDialog = ref<boolean>(false);
 
 const { isDark } = useRotkiTheme();
 
-const { chartOption } = useNetValueChartConfig(() => chartData);
+const { chartOption } = useNetValueChartConfig(() => chartData, zoomRange);
+
+// datazoom fires on every drag frame; debounce the model write so consumers
+// only recompute once the user settles on a range.
+const updateZoomRange = useDebounceFn((range: NetValueZoomRange | undefined) => {
+  set(zoomRange, range);
+}, 100);
+
 const { setupChartEventHandlers, setupZoomToolHandler, tooltipData } = useNetValueEventHandlers({
   chartContainer,
   chartData: () => chartData,
@@ -33,6 +43,9 @@ const { setupChartEventHandlers, setupZoomToolHandler, tooltipData } = useNetVal
     set(selectedTimestamp, timestamp);
     set(selectedBalance, balance);
     set(showExportSnapshotDialog, true);
+  },
+  onZoomChange: (range: NetValueZoomRange | undefined) => {
+    updateZoomRange(range);
   },
 });
 

--- a/frontend/app/src/modules/dashboard/graph/net-value-stats.spec.ts
+++ b/frontend/app/src/modules/dashboard/graph/net-value-stats.spec.ts
@@ -1,0 +1,97 @@
+import { bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { computeNetValueDelta } from '@/modules/dashboard/graph/net-value-stats';
+
+describe('computeNetValueDelta', () => {
+  const times = [1000, 2000, 3000, 4000, 5000];
+  const data = [10, 20, 30, 40, 50].map(v => bigNumberify(v));
+
+  it('should match legacy behaviour when no zoom is set', () => {
+    const result = computeNetValueDelta(data, times, bigNumberify(60));
+    expect(result.startingValue.toNumber()).toBe(10);
+    expect(result.endValue.toNumber()).toBe(60);
+    expect(result.balanceDelta.toNumber()).toBe(50);
+  });
+
+  it('should match legacy behaviour when zoom covers the full range', () => {
+    const result = computeNetValueDelta(
+      data,
+      times,
+      bigNumberify(60),
+      { end: 5000, start: 1000 },
+    );
+    expect(result.startingValue.toNumber()).toBe(10);
+    expect(result.endValue.toNumber()).toBe(60);
+    expect(result.balanceDelta.toNumber()).toBe(50);
+  });
+
+  it('should derive start and end from the visible window when zoomed', () => {
+    const result = computeNetValueDelta(
+      data,
+      times,
+      bigNumberify(60),
+      { end: 4000, start: 2000 },
+    );
+    expect(result.startingValue.toNumber()).toBe(20);
+    expect(result.endValue.toNumber()).toBe(40);
+    expect(result.balanceDelta.toNumber()).toBe(20);
+  });
+
+  it('should produce a negative delta when the window value drops', () => {
+    const dropping = [50, 40, 30, 20, 10].map(v => bigNumberify(v));
+    const result = computeNetValueDelta(
+      dropping,
+      times,
+      bigNumberify(10),
+      { end: 5000, start: 3000 },
+    );
+    expect(result.startingValue.toNumber()).toBe(30);
+    expect(result.endValue.toNumber()).toBe(10);
+    expect(result.balanceDelta.toNumber()).toBe(-20);
+  });
+
+  it('should skip leading zeros inside the zoom window', () => {
+    const sparse = [0, 0, 25, 30, 50].map(v => bigNumberify(v));
+    const result = computeNetValueDelta(
+      sparse,
+      times,
+      bigNumberify(60),
+      { end: 5000, start: 1000 },
+    );
+    // Full range so legacy path runs and skips leading zeros.
+    expect(result.startingValue.toNumber()).toBe(25);
+    expect(result.endValue.toNumber()).toBe(60);
+  });
+
+  it('should skip leading zeros inside a partial zoom window', () => {
+    const sparse = [10, 0, 0, 40, 50].map(v => bigNumberify(v));
+    const result = computeNetValueDelta(
+      sparse,
+      times,
+      bigNumberify(60),
+      { end: 4000, start: 2000 },
+    );
+    expect(result.startingValue.toNumber()).toBe(40);
+    expect(result.endValue.toNumber()).toBe(40);
+    expect(result.balanceDelta.toNumber()).toBe(0);
+  });
+
+  it('should return zeros for an empty dataset', () => {
+    const result = computeNetValueDelta([], [], bigNumberify(0));
+    expect(result.startingValue.toNumber()).toBe(0);
+    expect(result.endValue.toNumber()).toBe(0);
+    expect(result.balanceDelta.toNumber()).toBe(0);
+  });
+
+  it('should return zeros when the zoom window contains no datapoints', () => {
+    const result = computeNetValueDelta(
+      data,
+      times,
+      bigNumberify(60),
+      { end: 999, start: 100 },
+    );
+    expect(result.startingValue.toNumber()).toBe(0);
+    expect(result.endValue.toNumber()).toBe(0);
+    expect(result.balanceDelta.toNumber()).toBe(0);
+  });
+});

--- a/frontend/app/src/modules/dashboard/graph/net-value-stats.ts
+++ b/frontend/app/src/modules/dashboard/graph/net-value-stats.ts
@@ -1,0 +1,87 @@
+import { type BigNumber, Zero } from '@rotki/common';
+
+export interface NetValueZoomRange {
+  /** Inclusive start timestamp in seconds. */
+  start: number;
+  /** Inclusive end timestamp in seconds. */
+  end: number;
+}
+
+export interface NetValueDeltaResult {
+  startingValue: BigNumber;
+  endValue: BigNumber;
+  balanceDelta: BigNumber;
+}
+
+function firstNonZero(data: BigNumber[], from: number, to: number): BigNumber {
+  // Skip leading zeros — a fresh portfolio reports zero before its first snapshot.
+  let start = data[from];
+  if (!start)
+    return Zero;
+  if (start.isZero()) {
+    for (let i = from + 1; i <= to; i++) {
+      if (data[i]?.gt(0)) {
+        start = data[i];
+        break;
+      }
+    }
+  }
+  return start;
+}
+
+interface IndexRange {
+  first: number;
+  last: number;
+}
+
+function findWindowIndices(times: number[], zoom: NetValueZoomRange): IndexRange {
+  let first = -1;
+  let last = -1;
+  for (const [i, t] of times.entries()) {
+    if (t < zoom.start || t > zoom.end)
+      continue;
+    if (first === -1)
+      first = i;
+    last = i;
+  }
+  return { first, last };
+}
+
+function isFullRange(times: number[], zoom: NetValueZoomRange | undefined): boolean {
+  if (!zoom)
+    return true;
+  const last = times.at(-1);
+  return last !== undefined && zoom.start <= times[0] && zoom.end >= last;
+}
+
+/**
+ * Without a zoom (or when zoom covers the full range) returns the legacy
+ * delta: first non-zero datapoint vs live `totalNetWorth`. With a partial
+ * zoom, both ends come from the visible window.
+ */
+export function computeNetValueDelta(
+  data: BigNumber[],
+  times: number[],
+  totalNetWorth: BigNumber,
+  zoom?: NetValueZoomRange,
+): NetValueDeltaResult {
+  if (data.length === 0 || times.length === 0) {
+    return { balanceDelta: Zero, endValue: Zero, startingValue: Zero };
+  }
+
+  if (!zoom || isFullRange(times, zoom)) {
+    const startingValue = firstNonZero(data, 0, data.length - 1);
+    const balanceDelta = totalNetWorth.minus(startingValue);
+    return { balanceDelta, endValue: totalNetWorth, startingValue };
+  }
+
+  const { first, last } = findWindowIndices(times, zoom);
+  if (first === -1) {
+    return { balanceDelta: Zero, endValue: Zero, startingValue: Zero };
+  }
+
+  const startingValue = firstNonZero(data, first, last);
+  const endValue = data[last] ?? Zero;
+  const balanceDelta = endValue.minus(startingValue);
+  return { balanceDelta, endValue, startingValue };
+}

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-chart-config.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-chart-config.ts
@@ -8,6 +8,7 @@ import type {
 } from 'echarts';
 import type { DataZoomComponentOption, GridComponentOption } from 'echarts/components';
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { NetValueZoomRange } from '@/modules/dashboard/graph/net-value-stats';
 import type { NetValueChartData } from '@/modules/dashboard/graph/types';
 import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
 import { useGraph } from '@/modules/statistics/use-graph';
@@ -21,7 +22,10 @@ interface UseNetValueChartConfigReturn {
   chartOption: ComputedRef<EChartsOption>;
 }
 
-export function useNetValueChartConfig(chartData: MaybeRefOrGetter<NetValueChartData>): UseNetValueChartConfigReturn {
+export function useNetValueChartConfig(
+  chartData: MaybeRefOrGetter<NetValueChartData>,
+  zoomRange: MaybeRefOrGetter<NetValueZoomRange | undefined> = () => undefined,
+): UseNetValueChartConfigReturn {
   const data = computed<number[][]>(() => {
     const { data, times } = toValue(chartData);
     if (!(times?.length && data?.length)) {
@@ -37,6 +41,18 @@ export function useNetValueChartConfig(chartData: MaybeRefOrGetter<NetValueChart
   const { graphZeroBased, showGraphRangeSelector } = storeToRefs(useFrontendSettingsStore());
   const { baseColor, gradient } = useGraph();
 
+  const MS = 1000;
+
+  // Persist the active zoom across chart rebuilds (chartData refreshes every
+  // balance update). Without this, dataZoom rebuilds with no start/end and
+  // ECharts snaps the slider back to full range.
+  const zoomBounds = computed<{ startValue?: number; endValue?: number }>(() => {
+    const range = toValue(zoomRange);
+    if (!range)
+      return {};
+    return { endValue: range.end * MS, startValue: range.start * MS };
+  });
+
   const createSliderZoomOptions = (): DataZoomComponentOption => ({
     handleSize: 20,
     height: 30,
@@ -46,6 +62,7 @@ export function useNetValueChartConfig(chartData: MaybeRefOrGetter<NetValueChart
     showDetail: false,
     type: 'slider',
     zoomOnMouseWheel: true,
+    ...get(zoomBounds),
   });
 
   const createInsideDataZoom = (): DataZoomComponentOption => ({
@@ -56,6 +73,7 @@ export function useNetValueChartConfig(chartData: MaybeRefOrGetter<NetValueChart
     showDetail: false,
     type: 'inside',
     zoomOnMouseWheel: true,
+    ...get(zoomBounds),
   });
 
   const createDataZoomConfig = (): DataZoomComponentOption[] => {

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.spec.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { readZoomFields, resolveZoomRange } from '@/modules/dashboard/graph/use-net-value-event-handlers';
+
+describe('readZoomFields', () => {
+  it('should read top-level fields when batch is absent (slider drag shape)', () => {
+    expect(readZoomFields({ end: 80, endValue: 2000, start: 20, startValue: 1000 })).toEqual({
+      end: 80,
+      endValue: 2000,
+      start: 20,
+      startValue: 1000,
+    });
+  });
+
+  it('should read batch[0] when present (inside-zoom shape)', () => {
+    expect(readZoomFields({
+      batch: [{ end: 90, endValue: 3000, start: 10, startValue: 500 }],
+    })).toEqual({ end: 90, endValue: 3000, start: 10, startValue: 500 });
+  });
+
+  it('should accept percent-only batch entries (slider without axis values)', () => {
+    expect(readZoomFields({ batch: [{ end: 75, start: 25 }] })).toEqual({
+      end: 75,
+      endValue: undefined,
+      start: 25,
+      startValue: undefined,
+    });
+  });
+
+  it('should return undefined for non-object input', () => {
+    expect(readZoomFields(undefined)).toBeUndefined();
+    expect(readZoomFields(null)).toBeUndefined();
+    expect(readZoomFields('event')).toBeUndefined();
+  });
+
+  it('should return undefined when batch is empty and no top-level fields are set', () => {
+    expect(readZoomFields({ batch: [null] })).toBeUndefined();
+    // empty batch falls through to the top-level read, which yields all-undefined fields
+    expect(resolveZoomRange(readZoomFields({ batch: [] }), [1, 2])).toBeUndefined();
+  });
+});
+
+describe('resolveZoomRange', () => {
+  const times = [1000, 2000, 3000, 4000, 5000];
+
+  it('should convert ms axis values to second-based range', () => {
+    expect(resolveZoomRange({ endValue: 4000000, startValue: 2000000 }, times)).toEqual({
+      end: 4000,
+      start: 2000,
+    });
+  });
+
+  it('should map percentage range against the times window when axis values are absent', () => {
+    // 25%..75% of [1000, 5000] -> [2000, 4000]
+    expect(resolveZoomRange({ end: 75, start: 25 }, times)).toEqual({ end: 4000, start: 2000 });
+  });
+
+  it('should prefer axis values when both shapes are present', () => {
+    expect(resolveZoomRange({ end: 100, endValue: 3000000, start: 0, startValue: 1500000 }, times)).toEqual({
+      end: 3000,
+      start: 1500,
+    });
+  });
+
+  it('should return undefined when only one bound is provided', () => {
+    expect(resolveZoomRange({ start: 25 }, times)).toBeUndefined();
+    expect(resolveZoomRange({ startValue: 1000 }, times)).toBeUndefined();
+  });
+
+  it('should return undefined when fields are missing or times empty', () => {
+    expect(resolveZoomRange(undefined, times)).toBeUndefined();
+    expect(resolveZoomRange({ end: 75, start: 25 }, [])).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.ts
@@ -1,15 +1,65 @@
 import type { EChartsType } from 'echarts/core';
 import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue';
 import type VChart from 'vue-echarts';
+import type { NetValueZoomRange } from '@/modules/dashboard/graph/net-value-stats';
 import type { NetValueChartData } from '@/modules/dashboard/graph/types';
 import { assert, type BigNumber } from '@rotki/common';
 import { type TooltipData, useGraphTooltip } from '@/modules/statistics/use-graph-tooltip';
+
+// ECharts emits datazoom in two shapes: with a `batch` array (inside-zoom),
+// or with the fields at the top level (slider drag). Each shape may carry
+// axis values (startValue/endValue, in ms) or only percentages (start/end,
+// 0–100 of the x-axis range) — slider drag typically only provides the
+// percentages, so we accept either.
+interface ZoomFields {
+  startValue?: unknown;
+  endValue?: unknown;
+  start?: unknown;
+  end?: unknown;
+}
+
+function isObjectValue(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function readZoomFields(event: unknown): ZoomFields | undefined {
+  if (isObjectValue(event) && 'batch' in event && Array.isArray(event.batch) && event.batch.length > 0) {
+    const first = event.batch[0];
+    if (!isObjectValue(first))
+      return undefined;
+    return { end: first.end, endValue: first.endValue, start: first.start, startValue: first.startValue };
+  }
+  if (isObjectValue(event))
+    return { end: event.end, endValue: event.endValue, start: event.start, startValue: event.startValue };
+  return undefined;
+}
+
+const ZOOM_MS = 1000;
+
+export function resolveZoomRange(fields: ZoomFields | undefined, times: number[]): NetValueZoomRange | undefined {
+  if (typeof fields?.startValue === 'number' && typeof fields?.endValue === 'number') {
+    return { end: Math.ceil(fields.endValue / ZOOM_MS), start: Math.floor(fields.startValue / ZOOM_MS) };
+  }
+  if (typeof fields?.start === 'number' && typeof fields?.end === 'number') {
+    const first = times[0];
+    const last = times.at(-1);
+    if (last === undefined)
+      return undefined;
+    const span = last - first;
+    return {
+      end: Math.ceil(first + (span * fields.end) / 100),
+      start: Math.floor(first + (span * fields.start) / 100),
+    };
+  }
+  return undefined;
+}
 
 interface UseNetValueEventHandlersParams {
   chartInstance: Readonly<ShallowRef<InstanceType<typeof VChart> | null>>;
   chartContainer: Readonly<ShallowRef<HTMLElement | null>>;
   chartData: MaybeRefOrGetter<NetValueChartData>;
   onHover: (timestamp: number, value: BigNumber) => void;
+  onZoomChange?: (range: NetValueZoomRange | undefined) => void;
 }
 
 interface UseNetValueEventHandlersReturn {
@@ -32,6 +82,7 @@ export function useNetValueEventHandlers(params: UseNetValueEventHandlersParams)
     chartData,
     chartInstance,
     onHover,
+    onZoomChange,
   } = params;
 
   const { resetTooltipData, tooltipData } = useGraphTooltip();
@@ -247,6 +298,35 @@ export function useNetValueEventHandlers(params: UseNetValueEventHandlersParams)
     container.addEventListener('mouseup', containerEventHandlers.mouseup);
   }
 
+  function setupZoomChangeHandler(instance: EChartsType): void {
+    if (!onZoomChange)
+      return;
+
+    const handler = (...args: unknown[]): void => {
+      const { times } = toValue(chartData);
+      const last = times.at(-1);
+      if (times.length === 0 || last === undefined) {
+        onZoomChange(undefined);
+        return;
+      }
+
+      const range = resolveZoomRange(readZoomFields(args[0]), times);
+      if (range === undefined) {
+        onZoomChange(undefined);
+        return;
+      }
+
+      // Full-range selection collapses to undefined so consumers stay on the unzoomed path.
+      if (range.start <= times[0] && range.end >= last) {
+        onZoomChange(undefined);
+        return;
+      }
+      onZoomChange(range);
+    };
+
+    instance.on('datazoom', handler);
+  }
+
   function setupZoomToolHandler(): void {
     const instance = get(chartInstance)?.chart;
     if (!instance) {
@@ -285,11 +365,13 @@ export function useNetValueEventHandlers(params: UseNetValueEventHandlersParams)
     setupMouseLeaveHandler(instance);
     setupContainerClickHandler(container);
     setupZoomToolHandler();
+    setupZoomChangeHandler(instance);
 
     // Store cleanup functions
     chartEventHandlers = [
       (): EChartsType => instance?.off('updateAxisPointer'),
       (): EChartsType => instance?.off('finished'),
+      (): EChartsType => instance?.off('datazoom'),
       (): void => instance?.getZr()?.off('dblclick'),
       (): void => instance?.getZr()?.off('mousemove'),
       (): void => instance?.getZr()?.off('globalout'),


### PR DESCRIPTION
## Summary

Closes #12112.

- Dashboard header's percentage / arrow / colour ignored the chart's `dataZoom` range — dragging the slider did not change the headline number, only the chart axes.
- Adds a pure `computeNetValueDelta` helper that, when zoomed, derives `startingValue` and `endValue` from datapoints inside the visible window. Full-range selection (or no zoom) preserves the legacy result: first non-zero datapoint vs live `totalNetWorth`.
- `NetWorthChart` now listens to ECharts `datazoom`, converts ms → s and emits `update:zoomRange` (or `undefined` for full range / data swap). `OverallBalances` consumes that to drive the percentage / delta computeds.
- 8 unit tests cover full-range identity, partial zoom (gain & drop), leading-zero skipping, empty data, and out-of-range windows.