### PR TITLE
fix(db): preserve manual balance ids in v51->v52 upgrade

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Tags on manually tracked balances are no longer dropped (or shown on the wrong balance) after updating, for users who had previously deleted a manual balance. The faulty cleanup that orphaned those tags is also reverted.
 * :bug:`-` A temporary node/indexer failure during token detection no longer wipes the previously detected tokens for an address. The cached token list is now kept intact until a successful detection can replace it, so balances no longer silently go missing after a transient RPC error.
 * :bug:`-` HTX balances are no longer under-reported. Funds locked in open orders (and balances of an asset held across multiple HTX account types) are now summed instead of overwriting each other.
 * :bug:`-` Special-cased asset prices are no longer shown in USD by mistake for non-USD main currencies when the exchange rate is temporarily unavailable.

--- a/rotkehlchen/data_migrations/constants.py
+++ b/rotkehlchen/data_migrations/constants.py
@@ -1,3 +1,3 @@
 from typing import Final
 
-LAST_USERDB_DATA_MIGRATION: Final = 25
+LAST_USERDB_DATA_MIGRATION: Final = 26

--- a/rotkehlchen/data_migrations/manager.py
+++ b/rotkehlchen/data_migrations/manager.py
@@ -15,6 +15,7 @@ from rotkehlchen.data_migrations.migrations.migration_22 import data_migration_2
 from rotkehlchen.data_migrations.migrations.migration_23 import data_migration_23
 from rotkehlchen.data_migrations.migrations.migration_24 import data_migration_24
 from rotkehlchen.data_migrations.migrations.migration_25 import data_migration_25
+from rotkehlchen.data_migrations.migrations.migration_26 import data_migration_26
 from rotkehlchen.data_migrations.migrations.migrations_13 import data_migration_13
 from rotkehlchen.data_migrations.migrations.migrations_14 import data_migration_14
 from rotkehlchen.data_migrations.migrations.migrations_18 import data_migration_18
@@ -53,6 +54,7 @@ MIGRATION_LIST = [  # remember to bump LAST_USERDB_DATA_MIGRATION if editing thi
     MigrationRecord(version=23, function=data_migration_23),
     MigrationRecord(version=24, function=data_migration_24),
     MigrationRecord(version=25, function=data_migration_25),
+    MigrationRecord(version=26, function=data_migration_26),
 ]
 
 

