### PR TITLE
fix(history): clear ignored-asset flag on unignore

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` When you unignore an asset from a history event, its group no longer keeps flagging hidden ignored assets, so you are not misled into thinking events are still hidden when there is nothing left to reveal.
 * :bug:`-` In an expanded linked movement, each leg now shows its own location icon: the exchange icon on the exchange deposit/withdrawal and the chain icon on the on-chain transfer leg, instead of the exchange icon incorrectly appearing on the on-chain leg.
 * :bug:`-` Tags on manually tracked balances are no longer dropped (or shown on the wrong balance) after updating, for users who had previously deleted a manual balance. The faulty cleanup that orphaned those tags is also reverted.
 * :bug:`-` A temporary node/indexer failure during token detection no longer wipes the previously detected tokens for an address. The cached token list is now kept intact until a successful detection can replace it, so balances no longer silently go missing after a transient RPC error.

--- a/frontend/app/src/modules/history/events/use-history-events-data.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-data.spec.ts
@@ -12,6 +12,7 @@ const mockItemsPerPage = ref<number>(10);
 const mockFetchHistoryEvents = vi.fn();
 const mockIsAssetIgnored = vi.fn();
 const mockCancelByTag = vi.fn();
+const mockIgnoredAssets = ref<string[]>([]);
 
 vi.mock('@/modules/history/events/use-history-events', () => ({
   useHistoryEvents: vi.fn(() => ({
@@ -38,7 +39,7 @@ vi.mock('@/modules/history/events/use-history-events-status', () => ({
 vi.mock('@/modules/assets/use-assets-store', () => ({
   useAssetsStore: vi.fn(() => ({
     isAssetIgnored: mockIsAssetIgnored,
-    ignoredAssets: ref<string[]>([]),
+    ignoredAssets: mockIgnoredAssets,
   })),
 }));
 
@@ -103,6 +104,7 @@ describe('use-history-events-data', () => {
     scope = effectScope();
     mockFetchHistoryEvents.mockResolvedValue({ data: [] });
     mockIsAssetIgnored.mockReturnValue(false);
+    set(mockIgnoredAssets, []);
   });
 
   afterEach(() => {
@@ -1020,6 +1022,140 @@ describe('use-history-events-data', () => {
       const result = scope.run(() => useHistoryEventsData(options, emit))!;
 
       expect(result.isSubgroupIncomplete([])).toBe(false);
+    });
+  });
+
+  describe('showing ignored assets reconciliation', () => {
+    async function waitForFetchEvents(): Promise<void> {
+      await nextTick();
+      await vi.runAllTimersAsync();
+      await nextTick();
+      await vi.runAllTimersAsync();
+      await nextTick();
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should drop showing-ignored-assets state once the asset is unignored', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const ethEvent = createMockEvent({ asset: 'ETH', groupIdentifier: 'group1', identifier: 1 });
+      const btcEvent = createMockEvent({ asset: 'BTC', groupIdentifier: 'group1', identifier: 2 });
+
+      mockFetchHistoryEvents.mockResolvedValue({ data: [ethEvent, btcEvent] });
+      mockIsAssetIgnored.mockImplementation((asset: string) => get(mockIgnoredAssets).includes(asset));
+      set(mockIgnoredAssets, ['BTC']);
+
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([ethEvent]));
+      const options = {
+        excludeIgnored: ref<boolean>(true),
+        groupLoading: ref<boolean>(false),
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
+
+      await waitForFetchEvents();
+
+      // BTC is ignored and hidden, so the group is flagged as having hidden ignored assets
+      expect(get(result.groupsWithHiddenIgnoredAssets).has('group1')).toBe(true);
+
+      // The user reveals the ignored asset for this group (clicking the header eye)
+      result.toggleShowIgnoredAssets('group1');
+      await nextTick();
+      expect(get(result.groupsShowingIgnoredAssets).has('group1')).toBe(true);
+      // While revealed, nothing is hidden anymore
+      expect(get(result.groupsWithHiddenIgnoredAssets).has('group1')).toBe(false);
+
+      // The user unignores BTC
+      set(mockIgnoredAssets, []);
+      await nextTick();
+
+      // The stale "showing" state must be cleared so the header indicator disappears
+      expect(get(result.groupsShowingIgnoredAssets).has('group1')).toBe(false);
+      expect(get(result.groupsWithHiddenIgnoredAssets).has('group1')).toBe(false);
+    });
+
+    it('should keep showing-ignored-assets state while the asset is still ignored', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const ethEvent = createMockEvent({ asset: 'ETH', groupIdentifier: 'group1', identifier: 1 });
+      const btcEvent = createMockEvent({ asset: 'BTC', groupIdentifier: 'group1', identifier: 2 });
+
+      mockFetchHistoryEvents.mockResolvedValue({ data: [ethEvent, btcEvent] });
+      mockIsAssetIgnored.mockImplementation((asset: string) => get(mockIgnoredAssets).includes(asset));
+      set(mockIgnoredAssets, ['BTC']);
+
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([ethEvent]));
+      const options = {
+        excludeIgnored: ref<boolean>(true),
+        groupLoading: ref<boolean>(false),
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
+
+      await waitForFetchEvents();
+
+      result.toggleShowIgnoredAssets('group1');
+      await nextTick();
+      expect(get(result.groupsShowingIgnoredAssets).has('group1')).toBe(true);
+
+      // Ignoring an unrelated asset must not prune the still-valid showing state
+      set(mockIgnoredAssets, ['BTC', 'DOGE']);
+      await nextTick();
+
+      expect(get(result.groupsShowingIgnoredAssets).has('group1')).toBe(true);
+    });
+
+    it('should not unignore the asset when revealing a group', async () => {
+      const { useHistoryEventsData } = await import('./use-history-events-data');
+
+      const ethEvent = createMockEvent({ asset: 'ETH', groupIdentifier: 'group1', identifier: 1 });
+      const btcEvent = createMockEvent({ asset: 'BTC', groupIdentifier: 'group1', identifier: 2 });
+
+      mockFetchHistoryEvents.mockResolvedValue({ data: [ethEvent, btcEvent] });
+      mockIsAssetIgnored.mockImplementation((asset: string) => get(mockIgnoredAssets).includes(asset));
+      set(mockIgnoredAssets, ['BTC']);
+
+      const groups = ref<Collection<HistoryEventRow>>(createMockCollection([ethEvent]));
+      const options = {
+        excludeIgnored: ref<boolean>(true),
+        groupLoading: ref<boolean>(false),
+        groups,
+        pageParams: ref<HistoryEventRequestPayload | undefined>(undefined),
+      };
+
+      const emit = vi.fn();
+      const result = scope.run(() => useHistoryEventsData(options, emit))!;
+
+      await waitForFetchEvents();
+
+      // Revealing only changes what is displayed; it must never touch the ignore list
+      result.toggleShowIgnoredAssets('group1');
+      await nextTick();
+      expect(get(result.groupsShowingIgnoredAssets).has('group1')).toBe(true);
+
+      // BTC is still ignored after revealing, and the group still has an ignored asset
+      expect(get(mockIgnoredAssets)).toEqual(['BTC']);
+      expect(get(result.groupsWithHiddenIgnoredAssets).has('group1')).toBe(false);
+
+      // Hiding again leaves the ignore list untouched and re-hides the asset
+      result.toggleShowIgnoredAssets('group1');
+      await nextTick();
+      expect(get(mockIgnoredAssets)).toEqual(['BTC']);
+      expect(get(result.groupsShowingIgnoredAssets).has('group1')).toBe(false);
+      expect(get(result.groupsWithHiddenIgnoredAssets).has('group1')).toBe(true);
     });
   });
 });

--- a/frontend/app/src/modules/history/events/use-history-events-data.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-data.ts
@@ -48,7 +48,7 @@ interface UseHistoryEventsDataReturn {
   /** Events grouped by groupIdentifier, with both hidden and ignored-asset events filtered out. */
   displayedEventsMapped: ComputedRef<Record<string, HistoryEventRow[]>>;
   groupsWithHiddenIgnoredAssets: ComputedRef<Set<string>>;
-  groupsShowingIgnoredAssets: Ref<Set<string>>;
+  groupsShowingIgnoredAssets: ComputedRef<Set<string>>;
   hasIgnoredEvent: ComputedRef<boolean>;
   groups: ComputedRef<HistoryEventEntry[]>;
   events: ComputedRef<HistoryEventEntry[]>;
@@ -167,18 +167,49 @@ export function useHistoryEventsData(
     return mapping;
   });
 
-  // Track which groups have opted to show ignored assets (per-group toggle)
-  const groupsShowingIgnoredAssets = shallowRef<Set<string>>(new Set());
+  // User intent: which groups the user has toggled to reveal their ignored
+  // assets. This is the only mutable piece of state; everything else is derived.
+  const showIgnoredAssetsIntent = shallowRef<Set<string>>(new Set());
+
+  // Groups that currently contain at least one event with an ignored asset.
+  const groupsWithIgnoredAssets = computed<Set<string>>(() => {
+    const result = new Set<string>();
+    for (const [groupId, rows] of Object.entries(get(completeEventsMapped))) {
+      const hasIgnored = rows.some(row => Array.isArray(row)
+        ? row.some(item => isAssetIgnored(item.asset))
+        : isAssetIgnored(row.asset));
+      if (hasIgnored)
+        result.add(groupId);
+    }
+    return result;
+  });
+
+  // Effective showing state: the user's intent intersected with the groups that
+  // still actually have an ignored asset. Deriving (rather than mutating) means
+  // stale state is impossible — unignoring an asset drops it automatically.
+  const groupsShowingIgnoredAssets = computed<Set<string>>(() => {
+    const valid = get(groupsWithIgnoredAssets);
+    return new Set([...get(showIgnoredAssetsIntent)].filter(groupId => valid.has(groupId)));
+  });
+
+  // Groups that have an ignored-asset event currently hidden: those with an
+  // ignored asset that the user has not revealed via the per-group toggle.
+  const groupsWithHiddenIgnoredAssets = computed<Set<string>>(() => {
+    if (!toValue(excludeIgnored))
+      return new Set();
+
+    const showing = get(groupsShowingIgnoredAssets);
+    return new Set([...get(groupsWithIgnoredAssets)].filter(groupId => !showing.has(groupId)));
+  });
 
   function toggleShowIgnoredAssets(groupId: string): void {
-    const current = get(groupsShowingIgnoredAssets);
-    const newSet = new Set(current);
-    if (newSet.has(groupId))
-      newSet.delete(groupId);
+    const next = new Set(get(showIgnoredAssetsIntent));
+    if (next.has(groupId))
+      next.delete(groupId);
     else
-      newSet.add(groupId);
+      next.add(groupId);
 
-    set(groupsShowingIgnoredAssets, newSet);
+    set(showIgnoredAssetsIntent, next);
   }
 
   /** Events grouped by groupIdentifier, with both hidden and ignored-asset events filtered out. */
@@ -220,33 +251,6 @@ export function useHistoryEventsData(
     events,
     event => Array.isArray(event) ? event.some(item => item.ignoredInAccounting) : event.ignoredInAccounting,
   );
-
-  function flattenedEventCount(rows: HistoryEventRow[]): number {
-    let count = 0;
-    for (const row of rows)
-      count += Array.isArray(row) ? row.length : 1;
-
-    return count;
-  }
-
-  // Track which groups have events hidden due to ignored assets filter
-  const groupsWithHiddenIgnoredAssets = computed<Set<string>>(() => {
-    if (!toValue(excludeIgnored))
-      return new Set();
-
-    const all = get(completeEventsMapped);
-    const displayed = get(displayedEventsMapped);
-    const result = new Set<string>();
-
-    for (const groupId of Object.keys(all)) {
-      const allCount = flattenedEventCount(all[groupId] ?? []);
-      const displayedCount = flattenedEventCount(displayed[groupId] ?? []);
-      if (allCount > displayedCount)
-        result.add(groupId);
-    }
-
-    return result;
-  });
 
   // Map each event identifier to its complete subgroup size for detecting incomplete subgroups
   const completeSubgroupSizes = computed<Map<number, number>>(() => {


### PR DESCRIPTION
### Problem

In the history events view, a group flags that it has *hidden ignored assets* (so the user can reveal them). To unignore an asset the user first reveals it, then unignores it from the asset menu. After unignoring, the group kept flagging hidden ignored assets even though there was nothing left to hide — because the per-group "showing" toggle state was plain user-toggle state that was never reconciled against the ignored-assets store.

### Fix

Rather than patching the stale state with a watcher, the per-group state is now **derived**:

- `showIgnoredAssetsIntent` is the only mutable state (what the user toggled).
- `groupsShowingIgnoredAssets` = intent ∩ groups that still actually contain an ignored asset.
- `groupsWithHiddenIgnoredAssets` = those groups minus the ones being shown.

This makes stale state impossible by construction (unignoring an asset drops the group automatically), removes the reconciliation watcher, and collapses a duplicate pass over the events into a single one.

Revealing and unignoring stay fully decoupled — toggling reveal never touches the ignore list.

### Tests

- Drops the showing state once the asset is unignored.
- Keeps it while the asset is still ignored (and when an unrelated asset is ignored).
- Revealing a group does not unignore the asset (new regression guard).

32/32 unit tests pass; typecheck and lint clean.