### PR TITLE
feat(frontend): auto-detect tokens on login with cooldown

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`12094` You can now have rotki automatically scan for new tokens each time you log in, and tune how often that on-login scan should actually run via a configurable cooldown.
 * :feature:`12241` You can now silence the "No indexers available" notification for individual chains you don't plan to configure an indexer for, and re-enable notifications later from the EVM settings page.
 * :bug:`12113` Switching the dashboard timeframe now resets the net worth chart back to the full range instead of carrying over the previous zoom selection.
 * :bug:`12112` The dashboard's net worth percentage and trend indicator now follow the chart's data-zoom selection.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3161,6 +3161,17 @@
         "error": "Error setting tokens auto detection"
       }
     },
+    "auto_detect_tokens_cooldown": {
+      "label": "Cooldown in hours",
+      "subtitle": "Minimum time between two automatic token-detection runs. Manual re-detect ignores this.",
+      "title": "Auto detect tokens cooldown",
+      "validation": {
+        "error": "Error saving the auto-detect cooldown",
+        "invalid_value": "Cooldown must be between {start} and {end} hours",
+        "non_empty": "Cooldown cannot be empty",
+        "success": "Auto-detect cooldown updated"
+      }
+    },
     "balance_frequency": {
       "label": "Balance data saving frequency in hours",
       "title": "Balance saving",

--- a/frontend/app/src/modules/balances/blockchain/use-auto-token-detection.spec.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-auto-token-detection.spec.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAutoTokenDetection } from '@/modules/balances/blockchain/use-auto-token-detection';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+
+const detectAllTokens = vi.fn();
+const updateFrontendSetting = vi.fn();
+const autoDetectTokensRef = ref<boolean>(true);
+
+vi.mock('@/modules/balances/blockchain/use-token-detection-orchestrator', () => ({
+  useTokenDetectionOrchestrator: (): Record<string, ReturnType<typeof vi.fn>> => ({
+    detectAllTokens,
+    detectTokens: vi.fn(),
+    useIsDetecting: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): Record<string, ReturnType<typeof vi.fn>> => ({
+    applyFrontendSettingLocal: vi.fn(),
+    enableModule: vi.fn(),
+    setKrakenAccountType: vi.fn(),
+    update: vi.fn(),
+    updateFrontendSetting,
+  }),
+}));
+
+vi.mock('@/modules/settings/use-general-settings-store', () => ({
+  useGeneralSettingsStore: (): { autoDetectTokens: typeof autoDetectTokensRef } => ({
+    autoDetectTokens: autoDetectTokensRef,
+  }),
+}));
+
+const HOUR_MS = 60 * 60 * 1000;
+
+describe('useAutoTokenDetection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    detectAllTokens.mockReset().mockResolvedValue(undefined);
+    updateFrontendSetting.mockReset().mockResolvedValue({ success: true });
+    set(autoDetectTokensRef, true);
+    useFrontendSettingsStore().update({ autoDetectTokensCooldownHours: 24, lastAutoDetectAt: 0 });
+  });
+
+  it('should run detection when auto-detect is on and cooldown has elapsed', async () => {
+    const { maybeDetect } = useAutoTokenDetection();
+    await maybeDetect();
+
+    expect(detectAllTokens).toHaveBeenCalledTimes(1);
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ lastAutoDetectAt: expect.any(Number) });
+  });
+
+  it('should skip detection when auto-detect is disabled', async () => {
+    set(autoDetectTokensRef, false);
+    const { maybeDetect } = useAutoTokenDetection();
+    await maybeDetect();
+
+    expect(detectAllTokens).not.toHaveBeenCalled();
+    expect(updateFrontendSetting).not.toHaveBeenCalled();
+  });
+
+  it('should skip detection when last run is within the cooldown window', async () => {
+    useFrontendSettingsStore().update({
+      autoDetectTokensCooldownHours: 24,
+      lastAutoDetectAt: Date.now() - 1 * HOUR_MS,
+    });
+    const { maybeDetect } = useAutoTokenDetection();
+    await maybeDetect();
+
+    expect(detectAllTokens).not.toHaveBeenCalled();
+    expect(updateFrontendSetting).not.toHaveBeenCalled();
+  });
+
+  it('should run detection when the cooldown window has elapsed', async () => {
+    useFrontendSettingsStore().update({
+      autoDetectTokensCooldownHours: 24,
+      lastAutoDetectAt: Date.now() - 25 * HOUR_MS,
+    });
+    const { maybeDetect } = useAutoTokenDetection();
+    await maybeDetect();
+
+    expect(detectAllTokens).toHaveBeenCalledTimes(1);
+    expect(updateFrontendSetting).toHaveBeenCalledTimes(1);
+  });
+
+  it('should run detection once when called concurrently', async () => {
+    let resolve!: () => void;
+    detectAllTokens.mockReturnValueOnce(new Promise<void>((r) => {
+      resolve = r;
+    }));
+    const { maybeDetect } = useAutoTokenDetection();
+
+    const first = maybeDetect();
+    const second = maybeDetect();
+    resolve();
+    await Promise.all([first, second]);
+
+    expect(detectAllTokens).toHaveBeenCalledTimes(1);
+    expect(updateFrontendSetting).toHaveBeenCalledTimes(1);
+  });
+
+  it('should report the skip reason via skipReason()', () => {
+    const { skipReason } = useAutoTokenDetection();
+    expect(skipReason()).toBeNull();
+
+    set(autoDetectTokensRef, false);
+    expect(skipReason()).toBe('auto-detect-tokens disabled');
+
+    set(autoDetectTokensRef, true);
+    useFrontendSettingsStore().update({
+      autoDetectTokensCooldownHours: 24,
+      lastAutoDetectAt: Date.now() - 1 * HOUR_MS,
+    });
+    expect(skipReason()).toMatch(/^within cooldown \(\d+m remaining\)$/);
+  });
+
+  it('should run detection when lastAutoDetectAt is in the future (clock skew)', async () => {
+    useFrontendSettingsStore().update({
+      autoDetectTokensCooldownHours: 24,
+      lastAutoDetectAt: Date.now() + 48 * HOUR_MS,
+    });
+    const { maybeDetect } = useAutoTokenDetection();
+    await maybeDetect();
+
+    expect(detectAllTokens).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still update lastAutoDetectAt when detection throws', async () => {
+    detectAllTokens.mockRejectedValueOnce(new Error('boom'));
+    const { maybeDetect } = useAutoTokenDetection();
+    await maybeDetect();
+
+    expect(detectAllTokens).toHaveBeenCalledTimes(1);
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ lastAutoDetectAt: expect.any(Number) });
+  });
+});

