### PR TITLE
fix: reconnect after asset-update restart on Windows

### DIFF
--- a/frontend/app/electron/main/subprocess-handler.ts
+++ b/frontend/app/electron/main/subprocess-handler.ts
@@ -184,16 +184,24 @@ export class SubprocessHandler {
     this.coreManager.onExit((code, signal, lastError) => {
       this.logger.error(`rotki-core exited with signal: ${signal} (Code: ${code})`);
       /**
-       * On win32 we can also get a null code on SIGTERM
+       * On win32 we can also get a null code on SIGTERM. On win32 we use
+       * `taskkill /f` to terminate the core process during a user-triggered
+       * shutdown or restart, which exits with a non-zero code — so suppress
+       * the TERMINATED error while we are intentionally tearing the process
+       * down.
        */
-      if (!(code === 0 || code === null)) {
-        // Notify the main window every 2 seconds until it acks the notification
-        listener.onProcessError(lastError, BackendCode.TERMINATED);
+      if (this.exiting || code === 0 || code === null) {
+        return;
       }
+      // Notify the main window every 2 seconds until it acks the notification
+      listener.onProcessError(lastError, BackendCode.TERMINATED);
     });
 
     this.coreManager.onError((error) => {
       this.logger.error('Encountered an error while trying to start rotki-core', error);
+      if (this.exiting) {
+        return;
+      }
       listener.onProcessError(error, BackendCode.TERMINATED);
     });
 

--- a/frontend/app/src/modules/shell/app/use-backend-management.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-management.spec.ts
@@ -1,0 +1,168 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMainStore } from '@/modules/core/common/use-main-store';
+import '@test/i18n';
+
+const mockConnect = vi.fn();
+const mockSetWsConnectionEnabled = vi.fn();
+const mockRestartBackend = vi.fn();
+const mockConfig = vi.fn();
+const mockGetBackendUrl = vi.fn();
+
+vi.mock('@/modules/shell/app/use-backend-connection', () => ({
+  useBackendConnection: vi.fn(() => ({
+    cancelConnectionAttempts: vi.fn(),
+    connect: mockConnect,
+    getInfo: vi.fn(),
+    getVersion: vi.fn(),
+    stopConnectionAttempts: vi.fn(),
+  })),
+}));
+
+vi.mock('@/modules/shell/app/use-websocket-connection', () => ({
+  useWebsocketConnection: vi.fn(() => ({
+    connect: vi.fn(),
+    connected: ref(false),
+    disconnect: vi.fn(),
+    setConnectionEnabled: mockSetWsConnectionEnabled,
+  })),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: vi.fn(() => ({
+    get isPackaged(): boolean {
+      return true;
+    },
+    config: mockConfig,
+    restartBackend: mockRestartBackend,
+    setLogLevel: vi.fn(),
+  })),
+}));
+
+vi.mock('@/modules/shell/app/backend-options', () => ({
+  clearUserOptions: vi.fn(),
+  loadUserOptions: vi.fn((): Record<string, unknown> => ({})),
+  saveUserOptions: vi.fn(),
+}));
+
+vi.mock('@/modules/auth/account-management', () => ({
+  deleteBackendUrl: vi.fn(),
+  getBackendUrl: (): { url: string; sessionOnly: boolean } => mockGetBackendUrl(),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  getDefaultLogLevel: vi.fn((): string => 'WARNING'),
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+  setLevel: vi.fn(),
+}));
+
+describe('useBackendManagement', () => {
+  let scope: ReturnType<typeof effectScope>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    scope = effectScope();
+    vi.clearAllMocks();
+    mockConfig.mockResolvedValue({});
+    mockRestartBackend.mockResolvedValue(true);
+    mockGetBackendUrl.mockReturnValue({ sessionOnly: false, url: '' });
+  });
+
+  afterEach(() => {
+    scope.stop();
+    vi.clearAllMocks();
+  });
+
+  async function importModule(): Promise<typeof import('./use-backend-management')> {
+    return import('./use-backend-management');
+  }
+
+  describe('restartBackend', () => {
+    it('should re-enable connectionEnabled after restart when it was disabled by a prior termination error', async () => {
+      const store = useMainStore();
+      const { connectionEnabled } = storeToRefs(store);
+      // simulate prior TERMINATED error having disabled connection attempts
+      set(connectionEnabled, false);
+
+      const { useBackendManagement } = await importModule();
+      const { restartBackend } = scope.run(() => useBackendManagement())!;
+      await restartBackend();
+
+      expect(get(connectionEnabled)).toBe(true);
+      expect(mockSetWsConnectionEnabled).toHaveBeenCalledWith(true);
+      expect(mockConnect).toHaveBeenCalled();
+    });
+
+    it('should call interop.restartBackend before re-enabling and connecting', async () => {
+      const callOrder: string[] = [];
+      mockRestartBackend.mockImplementation(async (): Promise<boolean> => {
+        callOrder.push('restart');
+        return true;
+      });
+      mockSetWsConnectionEnabled.mockImplementation((): void => {
+        callOrder.push('setWs');
+      });
+      mockConnect.mockImplementation((): void => {
+        callOrder.push('connect');
+      });
+
+      const { useBackendManagement } = await importModule();
+      const { restartBackend } = scope.run(() => useBackendManagement())!;
+      await restartBackend();
+
+      expect(callOrder).toEqual(['restart', 'setWs', 'connect']);
+    });
+
+    it('should leave connectionEnabled true when it was already true', async () => {
+      const store = useMainStore();
+      const { connectionEnabled } = storeToRefs(store);
+
+      const { useBackendManagement } = await importModule();
+      const { restartBackend } = scope.run(() => useBackendManagement())!;
+      await restartBackend();
+
+      expect(get(connectionEnabled)).toBe(true);
+      expect(mockSetWsConnectionEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('should set connected to false during restart', async () => {
+      const store = useMainStore();
+      store.setConnected(true);
+
+      const { useBackendManagement } = await importModule();
+      const { restartBackend } = scope.run(() => useBackendManagement())!;
+      await restartBackend();
+
+      expect(get(store.connected)).toBe(false);
+    });
+  });
+
+  describe('backendChanged', () => {
+    it('should re-enable connections when restarting due to a null url', async () => {
+      const store = useMainStore();
+      const { connectionEnabled } = storeToRefs(store);
+      set(connectionEnabled, false);
+
+      const { useBackendManagement } = await importModule();
+      const { backendChanged } = scope.run(() => useBackendManagement())!;
+      await backendChanged(null);
+
+      expect(get(connectionEnabled)).toBe(true);
+      expect(mockSetWsConnectionEnabled).toHaveBeenCalledWith(true);
+      expect(mockConnect).toHaveBeenCalled();
+    });
+
+    it('should connect to a custom url without restarting', async () => {
+      const { useBackendManagement } = await importModule();
+      const { backendChanged } = scope.run(() => useBackendManagement())!;
+      await backendChanged('http://custom:4242');
+
+      expect(mockRestartBackend).not.toHaveBeenCalled();
+      expect(mockConnect).toHaveBeenCalledWith('http://custom:4242');
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/app/use-backend-management.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-management.ts
@@ -7,6 +7,7 @@ import { useMainStore } from '@/modules/core/common/use-main-store';
 import { clearUserOptions, loadUserOptions, saveUserOptions } from '@/modules/shell/app/backend-options';
 import { useBackendConnection } from '@/modules/shell/app/use-backend-connection';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { useWebsocketConnection } from '@/modules/shell/app/use-websocket-connection';
 
 interface UseBackendManagementReturn {
   applyUserOptions: (config: Partial<BackendOptions>, skipRestart: boolean) => Promise<void>;
@@ -26,9 +27,10 @@ interface UseBackendManagementReturn {
 export function useBackendManagement(loaded: () => void = () => {}): UseBackendManagementReturn {
   const interop = useInterop();
   const store = useMainStore();
-  const { connected } = storeToRefs(store);
+  const { connected, connectionEnabled } = storeToRefs(store);
   const { setConnected } = store;
   const { connect } = useBackendConnection();
+  const { setConnectionEnabled: setWsConnectionEnabled } = useWebsocketConnection();
 
   const defaultLogLevel = computed<LogLevel>(() => getDefaultLogLevel());
   const logLevel = ref<LogLevel>(get(defaultLogLevel));
@@ -43,6 +45,11 @@ export function useBackendManagement(loaded: () => void = () => {}): UseBackendM
   const restartBackendWithOptions = async (options: Partial<BackendOptions>): Promise<void> => {
     setConnected(false);
     await interop.restartBackend(options);
+    // Re-enable connections in case a prior process termination disabled them
+    // (e.g. on Windows, taskkill exits the core process with a non-zero code, which
+    // is reported as a TERMINATED startup error and disables connection attempts).
+    set(connectionEnabled, true);
+    setWsConnectionEnabled(true);
     connect();
   };
 

--- a/package.py
+++ b/package.py
@@ -161,7 +161,7 @@ class Environment:
             return
 
         unmerged_commits = subprocess.check_output(
-            'git rev-list HEAD..bugfixes --no-merges | wc -l | xargs echo -n',
+            'git rev-list --count --no-merges HEAD..bugfixes',
             encoding='utf8',
             shell=True,
         ).strip()


### PR DESCRIPTION
## Summary
- Fix the UI hanging on "Connecting to rotki-backend" after an asset-update restart on Windows. The renderer was disabling connection attempts when the core process was force-killed during the restart, and the auto-reconnect that follows was a no-op.
- Root cause (`subprocess-handler.ts`): on Windows the core process is terminated via `taskkill /f`, which exits with a non-zero code. The `onExit`/`onError` handlers treated this as a TERMINATED startup error and notified the renderer, even though the shutdown was triggered by the app itself. Fix: skip the error notification while `this.exiting` is `true`.
- Defensive fix (`use-backend-management.ts`): `restartBackendWithOptions` now re-enables `connectionEnabled` and the websocket connection flag before calling `connect()`, mirroring the existing `onRestart` IPC handler. Recovers gracefully even if some other path disabled connection attempts.
- Packaging (`package.py`): replace the Unix-only `git rev-list ... | wc -l | xargs echo -n` with `git rev-list --count --no-merges HEAD..bugfixes` so the unmerged-bugfixes check works on Windows too.

## Test plan
- [x] `pnpm run test:unit src/modules/shell/app/` — 40 passed (including 6 new cases in `use-backend-management.spec.ts`)
- [x] `pnpm run lint-staged` on the changed files
- [ ] Manual: trigger an asset update on Windows and confirm the UI reconnects to the backend after restart
- [ ] Manual: run `package.py` on Windows and confirm the unmerged-bugfixes check executes