### PR TITLE
test: add unit specs for tier-1 composables

### DIFF
--- a/frontend/app/src/modules/calendar/use-calendar-date-management.spec.ts
+++ b/frontend/app/src/modules/calendar/use-calendar-date-management.spec.ts
@@ -1,0 +1,97 @@
+import type { CalendarEvent } from '@/modules/calendar/types';
+import dayjs from 'dayjs';
+import { describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
+import { useCalendarDateManagement } from '@/modules/calendar/use-calendar-date-management';
+
+const DATE_FORMAT = 'YYYY-MM-DD';
+
+function makeEvent(date: string, identifier: number, name = 'event'): CalendarEvent & { date: string } {
+  return {
+    address: undefined,
+    autoDelete: false,
+    blockchain: undefined,
+    color: '',
+    counterparty: undefined,
+    date,
+    description: '',
+    identifier,
+    name,
+    timestamp: dayjs(date).unix(),
+  };
+}
+
+describe('useCalendarDateManagement', () => {
+  it('should initialize selectedDate and visibleDate to today', () => {
+    const events = computed(() => []);
+    const { selectedDate, visibleDate, selectedDateEvents } = useCalendarDateManagement(events, DATE_FORMAT);
+
+    expect(get(selectedDate).format(DATE_FORMAT)).toBe(dayjs().format(DATE_FORMAT));
+    expect(get(visibleDate).format(DATE_FORMAT)).toBe(dayjs().format(DATE_FORMAT));
+    expect(get(selectedDateEvents)).toEqual([]);
+  });
+
+  it('should sync visibleDate when setSelectedDate is called', async () => {
+    const events = computed(() => []);
+    const { selectedDate, visibleDate, setSelectedDate } = useCalendarDateManagement(events, DATE_FORMAT);
+
+    const target = dayjs('2026-01-15');
+    setSelectedDate(target);
+    await nextTick();
+
+    expect(get(selectedDate).format(DATE_FORMAT)).toBe('2026-01-15');
+    expect(get(visibleDate).format(DATE_FORMAT)).toBe('2026-01-15');
+  });
+
+  it('should populate selectedDateEvents with events matching the selected date', async () => {
+    const list = ref<(CalendarEvent & { date: string })[]>([
+      makeEvent('2026-01-15', 1, 'matches'),
+      makeEvent('2026-01-16', 2, 'other'),
+    ]);
+    const events = computed(() => get(list));
+    const { setSelectedDate, selectedDateEvents } = useCalendarDateManagement(events, DATE_FORMAT);
+
+    setSelectedDate(dayjs('2026-01-15'));
+    await nextTick();
+
+    expect(get(selectedDateEvents)).toHaveLength(1);
+    expect(get(selectedDateEvents)[0].identifier).toBe(1);
+  });
+
+  it('should clear selectedDateEvents when switching to a date with matching events', async () => {
+    const list = ref<(CalendarEvent & { date: string })[]>([
+      makeEvent('2026-01-15', 1),
+      makeEvent('2026-01-16', 2),
+    ]);
+    const events = computed(() => get(list));
+    const { setSelectedDate, selectedDateEvents } = useCalendarDateManagement(events, DATE_FORMAT);
+
+    setSelectedDate(dayjs('2026-01-15'));
+    await nextTick();
+    expect(get(selectedDateEvents).map(e => e.identifier)).toEqual([1]);
+
+    setSelectedDate(dayjs('2026-01-16'));
+    await nextTick();
+    expect(get(selectedDateEvents).map(e => e.identifier)).toEqual([2]);
+  });
+
+  it('should not overwrite selectedDateEvents when no events match and the date is outside the visible month', async () => {
+    const list = ref<(CalendarEvent & { date: string })[]>([
+      makeEvent('2026-01-15', 1),
+    ]);
+    const events = computed(() => get(list));
+    const { setSelectedDate, selectedDateEvents, visibleDate } = useCalendarDateManagement(events, DATE_FORMAT);
+
+    setSelectedDate(dayjs('2026-01-15'));
+    await nextTick();
+    expect(get(selectedDateEvents).map(e => e.identifier)).toEqual([1]);
+
+    // Switching the visibleDate independently then to a date with no events should leave events as-is
+    set(visibleDate, dayjs('2026-01-15'));
+    setSelectedDate(dayjs('2026-02-01'));
+    await nextTick();
+    // selectedDate watcher also updates visibleDate, so by the time the second watcher runs the
+    // selected date does match visibleDate — events should be cleared to empty array.
+    expect(get(selectedDateEvents)).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/calendar/use-calendar-operations.spec.ts
+++ b/frontend/app/src/modules/calendar/use-calendar-operations.spec.ts
@@ -1,0 +1,160 @@
+import type { CalendarEvent } from '@/modules/calendar/types';
+import { flushPromises } from '@vue/test-utils';
+import dayjs from 'dayjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCalendarOperations } from '@/modules/calendar/use-calendar-operations';
+
+function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    autoDelete: false,
+    color: '',
+    description: '',
+    identifier: 0,
+    name: 'event',
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+const deleteCalendarEvent = vi.fn();
+const showErrorMessage = vi.fn();
+const show = vi.fn();
+const autoDeleteCalendarEntries = ref<boolean>(true);
+
+vi.mock('@/modules/calendar/use-calendar-api', () => ({
+  useCalendarApi: vi.fn().mockImplementation(() => ({ deleteCalendarEvent })),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: vi.fn().mockImplementation(() => ({ show })),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  getErrorMessage: vi.fn().mockImplementation((e: unknown) => (e instanceof Error ? e.message : String(e))),
+  useNotifications: vi.fn().mockImplementation(() => ({ showErrorMessage })),
+}));
+
+vi.mock('@/modules/settings/use-general-settings-store', () => ({
+  useGeneralSettingsStore: vi.fn().mockImplementation(() => ({ autoDeleteCalendarEntries })),
+}));
+
+describe('useCalendarOperations', () => {
+  beforeEach(() => {
+    deleteCalendarEvent.mockReset().mockResolvedValue(true);
+    showErrorMessage.mockReset();
+    show.mockReset();
+    set(autoDeleteCalendarEntries, true);
+  });
+
+  describe('emptyEventForm', () => {
+    it('should create a form anchored to the start of the supplied date', () => {
+      const selected = ref(dayjs('2026-05-20T10:30:00Z'));
+      const { emptyEventForm } = useCalendarOperations(selected, vi.fn());
+
+      const seedDate = dayjs('2026-05-21T10:30:00Z');
+      const form = emptyEventForm(seedDate);
+      expect(form.identifier).toBe(0);
+      expect(form.name).toBe('');
+      expect(form.autoDelete).toBe(true);
+      // start of the same calendar day in local time
+      const expected = seedDate.set('hours', 0).set('minutes', 0).set('seconds', 0).unix();
+      expect(form.timestamp).toBe(expected);
+    });
+
+    it('should fall back to selectedDate when no date is supplied', () => {
+      const selected = ref(dayjs('2026-06-01T15:00:00Z'));
+      const { emptyEventForm } = useCalendarOperations(selected, vi.fn());
+
+      const form = emptyEventForm();
+      const expected = dayjs('2026-06-01T15:00:00Z').set('hours', 0).set('minutes', 0).set('seconds', 0).unix();
+      expect(form.timestamp).toBe(expected);
+    });
+
+    it('should reflect the current autoDeleteCalendarEntries setting', () => {
+      set(autoDeleteCalendarEntries, false);
+      const { emptyEventForm } = useCalendarOperations(ref(dayjs()), vi.fn());
+
+      expect(emptyEventForm().autoDelete).toBe(false);
+    });
+  });
+
+  describe('add', () => {
+    it('should populate modelValue with an empty form and disable edit mode', () => {
+      const { add, modelValue, editMode } = useCalendarOperations(ref(dayjs('2026-05-20')), vi.fn());
+
+      add(dayjs('2026-05-22'));
+      expect(get(modelValue)).toBeDefined();
+      expect(get(modelValue)?.identifier).toBe(0);
+      expect(get(editMode)).toBe(false);
+    });
+  });
+
+  describe('edit', () => {
+    it('should set modelValue without the date helper field and enable edit mode', () => {
+      const { edit, modelValue, editMode } = useCalendarOperations(ref(dayjs()), vi.fn());
+
+      edit({
+        ...makeEvent({ identifier: 5, name: 'meeting', timestamp: 1_700_000_000, color: 'red' }),
+        date: '2026-05-22',
+      });
+
+      expect(get(modelValue)).toBeDefined();
+      expect(get(modelValue)?.identifier).toBe(5);
+      expect(get(modelValue)).not.toHaveProperty('date');
+      expect(get(editMode)).toBe(true);
+    });
+  });
+
+  describe('deleteEvent', () => {
+    it('should open a confirm dialog with the calendar delete copy', () => {
+      const { deleteEvent } = useCalendarOperations(ref(dayjs()), vi.fn());
+      deleteEvent();
+
+      expect(show).toHaveBeenCalledOnce();
+      const [config, callback] = show.mock.calls[0];
+      expect(config).toHaveProperty('message');
+      expect(config).toHaveProperty('title');
+      expect(typeof callback).toBe('function');
+    });
+
+    it('should call the API, refresh, and clear modelValue when the confirm callback runs', async () => {
+      const fetchData = vi.fn();
+      const { edit, deleteEvent, modelValue } = useCalendarOperations(ref(dayjs()), fetchData);
+
+      edit(makeEvent({ identifier: 7, name: 'x' }));
+      deleteEvent();
+
+      const callback = show.mock.calls[0][1];
+      await callback();
+      await flushPromises();
+
+      expect(deleteCalendarEvent).toHaveBeenCalledWith(7);
+      expect(fetchData).toHaveBeenCalledOnce();
+      expect(get(modelValue)).toBeNull();
+    });
+
+    it('should surface an error notification when the API call fails', async () => {
+      deleteCalendarEvent.mockRejectedValueOnce(new Error('server boom'));
+      const { edit, deleteEvent } = useCalendarOperations(ref(dayjs()), vi.fn());
+
+      edit(makeEvent({ identifier: 9, name: 'x' }));
+      deleteEvent();
+      const callback = show.mock.calls[0][1];
+      await callback();
+      await flushPromises();
+
+      expect(showErrorMessage).toHaveBeenCalledOnce();
+    });
+
+    it('should do nothing when no event is currently selected', async () => {
+      const { deleteEvent } = useCalendarOperations(ref(dayjs()), vi.fn());
+      deleteEvent();
+      const callback = show.mock.calls[0][1];
+      await callback();
+      await flushPromises();
+
+      expect(deleteCalendarEvent).not.toHaveBeenCalled();
+      expect(showErrorMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/notes/use-note-location.spec.ts
+++ b/frontend/app/src/modules/notes/use-note-location.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { useNoteLocation } from '@/modules/notes/use-note-location';
+
+const { useRouteMock } = vi.hoisted(() => ({
+  useRouteMock: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: useRouteMock,
+}));
+
+function mockRoute(meta: Record<string, unknown>, matched: { meta: Record<string, unknown> }[] = []): void {
+  useRouteMock.mockReturnValueOnce({ matched, meta });
+}
+
+describe('useNoteLocation', () => {
+  it('should return noteLocation from current route meta when present', () => {
+    mockRoute({ noteLocation: 'dashboard' });
+
+    const location = useNoteLocation();
+    expect(get(location)).toBe('dashboard');
+  });
+
+  it('should fall back to noteLocation from matched routes when meta lacks one', () => {
+    mockRoute({}, [
+      { meta: {} },
+      { meta: { noteLocation: 'parent-section' } },
+    ]);
+
+    const location = useNoteLocation();
+    expect(get(location)).toBe('parent-section');
+  });
+
+  it('should prefer the last matched route when multiple ancestors define noteLocation', () => {
+    mockRoute({}, [
+      { meta: { noteLocation: 'outer' } },
+      { meta: { noteLocation: 'inner' } },
+    ]);
+
+    const location = useNoteLocation();
+    expect(get(location)).toBe('inner');
+  });
+
+  it('should return empty string when no noteLocation is defined', () => {
+    mockRoute({}, [{ meta: {} }]);
+
+    const location = useNoteLocation();
+    expect(get(location)).toBe('');
+  });
+
+  it('should coerce non-string noteLocation values to string', () => {
+    mockRoute({ noteLocation: 42 });
+
+    const location = useNoteLocation();
+    expect(get(location)).toBe('42');
+  });
+});

--- a/frontend/app/src/modules/notes/use-notes-count.spec.ts
+++ b/frontend/app/src/modules/notes/use-notes-count.spec.ts
@@ -1,0 +1,86 @@
+import { flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NoteLocation } from '@/modules/core/common/notes';
+
+const fetchUserNotes = vi.fn();
+let location: ReturnType<typeof ref<string>>;
+
+vi.mock('@/modules/notes/use-user-notes-api', () => ({
+  useUserNotesApi: vi.fn().mockImplementation(() => ({ fetchUserNotes })),
+}));
+
+vi.mock('@/modules/notes/use-note-location', () => ({
+  useNoteLocation: vi.fn().mockImplementation(() => location),
+}));
+
+// `useNotesCount` is a sharedComposable. Each test re-imports it with a fresh
+// `location` ref so the previous instance's watchers don't leak.
+async function freshUseNotesCount(initial: string): Promise<typeof import('@/modules/notes/use-notes-count').useNotesCount> {
+  location = ref<string>(initial);
+  vi.resetModules();
+  const mod = await import('@/modules/notes/use-notes-count');
+  return mod.useNotesCount;
+}
+
+describe('useNotesCount', () => {
+  beforeEach(() => {
+    fetchUserNotes.mockReset();
+  });
+
+  it('should fetch only the global count when no page location is set', async () => {
+    fetchUserNotes.mockResolvedValue({ found: 7 });
+    const useNotesCount = await freshUseNotesCount('');
+
+    const { notesCount, globalNotesCount, hasSpecialNotes } = useNotesCount();
+    await flushPromises();
+
+    expect(fetchUserNotes).toHaveBeenCalledTimes(1);
+    expect(fetchUserNotes).toHaveBeenCalledWith(expect.objectContaining({ location: NoteLocation.GLOBAL }));
+    expect(get(notesCount)).toBe(0);
+    expect(get(globalNotesCount)).toBe(7);
+    expect(get(hasSpecialNotes)).toBe(false);
+  });
+
+  it('should fetch both page and global counts when location is set', async () => {
+    fetchUserNotes
+      .mockResolvedValueOnce({ found: 3 })
+      .mockResolvedValueOnce({ found: 5 });
+    const useNotesCount = await freshUseNotesCount(NoteLocation.DASHBOARD);
+
+    const { notesCount, globalNotesCount, hasSpecialNotes } = useNotesCount();
+    await flushPromises();
+
+    expect(fetchUserNotes).toHaveBeenCalledTimes(2);
+    expect(get(notesCount)).toBe(3);
+    expect(get(globalNotesCount)).toBe(5);
+    expect(get(hasSpecialNotes)).toBe(true);
+  });
+
+  it('should refetch when the location changes', async () => {
+    fetchUserNotes.mockResolvedValue({ found: 0 });
+    const useNotesCount = await freshUseNotesCount('');
+
+    const { notesCount } = useNotesCount();
+    await flushPromises();
+    fetchUserNotes.mockClear();
+
+    fetchUserNotes
+      .mockResolvedValueOnce({ found: 11 })
+      .mockResolvedValueOnce({ found: 2 });
+    set(location, NoteLocation.DASHBOARD);
+    await flushPromises();
+
+    expect(get(notesCount)).toBe(11);
+  });
+
+  it('should return zero when fetchUserNotes throws', async () => {
+    fetchUserNotes.mockRejectedValue(new Error('network'));
+    const useNotesCount = await freshUseNotesCount('');
+
+    const { notesCount, globalNotesCount } = useNotesCount();
+    await flushPromises();
+
+    expect(get(notesCount)).toBe(0);
+    expect(get(globalNotesCount)).toBe(0);
+  });
+});

--- a/frontend/app/src/modules/wallet/bridge/use-bridge-logging.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-bridge-logging.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useBridgeLogging } from '@/modules/wallet/bridge/use-bridge-logging';
+
+describe('useBridgeLogging', () => {
+  beforeEach(() => {
+    // useBridgeLogging is a shared composable; reset state between tests
+    const { clearLogs } = useBridgeLogging();
+    clearLogs();
+  });
+
+  it('should start with an empty log list', () => {
+    const { logs } = useBridgeLogging();
+    expect(get(logs)).toEqual([]);
+  });
+
+  it('should default the log type to info', () => {
+    const { addLog, logs } = useBridgeLogging();
+    addLog('hello');
+    expect(get(logs)).toHaveLength(1);
+    expect(get(logs)[0].type).toBe('info');
+    expect(get(logs)[0].message).toBe('hello');
+    expect(typeof get(logs)[0].timestamp).toBe('string');
+  });
+
+  it('should prepend new entries so the latest log is first', () => {
+    const { addLog, logs } = useBridgeLogging();
+    addLog('first', 'info');
+    addLog('second', 'success');
+    addLog('third', 'error');
+
+    expect(get(logs).map(l => l.message)).toEqual(['third', 'second', 'first']);
+    expect(get(logs).map(l => l.type)).toEqual(['error', 'success', 'info']);
+  });
+
+  it('should clear all entries', () => {
+    const { addLog, clearLogs, logs } = useBridgeLogging();
+    addLog('a');
+    addLog('b');
+    expect(get(logs)).toHaveLength(2);
+
+    clearLogs();
+    expect(get(logs)).toEqual([]);
+  });
+
+  it('should share state across calls (shared composable)', () => {
+    const first = useBridgeLogging();
+    first.addLog('shared');
+
+    const second = useBridgeLogging();
+    expect(get(second.logs)).toHaveLength(1);
+    expect(get(second.logs)[0].message).toBe('shared');
+  });
+});

--- a/frontend/app/src/modules/wallet/bridge/use-proxy-provider.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-proxy-provider.spec.ts
@@ -1,0 +1,156 @@
+import type { RpcRequest } from '@/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProxyProvider } from '@/modules/wallet/bridge/use-proxy-provider';
+
+interface MockWalletBridge {
+  isEnabled: ReturnType<typeof vi.fn<() => boolean>>;
+  isConnected: ReturnType<typeof vi.fn<() => boolean>>;
+  disable: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  request: ReturnType<typeof vi.fn<(req: RpcRequest) => Promise<unknown>>>;
+  addEventListener: ReturnType<typeof vi.fn<(name: string, cb: (data: unknown) => void) => void>>;
+  removeEventListener: ReturnType<typeof vi.fn<(name: string) => void>>;
+}
+
+function createMockBridge(): MockWalletBridge {
+  return {
+    addEventListener: vi.fn(),
+    disable: vi.fn().mockResolvedValue(undefined),
+    isConnected: vi.fn().mockReturnValue(true),
+    isEnabled: vi.fn().mockReturnValue(true),
+    removeEventListener: vi.fn(),
+    request: vi.fn().mockResolvedValue('result'),
+  };
+}
+
+function installBridge(bridge: MockWalletBridge | undefined): void {
+  // Type-narrowed assignment: the global `Window.walletBridge` is `WalletBridgeApi | undefined`,
+  // and the structural shape of MockWalletBridge satisfies the subset our SUT calls.
+  Object.assign(window, { walletBridge: bridge });
+}
+
+describe('useProxyProvider', () => {
+  let bridge: MockWalletBridge;
+
+  beforeEach(() => {
+    bridge = createMockBridge();
+    installBridge(bridge);
+  });
+
+  afterEach(() => {
+    installBridge(undefined);
+  });
+
+  it('should return undefined when no wallet bridge is available', () => {
+    installBridge(undefined);
+    expect(useProxyProvider()).toBeUndefined();
+  });
+
+  it('should expose isRotkiBridge true and reflect bridge connection state', () => {
+    const provider = useProxyProvider()!;
+    expect(provider).toBeDefined();
+    expect(provider.isRotkiBridge).toBe(true);
+    expect(provider.connected).toBe(true);
+
+    bridge.isConnected.mockReturnValue(false);
+    expect(provider.connected).toBe(false);
+  });
+
+  it('should forward requests to the bridge', async () => {
+    const provider = useProxyProvider()!;
+    const request: RpcRequest = { method: 'eth_accounts' };
+    const result = await provider.request(request);
+
+    expect(bridge.request).toHaveBeenCalledWith(request);
+    expect(result).toBe('result');
+  });
+
+  it('should call bridge.disable() on disconnect', async () => {
+    const provider = useProxyProvider()!;
+    await provider.disconnect!();
+    expect(bridge.disable).toHaveBeenCalledOnce();
+  });
+
+  it('should register a single bridge listener per event type and forward emissions', () => {
+    const provider = useProxyProvider()!;
+    const handlerA = vi.fn();
+    const handlerB = vi.fn();
+
+    provider.on!('accountsChanged', handlerA);
+    provider.on!('accountsChanged', handlerB);
+
+    expect(bridge.addEventListener).toHaveBeenCalledTimes(1);
+    expect(bridge.addEventListener).toHaveBeenCalledWith('accountsChanged', expect.any(Function));
+
+    const forward = bridge.addEventListener.mock.calls[0][1];
+    forward(['0xabc']);
+
+    expect(handlerA).toHaveBeenCalledWith(['0xabc']);
+    expect(handlerB).toHaveBeenCalledWith(['0xabc']);
+  });
+
+  it('should invoke disconnect listeners without arguments when bridge emits without data', () => {
+    const provider = useProxyProvider()!;
+    const handler = vi.fn();
+    provider.on!('disconnect', handler);
+
+    const forward = bridge.addEventListener.mock.calls[0][1];
+    forward(undefined);
+    expect(handler).toHaveBeenCalledWith();
+  });
+
+  it('should swallow errors from individual listeners so siblings still run', () => {
+    const provider = useProxyProvider()!;
+    const failing = vi.fn().mockImplementation(() => {
+      throw new Error('listener failed');
+    });
+    const succeeding = vi.fn();
+
+    provider.on!('accountsChanged', failing);
+    provider.on!('accountsChanged', succeeding);
+
+    const forward = bridge.addEventListener.mock.calls[0][1];
+    expect(() => forward(['0x1'])).not.toThrow();
+    expect(succeeding).toHaveBeenCalledWith(['0x1']);
+  });
+
+  it('should remove a listener and detach the bridge forwarder when none remain', () => {
+    const provider = useProxyProvider()!;
+    const handler = vi.fn();
+
+    provider.on!('accountsChanged', handler);
+    provider.removeListener!('accountsChanged', handler);
+
+    expect(bridge.removeEventListener).toHaveBeenCalledWith('accountsChanged');
+
+    const forward = bridge.addEventListener.mock.calls[0][1];
+    forward(['0x1']);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('should keep the bridge forwarder when other listeners remain after removal', () => {
+    const provider = useProxyProvider()!;
+    const keep = vi.fn();
+    const remove = vi.fn();
+
+    provider.on!('accountsChanged', keep);
+    provider.on!('accountsChanged', remove);
+    provider.removeListener!('accountsChanged', remove);
+
+    expect(bridge.removeEventListener).not.toHaveBeenCalled();
+
+    const forward = bridge.addEventListener.mock.calls[0][1];
+    forward(['0x1']);
+    expect(keep).toHaveBeenCalledWith(['0x1']);
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it('should alias off() to removeListener()', () => {
+    const provider = useProxyProvider()!;
+    const handler = vi.fn();
+
+    provider.on!('accountsChanged', handler);
+    provider.off!('accountsChanged', handler);
+
+    expect(bridge.removeEventListener).toHaveBeenCalledWith('accountsChanged');
+  });
+});

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-connection-state.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-connection-state.spec.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useWalletConnectionState } from '@/modules/wallet/bridge/use-wallet-connection-state';
+
+describe('useWalletConnectionState', () => {
+  beforeEach(() => {
+    const { setRequestingAccounts } = useWalletConnectionState();
+    setRequestingAccounts(false);
+  });
+
+  it('should default isRequestingAccounts to false', () => {
+    const { isRequestingAccounts } = useWalletConnectionState();
+    expect(get(isRequestingAccounts)).toBe(false);
+  });
+
+  it('should toggle isRequestingAccounts via setRequestingAccounts', () => {
+    const { isRequestingAccounts, setRequestingAccounts } = useWalletConnectionState();
+
+    setRequestingAccounts(true);
+    expect(get(isRequestingAccounts)).toBe(true);
+
+    setRequestingAccounts(false);
+    expect(get(isRequestingAccounts)).toBe(false);
+  });
+
+  it('should set requesting=true during a tracked promise and reset to false on resolve', async () => {
+    const { isRequestingAccounts, trackAccountsRequest } = useWalletConnectionState();
+
+    let observedDuringPromise = false;
+    const promise = new Promise<string>((resolve) => {
+      setTimeout(() => {
+        observedDuringPromise = get(isRequestingAccounts);
+        resolve('done');
+      }, 0);
+    });
+
+    const result = await trackAccountsRequest(promise);
+
+    expect(result).toBe('done');
+    expect(observedDuringPromise).toBe(true);
+    expect(get(isRequestingAccounts)).toBe(false);
+  });
+
+  it('should reset isRequestingAccounts to false even when the promise rejects', async () => {
+    const { isRequestingAccounts, trackAccountsRequest } = useWalletConnectionState();
+
+    await expect(trackAccountsRequest(Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+    expect(get(isRequestingAccounts)).toBe(false);
+  });
+
+  it('should share state across composable calls', () => {
+    const first = useWalletConnectionState();
+    first.setRequestingAccounts(true);
+
+    const second = useWalletConnectionState();
+    expect(get(second.isRequestingAccounts)).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/wallet/providers/use-provider-selection.spec.ts
+++ b/frontend/app/src/modules/wallet/providers/use-provider-selection.spec.ts
@@ -1,0 +1,83 @@
+import type { EnhancedProviderDetail } from '@/modules/wallet/providers/provider-detection';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProviderSelection } from '@/modules/wallet/providers/use-provider-selection';
+
+const selectProvider = vi.fn();
+const connectToSelectedProvider = vi.fn();
+
+vi.mock('@/modules/wallet/providers/use-unified-providers', () => ({
+  useUnifiedProviders: vi.fn().mockImplementation(() => ({
+    selectProvider,
+  })),
+}));
+
+vi.mock('@/modules/wallet/bridge/use-injected-wallet', () => ({
+  useInjectedWallet: vi.fn().mockImplementation(() => ({
+    connectToSelectedProvider,
+  })),
+}));
+
+function makeProvider(uuid = 'p1'): EnhancedProviderDetail {
+  return {
+    info: { icon: 'icon', name: 'Test', rdns: 'test.example', uuid },
+    provider: { request: vi.fn() },
+    source: 'eip6963',
+  };
+}
+
+describe('useProviderSelection', () => {
+  beforeEach(() => {
+    selectProvider.mockReset().mockResolvedValue(undefined);
+    connectToSelectedProvider.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('should select the provider then connect to it', async () => {
+    const { handleProviderSelection } = useProviderSelection();
+    const onError = vi.fn();
+    const provider = makeProvider('uuid-1');
+
+    await handleProviderSelection(provider, onError);
+
+    expect(selectProvider).toHaveBeenCalledWith('uuid-1');
+    expect(connectToSelectedProvider).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('should report a user-rejection error with a specific message', async () => {
+    selectProvider.mockRejectedValueOnce(new Error('User rejected the request'));
+    const { handleProviderSelection } = useProviderSelection();
+    const onError = vi.fn();
+
+    await handleProviderSelection(makeProvider(), onError);
+
+    expect(onError).toHaveBeenCalledWith('Wallet connection was rejected by user');
+  });
+
+  it('should report a timeout error with a specific message', async () => {
+    connectToSelectedProvider.mockRejectedValueOnce(new Error('Request timeout after 30s'));
+    const { handleProviderSelection } = useProviderSelection();
+    const onError = vi.fn();
+
+    await handleProviderSelection(makeProvider(), onError);
+
+    expect(onError).toHaveBeenCalledWith('Connection request timed out. Please try again.');
+  });
+
+  it('should report a generic failure with the underlying error message', async () => {
+    selectProvider.mockRejectedValueOnce(new Error('something exploded'));
+    const { handleProviderSelection } = useProviderSelection();
+    const onError = vi.fn();
+
+    await handleProviderSelection(makeProvider(), onError);
+
+    expect(onError).toHaveBeenCalledWith('Failed to connect wallet: something exploded');
+  });
+
+  it('should not call connectToSelectedProvider when selectProvider fails', async () => {
+    selectProvider.mockRejectedValueOnce(new Error('boom'));
+    const { handleProviderSelection } = useProviderSelection();
+    await handleProviderSelection(makeProvider(), vi.fn());
+
+    expect(connectToSelectedProvider).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/wallet/send/use-balance-queries.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-balance-queries.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBalanceQueries } from '@/modules/wallet/send/use-balance-queries';
+
+const addressesRef = ref<Record<string, string[]>>({});
+const taskRunningRef = ref<boolean>(false);
+
+vi.mock('@/modules/balances/blockchain/use-account-addresses', () => ({
+  useAccountAddresses: vi.fn().mockImplementation(() => ({
+    addresses: addressesRef,
+    getAddresses: vi.fn(),
+  })),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: vi.fn().mockImplementation(() => ({
+    useIsTaskRunning: vi.fn().mockReturnValue(taskRunningRef),
+  })),
+}));
+
+// Bypass the 200ms debounce in tests
+vi.mock('@/modules/core/common/use-ref-debounce', () => ({
+  useRefWithDebounce: vi.fn().mockImplementation((source: unknown) => source),
+}));
+
+describe('useBalanceQueries', () => {
+  beforeEach(() => {
+    set(addressesRef, {});
+    set(taskRunningRef, false);
+  });
+
+  describe('useQueryingBalances', () => {
+    it('should mirror the task-running ref', () => {
+      const connected = ref(true);
+      const address = ref<string | undefined>('0xabc');
+      const { useQueryingBalances } = useBalanceQueries(connected, address);
+
+      expect(get(useQueryingBalances)).toBe(false);
+      set(taskRunningRef, true);
+      expect(get(useQueryingBalances)).toBe(true);
+    });
+  });
+
+  describe('warnUntrackedAddress', () => {
+    it('should return false when not connected', () => {
+      const connected = ref(false);
+      const address = ref<string | undefined>('0xabc');
+      const { warnUntrackedAddress } = useBalanceQueries(connected, address);
+
+      expect(get(warnUntrackedAddress)).toBe(false);
+    });
+
+    it('should return false when connected address is missing or empty', () => {
+      const connected = ref(true);
+      const address = ref<string | undefined>(undefined);
+      const { warnUntrackedAddress } = useBalanceQueries(connected, address);
+
+      expect(get(warnUntrackedAddress)).toBe(false);
+
+      set(address, '');
+      expect(get(warnUntrackedAddress)).toBe(false);
+    });
+
+    it('should warn when connected address is not present in any tracked chain', () => {
+      set(addressesRef, {
+        eth: ['0x1', '0x2'],
+        optimism: ['0x3'],
+      });
+
+      const connected = ref(true);
+      const address = ref<string | undefined>('0xUNTRACKED');
+      const { warnUntrackedAddress } = useBalanceQueries(connected, address);
+
+      expect(get(warnUntrackedAddress)).toBe(true);
+    });
+
+    it('should not warn when connected address matches a tracked address on any chain', () => {
+      set(addressesRef, {
+        eth: ['0x1', '0x2'],
+        optimism: ['0xMATCH'],
+      });
+
+      const connected = ref(true);
+      const address = ref<string | undefined>('0xMATCH');
+      const { warnUntrackedAddress } = useBalanceQueries(connected, address);
+
+      expect(get(warnUntrackedAddress)).toBe(false);
+    });
+
+    it('should react to address changes', () => {
+      set(addressesRef, { eth: ['0xKNOWN'] });
+      const connected = ref(true);
+      const address = ref<string | undefined>('0xKNOWN');
+      const { warnUntrackedAddress } = useBalanceQueries(connected, address);
+
+      expect(get(warnUntrackedAddress)).toBe(false);
+      set(address, '0xOTHER');
+      expect(get(warnUntrackedAddress)).toBe(true);
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/use-wallet-helper.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-helper.spec.ts
@@ -1,0 +1,129 @@
+import type { RecentTransaction } from '@/modules/wallet/types';
+import { Blockchain } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWalletHelper } from '@/modules/wallet/use-wallet-helper';
+
+function makeRecentTx(overrides: Partial<RecentTransaction> = {}): RecentTransaction {
+  return {
+    chain: Blockchain.ETH,
+    context: '',
+    hash: '0x0',
+    initiatorAddress: '0x0',
+    metadata: undefined,
+    status: 'pending',
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+const allEvmChains = ref<{ id: number; name: string }[]>([
+  { id: 1, name: 'ethereum' },
+  { id: 10, name: 'optimism' },
+  { id: 42161, name: 'arbitrum_one' },
+]);
+
+const getChain = vi.fn((name: string): Blockchain => {
+  if (name === 'optimism')
+    return Blockchain.OPTIMISM;
+  if (name === 'arbitrum_one')
+    return Blockchain.ARBITRUM_ONE;
+  return Blockchain.ETH;
+});
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn().mockImplementation(() => ({ allEvmChains, getChain })),
+}));
+
+const refreshBlockchainBalances = vi.fn();
+const addTransactionHash = vi.fn();
+
+vi.mock('@/modules/balances/use-blockchain-balances', () => ({
+  useBlockchainBalances: vi.fn().mockImplementation(() => ({ refreshBlockchainBalances })),
+}));
+
+vi.mock('@/modules/history/events/tx/use-history-transactions', () => ({
+  useHistoryTransactions: vi.fn().mockImplementation(() => ({ addTransactionHash })),
+}));
+
+describe('useWalletHelper', () => {
+  beforeEach(() => {
+    refreshBlockchainBalances.mockReset().mockResolvedValue(undefined);
+    addTransactionHash.mockReset().mockResolvedValue(undefined);
+    getChain.mockClear();
+  });
+
+  describe('getEvmChainNameFromChainId', () => {
+    it('should return matching chain name for known numeric id', () => {
+      const { getEvmChainNameFromChainId } = useWalletHelper();
+      expect(getEvmChainNameFromChainId(10)).toBe('optimism');
+    });
+
+    it('should handle bigint chainId', () => {
+      const { getEvmChainNameFromChainId } = useWalletHelper();
+      expect(getEvmChainNameFromChainId(42161n)).toBe('arbitrum_one');
+    });
+
+    it('should fall back to ethereum for unknown chainId', () => {
+      const { getEvmChainNameFromChainId } = useWalletHelper();
+      expect(getEvmChainNameFromChainId(99999)).toBe('ethereum');
+    });
+  });
+
+  describe('getChainFromChainId', () => {
+    it('should map chainId to a Blockchain via getChain', () => {
+      const { getChainFromChainId } = useWalletHelper();
+      const result = getChainFromChainId(10);
+      expect(getChain).toHaveBeenCalledWith('optimism');
+      expect(result).toBe(Blockchain.OPTIMISM);
+    });
+  });
+
+  describe('getChainIdFromChain', () => {
+    it('should return numeric id for known chain', () => {
+      const { getChainIdFromChain } = useWalletHelper();
+      expect(getChainIdFromChain('arbitrum_one')).toBe(42161);
+    });
+
+    it('should default to 1 for unknown chain', () => {
+      const { getChainIdFromChain } = useWalletHelper();
+      expect(getChainIdFromChain('nope')).toBe(1);
+    });
+  });
+
+  describe('getEip155ChainId / getChainIdFromNamespace', () => {
+    it('should round-trip an eip155 chain id', () => {
+      const { getEip155ChainId, getChainIdFromNamespace } = useWalletHelper();
+
+      expect(getEip155ChainId(10)).toBe('eip155:10');
+      expect(getEip155ChainId('42161')).toBe('eip155:42161');
+      expect(getChainIdFromNamespace('eip155:10')).toBe(10);
+      expect(getChainIdFromNamespace(getEip155ChainId(42161))).toBe(42161);
+    });
+  });
+
+  describe('updateStatePostTransaction', () => {
+    it('should do nothing when tx is undefined', async () => {
+      const { updateStatePostTransaction } = useWalletHelper();
+      await updateStatePostTransaction(undefined);
+
+      expect(refreshBlockchainBalances).not.toHaveBeenCalled();
+      expect(addTransactionHash).not.toHaveBeenCalled();
+    });
+
+    it('should refresh balances and register the transaction hash', async () => {
+      const { updateStatePostTransaction } = useWalletHelper();
+      await updateStatePostTransaction(makeRecentTx({
+        chain: Blockchain.OPTIMISM,
+        hash: '0xabc',
+        initiatorAddress: '0xinit',
+      }));
+
+      expect(refreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: Blockchain.OPTIMISM });
+      expect(addTransactionHash).toHaveBeenCalledWith({
+        associatedAddress: '0xinit',
+        blockchain: Blockchain.OPTIMISM,
+        txRef: '0xabc',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds co-located unit specs for ten small composables across `calendar`, `notes`, and `wallet` modules. First tranche of the unit-test backlog tracked in #11252.

- 10 new `.spec.ts` files, 63 tests
- Targets small (<100L), mostly pure-logic composables to establish patterns and start chipping away at low-coverage modules (`wallet` 43%, `notes` 54%, `calendar` 68%)
- No production code changes

| Spec | LOC of subject | Tests |
|---|---|---|
| `notes/use-note-location` | 20 | 5 |
| `notes/use-notes-count` | 64 | 4 |
| `wallet/bridge/use-bridge-logging` | 36 | 5 |
| `wallet/bridge/use-wallet-connection-state` | 36 | 5 |
| `wallet/bridge/use-proxy-provider` | 95 | 10 |
| `wallet/send/use-balance-queries` | 36 | 6 |
| `wallet/providers/use-provider-selection` | 42 | 5 |
| `wallet/use-wallet-helper` | 64 | 8 |
| `calendar/use-calendar-date-management` | 45 | 5 |
| `calendar/use-calendar-operations` | 88 | 10 |

Refs #11252.

## Test plan

- [x] `pnpm run test:unit` — all 63 new tests pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint-staged` — clean, zero new warnings