### PR TITLE
feat(frontend): multi-instance dev launcher

### DIFF
--- a/frontend/app/electron/main/core-args.ts
+++ b/frontend/app/electron/main/core-args.ts
@@ -1,9 +1,35 @@
 import type { BackendOptions } from '@shared/ipc';
+import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { assert } from '@rotki/common';
 import { resolveLogLevel } from './resolve-log-level';
+
+/**
+ * In dev mode the backend defaults to the `python` on PATH, which fails
+ * unless a venv is active. Mirror the dev launcher's behaviour
+ * (`frontend/scripts/dev/prerequisites.ts`): if no venv and `uv` is
+ * available, run the backend via `uv run --locked` so it resolves against
+ * the repo's uv.lock without requiring the developer to activate anything.
+ * Cached because this is invoked per-spawn and `execSync` is not free.
+ */
+let uvAvailable: boolean | undefined;
+
+function shouldUseUv(): boolean {
+  if (process.env.VIRTUAL_ENV)
+    return false;
+  if (uvAvailable === undefined) {
+    try {
+      execSync('uv --version', { stdio: 'ignore' });
+      uvAvailable = true;
+    }
+    catch {
+      uvAvailable = false;
+    }
+  }
+  return uvAvailable;
+}
 
 const BACKEND_DIRECTORY = 'backend';
 
@@ -103,6 +129,10 @@ export const RotkiCoreConfig = {
           profilingCmd,
           profilingArgs?.split(' '),
         ).withCorsUrl(devServerUrl);
