### PR TITLE
fix(docker): raise nginx upload limit and surface proxy HTML errors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* :release:`1.43.0 <2026-05-06>`
+* :release:`1.43.0 <2026-05-08>`
+* :bug:`-` Docker users can once again import data, snapshots, and asset icons larger than 1 MiB; the bundled nginx no longer rejects them with a 413 before they reach rotki.
 * :feature:`12143` CSV imports now accept an optional timezone so files whose dates lack timezone information can be interpreted in the correct local time instead of defaulting to UTC.
 * :feature:`-` After a rotki update, a friendly prompt will walk you through any new recommended settings. You can accept the ones you like, keep what you have for the rest.
 * :feature:`12102` New giveth donation events will now be properly decoded on all supported chains.

--- a/frontend/app/src/modules/core/api/response-handlers.spec.ts
+++ b/frontend/app/src/modules/core/api/response-handlers.spec.ts
@@ -38,6 +38,14 @@ describe('response-handlers', () => {
 
       expect(result).toEqual([{ itemName: 'first' }, { itemName: 'second' }]);
     });
+
+    it('should return null when the body is not valid JSON', () => {
+      const html = '<html><head><title>413 Request Entity Too Large</title></head></html>';
+
+      expect(createResponseParser({})(html)).toBeNull();
+      expect(createResponseParser({ skipCamelCase: true })(html)).toBeNull();
+      expect(createResponseParser({ skipRootCamelCase: true })(html)).toBeNull();
+    });
   });
 
   describe('createStatusError', () => {
@@ -65,6 +73,27 @@ describe('response-handlers', () => {
 
       expect(error).toBeInstanceOf(FetchError);
       expect(error.data).toEqual(data);
+    });
+
+    it('should use a payload-too-large fallback message for 413', () => {
+      const error = createStatusError(413);
+
+      expect(error.status).toBe(413);
+      expect(error.message).toMatch(/exceeds the limit/i);
+    });
+
+    it('should prefer an explicit message over the 413 fallback', () => {
+      const error = createStatusError(413, 'Custom message');
+
+      expect(error.message).toBe('Custom message');
+    });
+
+    it('should use a backend-unreachable fallback message for 502/503/504', () => {
+      for (const status of [502, 503, 504]) {
+        const error = createStatusError(status);
+        expect(error.status).toBe(status);
+        expect(error.message).toMatch(/backend is unreachable/i);
+      }
     });
 
     it('should handle various HTTP status codes', () => {

--- a/frontend/app/src/modules/core/api/response-handlers.ts
+++ b/frontend/app/src/modules/core/api/response-handlers.ts
@@ -8,26 +8,45 @@ export interface ResponseParserOptions {
 
 /**
  * Creates a response parser function based on transformation options.
+ *
+ * Falls back to `null` when the body is not valid JSON (e.g. an HTML 413
+ * page from a reverse proxy) so the caller still reaches the status check
+ * instead of crashing on a SyntaxError.
  */
 export function createResponseParser(
   options: ResponseParserOptions,
 ): (text: string) => unknown {
   if (options.skipCamelCase)
-    return (text: string) => JSON.parse(text);
-  if (options.skipRootCamelCase)
-    return (text: string) => noRootCamelCaseTransformer(JSON.parse(text));
-  return (text: string) => camelCaseTransformer(JSON.parse(text));
+    return (text: string): unknown => tryParseJson(text);
+  if (options.skipRootCamelCase) {
+    return (text: string): unknown => {
+      const json = tryParseJson(text);
+      return json === null ? null : noRootCamelCaseTransformer(json);
+    };
+  }
+  return (text: string): unknown => {
+    const json = tryParseJson(text);
+    return json === null ? null : camelCaseTransformer(json);
+  };
 }
 
 /**
  * Creates and throws a FetchError with status information.
  */
 export function createStatusError(status: number, message?: string, data?: unknown): FetchError {
-  const error = new FetchError(message || `Request failed with status ${status}`);
+  const error = new FetchError(message || defaultMessageForStatus(status));
   error.status = status;
   error.statusCode = status;
   error.data = data;
   return error;
+}
+
+function defaultMessageForStatus(status: number): string {
+  if (status === 413)
+    return 'The request body exceeds the limit configured on the server (likely a reverse proxy in front of rotki). Increase its upload size limit or use a smaller file.';
+  if (status === 502 || status === 503 || status === 504)
+    return 'The rotki backend is unreachable. It may be starting up, restarting, or overloaded — try again in a moment.';
+  return `Request failed with status ${status}`;
 }
 
 /**
@@ -35,7 +54,7 @@ export function createStatusError(status: number, message?: string, data?: unkno
  */
 export function tryParseJson<T>(text: string): T | null {
   try {
-    return JSON.parse(text) as T;
+    return JSON.parse(text);
   }
   catch {
     return null;

--- a/packaging/docker/nginx.conf
+++ b/packaging/docker/nginx.conf
@@ -25,6 +25,23 @@
         proxy_redirect off;
     }
 
+    # Multipart-upload endpoints. The default `client_max_body_size` (1 MiB)
+    # is too small for things like data imports and DB snapshots. When adding
+    # a new endpoint that accepts file uploads, append its path to this regex.
+    location ~ ^/api/1/(import|snapshots|assets/user|assets/icon/modify|accounting/rules/import)$ {
+        client_max_body_size 50m;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_pass_header Set-Cookie;
+        proxy_pass http://localhost:4242$request_uri;
+        proxy_ssl_session_reuse off;
+        proxy_set_header Host $http_host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_redirect off;
+    }
+
     location /colibri/ {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -187,6 +187,10 @@ URLS = list[
 ]
 
 
+# If you add an endpoint that accepts multipart file uploads, also update the
+# regex `location` block in packaging/docker/nginx.conf so the path gets the
+# higher `client_max_body_size`. The default cap is 1 MiB and applies to every
+# path not listed there.
 URLS_V1: URLS = [
     ('/users', UsersResource),
     ('/watchers', WatchersResource),


### PR DESCRIPTION
## Summary
- The bundled docker `nginx.conf` did not set `client_max_body_size`, so the default 1 MiB cap rejected legitimate import uploads (data imports, snapshots, user assets, asset icons, accounting rules) with a `413` before they ever reached the backend. A user reported hitting it on a ~1.3 MiB import. Bumped the cap to 50 MiB on the multipart-upload paths only, leaving the default 1 MiB in place for everything else under `/api/1/`.
- When a reverse proxy returns an HTML error page (the 413 above, but also 502/503/504 when the backend is unreachable), the frontend api client tried to `JSON.parse` the body and crashed with a `SyntaxError` before the status check ran — the user saw an opaque "Unexpected token <" toast. Made the response parser tolerant of non-JSON bodies and added actionable fallback messages in `createStatusError` for 413 (proxy upload limit) and 502/503/504 (backend unreachable).
- Documented the contract in both `nginx.conf` and `rotkehlchen/api/server.py` so future upload endpoints get added to the nginx allowlist.

Closes #12161

## Test plan
- [x] Reproduce the original 413 against the unfixed image: `curl -i -X POST http://host:8084/api/1/import -F source=cointracking -F file=@2mb.csv` → `413 Request Entity Too Large` from nginx.
- [x] Same request after rebuild → backend JSON envelope (`{"result": null, "message": "Invalid CSV format..."}`), confirming nginx forwarded the body.
- [x] `pnpm run test:unit src/modules/core/api/response-handlers.spec.ts` → 19/19 pass (3 new cases: non-JSON parse, 413 fallback, 502/503/504 fallback).
- [x] `pnpm run lint-staged` and `pnpm run typecheck` clean.
- [ ] Manual: trigger backend down → frontend toast shows the new "backend is unreachable" message instead of "Unexpected token <".