### PR TITLE
fix(frontend): show on-chain balances on /locations/<chain>

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`12304` Opening a location breakdown page for a blockchain (e.g. ``/locations/ethereum``) now shows that chain's on-chain assets and total — previously the page rendered as 0 value with an empty/loading table whenever the location identifier was a chain alias.
 * :feature:`12049` rotki now runs a DB integrity check before uploading a cloud backup or replacing the local DB with a downloaded copy
 * :feature:`3668` Gate exchange is now supported, including Global, Europe, and US regions.
 * :feature:`12250` You can now reach every RPC endpoint, including the ETH Beacon Node, Polkadot, Kusama and Bitcoin Mempool, without horizontal scrolling on the RPC settings page. Endpoints are listed in a grouped vertical rail (EVM chains and other endpoints) that scales as new chains are added.

--- a/frontend/app/src/modules/balances/LocationValueRow.vue
+++ b/frontend/app/src/modules/balances/LocationValueRow.vue
@@ -1,18 +1,20 @@
 <script setup lang="ts">
-import { type BigNumber, Zero } from '@rotki/common';
+import type { BigNumber } from '@rotki/common';
 import { FiatDisplay } from '@/modules/assets/amount-display';
 import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
+import { bigNumberSum } from '@/modules/core/common/data/calculation';
 
 const { identifier } = defineProps<{ identifier: string }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { balancesByLocation } = useAggregatedBalances();
+const { useLocationBreakdown } = useAggregatedBalances();
+const breakdown = useLocationBreakdown(() => identifier);
 
-const totalValue = computed<BigNumber>(() => {
-  const locations = get(balancesByLocation);
-  return locations?.[identifier] ?? Zero;
-});
+// Sum the breakdown directly so the tile always matches the table below.
+// `balancesByLocation` doesn't expose chain-aliased keys (e.g. 'ethereum')
+// and would otherwise undercount when a manual balance shares the alias label.
+const totalValue = computed<BigNumber>(() => bigNumberSum(get(breakdown).map(entry => entry.value)));
 </script>
 
 <template>

--- a/frontend/app/src/modules/balances/use-aggregated-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-aggregated-balances.spec.ts
@@ -27,6 +27,19 @@ import { useSessionSettingsStore } from '@/modules/settings/use-session-settings
 import { useAggregatedBalances } from './use-aggregated-balances';
 import '@test/i18n';
 