+      }
+      else if (shouldUseUv()) {
+        command = builder.setCommand('uv', ['run', '--locked', 'python', ...pythonArgs])
+          .withCorsUrl(devServerUrl);
       }
       else {
         command = builder.setCommand('python', pythonArgs)

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -94,7 +94,6 @@
     "c8": "catalog:",
     "dmg-license": "catalog:",
     "dotenv": "catalog:",
-    "dotenv-cli": "catalog:",
     "electron": "catalog:",
     "electron-builder": "catalog:",
     "electron-store": "catalog:",

--- a/frontend/app/scripts/start-backend.ts
+++ b/frontend/app/scripts/start-backend.ts
@@ -37,6 +37,7 @@ function startBackend(options: BackendOptions): void {
 
   const args = [
     'run',
+    '--locked',
     '-m',
     'rotkehlchen',
     '--rest-api-port',

--- a/frontend/dev-proxy/README.md
+++ b/frontend/dev-proxy/README.md
@@ -1,100 +1,123 @@
 # rotki development proxy
 
-The proxy's purpose is to provide an easy way to develop the frontend in parallel
-with the backend, and provide an easy way to test the premium features.
+The dev-proxy provides two features beyond a plain pass-through to the Python
+backend:
 
-The proxy will automatically pass any requests to the real backend, unless a mocked
-endpoint implementation exists.
+1. **Premium components serving** — serves locally-developed premium statistics
+   components in place of the production bundle, so you can iterate on them
+   without a release.
+2. **Async-query mocking** — overrides specific backend responses from a JSON
+   file so you can exercise edge cases (slow queries, partial results, errors)
+   without changing backend code.
 
-All mock endpoint implementations should be before:
+If you need neither, the proxy is just a slow extra hop — the Python backend
+already permits CORS from any `http://localhost:*` origin, so the frontend can
+talk to it directly.
 
-```TypeScript
-server.use(createProxyMiddleware({ target: backend }));
-```
+## Quick start
 
-Otherwise the real backend will handle the requests.
+The proxy is now spawned automatically by `pnpm dev` / `pnpm dev:web` when
+either of its features is in use. You usually do **not** need to start it
+yourself.
 
-## Configuration
+### Premium components
 
-You can configure the proxy, with the following environment variables:
+1. Set `PREMIUM_COMPONENT_DIR` in `frontend/app/.env.development.local` (or in
+   your shell):
 
-- `PORT` The port where the proxy listens for incoming connections. (Default: 4243)
-- `BACKEND` The url of the real backend. (Default: `http://localhost:4242`)
-- `PREMIUM_COMPONENT_DIR` The premium components directory. (Optional)
+   ```env
+   PREMIUM_COMPONENT_DIR=/home/you/development/repos/rotki-premium-statistics
+   ```
 
-> The premium components directory is needed only if you need to test the premium components themselves.
-> Assuming that the premium-components repo is at the same parent folder as the application repository one would
-> have to add the following in the `.env` file.
->
-> `PREMIUM_COMPONENT_DIR=/home/user/path/premium-components/packages/premium-components`
+2. Build the premium bundle inside that directory:
 
-You can provide this configuration in a `.env` file in the `dev-proxy` directory.
+   ```bash
+   npm ci
+   npm run build
+   ```
 
-## Starting the proxy
+3. Run `pnpm dev:web` (or `pnpm dev`). You should see `dev-proxy: on (auto)`
+   in the startup log — the proxy is now in front of the backend serving your
+   local components.
 
-From the parent directory
+### Async-query mocking
+
+1. Create `frontend/dev-proxy/async-mock.json` (see `async-mock.example.json`
+   in this directory for the shape).
+2. Run `pnpm dev:web` — the proxy auto-starts because the file exists.
+
+`async-mock.json` is in `frontend/dev-proxy/.gitignore`, so it stays personal.
+
+### Forcing on/off
+
+`pnpm dev:web --proxy` forces the proxy on regardless of auto-detect.
+`pnpm dev:web --no-proxy` forces it off — useful for skipping the extra hop
+even when you have a premium-components dir set.
+
+## How auto-detection decides
+
+`shouldUseProxy()` in `frontend/scripts/start-dev.ts`:
+
+- `--proxy` / `--no-proxy` flags always win.
+- Otherwise, the proxy is **on** if either is true:
+  - `PREMIUM_COMPONENT_DIR` is set to a real directory.
+  - `frontend/dev-proxy/async-mock.json` exists.
+- Otherwise it's **off**.
+
+The detection runs against `process.env` after `frontend/app/.env.development.local`
+has been loaded. `frontend/dev-proxy/.env` is **not** consulted by start-dev —
+that file is only read by the proxy subprocess itself, so putting
+`PREMIUM_COMPONENT_DIR` there alone will not trigger auto-on.
+
+## What the proxy reads
+
+When start-dev spawns the proxy, it overrides the proxy's `PORT` and `BACKEND`
+on the spawn env. Anything else (`PREMIUM_COMPONENT_DIR`, etc.) flows through
+from the parent `process.env`, then from `frontend/dev-proxy/.env` as a fallback
+for keys not already set.
+
+| Variable                  | Source                                                                        | Default                  |
+|---------------------------|-------------------------------------------------------------------------------|--------------------------|
+| `PORT`                    | start-dev spawn env (slot-aware)                                              | `4243`                   |
+| `BACKEND`                 | start-dev spawn env (actual Python REST port)                                 | `http://localhost:4242`  |
+| `PREMIUM_COMPONENT_DIR`   | `frontend/app/.env.development.local`, shell env, or `frontend/dev-proxy/.env`| unset                    |
+
+## Running the proxy standalone
+
+Mostly useful if you want the proxy without the rest of the dev stack — for
+example, pointing it at an already-running backend in a different terminal.
 
 ```bash
 pnpm install --frozen-lockfile
 pnpm run --filter @rotki/dev-proxy serve
 ```
 
-## Setup rotki
+In that mode `PORT`, `BACKEND`, and `PREMIUM_COMPONENT_DIR` all come from
+`frontend/dev-proxy/.env`. The frontend then needs `VITE_BACKEND_URL=http://localhost:4243`
+(or whatever proxy port you chose) so it routes through the proxy.
 
-In order to use rotki with this development proxy you need to create a `.env.development.local`
-environment file. Put the file in the frontend directory of rotki. (`frontend/app`).
+> **Heads-up — old workflow:** previous versions of this README documented
+> setting `VITE_BACKEND_URL=http://localhost:4243` in
+> `frontend/app/.env.development.local` to opt into proxy mode. That trigger has
+> been replaced by the auto-detection above; with the new dev:web flow the
+> managed env block writes `VITE_BACKEND_URL` for you, pointing at the proxy
+> port when on and the backend port when off.
 
-The file must contain the following entry:
+## Async-mock JSON shape
 
-```env
-VITE_BACKEND_URL=http://localhost:4243
-```
-
-> Adjust accordingly to if you used a custom port for the proxy.
-
-After that you can start rotki via:
-
-```bash
-pnpm run dev
-```
-
-## Serving the premium components
-
-To serve the premium components using the proxy, you must set the `PREMIUM_COMPONENT_DIR`
-environment variable. The variable should contain the directory where you store your
-premium components source code. You must have the variable set before starting the
-proxy, otherwise the proxy will serve the production components instead.
-
-Before accessing the premium components via the proxy, you must first build the bundle.
-In order to build the bundle you need to go to the premium components directory and
-run the following.
-
-```bash
-npm ci
-npm run build
-```
-
-## Mocking async queries
-
-Look into the `async-mock.example.json` and create an `async-mock.json` file in the same
-directory. Follow a similar structure as the example.
+Look into the `async-mock.example.json` file in this directory and copy it to
+`async-mock.json`. The structure is:
 
 ```json
 {
   "/api/1/assets/updates": {
     "GET": [
       {
-        "result": {
-          "local_version": 1,
-          "remote_version": 6
-        },
+        "result": { "local_version": 1, "remote_version": 6 },
         "message": ""
       },
       {
-        "result": {
-          "local_version": 2,
-          "remote_version": 5
-        },
+        "result": { "local_version": 2, "remote_version": 5 },
         "message": ""
       }
     ]
@@ -102,10 +125,19 @@ directory. Follow a similar structure as the example.
 }
 ```
 
-You can put the mocked url on the root of the json and under that you can add the request
-verb. The request verb can either be an object or an array.
+You can put the mocked URL on the root of the JSON and under that add the
+request verb. The verb's value can either be an object or an array:
 
-If an object is used, this object will be returned every time you query the same endpoint/verb combination.
-If an array is used instead for each request the next index available will be served. e.g. The first request
-will serve the item at index `0`, the second the item and index `1` etc. If the end of the available responses
-is reached the last item will keep being returned for any consequent requests.
+- **Object** — returned every time you query the same endpoint/verb combination.
+- **Array** — each request returns the next index. The first request serves
+  index `0`, the second serves `1`, etc. When the end is reached the last item
+  keeps being returned for any subsequent requests.
+
+## Implementation notes
+
+- Mock endpoint implementations live in `src/mocked-apis/`. The proxy registers
+  any mock-matched handlers **before** the generic
+  `createProxyMiddleware({ target: backend })` so they take precedence over the
+  pass-through.
+- WebSocket forwarding is enabled (`ws: true`), so the backend's `/ws/`
+  endpoint reaches the renderer through the same proxy hop.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,8 @@
     "npm-run-all2": "catalog:",
     "rimraf": "catalog:",
     "semver": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "zod": "catalog:"
   },
   "engines": {
     "node": ">=24 <25",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -129,9 +129,6 @@ catalogs:
     dotenv:
       specifier: 17.4.2
       version: 17.4.2
-    dotenv-cli:
-      specifier: 11.0.0
-      version: 11.0.0
     echarts:
       specifier: 6.0.0
       version: 6.0.0
@@ -352,6 +349,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
 
   app:
     dependencies:
@@ -521,9 +521,6 @@ importers:
       dotenv:
         specifier: 'catalog:'
         version: 17.4.2
-      dotenv-cli:
-        specifier: 'catalog:'
-        version: 11.0.0
       electron:
         specifier: 'catalog:'
         version: 41.6.0
@@ -3646,16 +3643,8 @@ packages:
     resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
     engines: {node: '>=20'}
 
-  dotenv-cli@11.0.0:
-    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
-    hasBin: true
-
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
-    engines: {node: '>=12'}
-
-  dotenv-expand@12.0.3:
-    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
     engines: {node: '>=12'}
 
   dotenv@16.6.1:
@@ -11163,18 +11152,7 @@ snapshots:
     dependencies:
       type-fest: 5.5.0
 
-  dotenv-cli@11.0.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      dotenv: 17.4.2
-      dotenv-expand: 12.0.3
-      minimist: 1.2.8
-
   dotenv-expand@11.0.7:
-    dependencies:
-      dotenv: 16.6.1
-
-  dotenv-expand@12.0.3:
     dependencies:
       dotenv: 16.6.1
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -68,7 +68,6 @@ catalog:
   dexie: 4.4.2
   dmg-license: 1.0.11
   dotenv: 17.4.2
-  dotenv-cli: 11.0.0
   echarts: 6.0.0
   electron: 41.6.0
   electron-builder: 26.10.0

--- a/frontend/scripts/copy-data.ts
+++ b/frontend/scripts/copy-data.ts
@@ -1,15 +1,22 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { cancel, intro, isCancel, multiselect, outro } from '@clack/prompts';
 import { cac } from 'cac';
 import consola from 'consola';
+import { baseDataDir, copyTree } from './dev-instance';
 
 const APP_NAME = 'rotki';
 const DATA_DIR = 'data';
 const DEVELOP_DATA_DIR = 'develop_data';
 const USER_DIR = 'users';
+
+function copyAndLog(src: string, dst: string): void {
+  copyTree(src, dst, {
+    preserveMtime: true,
+    onFile: ({ src: s, dst: d }) => consola.info(`Copying ${s} to ${d}`),
+  });
+}
 
 async function promptUser(appDataDir: string): Promise<void> {
   intro('Select which users and data directories to copy from data to develop_data.');
@@ -61,7 +68,7 @@ async function promptUser(appDataDir: string): Promise<void> {
       fs.rmSync(targetUserDir, { recursive: true });
     }
     consola.info(`Copying ${sourceUserDir} to ${targetUserDir}`);
-    copyDir(sourceUserDir, targetUserDir);
+    copyTree(sourceUserDir, targetUserDir, { preserveMtime: true });
   }
 
   for (const selectedDir of selectedDataDirs) {
@@ -72,41 +79,13 @@ async function promptUser(appDataDir: string): Promise<void> {
       fs.rmSync(targetDataDir, { recursive: true });
     }
     consola.info(`Copying ${sourceDataDir} to ${targetDataDir}`);
-    copyDir(sourceDataDir, targetDataDir);
+    copyTree(sourceDataDir, targetDataDir, { preserveMtime: true });
   }
 
   outro('Copying is complete.');
 }
 
-function copyFile(src: string, dest: string): void {
-  fs.mkdirSync(path.dirname(dest), { recursive: true });
-  fs.copyFileSync(src, dest);
-  const stats = fs.statSync(src);
-  fs.utimesSync(dest, stats.atime, stats.mtime);
-}
-
-function copyDir(src: string, dest: string, log = false): void {
-  fs.mkdirSync(dest, { recursive: true });
-  const entries = fs.readdirSync(src, { withFileTypes: true });
-
-  for (const entry of entries) {
-    const srcPath = path.join(src, entry.name);
-    const destPath = path.join(dest, entry.name);
-
-    if (log) {
-      consola.info(`Copying ${srcPath} to ${destPath}`);
-    }
-
-    if (entry.isDirectory()) {
-      copyDir(srcPath, destPath);
-    }
-    else {
-      copyFile(srcPath, destPath);
-    }
-  }
-}
-
-function copyData(appDataDir: string) {
+function copyData(appDataDir: string): void {
   const dataDir = path.join(appDataDir, DATA_DIR);
   const developDataDir = path.join(appDataDir, DEVELOP_DATA_DIR);
 
@@ -120,43 +99,18 @@ function copyData(appDataDir: string) {
   consola.success(`Removed content from ${developDataDir}`);
 
   const dirContents = fs.readdirSync(dataDir);
-  consola.info(`Preparing to Copy ${dirContents.length} files/directories from ${dataDir} to ${developDataDir}`);
+  consola.info(`Preparing to copy ${dirContents.length} files/directories from ${dataDir} to ${developDataDir}`);
 
-  copyDir(dataDir, developDataDir, true);
+  copyAndLog(dataDir, developDataDir);
 
   consola.success(`Copied all content from ${dataDir} to ${developDataDir}`);
 }
 
 function resolveDataDirectory(): string {
-  const platform = os.platform();
-  const homedir = os.homedir();
-
-  let baseDir: string;
-
-  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
-  switch (platform) {
-    case 'win32':
-      baseDir = process.env.LOCALAPPDATA ?? path.join(homedir, 'AppData', 'Local');
-      break;
-
-    case 'darwin':
-      baseDir = path.join(homedir, 'Library', 'Application Support');
-      break;
-
-    case 'linux':
-      baseDir = process.env.XDG_DATA_HOME ?? path.join(homedir, '.local', 'share');
-      break;
-
-    default:
-      baseDir = path.join(homedir, '.local', 'share');
-  }
-
-  const appDataDir = path.join(baseDir, APP_NAME);
-
+  const appDataDir = path.join(baseDataDir(), APP_NAME);
   if (!fs.existsSync(appDataDir)) {
     throw new Error(`Data directory ${appDataDir} does not exist`);
   }
-
   return appDataDir;
 }
 

--- a/frontend/scripts/dev-instance/env-file.ts
+++ b/frontend/scripts/dev-instance/env-file.ts
@@ -1,0 +1,163 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { parse as parseDotenv } from 'dotenv';
+
+export const MANAGED_ENV_KEYS = [
+  'INSTANCE_NAME',
+  'INSTANCE_PORT_SLOT',
+  'VITE_BACKEND_URL',
+  'VITE_COLIBRI_URL',
+  'DEV_PORT',
+] as const;
+
+/**
+ * Sentinel comments wrapping the dev:web-managed block. The exact string is
+ * load-bearing: writeEnvFile and clearManagedEnvBlock locate the block by
+ * matching these lines. Changing the wording later would orphan blocks written
+ * by older versions of the script.
+ */
+const BLOCK_START = '# >>> rotki dev:web managed (do not edit by hand)';
+const BLOCK_END = '# <<< rotki dev:web managed';
+
+export function loadEnvFile(file: string): Record<string, string> {
+  if (!fs.existsSync(file)) {
+    return {};
+  }
+  return parseDotenv(fs.readFileSync(file));
+}
+
+/** Returns the key name of an env-file line, or undefined if it isn't a KEY=VAL line. */
+function envLineKey(line: string): string | undefined {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#'))
+    return undefined;
+  const eq = trimmed.indexOf('=');
+  return eq === -1 ? undefined : trimmed.slice(0, eq).trim();
+}
+
+function buildManagedBlock(managed: readonly string[], updates: Record<string, string>): string[] {
+  const lines = [BLOCK_START];
+  for (const key of managed) {
+    if (key in updates)
+      lines.push(`${key}=${updates[key]}`);
+  }
+  lines.push(BLOCK_END);
+  return lines;
+}
+
+interface RewriteResult {
+  /** Lines to write out, in order. */
+  kept: string[];
+  /** Whether the input contained a START/END block. */
+  hadBlock: boolean;
+  /** Whether anything was removed/replaced relative to the input. */
+  changed: boolean;
+}
+
+/**
+ * Walks an env file line-by-line and:
+ *  - replaces the existing START/END block with `replacement` (or removes the
+ *    block entirely if `replacement` is null)
+ *  - strips orphan managed keys living OUTSIDE the block (left over from
+ *    pre-marker versions or manual edits)
+ *  - preserves every other line verbatim
+ */
+function rewriteEnvBlock(
+  lines: string[],
+  managed: Set<string>,
+  replacement: string[] | null,
+): RewriteResult {
+  const kept: string[] = [];
+  let hadBlock = false;
+  let changed = false;
+  let inBlock = false;
+  let blockEmitted = false;
+  for (const rawLine of lines) {
+    // Tolerate CRLF line endings: an .env edited on Windows or copied from a
+    // CRLF source ends each line with \r after splitting on '\n'. Strip a
+    // trailing \r before matching the sentinel comments so the block is
+    // detected and not duplicated on every run.
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    if (line === BLOCK_START) {
+      inBlock = true;
+      hadBlock = true;
+      changed = true;
+      if (replacement && !blockEmitted) {
+        kept.push(...replacement);
+        blockEmitted = true;
+      }
+      continue;
+    }
+    if (line === BLOCK_END) {
+      inBlock = false;
+      continue;
+    }
+    if (inBlock)
+      continue;
+    const key = envLineKey(line);
+    if (key !== undefined && managed.has(key)) {
+      changed = true;
+      continue;
+    }
+    kept.push(line);
+  }
+  return { kept, hadBlock, changed };
+}
+
+function writeAtomic(file: string, contents: string): void {
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, contents.endsWith('\n') || contents.length === 0 ? contents : `${contents}\n`, 'utf-8');
+  fs.renameSync(tmp, file);
+}
+
+export function writeEnvFile(
+  file: string,
+  updates: Record<string, string>,
+  opts: { managed: readonly string[] },
+): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const existing = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : '';
+  const managed = new Set(opts.managed);
+  const newBlock = buildManagedBlock(opts.managed, updates);
+  const { kept, hadBlock } = rewriteEnvBlock(existing.split('\n'), managed, newBlock);
+
+  if (!hadBlock) {
+    if (kept.length > 0 && kept.at(-1) !== '')
+      kept.push('');
+    kept.push(...newBlock);
+  }
+
+  writeAtomic(file, kept.join('\n'));
+}
+
+/**
+ * Reads `INSTANCE_NAME` from the managed env block at `file`. Returns
+ * undefined if the file or the key is missing. Used to decide whether a
+ * cleanup path should erase the env trail (it should only erase a block that
+ * belongs to the instance being removed).
+ */
+export function readManagedInstanceName(file: string): string | undefined {
+  if (!fs.existsSync(file))
+    return undefined;
+  const parsed = parseDotenv(fs.readFileSync(file));
+  const name = parsed.INSTANCE_NAME;
+  return name && name.length > 0 ? name : undefined;
+}
+
+/**
+ * Removes the dev:web-managed block (and any orphan managed keys) from `file`.
+ * Leaves every unmanaged line untouched. Useful when an instance is cleaned and
+ * we want to remove the env trail it wrote.
+ */
+export function clearManagedEnvBlock(file: string, opts: { managed: readonly string[] } = { managed: MANAGED_ENV_KEYS }): void {
+  if (!fs.existsSync(file))
+    return;
+  const managed = new Set(opts.managed);
+  const { kept, changed } = rewriteEnvBlock(fs.readFileSync(file, 'utf-8').split('\n'), managed, null);
+  if (!changed)
+    return;
+  while (kept.length > 0 && kept.at(-1) === '')
+    kept.pop();
+  writeAtomic(file, kept.join('\n'));
+}

--- a/frontend/scripts/dev-instance/format.ts
+++ b/frontend/scripts/dev-instance/format.ts
@@ -1,0 +1,54 @@
+/**
+ * Extracts a human-readable message from an unknown error without type assertion.
+ */
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error)
+    return error.message;
+  if (typeof error === 'string')
+    return error;
+  return String(error);
+}
+
+/**
+ * Returns a NodeJS-style `code` from an error object, or undefined if not present.
+ */
+export function errorCode(error: unknown): string | undefined {
+  if (!(error instanceof Error) || !('code' in error))
+    return undefined;
+  const code: unknown = error.code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+export function humanBytes(bytes: number): string {
+  if (bytes < 1024)
+    return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(1)} ${units[unit]}`;
+}
+
+/**
+ * Renders a port number in ANSI bold for log output. Use everywhere a port is
+ * surfaced to the developer so the number stands out from surrounding text.
+ * `[22m` turns off bold without resetting other attributes.
+ */
+export function formatPort(port: number | string): string {
+  return `[1m${port}[22m`;
+}
+
+/** Renders `host:port` with the port number bolded. */
+export function formatHostPort(host: string, port: number | string): string {
+  return `${host}:${formatPort(port)}`;
+}
+
+export function formatTable(rows: string[][]): string {
+  if (rows.length === 0)
+    return '';
+  const widths = rows[0].map((_, col) => Math.max(...rows.map(r => r[col].length)));
+  return rows.map(r => r.map((c, i) => c.padEnd(widths[i])).join('  ')).join('\n');
+}

--- a/frontend/scripts/dev-instance/fs-walk.ts
+++ b/frontend/scripts/dev-instance/fs-walk.ts
@@ -1,0 +1,186 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import consola from 'consola';
+
+import { errorMessage } from './format';
+
+const logger = consola.withTag('dev-instance:fs-walk');
+
+/**
+ * Files we never carry over from a live rotki data dir: SQLite WAL/SHM
+ * companion files (carrying them would corrupt the seeded DB) and live logs.
+ */
+const SEED_HARD_SKIP_PATTERNS = [/\.log$/i, /\.sqlite-wal$/i, /\.sqlite-shm$/i, /\.db-wal$/i, /\.db-shm$/i];
+const SEED_HARD_SKIP_DIRS = new Set(['logs']);
+
+/** Soft-skipped: not copied by default; pass `includeBackups: true` to opt in. */
+const SEED_BACKUP_PATTERNS = [/\.backup$/i];
+
+export interface SeedSkipOptions {
+  /** When true, includes `*.backup` files in the seed. Default: false. */
+  includeBackups?: boolean;
+}
+
+export function buildSeedSkip(opts: SeedSkipOptions = {}): WalkSkip {
+  return (name: string, isDir: boolean): boolean => {
+    if (isDir)
+      return SEED_HARD_SKIP_DIRS.has(name.toLowerCase());
+    if (SEED_HARD_SKIP_PATTERNS.some(p => p.test(name)))
+      return true;
+    if (!opts.includeBackups && SEED_BACKUP_PATTERNS.some(p => p.test(name)))
+      return true;
+    return false;
+  };
+}
+
+/** Convenience: default skip predicate (no backups). */
+export const shouldSkipSeedEntry = buildSeedSkip();
+
+export type WalkSkip = (name: string, isDir: boolean) => boolean;
+
+export function walkFiles(root: string, onFile: (full: string, size: number) => void, skip?: WalkSkip): void {
+  const visit = (current: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    }
+    catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (skip?.(entry.name, entry.isDirectory())) {
+        continue;
+      }
+      const full = path.join(current, entry.name);
+      try {
+        if (entry.isDirectory()) {
+          visit(full);
+        }
+        else if (entry.isFile()) {
+          onFile(full, fs.statSync(full).size);
+        }
+      }
+      catch {
+        // unreadable entries are skipped
+      }
+    }
+  };
+  visit(root);
+}
+
+export function dirSizeBytes(dir: string, skip?: WalkSkip): number {
+  let total = 0;
+  walkFiles(dir, (_, size) => {
+    total += size;
+  }, skip);
+  return total;
+}
+
+export function estimateSeedSize(source: string, opts: SeedSkipOptions = {}): number {
+  return dirSizeBytes(source, buildSeedSkip(opts));
+}
+
+export function freeDiskBytes(targetDir: string): number | undefined {
+  try {
+    const probeDir = fs.existsSync(targetDir) ? targetDir : path.dirname(targetDir);
+    const stat = fs.statfsSync(probeDir);
+    return stat.bavail * stat.bsize;
+  }
+  catch (error) {
+    logger.warn(`Failed to read free disk space at ${targetDir}: ${errorMessage(error)}`);
+    return undefined;
+  }
+}
+
+export interface CopyTreeOptions {
+  /** Predicate to skip an entry by name. Default: copy everything. */
+  skip?: WalkSkip;
+  /** Preserve source file mtime/atime on the destination. Default: false. */
+  preserveMtime?: boolean;
+  /**
+   * Called per file copied, with byte size. Useful for progress reporting.
+   * Aggregation/throttling is the caller's responsibility.
+   */
+  onFile?: (info: { src: string; dst: string; size: number }) => void;
+}
+
+/**
+ * Recursively copies `sourceDir` → `targetDir` preserving directory layout.
+ * Symlinks are recreated as symlinks (never followed). Errors propagate; the
+ * caller decides whether to clean up the partial copy.
+ */
+export function copyTree(sourceDir: string, targetDir: string, opts: CopyTreeOptions = {}): void {
+  const walk = (src: string, dst: string): void => {
+    fs.mkdirSync(dst, { recursive: true });
+    const entries = fs.readdirSync(src, { withFileTypes: true });
+    for (const entry of entries) {
+      if (opts.skip?.(entry.name, entry.isDirectory())) {
+        continue;
+      }
+      const srcPath = path.join(src, entry.name);
+      const dstPath = path.join(dst, entry.name);
+      if (entry.isSymbolicLink()) {
+        const link = fs.readlinkSync(srcPath);
+        fs.symlinkSync(link, dstPath);
+      }
+      else if (entry.isDirectory()) {
+        walk(srcPath, dstPath);
+      }
+      else if (entry.isFile()) {
+        fs.copyFileSync(srcPath, dstPath);
+        const size = fs.statSync(dstPath).size;
+        if (opts.preserveMtime) {
+          const stat = fs.statSync(srcPath);
+          fs.utimesSync(dstPath, stat.atime, stat.mtime);
+        }
+        opts.onFile?.({ src: srcPath, dst: dstPath, size });
+      }
+    }
+  };
+  walk(sourceDir, targetDir);
+}
+
+export interface SeedProgress {
+  files: number;
+  bytes: number;
+}
+
+export interface SeedInstanceOptions extends SeedSkipOptions {
+  onProgress?: (p: SeedProgress) => void;
+}
+
+export function seedInstance(
+  targetDir: string,
+  sourceDir: string,
+  opts: SeedInstanceOptions = {},
+): void {
+  fs.mkdirSync(targetDir, { recursive: true });
+  const progress: SeedProgress = { files: 0, bytes: 0 };
+  const lastEmit = { time: Date.now(), bytes: 0 };
+
+  const emit = (): void => {
+    const now = Date.now();
+    if (now - lastEmit.time >= 250 || progress.bytes - lastEmit.bytes >= 500 * 1024 * 1024) {
+      opts.onProgress?.(progress);
+      lastEmit.time = now;
+      lastEmit.bytes = progress.bytes;
+    }
+  };
+
+  try {
+    copyTree(sourceDir, targetDir, {
+      skip: buildSeedSkip({ includeBackups: opts.includeBackups }),
+      onFile: ({ size }) => {
+        progress.files += 1;
+        progress.bytes += size;
+        emit();
+      },
+    });
+    opts.onProgress?.(progress);
+  }
+  catch (error) {
+    logger.error(`Seed copy failed: ${errorMessage(error)}`);
+    fs.rmSync(targetDir, { recursive: true, force: true });
+    throw error;
+  }
+}

--- a/frontend/scripts/dev-instance/git.ts
+++ b/frontend/scripts/dev-instance/git.ts
@@ -1,0 +1,48 @@
+import { execSync } from 'node:child_process';
+import consola from 'consola';
+
+import { errorMessage } from './format';
+
+const logger = consola.withTag('dev-instance:git');
+
+export function getCurrentGitBranch(): string | undefined {
+  try {
+    const out = execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return out === 'HEAD' || out.length === 0 ? undefined : out;
+  }
+  catch {
+    return undefined;
+  }
+}
+
+export function getCurrentGitWorktree(): string | undefined {
+  try {
+    return execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim() || undefined;
+  }
+  catch {
+    return undefined;
+  }
+}
+
+export function liveWorktreePaths(): Set<string> {
+  try {
+    const raw = execSync('git worktree list --porcelain', { encoding: 'utf-8' });
+    const paths = new Set<string>();
+    for (const line of raw.split('\n')) {
+      if (line.startsWith('worktree ')) {
+        paths.add(line.slice('worktree '.length).trim());
+      }
+    }
+    return paths;
+  }
+  catch (error) {
+    logger.warn(`Failed to list git worktrees: ${errorMessage(error)}`);
+    return new Set();
+  }
+}

--- a/frontend/scripts/dev-instance/index.ts
+++ b/frontend/scripts/dev-instance/index.ts
@@ -1,0 +1,58 @@
+// Public surface of the dev-instance subsystem.
+// Internal helpers stay unexported from this barrel; consumers (start-dev.ts,
+// copy-data.ts, future scripts) import only the names below.
+
+export {
+  clearManagedEnvBlock,
+  loadEnvFile,
+  MANAGED_ENV_KEYS,
+  readManagedInstanceName,
+  writeEnvFile,
+} from './env-file';
+
+export {
+  copyTree,
+  type CopyTreeOptions,
+  estimateSeedSize,
+  freeDiskBytes,
+  seedInstance,
+  type SeedProgress,
+  shouldSkipSeedEntry,
+} from './fs-walk';
+
+export { type InstanceRuntime, prepareInstance, type PrepareInstanceOptions } from './instance';
+
+export {
+  cleanAll,
+  cleanInstance,
+  type InstanceSummary,
+  listInstances,
+  printInstanceList,
+  pruneInstances,
+  repairRegistry,
+} from './lifecycle';
+
+export { baseDataDir } from './paths';
+
+export {
+  resolveInstanceDir,
+  resolveInstanceParent,
+  resolveSeedSource,
+  sanitizeName,
+} from './paths';
+
+export {
+  allocatePortSlot,
+  DEFAULT_PORTS,
+  INSTANCE_BASE_PORT,
+  INSTANCE_SLOT_STEP,
+  MAX_PORT,
+  type PortName,
+  type PortSet,
+  portsForSlot,
+  PortSlotAllocationError,
+  releasePortSlot,
+  RESERVED_SLOTS_END,
+} from './port-registry';
+
+export { type InstanceMeta, readMetadata, touchLastUsed, writeMetadata } from './sidecar';

--- a/frontend/scripts/dev-instance/instance.ts
+++ b/frontend/scripts/dev-instance/instance.ts
@@ -1,0 +1,196 @@
+import fs from 'node:fs';
+import process from 'node:process';
+import consola from 'consola';
+import { loadEnvFile, MANAGED_ENV_KEYS, writeEnvFile } from './env-file';
+import { formatHostPort, formatPort, humanBytes } from './format';
+import { estimateSeedSize, freeDiskBytes, seedInstance } from './fs-walk';
+import { getCurrentGitBranch, getCurrentGitWorktree } from './git';
+import { resolveInstanceDir, resolveSeedSource, sanitizeName } from './paths';
+import { probePortsLive } from './port-probe';
+import { allocatePortSlot, type PortSet, portsForSlot } from './port-registry';
+import { type InstanceMeta, readMetadata, SIDECAR_VERSION, writeMetadata } from './sidecar';
+
+const logger = consola.withTag('dev-instance:instance');
+
+const SEED_BUFFER_RATIO = 1.1;
+
+export interface InstanceRuntime {
+  name: string;
+  slot: number;
+  dir: string;
+  ports: PortSet;
+  meta: InstanceMeta;
+}
+
+export interface PrepareInstanceOptions {
+  name: string;
+  slotHint?: number;
+  seed: boolean;
+  acceptManagedEnv: boolean;
+  envFile: string;
+  /** Whether VITE_BACKEND_URL should point at the proxy port or directly at the backend port. */
+  useProxy: boolean;
+  /** When true, include `*.backup` files in the seed copy. Default false. */
+  includeBackups?: boolean;
+}
+
+function envKeysDiverge(
+  envBefore: Record<string, string>,
+  desired: Record<string, string>,
+): string[] {
+  const diverging: string[] = [];
+  for (const key of MANAGED_ENV_KEYS) {
+    const before = envBefore[key];
+    if (before !== undefined && before !== desired[key]) {
+      diverging.push(key);
+    }
+  }
+  return diverging;
+}
+
+function computeDesiredManagedEnv(name: string, slot: number, ports: PortSet, useProxy: boolean): Record<string, string> {
+  return {
+    INSTANCE_NAME: name,
+    INSTANCE_PORT_SLOT: String(slot),
+    VITE_BACKEND_URL: `http://127.0.0.1:${useProxy ? ports.proxy : ports.restApi}`,
+    VITE_COLIBRI_URL: `http://127.0.0.1:${ports.colibri}`,
+    DEV_PORT: String(ports.dev),
+  };
+}
+
+async function refuseIfSlotLive(name: string, slot: number): Promise<void> {
+  const live = await probePortsLive(slot);
+  if (live.length === 0)
+    return;
+  const lines = [
+    `Instance "${name}" is already live on slot ${slot}:`,
+    ...live.map((entry) => {
+      const pid = entry.pid !== undefined ? ` (PID ${entry.pid})` : '';
+      return `  ${entry.name.padEnd(8)} ${formatHostPort('localhost', entry.port)}${pid}`;
+    }),
+    'Pass --instance <other-name> for a fresh slot or stop the running one.',
+  ];
+  logger.error(lines.join('\n'));
+  process.exit(1);
+}
+
+function refuseOnEnvDivergence(
+  context: { name: string; slot: number; ports: PortSet },
+  envFile: string,
+  divergingKeys: string[],
+  envBefore: Record<string, string>,
+  desiredEnv: Record<string, string>,
+): void {
+  const { name, slot, ports } = context;
+  const portLine = `backend=${formatPort(ports.restApi)} proxy=${formatPort(ports.proxy)} colibri=${formatPort(ports.colibri)} dev=${formatPort(ports.dev)}`;
+  const lines = [
+    `Instance "${name}" → slot ${slot} (${portLine})`,
+    `Detected user-customized managed env keys in ${envFile}:`,
+    ...divergingKeys.map(key => `  ${key} = ${envBefore[key]}  (slot ${slot} expects ${desiredEnv[key]})`),
+    '',
+    'To resolve, pick ONE:',
+    '  --accept-managed-env       let dev:web own these keys for this instance',
+    '  --no-instance              run today\'s default behaviour, ignore INSTANCE_NAME',
+    '  INSTANCE_PORT_SLOT=<slot>  pin the slot whose ports already match your env (slot 0 = defaults)',
+    '',
+    'Unmanaged keys are always preserved.',
+  ];
+  logger.error(lines.join('\n'));
+  process.exit(1);
+}
+
+function seedFromSource(name: string, dir: string, source: string, includeBackups: boolean): void {
+  const estimated = estimateSeedSize(source, { includeBackups });
+  const free = freeDiskBytes(dir);
+  if (free !== undefined && free < estimated * SEED_BUFFER_RATIO) {
+    logger.error(
+      `Insufficient disk space to seed instance "${name}": `
+      + `${humanBytes(free)} free, need ~${humanBytes(estimated)} (+10% buffer).`,
+    );
+    process.exit(1);
+  }
+  const backupNote = includeBackups ? ' (including *.backup)' : '';
+  logger.info(`Seeding instance "${name}" from ${source}${backupNote} (~${humanBytes(estimated)})…`);
+  seedInstance(dir, source, {
+    includeBackups,
+    onProgress: ({ files, bytes }) => {
+      logger.info(`  copied ${files} files, ${humanBytes(bytes)}`);
+    },
+  });
+  logger.success(`Seed complete for "${name}"`);
+}
+
+function ensureInstanceData(name: string, dir: string, wantSeed: boolean, includeBackups: boolean): void {
+  const needsSeed = !fs.existsSync(dir) || fs.readdirSync(dir).length === 0;
+  if (!needsSeed)
+    return;
+  if (!wantSeed) {
+    fs.mkdirSync(dir, { recursive: true });
+    return;
+  }
+  const source = resolveSeedSource();
+  if (!source) {
+    logger.warn(
+      'No rotki seed data dir found (set ROTKI_SEED_SOURCE to override). '
+      + 'Creating an empty instance data dir — backend will start with no preloaded assets/users.',
+    );
+    fs.mkdirSync(dir, { recursive: true });
+    return;
+  }
+  seedFromSource(name, dir, source, includeBackups);
+}
+
+function buildMeta(
+  name: string,
+  slot: number,
+  existingMeta: InstanceMeta | null,
+  consentNow: boolean,
+): InstanceMeta {
+  const now = new Date().toISOString();
+  if (existingMeta) {
+    return {
+      ...existingMeta,
+      portSlot: slot,
+      branch: getCurrentGitBranch() ?? existingMeta.branch,
+      worktreePath: getCurrentGitWorktree() ?? existingMeta.worktreePath,
+      acceptedManagedEnv: consentNow || existingMeta.acceptedManagedEnv === true,
+      lastUsedAt: now,
+    };
+  }
+  return {
+    version: SIDECAR_VERSION,
+    name,
+    portSlot: slot,
+    branch: getCurrentGitBranch(),
+    worktreePath: getCurrentGitWorktree(),
+    acceptedManagedEnv: consentNow,
+    createdAt: now,
+    lastUsedAt: now,
+  };
+}
+
+export async function prepareInstance(opts: PrepareInstanceOptions): Promise<InstanceRuntime> {
+  const name = sanitizeName(opts.name);
+  const dir = resolveInstanceDir(name);
+  const slot = await allocatePortSlot(name, opts.slotHint);
+  const ports = portsForSlot(slot);
+
+  await refuseIfSlotLive(name, slot);
+
+  const desiredEnv = computeDesiredManagedEnv(name, slot, ports, opts.useProxy);
+  const envBefore = loadEnvFile(opts.envFile);
+  const existingMeta = readMetadata(dir);
+  const alreadyConsented = existingMeta?.acceptedManagedEnv === true;
+  const divergingKeys = envKeysDiverge(envBefore, desiredEnv);
+  if (divergingKeys.length > 0 && !alreadyConsented && !opts.acceptManagedEnv) {
+    refuseOnEnvDivergence({ name, slot, ports }, opts.envFile, divergingKeys, envBefore, desiredEnv);
+  }
+
+  ensureInstanceData(name, dir, opts.seed, opts.includeBackups === true);
+  writeEnvFile(opts.envFile, desiredEnv, { managed: MANAGED_ENV_KEYS });
+
+  const meta = buildMeta(name, slot, existingMeta, alreadyConsented || opts.acceptManagedEnv || divergingKeys.length === 0);
+  writeMetadata(dir, meta);
+
+  return { name, slot, dir, ports, meta };
+}

--- a/frontend/scripts/dev-instance/lifecycle.ts
+++ b/frontend/scripts/dev-instance/lifecycle.ts
@@ -1,0 +1,284 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { confirm, isCancel } from '@clack/prompts';
+import consola from 'consola';
+import { clearManagedEnvBlock, readManagedInstanceName } from './env-file';
+import { formatHostPort, formatTable, humanBytes } from './format';
+import { dirSizeBytes } from './fs-walk';
+import { liveWorktreePaths } from './git';
+import { resolveInstanceDir, resolveInstanceParent, sanitizeName } from './paths';
+import { probePortsLive } from './port-probe';
+import { readPortIndex, releasePortSlot, writePortIndex } from './port-registry';
+import { type InstanceMeta, readMetadata } from './sidecar';
+
+const logger = consola.withTag('dev-instance:lifecycle');
+
+export interface InstanceSummary {
+  name: string;
+  dir: string;
+  meta: InstanceMeta | null;
+  sizeBytes: number;
+  worktreeExists: boolean;
+  live: boolean;
+}
+
+export async function listInstances(): Promise<InstanceSummary[]> {
+  const parent = resolveInstanceParent();
+  if (!fs.existsSync(parent)) {
+    return [];
+  }
+  const worktrees = liveWorktreePaths();
+  const dirEntries = fs.readdirSync(parent, { withFileTypes: true }).filter(e => e.isDirectory());
+  const summaries = await Promise.all(dirEntries.map(async (entry) => {
+    const dir = path.join(parent, entry.name);
+    const meta = readMetadata(dir);
+    const live = meta ? (await probePortsLive(meta.portSlot)).length > 0 : false;
+    return {
+      name: meta?.name ?? entry.name,
+      dir,
+      meta,
+      sizeBytes: dirSizeBytes(dir),
+      worktreeExists: meta?.worktreePath ? worktrees.has(meta.worktreePath) : false,
+      live,
+    } satisfies InstanceSummary;
+  }));
+  summaries.sort((a, b) => {
+    const aTs = a.meta?.lastUsedAt ?? '';
+    const bTs = b.meta?.lastUsedAt ?? '';
+    return bTs.localeCompare(aTs);
+  });
+  return summaries;
+}
+
+function formatWorktreeStatus(s: InstanceSummary): string {
+  if (!s.meta?.worktreePath)
+    return '-';
+  return s.worktreeExists ? 'yes' : 'missing';
+}
+
+export async function printInstanceList(): Promise<void> {
+  const summaries = await listInstances();
+  if (summaries.length === 0) {
+    logger.info(`No instances under ${resolveInstanceParent()}`);
+    return;
+  }
+  const header = ['NAME', 'BRANCH', 'WORKTREE', 'SLOT', 'SIZE', 'LAST USED', 'LIVE'];
+  const rows: string[][] = [header];
+  for (const s of summaries) {
+    rows.push([
+      s.name,
+      s.meta?.branch ?? '-',
+      formatWorktreeStatus(s),
+      s.meta?.portSlot !== undefined ? String(s.meta.portSlot) : '?',
+      humanBytes(s.sizeBytes),
+      s.meta?.lastUsedAt ? s.meta.lastUsedAt.replace('T', ' ').slice(0, 19) : '-',
+      s.live ? 'yes' : 'no',
+    ]);
+  }
+  console.log(formatTable(rows));
+}
+
+/**
+ * If `envFile` is provided and its managed block names `instanceName`, strip
+ * the block. This keeps stale `VITE_BACKEND_URL` / `INSTANCE_NAME` etc. from
+ * pointing at a slot whose data dir we just deleted. We never touch a block
+ * that belongs to a *different* still-live instance.
+ */
+function clearEnvBlockIfOwned(envFile: string | undefined, instanceName: string): void {
+  if (!envFile)
+    return;
+  const owner = readManagedInstanceName(envFile);
+  if (owner === undefined)
+    return;
+  if (sanitizeName(owner) !== sanitizeName(instanceName))
+    return;
+  clearManagedEnvBlock(envFile);
+  logger.info(`Cleared managed env block for "${instanceName}" from ${envFile}`);
+}
+
+export async function refuseIfLive(name: string, slot: number): Promise<boolean> {
+  const live = await probePortsLive(slot);
+  if (live.length === 0) {
+    return false;
+  }
+  const lines = [
+    `Instance "${name}" is live on slot ${slot}:`,
+    ...live.map((entry) => {
+      const pid = entry.pid !== undefined ? ` (PID ${entry.pid})` : '';
+      return `  ${entry.name.padEnd(8)} ${formatHostPort('localhost', entry.port)}${pid}`;
+    }),
+    'Stop the running instance before continuing.',
+  ];
+  logger.error(lines.join('\n'));
+  return true;
+}
+
+export async function cleanInstance(name: string, opts: { yes?: boolean; envFile?: string } = {}): Promise<void> {
+  const sanitized = sanitizeName(name);
+  const dir = resolveInstanceDir(sanitized);
+  if (!fs.existsSync(dir)) {
+    logger.warn(`Instance "${sanitized}" does not exist at ${dir}`);
+    await releasePortSlot(sanitized);
+    clearEnvBlockIfOwned(opts.envFile, sanitized);
+    return;
+  }
+  const meta = readMetadata(dir);
+  const slot = meta?.portSlot ?? readPortIndex().slots[sanitized];
+  if (slot !== undefined && await refuseIfLive(sanitized, slot)) {
+    process.exitCode = 1;
+    return;
+  }
+  if (!opts.yes) {
+    const answer = await confirm({ message: `Delete instance "${sanitized}" at ${dir}?`, initialValue: false });
+    if (isCancel(answer) || !answer) {
+      logger.info('Aborted.');
+      return;
+    }
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+  await releasePortSlot(sanitized);
+  clearEnvBlockIfOwned(opts.envFile, sanitized);
+  logger.success(`Removed instance "${sanitized}"`);
+}
+
+async function removeSummary(s: InstanceSummary, envFile?: string): Promise<void> {
+  if (s.meta?.portSlot !== undefined && await refuseIfLive(s.name, s.meta.portSlot)) {
+    logger.error(`Skipping "${s.name}" because it is live.`);
+    process.exitCode = 1;
+    return;
+  }
+  fs.rmSync(s.dir, { recursive: true, force: true });
+  await releasePortSlot(s.name);
+  clearEnvBlockIfOwned(envFile, s.name);
+  logger.success(`Removed "${s.name}"`);
+}
+
+async function confirmedYes(message: string): Promise<boolean> {
+  const answer = await confirm({ message, initialValue: false });
+  return !isCancel(answer) && answer === true;
+}
+
+function describeCleanAllPlan(parent: string, summaries: InstanceSummary[]): void {
+  const instanceCount = summaries.filter(s => s.meta).length;
+  const orphanCount = summaries.length - instanceCount;
+  const headline = orphanCount > 0
+    ? `About to remove ${instanceCount} instance(s) + ${orphanCount} orphan dir(s) under: ${parent}`
+    : `About to remove ${instanceCount} instance(s) under: ${parent}`;
+  logger.warn(headline);
+  for (const s of summaries) {
+    const label = s.meta ? 'instance' : 'orphan — no sidecar';
+    logger.warn(`  - ${s.name} (${label}) at ${s.dir}`);
+  }
+}
+
+export async function cleanAll(opts: { yes?: boolean; envFile?: string } = {}): Promise<void> {
+  const parent = resolveInstanceParent();
+  const summaries = await listInstances();
+  if (summaries.length === 0) {
+    logger.info(`No instances to clean under ${parent}`);
+    return;
+  }
+  describeCleanAllPlan(parent, summaries);
+  if (!opts.yes) {
+    if (!await confirmedYes(`Remove ALL ${summaries.length} entries?`)) {
+      logger.info('Aborted.');
+      return;
+    }
+    if (!await confirmedYes(`Really delete every directory under ${parent}?`)) {
+      logger.info('Aborted.');
+      return;
+    }
+  }
+  for (const s of summaries) {
+    await removeSummary(s, opts.envFile);
+  }
+}
+
+function parseDuration(raw: string): number {
+  const match = raw.match(/^(\d+)([dhm])$/);
+  if (!match) {
+    throw new Error(`Invalid duration "${raw}", expected formats like 30d, 12h, 45m`);
+  }
+  const value = Number.parseInt(match[1], 10);
+  const unit = match[2];
+  const unitMs: Record<string, number> = { d: 86_400_000, h: 3_600_000, m: 60_000 };
+  return value * unitMs[unit];
+}
+
+function isPruneCandidate(s: InstanceSummary, olderThanMs: number | undefined, now: number): boolean {
+  if (!s.meta)
+    return false;
+  const worktreeGone = !!s.meta.worktreePath && !s.worktreeExists;
+  if (!worktreeGone)
+    return false;
+  if (olderThanMs === undefined)
+    return true;
+  const lastUsed = Date.parse(s.meta.lastUsedAt);
+  return !Number.isFinite(lastUsed) || now - lastUsed >= olderThanMs;
+}
+
+async function executePrune(targets: InstanceSummary[], envFile?: string): Promise<void> {
+  for (const t of targets) {
+    if (t.meta && await refuseIfLive(t.name, t.meta.portSlot)) {
+      logger.error(`Skipping "${t.name}" because it is live.`);
+      process.exitCode = 1;
+      continue;
+    }
+    fs.rmSync(t.dir, { recursive: true, force: true });
+    await releasePortSlot(t.name);
+    clearEnvBlockIfOwned(envFile, t.name);
+    logger.success(`Pruned "${t.name}"`);
+  }
+}
+
+export async function pruneInstances(opts: { yes?: boolean; olderThan?: string; envFile?: string } = {}): Promise<void> {
+  const olderThanMs = opts.olderThan ? parseDuration(opts.olderThan) : undefined;
+  const now = Date.now();
+  const summaries = await listInstances();
+  const targets = summaries.filter(s => isPruneCandidate(s, olderThanMs, now));
+  if (targets.length === 0) {
+    logger.info('No prune candidates found.');
+    return;
+  }
+  logger.info(`${opts.yes ? 'Pruning' : 'Would prune'} ${targets.length} instance(s):`);
+  for (const t of targets) {
+    logger.info(`  - ${t.name} (worktree ${t.meta?.worktreePath ?? '?'}, lastUsed ${t.meta?.lastUsedAt})`);
+  }
+  if (!opts.yes) {
+    logger.info('Re-run with --yes to delete.');
+    return;
+  }
+  await executePrune(targets, opts.envFile);
+}
+
+export async function repairRegistry(opts: { yes?: boolean } = {}): Promise<void> {
+  const summaries = await listInstances();
+  const rebuilt: Record<string, number> = {};
+  for (const s of summaries) {
+    if (s.meta) {
+      rebuilt[sanitizeName(s.meta.name)] = s.meta.portSlot;
+    }
+  }
+  const current = readPortIndex();
+  const stableStringify = (obj: Record<string, number>): string => {
+    const sorted: Record<string, number> = {};
+    for (const k of Object.keys(obj).sort()) sorted[k] = obj[k];
+    return JSON.stringify(sorted, null, 2);
+  };
+  const before = stableStringify(current.slots);
+  const after = stableStringify(rebuilt);
+  if (before === after) {
+    logger.info('Port index already matches sidecars. Nothing to do.');
+    return;
+  }
+  logger.info('Port-index diff:');
+  logger.info(`  before: ${before}`);
+  logger.info(`  after:  ${after}`);
+  if (!opts.yes) {
+    logger.info('Re-run with --yes to write.');
+    return;
+  }
+  writePortIndex({ version: 1, slots: rebuilt });
+  logger.success('Port index rebuilt from sidecars.');
+}

--- a/frontend/scripts/dev-instance/paths.ts
+++ b/frontend/scripts/dev-instance/paths.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+const APP_NAME = 'rotki';
+const PROD_DATA_SUBDIR = 'data';
+const DEV_PARENT_NAME = 'rotki-dev';
+
+export function sanitizeName(raw: string): string {
+  const trimmed = raw.trim().toLowerCase();
+  const sanitized = trimmed.replace(/[^\d._a-z-]+/g, '-').replace(/^-+|-+$/g, '');
+  if (!sanitized) {
+    throw new Error(`Instance name "${raw}" sanitizes to an empty string`);
+  }
+  if (sanitized.length > 64) {
+    return sanitized.slice(0, 64);
+  }
+  return sanitized;
+}
+
+export function baseDataDir(): string {
+  const platform = os.platform();
+  const home = os.homedir();
+  if (platform === 'win32') {
+    return process.env.LOCALAPPDATA ?? path.join(home, 'AppData', 'Local');
+  }
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support');
+  }
+  return process.env.XDG_DATA_HOME ?? path.join(home, '.local', 'share');
+}
+
+/**
+ * Resolves the prod rotki user-data dir (the `--data-dir` rotkehlchen expects).
+ *
+ * Layout on a typical install is `<XDG_DATA_HOME>/rotki/data/` (with `users/`,
+ * `globaldb.sqlite`, etc. inside). The outer `<XDG_DATA_HOME>/rotki/` dir also
+ * holds electron cache/logs/develop_data which we do NOT want to seed from.
+ *
+ * `ROTKI_SEED_SOURCE` overrides this — point it at any directory you want to
+ * use as the seed (e.g. `<XDG_DATA_HOME>/rotki/develop_data` to clone the
+ * existing dev mirror instead of prod data).
+ */
+export function resolveSeedSource(): string | null {
+  const override = process.env.ROTKI_SEED_SOURCE;
+  if (override) {
+    return fs.existsSync(override) ? override : null;
+  }
+  const candidate = path.join(baseDataDir(), APP_NAME, PROD_DATA_SUBDIR);
+  return fs.existsSync(candidate) ? candidate : null;
+}
+
+export function resolveInstanceParent(): string {
+  const override = process.env.ROTKI_DEV_INSTANCES_DIR;
+  if (override) {
+    return override;
+  }
+  return path.join(baseDataDir(), DEV_PARENT_NAME);
+}
+
+export function resolveInstanceDir(name: string): string {
+  return path.join(resolveInstanceParent(), sanitizeName(name));
+}
+
+export function ensureInstanceParent(): string {
+  const parent = resolveInstanceParent();
+  fs.mkdirSync(parent, { recursive: true });
+  return parent;
+}

--- a/frontend/scripts/dev-instance/port-probe.ts
+++ b/frontend/scripts/dev-instance/port-probe.ts
@@ -1,0 +1,67 @@
+import { execSync } from 'node:child_process';
+import net from 'node:net';
+import os from 'node:os';
+import { MAX_PORT, type PortName, portsForSlot } from './port-registry';
+
+async function isPortListening(port: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const socket = new net.Socket();
+    const finalize = (listening: boolean): void => {
+      socket.destroy();
+      resolve(listening);
+    };
+    socket.setTimeout(200);
+    socket.once('connect', () => finalize(true));
+    socket.once('timeout', () => finalize(false));
+    socket.once('error', () => finalize(false));
+    socket.connect(port, '127.0.0.1');
+  });
+}
+
+function runPidProbe(cmd: string, args: string[], pattern: RegExp): number | undefined {
+  try {
+    const out = execSync([cmd, ...args].join(' '), { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+    const match = out.match(pattern);
+    return match ? Number.parseInt(match[1], 10) : undefined;
+  }
+  catch {
+    return undefined;
+  }
+}
+
+function pidForPort(port: number): number | undefined {
+  if (!Number.isInteger(port) || port <= 0 || port > MAX_PORT) {
+    return undefined;
+  }
+  const platform = os.platform();
+  if (platform === 'linux') {
+    return runPidProbe('ss', ['-lntpH', `'sport = :${port}'`], /pid=(\d+)/);
+  }
+  if (platform === 'darwin') {
+    return runPidProbe('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-Fp'], /^p(\d+)/m);
+  }
+  if (platform === 'win32') {
+    return runPidProbe('netstat', ['-ano', '-p', 'TCP'], new RegExp(`\\s127\\.0\\.0\\.1:${port}\\s.*LISTENING\\s+(\\d+)`));
+  }
+  return undefined;
+}
+
+export interface LiveProbeResult {
+  name: PortName;
+  port: number;
+  pid?: number;
+}
+
+const ALL_PORT_NAMES: readonly PortName[] = ['restApi', 'proxy', 'colibri', 'dev'];
+
+export async function probePortsLive(slot: number): Promise<LiveProbeResult[]> {
+  const ports = portsForSlot(slot);
+  const results: LiveProbeResult[] = [];
+  for (const name of ALL_PORT_NAMES) {
+    const port = ports[name];
+    if (await isPortListening(port)) {
+      results.push({ name, port, pid: pidForPort(port) });
+    }
+  }
+  return results;
+}

--- a/frontend/scripts/dev-instance/port-registry.ts
+++ b/frontend/scripts/dev-instance/port-registry.ts
@@ -1,0 +1,251 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import consola from 'consola';
+import { z } from 'zod/v4';
+import { errorCode, errorMessage } from './format';
+import { ensureInstanceParent, resolveInstanceParent, sanitizeName } from './paths';
+
+export const DEFAULT_PORTS = {
+  restApi: 4242,
+  proxy: 4243,
+  colibri: 4343,
+  dev: 8080,
+} as const;
+
+export type PortName = keyof typeof DEFAULT_PORTS;
+
+/** Highest valid TCP port (IANA, 16-bit unsigned). */
+export const MAX_PORT = 65_535;
+
+/**
+ * Instance slots ≥ 1 are packed into a tight contiguous block starting here.
+ * Picked because:
+ *   - it is above Chromium's last restricted port (10080 = amanda); the old
+ *     layout (defaults + slot*200) put slot 10's dev port on 10080, which
+ *     Chrome/Vivaldi refuse to load.
+ *   - it is far below the e2e fixed ports (30301–30304 in playwright.config.ts).
+ *   - it is well inside the user range (1024–49151), nowhere near ephemeral.
+ */
+export const INSTANCE_BASE_PORT = 13_000;
+
+/**
+ * Each slot owns 4 contiguous ports (backend, proxy, colibri, dev). A step of
+ * 10 leaves 6 ports of slack between neighbours so TIME_WAIT sockets from one
+ * slot can't bleed into the next. With the 1000-slot cap below, the highest
+ * port we'd ever pick is 13_000 + 999*10 + 3 = 22_993.
+ */
+export const INSTANCE_SLOT_STEP = 10;
+
+/** First slot index handed out by the allocator. Slot 0 = `DEFAULT_PORTS`,
+ *  reserved for the non-instance ("plain `pnpm dev`") case. */
+export const RESERVED_SLOTS_END = 1;
+
+const NODE_INSPECT_PORT = 9229;
+const PORT_INDEX_FILENAME = '.port-index.json';
+
+/**
+ * Ports we must never allocate to a dev instance, even if the math lands on
+ * them. Currently:
+ *   - 9229: default node --inspect port; a slot landing here breaks debugger
+ *     attach.
+ *   - 30301–30304: hard-coded e2e ports (playwright.config.ts). Running an
+ *     instance on one of these would clash with a Playwright run.
+ */
+const RESERVED_PORTS = new Set<number>([NODE_INSPECT_PORT, 30_301, 30_302, 30_303, 30_304]);
+
+export interface PortSet {
+  restApi: number;
+  proxy: number;
+  colibri: number;
+  dev: number;
+}
+
+const PortIndexSchema = z.object({
+  version: z.number().default(1),
+  slots: z.record(z.string(), z.number()).default({}),
+});
+
+export type PortIndex = z.infer<typeof PortIndexSchema>;
+
+const logger = consola.withTag('dev-instance:port-registry');
+
+export function portsForSlot(slot: number): PortSet {
+  if (slot === 0) {
+    return { ...DEFAULT_PORTS };
+  }
+  // Layout within a slot's block: dev sits on the base port so the URL you
+  // open in the browser is the "round" number (e.g. 13000), and the three
+  // backend services follow in order python → proxy → colibri.
+  const base = INSTANCE_BASE_PORT + (slot - 1) * INSTANCE_SLOT_STEP;
+  return {
+    dev: base,
+    restApi: base + 1,
+    proxy: base + 2,
+    colibri: base + 3,
+  };
+}
+
+function slotHasReservedConflict(slot: number): boolean {
+  if (slot < 1)
+    return true; // slot 0 belongs to the default (non-instance) mode
+  const ports = portsForSlot(slot);
+  return Object.values(ports).some(p => p > MAX_PORT || RESERVED_PORTS.has(p));
+}
+
+export function readPortIndex(): PortIndex {
+  const file = path.join(resolveInstanceParent(), PORT_INDEX_FILENAME);
+  if (!fs.existsSync(file)) {
+    return { version: 1, slots: {} };
+  }
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const result = PortIndexSchema.safeParse(parsed);
+    if (!result.success) {
+      logger.warn(`Port index at ${file} has unexpected shape, ignoring: ${result.error.message}`);
+      return { version: 1, slots: {} };
+    }
+    return result.data;
+  }
+  catch (error) {
+    logger.warn(`Failed to read port index at ${file}: ${errorMessage(error)}`);
+    return { version: 1, slots: {} };
+  }
+}
+
+export function atomicWriteJson(file: string, value: unknown): void {
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+  fs.renameSync(tmp, file);
+}
+
+export function writePortIndex(index: PortIndex): void {
+  ensureInstanceParent();
+  atomicWriteJson(path.join(resolveInstanceParent(), PORT_INDEX_FILENAME), index);
+}
+
+const LOCK_DIR_NAME = '.port-index.lock';
+const LOCK_STALE_MS = 10_000;
+const LOCK_POLL_MS = 50;
+const LOCK_MAX_WAIT_MS = 5_000;
+
+export async function withRegistryLock<T>(fn: () => Promise<T> | T): Promise<T> {
+  ensureInstanceParent();
+  const lockDir = path.join(resolveInstanceParent(), LOCK_DIR_NAME);
+  const start = Date.now();
+  while (true) {
+    try {
+      fs.mkdirSync(lockDir);
+      break;
+    }
+    catch (error) {
+      if (errorCode(error) !== 'EEXIST') {
+        throw error;
+      }
+      try {
+        const age = Date.now() - fs.statSync(lockDir).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          logger.warn(`Removing stale port-index lock (${age}ms old)`);
+          fs.rmSync(lockDir, { recursive: true, force: true });
+          continue;
+        }
+      }
+      catch {
+        continue;
+      }
+      if (Date.now() - start > LOCK_MAX_WAIT_MS) {
+        throw new Error(`Timed out waiting for port-index lock at ${lockDir}`);
+      }
+      await new Promise(resolve => setTimeout(resolve, LOCK_POLL_MS));
+    }
+  }
+  try {
+    return await fn();
+  }
+  finally {
+    try {
+      fs.rmSync(lockDir, { recursive: true, force: true });
+    }
+    catch {
+      // best-effort
+    }
+  }
+}
+
+/**
+ * Thrown by `allocatePortSlot` for conditions a developer can resolve (slot
+ * conflicts, exhausted range). The CLI catches these and prints `.message`
+ * without a stack trace.
+ */
+export class PortSlotAllocationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PortSlotAllocationError';
+  }
+}
+
+function isSlotInUse(index: PortIndex, slot: number, exceptName?: string): boolean {
+  for (const [name, s] of Object.entries(index.slots)) {
+    if (s === slot && name !== exceptName) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function allocatePortSlot(name: string, hint?: number): Promise<number> {
+  const sanitized = sanitizeName(name);
+  return withRegistryLock(() => {
+    const index = readPortIndex();
+
+    if (hint !== undefined) {
+      if (slotHasReservedConflict(hint)) {
+        throw new PortSlotAllocationError(
+          `Port slot ${hint} resolves to a reserved port (node --inspect on ${NODE_INSPECT_PORT}, the e2e ports 30301–30304) or exceeds the max TCP port.\n`
+          + `  Pick a different slot (1 or higher) or unset INSTANCE_PORT_SLOT.`,
+        );
+      }
+      if (isSlotInUse(index, hint, sanitized)) {
+        const owner = Object.entries(index.slots).find(([n, s]) => s === hint && n !== sanitized)?.[0];
+        throw new PortSlotAllocationError(
+          `Port slot ${hint} is already owned by instance "${owner}", not "${sanitized}".\n`
+          + `  To resolve, pick ONE:\n`
+          + `    --clean ${owner}              free the slot by removing that instance\n`
+          + `    INSTANCE_PORT_SLOT=<other>    pick a different slot\n`
+          + `    unset INSTANCE_PORT_SLOT      let dev:web allocate a fresh slot for "${sanitized}"`,
+        );
+      }
+      index.slots[sanitized] = hint;
+      writePortIndex(index);
+      return hint;
+    }
+
+    const existing = index.slots[sanitized];
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    let slot = RESERVED_SLOTS_END;
+    while (isSlotInUse(index, slot) || slotHasReservedConflict(slot)) {
+      slot += 1;
+      if (slot > 1000) {
+        throw new PortSlotAllocationError('Unable to allocate a free port slot (exhausted search space).');
+      }
+    }
+    index.slots[sanitized] = slot;
+    writePortIndex(index);
+    return slot;
+  });
+}
+
+export async function releasePortSlot(name: string): Promise<void> {
+  const sanitized = sanitizeName(name);
+  await withRegistryLock(() => {
+    const index = readPortIndex();
+    if (!(sanitized in index.slots)) {
+      return;
+    }
+    delete index.slots[sanitized];
+    writePortIndex(index);
+  });
+}

--- a/frontend/scripts/dev-instance/sidecar.ts
+++ b/frontend/scripts/dev-instance/sidecar.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import consola from 'consola';
+import { z } from 'zod/v4';
+import { errorMessage } from './format';
+import { atomicWriteJson } from './port-registry';
+
+const SIDECAR_FILENAME = '.rotki-instance.json';
+
+export const SIDECAR_VERSION = 1;
+
+const logger = consola.withTag('dev-instance:sidecar');
+
+const InstanceMetaSchema = z.object({
+  version: z.number(),
+  name: z.string(),
+  portSlot: z.number(),
+  branch: z.string().optional(),
+  worktreePath: z.string().optional(),
+  acceptedManagedEnv: z.boolean().optional(),
+  createdAt: z.string().optional(),
+  lastUsedAt: z.string().optional(),
+});
+
+type ParsedSidecar = z.infer<typeof InstanceMetaSchema>;
+
+export interface InstanceMeta {
+  version: number;
+  name: string;
+  branch?: string;
+  worktreePath?: string;
+  portSlot: number;
+  acceptedManagedEnv?: boolean;
+  createdAt: string;
+  lastUsedAt: string;
+}
+
+function metaPath(dir: string): string {
+  return path.join(dir, SIDECAR_FILENAME);
+}
+
+function applyMetaDefaults(parsed: ParsedSidecar): InstanceMeta {
+  const now = new Date().toISOString();
+  return {
+    version: SIDECAR_VERSION,
+    name: parsed.name,
+    portSlot: parsed.portSlot,
+    branch: parsed.branch,
+    worktreePath: parsed.worktreePath,
+    acceptedManagedEnv: parsed.acceptedManagedEnv,
+    createdAt: parsed.createdAt ?? now,
+    lastUsedAt: parsed.lastUsedAt ?? parsed.createdAt ?? now,
+  };
+}
+
+export function readMetadata(dir: string): InstanceMeta | null {
+  const file = metaPath(dir);
+  if (!fs.existsSync(file))
+    return null;
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const result = InstanceMetaSchema.safeParse(parsed);
+    if (!result.success) {
+      logger.warn(`Sidecar at ${file} missing required fields, skipping: ${result.error.message}`);
+      return null;
+    }
+    if (result.data.version !== SIDECAR_VERSION) {
+      logger.warn(
+        `Sidecar at ${file} has version ${result.data.version}, expected ${SIDECAR_VERSION}; `
+        + `skipping (add a migrator before bumping SIDECAR_VERSION).`,
+      );
+      return null;
+    }
+    return applyMetaDefaults(result.data);
+  }
+  catch (error) {
+    logger.warn(`Failed to read sidecar ${file}: ${errorMessage(error)}`);
+    return null;
+  }
+}
+
+export function writeMetadata(dir: string, meta: InstanceMeta): void {
+  fs.mkdirSync(dir, { recursive: true });
+  atomicWriteJson(metaPath(dir), meta);
+}
+
+export function touchLastUsed(dir: string): void {
+  const meta = readMetadata(dir);
+  if (!meta) {
+    return;
+  }
+  meta.lastUsedAt = new Date().toISOString();
+  writeMetadata(dir, meta);
+}

--- a/frontend/scripts/dev/prerequisites.ts
+++ b/frontend/scripts/dev/prerequisites.ts
@@ -1,0 +1,98 @@
+import { execSync } from 'node:child_process';
+import net from 'node:net';
+import process from 'node:process';
+import consola from 'consola';
+import { MAX_PORT } from '../dev-instance';
+
+const logger = consola.withTag('dev:prerequisites');
+
+let useUvForPython = false;
+
+export function isUsingUvForPython(): boolean {
+  return useUvForPython;
+}
+
+function checkForCargo(): boolean {
+  try {
+    const cargoVersion = execSync('cargo --version', { encoding: 'utf-8' });
+    logger.info(`detected cargo: ${cargoVersion.trim()}`);
+    return /cargo\s\d+\.\d+\.\d+/.test(cargoVersion);
+  }
+  catch {
+    return false;
+  }
+}
+
+function checkForUv(): boolean {
+  try {
+    const uvVersion = execSync('uv --version', { encoding: 'utf-8' });
+    logger.info(`detected uv: ${uvVersion.trim()}`);
+    return true;
+  }
+  catch {
+    return false;
+  }
+}
+
+export function ensurePrerequisites(): void {
+  if (!process.env.VIRTUAL_ENV) {
+    if (checkForUv()) {
+      useUvForPython = true;
+      logger.info('No python virtualenv active; invoking the backend via `uv run`.');
+    }
+    else {
+      logger.error(
+        'No python virtualenv active and `uv` is not on PATH.\n'
+        + 'Activate a venv (e.g. `source .venv/bin/activate`) or install uv (https://docs.astral.sh/uv/).',
+      );
+      process.exit(1);
+    }
+  }
+
+  if (!checkForCargo()) {
+    logger.error('Cargo is not available — install the Rust toolchain via https://rustup.rs/ and re-run.');
+    process.exit(1);
+  }
+}
+
+export function parsePort(raw: string | undefined, defaultValue: number): number {
+  if (!raw)
+    return defaultValue;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0 || n > MAX_PORT)
+    return defaultValue;
+  return n;
+}
+
+export function getDebuggerPort(): number | null {
+  const raw = process.env.DEBUGGER_PORT;
+  if (!raw)
+    return null;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 && n <= MAX_PORT ? n : null;
+}
+
+async function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise<boolean>((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.once('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EADDRINUSE' || err.code === 'EACCES')
+        resolve(false);
+      else
+        reject(err);
+    });
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+export async function selectPort(startPort: number): Promise<number> {
+  for (let port = startPort; port <= MAX_PORT; port++) {
+    if (await isPortAvailable(port))
+      return port;
+  }
+  throw new Error('no free ports found');
+}

