### PR TITLE
fix(frontend): exclude disabled chains from history sync progress

### DIFF
--- a/frontend/app/src/modules/history/events/tx/use-history-transaction-accounts.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-transaction-accounts.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
 import { useHistoryTransactionAccounts } from './use-history-transaction-accounts';
 
 vi.mock('@/modules/core/common/use-supported-chains', () => ({
@@ -162,6 +163,70 @@ describe('useHistoryTransactionAccounts', () => {
 
       const zksyncAccount = accounts.find(acc => acc.chain === 'zksync_lite');
       expect(zksyncAccount).toBeUndefined();
+    });
+  });
+
+  describe('filterDisabledChainAccounts', () => {
+    const sample = [
+      { address: '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c', chain: 'eth' },
+      { address: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F', chain: 'eth' },
+      { address: '0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199', chain: 'optimism' },
+      { address: '0xdD2FD4581271e230360230F9337D5c0430Bf44C0', chain: 'polygon_pos' },
+      { address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh', chain: 'btc' },
+    ];
+
+    function setDisabled(value: Record<string, string[]>): void {
+      const store = useGeneralSettingsStore();
+      store.update({ ...store.settings, disabledChainQueries: value });
+    }
+
+    it('should return input unchanged when the setting is empty', () => {
+      expect(composable.filterDisabledChainAccounts(sample)).toEqual(sample);
+    });
+
+    it('should drop all accounts on a chain disabled with an empty list', () => {
+      setDisabled({ eth: [] });
+      const filtered = composable.filterDisabledChainAccounts(sample);
+      expect(filtered).toHaveLength(3);
+      expect(filtered.every(a => a.chain !== 'eth')).toBe(true);
+    });
+
+    it('should drop only the listed addresses on a partially-disabled chain', () => {
+      setDisabled({ eth: ['0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c'] });
+      const filtered = composable.filterDisabledChainAccounts(sample);
+      expect(filtered).toHaveLength(4);
+      expect(filtered).not.toContainEqual({
+        address: '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c',
+        chain: 'eth',
+      });
+      expect(filtered).toContainEqual({
+        address: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+        chain: 'eth',
+      });
+    });
+
+    it('should leave chains not present in the setting untouched', () => {
+      setDisabled({ optimism: [] });
+      const filtered = composable.filterDisabledChainAccounts(sample);
+      expect(filtered).toHaveLength(4);
+      expect(filtered.every(a => a.chain !== 'optimism')).toBe(true);
+      expect(filtered).toContainEqual({
+        address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+        chain: 'btc',
+      });
+    });
+
+    it('should combine full-chain and per-address rules across chains', () => {
+      setDisabled({
+        eth: ['0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c'],
+        polygon_pos: [],
+      });
+      const filtered = composable.filterDisabledChainAccounts(sample);
+      expect(filtered).toEqual([
+        { address: '0x71C7656EC7ab88b098defB751B7401B5f6d8976F', chain: 'eth' },
+        { address: '0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199', chain: 'optimism' },
+        { address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh', chain: 'btc' },
+      ]);
     });
   });
 });

--- a/frontend/app/src/modules/history/events/tx/use-history-transaction-accounts.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-transaction-accounts.ts
@@ -2,8 +2,10 @@ import { get } from '@vueuse/core';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { type ChainAddress, TransactionChainType } from '@/modules/history/events/event-payloads';
+import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
 
 interface UseHistoryTransactionAccountsReturn {
+  filterDisabledChainAccounts: (accounts: ChainAddress[]) => ChainAddress[];
   getAllAccounts: (chains?: string[]) => ChainAddress[];
   getBitcoinAccounts: (chains?: string[]) => ChainAddress[];
   getEvmAccounts: (chains?: string[]) => ChainAddress[];
@@ -15,6 +17,7 @@ interface UseHistoryTransactionAccountsReturn {
 export function useHistoryTransactionAccounts(): UseHistoryTransactionAccountsReturn {
   const { addresses } = useAccountAddresses();
   const { isBtcChains, isEvmLikeChains, isSolanaChains, supportsTransactions } = useSupportedChains();
+  const { disabledChainQueries } = storeToRefs(useGeneralSettingsStore());
 
   const getAccountsByChainType = (
     chainFilter: (chain: string) => boolean,
@@ -48,6 +51,19 @@ export function useHistoryTransactionAccounts(): UseHistoryTransactionAccountsRe
     ...getSolanaAccounts(chains),
   ];
 
+  const filterDisabledChainAccounts = (accounts: ChainAddress[]): ChainAddress[] => {
+    const disabled = get(disabledChainQueries);
+    return accounts.filter(({ address, chain }) => {
+      const rule = disabled[chain];
+      if (rule === undefined)
+        return true;
+      // Backend contract: an empty rule array means the entire chain is disabled.
+      if (rule.length === 0)
+        return false;
+      return !rule.includes(address);
+    });
+  };
+
   const getTransactionTypeFromChain = (chain: string): TransactionChainType => {
     if (isEvmLikeChains(chain))
       return TransactionChainType.EVMLIKE;
@@ -60,6 +76,7 @@ export function useHistoryTransactionAccounts(): UseHistoryTransactionAccountsRe
   };
 
   return {
+    filterDisabledChainAccounts,
     getAllAccounts,
     getBitcoinAccounts,
     getEvmAccounts,

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
@@ -33,7 +33,7 @@ const mockExchanges: Exchange[] = [
 
 // Mock stores and composables
 const mockTxQueryStatusStore = {
-  initializeQueryStatus: vi.fn(),
+  initializeQueryStatus: vi.fn<(accounts: ChainAddress[]) => void>(),
   resetQueryStatus: vi.fn(),
   stopSyncing: vi.fn(),
 };
@@ -45,6 +45,7 @@ const mockEventsQueryStatusStore = {
 };
 
 const mockHistoryTransactionAccounts = {
+  filterDisabledChainAccounts: vi.fn((accounts: ChainAddress[]) => accounts),
   getAllAccounts: vi.fn(() => [...mockEvmAccounts, ...mockBitcoinAccounts]),
 };
 
@@ -69,7 +70,7 @@ const mockDecodingStatusStore = {
 };
 
 const mockTransactionSync = {
-  syncTransactionsByChains: vi.fn().mockResolvedValue(undefined),
+  syncTransactionsByChains: vi.fn<(accounts: ChainAddress[], showProgress: boolean) => Promise<void>>().mockResolvedValue(undefined),
   waitForDecoding: vi.fn().mockResolvedValue(undefined),
 };
 
@@ -150,6 +151,7 @@ describe('useRefreshTransactions', () => {
 
     // Reset mock return values to defaults
     mockHistoryTransactionAccounts.getAllAccounts.mockReturnValue([...mockEvmAccounts, ...mockBitcoinAccounts]);
+    mockHistoryTransactionAccounts.filterDisabledChainAccounts.mockImplementation((accounts: ChainAddress[]) => accounts);
     set(mockExchangeData.syncingExchanges, mockExchanges);
   });
 
@@ -704,6 +706,50 @@ describe('useRefreshTransactions', () => {
       // fetchUndecodedTransactionsStatus should still be called once for fullRefresh
       // but NOT queued again for the final status check
       expect(mockHistoryTransactionDecoding.fetchUndecodedTransactionsStatus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('disabled chain queries', () => {
+    it('should exclude disabled-chain accounts from sync init and dispatch on full refresh', async () => {
+      mockHistoryTransactionAccounts.filterDisabledChainAccounts.mockImplementation(
+        (accounts: ChainAddress[]) => accounts.filter(a => a.chain !== 'optimism'),
+      );
+
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+      await refreshTransactions();
+
+      const initArgs = mockTxQueryStatusStore.initializeQueryStatus.mock.calls[0]?.[0] ?? [];
+      expect(initArgs.every(a => a.chain !== 'optimism')).toBe(true);
+
+      const syncArgs = mockTransactionSync.syncTransactionsByChains.mock.calls[0]?.[0] ?? [];
+      expect(syncArgs.every(a => a.chain !== 'optimism')).toBe(true);
+    });
+
+    it('should not start a refresh when every requested account is disabled', async () => {
+      mockHistoryTransactionAccounts.filterDisabledChainAccounts.mockReturnValue([]);
+      set(mockExchangeData.syncingExchanges, []);
+
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+      await refreshTransactions({ payload: { accounts: mockEvmAccounts } });
+
+      expect(mockTxQueryStatusStore.initializeQueryStatus).not.toHaveBeenCalled();
+      expect(mockTransactionSync.syncTransactionsByChains).not.toHaveBeenCalled();
+      expect(mockOnHistoryStarted).not.toHaveBeenCalled();
+    });
+
+    it('should also filter explicit caller-supplied accounts', async () => {
+      mockHistoryTransactionAccounts.filterDisabledChainAccounts.mockImplementation(
+        (accounts: ChainAddress[]) => accounts.filter(a => a.chain !== 'eth'),
+      );
+
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+      await refreshTransactions({
+        payload: { accounts: mockEvmAccounts },
+        userInitiated: true,
+      });
+
+      const syncArgs = mockTransactionSync.syncTransactionsByChains.mock.calls[0]?.[0] ?? [];
+      expect(syncArgs).toEqual([mockEvmAccounts[1]]);
     });
   });
 

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
@@ -44,7 +44,7 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
 
   const { initializeQueryStatus, resetQueryStatus, stopSyncing: stopTxSyncing } = useTxQueryStatusStore();
   const { initializeQueryStatus: initializeExchangeEventsQueryStatus, resetQueryStatus: resetExchangesQueryStatus, stopSyncing: stopEventsSyncing } = useEventsQueryStatusStore();
-  const { getAllAccounts } = useHistoryTransactionAccounts();
+  const { filterDisabledChainAccounts, getAllAccounts } = useHistoryTransactionAccounts();
   const { fetchDisabled, isFirstLoad, resetStatus, setStatus } = useStatusUpdater(Section.HISTORY);
   const { fetchUndecodedTransactionsBreakdown, fetchUndecodedTransactionsStatus } = useHistoryTransactionDecoding();
   const { resetDecodingSyncProgress, resetUndecodedTransactionsStatus, stopDecodingSyncProgress } = useDecodingStatusStore();
@@ -122,9 +122,11 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     else
       resolved = { accounts: payload.accounts || [], exchanges: payload.exchanges || [] };
 
+    const accounts = filterDisabledChainAccounts(resolved.accounts);
+
     return {
-      accounts: resolved.accounts,
-      decodableAccounts: resolved.accounts.filter(account => isDecodableChains(account.chain)),
+      accounts,
+      decodableAccounts: accounts.filter(account => isDecodableChains(account.chain)),
       exchanges: resolved.exchanges,
       fullRefresh,
       queryExchanges: fullRefresh || !!payload.exchanges,
@@ -241,7 +243,11 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     const fullRefresh = Object.keys(payload).length === 0;
 
     const usedExchanges = filterSyncingExchanges(payload.exchanges);
-    const allCurrentAccounts = resolveInputAccounts(payload.accounts, fullRefresh, chains);
+    // Filter before novelty detection so disabled-chain accounts are not flagged as newly
+    // added and queued as pending refreshes that the backend would silently skip.
+    const allCurrentAccounts = filterDisabledChainAccounts(
+      resolveInputAccounts(payload.accounts, fullRefresh, chains),
+    );
     const novelty = detectNovelty(allCurrentAccounts, usedExchanges);
 
     if (shouldNotRefresh(userInitiated, novelty))


### PR DESCRIPTION
## Summary
- The history refresh seeded the sync-progress store with every tracked account, but the backend skips addresses listed in the `disabledChainQueries` setting. The progress UI then sat stuck on those entries because the WebSocket updates never arrived (chain row never reached `COMPLETE`).
- Add a `filterDisabledChainAccounts` helper in `useHistoryTransactionAccounts` mirroring `chain/aggregator.py:get_active_addresses` semantics (missing key = enabled, `[]` = full chain disabled, `[addr…]` = drop those addresses).
- Apply it in `useRefreshTransactions` at two points: once over `allCurrentAccounts` before novelty detection so disabled accounts are not flagged as newly-added / queued as pending, and once inside `resolveRefreshTargets` so both `initializeQueryStatus` and `syncTransactionsByChains` only receive active accounts.

## Test plan
- [x] `pnpm run test:unit src/modules/history/events/tx/use-history-transaction-accounts.spec.ts` — 20 passing (5 new cases: empty setting, full-chain disable, per-address disable, untouched chains, combined rules)
- [x] `pnpm run test:unit src/modules/history/events/tx/use-refresh-transactions.spec.ts` — 45 passing (3 new cases: full refresh excludes disabled chain, no-op when nothing remains after filtering, explicit caller-supplied accounts also filtered)
- [x] `pnpm run lint-staged`
- [x] `pnpm run typecheck`
- [ ] Manual: configure `disabledChainQueries` (full chain + partial address), trigger a refresh, confirm progress UI completes and disabled entries don't appear.