### PR TITLE
perf(accounting): cache ignored_asset_ids in event loop

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`12112` The dashboard's net worth percentage and trend indicator now follow the chart's data-zoom selection.
+* :feature:`11988` rotki now has a setting to selectively enable/disable chain / address query for transaction history. That means you can skip history querying for specific chains or chain/address combinations.
 * :feature:`12111` Free-text typed in the History events filter without a key=value prefix is now applied as a notes search on Enter, so you can quickly find events by any word in their notes instead of having to remember the notes= prefix.
 
 * :release:`1.43.0 <2026-05-08>`

--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -106,13 +106,8 @@ class EventsAccountant:
                 return 1
 
             in_event = cast('HistoryBaseEntry', next(events_iterator))  # consume the paired event
-
-            with self.pot.database.conn.read_ctx() as cursor:
-                if (
-                    event.asset in (ignored_assets := self.pot.database.get_ignored_asset_ids(cursor)) or  # noqa: E501
-                    in_event.asset in ignored_assets
-                ):
-                    return 2
+            if event.asset in self.pot.ignored_asset_ids or in_event.asset in self.pot.ignored_asset_ids:  # noqa: E501
+                return 2
 
             # event_direction is OUT (first event is always the deposit/spend)
             # paired_direction is IN (second event is always the receive/withdraw)
@@ -172,13 +167,12 @@ class EventsAccountant:
                 fee_events.append(cast('HistoryBaseEntry', next(events_iterator)))  # guaranteed by if check  # noqa: E501
                 processed_event_count += 1
 
-            with self.pot.database.conn.read_ctx() as cursor:
-                if (
-                        event.asset in (ignored_assets := self.pot.database.get_ignored_asset_ids(cursor)) or  # noqa: E501
-                        in_event.asset in ignored_assets or
-                        any(fee_event.asset in ignored_assets for fee_event in fee_events)
-                ):  # return early if any events in the swap group have ignored assets.
-                    return processed_event_count
+            if (
+                    event.asset in self.pot.ignored_asset_ids or
+                    in_event.asset in self.pot.ignored_asset_ids or
+                    any(fee_event.asset in self.pot.ignored_asset_ids for fee_event in fee_events)
+            ):  # return early if any events in the swap group have ignored assets.
+                return processed_event_count
 
             return self._process_swap(
                 timestamp=timestamp,


### PR DESCRIPTION
Use the pot.ignored_asset_ids set that's already populated by pot.reset() at report start, instead of opening a fresh read_ctx and re-running get_ignored_asset_ids per BASIS_TRANSFER and per SWAP event.

Accounting runs are point-in-time, so the cached set is semantically identical to the per-event DB fetch.