### PR TITLE
integrity-check SQLite DB before cloud backup upload/download

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`12049` rotki now runs a DB integrity check before uploading a cloud backup or replacing the local DB with a downloaded copy
 * :feature:`12250` You can now reach every RPC endpoint, including the ETH Beacon Node, Polkadot, Kusama and Bitcoin Mempool, without horizontal scrolling on the RPC settings page. Endpoints are listed in a grouped vertical rail (EVM chains and other endpoints) that scales as new chains are added.
 * :feature:`12254` The EVM "Skip Token Detection" setting has been renamed to "Skip Account Activity Detection" to accurately describe its behavior — it controls cross-chain account activity scanning, not ERC-20 token discovery.
 * :feature:`12094` You can now have rotki automatically scan for new tokens each time you log in, and tune how often that on-login scan should actually run via a configurable cooldown.

--- a/rotkehlchen/data_handler.py
+++ b/rotkehlchen/data_handler.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import logging
 import shutil
+import tempfile
 import zlib
 from collections.abc import Sequence
 from pathlib import Path
@@ -11,9 +12,10 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.misc import USERDB_NAME, USERSDIR_NAME
 from rotkehlchen.crypto import decrypt, encrypt
 from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.db.misc import plaintext_db_integrity_check
 from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.errors.api import AuthenticationError
-from rotkehlchen.errors.misc import SystemPermissionError
+from rotkehlchen.errors.misc import DataIntegrityError, SystemPermissionError
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.user_messages import MessagesAggregator
 from rotkehlchen.utils.misc import timestamp_to_date, ts_now
@@ -235,6 +237,7 @@ class DataHandler:
         there is a DB upgrade and there is an error or if the version is older
         than the one supported.
         - SystemPermissionError if the DB file permissions are not correct
+        - DataIntegrityError if the downloaded database fails the SQLite integrity check
         """
         log.info('Decompress and decrypt DB')
         # First make a backup of the DB we are about to replace
@@ -247,4 +250,13 @@ class DataHandler:
 
         decrypted_data = decrypt(self.db.password.encode(), encrypted_data)
         decompressed_data = zlib.decompress(decrypted_data)
+        # Verify the downloaded plaintext DB before letting it overwrite the local one
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:  # needed on windows, see https://tinyurl.com/tmp-win-err  # noqa: E501
+            tempdbpath = Path(tmpdirname) / 'remote.db'
+            tempdbpath.write_bytes(decompressed_data)
+            ok, integrity_error = plaintext_db_integrity_check(tempdbpath)
+        if not ok:
+            message = f'Downloaded database failed the integrity check: {integrity_error}'
+            log.error(message)
+            raise DataIntegrityError(message)
         self.db.import_unencrypted(decompressed_data)

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -66,7 +66,7 @@ from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import UserNotesFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.loopring import DBLoopring
-from rotkehlchen.db.misc import detect_sqlcipher_version
+from rotkehlchen.db.misc import detect_sqlcipher_version, evaluate_integrity_check_rows
 from rotkehlchen.db.schema import DB_SCRIPT_CREATE_TABLES
 from rotkehlchen.db.schema_transient import DB_SCRIPT_CREATE_TRANSIENT_TABLES
 from rotkehlchen.db.settings import (
@@ -561,6 +561,20 @@ class DBHandler:
         if conn:
             conn.close()
             setattr(self, conn_attribute, None)
+
+    def db_integrity_check(self) -> tuple[bool, str | None]:
+        """Run `PRAGMA integrity_check` on the user DB.
+
+        Returns (True, None) if the database is structurally sound. Otherwise returns
+        (False, error_message) with the messages reported by SQLite, or with the database
+        error raised when running the pragma.
+        """
+        try:
+            with self.conn.read_ctx() as cursor:
+                rows = cursor.execute('PRAGMA integrity_check;').fetchall()
+        except sqlcipher.DatabaseError as e:  # pylint: disable=no-member
+            return False, str(e)
+        return evaluate_integrity_check_rows(rows)
 
     def export_unencrypted(self, tempdbfile: 'tempfile._TemporaryFileWrapper[bytes]') -> Path:
         """Export the unencrypted DB to the temppath as plaintext DB

