### PR TITLE
refactor(frontend): simplify ExternalLink and drop !important overrides

### DIFF
--- a/frontend/app/src/modules/premium/SponsorshipView.vue
+++ b/frontend/app/src/modules/premium/SponsorshipView.vue
@@ -71,7 +71,7 @@ const data: Sponsor = {
         <div class="w-full flex justify-center">
           <ExternalLink
             color="primary"
-            class="!text-xs text-center [&>span]:!whitespace-pre-line"
+            class="text-xs text-center whitespace-pre-line"
             :url="externalLinks.sponsor"
           >
             {{ t('sponsorship.sponsor') }}

--- a/frontend/app/src/modules/shell/components/ExternalLink.spec.ts
+++ b/frontend/app/src/modules/shell/components/ExternalLink.spec.ts
@@ -1,0 +1,103 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
+
+vi.mock('@/modules/shell/app/use-electron-interop', (): Record<string, unknown> => ({
+  useInterop: (): { isPackaged: boolean; openUrl: ReturnType<typeof vi.fn> } => ({
+    isPackaged: false,
+    openUrl: vi.fn(),
+  }),
+}));
+
+vi.mock('@shared/external-links', (): Record<string, unknown> => ({
+  externalLinks: {
+    premium: 'https://rotki.com/products',
+  },
+}));
+
+describe('external-link', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ExternalLink>>;
+
+  afterEach((): void => {
+    wrapper?.unmount();
+  });
+
+  it('should render an anchor when url is provided', () => {
+    wrapper = mount(ExternalLink, {
+      props: { url: 'https://example.com' },
+      slots: { default: 'click me' },
+    });
+
+    const anchor = wrapper.find('a');
+    expect(anchor.exists()).toBe(true);
+    expect(anchor.attributes('href')).toBe('https://example.com');
+    expect(anchor.attributes('target')).toBe('_blank');
+    expect(anchor.text()).toBe('click me');
+  });
+
+  it('should render the text prop when no default slot is provided', () => {
+    wrapper = mount(ExternalLink, {
+      props: { text: 'fallback', url: 'https://example.com' },
+    });
+
+    expect(wrapper.find('a').text()).toBe('fallback');
+  });
+
+  it('should apply the primary color class by default', () => {
+    wrapper = mount(ExternalLink, { props: { url: 'https://example.com' } });
+
+    const classes = wrapper.find('a').classes();
+    expect(classes).toContain('text-rui-primary');
+    expect(classes).toContain('underline');
+  });
+
+  it('should apply the warning color class when color="warning"', () => {
+    wrapper = mount(ExternalLink, {
+      props: { color: 'warning', url: 'https://example.com' },
+    });
+
+    expect(wrapper.find('a').classes()).toContain('text-rui-warning');
+  });
+
+  it('should render an anchor wrapping the slot when custom is true', () => {
+    wrapper = mount(ExternalLink, {
+      props: { custom: true, url: 'https://example.com' },
+      slots: { default: '<button data-test="inner">go</button>' },
+    });
+
+    const anchor = wrapper.find('a');
+    expect(anchor.exists()).toBe(true);
+    expect(anchor.attributes('href')).toBe('https://example.com');
+    expect(anchor.find('[data-test="inner"]').exists()).toBe(true);
+    expect(anchor.classes()).not.toContain('underline');
+  });
+
+  it('should use the premium url when premium is true and no url provided', () => {
+    wrapper = mount(ExternalLink, { props: { premium: true } });
+
+    expect(wrapper.find('a').attributes('href')).toBe('https://rotki.com/products');
+  });
+
+  it('should render a div with the slot when neither url nor premium is set', () => {
+    wrapper = mount(ExternalLink, {
+      slots: { default: 'plain' },
+    });
+
+    expect(wrapper.find('a').exists()).toBe(false);
+    expect(wrapper.find('div').exists()).toBe(true);
+    expect(wrapper.text()).toBe('plain');
+  });
+
+  it('should show the confirmation dialog on click when confirm is true', async () => {
+    wrapper = mount(ExternalLink, {
+      attachTo: document.body,
+      props: { confirm: true, url: 'https://example.com' },
+      slots: { default: 'click' },
+    });
+
+    await wrapper.find('a').trigger('click');
+    await nextTick();
+
+    expect(document.body.textContent).toContain('https://example.com');
+  });
+});

--- a/frontend/app/src/modules/shell/components/ExternalLink.vue
+++ b/frontend/app/src/modules/shell/components/ExternalLink.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import type { ContextColorsType } from '@rotki/ui-library';
 import { externalLinks } from '@shared/external-links';
-import { truncateAddress } from '@/modules/core/common/display/truncate';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
 import ConfirmDialog from '@/modules/shell/components/dialogs/ConfirmDialog.vue';
 import { useLinks } from '@/modules/shell/layout/use-links';
@@ -10,49 +10,55 @@ defineOptions({
 });
 
 const {
+  color = 'primary',
   confirm = false,
   custom = false,
   premium = false,
   text = '',
-  truncate = false,
   url,
 } = defineProps<{
   url?: string;
-  truncate?: boolean;
   text?: string;
   custom?: boolean;
   premium?: boolean;
   confirm?: boolean;
+  color?: ContextColorsType;
 }>();
 
 defineSlots<{
   default: () => any;
-  append: () => any;
 }>();
