### PR TITLE
fix(poloniex): accumulate trades across 180-day chunks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :bug:`-` Poloniex history should now be properly queried again.
+
 * :release:`1.43.1 <2026-05-18>`
 * :feature:`12215` Cryptocompare is now removed from the default list of oracles if no API key is set.
 * :bug:`12233` Importing a custom CSV that contains an asset which is unsupported on the given exchange (e.g. GLD on Bittrex) no longer crashes the import task. The offending row is reported as an error and the rest of the file is imported normally.

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -634,6 +634,9 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
                     ]:
                         try:
                             asset = get_asset_func(param)  # type: ignore[operator]
+                        except UnsupportedAsset:
+                            log.warning(f'Found unsupported asset {bfx_symbol} in Bitfinex. Support for it has to be added.')  # noqa: E501
+                            break  # Don't try fallbacks; this asset is explicitly unsupported
                         except UnknownAsset:
                             continue
 

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -325,14 +325,17 @@ class Poloniex(ExchangeInterface, SignatureGeneratorMixin):
                 'limit': self.TRADES_LIMIT,
             })
             results_length = len(new_data)
+            existing_ids = {x['id'] for x in data}
             if results_length < self.TRADES_LIMIT:
-                data = new_data
+                # got all the trades for this 180 day chunk. Accumulate them (deduplicating
+                # against previous chunks) and move on to the next chunk. Note we extend
+                # instead of overwriting since data may hold trades from previous chunks.
+                data.extend(trade for trade in new_data if trade['id'] not in existing_ids)
                 current_start_ms = current_end_ms
-                continue  # simple case - only one query needed for this 180 day chunk
+                continue
 
             latest_ts_ms = current_start_ms
             # add results to data and prepare for next query
-            existing_ids = {x['id'] for x in data}
             for trade in new_data:
                 try:
                     timestamp_ms = trade['createTime']
@@ -354,13 +357,9 @@ class Poloniex(ExchangeInterface, SignatureGeneratorMixin):
                     )
                     continue
 
-            if results_length < self.TRADES_LIMIT:
-                current_start_ms = current_end_ms
-                continue  # last query has less than limit. We are done with this 180 day chunk.
-
-            # otherwise we query again from the last ts seen in the last result
+            # the chunk returned TRADES_LIMIT results so it may have more. Query again
+            # from the last ts seen in the last result.
             current_start_ms = latest_ts_ms
-            continue
 
         return data
 

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -184,6 +184,10 @@ def test_assets_are_known(mock_bitfinex, globaldb):
             asset_from_bitfinex(bitfinex_name=symbol)
         except UnsupportedAsset:
             assert is_asset_symbol_unsupported(globaldb, Location.BITFINEX, symbol)
+            test_warnings.warn(UserWarning(
+                f'Found unsupported asset with symbol {symbol} in '
+                f'{mock_bitfinex.name}. Support for it has to be added',
+            ))
         except UnknownAsset as e:
             test_warnings.warn(UserWarning(
                 f'Found unknown asset {e.identifier} with symbol {symbol} in '

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -1,6 +1,8 @@
+import json
 import warnings as test_warnings
 from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -227,6 +229,39 @@ def test_query_trade_history(poloniex: 'Poloniex'):
             ),
             location_label=poloniex.name,
         )]
+
+
+def test_query_trade_history_multiple_chunks(poloniex: 'Poloniex') -> None:
+    """Regression test for trades spanning more than one 180-day chunk.
+
+    Poloniex limits the /trades query window to 180 days, so a long history range is
+    split into 180-day chunks. Trades from earlier chunks must be accumulated and not
+    overwritten by the results of the last chunk.
+    """
+    end_ts = Timestamp((start_ts := Timestamp(1500000000)) + 400 * 86400)  # ~400 days -> 3 chunks
+    start_ms = start_ts * 1000
+    # one trade comfortably inside each of the 3 chunks (each chunk has < TRADES_LIMIT trades)
+    all_trades = [
+        {'id': 1, 'createTime': start_ms + 86_400_000},      # ~day 1   -> chunk 1
+        {'id': 2, 'createTime': start_ms + 20_000_000_000},  # ~day 231 -> chunk 2
+        {'id': 3, 'createTime': start_ms + 33_000_000_000},  # ~day 382 -> chunk 3
+    ]
+
+    def mock_api_return(url: str, **kwargs):  # pylint: disable=unused-argument
+        if '/trades' not in url:
+            return MockResponse(200, '{"withdrawals": [], "deposits": []}')
+
+        params = parse_qs(urlparse(url).query)
+        window_start, window_end = int(params['startTime'][0]), int(params['endTime'][0])
+        # emulate poloniex only returning the trades within the requested [startTime, endTime]
+        return MockResponse(200, json.dumps(
+            [t for t in all_trades if window_start <= t['createTime'] <= window_end],
+        ))
+
+    with patch.object(poloniex.session, 'get', side_effect=mock_api_return):
+        raw_trades = poloniex.return_trade_history(start=start_ts, end=end_ts)
+
+    assert {trade['id'] for trade in raw_trades} == {1, 2, 3}
 
 
 def test_query_trade_history_unexpected_data(poloniex):


### PR DESCRIPTION
return_trade_history overwrote the accumulated trades with data = new_data whenever a 180-day chunk returned fewer than TRADES_LIMIT results, so any history needing more than one query (range > 180 days, or any window with
>100 trades) kept only the last partial response and dropped everything
before it. Accumulate with id-based dedup instead and drop the dead duplicate results_length check. Add a regression test covering trades that span multiple chunks.

