### PR TITLE
ci: cap e2e shard job at 20 minutes

### DIFF
--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -103,6 +103,7 @@ jobs:
       CI: true
       GROUP: ${{ matrix.group }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 20` at the job level on the e2e matrix in `task_e2e_tests.yml`.
- The existing `timeout-minutes: 20` is scoped to the `Run e2e tests` step only, so a hang in an earlier step (e.g. `Install Playwright system dependencies` running `npx playwright install-deps chromium`) could ride out GitHub's 6h hard limit — as seen on PR #12202, where shard-2 ran 6h05m before being killed while the other shards finished in 5–9 min.

## Sizing
Recent runs: per-shard avg ~6–9 min, worst observed ~11 min. 20 min ≈ 2× the worst case. Matrix recently changed from 4 numeric shards to 5 named groups; we'll monitor and adjust if any group runs hot.

## Test plan
- [ ] CI green on this PR (all 5 e2e groups complete under 20 min)