### PR TITLE
feat(frontend): vertical rail for RPC settings (#12250)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`12250` You can now reach every RPC endpoint, including the ETH Beacon Node, Polkadot, Kusama and Bitcoin Mempool, without horizontal scrolling on the RPC settings page. Endpoints are listed in a grouped vertical rail (EVM chains and other endpoints) that scales as new chains are added.
 * :feature:`12254` The EVM "Skip Token Detection" setting has been renamed to "Skip Account Activity Detection" to accurately describe its behavior — it controls cross-chain account activity scanning, not ERC-20 token discovery.
 * :feature:`12094` You can now have rotki automatically scan for new tokens each time you log in, and tune how often that on-login scan should actually run via a configurable cooldown.
 * :feature:`12241` You can now silence the "No indexers available" notification for individual chains you don't plan to configure an indexer for, and re-enable notifications later from the EVM settings page.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3354,6 +3354,10 @@
           "title": "Consensus layer RPC"
         }
       },
+      "groups": {
+        "evm": "EVM chains",
+        "other": "Other endpoints"
+      },
       "subtitle": "Manage and view your RPC node.",
       "title": "RPC node setting"
     },

--- a/frontend/app/src/modules/settings/general/rpc/RpcSettingOption.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/RpcSettingOption.spec.ts
@@ -1,0 +1,64 @@
+import { Blockchain } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import RpcSettingOption from '@/modules/settings/general/rpc/RpcSettingOption.vue';
+import { RpcSettingKey } from '@/modules/settings/general/rpc/use-rpc-settings-tabs';
+
+vi.mock('@/modules/history/LocationDisplay.vue', () => ({
+  default: {
+    name: 'LocationDisplay',
+    props: ['identifier', 'horizontal', 'size', 'openDetails'],
+    template: '<span data-testid="location-display">{{ identifier }}</span>',
+  },
+}));
+
+vi.mock('@/modules/shell/components/AppImage.vue', () => ({
+  default: {
+    name: 'AppImage',
+    props: ['src', 'size', 'contain'],
+    template: '<img data-testid="app-image" :src="src" />',
+  },
+}));
+
+function mountOption(props: InstanceType<typeof RpcSettingOption>['$props']): VueWrapper {
+  return mount(RpcSettingOption, { props });
+}
+
+describe('rpcSettingOption', () => {
+  it('should render LocationDisplay for chain-backed tabs', () => {
+    const wrapper = mountOption({ tab: { chain: Blockchain.ETH } });
+    const display = wrapper.find('[data-testid=location-display]');
+    expect(display.exists()).toBe(true);
+    expect(display.text()).toBe(Blockchain.ETH);
+    expect(wrapper.find('[data-testid=app-image]').exists()).toBe(false);
+  });
+
+  it('should render AppImage and name for custom tabs', () => {
+    const wrapper = mountOption({
+      tab: {
+        id: 'eth_consensus_layer',
+        image: '/img/beacon.svg',
+        name: 'ETH Beacon Node',
+        setting: RpcSettingKey.BEACON,
+      },
+    });
+    const image = wrapper.find('[data-testid=app-image]');
+    expect(image.exists()).toBe(true);
+    expect(image.attributes('src')).toBe('/img/beacon.svg');
+    expect(wrapper.text()).toContain('ETH Beacon Node');
+    expect(wrapper.find('[data-testid=location-display]').exists()).toBe(false);
+  });
+
+  it('should not render a group header by default', () => {
+    const wrapper = mountOption({ tab: { chain: Blockchain.ETH } });
+    expect(wrapper.text()).not.toContain('OTHER');
+  });
+
+  it('should render the supplied group label above the row', () => {
+    const wrapper = mountOption({
+      tab: { chain: Blockchain.SOLANA },
+      groupLabel: 'Other endpoints',
+    });
+    expect(wrapper.text()).toContain('Other endpoints');
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/RpcSettingOption.vue
+++ b/frontend/app/src/modules/settings/general/rpc/RpcSettingOption.vue
@@ -1,26 +1,12 @@
 <script setup lang="ts">
-import type { Blockchain } from '@rotki/common';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
+import { isChainTab, type RpcSettingTab } from '@/modules/settings/general/rpc/use-rpc-settings-tabs';
 import AppImage from '@/modules/shell/components/AppImage.vue';
 
-interface ChainTab {
-  chain: Blockchain;
-}
-
-interface CustomTab {
-  id: string;
-  name: string;
-  image: string;
-}
-
 const { tab, groupLabel } = defineProps<{
-  tab: ChainTab | CustomTab;
+  tab: RpcSettingTab;
   groupLabel?: string;
 }>();
-
-function isChain(item: ChainTab | CustomTab): item is ChainTab {
-  return 'chain' in item;
-}
 </script>
 
 <template>
@@ -33,7 +19,7 @@ function isChain(item: ChainTab | CustomTab): item is ChainTab {
     </div>
     <div class="flex items-center gap-2">
       <LocationDisplay
-        v-if="isChain(tab)"
+        v-if="isChainTab(tab)"
         :open-details="false"
         :identifier="tab.chain"
         horizontal
@@ -47,7 +33,7 @@ function isChain(item: ChainTab | CustomTab): item is ChainTab {
         class="icon-bg"
       />
       <span
-        v-if="!isChain(tab)"
+        v-if="!isChainTab(tab)"
         class="text-rui-text-secondary"
       >
         {{ tab.name }}

--- a/frontend/app/src/modules/settings/general/rpc/RpcSettingOption.vue
+++ b/frontend/app/src/modules/settings/general/rpc/RpcSettingOption.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import type { Blockchain } from '@rotki/common';
+import LocationDisplay from '@/modules/history/LocationDisplay.vue';
+import AppImage from '@/modules/shell/components/AppImage.vue';
+
+interface ChainTab {
+  chain: Blockchain;
+}
+
+interface CustomTab {
+  id: string;
+  name: string;
+  image: string;
+}
+
+const { tab, groupLabel } = defineProps<{
+  tab: ChainTab | CustomTab;
+  groupLabel?: string;
+}>();
+
+function isChain(item: ChainTab | CustomTab): item is ChainTab {
+  return 'chain' in item;
+}
+</script>
+
+<template>
+  <div class="flex flex-col w-full">
+    <div
+      v-if="groupLabel"
+      class="px-3 pt-2 pb-1 -mx-3 mb-1 text-xs font-medium uppercase tracking-wider text-rui-text-secondary border-t border-default"
+    >
+      {{ groupLabel }}
+    </div>
+    <div class="flex items-center gap-2">
+      <LocationDisplay
+        v-if="isChain(tab)"
+        :open-details="false"
+        :identifier="tab.chain"
+        horizontal
+        size="20px"
+      />
+      <AppImage
+        v-else
+        :src="tab.image"
+        size="20px"
+        contain
+        class="icon-bg"
+      />
+      <span
+        v-if="!isChain(tab)"
+        class="text-rui-text-secondary"
+      >
+        {{ tab.name }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/settings/general/rpc/RpcSettings.vue
+++ b/frontend/app/src/modules/settings/general/rpc/RpcSettings.vue
@@ -1,139 +1,31 @@
 <script setup lang="ts">
-import type { Component } from 'vue';
 import type BlockchainRpcNodeManager from '@/modules/settings/general/rpc/BlockchainRpcNodeManager.vue';
 import type SimpleRpcNodeManager from '@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue';
-import { assert, Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
-import { getPublicProtocolImagePath, getPublicServiceImagePath } from '@/modules/core/common/file/file';
-import { isOfEnum } from '@/modules/core/common/helpers/is-of-enum';
-import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import RpcSettingOption from '@/modules/settings/general/rpc/RpcSettingOption.vue';
+import { isChainTab, tabKey, useRpcSettingsTabs } from '@/modules/settings/general/rpc/use-rpc-settings-tabs';
 import { SettingsHighlightIds } from '@/modules/settings/setting-highlight-ids';
 import SettingCategoryHeader from '@/modules/settings/SettingCategoryHeader.vue';
 
+const BlockchainRpcNodeManagerAsync = defineAsyncComponent(() => import('@/modules/settings/general/rpc/BlockchainRpcNodeManager.vue'));
+const SimpleRpcNodeManagerAsync = defineAsyncComponent(() => import('@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue'));
+
 const { t } = useI18n({ useScope: 'global' });
-
-const route = useRoute();
-const router = useRouter();
-
-interface ChainRpcSettingTab {
-  chain: Blockchain;
-  component: Component;
-  setting?: string;
-}
-
-interface CustomRpcSettingTab {
-  id: string;
-  name: string;
-  image: string;
-  component: Component;
-  setting?: string;
-}
-
-type RpcSettingTab = ChainRpcSettingTab | CustomRpcSettingTab;
-
-// Key-based selection (chain id or custom tab id) — survives the tab list
-// being populated asynchronously (txEvmChains may load after mount).
-const selectedKey = ref<string>(Blockchain.ETH);
-const evmRpcNodeManagerRef = useTemplateRef<InstanceType<typeof BlockchainRpcNodeManager | typeof SimpleRpcNodeManager>[]>('evmRpcNodeManagerRef');
-const railRef = useTemplateRef<HTMLDivElement>('railRef');
-
-const { getChainName, txEvmChains } = useSupportedChains();
 const { isMdAndUp } = useBreakpoint();
 
-const evmChainTabs = useArrayMap(txEvmChains, (chain) => {
-  assert(isOfEnum(Blockchain)(chain.id));
-  return {
-    chain: chain.id,
-    component: defineAsyncComponent(() => import('@/modules/settings/general/rpc/BlockchainRpcNodeManager.vue')),
-  } satisfies RpcSettingTab;
-});
+const {
+  selectedKey,
+  rpcSettingTabs,
+  evmRailOptions,
+  otherRailOptions,
+  allRailOptions,
+  firstOtherKey,
+  canAddNode,
+  selectTab,
+} = useRpcSettingsTabs();
 
-const otherTabs = computed<RpcSettingTab[]>(() => [
-  {
-    // Solana is non-EVM but uses the same multi-node RPC manager as EVM chains.
-    chain: Blockchain.SOLANA,
-    component: defineAsyncComponent(() => import('@/modules/settings/general/rpc/BlockchainRpcNodeManager.vue')),
-  },
-  {
-    component: defineAsyncComponent(() => import('@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue')),
-    id: 'btc_mempool_space',
-    image: getPublicServiceImagePath('mempool.png'),
-    name: 'Bitcoin Mempool',
-    setting: 'btcMempoolApi',
-  },
-  {
-    chain: Blockchain.KSM,
-    component: defineAsyncComponent(() => import('@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue')),
-    setting: 'ksmRpcEndpoint',
-  },
-  {
-    chain: Blockchain.DOT,
-    component: defineAsyncComponent(() => import('@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue')),
-    setting: 'dotRpcEndpoint',
-  },
-  {
-    component: defineAsyncComponent(() => import('@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue')),
-    id: 'eth_consensus_layer',
-    image: getPublicProtocolImagePath('ethereum.svg'),
-    name: 'ETH Beacon Node',
-    setting: 'beaconRpcEndpoint',
-  },
-]);
-
-const rpcSettingTabs = computed<RpcSettingTab[]>(() => [
-  ...get(evmChainTabs),
-  ...get(otherTabs),
-]);
-
-interface RailOption {
-  key: string;
-  label: string;
-  tab: RpcSettingTab;
-  group: 'evm' | 'other';
-}
-
-function tabKey(tab: RpcSettingTab): string {
-  return isChain(tab) ? tab.chain : tab.id;
-}
-
-function toRailOption(group: 'evm' | 'other') {
-  return (tab: RpcSettingTab): RailOption => ({
-    key: tabKey(tab),
-    label: isChain(tab) ? getChainName(tab.chain) : tab.name,
-    tab,
-    group,
-  });
-}
-
-const evmRailOptions = computed<RailOption[]>(() => get(evmChainTabs).map(toRailOption('evm')));
-
-const otherRailOptions = computed<RailOption[]>(() => get(otherTabs).map(toRailOption('other')));
-
-const allRailOptions = computed<RailOption[]>(() => [...get(evmRailOptions), ...get(otherRailOptions)]);
-
-const firstOtherKey = computed<string | undefined>(() => get(otherRailOptions)[0]?.key);
-
-const activeTab = computed<RpcSettingTab | undefined>(() => {
-  const key = get(selectedKey);
-  return get(rpcSettingTabs).find(tab => tabKey(tab) === key);
-});
-
-// Single-value endpoints (BTC Mempool, KSM, DOT, Beacon) carry a `setting` key
-// and only ever store one URL — the "Add node" button doesn't apply.
-const canAddNode = computed<boolean>(() => {
-  const tab = get(activeTab);
-  return !!tab && !tab.setting;
-});
-
-function isChain(item: RpcSettingTab): item is ChainRpcSettingTab {
-  return 'chain' in item;
-}
-
-function selectTab(key: string | null | undefined): void {
-  if (key)
-    set(selectedKey, key);
-}
+const evmRpcNodeManagerRef = useTemplateRef<InstanceType<typeof BlockchainRpcNodeManager | typeof SimpleRpcNodeManager>[]>('evmRpcNodeManagerRef');
+const railRef = useTemplateRef<HTMLDivElement>('railRef');
 
 function addNodeClick(): void {
   const refElement = get(evmRpcNodeManagerRef);
@@ -149,25 +41,8 @@ function scrollActiveIntoView(): void {
   }));
 }
 
-onMounted(() => {
-  const tabQuery = get(route).query.tab;
-  if (typeof tabQuery === 'string' && tabQuery)
-    set(selectedKey, tabQuery);
-  scrollActiveIntoView();
-});
-
-watch(selectedKey, (key) => {
-  if (!key)
-    return;
-  const currentRoute = get(route);
-  if (currentRoute.query.tab !== key) {
-    startPromise(router.replace({
-      query: { ...currentRoute.query, tab: key },
-    }));
-  }
-  scrollActiveIntoView();
-});
-
+onMounted(() => scrollActiveIntoView());
+watch(selectedKey, () => scrollActiveIntoView());
 // When the chain list populates after mount, re-scroll so the active rail item
 // is visible (relevant for deep-links into entries far down the list).
 watch(rpcSettingTabs, () => scrollActiveIntoView());
@@ -292,15 +167,13 @@ watch(rpcSettingTabs, () => scrollActiveIntoView());
             v-if="tabKey(tab) === selectedKey"
             :key="tabKey(tab)"
           >
-            <Component
-              :is="tab.component"
-              v-if="!tab.setting && 'chain' in tab"
+            <BlockchainRpcNodeManagerAsync
+              v-if="isChainTab(tab) && !tab.setting"
               ref="evmRpcNodeManagerRef"
               :chain="tab.chain"
             />
-            <Component
-              :is="tab.component"
-              v-else
+            <SimpleRpcNodeManagerAsync
+              v-else-if="tab.setting"
               ref="evmRpcNodeManagerRef"
               :setting="tab.setting"
             />

--- a/frontend/app/src/modules/settings/general/rpc/RpcSettings.vue
+++ b/frontend/app/src/modules/settings/general/rpc/RpcSettings.vue
@@ -3,17 +3,18 @@ import type { Component } from 'vue';
 import type BlockchainRpcNodeManager from '@/modules/settings/general/rpc/BlockchainRpcNodeManager.vue';
 import type SimpleRpcNodeManager from '@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue';
 import { assert, Blockchain } from '@rotki/common';
+import { startPromise } from '@shared/utils';
 import { getPublicProtocolImagePath, getPublicServiceImagePath } from '@/modules/core/common/file/file';
 import { isOfEnum } from '@/modules/core/common/helpers/is-of-enum';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import LocationDisplay from '@/modules/history/LocationDisplay.vue';
+import RpcSettingOption from '@/modules/settings/general/rpc/RpcSettingOption.vue';
 import { SettingsHighlightIds } from '@/modules/settings/setting-highlight-ids';
 import SettingCategoryHeader from '@/modules/settings/SettingCategoryHeader.vue';
-import AppImage from '@/modules/shell/components/AppImage.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 
 const route = useRoute();
+const router = useRouter();
 
 interface ChainRpcSettingTab {
   chain: Blockchain;
@@ -31,10 +32,15 @@ interface CustomRpcSettingTab {
 
 type RpcSettingTab = ChainRpcSettingTab | CustomRpcSettingTab;
 
-const rpcSettingTab = ref<number>(0);
+// Key-based selection (chain id or custom tab id) — survives the tab list
+// being populated asynchronously (txEvmChains may load after mount).
+const selectedKey = ref<string>(Blockchain.ETH);
 const evmRpcNodeManagerRef = useTemplateRef<InstanceType<typeof BlockchainRpcNodeManager | typeof SimpleRpcNodeManager>[]>('evmRpcNodeManagerRef');
+const railRef = useTemplateRef<HTMLDivElement>('railRef');
 
-const { txEvmChains } = useSupportedChains();
+const { getChainName, txEvmChains } = useSupportedChains();
+const { isMdAndUp } = useBreakpoint();
+
 const evmChainTabs = useArrayMap(txEvmChains, (chain) => {
   assert(isOfEnum(Blockchain)(chain.id));
   return {
@@ -43,19 +49,18 @@ const evmChainTabs = useArrayMap(txEvmChains, (chain) => {
   } satisfies RpcSettingTab;
 });
 
-const rpcSettingTabs = computed<RpcSettingTab[]>(() => [
-  ...get(evmChainTabs),
+const otherTabs = computed<RpcSettingTab[]>(() => [
+  {
+    // Solana is non-EVM but uses the same multi-node RPC manager as EVM chains.
+    chain: Blockchain.SOLANA,
+    component: defineAsyncComponent(() => import('@/modules/settings/general/rpc/BlockchainRpcNodeManager.vue')),
+  },
   {
     component: defineAsyncComponent(() => import('@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue')),
     id: 'btc_mempool_space',
     image: getPublicServiceImagePath('mempool.png'),
     name: 'Bitcoin Mempool',
     setting: 'btcMempoolApi',
-  },
-  {
-    // Solana behaves like EVM RPC nodes in UI/API
-    chain: Blockchain.SOLANA,
-    component: defineAsyncComponent(() => import('@/modules/settings/general/rpc/BlockchainRpcNodeManager.vue')),
   },
   {
     chain: Blockchain.KSM,
@@ -76,42 +81,102 @@ const rpcSettingTabs = computed<RpcSettingTab[]>(() => [
   },
 ]);
 
+const rpcSettingTabs = computed<RpcSettingTab[]>(() => [
+  ...get(evmChainTabs),
+  ...get(otherTabs),
+]);
+
+interface RailOption {
+  key: string;
+  label: string;
+  tab: RpcSettingTab;
+  group: 'evm' | 'other';
+}
+
+function tabKey(tab: RpcSettingTab): string {
+  return isChain(tab) ? tab.chain : tab.id;
+}
+
+function toRailOption(group: 'evm' | 'other') {
+  return (tab: RpcSettingTab): RailOption => ({
+    key: tabKey(tab),
+    label: isChain(tab) ? getChainName(tab.chain) : tab.name,
+    tab,
+    group,
+  });
+}
+
+const evmRailOptions = computed<RailOption[]>(() => get(evmChainTabs).map(toRailOption('evm')));
+
+const otherRailOptions = computed<RailOption[]>(() => get(otherTabs).map(toRailOption('other')));
+
+const allRailOptions = computed<RailOption[]>(() => [...get(evmRailOptions), ...get(otherRailOptions)]);
+
+const firstOtherKey = computed<string | undefined>(() => get(otherRailOptions)[0]?.key);
+
+const activeTab = computed<RpcSettingTab | undefined>(() => {
+  const key = get(selectedKey);
+  return get(rpcSettingTabs).find(tab => tabKey(tab) === key);
+});
+
+// Single-value endpoints (BTC Mempool, KSM, DOT, Beacon) carry a `setting` key
+// and only ever store one URL — the "Add node" button doesn't apply.
+const canAddNode = computed<boolean>(() => {
+  const tab = get(activeTab);
+  return !!tab && !tab.setting;
+});
+
 function isChain(item: RpcSettingTab): item is ChainRpcSettingTab {
   return 'chain' in item;
 }
 
-function addNodeClick() {
+function selectTab(key: string | null | undefined): void {
+  if (key)
+    set(selectedKey, key);
+}
+
+function addNodeClick(): void {
   const refElement = get(evmRpcNodeManagerRef);
   if (refElement?.[0]) {
     refElement[0].addNewRpcNode();
   }
 }
 
+function scrollActiveIntoView(): void {
+  startPromise(nextTick(() => {
+    const active = get(railRef)?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]');
+    active?.scrollIntoView({ block: 'nearest' });
+  }));
+}
+
 onMounted(() => {
   const tabQuery = get(route).query.tab;
-  if (tabQuery) {
-    const tabs = get(rpcSettingTabs);
-    const tabIndex = tabs.findIndex((tab) => {
-      if ('id' in tab) {
-        return tab.id === tabQuery;
-      }
-      if ('chain' in tab) {
-        return tab.chain === tabQuery;
-      }
-      return false;
-    });
-
-    if (tabIndex !== -1) {
-      set(rpcSettingTab, tabIndex);
-    }
-  }
+  if (typeof tabQuery === 'string' && tabQuery)
+    set(selectedKey, tabQuery);
+  scrollActiveIntoView();
 });
+
+watch(selectedKey, (key) => {
+  if (!key)
+    return;
+  const currentRoute = get(route);
+  if (currentRoute.query.tab !== key) {
+    startPromise(router.replace({
+      query: { ...currentRoute.query, tab: key },
+    }));
+  }
+  scrollActiveIntoView();
+});
+
+// When the chain list populates after mount, re-scroll so the active rail item
+// is visible (relevant for deep-links into entries far down the list).
+watch(rpcSettingTabs, () => scrollActiveIntoView());
 </script>
 
 <template>
   <div
     :id="SettingsHighlightIds.RPC_NODES"
-    class="mt-4"
+    class="mt-4 md:h-full md:flex md:flex-col md:min-h-0"
   >
     <div class="pb-5 border-b border-default flex flex-wrap gap-4 items-center justify-between">
       <SettingCategoryHeader>
@@ -123,8 +188,10 @@ onMounted(() => {
         </template>
       </SettingCategoryHeader>
       <RuiButton
+        v-if="canAddNode"
         color="primary"
         data-cy="add-node"
+        data-testid="add-node"
         @click="addNodeClick()"
       >
         <template #prepend>
@@ -136,60 +203,110 @@ onMounted(() => {
         {{ t('evm_rpc_node_manager.add_button') }}
       </RuiButton>
     </div>
-    <div class="pt-6">
-      <RuiTabs
-        v-model="rpcSettingTab"
-        color="primary"
-        class="!h-auto"
-      >
-        <RuiTab
-          v-for="tab in rpcSettingTabs"
-          :key="isChain(tab) ? tab.chain : tab.id"
+    <div class="pt-6 md:flex md:items-stretch md:gap-6 md:flex-1 md:min-h-0">
+      <template v-if="isMdAndUp">
+        <div
+          ref="railRef"
+          class="w-[220px] shrink-0 flex flex-col gap-4 md:overflow-y-auto md:pr-1 md:-mr-1"
+          data-testid="rpc-settings-rail"
         >
-          <LocationDisplay
-            v-if="isChain(tab)"
-            :open-details="false"
-            :identifier="tab.chain"
-            horizontal
-            size="16px"
-          />
-
-          <div
-            v-else
-            class="flex items-center gap-1"
-          >
-            <AppImage
-              :src="tab.image"
-              size="16px"
-              contain
-              class="icon-bg"
-            />
-            <span class="capitalize text-rui-text-secondary">
-              {{ tab.name }}
-            </span>
+          <div>
+            <div class="px-3 pb-2 text-xs font-medium uppercase tracking-wider text-rui-text-secondary">
+              {{ t('general_settings.rpc_node_setting.groups.evm') }}
+            </div>
+            <RuiTabs
+              vertical
+              indicator-position="start"
+              color="primary"
+              class="!h-auto"
+            >
+              <RuiTab
+                v-for="option in evmRailOptions"
+                :key="option.key"
+                align="start"
+                :active="selectedKey === option.key"
+                @click="selectTab(option.key)"
+              >
+                <RpcSettingOption :tab="option.tab" />
+              </RuiTab>
+            </RuiTabs>
           </div>
-        </RuiTab>
-      </RuiTabs>
-      <RuiDivider class="mb-4" />
-      <RuiTabItems v-model="rpcSettingTab">
-        <RuiTabItem
-          v-for="tab in rpcSettingTabs"
-          :key="isChain(tab) ? tab.chain : tab.id"
+          <div>
+            <div class="px-3 pb-2 text-xs font-medium uppercase tracking-wider text-rui-text-secondary">
+              {{ t('general_settings.rpc_node_setting.groups.other') }}
+            </div>
+            <RuiTabs
+              vertical
+              indicator-position="start"
+              color="primary"
+              class="!h-auto"
+            >
+              <RuiTab
+                v-for="option in otherRailOptions"
+                :key="option.key"
+                align="start"
+                :active="selectedKey === option.key"
+                @click="selectTab(option.key)"
+              >
+                <RpcSettingOption :tab="option.tab" />
+              </RuiTab>
+            </RuiTabs>
+          </div>
+        </div>
+      </template>
+      <template v-else>
+        <div
+          class="pb-4 w-full"
+          data-testid="rpc-settings-dropdowns"
         >
-          <Component
-            :is="tab.component"
-            v-if="!tab.setting && 'chain' in tab"
-            ref="evmRpcNodeManagerRef"
-            :chain="tab.chain"
-          />
-          <Component
-            :is="tab.component"
-            v-else
-            ref="evmRpcNodeManagerRef"
-            :setting="tab.setting"
-          />
-        </RuiTabItem>
-      </RuiTabItems>
+          <RuiMenuSelect
+            :model-value="selectedKey"
+            :options="allRailOptions"
+            :label="t('general_settings.rpc_node_setting.title')"
+            variant="outlined"
+            key-attr="key"
+            text-attr="label"
+            :hide-details="true"
+            @update:model-value="selectTab($event)"
+          >
+            <template #item="{ item }">
+              <RpcSettingOption
+                :tab="item.tab"
+                :group-label="item.key === firstOtherKey ? t('general_settings.rpc_node_setting.groups.other') : undefined"
+              />
+            </template>
+            <template #selection="{ item }">
+              <RpcSettingOption :tab="item.tab" />
+            </template>
+          </RuiMenuSelect>
+        </div>
+      </template>
+
+      <div class="flex-1 min-w-0 md:overflow-y-auto">
+        <RuiDivider
+          v-if="!isMdAndUp"
+          class="mb-4"
+        />
+        <template v-for="tab in rpcSettingTabs">
+          <div
+            v-if="tabKey(tab) === selectedKey"
+            :key="tabKey(tab)"
+          >
+            <Component
+              :is="tab.component"
+              v-if="!tab.setting && 'chain' in tab"
+              ref="evmRpcNodeManagerRef"
+              :chain="tab.chain"
+            />
+            <Component
+              :is="tab.component"
+              v-else
+              ref="evmRpcNodeManagerRef"
+              :setting="tab.setting"
+            />
+          </div>
+        </template>
+      </div>
     </div>
   </div>
 </template>

--- a/frontend/app/src/modules/settings/general/rpc/use-rpc-settings-tabs.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-rpc-settings-tabs.spec.ts
@@ -1,0 +1,218 @@
+import { Blockchain } from '@rotki/common';
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { defineComponent, h, type Ref } from 'vue';
+import { RpcSettingKey, tabKey, useRpcSettingsTabs, type UseRpcSettingsTabsReturn } from '@/modules/settings/general/rpc/use-rpc-settings-tabs';
+
+interface MockChain {
+  id: string;
+  type: 'evm';
+  name: string;
+}
+
+const { txEvmChainsRef, useRouteMock, useRouterMock } = await vi.hoisted(async () => {
+  const vue = await import('vue');
+  return {
+    txEvmChainsRef: vue.ref<MockChain[]>([]),
+    useRouteMock: vi.fn(),
+    useRouterMock: vi.fn(),
+  };
+});
+
+vi.mock('vue-router', () => ({
+  useRoute: useRouteMock,
+  useRouter: useRouterMock,
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn().mockReturnValue({
+    txEvmChains: txEvmChainsRef,
+    getChainName: (id: string): string => txEvmChainsRef.value.find(c => c.id === id)?.name ?? id,
+  }),
+}));
+
+function mountWithComposable(): { wrapper: ReturnType<typeof mount>; result: UseRpcSettingsTabsReturn } {
+  let captured: UseRpcSettingsTabsReturn | undefined;
+  const Host = defineComponent({
+    setup(): () => ReturnType<typeof h> {
+      captured = useRpcSettingsTabs();
+      return (): ReturnType<typeof h> => h('div');
+    },
+  });
+  const wrapper = mount(Host);
+  return { result: captured!, wrapper };
+}
+
+describe('useRpcSettingsTabs', () => {
+  let mockRoute: Ref<{ query: Record<string, unknown> }>;
+  let mockRouter: { replace: Mock };
+
+  beforeEach(() => {
+    const emptyQuery: Record<string, unknown> = {};
+    mockRoute = ref({ query: emptyQuery });
+    mockRouter = {
+      replace: vi.fn(async ({ query }: { query: Record<string, unknown> }) => {
+        set(mockRoute, { query });
+      }),
+    };
+    useRouteMock.mockReturnValue(mockRoute);
+    useRouterMock.mockReturnValue(mockRouter);
+    set(txEvmChainsRef, [
+      { id: 'eth', name: 'Ethereum', type: 'evm' },
+      { id: 'optimism', name: 'Optimism', type: 'evm' },
+      { id: 'base', name: 'Base', type: 'evm' },
+    ]);
+  });
+
+  describe('selection', () => {
+    it('should default selection to Ethereum', () => {
+      const { result } = mountWithComposable();
+      expect(result.selectedKey.value).toBe(Blockchain.ETH);
+    });
+
+    it('should read the initial selection from the route query on mount', async () => {
+      set(mockRoute, { query: { tab: 'eth_consensus_layer' } });
+      const { result } = mountWithComposable();
+      await flushPromises();
+      expect(result.selectedKey.value).toBe('eth_consensus_layer');
+    });
+
+    it('should react to ?tab= changes while mounted', async () => {
+      const { result } = mountWithComposable();
+      await flushPromises();
+      expect(result.selectedKey.value).toBe(Blockchain.ETH);
+
+      set(mockRoute, { query: { tab: 'eth_consensus_layer' } });
+      await flushPromises();
+      expect(result.selectedKey.value).toBe('eth_consensus_layer');
+    });
+
+    it('should update the URL when selectTab is called', async () => {
+      const { result } = mountWithComposable();
+      result.selectTab('ksm');
+      await flushPromises();
+      expect(mockRouter.replace).toHaveBeenCalledWith({ query: { tab: 'ksm' } });
+    });
+
+    it('should not push a URL update when tab already matches', async () => {
+      set(mockRoute, { query: { tab: 'ksm' } });
+      const { result } = mountWithComposable();
+      await flushPromises();
+      mockRouter.replace.mockClear();
+      result.selectTab('ksm');
+      await flushPromises();
+      expect(mockRouter.replace).not.toHaveBeenCalled();
+    });
+
+    it('should ignore empty selectTab values', async () => {
+      const { result } = mountWithComposable();
+      result.selectTab(null);
+      result.selectTab(undefined);
+      result.selectTab('');
+      expect(result.selectedKey.value).toBe(Blockchain.ETH);
+    });
+
+    it('should preserve selection when txEvmChains populates after mount', async () => {
+      // Regression: the previous index-based selection lost the user's tab
+      // when the chain list arrived asynchronously.
+      set(txEvmChainsRef, []);
+      set(mockRoute, { query: { tab: 'eth_consensus_layer' } });
+      const { result } = mountWithComposable();
+      await flushPromises();
+      expect(result.selectedKey.value).toBe('eth_consensus_layer');
+
+      set(txEvmChainsRef, [
+        { id: 'eth', name: 'Ethereum', type: 'evm' },
+        { id: 'optimism', name: 'Optimism', type: 'evm' },
+      ]);
+      await flushPromises();
+      expect(result.selectedKey.value).toBe('eth_consensus_layer');
+      expect(result.activeTab.value).toBeDefined();
+      expect(result.activeTab.value && 'id' in result.activeTab.value
+        ? result.activeTab.value.id
+        : undefined).toBe('eth_consensus_layer');
+    });
+  });
+
+  describe('groups', () => {
+    it('should split EVM chains and other endpoints into separate groups', () => {
+      const { result } = mountWithComposable();
+      const evmKeys = result.evmRailOptions.value.map(o => o.key);
+      const otherKeys = result.otherRailOptions.value.map(o => o.key);
+      expect(evmKeys).toEqual(['eth', 'optimism', 'base']);
+      expect(otherKeys).toEqual([Blockchain.SOLANA, 'btc_mempool_space', Blockchain.KSM, Blockchain.DOT, 'eth_consensus_layer']);
+    });
+
+    it('should expose Solana as the first other-group entry', () => {
+      const { result } = mountWithComposable();
+      expect(result.firstOtherKey.value).toBe(Blockchain.SOLANA);
+    });
+
+    it('should put Solana in the other group, not EVM', () => {
+      const { result } = mountWithComposable();
+      expect(result.evmRailOptions.value.find(o => o.key === Blockchain.SOLANA)).toBeUndefined();
+      expect(result.otherRailOptions.value.find(o => o.key === Blockchain.SOLANA)).toBeDefined();
+    });
+
+    it('should concatenate EVM and other into allRailOptions in order', () => {
+      const { result } = mountWithComposable();
+      const all = result.allRailOptions.value.map(o => o.key);
+      expect(all).toEqual([
+        'eth',
+        'optimism',
+        'base',
+        Blockchain.SOLANA,
+        'btc_mempool_space',
+        Blockchain.KSM,
+        Blockchain.DOT,
+        'eth_consensus_layer',
+      ]);
+    });
+
+    it('should label rail options with chain names', () => {
+      const { result } = mountWithComposable();
+      const ethOption = result.evmRailOptions.value.find(o => o.key === 'eth');
+      expect(ethOption?.label).toBe('Ethereum');
+    });
+  });
+
+  describe('canAddNode', () => {
+    it('should be true on EVM chains', () => {
+      const { result } = mountWithComposable();
+      result.selectTab('eth');
+      expect(result.canAddNode.value).toBe(true);
+    });
+
+    it('should be true on Solana', () => {
+      const { result } = mountWithComposable();
+      result.selectTab(Blockchain.SOLANA);
+      expect(result.canAddNode.value).toBe(true);
+    });
+
+    it.each([
+      ['btc_mempool_space'],
+      [Blockchain.KSM],
+      [Blockchain.DOT],
+      ['eth_consensus_layer'],
+    ])('should be false on single-value endpoint %s', (key) => {
+      const { result } = mountWithComposable();
+      result.selectTab(key);
+      expect(result.canAddNode.value).toBe(false);
+    });
+  });
+
+  describe('tabKey helper', () => {
+    it('should return chain id for chain tabs', () => {
+      expect(tabKey({ chain: Blockchain.ETH })).toBe(Blockchain.ETH);
+    });
+
+    it('should return custom id for custom tabs', () => {
+      expect(tabKey({
+        id: 'eth_consensus_layer',
+        image: '',
+        name: 'ETH Beacon Node',
+        setting: RpcSettingKey.BEACON,
+      })).toBe('eth_consensus_layer');
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/use-rpc-settings-tabs.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-rpc-settings-tabs.ts
@@ -1,0 +1,160 @@
+import type { ComputedRef, DeepReadonly, Ref } from 'vue';
+import { assert, Blockchain } from '@rotki/common';
+import { startPromise } from '@shared/utils';
+import { getPublicProtocolImagePath, getPublicServiceImagePath } from '@/modules/core/common/file/file';
+import { isOfEnum } from '@/modules/core/common/helpers/is-of-enum';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+
+export const RpcSettingKey = {
+  BEACON: 'beaconRpcEndpoint',
+  BTC_MEMPOOL: 'btcMempoolApi',
+  DOT: 'dotRpcEndpoint',
+  KSM: 'ksmRpcEndpoint',
+} as const;
+
+export type RpcSettingKey = typeof RpcSettingKey[keyof typeof RpcSettingKey];
+
+export interface ChainRpcSettingTab {
+  chain: Blockchain;
+  setting?: RpcSettingKey;
+}
+
+export interface CustomRpcSettingTab {
+  id: string;
+  name: string;
+  image: string;
+  setting: RpcSettingKey;
+}
+
+export type RpcSettingTab = ChainRpcSettingTab | CustomRpcSettingTab;
+
+export interface RpcRailOption {
+  key: string;
+  label: string;
+  tab: RpcSettingTab;
+  group: 'evm' | 'other';
+}
+
+export function isChainTab(item: RpcSettingTab): item is ChainRpcSettingTab {
+  return 'chain' in item;
+}
+
+export function tabKey(tab: RpcSettingTab): string {
+  return isChainTab(tab) ? tab.chain : tab.id;
+}
+
+export interface UseRpcSettingsTabsReturn {
+  selectedKey: DeepReadonly<Ref<string>>;
+  rpcSettingTabs: ComputedRef<RpcSettingTab[]>;
+  evmRailOptions: ComputedRef<RpcRailOption[]>;
+  otherRailOptions: ComputedRef<RpcRailOption[]>;
+  allRailOptions: ComputedRef<RpcRailOption[]>;
+  firstOtherKey: ComputedRef<string | undefined>;
+  activeTab: ComputedRef<RpcSettingTab | undefined>;
+  canAddNode: ComputedRef<boolean>;
+  selectTab: (key: string | null | undefined) => void;
+}
+
+export function useRpcSettingsTabs(): UseRpcSettingsTabsReturn {
+  const route = useRoute();
+  const router = useRouter();
+  const { getChainName, txEvmChains } = useSupportedChains();
+
+  // Key-based selection (chain id or custom tab id) — survives the tab list
+  // being populated asynchronously (txEvmChains may load after mount).
+  const selectedKey = ref<string>(Blockchain.ETH);
+
+  const evmChainTabs = useArrayMap(txEvmChains, (chain): RpcSettingTab => {
+    assert(isOfEnum(Blockchain)(chain.id));
+    return { chain: chain.id };
+  });
+
+  const otherTabs = computed<RpcSettingTab[]>(() => [
+    // Solana is non-EVM but uses the same multi-node RPC manager as EVM chains.
+    { chain: Blockchain.SOLANA },
+    {
+      id: 'btc_mempool_space',
+      image: getPublicServiceImagePath('mempool.png'),
+      name: 'Bitcoin Mempool',
+      setting: RpcSettingKey.BTC_MEMPOOL,
+    },
+    { chain: Blockchain.KSM, setting: RpcSettingKey.KSM },
+    { chain: Blockchain.DOT, setting: RpcSettingKey.DOT },
+    {
+      id: 'eth_consensus_layer',
+      image: getPublicProtocolImagePath('ethereum.svg'),
+      name: 'ETH Beacon Node',
+      setting: RpcSettingKey.BEACON,
+    },
+  ]);
+
+  const rpcSettingTabs = computed<RpcSettingTab[]>(() => [
+    ...get(evmChainTabs),
+    ...get(otherTabs),
+  ]);
+
+  function toRailOption(group: 'evm' | 'other') {
+    return (tab: RpcSettingTab): RpcRailOption => ({
+      key: tabKey(tab),
+      label: isChainTab(tab) ? getChainName(tab.chain) : tab.name,
+      tab,
+      group,
+    });
+  }
+
+  const evmRailOptions = computed<RpcRailOption[]>(() => get(evmChainTabs).map(toRailOption('evm')));
+  const otherRailOptions = computed<RpcRailOption[]>(() => get(otherTabs).map(toRailOption('other')));
+  const allRailOptions = computed<RpcRailOption[]>(() => [...get(evmRailOptions), ...get(otherRailOptions)]);
+  const firstOtherKey = computed<string | undefined>(() => get(otherRailOptions)[0]?.key);
+
+  const activeTab = computed<RpcSettingTab | undefined>(() => {
+    const key = get(selectedKey);
+    return get(rpcSettingTabs).find(tab => tabKey(tab) === key);
+  });
+
+  // Single-value endpoints (BTC Mempool, KSM, DOT, Beacon) carry a `setting` key
+  // and only ever store one URL — the "Add node" button doesn't apply.
+  const canAddNode = computed<boolean>(() => {
+    const tab = get(activeTab);
+    return !!tab && !tab.setting;
+  });
+
+  function selectTab(key: string | null | undefined): void {
+    if (key)
+      set(selectedKey, key);
+  }
+
+  // Route → state: react to the tab query, including when the user
+  // navigates back to the page with a different ?tab=. immediate: true
+  // covers the initial mount case.
+  watch(() => get(route).query.tab, (tab) => {
+    if (typeof tab !== 'string' || !tab)
+      return;
+    if (get(selectedKey) !== tab)
+      set(selectedKey, tab);
+  }, { immediate: true });
+
+  // State → route: keep the URL in sync when the user picks a tab.
+  watch(selectedKey, (key) => {
+    if (!key)
+      return;
+    const currentRoute = get(route);
+    if (currentRoute.query.tab === key)
+      return;
+    startPromise(router.replace({
+      query: { ...currentRoute.query, tab: key },
+    }));
+  });
+
+  return {
+    selectedKey: readonly(selectedKey),
+    rpcSettingTabs,
+    evmRailOptions,
+    otherRailOptions,
+    allRailOptions,
+    firstOtherKey,
+    activeTab,
+    canAddNode,
+    selectTab,
+  };
+}

--- a/frontend/app/tests/e2e/pages/rpc-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/rpc-settings-page.ts
@@ -32,6 +32,34 @@ export class RpcSettingsPage {
     await expect(this.page.getByTestId('add-node')).toHaveCount(0);
   }
 
+  async visitWithTab(tab: string): Promise<void> {
+    await this.page.goto(`/#/settings/rpc?tab=${tab}`);
+    await this.page.getByTestId('rpc-settings-rail').waitFor({ state: 'visible' });
+  }
+
+  async expectActiveTab(label: string): Promise<void> {
+    const active = this.page.getByTestId('rpc-settings-rail').locator('[role="tab"][aria-selected="true"]');
+    await expect(active).toHaveText(new RegExp(label));
+  }
+
+  async clickRailTab(label: string): Promise<void> {
+    await this.page.getByTestId('rpc-settings-rail').locator('[role="tab"]', { hasText: label }).click();
+  }
+
+  async expectUrlTab(tab: string): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`tab=${tab}(?:&|$)`));
+  }
+
+  async expectSolanaUnderOtherEndpoints(): Promise<void> {
+    const rail = this.page.getByTestId('rpc-settings-rail');
+    const groups = rail.locator('> div');
+    const otherGroup = groups.nth(1);
+    await expect(otherGroup).toContainText('Other endpoints');
+    await expect(otherGroup).toContainText('Solana');
+    const evmGroup = groups.nth(0);
+    await expect(evmGroup).not.toContainText('Solana');
+  }
+
   async changePassword(currentPassword: string, newPassword: string): Promise<void> {
     await this.page.locator('[data-cy=current-password-input] input').clear();
     await this.page.locator('[data-cy=current-password-input] input').fill(currentPassword);

--- a/frontend/app/tests/e2e/pages/rpc-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/rpc-settings-page.ts
@@ -10,7 +10,26 @@ export class RpcSettingsPage {
     await this.page.locator('[data-cy=settings-button]').click();
     await this.page.locator('[data-cy=user-dropdown]').waitFor({ state: 'detached' });
     await this.page.locator('[data-cy="settings__rpc"]').click();
-    await this.page.locator('[data-cy=add-node]').waitFor({ state: 'visible' });
+    // Default Playwright viewport is wide enough to show the rail.
+    await this.page.getByTestId('rpc-settings-rail').waitFor({ state: 'visible' });
+  }
+
+  async expectRailVisible(): Promise<void> {
+    await expect(this.page.getByTestId('rpc-settings-rail')).toBeVisible();
+    await expect(this.page.getByTestId('rpc-settings-dropdowns')).toHaveCount(0);
+  }
+
+  async expectDropdownFallbackVisible(): Promise<void> {
+    await expect(this.page.getByTestId('rpc-settings-dropdowns')).toBeVisible();
+    await expect(this.page.getByTestId('rpc-settings-rail')).toHaveCount(0);
+  }
+
+  async expectAddNodeVisible(): Promise<void> {
+    await expect(this.page.getByTestId('add-node')).toBeVisible();
+  }
+
+  async expectAddNodeHidden(): Promise<void> {
+    await expect(this.page.getByTestId('add-node')).toHaveCount(0);
   }
 
   async changePassword(currentPassword: string, newPassword: string): Promise<void> {

--- a/frontend/app/tests/e2e/specs/settings/rpc.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/rpc.spec.ts
@@ -38,6 +38,38 @@ test.describe.serial('settings::rpc', () => {
     await pageRpc.visit();
     await pageRpc.confirmRPCAddition(name, endpoint);
   });
+
+  test('deep-link via ?tab= selects the Beacon Node and hides Add Node', async () => {
+    await pageRpc.visitWithTab('eth_consensus_layer');
+    await pageRpc.expectActiveTab('ETH Beacon Node');
+    await pageRpc.expectAddNodeHidden();
+  });
+
+  test('clicking a rail tab updates the URL', async () => {
+    await pageRpc.visit();
+    await pageRpc.clickRailTab('Polkadot');
+    await pageRpc.expectUrlTab('dot');
+    await pageRpc.expectActiveTab('Polkadot');
+  });
+
+  test('Add Node is hidden on every single-value endpoint', async () => {
+    for (const label of ['Bitcoin Mempool', 'Kusama', 'Polkadot', 'ETH Beacon Node']) {
+      await pageRpc.clickRailTab(label);
+      await pageRpc.expectAddNodeHidden();
+    }
+  });
+
+  test('Add Node is visible on EVM chains and Solana', async () => {
+    for (const label of ['Ethereum', 'Solana']) {
+      await pageRpc.clickRailTab(label);
+      await pageRpc.expectAddNodeVisible();
+    }
+  });
+
+  test('Solana is grouped under Other endpoints, not EVM chains', async () => {
+    await pageRpc.visit();
+    await pageRpc.expectSolanaUnderOtherEndpoints();
+  });
 });
 
 test.describe.serial('settings::rpc narrow viewport', () => {

--- a/frontend/app/tests/e2e/specs/settings/rpc.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/rpc.spec.ts
@@ -39,3 +39,30 @@ test.describe.serial('settings::rpc', () => {
     await pageRpc.confirmRPCAddition(name, endpoint);
   });
 });
+
+test.describe.serial('settings::rpc narrow viewport', () => {
+  let ctx: SharedTestContext;
+  let pageRpc: RpcSettingsPage;
+
+  // Below the Tailwind md breakpoint (768px) the rail collapses into dropdowns.
+  test.use({ viewport: { width: 600, height: 800 } });
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request);
+    pageRpc = new RpcSettingsPage(ctx.sharedPage);
+    await ctx.sharedPage.locator('[data-cy=user-menu-button]').click();
+    await ctx.sharedPage.locator('[data-cy=user-dropdown]').waitFor({ state: 'visible' });
+    await ctx.sharedPage.locator('[data-cy=settings-button]').click();
+    await ctx.sharedPage.locator('[data-cy=user-dropdown]').waitFor({ state: 'detached' });
+    await ctx.sharedPage.locator('[data-cy="settings__rpc"]').click();
+    await ctx.sharedPage.getByTestId('rpc-settings-dropdowns').waitFor({ state: 'visible' });
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('shows dropdown fallback instead of the rail', async () => {
+    await pageRpc.expectDropdownFallbackVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #12250.

Replaces the overflowing horizontal tab strip on `/settings/rpc` with a grouped vertical rail (EVM chains / Other endpoints) that scales as new chains are added, so the Beacon Node, Polkadot, Kusama and Bitcoin Mempool entries are no longer hidden off-screen at typical window widths.

- **Rail layout** with two group headers; rail and content area each get their own internal scroller so neither pushes the other off-screen.
- **Mobile fallback** (< md breakpoint) collapses to a single `RuiMenuSelect` with chain/service icons on every row and an `OTHER ENDPOINTS` divider inline before the first non-EVM item.
- **Key-based selection** (chain id or custom tab id) survives `txEvmChains` populating asynchronously, fixing a regression where deep-links to entries beyond the initial list would land on the wrong tab.
- **URL sync** in both directions: `?tab=<id>` is read on mount and re-written when the user clicks a different tab; existing deep-links from `AccountFormApiKeyAlertContent` and `HistoricalBalancesContent` continue to work.
- **Add Node** button is hidden on single-value endpoints (BTC Mempool, KSM, DOT, Beacon) where adding doesn't apply.
- **Solana** is grouped under "Other endpoints" (not EVM) since it isn't EVM-compatible, even though it shares the multi-node manager.
- **Refactor**: tab state, group split, selection, URL sync and `canAddNode` extracted into `useRpcSettingsTabs` so the SFC owns only template + the DOM-bound scroll-into-view. Internal setting keys are now a const enumlike (`RpcSettingKey`).

## Test plan

- [x] Typecheck (`pnpm run typecheck`) clean
- [x] Lint-staged passes on every touched file
- [x] Unit tests pass: 27/27 across `use-rpc-settings-tabs.spec.ts` (19) and `RpcSettingOption.spec.ts` (4), plus the pre-existing `SimpleRpcNodeManagerForm.spec.ts` (4)
- [x] Manual UI verification at 1280px and 700px viewports via chrome-devtools MCP
- [ ] CI e2e suite covers the new flows (deep-link selects the right tab, rail click updates URL, Add Node hidden on each single-value endpoint, narrow-viewport dropdown fallback, Solana under Other endpoints)