--- a/frontend/scripts/dev/process-pool.ts
+++ b/frontend/scripts/dev/process-pool.ts
@@ -1,0 +1,199 @@
+import type { Buffer } from 'node:buffer';
+import { type ChildProcess, spawn, spawnSync } from 'node:child_process';
+import process from 'node:process';
+import consola from 'consola';
+import { errorCode, errorMessage } from '../dev-instance/format';
+
+const isWindows = process.platform === 'win32';
+
+interface OutputListener {
+  out: (buffer: Buffer) => void;
+  err: (buffer: Buffer) => void;
+}
+
+interface TrackedProcess {
+  child: ChildProcess;
+  name: string;
+  listeners: OutputListener;
+}
+
+const SHUTDOWN_GRACE_MS = 5_000;
+
+const logger = consola.withTag('dev:process-pool');
+const tracked: TrackedProcess[] = [];
+
+export interface SpawnOpts {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * Quotes a single argument so the shell (`shell: true` mode of spawn) treats
+ * it as a single token. Without this, an arg like `--data-dir=/Users/jo/My
+ * Project/data` gets re-split by /bin/sh on whitespace and the child sees
+ * two broken args. Used for every arg we pass through process-pool because
+ * we don't control whether the data-dir / log-path contains spaces.
+ */
+function shellQuoteArg(arg: string): string {
+  if (arg === '')
+    return '""';
+  // Conservative allowlist of shell-safe chars — anything outside gets quoted.
+  if (/^[\w%+,./:=@-]+$/.test(arg))
+    return arg;
+  if (process.platform === 'win32') {
+    // cmd.exe: double-quote, escape inner double quotes by doubling.
+    return `"${arg.replace(/"/g, '""')}"`;
+  }
+  // POSIX sh: single quotes preserve literally; escape any single-quote
+  // inside by closing, inserting an escaped quote, and reopening.
+  return `'${arg.replace(/'/g, '\'\\\'\'')}'`;
+}
+
+export function startProcess(cmd: string, tag: string, name: string, args: string[] = [], opts: SpawnOpts = {}): ChildProcess {
+  const childLogger = consola.withTag(tag);
+  const listeners: OutputListener = {
+    out: (buffer: Buffer): void => {
+      childLogger.log(buffer.toString().replace(/\n$/, ''));
+    },
+    err: (buffer: Buffer): void => {
+      childLogger.log(buffer.toString().replace(/\n$/, ''));
+    },
+  };
+
+  const env: NodeJS.ProcessEnv = {
+    FORCE_COLOR: '1',
+    ...process.env,
+    NODE_ENV: 'development',
+    ...(opts.env ?? {}),
+  };
+
+  // Node 24 deprecates passing `args` together with `shell: true` (DEP0190),
+  // so we hand-build the full command string ourselves with each arg shell-
+  // quoted. Functionally identical to spawn(cmd, args, {shell:true}) — the
+  // shell concatenates them the same way — but the deprecation no longer fires.
+  const fullCmd = args.length === 0
+    ? cmd
+    : `${cmd} ${args.map(shellQuoteArg).join(' ')}`;
+  const child = spawn(fullCmd, {
+    cwd: opts.cwd,
+    shell: true,
+    stdio: [process.stdin, 'pipe', 'pipe'],
+    env,
+    // POSIX: each child becomes its own process-group leader so a kill on
+    // `-pid` reaches the whole tree (e.g. `cargo run` → colibri binary,
+    // `pnpm run … serve` → vite). Without this, shell:true means SIGTERM
+    // only kills the shell and the real worker leaks.
+    //
+    // Windows: detached:true with shell:true spawns a new console window
+    // for every child, and POSIX process groups don't exist anyway — we
+    // tree-kill via `taskkill /T /F` in `killGroup`. windowsHide keeps the
+    // cmd.exe wrapper from flashing a console.
+    detached: !isWindows,
+    windowsHide: isWindows,
+  });
+
+  child.stdout?.on('data', listeners.out);
+  child.stderr?.on('data', listeners.err);
+  tracked.push({ child, name, listeners });
+  return child;
+}
+
+function killGroup(pid: number, signal: NodeJS.Signals): void {
+  if (isWindows) {
+    // No POSIX process groups on Windows. `taskkill /T` walks the child
+    // tree via the job/parent-pid table — this is the only reliable way
+    // to reach cargo's spawned colibri.exe or pnpm's node workers.
+    // `/F` is required because SIGINT/SIGTERM aren't deliverable to a
+    // process that isn't sharing our console (cmd.exe shell wrappers).
+    spawnSync('taskkill', ['/pid', String(pid), '/T', '/F'], { windowsHide: true });
+    return;
+  }
+  try {
+    process.kill(-pid, signal);
+  }
+  catch (error) {
+    const code = errorCode(error);
+    if (code === 'ESRCH')
+      return; // already gone
+    // EPERM or anything else: fall through to direct pid as a fallback.
+    try {
+      process.kill(pid, signal);
+    }
+    catch {
+      // best-effort
+    }
+  }
+}
+
+function hasExited(child: ChildProcess): boolean {
+  return child.killed || child.exitCode !== null;
+}
+
+function softKill(entry: TrackedProcess): boolean {
+  const { child, name, listeners } = entry;
+  if (hasExited(child))
+    return false;
+  const pid = child.pid;
+  if (pid === undefined)
+    return false;
+  logger.info(`terminating process: ${name} (${pid})`);
+  child.stdout?.off('data', listeners.out);
+  child.stderr?.off('data', listeners.err);
+  // SIGINT, not SIGTERM: detached:true puts each child in its own process
+  // group, so the terminal's Ctrl+C never reaches them. Electron, vite and
+  // cargo all install graceful SIGINT handlers (they expect Ctrl+C) but
+  // electron's main process does not treat SIGTERM the same way and hangs
+  // on shutdown. Match the Ctrl+C semantics they expect.
+  killGroup(pid, 'SIGINT');
+  return true;
+}
+
+async function waitForExit(survivors: TrackedProcess[], deadline: number): Promise<void> {
+  while (Date.now() < deadline) {
+    if (survivors.every(s => hasExited(s.child)))
+      return;
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+function escalateSurvivors(survivors: TrackedProcess[]): void {
+  for (const { child, name } of survivors) {
+    if (hasExited(child))
+      continue;
+    const pid = child.pid;
+    if (pid === undefined)
+      continue;
+    logger.warn(`escalating SIGKILL to ${name} (${pid}) after ${SHUTDOWN_GRACE_MS}ms grace`);
+    killGroup(pid, 'SIGKILL');
+  }
+}
+
+export async function terminateSubprocesses(): Promise<void> {
+  const survivors: TrackedProcess[] = [];
+  while (tracked.length > 0) {
+    const entry = tracked.pop();
+    if (entry && softKill(entry))
+      survivors.push(entry);
+  }
+  if (survivors.length === 0)
+    return;
+  await waitForExit(survivors, Date.now() + SHUTDOWN_GRACE_MS);
+  escalateSurvivors(survivors);
+}
+
+let shutdownRegistered = false;
+
+export function registerShutdownHandlers(): void {
+  if (shutdownRegistered)
+    return;
+  shutdownRegistered = true;
+  const shutdown = (signal: NodeJS.Signals): void => {
+    logger.info(`received ${signal}, terminating subprocesses`);
+    terminateSubprocesses()
+      .catch(error => logger.error(`shutdown error: ${errorMessage(error)}`))
+      .finally(() => process.exit(0));
+  };
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGHUP', () => shutdown('SIGHUP'));
+}

--- a/frontend/scripts/dev/services.ts
+++ b/frontend/scripts/dev/services.ts
@@ -1,0 +1,414 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import { platform } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import consola from 'consola';
+import { DEFAULT_PORTS, type InstanceRuntime } from '../dev-instance';
+import { formatPort } from '../dev-instance/format';
+import { getDebuggerPort, isUsingUvForPython, selectPort } from './prerequisites';
+import { startProcess } from './process-pool';
+
+const logger = consola.withTag('dev:services');
+
+const colors = {
+  red: (msg: string) => `\u001B[31m${msg}\u001B[0m`,
+  green: (msg: string) => `\u001B[32m${msg}\u001B[0m`,
+  yellow: (msg: string) => `\u001B[33m${msg}\u001B[0m`,
+  magenta: (msg: string) => `\u001B[35m${msg}\u001B[0m`,
+} as const;
+
+const PROXY = 'proxy';
+const ROTKI = 'rotki';
+const BACKEND = 'backend';
+const COLIBRI = 'colibri';
+
+const READINESS_TIMEOUT_MS = 60_000;
+const READINESS_POLL_MS = 250;
+
+const isWindows = platform() === 'win32';
+
+/**
+ * Mirrors `__get_windows_cargo_env` in `package.py`: when colibri builds on
+ * Windows, `rusqlite`'s `bundled-sqlcipher-vendored-openssl` feature compiles
+ * OpenSSL from source, whose Configure script is a Perl script. Git for
+ * Windows ships a mingw64 Perl that mishandles string interpolation in OpenSSL's
+ * Configure (e.g. eats `$M` from `SYS$MANAGER:[OPENSSL]`), making the build
+ * fail with a cryptic `Number found where operator expected` error. Strawberry
+ * Perl handles this correctly, so we prepend it on PATH.
+ *
+ * Important: Windows env is case-insensitive, but Node spawns children with
+ * the literal keys you pass. If we add `PATH` while `process.env` still has
+ * `Path`, the child receives both and which one wins is undefined — the
+ * original Git Perl keeps winning. We must replace the existing key in place
+ * (not add a duplicate-cased one).
+ *
+ * Returns undefined on POSIX, or null on Windows when Strawberry isn't
+ * installed (caller decides whether to warn/abort).
+ */
+function buildColibriEnv(): Record<string, string> | null | undefined {
+  if (!isWindows)
+    return undefined;
+  const strawberryPaths = [
+    'C:\\Strawberry\\perl\\bin',
+    'C:\\Strawberry\\perl\\site\\bin',
+    'C:\\Strawberry\\c\\bin',
+  ];
+  const existing = strawberryPaths.filter(p => fs.existsSync(p));
+  if (existing.length === 0)
+    return null;
+
+  const merged: Record<string, string> = {};
+  let pathKey = 'Path';
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined)
+      continue;
+    if (key.toUpperCase() === 'PATH') {
+      pathKey = key;
+      continue;
+    }
+    merged[key] = value;
+  }
+  const currentPath = process.env.Path ?? process.env.PATH ?? '';
+  const parts = currentPath.split(';').filter(p => p && !existing.includes(p));
+  merged[pathKey] = [...existing, ...parts].join(';');
+  return merged;
+}
+
+export interface BackendEnv {
+  VITE_BACKEND_URL: string;
+  VITE_COLIBRI_URL: string;
+}
+
+export interface BackendSpawnOptions {
+  webPort: number;
+  strictPort: boolean;
+  logDir: string;
+  dataDir?: string;
+  profilingArgs?: string;
+  profilingCmd?: string;
+}
+
+async function startPythonBackend(opts: BackendSpawnOptions): Promise<number> {
+  const chosenPort = opts.strictPort ? opts.webPort : await selectPort(opts.webPort);
+  logger.info(`Starting python backend on port ${formatPort(chosenPort)}`);
+
+  const args = [
+    ...(opts.profilingArgs ? opts.profilingArgs.split(' ') : []),
+    ...(opts.profilingCmd ? ['python'] : []),
+    '-m',
+    'rotkehlchen',
+    '--rest-api-port',
+    chosenPort.toString(),
+    '--api-cors',
+    'http://localhost:*',
+    '--logfile',
+    `${path.join(opts.logDir, 'backend.log')}`,
+    ...(opts.dataDir ? ['--data-dir', opts.dataDir] : []),
+  ];
+
+  // `uv run --locked` honours uv.lock and errors if it's out of date,
+  // matching `cargo run --locked` semantics — no silent dep drift in dev.
+  const defaultPythonCmd = isUsingUvForPython() ? 'uv run --locked python' : 'python';
+  startProcess(opts.profilingCmd ?? defaultPythonCmd, colors.yellow(BACKEND), BACKEND, args, {
+    cwd: path.join('..'),
+  });
+  return chosenPort;
+}
+
+interface ColibriSpawnOptions {
+  colibriPort: number;
+  strictPort: boolean;
+  logDir: string;
+  dataDir?: string;
+}
+
+async function buildColibriEagerly(cwd: string): Promise<void> {
+  // Windows-only: `rusqlite`'s `bundled-sqlcipher-vendored-openssl` feature
+  // compiles OpenSSL from source, which on a cold cache can take several
+  // minutes on Windows — well past the readiness timeout. Run `cargo build`
+  // synchronously first so the user sees the compile progress, and the
+  // subsequent `cargo run` only races the socket bind. Incremental rebuilds
+  // are near-instant, so this is cheap once the cache is warm.
+  logger.info('Pre-building colibri (cargo build --locked) — first build compiles vendored openssl and may take a while');
+  const buildEnv = buildColibriEnv();
+  if (buildEnv === null) {
+    logger.warn(
+      'Strawberry Perl not found at C:\\Strawberry — OpenSSL build will likely fail. '
+      + 'Install Strawberry Perl from https://strawberryperl.com and re-run.',
+    );
+  }
+  else if (buildEnv) {
+    logger.info('Prioritizing Strawberry Perl on PATH for cargo build (vendored openssl)');
+  }
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('cargo', ['build', '--locked'], {
+      cwd,
+      stdio: 'inherit',
+      shell: true,
+      windowsHide: true,
+      env: buildEnv ?? process.env,
+    });
+    child.on('exit', (code) => {
+      if (code === 0)
+        resolve();
+      else
+        reject(new Error(`cargo build --locked exited with code ${code}`));
+    });
+    child.on('error', reject);
+  });
+}
+
+async function startColibriService(opts: ColibriSpawnOptions): Promise<number> {
+  const chosenPort = opts.strictPort ? opts.colibriPort : await selectPort(opts.colibriPort);
+
+  const colibriCwd = path.join('..', 'colibri');
+  if (isWindows)
+    await buildColibriEagerly(colibriCwd);
+
+  logger.info(`Starting colibri on port ${formatPort(chosenPort)}`);
+
+  // `cargo run --locked` rebuilds incrementally on its own; on win32 we
+  // already pre-built above, so this is just a launch.
+  const colibriArgs: string[] = [
+    `--logfile-path=${path.join(opts.logDir, 'colibri.log')}`,
+    `--port=${chosenPort}`,
+    '--api-cors=http://localhost:*',
+    ...(opts.dataDir ? [`--data-directory=${opts.dataDir}`] : []),
+  ];
+
+  startProcess('cargo run --locked -- ', colors.red(COLIBRI), COLIBRI, colibriArgs, {
+    cwd: colibriCwd,
+    env: buildColibriEnv(),
+  });
+  return chosenPort;
+}
+
+export interface BackendServicesOptions {
+  webPort: number;
+  colibriPort: number;
+  strictPort: boolean;
+  dataDir?: string;
+  profilingArgs?: string;
+  profilingCmd?: string;
+}
+
+export async function startBackendServices(opts: BackendServicesOptions): Promise<BackendEnv> {
+  const logDir = path.join(process.cwd(), 'logs');
+  if (!fs.existsSync(logDir))
+    fs.mkdirSync(logDir);
+
+  // python and colibri are independent — start them concurrently so the slower
+  // one (cargo build on first run) overlaps with python's startup.
+  const [restApiPort, colibriHttpPort] = await Promise.all([
+    startPythonBackend({
+      webPort: opts.webPort,
+      strictPort: opts.strictPort,
+      logDir,
+      dataDir: opts.dataDir,
+      profilingArgs: opts.profilingArgs,
+      profilingCmd: opts.profilingCmd,
+    }),
+    startColibriService({
+      colibriPort: opts.colibriPort,
+      strictPort: opts.strictPort,
+      logDir,
+      dataDir: opts.dataDir,
+    }),
+  ]);
+
+  return {
+    VITE_BACKEND_URL: `http://localhost:${restApiPort}`,
+    VITE_COLIBRI_URL: `http://localhost:${colibriHttpPort}`,
+  };
+}
+
+async function waitForHttpReady(
+  label: string,
+  port: number,
+  pathname: string,
+  timeoutMs: number = READINESS_TIMEOUT_MS,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  const url = `http://127.0.0.1:${port}${pathname}`;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+      if (res.ok) {
+        logger.info(`${label} ready on port ${formatPort(port)}`);
+        return true;
+      }
+    }
+    catch {
+      // not yet listening / not yet responding — keep polling
+    }
+    await new Promise(resolve => setTimeout(resolve, READINESS_POLL_MS));
+  }
+  logger.error(`${label} on port ${formatPort(port)} did not respond to ${pathname} within ${timeoutMs}ms`);
+  return false;
+}
+
+export async function waitForBackendReady(port: number, timeoutMs: number = READINESS_TIMEOUT_MS): Promise<boolean> {
+  return waitForHttpReady('backend', port, '/api/1/ping', timeoutMs);
+}
+
+export async function waitForColibriReady(port: number, timeoutMs: number = READINESS_TIMEOUT_MS): Promise<boolean> {
+  return waitForHttpReady('colibri', port, '/health', timeoutMs);
+}
+
+export interface DevServerOptions {
+  noElectron: boolean;
+  devPort?: number;
+  backendEnv?: BackendEnv;
+  onExit?: () => void;
+}
+
+export function startDevServer(opts: DevServerOptions): void {
+  logger.info('Starting rotki dev mode');
+
+  // --remote-debugging-port only does something in electron mode (it forwards
+  // to the spawned electron child via setupMainPackageWatcher). In --web mode
+  // serve.ts ignores it, so don't bother passing it.
+  const debuggerPort = opts.noElectron ? null : getDebuggerPort();
+  const debuggerArgs = debuggerPort ? ` --remote-debugging-port=${debuggerPort}` : '';
+  if (debuggerArgs)
+    logger.info(`starting rotki with args:${debuggerArgs}`);
+
+  const baseServeCmd = opts.noElectron ? 'pnpm run --filter rotki serve' : 'pnpm run --filter rotki electron:serve';
+  // Forward `--port` to the serve script directly — no `--` separator. With
+  // `--` cac inside serve.ts treats following flags as positional and ignores
+  // `--port`, so the dev server keeps listening on its default 8080.
+  const serveCmd = opts.noElectron && opts.devPort !== undefined
+    ? `${baseServeCmd} --port ${opts.devPort}`
+    : baseServeCmd;
+
+  const child = startProcess(`${serveCmd}${debuggerArgs}`, colors.magenta(ROTKI), ROTKI, [], {
+    env: opts.backendEnv ? { ...opts.backendEnv } : undefined,
+  });
+
+  child.on('exit', () => {
+    logger.info('dev rotki process exited');
+    opts.onExit?.();
+  });
+}
+
+export function startDevProxy(env?: Record<string, string>): void {
+  const portInfo = env?.PORT ? ` on port ${formatPort(env.PORT)}` : '';
+  logger.info(`Starting dev-proxy${portInfo}`);
+  startProcess('pnpm run --filter @rotki/dev-proxy serve', colors.green(PROXY), PROXY, [], { env });
+}
+
+export interface DevEnvironmentOptions {
+  webPort: number;
+  colibriPort: number;
+  noElectron: boolean;
+  profilingArgs?: string;
+  profilingCmd?: string;
+  instance: InstanceRuntime | null;
+  /** Whether to spawn the dev-proxy in front of the backend. */
+  useProxy: boolean;
+  onChildExit: () => void;
+}
+
+async function awaitBackendsReady(restApiPort: number | null, colibriPort: number | null): Promise<void> {
+  // Block the dev server on both services being live so Vite doesn't proxy
+  // requests to a backend that hasn't bound its socket yet (manifests as a
+  // burst of ECONNREFUSED on first load). Probes run concurrently — colibri
+  // is usually slower on a cold cargo build than python's import startup.
+  // If either probe times out we abort: the previous "warn and continue"
+  // behaviour produced a dev server pointed at a non-existent backend.
+  const [backendOk, colibriOk] = await Promise.all([
+    restApiPort !== null ? waitForBackendReady(restApiPort) : Promise.resolve(true),
+    colibriPort !== null ? waitForColibriReady(colibriPort) : Promise.resolve(true),
+  ]);
+  if (backendOk && colibriOk)
+    return;
+  const failed = [!backendOk && 'backend', !colibriOk && 'colibri'].filter(Boolean).join(' and ');
+  throw new Error(`${failed} did not become ready — refusing to start the dev server.`);
+}
+
+async function startBackendForMode(
+  instance: InstanceRuntime | null,
+  opts: DevEnvironmentOptions,
+): Promise<{ backendEnv: BackendEnv; devPort: number | undefined }> {
+  const backendEnv = await startBackendServices({
+    webPort: instance ? instance.ports.restApi : opts.webPort,
+    colibriPort: instance ? instance.ports.colibri : opts.colibriPort,
+    strictPort: instance !== null,
+    dataDir: instance?.dir,
+    profilingArgs: opts.profilingArgs,
+    profilingCmd: opts.profilingCmd,
+  });
+
+  const restApiPort = instance?.ports.restApi ?? extractPort(backendEnv.VITE_BACKEND_URL);
+  const colibriPort = instance?.ports.colibri ?? extractPort(backendEnv.VITE_COLIBRI_URL);
+  await awaitBackendsReady(restApiPort, colibriPort);
+  return { backendEnv, devPort: instance?.ports.dev };
+}
+
+function spawnProxyForBackend(instance: InstanceRuntime | null, backendEnv: BackendEnv): void {
+  // Web mode — we know the actual backend port (instance slot or selectPort
+  // drift). Point VITE_BACKEND_URL at the proxy so Vite picks it up.
+  const proxyPort = instance?.ports.proxy ?? DEFAULT_PORTS.proxy;
+  process.env.VITE_BACKEND_URL = `http://127.0.0.1:${proxyPort}`;
+  startDevProxy({ PORT: String(proxyPort), BACKEND: backendEnv.VITE_BACKEND_URL });
+}
+
+function spawnProxyForElectron(): void {
+  // Electron mode — electron's main process spawns its own backend; start-dev
+  // doesn't know the chosen port. Match the long-standing convention:
+  // backend defaults to DEFAULT_PORTS.restApi, proxy listens on DEFAULT_PORTS.proxy
+  // and forwards. Set VITE_BACKEND_URL so the Vite-served renderer hits the proxy.
+  process.env.VITE_BACKEND_URL = `http://127.0.0.1:${DEFAULT_PORTS.proxy}`;
+  startDevProxy({
+    PORT: String(DEFAULT_PORTS.proxy),
+    BACKEND: `http://127.0.0.1:${DEFAULT_PORTS.restApi}`,
+  });
+}
+
+function pointFrontendAtBackend(backendEnv: BackendEnv): void {
+  // No proxy — Vite reads VITE_BACKEND_URL and connects directly. The Python
+  // backend's --api-cors=http://localhost:* permits the Vite origin.
+  process.env.VITE_BACKEND_URL = backendEnv.VITE_BACKEND_URL;
+}
+
+export async function startDevelopmentEnvironment(opts: DevEnvironmentOptions): Promise<void> {
+  const { instance, noElectron, useProxy, onChildExit } = opts;
+
+  let backendEnv: BackendEnv | undefined;
+  let devPort: number | undefined;
+
+  if (noElectron) {
+    ({ backendEnv, devPort } = await startBackendForMode(instance, opts));
+  }
+
+  if (backendEnv) {
+    if (useProxy)
+      spawnProxyForBackend(instance, backendEnv);
+    else
+      pointFrontendAtBackend(backendEnv);
+  }
+  else if (useProxy) {
+    // Electron mode + proxy: spawn it with defaults (electron's backend lands
+    // at 4242, proxy fronts it at 4243). This matches the pre-refactor
+    // behaviour triggered by VITE_BACKEND_URL being present in .env.
+    spawnProxyForElectron();
+  }
+
+  startDevServer({ noElectron, devPort, backendEnv, onExit: onChildExit });
+
+  // win32 historically had no readiness wait — give hot-reload subscribers a
+  // moment to attach before the first Vite compile.
+  if (noElectron && platform() === 'win32') {
+    await new Promise(resolve => setTimeout(resolve, 1_000));
+  }
+}
+
+function extractPort(url: string): number | null {
+  try {
+    return Number.parseInt(new URL(url).port, 10) || null;
+  }
+  catch {
+    return null;
+  }
+}

