### PR TITLE
ci: workflow hardening follow-ups

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -26,7 +26,6 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -104,7 +103,6 @@ jobs:
     runs-on: ${{ matrix.os.runner }}
     permissions:
       contents: read
-      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -186,7 +184,6 @@ jobs:
     environment: windows_sign
     permissions:
       contents: read
-      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -248,7 +245,6 @@ jobs:
     environment: docker
     permissions:
       contents: read
-      actions: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -391,9 +391,10 @@ jobs:
           do
             echo "Processing entry $idx: ${data[$idx]}"
             if [[ ${data[$idx]} == "failure" ]]; then
-                ./.github/scripts/notifier.py --webhook ${{ secrets.DISCORD_WEBHOOK }} --run-id ${{ github.run_id }}
+                ./.github/scripts/notifier.py --webhook "$DISCORD_WEBHOOK" --run-id "$GITHUB_RUN_ID"
                 exit 1;
             fi
           done
         env:
           RESULT: ${{ toJSON(needs.*.result) }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/rotki_nightly.yml
+++ b/.github/workflows/rotki_nightly.yml
@@ -54,7 +54,6 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     permissions:
       contents: read
-      actions: write
 
   backend-coverage:
     name: 'Backend coverage upload'

--- a/.github/workflows/rotki_nightly.yml
+++ b/.github/workflows/rotki_nightly.yml
@@ -148,9 +148,10 @@ jobs:
           do
             echo "Processing entry $idx: ${data[$idx]}"
             if [[ ${data[$idx]} == "failure" ]]; then
-                ./.github/scripts/notifier.py --webhook ${{ secrets.DISCORD_WEBHOOK }} --run-id ${{ github.run_id }} --test
+                ./.github/scripts/notifier.py --webhook "$DISCORD_WEBHOOK" --run-id "$GITHUB_RUN_ID" --test
                 exit 1;
             fi
           done
         env:
           RESULT: ${{ toJSON(needs.*.result) }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -71,7 +71,10 @@ jobs:
                 exit 0
             fi
 
-            if [ "$(curl --silent "https://api.github.com/repos/rotki/test-caching/pulls?state=open&head=$AUTHOR:$SOURCE_BRANCH&base=$TARGET_BRANCH" | jq "length")" == "0" ]; then
+            encoded_author=$(jq -nr --arg v "$AUTHOR" '$v|@uri')
+            encoded_source=$(jq -nr --arg v "$SOURCE_BRANCH" '$v|@uri')
+            encoded_target=$(jq -nr --arg v "$TARGET_BRANCH" '$v|@uri')
+            if [ "$(curl --silent "https://api.github.com/repos/rotki/test-caching/pulls?state=open&head=${encoded_author}:${encoded_source}&base=${encoded_target}" | jq "length")" == "0" ]; then
                 echo "Found the $SOURCE_BRANCH branch on $AUTHOR's test-caching fork. But no PR found. Aborting."
                 exit 1
             fi


### PR DESCRIPTION
## Summary
Follow-up to #12190. Three small, independent hardening fixes across the remaining workflows.

1. **Drop unused `actions: write`** from `rotki_dev_builds.yml` (build-linux, build-macos, build-windows, build-docker) and the e2e call in `rotki_nightly.yml`. Same reasoning as #12190 — the scope was added defensively in d36a4e4158 (Feb 2025 hardening) but no step in these jobs calls the Actions REST write API. Cache and artifact services authenticate via the runner-issued `ACTIONS_RUNTIME_TOKEN`, not GITHUB_TOKEN.

2. **Pass `DISCORD_WEBHOOK` via `env:`** instead of template-interpolating `${{ secrets.DISCORD_WEBHOOK }}` directly into shell. GH masks log output but not `/proc`; the env-based form keeps the secret out of the process command line and is safe against `$()`/backtick contents.

3. **URL-encode VCR-lookup query params** in `task_backend_tests.yml`. The freshness check interpolates `github.head_ref`, `github.base_ref`, and `pull_request.user.login` into a `curl` query string. Branch names legally contain `&` and `#` — a malicious fork branch like `x&base=develop` could bypass the `&base=$TARGET_BRANCH` filter. Now encoded with `jq -nr --arg v "..." '\$v|@uri'`.

## Test plan
- [ ] `dev-builds.yml` build matrix runs green on a tag push (caches/artifacts still work)
- [ ] Nightly e2e job runs green (already proven by #12190)
- [ ] Test-backend VCR freshness check still validates a rebased cassettes branch correctly
- [ ] No regression in Discord notifications on failure

## Verification
After this PR:

```
$ grep "actions: write" .github/workflows/    # zero hits
$ grep "curl.*\${{"      .github/workflows/   # zero hits
```