### PR TITLE
Ratelimit and parallelization

### DIFF
--- a/rotkehlchen/api/services/external_services.py
+++ b/rotkehlchen/api/services/external_services.py
@@ -84,9 +84,16 @@ class ExternalServicesService:
 
         Without this, a paid key swapped in for a free one (or vice versa) would
         keep using the previous tier's discovered rate-limit until rotki restarts.
+        Routescan in particular only ever shrinks via 429s (no widening probe),
+        so without a reset a key change after a shrink would inherit the lower
+        rate forever.
         """
         if service == ExternalService.ETHERSCAN:
             self.rotkehlchen.etherscan.on_api_key_changed()
+        elif service == ExternalService.BLOCKSCOUT:
+            self.rotkehlchen.blockscout.on_api_key_changed()
+        elif service == ExternalService.ROUTESCAN:
+            self.rotkehlchen.routescan.on_api_key_changed()
         elif service == ExternalService.COINGECKO:
             self.rotkehlchen.coingecko.on_api_key_changed()
         elif service == ExternalService.CRYPTOCOMPARE:

--- a/rotkehlchen/api/services/external_services.py
+++ b/rotkehlchen/api/services/external_services.py
@@ -79,6 +79,21 @@ class ExternalServicesService:
 
         self._refresh_solana_helius_rpc_node()
 
+    def _reset_rate_limiter_for(self, service: ExternalService) -> None:
+        """Tell the matching client that its api key changed so it re-probes its tier.
+
+        Without this, a paid key swapped in for a free one (or vice versa) would
+        keep using the previous tier's discovered rate-limit until rotki restarts.
+        """
+        if service == ExternalService.ETHERSCAN:
+            self.rotkehlchen.etherscan.on_api_key_changed()
+        elif service == ExternalService.COINGECKO:
+            self.rotkehlchen.coingecko.on_api_key_changed()
+        elif service == ExternalService.CRYPTOCOMPARE:
+            self.rotkehlchen.cryptocompare.on_api_key_changed()
+        elif service == ExternalService.DEFILLAMA:
+            self.rotkehlchen.defillama.on_api_key_changed()
+
     def add_services(
             self,
             services: list[ExternalServiceApiCredentials],
@@ -111,6 +126,9 @@ class ExternalServicesService:
                 credentials=services,
             )
 
+        for service in services:
+            self._reset_rate_limiter_for(service.service)
+
         if should_renable_etherscan:
             self.rotkehlchen.chains_aggregator.renable_etherscan_indixer()
         if helius_api_key is not None:
@@ -123,6 +141,8 @@ class ExternalServicesService:
             services: list[ExternalService],
     ) -> dict[str, Any]:
         self.rotkehlchen.data.db.delete_external_service_credentials(services)
+        for service in services:
+            self._reset_rate_limiter_for(service)
         if ExternalService.HELIUS in services:
             self._sync_helius_rpc_node(api_key=None)
         return self._build_payload()

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -673,9 +673,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         client and the chain is not synced
         """
         xpub_manager = XpubManager(chains_aggregator=self)
-        chains_to_query: list[SupportedBlockchain] = (
-            list(SupportedBlockchain) if blockchain is None else [blockchain]
-        )
+        chains_to_query: list[SupportedBlockchain] = list(SupportedBlockchain) if blockchain is None else [blockchain]  # noqa: E501
 
         def _query_one(chain: SupportedBlockchain) -> None:
             if chain == SupportedBlockchain.ETHEREUM_BEACONCHAIN:

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -7,6 +7,7 @@ from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, cast, overload
 
+import gevent
 import requests
 from gevent.lock import Semaphore
 from web3.exceptions import BadFunctionCallOutput, Web3Exception
@@ -672,17 +673,39 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         client and the chain is not synced
         """
         xpub_manager = XpubManager(chains_aggregator=self)
-        for chain in SupportedBlockchain if blockchain is None else [blockchain]:
+        chains_to_query: list[SupportedBlockchain] = (
+            list(SupportedBlockchain) if blockchain is None else [blockchain]
+        )
+
+        def _query_one(chain: SupportedBlockchain) -> None:
             if chain == SupportedBlockchain.ETHEREUM_BEACONCHAIN:
                 self.query_eth2_balances(ignore_cache=ignore_cache)
-                self._update_blockchain_balances_cache(blockchain=chain, addresses=addresses)
-                continue
+                return
 
             if ignore_cache is True and chain.is_bitcoin():
                 xpub_manager.check_for_new_xpub_addresses(blockchain=chain)  # type: ignore[arg-type] # mypy doesn't understand is_bitcoin()
 
             self._query_chain_balances(blockchain=chain, ignore_cache=ignore_cache, addresses=addresses)  # noqa: E501
+
+        # Query all chains concurrently. Cross-chain calls into independent backends
+        # (per-chain RPC nodes, blockstream, beaconchain) parallelize freely; calls
+        # into shared upstreams (etherscan-v2's unified key, price oracles) are gated
+        # by the per-client TokenBucket so we don't trip shared rate limits.
+        greenlets = {chain: gevent.spawn(_query_one, chain) for chain in chains_to_query}
+        gevent.joinall(list(greenlets.values()))
+
+        # Persist the cache only for chains that succeeded. Preserve the original
+        # contract by reraising the first failure after all chains have settled.
+        first_exception: BaseException | None = None
+        for chain, greenlet in greenlets.items():
+            if greenlet.exception is not None:
+                if first_exception is None:
+                    first_exception = greenlet.exception
+                continue
             self._update_blockchain_balances_cache(blockchain=chain, addresses=addresses)
+
+        if first_exception is not None:
+            raise first_exception
 
         self.totals = self.balances.recalculate_totals()
         return self.get_balances_update(blockchain)

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -694,18 +694,25 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
 
         # Persist the cache only for chains that succeeded. Preserve the original
         # contract by reraising the first failure after all chains have settled.
+        # Additional failures are logged so they aren't silently swallowed when
+        # multiple chains fail in the same refresh.
         first_exception: BaseException | None = None
         for chain, greenlet in greenlets.items():
             if greenlet.exception is not None:
                 if first_exception is None:
                     first_exception = greenlet.exception
+                else:
+                    log.error(f'Failed to query {chain} balances: {greenlet.exception!s}')
                 continue
             self._update_blockchain_balances_cache(blockchain=chain, addresses=addresses)
 
+        # Recompute totals regardless of failures: succeeded chains have already
+        # mutated self.balances, and a failing chain may have cleared its own
+        # entries before raising — leaving the cached self.totals out of sync.
+        self.totals = self.balances.recalculate_totals()
         if first_exception is not None:
             raise first_exception
 
-        self.totals = self.balances.recalculate_totals()
         return self.get_balances_update(blockchain)
 
     def get_active_addresses(

--- a/rotkehlchen/externalapis/blockscout.py
+++ b/rotkehlchen/externalapis/blockscout.py
@@ -139,6 +139,7 @@ class Blockscout(ExternalServiceWithApiKey, EtherscanLikeApi):
         backoff_in_seconds = 10
 
         while True:
+            self._rate_limiter.acquire()
             try:
                 request_kwargs: dict[str, Any] = {'timeout': timeout}
                 if query_params is not None:
@@ -154,6 +155,7 @@ class Blockscout(ExternalServiceWithApiKey, EtherscanLikeApi):
                 raise RemoteError(f'Querying {query_str} failed due to {e!s}') from e
 
             if response.status_code == 429:
+                self._rate_limiter.shrink_after_429()
                 if times == 0:
                     msg = (
                         f'Blockscout API request {response.url} failed '

--- a/rotkehlchen/externalapis/blockscout.py
+++ b/rotkehlchen/externalapis/blockscout.py
@@ -33,6 +33,7 @@ from rotkehlchen.types import (
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import from_wei, iso8601ts_to_timestamp, set_user_agent, ts_sec_to_ms
 from rotkehlchen.utils.network import create_session
+from rotkehlchen.utils.rate_limiter import TokenBucket
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -45,6 +46,11 @@ if TYPE_CHECKING:
 # https://docs.blockscout.com/devs/apis/rpc/account#get-transactions-by-address
 BLOCKSCOUT_PAGINATION_LIMIT = 10000
 BLOCKSCOUT_PRO_API_BASE_URL = 'https://api.blockscout.com'
+# Blockscout has no documented hard rate limit on the free public endpoints.
+# Pick a conservative shared cap so parallel chain refreshes don't accidentally
+# DoS our own backend.
+BLOCKSCOUT_RATE_LIMIT_RPS: Final = 10.0
+BLOCKSCOUT_RATE_LIMIT_BURST: Final = 20
 AUTOSCOUT_INSTANCES: Final[dict[ChainID, str]] = {  # self launched instances by chains. Not in the PRO apis  # noqa: E501
     ChainID.HYPERLIQUID: 'https://www.hyperscan.com',
 }
@@ -73,6 +79,10 @@ class Blockscout(ExternalServiceWithApiKey, EtherscanLikeApi):
             name='Blockscout',
             pagination_limit=BLOCKSCOUT_PAGINATION_LIMIT,
             default_api_key=ApiKey(''),  # no default api key used for blockscout
+            rate_limiter=TokenBucket(
+                rps=BLOCKSCOUT_RATE_LIMIT_RPS,
+                capacity=BLOCKSCOUT_RATE_LIMIT_BURST,
+            ),
         )
         self.session = create_session()
         set_user_agent(self.session)

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -22,7 +22,7 @@ from rotkehlchen.types import ChainID, ExternalService, Price, Timestamp, TokenK
 from rotkehlchen.utils.misc import set_user_agent, timestamp_to_date, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
 from rotkehlchen.utils.network import create_session
-from rotkehlchen.utils.rate_limiter import TokenBucket, parse_rate_limit_headers
+from rotkehlchen.utils.rate_limiter import TokenBucket
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -547,8 +547,8 @@ class Coingecko(
         """One-shot Pro tier probe. Demo keys (or missing keys) just stay at defaults.
 
         Best-effort: any failure (network, HTTP, JSON) leaves _probed=True so we