--- a/frontend/scripts/start-dev.ts
+++ b/frontend/scripts/start-dev.ts
@@ -1,347 +1,294 @@
-import type { Buffer } from 'node:buffer';
-import { type ChildProcess, execSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
-import net from 'node:net';
-import { platform } from 'node:os';
-import path from 'node:path';
-import process, { exit } from 'node:process';
-import { assert } from '@rotki/common';
+import process from 'node:process';
 import { cac } from 'cac';
 import consola from 'consola';
 import { config } from 'dotenv';
-import { omit } from 'es-toolkit';
+import {
+  cleanAll,
+  cleanInstance,
+  clearManagedEnvBlock,
+  DEFAULT_PORTS,
+  type InstanceRuntime,
+  PortSlotAllocationError,
+  prepareInstance,
+  printInstanceList,
+  pruneInstances,
+  readManagedInstanceName,
+  repairRegistry,
+} from './dev-instance';
+import { errorMessage, formatPort } from './dev-instance/format';
+import { getCurrentGitBranch } from './dev-instance/git';
+import { ensurePrerequisites, parsePort } from './dev/prerequisites';
+import { registerShutdownHandlers, terminateSubprocesses } from './dev/process-pool';
+import { startDevelopmentEnvironment } from './dev/services';
 
-interface OutputListener {
-  out: (buffer: Buffer) => void;
-  err: (buffer: Buffer) => void;
+const ENV_FILE_RELATIVE = 'app/.env.development.local';
+
+const logger = consola.withTag('[36mdev[0m');
+
+interface DevCliOptions {
+  web?: boolean;
+  webPort?: string;
+  colibriPort?: string;
+  profilingArgs?: string;
+  profilingCmd?: string;
+
+  // management subcommands
+  list?: boolean;
+  clean?: string | boolean;
+  cleanAll?: boolean;
+  prune?: boolean;
+  repair?: boolean;
+  yes?: boolean;
+  olderThan?: string;
+
+  // runtime instance-mode flags
+  instance?: string | boolean;
+  seed?: boolean;
+  acceptManagedEnv?: boolean;
+  includeBackups?: boolean;
+
+  // dev-proxy gate
+  proxy?: boolean;
 }
 
-interface BackendEnv {
-  VITE_BACKEND_URL: string;
-  VITE_COLIBRI_URL: string;
-}
-
-const DEFAULT_BACKEND_PORT = 4242;
-const DEFAULT_COLIBRI_PORT = 4343;
-
-const PROXY = 'proxy';
-const ROTKI = 'rotki';
-const BACKEND = 'backend';
-const COLIBRI = 'colibri';
-
-function getPort(port: string, defaultValue: number): number {
-  if (!port) {
-    return defaultValue;
+async function dispatchManagementSubcommand(options: DevCliOptions): Promise<boolean> {
+  if (options.list) {
+    await printInstanceList();
+    return true;
   }
-  const portNumber = parseInt(port);
-  if (!isFinite(portNumber) || portNumber < 0 || portNumber > 65535) {
-    return defaultValue;
+  if (options.cleanAll) {
+    await cleanAll({ yes: options.yes, envFile: ENV_FILE_RELATIVE });
+    return true;
   }
-  return portNumber;
+  if (options.clean !== undefined) {
+    if (typeof options.clean !== 'string' || options.clean.length === 0) {
+      logger.error('--clean requires an instance name (e.g. --clean my-instance)');
+      process.exit(1);
+    }
+    await cleanInstance(options.clean, { yes: options.yes, envFile: ENV_FILE_RELATIVE });
+    return true;
+  }
+  if (options.prune) {
+    await pruneInstances({ yes: options.yes, olderThan: options.olderThan, envFile: ENV_FILE_RELATIVE });
+    return true;
+  }
+  if (options.repair) {
+    await repairRegistry({ yes: options.yes });
+    return true;
+  }
+  return false;
 }
 
-async function isPortAvailable(port: number): Promise<boolean> {
-  return new Promise<boolean>((resolve, reject) => {
-    const server = net.createServer();
-
-    server.unref();
-
-    server.once('error', (err: any) => {
-      if (err.code === 'EADDRINUSE' || err.code === 'EACCES')
-        resolve(false);
-      else
-        reject(err instanceof Error ? err : new Error(err));
-    });
-
-    server.once('listening', () => {
-      server.close(() => resolve(true));
-    });
-
-    server.listen(port, '127.0.0.1');
-  });
+function loadDevEnv(): void {
+  if (fs.existsSync(ENV_FILE_RELATIVE)) {
+    config({ path: ENV_FILE_RELATIVE });
+  }
 }
 
-export async function selectPort(startPort: number): Promise<number> {
-  for (let portNumber = startPort; portNumber <= 65535; portNumber++) {
-    if (await isPortAvailable(portNumber))
-      return portNumber;
-  }
-  throw new Error('no free ports found');
-}
+const DEV_PROXY_ASYNC_MOCK = 'dev-proxy/async-mock.json';
 
-function checkForCargo(): boolean {
-  try {
-    const cargoVersion = execSync('cargo --version', { encoding: 'utf-8' });
-    consola.info(`detected cargo: ${cargoVersion}`);
-    return /cargo\s\d+\.\d+\.\d+/.test(cargoVersion);
-  }
-  catch {
-    consola.error('Cargo is not installed');
+/**
+ * Resolves whether to spawn the dev-proxy:
+ *  - explicit `--proxy` / `--no-proxy` always wins
+ *  - else auto-on if PREMIUM_COMPONENT_DIR resolves to a real dir, or
+ *    dev-proxy/async-mock.json exists (the two features the proxy provides
+ *    beyond plain pass-through)
+ *  - else off — the frontend talks directly to the backend (CORS allows it)
+ *
+ * Note: `PREMIUM_COMPONENT_DIR` must be set in `frontend/app/.env.development.local`
+ * or in the shell for auto-detect to see it — `frontend/dev-proxy/.env` is only
+ * read by the proxy subprocess itself.
+ */
+function shouldUseProxy(options: DevCliOptions): boolean {
+  if (options.proxy === true)
+    return true;
+  if (options.proxy === false)
     return false;
-  }
+  const premiumDir = process.env.PREMIUM_COMPONENT_DIR;
+  if (premiumDir && fs.existsSync(premiumDir) && fs.statSync(premiumDir).isDirectory())
+    return true;
+  if (fs.existsSync(DEV_PROXY_ASYNC_MOCK))
+    return true;
+  return false;
 }
 
-const colors = {
-  red: (msg: string) => `\u001B[31m${msg}\u001B[0m`,
-  green: (msg: string) => `\u001B[32m${msg}\u001B[0m`,
-  yellow: (msg: string) => `\u001B[33m${msg}\u001B[0m`,
-  blue: (msg: string) => `\u001B[34m${msg}\u001B[0m`,
-  magenta: (msg: string) => `\u001B[35m${msg}\u001B[0m`,
-  cyan: (msg: string) => `\u001B[36m${msg}\u001B[0m`,
-} as const;
-
-const logger = consola.withTag(colors.cyan('dev'));
-
-if (!process.env.VIRTUAL_ENV) {
-  logger.info('No python virtual environment detected');
-  process.exit(1);
-}
-
-const cargoInstalled = checkForCargo();
-if (cargoInstalled) {
-  consola.info('Cargo is installed building colibri binary');
-  execSync('cargo build', {
-    encoding: 'utf-8',
-    cwd: path.join('..', 'colibri'),
-    stdio: 'inherit',
-  });
-}
-
-let startDevProxy = false;
-const devEnvExists = fs.existsSync('app/.env.development.local');
-if (devEnvExists) {
-  config({ path: 'app/.env.development.local' });
-  startDevProxy = !!process.env.VITE_BACKEND_URL;
-}
-
-const pids: Record<number, string> = {};
-const listeners: Record<number, OutputListener> = {};
-const subprocesses: ChildProcess[] = [];
-
-function startProcess(
-  cmd: string,
-  tag: string,
-  name: string,
-  args: string[] = [],
-  opts: Record<string, any> = {},
-): ChildProcess {
-  const logger = consola.withTag(tag);
-  const createListeners = (): OutputListener => ({
-    out: (buffer: Buffer): void => {
-      logger.log(buffer.toString().replace(/\n$/, ''));
-    },
-    err: (buffer: Buffer): void => {
-      logger.log(buffer.toString().replace(/\n$/, ''));
-    },
-  });
-
-  const envVars = opts?.env ?? {};
-  const env = {
-    FORCE_COLOR: '1',
-    ...process.env,
-    NODE_ENV: 'development',
-    ...envVars,
-  };
-
-  const child = spawn(cmd, args, {
-    ...omit(opts, ['env']),
-    shell: true,
-    stdio: [process.stdin],
-    env,
-  });
-
-  subprocesses.push(child);
-
-  const stdListeners = createListeners();
-  child.stdout?.on('data', stdListeners.out);
-  child.stderr?.on('data', stdListeners.err);
-  const pid = child.pid;
-  assert(pid !== undefined, 'pid is undefined');
-  pids[pid] = name;
-  listeners[pid] = stdListeners;
-  return child;
-}
-
-function terminateSubprocesses(): void {
-  let subprocess;
-  // eslint-disable-next-line no-cond-assign
-  while ((subprocess = subprocesses.pop())) {
-    if (subprocess.killed)
-      continue;
-
-    const pid = subprocess.pid;
-    if (pid === undefined) {
-      continue;
+function pickInstanceName(option: DevCliOptions['instance']): string | undefined {
+  if (typeof option === 'string' && option.length > 0)
+    return option;
+  if (option === true) {
+    // Bare `--instance` → user explicitly wants instance mode without typing a name.
+    // Fall back to INSTANCE_NAME env (wt-managed case), then current git branch,
+    // then error.
+    const envName = process.env.INSTANCE_NAME;
+    if (envName)
+      return envName;
+    const branch = getCurrentGitBranch();
+    if (branch) {
+      logger.info(`--instance with no name — deriving from current git branch "${branch}"`);
+      return branch;
     }
-
-    const name = pids[pid] ?? '';
-    logger.info(`terminating process: ${name} (${pid})`);
-    const ls = listeners[pid];
-    if (ls) {
-      subprocess.stdout?.off('data', ls.out);
-      subprocess.stderr?.off('data', ls.err);
-      delete listeners[pid];
-    }
-
-    subprocess.kill();
+    logger.error(
+      '--instance requires a name (e.g. --instance scratch).\n'
+      + 'No INSTANCE_NAME env var or git branch was available to derive one. '
+      + 'Use --no-instance to disable instance mode.',
+    );
+    process.exit(1);
   }
+  return process.env.INSTANCE_NAME || undefined;
 }
 
-function getDebuggerPort(): number | null {
+function readSlotHint(resolvedName: string): number | undefined {
+  const raw = process.env.INSTANCE_PORT_SLOT;
+  if (raw === undefined)
+    return undefined;
+  // INSTANCE_NAME and INSTANCE_PORT_SLOT are written as a pair by the managed
+  // env block. If the resolved instance differs from the name that block was
+  // written for, the slot hint doesn't apply to us — ignore it rather than
+  // trying to grab another instance's slot.
+  const pairedName = process.env.INSTANCE_NAME;
+  if (pairedName && pairedName !== resolvedName) {
+    logger.info(
+      `Ignoring INSTANCE_PORT_SLOT=${raw}: it was paired with INSTANCE_NAME="${pairedName}", `
+      + `but this run resolved to "${resolvedName}".`,
+    );
+    return undefined;
+  }
+  const slot = Number.parseInt(raw, 10);
+  if (!Number.isFinite(slot)) {
+    logger.error(`INSTANCE_PORT_SLOT="${raw}" is not a valid integer.`);
+    process.exit(1);
+  }
+  return slot;
+}
+
+async function resolveInstance(options: DevCliOptions, useProxy: boolean): Promise<InstanceRuntime | null> {
+  if (options.instance === false) {
+    // Explicit --no-instance: erase any stale managed block from a prior
+    // instance run so Vite doesn't read INSTANCE_PORT_SLOT / VITE_BACKEND_URL
+    // pointing at a slot we're no longer using.
+    const staleOwner = readManagedInstanceName(ENV_FILE_RELATIVE);
+    if (staleOwner !== undefined) {
+      clearManagedEnvBlock(ENV_FILE_RELATIVE);
+      logger.info(`--no-instance: cleared managed env block left over from "${staleOwner}"`);
+    }
+    return null;
+  }
+  const name = pickInstanceName(options.instance);
+  if (!name)
+    return null;
+  return prepareInstance({
+    name,
+    slotHint: readSlotHint(name),
+    seed: options.seed !== false,
+    acceptManagedEnv: options.acceptManagedEnv === true,
+    envFile: ENV_FILE_RELATIVE,
+    useProxy,
+    includeBackups: options.includeBackups === true,
+  });
+}
+
+function setupProfilingEnvironment(options: DevCliOptions): void {
+  if (options.profilingCmd)
+    process.env.ROTKI_BACKEND_PROFILING_CMD = options.profilingCmd;
+  if (options.profilingArgs)
+    process.env.ROTKI_BACKEND_PROFILING_ARGS = options.profilingArgs;
+}
+
+function exitOnAllocationError<T>(error: unknown): T {
+  if (error instanceof PortSlotAllocationError) {
+    logger.error(error.message);
+    process.exit(1);
+  }
+  throw error;
+}
+
+async function tearDownAndExit(error: unknown, exitCode: number): Promise<never> {
+  logger.error(errorMessage(error));
   try {
-    const debuggerPort = process.env.DEBUGGER_PORT;
-    if (debuggerPort) {
-      const portNum = Number.parseInt(debuggerPort);
-      return isFinite(portNum) && (portNum > 0 || portNum < 65535) ? portNum : null;
-    }
-    return null;
+    await terminateSubprocesses();
   }
-  catch {
-    return null;
+  catch (shutdownError) {
+    logger.error(`shutdown error: ${errorMessage(shutdownError)}`);
   }
+  process.exit(exitCode);
 }
 
-async function startPythonBackend(
-  webPort: number,
-  logDir: string,
-  profilingArgs?: string,
-  profilingCmd?: string,
-): Promise<number> {
-  const availableWebPort = await selectPort(webPort);
-  logger.info(`Starting python backend at port: ${availableWebPort}`);
-
-  const args = [
-    ...(profilingArgs ? profilingArgs.split(' ') : []),
-    ...(profilingCmd ? ['python'] : []),
-    '-m',
-    'rotkehlchen',
-    '--rest-api-port',
-    availableWebPort.toString(),
-    '--api-cors',
-    'http://localhost:*',
-    '--logfile',
-    `${path.join(logDir, 'backend.log')}`,
-  ];
-
-  startProcess(profilingCmd ?? 'python', colors.yellow(BACKEND), BACKEND, args, {
-    cwd: path.join('..'),
-  });
-  return availableWebPort;
-}
-
-async function startColibriService(colibriPort: number, logDir: string): Promise<number> {
-  const availableColibriPort = await selectPort(colibriPort);
-
-  logger.info(`Starting colibri at port: ${availableColibriPort}`);
-
-  const colibriArgs: string[] = [
-    `--logfile-path=${path.join(logDir, 'colibri.log')}`,
-    `--port=${availableColibriPort}`,
-    '--api-cors=http://localhost:*',
-  ];
-
-  startProcess('cargo run --locked -- ', colors.red(COLIBRI), COLIBRI, colibriArgs, {
-    cwd: path.join('..', 'colibri'),
-  });
-  return availableColibriPort;
-}
-
-async function startBackendServices(
-  webPort: number,
-  colibriPort: number,
-  profilingArgs?: string,
-  profilingCmd?: string,
-): Promise<BackendEnv> {
-  const logDir = path.join(process.cwd(), 'logs');
-  if (!fs.existsSync(logDir))
-    fs.mkdirSync(logDir);
-
-  const availableWebPort = await startPythonBackend(webPort, logDir, profilingArgs, profilingCmd);
-  const availableColibriPort = await startColibriService(colibriPort, logDir);
-
-  return {
-    VITE_BACKEND_URL: `http://localhost:${availableWebPort}`,
-    VITE_COLIBRI_URL: `http://localhost:${availableColibriPort}`,
-  };
-}
-
-function startDevServer(noElectron: boolean, backendEnv?: BackendEnv) {
-  logger.info('Starting rotki dev mode');
-
-  const debuggerPort = getDebuggerPort();
-  const args = debuggerPort ? ` --remote-debugging-port=${debuggerPort}` : '';
-  if (args)
-    logger.info(`starting rotki with args: ${args}`);
-
-  const serveCmd = noElectron ? 'pnpm run --filter rotki serve' : 'pnpm run --filter rotki electron:serve';
-  const cmd = platform() === 'win32' ? serveCmd : `sleep 20 && ${serveCmd}`;
-
-  const devRotkiProcess = startProcess(`${cmd} ${args}`, colors.magenta(ROTKI), ROTKI, [], {
-    env: backendEnv,
-  });
-
-  devRotkiProcess.on('exit', () => {
-    logger.info('dev rotki process exited, terminating subprocesses');
-    terminateSubprocesses();
-    process.exit(0);
-  });
-}
-
-async function startDevelopmentEnvironment(
-  webPort: number,
-  colibriPort: number,
-  noElectron: boolean,
-  profilingArgs?: string,
-  profilingCmd?: string,
-): Promise<void> {
-  process.on('SIGINT', () => {
-    logger.info(`preparing to terminate subprocesses`);
-    terminateSubprocesses();
-    exit(0);
-  });
-
-  if (startDevProxy) {
-    logger.info('Starting dev-proxy');
-    startProcess('pnpm run --filter @rotki/dev-proxy serve', colors.green(PROXY), PROXY);
+async function runDevAction(options: DevCliOptions): Promise<void> {
+  try {
+    if (await dispatchManagementSubcommand(options))
+      process.exit(process.exitCode ?? 0);
+  }
+  catch (error) {
+    exitOnAllocationError(error);
   }
 
-  let backendEnv: BackendEnv | undefined;
+  ensurePrerequisites();
+  loadDevEnv();
 
-  if (noElectron) {
-    backendEnv = await startBackendServices(webPort, colibriPort, profilingArgs, profilingCmd);
+  const useProxy = shouldUseProxy(options);
+  logger.info(`dev-proxy: ${useProxy ? 'on' : 'off'}${options.proxy === undefined ? ' (auto)' : ''}`);
+
+  let instance: InstanceRuntime | null;
+  try {
+    instance = await resolveInstance(options, useProxy);
+  }
+  catch (error) {
+    return exitOnAllocationError(error);
+  }
+  if (instance) {
+    logger.info(`Instance "${instance.name}" → slot ${instance.slot}, dir ${instance.dir}`);
+    logger.info(
+      `  ports: backend=${formatPort(instance.ports.restApi)} proxy=${formatPort(instance.ports.proxy)} `
+      + `colibri=${formatPort(instance.ports.colibri)} dev=${formatPort(instance.ports.dev)}`,
+    );
   }
 
-  startDevServer(noElectron, backendEnv);
-}
+  registerShutdownHandlers();
+  setupProfilingEnvironment(options);
 
-function setupProfilingEnvironment({ profilingArgs, profilingCmd }: { profilingCmd?: string; profilingArgs?: string }): void {
-  if (profilingCmd)
-    process.env.ROTKI_BACKEND_PROFILING_CMD = profilingCmd;
-
-  if (profilingArgs)
-    process.env.ROTKI_BACKEND_PROFILING_ARGS = profilingArgs;
+  try {
+    await startDevelopmentEnvironment({
+      webPort: parsePort(options.webPort, DEFAULT_PORTS.restApi),
+      colibriPort: parsePort(options.colibriPort, DEFAULT_PORTS.colibri),
+      noElectron: !!options.web,
+      profilingArgs: options.profilingArgs,
+      profilingCmd: options.profilingCmd,
+      instance,
+      useProxy,
+      onChildExit: () => {
+        terminateSubprocesses()
+          .catch(error => logger.error(`shutdown error: ${errorMessage(error)}`))
+          .finally(() => process.exit(0));
+      },
+    });
+  }
+  catch (error) {
+    await tearDownAndExit(error, 1);
+  }
 }
 
 const cli = cac();
 
 cli.command('', 'Start the development environment')
   .option('--web', 'Start without electron as a web service (starts the backend too)')
-  .option('--web-port <number>', 'The port to use for the web server', {
-    default: DEFAULT_BACKEND_PORT,
-  })
-  .option('--colibri-port <number>', 'The port to use for the colibri server', {
-    default: DEFAULT_COLIBRI_PORT,
-  })
-  .option('--profiling-args <string>', 'Arguments to pass to the backend process')
-  .option('--profiling-cmd <string>', 'Command to use to start the backend process')
-  .action(async (options) => {
-    const webPort = getPort(options.webPort, DEFAULT_BACKEND_PORT);
-    const colibriPort = getPort(options.colibriPort, DEFAULT_COLIBRI_PORT);
-    const noElectron = options.web;
-
-    setupProfilingEnvironment(options);
-    await startDevelopmentEnvironment(webPort, colibriPort, noElectron, options.profilingArgs, options.profilingCmd);
-  });
+  .option('--web-port <number>', 'The port to use for the web server', { default: DEFAULT_PORTS.restApi })
+  .option('--colibri-port <number>', 'The port to use for the colibri server', { default: DEFAULT_PORTS.colibri })
+  .option('--profiling-args <string>', 'Arguments to pass to the backend process (see docs.rotki.com/contribution-guides/code-profiling.html)')
+  .option('--profiling-cmd <string>', 'Command used to start the backend process (see docs.rotki.com/contribution-guides/code-profiling.html)')
+  .option('--instance [name]', 'Run with an isolated data dir / port slot; --no-instance forces default mode even if INSTANCE_NAME is set')
+  .option('--seed', 'Seed the instance data dir from the prod rotki data dir on first run (default: true); pass --no-seed to skip', { default: true })
+  .option('--include-backups', 'Include `*.backup` files when seeding (default: skipped to keep the seed lean)')
+  .option('--accept-managed-env', 'Consent to dev:web managing INSTANCE_*, VITE_BACKEND_URL, VITE_COLIBRI_URL, DEV_PORT in .env.development.local')
+  .option('--proxy', 'Force the dev-proxy on (default: auto, on iff PREMIUM_COMPONENT_DIR is set or async-mock.json exists)')
+  .option('--list', 'List dev instances and exit')
+  .option('--clean [name]', 'Remove a single instance and exit (name is required; passing --clean without a name shows usage)')
+  .option('--clean-all', 'Remove all instances and exit (double-confirm)')
+  .option('--prune', 'Remove instances whose worktrees no longer exist (dry-run unless --yes)')
+  .option('--repair', 'Rebuild .port-index.json from sidecars (dry-run unless --yes)')
+  .option('--older-than <duration>', 'Used with --prune; only consider instances whose lastUsedAt is older (e.g. 30d, 12h, 45m)')
+  .option('--yes', 'Skip confirmation prompts for --clean/--clean-all/--prune/--repair')
+  .action(runDevAction);
 
 cli.help();
 cli.parse();


### PR DESCRIPTION
## Summary

Adds `--instance <name>` to `pnpm dev` so multiple branches / experiments can run side-by-side without colliding on the default 4242 / 4343 / 8080 ports.

- New `scripts/dev-instance/` (sidecar, port registry, env-block writer, seeding, lifecycle) and `scripts/dev/` (process pool, prerequisites, services) modules, with `scripts/start-dev.ts` as the cac entry point.
- Per-instance slot allocation backed by a JSON port index + filesystem lock. Slots are validated when hinted via `INSTANCE_PORT_SLOT`.
- Managed env block in `app/.env.development.local` owned by `dev:web`: rewritten when an instance starts, cleared on `--clean` / `--clean-all` / `--prune` / `--no-instance` if the block belongs to the affected instance.
- Children spawn as their own process group; Ctrl+C now delivers SIGINT to each group so electron, vite and cargo quit cleanly.
- Management subcommands: `--list`, `--clean <name>`, `--clean-all`, `--prune [--older-than 30d]`, `--repair` (dry-run unless `--yes`).
- Prerequisite checks log `uv` and `cargo` versions; missing cargo is now a hard error (colibri can't start without it).

## Test plan

- [ ] macOS: `pnpm dev`, `pnpm dev --web`, `pnpm dev --instance scratch`, `Ctrl+C` shuts everything down within the 5s grace.
- [ ] Windows: same matrix; verify `pidForPort` (netstat) and detached process groups work.
- [ ] Linux (already exercised locally): instance switch rewrites the managed env block; `--clean scratch` clears it; `--no-instance` clears it; second `--instance scratch` reuses the same slot.
- [ ] `--list`, `--prune`, `--repair` behave as documented.
- [ ] `INSTANCE_PORT_SLOT` paired with a different `INSTANCE_NAME` is ignored (logged) rather than colliding.