### PR TITLE
fix(frontend): surface chain locations in global search

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`12306` Chain locations (e.g. ``ethereum``, ``optimism``) with on-chain balances are now reachable via global search, even when no manual balance is tagged with that label.
 * :bug:`12304` Opening a location breakdown page for a blockchain (e.g. ``/locations/ethereum``) now shows that chain's on-chain assets and total — previously the page rendered as 0 value with an empty/loading table whenever the location identifier was a chain alias.
 * :feature:`12049` rotki now runs a DB integrity check before uploading a cloud backup or replacing the local DB with a downloaded copy
 * :feature:`3668` Gate exchange is now supported, including Global, Europe, and US regions.

--- a/frontend/app/src/modules/balances/use-aggregated-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-aggregated-balances.spec.ts
@@ -23,6 +23,7 @@ import { BalanceType } from '@/modules/balances/types/balances';
 import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { TRADE_LOCATION_BANKS } from '@/modules/core/common/defaults';
+import { useLocationStore } from '@/modules/core/common/use-location-store';
 import { useSessionSettingsStore } from '@/modules/settings/use-session-settings-store';
 import { useAggregatedBalances } from './use-aggregated-balances';
 import '@test/i18n';
@@ -495,6 +496,45 @@ describe('useAggregatedBalances', () => {
       const ethBreakdown = ethItems[0];
       expect(ethBreakdown.amount).toEqual(bigNumberify(5));
       expect(ethBreakdown.value).toEqual(bigNumberify(20000));
+    });
+  });
+
+  describe('balancesByChainLocation', () => {
+    it('should expose per-chain on-chain totals keyed by trade-location identifier', () => {
+      matchChainMock.mockImplementation(location => (location === 'ethereum' ? 'eth' : undefined));
+
+      const { updateBalances } = useBalancesStore();
+      const { updateAccounts } = useBlockchainAccountsStore();
+      const { allLocations } = storeToRefs(useLocationStore());
+      const { balancesByChainLocation } = useAggregatedBalances();
+
+      set(allLocations, {
+        ethereum: { isExchange: false, label: 'Ethereum' },
+        kraken: { isExchange: true, label: 'Kraken' },
+      });
+
+      updateBalances('eth', testEthereumBalances);
+      updateAccounts('eth', testAccounts);
+
+      const result = get(balancesByChainLocation);
+
+      expect(result.ethereum).toBeDefined();
+      expect(result.ethereum.gt(0)).toBe(true);
+      // Non-chain locations (exchanges) are not included here.
+      expect(result.kraken).toBeUndefined();
+    });
+
+    it('should skip chains with no on-chain balance', () => {
+      matchChainMock.mockImplementation(location => (location === 'ethereum' ? 'eth' : undefined));
+
+      const { allLocations } = storeToRefs(useLocationStore());
+      const { balancesByChainLocation } = useAggregatedBalances();
+
+      set(allLocations, {
+        ethereum: { isExchange: false, label: 'Ethereum' },
+      });
+
+      expect(get(balancesByChainLocation)).toEqual({});
     });
   });
 

--- a/frontend/app/src/modules/balances/use-aggregated-balances.ts
+++ b/frontend/app/src/modules/balances/use-aggregated-balances.ts
@@ -16,6 +16,7 @@ import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { getBlockchainLocationBreakdown, getExchangeByLocationBalances, useLocationBreakdown } from '@/modules/balances/use-location-breakdown';
 import { bigNumberSum } from '@/modules/core/common/data/calculation';
 import { TRADE_LOCATION_BLOCKCHAIN } from '@/modules/core/common/defaults';
