### PR TITLE
fix: avoid digit-boundary collisions in HistoryBaseEntry.__hash__

### DIFF
--- a/rotkehlchen/history/events/structures/base.py
+++ b/rotkehlchen/history/events/structures/base.py
@@ -517,7 +517,7 @@ class HistoryBaseEntry(AccountingEventMixin, ABC, Generic[ExtraDataType]):
         if self.identifier is not None:
             return hash(self.identifier)
 
-        return hash(str(self.group_identifier) + str(self.sequence_index))
+        return hash((self.group_identifier, self.sequence_index))
 
 
 class HistoryEvent(HistoryBaseEntry):

--- a/rotkehlchen/tests/unit/test_history_events.py
+++ b/rotkehlchen/tests/unit/test_history_events.py
@@ -71,6 +71,25 @@ def test_serialize_with_invalid_type_subtype():
     }
 
 
+def test_hash_does_not_collide_on_digit_boundary():
+    """Regression: __hash__ must not collide for pairs like (gid='0xabc', seq=12)
+    and (gid='0xabc1', seq=2) which would share the same hash under naive
+    str(group_identifier) + str(sequence_index) concatenation."""
+    def make(gid: str, seq: int) -> HistoryEvent:
+        return HistoryEvent(
+            group_identifier=gid,
+            sequence_index=seq,
+            timestamp=TimestampMS(1),
+            location=Location.KRAKEN,
+            event_type=HistoryEventType.TRANSFER,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_ETH,
+            amount=ONE,
+        )
+
+    assert hash(make('0xabc', 12)) != hash(make('0xabc1', 2))
+
+
 @pytest.mark.parametrize('base_accounts', [[make_evm_address()]])
 def test_informational_events(database: 'DBHandler', base_accounts: list[ChecksumEvmAddress]):
     """Test that informational events don't trigger price queries"""


### PR DESCRIPTION
Hash via tuple (group_identifier, sequence_index) instead of concatenating their str() forms. The old form let pairs like ('0xabc', 12) and ('0xabc1', 2) share a hash, degrading set/dict performance for unsaved events. Mirrors the fix in 95cfbea803 for the group_id label and adds a regression unit test.