### PR TITLE
fix(electron): don't hijack HTML handler on Linux

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 * :bug:`-` A temporary node/indexer failure during token detection no longer wipes the previously detected tokens for an address. The cached token list is now kept intact until a successful detection can replace it, so balances no longer silently go missing after a transient RPC error.
 * :bug:`-` HTX balances are no longer under-reported. Funds locked in open orders (and balances of an asset held across multiple HTX account types) are now summed instead of overwriting each other.
 * :bug:`12329` ENS domain extensions made through the renewal wrapper are now decoded as renewal events.
+* :bug:`12323` rotki no longer hijacks the system's default browser for HTML files on Linux (GNOME with older xdg-utils) when registering its ``rotki://`` link handler, and restores the association for users already affected by a previous version.
 * :bug:`-` Special-cased asset prices are no longer shown in USD by mistake for non-USD main currencies when the exchange rate is temporarily unavailable.
 * :bug:`-` Tags of an address tracked on multiple chains are now kept when you remove the address from only one of those chains.
 * :bug:`-` Changing the selected trade pairs of a Binance or Binance US exchange now correctly fetches the history of the newly added pairs.

--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -1,5 +1,6 @@
 import type { AppConfig } from '@electron/main/app-config';
 import process from 'node:process';
+import { protectHtmlAssociation } from '@electron/main/html-mime-protection';
 import { IpcManager } from '@electron/main/ipc-setup';
 import { LogService } from '@electron/main/log-service';
 import { MenuManager } from '@electron/main/menu';
