### PR TITLE
Perfs

### DIFF
--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -224,6 +224,9 @@ class Accountant:
                 )
                 break
 
+        for pot in self.pots:  # flush any buffered processed-event rows to the report DB
+            pot.flush_pending_report_rows()
+
         dbpnl.add_report_overview(
             report_id=report_id,
             last_processed_timestamp=last_event_ts,

--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -107,12 +107,9 @@ class EventsAccountant:
 
             in_event = cast('HistoryBaseEntry', next(events_iterator))  # consume the paired event
 
-            with self.pot.database.conn.read_ctx() as cursor:
-                if (
-                    event.asset in (ignored_assets := self.pot.database.get_ignored_asset_ids(cursor)) or  # noqa: E501
-                    in_event.asset in ignored_assets
-                ):
-                    return 2
+            ignored_assets = self.pot.ignored_asset_ids
+            if event.asset in ignored_assets or in_event.asset in ignored_assets:
+                return 2
 
             # event_direction is OUT (first event is always the deposit/spend)
             # paired_direction is IN (second event is always the receive/withdraw)
@@ -172,13 +169,13 @@ class EventsAccountant:
                 fee_events.append(cast('HistoryBaseEntry', next(events_iterator)))  # guaranteed by if check  # noqa: E501
                 processed_event_count += 1
 
-            with self.pot.database.conn.read_ctx() as cursor:
-                if (
-                        event.asset in (ignored_assets := self.pot.database.get_ignored_asset_ids(cursor)) or  # noqa: E501
-                        in_event.asset in ignored_assets or
-                        any(fee_event.asset in ignored_assets for fee_event in fee_events)
-                ):  # return early if any events in the swap group have ignored assets.
-                    return processed_event_count
+            ignored_assets = self.pot.ignored_asset_ids
+            if (
+                    event.asset in ignored_assets or
+                    in_event.asset in ignored_assets or
+                    any(fee_event.asset in ignored_assets for fee_event in fee_events)
+            ):  # return early if any events in the swap group have ignored assets.
+                return processed_event_count
 
             return self._process_swap(
                 timestamp=timestamp,

--- a/rotkehlchen/accounting/pot.py
+++ b/rotkehlchen/accounting/pot.py
@@ -36,6 +36,9 @@ if TYPE_CHECKING:
 
 # keeping it small since reusing will only be assets in same event since we only go forward in time
 PROFIT_CURRENCY_RATE_CACHE_SIZE: Final = 64
+# how many processed-event rows to buffer before flushing them to the transient report DB
+# in a single batched transaction (instead of one commit per processed event)
+REPORT_ROWS_FLUSH_SIZE: Final = 1000
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -84,26 +87,49 @@ class AccountingPot(CustomizableDateMixin):
         self.dbeth2 = DBEth2(database)
         self.query_start_ts = self.query_end_ts = Timestamp(0)
         self.report_id: int | None = None
+        self._dbpnl = DBAccountingReports(database)
+        # buffer of serialized pnl_events rows, flushed in batches to avoid one DB
+        # commit per processed event (the dominant I/O cost of large PnL reports)
+        self._pending_report_rows: list[tuple[int, Timestamp, str, str, str, str | None]] = []
         # memoize profit-currency rates per report. profit_currency is fixed for the
         # duration of a report so keying on (asset identifier, timestamp) is enough.
         # Only successful lookups are cached so error paths keep being retried.
         self._profit_currency_rates: LRUCacheWithRemove[tuple[str, Timestamp], Price] = LRUCacheWithRemove(maxsize=PROFIT_CURRENCY_RATE_CACHE_SIZE)  # noqa: E501
 
     def _add_processed_event(self, event: ProcessedAccountingEvent) -> None:
-        dbpnl = DBAccountingReports(self.database)
         self.processed_events.append(event)
+        if self.is_dummy_pot:  # dummy pots never persist events (see __init__ docstring)
+            return
+
         try:
-            dbpnl.add_report_data(
+            row = DBAccountingReports.serialize_report_row(
                 report_id=self.report_id,  # type: ignore # report id is initialized by now
                 time=event.timestamp,
                 ts_converter=self.timestamp_to_date,
                 event=event,
             )
-        except (DeserializationError, InputError) as e:
+        except DeserializationError as e:
             log.error(str(e))
             return
 
+        self._pending_report_rows.append(row)
+        if len(self._pending_report_rows) >= REPORT_ROWS_FLUSH_SIZE:
+            self.flush_pending_report_rows()
+
         log.debug(event.to_string(self.timestamp_to_date))
+
+    def flush_pending_report_rows(self) -> None:
+        """Persist any buffered processed-event rows to the transient report DB in a single
+        batched transaction. Called periodically during processing and once at report end."""
+        if len(self._pending_report_rows) == 0:
+            return
+
+        try:
+            self._dbpnl.add_report_data_rows(self._pending_report_rows)
+        except InputError as e:
+            log.error(str(e))
+
+        self._pending_report_rows = []
 
     def get_rate_in_profit_currency(self, asset: Asset, timestamp: Timestamp) -> Price:
         """Get the profit_currency price of asset in the given timestamp
@@ -151,6 +177,7 @@ class AccountingPot(CustomizableDateMixin):
         self.cost_basis.reset(settings)
         self.events_accountant.reset()
         self.processed_events = []
+        self._pending_report_rows = []
 
     def add_in_event(
             self,  # pylint: disable=unused-argument

--- a/rotkehlchen/assets/asset.py
+++ b/rotkehlchen/assets/asset.py
@@ -262,9 +262,11 @@ class Asset:
             return False
 
         if isinstance(other, Asset):
-            return self.identifier.lower() == other.identifier.lower()
+            # fast path: identifiers are normally already-normalized and identical,
+            # so avoid lowercasing both sides on every comparison
+            return self.identifier == other.identifier or self.identifier.lower() == other.identifier.lower()  # noqa: E501
         if isinstance(other, str):
-            return self.identifier.lower() == other.lower()
+            return self.identifier == other or self.identifier.lower() == other.lower()
 
         return False
 

--- a/rotkehlchen/db/reports.py
+++ b/rotkehlchen/db/reports.py
@@ -233,6 +233,59 @@ class DBAccountingReports:
                     f'Could not delete PnL report {report_id} from the DB. Report was not found',
                 )
 
+    PNL_EVENTS_INSERT = (
+        'INSERT INTO pnl_events(report_id, timestamp, data, pnl_taxable, pnl_free, asset) '
+        'VALUES(?, ?, ?, ?, ?, ?);'
+    )
+
+    @staticmethod
+    def serialize_report_row(
+            report_id: int,
+            time: Timestamp,
+            ts_converter: Callable[[Timestamp], str],
+            event: ProcessedAccountingEvent,
+    ) -> tuple[int, Timestamp, str, str, str, str | None]:
+        """Serialize a processed accounting event into a pnl_events row tuple.
+
+        May raise DeserializationError if there is a conflict at serialization of the event.
+        """
+        try:
+            asset_symbol: str | None = event.asset.symbol_or_name()
+        except WrongAssetType:
+            asset_symbol = None
+
+        return (
+            report_id,
+            time,
+            event.serialize_for_db(ts_converter),
+            str(event.pnl.taxable),
+            str(event.pnl.free),
+            asset_symbol,
+        )
+
+    def add_report_data_rows(
+            self,
+            rows: list[tuple[int, Timestamp, str, str, str, str | None]],
+    ) -> None:
+        """Batch-insert pre-serialized pnl_events rows in a single transient-DB transaction.
+
+        Batching keeps a whole report's writes in one commit instead of one commit per
+        processed event, which dominates the I/O cost of large PnL reports.
+
+        May raise InputError if the rows can not be written. Probably report id does not exist.
+        """
+        if len(rows) == 0:
+            return
+
+        with self.db.transient_write() as cursor:
+            try:
+                cursor.executemany(self.PNL_EVENTS_INSERT, rows)
+            except sqlcipher.IntegrityError as e:  # pylint: disable=no-member
+                raise InputError(
+                    f'Could not write report data to the DB due to {e!s}. '
+                    f'Probably the report does not exist?',
+                ) from e
+
     def add_report_data(
             self,
             report_id: int,
@@ -240,41 +293,18 @@ class DBAccountingReports:
             ts_converter: Callable[[Timestamp], str],
             event: ProcessedAccountingEvent,
     ) -> None:
-        """Adds a new entry to a transient report for the PnL history in a given time range
+        """Adds a single processed event to a transient report.
+
         May raise:
         - DeserializationError if there is a conflict at serialization of the event
         - InputError if the event can not be written to the DB. Probably report id does not exist.
         """
-        data = event.serialize_for_db(ts_converter)
-
-        try:
-            asset_symbol = event.asset.symbol_or_name()
-        except WrongAssetType:
-            asset_symbol = None
-
-        query = """
-        INSERT INTO pnl_events(
-            report_id, timestamp, data, pnl_taxable, pnl_free, asset
-        )
-        VALUES(?, ?, ?, ?, ?, ?);"""
-        with self.db.transient_write() as cursor:
-            try:
-                cursor.execute(
-                    query,
-                    (
-                        report_id,
-                        time,
-                        data,
-                        str(event.pnl.taxable),
-                        str(event.pnl.free),
-                        asset_symbol,
-                    ),
-                )
-            except sqlcipher.IntegrityError as e:  # pylint: disable=no-member
-                raise InputError(
-                    f'Could not write {event} data to the DB due to {e!s}. '
-                    f'Probably report {report_id} does not exist?',
-                ) from e
+        self.add_report_data_rows([self.serialize_report_row(
+            report_id=report_id,
+            time=time,
+            ts_converter=ts_converter,
+            event=event,
+        )])
 
     def get_report_data(
             self,

--- a/rotkehlchen/fval.py
+++ b/rotkehlchen/fval.py
@@ -49,6 +49,15 @@ class FVal:
                 f'Found {type(data)}.',
             ) from e
 
+    @classmethod
+    def _from_decimal(cls, num: Decimal) -> 'FVal':
+        """Wrap an already-final Decimal without re-running __init__'s type dispatch and
+        its redundant Decimal() copy. The arithmetic operators below all produce a finished
+        Decimal, so this is a safe, byte-identical fast path."""
+        instance = cls.__new__(cls)
+        instance.num = num
+        return instance
+
     def __str__(self) -> str:
         s = format(self.num.normalize(), 'f')
         return '0' if s == '-0' else s
@@ -60,86 +69,65 @@ class FVal:
         return hash(self.num)
 
     def __gt__(self, other: AcceptableFValOtherInput) -> bool:
-        evaluated_other = _evaluate_input(other)
-        return self.num.compare_signal(evaluated_other) == Decimal(1)
+        return self.num > _evaluate_input(other)
 
     def __lt__(self, other: AcceptableFValOtherInput) -> bool:
-        evaluated_other = _evaluate_input(other)
-        return self.num.compare_signal(evaluated_other) == Decimal(-1)
+        return self.num < _evaluate_input(other)
 
     def __le__(self, other: AcceptableFValOtherInput) -> bool:
-        evaluated_other = _evaluate_input(other)
-        return self.num.compare_signal(evaluated_other) in (Decimal(-1), Decimal(0))
+        return self.num <= _evaluate_input(other)
 
     def __ge__(self, other: AcceptableFValOtherInput) -> bool:
-        evaluated_other = _evaluate_input(other)
-        return self.num.compare_signal(evaluated_other) in (Decimal(1), Decimal(0))
+        return self.num >= _evaluate_input(other)
 
     def __eq__(self, other: object) -> bool:
-        evaluated_other: Decimal | int
         if isinstance(other, FVal):
-            evaluated_other = other.num
-        elif not isinstance(other, int):
-            return False
-        else:
-            evaluated_other = other
-
-        return self.num.compare_signal(evaluated_other) == Decimal(0)
+            return self.num == other.num
+        if isinstance(other, int):  # note: bool is an int subclass, matching prior behavior
+            return self.num == other
+        return False
 
     def __add__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__add__(evaluated_other))
+        return FVal._from_decimal(self.num + _evaluate_input(other))
 
     def __sub__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__sub__(evaluated_other))
+        return FVal._from_decimal(self.num - _evaluate_input(other))
 
     def __mul__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__mul__(evaluated_other))
