### PR TITLE
fix: clean up orphan snapshot rows on delete

### DIFF
--- a/rotkehlchen/db/snapshots.py
+++ b/rotkehlchen/db/snapshots.py
@@ -266,11 +266,13 @@ class DBSnapshot:
         May raise:
         - InputError
         """
-        write_cursor.execute('DELETE FROM timed_balances WHERE timestamp=?', (timestamp,))
-        if write_cursor.rowcount == 0:
-            raise InputError('No snapshot found for the specified timestamp')
-        write_cursor.execute('DELETE FROM timed_location_data WHERE timestamp=?', (timestamp,))
-        if write_cursor.rowcount == 0:
+        balances_deleted = write_cursor.execute(
+            'DELETE FROM timed_balances WHERE timestamp=?', (timestamp,),
+        ).rowcount
+        location_deleted = write_cursor.execute(
+            'DELETE FROM timed_location_data WHERE timestamp=?', (timestamp,),
+        ).rowcount
+        if balances_deleted == 0 and location_deleted == 0:
             raise InputError('No snapshot found for the specified timestamp')
 
     def add_nft_asset_ids(self, write_cursor: 'DBCursor', entries: list[str]) -> None:

--- a/rotkehlchen/tests/api/test_snapshots.py
+++ b/rotkehlchen/tests/api/test_snapshots.py
@@ -737,6 +737,24 @@ def test_delete_snapshot(rotkehlchen_api_server: 'APIServer') -> None:
     )
 
 
+def test_delete_snapshot_with_orphan_rows(rotkehlchen_api_server: 'APIServer') -> None:
+    """Regression: if only one of the two snapshot tables has rows for the given
+    timestamp (drift from a prior partial failure), delete should still succeed
+    and clean up rather than misreport 'No snapshot found'."""
+    db = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
+    ts = ts_now()
+    with db.user_write() as cursor:
+        _populate_db_with_balances(cursor, db, ts)  # only balances, no location_data
+
+    response = requests.delete(
+        api_url_for(rotkehlchen_api_server, 'dbsnapshotsresource'),
+        json={'timestamp': ts},
+    )
+    assert_simple_ok_response(response)
+    cursor = db.conn.cursor()
+    assert len(cursor.execute('SELECT timestamp FROM timed_balances WHERE timestamp=?', (ts,)).fetchall()) == 0  # noqa: E501
+
+
 def test_get_snapshot_json(rotkehlchen_api_server: 'APIServer') -> None:
     db = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
     ts = ts_now()


### PR DESCRIPTION
DBSnapshot.delete() raised 'No snapshot found' after the first DELETE if the second table had no rows, leaving partial state irrecoverable from the API. Run both DELETEs unconditionally and only raise when neither table had a row for the given timestamp. The drift case is rare in practice (asset-merge via replace_asset can strip a single-asset snapshot's timed_balances rows while leaving timed_location_data behind) but the previous error message lied and made cleanup impossible.
