### PR TITLE
fix: prevent partial-commit corruption in set_rotkehlchen_premium

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -2862,18 +2862,16 @@ class DBHandler:
 
     def set_rotkehlchen_premium(self, credentials: PremiumCredentials) -> None:
         """Save the rotki premium credentials in the DB"""
-        cursor = self.conn.cursor()
-        # We don't care about previous value so simple insert or replace should work
-        cursor.execute(
-            'INSERT OR REPLACE INTO user_credentials'
-            '(name, api_key, api_secret, passphrase) VALUES (?, ?, ?, ?)',
-            ('rotkehlchen', credentials.serialize_key(), credentials.serialize_secret(), None),
-        )
-        self.conn.commit()
-        cursor.close()
-        # Do not update the last write here. If we are starting in a new machine
-        # then this write is mandatory and to sync with data from server we need
-        # an empty last write ts in that case
+        # Use write_ctx directly (not user_write) to skip the last_write_ts bump.
+        # If we are starting on a new machine then this write is mandatory and to
+        # sync with data from server we need an empty last_write_ts in that case.
+        with self.conn.write_ctx() as cursor:
+            # We don't care about previous value so simple insert or replace should work
+            cursor.execute(
+                'INSERT OR REPLACE INTO user_credentials'
+                '(name, api_key, api_secret, passphrase) VALUES (?, ?, ?, ?)',
+                ('rotkehlchen', credentials.serialize_key(), credentials.serialize_secret(), None),
+            )
 
     def delete_premium_credentials(self) -> bool:
         """Delete the rotki premium credentials in the DB for the logged-in user"""

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -1553,9 +1553,14 @@ def test_set_get_rotkehlchen_premium_credentials(data_dir, username, sql_vm_inst
     msg_aggregator = MessagesAggregator()
     data = DataHandler(data_dir, msg_aggregator, sql_vm_instructions_cb)
     data.unlock(username, '123', create_new=True, resume_from_backup=False)
+    with data.db.conn.read_ctx() as cursor:
+        last_write_ts_before = data.db.get_setting(cursor, 'last_write_ts')
     data.db.set_rotkehlchen_premium(credentials)
     with data.db.conn.read_ctx() as cursor:
         returned_credentials = data.db.get_rotkehlchen_premium(cursor)
+        # Setting premium credentials must not bump last_write_ts: a fresh
+        # install needs an empty last_write_ts to sync state from the server.
+        assert data.db.get_setting(cursor, 'last_write_ts') == last_write_ts_before
     assert returned_credentials == credentials
     assert returned_credentials.serialize_key() == api_key
     assert returned_credentials.serialize_secret() == secret


### PR DESCRIPTION
set_rotkehlchen_premium used a bare cursor and called self.conn.commit() directly, bypassing the gevent driver's transaction_lock. While another greenlet was inside a write_ctx with a BEGIN-issued transaction, this call's commit() would prematurely commit that greenlet's in-flight writes too, defeating its own rollback path if it later errored.

Switch to self.conn.write_ctx() (not user_write) so the call takes the write lock like every other writer while preserving the existing 'do not bump last_write_ts here' invariant (commit_ts defaults to False). A regression assertion in test_set_get_rotkehlchen_premium_credentials guards the last_write_ts behavior.

