### PR TITLE
chore(frontend): bump @rotki/ui-library to 2.20.2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Pressing Enter while searching in an autocomplete field no longer accidentally submits the form when there are no matches.
 * :bug:`-` There should no longer be any errors when exporting CSV from PnL report containing an event with notes being Null.
 * :bug:`-` 1inch swaps settling through a balancer pool should now be properly decoded.
 * :bug:`12173` Beaconcha.in queries with legacy API keys will work correctly again.

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.3.2
       version: 1.3.2
     '@rotki/ui-library':
-      specifier: 2.20.1
-      version: 2.20.1
+      specifier: 2.20.2
+      version: 2.20.2
     '@tsconfig/node24':
       specifier: 24.0.4
       version: 24.0.4
@@ -370,7 +370,7 @@ importers:
         version: link:../common
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.20.1(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
+        version: 2.20.2(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
@@ -1908,8 +1908,8 @@ packages:
     peerDependencies:
       eslint: ^9.20.0
 
-  '@rotki/ui-library@2.20.1':
-    resolution: {integrity: sha512-ZjvXHwtcnNDYroFl3aWrNQQBqtOwGR5A2qm88mQ/AW3rGq2QwTurYpI+40j2Q5SjVum+ie21xbglQE8k1BCt0g==}
+  '@rotki/ui-library@2.20.2':
+    resolution: {integrity: sha512-KDd7+WWAwo+QJVW6X2Oa4sC0tSLIz1Ao5aV0+pJmM0OShWL5QNIPLkmmCZbkQ0L6JTYZxcL8YrL8UVgCLEPZ7w==}
     engines: {node: '>=24 <25', pnpm: '>=10 <11'}
     peerDependencies:
       dayjs: '>=1.11.13 <12'
@@ -8557,7 +8557,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rotki/ui-library@2.20.1(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
+  '@rotki/ui-library@2.20.2(dayjs@1.11.20)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.32)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3)))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@vueuse/core': 14.2.1(vue@3.5.32(typescript@5.9.3))

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   '@reown/appkit-adapter-ethers': 1.8.19
   '@rotki/eslint-config': 5.0.1
   '@rotki/eslint-plugin': 1.3.2
-  '@rotki/ui-library': 2.20.1
+  '@rotki/ui-library': 2.20.2
   '@tsconfig/node24': 24.0.4
   '@types/body-parser': 1.19.6
   '@types/express': 5.0.6


### PR DESCRIPTION
## Summary
- Bumps `@rotki/ui-library` to 2.20.2, which fixes the autocomplete field submitting the surrounding form when Enter is pressed with no matching option.
- Adds a corresponding changelog entry.

## Test plan
- [x] `pnpm install`
- [x] `pnpm run typecheck`