### PR TITLE
fix(frontend): account flow rough edges around fresh installs and stale usernames

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Changelog
 * :bug:`12178` Users can now fix a rejected Kusama, Polkadot, beacon chain, or BTC mempool endpoint by editing the URL in place. The error message clears as soon as you start typing.
 * :bug:`-` Typing dates and times by keyboard now produces the value you intended, instead of occasionally picking up stray digits from the previous segment.
 * :bug:`12088` Cancelling the create-account wizard on a fresh install no longer drops you on an empty Unlock screen; the wizard's "Already have an account? Log in" shortcut is also hidden when no profiles exist.
+* :bug:`-` Creating a new account now updates the remembered username so the login screen pre-fills with the new account on next launch.
 
 * :release:`1.43.0 <2026-05-08>`
 * :bug:`-` Docker users can once again import data, snapshots, and asset icons larger than 1 MiB; the bundled nginx no longer rejects them with a 413 before they reach rotki.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Changelog
 * :bug:`-` Newer zerox swaps in base will now be properly decoded.
 * :bug:`12178` Users can now fix a rejected Kusama, Polkadot, beacon chain, or BTC mempool endpoint by editing the URL in place. The error message clears as soon as you start typing.
 * :bug:`-` Typing dates and times by keyboard now produces the value you intended, instead of occasionally picking up stray digits from the previous segment.
+* :bug:`12088` Cancelling the create-account wizard on a fresh install no longer drops you on an empty Unlock screen; the wizard's "Already have an account? Log in" shortcut is also hidden when no profiles exist.
 
 * :release:`1.43.0 <2026-05-08>`
 * :bug:`-` Docker users can once again import data, snapshots, and asset icons larger than 1 MiB; the bundled nginx no longer rejects them with a 413 before they reach rotki.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
 * :bug:`-` Typing dates and times by keyboard now produces the value you intended, instead of occasionally picking up stray digits from the previous segment.
 * :bug:`12088` Cancelling the create-account wizard on a fresh install no longer drops you on an empty Unlock screen; the wizard's "Already have an account? Log in" shortcut is also hidden when no profiles exist.
 * :bug:`-` Creating a new account now updates the remembered username so the login screen pre-fills with the new account on next launch.
+* :bug:`-` The login screen no longer pre-fills the username field with a remembered account that no longer exists.
 
 * :release:`1.43.0 <2026-05-08>`
 * :bug:`-` Docker users can once again import data, snapshots, and asset icons larger than 1 MiB; the bundled nginx no longer rejects them with a 413 before they reach rotki.

--- a/frontend/app/src/modules/auth/create-account/CreateAccountWizard.vue
+++ b/frontend/app/src/modules/auth/create-account/CreateAccountWizard.vue
@@ -8,6 +8,7 @@ import CreateAccountCredentials
 import CreateAccountIntroduction
   from '@/modules/auth/create-account/introduction/CreateAccountIntroduction.vue';
 import CreateAccountPremium from '@/modules/auth/create-account/premium/CreateAccountPremium.vue';
+import { useSavedProfiles } from '@/modules/auth/use-saved-profiles';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 import RotkiLogo from '@/modules/shell/components/RotkiLogo.vue';
 
@@ -41,6 +42,10 @@ function nextStep(): void {
 }
 
 const { t } = useI18n({ useScope: 'global' });
