### PR TITLE
Fix swap fee group_id collision from digit concatenation

### DIFF
--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -232,7 +232,10 @@ class EventsAccountant:
             log.debug(f'Skipping {self} at accounting for a swap due to inability to find a price')
             return 2
 
-        group_id = out_event.group_identifier + str(out_event.sequence_index) + str(in_event.sequence_index)  # noqa: E501
+        # Separate sequence indices with delimiters so that pairs like
+        # `(1, 234)` and `(12, 34)` produce distinct group_ids within the
+        # same group_identifier (concatenation alone collides).
+        group_id = f'{out_event.group_identifier}-{out_event.sequence_index}-{in_event.sequence_index}'  # noqa: E501
         extra_data = general_extra_data | {'group_id': group_id}
         _, trade_taxable_amount = self.pot.add_out_event(
             originating_event_id=out_event.identifier,

--- a/rotkehlchen/tests/unit/accounting/evm/test_cowswap.py
+++ b/rotkehlchen/tests/unit/accounting/evm/test_cowswap.py
@@ -77,12 +77,12 @@ def test_cowswap_swap_with_fee(accountant: 'Accountant'):
         pot.events_accountant.process(event=event, events_iterator=events_iterator)  # type: ignore
 
     extra_data_out = {
-        'group_id': '1' + str(tx_hash) + '12',
+        'group_id': f'1{tx_hash!s}-1-2',
         'tx_ref': str(tx_hash),
         'direction': 'out',
     }
     extra_data_in = {
-        'group_id': '1' + str(tx_hash) + '12',
+        'group_id': f'1{tx_hash!s}-1-2',
         'tx_ref': str(tx_hash),
         'direction': 'in',
     }

--- a/rotkehlchen/tests/unit/accounting/test_default_settings.py
+++ b/rotkehlchen/tests/unit/accounting/test_default_settings.py
@@ -363,7 +363,7 @@ def test_accounting_swap_settings(accounting_pot: 'AccountingPot', counterparty:
         index=1,
         extra_data={
             'tx_ref': EXAMPLE_TX_HASH_HEX,
-            'group_id': f'{swap_spend_event.group_identifier}12',
+            'group_id': f'{swap_spend_event.group_identifier}-1-2',
             'direction': 'out',
         },
     )
@@ -384,7 +384,7 @@ def test_accounting_swap_settings(accounting_pot: 'AccountingPot', counterparty:
         index=2,
         extra_data={
             'tx_ref': EXAMPLE_TX_HASH_HEX,
-            'group_id': f'{swap_receive_event.group_identifier}12',
+            'group_id': f'{swap_receive_event.group_identifier}-1-2',
             'direction': 'in',
         },
     )


### PR DESCRIPTION
Swap fee accounting events no longer collide on their group_id label when two swap pairs in the same transaction have specific sequence_index digit combinations.