### PR TITLE
ci: bump action-job-checker to v6

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -30,7 +30,7 @@ jobs:
       frontend_tasks: ${{ steps.checker.outputs.frontend_tasks }}
       e2e_tasks: ${{ steps.checker.outputs.e2e_tasks }}
       documentation_tasks: ${{ steps.checker.outputs.documentation_tasks }}
-      test_environment: ${{ steps.checker.outputs.test_environment }}
+      test_environment: ${{ steps.checker.outputs.backend_environment }}
     permissions:
       contents: read
     steps:
@@ -40,20 +40,35 @@ jobs:
           persist-credentials: false
 
       - name: Run check action
-        uses: rotki/action-job-checker@7e0e1933df593a14ee57c51d2be1f0014d4191d0  # v5.0.0
+        uses: rotki/action-job-checker@c507ef41d38d78c43014d42175dc1725019f0c23  # v6.1.0
         id: checker
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          documentation_paths: |
-            docs
-          colibri_paths: |
-            colibri
-          backend_paths: |
-            rotkehlchen
-            pyproject.toml
-            .github/workflows/task_backend_tests.yml
-          frontend_paths: |
-            frontend
+          config: |
+            # yaml-language-server: $schema=https://raw.githubusercontent.com/rotki/action-job-checker/v6.1.0/schema.json
+            groups:
+              - name: frontend
+                paths: [frontend]
+                run_tag: run frontend
+                implies: [e2e]
+              - name: e2e
+                run_tag: run e2e
+              - name: backend
+                paths:
+                  - rotkehlchen
+                  - pyproject.toml
+                  - .github/workflows/task_backend_tests.yml
+                run_tag: run backend
+                skip_tag: skip py tests
+                environments:
+                  - tag: run nft py tests
+                    value: nfts
+                  - tag: run all py tests
+                    value: nightly
+              - name: colibri
+                paths: [colibri]
+              - name: documentation
+                paths: [docs]
 
   check-typos:
     name: 'Check Typos'


### PR DESCRIPTION
## Summary
- v6 replaced per-category path inputs (`backend_paths`, `frontend_paths`, etc.) with a unified `config` block of group definitions.
- Migrate the five existing groups (frontend, e2e, backend, colibri, documentation) and preserve every commit-message tag v5 supported: `run frontend`, `run e2e`, `skip py tests`, `run all py tests`, `run nft py tests` (the last two via the new per-group `environments` mapping).
- The action now emits `<group>_environment` instead of a fixed `test_environment`. Remap `backend_environment` to `test_environment` at the job-output level so `task_backend_tests.yml` keeps working without changes downstream.
- Pin to commit SHA and add a `yaml-language-server` schema comment for IDE autocomplete.

## Test plan
- [ ] Push a no-op change under `docs/` and confirm only `documentation_tasks=true`.
- [ ] Push a change under `frontend/` and confirm `frontend_tasks=true` and `e2e_tasks=true` (via `implies`).
- [ ] Push a change under `rotkehlchen/` with `[run all py tests]` in the commit message and confirm `test_environment=nightly` is passed to `task_backend_tests.yml`.
- [ ] Confirm `[skip py tests]` on a backend-touching commit skips the backend group.