### PR TITLE
feat(frontend): suppress no-indexers notification per chain

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`12241` You can now silence the "No indexers available" notification for individual chains you don't plan to configure an indexer for, and re-enable notifications later from the EVM settings page.
 * :bug:`12113` Switching the dashboard timeframe now resets the net worth chart back to the full range instead of carrying over the previous zoom selection.
 * :bug:`12112` The dashboard's net worth percentage and trend indicator now follow the chart's data-zoom selection.
 * :feature:`11988` rotki now has a setting to selectively enable/disable chain / address query for transaction history. That means you can skip history querying for specific chains or chain/address combinations.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2671,6 +2671,14 @@
       "no_indexers_warning": "At least one indexer must be selected. The list cannot be empty.",
       "remove_chain": "Remove chain specific setting",
       "subtitle": "Indexers are used to query history events. Configure the priority order of indexers for each EVM chain. If the first indexer fails, the next one will be tried, and so on.",
+      "suppressed_no_indexer_chains": {
+        "error": "Failed to update suppressed chains.",
+        "hint": "Select chains to silence the \"No indexers available\" notification. Remove a chain to start showing notifications again.",
+        "label": "Suppressed chains",
+        "subtitle": "Manage the chains for which the \"No indexers available\" notification is silenced.",
+        "success": "Suppressed chains updated",
+        "title": "Suppressed \"No indexers available\" notifications"
+      },
       "title": "Indexer Order"
     }
   },