+
+const showConfirmation = ref<boolean>(false);
 
 const { isPackaged, openUrl } = useInterop();
 const { t } = useI18n({ useScope: 'global' });
 
 const { href, linkTarget, onLinkClick: defaultOnLinkClick } = useLinks(() => url);
 
-const displayText = computed<string>(() => (truncate ? truncateAddress(text) : text));
-
 const targetUrl = computed<string>(() => url ?? externalLinks.premium);
 
-const showConfirmation = ref<boolean>(false);
+const colorClass = computed<string>(() => {
+  const map: Record<ContextColorsType, string> = {
+    error: 'text-rui-error hover:text-rui-error-darker',
+    info: 'text-rui-info hover:text-rui-info-darker',
+    primary: 'text-rui-primary hover:text-rui-primary-darker',
+    secondary: 'text-rui-secondary hover:text-rui-secondary-darker',
+    success: 'text-rui-success hover:text-rui-success-darker',
+    warning: 'text-rui-warning hover:text-rui-warning-darker',
+  };
+  return map[color] ?? map.primary;
+});
 
 async function onLinkClick(event?: Event): Promise<void> {
-  // If confirm is not enabled, use default behavior
   if (!confirm) {
     defaultOnLinkClick();
     return;
   }
 
-  // Prevent default navigation
   if (event)
     event.preventDefault();
 
-  // Show confirmation dialog
   set(showConfirmation, true);
 }
 
@@ -67,24 +73,19 @@ function cancelOpen(): void {
 </script>
 
 <template>
-  <RuiButton
+  <component
+    :is="isPackaged ? 'button' : 'a'"
     v-if="(url || premium) && !custom"
-    :tag="isPackaged ? 'button' : 'a'"
-    :href="href"
+    :href="isPackaged ? undefined : href"
     :target="linkTarget"
+    :type="isPackaged ? 'button' : undefined"
     v-bind="$attrs"
-    variant="text"
-    class="!inline !text-[1em] !p-0 !px-0.5 !-mx-0.5 !font-[inherit] [&_span]:underline"
+    class="cursor-pointer underline"
+    :class="colorClass"
     @click="onLinkClick($event)"
   >
-    <slot>{{ displayText }}</slot>
-    <template
-      v-if="$slots.append"
-      #append
-    >
-      <slot name="append" />
-    </template>
-  </RuiButton>
+    <slot>{{ text }}</slot>
+  </component>
   <a
     v-else-if="url || premium"
     :href="href"
@@ -93,7 +94,7 @@ function cancelOpen(): void {
     v-bind="$attrs"
     @click="onLinkClick($event)"
   >
-    <slot>{{ displayText }}</slot>
+    <slot>{{ text }}</slot>
   </a>
   <div
     v-else

--- a/frontend/app/src/modules/statistics/wrapped/components/WrappedAlerts.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/WrappedAlerts.vue
@@ -29,18 +29,18 @@ const { t } = useI18n({ useScope: 'global' });
       <div class="flex justify-between items-center">
         {{ t('wrapped.premium_nudge') }}
         <ExternalLink
-          :text="t('wrapped.get_rotki_premium')"
-          variant="default"
           premium
-          class="!flex [&_span]:!no-underline !px-3 !py-2"
-          color="primary"
+          custom
         >
-          <template #append>
-            <RuiIcon
-              name="lu-external-link"
-              size="12"
-            />
-          </template>
+          <RuiButton color="primary">
+            {{ t('wrapped.get_rotki_premium') }}
+            <template #append>
+              <RuiIcon
+                name="lu-external-link"
+                size="12"
+              />
+            </template>
+          </RuiButton>
         </ExternalLink>
       </div>
     </RuiAlert>


### PR DESCRIPTION
## Summary
- Replaced the `RuiButton`-wrapped inline-link rendering in `ExternalLink` with a plain `<a>`/`<button>` and a small color-class lookup, removing the entire `!text-[1em] !p-0 !px-0.5 !-mx-0.5 !font-[inherit] !inline [&_span]:underline` override cluster.
- The overrides were originally needed to fake inline text styling on top of `RuiButton`. After the `@rotki/ui-library` 2.12 → 2.20 bump, the new `text-sm leading-5` defaults on `RuiButton`'s root started winning over the `!important` overrides in the cascade, which made the sidebar sponsor link visibly larger than in 1.42.1.
- Migrated `WrappedAlerts` — the only caller that was visually emulating a real button via override hacks — to `custom + RuiButton`. All other ~70 call sites continue to work unchanged.
- Dropped the unused `truncate` prop (plus `truncateAddress` import).
- Added `ExternalLink.spec.ts` covering each render branch (anchor, custom slot, color classes, text-prop fallback, premium URL fallback, confirm dialog, div fallback).

## Test plan
- [x] `pnpm run typecheck` — clean
- [x] `pnpm --filter rotki test:unit src/modules/shell/components/ExternalLink.spec.ts src/modules/premium/SponsorshipView.spec.ts` — 17/17 pass
- [x] `pnpm run lint-staged` on the touched files — clean
- [x] Cross-checked sidebar sponsor link, "Manage or upgrade subscription", "Get premium", inline i18n-t links, and `custom + RuiButton` icon buttons on the asset detail page against a 1.42.1 instance — visually equivalent, computed styles match.
- [x] Console clean after navigating through several routes.