### PR TITLE
fix(eth2): avoid IndexError when processing withdrawal events

### DIFF
--- a/rotkehlchen/history/events/structures/eth2.py
+++ b/rotkehlchen/history/events/structures/eth2.py
@@ -223,11 +223,19 @@ class EthWithdrawalEvent(EthStakingEvent):
             events_iterator: Iterator['AccountingEventMixin'],  # pylint: disable=unused-argument
     ) -> int:
         with accounting.database.conn.read_ctx() as cursor:
-            validator_info = accounting.dbeth2.get_validators_with_status(
+            validators_info = accounting.dbeth2.get_validators_with_status(
                 cursor=cursor,
                 validator_indices={self.validator_index},
-            )[0]
+            )
 
+        if len(validators_info) == 0:
+            log.error(
+                f'Could not find validator {self.validator_index} in the DB while processing '
+                f'{self} for accounting. Skipping the event.',
+            )
+            return 1
+
+        validator_info = validators_info[0]
         event_ts, is_exit = self.get_timestamp_in_sec(), self.is_exit_or_blocknumber != 0
         name = 'Exit' if is_exit else 'Withdrawal'
         if validator_info.validator_type != ValidatorType.ACCUMULATING:
@@ -251,10 +259,17 @@ class EthWithdrawalEvent(EthStakingEvent):
                     withdrawals_pnl=defaultdict(lambda: ZERO),
                     exits_pnl=defaultdict(lambda: ZERO),
                 )
-                if len(validator_balances := list(balances[self.validator_index].values())) == 0 or validator_balances[-1] < self.amount:  # noqa: E501
+                if len(validator_balances := list(balances[self.validator_index].values())) == 0:
                     log.error(
-                        f'Validator {self.validator_index} has an unexpected last balance ({validator_balances[-1]}) '  # noqa: E501
-                        f'less than exit amount ({self.amount}) for {self}. Using zero as amount',
+                        f'Validator {self.validator_index} has no balance history before its '
+                        f'exit event {self}. Using zero as amount',
+                    )
+                    profit_or_loss_amount = ZERO
+                elif validator_balances[-1] < self.amount:
+                    log.error(
+                        f'Validator {self.validator_index} has an unexpected last balance '
+                        f'({validator_balances[-1]}) less than exit amount ({self.amount}) for '
+                        f'{self}. Using zero as amount',
                     )
                     profit_or_loss_amount = ZERO
                 else:

--- a/rotkehlchen/tests/unit/accounting/test_staking.py
+++ b/rotkehlchen/tests/unit/accounting/test_staking.py
@@ -360,3 +360,68 @@ def test_eth_withdrawal_processing(accountant: Accountant, ethereum_accounts: li
 
     assert processed_events[4].notes == f'Exit of 60 ETH from validator {v_accum_2}. Loss of -4 incurred'  # noqa: E501
     assert processed_events[4].pnl.taxable == FVal(-4) * 3000  # $6000 taxable
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b']])
+@pytest.mark.parametrize('should_mock_price_queries', [True])
+@pytest.mark.parametrize('default_mock_price_value', [ONE])
+@pytest.mark.parametrize('db_settings', [{
+    'eth_staking_taxable_after_withdrawal_enabled': True,
+}])
+def test_eth_withdrawal_unknown_validator(
+        accountant: Accountant,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """A withdrawal/exit event referencing a validator that is missing from the
+    eth2_validators table (e.g. the validator was deleted but its events remained) must be
+    skipped, not raise an IndexError that aborts the entire PnL report."""
+    accountant.process_history(
+        start_ts=Timestamp(0),
+        end_ts=ts_now(),
+        events=[EthWithdrawalEvent(
+            validator_index=99999,  # not present in eth2_validators
+            timestamp=TimestampMS(1729000004000),
+            amount=FVal(32),
+            withdrawal_address=ethereum_accounts[0],
+            is_exit=True,
+        )],
+    )
+    assert len(accountant.pots[0].processed_events) == 0
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b']])
+@pytest.mark.parametrize('should_mock_price_queries', [True])
+@pytest.mark.parametrize('default_mock_price_value', [ONE])
+@pytest.mark.parametrize('db_settings', [{
+    'eth_staking_taxable_after_withdrawal_enabled': True,
+}])
+def test_accumulating_validator_exit_without_balance_history(
+        accountant: Accountant,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """An accumulating validator exit with no preceding balance events in the DB must not
+    raise an IndexError when logging the missing last balance. It should fall back to a zero
+    profit/loss amount instead of crashing the PnL report."""
+    with accountant.db.conn.write_ctx() as write_cursor:
+        DBEth2(accountant.db).add_or_update_validators(write_cursor, [
+            ValidatorDetails(
+                validator_index=(vindex := 2002),
+                public_key=Eth2PubKey('0xbeeff7a39b4e56a5f5a9e06550a8b9a3251c4a8d8b7c5c9e5d8e9f0a1b2c3d4'),
+                validator_type=ValidatorType.ACCUMULATING,
+            ),
+        ])
+    accountant.process_history(
+        start_ts=Timestamp(0),
+        end_ts=ts_now(),
+        events=[EthWithdrawalEvent(
+            validator_index=vindex,
+            timestamp=TimestampMS(1729000004000),
+            amount=FVal(32),  # <= MAX_EFFECTIVE_BALANCE, so it takes the no-profit branch
+            withdrawal_address=ethereum_accounts[0],
+            is_exit=True,
+        )],
+    )
+    # reaching here without an IndexError is the regression check. The exit falls back to a
+    # zero profit/loss amount, which records no taxable event.
+    assert len(accountant.pots[0].processed_events) == 0
+    assert accountant.pots[0].pnls.taxable == ZERO


### PR DESCRIPTION
EthWithdrawalEvent.process raised an IndexError in two cases that abort the whole PnL report:
- get_validators_with_status(...)[0] when the validator is missing from the eth2_validators table (e.g. deleted while its events remain). Now the event is skipped with a logged error.
- the empty-balances branch of an accumulating validator exit dereferenced validator_balances[-1] inside the error log. Split into a dedicated empty-list branch so [-1] is only accessed when the list is non-empty.

Add regression tests for both, covering an exit for an unknown validator and an accumulating exit with no preceding balance history.