### PR TITLE
Adjust etherscan rate limits

### DIFF
--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -40,6 +40,7 @@ class DBCacheStatic(Enum):
     LAST_HISTORICAL_BALANCE_PROCESSING_TS: Final = 'last_historical_balance_processing_ts'
     LAST_INTERNAL_TX_CONFLICTS_REPULL_TS: Final = 'last_internal_tx_conflicts_repull_ts'
     BEACONCHAIN_VALIDATOR_QUERY_LIMIT: Final = 'beaconchain_validator_query_limit'
+    ETHERSCAN_API_KEY_TIER: Final = 'etherscan_api_key_tier'
 
 
 class LabeledLocationArgsType(TypedDict):

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -720,10 +720,10 @@ class DBHandler:
 
     @staticmethod
     def _deserialize_static_cache_value(name: DBCacheStatic, value: str) -> Timestamp | str:
-        # Return string for these cache entries, timestamp for all others
-        if name in (
+        if name in (  # Return string for these cache entries, timestamp for all others
             DBCacheStatic.DOCKER_DEVICE_INFO,
             DBCacheStatic.MONERIUM_OAUTH_CREDENTIALS,
+            DBCacheStatic.ETHERSCAN_API_KEY_TIER,
             DBCacheStatic.STALE_BALANCES_FROM_TS,
             DBCacheStatic.STALE_BALANCES_MODIFICATION_TS,
             DBCacheStatic.BEACONCHAIN_VALIDATOR_QUERY_LIMIT,
@@ -738,6 +738,7 @@ class DBHandler:
             cursor: 'DBCursor',
             name: Literal[
                 DBCacheStatic.DOCKER_DEVICE_INFO,
+                DBCacheStatic.ETHERSCAN_API_KEY_TIER,
                 DBCacheStatic.MONERIUM_OAUTH_CREDENTIALS,
                 DBCacheStatic.STALE_BALANCES_FROM_TS,
                 DBCacheStatic.STALE_BALANCES_MODIFICATION_TS,

--- a/rotkehlchen/externalapis/blockscout.py
+++ b/rotkehlchen/externalapis/blockscout.py
@@ -129,10 +129,6 @@ class Blockscout(ExternalServiceWithApiKey, EtherscanLikeApi):
             http_method: Literal['get', 'post'] = 'get',
     ) -> dict[str, Any]:
         """Shared logic between v1 and v2 for querying blockscout api"""
-        log.debug(
-            f'Querying blockscout API for {query_str} with body {params} '
-            f'and query params {query_params}',
-        )
         times = (cached_settings := CachedSettings()).get_query_retry_limit()
         retries_num = times
         timeout = timeout or cached_settings.get_timeout_tuple()
@@ -140,6 +136,10 @@ class Blockscout(ExternalServiceWithApiKey, EtherscanLikeApi):
 
         while True:
             self._rate_limiter.acquire()
+            log.debug(
+                f'Querying blockscout API for {query_str} with body {params} '
+                f'and query params {query_params}',
+            )
             try:
                 request_kwargs: dict[str, Any] = {'timeout': timeout}
                 if query_params is not None:

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -87,6 +87,7 @@ class Etherscan(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
             rate_limiter=TokenBucket(
                 rps=FREE_ETHERSCAN_RATE_LIMIT_RPS,
                 capacity=FREE_ETHERSCAN_RATE_LIMIT_BURST,
+                minimum_rps=FREE_ETHERSCAN_RATE_LIMIT_RPS,
             ),
         )
         self.detect_api_key_tier()
@@ -154,6 +155,7 @@ class Etherscan(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
             self._rate_limiter.reset(
                 rps=FREE_ETHERSCAN_RATE_LIMIT_RPS,
                 capacity=FREE_ETHERSCAN_RATE_LIMIT_BURST,
+                minimum_rps=FREE_ETHERSCAN_RATE_LIMIT_RPS,
             )
             return
 
@@ -162,7 +164,7 @@ class Etherscan(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
                 return
             self._cache_api_key_tier(tier=tier)
 
-        self._rate_limiter.reset(rps=tier.rps, capacity=tier.burst)
+        self._rate_limiter.reset(rps=tier.rps, capacity=tier.burst, minimum_rps=tier.rps)
         log.debug(f'Detected Etherscan API key tier {tier.name}. Set rate limit to {tier.rps} rps')
 
     def on_api_key_changed(self) -> None:

--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple
 
 import gevent
 from requests import Response
@@ -7,7 +7,7 @@ from sqlcipher3 import dbapi2 as sqlcipher
 
 from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2ChainIdsWithL1FeesType
 from rotkehlchen.chain.structures import TimestampOrBlockRange
-from rotkehlchen.db.cache import DBCacheDynamic
+from rotkehlchen.db.cache import DBCacheDynamic, DBCacheStatic
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.misc import ChainNotSupported, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
@@ -39,10 +39,30 @@ log = RotkehlchenLogsAdapter(logger)
 ETHERSCAN_PAGINATION_LIMIT: Final = 10000
 ETHERSCAN_BASE_URL: Final = 'https://api.etherscan.io/v2/api'
 ROTKI_PACKAGED_KEY: Final = ApiKey('W9CEV6QB9NIPUEHD6KNEYM4PDX6KBPRVVR')
-# Etherscan v2 free tier is 5 req/s on a single API key shared across all
-# chains. We stay slightly under to leave room for the occasional retry.
-ETHERSCAN_RATE_LIMIT_RPS: Final = 4.0
-ETHERSCAN_RATE_LIMIT_BURST: Final = 8
+# Etherscan v2 free tier is 3 req/s on a single API key shared across all
+# chains. Keep the default at the documented free-tier rate; higher tiers can
+# still proceed, and 429 responses will shrink dynamically if needed.
+FREE_ETHERSCAN_RATE_LIMIT_RPS: Final = 3.0
+FREE_ETHERSCAN_RATE_LIMIT_BURST: Final = 3
+
+
+class EtherscanTier(NamedTuple):
+    name: Literal['free_or_lite', 'standard', 'advanced', 'professional', 'pro_plus']
+    rps: float
+    burst: int
+
+
+ETHERSCAN_TIER_BY_DAILY_LIMIT: Final[dict[int, EtherscanTier]] = {
+    100000: EtherscanTier(
+        name='free_or_lite',
+        rps=FREE_ETHERSCAN_RATE_LIMIT_RPS,
+        burst=FREE_ETHERSCAN_RATE_LIMIT_BURST,
+    ),
+    200000: EtherscanTier(name='standard', rps=10.0, burst=10),
+    500000: EtherscanTier(name='advanced', rps=20.0, burst=20),
+    1000000: EtherscanTier(name='professional', rps=30.0, burst=30),
+    1500000: EtherscanTier(name='pro_plus', rps=30.0, burst=30),
+}
 
 
 class Etherscan(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
@@ -65,10 +85,92 @@ class Etherscan(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
             default_api_key=ROTKI_PACKAGED_KEY,
             pagination_limit=ETHERSCAN_PAGINATION_LIMIT,
             rate_limiter=TokenBucket(
-                rps=ETHERSCAN_RATE_LIMIT_RPS,
-                capacity=ETHERSCAN_RATE_LIMIT_BURST,
+                rps=FREE_ETHERSCAN_RATE_LIMIT_RPS,
+                capacity=FREE_ETHERSCAN_RATE_LIMIT_BURST,
             ),
         )
+        self.detect_api_key_tier()
+
+    def _cache_api_key_tier(self, tier: EtherscanTier) -> None:
+        with self.db.user_write() as write_cursor:
+            self.db.set_static_cache(
+                write_cursor=write_cursor,
+                name=DBCacheStatic.ETHERSCAN_API_KEY_TIER,
+                value=tier.name,
+            )
+
+    def _get_cached_api_key_tier(self) -> EtherscanTier | None:
+        with self.db.conn.read_ctx() as cursor:
+            if (cached_value := self.db.get_static_cache(
+                cursor=cursor,
+                name=DBCacheStatic.ETHERSCAN_API_KEY_TIER,
+            )) is None:
+                return None
+
+        for tier in ETHERSCAN_TIER_BY_DAILY_LIMIT.values():
+            if tier.name == cached_value:
+                return tier
+        return None
+
+    def _delete_cached_api_key_tier(self) -> None:
+        with self.db.user_write() as write_cursor:
+            write_cursor.execute(
+                'DELETE FROM key_value_cache WHERE name=?',
+                (DBCacheStatic.ETHERSCAN_API_KEY_TIER.value,),
+            )
+
+    def _query_api_key_tier(self, api_key: ApiKey) -> EtherscanTier | None:
+        try:
+            result = self._query(
+                chain_id=ChainID.ETHEREUM,
+                module='getapilimit',
+                action='getapilimit',
+            )
+        except RemoteError as e:
+            log.debug(f'Failed to query Etherscan API key tier for {api_key} due to {e!s}')
+            return None
+
+        if not isinstance(result, dict) or not isinstance(
+            credit_limit := result.get('creditLimit'),
+            int,
+        ):
+            log.debug(f'Etherscan API key tier query returned unexpected result: {result}')
+            return None
+
+        if (tier := ETHERSCAN_TIER_BY_DAILY_LIMIT.get(credit_limit)) is None:
+            log.debug(f'Etherscan API key has unknown daily credit limit: {credit_limit}')
+            return None
+
+        return tier
+
+    def detect_api_key_tier(self) -> None:
+        """Read/cache Etherscan's daily limit and adjust the token bucket.
+
+        The getapilimit endpoint exposes only daily credits, not per-second limits. This means
+        Free and Lite are indistinguishable (both 100k/day), so the 100k bucket stays at the
+        documented Free tier of 3 rps.
+        """
+        if (api_key := self._get_api_key()) is None:
+            self._rate_limiter.reset(
+                rps=FREE_ETHERSCAN_RATE_LIMIT_RPS,
+                capacity=FREE_ETHERSCAN_RATE_LIMIT_BURST,
+            )
+            return
+
+        if (tier := self._get_cached_api_key_tier()) is None:
+            if (tier := self._query_api_key_tier(api_key)) is None:
+                return
+            self._cache_api_key_tier(tier=tier)
+
+        self._rate_limiter.reset(rps=tier.rps, capacity=tier.burst)
+        log.debug(f'Detected Etherscan API key tier {tier.name}. Set rate limit to {tier.rps} rps')
+
+    def on_api_key_changed(self) -> None:
+        self.api_key = None
+        self.last_ts = Timestamp(0)
+        self._delete_cached_api_key_tier()
+        super().on_api_key_changed()
+        self.detect_api_key_tier()
 
     @staticmethod
     def _get_url(chain_id: ChainID) -> str:

--- a/rotkehlchen/externalapis/etherscan_like.py
+++ b/rotkehlchen/externalapis/etherscan_like.py
@@ -106,6 +106,7 @@ class EtherscanLikeApi(ABC):
         # Remember the default rate so on_api_key_changed() can roll back to it.
         self._default_rps = rate_limiter.rps
         self._default_capacity = int(rate_limiter.capacity)
+        self._default_minimum_rps = rate_limiter.minimum_rps
 
     def on_api_key_changed(self) -> None:
         """Reset the rate limiter to free-tier defaults so a new key starts fresh.
@@ -114,7 +115,11 @@ class EtherscanLikeApi(ABC):
         so the bucket relies on the 429-driven shrink in _query() to converge
         back down if the new key turns out to be on a more restrictive tier.
         """
-        self._rate_limiter.reset(rps=self._default_rps, capacity=self._default_capacity)
+        self._rate_limiter.reset(
+            rps=self._default_rps,
+            capacity=self._default_capacity,
+            minimum_rps=self._default_minimum_rps,
+        )
 
     @staticmethod
     @abc.abstractmethod

--- a/rotkehlchen/externalapis/etherscan_like.py
+++ b/rotkehlchen/externalapis/etherscan_like.py
@@ -279,6 +279,7 @@ class EtherscanLikeApi(ABC):
             module: str,
             action: Literal[
                 'eth_getBlockByNumber',
+                'getapilimit',
                 'getblockreward',
             ],
             options: dict[str, Any] | None = None,
@@ -342,8 +343,8 @@ class EtherscanLikeApi(ABC):
         api_url = self._get_url(chain_id=chain_id)
         response = None
         while backoff < backoff_limit:
-            log.debug(f'Querying {self.name} for {chain_id}: {api_url} with params: {params}')
             self._rate_limiter.acquire()
+            log.debug(f'Querying {self.name} for {chain_id}: {api_url} with params: {params}')
             try:
                 response = self.session.get(url=api_url, params=params, timeout=timeout)
             except requests.exceptions.RequestException as e:

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -8,11 +8,12 @@ from rotkehlchen.chain.accounts import BlockchainAccountData
 from rotkehlchen.chain.ethereum.constants import ETHEREUM_GENESIS
 from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
 from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.dbhandler import DBHandler
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmTransactionsFilterQuery
 from rotkehlchen.errors.misc import RemoteError
-from rotkehlchen.externalapis.etherscan import Etherscan
+from rotkehlchen.externalapis.etherscan import ETHERSCAN_TIER_BY_DAILY_LIMIT, Etherscan
 from rotkehlchen.externalapis.etherscan_like import HasChainActivity
 from rotkehlchen.serialization.deserialize import deserialize_evm_transaction
 from rotkehlchen.tests.utils.mock import MockResponse
@@ -52,7 +53,8 @@ def fixture_temp_etherscan(function_scope_messages_aggregator, tmpdir_factory, s
                 ExternalServiceApiCredentials(service=ExternalService.ETHERSCAN, api_key=api_key),
             ])
 
-    return Etherscan(database=db, msg_aggregator=function_scope_messages_aggregator)
+    with patch.object(Etherscan, 'detect_api_key_tier', return_value=None):
+        return Etherscan(database=db, msg_aggregator=function_scope_messages_aggregator)
 
 
 def patch_etherscan(etherscan, response_msg):
@@ -105,6 +107,44 @@ def test_maximum_daily_rate_limit_reached(temp_etherscan, **kwargs):  # pylint: 
             '0x4678f0a6958e4D2Bc4F1BAF7Bc52E8F3564f3fE4',
             '0xc455279100000000000000000000000027a2eaaa8bebea8d23db486fb49627c165baacb5',
         )
+
+
+def test_detect_api_key_tier_caches_and_reuses_value(temp_etherscan: Etherscan) -> None:
+    temp_etherscan._delete_cached_api_key_tier()
+    with patch.object(
+        temp_etherscan,
+        '_query',
+        return_value={'creditLimit': 500000},
+    ) as query_mock:
+        temp_etherscan.detect_api_key_tier()
+
+    assert temp_etherscan._rate_limiter.rps == 20.0
+    assert temp_etherscan._rate_limiter.capacity == 20
+    with temp_etherscan.db.conn.read_ctx() as cursor:
+        assert temp_etherscan.db.get_static_cache(
+            cursor=cursor,
+            name=DBCacheStatic.ETHERSCAN_API_KEY_TIER,
+        ) == 'advanced'
+
+    temp_etherscan._rate_limiter.reset(rps=3.0, capacity=3)
+    temp_etherscan.detect_api_key_tier()
+    assert query_mock.call_count == 1
+    assert temp_etherscan._rate_limiter.rps == 20.0
+    assert temp_etherscan._rate_limiter.capacity == 20
+
+
+def test_api_key_change_invalidates_cached_tier(temp_etherscan: Etherscan) -> None:
+    temp_etherscan._cache_api_key_tier(tier=ETHERSCAN_TIER_BY_DAILY_LIMIT[500000])
+    with patch.object(temp_etherscan, '_query', return_value={'creditLimit': 200000}):
+        temp_etherscan.on_api_key_changed()
+
+    assert temp_etherscan._rate_limiter.rps == 10.0
+    assert temp_etherscan._rate_limiter.capacity == 10
+    with temp_etherscan.db.conn.read_ctx() as cursor:
+        assert temp_etherscan.db.get_static_cache(
+            cursor=cursor,
+            name=DBCacheStatic.ETHERSCAN_API_KEY_TIER,
+        ) == 'standard'
 
 
 def test_deserialize_transaction_from_etherscan():

--- a/rotkehlchen/tests/fixtures/blockchain.py
+++ b/rotkehlchen/tests/fixtures/blockchain.py
@@ -108,6 +108,7 @@ def _initialize_and_yield_evm_inquirer_fixture(
     nodes_to_connect_to = maybe_modify_rpc_nodes(database, blockchain, manager_connect_at_start)
 
     with ExitStack() as init_stack:
+        init_stack.enter_context(patch.object(Etherscan, 'detect_api_key_tier', return_value=None))
         if mock_other_web3 is True:
             init_stack.enter_context(patch(  # at init of Inquirer attempt no connection if mocking
                 class_path,

--- a/rotkehlchen/tests/fixtures/rotkehlchen.py
+++ b/rotkehlchen/tests/fixtures/rotkehlchen.py
@@ -15,6 +15,7 @@ from rotkehlchen.data_migrations.constants import LAST_USERDB_DATA_MIGRATION
 from rotkehlchen.db.settings import CachedSettings, DBSettings, ModifiableDBSettings
 from rotkehlchen.db.updates import RotkiDataUpdater
 from rotkehlchen.exchanges.constants import EXCHANGES_WITH_PASSPHRASE, EXCHANGES_WITHOUT_API_SECRET
+from rotkehlchen.externalapis.etherscan import Etherscan
 from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.history.types import HistoricalPriceOracle
 from rotkehlchen.inquirer import Inquirer
@@ -405,6 +406,7 @@ def initialize_mock_rotkehlchen_instance(
 
     with ExitStack() as stack:
         stack.enter_context(data_unlock_patch)
+        stack.enter_context(patch.object(Etherscan, 'detect_api_key_tier', return_value=None))
         patch_and_enter_before_unlock(
             rotki=rotki,
             stack=stack,
@@ -565,7 +567,8 @@ def fixture_uninitialized_rotkehlchen(cli_args, inquirer, asset_resolver, global
     Adding the AssetResolver as a requirement so that the first initialization happens here
     """
     rotki = Rotkehlchen(cli_args)
-    yield rotki
+    with patch.object(Etherscan, 'detect_api_key_tier', return_value=None):
+        yield rotki
     rotki.data.logout()
 
 

--- a/rotkehlchen/utils/rate_limiter.py
+++ b/rotkehlchen/utils/rate_limiter.py
@@ -43,12 +43,15 @@ class TokenBucket:
     trust the previously-discovered rate).
     """
 
-    def __init__(self, rps: float, capacity: int) -> None:
+    def __init__(self, rps: float, capacity: int, minimum_rps: float = _MIN_RPS_FLOOR) -> None:
         if rps <= 0:
             raise ValueError(f'rps must be positive, got {rps}')
         if capacity < 1:
             raise ValueError(f'capacity must be >= 1, got {capacity}')
+        if minimum_rps <= 0:
+            raise ValueError(f'minimum_rps must be positive, got {minimum_rps}')
         self.rps = rps
+        self.minimum_rps = minimum_rps
         self.capacity = float(capacity)
         self.tokens = float(capacity)
         self.last_refill = time.monotonic()
@@ -94,14 +97,18 @@ class TokenBucket:
     def shrink_after_429(self) -> None:
         """Halve rps (with a floor) after a 429. Capacity untouched."""
         with self._lock:
-            self.rps = max(_MIN_RPS_FLOOR, self.rps / 2)
+            self.rps = max(self.minimum_rps, self.rps / 2)
 
-    def reset(self, rps: float, capacity: int) -> None:
+    def reset(self, rps: float, capacity: int, minimum_rps: float | None = None) -> None:
         """Hard-set rps and capacity (e.g. after an API key change)."""
         if rps <= 0 or capacity < 1:
             raise ValueError(f'invalid reset values: {rps=}, {capacity=}')
+        if minimum_rps is not None and minimum_rps <= 0:
+            raise ValueError(f'invalid reset value: {minimum_rps=}')
         with self._lock:
             self.rps = rps
+            if minimum_rps is not None:
+                self.minimum_rps = minimum_rps
             self.capacity = float(capacity)
             self.tokens = min(self.tokens, self.capacity)
 


### PR DESCRIPTION
This commit checks and saves the tier of an etherscan api key so rate limits are adjusted dinamically. Also adjust the numbers that we had for the free tier so the app doesn't get rate limited by accident, that was slowing down the queries

