### PR TITLE
fix(okx): paginate withdrawal history on ts not ordId

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` OKX withdrawal history is now queried correctly for accounts with more than 100 withdrawals, instead of failing and aborting the whole OKX history sync.
 * :bug:`-` When you unignore an asset from a history event, its group no longer keeps flagging hidden ignored assets, so you are not misled into thinking events are still hidden when there is nothing left to reveal.
 * :bug:`-` In an expanded linked movement, each leg now shows its own location icon: the exchange icon on the exchange deposit/withdrawal and the chain icon on the on-chain transfer leg, instead of the exchange icon incorrectly appearing on the on-chain leg.
 * :bug:`-` Tags on manually tracked balances are no longer dropped (or shown on the wrong balance) after updating, for users who had previously deleted a manual balance. The faulty cleanup that orphaned those tags is also reverted.

--- a/rotkehlchen/exchanges/okx.py
+++ b/rotkehlchen/exchanges/okx.py
@@ -355,7 +355,7 @@ class Okx(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
         )
         withdrawals = self._api_query_list_paginated(
             endpoint=OkxEndpoint.WITHDRAWALS,
-            pagination_key='ordId',
+            pagination_key='ts',
             options={
                 'start_ts': start_ts,
                 'end_ts': end_ts,

--- a/rotkehlchen/tests/exchanges/test_okx.py
+++ b/rotkehlchen/tests/exchanges/test_okx.py
@@ -976,3 +976,55 @@ def test_okx_query_deposits_withdrawals(mock_okx: 'Okx') -> None:
     ]
 
     assert asset_movements == expected_asset_movements
+
+
+def test_okx_withdrawals_pagination(mock_okx: 'Okx') -> None:
+    """Regression test for withdrawal history pagination.
+
+    Withdrawal records have no `ordId` field (only trade records do), so
+    paginating them on `ordId` raised KeyError and aborted the whole OKX
+    query once a user had more than MAX_RESULTS withdrawals. Pagination must
+    use the `ts` cursor, matching the deposit path and OKX's documented
+    `after` semantics.
+    """
+    def make_withdrawal(idx: int) -> str:
+        return f"""
+      {{
+         "chain":"USDT-Arbitrum one",
+         "fee":"0.1",
+         "amt":"100.0",
+         "txId":"0xwithdrawal{idx}",
+         "ccy":"USDT",
+         "to":"0x388c818ca8b9251b393131c08a736a67ccb19297",
+         "state":"2",
+         "nonTradableAsset":false,
+         "ts":"{1670953159000 - idx * 1000}",
+         "wdId":"{idx}",
+         "feeCcy":"USDT"
+      }}"""
+
+    seen_after: list[str] = []
+
+    def mock_request(method, url, **_kwargs):  # pylint: disable=unused-argument
+        if 'withdrawal' in url:
+            # `after` is always present but empty on the first page
+            if (after := url.split('after=')[1].split('&')[0]) != '':
+                seen_after.append(after)  # second (final) page stops pagination
+                records = make_withdrawal(idx=100)
+            else:  # first page: exactly MAX_RESULTS records -> triggers pagination
+                records = ','.join(make_withdrawal(idx=i) for i in range(mock_okx.MAX_RESULTS))
+            return MockResponse(200, f'{{"code":"0","data":[{records}],"msg":""}}')
+        return MockResponse(200, '{"code":"0","data":[]}')
+
+    with patch.object(mock_okx.session, 'request', side_effect=mock_request):
+        asset_movements, _ = mock_okx.query_online_history_events(
+            Timestamp(1609103082),
+            Timestamp(1672175105),
+        )
+
+    # pagination must have happened on the `ts` of the last record of page 1
+    assert seen_after == [str(1670953159000 - (mock_okx.MAX_RESULTS - 1) * 1000)]
+    # 100 + 1 withdrawals, each producing a SPEND and a FEE movement
+    assert sum(
+        movement.event_subtype == HistoryEventSubType.SPEND for movement in asset_movements
+    ) == mock_okx.MAX_RESULTS + 1


### PR DESCRIPTION
Withdrawal records have no ordId field, so paginating on it raised KeyError and aborted the whole OKX history sync once a user had more than MAX_RESULTS withdrawals. Use the ts cursor instead, matching the deposit path and OKX's documented after semantics. Add a regression test covering >MAX_RESULTS withdrawals.

