### PR TITLE
test(frontend): unit specs for tier-2 integrations composables

### DIFF
--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-auth-state.spec.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-auth-state.spec.ts
@@ -1,0 +1,224 @@
+import type { Ref } from 'vue';
+import { describe, expect, it } from 'vitest';
+import { AuthStep, GnosisPayError } from './types';
+import { useGnosisPayAuthState, useGnosisPayAuthSteps } from './use-gnosis-pay-auth-state';
+
+describe('useGnosisPayAuthState', () => {
+  it('should initialize with default state', () => {
+    const state = useGnosisPayAuthState();
+
+    expect(get(state.errorType)).toBeNull();
+    expect(get(state.errorContext)).toEqual({});
+    expect(get(state.signingInProgress)).toBe(false);
+    expect(get(state.validatingAddress)).toBe(false);
+    expect(get(state.isAddressValid)).toBe(false);
+    expect(get(state.gnosisPayAdminsMapping)).toEqual({});
+    expect(get(state.controlledSafeAddresses)).toEqual([]);
+    expect(get(state.checkingRegisteredAccounts)).toBe(false);
+    expect(get(state.hasRegisteredAccounts)).toBe(false);
+    expect(get(state.signInSuccess)).toBe(false);
+    expect(get(state.errorCloseable)).toBe(true);
+    expect(get(state.showNoRegisteredAccountsError)).toBe(false);
+  });
+
+  describe('errorCloseable', () => {
+    it('should be true when there is no error', () => {
+      const { errorCloseable } = useGnosisPayAuthState();
+      expect(get(errorCloseable)).toBe(true);
+    });
+
+    it.each([
+      [GnosisPayError.NO_REGISTERED_ACCOUNTS],
+      [GnosisPayError.INVALID_ADDRESS],
+    ])('should be false for non-closeable error %s', (errorType) => {
+      const state = useGnosisPayAuthState();
+      state.setError(errorType);
+      expect(get(state.errorCloseable)).toBe(false);
+    });
+
+    it.each([
+      [GnosisPayError.NO_WALLET_CONNECTED],
+      [GnosisPayError.SIGNATURE_REJECTED],
+      [GnosisPayError.CONNECTION_FAILED],
+      [GnosisPayError.OTHER],
+    ])('should be true for closeable error %s', (errorType) => {
+      const state = useGnosisPayAuthState();
+      state.setError(errorType);
+      expect(get(state.errorCloseable)).toBe(true);
+    });
+  });
+
+  describe('showNoRegisteredAccountsError', () => {
+    it('should be true only when the error type is NO_REGISTERED_ACCOUNTS', () => {
+      const state = useGnosisPayAuthState();
+
+      state.setError(GnosisPayError.NO_REGISTERED_ACCOUNTS);
+      expect(get(state.showNoRegisteredAccountsError)).toBe(true);
+
+      state.setError(GnosisPayError.INVALID_ADDRESS);
+      expect(get(state.showNoRegisteredAccountsError)).toBe(false);
+    });
+  });
+
+  describe('setError', () => {
+    it('should store the error type and context', () => {
+      const state = useGnosisPayAuthState();
+      state.setError(GnosisPayError.OTHER, { message: 'oops' });
+
+      expect(get(state.errorType)).toBe(GnosisPayError.OTHER);
+      expect(get(state.errorContext)).toEqual({ message: 'oops' });
+    });
+
+    it('should default to an empty context when none is provided', () => {
+      const state = useGnosisPayAuthState();
+      state.setError(GnosisPayError.SIGNATURE_REJECTED);
+
+      expect(get(state.errorContext)).toEqual({});
+    });
+  });
+
+  describe('clearError', () => {
+    it('should reset errorType and errorContext', () => {
+      const state = useGnosisPayAuthState();
+      state.setError(GnosisPayError.OTHER, { message: 'oops' });
+
+      state.clearError();
+
+      expect(get(state.errorType)).toBeNull();
+      expect(get(state.errorContext)).toEqual({});
+    });
+  });
+
+  describe('clearValidation', () => {
+    it('should reset address validation state', () => {
+      const state = useGnosisPayAuthState();
+      set(state.isAddressValid, true);
+      set(state.controlledSafeAddresses, ['0xsafe']);
+
+      state.clearValidation();
+
+      expect(get(state.isAddressValid)).toBe(false);
+      expect(get(state.controlledSafeAddresses)).toEqual([]);
+    });
+  });
+
+  describe('resetAuthState', () => {
+    it('should clear error, validation, sign-in success and progress flags', () => {
+      const state = useGnosisPayAuthState();
+      state.setError(GnosisPayError.OTHER, { message: 'oops' });
+      set(state.isAddressValid, true);
+      set(state.controlledSafeAddresses, ['0xsafe']);
+      set(state.signInSuccess, true);
+      set(state.signingInProgress, true);
+      set(state.validatingAddress, true);
+
+      state.resetAuthState();
+
+      expect(get(state.errorType)).toBeNull();
+      expect(get(state.errorContext)).toEqual({});
+      expect(get(state.isAddressValid)).toBe(false);
+      expect(get(state.controlledSafeAddresses)).toEqual([]);
+      expect(get(state.signInSuccess)).toBe(false);
+      expect(get(state.signingInProgress)).toBe(false);
+      expect(get(state.validatingAddress)).toBe(false);
+    });
+  });
+});
+
+describe('useGnosisPayAuthSteps', () => {
+  interface StepsOverrides {
+    hasRegisteredAccounts?: boolean;
+    isWalletConnected?: boolean;
+    validatingAddress?: boolean;
+    signInSuccess?: boolean;
+  }
+
+  function createSteps(overrides: StepsOverrides = {}): {
+    hasRegisteredAccounts: Ref<boolean>;
+    isWalletConnected: Ref<boolean>;
+    signInSuccess: Ref<boolean>;
+    steps: ReturnType<typeof useGnosisPayAuthSteps>;
+    validatingAddress: Ref<boolean>;
+  } {
+    const hasRegisteredAccounts = ref<boolean>(overrides.hasRegisteredAccounts ?? false);
+    const isWalletConnected = ref<boolean>(overrides.isWalletConnected ?? false);
+    const validatingAddress = ref<boolean>(overrides.validatingAddress ?? false);
+    const signInSuccess = ref<boolean>(overrides.signInSuccess ?? false);
+    const steps = useGnosisPayAuthSteps(hasRegisteredAccounts, isWalletConnected, validatingAddress, signInSuccess);
+    return { hasRegisteredAccounts, isWalletConnected, signInSuccess, steps, validatingAddress };
+  }
+
+  it('should report NOT_READY when there are no registered accounts', () => {
+    const { steps } = createSteps({ hasRegisteredAccounts: false });
+    expect(get(steps.currentStep)).toBe(AuthStep.NOT_READY);
+  });
+
+  it('should report CONNECT_WALLET when accounts exist but wallet not connected', () => {
+    const { steps } = createSteps({ hasRegisteredAccounts: true, isWalletConnected: false });
+    expect(get(steps.currentStep)).toBe(AuthStep.CONNECT_WALLET);
+  });
+
+  it('should report VALIDATE_ADDRESS while validating', () => {
+    const { steps } = createSteps({
+      hasRegisteredAccounts: true,
+      isWalletConnected: true,
+      validatingAddress: true,
+    });
+    expect(get(steps.currentStep)).toBe(AuthStep.VALIDATE_ADDRESS);
+  });
+
+  it('should report SIGN_MESSAGE when validated but not signed in', () => {
+    const { steps } = createSteps({
+      hasRegisteredAccounts: true,
+      isWalletConnected: true,
+      signInSuccess: false,
+      validatingAddress: false,
+    });
+    expect(get(steps.currentStep)).toBe(AuthStep.SIGN_MESSAGE);
+  });
+
+  it('should report COMPLETE when signed in', () => {
+    const { steps } = createSteps({
+      hasRegisteredAccounts: true,
+      isWalletConnected: true,
+      signInSuccess: true,
+      validatingAddress: false,
+    });
+    expect(get(steps.currentStep)).toBe(AuthStep.COMPLETE);
+  });
+
+  it('should react when source refs change', () => {
+    const { hasRegisteredAccounts, isWalletConnected, steps } = createSteps();
+    expect(get(steps.currentStep)).toBe(AuthStep.NOT_READY);
+
+    set(hasRegisteredAccounts, true);
+    expect(get(steps.currentStep)).toBe(AuthStep.CONNECT_WALLET);
+
+    set(isWalletConnected, true);
+    expect(get(steps.currentStep)).toBe(AuthStep.SIGN_MESSAGE);
+  });
+
+  describe('isStepComplete / isStepCurrent', () => {
+    it('should identify steps before currentStep as complete', () => {
+      const { steps } = createSteps({
+        hasRegisteredAccounts: true,
+        isWalletConnected: true,
+        signInSuccess: false,
+      });
+      // currentStep === SIGN_MESSAGE (3)
+      expect(steps.isStepComplete(AuthStep.NOT_READY)).toBe(true);
+      expect(steps.isStepComplete(AuthStep.CONNECT_WALLET)).toBe(true);
+      expect(steps.isStepComplete(AuthStep.VALIDATE_ADDRESS)).toBe(true);
+      expect(steps.isStepComplete(AuthStep.SIGN_MESSAGE)).toBe(false);
+    });
+
+    it('should identify only the matching step as current', () => {
+      const { steps } = createSteps({
+        hasRegisteredAccounts: true,
+        isWalletConnected: false,
+      });
+      expect(steps.isStepCurrent(AuthStep.CONNECT_WALLET)).toBe(true);
+      expect(steps.isStepCurrent(AuthStep.SIGN_MESSAGE)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-signing.spec.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-signing.spec.ts
@@ -1,0 +1,287 @@
+import type { BrowserProvider } from 'ethers';
+import type { Ref } from 'vue';
+import type { TaskResult } from '@/modules/core/tasks/use-task-handler';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { GnosisPayError, type GnosisPayErrorContext } from './types';
+import { useGnosisPaySigning } from './use-gnosis-pay-signing';
+
+const fetchNonce = vi.fn();
+const verifySiweSignature = vi.fn();
+const runTask = vi.fn();
+const showErrorMessage = vi.fn();
+const signMessage = vi.fn();
+const getSigner = vi.fn();
+const injectedGetBrowserProvider = vi.fn();
+const wcGetBrowserProvider = vi.fn();
+const walletMode = ref<string>('local-bridge');
+
+vi.mock('@/modules/integrations/gnosis-pay/use-gnosis-pay-api', () => ({
+  useGnosisPaySiweApi: vi.fn().mockImplementation(() => ({
+    fetchNonce,
+    verifySiweSignature,
+  })),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-handler', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/tasks/use-task-handler')>(
+    '@/modules/core/tasks/use-task-handler',
+  );
+  return {
+    ...actual,
+    useTaskHandler: vi.fn().mockImplementation(() => ({ runTask })),
+  };
+});
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn().mockImplementation(() => ({ showErrorMessage })),
+}));
+
+vi.mock('@/modules/wallet/bridge/use-injected-wallet', () => ({
+  useInjectedWallet: vi.fn().mockImplementation(() => ({
+    getBrowserProvider: injectedGetBrowserProvider,
+  })),
+}));
+
+vi.mock('@/modules/wallet/use-wallet-connect', () => ({
+  useWalletConnect: vi.fn().mockImplementation(() => ({
+    getBrowserProvider: wcGetBrowserProvider,
+  })),
+}));
+
+vi.mock('@/modules/wallet/use-wallet-store', () => ({
+  useWalletStore: vi.fn().mockImplementation(() => ({ walletMode })),
+}));
+
+vi.mock('@/modules/wallet/constants', () => ({
+  WALLET_MODES: { LOCAL_BRIDGE: 'local-bridge', WALLET_CONNECT: 'walletconnect' },
+  isUserRejectedError: (error: unknown): boolean => String(error).includes('User rejected'),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+function makeSuccess<T>(result: T): TaskResult<T> {
+  return { result, success: true };
+}
+
+function makeFailure(message: string, opts: Partial<{ cancelled: boolean; skipped: boolean }> = {}): TaskResult<never> {
+  return {
+    backendCancelled: false,
+    cancelled: opts.cancelled ?? false,
+    message,
+    skipped: opts.skipped ?? false,
+    success: false,
+  };
+}
+
+interface Harness {
+  clearError: Mock<() => void>;
+  connectedAddress: Ref<string | undefined>;
+  errorType: Ref<GnosisPayError | null>;
+  onSignInComplete?: Mock<() => void | Promise<void>>;
+  setError: Mock<(type: GnosisPayError, context?: GnosisPayErrorContext) => void>;
+  signingInProgress: Ref<boolean>;
+  signInSuccess: Ref<boolean>;
+}
+
+function makeHarness(overrides: Partial<Harness> = {}): Harness {
+  return {
+    clearError: vi.fn(),
+    connectedAddress: ref<string | undefined>('0xConnected'),
+    errorType: ref<GnosisPayError | null>(null),
+    setError: vi.fn(),
+    signingInProgress: ref<boolean>(false),
+    signInSuccess: ref<boolean>(false),
+    ...overrides,
+  };
+}
+
+describe('useGnosisPaySigning', () => {
+  beforeEach(() => {
+    fetchNonce.mockReset();
+    verifySiweSignature.mockReset();
+    runTask.mockReset();
+    showErrorMessage.mockReset();
+    signMessage.mockReset().mockResolvedValue('0xSignature');
+    getSigner.mockReset().mockResolvedValue({ signMessage });
+    const fakeProvider: Pick<BrowserProvider, 'getSigner'> = { getSigner };
+    injectedGetBrowserProvider.mockReset().mockReturnValue(fakeProvider);
+    wcGetBrowserProvider.mockReset().mockReturnValue(fakeProvider);
+    set(walletMode, 'local-bridge');
+  });
+
+  it('should clear error when starting a fresh sign-in', async () => {
+    const harness = makeHarness();
+    runTask.mockImplementation(async (fn: () => Promise<unknown>) => {
+      await fn();
+      return makeSuccess('nonce-1');
+    });
+    runTask.mockImplementationOnce(async () => makeSuccess('nonce-1'));
+    runTask.mockImplementationOnce(async () => makeSuccess(true));
+
+    const { signInWithEthereum } = useGnosisPaySigning({ ...harness, signInSuccess: harness.signInSuccess });
+    await signInWithEthereum();
+
+    expect(harness.clearError).toHaveBeenCalled();
+  });
+
+  it('should preserve INVALID_ADDRESS warning while signing', async () => {
+    const harness = makeHarness({ errorType: ref(GnosisPayError.INVALID_ADDRESS) });
+    runTask.mockImplementationOnce(async () => makeSuccess('nonce'));
+    runTask.mockImplementationOnce(async () => makeSuccess(true));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(harness.clearError).not.toHaveBeenCalled();
+  });
+
+  it('should set NO_WALLET_CONNECTED when no address is connected', async () => {
+    const harness = makeHarness({ connectedAddress: ref<string | undefined>(undefined) });
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(harness.setError).toHaveBeenCalledWith(GnosisPayError.NO_WALLET_CONNECTED);
+    expect(runTask).not.toHaveBeenCalled();
+    expect(get(harness.signingInProgress)).toBe(false);
+  });
+
+  it('should sign in successfully and invoke onSignInComplete', async () => {
+    const onSignInComplete = vi.fn();
+    const harness = makeHarness();
+    runTask.mockImplementationOnce(async () => makeSuccess('nonce-123'));
+    runTask.mockImplementationOnce(async () => makeSuccess(true));
+
+    const { signInWithEthereum } = useGnosisPaySigning({ ...harness, onSignInComplete });
+    await signInWithEthereum();
+
+    expect(fetchNonce).not.toHaveBeenCalled();
+    expect(runTask).toHaveBeenCalledTimes(2);
+    expect(signMessage).toHaveBeenCalledTimes(1);
+    const signedMessage = String(signMessage.mock.calls[0][0]);
+    expect(signedMessage).toContain('0xConnected');
+    expect(signedMessage).toContain('Nonce: nonce-123');
+    expect(get(harness.signInSuccess)).toBe(true);
+    expect(onSignInComplete).toHaveBeenCalled();
+    expect(get(harness.signingInProgress)).toBe(false);
+  });
+
+  it('should bail out when fetching the nonce fails actionably', async () => {
+    const harness = makeHarness();
+    runTask.mockImplementationOnce(async () => makeFailure('nonce error'));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(showErrorMessage).toHaveBeenCalled();
+    expect(signMessage).not.toHaveBeenCalled();
+    expect(get(harness.signInSuccess)).toBe(false);
+  });
+
+  it('should not show error message when nonce fetch is cancelled', async () => {
+    const harness = makeHarness();
+    runTask.mockImplementationOnce(async () => makeFailure('cancelled', { cancelled: true }));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(showErrorMessage).not.toHaveBeenCalled();
+    expect(signMessage).not.toHaveBeenCalled();
+  });
+
+  it('should bail out when verification fails', async () => {
+    const harness = makeHarness();
+    runTask.mockImplementationOnce(async () => makeSuccess('nonce'));
+    runTask.mockImplementationOnce(async () => makeFailure('verify failed'));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(showErrorMessage).toHaveBeenCalled();
+    expect(get(harness.signInSuccess)).toBe(false);
+  });
+
+  it('should show generic failure when verification returns false', async () => {
+    const harness = makeHarness();
+    runTask.mockImplementationOnce(async () => makeSuccess('nonce'));
+    runTask.mockImplementationOnce(async () => makeSuccess(false));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(showErrorMessage).toHaveBeenCalled();
+    expect(get(harness.signInSuccess)).toBe(false);
+  });
+
+  it('should detect a user-rejected signature error', async () => {
+    const harness = makeHarness();
+    runTask.mockImplementationOnce(async () => makeSuccess('nonce'));
+    signMessage.mockRejectedValueOnce(new Error('User rejected the request'));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(harness.setError).toHaveBeenCalledWith(GnosisPayError.SIGNATURE_REJECTED);
+    expect(showErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('should show a generic error when signing throws an unknown error', async () => {
+    const harness = makeHarness();
+    runTask.mockImplementationOnce(async () => makeSuccess('nonce'));
+    signMessage.mockRejectedValueOnce(new Error('boom'));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(harness.setError).not.toHaveBeenCalledWith(GnosisPayError.SIGNATURE_REJECTED);
+    expect(showErrorMessage).toHaveBeenCalled();
+  });
+
+  it('should use the wallet-connect provider when in walletconnect mode', async () => {
+    set(walletMode, 'walletconnect');
+    const harness = makeHarness();
+    runTask.mockImplementationOnce(async () => makeSuccess('nonce'));
+    runTask.mockImplementationOnce(async () => makeSuccess(true));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(wcGetBrowserProvider).toHaveBeenCalled();
+    expect(injectedGetBrowserProvider).not.toHaveBeenCalled();
+  });
+
+  it('should always reset signingInProgress when finished', async () => {
+    const harness = makeHarness();
+    runTask.mockImplementationOnce(async () => {
+      throw new Error('unexpected');
+    });
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(get(harness.signingInProgress)).toBe(false);
+  });
+
+  it('should run the task helpers with the expected task types', async () => {
+    const harness = makeHarness();
+    runTask.mockImplementationOnce(async (fn: () => Promise<string>) => {
+      await fn();
+      return makeSuccess('nonce');
+    });
+    runTask.mockImplementationOnce(async (fn: () => Promise<boolean>) => {
+      await fn();
+      return makeSuccess(true);
+    });
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(fetchNonce).toHaveBeenCalled();
+    expect(verifySiweSignature).toHaveBeenCalled();
+    const verifyArgs = verifySiweSignature.mock.calls[0];
+    expect(verifyArgs[0]).toContain('0xConnected');
+    expect(verifyArgs[1]).toBe('0xSignature');
+  });
+});

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-wallet.spec.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-wallet.spec.ts
@@ -1,0 +1,287 @@
+import type { Ref } from 'vue';
+import type { EnhancedProviderDetail } from '@/modules/wallet/providers/provider-detection';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { type GnosisPayAdminsMapping, GnosisPayError } from './types';
+import { useGnosisPayWallet } from './use-gnosis-pay-wallet';
+
+const fetchGnosisPayAdmins = vi.fn();
+const connectWallet = vi.fn();
+const disconnectWallet = vi.fn();
+const handleProviderSelectionBase = vi.fn();
+const connected = ref<boolean>(false);
+const connectedAddress = ref<string | undefined>();
+
+vi.mock('@/modules/integrations/gnosis-pay/use-gnosis-pay-api', () => ({
+  useGnosisPaySiweApi: vi.fn().mockImplementation(() => ({
+    fetchGnosisPayAdmins,
+  })),
+}));
+
+vi.mock('@/modules/wallet/use-wallet-store', () => ({
+  useWalletStore: vi.fn().mockImplementation(() => ({
+    connect: connectWallet,
+    connected,
+    connectedAddress,
+    disconnect: disconnectWallet,
+  })),
+}));
+
+vi.mock('@/modules/wallet/providers/use-provider-selection', () => ({
+  useProviderSelection: vi.fn().mockImplementation(() => ({
+    handleProviderSelection: handleProviderSelectionBase,
+  })),
+}));
+
+vi.mock('@/modules/core/common/logging/error-handling', () => ({
+  getErrorMessage: vi.fn().mockImplementation(err => (err instanceof Error ? err.message : String(err))),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+interface Options {
+  checkingRegisteredAccounts: Ref<boolean>;
+  clearError: Mock<() => void>;
+  clearValidation: Mock<() => void>;
+  controlledSafeAddresses: Ref<string[]>;
+  gnosisPayAdminsMapping: Ref<GnosisPayAdminsMapping>;
+  hasRegisteredAccounts: Ref<boolean>;
+  isAddressValid: Ref<boolean>;
+  setError: Mock<(type: GnosisPayError, context?: { adminsMapping?: GnosisPayAdminsMapping; message?: string }) => void>;
+  validatingAddress: Ref<boolean>;
+}
+
+function makeOptions(overrides: Partial<Options> = {}): Options {
+  return {
+    checkingRegisteredAccounts: ref<boolean>(false),
+    clearError: vi.fn(),
+    clearValidation: vi.fn(),
+    controlledSafeAddresses: ref<string[]>([]),
+    gnosisPayAdminsMapping: ref<GnosisPayAdminsMapping>({}),
+    hasRegisteredAccounts: ref<boolean>(false),
+    isAddressValid: ref<boolean>(false),
+    setError: vi.fn(),
+    validatingAddress: ref<boolean>(false),
+    ...overrides,
+  };
+}
+
+describe('useGnosisPayWallet', () => {
+  beforeEach(() => {
+    fetchGnosisPayAdmins.mockReset();
+    connectWallet.mockReset().mockResolvedValue(undefined);
+    disconnectWallet.mockReset().mockResolvedValue(undefined);
+    handleProviderSelectionBase.mockReset().mockResolvedValue(undefined);
+    set(connected, false);
+    set(connectedAddress, undefined);
+  });
+
+  describe('isWalletConnected', () => {
+    it('should require both connected flag and a connected address', () => {
+      const { isWalletConnected } = useGnosisPayWallet(makeOptions());
+      expect(get(isWalletConnected)).toBe(false);
+
+      set(connected, true);
+      expect(get(isWalletConnected)).toBe(false);
+
+      set(connectedAddress, '0xAbc');
+      expect(get(isWalletConnected)).toBe(true);
+
+      set(connected, false);
+      expect(get(isWalletConnected)).toBe(false);
+    });
+  });
+
+  describe('checkRegisteredAccounts', () => {
+    it('should set NO_REGISTERED_ACCOUNTS error when admin mapping is empty', async () => {
+      fetchGnosisPayAdmins.mockResolvedValue({});
+      const options = makeOptions();
+
+      const { checkRegisteredAccounts } = useGnosisPayWallet(options);
+      await checkRegisteredAccounts();
+
+      expect(options.clearError).toHaveBeenCalled();
+      expect(options.setError).toHaveBeenCalledWith(GnosisPayError.NO_REGISTERED_ACCOUNTS);
+      expect(get(options.hasRegisteredAccounts)).toBe(false);
+      expect(get(options.checkingRegisteredAccounts)).toBe(false);
+    });
+
+    it('should populate adminsMapping when accounts are returned', async () => {
+      const mapping: GnosisPayAdminsMapping = { '0xSafe1': ['0xAdmin1', '0xAdmin2'] };
+      fetchGnosisPayAdmins.mockResolvedValue(mapping);
+      const options = makeOptions();
+
+      const { checkRegisteredAccounts } = useGnosisPayWallet(options);
+      await checkRegisteredAccounts();
+
+      expect(options.setError).not.toHaveBeenCalled();
+      expect(get(options.hasRegisteredAccounts)).toBe(true);
+      expect(get(options.gnosisPayAdminsMapping)).toEqual(mapping);
+    });
+
+    it('should map api errors to GnosisPayError.OTHER', async () => {
+      fetchGnosisPayAdmins.mockRejectedValue(new Error('network down'));
+      const options = makeOptions();
+
+      const { checkRegisteredAccounts } = useGnosisPayWallet(options);
+      await checkRegisteredAccounts();
+
+      expect(options.setError).toHaveBeenCalledWith(GnosisPayError.OTHER, { message: 'network down' });
+      expect(get(options.hasRegisteredAccounts)).toBe(false);
+      expect(get(options.checkingRegisteredAccounts)).toBe(false);
+    });
+  });
+
+  describe('handleProviderSelection', () => {
+    it('should forward provider to base and pass a CONNECTION_FAILED error callback', async () => {
+      const options = makeOptions();
+      const provider: EnhancedProviderDetail = {
+        info: { icon: '', name: 'Test Wallet', rdns: 'test.wallet', uuid: 'wallet-1' },
+        provider: { request: vi.fn() },
+        source: 'eip6963',
+      };
+
+      const { handleProviderSelection } = useGnosisPayWallet(options);
+      await handleProviderSelection(provider);
+
+      expect(handleProviderSelectionBase).toHaveBeenCalledTimes(1);
+      const [calledProvider, onError] = handleProviderSelectionBase.mock.calls[0];
+      expect(calledProvider).toBe(provider);
+
+      onError('connection refused');
+      expect(options.setError).toHaveBeenCalledWith(
+        GnosisPayError.CONNECTION_FAILED,
+        { message: 'connection refused' },
+      );
+    });
+  });
+
+  describe('validateAddress', () => {
+    it('should set NO_WALLET_CONNECTED when no address is connected', async () => {
+      const options = makeOptions();
+
+      const { validateAddress } = useGnosisPayWallet(options);
+      await validateAddress();
+
+      expect(options.setError).toHaveBeenCalledWith(GnosisPayError.NO_WALLET_CONNECTED);
+      expect(get(options.isAddressValid)).toBe(false);
+    });
+
+    it('should set INVALID_ADDRESS when the connected address controls no safe', async () => {
+      const adminsMapping: GnosisPayAdminsMapping = { '0xSafe': ['0xOther'] };
+      const options = makeOptions({
+        gnosisPayAdminsMapping: ref<GnosisPayAdminsMapping>(adminsMapping),
+      });
+      set(connectedAddress, '0xConnected');
+
+      const { validateAddress } = useGnosisPayWallet(options);
+      await validateAddress();
+
+      expect(options.setError).toHaveBeenCalledWith(
+        GnosisPayError.INVALID_ADDRESS,
+        { adminsMapping },
+      );
+      expect(get(options.isAddressValid)).toBe(false);
+    });
+
+    it('should mark address valid and populate controlled safes (case-insensitive)', async () => {
+      const adminsMapping: GnosisPayAdminsMapping = {
+        '0xSafeA': ['0xMINE'],
+        '0xSafeB': ['0xother'],
+        '0xSafeC': ['0xmine', '0xanother'],
+      };
+      const options = makeOptions({
+        gnosisPayAdminsMapping: ref<GnosisPayAdminsMapping>(adminsMapping),
+      });
+      set(connectedAddress, '0xMine');
+
+      const { validateAddress } = useGnosisPayWallet(options);
+      await validateAddress();
+
+      expect(get(options.isAddressValid)).toBe(true);
+      expect(get(options.controlledSafeAddresses)).toEqual(['0xSafeA', '0xSafeC']);
+      expect(options.setError).not.toHaveBeenCalled();
+    });
+
+    it('should map unexpected errors to GnosisPayError.OTHER', async () => {
+      const throwingMapping: GnosisPayAdminsMapping = {};
+      Object.defineProperty(throwingMapping, 'safeKey', {
+        configurable: true,
+        enumerable: true,
+        get(): string[] {
+          throw new Error('mapping access failed');
+        },
+      });
+      const options = makeOptions({
+        gnosisPayAdminsMapping: ref<GnosisPayAdminsMapping>(throwingMapping),
+      });
+      set(connectedAddress, '0xAddr');
+
+      const { validateAddress } = useGnosisPayWallet(options);
+      await validateAddress();
+
+      // clearValidation should be called twice (once before validation, once in catch block)
+      expect(options.clearValidation).toHaveBeenCalled();
+      expect(options.setError).toHaveBeenCalledWith(
+        GnosisPayError.OTHER,
+        expect.objectContaining({ message: expect.any(String) }),
+      );
+      expect(get(options.validatingAddress)).toBe(false);
+    });
+  });
+
+  describe('connect', () => {
+    it('should call the wallet store connect', async () => {
+      const options = makeOptions();
+
+      const { connect } = useGnosisPayWallet(options);
+      await connect();
+
+      expect(options.clearError).toHaveBeenCalled();
+      expect(options.clearValidation).toHaveBeenCalled();
+      expect(connectWallet).toHaveBeenCalled();
+      expect(options.setError).not.toHaveBeenCalled();
+    });
+
+    it('should set CONNECTION_FAILED when connect throws', async () => {
+      connectWallet.mockRejectedValueOnce(new Error('refused'));
+      const options = makeOptions();
+
+      const { connect } = useGnosisPayWallet(options);
+      await connect();
+
+      expect(options.setError).toHaveBeenCalledWith(
+        GnosisPayError.CONNECTION_FAILED,
+        { message: 'refused' },
+      );
+    });
+  });
+
+  describe('disconnect', () => {
+    it('should call the wallet store disconnect', async () => {
+      const options = makeOptions();
+
+      const { disconnect } = useGnosisPayWallet(options);
+      await disconnect();
+
+      expect(options.clearError).toHaveBeenCalled();
+      expect(options.clearValidation).toHaveBeenCalled();
+      expect(disconnectWallet).toHaveBeenCalled();
+      expect(options.setError).not.toHaveBeenCalled();
+    });
+
+    it('should set CONNECTION_FAILED when disconnect throws', async () => {
+      disconnectWallet.mockRejectedValueOnce(new Error('cannot disconnect'));
+      const options = makeOptions();
+
+      const { disconnect } = useGnosisPayWallet(options);
+      await disconnect();
+
+      expect(options.setError).toHaveBeenCalledWith(
+        GnosisPayError.CONNECTION_FAILED,
+        { message: 'cannot disconnect' },
+      );
+    });
+  });
+});

--- a/frontend/app/src/modules/integrations/monerium/use-monerium-auth.spec.ts
+++ b/frontend/app/src/modules/integrations/monerium/use-monerium-auth.spec.ts
@@ -1,0 +1,232 @@
+import type { MoneriumOAuthResult, MoneriumStatus } from './types';
+import { flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMoneriumOAuth } from './use-monerium-auth';
+
+const getStatus = vi.fn();
+const completeOAuthApi = vi.fn();
+const disconnectApi = vi.fn();
+const logged = ref<boolean>(false);
+const allowed = ref<boolean>(false);
+
+vi.mock('@/modules/integrations/monerium/use-monerium-api', () => ({
+  useMoneriumOAuthApi: vi.fn().mockImplementation(() => ({
+    completeOAuth: completeOAuthApi,
+    disconnect: disconnectApi,
+    getStatus,
+  })),
+}));
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: vi.fn().mockImplementation(() => ({ logged })),
+}));
+
+vi.mock('@/modules/premium/use-feature-access', () => ({
+  PremiumFeature: { MONERIUM: 'monerium' },
+  useFeatureAccess: vi.fn().mockImplementation(() => ({ allowed })),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+describe('useMoneriumOAuth', () => {
+  beforeEach(async () => {
+    // useMoneriumOAuth is wrapped in createSharedComposable, so the shared
+    // instance persists across tests. Park it in the "skip" branch (logged or
+    // premium are false) before clearing mock history, so any prior async
+    // effect resolves first.
+    set(logged, false);
+    set(allowed, false);
+    await flushPromises();
+    vi.clearAllMocks();
+    getStatus.mockResolvedValue({ authenticated: false });
+    completeOAuthApi.mockReset();
+    disconnectApi.mockReset();
+  });
+
+  it('should fetch status when user is logged in and premium feature is allowed', async () => {
+    const statusResponse: MoneriumStatus = { authenticated: true, userEmail: 'a@b.com' };
+    getStatus.mockResolvedValue(statusResponse);
+    set(logged, true);
+    set(allowed, true);
+
+    const { authenticated, status } = useMoneriumOAuth();
+    await flushPromises();
+
+    expect(getStatus).toHaveBeenCalledTimes(1);
+    expect(get(status)).toEqual(statusResponse);
+    expect(get(authenticated)).toBe(true);
+  });
+
+  it('should not fetch status when user is not logged in', async () => {
+    set(logged, false);
+    set(allowed, true);
+
+    const { authenticated, status } = useMoneriumOAuth();
+    await flushPromises();
+
+    expect(getStatus).not.toHaveBeenCalled();
+    expect(get(status)).toBeUndefined();
+    expect(get(authenticated)).toBe(false);
+  });
+
+  it('should not fetch status when feature is not allowed', async () => {
+    set(logged, true);
+    set(allowed, false);
+
+    useMoneriumOAuth();
+    await flushPromises();
+
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to unauthenticated status when getStatus throws', async () => {
+    getStatus.mockRejectedValue(new Error('boom'));
+    set(logged, true);
+    set(allowed, true);
+
+    const { authenticated, status } = useMoneriumOAuth();
+    await flushPromises();
+
+    expect(get(status)).toEqual({ authenticated: false });
+    expect(get(authenticated)).toBe(false);
+  });
+
+  describe('refreshStatus', () => {
+    it('should update status from the api', async () => {
+      set(logged, true);
+      set(allowed, true);
+      const { authenticated, refreshStatus, status } = useMoneriumOAuth();
+      await flushPromises();
+
+      getStatus.mockResolvedValueOnce({ authenticated: true, userEmail: 'x@y.com' });
+      await refreshStatus();
+
+      expect(get(status)).toEqual({ authenticated: true, userEmail: 'x@y.com' });
+      expect(get(authenticated)).toBe(true);
+    });
+
+    it('should set authenticated=false when refresh fails', async () => {
+      set(logged, true);
+      set(allowed, true);
+      const { refreshStatus, status } = useMoneriumOAuth();
+      await flushPromises();
+
+      getStatus.mockRejectedValueOnce(new Error('network'));
+      await refreshStatus();
+
+      expect(get(status)).toEqual({ authenticated: false });
+    });
+
+    it('should toggle loading flag around the request', async () => {
+      set(logged, true);
+      set(allowed, true);
+      const { loading, refreshStatus } = useMoneriumOAuth();
+      await flushPromises();
+
+      let resolveFn!: (value: MoneriumStatus) => void;
+      getStatus.mockImplementationOnce(async () => new Promise<MoneriumStatus>((resolve) => {
+        resolveFn = resolve;
+      }));
+
+      const promise = refreshStatus();
+      expect(get(loading)).toBe(true);
+      resolveFn({ authenticated: true });
+      await promise;
+      expect(get(loading)).toBe(false);
+    });
+  });
+
+  describe('setStatus', () => {
+    it('should update status synchronously', async () => {
+      set(logged, true);
+      set(allowed, true);
+      const { authenticated, setStatus, status } = useMoneriumOAuth();
+      await flushPromises();
+
+      setStatus({ authenticated: true, userEmail: 'c@d.com' });
+
+      expect(get(status)).toEqual({ authenticated: true, userEmail: 'c@d.com' });
+      expect(get(authenticated)).toBe(true);
+    });
+  });
+
+  describe('completeOAuth', () => {
+    it('should call the api, update status and refresh', async () => {
+      const apiResult: MoneriumOAuthResult = {
+        defaultProfileId: 'p1',
+        message: 'ok',
+        profiles: [{ id: 'p1', name: 'profile-1' }],
+        userEmail: 'user@example.com',
+      };
+      completeOAuthApi.mockResolvedValue(apiResult);
+      getStatus.mockResolvedValue({ authenticated: true, userEmail: 'user@example.com' });
+      set(logged, true);
+      set(allowed, true);
+
+      const { completeOAuth, status } = useMoneriumOAuth();
+      await flushPromises();
+
+      const result = await completeOAuth('access', 'refresh', 7200);
+
+      expect(completeOAuthApi).toHaveBeenCalledWith('access', 'refresh', 7200);
+      expect(result).toEqual(apiResult);
+      expect(get(status)?.authenticated).toBe(true);
+    });
+
+    it('should default expiresIn to 3600 seconds when not provided', async () => {
+      completeOAuthApi.mockResolvedValue({ message: 'ok' });
+      getStatus.mockResolvedValue({ authenticated: true });
+      set(logged, true);
+      set(allowed, true);
+
+      const { completeOAuth } = useMoneriumOAuth();
+      await flushPromises();
+
+      await completeOAuth('a', 'r');
+
+      expect(completeOAuthApi).toHaveBeenCalledWith('a', 'r', 3600);
+    });
+
+    it('should propagate api errors', async () => {
+      completeOAuthApi.mockRejectedValue(new Error('oauth failed'));
+      set(logged, true);
+      set(allowed, true);
+
+      const { completeOAuth } = useMoneriumOAuth();
+      await flushPromises();
+
+      await expect(completeOAuth('a', 'r')).rejects.toThrow('oauth failed');
+    });
+  });
+
+  describe('disconnect', () => {
+    it('should call api and refresh status to unauthenticated', async () => {
+      disconnectApi.mockResolvedValue(true);
+      getStatus.mockResolvedValue({ authenticated: false });
+      set(logged, true);
+      set(allowed, true);
+
+      const { authenticated, disconnect, status } = useMoneriumOAuth();
+      await flushPromises();
+
+      await disconnect();
+
+      expect(disconnectApi).toHaveBeenCalled();
+      expect(get(status)).toEqual({ authenticated: false });
+      expect(get(authenticated)).toBe(false);
+    });
+
+    it('should propagate api errors', async () => {
+      disconnectApi.mockRejectedValue(new Error('disconnect failed'));
+      set(logged, true);
+      set(allowed, true);
+
+      const { disconnect } = useMoneriumOAuth();
+      await flushPromises();
+
+      await expect(disconnect()).rejects.toThrow('disconnect failed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds co-located unit specs for the four integrations composables in the Tier 2 plan from #11252 — Monerium auth and the Gnosis Pay auth-state, signing, and wallet flows.
- 61 new tests across four files; no production code changes.

## Test plan
- [x] `pnpm run test:unit src/modules/integrations/` — 70 passed (6 files)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint-staged`