@@ -83,27 +84,47 @@ export class Application {
   }
 
   private registerAsDefaultProtocolHandler() {
-    // Register the app as the default handler for rotki:// protocol
+    // On Linux, registering a URL-scheme handler via xdg-settings can hijack the
+    // default text/html association on GNOME with old xdg-utils (issue #12323,
+    // xdg-utils#180). Run the registration inside a guard that snapshots and
+    // restores the text/html handler if our call corrupts it.
+    protectHtmlAssociation(this.logger, () => this.registerProtocolClient());
+  }
+
+  private registerProtocolClient(): boolean {
     if (process.defaultApp) {
-      // In development
-      if (process.argv.length >= 2) {
-        this.logger.info(`Registering ${process.execPath} ${process.argv[1]} as the default handler for rotki:// protocol`);
-        const registrationSuccess = app.setAsDefaultProtocolClient('rotki', process.execPath, [process.argv[1]]);
-        if (!registrationSuccess) {
-          this.protocolRegistrationFailed = true;
-          this.logger.warn(`Failed to register ${process.execPath} ${process.argv[1]} as the default handler for rotki:// protocol`);
-        }
-      }
-    }
-    else {
-      // In production
-      this.logger.info(`Registering the app as the default handler for rotki:// protocol`);
-      const registrationSuccess = app.setAsDefaultProtocolClient('rotki');
+      // In development we always (re)register so rotki:// deep links point at the
+      // current dev binary. On Linux app.isDefaultProtocolClient ignores the
+      // path/args, so guarding here would wrongly skip when a production install
+      // already claimed the scheme.
+      if (process.argv.length < 2)
+        return false;
+
+      const devArgs = [process.argv[1]];
+      this.logger.info(`Registering ${process.execPath} ${process.argv[1]} as the default handler for rotki:// protocol`);
+      const registrationSuccess = app.setAsDefaultProtocolClient('rotki', process.execPath, devArgs);
       if (!registrationSuccess) {
         this.protocolRegistrationFailed = true;
-        this.logger.warn(`Failed to register the app as the default handler for rotki:// protocol`);
+        this.logger.warn(`Failed to register ${process.execPath} ${process.argv[1]} as the default handler for rotki:// protocol`);
       }
+      return true;
     }
+
+    // In production, skip re-registering when we are already the default handler
+    // so we do not re-run the (destructive on affected Linux setups) xdg-settings
+    // call on every launch.
+    if (app.isDefaultProtocolClient('rotki')) {
+      this.logger.info('rotki:// protocol handler already registered; skipping');
+      return false;
+    }
+
+    this.logger.info(`Registering the app as the default handler for rotki:// protocol`);
+    const registrationSuccess = app.setAsDefaultProtocolClient('rotki');
+    if (!registrationSuccess) {
+      this.protocolRegistrationFailed = true;
+      this.logger.warn(`Failed to register the app as the default handler for rotki:// protocol`);
+    }
+    return true;
   }
 
   private async initialize() {

--- a/frontend/app/electron/main/html-mime-protection.spec.ts
+++ b/frontend/app/electron/main/html-mime-protection.spec.ts
@@ -1,0 +1,160 @@
+import type { LogService } from '@electron/main/log-service';
+import process from 'node:process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { protectHtmlAssociation } from './html-mime-protection';
+
+const { execFileSync } = vi.hoisted(() => ({ execFileSync: vi.fn() }));
+
+vi.mock('node:child_process', () => ({ default: { execFileSync }, execFileSync }));
+
+function createLogger(): LogService {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as LogService;
+}
+
+/**
+ * Routes mocked xdg-mime/xdg-settings calls. `htmlHandler` is read for
+ * `query default text/html` and updated by the register() callback.
+ */
+function mockCommands(state: { htmlHandler?: string; defaultBrowser?: string }): void {
+  execFileSync.mockImplementation((command: string, args: string[]) => {
+    if (command === 'xdg-mime' && args[0] === 'query')
+      return `${state.htmlHandler ?? ''}\n`;
+
+    if (command === 'xdg-mime' && args[0] === 'default') {
+      state.htmlHandler = args[1];
+      return '';
+    }
+
+    if (command === 'xdg-settings' && args[0] === 'get')
+      return `${state.defaultBrowser ?? ''}\n`;
+
+    return '';
+  });
+}
+
+describe('protectHtmlAssociation', () => {
+  const originalPlatform = process.platform;
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  }
+
+  beforeEach(() => {
+    execFileSync.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+
+  function queryCallCount(): number {
+    return execFileSync.mock.calls.filter(([command, args]) => command === 'xdg-mime' && args[0] === 'query').length;
+  }
+
+  function restoreCallCount(): number {
+    return execFileSync.mock.calls.filter(([command, args]) => command === 'xdg-mime' && args[0] === 'default').length;
+  }
+
+  it('should run register without touching xdg tools on non-linux platforms', () => {
+    setPlatform('darwin');
+    const register = vi.fn((): boolean => true);
+
+    protectHtmlAssociation(createLogger(), register);
+
+    expect(register).toHaveBeenCalledOnce();
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should not restore when registration leaves the text/html handler untouched', () => {
+    setPlatform('linux');
+    const state = { htmlHandler: 'firefox.desktop' };
+    mockCommands(state);
+    // registration runs but does not hijack text/html
+    const register = vi.fn((): boolean => true);
+
+    protectHtmlAssociation(createLogger(), register);
+
+    expect(register).toHaveBeenCalledOnce();
+    expect(state.htmlHandler).toBe('firefox.desktop');
+    expect(restoreCallCount()).toBe(0);
+  });
+
+  it('should restore the previous handler when registration hijacks text/html', () => {
+    setPlatform('linux');
+    const state = { htmlHandler: 'firefox.desktop' };
+    mockCommands(state);
+    const register = vi.fn((): boolean => {
+      state.htmlHandler = 'rotki.desktop';
+      return true;
+    });
+
+    protectHtmlAssociation(createLogger(), register);
+
+    expect(state.htmlHandler).toBe('firefox.desktop');
+    expect(execFileSync).toHaveBeenCalledWith('xdg-mime', ['default', 'firefox.desktop', 'text/html'], expect.anything());
+  });
+
+  it('should heal an already-corrupted handler using the default web browser', () => {
+    setPlatform('linux');
+    // text/html is already rotki.desktop (corrupted on a previous launch) and the
+    // guard skips re-registration on this launch
+    const state = { htmlHandler: 'rotki.desktop', defaultBrowser: 'google-chrome.desktop' };
+    mockCommands(state);
+    const register = vi.fn((): boolean => false);
+
+    protectHtmlAssociation(createLogger(), register);
+
+    expect(state.htmlHandler).toBe('google-chrome.desktop');
+    expect(execFileSync).toHaveBeenCalledWith('xdg-mime', ['default', 'google-chrome.desktop', 'text/html'], expect.anything());
+  });
+
+  it('should not attempt a restore when no sane handler can be determined', () => {
+    setPlatform('linux');
+    const state = { htmlHandler: 'rotki.desktop' };
+    mockCommands(state); // no default browser available
+    const register = vi.fn((): boolean => false);
+
+    protectHtmlAssociation(createLogger(), register);
+
+    expect(restoreCallCount()).toBe(0);
+  });
+
+  it('should query text/html only once when registration is skipped', () => {
+    setPlatform('linux');
+    const state = { htmlHandler: 'firefox.desktop' };
+    mockCommands(state);
+    const register = vi.fn((): boolean => false);
+
+    protectHtmlAssociation(createLogger(), register);
+
+    expect(queryCallCount()).toBe(1);
+    expect(restoreCallCount()).toBe(0);
+  });
+
+  it('should re-check text/html after an actual registration', () => {
+    setPlatform('linux');
+    const state = { htmlHandler: 'firefox.desktop' };
+    mockCommands(state);
+    const register = vi.fn((): boolean => true);
+
+    protectHtmlAssociation(createLogger(), register);
+
+    expect(queryCallCount()).toBe(2);
+  });
+
+  it('should swallow errors from xdg tools and still run register', () => {
+    setPlatform('linux');
+    execFileSync.mockImplementation(() => {
+      throw new Error('xdg-mime not found');
+    });
+    const register = vi.fn((): boolean => true);
+
+    expect(() => protectHtmlAssociation(createLogger(), register)).not.toThrow();
+    expect(register).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/electron/main/html-mime-protection.ts
+++ b/frontend/app/electron/main/html-mime-protection.ts
@@ -1,0 +1,90 @@
+import type { LogService } from '@electron/main/log-service';
+import { execFileSync } from 'node:child_process';
+import process from 'node:process';
+
+const HTML_MIME_TYPE = 'text/html';
+const ROTKI_DESKTOP = 'rotki.desktop';
+// Cap each xdg-* invocation so a hanging tool (slow dbus/portal, networked home)
+// cannot freeze the startup path while we wait for it.
+const XDG_TIMEOUT_MS = 3000;
+
+function runXdg(command: string, args: string[], logger: LogService): string | undefined {
+  try {
+    const result = execFileSync(command, args, { encoding: 'utf8', timeout: XDG_TIMEOUT_MS });
+    const value = result.trim();
+    return value.length > 0 ? value : undefined;
+  }
+  catch (error) {
+    logger.warn(`Failed to run ${command} ${args.join(' ')}`, error);
+    return undefined;
+  }
+}
+
+function queryHtmlHandler(logger: LogService): string | undefined {
+  return runXdg('xdg-mime', ['query', 'default', HTML_MIME_TYPE], logger);
+}
+
+function queryDefaultWebBrowser(logger: LogService): string | undefined {
+  const browser = runXdg('xdg-settings', ['get', 'default-web-browser'], logger);
+  return browser && browser !== ROTKI_DESKTOP ? browser : undefined;
+}
+
+function restoreHtmlHandler(handler: string, logger: LogService): void {
+  try {
+    execFileSync('xdg-mime', ['default', handler, HTML_MIME_TYPE], { timeout: XDG_TIMEOUT_MS });
+    logger.info(`Restored the default ${HTML_MIME_TYPE} handler to ${handler}`);
+  }
+  catch (error) {
+    logger.warn(`Failed to restore the default ${HTML_MIME_TYPE} handler to ${handler}`, error);
+  }
+}
+
+/**
+ * Runs `register` while protecting the system's text/html association (issue #12323).
+ *
+ * On Linux/GNOME with old xdg-utils (<1.2.0, e.g. Ubuntu 24.04's 1.1.3), Electron's
+ * app.setAsDefaultProtocolClient shells out to `xdg-settings set
+ * default-url-scheme-handler`, whose buggy GNOME path (xdg-utils#180) also rewrites
+ * the default text/html handler in ~/.config/mimeapps.list. Registering rotki:// thus
+ * hijacks HTML files.
+ *
+ * We snapshot the text/html handler before registering and restore it if the call
+ * changed it to rotki.desktop. We also heal users already corrupted by a previous
+ * launch (snapshot is already rotki.desktop / unavailable) by falling back to the
+ * system default web browser, which is the correct text/html handler.
+ *
+ * On non-Linux platforms `register` is run unchanged; the bug is xdg-specific.
+ *
+ * `register` returns whether it actually attempted to (re)register the protocol.
+ * When it returns false (already registered / nothing to do) we skip the second
+ * snapshot, since only an actual registration can hijack text/html.
+ */
+export function protectHtmlAssociation(logger: LogService, register: () => boolean): void {
+  if (process.platform !== 'linux') {
+    register();
+    return;
+  }
+
+  const before = queryHtmlHandler(logger);
+
+  const registered = register();
+
+  // Only an actual registration can change text/html; if we skipped it the state
+  // is unchanged, so reuse `before` instead of spawning a second query.
+  const after = registered ? queryHtmlHandler(logger) : before;
+
+  // Only act if text/html ended up pointing at rotki; anything else we leave
+  // untouched so we can never make the association worse.
+  if (after !== ROTKI_DESKTOP)
+    return;
+
+  const restoreTo = before && before !== ROTKI_DESKTOP ? before : queryDefaultWebBrowser(logger);
+
+  if (restoreTo) {
+    logger.warn(`The default ${HTML_MIME_TYPE} handler was hijacked to ${ROTKI_DESKTOP}; restoring it (xdg-utils#180)`);
+    restoreHtmlHandler(restoreTo, logger);
+  }
+  else {
+    logger.warn(`The default ${HTML_MIME_TYPE} handler is ${ROTKI_DESKTOP} but no prior handler could be determined to restore it`);
+  }
+}


### PR DESCRIPTION
## Problem

Fixes #12323. On Ubuntu 24.04 (and other GNOME setups with old `xdg-utils`), launching rotki makes it the default handler for `text/html`, rewriting `~/.config/mimeapps.list`.

Root cause: `app.setAsDefaultProtocolClient('rotki')` (added for `rotki://` OAuth callbacks) shells out to `xdg-settings set default-url-scheme-handler`. The GNOME code path in old `xdg-utils` (<1.2.0, e.g. Ubuntu 24.04's 1.1.3 — [xdg-utils#180](https://gitlab.freedesktop.org/xdg/xdg-utils/-/issues/180)) also rewrites the default `text/html` handler. We registered unconditionally on every launch, so it re-hijacked HTML each start. Bumping Electron doesn't help ([electron#20382](https://github.com/electron/electron/issues/20382) was closed as an xdg bug); the fix path merged in xdg-utils ≥ 1.2.0, which affected users can't easily get.

## Fix

New `electron/main/html-mime-protection.ts` wraps the registration on Linux:
- snapshots `xdg-mime query default text/html` before registering;
- if the call hijacks it to `rotki.desktop`, restores the previous handler;
- heals users already corrupted by a previous launch (snapshot already `rotki.desktop`/unavailable) via the system default web browser;
- only ever acts when an actual hijack is detected — it can't make the association worse;
- bounds each `xdg-*` subprocess with a timeout so a hanging tool can't freeze startup.

In `application.ts`, production registration is now guarded with `isDefaultProtocolClient` so we don't re-run the destructive call every launch (dev still re-registers so `rotki://` points at the dev binary). Non-Linux platforms are unchanged — the bug is xdg-specific.

## Testing

- New unit tests in `html-mime-protection.spec.ts` (8 cases: no-op on non-Linux, restore-on-hijack, heal-already-corrupted, no-restore-when-no-sane-handler, single-query-when-skipped, re-check-after-register, error swallowing).
- `pnpm run typecheck` and lint clean.
- Manual end-to-end verification on an Ubuntu 24.04 GNOME VM is pending (can't reproduce on a modern-`xdg-utils` host).