### PR TITLE
fix(frontend): invalidate historic price cache on oracle price edit/delete

### DIFF
--- a/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceEditDialog.spec.ts
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceEditDialog.spec.ts
@@ -1,0 +1,107 @@
+import type { OraclePriceEntry } from '@/modules/assets/prices/price-types';
+import { bigNumberify } from '@rotki/common';
+import { mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@test/i18n';
+
+const mockEditHistoricalPrice = vi.fn();
+const mockResetHistoricalPricesData = vi.fn();
+const mockShowErrorMessage = vi.fn();
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: vi.fn().mockReturnValue({
+    editHistoricalPrice: (...args: unknown[]) => mockEditHistoricalPrice(...args),
+  }),
+}));
+
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: vi.fn().mockReturnValue({
+    resetHistoricalPricesData: (...args: unknown[]) => mockResetHistoricalPricesData(...args),
+  }),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: vi.fn().mockReturnValue({
+    getAssetField: vi.fn().mockImplementation((asset: string) => asset),
+  }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn().mockReturnValue({
+    showErrorMessage: (...args: unknown[]) => mockShowErrorMessage(...args),
+  }),
+}));
+
+const OraclePriceEditDialog = (await import('@/modules/assets/prices/components/oracle/OraclePriceEditDialog.vue')).default;
+
+function createEntry(overrides: Partial<OraclePriceEntry> = {}): OraclePriceEntry {
+  return {
+    fromAsset: 'ETH',
+    price: bigNumberify('2500'),
+    sourceType: 'coingecko',
+    timestamp: 1700000000,
+    toAsset: 'USD',
+    ...overrides,
+  };
+}
+
+describe('oraclePriceEditDialog', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockEditHistoricalPrice.mockClear().mockResolvedValue(true);
+    mockResetHistoricalPricesData.mockClear();
+    mockShowErrorMessage.mockClear();
+  });
+
+  it('should invalidate the historic price cache after a successful edit', async () => {
+    const entry = createEntry();
+    const wrapper = mount(OraclePriceEditDialog, {
+      shallow: true,
+      props: { modelValue: entry },
+    });
+    await flushPromises();
+
+    const vm = wrapper.vm as unknown as {
+      editedPrice: string;
+      save: () => Promise<void>;
+    };
+    vm.editedPrice = '3000';
+    await vm.save();
+    await flushPromises();
+
+    expect(mockEditHistoricalPrice).toHaveBeenCalledWith({
+      fromAsset: 'ETH',
+      price: '3000',
+      sourceType: 'coingecko',
+      timestamp: 1700000000,
+      toAsset: 'USD',
+    });
+    expect(mockResetHistoricalPricesData).toHaveBeenCalledWith([
+      { fromAsset: 'ETH', timestamp: 1700000000 },
+    ]);
+    expect(wrapper.emitted('refresh')).toHaveLength(1);
+  });
+
+  it('should not invalidate the cache when the edit fails', async () => {
+    mockEditHistoricalPrice.mockRejectedValueOnce(new Error('boom'));
+    const entry = createEntry();
+    const wrapper = mount(OraclePriceEditDialog, {
+      shallow: true,
+      props: { modelValue: entry },
+    });
+    await flushPromises();
+
+    const vm = wrapper.vm as unknown as {
+      editedPrice: string;
+      save: () => Promise<void>;
+    };
+    vm.editedPrice = '3000';
+    await vm.save();
+    await flushPromises();
+
+    expect(mockResetHistoricalPricesData).not.toHaveBeenCalled();
+    expect(mockShowErrorMessage).toHaveBeenCalledOnce();
+    expect(wrapper.emitted('refresh')).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceEditDialog.vue
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceEditDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { OraclePriceEntry } from '@/modules/assets/prices/price-types';
 import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -15,6 +16,7 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 const { getAssetField } = useAssetInfoRetrieval();
 const { editHistoricalPrice } = useAssetPricesApi();
+const { resetHistoricalPricesData } = useHistoricPriceCache();
 const { showErrorMessage } = useNotifications();
 
 const loading = ref<boolean>(false);
@@ -49,6 +51,7 @@ async function save(): Promise<void> {
       timestamp: item.timestamp,
       toAsset: item.toAsset,
     });
+    resetHistoricalPricesData([{ fromAsset: item.fromAsset, timestamp: item.timestamp }]);
     set(modelValue, undefined);
     emit('refresh');
   }