--- a/frontend/app/src/modules/balances/blockchain/use-auto-token-detection.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-auto-token-detection.ts
@@ -1,0 +1,77 @@
+import { useTokenDetectionOrchestrator } from '@/modules/balances/blockchain/use-token-detection-orchestrator';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
+import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
+
+interface UseAutoTokenDetectionReturn {
+  willDetect: () => boolean;
+  maybeDetect: () => Promise<void>;
+  skipReason: () => string | null;
+}
+
+const HOUR_IN_MS = 60 * 60 * 1000;
+
+export function useAutoTokenDetection(): UseAutoTokenDetectionReturn {
+  const { detectAllTokens } = useTokenDetectionOrchestrator();
+  const { autoDetectTokens } = storeToRefs(useGeneralSettingsStore());
+  const { autoDetectTokensCooldownHours, lastAutoDetectAt } = storeToRefs(useFrontendSettingsStore());
+  const { updateFrontendSetting } = useSettingsOperations();
+
+  const inFlight = ref<boolean>(false);
+
+  function isCooldownElapsed(): boolean {
+    const now = Date.now();
+    const lastAt = get(lastAutoDetectAt);
+    // Clock-skew guard: if the stored timestamp is in the future
+    // (DB restore, clock rollback), treat it as never-run.
+    const elapsed = lastAt > now ? Number.POSITIVE_INFINITY : now - lastAt;
+    const cooldownMs = get(autoDetectTokensCooldownHours) * HOUR_IN_MS;
+    return elapsed >= cooldownMs;
+  }
+
+  function skipReason(): string | null {
+    if (get(inFlight))
+      return 'already in-flight';
+    if (!get(autoDetectTokens))
+      return 'auto-detect-tokens disabled';
+    if (!isCooldownElapsed()) {
+      const lastAt = get(lastAutoDetectAt);
+      const remainingMs = get(autoDetectTokensCooldownHours) * HOUR_IN_MS - (Date.now() - lastAt);
+      return `within cooldown (${Math.round(remainingMs / 60_000)}m remaining)`;
+    }
+    return null;
+  }
+
+  function willDetect(): boolean {
+    return skipReason() === null;
+  }
+
+  async function maybeDetect(): Promise<void> {
+    const skip = skipReason();
+    if (skip !== null) {
+      logger.debug(`Auto token detection skipped: ${skip}`);
+      return;
+    }
+
+    const now = Date.now();
+    logger.info('Auto token detection: running');
+
+    set(inFlight, true);
+    try {
+      await detectAllTokens();
+    }
+    catch (error: unknown) {
+      logger.error('Auto token detection failed on initial load', error);
+    }
+    finally {
+      // Always persist the timestamp, even on failure, so a persistently broken
+      // chain doesn't trigger detection on every login.
+      await updateFrontendSetting({ lastAutoDetectAt: now });
+      set(inFlight, false);
+      logger.debug(`Auto token detection: persisted lastAutoDetectAt=${now}`);
+    }
+  }
+
+  return { maybeDetect, skipReason, willDetect };
+}

