### PR TITLE
fix: coerce null notes when deserializing saved PnL report events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` There should no longer be any errors when exporting CSV from PnL report containing an event with notes being Null.
 * :bug:`-` 1inch swaps settling through a balancer pool should now be properly decoded.
 * :bug:`12173` Beaconcha.in queries with legacy API keys will work correctly again.
 * :bug:`-` Newer zerox swaps in base will now be properly decoded.

--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -288,7 +288,7 @@ class EventsAccountant:
             fee_out_event = (self.pot.add_out_event, {
                 'originating_event_id': fee_event.identifier,
                 'event_type': AccountingEventType.FEE,
-                'notes': fee_event.notes,
+                'notes': fee_event.notes or '',
                 'location': fee_event.location,
                 'timestamp': timestamp,
                 'asset': fee_event.asset,

--- a/rotkehlchen/accounting/structures/processed_event.py
+++ b/rotkehlchen/accounting/structures/processed_event.py
@@ -132,7 +132,7 @@ class ProcessedAccountingEvent:
             'pnl_taxable': str(self.pnl.taxable),
             'pnl_free': str(self.pnl.free),
         }
-        tx_hash = self.extra_data.get('tx_hash', None)
+        tx_ref = self.extra_data.get('tx_ref')
         if export_type == AccountingEventExportType.CSV:
             taxable_basis = free_basis = ''
             if self.cost_basis is not None:
@@ -144,8 +144,8 @@ class ProcessedAccountingEvent:
                 exported_dict['asset'] = self.asset.symbol_or_name()
             except UnknownAsset:
                 exported_dict['asset'] = ''
-            if tx_hash is not None:
-                exported_dict['notes'] = f'{evm_explorer}{tx_hash}  ->  {self.notes}'
+            if tx_ref is not None:
+                exported_dict['notes'] = f'{evm_explorer}{tx_ref}  ->  {self.notes}'
 
             if self.location in EVM_EVMLIKE_LOCATIONS and database is not None:
                 # call _maybe_add_label_with_address on each address in the note
@@ -166,8 +166,8 @@ class ProcessedAccountingEvent:
             exported_dict['cost_basis'] = cost_basis
 
         if export_type == AccountingEventExportType.API:
-            if tx_hash is not None:
-                exported_dict['notes'] = f'transaction {tx_hash} {self.notes}'
+            if tx_ref is not None:
+                exported_dict['notes'] = f'transaction {tx_ref} {self.notes}'
 
             group_id = self.extra_data.get('group_id', None)
             if group_id is not None:
@@ -179,7 +179,7 @@ class ProcessedAccountingEvent:
         """This is used to serialize to dict for saving to the DB"""
         data = self.to_exported_dict(ts_converter=ts_converter, export_type=AccountingEventExportType.DB)  # noqa: E501
         data['extra_data'] = self.extra_data
-        data['notes'] = self.notes  # undo the tx_hash addition to notes before going to the DB
+        data['notes'] = self.notes  # undo the tx_ref addition to notes before going to the DB
         data['index'] = self.index
         data['count_entire_amount_spend'] = self.count_entire_amount_spend
         data['count_cost_basis_pnl'] = self.count_cost_basis_pnl

--- a/rotkehlchen/accounting/structures/processed_event.py
+++ b/rotkehlchen/accounting/structures/processed_event.py
@@ -261,7 +261,7 @@ class ProcessedAccountingEvent:
                 cost_basis = CostBasisInfo.deserialize(data['cost_basis'])
             event = cls(
                 event_type=AccountingEventType.deserialize(data['type']),
-                notes=data['notes'],
+                notes=data['notes'] or '',  # historic reports may have stored null notes
                 location=Location.deserialize(data['location']),
                 timestamp=timestamp,
                 asset=Asset(data['asset_identifier']).check_existence(),

--- a/rotkehlchen/chain/ethereum/modules/makerdao/accountant.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/accountant.py
@@ -54,7 +54,7 @@ class MakerdaoAccountant(ModuleAccountantInterface):
                 asset=A_DAI,
                 amount=loss,
                 taxable=True,
-                extra_data={'tx_hash': str(event.tx_ref)},
+                extra_data={'tx_ref': str(event.tx_ref)},
             )
             self.vault_balances[cdp_id] = ZERO
         return 1
@@ -87,7 +87,7 @@ class MakerdaoAccountant(ModuleAccountantInterface):
                 asset=A_DAI,
                 amount=profit,
                 taxable=True,
-                extra_data={'tx_hash': str(event.tx_ref)},
+                extra_data={'tx_ref': str(event.tx_ref)},
             )
             self.dsr_balances[address] = ZERO
         return 1

--- a/rotkehlchen/tests/api/test_pnl_csv.py
+++ b/rotkehlchen/tests/api/test_pnl_csv.py
@@ -288,7 +288,10 @@ def test_history_export_download_csv(
         json={'directory_path': str(csv_dir)},
     )
     rows = assert_csv_export_response(response, csv_dir, expected_num_of_events=1)
-    assert f'Test note to check if label is added with {ETH_ADDRESS1} [ETH_ADDRESS1 IN ZKSYNC] address' in rows[0]['notes']  # noqa: E501
+    assert rows[0]['notes'] == (
+        f'https://zkscan.io/explorer/transactions/{tx_hash!s}  ->  Test note to check '
+        f'if label is added with {ETH_ADDRESS1} [ETH_ADDRESS1 IN ZKSYNC] address'
+    )
 
 
 @pytest.mark.parametrize('initialize_accounting_rules', [True])

--- a/rotkehlchen/tests/db/test_reports.py
+++ b/rotkehlchen/tests/db/test_reports.py
@@ -1,8 +1,12 @@
+import json
 from typing import TYPE_CHECKING
 
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.pnl import PNL, PnlTotals
-from rotkehlchen.accounting.structures.processed_event import ProcessedAccountingEvent
+from rotkehlchen.accounting.structures.processed_event import (
+    AccountingEventExportType,
+    ProcessedAccountingEvent,
+)
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_DAI, A_ETH
 from rotkehlchen.db.filtering import ReportDataFilterQuery
@@ -304,3 +308,41 @@ def test_get_report_data_pagination_total_count(database: 'DBHandler') -> None:
     assert len(results) == 1
     assert entries_found == 2
     assert entries_total == 2
+
+
+def test_deserialize_event_with_null_notes_can_be_csv_exported(database: 'DBHandler') -> None:
+    """Regression test: historic reports may have persisted events with a null notes
+    field. The CSV export ran EVM_ADDRESS_REGEX.sub on those notes, which raised
+    `TypeError: expected string or bytes-like object, got 'NoneType'` for EVM-location
+    events, causing the export endpoint to 500.
+    """
+    event = ProcessedAccountingEvent(
+        event_type=AccountingEventType.TRANSACTION_EVENT,
+        notes='placeholder',  # will be overwritten with null in the stored payload
+        location=Location.ETHEREUM,
+        timestamp=Timestamp(1741634066),
+        asset=A_ETH,
+        free_amount=ONE,
+        taxable_amount=ZERO,
+        price=Price(FVal('2000')),
+        pnl=PNL(free=ZERO, taxable=ZERO),
+        cost_basis=None,
+        index=0,
+        extra_data={},
+    )
+    stored = json.loads(event.serialize_for_db(ts_converter=timestamp_to_date))
+    stored['notes'] = None  # simulate a historic row saved with null notes
+
+    restored = ProcessedAccountingEvent.deserialize_from_db(
+        timestamp=event.timestamp,
+        stringified_json=json.dumps(stored),
+    )
+    # this is what crashed before the fix: EVM_ADDRESS_REGEX.sub on a None string
+    exported = restored.to_exported_dict(
+        ts_converter=timestamp_to_date,
+        export_type=AccountingEventExportType.CSV,
+        database=database,
+        evm_explorer='https://etherscan.io/tx/',
+    )
+    assert restored.notes == ''
+    assert exported['notes'] == ''


### PR DESCRIPTION
Historic saved reports could persist null notes for processed accounting events. CSV export then crashed on EVM-location events with 'expected string or bytes-like object, got NoneType' because EVM_ADDRESS_REGEX.sub received None.

Coerce notes to '' in ProcessedAccountingEvent.deserialize_from_db so the dataclass invariant (notes: str) holds for restored events. Add a regression test that reproduces the exact crash without the fix.
