### PR TITLE
chore(deps): bump pnpm to 11.1.2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rotki-workspace",
   "version": "1.0.0",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.1.2",
   "description": "A portfolio tracking, asset analytics and tax reporting application specializing in Cryptoassets that protects your privacy",
   "type": "module",
   "license": "AGPL-3.0",
@@ -55,7 +55,7 @@
   },
   "engines": {
     "node": ">=24 <25",
-    "pnpm": ">=10 <11"
+    "pnpm": ">=11 <12"
   },
   "lint-staged": {
     "*": "eslint",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -300,12 +300,8 @@ overrides:
   yaml-eslint-parser: 1.3.2
 
 patchedDependencies:
-  app-builder-lib:
-    hash: 74f87c34f13b5c0d45e0c56b221cf7c77dac257298868081bdacddaa543aa97f
-    path: patches/app-builder-lib.patch
-  bignumber.js@9.3.1:
-    hash: 61396dd0164598dffc80190e90a8d2bd4ec88d03f7ec9956ab22182f63c0cb1d
-    path: patches/bignumber.js@9.3.1.patch
+  app-builder-lib: 74f87c34f13b5c0d45e0c56b221cf7c77dac257298868081bdacddaa543aa97f
+  bignumber.js@9.3.1: 61396dd0164598dffc80190e90a8d2bd4ec88d03f7ec9956ab22182f63c0cb1d
 
 importers:
 


### PR DESCRIPTION
## Summary
- Bump pnpm from 10.33.0 → 11.1.2 (latest 11.x past 7-day release-age rule)
- Update `engines.pnpm` range to `>=11 <12`
- Lockfile regenerated with pnpm 11

pnpm 11 highlights: pure ESM, Node 22+ required (we're on Node 24), `minimumReleaseAge` defaults to 1d (we keep 7d), `allowBuilds` map (already present), supply-chain protections on by default.

CI is wired via `pnpm/action-setup` with `package_json_file: frontend/package.json`, so updating `packageManager` propagates automatically — no workflow changes needed.

## Test plan
- [x] `pnpm install` (clean) succeeds with pnpm 11.1.2
- [x] `pnpm run typecheck`
- [x] `pnpm -w run lint` (0 errors)
- [x] `pnpm run test:unit` (354 files / 3664 tests)
- [ ] CI green
- [ ] Smoke-test electron app boot locally