### PR TITLE
fix(frontend): reset simple RPC endpoint error on edit

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :bug:`-` 1inch swaps settling through a balancer pool should now be properly decoded.
 * :bug:`-` Newer zerox swaps in base will now be properly decoded.
+* :bug:`12178` Users can now fix a rejected Kusama, Polkadot, beacon chain, or BTC mempool endpoint by editing the URL in place. The error message clears as soon as you start typing.
 
 * :release:`1.43.0 <2026-05-08>`
 * :bug:`-` Docker users can once again import data, snapshots, and asset icons larger than 1 MiB; the bundled nginx no longer rejects them with a 413 before they reach rotki.

--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue
@@ -27,11 +27,13 @@ const { updateSetting } = useSettings();
 const value = computed(() => get(generalSettings[setting]));
 
 function addNewRpcNode() {
+  set(errorMessages, {});
   set(openDialog, true);
   set(inputUrl, '');
 }
 
 function edit(item: string) {
+  set(errorMessages, {});
   set(openDialog, true);
   set(inputUrl, item);
 }
@@ -158,6 +160,7 @@ defineExpose({
       v-model="inputUrl"
       v-model:state-updated="stateUpdated"
       v-model:error-messages="errorMessages"
+      :disabled="submitting"
     />
   </BigDialog>
 </template>

--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.spec.ts
@@ -1,0 +1,79 @@
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import SimpleRpcNodeManagerForm from '@/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue';
+
+type FormInstance = InstanceType<typeof SimpleRpcNodeManagerForm>;
+
+describe('settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<FormInstance>;
+
+  beforeAll(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    modelValue: string = '',
+    errorMessages: ValidationErrors = {},
+  ): VueWrapper<FormInstance> {
+    return mount(SimpleRpcNodeManagerForm, {
+      global: {
+        plugins: [pinia],
+      },
+      props: {
+        errorMessages,
+        modelValue,
+        'onUpdate:errorMessages': async (value: ValidationErrors): Promise<void> => wrapper.setProps({ errorMessages: value }),
+        'onUpdate:modelValue': async (value: string): Promise<void> => wrapper.setProps({ modelValue: value }),
+      },
+    });
+  }
+
+  it('should fail validation when the url is empty', async () => {
+    wrapper = createWrapper('');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const valid = await wrapper.vm.validate();
+    expect(valid).toBe(false);
+  });
+
+  it('should pass validation with a non-empty url', async () => {
+    wrapper = createWrapper('https://example.com');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const valid = await wrapper.vm.validate();
+    expect(valid).toBe(true);
+  });
+
+  it('should clear external error messages when the url changes', async () => {
+    wrapper = createWrapper('https://bad-url', { modelValue: ['Invalid endpoint'] });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.props('errorMessages')).toEqual({ modelValue: ['Invalid endpoint'] });
+
+    await wrapper.setProps({ modelValue: 'https://bad-url/fixed' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.props('errorMessages')).toEqual({});
+  });
+
+  it('should leave error messages untouched when the url is unchanged', async () => {
+    const errors: ValidationErrors = { modelValue: ['Invalid endpoint'] };
+    wrapper = createWrapper('https://bad-url', errors);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.props('errorMessages')).toEqual({ modelValue: ['Invalid endpoint'] });
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue
@@ -10,6 +10,10 @@ const errors = defineModel<ValidationErrors>('errorMessages', { required: true }
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 const modelValue = defineModel<string>({ required: true });
 
+const { disabled = false } = defineProps<{
+  disabled?: boolean;
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 
 const rules = {
@@ -31,6 +35,11 @@ const v$ = useVuelidate(
 
 useFormStateWatcher(states, stateUpdated);
 
+watch(modelValue, () => {
+  if (Object.keys(get(errors)).length > 0)
+    set(errors, {});
+});
+
 defineExpose({
   validate: async () => await get(v$).$validate(),
 });
@@ -45,6 +54,7 @@ defineExpose({
     :label="t('general_settings.labels.node_rpc_endpoint')"
     type="text"
     clearable
+    :disabled="disabled"
     :error-messages="toMessages(v$.modelValue)"
   />
 </template>


### PR DESCRIPTION
Fixes #12178

## Summary
- The simple RPC node dialog (Kusama, Polkadot, beacon chain, BTC mempool) kept the backend rejection error stuck on the field, so an invalid URL could not be corrected without closing and reopening the dialog.
- Vuelidate external results are now cleared when the URL changes and when the dialog is reopened, and the input is disabled while submitting.
- Adds unit tests covering validation and the error-reset behavior.

## Test plan
- [ ] Open Settings → General → RPC and edit a simple RPC endpoint (e.g. beacon chain).
- [ ] Save an invalid URL and confirm the inline error appears.
- [ ] Start editing the URL and confirm the error clears immediately.
- [ ] Save a valid URL and confirm the dialog closes.
- [ ] `pnpm run test:unit src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.spec.ts`