+import { useLocations } from '@/modules/core/common/use-locations';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 
 interface UseAggregatedBalancesReturn {
@@ -31,6 +32,7 @@ interface UseAggregatedBalancesReturn {
   useExchangeBalances: (exchange?: MaybeRefOrGetter<string>) => ComputedRef<AssetBalanceWithPriceAndChains[]>;
   useLocationBreakdown: (location: MaybeRefOrGetter<string>) => ComputedRef<AssetBalanceWithPriceAndChains[]>;
   balancesByLocation: ComputedRef<Record<string, BigNumber>>;
+  balancesByChainLocation: ComputedRef<Record<string, BigNumber>>;
 }
 
 export function useAggregatedBalances(): UseAggregatedBalancesReturn {
@@ -39,6 +41,7 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
   const { exchanges, getBaseExchangeBalances, useBaseExchangeBalances } = useExchangeData();
   const { balances: blockchainBalances, manualBalances, manualLiabilities } = storeToRefs(useBalancesStore());
   const { manualBalanceByLocation } = useManualBalanceData();
+  const { tradeLocations } = useLocations();
 
   const resolveAssetIdentifier = useResolveAssetIdentifier();
   const { getCollectionId, getCollectionMainAsset } = useCollectionInfo();
@@ -206,8 +209,33 @@ export function useAggregatedBalances(): UseAggregatedBalancesReturn {
     return map;
   });
 
+  // Per-chain on-chain totals keyed by trade-location identifier (e.g. 'ethereum').
+  // Drives chain discoverability in global search; kept separate from
+  // `balancesByLocation` so the umbrella `'blockchain'` aggregate stays
+  // authoritative for premium consumers iterating that map.
+  const balancesByChainLocation = computed<Record<string, BigNumber>>(() => {
+    const balances = get(blockchainBalances);
+    const locations = get(tradeLocations);
+    const result: Record<string, BigNumber> = {};
+    for (const location of locations) {
+      const chain = matchChain(location.identifier);
+      if (!chain || !balances[chain])
+        continue;
+      const assets = getBlockchainLocationBreakdown(
+        { [chain]: balances[chain] },
+        resolveAssetIdentifier,
+        asset => isAssetIgnored(asset),
+      );
+      const total = bigNumberSum(Object.values(assets).map(asset => asset.value));
+      if (!total.isZero())
+        result[location.identifier] = total;
+    }
+    return result;
+  });
+
   return {
     assets,
+    balancesByChainLocation,
     balancesByLocation,
     getAssetPriceInfo,
     getBalances,

--- a/frontend/app/src/modules/shell/components/GlobalSearch.vue
+++ b/frontend/app/src/modules/shell/components/GlobalSearch.vue
@@ -54,7 +54,7 @@ const router = useRouter();
 const interop = useInterop();
 
 const { connectedExchanges } = storeToRefs(useSessionSettingsStore());
-const { balancesByLocation, getBalances } = useAggregatedBalances();
+const { balancesByChainLocation, balancesByLocation, getBalances } = useAggregatedBalances();
 const { getLocationData } = useLocations();
 const { assetSearch } = useAssetInfoRetrieval();
 
@@ -298,13 +298,24 @@ async function getAssets(keyword: string): Promise<SearchItemWithoutValue[]> {
 
 function* transformLocations(): IterableIterator<SearchItemWithoutValue> {
   const locationBalances = get(balancesByLocation);
+  const chainBalances = get(balancesByChainLocation);
 
-  for (const identifier in locationBalances) {
+  // Merge per-chain on-chain totals so chain locations (e.g. 'ethereum')
+  // surface in global search even when the user has no manual balance
+  // tagged with that label. When both exist for the same identifier, sum.
+  const merged: Record<string, BigNumber> = { ...locationBalances };
+  for (const identifier in chainBalances) {
+    const existing = merged[identifier];
+    const chainTotal = chainBalances[identifier];
+    merged[identifier] = existing ? existing.plus(chainTotal) : chainTotal;
+  }
+
+  for (const identifier in merged) {
     const location = getLocationData(identifier);
     if (!location)
       continue;
 
-    const total = locationBalances[identifier];
+    const total = merged[identifier];
     yield {
       location,
       route: {


### PR DESCRIPTION
## Summary

- `balancesByLocation` only keys on-chain totals under the umbrella `'blockchain'` slug, so chain locations like `ethereum`/`optimism` were not discoverable from global search unless a manual balance happened to be tagged with that label.
- Exposes a sibling `balancesByChainLocation` map from `useAggregatedBalances` that walks `tradeLocations`, resolves each chain alias via `matchChain`, and totals that chain's on-chain balances.
- `GlobalSearch.transformLocations` merges it with the existing map (summing on collision) so chain entries appear with the correct combined total. `balancesByLocation` is intentionally left unchanged so the umbrella aggregate stays authoritative for any premium consumer iterating that map.

Closes #12306

## Test plan

- [x] `pnpm run test:unit src/modules/balances/use-aggregated-balances.spec.ts` (24/24 pass, including 2 new tests for `balancesByChainLocation`)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint-staged`
- [x] Manually verified chain locations (e.g. `ethereum`) now appear in global search and route to `/locations/ethereum` with the correct total.