--- a/rotkehlchen/db/misc.py
+++ b/rotkehlchen/db/misc.py
@@ -3,6 +3,9 @@ due. Needed in packaging since that code has log.trace and should only be
 imported if trace level has been setup"""
 
 import re
+import sqlite3
+from contextlib import closing
+from pathlib import Path
 
 from sqlcipher3 import dbapi2 as sqlcipher
 
@@ -22,3 +25,28 @@ def detect_sqlcipher_version() -> int:
         raise ValueError(f'Could not process the version returned by SQLCipher: {version}')
 
     return int(match.group(1))
+
+
+def evaluate_integrity_check_rows(rows: list[tuple[str, ...]]) -> tuple[bool, str | None]:
+    """Inspect rows returned by `PRAGMA integrity_check` and return whether the DB is sound.
+
+    A sound DB returns a single row with the value `ok`. Otherwise SQLite returns one or more
+    rows describing what is wrong. We collapse them into a single message for logging.
+    """
+    if len(rows) == 1 and rows[0][0] == 'ok':
+        return True, None
+    return False, '; '.join(str(row[0]) for row in rows)
+
+
+def plaintext_db_integrity_check(db_path: Path) -> tuple[bool, str | None]:
+    """Run `PRAGMA integrity_check` on a plaintext sqlite database file at the given path.
+
+    Returns (True, None) when sound and (False, error_message) otherwise. Any sqlite error
+    raised while opening or running the pragma is also reported as a failure.
+    """
+    try:
+        with closing(sqlite3.connect(db_path)) as conn:
+            rows = conn.execute('PRAGMA integrity_check;').fetchall()
+    except sqlite3.DatabaseError as e:
+        return False, str(e)
+    return evaluate_integrity_check_rows(rows)

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -11,12 +11,13 @@ from rotkehlchen.constants.misc import USERSDIR_NAME
 from rotkehlchen.data_handler import DataHandler
 from rotkehlchen.data_migrations.manager import DataMigrationManager
 from rotkehlchen.db.cache import DBCacheStatic
+from rotkehlchen.db.misc import plaintext_db_integrity_check
 from rotkehlchen.errors.api import (
     PremiumAuthenticationError,
     PremiumPermissionError,
     RotkehlchenPermissionError,
 )
-from rotkehlchen.errors.misc import RemoteError, UnableToDecryptRemoteData
+from rotkehlchen.errors.misc import DataIntegrityError, RemoteError, UnableToDecryptRemoteData
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import (
     Premium,
@@ -146,6 +147,9 @@ class PremiumSyncManager(LockableQueryMixIn):
                 'The given password can not unlock the database that was retrieved  from '
                 'the server. Make sure to use the same password as when the account was created.',
             ) from e
+        except DataIntegrityError as e:
+            log.error('sync from server -- downloaded db integrity check failed', error=str(e))
+            return False, str(e)
 
         # Need to run migrations in case the app was updated since last sync and in
         # case this is a request to sync from the API, where all modules are initialized
@@ -187,6 +191,17 @@ class PremiumSyncManager(LockableQueryMixIn):
         """
         assert self.premium is not None, 'caller should make sure premium exists'
         log.debug('Starting maybe_upload_data_to_server')
+        ok, integrity_error = self.data.db.db_integrity_check()
+        if not ok:
+            message = f'Local database failed the integrity check: {integrity_error}'
+            log.error(f'upload to server aborted -- {message}')
+            self.data.msg_aggregator.add_message(
+                message_type=WSMessageType.DATABASE_UPLOAD_RESULT,
+                data={'uploaded': False, 'actionable': True, 'message': message},
+            )
+            self.last_upload_attempt_ts = ts_now()
+            return False, message
+
         try:
             metadata = self._query_last_data_metadata()
         except (RemoteError, PremiumAuthenticationError) as e:
