### PR TITLE
Fix Hyperliquid pagination 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`12215` Cryptocompare is now removed from the default list of oracles if no API key is set.
+* :bug:`-` Hyperliquid history pagination no longer skips entries when many fills share the same millisecond at a page boundary.
 * :bug:`-` Searching Monad and Hyperliquid assets should now work properly.
 * :bug:`-` Multi-eth donations in giveth should now be properly decoded.
 * :feature:`12179` Blocks produced by validators will be queried in the case of missing beaconcha.in API keys.

--- a/rotkehlchen/externalapis/hyperliquid.py
+++ b/rotkehlchen/externalapis/hyperliquid.py
@@ -607,8 +607,13 @@ class HyperliquidAPI:
     ) -> Iterator[EntryContext]:
         """Query a user history endpoint in pages and iterate unique entries.
 
-        The API caps each response, so this method paginates backwards by reducing
-        `endTime` to one millisecond before the oldest item in the previous page.
+        The API caps each response, so this method paginates backwards by lowering
+        `endTime` to the oldest item on the previous page when we made progress
+        past that millisecond — per-entry dedup keeps overlapping boundary entries
+        from yielding twice. Once a millisecond is fully drained (the next page
+        returned only duplicates) we advance past it. If the page cap truncates
+        entries at a single millisecond beyond what one extra query can recover
+        we log a warning, since the API exposes no within-millisecond cursor.
 
         A single request covers the first perp dex, all HIP-3 builder-deployed perp
         dexs, and spot: Hyperliquid's history endpoints do not accept a `dex` param
@@ -642,6 +647,7 @@ class HyperliquidAPI:
                 break
 
             oldest_time = cursor_end
+            new_yields = 0
             for entry in page_entries:
                 try:
                     entry_time_ms = deserialize_timestamp_ms_from_intms(entry['time'])
@@ -680,9 +686,32 @@ class HyperliquidAPI:
                 ) is None:
                     continue
                 yield context
+                new_yields += 1
 
-            if oldest_time >= cursor_end:
-                break
+            # Advance the cursor backwards. The API caps each response, so the
+            # entries at the oldest millisecond on a page may have been
+            # truncated. If we yielded new entries and made progress past that
+            # boundary (oldest_time < cursor_end), keep the boundary inclusive
+            # on the next query so any truncated entries at oldest_time are
+            # captured — per-entry dedup keeps overlap from yielding twice.
+            # Otherwise we've drained that millisecond (or got stuck on it) and
+            # have to advance past, accepting any extras the page cap dropped.
+            if new_yields > 0 and oldest_time < cursor_end:
+                cursor_end = TimestampMS(oldest_time)
+                continue
+
+            if new_yields > 0:
+                # Full page at the cursor boundary: there may be more entries
+                # at this exact millisecond that the page cap dropped and the
+                # API has no within-millisecond cursor for us to recover them.
+                log.warning(
+                    f'Hyperliquid {query_type} for {address} returned a full '
+                    f'page of new entries at {oldest_time}ms. Some entries at '
+                    f'that millisecond may be missing from this sync.',
+                )
+
+            if oldest_time == 0:
+                break  # avoid wrapping below zero
             cursor_end = TimestampMS(oldest_time - 1)
 
         if page >= HYPERLIQUID_MAX_HISTORY_PAGES and cursor_end >= start_ms:

--- a/rotkehlchen/tests/unit/test_hyperliquid_entry_id.py
+++ b/rotkehlchen/tests/unit/test_hyperliquid_entry_id.py
@@ -51,7 +51,7 @@ def test_iter_entries_does_not_collapse_partial_fills_sharing_oid() -> None:
         'tid': 2, 'oid': shared_oid, 'hash': '0xtx', 'time': same_time, 'sz': '6',
     }
 
-    with patch.object(api, '_query_list', return_value=[fill_a, fill_b]):
+    with patch.object(api, '_query_list', side_effect=[[fill_a, fill_b], []]):
         contexts = list(api._iter_entries_by_time(
             query_type='userFillsByTime',
             address=address,
@@ -73,10 +73,13 @@ def test_iter_entries_dedups_same_tid_across_pages() -> None:
         'tid': 42, 'oid': 1, 'hash': '0xtx', 'time': 1700000000000, 'sz': '1',
     }
 
-    # Return the duplicate on the first page, then nothing. The backwards
-    # pagination would normally advance the cursor, but with a single entry
-    # we exit because `oldest_time >= cursor_end`.
-    with patch.object(api, '_query_list', return_value=[duplicate_fill, duplicate_fill]):
+    # Page 1 returns the entry, page 2 returns it again (overlapping window),
+    # page 3 is empty and terminates pagination.
+    with patch.object(api, '_query_list', side_effect=[
+        [duplicate_fill],
+        [duplicate_fill],
+        [],
+    ]):
         contexts = list(api._iter_entries_by_time(
             query_type='userFillsByTime',
             address=address,
@@ -85,3 +88,45 @@ def test_iter_entries_dedups_same_tid_across_pages() -> None:
         ))
 
     assert len(contexts) == 1
+
+
+def test_iter_entries_recovers_truncated_boundary_entries() -> None:
+    """When a page contains entries spanning multiple milliseconds and the
+    oldest ms had additional entries truncated by the API page cap, the next
+    query is repeated at that boundary so the remaining entries can be
+    fetched. Per-entry dedup prevents already-yielded entries from being
+    emitted twice.
+    """
+    api = HyperliquidAPI()
+    address = string_to_evm_address('0x7fC1b7863251Ac7F83c7a4E83ccd00d129Ee844c')
+    boundary_ts = 1700000000000
+    newer_fill: dict[str, Any] = {
+        'tid': 1, 'oid': 1, 'hash': '0xtx', 'time': boundary_ts + 10, 'sz': '1',
+    }
+    boundary_fill_a: dict[str, Any] = {
+        'tid': 2, 'oid': 2, 'hash': '0xtx', 'time': boundary_ts, 'sz': '2',
+    }
+    boundary_fill_b: dict[str, Any] = {
+        'tid': 3, 'oid': 3, 'hash': '0xtx', 'time': boundary_ts, 'sz': '3',
+    }
+    older_fill: dict[str, Any] = {
+        'tid': 4, 'oid': 4, 'hash': '0xtx', 'time': boundary_ts - 5, 'sz': '4',
+    }
+
+    # Page 1: newer + boundary_a (boundary_b is truncated by the page cap).
+    # Page 2: re-queried with endTime=boundary, returns boundary_a (deduped),
+    #         boundary_b (new — recovered), and an older entry.
+    # Page 3: empty, terminates pagination.
+    with patch.object(api, '_query_list', side_effect=[
+        [newer_fill, boundary_fill_a],
+        [boundary_fill_a, boundary_fill_b, older_fill],
+        [],
+    ]):
+        contexts = list(api._iter_entries_by_time(
+            query_type='userFillsByTime',
+            address=address,
+            start_ts=Timestamp(1699999998),
+            end_ts=Timestamp(1700000001),
+        ))
+
+    assert [ctx.entry['tid'] for ctx in contexts] == [1, 2, 3, 4]


### PR DESCRIPTION
Fix Hyperliquid pagination dropping entries at same-millisecond page boundary