### PR TITLE
Bugs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Tags of an address tracked on multiple chains are now kept when you remove the address from only one of those chains.
 * :bug:`-` Changing the selected trade pairs of a Binance or Binance US exchange now correctly fetches the history of the newly added pairs.
 * :bug:`-` HTX deposit and withdrawal history is now queried correctly for accounts with more than 500 transfers, instead of getting stuck re-fetching the same first page.
 * :bug:`-` Coinbase Advanced Trade buys are no longer sometimes imported as sells when the trade direction is missing from the API.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Changing the selected trade pairs of a Binance or Binance US exchange now correctly fetches the history of the newly added pairs.
 * :bug:`-` HTX deposit and withdrawal history is now queried correctly for accounts with more than 500 transfers, instead of getting stuck re-fetching the same first page.
 * :bug:`-` Coinbase Advanced Trade buys are no longer sometimes imported as sells when the trade direction is missing from the API.
 * :bug:`-` Swaps through a newer zeroxsettler will now be properly decoded by rotki.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Special-cased asset prices are no longer shown in USD by mistake for non-USD main currencies when the exchange rate is temporarily unavailable.
 * :bug:`-` Tags of an address tracked on multiple chains are now kept when you remove the address from only one of those chains.
 * :bug:`-` Changing the selected trade pairs of a Binance or Binance US exchange now correctly fetches the history of the newly added pairs.
 * :bug:`-` HTX deposit and withdrawal history is now queried correctly for accounts with more than 500 transfers, instead of getting stuck re-fetching the same first page.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` HTX deposit and withdrawal history is now queried correctly for accounts with more than 500 transfers, instead of getting stuck re-fetching the same first page.
 * :bug:`-` Coinbase Advanced Trade buys are no longer sometimes imported as sells when the trade direction is missing from the API.
 * :bug:`-` Swaps through a newer zeroxsettler will now be properly decoded by rotki.
 * :bug:`-` Poloniex history should now be properly queried again.

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -1790,12 +1790,17 @@ class DBHandler:
                 solana_tx_db.delete_data_for_address(write_cursor, address)  # type: ignore
 
         write_cursor.executemany(
-            'DELETE FROM tag_mappings WHERE object_reference = ?;',
-            [(account,) for account in accounts],
-        )
-        write_cursor.executemany(
             'DELETE FROM blockchain_accounts WHERE '
             'blockchain = ? and account = ?;', tuples,
+        )
+        # Only remove the address' tag mappings if it is no longer tracked on any
+        # other chain. The same address (e.g. an EVM address) can be tracked on
+        # multiple chains, all sharing a single address-keyed tag mapping, so the
+        # mapping must survive until the address is removed from its last chain.
+        write_cursor.executemany(
+            'DELETE FROM tag_mappings WHERE object_reference = ? AND NOT EXISTS('
+            'SELECT 1 FROM blockchain_accounts WHERE account = ?);',
+            [(account, account) for account in accounts],
         )
 
     def get_tokens_for_address(

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -2383,7 +2383,7 @@ class DBHandler:
                 # from the possible new pairs
                 write_cursor.execute(
                     'DELETE FROM used_query_ranges WHERE name LIKE ? ESCAPE ?;',
-                    (f'{location!s}\\_history_events_\\_{name}', '\\'),
+                    (f'{location!s}\\_history_events\\_{name}', '\\'),
                 )
             except sqlcipher.DatabaseError as e:  # pylint: disable=no-member
                 raise InputError(f'Could not update DB user_credentials_mappings due to {e!s}') from e  # noqa: E501

--- a/rotkehlchen/exchanges/htx.py
+++ b/rotkehlchen/exchanges/htx.py
@@ -246,7 +246,7 @@ class Htx(ExchangeInterface, SignatureGeneratorMixin):
         # copy since we are modifying the dict and could affect other queries using
         # the same options
         query_options = options.copy()
-        while len(output := self._query(absolute_path=endpoint, options=options)) != 0:
+        while len(output := self._query(absolute_path=endpoint, options=query_options)) != 0:
             result.extend(output)
             try:
                 query_options['from'] = output[-1]['id'] + 1  # from is inclusive, so we want after

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -683,17 +683,21 @@ class Inquirer:
             else:
                 assets_without_special_price.append(from_asset)
 
-        if (
-                to_asset != A_USD and
+        if to_asset == A_USD:
+            found_prices = usd_found_prices
+        elif (
                 len(usd_found_prices) > 0 and
                 (rate_price := Inquirer.find_price(from_asset=A_USD, to_asset=to_asset)) != ZERO_PRICE  # noqa: E501
-        ):  # convert USD prices to target currency if needed
+        ):  # convert the USD prices to the target currency
             found_prices = {
                 asset: (Price(price * rate_price), oracle)
                 for asset, (price, oracle) in usd_found_prices.items()
             }
         else:
-            found_prices = usd_found_prices
+            # We found USD-denominated special prices but could not obtain the USD->target
+            # rate (e.g. a transient fiat-rate failure). Returning the USD values labeled as
+            # `to_asset` would corrupt the valuation, so report these assets as unpriced.
+            assets_without_special_price.extend(usd_found_prices)
 
         if len(eur_collection_assets) > 0:
             # EURe collection assets are pegged to EUR (1:1 by definition).

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -113,6 +113,7 @@ from rotkehlchen.types import (
     ExchangeLocationID,
     ExternalService,
     ExternalServiceApiCredentials,
+    HexColorCode,
     Location,
     SupportedBlockchain,
     Timestamp,
@@ -1882,6 +1883,57 @@ def test_edit_binance_pairs_clears_history_events_query_range(database: DBHandle
             'editing binance pairs should have cleared the history events query range'
         assert database.get_used_query_range(cursor, trades_range) is not None, \
             'unrelated query ranges must not be deleted when editing binance pairs'
+
+
+def test_remove_multichain_address_keeps_tags_on_other_chains(database: DBHandler) -> None:
+    """Removing a multi-chain address from one chain must not delete its tags while
+    the same address is still tracked on another chain.
+
+    Regression test: tag mappings are keyed by address only (a single mapping shared
+    across chains), and removal previously deleted them unconditionally by address,
+    wiping the tags of every other chain the address was still tracked on.
+    """
+    address = string_to_evm_address('0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12')
+
+    def has_tag() -> bool:
+        with database.conn.read_ctx() as cursor:
+            return cursor.execute(
+                'SELECT COUNT(*) FROM tag_mappings WHERE object_reference=? AND tag_name=?',
+                (address, 'hot'),
+            ).fetchone()[0] > 0
+
+    with database.user_write() as write_cursor:
+        database.add_tag(
+            write_cursor=write_cursor,
+            name='hot',
+            description='hot wallet',
+            background_color=HexColorCode('ffffff'),
+            foreground_color=HexColorCode('000000'),
+        )
+        # the same address is tracked on two evm chains, tagged on both
+        database.add_blockchain_accounts(
+            write_cursor,
+            [
+                BlockchainAccountData(chain=SupportedBlockchain.ETHEREUM, address=address, tags=['hot']),  # noqa: E501
+                BlockchainAccountData(chain=SupportedBlockchain.POLYGON_POS, address=address, tags=['hot']),  # noqa: E501
+            ],
+        )
+
+    assert has_tag(), 'the tag mapping should exist after adding the tagged account'
+
+    # removing the address from a single chain must keep the tag (still on the other)
+    with database.user_write() as write_cursor:
+        database.remove_single_blockchain_accounts(
+            write_cursor, SupportedBlockchain.POLYGON_POS, [address],
+        )
+    assert has_tag(), 'tag must survive while the address is still tracked on another chain'
+
+    # removing it from the last remaining chain should finally drop the tag mapping
+    with database.user_write() as write_cursor:
+        database.remove_single_blockchain_accounts(
+            write_cursor, SupportedBlockchain.ETHEREUM, [address],
+        )
+    assert not has_tag(), 'tag mapping should be removed once the address is gone from all chains'
 
 
 def test_fresh_db_adds_version(user_data_dir, sql_vm_instructions_cb):

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -1834,6 +1834,56 @@ def test_add_edit_remove_kraken_futures(database: DBHandler) -> None:
     assert kraken_extras == {}
 
 
+def test_edit_binance_pairs_clears_history_events_query_range(database: DBHandler) -> None:
+    """Editing Binance selected trade pairs must clear that exchange's
+    ``_history_events_`` used_query_range, so history for any newly added pairs is
+    fetched again instead of being treated as already covered.
+
+    Regression test for a typo in the DELETE's LIKE pattern (an unescaped ``_``
+    acting as a single-char wildcard) which made it match nothing: the range
+    survived the edit and trades for the new pairs were never backfilled.
+    """
+    name = 'binance1'
+    database.add_exchange(
+        name=name,
+        location=Location.BINANCE,
+        api_key=ApiKey('binance_api_key'),
+        api_secret=ApiSecret(b'binance_api_secret'),
+    )
+    # range name built exactly like ExchangeInterface.query_history_events does
+    events_range = f'{Location.BINANCE!s}_history_events_{name}'
+    trades_range = f'{Location.BINANCE!s}_trades_{name}'  # unrelated, must survive
+    with database.user_write() as write_cursor:
+        for range_name in (events_range, trades_range):
+            database.update_used_query_range(
+                write_cursor=write_cursor,
+                name=range_name,
+                start_ts=Timestamp(0),
+                end_ts=Timestamp(1500000000),
+            )
+
+        database.edit_exchange(
+            write_cursor,
+            name=name,
+            location=Location.BINANCE,
+            new_name=None,
+            api_key=None,
+            api_secret=None,
+            passphrase=None,
+            kraken_account_type=None,
+            kraken_futures_api_key=None,
+            kraken_futures_api_secret=None,
+            binance_selected_trade_pairs=['ETHBTC', 'BTCUSDT'],
+            okx_location=None,
+        )
+
+    with database.conn.read_ctx() as cursor:
+        assert database.get_used_query_range(cursor, events_range) is None, \
+            'editing binance pairs should have cleared the history events query range'
+        assert database.get_used_query_range(cursor, trades_range) is not None, \
+            'unrelated query ranges must not be deleted when editing binance pairs'
+
+
 def test_fresh_db_adds_version(user_data_dir, sql_vm_instructions_cb):
     """Test that the DB version gets committed to a fresh DB.
 

--- a/rotkehlchen/tests/exchanges/test_htx.py
+++ b/rotkehlchen/tests/exchanges/test_htx.py
@@ -12,7 +12,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import asset_from_htx
 from rotkehlchen.constants.assets import A_CRV, A_DAI, A_USDT, A_ZRX
 from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
-from rotkehlchen.exchanges.htx import Htx
+from rotkehlchen.exchanges.htx import PAGINATION_LIMIT, Htx
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.swap import SwapEvent
@@ -348,3 +348,40 @@ def test_trades(htx_exchange: Htx) -> None:
             unique_id='3409716930791340',
         ),
     )]
+
+
+def test_paginated_query_advances_cursor(htx_exchange: Htx) -> None:
+    """Regression test: deposit/withdrawal pagination must send the advancing `from`
+    cursor on each request.
+
+    A bug previously queried the original options dict (which never received the
+    cursor), so every page re-fetched the same first PAGINATION_LIMIT records. For
+    accounts with more than PAGINATION_LIMIT transfers in the window this looped
+    forever and accumulated duplicates. Here the second page is short, so a correct
+    implementation stops after two requests; the old code keeps re-requesting the
+    full first page and trips the call cap.
+    """
+    page1 = [{'id': i, 'created-at': 2000} for i in range(PAGINATION_LIMIT)]  # full page, newest
+    page2 = [{'id': PAGINATION_LIMIT + i, 'created-at': 1000} for i in range(3)]  # short -> stop
+    seen_options: list[dict[str, Any]] = []
+
+    def mock_query(absolute_path: str, options: dict[str, Any] | None = None) -> list[dict[str, Any]]:  # noqa: E501
+        seen_options.append(dict(options or {}))
+        if len(seen_options) > 5:
+            raise AssertionError('pagination did not advance the cursor (infinite loop)')
+        return page2 if 'from' in (options or {}) else page1
+
+    with patch.object(htx_exchange, '_query', side_effect=mock_query):
+        result = htx_exchange._paginated_query(
+            endpoint='/v1/query/deposit-withdraw',
+            options={'type': 'deposit', 'size': PAGINATION_LIMIT, 'direct': 'next'},
+            start_ts=Timestamp(0),
+        )
+
+    assert len(seen_options) == 2, 'should fetch exactly two pages'
+    assert 'from' not in seen_options[0], 'first request must not carry a cursor'
+    # cursor must be the last (oldest) id of page1 + 1, since results are descending
+    assert seen_options[1]['from'] == PAGINATION_LIMIT - 1 + 1
+    ids = [entry['id'] for entry in result]
+    # all records collected exactly once, no duplicates
+    assert len(ids) == len(set(ids)) == PAGINATION_LIMIT + 3

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -695,16 +695,39 @@ def test_eur_pegged_asset_special_price_non_usd(inquirer: 'Inquirer') -> None:
             to_asset=A_JPY,
         )
 
-    assert len(assets_without_price) == 0
     # EURe should be priced at the EUR→JPY rate
     price, oracle = found_prices[A_ETH_EURE]
     assert price == eur_jpy_rate
     assert oracle == CurrentPriceOracle.FIAT
-    # KFEE has a USD price of 0.01, but USD→JPY returned ZERO_PRICE
-    # so it falls back to the raw USD price
-    kfee_price, kfee_oracle = found_prices[A_KFEE]
-    assert kfee_price == Price(FVal('0.01'))
-    assert kfee_oracle == CurrentPriceOracle.FIAT
+    # KFEE has a USD price of 0.01, but USD→JPY returned ZERO_PRICE, so it cannot be
+    # converted to the target currency. It must be reported as unpriced rather than
+    # returning the USD value labeled as JPY, which would corrupt the valuation.
+    assert A_KFEE not in found_prices
+    assert A_KFEE in assets_without_price
+
+
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
+def test_special_price_unpriced_when_target_rate_unavailable(inquirer: 'Inquirer') -> None:
+    """Regression test: a special-asset USD price must not be returned labeled as a
+    non-USD target currency when the USD->target rate is unavailable. Otherwise e.g. a
+    0.01 USD KFEE value would be shown as 0.01 of the (very different) target currency.
+    """
+    with patch.object(Inquirer, 'find_price', return_value=ZERO_PRICE):  # USD->EUR unavailable
+        assets_without_price, found_prices = Inquirer._get_special_prices(
+            from_assets=[A_KFEE],
+            to_asset=A_EUR,
+        )
+    assert A_KFEE not in found_prices, 'the USD value must not be returned as the EUR price'
+    assert A_KFEE in assets_without_price
+
+    # sanity: when the USD->EUR rate IS available, KFEE is converted correctly
+    with patch.object(Inquirer, 'find_price', return_value=Price(FVal('0.9'))):
+        assets_without_price, found_prices = Inquirer._get_special_prices(
+            from_assets=[A_KFEE],
+            to_asset=A_EUR,
+        )
+    assert A_KFEE not in assets_without_price
+    assert found_prices[A_KFEE][0] == Price(FVal('0.009'))  # 0.01 USD * 0.9 USD/EUR
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])


### PR DESCRIPTION
  1. HTX pagination cursor ignored (463186eee4)
  The deposit/withdrawal pagination wrote the advancing from cursor to a copy of the options dict but kept querying the original, so every page re-fetched the same first 500 records — an infinite loop and duplicate data for accounts with >500 transfers. Now the cursor is
  actually sent.

  2. Binance pair-edit query-range typo (b630f95feb)
  A stray underscore turned the LIKE pattern into a wildcard that matched nothing, so editing a Binance/Binance US exchange's trade pairs never cleared the history query range and trades for newly added pairs were never backfilled. Pattern fixed to match the stored range
  name.

  3. Multi-chain address removal wiped tags (99eb1c72d3)
  Tags are keyed by bare address (shared across chains), but removing an address from one chain deleted its tag mapping unconditionally — wiping the tags on every other chain it was still tracked on. Now the mapping is only removed once the address is gone from all chains.

  4. Non-USD special prices mislabeled as USD (d929c2cb12)
  When the USD→main-currency rate was momentarily unavailable, special-cased asset prices (KFEE, BSQ, LP/vault tokens) were returned as raw USD values labeled as the user's currency, corrupting valuations for non-USD users. Such assets are now reported as unpriced until
  the rate is available.