-        don't double the request rate by re-probing on every query. Header-based
-        widening in _adapt_to_headers acts as the long-term safety net.
+        don't double the request rate by re-probing on every query. If the probe
+        misses the real tier, 429-driven shrink in _query() converges the bucket.
         """
         if self._probed:
             return
@@ -583,11 +583,6 @@ class Coingecko(
         if isinstance(rpm, int) and rpm > 0:
             self._rate_limiter.widen(observed_rps=rpm / 60, observed_capacity=min(rpm, 200))
             log.debug(f'Coingecko tier probe widened rate to {rpm}/min')
-
-    def _adapt_to_headers(self, response: requests.Response) -> None:
-        rps, cap = parse_rate_limit_headers(response.headers)
-        if rps is not None:
-            self._rate_limiter.widen(observed_rps=rps, observed_capacity=cap)
 
     def on_api_key_changed(self) -> None:
         """Called from the External Services save/delete hook on key change."""
@@ -665,8 +660,6 @@ class Coingecko(
                 f'code: {response.status_code}'
             )
             raise RemoteError(msg)
-
-        self._adapt_to_headers(response)
 
         try:
             decoded_json = json.loads(response.text)

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -22,7 +22,7 @@ from rotkehlchen.types import ChainID, ExternalService, Price, Timestamp, TokenK
 from rotkehlchen.utils.misc import set_user_agent, timestamp_to_date, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
 from rotkehlchen.utils.network import create_session
-from rotkehlchen.utils.rate_limiter import TokenBucket
+from rotkehlchen.utils.rate_limiter import TokenBucket, parse_rate_limit_headers
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -541,6 +541,58 @@ class Coingecko(
             rps=COINGECKO_RATE_LIMIT_RPS,
             capacity=COINGECKO_RATE_LIMIT_BURST,
         )
+        self._probed = False
+
+    def _maybe_probe(self) -> None:
+        """One-shot Pro tier probe. Demo keys (or missing keys) just stay at defaults."""
+        if self._probed:
+            return
+        self._probed = True  # set first so transient failures don't trigger a retry storm
+        if (api_key := self._get_api_key()) is None:
+            return  # demo tier, nothing to probe
+        try:
+            response = self.session.get(
+                url='https://pro-api.coingecko.com/api/v3/key',
+                headers={'x-cg-pro-api-key': api_key},
+                timeout=CachedSettings().get_timeout_tuple(),
+            )
+        except requests.exceptions.RequestException as e:
+            log.debug(f'Coingecko tier probe failed at the network layer: {e!s}')
+            self._probed = False  # allow retry on the next query
+            return
+
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            log.debug('Coingecko Pro probe returned 401; treating as demo/free tier')
+            return
+        if response.status_code != HTTPStatus.OK:
+            log.debug(f'Coingecko tier probe got HTTP {response.status_code}; ignoring')
+            self._probed = False
+            return
+
+        try:
+            data = response.json()
+        except (json.decoder.JSONDecodeError, ValueError):
+            log.debug('Coingecko tier probe returned non-json body')
+            return
+
+        # CoinGecko Pro response shape: {"plan": "...", "rate_limit_request_per_minute": N, ...}
+        rpm = data.get('rate_limit_request_per_minute') if isinstance(data, dict) else None
+        if isinstance(rpm, int) and rpm > 0:
+            self._rate_limiter.widen(observed_rps=rpm / 60, observed_capacity=min(rpm, 200))
+            log.debug(f'Coingecko tier probe widened rate to {rpm}/min')
+
+    def _adapt_to_headers(self, response: requests.Response) -> None:
+        rps, cap = parse_rate_limit_headers(response.headers)
+        if rps is not None:
+            self._rate_limiter.widen(observed_rps=rps, observed_capacity=cap)
+
+    def on_api_key_changed(self) -> None:
+        """Called from the External Services save/delete hook on key change."""
+        self._rate_limiter.reset(
+            rps=COINGECKO_RATE_LIMIT_RPS,
+            capacity=COINGECKO_RATE_LIMIT_BURST,
+        )
+        self._probed = False
 
     @overload
     def _query(
@@ -585,6 +637,7 @@ class Coingecko(
             self.session.headers.pop('x-cg-pro-api-key', None)
 
         log.debug(f'Querying coingecko: {url=} with {options=}')
+        self._maybe_probe()
         self._rate_limiter.acquire()
         try:
             response = self.session.get(
@@ -598,6 +651,7 @@ class Coingecko(
 
         if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
             self.last_rate_limit = ts_now()
+            self._rate_limiter.shrink_after_429()
             msg = f'Got rate limited by coingecko querying {url}'
             log.warning(msg)
             raise RemoteError(message=msg, error_code=HTTPStatus.TOO_MANY_REQUESTS)
@@ -608,6 +662,8 @@ class Coingecko(
                 f'code: {response.status_code}'
             )
             raise RemoteError(msg)
+
+        self._adapt_to_headers(response)
 
         try:
             decoded_json = json.loads(response.text)

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -547,8 +547,11 @@ class Coingecko(
         """One-shot Pro tier probe. Demo keys (or missing keys) just stay at defaults.
 
         Best-effort: any failure (network, HTTP, JSON) leaves _probed=True so we
