### PR TITLE
ci: drop unused actions:write from e2e job

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -333,7 +333,6 @@ jobs:
       ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
     permissions:
       contents: read
-      actions: write
 
   done:
     name: 'Success check'

--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -107,7 +107,6 @@ jobs:
       matrix:
         shard: [ 1, 2, 3, 4 ]
     permissions:
-      actions: write
       contents: read
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Remove `actions: write` from the e2e workflow permissions (`rotki_ci.yml` test-e2e job and `task_e2e_tests.yml` e2e job)
- Leaves `contents: read` only — matches `lint-backend` and `test-backend`, which already cache successfully under that scope

## Why
The e2e job declared `actions: write` but nothing in it calls the REST endpoints that require it (no `gh run` cancel/rerun, no cache/artifact delete API calls). The Actions Cache Service and Artifact Service authenticate via the runner-issued `ACTIONS_RUNTIME_TOKEN`, not the GITHUB_TOKEN scopes controlled by `permissions:`.

The scope was added in d36a4e4158 (Feb 2025 bulk hardening pass) as overcaution around caching — every job that touched a cache received `actions: write`, while jobs without caching did not. Tightening it now closes a defense-in-depth gap: an internal-branch PR (collaborator with push access) would otherwise carry a token capable of poisoning the PR-scope Actions Cache.

## Test plan
- [ ] e2e job runs green (caches restore/save normally)
- [ ] Artifact upload/download still works
- [ ] Codecov upload still works

[run e2e]