### PR TITLE
fix(kraken): convert all adjustment pairs, not every other one

### DIFF
--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -786,12 +786,18 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             max_ts = max(max_ts, ts_ms_to_sec(events[0].timestamp))
 
         adjustments.sort(key=lambda x: x.timestamp)
+        # Collect the adjustments that aren't converted into SwapEvents in a new list instead of
+        # removing them from `adjustments` while iterating it. pairwise() iterates a single shared
+        # iterator, so mutating the list mid-iteration shifts the indices and skips pairs.
+        unconverted_adjustments: list[HistoryEvent] = adjustments
         if len(adjustments) % 2 == 0:
+            unconverted_adjustments = []
             for a1, a2 in pairwise(adjustments):
                 if a1.event_subtype is None or a2.event_subtype is None:
                     log.warning(
                         f'Found two kraken adjustment entries without a subtype: {a1} {a2}',
                     )
+                    unconverted_adjustments.extend((a1, a2))
                     continue
 
                 if a1.event_subtype == HistoryEventSubType.SPEND and a2.event_subtype == HistoryEventSubType.RECEIVE:  # noqa: E501
@@ -804,6 +810,7 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                     log.warning(
                         f'Found two kraken adjustment with unmatching subtype {a1} {a2}',
                     )
+                    unconverted_adjustments.extend((a1, a2))
                     continue
 
                 swap_events.extend(create_swap_events(
@@ -817,9 +824,6 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                     ),
                     location_label=self.name,
                 ))
-                # Remove these adjustments since they are now represented by SwapEvents
-                adjustments.remove(a1)
-                adjustments.remove(a2)
 
         else:
             log.warning(
@@ -827,7 +831,7 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 f'Skipping reading them. {adjustments}',
             )
 
-        return swap_events + adjustments, Timestamp(max_ts)
+        return swap_events + unconverted_adjustments, Timestamp(max_ts)
 
     def process_kraken_raw_events(
             self,

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -1,4 +1,5 @@
 import binascii
+import json
 import warnings as test_warnings
 from collections import defaultdict
 from contextlib import ExitStack
@@ -675,6 +676,47 @@ def test_kraken_trade_with_adjustment(kraken):
     warnings = kraken.msg_aggregator.consume_warnings()
     assert len(errors) == 0
     assert len(warnings) == 0
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_kraken_multiple_adjustment_pairs(kraken):
+    """Regression test: all adjustment pairs must be converted to SwapEvents.
+
+    process_kraken_trades used to remove() from the adjustments list while iterating it via
+    pairwise() (a single shared iterator). Mutating mid-iteration shifted the indices and skipped
+    every other pair when there were 4+ adjustments, leaving those pairs as raw ADJUSTMENT events
+    instead of swaps.
+    """
+    ledger = {}
+    for idx, (asset, amount) in enumerate(
+        [('XDAO', '-0.001'), ('XETH', '0.002'),   # pair 1: spend + receive
+         ('XDAO', '-0.003'), ('XETH', '0.004')],  # pair 2: spend + receive
+        start=1,
+    ):
+        ledger[f'L{idx}'] = {
+            'refid': str(idx),
+            'time': 1636406000.0 + idx / 10,  # increasing so the sort keeps the pairs adjacent
+            'type': 'adjustment',
+            'subtype': '',
+            'aclass': 'currency',
+            'asset': asset,
+            'amount': amount,
+            'fee': '0',
+            'balance': '1',
+        }
+
+    with _patch_ledger(kraken, json.dumps({'ledger': ledger, 'count': len(ledger)})):
+        kraken.query_history_events()
+
+    with kraken.db.conn.read_ctx() as cursor:
+        events = DBHistoryEvents(kraken.db).get_history_events_internal(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(location=Location.KRAKEN),
+        )
+
+    # both pairs must convert: 2 pairs -> 4 SwapEvents, with nothing left as raw adjustments
+    assert len([e for e in events if not isinstance(e, SwapEvent)]) == 0
+    assert len([e for e in events if isinstance(e, SwapEvent)]) == 4
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])


### PR DESCRIPTION
process_kraken_trades removed entries from the adjustments list while iterating it via pairwise(), which uses a single shared iterator. Mutating the list mid-iteration shifted the indices and skipped every other pair when there were 4+ adjustments, so those pairs leaked out as raw ADJUSTMENT events instead of being converted to SwapEvents. Collect the unconverted adjustments in a separate list instead of removing during iteration.

Add a regression test feeding two adjustment pairs and asserting both are converted (fails on the old code, passes with the fix).