+        return FVal._from_decimal(self.num * _evaluate_input(other))
 
     def __truediv__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__truediv__(evaluated_other))
+        return FVal._from_decimal(self.num / _evaluate_input(other))
 
     def __floordiv__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__floordiv__(evaluated_other))
+        return FVal._from_decimal(self.num // _evaluate_input(other))
 
     def __pow__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__pow__(evaluated_other))
+        return FVal._from_decimal(self.num ** _evaluate_input(other))
 
     def __radd__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__radd__(evaluated_other))
+        return FVal._from_decimal(_evaluate_input(other) + self.num)
 
     def __rsub__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__rsub__(evaluated_other))
+        return FVal._from_decimal(_evaluate_input(other) - self.num)
 
     def __rmul__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__rmul__(evaluated_other))
+        return FVal._from_decimal(_evaluate_input(other) * self.num)
 
     def __rtruediv__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__rtruediv__(evaluated_other))
+        return FVal._from_decimal(_evaluate_input(other) / self.num)
 
     def __rfloordiv__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__rfloordiv__(evaluated_other))
+        return FVal._from_decimal(_evaluate_input(other) // self.num)
 
     def __mod__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__mod__(evaluated_other))
+        return FVal._from_decimal(self.num % _evaluate_input(other))
 
     def __rmod__(self, other: AcceptableFValOtherInput) -> 'FVal':
