### PR TITLE
Fix duplicate balance in hyperliquid

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 * :bug:`-` Changing the selected trade pairs of a Binance or Binance US exchange now correctly fetches the history of the newly added pairs.
 * :bug:`-` HTX deposit and withdrawal history is now queried correctly for accounts with more than 500 transfers, instead of getting stuck re-fetching the same first page.
 * :bug:`-` Coinbase Advanced Trade buys are no longer sometimes imported as sells when the trade direction is missing from the API.
+* :bug:`12319` Hyperliquid Valantis staked HYPE balances will no longer be shown twice as both stHYPE and wstHYPE.
 * :bug:`-` Swaps through a newer zeroxsettler will now be properly decoded by rotki.
 * :bug:`-` Poloniex history should now be properly queried again.
 * :bug:`-` Dismissing a calendar reminder (such as an L2 bridge claim) now sticks, instead of popping up again days later as if you had never acknowledged it.

--- a/rotkehlchen/chain/hyperliquid/manager.py
+++ b/rotkehlchen/chain/hyperliquid/manager.py
@@ -30,6 +30,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 HYPERLIQUID_CORE_HISTORY_RANGE_PREFIX: Final = 'hyperliquid_core_history'
+HYPERLIQUID_EVM_TOKEN_PREFIX: Final = 'eip155:999/erc20:'
+STHYPE_IDENTIFIER: Final = 'eip155:999/erc20:0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1'
+WSTHYPE_IDENTIFIER: Final = 'eip155:999/erc20:0x94e8396e0869c9F2200760aF0621aFd240E1CF38'
 
 
 class HyperliquidManager(EvmManager):
@@ -68,6 +71,17 @@ class HyperliquidManager(EvmManager):
     ) -> defaultdict[ChecksumEvmAddress, BalanceSheet]:
         """Query EVM on-chain balances plus Hyperliquid core spot/perp balances."""
         balances = defaultdict(BalanceSheet, super().query_balances(addresses))
+        for address in addresses:
+            if (
+                (assets := balances[address].assets) and
+                (wsthype := next((asset for asset in assets if asset.identifier == WSTHYPE_IDENTIFIER), None)) is not None and  # noqa: E501
+                (sthype := next((asset for asset in assets if asset.identifier == STHYPE_IDENTIFIER), None)) is not None  # noqa: E501
+            ):
+                log.debug(
+                    f'Skipping {sthype} balance for {address} since it represents the same '
+                    f'Valantis staked HYPE position as {wsthype}',
+                )
+                del assets[sthype]
 
         api = HyperliquidAPI()
         main_currency = CachedSettings().main_currency
@@ -86,6 +100,16 @@ class HyperliquidManager(EvmManager):
                     )
                 except RemoteError:
                     price = ZERO_PRICE