-        don't double the request rate by re-probing on every query. If the probe
-        misses the real tier, 429-driven shrink in _query() converges the bucket.
+        don't fire a probe + a query on every call. If the probe fails or misses
+        the real tier the bucket stays at defaults; 429-driven shrink in _query()
+        can only narrow it further (there is no widening fallback), so paid users
+        whose probe permanently fails will run at demo-tier pacing until rotki
+        restarts or the key is re-saved.
         """
         if self._probed:
             return

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -544,10 +544,15 @@ class Coingecko(
         self._probed = False
 
     def _maybe_probe(self) -> None:
-        """One-shot Pro tier probe. Demo keys (or missing keys) just stay at defaults."""
+        """One-shot Pro tier probe. Demo keys (or missing keys) just stay at defaults.
+
+        Best-effort: any failure (network, HTTP, JSON) leaves _probed=True so we
+        don't double the request rate by re-probing on every query. Header-based
+        widening in _adapt_to_headers acts as the long-term safety net.
+        """
         if self._probed:
             return
-        self._probed = True  # set first so transient failures don't trigger a retry storm
+        self._probed = True
         if (api_key := self._get_api_key()) is None:
             return  # demo tier, nothing to probe
         try:
@@ -558,7 +563,6 @@ class Coingecko(
             )
         except requests.exceptions.RequestException as e:
             log.debug(f'Coingecko tier probe failed at the network layer: {e!s}')
-            self._probed = False  # allow retry on the next query
             return
 
         if response.status_code == HTTPStatus.UNAUTHORIZED:
@@ -566,7 +570,6 @@ class Coingecko(
             return
         if response.status_code != HTTPStatus.OK:
             log.debug(f'Coingecko tier probe got HTTP {response.status_code}; ignoring')
-            self._probed = False
             return
 
         try:

--- a/rotkehlchen/externalapis/coingecko.py
+++ b/rotkehlchen/externalapis/coingecko.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, overload
 
 import requests
 
@@ -22,12 +22,20 @@ from rotkehlchen.types import ChainID, ExternalService, Price, Timestamp, TokenK
 from rotkehlchen.utils.misc import set_user_agent, timestamp_to_date, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
 from rotkehlchen.utils.network import create_session
+from rotkehlchen.utils.rate_limiter import TokenBucket
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
+
+# CoinGecko demo (free) tier: 30 calls/minute = 0.5 rps. Pro tiers go higher but
+# share this single client instance — users with a pro key can lift this via
+# settings overrides in a follow-up. Burst lets brief multi-asset bulk fetches
+# (price lookups) finish without artificial pacing.
+COINGECKO_RATE_LIMIT_RPS: Final = 0.45
+COINGECKO_RATE_LIMIT_BURST: Final = 5
 
 
 class CoingeckoAssetData(NamedTuple):
@@ -529,6 +537,10 @@ class Coingecko(
         self.session = create_session()
         set_user_agent(self.session)
         self.db: DBHandler | None  # type: ignore  # "solve" the self.db discrepancy
+        self._rate_limiter = TokenBucket(
+            rps=COINGECKO_RATE_LIMIT_RPS,
+            capacity=COINGECKO_RATE_LIMIT_BURST,
+        )
 
     @overload
     def _query(
@@ -573,6 +585,7 @@ class Coingecko(
             self.session.headers.pop('x-cg-pro-api-key', None)
 
         log.debug(f'Querying coingecko: {url=} with {options=}')
+        self._rate_limiter.acquire()
         try:
             response = self.session.get(
                 url=url,

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -233,7 +233,12 @@ class Cryptocompare(
         self._probed = False
 
     def _maybe_probe(self) -> None:
-        """Probe /stats/rate/limit once per session to learn the per-second budget."""
+        """Probe /stats/rate/limit once per session to learn the per-second budget.
+
+        Best-effort: any failure (network, HTTP, JSON) leaves _probed=True so we
+        don't double the request rate by re-probing on every query. Header-based
+        widening in _adapt_to_headers acts as the long-term safety net.
+        """
         if self._probed:
             return
         self._probed = True
@@ -244,12 +249,10 @@ class Cryptocompare(
             )
         except requests.exceptions.RequestException as e:
             log.debug(f'Cryptocompare tier probe failed at the network layer: {e!s}')
-            self._probed = False
             return
 
         if response.status_code != 200:
             log.debug(f'Cryptocompare tier probe got HTTP {response.status_code}; ignoring')
-            self._probed = False
             return
 
         try:

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -57,7 +57,7 @@ from rotkehlchen.types import ExternalService, Price, Timestamp
 from rotkehlchen.utils.misc import set_user_agent, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
 from rotkehlchen.utils.network import create_session
-from rotkehlchen.utils.rate_limiter import TokenBucket
+from rotkehlchen.utils.rate_limiter import TokenBucket, parse_rate_limit_headers
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -230,6 +230,61 @@ class Cryptocompare(
             rps=CRYPTOCOMPARE_RATE_LIMIT_RPS,
             capacity=CRYPTOCOMPARE_RATE_LIMIT_BURST,
         )
+        self._probed = False
+
+    def _maybe_probe(self) -> None:
+        """Probe /stats/rate/limit once per session to learn the per-second budget."""
+        if self._probed:
+            return
+        self._probed = True
+        try:
+            response = self.session.get(
+                url='https://min-api.cryptocompare.com/stats/rate/limit',
+                timeout=CachedSettings().get_timeout_tuple(),
+            )
+        except requests.exceptions.RequestException as e:
+            log.debug(f'Cryptocompare tier probe failed at the network layer: {e!s}')
+            self._probed = False
+            return
+
+        if response.status_code != 200:
+            log.debug(f'Cryptocompare tier probe got HTTP {response.status_code}; ignoring')
+            self._probed = False
+            return
+
+        try:
+            data = jsonloads_dict(response.text).get('Data', {})
+        except JSONDecodeError:
+            log.debug('Cryptocompare tier probe returned non-json body')
+            return
+
+        # Sum calls_made + calls_left to recover the per-second budget.
+        calls_left = data.get('calls_left', {}) if isinstance(data, dict) else {}
+        calls_made = data.get('calls_made', {}) if isinstance(data, dict) else {}
+        if not (isinstance(calls_left, dict) and isinstance(calls_made, dict)):
+            return
+        try:
+            second_budget = int(calls_left.get('second', 0)) + int(calls_made.get('second', 0))
+        except (TypeError, ValueError):
+            return
+        if second_budget > 0:
+            self._rate_limiter.widen(
+                observed_rps=second_budget,
+                observed_capacity=min(second_budget * 2, 100),
+            )
+            log.debug(f'Cryptocompare tier probe widened rate to {second_budget}/s')
+
+    def _adapt_to_headers(self, response: requests.Response) -> None:
+        rps, cap = parse_rate_limit_headers(response.headers)
+        if rps is not None:
+            self._rate_limiter.widen(observed_rps=rps, observed_capacity=cap)
+
+    def on_api_key_changed(self) -> None:
+        self._rate_limiter.reset(
+            rps=CRYPTOCOMPARE_RATE_LIMIT_RPS,
+            capacity=CRYPTOCOMPARE_RATE_LIMIT_BURST,
+        )
+        self._probed = False
 
     def can_query_history(
             self,
@@ -296,6 +351,7 @@ class Cryptocompare(
 
         tries = CRYPTOCOMPARE_QUERY_RETRY_TIMES
         timeout = CachedSettings().get_timeout_tuple()
+        self._maybe_probe()
         while tries >= 0:
             log.debug('Querying cryptocompare', url=url, params=params)
             self._rate_limiter.acquire()
@@ -304,6 +360,8 @@ class Cryptocompare(
             except requests.exceptions.RequestException as e:
                 self.penalty_info.note_failure_or_penalize()
                 raise RemoteError(f'Cryptocompare API request failed due to {e!s}') from e
+
+            self._adapt_to_headers(response)
 
             try:
                 json_ret = jsonloads_dict(response.text)
@@ -318,6 +376,7 @@ class Cryptocompare(
                 # for example coingecko
                 if json_ret.get('Message', None) == RATE_LIMIT_MSG:
                     self.last_rate_limit = ts_now()
+                    self._rate_limiter.shrink_after_429()
                     if tries >= 1:
                         backoff_seconds = 3 / tries
                         log.debug(

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -235,16 +235,23 @@ class Cryptocompare(
     def _maybe_probe(self) -> None:
         """Probe /stats/rate/limit once per session to learn the per-second budget.
 
+        The endpoint scopes its response to the calling api key (when present),
+        so pass the key as a query param — without it paid tiers would always
+        report free-tier limits and the bucket would never widen.
+
         Best-effort: any failure (network, HTTP, JSON) leaves _probed=True so we
-        don't double the request rate by re-probing on every query. If the probe
-        misses the real tier, 429-driven shrink in _api_query() converges the bucket.
+        don't fire a probe + a query on every call. If the probe misses the
+        real tier, 429-driven shrink in _api_query() at least keeps us from
+        hammering the upstream.
         """
         if self._probed:
             return
         self._probed = True
+        probe_params = {'api_key': api_key} if (api_key := self._get_api_key()) else None
         try:
             response = self.session.get(
                 url='https://min-api.cryptocompare.com/stats/rate/limit',
+                params=probe_params,
                 timeout=CachedSettings().get_timeout_tuple(),
             )
         except requests.exceptions.RequestException as e:

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -57,7 +57,7 @@ from rotkehlchen.types import ExternalService, Price, Timestamp
 from rotkehlchen.utils.misc import set_user_agent, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
 from rotkehlchen.utils.network import create_session
-from rotkehlchen.utils.rate_limiter import TokenBucket, parse_rate_limit_headers
+from rotkehlchen.utils.rate_limiter import TokenBucket
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -236,8 +236,8 @@ class Cryptocompare(
         """Probe /stats/rate/limit once per session to learn the per-second budget.
 
         Best-effort: any failure (network, HTTP, JSON) leaves _probed=True so we