@@ -216,6 +231,17 @@ class PremiumSyncManager(LockableQueryMixIn):
 
         with tempfile.NamedTemporaryFile(delete=False, suffix='.db') as tempdbfile:
             tempdbpath = self.data.db.export_unencrypted(tempdbfile)
+            exported_ok, exported_error = plaintext_db_integrity_check(tempdbpath)
+            if not exported_ok:
+                tempdbpath.unlink(missing_ok=True)
+                message = f'Exported database failed the integrity check: {exported_error}'
+                log.error(f'upload to server aborted -- {message}')
+                self.data.msg_aggregator.add_message(
+                    message_type=WSMessageType.DATABASE_UPLOAD_RESULT,
+                    data={'uploaded': False, 'actionable': True, 'message': message},
+                )
+                self.last_upload_attempt_ts = ts_now()
+                return False, message
             greenlet = gevent.get_hub().threadpool.spawn(self.data.compress_and_encrypt_db, tempdbpath)  # noqa: E501
             data, our_hash = greenlet.get()
 

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import sqlite3
 import tempfile
 import time
 from contextlib import suppress
@@ -37,7 +38,11 @@ from rotkehlchen.db.constants import KRAKEN_FUTURES_API_KEY_KEY, KRAKEN_FUTURES_
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.filtering import AddressbookFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
-from rotkehlchen.db.misc import detect_sqlcipher_version
+from rotkehlchen.db.misc import (
+    detect_sqlcipher_version,
+    evaluate_integrity_check_rows,
+    plaintext_db_integrity_check,
+)
 from rotkehlchen.db.queried_addresses import QueriedAddresses
 from rotkehlchen.db.schema import DB_CREATE_USER_NOTES
 from rotkehlchen.db.settings import (
@@ -1892,6 +1897,50 @@ def test_db_schema_sanity_check(database: 'DBHandler', caplog) -> None:
         with pytest.raises(DBSchemaError) as exception_info:
             connection.schema_sanity_check()
     assert "Tables {'user_notes'} are missing" in str(exception_info.value)
+
+
+def test_db_integrity_check(database: 'DBHandler') -> None:
+    """The integrity check on a healthy user DB should pass and on a corrupted file fail."""
+    ok, error = database.db_integrity_check()
+    assert ok is True
+    assert error is None
+
+
+def test_plaintext_db_integrity_check(tmp_path: Path) -> None:
+    """Verify the plaintext integrity check helper on healthy, corrupt and missing files."""
+    healthy_db = tmp_path / 'healthy.db'
+    with sqlite3.connect(healthy_db) as conn:
+        conn.execute('CREATE TABLE foo (id INTEGER PRIMARY KEY, value TEXT)')
+        conn.execute('INSERT INTO foo(value) VALUES (?)', ('bar',))
+        conn.commit()
+    ok, error = plaintext_db_integrity_check(healthy_db)
+    assert ok is True
+    assert error is None
+
+    # Corrupt the file by overwriting most of it with garbage but keeping a sqlite header
+    corrupted_db = tmp_path / 'corrupted.db'
+    corrupted_db.write_bytes(b'SQLite format 3\x00' + b'\x00' * 1024)
+    ok, error = plaintext_db_integrity_check(corrupted_db)
+    assert ok is False
+    assert error is not None and error != ''
+
+    # Not a sqlite file at all
+    not_a_db = tmp_path / 'not-a-db.db'
+    not_a_db.write_bytes(b'this is plain text not a database')
+    ok, error = plaintext_db_integrity_check(not_a_db)
+    assert ok is False
+    assert error is not None and error != ''
+
+
+def test_evaluate_integrity_check_rows() -> None:
+    """The row evaluator should return ok only on the canonical `ok` row from SQLite."""
+    assert evaluate_integrity_check_rows([('ok',)]) == (True, None)
+    ok, error = evaluate_integrity_check_rows([('row 1 missing from index foo',)])
+    assert ok is False
+    assert error == 'row 1 missing from index foo'
+    ok, error = evaluate_integrity_check_rows([('error a',), ('error b',)])
+    assert ok is False
+    assert error == 'error a; error b'
 
 
 def test_db_add_skipped_external_event_twice(database: 'DBHandler') -> None:

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -276,6 +276,58 @@ def test_upload_data_to_server_smaller_db(rotkehlchen_instance, db_settings: dic
             assert post_mock.called
 
 
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+def test_upload_aborts_on_local_db_integrity_failure(rotkehlchen_instance: 'Rotkehlchen') -> None:
+    """If the local DB fails the integrity check, no upload happens and the user is notified."""
+    with rotkehlchen_instance.data.db.user_write() as write_cursor:
+        # Write to the DB so last_write_ts is non-zero and would normally trigger an upload
+        rotkehlchen_instance.data.db.set_settings(
+            write_cursor,
+            ModifiableDBSettings(main_currency=A_EUR.resolve_to_asset_with_oracles()),
+        )
+
+    assert rotkehlchen_instance.premium is not None
+    patched_post = patch.object(rotkehlchen_instance.premium.session, 'post')
+    patched_get = create_patched_requests_get_for_premium(
+        session=rotkehlchen_instance.premium.session,
+        metadata_last_modify_ts=0,
+        metadata_data_hash='somehash',
+        metadata_data_size=2,
+        saved_data=b'foo',
+    )
+    integrity_message = 'row 1 missing from index foo'
+    integrity_patch = patch.object(
+        rotkehlchen_instance.data.db,
+        'db_integrity_check',
+        return_value=(False, integrity_message),
+    )
+    ws_patch = patch.object(rotkehlchen_instance.msg_aggregator, 'add_message')
+
+    with patched_get, integrity_patch, patched_post as post_mock, ws_patch as ws_mock:
+        success, error = rotkehlchen_instance.premium_sync_manager.maybe_upload_data_to_server(
+            force_upload=True,
+        )
+
+    assert success is False
+    assert error is not None and integrity_message in error
+    assert not post_mock.called
+    assert ws_mock.call_args_list == [
+        call(
+            message_type=WSMessageType.DATABASE_UPLOAD_RESULT,
+            data={
+                'uploaded': False,
+                'actionable': True,
+                'message': f'Local database failed the integrity check: {integrity_message}',
+            },
+        ),
+    ]
+    # The local last upload ts should remain unset since no upload happened
+    with rotkehlchen_instance.data.db.conn.read_ctx() as cursor:
+        assert rotkehlchen_instance.data.db.get_static_cache(
+            cursor=cursor, name=DBCacheStatic.LAST_DATA_UPLOAD_TS,
+        ) is None
+
+
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('start_with_valid_premium', [True])
 def test_try_premium_at_start_new_account_can_pull_data(
@@ -667,8 +719,8 @@ def test_upload_data_to_server_db_locked(rotkehlchen_instance):
         export occur under a critical section
         """
         with db.conn.read_ctx() as cursor:
-            result = cursor.execute('SELECT * FROM pragma_database_list;')
-            assert len(result.fetchall()) == 1, 'the plaintext DB should not be attached here'
+            attached = {row[1] for row in cursor.execute('SELECT * FROM pragma_database_list;').fetchall()}  # noqa: E501
+            assert 'plaintext' not in attached, 'the plaintext DB should not be attached here'
 
     with db.user_write() as cursor:
         last_ts = rotkehlchen_instance.data.db.get_static_cache(


### PR DESCRIPTION
Run PRAGMA integrity_check on the user DB before exporting and uploading to the cloud backup, on the exported plaintext file before compression, and on the decompressed remote DB before it replaces the local one. On failure, abort the operation, log the error and notify the user via the DATABASE_UPLOAD_RESULT websocket message.

Fix https://github.com/rotki/rotki/issues/12049

