### PR TITLE
fix: keep CSV import task alive when asset is unsupported on a location

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`12215` Cryptocompare is now removed from the default list of oracles if no API key is set.
+* :bug:`12233` Importing a custom CSV that contains an asset which is unsupported on the given exchange (e.g. GLD on Bittrex) no longer crashes the import task. The offending row is reported as an error and the rest of the file is imported normally.
 * :bug:`-` Hyperliquid history pagination no longer skips entries when many fills share the same millisecond at a page boundary.
 * :bug:`-` Reviewing newly detected Monad and Hyperliquid tokens now shows the chain icon and a working block-explorer link next to the address, so you can confirm what was detected without leaving the page.
 * :bug:`-` The chain icon on an asset no longer flickers behind the asset image while it loads, so you can tell which chain a token belongs to from the moment it appears.

--- a/rotkehlchen/data_import/importers/bitcoin_tax.py
+++ b/rotkehlchen/data_import/importers/bitcoin_tax.py
@@ -12,7 +12,7 @@ from rotkehlchen.data_import.utils import (
     hash_csv_row,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.base import HistoryEvent
@@ -262,6 +262,13 @@ class BitcoinTaxImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/bitstamp.py
+++ b/rotkehlchen/data_import/importers/bitstamp.py
@@ -7,7 +7,7 @@ from rotkehlchen.assets.converters import asset_from_bitstamp
 from rotkehlchen.data_import.importers.constants import BITSTAMP_EVENT_PREFIX
 from rotkehlchen.data_import.utils import BaseExchangeImporter
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import (
@@ -118,6 +118,13 @@ class BitstampTransactionsImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/bittrex.py
+++ b/rotkehlchen/data_import/importers/bittrex.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from rotkehlchen.assets.converters import asset_from_bittrex
 from rotkehlchen.data_import.utils import BaseExchangeImporter, maybe_set_transaction_extra_data
 from rotkehlchen.db.drivers.gevent import DBCursor
+from rotkehlchen.errors.asset import UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.utils import deserialize_asset_movement_address, get_key_if_has_val
@@ -249,6 +250,13 @@ class BittrexImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Deserialization error: {e!s}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except KeyError as e:

--- a/rotkehlchen/data_import/importers/blockfi_trades.py
+++ b/rotkehlchen/data_import/importers/blockfi_trades.py
@@ -7,7 +7,7 @@ from rotkehlchen.assets.converters import asset_from_blockfi
 from rotkehlchen.constants import ZERO
 from rotkehlchen.data_import.utils import BaseExchangeImporter, SkippedCSVEntry
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events
@@ -93,6 +93,13 @@ class BlockfiTradesImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/blockfi_transactions.py
+++ b/rotkehlchen/data_import/importers/blockfi_transactions.py
@@ -12,7 +12,7 @@ from rotkehlchen.data_import.utils import (
     hash_csv_row,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -143,6 +143,13 @@ class BlockfiTransactionsImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/blockpit.py
+++ b/rotkehlchen/data_import/importers/blockpit.py
@@ -11,7 +11,7 @@ from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.data_import.importers.constants import BLOCKPIT_EVENT_PREFIX
 from rotkehlchen.data_import.utils import BaseExchangeImporter, UnsupportedCSVEntry, hash_csv_row
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -224,6 +224,13 @@ class BlockpitImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/coinbasepro.py
+++ b/rotkehlchen/data_import/importers/coinbasepro.py
@@ -8,7 +8,7 @@ from rotkehlchen.assets.converters import asset_from_coinbasepro
 from rotkehlchen.data_import.importers.constants import COINBASEPRO_EVENT_PREFIX
 from rotkehlchen.data_import.utils import BaseExchangeImporter
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -178,6 +178,11 @@ class CoinbaseProImporter(BaseExchangeImporter):
                     row_index=index, csv_row=row,
                     msg=f'Unknown asset {e.identifier}.', is_error=True,
                 )
+            except UnsupportedAsset as e:
+                self.send_message(
+                    row_index=index, csv_row=row,
+                    msg=str(e), is_error=True,
+                )
             except DeserializationError as e:
                 self.send_message(
                     row_index=index, csv_row=row,
@@ -196,6 +201,12 @@ class CoinbaseProImporter(BaseExchangeImporter):
                 self.send_message(
                     row_index=0, csv_row=rows[0],
                     msg=f'Unknown asset {e.identifier} in trade {trade_id}.',
+                    is_error=True,
+                )
+            except UnsupportedAsset as e:
+                self.send_message(
+                    row_index=0, csv_row=rows[0],
+                    msg=f'{e!s} (trade {trade_id}).',
                     is_error=True,
                 )
             except (DeserializationError, ValueError) as e:

--- a/rotkehlchen/data_import/importers/coinledger.py
+++ b/rotkehlchen/data_import/importers/coinledger.py
@@ -12,7 +12,7 @@ from rotkehlchen.data_import.utils import (
     maybe_set_transaction_extra_data,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -225,6 +225,13 @@ class CoinledgerImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/cointracking.py
+++ b/rotkehlchen/data_import/importers/cointracking.py
@@ -17,7 +17,7 @@ from rotkehlchen.data_import.utils import (
     hash_csv_row,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import (
@@ -240,6 +240,13 @@ class CointrackingImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except (IndexError, ValueError):

--- a/rotkehlchen/data_import/importers/cryptocom.py
+++ b/rotkehlchen/data_import/importers/cryptocom.py
@@ -15,7 +15,7 @@ from rotkehlchen.data_import.utils import (
     hash_csv_row,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -568,6 +568,8 @@ class CryptocomImporter(BaseExchangeImporter):
                 raise InputError(f'Crypto.com csv missing entry for {e!s}') from e
             except UnknownAsset as e:
                 raise InputError(f'Encountered unknown asset {e!s} at crypto.com csv import') from e  # noqa: E501
+            except UnsupportedAsset as e:
+                raise InputError(f'Encountered unsupported asset at crypto.com csv import: {e!s}') from e  # noqa: E501
 
             for index, row in enumerate(data, start=1):
                 try:
@@ -579,6 +581,13 @@ class CryptocomImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/kucoin.py
+++ b/rotkehlchen/data_import/importers/kucoin.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.assets.converters import asset_from_kucoin
 from rotkehlchen.data_import.utils import BaseExchangeImporter, hash_csv_row
 from rotkehlchen.db.drivers.gevent import DBCursor
+from rotkehlchen.errors.asset import UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.utils import get_key_if_has_val
@@ -107,6 +108,13 @@ class KucoinImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Deserialization error: {e!s}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except KeyError as e:

--- a/rotkehlchen/data_import/importers/nexo.py
+++ b/rotkehlchen/data_import/importers/nexo.py
@@ -12,7 +12,7 @@ from rotkehlchen.data_import.utils import (
     hash_csv_row,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -218,6 +218,13 @@ class NexoImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/rotki_events.py
+++ b/rotkehlchen/data_import/importers/rotki_events.py
@@ -10,7 +10,7 @@ from rotkehlchen.data_import.utils import (
     process_rotki_generic_import_csv_fields,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.base import HistoryBaseEntry, HistoryEvent
@@ -101,6 +101,13 @@ class RotkiGenericEventsImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=f'{e!s} for location {row.get("Location", "")}.',
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/rotki_trades.py
+++ b/rotkehlchen/data_import/importers/rotki_trades.py
@@ -8,7 +8,7 @@ from rotkehlchen.data_import.utils import (
     process_rotki_generic_import_csv_fields,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events
@@ -74,6 +74,13 @@ class RotkiGenericTradesImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=f'{e!s} for location {row.get("Location", "")}.',
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/shapeshift_trades.py
+++ b/rotkehlchen/data_import/importers/shapeshift_trades.py
@@ -8,7 +8,7 @@ from rotkehlchen.constants.assets import A_DAI, A_SAI
 from rotkehlchen.constants.timing import SAI_DAI_MIGRATION_TS
 from rotkehlchen.data_import.utils import BaseExchangeImporter, SkippedCSVEntry, hash_csv_row
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events
@@ -112,6 +112,13 @@ Trade from ShapeShift with ShapeShift Deposit Address:
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/uphold_transactions.py
+++ b/rotkehlchen/data_import/importers/uphold_transactions.py
@@ -6,7 +6,7 @@ from rotkehlchen.assets.converters import asset_from_uphold
 from rotkehlchen.constants import ZERO
 from rotkehlchen.data_import.utils import BaseExchangeImporter, SkippedCSVEntry, hash_csv_row
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
@@ -198,6 +198,13 @@ Activity from uphold with uphold transaction id:
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
+                        is_error=True,
+                    )
+                except UnsupportedAsset as e:
+                    self.send_message(
+                        row_index=index,
+                        csv_row=row,
+                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/tests/unit/test_data_import_utils.py
+++ b/rotkehlchen/tests/unit/test_data_import_utils.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from typing import Any
 
 from rotkehlchen.constants.assets import A_ETH
+from rotkehlchen.data_import.importers.rotki_events import RotkiGenericEventsImporter
+from rotkehlchen.data_import.importers.rotki_trades import RotkiGenericTradesImporter
 from rotkehlchen.data_import.utils import BaseExchangeImporter, detect_duplicate_event
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.fval import FVal
@@ -55,3 +57,53 @@ def test_detect_duplicate_event_escapes_like(database) -> None:
             importer=importer,
             write_cursor=write_cursor,
         ) is False
+
+
+def test_rotki_generic_trades_unsupported_asset(database, tmp_path) -> None:
+    """Regression for https://github.com/rotki/rotki/issues/12233.
+
+    An UnsupportedAsset on a row (GLD on Bittrex is blacklisted in
+    location_unsupported_assets) must not crash the import task — it should be
+    surfaced as a per-row error and the rest of the file should import fine.
+    """
+    filepath = tmp_path / 'rotki_generic_trades.csv'
+    filepath.write_text(
+        'Location,Spend Currency,Receive Currency,Receive Amount,Spend Amount,'
+        'Fee,Fee Currency,Description,Timestamp\n'
+        'bittrex,GLD,BTC,0.01,100,,,Trade GLD for BTC,1545575255000\n'
+        'kraken,LTC,BTC,4.3241,392.8870,,,Trade LTC for BTC,1659171600000\n',
+    )
+
+    importer = RotkiGenericTradesImporter(db=database)
+    success, msg = importer.import_csv(filepath=filepath)
+    assert success is True
+    assert msg == ''
+    assert importer.total_entries == 2
+    assert importer.imported_entries == 1
+    error_msgs = [m for m in importer.import_msgs if m.get('is_error')]
+    assert len(error_msgs) == 1
+    assert 'GLD' in error_msgs[0]['msg']
+    assert 'not supported' in error_msgs[0]['msg']
+    assert 'bittrex' in error_msgs[0]['msg']
+
+
+def test_rotki_generic_events_unsupported_asset(database, tmp_path) -> None:
+    """Same regression for the rotki generic events importer."""
+    filepath = tmp_path / 'rotki_generic_events.csv'
+    filepath.write_text(
+        'Type,Location,Currency,Amount,Fee,Fee Currency,Description,Timestamp\n'
+        'Deposit,bittrex,GLD,100,,,Deposit GLD,1545575255000\n'
+        'Deposit,kraken,LTC,5,,,Deposit LTC,1659171600000\n',
+    )
+
+    importer = RotkiGenericEventsImporter(db=database)
+    success, msg = importer.import_csv(filepath=filepath)
+    assert success is True
+    assert msg == ''
+    assert importer.total_entries == 2
+    assert importer.imported_entries == 1
+    error_msgs = [m for m in importer.import_msgs if m.get('is_error')]
+    assert len(error_msgs) == 1
+    assert 'GLD' in error_msgs[0]['msg']
+    assert 'not supported' in error_msgs[0]['msg']
+    assert 'bittrex' in error_msgs[0]['msg']


### PR DESCRIPTION
Caught UnsupportedAsset per row in the rotki generic trades/events importers (reported in #12233) and in the other 14 CSV importers that route assets through exchange-specific converters. Previously the exception propagated out of the greenlet and the user saw 'backend query task died unexpectedly'.

Added regression tests for both rotki generic importers using the user's exact failure case (bittrex,GLD), plus a changelog entry.