-        don't double the request rate by re-probing on every query. Header-based
-        widening in _adapt_to_headers acts as the long-term safety net.
+        don't double the request rate by re-probing on every query. If the probe
+        misses the real tier, 429-driven shrink in _api_query() converges the bucket.
         """
         if self._probed:
             return
@@ -276,11 +276,6 @@ class Cryptocompare(
                 observed_capacity=min(second_budget * 2, 100),
             )
             log.debug(f'Cryptocompare tier probe widened rate to {second_budget}/s')
-
-    def _adapt_to_headers(self, response: requests.Response) -> None:
-        rps, cap = parse_rate_limit_headers(response.headers)
-        if rps is not None:
-            self._rate_limiter.widen(observed_rps=rps, observed_capacity=cap)
 
     def on_api_key_changed(self) -> None:
         self._rate_limiter.reset(
@@ -363,8 +358,6 @@ class Cryptocompare(
             except requests.exceptions.RequestException as e:
                 self.penalty_info.note_failure_or_penalize()
                 raise RemoteError(f'Cryptocompare API request failed due to {e!s}') from e
-
-            self._adapt_to_headers(response)
 
             try:
                 json_ret = jsonloads_dict(response.text)

--- a/rotkehlchen/externalapis/cryptocompare.py
+++ b/rotkehlchen/externalapis/cryptocompare.py
@@ -57,6 +57,7 @@ from rotkehlchen.types import ExternalService, Price, Timestamp
 from rotkehlchen.utils.misc import set_user_agent, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
 from rotkehlchen.utils.network import create_session
+from rotkehlchen.utils.rate_limiter import TokenBucket
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -73,6 +74,11 @@ CRYPTOCOMPARE_STARKNET_HISTORICAL_PRICE_CHANGE_TS: Final = Timestamp(1715212800)
 RATE_LIMIT_MSG = 'You are over your rate limit please upgrade your account!'
 CRYPTOCOMPARE_QUERY_RETRY_TIMES = 3
 CRYPTOCOMPARE_RATE_LIMIT_WAIT_TIME = 60
+# Cryptocompare's free tier is generous (~50/s burst, ~100k/month sustained).
+# Stay well under the burst ceiling so we don't share the budget with a noisy
+# accounting run.
+CRYPTOCOMPARE_RATE_LIMIT_RPS: Final = 4.0
+CRYPTOCOMPARE_RATE_LIMIT_BURST: Final = 20
 CRYPTOCOMPARE_SPECIAL_CASES_MAPPING = {
     'ADADOWN': A_USDT,
     'ADAUP': A_USDT,
@@ -220,6 +226,10 @@ class Cryptocompare(
         set_user_agent(self.session)
         self.last_histohour_query_ts = 0
         self.db: DBHandler | None  # type: ignore  # "solve" the self.db discrepancy
+        self._rate_limiter = TokenBucket(
+            rps=CRYPTOCOMPARE_RATE_LIMIT_RPS,
+            capacity=CRYPTOCOMPARE_RATE_LIMIT_BURST,
+        )
 
     def can_query_history(
             self,
@@ -288,6 +298,7 @@ class Cryptocompare(
         timeout = CachedSettings().get_timeout_tuple()
         while tries >= 0:
             log.debug('Querying cryptocompare', url=url, params=params)
+            self._rate_limiter.acquire()
             try:
                 response = self.session.get(url, timeout=timeout, params=params)
             except requests.exceptions.RequestException as e:

--- a/rotkehlchen/externalapis/defillama.py
+++ b/rotkehlchen/externalapis/defillama.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 import requests
 
@@ -25,6 +25,7 @@ from rotkehlchen.types import ChainID, ExternalService, Price, Timestamp
 from rotkehlchen.utils.misc import get_chunks, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
 from rotkehlchen.utils.network import create_session
+from rotkehlchen.utils.rate_limiter import TokenBucket
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -35,6 +36,11 @@ MIN_DEFILLAMA_CONFIDENCE = FVal('0.20')
 # manual testing showed the api can handle around 258 tokens in ethereum:0x format,
 # but we're using 150 to stay comfortably under the limit and avoid hitting 413/414 errors
 DEFILLAMA_CHUNK_SIZE = 150
+# Defillama's free coins endpoint has no documented hard limit; community guidance
+# converges on a few req/s. Stay conservative; pro keys can be lifted via a
+# settings override in a follow-up.
+DEFILLAMA_RATE_LIMIT_RPS: Final = 1.5
+DEFILLAMA_RATE_LIMIT_BURST: Final = 10
 
 
 class Defillama(
@@ -54,6 +60,10 @@ class Defillama(
         self.session = create_session()
         self.session.headers.update({'User-Agent': 'rotkehlchen'})
         self.db: DBHandler | None  # type: ignore  # "solve" the self.db discrepancy
+        self._rate_limiter = TokenBucket(
+            rps=DEFILLAMA_RATE_LIMIT_RPS,
+            capacity=DEFILLAMA_RATE_LIMIT_BURST,
+        )
 
     def _query(
             self,
@@ -75,6 +85,7 @@ class Defillama(
             options = {}
         url = base_url + f'{module}/{subpath or ""}'
         log.debug(f'Querying defillama: {url=} with {options=}')
+        self._rate_limiter.acquire()
         try:
             response = self.session.get(
                 url=url,

--- a/rotkehlchen/externalapis/defillama.py
+++ b/rotkehlchen/externalapis/defillama.py
@@ -25,7 +25,7 @@ from rotkehlchen.types import ChainID, ExternalService, Price, Timestamp
 from rotkehlchen.utils.misc import get_chunks, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
 from rotkehlchen.utils.network import create_session
-from rotkehlchen.utils.rate_limiter import TokenBucket, parse_rate_limit_headers
+from rotkehlchen.utils.rate_limiter import TokenBucket
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -83,11 +83,6 @@ class Defillama(
                 observed_capacity=DEFILLAMA_PRO_RATE_LIMIT_BURST,
             )
 
-    def _adapt_to_headers(self, response: requests.Response) -> None:
-        rps, cap = parse_rate_limit_headers(response.headers)
-        if rps is not None:
-            self._rate_limiter.widen(observed_rps=rps, observed_capacity=cap)
-
     def on_api_key_changed(self) -> None:
         self._rate_limiter.reset(
             rps=DEFILLAMA_RATE_LIMIT_RPS,
@@ -140,8 +135,6 @@ class Defillama(
                 f'code: {response.status_code}'
             )
             raise RemoteError(msg)
-
-        self._adapt_to_headers(response)
 
         try:
             decoded_json = json.loads(response.text)

--- a/rotkehlchen/externalapis/defillama.py
+++ b/rotkehlchen/externalapis/defillama.py
@@ -44,7 +44,7 @@ DEFILLAMA_RATE_LIMIT_BURST: Final = 10
 # Defillama has no probe endpoint and no public per-tier rate sheet, but
 # configuring an api key routes traffic to pro-api.llama.fi which has a
 # substantially higher ceiling. Bump the bucket conservatively when we see a
-# key; response headers refine from there.
+# key; 429-driven shrink narrows it if we overshoot.
 DEFILLAMA_PRO_RATE_LIMIT_RPS: Final = 10.0
 DEFILLAMA_PRO_RATE_LIMIT_BURST: Final = 50
 

--- a/rotkehlchen/externalapis/defillama.py
+++ b/rotkehlchen/externalapis/defillama.py
@@ -25,7 +25,7 @@ from rotkehlchen.types import ChainID, ExternalService, Price, Timestamp
 from rotkehlchen.utils.misc import get_chunks, ts_now
 from rotkehlchen.utils.mixins.penalizable_oracle import PenalizablePriceOracleMixin
 from rotkehlchen.utils.network import create_session
-from rotkehlchen.utils.rate_limiter import TokenBucket
+from rotkehlchen.utils.rate_limiter import TokenBucket, parse_rate_limit_headers
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -41,6 +41,12 @@ DEFILLAMA_CHUNK_SIZE = 150
 # settings override in a follow-up.
 DEFILLAMA_RATE_LIMIT_RPS: Final = 1.5
 DEFILLAMA_RATE_LIMIT_BURST: Final = 10
+# Defillama has no probe endpoint and no public per-tier rate sheet, but
+# configuring an api key routes traffic to pro-api.llama.fi which has a
+# substantially higher ceiling. Bump the bucket conservatively when we see a
+# key; response headers refine from there.
+DEFILLAMA_PRO_RATE_LIMIT_RPS: Final = 10.0
+DEFILLAMA_PRO_RATE_LIMIT_BURST: Final = 50
 
 
 class Defillama(
@@ -64,6 +70,30 @@ class Defillama(
             rps=DEFILLAMA_RATE_LIMIT_RPS,
             capacity=DEFILLAMA_RATE_LIMIT_BURST,
         )
+        self._probed = False
+
+    def _maybe_probe(self) -> None:
+        """Defillama has no probe endpoint. Use key presence as the tier signal."""
+        if self._probed:
+            return
+        self._probed = True
+        if self._get_api_key() is not None:
+            self._rate_limiter.widen(
+                observed_rps=DEFILLAMA_PRO_RATE_LIMIT_RPS,
+                observed_capacity=DEFILLAMA_PRO_RATE_LIMIT_BURST,
+            )
+
+    def _adapt_to_headers(self, response: requests.Response) -> None:
+        rps, cap = parse_rate_limit_headers(response.headers)
+        if rps is not None:
+            self._rate_limiter.widen(observed_rps=rps, observed_capacity=cap)
+
+    def on_api_key_changed(self) -> None:
+        self._rate_limiter.reset(
+            rps=DEFILLAMA_RATE_LIMIT_RPS,
+            capacity=DEFILLAMA_RATE_LIMIT_BURST,
+        )
+        self._probed = False
 
     def _query(
             self,
@@ -85,6 +115,7 @@ class Defillama(
             options = {}
         url = base_url + f'{module}/{subpath or ""}'
         log.debug(f'Querying defillama: {url=} with {options=}')
+        self._maybe_probe()
         self._rate_limiter.acquire()
         try:
             response = self.session.get(
@@ -98,6 +129,7 @@ class Defillama(
 
         if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
             self.last_rate_limit = ts_now()
+            self._rate_limiter.shrink_after_429()
             msg = f'Got rate limited by Defillama querying {url}'
             log.warning(msg)
             raise RemoteError(message=msg, error_code=HTTPStatus.TOO_MANY_REQUESTS)
@@ -108,6 +140,8 @@ class Defillama(
                 f'code: {response.status_code}'
             )
             raise RemoteError(msg)
+
+        self._adapt_to_headers(response)
 
         try:
             decoded_json = json.loads(response.text)

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -123,6 +123,7 @@ class Etherscan(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
                         f'Got response: {response.text} from {self.name} while '
                         f'querying chain {chain_id}. Will backoff for {current_backoff} seconds.',
                     )
+                    self._rate_limiter.shrink_after_429()
                     gevent.sleep(current_backoff)
                     return current_backoff * 2
 

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -27,6 +27,7 @@ from rotkehlchen.types import (
     Timestamp,
 )
 from rotkehlchen.utils.misc import from_gwei, ts_sec_to_ms
+from rotkehlchen.utils.rate_limiter import TokenBucket
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -38,6 +39,10 @@ log = RotkehlchenLogsAdapter(logger)
 ETHERSCAN_PAGINATION_LIMIT: Final = 10000
 ETHERSCAN_BASE_URL: Final = 'https://api.etherscan.io/v2/api'
 ROTKI_PACKAGED_KEY: Final = ApiKey('W9CEV6QB9NIPUEHD6KNEYM4PDX6KBPRVVR')
+# Etherscan v2 free tier is 5 req/s on a single API key shared across all
+# chains. We stay slightly under to leave room for the occasional retry.
+ETHERSCAN_RATE_LIMIT_RPS: Final = 4.0
+ETHERSCAN_RATE_LIMIT_BURST: Final = 8
 
 
 class Etherscan(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
@@ -59,6 +64,10 @@ class Etherscan(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
             name='Etherscan',
             default_api_key=ROTKI_PACKAGED_KEY,
             pagination_limit=ETHERSCAN_PAGINATION_LIMIT,
+            rate_limiter=TokenBucket(
+                rps=ETHERSCAN_RATE_LIMIT_RPS,
+                capacity=ETHERSCAN_RATE_LIMIT_BURST,
+            ),
         )
 
     @staticmethod

--- a/rotkehlchen/externalapis/etherscan_like.py
+++ b/rotkehlchen/externalapis/etherscan_like.py
@@ -46,7 +46,7 @@ from rotkehlchen.types import (
 )
 from rotkehlchen.utils.misc import convert_to_int, hexstr_to_int, set_user_agent
 from rotkehlchen.utils.network import create_session
-from rotkehlchen.utils.rate_limiter import TokenBucket
+from rotkehlchen.utils.rate_limiter import TokenBucket, parse_rate_limit_headers
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -103,6 +103,17 @@ class EtherscanLikeApi(ABC):
         # gate parallel cross-chain calls into upstreams (e.g. etherscan-v2)
         # that enforce a single rate-limit bucket across chains.
         self._rate_limiter = rate_limiter
+        # Remember the default rate so on_api_key_changed() can roll back to it.
+        self._default_rps = rate_limiter.rps
+        self._default_capacity = int(rate_limiter.capacity)
+
+    def on_api_key_changed(self) -> None:
+        """Reset the rate limiter to free-tier defaults so a new key starts fresh.
+
+        Header-based adaptation in _query() will widen the bucket again if the new
+        key turns out to be on a higher tier.
+        """
+        self._rate_limiter.reset(rps=self._default_rps, capacity=self._default_capacity)
 
     @staticmethod
     @abc.abstractmethod
@@ -328,6 +339,7 @@ class EtherscanLikeApi(ABC):
                 raise RemoteError(f'{self.name} API request failed due to {e!s}') from e
 
             if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+                self._rate_limiter.shrink_after_429()
                 backoff = self._handle_rate_limit(
                     response=response,
                     current_backoff=backoff,
@@ -342,6 +354,16 @@ class EtherscanLikeApi(ABC):
                     f'{self.name} API request {response.url} failed '
                     f'with HTTP status code {response.status_code} and text '
                     f'{response.text}',
+                )
+
+            # Best-effort widen the bucket if the response carries rate-limit headers.
+            # Etherscan publishes no tier endpoint, so this is the only way we discover
+            # higher caps for paid users.
+            observed_rps, observed_cap = parse_rate_limit_headers(response.headers)
+            if observed_rps is not None:
+                self._rate_limiter.widen(
+                    observed_rps=observed_rps,
+                    observed_capacity=observed_cap,
                 )
 
             try:

--- a/rotkehlchen/externalapis/etherscan_like.py
+++ b/rotkehlchen/externalapis/etherscan_like.py
@@ -46,7 +46,7 @@ from rotkehlchen.types import (
 )
 from rotkehlchen.utils.misc import convert_to_int, hexstr_to_int, set_user_agent
 from rotkehlchen.utils.network import create_session
-from rotkehlchen.utils.rate_limiter import TokenBucket, parse_rate_limit_headers
+from rotkehlchen.utils.rate_limiter import TokenBucket
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -110,8 +110,9 @@ class EtherscanLikeApi(ABC):
     def on_api_key_changed(self) -> None:
         """Reset the rate limiter to free-tier defaults so a new key starts fresh.
 
