### PR TITLE
fix(history): location icons in linked movements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` In an expanded linked movement, each leg now shows its own location icon: the exchange icon on the exchange deposit/withdrawal and the chain icon on the on-chain transfer leg, instead of the exchange icon incorrectly appearing on the on-chain leg.
 * :bug:`-` Tags on manually tracked balances are no longer dropped (or shown on the wrong balance) after updating, for users who had previously deleted a manual balance. The faulty cleanup that orphaned those tags is also reverted.
 * :bug:`-` A temporary node/indexer failure during token detection no longer wipes the previously detected tokens for an address. The cached token list is now kept intact until a successful detection can replace it, so balances no longer silently go missing after a transient RPC error.
 * :bug:`-` HTX balances are no longer under-reported. Funds locked in open orders (and balances of an asset held across multiple HTX account types) are now summed instead of overwriting each other.

--- a/frontend/app/src/modules/history/events/HistoryEventType.spec.ts
+++ b/frontend/app/src/modules/history/events/HistoryEventType.spec.ts
@@ -1,0 +1,129 @@
+import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HistoryEventAccountingRuleStatus, type HistoryEventEntry } from '@/modules/history/events/schemas';
+import HistoryEventType from './HistoryEventType.vue';
+
+vi.mock('@/modules/history/events/mapping/use-history-event-mappings', () => ({
+  useHistoryEventMappings: vi.fn().mockReturnValue({
+    getEventTypeData: (): ComputedRef<{ label: string; icon: string; color: string; identifier: string }> =>
+      computed(() => ({ color: 'primary', icon: 'lu-circle', identifier: 'transfer', label: 'Transfer' })),
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn().mockReturnValue({
+    // Treat blockchains as matched, exchanges (e.g. kraken) as unmatched.
+    matchChain: (location: string): string | undefined =>
+      ['ethereum', 'optimism'].includes(location) ? location : undefined,
+  }),
+}));
+
+describe('history/events/HistoryEventType', () => {
+  let pinia: Pinia;
+
+  const stubs = {
+    HistoryEventTypeCombination: { template: '<div data-testid="combination" />' },
+    HistoryEventTypeCounterparty: {
+      props: ['counterparty', 'address', 'location'],
+      template: '<div data-testid="counterparty-badge"><slot /></div>',
+    },
+    HistoryEventTypeLocationBadge: {
+      props: ['location'],
+      template: '<div data-testid="location-badge"><slot /></div>',
+    },
+    HistoryEventAccount: { template: '<div />' },
+    HistoryEventStateChip: { template: '<div />' },
+  };
+
+  const commonFields = {
+    amount: bigNumberify('100'),
+    asset: 'ETH',
+    eventAccountingRuleStatus: HistoryEventAccountingRuleStatus.PROCESSED,
+    eventSubtype: 'spend',
+    eventType: 'withdrawal',
+    groupIdentifier: 'group1',
+    hidden: false,
+    identifier: 1,
+    ignoredInAccounting: false,
+    locationLabel: 'Account 1',
+    sequenceIndex: 0,
+    states: [],
+    timestamp: 1000000,
+  };
+
+  function createEvmEvent(location: string, counterparty: string | null): HistoryEventEntry {
+    return {
+      ...commonFields,
+      address: null,
+      counterparty,
+      entryType: HistoryEventEntryType.EVM_EVENT,
+      extraData: null,
+      location,
+      txRef: 'tx1',
+    };
+  }
+
+  function createAssetMovement(location: string): HistoryEventEntry {
+    return {
+      ...commonFields,
+      entryType: HistoryEventEntryType.ASSET_MOVEMENT_EVENT,
+      extraData: null,
+      location,
+    };
+  }
+
+  function createOnlineEvent(location: string): HistoryEventEntry {
+    return {
+      ...commonFields,
+      entryType: HistoryEventEntryType.HISTORY_EVENT,
+      location,
+    };
+  }
+
+  function createWrapper(
+    event: HistoryEventEntry,
+    matchedMovement?: boolean,
+  ): VueWrapper<InstanceType<typeof HistoryEventType>> {
+    return mount(HistoryEventType, {
+      global: { plugins: [pinia], stubs },
+      props: { event, matchedMovement },
+    });
+  }
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  it('should show the location badge on the exchange-side asset movement of a matched movement', () => {
+    const wrapper = createWrapper(createAssetMovement('kraken'), true);
+
+    expect(wrapper.find('[data-testid="location-badge"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="counterparty-badge"]').exists()).toBe(false);
+  });
+
+  it('should show the chain icon and suppress the counterparty badge on the on-chain leg of a matched movement', () => {
+    const wrapper = createWrapper(createEvmEvent('optimism', 'kraken'), true);
+
+    expect(wrapper.find('[data-testid="counterparty-badge"]').exists()).toBe(false);
+    const badge = wrapper.find('[data-testid="location-badge"]');
+    expect(badge.exists()).toBe(true);
+    expect(wrapper.findComponent(stubs.HistoryEventTypeLocationBadge).props('location')).toBe('optimism');
+  });
+
+  it('should still show the counterparty badge for a normal on-chain event (not a matched movement)', () => {
+    const wrapper = createWrapper(createEvmEvent('optimism', 'kraken'), false);
+
+    expect(wrapper.find('[data-testid="counterparty-badge"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="location-badge"]').exists()).toBe(false);
+  });
+
+  it('should not show the location badge for a non-asset-movement event on an exchange', () => {
+    const wrapper = createWrapper(createOnlineEvent('kraken'), true);
+
+    expect(wrapper.find('[data-testid="location-badge"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="counterparty-badge"]').exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/history/events/HistoryEventType.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventType.vue
@@ -1,24 +1,64 @@
 <script setup lang="ts">
 import type { RuiIcons } from '@rotki/ui-library';
 import type { HistoryEventEntry, HistoryEventState } from '@/modules/history/events/schemas';
+import { HistoryEventEntryType } from '@rotki/common';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import HistoryEventAccount from '@/modules/history/events/HistoryEventAccount.vue';
 import HistoryEventStateChip from '@/modules/history/events/HistoryEventStateChip.vue';
 import HistoryEventTypeCombination from '@/modules/history/events/HistoryEventTypeCombination.vue';
 import HistoryEventTypeCounterparty from '@/modules/history/events/HistoryEventTypeCounterparty.vue';
+import HistoryEventTypeLocationBadge from '@/modules/history/events/HistoryEventTypeLocationBadge.vue';
 import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
 
-const { event, groupLocationLabel, icon, highlight, hideStateChips } = defineProps<{
+const { event, groupLocationLabel, icon, highlight, hideStateChips, matchedMovement } = defineProps<{
   event: HistoryEventEntry;
   groupLocationLabel?: string;
   icon?: RuiIcons;
   highlight?: boolean;
   hideStateChips?: boolean;
+  /** Set when the event is rendered inside an expanded linked (matched) movement. */
+  matchedMovement?: boolean;
 }>();
 
 const { getEventTypeData } = useHistoryEventMappings();
+const { matchChain } = useSupportedChains();
+
 const attrs = getEventTypeData(() => event);
 
+const counterparty = computed<string | undefined>(() =>
+  'counterparty' in event ? (event.counterparty ?? undefined) : undefined,
+);
+
+const address = computed<string | undefined>(() =>
+  'address' in event ? (event.address ?? undefined) : undefined,
+);
+
 const isInformational = computed<boolean>(() => event.eventType === 'informational');
+
+// Whether the event's own location is an exchange (e.g. kraken) rather than a blockchain.
+const isExchangeLocation = computed<boolean>(() => !matchChain(event.location));
+
+const hasCounterpartyBadge = computed<boolean>(() => !!get(counterparty) || !!get(address));
+
+// The exchange-side leg of a linked movement: the asset movement at the exchange location.
+const isExchangeMovementLeg = computed<boolean>(() =>
+  !!matchedMovement
+  && get(isExchangeLocation)
+  && event.entryType === HistoryEventEntryType.ASSET_MOVEMENT_EVENT,
+);
+
+// The on-chain leg of a linked movement: the transfer that happened on a blockchain.
+const isOnChainLeg = computed<boolean>(() => !!matchedMovement && !get(isExchangeLocation));
+
+// Surface a location icon on each leg: the exchange icon on the exchange-side asset movement,
+// and the chain icon on the on-chain leg.
+const showLocationBadge = computed<boolean>(() => get(isExchangeMovementLeg) || get(isOnChainLeg));
+
+// The on-chain leg carries a synthetic counterparty pointing at the exchange. Suppress it so
+// the chain icon shows on that leg instead.
+const showCounterpartyBadge = computed<boolean>(() =>
+  get(hasCounterpartyBadge) && !get(isOnChainLeg),
+);
 
 const eventStates = computed<HistoryEventState[]>(() => event.states ?? []);
 
@@ -38,9 +78,9 @@ const showLocationLabel = computed<boolean>(() => {
     class="flex items-center text-left min-w-0"
   >
     <HistoryEventTypeCounterparty
-      v-if="('counterparty' in event && event.counterparty) || ('address' in event && event.address)"
-      :counterparty="event.counterparty || undefined"
-      :address="event.address || undefined"
+      v-if="showCounterpartyBadge"
+      :counterparty="counterparty"
+      :address="address"
       :location="event.location"
       class="shrink-0"
     >
@@ -51,6 +91,18 @@ const showLocationLabel = computed<boolean>(() => {
         :show-info="isInformational"
       />
     </HistoryEventTypeCounterparty>
+    <HistoryEventTypeLocationBadge
+      v-else-if="showLocationBadge"
+      :location="event.location"
+      class="shrink-0"
+    >
+      <HistoryEventTypeCombination
+        :highlight="highlight"
+        :icon="icon"
+        :type="attrs"
+        :show-info="isInformational"
+      />
+    </HistoryEventTypeLocationBadge>
     <HistoryEventTypeCombination
       v-else
       :highlight="highlight"

--- a/frontend/app/src/modules/history/events/HistoryEventTypeLocationBadge.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventTypeLocationBadge.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { useLocations } from '@/modules/core/common/use-locations';
+import LocationIcon from '@/modules/shell/components/display/LocationIcon.vue';
+
+const { location } = defineProps<{
+  location: string;
+}>();
+
+defineSlots<{
+  default: () => void;
+}>();
+
+const { useLocationData } = useLocations();
+
+const locationData = useLocationData(() => location);
+</script>
+
+<template>
+  <RuiBadge
+    class="[&_span]:!px-0"
+    color="default"
+    offset-x="-8"
+    offset-y="6"
+  >
+    <template #icon>
+      <RuiTooltip
+        :popper="{ placement: 'top', scroll: false, resize: false }"
+        :open-delay="400"
+      >
+        <template #activator>
+          <div class="rounded-full overflow-hidden bg-rui-grey-100 border-2 border-white dark:border-black size-6 flex items-center justify-center">
+            <LocationIcon
+              icon
+              :item="location"
+              size="20px"
+            />
+          </div>
+        </template>
+        <div class="capitalize">
+          {{ locationData?.name ?? location }}
+        </div>
+      </RuiTooltip>
+    </template>
+    <slot />
+  </RuiBadge>
+</template>

--- a/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.vue
@@ -15,6 +15,7 @@ const {
   index,
   completeGroupEvents,
   groupLocationLabel,
+  matchedMovement,
   hideActions,
   highlight,
   highlightType,
@@ -29,6 +30,8 @@ const {
    */
   completeGroupEvents: HistoryEventEntry[];
   groupLocationLabel?: string;
+  /** Set when this row is a sub-event of an expanded linked (matched) movement. */
+  matchedMovement?: boolean;
   hideActions?: boolean;
   highlight?: boolean;
   highlightType?: HighlightType;
@@ -99,6 +102,7 @@ const isCard = computed<boolean>(() => variant === 'card');
           :event="event"
           :chain="chain"
           :group-location-label="groupLocationLabel"
+          :matched-movement="matchedMovement"
           :highlight="highlight"
           class="min-w-0 flex-1"
         />
@@ -163,6 +167,7 @@ const isCard = computed<boolean>(() => variant === 'card');
       :event="event"
       :chain="chain"
       :group-location-label="groupLocationLabel"
+      :matched-movement="matchedMovement"
       :highlight="highlight"
       class="w-56 shrink-0"
     />

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -360,6 +360,7 @@ function isShowingIgnoredAssets(groupId: string): boolean {
             :index="row.index"
             :complete-group-events="getCompleteEventsForItem(row.groupId, row.data)"
             :group-location-label="findGroup(row.groupId)?.locationLabel ?? undefined"
+            :matched-movement="row.matchedMovement"
             :hide-actions="hideActions"
             :highlight="isHighlighted(row.data)"
             :highlight-type="getHighlightType(row.data)"

--- a/frontend/app/src/modules/history/events/use-virtual-rows.ts
+++ b/frontend/app/src/modules/history/events/use-virtual-rows.ts
@@ -41,6 +41,8 @@ export interface EventDetailRow {
   groupId: string;
   data: HistoryEventEntry;
   index: number;
+  /** True when this row is a sub-event of an expanded linked (matched) movement. */
+  matchedMovement?: boolean;
 }
 
 export interface EventPlaceholderRow {
@@ -190,6 +192,7 @@ export function useVirtualRows(
                   groupId,
                   data: subEvent,
                   index: subIndex,
+                  matchedMovement: true,
                 });
               });
             }


### PR DESCRIPTION
## Summary

In an **expanded linked (matched) movement**, each leg now shows its own location icon:
- the **exchange icon** on the exchange-side deposit/withdrawal (the asset movement), and
- the **chain icon** on the on-chain transfer leg.

Previously the synthetic exchange counterparty that the backend writes onto the on-chain leg (`rotkehlchen/tasks/events.py`) caused the exchange icon to render on the on-chain "Account Withdraw" leg, while the actual exchange-side asset movement got no icon at all.

This is a **frontend-only** change — no backend data is modified. It is scoped strictly to the expanded matched-movement rows; standalone events and normal protocol/counterparty badges are unaffected.

## Changes
- New `HistoryEventTypeLocationBadge.vue` — badge overlay rendering a location/exchange/chain icon.
- `HistoryEventType.vue` — badge selection split into `isExchangeMovementLeg` / `isOnChainLeg`; suppresses the synthetic counterparty on the on-chain leg and shows the chain icon there instead.
- `use-virtual-rows.ts` / `HistoryEventsVirtualTable.vue` / `HistoryEventsDetailItem.vue` — thread a `matchedMovement` flag down to the expanded sub-rows.

## Testing
- Added `HistoryEventType.spec.ts` covering: exchange-side asset movement → exchange badge; on-chain leg → chain badge + counterparty suppressed; non-matched on-chain event → counterparty badge still shows (regression guard); non-asset-movement event at an exchange → no badge.
- `pnpm run test:unit`, `lint-staged`, and `typecheck` all pass.
- Manually verified against a matched Crypto.com DAI deposit ↔ on-chain DAI send.