--- a/frontend/app/src/modules/balances/use-balance-fetching.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-fetching.spec.ts
@@ -1,6 +1,52 @@
+import flushPromises from 'flush-promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useBalanceFetching } from './use-balance-fetching';
 import '@test/i18n';
+
+const { refreshBlockchainBalances, maybeDetect, skipReason, willDetect } = vi.hoisted(() => ({
+  maybeDetect: vi.fn().mockResolvedValue(undefined),
+  refreshBlockchainBalances: vi.fn().mockResolvedValue(undefined),
+  skipReason: vi.fn().mockReturnValue('auto-detect-tokens disabled'),
+  willDetect: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/modules/balances/use-blockchain-balances', () => ({
+  useBlockchainBalances: vi.fn().mockReturnValue({
+    fetchBlockchainBalances: vi.fn().mockResolvedValue({}),
+    refreshBlockchainBalances,
+  }),
+}));
+
+vi.mock('@/modules/balances/blockchain/use-auto-token-detection', () => ({
+  useAutoTokenDetection: (): { maybeDetect: typeof maybeDetect; skipReason: typeof skipReason; willDetect: typeof willDetect } => ({
+    maybeDetect,
+    skipReason,
+    willDetect,
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const { computed } = await import('vue');
+  const { Blockchain } = await import('@rotki/common');
+  return {
+    useSupportedChains: vi.fn().mockReturnValue({
+      supportedChains: computed(() => [
+        { id: Blockchain.ETH, type: 'evm', name: 'Ethereum', image: '', nativeToken: 'ETH' },
+        { id: Blockchain.BTC, type: 'bitcoin', name: 'Bitcoin', image: '', nativeToken: 'BTC' },
+      ]),
+      txEvmChains: computed(() => [
+        { id: Blockchain.ETH, evmChainName: 'ethereum', type: 'evm', name: 'Ethereum', image: '', nativeToken: 'ETH' },
+      ]),
+    }),
+  };
+});
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn().mockReturnValue({
+    notifyError: vi.fn(),
+  }),
+  getErrorMessage: vi.fn(),
+}));
 
 vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