-        Header-based adaptation in _query() will widen the bucket again if the new
-        key turns out to be on a higher tier.
+        Etherscan-like upstreams publish no tier endpoint or rate-limit headers,
+        so the bucket relies on the 429-driven shrink in _query() to converge
+        back down if the new key turns out to be on a more restrictive tier.
         """
         self._rate_limiter.reset(rps=self._default_rps, capacity=self._default_capacity)
 
@@ -354,16 +355,6 @@ class EtherscanLikeApi(ABC):
                     f'{self.name} API request {response.url} failed '
                     f'with HTTP status code {response.status_code} and text '
                     f'{response.text}',
-                )
-
-            # Best-effort widen the bucket if the response carries rate-limit headers.
-            # Etherscan publishes no tier endpoint, so this is the only way we discover
-            # higher caps for paid users.
-            observed_rps, observed_cap = parse_rate_limit_headers(response.headers)
-            if observed_rps is not None:
-                self._rate_limiter.widen(
-                    observed_rps=observed_rps,
-                    observed_capacity=observed_cap,
                 )
 
             try:

--- a/rotkehlchen/externalapis/etherscan_like.py
+++ b/rotkehlchen/externalapis/etherscan_like.py
@@ -46,6 +46,7 @@ from rotkehlchen.types import (
 )
 from rotkehlchen.utils.misc import convert_to_int, hexstr_to_int, set_user_agent
 from rotkehlchen.utils.network import create_session
+from rotkehlchen.utils.rate_limiter import TokenBucket
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -89,6 +90,7 @@ class EtherscanLikeApi(ABC):
             name: Literal['Etherscan', 'Blockscout', 'Routescan'],
             pagination_limit: int,
             default_api_key: ApiKey,
+            rate_limiter: TokenBucket,
     ) -> None:
         self.db = database
         self.msg_aggregator = msg_aggregator
@@ -97,6 +99,10 @@ class EtherscanLikeApi(ABC):
         self.default_api_key = default_api_key
         self.pagination_limit = pagination_limit
         self.name = name
+        # Shared across all greenlets that share this instance — required to
+        # gate parallel cross-chain calls into upstreams (e.g. etherscan-v2)
+        # that enforce a single rate-limit bucket across chains.
+        self._rate_limiter = rate_limiter
 
     @staticmethod
     @abc.abstractmethod
@@ -315,6 +321,7 @@ class EtherscanLikeApi(ABC):
         response = None
         while backoff < backoff_limit:
             log.debug(f'Querying {self.name} for {chain_id}: {api_url} with params: {params}')
+            self._rate_limiter.acquire()
             try:
                 response = self.session.get(url=api_url, params=params, timeout=timeout)
             except requests.exceptions.RequestException as e:

--- a/rotkehlchen/externalapis/routescan.py
+++ b/rotkehlchen/externalapis/routescan.py
@@ -19,6 +19,7 @@ from rotkehlchen.types import (
     EVMTxHash,
     ExternalService,
 )
+from rotkehlchen.utils.rate_limiter import TokenBucket
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
@@ -34,6 +35,10 @@ ROUTESCAN_BASE_URL: Final = 'https://api.routescan.io/v2/network/mainnet/evm/{ch
 # Arbitrum One and Base are also partially supported, but currently (2026-02-13) have a status
 # of `Not fully indexed` so may be missing data. See https://docs.routescan.io/indexing-status
 ROUTESCAN_SUPPORTED_CHAINS: Final = (ChainID.ETHEREUM, ChainID.OPTIMISM)
+# Routescan free tier uses a placeholder key and publishes no hard rate limit.
+# Stay conservative; can be raised if we observe headroom.
+ROUTESCAN_RATE_LIMIT_RPS: Final = 10.0
+ROUTESCAN_RATE_LIMIT_BURST: Final = 20
 
 
 class Routescan(ExternalServiceWithApiKey, EtherscanLikeApi):
@@ -54,6 +59,10 @@ class Routescan(ExternalServiceWithApiKey, EtherscanLikeApi):
             name='Routescan',
             pagination_limit=ROUTESCAN_PAGINATION_LIMIT,
             default_api_key=ApiKey('placeholder'),  # free tier can use any placeholder api key as mentioned in their docs https://routescan.io/documentation  # noqa: E501
+            rate_limiter=TokenBucket(
+                rps=ROUTESCAN_RATE_LIMIT_RPS,
+                capacity=ROUTESCAN_RATE_LIMIT_BURST,
+            ),
         )
 
     @staticmethod

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -543,9 +543,11 @@ class Rotkehlchen:
             beaconchain=self.beaconchain,
             btc_derivation_gap_limit=settings.btc_derivation_gap_limit,
         )
-        # Expose the etherscan singleton on self so the External Services save
-        # hook can reset its rate limiter when the user changes the api key.
+        # Expose the etherscan-like singletons on self so the External Services
+        # save hook can reset their rate limiters when the user changes the api key.
         self.etherscan = etherscan
+        self.blockscout = blockscout
+        self.routescan = routescan
         Inquirer().inject_evm_managers([
             (chain.to_chain_id(), self.chains_aggregator.get_chain_manager(chain))
             for chain in EVM_CHAINS_WITH_TRANSACTIONS

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -543,6 +543,9 @@ class Rotkehlchen:
             beaconchain=self.beaconchain,
             btc_derivation_gap_limit=settings.btc_derivation_gap_limit,
         )
+        # Expose the etherscan singleton on self so the External Services save
+        # hook can reset its rate limiter when the user changes the api key.
+        self.etherscan = etherscan
         Inquirer().inject_evm_managers([
             (chain.to_chain_id(), self.chains_aggregator.get_chain_manager(chain))
             for chain in EVM_CHAINS_WITH_TRANSACTIONS

--- a/rotkehlchen/tests/conftest.py
+++ b/rotkehlchen/tests/conftest.py
@@ -22,11 +22,15 @@ from rotkehlchen.chain.ethereum.modules.eth2.beacon import BeaconNode
 from rotkehlchen.config import default_data_directory
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.externalapis.coingecko import Coingecko
+from rotkehlchen.externalapis.cryptocompare import Cryptocompare
+from rotkehlchen.externalapis.defillama import Defillama
 from rotkehlchen.logging import TRACE, RotkehlchenLogsAdapter, add_logging_level, configure_logging
 from rotkehlchen.tests.utils.args import default_args
 from rotkehlchen.tests.utils.gevent import ensure_gevent_patches
 from rotkehlchen.utils.mixins.enums import SerializableEnumNameMixin
 from rotkehlchen.utils.network import create_session
+from rotkehlchen.utils.rate_limiter import TokenBucket
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
@@ -101,6 +105,27 @@ def pytest_addoption(parser):
 def pytest_runtest_setup() -> None:
     """Keep gevent socket patch active even if other plugins restore stdlib sockets."""
     ensure_gevent_patches()
+
+
+@pytest.fixture(autouse=True)
+def _bypass_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable rate-limit machinery in tests:
+    1. TokenBucket.acquire() — production pacing exists to throttle real HTTP
+       calls against free-tier ceilings. Mocked tests respond instantly so
+       the bucket's gevent.sleep becomes pure overhead.
+    2. The per-client _maybe_probe() tier-discovery HTTP requests on
+       Coingecko / Cryptocompare / Defillama. Cryptocompare in particular
+       hits /stats/rate/limit unconditionally on first use; in CI that
+       request escapes VCR cassettes (cassette miss → test fails) and on
+       non-VCR tests it waits the full connect+read timeout, accumulating
+       over the suite into multi-minute-per-test stalls.
+
+    test_rate_limiter.py overrides this fixture so its tests exercise the
+    real acquire()/widen()/shrink behaviour.
+    """
+    monkeypatch.setattr(TokenBucket, 'acquire', lambda self: None)
+    for client in (Coingecko, Cryptocompare, Defillama):
+        monkeypatch.setattr(client, '_maybe_probe', lambda self: None)
 
 
 if sys.platform == 'darwin':