+
+                if (
+                    asset.identifier.startswith(HYPERLIQUID_EVM_TOKEN_PREFIX) and
+                    asset in balances[address].assets
+                ):
+                    log.debug(
+                        f'Skipping Hyperliquid core balance for {asset} at {address} '
+                        'since it is already present in HyperEVM balances',
+                    )
+                    continue
 
                 balances[address].assets[asset][DEFAULT_BALANCE_LABEL] += Balance(
                     amount=amount,

--- a/rotkehlchen/tests/unit/test_hyperliquid_core_balances.py
+++ b/rotkehlchen/tests/unit/test_hyperliquid_core_balances.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
-from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.chain.evm.types import NodeName, WeightedNode, string_to_evm_address
 from rotkehlchen.chain.hyperliquid.manager import HyperliquidManager
 from rotkehlchen.constants import DEFAULT_BALANCE_LABEL
 from rotkehlchen.constants.assets import A_HYPE, A_USDC
@@ -12,8 +14,14 @@ from rotkehlchen.constants.misc import ONE, ZERO
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.externalapis.hyperliquid import HyperliquidAPI
 from rotkehlchen.fval import FVal
+from rotkehlchen.types import ChainID, SupportedBlockchain
 
 ADDR_A = string_to_evm_address('0x7fC1b7863251Ac7F83c7a4E83ccd00d129Ee844c')
+REPORTED_STHYPE_HOLDER = string_to_evm_address('0xD2D4867b8886C0cfC3DE5CcD5203EC66C6183764')
+STHYPE_ADDRESS = string_to_evm_address('0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1')
+WSTHYPE_ADDRESS = string_to_evm_address('0x94e8396e0869c9F2200760aF0621aFd240E1CF38')
+A_STHYPE = Asset('eip155:999/erc20:0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1')
+A_WSTHYPE = Asset('eip155:999/erc20:0x94e8396e0869c9F2200760aF0621aFd240E1CF38')
 
 
 def test_query_balances_merges_evm_and_core_balances(
@@ -41,6 +49,60 @@ def test_query_balances_merges_evm_and_core_balances(
 
     assert result[ADDR_A].assets[A_HYPE][DEFAULT_BALANCE_LABEL].amount == FVal('0.075')
     assert result[ADDR_A].assets[A_USDC][DEFAULT_BALANCE_LABEL].amount == FVal('500')
+
+
+@pytest.mark.vcr(match_on=['uri', 'method', 'body'], record_mode='once')
+@pytest.mark.parametrize('hyperliquid_manager_connect_at_start', [(WeightedNode(
+    node_info=NodeName(
+        name='hyperliquid',
+        endpoint='https://rpc.hyperliquid.xyz/evm',
+        owned=False,
+        blockchain=SupportedBlockchain.HYPERLIQUID,
+    ),
+    active=True,
+    weight=ONE,
+),)])
+def test_query_balances_does_not_duplicate_reported_sthype_balance(
+        hyperliquid_manager: HyperliquidManager,
+        hyperliquid_manager_connect_at_start,
+        inquirer,
+        database,
+) -> None:
+    """Regression test for the reported Valantis wstHYPE/stHYPE double counting.
+
+    The reported account has both wstHYPE and stHYPE interfaces detected on HyperEVM.
+    They represent the same Valantis staked HYPE position and must not be shown as two
+    independent balances.
+    """
+    sthype = get_or_create_evm_token(
+        userdb=database,
+        evm_address=STHYPE_ADDRESS,
+        chain_id=ChainID.HYPERLIQUID,
+        symbol='stHYPE',
+        name='Staked HYPE',
+        decimals=18,
+    )
+    wsthype = get_or_create_evm_token(
+        userdb=database,
+        evm_address=WSTHYPE_ADDRESS,
+        chain_id=ChainID.HYPERLIQUID,
+        symbol='wstHYPE',
+        name='Staked HYPE Shares',
+        decimals=18,
+    )
+    with database.user_write() as write_cursor:
+        database.save_tokens_for_address(
+            write_cursor=write_cursor,
+            address=REPORTED_STHYPE_HOLDER,
+            blockchain=SupportedBlockchain.HYPERLIQUID,
+            tokens=[sthype, wsthype],
+        )
+
+    result = hyperliquid_manager.query_balances(addresses=[REPORTED_STHYPE_HOLDER])
+    assets = result[REPORTED_STHYPE_HOLDER].assets
+    wsthype_balance = assets[A_WSTHYPE][DEFAULT_BALANCE_LABEL].amount
+    assert wsthype_balance == FVal('0.000305155263028739')
+    assert A_STHYPE not in assets
 
 
 def test_query_balances_core_failure_returns_evm_only(


### PR DESCRIPTION
Fixes double counting of Hyperliquid assets that are visible both as HyperCore spot balances and HyperEVM ERC20 balances.

Some Hyperliquid spot assets, such as Valantis `STHYPE/wstHYPE`, have an `evmContract` and can therefore be returned by both:

- HyperEVM token balance querying
- HyperCore `spotClearinghouseState` balance querying

The previous merge logic always added HyperCore balances on top of HyperEVM balances, causing these assets to be counted twice.

- Detect Hyperliquid EVM token balances already present from the HyperEVM query.
- Skip adding the matching HyperCore balance for those assets.
- Add a regression test for the `STHYPE/wstHYPE` double-counting case.

```bash
uv run python pytestgeventwrapper.py rotkehlchen/tests/unit/test_hyperliquid_core_balances.py -q
```

Closes #12319
