### PR TITLE
Bump nginx base image to 1.30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN sed "s/fallback_version.*/fallback_version = \"$PACKAGE_FALLBACK_VERSION\"/"
     uv run python -c "import sys;from rotkehlchen.db.misc import detect_sqlcipher_version; version = detect_sqlcipher_version();sys.exit(0) if version == 4 else sys.exit(1)" && \
     PYTHONOPTIMIZE=2 uv run pyinstaller --noconfirm --clean --distpath /tmp/dist rotkehlchen.spec
 
-FROM nginx:1.28 AS runtime
+FROM nginx:1.30 AS runtime
 
 LABEL maintainer="Rotki Solutions GmbH <info@rotki.com>"
 


### PR DESCRIPTION
Addresses CVE-2026-42945 (ngx_http_rewrite_module heap overflow). Our nginx.conf does not use any rewrite/if/set directives so the vulnerable code path is unreachable, but the base image is bumped defensively to keep scanners clean.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