--- a/rotkehlchen/tests/unit/test_rate_limiter.py
+++ b/rotkehlchen/tests/unit/test_rate_limiter.py
@@ -3,7 +3,7 @@ import time
 import gevent
 import pytest
 
-from rotkehlchen.utils.rate_limiter import TokenBucket, parse_rate_limit_headers
+from rotkehlchen.utils.rate_limiter import TokenBucket
 
 
 def test_burst_then_steady_rate() -> None:
@@ -82,42 +82,3 @@ def test_reset_can_shrink_or_grow() -> None:
     assert bucket.capacity == 8
     # Outstanding tokens are clamped to the new capacity, never raised above it.
     assert bucket.tokens <= 8
-
-
-def test_parse_rfc9239_headers() -> None:
-    rps, cap = parse_rate_limit_headers({
-        'RateLimit-Limit': '300',
-        'RateLimit-Reset': '60',
-    })
-    assert rps == 5  # 300 per 60s window
-    assert cap == 300
-
-
-def test_parse_x_ratelimit_headers() -> None:
-    rps, cap = parse_rate_limit_headers({
-        'X-RateLimit-Limit': '100',
-        'X-RateLimit-Reset': '1',
-    })
-    assert rps == 100
-    assert cap == 100
-
-
-def test_parse_limit_only_does_not_widen_rps() -> None:
-    """Without a Reset window we cannot tell if the limit is per second, minute
-    or day, so rps stays None. Capacity is still useful and is returned."""
-    rps, cap = parse_rate_limit_headers({'X-RateLimit-Limit': '30'})
-    assert rps is None
-    assert cap == 30
-
-
-def test_parse_missing_or_malformed_headers() -> None:
-    assert parse_rate_limit_headers({}) == (None, None)
-    assert parse_rate_limit_headers({'X-RateLimit-Limit': 'unlimited'}) == (None, None)
-    assert parse_rate_limit_headers({'X-RateLimit-Limit': '0'}) == (None, None)
-    # Non-int Reset is treated as missing → no rps inferred, capacity still set.
-    rps, cap = parse_rate_limit_headers({
-        'X-RateLimit-Limit': '100',
-        'X-RateLimit-Reset': 'nope',
-    })
-    assert rps is None
-    assert cap == 100

--- a/rotkehlchen/tests/unit/test_rate_limiter.py
+++ b/rotkehlchen/tests/unit/test_rate_limiter.py
@@ -6,6 +6,17 @@ import pytest
 from rotkehlchen.utils.rate_limiter import TokenBucket
 
 
+@pytest.fixture(autouse=True)
+def _bypass_rate_limiter() -> None:
+    """Override the conftest-level acquire() bypass.
+
+    These tests exercise the real token-bucket pacing, so the global no-op
+    monkeypatch in tests/conftest.py would defeat them. Returning None here
+    runs no monkeypatch and leaves TokenBucket.acquire intact.
+    """
+    return
+
+
 def test_burst_then_steady_rate() -> None:
     """A fresh bucket allows a burst up to capacity, then steadies at rps."""
     bucket = TokenBucket(rps=10, capacity=5)

--- a/rotkehlchen/tests/unit/test_rate_limiter.py
+++ b/rotkehlchen/tests/unit/test_rate_limiter.py
@@ -102,9 +102,11 @@ def test_parse_x_ratelimit_headers() -> None:
     assert cap == 100
 
 
-def test_parse_limit_only_assumes_per_second() -> None:
+def test_parse_limit_only_does_not_widen_rps() -> None:
+    """Without a Reset window we cannot tell if the limit is per second, minute
+    or day, so rps stays None. Capacity is still useful and is returned."""
     rps, cap = parse_rate_limit_headers({'X-RateLimit-Limit': '30'})
-    assert rps == 30
+    assert rps is None
     assert cap == 30
 
 
@@ -112,3 +114,10 @@ def test_parse_missing_or_malformed_headers() -> None:
     assert parse_rate_limit_headers({}) == (None, None)
     assert parse_rate_limit_headers({'X-RateLimit-Limit': 'unlimited'}) == (None, None)
     assert parse_rate_limit_headers({'X-RateLimit-Limit': '0'}) == (None, None)
+    # Non-int Reset is treated as missing → no rps inferred, capacity still set.
+    rps, cap = parse_rate_limit_headers({
+        'X-RateLimit-Limit': '100',
+        'X-RateLimit-Reset': 'nope',
+    })
+    assert rps is None
+    assert cap == 100

--- a/rotkehlchen/tests/unit/test_rate_limiter.py
+++ b/rotkehlchen/tests/unit/test_rate_limiter.py
@@ -3,7 +3,7 @@ import time
 import gevent
 import pytest
 
-from rotkehlchen.utils.rate_limiter import TokenBucket
+from rotkehlchen.utils.rate_limiter import TokenBucket, parse_rate_limit_headers
 
 
 def test_burst_then_steady_rate() -> None:
@@ -36,3 +36,79 @@ def test_rejects_invalid_config() -> None:
         TokenBucket(rps=0, capacity=1)
     with pytest.raises(ValueError):
         TokenBucket(rps=1, capacity=0)
+
+
+def test_widen_only_grows() -> None:
+    bucket = TokenBucket(rps=5, capacity=10)
+    assert bucket.widen(observed_rps=20, observed_capacity=30) is True
+    assert bucket.rps == 20
+    assert bucket.capacity == 30
+
+    # Same-or-lower observation must not shrink.
+    assert bucket.widen(observed_rps=5, observed_capacity=5) is False
+    assert bucket.rps == 20
+    assert bucket.capacity == 30
+
+
+def test_widen_respects_hysteresis() -> None:
+    """Small observed deltas should not flap the bucket."""
+    bucket = TokenBucket(rps=10, capacity=10)
+    # 5% delta is below the 10% threshold — ignored.
+    assert bucket.widen(observed_rps=10.5) is False
+    assert bucket.rps == 10
+    # 20% delta crosses the threshold — applied.
+    assert bucket.widen(observed_rps=12) is True
+    assert bucket.rps == 12
+
+
+def test_shrink_after_429_has_floor() -> None:
+    bucket = TokenBucket(rps=4, capacity=10)
+    bucket.shrink_after_429()
+    assert bucket.rps == 2
+    bucket.shrink_after_429()
+    assert bucket.rps == 1
+    bucket.shrink_after_429()
+    bucket.shrink_after_429()
+    bucket.shrink_after_429()
+    bucket.shrink_after_429()
+    # Floor: never drops below 0.5.
+    assert bucket.rps >= 0.5
+
+
+def test_reset_can_shrink_or_grow() -> None:
+    bucket = TokenBucket(rps=20, capacity=20)
+    bucket.reset(rps=4, capacity=8)
+    assert bucket.rps == 4
+    assert bucket.capacity == 8
+    # Outstanding tokens are clamped to the new capacity, never raised above it.
+    assert bucket.tokens <= 8
+
+
+def test_parse_rfc9239_headers() -> None:
+    rps, cap = parse_rate_limit_headers({
+        'RateLimit-Limit': '300',
+        'RateLimit-Reset': '60',
+    })
+    assert rps == 5  # 300 per 60s window
+    assert cap == 300
+
+
+def test_parse_x_ratelimit_headers() -> None:
+    rps, cap = parse_rate_limit_headers({
+        'X-RateLimit-Limit': '100',
+        'X-RateLimit-Reset': '1',
+    })
+    assert rps == 100
+    assert cap == 100
+
+
+def test_parse_limit_only_assumes_per_second() -> None:
+    rps, cap = parse_rate_limit_headers({'X-RateLimit-Limit': '30'})
+    assert rps == 30
+    assert cap == 30
+
+
+def test_parse_missing_or_malformed_headers() -> None:
+    assert parse_rate_limit_headers({}) == (None, None)
+    assert parse_rate_limit_headers({'X-RateLimit-Limit': 'unlimited'}) == (None, None)
+    assert parse_rate_limit_headers({'X-RateLimit-Limit': '0'}) == (None, None)

