### PR TITLE
fix(history-events): ignore implicit Action picker clears

### DIFF
--- a/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.spec.ts
+++ b/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.spec.ts
@@ -100,7 +100,11 @@ describe('historyEventActionPicker', () => {
     expect(updates[0][0]).toEqual({ eventSubtype: 'spend', eventType: 'trade' });
   });
 
-  it('should emit undefined when cleared', async () => {
+  it('should ignore implicit clears from the underlying autocomplete', async () => {
+    // RuiAutoComplete emits update:modelValue with undefined on Backspace-from-empty
+    // and on internal options resync. The picker is required and has no clear
+    // affordance, so these implicit clears must be discarded — the model value
+    // should only change in response to a row pick.
     findRowByTypeSubtype.mockReturnValue(row);
     const wrapper = mountPicker({ eventSubtype: 'spend', eventType: 'trade' });
     await flushPromises();
@@ -109,9 +113,7 @@ describe('historyEventActionPicker', () => {
     stub.vm.$emit('update:modelValue', undefined);
     await flushPromises();
 
-    const updates = wrapper.emitted('update:modelValue') ?? [];
-    expect(updates).toHaveLength(1);
-    expect(updates[0][0]).toBeUndefined();
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
   });
 
   it('should render the row content in the item slot', async () => {

--- a/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.vue
+++ b/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.vue
@@ -75,10 +75,13 @@ function subtitleFor(row: EventActionRow): string {
 }
 
 function onUpdate(verbKey: string | undefined): void {
-  if (!verbKey) {
-    set(modelValue, undefined);
+  // The picker is required and has no clear affordance, so we must reject
+  // RuiAutoComplete's implicit clears (Backspace-from-empty, options-watcher
+  // resync) and only react to genuine row selections. The defensive watcher
+  // above still clears the model when the current value is no longer mappable
+  // to a row (e.g. after an entry-type switch).
+  if (!verbKey)
     return;
-  }
 
   const row = get(rows).find(r => r.verbKey === verbKey);
   if (!row)


### PR DESCRIPTION
## Summary

The Action picker (#12270, downstream of #12002) silently wiped a hidden
selection on Backspace-from-empty and on RuiAutoComplete's internal
options-watcher resync. Both paths emit `update:modelValue` with
`undefined` from the library, and the previous implementation forwarded
that to the form model — even though the picker is `required` and
exposes no clear affordance.

The selection lives in the `#selection` slot, not in the input, so users
who tap Backspace while the input looks empty never see anything to
"delete." They just lose the action they had set.

This drops the forwarding: `onUpdate` now only reacts to genuine row
picks. The defensive watcher above still clears the model when the
current `eventType` / `eventSubtype` no longer maps to any row (e.g.
after an entry-type switch), so the only behaviour we lose is the
surprising one.

Reported by @yabirgb on #12270 (https://github.com/rotki/rotki/pull/12270#issuecomment-4534903224).

## Test plan

- [x] `pnpm run test:unit src/modules/history/events/action-picker/HistoryEventActionPicker.spec.ts` — 6/6 passing; the previous "should emit undefined when cleared" test is rewritten to assert the picker now ignores implicit clears.
- [x] `pnpm run lint-staged` clean
- [x] `pnpm run typecheck` clean
- [ ] Manual repro from the PR: open an existing event, hit Backspace ×2 with the picker focused, click outside — the original action should remain selected.