--- a/frontend/app/src/modules/assets/prices/use-oracle-prices.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-oracle-prices.spec.ts
@@ -6,11 +6,18 @@ import '@test/i18n';
 
 const mockFetchOraclePrices = vi.fn();
 const mockDeleteHistoricalPrice = vi.fn();
+const mockResetHistoricalPricesData = vi.fn();
 
 vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
   useAssetPricesApi: vi.fn().mockReturnValue({
     deleteHistoricalPrice: mockDeleteHistoricalPrice,
     fetchOraclePrices: mockFetchOraclePrices,
+  }),
+}));
+
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: vi.fn().mockReturnValue({
+    resetHistoricalPricesData: mockResetHistoricalPricesData,
   }),
 }));
 
@@ -47,6 +54,7 @@ describe('useOraclePrices', () => {
   beforeEach(() => {
     mockFetchOraclePrices.mockClear().mockResolvedValue(emptyCollection());
     mockDeleteHistoricalPrice.mockClear().mockResolvedValue(true);
+    mockResetHistoricalPricesData.mockClear();
   });
 
   it('should call fetchOraclePrices with provided payload', async () => {
@@ -120,6 +128,9 @@ describe('useOraclePrices', () => {
       timestamp: 1700000000,
       toAsset: 'USD',
     });
+    expect(mockResetHistoricalPricesData).toHaveBeenCalledWith([
+      { fromAsset: 'ETH', timestamp: 1700000000 },
+    ]);
     expect(success).toBe(true);
   });
 
@@ -137,5 +148,6 @@ describe('useOraclePrices', () => {
     });
 
     expect(success).toBe(false);
+    expect(mockResetHistoricalPricesData).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/modules/assets/prices/use-oracle-prices.ts
+++ b/frontend/app/src/modules/assets/prices/use-oracle-prices.ts
@@ -2,6 +2,7 @@ import type { MaybeRef } from 'vue';
 import type { OraclePriceEntry, OraclePricesQuery } from '@/modules/assets/prices/price-types';
 import type { Collection } from '@/modules/core/common/collection';
 import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
 import { defaultCollectionState } from '@/modules/core/common/data/collection-utils';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -15,6 +16,7 @@ export function useOraclePrices(): UseOraclePricesReturn {
   const { t } = useI18n({ useScope: 'global' });
 
   const { deleteHistoricalPrice, fetchOraclePrices } = useAssetPricesApi();
+  const { resetHistoricalPricesData } = useHistoricPriceCache();
   const { notifyError } = useNotifications();
 
   const fetchData = async (
@@ -40,6 +42,7 @@ export function useOraclePrices(): UseOraclePricesReturn {
         timestamp: item.timestamp,
         toAsset: item.toAsset,
       });
+      resetHistoricalPricesData([{ fromAsset: item.fromAsset, timestamp: item.timestamp }]);
       return true;
     }
     catch (error: unknown) {


### PR DESCRIPTION
## Summary
- Editing or deleting an entry from the oracle prices page (`/price-manager/oracle`) now invalidates the in-memory `useHistoricPriceCache` for the affected `(fromAsset, timestamp)` pair, so other consumers stop reading the stale value.
- Mirrors the invalidation already done by the manual-price flow in `use-historic-price-manager.ts`; the oracle-prices flow added in 3254781b35 was missing it.

## Test plan
- [x] `pnpm run test:unit src/modules/assets/prices/use-oracle-prices.spec.ts src/modules/assets/prices/components/oracle/OraclePriceEditDialog.spec.ts`
- [x] `pnpm run typecheck`
- [x] Manual: edit and delete an oracle price entry, confirm prices shown elsewhere update without a reload