+
+const { hasProfiles, loadProfiles } = useSavedProfiles();
+
+onBeforeMount(loadProfiles);
 
 const parsedError = computed<{ hasLink: boolean; parts: string[] }>(() => {
   const linkPlaceholder = '_DEVICE_LIMIT_LINK_';
@@ -186,7 +191,10 @@ function confirm() {
               </RuiTabItem>
             </RuiTabItems>
           </div>
-          <div class="items-center flex justify-stretch py-6 text-rui-text-secondary">
+          <div
+            v-if="hasProfiles"
+            class="items-center flex justify-stretch py-6 text-rui-text-secondary"
+          >
             <span>{{ t('create_account.have_account.description') }}</span>
             <RuiButton
               color="primary"

--- a/frontend/app/src/modules/auth/login/LoginForm.vue
+++ b/frontend/app/src/modules/auth/login/LoginForm.vue
@@ -10,8 +10,8 @@ import PremiumSyncConflictAlert from '@/modules/auth/login/PremiumSyncConflictAl
 import WelcomeMessageDisplay from '@/modules/auth/login/WelcomeMessageDisplay.vue';
 import { useLogout } from '@/modules/auth/use-logout';
 import { useRememberSettings } from '@/modules/auth/use-remember-settings';
+import { useSavedProfiles } from '@/modules/auth/use-saved-profiles';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
-import { useUsersApi } from '@/modules/auth/use-users-api';
 import { compareTextByKeyword } from '@/modules/core/common/display/assets';
 import { toMessages } from '@/modules/core/common/validation/validation';
 import { useDynamicMessages } from '@/modules/core/messaging/use-dynamic-messages';
@@ -39,7 +39,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const isTest = import.meta.env.VITE_TEST;
 
-const usersApi = useUsersApi();
+const { loadProfiles, savedUsernames } = useSavedProfiles();
 const authStore = useSessionAuthStore();
 const { conflictExist } = storeToRefs(authStore);
 const { resetIncompleteUpgradeConflict, resetSyncConflict } = authStore;
@@ -114,8 +114,6 @@ const isLoggedInError = useArraySome(() => errors, error => error.includes('is a
 
 const usernameError = useArrayFind(() => errors, error => error.startsWith('User '));
 const passwordError = useArrayFind(() => errors, error => error.startsWith('Wrong password '));
-
-const savedUsernames = ref<string[]>([]);
 
 const orderedUsernamesList = computed(() => {
   const search = get(usernameSearch) || '';
@@ -221,23 +219,11 @@ async function loadSettings() {
   }
 }
 
-const router = useRouter();
-
-async function loadProfiles() {
-  const profiles = await usersApi.getUserProfiles();
-  set(savedUsernames, profiles);
-}
-
 onBeforeMount(async () => {
   await loadSettings();
   await loadProfiles();
-  const profiles = get(savedUsernames);
-  if (profiles.length === 0) {
-    const { currentRoute } = router;
-    if (!get(currentRoute).query.disableNoUserRedirection)
-      newAccount();
-    else await router.replace({ query: {} });
-  }
+  if (get(savedUsernames).length === 0)
+    newAccount();
 });
 
 onMounted(() => {

--- a/frontend/app/src/modules/auth/login/LoginForm.vue
+++ b/frontend/app/src/modules/auth/login/LoginForm.vue
@@ -39,7 +39,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const isTest = import.meta.env.VITE_TEST;
 
-const { loadProfiles, savedUsernames } = useSavedProfiles();
+const { loadProfiles, resolveStoredUsername, savedUsernames } = useSavedProfiles();
 const authStore = useSessionAuthStore();
 const { conflictExist } = storeToRefs(authStore);
 const { resetIncompleteUpgradeConflict, resetSyncConflict } = authStore;
@@ -200,7 +200,8 @@ function checkRememberUsername() {
 async function loadSettings() {
   set(rememberPassword, !!get(savedRememberPassword));
   checkRememberUsername();
-  set(username, get(savedUsername));
+  set(username, resolveStoredUsername());
+
   const { sessionOnly, url } = getBackendUrl();
   set(customBackendUrl, url);
   set(customBackendSessionOnly, sessionOnly);
@@ -220,10 +221,12 @@ async function loadSettings() {
 }
 
 onBeforeMount(async () => {
-  await loadSettings();
   await loadProfiles();
-  if (get(savedUsernames).length === 0)
+  if (get(savedUsernames).length === 0) {
     newAccount();
+    return;
+  }
+  await loadSettings();
 });
 
 onMounted(() => {

--- a/frontend/app/src/modules/auth/use-account-management.spec.ts
+++ b/frontend/app/src/modules/auth/use-account-management.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import { useAccountManagement } from '@/modules/auth/use-account-management';
 import { useAutoLogin } from '@/modules/auth/use-auto-login';
 import { useLogin } from '@/modules/auth/use-login';
+import { useRememberSettings } from '@/modules/auth/use-remember-settings';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { Constraints } from '@/modules/core/common/constraints';
 import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
@@ -144,6 +145,45 @@ describe('useAccount', () => {
         credentials: { username: 'test', password: '1234' },
         initialSettings: { submitUsageAnalytics: false },
       });
+    });
+
+    it('should persist the new account as the last-used username on successful creation', async () => {
+      const authStore = useSessionAuthStore();
+      const { logged } = storeToRefs(authStore);
+      const { savedUsername } = useRememberSettings();
+
+      set(savedUsername, '');
+      set(logged, true);
+
+      vi.mocked(createAccount).mockResolvedValue({ success: true });
+
+      const { createNewAccount } = useAccountManagement();
+      await createNewAccount({
+        credentials: { username: 'fresh_user', password: '1234' },
+        initialSettings: { submitUsageAnalytics: false },
+      });
+
+      expect(get(savedUsername)).toBe('fresh_user');
+
+      set(savedUsername, '');
+      set(logged, false);
+    });
+
+    it('should not persist the username when account creation fails', async () => {
+      const { savedUsername } = useRememberSettings();
+      set(savedUsername, 'previous_user');
+
+      vi.mocked(createAccount).mockResolvedValue({ success: false, message: 'boom' });
+
+      const { createNewAccount } = useAccountManagement();
+      await createNewAccount({
+        credentials: { username: 'failed_user', password: '1234' },
+        initialSettings: { submitUsageAnalytics: false },
+      });
+
+      expect(get(savedUsername)).toBe('previous_user');
+
+      set(savedUsername, '');
     });
   });
 

--- a/frontend/app/src/modules/auth/use-account-management.ts
+++ b/frontend/app/src/modules/auth/use-account-management.ts
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import { lastLogin } from '@/modules/auth/account-management';
 import { useLoggedUserIdentifier } from '@/modules/auth/use-logged-user-identifier';
 import { useLogin } from '@/modules/auth/use-login';
+import { useRememberSettings } from '@/modules/auth/use-remember-settings';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { useMainStore } from '@/modules/core/common/use-main-store';
 import { useHistoryDataFetching } from '@/modules/history/use-history-data-fetching';
@@ -38,6 +39,7 @@ export function useAccountManagement(): UseAccountManagementReturn {
   const { clearUpgradeMessages } = authStore;
   const { isDevelop } = storeToRefs(useMainStore());
   const loggedUserIdentifier = useLoggedUserIdentifier();
+  const { savedUsername } = useRememberSettings();
   const { disconnect: disconnectWallet } = useWalletStore();
   const { fetchTransactionStatusSummary } = useHistoryDataFetching();
   const { updateFrontendSetting } = useSettingsOperations();
@@ -61,6 +63,7 @@ export function useAccountManagement(): UseAccountManagementReturn {
       if (get(logged)) {
         clearUpgradeMessages();
         set(lastLogin, username);
+        set(savedUsername, username);
         showGetPremiumButton();
         set(canRequestData, true);
         await fetchTransactionStatusSummary();

--- a/frontend/app/src/modules/auth/use-saved-profiles.spec.ts
+++ b/frontend/app/src/modules/auth/use-saved-profiles.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetUserProfiles = vi.fn();
+
+vi.mock('@/modules/auth/use-users-api', () => ({
+  useUsersApi: vi.fn(() => ({
+    getUserProfiles: mockGetUserProfiles,
+  })),
+}));
+
+describe('modules::auth::use-saved-profiles', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('should expose an empty list before loadProfiles is called', async () => {
+    const { useSavedProfiles } = await import('@/modules/auth/use-saved-profiles');
+    const { hasProfiles, savedUsernames } = useSavedProfiles();
+
+    expect(get(savedUsernames)).toEqual([]);
+    expect(get(hasProfiles)).toBe(false);
+  });
+
+  it('should populate savedUsernames and hasProfiles after loadProfiles resolves', async () => {
+    mockGetUserProfiles.mockResolvedValue(['alice', 'bob']);
+
+    const { useSavedProfiles } = await import('@/modules/auth/use-saved-profiles');
+    const { hasProfiles, loadProfiles, savedUsernames } = useSavedProfiles();
+
+    await loadProfiles();
+
+    expect(get(savedUsernames)).toEqual(['alice', 'bob']);
+    expect(get(hasProfiles)).toBe(true);
+  });
+
+  it('should report hasProfiles=false when the backend returns no profiles', async () => {
+    mockGetUserProfiles.mockResolvedValue([]);
+
+    const { useSavedProfiles } = await import('@/modules/auth/use-saved-profiles');
+    const { hasProfiles, loadProfiles, savedUsernames } = useSavedProfiles();
+
+    await loadProfiles();
+
+    expect(get(savedUsernames)).toEqual([]);
+    expect(get(hasProfiles)).toBe(false);
+  });
+
+  it('should share state between consumers (createSharedComposable)', async () => {
+    mockGetUserProfiles.mockResolvedValue(['alice']);
+
+    const { useSavedProfiles } = await import('@/modules/auth/use-saved-profiles');
+    const first = useSavedProfiles();
+    const second = useSavedProfiles();
+
+    await first.loadProfiles();
+
+    expect(get(second.savedUsernames)).toEqual(['alice']);
+    expect(get(second.hasProfiles)).toBe(true);
+    expect(mockGetUserProfiles).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/src/modules/auth/use-saved-profiles.spec.ts
+++ b/frontend/app/src/modules/auth/use-saved-profiles.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetUserProfiles = vi.fn();
+const mockSavedUsername = ref<string>('');
 
 vi.mock('@/modules/auth/use-users-api', () => ({
   useUsersApi: vi.fn(() => ({
@@ -8,10 +9,19 @@ vi.mock('@/modules/auth/use-users-api', () => ({
   })),
 }));
 
+vi.mock('@/modules/auth/use-remember-settings', () => ({
+  useRememberSettings: vi.fn(() => ({
+    savedRememberPassword: ref<string | null>(null),
+    savedRememberUsername: ref<string | null>(null),
+    savedUsername: mockSavedUsername,
+  })),
+}));
+
 describe('modules::auth::use-saved-profiles', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    set(mockSavedUsername, '');
   });
 
   it('should expose an empty list before loadProfiles is called', async () => {
@@ -44,6 +54,44 @@ describe('modules::auth::use-saved-profiles', () => {
 
     expect(get(savedUsernames)).toEqual([]);
     expect(get(hasProfiles)).toBe(false);
+  });
+
+  describe('resolveStoredUsername', () => {
+    it('should return an empty string when no username is stored', async () => {
+      mockGetUserProfiles.mockResolvedValue(['alice']);
+      set(mockSavedUsername, '');
+
+      const { useSavedProfiles } = await import('@/modules/auth/use-saved-profiles');
+      const { loadProfiles, resolveStoredUsername } = useSavedProfiles();
+      await loadProfiles();
+
+      expect(resolveStoredUsername()).toBe('');
+      expect(get(mockSavedUsername)).toBe('');
+    });
+
+    it('should return the stored username when it exists in the loaded profiles', async () => {
+      mockGetUserProfiles.mockResolvedValue(['alice', 'bob']);
+      set(mockSavedUsername, 'bob');
+
+      const { useSavedProfiles } = await import('@/modules/auth/use-saved-profiles');
+      const { loadProfiles, resolveStoredUsername } = useSavedProfiles();
+      await loadProfiles();
+
+      expect(resolveStoredUsername()).toBe('bob');
+      expect(get(mockSavedUsername)).toBe('bob');
+    });
+
+    it('should clear the persisted username and return empty when the stored profile is missing', async () => {
+      mockGetUserProfiles.mockResolvedValue(['alice']);
+      set(mockSavedUsername, 'ghost');
+
+      const { useSavedProfiles } = await import('@/modules/auth/use-saved-profiles');
+      const { loadProfiles, resolveStoredUsername } = useSavedProfiles();
+      await loadProfiles();
+
+      expect(resolveStoredUsername()).toBe('');
+      expect(get(mockSavedUsername)).toBe('');
+    });
   });
 
   it('should share state between consumers (createSharedComposable)', async () => {

--- a/frontend/app/src/modules/auth/use-saved-profiles.ts
+++ b/frontend/app/src/modules/auth/use-saved-profiles.ts
@@ -1,0 +1,26 @@
+import type { ComputedRef, Ref } from 'vue';
+import { createSharedComposable } from '@vueuse/core';
+import { useUsersApi } from '@/modules/auth/use-users-api';
+
+interface UseSavedProfilesReturn {
+  savedUsernames: Ref<string[]>;
+  hasProfiles: ComputedRef<boolean>;
+  loadProfiles: () => Promise<void>;
+}
+
+export const useSavedProfiles = createSharedComposable((): UseSavedProfilesReturn => {
+  const { getUserProfiles } = useUsersApi();
+  const savedUsernames = ref<string[]>([]);
+
+  const hasProfiles = computed<boolean>(() => get(savedUsernames).length > 0);
+
+  const loadProfiles = async (): Promise<void> => {
+    set(savedUsernames, await getUserProfiles());
+  };
+
+  return {
+    hasProfiles,
+    loadProfiles,
+    savedUsernames,
+  };
+});

--- a/frontend/app/src/modules/auth/use-saved-profiles.ts
+++ b/frontend/app/src/modules/auth/use-saved-profiles.ts
@@ -1,15 +1,18 @@
 import type { ComputedRef, Ref } from 'vue';
 import { createSharedComposable } from '@vueuse/core';
+import { useRememberSettings } from '@/modules/auth/use-remember-settings';
 import { useUsersApi } from '@/modules/auth/use-users-api';
 
 interface UseSavedProfilesReturn {
   savedUsernames: Ref<string[]>;
   hasProfiles: ComputedRef<boolean>;
   loadProfiles: () => Promise<void>;
+  resolveStoredUsername: () => string;
 }
 
 export const useSavedProfiles = createSharedComposable((): UseSavedProfilesReturn => {
   const { getUserProfiles } = useUsersApi();
+  const { savedUsername } = useRememberSettings();
   const savedUsernames = ref<string[]>([]);
 
   const hasProfiles = computed<boolean>(() => get(savedUsernames).length > 0);
@@ -18,9 +21,22 @@ export const useSavedProfiles = createSharedComposable((): UseSavedProfilesRetur
     set(savedUsernames, await getUserProfiles());
   };
 
+  const resolveStoredUsername = (): string => {
+    const stored = get(savedUsername);
+    if (!stored)
+      return '';
+
+    if (get(savedUsernames).includes(stored))
+      return stored;
+
+    set(savedUsername, '');
+    return '';
+  };
+
   return {
     hasProfiles,
     loadProfiles,
+    resolveStoredUsername,
     savedUsernames,
   };
 });

--- a/frontend/app/src/modules/shell/layout/use-navigation.spec.ts
+++ b/frontend/app/src/modules/shell/layout/use-navigation.spec.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppNavigation } from '@/modules/shell/layout/use-navigation';
+import { Routes } from '@/router/routes';
+
+const mockPush = vi.fn();
+const mockCurrentRoute = ref<{ path: string }>({ path: '/' });
+
+vi.mock('vue-router', () => ({
+  useRouter: vi.fn(() => ({
+    currentRoute: mockCurrentRoute,
+    push: mockPush,
+  })),
+}));
+
+describe('modules::shell::use-navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(mockCurrentRoute, { path: '/' });
+  });
+
+  describe('navigateToUserLogin', () => {
+    it('should push to /user/login with no query', async () => {
+      const { navigateToUserLogin } = useAppNavigation();
+
+      await navigateToUserLogin();
+
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      expect(mockPush).toHaveBeenCalledWith(Routes.USER_LOGIN);
+    });
+
+    it('should be a no-op when already on the login route', async () => {
+      set(mockCurrentRoute, { path: Routes.USER_LOGIN });
+
+      const { navigateToUserLogin } = useAppNavigation();
+      await navigateToUserLogin();
+
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigateToUserCreation', () => {
+    it('should push to /user/create', async () => {
+      const { navigateToUserCreation } = useAppNavigation();
+
+      await navigateToUserCreation();
+
+      expect(mockPush).toHaveBeenCalledWith(Routes.USER_CREATE);
+    });
+  });
+
+  describe('navigateToDashboard', () => {
+    it('should push to the dashboard route', async () => {
+      const { navigateToDashboard } = useAppNavigation();
+
+      await navigateToDashboard();
+
+      expect(mockPush).toHaveBeenCalledWith(Routes.DASHBOARD);
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/layout/use-navigation.ts
+++ b/frontend/app/src/modules/shell/layout/use-navigation.ts
@@ -1,24 +1,18 @@
-import { isEqual } from 'es-toolkit';
 import { Routes } from '@/router/routes';
 
 interface UseAppNavigationReturn {
   navigateToDashboard: () => Promise<void>;
   navigateToUserCreation: () => Promise<void>;
-  navigateToUserLogin: (disableNoUserRedirection?: boolean) => Promise<void>;
+  navigateToUserLogin: () => Promise<void>;
 }
 
 export function useAppNavigation(): UseAppNavigationReturn {
   const router = useRouter();
-  const navigateToUserLogin = async (disableNoUserRedirection: boolean = false): Promise<void> => {
-    const newQuery = disableNoUserRedirection ? { disableNoUserRedirection: '1' } : {};
-    const { path, query } = get(router.currentRoute);
-    if (path === Routes.USER_LOGIN && isEqual(query, newQuery))
+  const navigateToUserLogin = async (): Promise<void> => {
+    if (get(router.currentRoute).path === Routes.USER_LOGIN)
       return;
 
-    await router.push({
-      path: '/user/login',
-      query: newQuery,
-    });
+    await router.push(Routes.USER_LOGIN);
   };
 
   const navigateToUserCreation = async (): Promise<void> => {

--- a/frontend/app/src/pages/user/create/index.vue
+++ b/frontend/app/src/pages/user/create/index.vue
@@ -58,7 +58,7 @@ const steps = [
               :loading="loading"
               :error="error"
               @clear-error="error = ''"
-              @cancel="navigateToUserLogin(true)"
+              @cancel="navigateToUserLogin()"
               @confirm="createNewAccount($event)"
             />
           </UserHost>


### PR DESCRIPTION
## Summary

Three small frontend fixes around the account create / login flow:

- **Closes #12088** — cancelling the create-account wizard on a fresh install used to navigate to `/user/login` with a query flag that suppressed the no-profile redirect, leaving the Unlock UI rendered with zero profiles. Submitting then failed and the user could end up bouncing between login and create. The flag mechanism is dropped: `LoginForm` always redirects to create when no profiles exist, and the wizard's "Already have an account? Log in" footer is hidden when there are none.
- Creating a new account now also persists `savedUsername` (it already persisted `lastLogin`), so the next time the login screen renders, the username field pre-fills with the freshly created account.
- The login screen no longer pre-fills the username field with a remembered account that no longer exists on disk. The stored value is validated against the current profile list and cleared if stale, so the user gets an empty field instead of a "User X does not exist" submit error.

Profile loading is extracted into a shared composable (`useSavedProfiles`) so `LoginForm` and `CreateAccountWizard` share one fetch.

## Test plan

- [ ] Fresh install → app routes to `/user/create`. Click "Cancel" — does not show an empty Unlock screen.
- [ ] Fresh install → on `/user/create`, the "Already have an account? Log in" footer is hidden.
- [ ] Existing installs → cancel from create still goes back to login normally.
- [ ] Create a new account → log out → reopen app: username field pre-fills with the new account.
- [ ] Manually edit the data dir to delete the profile that `rotki.username` localStorage points to → open app: username field is empty, no error.
- [ ] `pnpm run test:unit` (frontend), `pnpm run typecheck`, `pnpm run lint` all green.