@@ -70,6 +116,38 @@ describe('useBalanceFetching', () => {
     it('should coordinate fetching of all balance types', async () => {
       const { fetch } = useBalanceFetching();
       await expect(fetch()).resolves.not.toThrow();
+    });
+  });
+
+  describe('refreshFromChain', () => {
+    beforeEach(() => {
+      refreshBlockchainBalances.mockClear();
+      maybeDetect.mockClear();
+      willDetect.mockReset();
+    });
+
+    it('should refresh all chains from network when detection is not going to run', async () => {
+      willDetect.mockReturnValue(false);
+      const { refreshFromChain } = useBalanceFetching();
+
+      refreshFromChain();
+      await flushPromises();
+
+      expect(refreshBlockchainBalances).toHaveBeenCalledTimes(1);
+      expect(refreshBlockchainBalances).toHaveBeenCalledWith();
+      expect(maybeDetect).not.toHaveBeenCalled();
+    });
+
+    it('should run detection and refresh only non-EVM chains from network when detection will run', async () => {
+      willDetect.mockReturnValue(true);
+      const { refreshFromChain } = useBalanceFetching();
+
+      refreshFromChain();
+      await flushPromises();
+
+      expect(maybeDetect).toHaveBeenCalledTimes(1);
+      expect(refreshBlockchainBalances).toHaveBeenCalledTimes(1);
+      expect(refreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: ['btc'] });
     });
   });
 

--- a/frontend/app/src/modules/balances/use-balance-fetching.ts
+++ b/frontend/app/src/modules/balances/use-balance-fetching.ts
@@ -4,9 +4,12 @@ import { useBlockchainAccountManagement } from '@/modules/accounts/use-blockchai
 import { usePriceRefresh } from '@/modules/assets/prices/use-price-refresh';
 import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
 import { useBalancesApi } from '@/modules/balances/api/use-balances-api';
+import { useAutoTokenDetection } from '@/modules/balances/blockchain/use-auto-token-detection';
 import { useExchanges } from '@/modules/balances/exchanges/use-exchanges';
 import { useManualBalances } from '@/modules/balances/manual/use-manual-balances';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { TaskType } from '@/modules/core/tasks/task-type';
 import { isActionableFailure, useTaskHandler } from '@/modules/core/tasks/use-task-handler';
