### PR TITLE
fix(settings): remove empty string endpoint values from DB

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -75,6 +75,7 @@ from rotkehlchen.db.settings import (
     DEFAULT_PREMIUM_SHOULD_SYNC,
     ROTKEHLCHEN_DB_VERSION,
     ROTKEHLCHEN_TRANSIENT_DB_VERSION,
+    STRING_KEYS_REMOVE_IF_EMPTY,
     CachedSettings,
     DBSettings,
     ModifiableDBSettings,
@@ -665,10 +666,27 @@ class DBHandler:
 
     def set_settings(self, write_cursor: 'DBCursor', settings: ModifiableDBSettings) -> None:
         settings_dict = settings.serialize()
-        write_cursor.executemany(
-            'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',
-            list(settings_dict.items()),
-        )
+        # Settings whose value is an empty string and which support being unset
+        # are removed from the DB (instead of stored as ''), so the dataclass
+        # default kicks in on the next read.
+        to_delete = [
+            (name,) for name, value in settings_dict.items()
+            if name in STRING_KEYS_REMOVE_IF_EMPTY and value == ''
+        ]
+        to_upsert = [
+            (name, value) for name, value in settings_dict.items()
+            if not (name in STRING_KEYS_REMOVE_IF_EMPTY and value == '')
+        ]
+        if len(to_delete) > 0:
+            write_cursor.executemany(
+                'DELETE FROM settings WHERE name=?',
+                to_delete,
+            )
+        if len(to_upsert) > 0:
+            write_cursor.executemany(
+                'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',
+                to_upsert,
+            )
         CachedSettings().update_entries(settings)
 
     def get_cache_for_api(self, cursor: 'DBCursor') -> dict[str, int]:

--- a/rotkehlchen/db/settings.py
+++ b/rotkehlchen/db/settings.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections.abc import Mapping, Sequence
 from contextvars import ContextVar
-from dataclasses import dataclass, field, fields
+from dataclasses import MISSING, dataclass, field, fields
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, NamedTuple, Optional
 
 from rotkehlchen.assets.asset import Asset, AssetWithOracles
@@ -154,6 +154,16 @@ STRING_KEYS: Final = (
     'frontend_settings',
     'csv_export_delimiter',
 )
+# String settings whose empty value means "not set". For these we delete the
+# row from the DB instead of storing an empty string and we treat any empty
+# value already in the DB as if the entry was missing (the dataclass default
+# is then applied).
+STRING_KEYS_REMOVE_IF_EMPTY: Final = frozenset({
+    'ksm_rpc_endpoint',
+    'dot_rpc_endpoint',
+    'beacon_rpc_endpoint',
+    'btc_mempool_api',
+})
 FVAL_KEYS: Final = (
     'asset_movement_amount_tolerance',
 )
@@ -242,9 +252,11 @@ class DBSettings:
     taxfree_after_period: int | None = DEFAULT_TAXFREE_AFTER_PERIOD
     balance_save_frequency: int = DEFAULT_BALANCE_SAVE_FREQUENCY
     include_gas_costs: bool = DEFAULT_INCLUDE_GAS_COSTS
-    ksm_rpc_endpoint: str = 'http://localhost:9933'
-    dot_rpc_endpoint: str = ''  # same as kusama -- must be set by user
-    beacon_rpc_endpoint: str = DEFAULT_BEACON_RPC  # must be set by user
+    # All three RPC endpoints below are optional. An empty value means the
+    # endpoint is not set; the default substrate/beacon behavior is used.
+    ksm_rpc_endpoint: str = ''
+    dot_rpc_endpoint: str = ''
+    beacon_rpc_endpoint: str = DEFAULT_BEACON_RPC
     btc_mempool_api: str = ''
     main_currency: Asset = DEFAULT_MAIN_CURRENCY
     date_display_format: str = DEFAULT_DATE_DISPLAY_FORMAT
@@ -304,6 +316,18 @@ class DBSettings:
             settings_dict[field_entry.name] = serialized_value
 
         return settings_dict
+
+
+# Cache of dataclass defaults so we don't instantiate DBSettings every time
+# we need to look up a default value for a setting.
+_DBSETTINGS_DEFAULTS: Final[dict[str, Any]] = {
+    field_entry.name: (
+        field_entry.default_factory()
+        if field_entry.default_factory is not MISSING
+        else field_entry.default
+    )
+    for field_entry in fields(DBSettings)
+}
 
 
 class ModifiableDBSettings(NamedTuple):
@@ -416,6 +440,8 @@ def db_settings_from_dict(
         elif key in INTEGER_KEYS:
             specified_args[key] = int(value)
         elif key in STRING_KEYS:
+            if key in STRING_KEYS_REMOVE_IF_EMPTY and value == '':
+                continue  # treat empty as not set so the dataclass default applies
             specified_args[key] = str(value)
         elif key in FVAL_KEYS:
             specified_args[key] = FVal(value)
@@ -566,6 +592,10 @@ class CachedSettings:
         self._refresh_indexers_cache()
 
     def update_entry(self, attr: str, value: DBSettingsFieldTypes) -> None:
+        if attr in STRING_KEYS_REMOVE_IF_EMPTY and value == '':
+            # Mirror the deserialization behavior: an empty value means the
+            # entry was unset, so fall back to the dataclass default.
+            value = _DBSETTINGS_DEFAULTS[attr]
         setattr(self._settings, attr, value)
         if attr in ('evm_indexers_order', 'default_evm_indexer_order'):
             self._refresh_indexers_cache()

--- a/rotkehlchen/tests/api/test_settings.py
+++ b/rotkehlchen/tests/api/test_settings.py
@@ -333,25 +333,92 @@ def test_default_evm_indexers_orders(rotkehlchen_api_server: 'APIServer') -> Non
     assert settings['default_evm_indexer_order'] == ['blockscout', 'routescan']
 
 
-@pytest.mark.parametrize('rpc_setting', ['ksm_rpc_endpoint'])
-def test_unset_rpc_endpoint(rotkehlchen_api_server: 'APIServer', rpc_setting: list[str]) -> None:
-    """Test the rpc endpoint can be unset"""
-    response = requests.get(api_url_for(rotkehlchen_api_server, 'settingsresource'))
+@pytest.mark.parametrize(('rpc_setting', 'initial_value'), [
+    ('ksm_rpc_endpoint', 'http://kusama.example:9933'),
+    ('dot_rpc_endpoint', 'http://polkadot.example:9934'),
+    ('beacon_rpc_endpoint', 'http://lighthouse.mynode.com:6969'),
+    ('btc_mempool_api', 'http://localhost:4080'),
+])
+def test_unset_rpc_endpoint(
+        rotkehlchen_api_server: 'APIServer',
+        rpc_setting: str,
+        initial_value: str,
+) -> None:
+    """Sending an empty string for these endpoint settings should remove the
+    DB row and revert the value to the dataclass default (which itself is
+    the empty string for ksm/dot/btc and the public node for beacon)."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    settings_url = api_url_for(rotkehlchen_api_server, 'settingsresource')
+    default_value = getattr(DBSettings(), rpc_setting)
+
+    ksm_connect_node = patch(
+        'rotkehlchen.chain.substrate.manager.SubstrateManager._connect_node',
+        return_value=(True, ''),
+    )
+    btc_connect_node = patch(
+        'rotkehlchen.chain.bitcoin.btc.manager.BitcoinManager._connect_node',
+        return_value=(True, ''),
+    )
+    beacon_set_endpoint = patch(
+        'rotkehlchen.chain.ethereum.modules.eth2.beacon.BeaconInquirer.set_rpc_endpoint',
+        return_value=None,
+    )
+    with ksm_connect_node, btc_connect_node, beacon_set_endpoint:
+        response = requests.put(settings_url, json={'settings': {rpc_setting: initial_value}})
+        assert_proper_response(response)
+        assert response.json()['result'][rpc_setting] == initial_value
+
+        # Sanity check: the row exists in the DB now.
+        with rotki.data.db.conn.read_ctx() as cursor:
+            assert cursor.execute(
+                'SELECT value FROM settings WHERE name=?', (rpc_setting,),
+            ).fetchone() == (initial_value,)
+
+        # Now unset by sending an empty string.
+        response = requests.put(settings_url, json={'settings': {rpc_setting: ''}})
+
     assert_proper_response(response)
     json_data = response.json()
     assert json_data['message'] == ''
-    result = json_data['result']
-    assert result[rpc_setting] != ''
+    # Response reflects the dataclass default, not an empty string.
+    assert json_data['result'][rpc_setting] == default_value
 
-    data = {'settings': {rpc_setting: ''}}
+    # The DB row must have been removed entirely.
+    with rotki.data.db.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT value FROM settings WHERE name=?', (rpc_setting,),
+        ).fetchone() is None
 
-    response = requests.put(api_url_for(rotkehlchen_api_server, 'settingsresource'), json=data)
-    assert_proper_response(response)
+    # Cached settings must also reflect the default.
+    assert getattr(CachedSettings().get_settings(), rpc_setting) == default_value
 
-    json_data = response.json()
-    result = json_data['result']
-    assert json_data['message'] == ''
-    assert result[rpc_setting] == ''
+
+@pytest.mark.parametrize('rpc_setting', [
+    'ksm_rpc_endpoint',
+    'dot_rpc_endpoint',
+    'beacon_rpc_endpoint',
+    'btc_mempool_api',
+])
+def test_empty_rpc_endpoint_in_db_treated_as_default(
+        rotkehlchen_api_server: 'APIServer',
+        rpc_setting: str,
+) -> None:
+    """An empty string already present in the DB (legacy state) must be
+    deserialized as if the entry was missing, i.e. the dataclass default
+    is applied."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    default_value = getattr(DBSettings(), rpc_setting)
+
+    with rotki.data.db.conn.write_ctx() as write_cursor:
+        write_cursor.execute(
+            'INSERT OR REPLACE INTO settings(name, value) VALUES(?, ?)',
+            (rpc_setting, ''),
+        )
+
+    with rotki.data.db.conn.read_ctx() as cursor:
+        settings = rotki.data.db.get_settings(cursor)
+
+    assert getattr(settings, rpc_setting) == default_value
 
 
 def test_disable_taxfree_after_period(rotkehlchen_api_server: 'APIServer') -> None:

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -509,7 +509,7 @@ def test_writing_fetching_data(data_dir, username, sql_vm_instructions_cb):
     assert 0 <= last_write_diff < 3
     expected_dict = {
         'have_premium': False,
-        'ksm_rpc_endpoint': 'http://localhost:9933',
+        'ksm_rpc_endpoint': '',
         'dot_rpc_endpoint': '',
         'beacon_rpc_endpoint': DEFAULT_BEACON_RPC,
         'btc_mempool_api': '',

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -9,6 +9,7 @@ from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_BTC, A_DAI, A_ETH, A_ETH2, A_USDC, A_USDT
 from rotkehlchen.constants.resolver import strethaddress_to_identifier
 from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.db.settings import STRING_KEYS_REMOVE_IF_EMPTY, DBSettings
 from rotkehlchen.errors.price import NoPriceForGivenTimestamp
 from rotkehlchen.exchanges.data_structures import MarginPosition
 from rotkehlchen.fval import FVal
@@ -958,6 +959,14 @@ def assert_pnl_debug_import(filepath: Path, database: DBHandler) -> None:
     for x in ('version', 'last_data_migration', 'last_write_ts'):
         settings_from_db.pop(x)
         settings_from_file.pop(x)
+
+    # An empty value for these endpoint settings means "not set" — the DB row
+    # is removed and the dataclass default is returned on read. Mirror that
+    # here so the comparison reflects the post-import state.
+    default_settings = DBSettings()
+    for key in STRING_KEYS_REMOVE_IF_EMPTY:
+        if settings_from_file.get(key) == '':
+            settings_from_file[key] = getattr(default_settings, key)
 
     assert settings_from_file == settings_from_db
     assert list(ignored_actions_ids_from_db) == ignored_actions_ids_from_file


### PR DESCRIPTION
The beacon/ksm/dot/btc rpc endpoint settings could be persisted as empty strings in the settings table. Treat empty as 'not set' end-to-end: delete the row on write and fall back to the dataclass default on read (both in db_settings_from_dict and CachedSettings). Also normalizes the ksm default to '' to match the other endpoints.
