### PR TITLE
ci: align codecov flags and fix frontend coverage glob

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,8 +8,13 @@ coverage:
     project: off
     patch: off
 
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
 flags:
-  backend:
+  backend-nightly:
     carryforward: true
     paths:
       - rotkehlchen
@@ -21,3 +26,11 @@ flags:
     carryforward: true
     paths:
       - frontend/app
+
+ignore:
+  - "**/*.d.ts"
+  - "**/*.spec.ts"
+  - "**/*.test.ts"
+  - "frontend/app/src/locales/**"
+  - "frontend/app/tests/**"
+  - "rotkehlchen/tests/**"

--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -212,7 +212,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./frontend/app/tests/e2e/coverage/lcov.info
-          flags: e2e-shard-${{ matrix.shard }}
+          flags: frontend_integration
           fail_ci_if_error: false
 
       - name: Upload test artifacts

--- a/.github/workflows/task_fe_unit_tests.yml
+++ b/.github/workflows/task_fe_unit_tests.yml
@@ -49,5 +49,6 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
+          files: ./frontend/app/tests/unit/coverage/lcov.info
           flags: frontend_unit
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/frontend/app/vitest.config.ts
+++ b/frontend/app/vitest.config.ts
@@ -44,7 +44,7 @@ export default mergeConfig(
         provider: 'v8',
         reportsDirectory: 'tests/unit/coverage',
         reporter: ['json', 'lcov', 'html'],
-        include: ['src/*'],
+        include: ['src/**'],
         exclude: ['node_modules', 'tests/', '**/*.d.ts', '**/*.spec.ts'],
       },
     },


### PR DESCRIPTION
## Summary
The frontend list in Codecov has been showing stale data for a while. Root cause and a few related misconfigurations:

- **`frontend/app/vitest.config.ts`** — `coverage.include: ['src/*']` only matches direct children of `src/`, so nothing under `src/modules/`, `src/components/`, etc. ever appeared in the lcov upload. Combined with `carryforward: true` on the `frontend_unit` flag, every nightly only refreshed a handful of top-level files and Codecov kept reporting the old pre-modularization paths for everything else. Fixed by changing the glob to `src/**`.
- **`task_e2e_tests.yml`** — uploads were tagged `flags: e2e-shard-${{ matrix.shard }}`, which are undeclared flags. The `frontend_integration` flag in `.codecov.yml` therefore never attached (no `paths:` mapping, no `carryforward`). Switched all four shards to `flags: frontend_integration`; Codecov merges multiple uploads under the same flag into a union, so per-shard coverage still combines correctly.
- **`.codecov.yml`** — the declared `backend` flag did not match the workflow's `flags: backend-nightly`, so the flag config was inert on backend uploads. Renamed to `backend-nightly` to match.
- **`task_fe_unit_tests.yml`** — pinned `files: ./frontend/app/tests/unit/coverage/lcov.info` instead of relying on codecov-action auto-discovery.
- **`.codecov.yml`** — added an `ignore:` block for `*.d.ts`, `*.spec.ts`, `*.test.ts`, `frontend/app/src/locales/`, `frontend/app/tests/`, `rotkehlchen/tests/` to denoise reports, and made the PR-comment layout explicit (`reach, diff, flags, files`).

Backend PR coverage is intentionally not collected (pytest+coverage is too slow on PRs) — PR backend numbers will continue to come from the nightly via carryforward, as today.

## Validation
- `curl --data-binary @.codecov.yml https://codecov.io/validate` → **Valid!**
- All three declared flags (`backend-nightly`, `frontend_unit`, `frontend_integration`) now match a real upload step.

## Test plan
- [ ] Wait for the first PR CI run after merge — Codecov comment should pick up the new `comment:` layout.
- [ ] Wait for the next nightly — the frontend list on Codecov should refresh with the full module tree (subdirs now included). Stale paths may take one or two nightlies to fully drop off as carryforward unwinds.
- [ ] Confirm the e2e shards' uploads merge under `frontend_integration` (single combined flag in the Codecov UI rather than four `e2e-shard-N`).

## Notes
Manual nightly trigger already works for anyone with write access via the Actions tab (`workflow_dispatch:` is already declared); no workflow change needed for that.