### PR TITLE
ci: use playwright native sharding for e2e

### DIFF
--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -97,16 +97,15 @@ jobs:
           retention-days: 1
 
   e2e:
-    name: '${{ matrix.group }}'
+    name: 'shard-${{ matrix.shard }}'
     needs: [ build-frontend, build-colibri ]
     env:
       CI: true
-      GROUP: ${{ matrix.group }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        group: [ app, settings, balances, history, import ]
+        shard: [ 1, 2, 3, 4 ]
     permissions:
       actions: write
       contents: read
@@ -197,10 +196,9 @@ jobs:
         timeout-minutes: 20
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-          GROUP: ${{ matrix.group }}
           E2E_COVERAGE: true
           VITE_COVERAGE: true
-        run: pnpm run test:e2e --project=chromium
+        run: pnpm run test:e2e --project=chromium --shard=${{ matrix.shard }}/4
         working-directory: ./frontend/app
 
       - name: Generate coverage report
@@ -214,21 +212,21 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./frontend/app/tests/e2e/coverage/lcov.info
-          flags: e2e-${{ matrix.group }}
+          flags: e2e-shard-${{ matrix.shard }}
           fail_ci_if_error: false
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: failure()
         with:
-          name: test-artifacts-${{ runner.os }}-${{ matrix.group }}
+          name: test-artifacts-${{ runner.os }}-shard-${{ matrix.shard }}
           path: ./frontend/app/tests/e2e/test-results
 
       - name: Upload backend logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
-          name: backend-logs-${{ runner.os }}-${{ matrix.group }}
+          name: backend-logs-${{ runner.os }}-shard-${{ matrix.shard }}
           path: ./frontend/app/.e2e/logs/*.log
 
       - name: Annotate backend log errors
@@ -254,7 +252,7 @@ jobs:
                 error_line=$(sanitize "$error_line")
                 echo "::error file=$filename,line=$linenum::Python Traceback: $error_line"
               else
-                echo "::error file=$filename,line=$linenum::Python Traceback found - check backend-logs-${{ runner.os }}-${{ matrix.group }} artifact"
+                echo "::error file=$filename,line=$linenum::Python Traceback found - check backend-logs-${{ runner.os }}-shard-${{ matrix.shard }} artifact"
               fi
             done < <(grep -n "Traceback (most recent call last)" "$logfile" 2>/dev/null || true)
 

--- a/frontend/app/tests/e2e/pages/manual-balances-page.ts
+++ b/frontend/app/tests/e2e/pages/manual-balances-page.ts
@@ -49,22 +49,28 @@ export class ManualBalancesPage {
     await expect(this.page.locator('[data-cy=manual-balances] tbody tr')).toHaveCount(visible + 1);
   }
 
+  private rowByLabel(label: string) {
+    return this.page
+      .locator('[data-cy=manual-balances] tbody tr')
+      .filter({ has: this.page.locator(`[data-cy=label][title="${label}"]`) });
+  }
+
   async balanceShouldMatch(balances: FixtureManualBalance[]): Promise<void> {
-    for (const [i, balance] of balances.entries()) {
-      const row = this.page.locator('[data-cy=manual-balances] tbody tr').nth(i);
+    for (const balance of balances) {
+      const row = this.rowByLabel(balance.label);
       await expect(row.locator('[data-cy=manual-balances__amount]')).toContainText(formatAmount(balance.amount));
     }
   }
 
   async balanceShouldNotMatch(balances: FixtureManualBalance[]): Promise<void> {
-    for (const [i, balance] of balances.entries()) {
-      const row = this.page.locator('[data-cy=manual-balances] tbody tr').nth(i);
+    for (const balance of balances) {
+      const row = this.rowByLabel(balance.label);
       await expect(row.locator('[data-cy=manual-balances__amount]')).not.toContainText(formatAmount(balance.amount));
     }
   }
 
-  async isVisible(position: number, balance: FixtureManualBalance): Promise<void> {
-    const row = this.page.locator('[data-cy=manual-balances] tbody tr').nth(position);
+  async isVisible(balance: FixtureManualBalance): Promise<void> {
+    const row = this.rowByLabel(balance.label);
 
     await expect(row.locator('[data-cy=label]')).toContainText(balance.label);
     await expect(row.locator('[data-cy=manual-balances__amount]')).toContainText(formatAmount(balance.amount));
@@ -113,9 +119,8 @@ export class ManualBalancesPage {
     return { total, balances };
   }
 
-  async editBalance(position: number, amount: string): Promise<void> {
-    const rows = this.page.locator('[data-cy=manual-balances] tbody tr');
-    const editButton = rows.nth(position).locator('button[data-cy=row-edit]');
+  async editBalance(label: string, amount: string): Promise<void> {
+    const editButton = this.rowByLabel(label).locator('button[data-cy=row-edit]');
 
     await editButton.waitFor({ state: 'visible' });
     await expect(editButton).not.toBeDisabled();
@@ -129,9 +134,8 @@ export class ManualBalancesPage {
     await expect(this.page.locator('[data-cy=price-refresh]')).not.toBeDisabled();
   }
 
-  async deleteBalance(position: number): Promise<void> {
-    const rows = this.page.locator('[data-cy=manual-balances] tbody tr');
-    await rows.nth(position).locator('button[data-cy=row-delete]').click();
+  async deleteBalance(label: string): Promise<void> {
+    await this.rowByLabel(label).locator('button[data-cy=row-delete]').click();
     await this.confirmDelete();
   }
 

--- a/frontend/app/tests/e2e/specs/balances/manual-balances.spec.ts
+++ b/frontend/app/tests/e2e/specs/balances/manual-balances.spec.ts
@@ -29,7 +29,7 @@ test.describe.serial('balances', () => {
       const balance = manualBalances[i];
       await manualBalancesPage.addBalance(balance);
       await manualBalancesPage.visibleEntries(i + 1);
-      await manualBalancesPage.isVisible(i, balance);
+      await manualBalancesPage.isVisible(balance);
     }
   });
 
@@ -119,18 +119,18 @@ test.describe.serial('balances', () => {
 
     const firstNewAmount = '200';
     await manualBalancesPage.visit();
-    await manualBalancesPage.editBalance(1, firstNewAmount);
+    await manualBalancesPage.editBalance(manualBalances[1].label, firstNewAmount);
     await manualBalancesPage.visibleEntries(3);
-    await manualBalancesPage.isVisible(1, {
+    await manualBalancesPage.isVisible({
       ...manualBalances[1],
       amount: firstNewAmount,
     });
 
     const secondNewAmount = '300';
     await manualBalancesPage.visit();
-    await manualBalancesPage.editBalance(1, secondNewAmount);
+    await manualBalancesPage.editBalance(manualBalances[1].label, secondNewAmount);
     await manualBalancesPage.visibleEntries(3);
-    await manualBalancesPage.isVisible(1, {
+    await manualBalancesPage.isVisible({
       ...manualBalances[1],
       amount: secondNewAmount,
     });
@@ -139,7 +139,7 @@ test.describe.serial('balances', () => {
     const apiManualBalance = { ...manualBalances[1], label: 'extra' };
     await manualBalancesPage.addBalance(apiManualBalance);
     await manualBalancesPage.visibleEntries(4);
-    await manualBalancesPage.isVisible(2, apiManualBalance);
+    await manualBalancesPage.isVisible(apiManualBalance);
   });
 
   test('change currency', async () => {
@@ -154,8 +154,8 @@ test.describe.serial('balances', () => {
     const manualBalancesPage = new ManualBalancesPage(ctx.sharedPage);
 
     await manualBalancesPage.visit();
-    await manualBalancesPage.deleteBalance(1);
+    await manualBalancesPage.deleteBalance(manualBalances[1].label);
     await manualBalancesPage.visibleEntries(3);
-    await manualBalancesPage.isVisible(0, manualBalances[0]);
+    await manualBalancesPage.isVisible(manualBalances[0]);
   });
 });


### PR DESCRIPTION
## Summary
- Replace custom `GROUP`-based matrix (`app`/`settings`/`balances`/`history`/`import`) with Playwright's native `--shard=N/4` across 4 runners.
- Tests are auto-balanced by test count instead of being pinned to spec folders, evening out wall time and removing the need to rebalance folders when specs are added/moved.
- `GROUP` env var support in `playwright.config.ts` is kept so local filtering (`GROUP=balances pnpm run test:e2e`) still works.

## Test plan
- [ ] CI: all 4 e2e shards run and pass
- [ ] Per-shard artifacts (test results, backend logs, coverage) upload with `shard-<n>` suffix
- [ ] Codecov receives 4 uploads tagged `e2e-shard-<n>`