@@ -4392,7 +4400,12 @@
     },
     "no_available_indexers": {
       "action": "Configure indexers",
+      "do_not_show_again": "Do not show again for this chain",
       "message": "No indexers are available for {chain}. Transaction queries for this chain were skipped. You can configure indexer settings to resolve this.",
+      "suppress_confirm": {
+        "message": "Future \"No indexers available\" notifications for {chain} will be suppressed. You can re-enable them later from the EVM settings page.",
+        "title": "Suppress notifications for {chain}?"
+      },
       "title": "No indexers available"
     },
     "premium": {

--- a/frontend/app/src/modules/core/messaging/handlers/no-available-indexers.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/no-available-indexers.spec.ts
@@ -1,0 +1,119 @@
+import { assert, type Notification, type NotificationAction, NotificationGroup } from '@rotki/common';
+import { mockT } from '@test/i18n';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { createNoAvailableIndexersHandler } from '@/modules/core/messaging/handlers/no-available-indexers';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+
+const updateFrontendSetting = vi.fn();
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): Record<string, ReturnType<typeof vi.fn>> => ({
+    applyFrontendSettingLocal: vi.fn(),
+    enableModule: vi.fn(),
+    setKrakenAccountType: vi.fn(),
+    update: vi.fn(),
+    updateFrontendSetting,
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): { getChainName: (chain: string) => string } => ({
+    getChainName: (chain: string): string => chain.toUpperCase(),
+  }),
+}));
+
+const router = { push: vi.fn() };
+
+describe('createNoAvailableIndexersHandler', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    updateFrontendSetting.mockReset();
+    updateFrontendSetting.mockResolvedValue({ success: true });
+  });
+
+  it('should return a notification when the chain is not suppressed', async () => {
+    const handler = createNoAvailableIndexersHandler(mockT, router);
+
+    const result = await handler.handle({ chain: 'optimism' });
+
+    expect(result).toMatchObject({
+      group: NotificationGroup.NO_AVAILABLE_INDEXERS,
+    });
+  });
+
+  it('should route to the EVM indexer settings when the user clicks the configure action', async () => {
+    const handler = createNoAvailableIndexersHandler(mockT, router);
+
+    const result = await handler.handle({ chain: 'binance_sc' });
+    assert(result);
+    const actions = Array.isArray(result.action) ? result.action : [result.action];
+    const configureAction = actions.find(a => a && a.label.includes('action') && !a.label.includes('do_not_show_again'));
+    assert(configureAction);
+
+    await configureAction.action();
+
+    expect(router.push).toHaveBeenCalledWith({ path: '/settings/evm', hash: '#indexer' });
+  });
+
+  it('should return null when the chain is in the suppression list', async () => {
+    const handler = createNoAvailableIndexersHandler(mockT, router);
+    const store = useFrontendSettingsStore();
+    store.update({ suppressNoIndexerChains: ['binance_sc'] });
+
+    const result = await handler.handle({ chain: 'binance_sc' });
+
+    expect(result).toBeNull();
+  });
+
+  function getSuppressAction(notification: Notification | null | void): NotificationAction {
+    assert(notification);
+    const actions = Array.isArray(notification.action) ? notification.action : [notification.action];
+    const suppressAction = actions.find(a => a && a.label.includes('do_not_show_again'));
+    assert(suppressAction);
+    return suppressAction;
+  }
+
+  it('should append the chain to suppressNoIndexerChains when the user confirms', async () => {
+    const handler = createNoAvailableIndexersHandler(mockT, router);
+    const confirmStore = useConfirmStore();
+
+    const result = await handler.handle({ chain: 'binance_sc' });
+    const suppressAction = getSuppressAction(result);
+
+    await suppressAction.action();
+    expect(confirmStore.visible).toBe(true);
+
+    await confirmStore.confirm();
+
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ suppressNoIndexerChains: ['binance_sc'] });
+  });
+
+  it('should not update the suppression list when the user dismisses the confirmation', async () => {
+    const handler = createNoAvailableIndexersHandler(mockT, router);
+    const confirmStore = useConfirmStore();
+
+    const result = await handler.handle({ chain: 'binance_sc' });
+    const suppressAction = getSuppressAction(result);
+
+    await suppressAction.action();
+    await confirmStore.dismiss();
+
+    expect(updateFrontendSetting).not.toHaveBeenCalled();
+  });
+
+  it('should skip the update when the chain was added to the list between notification and confirmation', async () => {
+    const handler = createNoAvailableIndexersHandler(mockT, router);
+    const store = useFrontendSettingsStore();
+    const confirmStore = useConfirmStore();
+
+    const result = await handler.handle({ chain: 'binance_sc' });
+    const suppressAction = getSuppressAction(result);
+
+    store.update({ suppressNoIndexerChains: ['binance_sc'] });
+    await suppressAction.action();
+    await confirmStore.confirm();
+
+    expect(updateFrontendSetting).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/core/messaging/handlers/no-available-indexers.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/no-available-indexers.ts
@@ -1,22 +1,61 @@
-import type { NotificationHandler } from '../interfaces';
+import type { Router } from 'vue-router';
+import type { MessageHandler } from '../interfaces';
 import type { NoAvailableIndexersData } from '@/modules/core/messaging/types';
-import { NotificationCategory, NotificationGroup, Priority, Severity, toHumanReadable } from '@rotki/common';
-import { createNotificationHandler } from '@/modules/core/messaging/utils';
+import { type NotificationAction, NotificationCategory, NotificationGroup, Priority, Severity } from '@rotki/common';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { createConditionalHandler } from '@/modules/core/messaging/utils';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
 import { Routes } from '@/router/routes';
 
-export function createNoAvailableIndexersHandler(t: ReturnType<typeof useI18n>['t'], router: ReturnType<typeof useRouter>): NotificationHandler<NoAvailableIndexersData> {
-  return createNotificationHandler<NoAvailableIndexersData>(({ chain }) => ({
-    action: {
-      action: async () => router.push({ path: Routes.SETTINGS_EVM.toString(), hash: '#indexer' }),
-      label: t('notification_messages.no_available_indexers.action'),
-      persist: true,
-    },
-    category: NotificationCategory.DEFAULT,
-    display: true,
-    group: NotificationGroup.NO_AVAILABLE_INDEXERS,
-    message: t('notification_messages.no_available_indexers.message', { chain: toHumanReadable(chain, 'capitalize') }),
-    priority: Priority.ACTION,
-    severity: Severity.WARNING,
-    title: t('notification_messages.no_available_indexers.title'),
-  }));
+export function createNoAvailableIndexersHandler(t: ReturnType<typeof useI18n>['t'], router: Pick<Router, 'push'>): MessageHandler<NoAvailableIndexersData> {
+  const { updateFrontendSetting } = useSettingsOperations();
+  const { suppressNoIndexerChains } = storeToRefs(useFrontendSettingsStore());
+  const { getChainName } = useSupportedChains();
+  const { show } = useConfirmStore();
+
+  return createConditionalHandler<NoAvailableIndexersData>(({ chain }) => {
+    if (get(suppressNoIndexerChains).includes(chain))
+      return null;
+
+    const chainName = getChainName(chain);
+
+    const actions: NotificationAction[] = [
+      {
+        action: async () => router.push({ path: Routes.SETTINGS_EVM.toString(), hash: '#indexer' }),
+        label: t('notification_messages.no_available_indexers.action'),
+        persist: true,
+      },
+      {
+        action: async (): Promise<void> => {
+          show(
+            {
+              message: t('notification_messages.no_available_indexers.suppress_confirm.message', { chain: chainName }),
+              title: t('notification_messages.no_available_indexers.suppress_confirm.title'),
+            },
+            async () => {
+              const currentList = get(suppressNoIndexerChains);
+              if (!currentList.includes(chain))
+                await updateFrontendSetting({ suppressNoIndexerChains: [...currentList, chain] });
+            },
+          );
+        },
+        danger: true,
+        icon: 'lu-bell-off',
+        label: t('notification_messages.no_available_indexers.do_not_show_again'),
+      },
+    ];
+
+    return {
+      action: actions,
+      category: NotificationCategory.DEFAULT,
+      display: true,
+      group: NotificationGroup.NO_AVAILABLE_INDEXERS,
+      message: t('notification_messages.no_available_indexers.message', { chain: chainName }),
+      priority: Priority.ACTION,
+      severity: Severity.WARNING,
+      title: t('notification_messages.no_available_indexers.title'),
+    };
+  });
 }

--- a/frontend/app/src/modules/settings/evm/IndexerOrderSetting.vue
+++ b/frontend/app/src/modules/settings/evm/IndexerOrderSetting.vue
@@ -438,6 +438,7 @@ watchImmediate([evmIndexersOrder, defaultEvmIndexerOrder], () => {
           </SettingsOption>
         </RuiTabItem>
       </RuiTabItems>
+      <slot name="footer" />
     </div>
   </div>
 </template>

--- a/frontend/app/src/modules/settings/evm/SuppressedNoIndexerChainsSetting.spec.ts
+++ b/frontend/app/src/modules/settings/evm/SuppressedNoIndexerChainsSetting.spec.ts
@@ -1,0 +1,85 @@
+import type { EvmChainInfo } from '@/modules/core/api/types/chains';
+import { Blockchain } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SuppressedNoIndexerChainsSetting from '@/modules/settings/evm/SuppressedNoIndexerChainsSetting.vue';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const { computed } = await import('vue');
+  const chains: EvmChainInfo[] = [
+    {
+      evmChainName: 'optimism',
+      id: Blockchain.OPTIMISM,
+      type: 'evm',
+      image: '',
+      name: 'Optimism',
+      nativeToken: 'ETH',
+    },
+    {
+      evmChainName: 'binance_sc',
+      id: 'binance_sc',
+      type: 'evm',
+      image: '',
+      name: 'BNB Smart Chain',
+      nativeToken: 'BNB',
+    },
+  ];
+  return {
+    useSupportedChains: vi.fn().mockReturnValue({
+      txEvmChains: computed(() => chains),
+      getChainName: (chain: string): string => chains.find(c => c.id === chain)?.name ?? chain,
+    }),
+  };
+});
+
+vi.mock('@/modules/settings/use-settings-operations', async () => {
+  const mod = await vi.importActual<typeof import('@/modules/settings/use-settings-operations')>(
+    '@/modules/settings/use-settings-operations',
+  );
+  return {
+    ...mod,
+    useSettingsOperations: vi.fn().mockReturnValue({
+      applyFrontendSettingLocal: vi.fn(),
+      enableModule: vi.fn(),
+      setKrakenAccountType: vi.fn(),
+      update: vi.fn(),
+      updateFrontendSetting: vi.fn().mockResolvedValue({ success: true }),
+    }),
+  };
+});
+
+describe('suppressedNoIndexerChainsSetting', () => {
+  let wrapper: VueWrapper<InstanceType<typeof SuppressedNoIndexerChainsSetting>>;
+
+  function createWrapper(): VueWrapper<InstanceType<typeof SuppressedNoIndexerChainsSetting>> {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    return mount(SuppressedNoIndexerChainsSetting, {
+      global: { plugins: [pinia] },
+      provide: libraryDefaults,
+    });
+  }
+
+  beforeEach(async (): Promise<void> => {
+    wrapper = createWrapper();
+    await flushPromises();
+  });
+
+  it('should render the suppressed chains setting with no chips by default', () => {
+    expect(wrapper.find('[data-cy=suppressed-no-indexer-chains-setting]').exists()).toBe(true);
+    expect(wrapper.find('[data-cy=suppressed-no-indexer-chains]').exists()).toBe(true);
+    expect(wrapper.findAll('.rui-chip')).toHaveLength(0);
+  });
+
+  it('should reflect the suppressed chain in the autocomplete value', async () => {
+    const store = useFrontendSettingsStore();
+    store.update({ suppressNoIndexerChains: ['binance_sc'] });
+    await nextTick();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('BNB Smart Chain');
+  });
+});

--- a/frontend/app/src/modules/settings/evm/SuppressedNoIndexerChainsSetting.vue
+++ b/frontend/app/src/modules/settings/evm/SuppressedNoIndexerChainsSetting.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import type { EvmChainInfo } from '@/modules/core/api/types/chains';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
+import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
+import { SettingsHighlightIds } from '@/modules/settings/setting-highlight-ids';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+import ChainIcon from '@/modules/shell/components/ChainIcon.vue';
+
+const { t } = useI18n({ useScope: 'global' });
+const { suppressNoIndexerChains } = storeToRefs(useFrontendSettingsStore());
+const { txEvmChains } = useSupportedChains();
+
+const [DefineChainItem, ReuseChainItem] = createReusableTemplate<{ item: EvmChainInfo; size: string }>();
+</script>
+
+<template>
+  <DefineChainItem #default="{ item, size }">
+    <div class="flex items-center gap-2">
+      <ChainIcon
+        :chain="item.id"
+        :size="size"
+      />
+      <span>{{ item.name }}</span>
+    </div>
+  </DefineChainItem>
+
+  <SettingsItem
+    :id="SettingsHighlightIds.SUPPRESSED_NO_INDEXER_CHAINS"
+    data-cy="suppressed-no-indexer-chains-setting"
+  >
+    <template #title>
+      {{ t('evm_settings.indexer.suppressed_no_indexer_chains.title') }}
+    </template>
+    <template #subtitle>
+      {{ t('evm_settings.indexer.suppressed_no_indexer_chains.subtitle') }}
+    </template>
+    <SettingsOption
+      #default="{ error, success, updateImmediate }"
+      frontend-setting
+      setting="suppressNoIndexerChains"
+      :error-message="t('evm_settings.indexer.suppressed_no_indexer_chains.error')"
+      :success-message="t('evm_settings.indexer.suppressed_no_indexer_chains.success')"
+    >
+      <RuiAutoComplete
+        :options="txEvmChains"
+        :label="t('evm_settings.indexer.suppressed_no_indexer_chains.label')"
+        :model-value="suppressNoIndexerChains"
+        :success-messages="success"
+        :error-messages="error"
+        :hint="t('evm_settings.indexer.suppressed_no_indexer_chains.hint')"
+        data-cy="suppressed-no-indexer-chains"
+        variant="outlined"
+        key-attr="id"
+        text-attr="name"
+        chips
+        :item-height="48"
+        auto-select-first
+        @update:model-value="updateImmediate($event)"
+      >
+        <template #selection="{ item }">
+          <ReuseChainItem
+            :item="item"
+            size="20px"
+          />
+        </template>
+        <template #item="{ item }">
+          <ReuseChainItem
+            :item="item"
+            size="24px"
+          />
+        </template>
+      </RuiAutoComplete>
+    </SettingsOption>
+  </SettingsItem>
+</template>

--- a/frontend/app/src/modules/settings/setting-highlight-ids.ts
+++ b/frontend/app/src/modules/settings/setting-highlight-ids.ts
@@ -53,6 +53,7 @@ export const SettingsHighlightIds = {
   SCRAMBLE: 'setting-scramble',
   SKIPPED_EVENTS: 'setting-skipped-events',
   SUBSCRIPT: 'setting-subscript',
+  SUPPRESSED_NO_INDEXER_CHAINS: 'setting-suppressed-no-indexer-chains',
   SUPPRESS_MISSING_KEY: 'setting-suppress-missing-key',
   TIMEFRAME: 'setting-timeframe',
   TREAT_ETH2_AS_ETH: 'setting-treat-eth2-as-eth',

--- a/frontend/app/src/modules/settings/types/frontend-settings.ts
+++ b/frontend/app/src/modules/settings/types/frontend-settings.ts
@@ -242,6 +242,7 @@ export const FrontendSettings = z.object({
   selectedTheme: ThemeEnum.default(Theme.AUTO),
   showGraphRangeSelector: z.boolean().default(true),
   subscriptDecimals: z.boolean().default(false),
+  suppressNoIndexerChains: z.array(z.string()).default([]),
   thousandSeparator: z.string().default(Defaults.DEFAULT_THOUSAND_SEPARATOR),
   timeframeSetting: TimeFrameSetting.default(TimeFramePersist.REMEMBER),
   useHistoricalAssetBalances: z.boolean().default(false),

--- a/frontend/app/src/modules/settings/types/user-settings.spec.ts
+++ b/frontend/app/src/modules/settings/types/user-settings.spec.ts
@@ -96,6 +96,7 @@ describe('user-types', () => {
       passwordConfirmationInterval: 604800,
       newlyDetectedTokensMaxCount: 500,
       newlyDetectedTokensTtlDays: 30,
+      suppressNoIndexerChains: [],
     };
 
     const raw = {

--- a/frontend/app/src/modules/settings/use-frontend-settings-store.spec.ts
+++ b/frontend/app/src/modules/settings/use-frontend-settings-store.spec.ts
@@ -30,6 +30,11 @@ describe('useFrontendSettingsStore', () => {
     expect(store.language).toBe(SupportedLanguage.GR);
   });
 
+  it('should default suppressNoIndexerChains to an empty array', () => {
+    const store = useFrontendSettingsStore(pinia);
+    expect(get(store.suppressNoIndexerChains)).toEqual([]);
+  });
+
   it('should restore settings', () => {
     const store = useFrontendSettingsStore(pinia);
     const state: FrontendSettings = {
@@ -116,6 +121,7 @@ describe('useFrontendSettingsStore', () => {
       passwordConfirmationInterval: 604800,
       newlyDetectedTokensMaxCount: 500,
       newlyDetectedTokensTtlDays: 30,
+      suppressNoIndexerChains: [],
     };
 
     store.update(state);

--- a/frontend/app/src/modules/settings/use-frontend-settings-store.ts
+++ b/frontend/app/src/modules/settings/use-frontend-settings-store.ts
@@ -32,6 +32,7 @@ export const useFrontendSettingsStore = defineStore('settings/frontend', () => {
   const amountRoundingMode = useComputedRef(settings, 'amountRoundingMode');
   const valueRoundingMode = useComputedRef(settings, 'valueRoundingMode');
   const subscriptDecimals = useComputedRef(settings, 'subscriptDecimals');
+  const suppressNoIndexerChains = useComputedRef(settings, 'suppressNoIndexerChains');
   const selectedTheme = useComputedRef(settings, 'selectedTheme');
   const lightTheme = useComputedRef(settings, 'lightTheme');
   const darkTheme = useComputedRef(settings, 'darkTheme');
@@ -137,6 +138,7 @@ export const useFrontendSettingsStore = defineStore('settings/frontend', () => {
     showGraphRangeSelector,
     showSuggestionsDialog,
     subscriptDecimals,
+    suppressNoIndexerChains,
     thousandSeparator,
     timeframeSetting,
     update,

--- a/frontend/app/src/modules/settings/use-settings-search.ts
+++ b/frontend/app/src/modules/settings/use-settings-search.ts
@@ -157,6 +157,7 @@ function getEvmTab(routes: SettingsRoutes, t: T): TabGroup {
     ] },
     { categoryId: SettingsCategoryIds.INDEXER, children: [
       { texts: [t('evm_settings.indexer.title')], keywords: [t('evm_settings.indexer.subtitle')] },
+      { texts: [t('evm_settings.indexer.title'), t('evm_settings.indexer.suppressed_no_indexer_chains.title')], keywords: [t('evm_settings.indexer.suppressed_no_indexer_chains.subtitle')], highlightId: SettingsHighlightIds.SUPPRESSED_NO_INDEXER_CHAINS },
     ] },
   ] };
 }

--- a/frontend/app/src/pages/settings/evm/index.vue
+++ b/frontend/app/src/pages/settings/evm/index.vue
@@ -3,6 +3,7 @@ import { NoteLocation } from '@/modules/core/common/notes';
 import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
 import SettingsPage from '@/modules/settings/controls/SettingsPage.vue';
 import IndexerOrderSetting from '@/modules/settings/evm/IndexerOrderSetting.vue';
+import SuppressedNoIndexerChainsSetting from '@/modules/settings/evm/SuppressedNoIndexerChainsSetting.vue';
 import EvmChainsToIgnoreSettings from '@/modules/settings/general/EvmChainsToIgnoreSettings.vue';
 import TreatEthAsEth2Setting from '@/modules/settings/general/TreatEthAsEth2Setting.vue';
 import { SettingsCategoryIds, SettingsHighlightIds } from '@/modules/settings/setting-highlight-ids';
@@ -50,6 +51,10 @@ const navigation = computed<{ id: string; label: string }[]>(() => [
         <EvmChainsToIgnoreSettings />
       </SettingsItem>
     </SettingCategory>
-    <IndexerOrderSetting :id="SettingsCategoryIds.INDEXER" />
+    <IndexerOrderSetting :id="SettingsCategoryIds.INDEXER">
+      <template #footer>
+        <SuppressedNoIndexerChainsSetting />
+      </template>
+    </IndexerOrderSetting>
   </SettingsPage>
 </template>


### PR DESCRIPTION
## Summary

- Adds a "Do not show again for this chain" action to the "No indexers available" notification, with a confirmation dialog before persisting.
- Stores the suppression list in a new frontend-only setting `suppressNoIndexerChains: string[]` so no backend changes are required.
- Surfaces a chain-picker management UI on the EVM settings page (inside the Indexer Order section) so users can add or remove suppressed chains without having to wait for the notification to fire.

Closes #12241

## Test plan

- [ ] Trigger the notification for a chain (e.g. BINANCE SC), click "Do not show again for this chain", confirm — notification disappears and future notifications for that chain are suppressed.
- [ ] Dismissing the confirmation dialog does not suppress the chain.
- [ ] The chain appears as a chip in EVM Settings → "Suppressed 'No indexers available' notifications".
- [ ] Removing the chip from the settings UI re-enables the notification for that chain.
- [ ] Adding a chain via the settings autocomplete (without triggering the notification first) also suppresses future notifications for it.
- [ ] The "Configure indexers" action still navigates to the EVM indexer settings.
- [ ] Settings search finds the new setting (search "suppress" / "no indexer").
- [ ] `pnpm run test:unit src/modules/core/messaging/ src/modules/settings/` passes.