+const matchChainMock = vi.fn<(location: string) => string | undefined>(() => undefined);
+
+vi.mock('@/modules/core/common/use-supported-chains', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/modules/core/common/use-supported-chains')>();
+  return {
+    ...actual,
+    useSupportedChains: vi.fn().mockImplementation(() => ({
+      ...actual.useSupportedChains(),
+      matchChain: matchChainMock,
+    })),
+  };
+});
+
 vi.mock('@/modules/assets/use-collection-info', () => ({
   useCollectionInfo: (): any => ({
     getCollectionId: vi.fn((asset: string): string | undefined => {
@@ -54,6 +67,7 @@ describe('useAggregatedBalances', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    matchChainMock.mockImplementation(() => undefined);
   });
 
   it('should aggregate balances from multiple sources with manual balance tracking', () => {
@@ -548,6 +562,63 @@ describe('useAggregatedBalances', () => {
         price: bigNumberify(-1),
         value: bigNumberify(150),
       }]);
+    });
+
+    it('should include blockchain balances when the location identifier is a chain alias', () => {
+      // Simulate `matchChain('ethereum') === 'eth'`. The same call is what
+      // `useSupportedChains` exposes for real chain identifiers, but in tests
+      // `supportedChains` is empty, so we wire it explicitly.
+      matchChainMock.mockImplementation(location => (location === 'ethereum' ? 'eth' : undefined));
+
+      const { manualBalances } = storeToRefs(useBalancesStore());
+      const { updateBalances } = useBalancesStore();
+      const { updateAccounts } = useBlockchainAccountsStore();
+      const { useLocationBreakdown } = useAggregatedBalances();
+
+      // One manual balance tagged with location 'ethereum'.
+      set(manualBalances, [{
+        amount: bigNumberify(10),
+        asset: 'ETH',
+        balanceType: BalanceType.ASSET,
+        identifier: 1,
+        label: 'Ethereum manual',
+        location: 'ethereum',
+        tags: [],
+        value: bigNumberify(10),
+      }]);
+
+      // And blockchain balances on the eth chain.
+      updateBalances('eth', testEthereumBalances);
+      updateAccounts('eth', testAccounts);
+
+      const breakdown = useLocationBreakdown('ethereum');
+      const result = get(breakdown);
+
+      // Both sources should contribute — the manual ETH adds to the blockchain
+      // ETH balance, and other chain assets (e.g. DAI from testEthereumBalances)
+      // should also appear.
+      const eth = result.find(entry => entry.asset === 'ETH');
+      expect(eth, 'eth entry should be present').toBeDefined();
+      expect(eth?.amount.gte(bigNumberify(10))).toBe(true);
+      expect(result.length).toBeGreaterThan(1);
+    });
+
+    it('should ignore exchange balances for chain-aliased locations', () => {
+      matchChainMock.mockImplementation(location => (location === 'ethereum' ? 'eth' : undefined));
+
+      const { exchangeBalances } = storeToRefs(useBalancesStore());
+      const { connectedExchanges } = storeToRefs(useSessionSettingsStore());
+      const { useLocationBreakdown } = useAggregatedBalances();
+
+      // An exchange named 'ethereum' must not pollute the chain breakdown.
+      set(connectedExchanges, [{ location: 'ethereum', name: 'Bogus' }]);
+      set(exchangeBalances, {
+        ethereum: {
+          ETH: createTestBalance(999, 999),
+        },
+      });
+
+      expect(get(useLocationBreakdown('ethereum'))).toEqual([]);
     });
 
     it('should return location breakdown with collection grouping for complex assets', () => {

--- a/frontend/app/src/modules/balances/use-aggregated-balances.ts
+++ b/frontend/app/src/modules/balances/use-aggregated-balances.ts
@@ -16,6 +16,7 @@ import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { getBlockchainLocationBreakdown, getExchangeByLocationBalances, useLocationBreakdown } from '@/modules/balances/use-location-breakdown';
 import { bigNumberSum } from '@/modules/core/common/data/calculation';
 import { TRADE_LOCATION_BLOCKCHAIN } from '@/modules/core/common/defaults';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 
 interface UseAggregatedBalancesReturn {
   useBalances: (hideIgnored?: boolean, groupMultiChain?: boolean, exclude?: ExclusionSource[]) => ComputedRef<AssetBalanceWithPriceAndChains[]>;
@@ -41,6 +42,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
 
   const resolveAssetIdentifier = useResolveAssetIdentifier();
   const { getCollectionId, getCollectionMainAsset } = useCollectionInfo();
+  const { matchChain } = useSupportedChains();
   const baseExchangeBalances = useBaseExchangeBalances();
 
   const blockchainAssetBalances = computed<AssetProtocolBalancesWithChains>(() => blockchainToAssetProtocolBalances(get(blockchainBalances)));
@@ -227,6 +229,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
       getCollectionMainAsset,
       getAssetPrice,
       NoPrice,
+      matchChain,
     ),
   };
 }

--- a/frontend/app/src/modules/balances/use-location-breakdown.ts
+++ b/frontend/app/src/modules/balances/use-location-breakdown.ts
@@ -52,15 +52,26 @@ export function useLocationBreakdown(
   getCollectionMainAsset: (collectionId: string) => string | undefined,
   getAssetPrice: (asset: string, defaultValue: BigNumber) => BigNumber,
   noPrice: BigNumber,
+  matchChain: (location: string) => string | undefined,
 ): ComputedRef<AssetBalanceWithPrice[]> {
   return computed<AssetBalanceWithPrice[]>(() => {
     const selectedLocation = toValue(location);
+    const isBlockchainLocation = selectedLocation === TRADE_LOCATION_BLOCKCHAIN;
+    // A location identifier may be a chain alias (e.g. 'ethereum' → 'eth').
+    // When it is, treat the location as that specific chain so blockchain
+    // balances scoped to that chain are surfaced (plus any manual balances
+    // tagged with the same location label).
+    const chain = isBlockchainLocation ? undefined : matchChain(selectedLocation);
+
+    let blockchainSource: AssetProtocolBalances = {};
+    if (isBlockchainLocation)
+      blockchainSource = blockchainToAssetProtocolBalances(toValue(blockchainBalances));
+    else if (chain)
+      blockchainSource = blockchainToAssetProtocolBalances(toValue(blockchainBalances), 'assets', [chain]);
 
     const sources: Record<string, AssetProtocolBalances> = {
-      blockchain: selectedLocation === TRADE_LOCATION_BLOCKCHAIN
-        ? blockchainToAssetProtocolBalances(toValue(blockchainBalances))
-        : {},
-      exchanges: selectedLocation === TRADE_LOCATION_BLOCKCHAIN
+      blockchain: blockchainSource,
+      exchanges: isBlockchainLocation || chain
         ? {}
         : toValue(useBaseExchangeBalances(selectedLocation)),
       manual: manualToAssetProtocolBalances(


### PR DESCRIPTION
## Summary
- `/locations/<chain>` (e.g. `/locations/ethereum`) showed a `0` total and an empty/loading asset table even when the user had balances on that chain.
- Root cause: `useLocationBreakdown` only treated the literal `'blockchain'` slug as the catch-all. Chain identifiers (`ethereum`, `optimism`, `base`, …) fell through to the exchange branch (no match) and produced an empty breakdown.
- Fix: when `matchChain(selectedLocation)` resolves a chain alias, scope the blockchain source to that chain. Manual balances tagged with the same label are still merged in.
- `LocationValueRow` now sums the breakdown directly so the tile total always matches the table below — `balancesByLocation` keys the blockchain aggregate under the umbrella `'blockchain'` slug and would otherwise undercount when a manual balance shares the alias label.
- Follow-up tracked in #12306: `balancesByLocation` itself isn't extended with chain-aliased keys yet, so global search / premium consumers don't surface those locations unless a manual balance happens to share the label.

Closes #12304.

## Test plan
- [ ] On `/locations/ethereum`: total tile and asset table both show on-chain ETH/mainnet balances + any manual balances tagged `ethereum`.
- [ ] Same flow for `/locations/optimism`, `/locations/base`, `/locations/gnosis`, etc.
- [ ] Existing locations (`/locations/kraken`, `/locations/external`) still show the same totals as before.
- [ ] Unit: `pnpm run test:unit src/modules/balances/use-aggregated-balances.spec.ts` (22 passing, including 2 new chain-alias cases).
- [ ] Lint + typecheck clean.