### PR TITLE
Stop acknowledged calendar reminders from re-firing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :bug:`-` Swaps through a newer zeroxsettler will now be properly decoded by rotki.
 * :bug:`-` Poloniex history should now be properly queried again.
+* :bug:`-` Dismissing a calendar reminder (such as an L2 bridge claim) now sticks, instead of popping up again days later as if you had never acknowledged it.
 
 * :release:`1.43.1 <2026-05-18>`
 * :feature:`12215` Cryptocompare is now removed from the default list of oracles if no API key is set.

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -837,6 +837,7 @@ class TaskManager:
         if (now := ts_now()) - self.last_calendar_reminder_check < 60 * 5:
             return None
 
+        self.last_calendar_reminder_check = now
         reminders: dict[int, list[CalendarNotification]] = defaultdict(list)
         with self.database.conn.read_ctx() as cursor:
             cursor.execute(
@@ -846,6 +847,7 @@ class TaskManager:
                 'calendar_reminders AS reminder LEFT JOIN calendar AS event '
                 'ON reminder.event_id = event.identifier WHERE '
                 '? > event.timestamp - reminder.secs_before '
+                'AND reminder.acknowledged = 0 '
                 'ORDER BY event.identifier, reminder.secs_before ASC',
                 (now,),
             )
@@ -859,7 +861,6 @@ class TaskManager:
         if len(reminders) == 0:
             return None
 
-        self.last_calendar_reminder_check = now
         return [self.greenlet_manager.spawn_and_track(
             after_seconds=None,
             task_name='Notify calendar reminders',

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -1068,6 +1068,66 @@ def test_send_ws_calendar_reminder(
 
 
 @pytest.mark.parametrize('max_tasks_num', [5])
+@pytest.mark.freeze_time('2023-04-16 22:31:11 GMT')
+@pytest.mark.parametrize('legacy_messages_via_websockets', [True])
+def test_acknowledged_calendar_reminder_does_not_retrigger(
+        rotkehlchen_api_server: 'APIServer',
+        websocket_connection: WebsocketReader,
+        legacy_messages_via_websockets: bool,  # pylint: disable=unused-argument
+        freezer,
+) -> None:
+    """Acknowledged reminders must not be re-sent on subsequent trigger cycles.
+
+    Regression test: previously the trigger query ignored the `acknowledged`
+    column, so reminders the user had dismissed kept reappearing.
+    """
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    database = rotki.data.db
+    task_manager = rotki.task_manager
+    assert task_manager is not None
+
+    calendar_db = DBCalendar(database)
+    calendar_db.create_calendar_entry(
+        calendar=CalendarEntry(
+            name='Bridge claim',
+            description='Claim Optimism bridge deposit on Ethereum',
+            timestamp=Timestamp(1713621899),  # 20/04/2024
+            counterparty=None,
+            address=None,
+            blockchain=None,
+            color=None,
+            auto_delete=False,
+        ),
+    )
+    calendar_db.create_reminder_entries([ReminderEntry(
+        identifier=1,
+        event_id=1,
+        secs_before=0,
+        acknowledged=False,
+    )])
+
+    freezer.move_to(datetime.datetime(2024, 4, 20, 20, 0, 1, tzinfo=datetime.UTC))
+    task_manager.potential_tasks = [task_manager._maybe_trigger_calendar_reminder]
+    task_manager.schedule()
+    gevent.joinall(task_manager.running_greenlets[task_manager._maybe_trigger_calendar_reminder])
+    websocket_connection.wait_until_messages_num(num=1, timeout=2)
+    websocket_connection.pop_message()
+
+    calendar_db.update_reminder_entry(ReminderEntry(
+        identifier=1,
+        event_id=1,
+        secs_before=0,
+        acknowledged=True,
+    ))
+
+    freezer.move_to(datetime.datetime(2024, 4, 25, 20, 0, 1, tzinfo=datetime.UTC))
+    task_manager.last_calendar_reminder_check = Timestamp(0)  # bypass 5-min throttle
+    assert task_manager._maybe_trigger_calendar_reminder() is None
+    assert task_manager.last_calendar_reminder_check != 0  # throttle set even on empty match
+    assert websocket_connection.messages_num() == 0
+
+
+@pytest.mark.parametrize('max_tasks_num', [5])
 @pytest.mark.freeze_time('2023-06-01 22:31:11 GMT')
 @pytest.mark.parametrize('db_settings', [
     {'auto_delete_calendar_entries': False},


### PR DESCRIPTION
## Summary
- The trigger query in `_maybe_trigger_calendar_reminder` did not filter by `acknowledged`, so dismissed reminders kept being re-sent over websocket every 5 minutes (and on every app restart, since the throttle is in-memory). Most visible on the L2 bridge claim reminders, which the `maybe_create_l2_bridging_reminder` task keeps alive for a week after the deposit.
- The PATCH `/api/1/calendar/reminders` endpoint was correctly persisting `acknowledged=1`; the column just wasn't consulted on the read side. Added the missing `AND reminder.acknowledged = 0` clause.
- Added a regression test (`test_acknowledged_calendar_reminder_does_not_retrigger`) that fails on the unfixed code and passes with the fix.

## Test plan
- [x] `uv run python pytestgeventwrapper.py rotkehlchen/tests/unit/test_tasks_manager.py::test_acknowledged_calendar_reminder_does_not_retrigger`
- [x] `uv run python pytestgeventwrapper.py rotkehlchen/tests/unit/test_tasks_manager.py::test_send_ws_calendar_reminder rotkehlchen/tests/unit/test_tasks_manager.py::test_calendar_entries_get_deleted`
- [x] `uv run make lint`