### PR TITLE
ci: bump rotki/action-gh-release to v3.0.0

### DIFF
--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: rotki/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        uses: rotki/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
@@ -165,7 +165,7 @@ jobs:
           uv run ./package.py --build full
 
       - name: Upload to release
-        uses: rotki/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        uses: rotki/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           name: Rotki ${{ env.RELEASE_VERSION }} -
@@ -279,7 +279,7 @@ jobs:
           path: dist/latest-mac-*.yml
 
       - name: Upload to release
-        uses: rotki/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        uses: rotki/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           name: Rotki ${{ env.RELEASE_VERSION }} -
@@ -326,7 +326,7 @@ jobs:
           node ./.github/scripts/merge-latest.mjs latest-mac/latest-mac-x86_64.yml latest-mac/latest-mac-arm64.yml latest-mac.yml
 
       - name: Upload to release
-        uses: rotki/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        uses: rotki/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           name: Rotki ${{ env.RELEASE_VERSION }} -
@@ -396,7 +396,7 @@ jobs:
         shell: powershell
 
       - name: Upload to release
-        uses: rotki/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        uses: rotki/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           name: Rotki ${{ env.RELEASE_VERSION }} -


### PR DESCRIPTION
## Summary
- Bump `rotki/action-gh-release` from v2.5.0 (`a06a81a`) to v3.0.0 (`b430933`) in all 5 usage sites in `rotki_release.yaml`
- The rotki fork was synced with upstream `softprops/action-gh-release` on 2026-05-08

## Why
Notable improvements relevant to this workflow:
- **Node 24 runtime** — all release runners (`ubuntu-latest`, `ubuntu-22.04`, `macos-15`, `macos-15-intel`, `windows-latest`) ship Node 24
- **422 `already_exists` recovery + draft canonicalization** — eliminates the race between the 4 parallel upload jobs

No behavioral change for rotki's usage pattern: draft-only releases, pre-stripped `tag_name`, no `prerelease` flag.

## Test plan
- [ ] Cut a pre-release tag from `develop` (e.g. `v1.x.y-rcN`) and watch the `Rotki Release` workflow end-to-end
- [ ] Verify `create_draft` produces a draft release
- [ ] Verify all 4 upload jobs (linux, macos x2, macos_updater, windows) attach assets without 422 retries
- [ ] Verify `latest-mac.yml` merge job uploads cleanly
- [ ] Verify the draft has all expected artifacts before promoting