### PR TITLE
Dynamic payload for eth staking calls

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` 1inch swaps settling through a balancer pool should now be properly decoded.
+* :bug:`12173` Beaconcha.in queries with legacy API keys will work correctly again.
 * :bug:`-` Newer zerox swaps in base will now be properly decoded.
 
 * :release:`1.43.0 <2026-05-08>`

--- a/rotkehlchen/chain/ethereum/modules/eth2/beacon.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/beacon.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Literal, overload
+from urllib.parse import urlparse
 
 import requests
 
@@ -51,11 +52,18 @@ class BeaconNode:
         self.session = create_session()
         self.set_rpc_endpoint(rpc_endpoint)
 
+    def _normalize_rpc_endpoint(self, rpc_endpoint: str) -> str:
+        """Ensure the RPC endpoint has a scheme (http/https)."""
+        parsed = urlparse(rpc_endpoint)
+        if not parsed.scheme:
+            return f'http://{rpc_endpoint.rstrip("/")}'
+        return rpc_endpoint.rstrip('/')
+
     def set_rpc_endpoint(self, rpc_endpoint: str) -> None:
         """May raise:
         - RemoteError if we can't connect to the given rpc endpoint
         """
-        self.rpc_endpoint = rpc_endpoint.rstrip('/')
+        self.rpc_endpoint = self._normalize_rpc_endpoint(rpc_endpoint)
         result = self.query(method='GET', endpoint='eth/v1/node/version')
         try:
             version = result['version']
@@ -145,7 +153,7 @@ class BeaconNode:
             self,
             indices_or_pubkeys: Sequence[int | Eth2PubKey],
             endpoint: Literal['eth/v1/beacon/states/head/validators'],
-            chunk_size: Literal[80, 100] = DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE,
+            chunk_size: int = DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE,
     ) -> list[dict]:
         """
         May raise:
@@ -248,7 +256,13 @@ class BeaconInquirer:
 
         # else we have to query beaconcha.in
         log.debug('Querying validator balances via beaconcha.in')
-        for entry in self.beaconchain.get_validator_data(indices_or_pubkeys):
+        try:
+            beaconchain_results = self.beaconchain.get_validator_data(indices_or_pubkeys)
+        except RemoteError as e:
+            log.error(f'Querying validator balances via beaconcha.in failed due to {e!s}')
+            return balance_mapping
+
+        for entry in beaconchain_results:
             try:
                 amount = from_gwei(entry['balance'])
                 balance_mapping[entry['pubkey']] = Balance(amount=amount, value=amount * price)

--- a/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
@@ -180,7 +180,10 @@ class Eth2(EthereumModule):
         """
         dbeth2 = DBEth2(self.database)
         if fetch_validators_for_eth1:
-            self.detect_and_refresh_validators(addresses)
+            try:
+                self.detect_and_refresh_validators(addresses)
+            except RemoteError as e:
+                log.error(f'Skipping eth2 validator detection during balance query due to {e!s}')
 
         with self.database.conn.read_ctx() as cursor:
             pubkey_to_ownership = dbeth2.get_active_pubkeys_to_ownership(cursor)

--- a/rotkehlchen/chain/ethereum/modules/eth2/utils.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/utils.py
@@ -1,6 +1,5 @@
 import logging
 from collections.abc import Sequence
-from typing import Literal
 
 from rotkehlchen.api.v1.types import IncludeExcludeFilterData
 from rotkehlchen.chain.ethereum.modules.eth2.constants import (
@@ -38,7 +37,7 @@ def form_withdrawal_notes(is_exit: bool, validator_index: int, amount: FVal) -> 
 
 def calculate_query_chunks(
         indices_or_pubkeys: Sequence[int | Eth2PubKey],
-        chunk_size: Literal[80, 100] = DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE,
+        chunk_size: int = DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE,
 ) -> list[Sequence[int | Eth2PubKey]]:
     """Split validator queries into chunks to respect API limits.
 

--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -39,6 +39,7 @@ class DBCacheStatic(Enum):
     STALE_BALANCES_MODIFICATION_TS: Final = 'stale_balances_modification_ts'
     LAST_HISTORICAL_BALANCE_PROCESSING_TS: Final = 'last_historical_balance_processing_ts'
     LAST_INTERNAL_TX_CONFLICTS_REPULL_TS: Final = 'last_internal_tx_conflicts_repull_ts'
+    BEACONCHAIN_VALIDATOR_QUERY_LIMIT: Final = 'beaconchain_validator_query_limit'
 
 
 class LabeledLocationArgsType(TypedDict):

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -768,6 +768,7 @@ class DBHandler:
             DBCacheStatic.MONERIUM_OAUTH_CREDENTIALS,
             DBCacheStatic.STALE_BALANCES_FROM_TS,
             DBCacheStatic.STALE_BALANCES_MODIFICATION_TS,
+            DBCacheStatic.BEACONCHAIN_VALIDATOR_QUERY_LIMIT,
         ):
             return value[0]
 
@@ -1297,6 +1298,11 @@ class DBHandler:
             write_cursor: 'DBCursor',
             credentials: list[ExternalServiceApiCredentials],
     ) -> None:
+        if any(credential.service == ExternalService.BEACONCHAIN for credential in credentials):
+            write_cursor.execute(
+                'DELETE FROM key_value_cache WHERE name=?;',
+                (DBCacheStatic.BEACONCHAIN_VALIDATOR_QUERY_LIMIT.value,),
+            )
         write_cursor.executemany(
             'INSERT OR REPLACE INTO external_service_credentials(name, api_key, api_secret) VALUES(?, ?, ?)',  # noqa: E501
             [c.serialize_for_db() for c in credentials],
@@ -1308,6 +1314,11 @@ class DBHandler:
                 'DELETE FROM external_service_credentials WHERE name=?;',
                 [(service.name.lower(),) for service in services],
             )
+            if ExternalService.BEACONCHAIN in services:
+                cursor.execute(
+                    'DELETE FROM key_value_cache WHERE name=?;',
+                    (DBCacheStatic.BEACONCHAIN_VALIDATOR_QUERY_LIMIT.value,),
+                )
 
     def get_all_external_service_credentials(self) -> list[ExternalServiceApiCredentials]:
         """Returns a list with all the external service credentials saved in the DB"""

--- a/rotkehlchen/externalapis/beaconchain/service.py
+++ b/rotkehlchen/externalapis/beaconchain/service.py
@@ -1,22 +1,28 @@
+import json
 import logging
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final, Literal
 
 import gevent
 import requests
 from gevent.lock import Semaphore
 
-from rotkehlchen.chain.ethereum.modules.eth2.constants import BEACONCHAIN_MAX_EPOCH
+from rotkehlchen.chain.ethereum.modules.eth2.constants import (
+    BEACONCHAIN_MAX_EPOCH,
+    DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE,
+)
 from rotkehlchen.chain.ethereum.modules.eth2.structures import ValidatorID
 from rotkehlchen.chain.ethereum.modules.eth2.utils import calculate_query_chunks
 from rotkehlchen.constants.timing import DAY_IN_SECONDS
-from rotkehlchen.db.cache import DBCacheDynamic
+from rotkehlchen.db.cache import DBCacheDynamic, DBCacheStatic
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import APIKeyNotAvailable, RemoteError
 from rotkehlchen.externalapis.interface import (
+    ExternalServiceWithApiKey,
     ExternalServiceWithRecommendedApiKey,
 )
 from rotkehlchen.history.events.structures.eth2 import EthBlockEvent
@@ -52,12 +58,17 @@ from .constants import BEACONCHAIN_READ_TIMEOUT, BEACONCHAIN_ROOT_URL, MAX_WAIT_
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
+BeaconChainEndpoint = Literal['block', 'block/rewards', 'validators', 'validators/proposal-slots']
+BeaconChainValidatorEndpoint = Literal['validators', 'validators/proposal-slots']
+BEACONCHAIN_VALIDATOR_LIMIT_RE: Final = re.compile(r'validator identifiers exceeds allowed limit')
+BEACONCHAIN_FREE_VALIDATOR_CHUNK_SIZE: Final = 20
+BEACONCHAIN_VALIDATOR_LIMIT_CACHE_TTL: Final = 30 * DAY_IN_SECONDS
 
 
 @dataclass(frozen=True)
 class BeaconChainQueryResponse:
     data: list[dict[str, Any]] | dict[str, Any]
-    next_cursor: str
+    next_cursor: str | None
 
 
 class BeaconChain(ExternalServiceWithRecommendedApiKey):
@@ -71,10 +82,11 @@ class BeaconChain(ExternalServiceWithRecommendedApiKey):
         self.url = f'{BEACONCHAIN_ROOT_URL}/api/v2/ethereum/'
         self.produced_blocks_lock = Semaphore()
         self.ratelimited_until = Timestamp(0)
+        self.validator_query_chunk_size: int = self._get_cached_validator_query_limit()
 
     def _query_with_paging(
             self,
-            endpoint: str,
+            endpoint: BeaconChainEndpoint,
             data: dict[str, Any] | None = None,
     ) -> BeaconChainQueryResponse:
         """
@@ -171,6 +183,12 @@ class BeaconChain(ExternalServiceWithRecommendedApiKey):
             break
 
         if response.status_code != 200:
+            if response.status_code == 403:
+                log.debug(
+                    f'Beaconcha.in API returned HTTP 403 for {endpoint=}. '
+                    f'This may indicate a validator query limit error. '
+                    f'Response text: {response.text}',
+                )
             raise RemoteError(
                 f'Beaconchain API request {response.url} failed '
                 f'with HTTP status code {response.status_code} and text '
@@ -190,35 +208,90 @@ class BeaconChain(ExternalServiceWithRecommendedApiKey):
         paging = json_ret.get('paging', {})
         return BeaconChainQueryResponse(
             data=json_ret['data'],
-            next_cursor=paging.get('next_cursor', '') if isinstance(paging, dict) else '',
+            next_cursor=paging.get('next_cursor') or None if isinstance(paging, dict) else None,
         )
 
     def is_rate_limited(self) -> bool:
         return self.ratelimited_until > ts_now()
 
-    def _query(
-            self,
-            endpoint: str,
-            data: dict[str, Any] | None = None,
-    ) -> list[dict[str, Any]] | dict[str, Any]:
-        """
-        May raise:
-        - RemoteError due to problems querying beaconcha.in API
-        """
-        return self._query_with_paging(endpoint=endpoint, data=data).data
+    def _get_cached_validator_query_limit(self) -> int:
+        """Read cached beaconcha.in validator query limit for the current API key."""
+        api_key = ExternalServiceWithApiKey._get_api_key(self)
+        if api_key is None:
+            return DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE
 
-    def _query_chunked_endpoint(
+        with self.db.conn.read_ctx() as cursor:
+            cache = self.db.get_static_cache(
+                cursor=cursor,
+                name=DBCacheStatic.BEACONCHAIN_VALIDATOR_QUERY_LIMIT,
+            )
+        if not isinstance(cache, str):
+            return DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE
+
+        try:
+            data = jsonloads_dict(cache)
+            limit = int(data['limit'])
+            timestamp = Timestamp(int(data['timestamp']))
+        except (KeyError, TypeError, ValueError, JSONDecodeError) as e:
+            log.warning(f'Ignoring invalid beaconcha.in validator limit cache: {cache}. {e!s}')
+            return DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE
+
+        if (
+                data.get('api_key') != api_key or
+                ts_now() - timestamp > BEACONCHAIN_VALIDATOR_LIMIT_CACHE_TTL or
+                limit <= 0
+        ):
+            return DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE
+
+        return min(limit, DEFAULT_BEACONCHAIN_API_VALIDATOR_CHUNK_SIZE)
+
+    def _maybe_update_validator_query_limit(self, error: RemoteError) -> bool:
+        """Detect and cache validator query limit for the current API key from errors."""
+        if (
+            BEACONCHAIN_VALIDATOR_LIMIT_RE.search(str(error)) is None or
+            self.validator_query_chunk_size <= BEACONCHAIN_FREE_VALIDATOR_CHUNK_SIZE
+        ):
+            return False
+
+        log.debug(
+            f'Detected beaconcha.in validator query limit error. '
+            f'Adjusting chunk size from {self.validator_query_chunk_size} '
+            f'to {BEACONCHAIN_FREE_VALIDATOR_CHUNK_SIZE}. Error: {error!s}',
+        )
+        self.validator_query_chunk_size = BEACONCHAIN_FREE_VALIDATOR_CHUNK_SIZE
+        if (api_key := self._get_api_key()) is not None:
+            with self.db.user_write() as write_cursor:
+                self.db.set_static_cache(
+                    write_cursor=write_cursor,
+                    name=DBCacheStatic.BEACONCHAIN_VALIDATOR_QUERY_LIMIT,
+                    value=json.dumps({
+                        'api_key': api_key,
+                        'limit': BEACONCHAIN_FREE_VALIDATOR_CHUNK_SIZE,
+                        'timestamp': ts_now(),
+                    }),
+                )
+        return True
+
+    def _query_chunked_endpoint_with_size(
             self,
             indices_or_pubkeys: Sequence[int | Eth2PubKey],
-            endpoint: str,
+            endpoint: BeaconChainValidatorEndpoint,
+            chunk_size: int,
     ) -> list[dict[str, Any]]:
-        chunks = calculate_query_chunks(indices_or_pubkeys)
+        """Query a validator endpoint by splitting identifiers using the given chunk size.
+
+        The chunk size is explicit so callers can first try the standard beaconcha.in limit and,
+        after detecting a legacy/free-tier key, retry once with the known free-tier size.
+        """
         data: list[dict[str, Any]] = []
-        for chunk in chunks:
-            result = self._query(
+        for chunk in calculate_query_chunks(
+            indices_or_pubkeys=indices_or_pubkeys,
+            chunk_size=chunk_size,
+        ):
+            result = self._query_with_paging(
                 endpoint=endpoint,
                 data={'validator': {'validator_identifiers': list(chunk)}},
-            )
+            ).data
             if isinstance(result, list):
                 data.extend(result)
             else:
@@ -226,32 +299,102 @@ class BeaconChain(ExternalServiceWithRecommendedApiKey):
 
         return data
 
+    def _query_chunked_endpoint(
+            self,
+            indices_or_pubkeys: Sequence[int | Eth2PubKey],
+            endpoint: BeaconChainValidatorEndpoint,
+    ) -> list[dict[str, Any]]:
+        try:
+            return self._query_chunked_endpoint_with_size(
+                indices_or_pubkeys=indices_or_pubkeys,
+                endpoint=endpoint,
+                chunk_size=self.validator_query_chunk_size,
+            )
+        except RemoteError as e:  # handle possible chunk size errors returned by beaconchain
+            if not self._maybe_update_validator_query_limit(e):
+                raise
+
+        log.debug(
+            f'Retrying beaconcha.in {endpoint} query with adjusted chunk size '
+            f'{BEACONCHAIN_FREE_VALIDATOR_CHUNK_SIZE} for '
+            f'{len(indices_or_pubkeys)} validators',
+        )
+        return self._query_chunked_endpoint_with_size(  # retry once with the adjusted free size
+            indices_or_pubkeys=indices_or_pubkeys,
+            endpoint=endpoint,
+            chunk_size=BEACONCHAIN_FREE_VALIDATOR_CHUNK_SIZE,
+        )
+
+    def _query_cursor_paginated_chunk(
+            self,
+            chunk: Sequence[int],
+            endpoint: BeaconChainValidatorEndpoint,
+            page_size: int,
+    ) -> list[dict[str, Any]]:
+        data: list[dict[str, Any]] = []
+        cursor: str | None = None
+        while True:
+            response = self._query_with_paging(
+                endpoint=endpoint,
+                data={
+                    'validator': {'validator_identifiers': list(chunk)},
+                    'cursor': cursor or '',
+                    'page_size': page_size,
+                },
+            )
+            result = response.data
+            data.extend(result)  # type: ignore[arg-type]  # is a list here
+            if not isinstance(result, list) or (cursor := response.next_cursor) in (None, ''):
+                break
+
+        return data
+
+    def _query_chunked_endpoint_with_cursor_pagination_with_size(
+            self,
+            indices: list[int],
+            endpoint: BeaconChainValidatorEndpoint,
+            page_size: int,
+            chunk_size: int,
+    ) -> list[dict[str, Any]]:
+        data: list[dict[str, Any]] = []
+        for chunk in calculate_query_chunks(indices_or_pubkeys=indices, chunk_size=chunk_size):
+            data.extend(self._query_cursor_paginated_chunk(
+                chunk=chunk,  # type: ignore[arg-type]  # chunk has the same type as indices
+                endpoint=endpoint,
+                page_size=page_size,
+            ))
+
+        return data
+
     def _query_chunked_endpoint_with_cursor_pagination(
             self,
             indices: list[int],
-            endpoint: str,
+            endpoint: BeaconChainValidatorEndpoint,
             page_size: int,
     ) -> list[dict[str, Any]]:
         """Queries chunked endpoints with cursor pagination in beaconchain."""
-        chunks = calculate_query_chunks(indices_or_pubkeys=indices, chunk_size=80)
-        data: list[dict[str, Any]] = []
-        for chunk in chunks:
-            cursor = ''
-            while True:
-                response = self._query_with_paging(
-                    endpoint=endpoint,
-                    data={
-                        'validator': {'validator_identifiers': list(chunk)},
-                        'cursor': cursor,
-                        'page_size': page_size,
-                    },
-                )
-                result = response.data
-                data.extend(result)  # type: ignore[arg-type]  # is a list here
-                if not isinstance(result, list) or (cursor := response.next_cursor) == '':
-                    break  # found the end for this chunk
+        try:
+            return self._query_chunked_endpoint_with_cursor_pagination_with_size(
+                indices=indices,
+                endpoint=endpoint,
+                page_size=page_size,
+                chunk_size=self.validator_query_chunk_size,
+            )
+        except RemoteError as e:
+            if not self._maybe_update_validator_query_limit(e):
+                raise
 
-        return data
+        log.debug(
+            f'Retrying beaconcha.in {endpoint} cursor-paginated query with adjusted '
+            f'chunk size {BEACONCHAIN_FREE_VALIDATOR_CHUNK_SIZE} for '
+            f'{len(indices)} validators',
+        )
+        return self._query_chunked_endpoint_with_cursor_pagination_with_size(
+            indices=indices,
+            endpoint=endpoint,
+            page_size=page_size,
+            chunk_size=BEACONCHAIN_FREE_VALIDATOR_CHUNK_SIZE,
+        )
 
     @staticmethod
     def _normalize_validator_entry(entry: dict[str, Any]) -> dict[str, Any]:
@@ -293,10 +436,16 @@ class BeaconChain(ExternalServiceWithRecommendedApiKey):
         }
 
     def _query_block_data(self, block_number: int) -> dict[str, Any]:
-        return self._query(endpoint='block', data={'block': {'number': block_number}})  # type: ignore[return-value]  # endpoint returns an object
+        return self._query_with_paging(
+            endpoint='block',
+            data={'block': {'number': block_number}},
+        ).data  # type: ignore[return-value]  # endpoint returns an object
 
     def _query_block_rewards(self, block_number: int) -> dict[str, Any]:
-        return self._query(endpoint='block/rewards', data={'block': {'number': block_number}})  # type: ignore[return-value]  # endpoint returns an object
+        return self._query_with_paging(
+            endpoint='block/rewards',
+            data={'block': {'number': block_number}},
+        ).data  # type: ignore[return-value]  # endpoint returns an object
 
     def get_validator_data(
             self,
@@ -520,10 +669,10 @@ class BeaconChain(ExternalServiceWithRecommendedApiKey):
         May raise:
         - RemoteError due to problems querying beaconcha.in API
         """
-        result = self._query(
+        result = self._query_with_paging(
             endpoint='validators',
             data={'validator': {'deposit_address': address}},
-        )
+        ).data
         if isinstance(result, list):
             data = result
         else:

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -564,6 +564,8 @@ class TaskManager:
             log.warning(
                 f'Skipping produced blocks query due to missing beaconcha.in API key: {e!s}',
             )
+        except RemoteError as e:
+            log.error(f'Skipping produced blocks query due to beaconcha.in error: {e!s}')
 
     def _maybe_query_produced_blocks(self) -> list[gevent.Greenlet] | None:
         """Schedules the blocks production query if enough time has passed"""

--- a/rotkehlchen/tests/external_apis/test_beaconchain.py
+++ b/rotkehlchen/tests/external_apis/test_beaconchain.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from rotkehlchen.chain.ethereum.modules.eth2.utils import calculate_query_chunks
+from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.errors.misc import APIKeyNotAvailable, RemoteError
 from rotkehlchen.externalapis.beaconchain.service import BeaconChain
 from rotkehlchen.tests.utils.mock import MockResponse
@@ -81,7 +82,7 @@ def test_rate_limit(beaconchain: BeaconChain, freezer):
         patch.object(beaconchain.session, 'request', mock_session_get),
         pytest.raises(RemoteError),
     ):
-        beaconchain._query(
+        beaconchain._query_with_paging(
             endpoint='validators/proposal-slots',
             data={'validator': {'validator_identifiers': [130, 131]}},
         )
@@ -91,7 +92,7 @@ def test_rate_limit(beaconchain: BeaconChain, freezer):
         patch.object(beaconchain.session, 'request', mock_session_get),
         pytest.raises(RemoteError),
     ):
-        beaconchain._query(
+        beaconchain._query_with_paging(
             endpoint='validators/proposal-slots',
             data={'validator': {'validator_identifiers': [130, 131]}},
         )
@@ -103,7 +104,7 @@ def test_rate_limit(beaconchain: BeaconChain, freezer):
         patch.object(beaconchain.session, 'request', mock_session_get),
         pytest.raises(RemoteError),
     ):
-        beaconchain._query(
+        beaconchain._query_with_paging(
             endpoint='validators/proposal-slots',
             data={'validator': {'validator_identifiers': [130, 131]}},
         )
@@ -132,10 +133,118 @@ def test_free_trial_expired_deletes_api_key(beaconchain: BeaconChain, database) 
         patch.object(beaconchain.session, 'request', mock_session_request),
         pytest.raises(APIKeyNotAvailable, match=r'Beaconcha\.in free trial expired'),
     ):
-        beaconchain._query(endpoint='validators/proposal-slots')
+        beaconchain._query_with_paging(endpoint='validators/proposal-slots')
 
     assert database.get_external_service_credentials(ExternalService.BEACONCHAIN) is None
     assert beaconchain.api_key is None
+
+
+def test_validator_limit_error_is_cached_and_retried(beaconchain: BeaconChain, database) -> None:
+    api_key = ApiKey('legacy-key')
+    with database.user_write() as write_cursor:
+        database.add_external_service_credentials(write_cursor, [ExternalServiceApiCredentials(
+            service=ExternalService.BEACONCHAIN,
+            api_key=api_key,
+        )])
+
+    requested_sizes = []
+
+    def mock_session_request(url: str, **kwargs: dict[str, Any]) -> MockResponse:  # pylint: disable=unused-argument
+        identifiers = kwargs['json']['validator']['validator_identifiers']
+        requested_sizes.append(len(identifiers))
+        if len(identifiers) > 20:
+            return MockResponse(
+                status_code=HTTPStatus.FORBIDDEN,
+                text='{"error":"number of validator identifiers exceeds allowed limit of 20 '
+                     'for your subscription tier. upgrade your subscription at '
+                     'https://beaconcha.in/pricing."}',
+            )
+
+        return MockResponse(
+            status_code=HTTPStatus.OK,
+            text='{"data": [' + ','.join(
+                '{'
+                f'"validator": {{"public_key": "0x{identifier:096x}", "index": {identifier}}},'
+                '"life_cycle_epochs": {},'
+                '"balances": {'
+                '"current": "32000000000000000000",'
+                '"effective": "32000000000000000000"'
+                '},'
+                '"withdrawal_credentials": {"credential": "0x00"},'
+                '"slashed": false,'
+                '"status": "active"'
+                '}'
+                for identifier in identifiers
+            ) + ']}',
+        )
+
+    with (
+        patch.object(beaconchain, '_get_api_key', return_value=api_key),
+        patch.object(beaconchain.session, 'request', mock_session_request),
+    ):
+        result = beaconchain.get_validator_data(list(range(25)))
+
+    assert len(result) == 25
+    assert requested_sizes == [25, 20, 5]
+    assert beaconchain.validator_query_chunk_size == 20
+    with database.conn.read_ctx() as cursor:
+        assert database.get_static_cache(
+            cursor=cursor,
+            name=DBCacheStatic.BEACONCHAIN_VALIDATOR_QUERY_LIMIT,
+        ) is not None
+
+    cached_beaconchain = BeaconChain(database=database, msg_aggregator=beaconchain.msg_aggregator)
+    assert cached_beaconchain.validator_query_chunk_size == 20
+
+    requested_sizes.clear()
+    with (
+        patch.object(cached_beaconchain.session, 'request', mock_session_request),
+    ):
+        result = cached_beaconchain.get_validator_data(list(range(25)))
+
+    assert len(result) == 25
+    assert requested_sizes == [20, 5]
+
+    database.delete_external_service_credentials([ExternalService.BEACONCHAIN])
+    with database.conn.read_ctx() as cursor:
+        assert database.get_static_cache(
+            cursor=cursor,
+            name=DBCacheStatic.BEACONCHAIN_VALIDATOR_QUERY_LIMIT,
+        ) is None
+
+
+def test_validator_limit_cache_reset(database) -> None:
+    """Ensure cached beaconcha.in validator limits are cleared on key changes/removal.
+
+    The limit is tied to a subscription tier/API key, so keeping it after changing or deleting
+    the key could incorrectly throttle future validator queries.
+    """
+    def cache_validator_limit() -> None:
+        with database.user_write() as write_cursor:
+            database.set_static_cache(
+                write_cursor=write_cursor,
+                name=DBCacheStatic.BEACONCHAIN_VALIDATOR_QUERY_LIMIT,
+                value='{"api_key": "old-key", "limit": 20, "timestamp": 1}',
+            )
+
+    def assert_no_validator_limit_cache() -> None:
+        with database.conn.read_ctx() as cursor:
+            assert database.get_static_cache(
+                cursor=cursor,
+                name=DBCacheStatic.BEACONCHAIN_VALIDATOR_QUERY_LIMIT,
+            ) is None
+
+    cache_validator_limit()
+    with database.user_write() as write_cursor:
+        database.add_external_service_credentials(write_cursor, [ExternalServiceApiCredentials(
+            service=ExternalService.BEACONCHAIN,
+            api_key=ApiKey('new-key'),
+        )])
+    assert_no_validator_limit_cache()
+
+    cache_validator_limit()
+    database.delete_external_service_credentials([ExternalService.BEACONCHAIN])
+    assert_no_validator_limit_cache()
 
 
 def test_query_with_paging_missing_next_cursor(beaconchain: BeaconChain) -> None:
@@ -157,7 +266,7 @@ def test_query_with_paging_missing_next_cursor(beaconchain: BeaconChain) -> None
         )
 
     assert response.data == [{'block': '1'}]
-    assert response.next_cursor == ''
+    assert response.next_cursor is None
 
 
 @pytest.mark.vcr(match_on=['beaconchain_matcher'], filter_headers=['authorization'])

--- a/rotkehlchen/tests/integration/test_eth2.py
+++ b/rotkehlchen/tests/integration/test_eth2.py
@@ -439,7 +439,7 @@ def test_beacon_node_rpc_queries(eth2: 'Eth2'):
     indices = list(range(1074000, 1074100))
     validators = [Eth2PubKey('0xa2f870e998e823e5c53527407dd4d17ca80de5416fc756154cd68862a0a8ada2910e4b2bf2c7a5152bd20e5e06900b7e')] + indices  # noqa: E501
 
-    with patch.object(eth2.beacon_inquirer.beaconchain, '_query', wraps=eth2.beacon_inquirer.beaconchain._query) as beaconchain_query:  # noqa: E501
+    with patch.object(eth2.beacon_inquirer.beaconchain, '_query_with_paging', wraps=eth2.beacon_inquirer.beaconchain._query_with_paging) as beaconchain_query:  # noqa: E501
         balances = eth2.beacon_inquirer.get_balances(indices_or_pubkeys=validators, has_premium=True)  # noqa: E501
         assert beaconchain_query.call_count == 0, 'beaconcha.in should not have been queried'
         assert len(balances) == len(validators)

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -953,6 +953,7 @@ def test_query_chunked_endpoint_with_cursor_pagination(eth2):
         BeaconChainQueryResponse(data=[{'block': '4'}], next_cursor=''),
     ]
 
+    eth2.beacon_inquirer.beaconchain.validator_query_chunk_size = 100
     with patch.object(
         eth2.beacon_inquirer.beaconchain,
         '_query_with_paging',


### PR DESCRIPTION
For legacy users the max payload is the same as for free users, 20 items per request. To not slow down other users in higher tiers we detect from the error returned that the user has a lower limit and change it to 20

Closes #12173