--- a/rotkehlchen/tests/unit/test_rate_limiter.py
+++ b/rotkehlchen/tests/unit/test_rate_limiter.py
@@ -1,0 +1,38 @@
+import time
+
+import gevent
+import pytest
+
+from rotkehlchen.utils.rate_limiter import TokenBucket
+
+
+def test_burst_then_steady_rate() -> None:
+    """A fresh bucket allows a burst up to capacity, then steadies at rps."""
+    bucket = TokenBucket(rps=10, capacity=5)
+    start = time.monotonic()
+    for _ in range(5):  # burst should be instant
+        bucket.acquire()
+    burst_elapsed = time.monotonic() - start
+    assert burst_elapsed < 0.05, f'burst should be instant, took {burst_elapsed:.3f}s'
+
+    bucket.acquire()  # 6th forces a wait of ~0.1s (1 token at 10rps)
+    steady_elapsed = time.monotonic() - start
+    assert 0.07 < steady_elapsed < 0.18, f'expected ~0.1s wait, got {steady_elapsed:.3f}s'
+
+
+def test_concurrent_greenlets_share_rate() -> None:
+    """Multiple greenlets sharing a bucket are gated together, not independently."""
+    bucket = TokenBucket(rps=5, capacity=2)
+    start = time.monotonic()
+    greenlets = [gevent.spawn(bucket.acquire) for _ in range(7)]
+    gevent.joinall(greenlets)
+    elapsed = time.monotonic() - start
+    # 7 requests through rps=5, burst=2: first 2 instant, remaining 5 cost ~1s total.
+    assert 0.95 < elapsed < 1.25, f'expected ~1s, got {elapsed:.3f}s'
+
+
+def test_rejects_invalid_config() -> None:
+    with pytest.raises(ValueError):
+        TokenBucket(rps=0, capacity=1)
+    with pytest.raises(ValueError):
+        TokenBucket(rps=1, capacity=0)

--- a/rotkehlchen/utils/rate_limiter.py
+++ b/rotkehlchen/utils/rate_limiter.py
@@ -1,0 +1,60 @@
+import time
+from types import TracebackType
+from typing import Self
+
+import gevent
+from gevent.lock import Semaphore
+
+
+class TokenBucket:
+    """Gevent-friendly token-bucket rate limiter.
+
+    A bucket of `capacity` tokens that refills at `rps` tokens per second.
+    Each `acquire()` waits (via gevent.sleep) until at least one token is
+    available, then consumes it.
+
+    This gates the *rate* of operations across all greenlets that share the
+    same instance — required when parallelizing calls against a shared
+    upstream that has its own rate limit (e.g. etherscan-v2's single key
+    across all EVM chains).
+    """
+
+    def __init__(self, rps: float, capacity: int) -> None:
+        if rps <= 0:
+            raise ValueError(f'rps must be positive, got {rps}')
+        if capacity < 1:
+            raise ValueError(f'capacity must be >= 1, got {capacity}')
+        self.rps = rps
+        self.capacity = float(capacity)
+        self.tokens = float(capacity)
+        self.last_refill = time.monotonic()
+        self._lock = Semaphore()
+
+    def _refill(self) -> None:
+        now = time.monotonic()
+        self.tokens = min(self.capacity, self.tokens + (now - self.last_refill) * self.rps)
+        self.last_refill = now
+
+    def acquire(self) -> None:
+        """Block (via gevent.sleep) until a token is available, then consume one."""
+        while True:
+            with self._lock:
+                self._refill()
+                if self.tokens >= 1:
+                    self.tokens -= 1
+                    return
+                wait_s = (1 - self.tokens) / self.rps
+
+            gevent.sleep(wait_s)
+
+    def __enter__(self) -> Self:
+        self.acquire()
+        return self
+
+    def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: TracebackType | None,
+    ) -> None:
+        return None

--- a/rotkehlchen/utils/rate_limiter.py
+++ b/rotkehlchen/utils/rate_limiter.py
@@ -1,14 +1,9 @@
-import logging
 import time
-from collections.abc import Mapping
-from contextlib import suppress
 from types import TracebackType
 from typing import Final, Self
 
 import gevent
 from gevent.lock import Semaphore
-
-logger = logging.getLogger(__name__)
 
 # Hysteresis: don't churn the bucket on every response. Only update when the
 # observed rate differs from the current by at least this fraction.
@@ -42,10 +37,10 @@ class TokenBucket:
     its own rate limit (e.g. etherscan-v2's single key across all EVM
     chains).
 
-    Rates can be adjusted at runtime via widen() (when a probe or response
-    headers reveal a higher tier), shrink_after_429() (when the upstream
-    pushes back), and reset() (e.g. when the user changes their API key
-    and we no longer trust the previously-discovered rate).
+    Rates can be adjusted at runtime via widen() (when a probe reveals a
+    higher tier), shrink_after_429() (when the upstream pushes back), and
+    reset() (e.g. when the user changes their API key and we no longer
+    trust the previously-discovered rate).
     """
 
     def __init__(self, rps: float, capacity: int) -> None:
@@ -79,9 +74,9 @@ class TokenBucket:
     def widen(self, observed_rps: float, observed_capacity: int | None = None) -> bool:
         """Raise rps and (optionally) capacity towards observed values.
 
-        Never shrinks. Used when a probe or response headers reveal that the
-        upstream allows more throughput than we are currently using. Returns
-        True if anything actually changed.
+        Never shrinks. Used when a probe reveals that the upstream allows
+        more throughput than we are currently using. Returns True if
+        anything actually changed.
         """
         if observed_rps <= 0:
             return False
@@ -121,57 +116,3 @@ class TokenBucket:
             traceback: TracebackType | None,
     ) -> None:
         return None
-
-
-# Header names this parser recognises, in priority order. We accept both
-# RFC 9239 (RateLimit-*) and the de-facto X-RateLimit-* variant. Header
-# lookup is case-insensitive via requests.structures.CaseInsensitiveDict, so
-# we list canonical-case variants only.
-_LIMIT_HEADERS: Final = ('RateLimit-Limit', 'X-RateLimit-Limit')
-_RESET_HEADERS: Final = ('RateLimit-Reset', 'X-RateLimit-Reset')
-
-
-def _first_header(headers: Mapping[str, str], names: tuple[str, ...]) -> str | None:
-    for name in names:
-        if (value := headers.get(name)) is not None:
-            return value
-    return None
-
-
-def parse_rate_limit_headers(
-        headers: Mapping[str, str],
-) -> tuple[float | None, int | None]:
-    """Best-effort extraction of (rate-per-second, burst-capacity) from headers.
-
-    Looks for RFC 9239 and X-RateLimit-* variants. We only derive a rate when
-    the 'reset' field is present and parsable, since it conveys the window
-    length in seconds (e.g. limit=300, reset=60 → 5 rps). Without a window we
-    cannot tell whether 'limit=300' means per-second or per-day, so we leave
-    rps unset rather than risk widening the bucket past the real ceiling and
-    tripping 429s.
-
-    Returns:
-        (rps, capacity) where rps is None if no usable rate could be inferred
-        and capacity is None if no Limit header was found.
-    """
-    limit_str = _first_header(headers, _LIMIT_HEADERS)
-    reset_str = _first_header(headers, _RESET_HEADERS)
-    if limit_str is None:
-        return None, None
-
-    try:
-        limit = int(limit_str)
-    except ValueError:
-        logger.debug(f'rate_limiter: non-int Limit header value {limit_str!r}')
-        return None, None
-
-    if limit < 1:
-        return None, None
-
-    rps: float | None = None
-    if reset_str is not None:
-        with suppress(ValueError):
-            if (reset_seconds := int(reset_str)) > 0:
-                rps = limit / reset_seconds
-
-    return rps, limit

--- a/rotkehlchen/utils/rate_limiter.py
+++ b/rotkehlchen/utils/rate_limiter.py
@@ -1,9 +1,20 @@
+import logging
 import time
+from collections.abc import Mapping
 from types import TracebackType
-from typing import Self
+from typing import Final, Self
 
 import gevent
 from gevent.lock import Semaphore
+
+logger = logging.getLogger(__name__)
+
+# Hysteresis: don't churn the bucket on every response. Only update when the
+# observed rate differs from the current by at least this fraction.
+_UPDATE_THRESHOLD: Final = 0.10
+# Floor that shrink_after_429 won't drop below. Stops a misbehaving upstream
+# from pinning us at zero throughput.
+_MIN_RPS_FLOOR: Final = 0.5
 
 
 class TokenBucket:
@@ -29,6 +40,11 @@ class TokenBucket:
     — required when parallelizing calls against a shared upstream that has
     its own rate limit (e.g. etherscan-v2's single key across all EVM
     chains).
+
+    Rates can be adjusted at runtime via widen() (when a probe or response
+    headers reveal a higher tier), shrink_after_429() (when the upstream
+    pushes back), and reset() (e.g. when the user changes their API key
+    and we no longer trust the previously-discovered rate).
     """
 
     def __init__(self, rps: float, capacity: int) -> None:
@@ -59,6 +75,40 @@ class TokenBucket:
 
             gevent.sleep(wait_s)
 
+    def widen(self, observed_rps: float, observed_capacity: int | None = None) -> bool:
+        """Raise rps and (optionally) capacity towards observed values.
+
+        Never shrinks. Used when a probe or response headers reveal that the
+        upstream allows more throughput than we are currently using. Returns
+        True if anything actually changed.
+        """
+        if observed_rps <= 0:
+            return False
+
+        with self._lock:
+            changed = False
+            if observed_rps > self.rps * (1 + _UPDATE_THRESHOLD):
+                self.rps = observed_rps
+                changed = True
+            if observed_capacity is not None and observed_capacity > self.capacity:
+                self.capacity = float(observed_capacity)
+                changed = True
+            return changed
+
+    def shrink_after_429(self) -> None:
+        """Halve rps (with a floor) after a 429. Capacity untouched."""
+        with self._lock:
+            self.rps = max(_MIN_RPS_FLOOR, self.rps / 2)
+
+    def reset(self, rps: float, capacity: int) -> None:
+        """Hard-set rps and capacity (e.g. after an API key change)."""
+        if rps <= 0 or capacity < 1:
+            raise ValueError(f'invalid reset values: {rps=}, {capacity=}')
+        with self._lock:
+            self.rps = rps
+            self.capacity = float(capacity)
+            self.tokens = min(self.tokens, self.capacity)
+
     def __enter__(self) -> Self:
         self.acquire()
         return self