-        evaluated_other = _evaluate_input(other)
-        return FVal(self.num.__rmod__(evaluated_other))
+        return FVal._from_decimal(_evaluate_input(other) % self.num)
 
     def __round__(self, ndigits: int) -> 'FVal':
-        return FVal(round(self.num, ndigits))
+        return FVal._from_decimal(round(self.num, ndigits))
 
     def __float__(self) -> float:
         return float(self.num)
@@ -147,10 +135,10 @@ class FVal:
     # --- Unary operands
 
     def __neg__(self) -> 'FVal':
-        return FVal(self.num.__neg__())
+        return FVal._from_decimal(-self.num)
 
     def __abs__(self) -> 'FVal':
-        return FVal(self.num.copy_abs())
+        return FVal._from_decimal(self.num.copy_abs())
 
     # --- Other operations
 

--- a/rotkehlchen/tests/unit/test_fval.py
+++ b/rotkehlchen/tests/unit/test_fval.py
@@ -1,4 +1,5 @@
 import math
+from decimal import InvalidOperation
 
 import pytest
 
@@ -101,6 +102,58 @@ def test_int_comparison():
     assert e <= c
     assert e >= c
     assert e == c
+
+
+def test_operators_preserve_decimal_value():
+    """The arithmetic/unary operators wrap the result via the _from_decimal fast path.
+    Pin that every result still equals the underlying raw Decimal operation, so the fast
+    path can never silently diverge from constructing FVal from the Decimal result."""
+    a, b = FVal('12.3456789'), FVal('0.98765')
+    assert (a + b).num == a.num + b.num
+    assert (a - b).num == a.num - b.num
+    assert (a * b).num == a.num * b.num
+    assert (a / b).num == a.num / b.num
+    assert (a // b).num == a.num // b.num
+    assert (a % b).num == a.num % b.num
+    assert (a ** 2).num == a.num ** 2
+    assert (-a).num == -a.num
+    assert abs(-a).num == a.num
+    assert round(a, 3).num == round(a.num, 3)
+    # reflected operators
+    assert (2 + b).num == 2 + b.num
+    assert (2 - b).num == 2 - b.num
+    assert (2 * b).num == 2 * b.num
+    assert isinstance(a + b, FVal)  # results are real FVal instances
+
+
+def test_comparisons_match_decimal():
+    """The native comparisons must match the Decimal semantics they replaced."""
+    a, b = FVal('1.0'), FVal('1.00')
+    assert a == b  # numerically equal despite different scale
+    assert a <= b
+    assert a >= b
+    assert not a < b
+    assert not a > b
+    assert FVal('2') > FVal('1')
+    assert FVal('1') < FVal('2')
+    assert FVal('2') == 2
+    assert FVal('2') != 3
+    assert FVal('2') != 'foo'  # non-numeric -> not equal, must not raise
+
+
+def test_nan_comparison_contract():
+    """A NaN never arises in practice (the decimal context traps the operations that would
+    produce one, and nothing constructs FVal('nan')), but pin the contract anyway: equality
+    returns False (standard IEEE behavior, and safe for dict/set membership), while ordering
+    raises InvalidOperation exactly like the previous compare_signal-based implementation."""
+    nan = FVal('nan')
+    assert nan.num.is_nan()
+    assert (nan == FVal(1)) is False
+    assert (nan == 1) is False
+    assert (FVal(1) == nan) is False
+    for bad in (lambda: nan > FVal(1), lambda: nan < FVal(1), lambda: nan >= FVal(1)):
+        with pytest.raises(InvalidOperation):
+            bad()
 
 
 def test_representation():


### PR DESCRIPTION
## Performance improvements
  
  - **`perf(accounting): avoid per-swap ignored-asset DB read`** — The SWAP and BASIS_TRANSFER accounting paths opened a fresh DB read-context and copied the ignored-asset set for every swap/transfer in a PnL report, when the same data is already held in memory on the pot.
  Use it directly. (~152× on the isolated lookup.)

  - **`perf(fval): faster arithmetic, comparisons and asset equality`** — FVal operators re-wrapped an already-final `Decimal` through the full `__init__` dispatch+copy on every call; comparisons built `Decimal(1/-1/0)` literals each time; `Asset.__eq__` lowercased both 
  identifiers even when already equal. Added a `_from_decimal` fast constructor, switched to native Decimal comparisons, and added an exact-match fast path. Measured **~24% faster** on a FVal-dense aggregation workload (2.80s → 2.12s); `__init__` cost dropped 0.975s → 
  0.258s. Behavior is identical for all non-NaN values (NaN can't arise in practice).

  - **`perf(accounting): batch PnL report event writes`** — `_add_processed_event` committed one transient-DB transaction per processed event. With the transient DB on WAL + `synchronous=FULL`, each commit is a real fsync (~0.107 ms/event), so a 30k–60k-event report spent
  **~3–6 seconds** purely on commits. Now buffers rows and flushes via `executemany` in batched transactions (74.7× on the isolated write path).