@@ -24,6 +27,15 @@ export const useBalanceFetching = createSharedComposable(() => {
   const { t } = useI18n({ useScope: 'global' });
   const { fetchNetValue } = useStatisticsDataFetching();
   const { refreshBlockchainBalances } = useBlockchainBalances();
+  const { maybeDetect: maybeAutoDetectTokens, skipReason: autoDetectSkipReason, willDetect } = useAutoTokenDetection();
+  const { supportedChains, txEvmChains } = useSupportedChains();
+
+  function getNonEvmTxChains(): string[] {
+    const evmIds = new Set(get(txEvmChains).map(c => c.id));
+    return get(supportedChains)
+      .map(c => c.id)
+      .filter(id => !evmIds.has(id));
+  }
 
   const fetchBalances = async (payload: Partial<AllBalancePayload> = {}): Promise<void> => {
     const outcome = await runTask(
@@ -47,7 +59,17 @@ export const useBalanceFetching = createSharedComposable(() => {
   };
 
   const refreshFromChain = (): void => {
-    startPromise(refreshBlockchainBalances());
+    if (willDetect()) {
+      const nonEvmChains = getNonEvmTxChains();
+      logger.debug(`refreshFromChain: detect-and-refresh-non-evm, non-EVM chains=[${nonEvmChains.join(', ')}]`);
+      startPromise(maybeAutoDetectTokens());
+      if (nonEvmChains.length > 0)
+        startPromise(refreshBlockchainBalances({ blockchain: nonEvmChains }));
+    }
+    else {
+      logger.debug(`refreshFromChain: refresh-all-no-detection (${autoDetectSkipReason() ?? 'unknown'}), refreshing all chains`);
+      startPromise(refreshBlockchainBalances());
+    }
     startPromise(fetchBalances());
   };
 

--- a/frontend/app/src/modules/settings/GeneralSettingsCategory.vue
+++ b/frontend/app/src/modules/settings/GeneralSettingsCategory.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
 import AskUserUponSizeDiscrepancySetting from '@/modules/settings/general/AskUserUponSizeDiscrepancySetting.vue';
+import AutoDetectTokensCooldownSetting from '@/modules/settings/general/AutoDetectTokensCooldownSetting.vue';
 import AutoDetectTokensSetting from '@/modules/settings/general/AutoDetectTokensSetting.vue';
 import BalanceSaveFrequencySetting from '@/modules/settings/general/BalanceSaveFrequencySetting.vue';
 import BtcDerivationGapLimitSetting from '@/modules/settings/general/BtcDerivationGapLimitSetting.vue';
@@ -27,6 +28,9 @@ const { t } = useI18n({ useScope: 'global' });
     </template>
     <UsageAnalyticsSetting :id="SettingsHighlightIds.USAGE_ANALYTICS" />
     <AutoDetectTokensSetting :id="SettingsHighlightIds.AUTO_DETECT_TOKENS" />
+    <SettingsItem :id="SettingsHighlightIds.AUTO_DETECT_TOKENS_COOLDOWN">
+      <AutoDetectTokensCooldownSetting />
+    </SettingsItem>
     <SettingsItem :id="SettingsHighlightIds.DISPLAY_DATE_IN_LOCALTIME">
       <template #title>
         {{ t('general_settings.display_date_in_localtime.title') }}

--- a/frontend/app/src/modules/settings/general/AutoDetectTokensCooldownSetting.spec.ts
+++ b/frontend/app/src/modules/settings/general/AutoDetectTokensCooldownSetting.spec.ts
@@ -1,0 +1,70 @@
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AutoDetectTokensCooldownSetting from '@/modules/settings/general/AutoDetectTokensCooldownSetting.vue';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+
+const autoDetectTokensRef = ref<boolean>(true);
+
+vi.mock('@/modules/settings/use-general-settings-store', () => ({
+  useGeneralSettingsStore: (): { autoDetectTokens: typeof autoDetectTokensRef } => ({
+    autoDetectTokens: autoDetectTokensRef,
+  }),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): Record<string, ReturnType<typeof vi.fn>> => ({
+    applyFrontendSettingLocal: vi.fn(),
+    enableModule: vi.fn(),
+    setKrakenAccountType: vi.fn(),
+    update: vi.fn(),
+    updateFrontendSetting: vi.fn().mockResolvedValue({ success: true }),
+  }),
+}));
+
+describe('autoDetectTokensCooldownSetting', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AutoDetectTokensCooldownSetting>>;
+
+  function createWrapper(): VueWrapper<InstanceType<typeof AutoDetectTokensCooldownSetting>> {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    return mount(AutoDetectTokensCooldownSetting, {
+      global: { plugins: [pinia] },
+      provide: libraryDefaults,
+    });
+  }
+
+  beforeEach(() => {
+    set(autoDetectTokensRef, true);
+  });
+
+  it('should render the cooldown input when auto-detect is enabled', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+
+    const input = wrapper.find<HTMLInputElement>('[data-cy=auto-detect-tokens-cooldown-input] input');
+    expect(input.exists()).toBe(true);
+    expect(input.element.value).toBe('24');
+  });
+
+  it('should hide the cooldown input when auto-detect is disabled', async () => {
+    set(autoDetectTokensRef, false);
+    wrapper = createWrapper();
+    await flushPromises();
+
+    expect(wrapper.find('[data-cy=auto-detect-tokens-cooldown-input]').exists()).toBe(false);
+  });
+
+  it('should sync the local input value when the store setting changes externally', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+
+    const store = useFrontendSettingsStore();
+    store.update({ autoDetectTokensCooldownHours: 48 });
+    await flushPromises();
+    await nextTick();
+
+    const input = wrapper.find<HTMLInputElement>('[data-cy=auto-detect-tokens-cooldown-input] input');
+    expect(input.element.value).toBe('48');
+  });
+});

--- a/frontend/app/src/modules/settings/general/AutoDetectTokensCooldownSetting.vue
+++ b/frontend/app/src/modules/settings/general/AutoDetectTokensCooldownSetting.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import useVuelidate from '@vuelidate/core';
+import { between, helpers, required } from '@vuelidate/validators';
+import { Constraints } from '@/modules/core/common/constraints';
+import { useValidation } from '@/modules/core/common/use-validation';
+import { toMessages } from '@/modules/core/common/validation/validation';
+import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
+
+const { autoDetectTokensCooldownHours } = storeToRefs(useFrontendSettingsStore());
+const cooldownHours = ref<string>(get(autoDetectTokensCooldownHours).toString());
+const { autoDetectTokens } = storeToRefs(useGeneralSettingsStore());
+
+const { t } = useI18n({ useScope: 'global' });
+
+const maxHours = Constraints.MAX_HOURS_DELAY;
+const rules = {
+  cooldownHours: {
+    between: helpers.withMessage(
+      t('general_settings.auto_detect_tokens_cooldown.validation.invalid_value', {
+        end: maxHours,
+        start: 1,
+      }),
+      between(1, maxHours),
+    ),
+    required: helpers.withMessage(
+      t('general_settings.auto_detect_tokens_cooldown.validation.non_empty'),
+      required,
+    ),
+  },
+};
+const v$ = useVuelidate(rules, { cooldownHours }, { $autoDirty: true });
+const { callIfValid } = useValidation(v$);
+
+function resetCooldown(): void {
+  set(cooldownHours, get(autoDetectTokensCooldownHours).toString());
+}
+
+function transform(value?: string): number | undefined {
+  return value ? Number.parseInt(value, 10) : undefined;
+}
+
+watch(autoDetectTokensCooldownHours, () => {
+  resetCooldown();
+});
+</script>
+
+<template>
+  <SettingsOption
+    v-if="autoDetectTokens"
+    frontend-setting
+    setting="autoDetectTokensCooldownHours"
+    :transform="transform"
+    :error-message="t('general_settings.auto_detect_tokens_cooldown.validation.error')"
+    :success-message="t('general_settings.auto_detect_tokens_cooldown.validation.success')"
+    @finished="resetCooldown()"
+  >
+    <template #title>
+      {{ t('general_settings.auto_detect_tokens_cooldown.title') }}
+    </template>
+    <template #subtitle>
+      {{ t('general_settings.auto_detect_tokens_cooldown.subtitle') }}
+    </template>
+    <template #default="{ error, success, update }">
+      <RuiTextField
+        v-model="cooldownHours"
+        variant="outlined"
+        color="primary"
+        min="1"
+        :max="maxHours"
+        data-cy="auto-detect-tokens-cooldown-input"
+        class="w-full"
+        :label="t('general_settings.auto_detect_tokens_cooldown.label')"
+        type="number"
+        :success-messages="success"
+        :error-messages="error || toMessages(v$.cooldownHours)"
+        @update:model-value="callIfValid($event, update)"
+      />
+    </template>
+  </SettingsOption>
+</template>

--- a/frontend/app/src/modules/settings/setting-highlight-ids.ts
+++ b/frontend/app/src/modules/settings/setting-highlight-ids.ts
@@ -11,6 +11,7 @@ export const SettingsHighlightIds = {
   ASSET_UPDATE: 'setting-asset-update',
   AUTO_CREATE_PROFIT_EVENTS: 'setting-auto-create-profit-events',
   AUTO_DETECT_TOKENS: 'setting-auto-detect-tokens',
+  AUTO_DETECT_TOKENS_COOLDOWN: 'setting-auto-detect-tokens-cooldown',
   BALANCE_SAVE_FREQUENCY: 'setting-balance-save-frequency',
   BTC_DERIVATION_GAP: 'setting-btc-derivation-gap',
   CHAINS_TO_SKIP_DETECTION: 'setting-chains-to-skip-detection',

--- a/frontend/app/src/modules/settings/types/frontend-settings.ts
+++ b/frontend/app/src/modules/settings/types/frontend-settings.ts
@@ -141,6 +141,14 @@ const EvmQueryIndicatorDismissalThreshold = z
   .max(Constraints.MAX_HOURS_DELAY)
   .int();
 
+const AutoDetectTokensCooldownHours = z
+  .number()
+  .min(1)
+  .max(Constraints.MAX_HOURS_DELAY)
+  .int();
+
+const LastAutoDetectAt = z.number().int().nonnegative();
+
 const NewlyDetectedTokensMaxCount = z
   .number()
   .min(Constraints.NEWLY_DETECTED_TOKENS_MIN_COUNT)
@@ -163,6 +171,7 @@ const EnablePasswordConfirmation = z.boolean();
 export const FrontendSettings = z.object({
   abbreviateNumber: z.boolean().default(false),
   amountRoundingMode: RoundingMode.default(BigNumber.ROUND_UP),
+  autoDetectTokensCooldownHours: AutoDetectTokensCooldownHours.default(24),
   balanceValueThreshold: BalanceValueThreshold.default({}),
   blockchainRefreshButtonBehaviour: BlockchainRefreshButtonBehaviourEnum.default(
     BlockchainRefreshButtonBehaviour.ONLY_REFRESH_BALANCES,
@@ -195,6 +204,7 @@ export const FrontendSettings = z.object({
   itemsPerPage: z.number().positive().int().default(10),
   language: SupportedLanguageEnum.default(SupportedLanguage.EN),
   lastAppliedSettingsVersion: z.string().default('0.0.0'),
+  lastAutoDetectAt: LastAutoDetectAt.default(0),
   lastKnownTimeframe: TimeFramePeriodEnum.default(TimeFramePeriod.ALL),
   lastPasswordConfirmed: LastPasswordConfirmed.default(0),
   lightTheme: ThemeColors.default(LIGHT_COLORS),

--- a/frontend/app/src/modules/settings/types/user-settings.spec.ts
+++ b/frontend/app/src/modules/settings/types/user-settings.spec.ts
@@ -97,6 +97,8 @@ describe('user-types', () => {
       newlyDetectedTokensMaxCount: 500,
       newlyDetectedTokensTtlDays: 30,
       suppressNoIndexerChains: [],
+      autoDetectTokensCooldownHours: 24,
+      lastAutoDetectAt: 0,
     };
 
     const raw = {

--- a/frontend/app/src/modules/settings/use-frontend-settings-store.spec.ts
+++ b/frontend/app/src/modules/settings/use-frontend-settings-store.spec.ts
@@ -35,6 +35,16 @@ describe('useFrontendSettingsStore', () => {
     expect(get(store.suppressNoIndexerChains)).toEqual([]);
   });
 
+  it('should default autoDetectTokensCooldownHours to 24', () => {
+    const store = useFrontendSettingsStore(pinia);
+    expect(get(store.autoDetectTokensCooldownHours)).toBe(24);
+  });
+
+  it('should default lastAutoDetectAt to 0', () => {
+    const store = useFrontendSettingsStore(pinia);
+    expect(get(store.lastAutoDetectAt)).toBe(0);
+  });
+
   it('should restore settings', () => {
     const store = useFrontendSettingsStore(pinia);
     const state: FrontendSettings = {
@@ -122,6 +132,8 @@ describe('useFrontendSettingsStore', () => {
       newlyDetectedTokensMaxCount: 500,
       newlyDetectedTokensTtlDays: 30,
       suppressNoIndexerChains: [],
+      autoDetectTokensCooldownHours: 24,
+      lastAutoDetectAt: 0,
     };
 
     store.update(state);

--- a/frontend/app/src/modules/settings/use-frontend-settings-store.ts
+++ b/frontend/app/src/modules/settings/use-frontend-settings-store.ts
@@ -13,7 +13,9 @@ export const useFrontendSettingsStore = defineStore('settings/frontend', () => {
   const defiSetupDone = useComputedRef(settings, 'defiSetupDone');
   const enablePasswordConfirmation = useComputedRef(settings, 'enablePasswordConfirmation');
   const language = useComputedRef(settings, 'language');
+  const autoDetectTokensCooldownHours = useComputedRef(settings, 'autoDetectTokensCooldownHours');
   const lastAppliedSettingsVersion = useComputedRef(settings, 'lastAppliedSettingsVersion');
+  const lastAutoDetectAt = useComputedRef(settings, 'lastAutoDetectAt');
   const timeframeSetting = useComputedRef(settings, 'timeframeSetting');
   const visibleTimeframes = useComputedRef(settings, 'visibleTimeframes');
   const lastKnownTimeframe = useComputedRef(settings, 'lastKnownTimeframe');
@@ -92,6 +94,7 @@ export const useFrontendSettingsStore = defineStore('settings/frontend', () => {
   return {
     abbreviateNumber,
     amountRoundingMode,
+    autoDetectTokensCooldownHours,
     balanceValueThreshold,
     blockchainRefreshButtonBehaviour,
     currencyLocation,
@@ -111,6 +114,7 @@ export const useFrontendSettingsStore = defineStore('settings/frontend', () => {
     itemsPerPage,
     language,
     lastAppliedSettingsVersion,
+    lastAutoDetectAt,
     lastKnownTimeframe,
     lastPasswordConfirmed,
     lightTheme,

--- a/frontend/app/src/modules/settings/use-settings-search.ts
+++ b/frontend/app/src/modules/settings/use-settings-search.ts
@@ -62,6 +62,7 @@ function getGeneralTab(routes: SettingsRoutes, t: T): TabGroup {
       { texts: [t('general_settings.title')], keywords: [t('general_settings.subtitle')] },
       { texts: [t('general_settings.title'), t('general_settings.usage_analytics.title')], highlightId: SettingsHighlightIds.USAGE_ANALYTICS },
       { texts: [t('general_settings.title'), t('general_settings.auto_detect_tokens.title')], highlightId: SettingsHighlightIds.AUTO_DETECT_TOKENS },
+      { texts: [t('general_settings.title'), t('general_settings.auto_detect_tokens_cooldown.title')], keywords: [t('general_settings.auto_detect_tokens_cooldown.subtitle')], highlightId: SettingsHighlightIds.AUTO_DETECT_TOKENS_COOLDOWN },
       { texts: [t('general_settings.title'), t('general_settings.display_date_in_localtime.title')], highlightId: SettingsHighlightIds.DISPLAY_DATE_IN_LOCALTIME },
       { texts: [t('general_settings.title'), t('sync_indicator.setting.ask_user_upon_size_discrepancy.title')], highlightId: SettingsHighlightIds.ASK_SIZE_DISCREPANCY },
       { texts: [t('general_settings.title'), t('general_settings.version_update_check.title')], highlightId: SettingsHighlightIds.VERSION_UPDATE_CHECK },


### PR DESCRIPTION
## Summary

- Triggers token detection on login (gated on the existing `auto_detect_tokens` setting) so users who open the app briefly between backend periodic-task cycles still see newly acquired tokens.
- Adds a configurable cooldown (`autoDetectTokensCooldownHours`, default `24`, min `1`) to prevent back-to-back logins from re-running detection. Stored in `frontend_settings` so it follows the user across devices.
- Avoids double-fetching balances: when on-login detection will run, `refreshFromChain` skips the chain-wide network refresh for EVM chains (detection writes their balances on the backend) and only network-refreshes non-EVM chains; otherwise it refreshes all chains as before.
- New cooldown setting UI placed next to "Auto detect tokens" in General Settings, gated by `v-if="autoDetectTokens"` so the cooldown is only visible when the master toggle is on. Registered in the settings search.

Closes #12094

## Flow

```
willDetect() = inFlight === false
            && autoDetectTokens === true
            && (lastAt > now ? Infinity : now - lastAt) >= cooldownMs

true  → detectAllTokens()  +  refreshBlockchainBalances({ blockchain: <non-EVM> })
false → refreshBlockchainBalances()                       (all chains)
```

`maybeDetect` always persists `lastAutoDetectAt` in `finally` — even when detection throws — so a persistently broken chain can't trigger detection on every login.

## Test plan

- [ ] Fresh login with auto-detect on and `lastAutoDetectAt = 0` → detection runs; verify newly-acquired tokens appear without manual re-detect.
- [ ] Log in again within 24h → detection skipped; classic refresh runs.
- [ ] Bump `autoDetectTokensCooldownHours` to e.g. `1` and confirm next login after 1h triggers detection again.
- [ ] Toggle `auto_detect_tokens` off → cooldown setting hides, on-login detection no longer runs, classic refresh path still works.
- [ ] Manual "re-detect tokens" button still works and does *not* advance the cooldown.
- [ ] Log in on a second device shortly after detection on the first device → second device honors the cooldown (timestamp persisted via `frontend_settings`).
- [ ] Settings search for "cooldown" / "auto detect" surfaces the new entry and scrolls to it.
- [ ] `pnpm run test:unit src/modules/balances/ src/modules/settings/` passes (501/501).

## Follow-ups (out of scope)

- Backend gating by `last_queried_timestamp` is still not wired (#5252).
- Detection currently re-fetches balances for the EVM chains it scanned even though the backend just wrote them; could be optimized inside the orchestrator.