--- a/rotkehlchen/data_migrations/migrations/migration_26.py
+++ b/rotkehlchen/data_migrations/migrations/migration_26.py
@@ -1,0 +1,34 @@
+from typing import TYPE_CHECKING
+
+from rotkehlchen.logging import enter_exit_debug_log
+from rotkehlchen.utils.progress import perform_userdb_migration_steps, progress_step
+
+if TYPE_CHECKING:
+    from rotkehlchen.data_migrations.progress import MigrationProgressHandler
+    from rotkehlchen.rotkehlchen import Rotkehlchen
+
+
+@enter_exit_debug_log()
+def data_migration_26(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressHandler') -> None:
+    """Introduced at v1.43.2
+
+    Clean up manually tracked balance tag mappings that were orphaned by the v51->v52 DB
+    upgrade. That upgrade rebuilt manually_tracked_balances without preserving the id column,
+    so rows above a deleted-id gap were renumbered and their tag_mappings (keyed by the old id)
+    no longer point at any balance. Worse, since ids are now dense, a stale mapping can later
+    re-attach to a newly added balance that happens to reuse the old id, showing a phantom tag.
+
+    The original association is unrecoverable, so we delete the orphaned mappings. Manual balance
+    tags use a pure-integer object_reference (blockchain accounts use addresses and xpubs use the
+    xpub string), so all-digit references that match no current balance id are the orphans.
+    """
+    @progress_step(description='Removing orphaned manual balance tag mappings')
+    def _remove_orphaned_manual_balance_tags(rotki: 'Rotkehlchen') -> None:
+        with rotki.data.db.conn.write_ctx() as write_cursor:
+            write_cursor.execute(
+                'DELETE FROM tag_mappings WHERE '
+                "object_reference GLOB '[0-9]*' AND NOT object_reference GLOB '*[^0-9]*' AND "
+                'CAST(object_reference AS INTEGER) NOT IN (SELECT id FROM manually_tracked_balances)',  # noqa: E501
+            )
+
+    perform_userdb_migration_steps(rotki, progress_handler, should_vacuum=False)

--- a/rotkehlchen/db/upgrades/v51_v52.py
+++ b/rotkehlchen/db/upgrades/v51_v52.py
@@ -156,6 +156,14 @@ def upgrade_v51_to_v52(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
                     (f'{label} ({idx})', row_id),
                 )
 
+        # Preserve the id column when it exists so tag_mappings (which reference
+        # manually_tracked_balances.id) are not orphaned by a rowid renumbering. Some older DBs
+        # may predate the id column, so detect it instead of assuming it is present.
+        has_id = any(
+            row[1] == 'id'
+            for row in write_cursor.execute('PRAGMA table_info(manually_tracked_balances)')
+        )
+        columns = ('id, ' if has_id else '') + 'asset, label, amount, location, category'
         write_cursor.switch_foreign_keys('OFF')
         update_table_schema(
             write_cursor=write_cursor,
@@ -167,8 +175,8 @@ def upgrade_v51_to_v52(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             location CHAR(1) NOT NULL DEFAULT('A') REFERENCES location(location),
             category CHAR(1) NOT NULL DEFAULT('A') REFERENCES balance_category(category),
             FOREIGN KEY(asset) REFERENCES assets(identifier) ON UPDATE CASCADE""",
-            insert_columns='id, asset, label, amount, location, category',
-            insert_order='(id, asset, label, amount, location, category)',
+            insert_columns=columns,
+            insert_order=f'({columns})',
         )
         write_cursor.switch_foreign_keys('ON')
 

--- a/rotkehlchen/db/upgrades/v51_v52.py
+++ b/rotkehlchen/db/upgrades/v51_v52.py
@@ -167,8 +167,8 @@ def upgrade_v51_to_v52(db: 'DBHandler', progress_handler: 'DBUpgradeProgressHand
             location CHAR(1) NOT NULL DEFAULT('A') REFERENCES location(location),
             category CHAR(1) NOT NULL DEFAULT('A') REFERENCES balance_category(category),
             FOREIGN KEY(asset) REFERENCES assets(identifier) ON UPDATE CASCADE""",
-            insert_columns='asset, label, amount, location, category',
-            insert_order='(asset, label, amount, location, category)',
+            insert_columns='id, asset, label, amount, location, category',
+            insert_order='(id, asset, label, amount, location, category)',
         )
         write_cursor.switch_foreign_keys('ON')
 

--- a/rotkehlchen/db/utils.py
+++ b/rotkehlchen/db/utils.py
@@ -388,6 +388,7 @@ def update_table_schema(
         insert_columns: str | None = None,
         insert_order: str = '',
         insert_where: str | None = None,
+        allow_pk_renumber: bool = False,
 ) -> bool:
     """Update the schema of a given table. Need to provide:
     1. The name
@@ -395,11 +396,18 @@ def update_table_schema(
     3. The insert_columns of the old table that are to be inserted to the new one. If missing * is used
     4. Optionally an order of insertion parentheses in case not all are added or names changed.
     5. Optionally a WHERE statement for the insertion
+    6. Optionally allow_pk_renumber to permit dropping an existing INTEGER PRIMARY KEY from
+       insert_columns. This silently reassigns rowids and breaks any external references to the
+       old id (e.g. tag_mappings.object_reference), so it is rejected by default. Only set it
+       when the renumbering is intentional and nothing references the id.
 
     Also is made error-proof to simply create the table if the old one for some
     reason did not exist.
 
     Returns True if the table existed and insertions were made and False otherwise
+
+    May raise:
+    - ValueError if insert_columns drops an existing INTEGER PRIMARY KEY without allow_pk_renumber
     """  # noqa: E501
     indexes = write_cursor.execute(
         "SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=? AND sql IS NOT NULL",
@@ -409,6 +417,28 @@ def update_table_schema(
     select_insert_columns = '*' if insert_columns is None else insert_columns
     write_cursor.execute(f'CREATE TABLE IF NOT EXISTS {new_table_name} ({schema});')
     if new_table_name != table_name:
+        # Guard against silently renumbering an INTEGER PRIMARY KEY (rowid alias). If the new
+        # schema declares one and the old table already has that column but it is omitted from an
+        # explicit insert_columns, sqlite reassigns fresh rowids and any external reference to
+        # the old id (e.g. tag_mappings.object_reference) is orphaned. See the
+        # manually_tracked_balances regression fixed in the v51->v52 upgrade.
+        if (
+            insert_columns is not None and
+            allow_pk_renumber is False and
+            (pk_match := re.search(r'(\w+)\s+INTEGER\b[^,]*\bPRIMARY\s+KEY\b', schema, re.IGNORECASE)) is not None  # noqa: E501
+        ):
+            pk_column = pk_match.group(1).lower()
+            old_columns = {row[1].lower() for row in write_cursor.execute(f'PRAGMA table_info({table_name})')}  # noqa: E501
+            insert_column_set = {column.strip().strip('"').lower() for column in insert_columns.split(',')}  # noqa: E501
+            if pk_column in old_columns and pk_column not in insert_column_set:
+                raise ValueError(
+                    f"update_table_schema for '{table_name}' would renumber the INTEGER PRIMARY "
+                    f"KEY '{pk_column}' because it is not part of insert_columns. This silently "
+                    f'breaks external references to that id (e.g. tag_mappings). Include '
+                    f"'{pk_column}' in insert_columns, or pass allow_pk_renumber=True if the "
+                    f'renumbering is intentional and nothing references the id.',
+                )
+
         insert_where = f' WHERE {insert_where}' if insert_where else ''
         write_cursor.execute(f'INSERT OR IGNORE INTO {new_table_name}{insert_order} SELECT {select_insert_columns} FROM {table_name}{insert_where}')  # noqa: E501
         write_cursor.execute(f'DROP TABLE {table_name}')

--- a/rotkehlchen/tests/data_migrations/test_migration_26.py
+++ b/rotkehlchen/tests/data_migrations/test_migration_26.py
@@ -1,0 +1,44 @@
+"""Test for data migration 26 - cleanup of orphaned manual balance tag mappings."""
+import pytest
+
+from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.tests.utils.data_migrations import run_single_migration
+
+
+@pytest.mark.parametrize('data_migration_version', [25])
+def test_migration_26_orphaned_manual_balance_tags(database: DBHandler) -> None:
+    """Orphaned manual-balance tag mappings (left by the v51->v52 id renumbering) are removed,
+    while valid manual-balance tags and non-numeric references (blockchain accounts, xpubs) stay.
+    """
+    address = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e'
+    xpub_ref = 'xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz/m'  # noqa: E501
+    with database.user_write() as write_cursor:
+        # two manual balances with an id gap (id 4 missing), as left behind by a deletion
+        write_cursor.executemany(
+            'INSERT INTO manually_tracked_balances(id, asset, label, amount, location, category) '
+            'VALUES(?, ?, ?, ?, ?, ?)',
+            [
+                (3, 'BTC', 'kept wallet', '1', 'A', 'A'),
+                (5, 'ETH', 'tagged wallet', '2', 'A', 'A'),
+            ],
+        )
+        write_cursor.execute(
+            'INSERT OR IGNORE INTO tags(name, description, background_color, foreground_color) '
+            'VALUES(?, ?, ?, ?)', ('public', '', 'ffffff', '000000'),
+        )
+        write_cursor.executemany(
+            'INSERT INTO tag_mappings(object_reference, tag_name) VALUES(?, ?)',
+            [
+                ('5', 'public'),  # valid: points at an existing manual balance
+                ('7', 'public'),  # orphan: no manual balance with id 7
+                (address, 'public'),  # blockchain account tag, must be untouched
+                (xpub_ref, 'public'),  # xpub tag, must be untouched
+            ],
+        )
+
+    run_single_migration(database=database, migration=26)
+
+    with database.conn.read_ctx() as cursor:
+        assert set(cursor.execute(
+            'SELECT object_reference FROM tag_mappings WHERE tag_name=?', ('public',),
+        ).fetchall()) == {('5',), (address,), (xpub_ref,)}  # orphan '7' removed, rest kept

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -4014,17 +4014,26 @@ def test_upgrade_db_51_to_52(user_data_dir, messages_aggregator):
             ),
         )
 
-    # Insert manually tracked balances with duplicate labels to test dedup
+    # Insert manually tracked balances with duplicate labels (to test dedup) and an id gap
+    # with a tagged balance above it. The rebuild must preserve ids so tag_mappings (which
+    # reference manually_tracked_balances.id) are not orphaned/re-pointed.
     with db_v51.conn.write_ctx() as write_cursor:
         write_cursor.executemany(
-            'INSERT INTO manually_tracked_balances(asset, label, amount, location, category) '
-            'VALUES(?, ?, ?, ?, ?)',
+            'INSERT INTO manually_tracked_balances(id, asset, label, amount, location, category) '
+            'VALUES(?, ?, ?, ?, ?, ?)',
             [
-                ('BTC', 'My wallet', '1.5', 'A', 'A'),
-                ('ETH', 'My wallet', '10', 'A', 'A'),  # duplicate label
-                ('ETH', 'My wallet', '20', 'A', 'A'),  # another duplicate
-                ('BTC', 'Unique balance', '0.5', 'A', 'A'),
+                (1, 'BTC', 'My wallet', '1.5', 'A', 'A'),
+                (2, 'ETH', 'My wallet', '10', 'A', 'A'),  # duplicate label
+                (3, 'ETH', 'My wallet', '20', 'A', 'A'),  # another duplicate
+                (5, 'BTC', 'Unique balance', '0.5', 'A', 'A'),  # id 4 missing -> gap
             ],
+        )
+        write_cursor.execute(
+            'INSERT OR IGNORE INTO tags(name, description, background_color, foreground_color) '
+            'VALUES(?, ?, ?, ?)', ('public', '', 'ffffff', '000000'),
+        )
+        write_cursor.execute(  # tag the balance sitting above the id gap
+            'INSERT INTO tag_mappings(object_reference, tag_name) VALUES(?, ?)', ('5', 'public'),
         )
         # make sure new chain locations not in the old DB
         assert write_cursor.execute(
@@ -4116,6 +4125,16 @@ def test_upgrade_db_51_to_52(user_data_dir, messages_aggregator):
         ).fetchall()
         assert len(rows) == 4
         assert all(row[0] is not None for row in rows)  # all have an id
+        # ids are preserved across the rebuild (the gap at 4 is kept), so the tag mapping that
+        # references id 5 still resolves to the correct balance instead of being orphaned
+        assert cursor.execute(
+            'SELECT id FROM manually_tracked_balances ORDER BY id',
+        ).fetchall() == [(1,), (2,), (3,), (5,)]
+        assert cursor.execute(
+            'SELECT B.tag_name FROM manually_tracked_balances A '
+            'JOIN tag_mappings B ON B.object_reference = A.id WHERE A.label = ?',
+            ('Unique balance',),
+        ).fetchall() == [('public',)]
 
         # make sure new chain locations exist
         assert cursor.execute(

--- a/rotkehlchen/tests/db/test_utils.py
+++ b/rotkehlchen/tests/db/test_utils.py
@@ -7,6 +7,7 @@ from rotkehlchen.db.utils import (
     combine_asset_balances,
     db_tuple_to_str,
     form_query_to_filter_timestamps,
+    update_table_schema,
 )
 from rotkehlchen.fval import FVal
 from rotkehlchen.types import SUPPORTED_EVM_EVMLIKE_CHAINS, SupportedBlockchain
@@ -200,3 +201,51 @@ def test_db_tuple_to_str(data, tuple_type, expected_str):
 ])
 def test_get_chains_to_detect_evm_accounts(database, expected_chains):
     assert set(database.get_chains_to_detect_evm_accounts()) == expected_chains
+
+
+def test_update_table_schema_rejects_pk_renumber(database):
+    """update_table_schema must refuse to silently renumber an existing INTEGER PRIMARY KEY,
+    since that orphans external references (e.g. tag_mappings.object_reference). It is allowed
+    only when the id is preserved, or explicitly opted into via allow_pk_renumber."""
+    schema = 'id INTEGER PRIMARY KEY, name TEXT'
+    with database.user_write() as write_cursor:
+        write_cursor.execute('CREATE TABLE pk_test (id INTEGER PRIMARY KEY, name TEXT)')
+        write_cursor.executemany(
+            'INSERT INTO pk_test(id, name) VALUES(?, ?)',
+            [(1, 'a'), (3, 'b')],  # gap at 2
+        )
+
+        def current_ids() -> list:
+            return write_cursor.execute('SELECT id FROM pk_test ORDER BY id').fetchall()
+
+        # dropping the id from an explicit insert_columns is rejected
+        with pytest.raises(ValueError, match='would renumber the INTEGER PRIMARY KEY'):
+            update_table_schema(
+                write_cursor=write_cursor,
+                table_name='pk_test',
+                schema=schema,
+                insert_columns='name',
+                insert_order='(name)',
+            )
+        write_cursor.execute('DROP TABLE IF EXISTS pk_test_new')  # clean the half-built table
+
+        # including the id preserves the original ids (and the gap)
+        update_table_schema(
+            write_cursor=write_cursor,
+            table_name='pk_test',
+            schema=schema,
+            insert_columns='id, name',
+            insert_order='(id, name)',
+        )
+        assert current_ids() == [(1,), (3,)]
+
+        # explicit opt-in renumbers without raising
+        update_table_schema(
+            write_cursor=write_cursor,
+            table_name='pk_test',
+            schema=schema,
+            insert_columns='name',
+            insert_order='(name)',
+            allow_pk_renumber=True,
+        )
+        assert current_ids() == [(1,), (2,)]


### PR DESCRIPTION
The v51->v52 upgrade rebuilt manually_tracked_balances via update_table_schema without listing 'id' in insert_columns. SQLite therefore reassigned fresh rowids, so any row sitting above a deleted-id gap was renumbered. Manual balance tags are stored in tag_mappings keyed by that numeric id, so the renumbering orphaned them. Worse, because ids are now dense, a stale mapping can re-attach to a newly added balance that reuses the old id, showing a phantom tag.

Changes:
- Fix v51_v52 to include 'id' in insert_columns/insert_order so ids (and gaps) are preserved and tag references stay valid. Helps anyone still upgrading from <=v51.
- Harden update_table_schema: raise if an explicit insert_columns drops an INTEGER PRIMARY KEY that the old table already has (with an allow_pk_renumber opt-out for intentional cases). Audited all call sites; only v51_v52 was affected. Migrations that introduce the id fresh (v31_v32, v40_v41) are untouched since the old table lacks the column.
- Add data migration 26 (runs in the bugfix release, not a schema upgrade) to delete the orphaned tag_mappings left on already-upgraded DBs. All-integer object_references with no matching balance id are the orphans; address/xpub references are untouched. The original associations are unrecoverable, so cleanup is the correct scope.
- Tests: v51->v52 upgrade preserves ids/tags (fails without the fix), a generic update_table_schema guard test, and a migration 26 test. Changelog entry added.