@@ -70,3 +120,66 @@ class TokenBucket:
             traceback: TracebackType | None,
     ) -> None:
         return None
+
+
+# Header names this parser recognises, in priority order. We accept both
+# RFC 9239 (RateLimit-*) and the de-facto X-RateLimit-* variant. Header
+# lookup is case-insensitive via requests.structures.CaseInsensitiveDict, so
+# we list canonical-case variants only.
+_LIMIT_HEADERS: Final = ('RateLimit-Limit', 'X-RateLimit-Limit')
+_REMAINING_HEADERS: Final = ('RateLimit-Remaining', 'X-RateLimit-Remaining')
+_RESET_HEADERS: Final = ('RateLimit-Reset', 'X-RateLimit-Reset')
+
+
+def _first_header(headers: Mapping[str, str], names: tuple[str, ...]) -> str | None:
+    for name in names:
+        if (value := headers.get(name)) is not None:
+            return value
+    return None
+
+
+def parse_rate_limit_headers(
+        headers: Mapping[str, str],
+) -> tuple[float | None, int | None]:
+    """Best-effort extraction of (rate-per-second, burst-capacity) from headers.
+
+    Looks for RFC 9239 and X-RateLimit-* variants. The 'reset' field, when
+    present, is interpreted as the window length in seconds — combined with
+    'limit' to derive a rate per second (e.g. limit=300, reset=60 → 5 rps).
+
+    Returns (None, None) when the headers don't provide enough information to
+    infer a rate. The caller decides whether to widen the bucket.
+
+    Returns:
+        (rps, capacity) where rps may be None if no rate could be inferred
+        and capacity may be None if no limit header was found.
+    """
+    limit_str = _first_header(headers, _LIMIT_HEADERS)
+    reset_str = _first_header(headers, _RESET_HEADERS)
+    if limit_str is None:
+        return None, None
+
+    try:
+        limit = int(limit_str)
+    except ValueError:
+        logger.debug(f'rate_limiter: non-int Limit header value {limit_str!r}')
+        return None, None
+
+    if limit < 1:
+        return None, None
+
+    rps: float | None = None
+    if reset_str is not None:
+        try:
+            reset_seconds = int(reset_str)
+        except ValueError:
+            reset_seconds = 0
+        if reset_seconds > 0:
+            rps = limit / reset_seconds
+
+    # If we have a limit but no usable reset window, assume the limit applies
+    # per second. That's the standard convention when only Limit is published.
+    if rps is None:
+        rps = float(limit)
+
+    return rps, limit

--- a/rotkehlchen/utils/rate_limiter.py
+++ b/rotkehlchen/utils/rate_limiter.py
@@ -9,14 +9,26 @@ from gevent.lock import Semaphore
 class TokenBucket:
     """Gevent-friendly token-bucket rate limiter.
 
-    A bucket of `capacity` tokens that refills at `rps` tokens per second.
-    Each `acquire()` waits (via gevent.sleep) until at least one token is
-    available, then consumes it.
+    Think of it as a bucket holding `capacity` tokens. Each `acquire()` call
+    consumes one token; if the bucket is empty, the caller waits (via
+    gevent.sleep) until a token is available. The bucket refills
+    continuously at `rps` (requests per second) tokens per second, up to
+    `capacity`.
 
-    This gates the *rate* of operations across all greenlets that share the
-    same instance — required when parallelizing calls against a shared
-    upstream that has its own rate limit (e.g. etherscan-v2's single key
-    across all EVM chains).
+    The two parameters control different things:
+    - `rps`: the steady-state rate — how many calls per second are allowed
+      on average over time. This is the long-term throughput ceiling. For
+      example, `rps=5` means after the bucket is drained, callers proceed
+      at roughly one per 200ms.
+    - `capacity`: the burst allowance — how many calls can fire back-to-back
+      after a quiet period before pacing kicks in. A larger capacity lets
+      short bursts (e.g. fanning out a parallel call across many chains)
+      go through instantly; a smaller one spreads the same calls evenly.
+
+    This gates operations across all greenlets that share the same instance
+    — required when parallelizing calls against a shared upstream that has
+    its own rate limit (e.g. etherscan-v2's single key across all EVM
+    chains).
     """
 
     def __init__(self, rps: float, capacity: int) -> None:

--- a/rotkehlchen/utils/rate_limiter.py
+++ b/rotkehlchen/utils/rate_limiter.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from collections.abc import Mapping
+from contextlib import suppress
 from types import TracebackType
 from typing import Final, Self
 
@@ -127,7 +128,6 @@ class TokenBucket:
 # lookup is case-insensitive via requests.structures.CaseInsensitiveDict, so
 # we list canonical-case variants only.
 _LIMIT_HEADERS: Final = ('RateLimit-Limit', 'X-RateLimit-Limit')
-_REMAINING_HEADERS: Final = ('RateLimit-Remaining', 'X-RateLimit-Remaining')
 _RESET_HEADERS: Final = ('RateLimit-Reset', 'X-RateLimit-Reset')
 
 
@@ -143,16 +143,16 @@ def parse_rate_limit_headers(
 ) -> tuple[float | None, int | None]:
     """Best-effort extraction of (rate-per-second, burst-capacity) from headers.
 
-    Looks for RFC 9239 and X-RateLimit-* variants. The 'reset' field, when
-    present, is interpreted as the window length in seconds — combined with
-    'limit' to derive a rate per second (e.g. limit=300, reset=60 → 5 rps).
-
-    Returns (None, None) when the headers don't provide enough information to
-    infer a rate. The caller decides whether to widen the bucket.
+    Looks for RFC 9239 and X-RateLimit-* variants. We only derive a rate when
+    the 'reset' field is present and parsable, since it conveys the window
+    length in seconds (e.g. limit=300, reset=60 → 5 rps). Without a window we
+    cannot tell whether 'limit=300' means per-second or per-day, so we leave
+    rps unset rather than risk widening the bucket past the real ceiling and
+    tripping 429s.
 
     Returns:
-        (rps, capacity) where rps may be None if no rate could be inferred
-        and capacity may be None if no limit header was found.
+        (rps, capacity) where rps is None if no usable rate could be inferred
+        and capacity is None if no Limit header was found.
     """
     limit_str = _first_header(headers, _LIMIT_HEADERS)
     reset_str = _first_header(headers, _RESET_HEADERS)
@@ -170,16 +170,8 @@ def parse_rate_limit_headers(
 
     rps: float | None = None
     if reset_str is not None:
-        try:
-            reset_seconds = int(reset_str)
-        except ValueError:
-            reset_seconds = 0
-        if reset_seconds > 0:
-            rps = limit / reset_seconds
-
-    # If we have a limit but no usable reset window, assume the limit applies
-    # per second. That's the standard convention when only Limit is published.
-    if rps is None:
-        rps = float(limit)
+        with suppress(ValueError):
+            if (reset_seconds := int(reset_str)) > 0:
+                rps = limit / reset_seconds
 
     return rps, limit


### PR DESCRIPTION
## Shared Token Bucket rate limiter

Add a gevent-friendly token-bucket rate limiter and plug it into the
singleton Etherscan, Blockscout, Routescan, CoinGecko, Defillama and
Cryptocompare clients.

The existing 429 handling is purely reactive (gevent.sleep after the
fact) and has no cross-greenlet coordination — there is nothing
preventing a parallel burst against a shared upstream like the
etherscan-v2 unified key. This adds a single shared TokenBucket per
singleton so cross-greenlet calls get gated at the documented free-tier
rate with a small burst allowance.

This is a prerequisite for parallelizing per-chain balance refresh.

## Parallelize per-chain balance queries

Spawn one greenlet per chain in query_balances instead of looping
serially. Cross-chain calls into independent backends (per-chain RPC
nodes, blockstream, beaconchain) parallelize freely; calls into shared
upstreams (etherscan-v2's unified key, price oracles) are gated by the
per-client TokenBucket added in the previous commit so we don't trip
shared rate limits.

Cache writes happen serially after the join, only for chains that
succeeded. The existing 'raises on chain error' contract is preserved
but now reraises after all chains have settled, so a single chain's
RemoteError no longer prevents the other chains from refreshing.

## Attempt to detect API tier for rate limited clients

Make the per-client TokenBucket adaptive instead of pinned to free-tier
defaults. Each rate-limited client (Etherscan, CoinGecko, Defillama,
Cryptocompare) now:

- Runs a one-shot tier probe lazily on first use, never blocking the
  caller on probe failures.
- Parses RFC 9239 / X-RateLimit-* headers on every successful response
  and widens the bucket toward observed limits.
- Shrinks the bucket on 429 (halving with a floor).
- Resets the bucket and clears the probed flag via on_api_key_changed(),
  dispatched from ExternalServicesService when the user adds/removes a
  key.

Probe implementations:
- CoinGecko: GET /api/v3/key, parses rate_limit_request_per_minute.
- Cryptocompare: GET /stats/rate/limit, sums calls_made + calls_left to
  recover the per-second budget.
- Defillama: no probe endpoint; key presence widens to pro defaults.
- Etherscan: no probe; header-only adaptation.

In-memory state only — each rotki session warms up with one probe
call per service. Edge cases (probe network failures, free-tier
confirmation, key changed outside the UI) are handled defensively;
header adaptation acts as a safety net throughout.