### PR TITLE
ci(e2e): bump playwright, add install timeouts

### DIFF
--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -103,6 +103,7 @@ jobs:
       CI: true
       GROUP: ${{ matrix.group }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -186,10 +187,12 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
         working-directory: ./frontend/app
         run: npx playwright install chromium
 
       - name: Install Playwright system dependencies
+        timeout-minutes: 10
         working-directory: ./frontend/app
         run: npx playwright install-deps chromium
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: 1.0.3
       version: 1.0.3
     '@playwright/test':
-      specifier: 1.59.1
-      version: 1.59.1
+      specifier: 1.60.0
+      version: 1.60.0
     '@reown/appkit':
       specifier: 1.8.19
       version: 1.8.19
@@ -482,7 +482,7 @@ importers:
         version: 1.0.3(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.60.0
       '@tsconfig/node24':
         specifier: 'catalog:'
         version: 24.0.4
@@ -1683,8 +1683,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5510,13 +5510,13 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8065,9 +8065,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.60.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -13194,11 +13194,11 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.59.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -32,7 +32,7 @@ catalog:
   '@intlify/eslint-plugin-vue-i18n': 4.3.0
   '@intlify/unplugin-vue-i18n': 11.1.1
   '@pinia/testing': 1.0.3
-  '@playwright/test': 1.59.1
+  '@playwright/test': 1.60.0
   '@reown/appkit': 1.8.19
   '@reown/appkit-adapter-ethers': 1.8.19
   '@rotki/eslint-config': 5.0.1


### PR DESCRIPTION
## Problem

The `Frontend e2e tests` jobs hang in CI: `npx playwright install chromium` reaches **100% of the browser download in ~1–2s**, then silently stalls during extraction. With no timeout on the install steps and no job-level timeout, the jobs sit until GitHub's 6h default and have to be cancelled manually.

Root cause is the known upstream bug where `playwright install` hangs during extraction on **Node ≥24.16** with **Playwright <1.60.0** (microsoft/playwright#40724, fixed in 1.60.0). Our `frontend/.nvmrc` pins a floating `v24`, which recently rolled past 24.16 while the catalog was still on `@playwright/test` `1.59.1` — so the combo started triggering. It's branch-independent (this reusable workflow runs on `bugfixes`, `develop`, `master`, nightly).

`develop` already resolved this (Playwright `1.60.0` + a job-level `timeout-minutes: 20`); this backports the equivalent fix to `bugfixes` without the larger group→shard matrix refactor on develop.

## Changes

- Bump `@playwright/test` `1.59.1` → `1.60.0` (vendors the upstream extraction fix; matches develop) + refreshed `pnpm-lock.yaml`.
- Add `timeout-minutes: 20` to the `e2e` job as a backstop (matches develop).
- Add `timeout-minutes: 10` to the **Install Playwright browsers** and **Install Playwright system dependencies** steps so any future install hang fails fast instead of parking the runner.

## Testing

CI on this PR exercises the change directly — the e2e jobs should now install Playwright and run to completion instead of hanging.