### PR TITLE
Fix chain icon and explorer link for newly detected Monad/Hyperliquid tokens

### DIFF
--- a/colibri/src/blockchain/types.rs
+++ b/colibri/src/blockchain/types.rs
@@ -16,6 +16,8 @@ pub enum SupportedBlockchain {
     BinanceSc,
     Ethereum,
     Gnosis,
+    Hyperliquid,
+    Monad,
     Optimism,
     PolygonPos,
     Scroll,
@@ -39,6 +41,8 @@ impl SupportedBlockchain {
             Self::BinanceSc => "BINANCE_SC",
             Self::Ethereum => "ETH",
             Self::Gnosis => "GNOSIS",
+            Self::Hyperliquid => "HYPERLIQUID",
+            Self::Monad => "MONAD",
             Self::Optimism => "OPTIMISM",
             Self::PolygonPos => "POLYGON_POS",
             Self::Scroll => "SCROLL",
@@ -55,6 +59,8 @@ impl SupportedBlockchain {
             Self::PolygonPos => "eip155:137/erc20:0x0000000000000000000000000000000000001010",
             Self::Gnosis => "XDAI",
             Self::BinanceSc => "BNB",
+            Self::Hyperliquid => "HYPE",
+            Self::Monad => "MON",
             Self::Solana => "SOL",
             // All others: the chain identifier is also its native token
             // (Ethereum→ETH, Bitcoin→BTC, Avalanche→AVAX, etc.)
@@ -72,6 +78,8 @@ impl SupportedBlockchain {
             100 => Some(Self::Gnosis),
             137 => Some(Self::PolygonPos),
             43114 => Some(Self::Avalanche),
+            143 => Some(Self::Monad),
+            999 => Some(Self::Hyperliquid),
             8453 => Some(Self::Base),
             42161 => Some(Self::ArbitrumOne),
             534352 => Some(Self::Scroll),
@@ -98,5 +106,33 @@ mod tests {
             SupportedBlockchain::from_chain_id(43114),
             Some(SupportedBlockchain::Avalanche)
         );
+    }
+
+    #[test]
+    fn test_from_chain_id_includes_monad() {
+        assert_eq!(
+            SupportedBlockchain::from_chain_id(143),
+            Some(SupportedBlockchain::Monad)
+        );
+    }
+
+    #[test]
+    fn test_from_chain_id_includes_hyperliquid() {
+        assert_eq!(
+            SupportedBlockchain::from_chain_id(999),
+            Some(SupportedBlockchain::Hyperliquid)
+        );
+    }
+
+    #[test]
+    fn test_native_token_id_for_new_chains() {
+        assert_eq!(SupportedBlockchain::Monad.native_token_id(), "MON");
+        assert_eq!(SupportedBlockchain::Hyperliquid.native_token_id(), "HYPE");
+    }
+
+    #[test]
+    fn test_as_str_for_new_chains() {
+        assert_eq!(SupportedBlockchain::Monad.as_str(), "MONAD");
+        assert_eq!(SupportedBlockchain::Hyperliquid.as_str(), "HYPERLIQUID");
     }
 }

--- a/docs/changelog.rst.orig
+++ b/docs/changelog.rst.orig
@@ -3,9 +3,12 @@ Changelog
 =========
 
 * :feature:`12215` Cryptocompare is now removed from the default list of oracles if no API key is set.
+<<<<<<< HEAD
 * :bug:`-` Hyperliquid history pagination no longer skips entries when many fills share the same millisecond at a page boundary.
+=======
 * :bug:`-` Reviewing newly detected Monad and Hyperliquid tokens now shows the chain icon and a working block-explorer link next to the address, so you can confirm what was detected without leaving the page.
 * :bug:`-` The chain icon on an asset no longer flickers behind the asset image while it loads, so you can tell which chain a token belongs to from the moment it appears.
+>>>>>>> a93f78b5bd (docs: changelog entries for newly detected token chain fixes)
 * :bug:`-` Searching Monad and Hyperliquid assets should now work properly.
 * :bug:`-` Multi-eth donations in giveth should now be properly decoded.
 * :feature:`12179` Blocks produced by validators will be queried in the case of missing beaconcha.in API keys.

--- a/frontend/app/src/modules/assets/detection/NewlyDetectedAssetTable.vue
+++ b/frontend/app/src/modules/assets/detection/NewlyDetectedAssetTable.vue
@@ -4,7 +4,6 @@ import { type BigNumber, getAddressFromEvmIdentifier, getAddressFromSolanaIdenti
 import { FiatDisplay } from '@/modules/assets/amount-display/components';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
-import { useAssetInfoCache } from '@/modules/assets/use-asset-info-cache';
 import { useSpamAsset } from '@/modules/assets/use-spam-asset';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
 import { arrayify } from '@/modules/core/common/data/array';
@@ -16,6 +15,7 @@ import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import HashLink from '@/modules/shell/components/HashLink.vue';
 import HintMenuIcon from '@/modules/shell/components/HintMenuIcon.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
+import { getTokenChain } from './get-token-chain';
 import { type NewDetectedToken, NewDetectedTokenKind } from './types';
 import { useNewlyDetectedTokens } from './use-newly-detected-tokens';
 
@@ -43,10 +43,8 @@ const { t } = useI18n({ useScope: 'global' });
 const selected = ref<string[]>([]);
 const tokenKindFilter = ref<NewDetectedTokenKind>();
 
-const { cache } = useAssetInfoCache();
-
 const { getAllIdentifiers, getData, isReady, removeNewDetectedTokens } = useNewlyDetectedTokens();
-const { getChain, isSolanaChains } = useSupportedChains();
+const { allEvmChains, isSolanaChains } = useSupportedChains();
 const { addresses } = useAccountAddresses();
 const { markAssetsAsSpam } = useSpamAsset();
 const { getAssetPrice } = usePriceUtils();
@@ -114,20 +112,13 @@ const cols = computed<DataTableColumn<Token>[]>(() => [
 useRememberTableSorting<Token>(TableId.NEWLY_DETECTED_ASSETS, sort, cols);
 
 const rows = computed<Token[]>(() => {
-  const currentCache = get(cache);
-  return get(state).data.map((data) => {
-    const evmChain = currentCache[data.tokenIdentifier]?.evmChain;
-    const chain = data.tokenKind === NewDetectedTokenKind.EVM && evmChain
-      ? getChain(evmChain)
-      : data.tokenKind;
-
-    return {
-      ...data,
-      address: TOKEN_KIND_MAPPING[data.tokenKind].addressFormatter(data.tokenIdentifier),
-      chain,
-      price: getAssetPrice(data.tokenIdentifier),
-    };
-  });
+  const evmChains = get(allEvmChains);
+  return get(state).data.map(data => ({
+    ...data,
+    address: TOKEN_KIND_MAPPING[data.tokenKind].addressFormatter(data.tokenIdentifier),
+    chain: getTokenChain(data, evmChains),
+    price: getAssetPrice(data.tokenIdentifier),
+  }));
 });
 
 const allSelected = computed<boolean>(() => {

--- a/frontend/app/src/modules/assets/detection/get-token-chain.spec.ts
+++ b/frontend/app/src/modules/assets/detection/get-token-chain.spec.ts
@@ -1,0 +1,84 @@
+import type { EvmChainEntries } from '@/modules/core/api/types/chains';
+import { describe, expect, it } from 'vitest';
+import { getTokenChain } from './get-token-chain';
+import { NewDetectedTokenKind } from './types';
+
+const allEvmChains: EvmChainEntries = [
+  { id: 1, label: 'Ethereum', name: 'ethereum' },
+  { id: 143, label: 'Monad', name: 'monad' },
+  { id: 999, label: 'Hyperliquid', name: 'hyperliquid' },
+];
+
+describe('getTokenChain', () => {
+  it('should resolve the evm chain name from a Monad token identifier', () => {
+    const chain = getTokenChain(
+      {
+        tokenIdentifier: 'eip155:143/erc20:0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A',
+        tokenKind: NewDetectedTokenKind.EVM,
+      },
+      allEvmChains,
+    );
+
+    expect(chain).toBe('monad');
+  });
+
+  it('should resolve the evm chain name from a Hyperliquid token identifier', () => {
+    const chain = getTokenChain(
+      {
+        tokenIdentifier: 'eip155:999/erc20:0x5555555555555555555555555555555555555555',
+        tokenKind: NewDetectedTokenKind.EVM,
+      },
+      allEvmChains,
+    );
+
+    expect(chain).toBe('hyperliquid');
+  });
+
+  it('should resolve the evm chain name from an Ethereum token identifier', () => {
+    const chain = getTokenChain(
+      {
+        tokenIdentifier: 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F',
+        tokenKind: NewDetectedTokenKind.EVM,
+      },
+      allEvmChains,
+    );
+
+    expect(chain).toBe('ethereum');
+  });
+
+  it('should fall back to the token kind when the chain id is not in the supported chains list', () => {
+    const chain = getTokenChain(
+      {
+        tokenIdentifier: 'eip155:424242/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F',
+        tokenKind: NewDetectedTokenKind.EVM,
+      },
+      allEvmChains,
+    );
+
+    expect(chain).toBe(NewDetectedTokenKind.EVM);
+  });
+
+  it('should fall back to the token kind when the identifier is malformed', () => {
+    const chain = getTokenChain(
+      {
+        tokenIdentifier: 'not-an-evm-identifier',
+        tokenKind: NewDetectedTokenKind.EVM,
+      },
+      allEvmChains,
+    );
+
+    expect(chain).toBe(NewDetectedTokenKind.EVM);
+  });
+
+  it('should return the solana token kind for solana tokens regardless of the supported chains list', () => {
+    const chain = getTokenChain(
+      {
+        tokenIdentifier: 'solana/token:So11111111111111111111111111111111111111112',
+        tokenKind: NewDetectedTokenKind.SOLANA,
+      },
+      allEvmChains,
+    );
+
+    expect(chain).toBe(NewDetectedTokenKind.SOLANA);
+  });
+});

--- a/frontend/app/src/modules/assets/detection/get-token-chain.ts
+++ b/frontend/app/src/modules/assets/detection/get-token-chain.ts
@@ -1,0 +1,29 @@
+import type { EvmChainEntries } from '@/modules/core/api/types/chains';
+import { getChainIdFromEvmIdentifier } from '@rotki/common';
+import { type NewDetectedToken, NewDetectedTokenKind } from './types';
+
+/**
+ * Resolves the chain location string for a newly-detected token.
+ *
+ * Used as the `location` prop for `HashLink` so the address/transaction column
+ * shows the chain icon and the explorer link. We derive the chain straight from
+ * the EVM identifier instead of waiting for the asset-info cache to populate —
+ * just-detected tokens are typically not yet cached at first render.
+ *
+ * Returns the evm chain name (e.g. `'monad'`, `'ethereum'`) for EVM tokens
+ * whose chain id is known, `'solana'` for Solana tokens, or the raw token kind
+ * as a last-resort fallback.
+ */
+export function getTokenChain(
+  token: Pick<NewDetectedToken, 'tokenIdentifier' | 'tokenKind'>,
+  allEvmChains: EvmChainEntries,
+): string {
+  if (token.tokenKind !== NewDetectedTokenKind.EVM)
+    return token.tokenKind;
+
+  const chainId = getChainIdFromEvmIdentifier(token.tokenIdentifier);
+  if (chainId === undefined)
+    return token.tokenKind;
+
+  return allEvmChains.find(entry => entry.id === chainId)?.name ?? token.tokenKind;
+}

--- a/frontend/app/src/modules/shell/components/AssetIcon.vue
+++ b/frontend/app/src/modules/shell/components/AssetIcon.vue
@@ -198,7 +198,7 @@ const { copied, copy } = useCopy(() => identifier);
       >
         <div
           v-if="showChain && chain"
-          class="!rounded-full !overflow-hidden bg-white z-[0] absolute flex items-center justify-center shadow-sm -bottom-1 -right-1 border border-rui-grey-300 dark:border-rui-grey-900"
+          class="!rounded-full !overflow-hidden bg-white z-[1] absolute flex items-center justify-center shadow-sm -bottom-1 -right-1 border border-rui-grey-300 dark:border-rui-grey-900"
           :style="{ marginTop: chainIconMargin, marginLeft: chainIconMargin }"
         >
           <EvmChainIcon

--- a/frontend/common/src/assets/index.ts
+++ b/frontend/common/src/assets/index.ts
@@ -89,6 +89,14 @@ export function getAddressFromEvmIdentifier(identifier?: string): string {
   return identifier.split(':')[2] ?? '';
 }
 
+export function getChainIdFromEvmIdentifier(identifier?: string): number | undefined {
+  if (!identifier || !isEvmIdentifier(identifier))
+    return undefined;
+
+  const chainId = Number.parseInt(identifier.split(':')[1].split('/')[0]);
+  return Number.isNaN(chainId) ? undefined : chainId;
+}
+
 function getAddressAndNftIdFromIdentifier(identifier: string): { address: string; nftId: string } {
   const addressAndId = identifier.split(':')[2];
   const addressParts = addressAndId?.split('/') ?? [];


### PR DESCRIPTION
## Summary

- Newly Detected Tokens table: derive chain from the EVM identifier instead of the asset-info cache, so the chain icon and block-explorer link are present from the first paint (previously the `location` fell back to `'evm'` and HashLink rendered only the copy icon).
- Colibri: add Monad and Hyperliquid to `SupportedBlockchain` (with tests) — closes the gaps in asset-search native-token resolution and the Uniswap V3/V4 NFT-position icon path. Complements `fd5decea07` which added them to `ChainID`.
- AssetIcon: bump the chain badge from `z-[0]` to `z-[1]` so it stays above the loading placeholder (which is later in the DOM with `z-auto`).

## Test plan

- [x] `pnpm run test:unit src/modules/assets/detection/get-token-chain.spec.ts` — 6 new tests pass.
- [x] `cargo test blockchain::types` in `colibri/` — 5 tests pass (3 new for Monad/Hyperliquid).
- [x] Manually verified in the web app with seeded rows.
- [ ] Reviewer: confirm no regression on the standard managed-assets table or asset-search dropdown.

### How to manually seed test tokens

1. Log in to a dev user in the web app.
2. Open DevTools → Console on any rotki page and run the snippet below (replace the username if yours differs from `kelsos`):

```js
(async () => {
  const userId = sessionStorage.getItem('rotki.logged_user_id'); // e.g. "kelsos.dev"
  const dbName = (await indexedDB.databases())
    .map(d => d.name)
    .find(n => n && n.endsWith(`.${userId}`));
  if (!dbName) throw new Error('no rotki user DB found');

  await new Promise((resolve, reject) => {
    const req = indexedDB.open(dbName);
    req.onerror = () => reject(req.error);
    req.onsuccess = () => {
      const db = req.result;
      const tx = db.transaction('newlyDetectedTokens', 'readwrite');
      const store = tx.objectStore('newlyDetectedTokens');
      const now = Date.now();
      [
        { tokenIdentifier: 'eip155:143/erc20:0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A', tokenKind: 'evm', detectedAt: now,        seenDescription: 'Manual seed: WMON on Monad' },
        { tokenIdentifier: 'eip155:999/erc20:0x5555555555555555555555555555555555555555', tokenKind: 'evm', detectedAt: now - 1000, seenDescription: 'Manual seed: WHYPE on Hyperliquid' },
        { tokenIdentifier: 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F',   tokenKind: 'evm', detectedAt: now - 2000, seenDescription: 'Manual seed: DAI on Ethereum' },
      ].forEach(row => store.add(row));
      tx.oncomplete = () => resolve();
      tx.onerror = () => reject(tx.error);
    };
  });
  console.log('seeded; reload the Newly Detected Assets page');
})();
```

3. Navigate to **Manage Assets → More → Newly Detected Tokens** and reload.
4. Expected: each address column shows a copy icon + an external-link icon. Hover the link to confirm it points to `monadscan.com/token/...`, `hyperscan.com/token/...`, and `etherscan.io/token/...` respectively. The Asset column shows the chain badge overlay (Monad / Hyperliquid / Ethereum) on the asset icon from the first frame.
5. To clean up, click the green check on each seeded row to dismiss them.