### PR TITLE
Reducing the Binary size

### DIFF
--- a/frontend/app/.electron-builder.config.ts
+++ b/frontend/app/.electron-builder.config.ts
@@ -91,6 +91,7 @@ export default {
     license: '../../LICENSE.md',
     createDesktopShortcut: false,
   },
+  electronLanguages: ['en-US', 'de', 'es', 'fr', 'el', 'ru', 'zh-CN'],
   mac: {
     target: [{
       target: 'default',

--- a/frontend/app/.electron-builder.config.ts
+++ b/frontend/app/.electron-builder.config.ts
@@ -55,6 +55,7 @@ async function afterSign(context: AfterPackContext): Promise<void> {
  */
 export default {
   appId: 'com.rotki.app',
+  compression: 'maximum',
   directories: {
     output: 'build',
     buildResources: 'buildResources',

--- a/package.py
+++ b/package.py
@@ -768,8 +768,10 @@ class BackendBuilder:
         backend_directory = self.__storage.backend_directory
         package_env = os.environ.copy()
         if self.__debug_symbols:
-            # Do not force optimized bytecode for debug-symbol test builds.
+            # Do not force optimized bytecode for debug-symbol test builds and
+            # propagate the flag to the spec so it skips stripping vendor libs.
             package_env.setdefault('PYTHONOPTIMIZE', '0')
+            package_env[BACKEND_DEBUG_SYMBOLS_ENV] = '1'
         else:
             package_env.setdefault('PYTHONOPTIMIZE', '2')
         package_ret_code = subprocess.call(

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -17,6 +17,9 @@ PyInstaller spec file to build one-folder distributions.
 """
 
 MACOS_IDENTITY = os.environ.get('IDENTITY', None)
+# Strip debug symbols from bundled native libraries unless an opt-in test build
+# of the backend with debug symbols was requested (see package.py).
+STRIP_BINARIES = os.environ.get('ROTKI_BACKEND_DEBUG_SYMBOLS', '').lower() not in {'1', 'true', 'yes', 'on'}  # noqa: E501
 
 
 def Entrypoint(dist, group, name, scripts=None, pathex=None, hiddenimports=None, hookspath=None, excludes=None, runtime_hooks=None, datas=None):  # noqa: E501
@@ -138,7 +141,7 @@ exe = EXE(
     exclude_binaries=True,
     name=executable_name,
     debug=False,
-    strip=False,
+    strip=STRIP_BINARIES,
     upx=False,
     console=True,
     codesign_identity=identity,
@@ -150,7 +153,7 @@ coll = COLLECT(
     a.binaries,
     a.zipfiles,
     a.datas,
-    strip=False,
+    strip=STRIP_BINARIES,
     upx=False,
     name='rotki-core',
     codesign_identity=identity,

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -95,6 +95,8 @@ a = Entrypoint(
         # polars submodules we never import. polars.sql is NOT excluded because
         # polars/__init__.py unconditionally imports SQLContext from it.
         'polars.testing', 'polars.ml',
+        # SelfTest suites bundled inside pycryptodome and pycryptodomex.
+        'Crypto.SelfTest', 'Cryptodome.SelfTest',
     ],
 )
 

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -18,8 +18,16 @@ PyInstaller spec file to build one-folder distributions.
 
 MACOS_IDENTITY = os.environ.get('IDENTITY', None)
 # Strip debug symbols from bundled native libraries unless an opt-in test build
-# of the backend with debug symbols was requested (see package.py).
-STRIP_BINARIES = os.environ.get('ROTKI_BACKEND_DEBUG_SYMBOLS', '').lower() not in {'1', 'true', 'yes', 'on'}  # noqa: E501
+# of the backend with debug symbols was requested (see package.py). Skipped on
+# Windows because PyInstaller drives GNU `strip` (available on the CI via
+# Strawberry Perl/MSYS), which corrupts PE binaries like python311.dll and
+# causes the resulting bundle to fail with "LoadLibrary: Invalid access to
+# memory location." Windows debug info lives in separate PDB files anyway, so
+# there is nothing to gain from stripping the bundled .dll/.pyd files.
+STRIP_BINARIES = (
+    platform.system().lower() != 'windows'
+    and os.environ.get('ROTKI_BACKEND_DEBUG_SYMBOLS', '').lower() not in {'1', 'true', 'yes', 'on'}
+)
 
 
 def Entrypoint(dist, group, name, scripts=None, pathex=None, hiddenimports=None, hookspath=None, excludes=None, runtime_hooks=None, datas=None):  # noqa: E501

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -97,6 +97,15 @@ a = Entrypoint(
         'polars.testing', 'polars.ml',
         # SelfTest suites bundled inside pycryptodome and pycryptodomex.
         'Crypto.SelfTest', 'Cryptodome.SelfTest',
+        # Test packages shipped inside runtime dependencies. None of these are
+        # imported at runtime; gevent.testing is only used by gevent.tests
+        # and a towncrier release helper in gevent/_util.py.
+        'gevent.tests', 'gevent.testing',
+        'greenlet.tests',
+        'zope.interface.tests',
+        'regex.tests',
+        'cytoolz.tests', 'toolz.tests',
+        'parsimonious.tests',
     ],
 )
 

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -106,6 +106,10 @@ a = Entrypoint(
         'regex.tests',
         'cytoolz.tests', 'toolz.tests',
         'parsimonious.tests',
+        # substrate-interface ships smoldot_light (~24 MB) as an optional
+        # transport, loaded lazily inside a try/except. rotki only uses the
+        # RPC/WebSocket transport, so the binding is never instantiated.
+        'smoldot_light',
     ],
 )
 

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -109,6 +109,17 @@ a = Entrypoint(
     ],
 )
 
+# Drop unused Google API discovery descriptors. google-api-python-client ships
+# pre-built JSON descriptors for ~575 Google APIs (~93 MB total); we only build
+# the Calendar v3 client (see rotkehlchen/externalapis/google_calendar.py).
+def _keep_google_discovery_entry(dest):
+    norm = dest.replace(os.sep, '/')
+    if '/discovery_cache/documents/' not in norm:
+        return True
+    return norm.rsplit('/', 1)[-1].startswith('calendar')
+
+a.datas = [entry for entry in a.datas if _keep_google_discovery_entry(entry[0])]
+
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)
 
 identity = None

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -90,7 +90,12 @@ a = Entrypoint(
             'rotkehlchen/chain/ethereum/modules/dxdaomesa/data',
         ),
     ],
-    excludes=['FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter', 'debugimporter'],
+    excludes=[
+        'FixTk', 'tcl', 'tk', '_tkinter', 'tkinter', 'Tkinter', 'debugimporter',
+        # polars submodules we never import. polars.sql is NOT excluded because
+        # polars/__init__.py unconditionally imports SQLContext from it.
+        'polars.testing', 'polars.ml',
+    ],
 )
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)


### PR DESCRIPTION
This is something that has been bothering me for a while so I put claude-code to work on

## What was done

A commit for each change. Some may be wrong and need either re-thinkign or removing

 1. 6077658c31 — exclude unused polars submodules
     Added polars.testing and polars.ml to the PyInstaller excludes.
     polars.sql was deliberately left in because polars/__init__.py
     unconditionally imports SQLContext from it.

  2. 52000647cd — drop pycryptodome SelfTest suites
     Excluded Crypto.SelfTest and Cryptodome.SelfTest — both libraries
     ship their full ~1.6 MB test suites inside the wheel, never
     imported at runtime.

  3. e0abd3c1c2 — drop test packages of runtime deps
     Excluded the .tests / .testing subpackages shipped inside gevent,
     greenlet, zope.interface, regex, cytoolz, toolz, and parsimonious.
     None are imported at runtime.

  4. 7ada351aa7 — drop unused Google API discovery descriptors
     Filtered a.datas in the spec to keep only the Calendar v3 JSON
     descriptor under googleapiclient/discovery_cache/documents/. ~575
     other API descriptors (~93 MB) were being bundled for no reason —
     we only call build('calendar', 'v3', ...).

  5. 5d9d4fe684 — exclude smoldot_light
     Added smoldot_light to excludes. It's a ~24 MB optional
     light-client transport pulled in by substrate-interface; rotki
     uses only the RPC/WS transport and substrate-interface guards
     the smoldot import behind try/except.

  6. cd68850d50 — strip debug symbols from native libraries
     Flipped PyInstaller's strip=False to strip=True on both EXE() and
     COLLECT(), gated by ROTKI_BACKEND_DEBUG_SYMBOLS so opt-in debug
     builds still keep symbols. Updated package.py to propagate the
     --debug-symbols flag into that env var so the spec sees it.

  7. de4cafd01e — restrict packaged Electron locales
     Added electronLanguages: ['en-US', 'de', 'es', 'fr', 'el', 'ru',
     'zh-CN'] to the electron-builder config. By default Electron ships
     ~50 Chromium .pak locale files; we now only bundle paks for the
     7 languages rotki is translated into.

  8. b8669c6c8d — use maximum compression for installer artifacts
     Added compression: 'maximum' to the electron-builder config.
     Slows packaging but applies highest LZMA2 preset to NSIS/AppImage/
     DMG payloads — typically 5–15% smaller installers.


## Open Question

Did not remove Polars. The biggest dependency in python.

Cost: polars-lts-cpu is 124 MB, of which 120 MB is a single
  compiled Rust binary (polars.abi3.so). PyInstaller excludes can't
  trim inside a .so, so the only way to reduce it is to drop polars
  entirely. That's larger than every other optimization we just
  landed combined.

  Used in only two files:
  
  1. rotkehlchen/balances/historical.py — SQL already does the LAG()
     window work; polars is only used for cum_sum, group_by + last,
     pivot, and forward-fill. Replaceable in ~30-50 lines of pure
     Python / SQL with no user-visible change.

  2. rotkehlchen/chain/ethereum/airdrops.py — uses pl.scan_parquet
     to read airdrop data published from the rotki/data repo. This
     is the blocker: pure-python parquet readers either don't exist
     or are similarly heavy (pyarrow ~80 MB).

  Refactoring only #1 saves 0 MB — polars stays for the parquet
  reader. The real question for the team:

    Are we willing to republish airdrop data from rotki/data in a
    lighter format (CSV / JSON / SQLite) so we can drop polars?

  If yes: ~120 MB off the unpacked backend, ~30-50 MB off each
  compressed installer. If no: drop the idea.

  Secondary: polars is genuinely nice for the historical.py
  dataframe work. The replacement is simple but slightly less
  expressive — that's the real cost beyond the migration.