### PR TITLE
fix(db): merge asset timed_balances exactly in python

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -725,6 +725,7 @@ python package.py
 4. Use the existing test infrastructure - comprehensive fixtures are available
 5. WebSocket messages follow specific format - check `api/websockets/typedefs.py`
 6. For all python backend constants make sure to use the `Final` type specifier.
+7. Never iterate over `cursor.execute(...).fetchall()`. `fetchall()` already walks the cursor and materializes every row into a list, so a following `for` loop iterates the data a second time. When you only need a single pass, iterate the cursor directly: `for row in cursor.execute(...):`. Reserve `fetchall()` for when you genuinely need the materialized list (e.g. to reuse it, get its length, or assert on it in a test). The same applies to a write cursor — prefer a read cursor (`self.conn.read_ctx()`) for plain `SELECT`s.
 
 ## Committing
 - Commits should be just to the point, not too long and not too short.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -661,6 +661,7 @@ python package.py
 4. Use the existing test infrastructure - comprehensive fixtures are available
 5. WebSocket messages follow specific format - check `api/websockets/typedefs.py`
 6. For all python backend constants make sure to use the `Final` type specifier.
+7. Never iterate over `cursor.execute(...).fetchall()`. `fetchall()` already walks the cursor and materializes every row into a list, so a following `for` loop iterates the data a second time. When you only need a single pass, iterate the cursor directly: `for row in cursor.execute(...):`. Reserve `fetchall()` for when you genuinely need the materialized list (e.g. to reuse it, get its length, or assert on it in a test). The same applies to a write cursor — prefer a read cursor (`self.conn.read_ctx()`) for plain `SELECT`s.
 
 ## Committing
 - Commits should be just to the point, not too long and not too short.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Merging assets now correctly combines their historical balances with exact precision, instead of failing or double-counting when both had a balance at the same timestamp.
 * :bug:`-` OKX withdrawal history is now queried correctly for accounts with more than 100 withdrawals, instead of failing and aborting the whole OKX history sync.
 * :bug:`-` When you unignore an asset from a history event, its group no longer keeps flagging hidden ignored assets, so you are not misled into thinking events are still hidden when there is nothing left to reveal.
 * :bug:`-` In an expanded linked movement, each leg now shows its own location icon: the exchange icon on the exchange deposit/withdrawal and the chain icon on the on-chain transfer leg, instead of the exchange icon incorrectly appearing on the on-chain leg.

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -3288,43 +3288,36 @@ class DBHandler:
             globaldb.delete_asset_by_identifier(source_identifier)
 
         if userdb_query != 0:
-            with self.user_write() as write_cursor:
-                write_cursor.execute(  # merge the assets in the timed_balances table
-                    """
-                    WITH merged_rows AS (
-                        SELECT
-                            category,
-                            timestamp,
-                            currency,
-                            SUM(amount) AS total_amount,
-                            SUM(usd_value) AS total_usd_value
-                        FROM timed_balances
-                        WHERE currency IN (?, ?)
-                        GROUP BY category, timestamp
-                    )
-                    UPDATE timed_balances AS tb
-                    SET
-                        currency = ?,
-                        amount = mr.total_amount,
-                        usd_value = mr.total_usd_value
-                    FROM merged_rows mr
-                    WHERE
-                        tb.category = mr.category AND
-                        tb.timestamp = mr.timestamp AND
-                        tb.currency = mr.currency AND
-                        tb.currency IN (?, ?);
-                    """,
-                    (
-                        source_identifier,
-                        target_asset.identifier,
-                        target_asset.identifier,
-                        target_asset.identifier,
-                        source_identifier,
-                    ),
+            # Merge the source and target rows in the timed_balances table. The summation
+            # is done in python with FVal because amount/usd_value are TEXT columns holding
+            # arbitrary-precision values; SQLite's SUM() would coerce them to floats and
+            # corrupt the stored balances. Collapsing per (category, timestamp) here also
+            # guarantees a single resulting row, which a plain UPDATE could not (it would
+            # leave the target's own row behind, duplicating and double-counting it).
+            merged: dict[tuple[str, int], list[FVal]] = defaultdict(lambda: [ZERO, ZERO])
+            with self.conn.read_ctx() as cursor:
+                cursor.execute(
+                    'SELECT category, timestamp, amount, usd_value FROM timed_balances '
+                    'WHERE currency IN (?, ?)',
+                    (source_identifier, target_asset.identifier),
                 )
+                for category, timestamp, amount, usd_value in cursor:
+                    totals = merged[category, timestamp]
+                    totals[0] += FVal(amount)
+                    totals[1] += FVal(usd_value)
+
+            with self.user_write() as write_cursor:
                 write_cursor.execute(
-                    'DELETE FROM timed_balances WHERE currency=?',
-                    (source_identifier,),
+                    'DELETE FROM timed_balances WHERE currency IN (?, ?)',
+                    (source_identifier, target_asset.identifier),
+                )
+                write_cursor.executemany(
+                    'INSERT INTO timed_balances(category, timestamp, currency, amount, usd_value) '
+                    'VALUES(?, ?, ?, ?, ?)',
+                    [
+                        (category, timestamp, target_asset.identifier, str(amount), str(usd_value))
+                        for (category, timestamp), (amount, usd_value) in merged.items()
+                    ],
                 )
                 # the tricky part here is that we need to disable foreign keys for this
                 # approach and disabling foreign keys needs a commit. So rollback is impossible.

--- a/rotkehlchen/tests/unit/test_assets.py
+++ b/rotkehlchen/tests/unit/test_assets.py
@@ -1200,13 +1200,24 @@ def test_merge_assets_timed_balances(database: 'DBHandler') -> None:
     """
     with database.conn.write_ctx() as write_cursor:
         serialized_balances = [
-            (0, 'BTC', '1.00', '178.44', BalanceType.ASSET.serialize_for_db()),
+            # ts 0: source(ETH) inserted BEFORE target(BTC) for the shared asset row. This is the
+            # case that used to leave a stale duplicate target row and double-count it, since the
+            # merge result depended on which row sqlite happened to pick in its GROUP BY.
             (0, 'ETH', '1.00', '87', BalanceType.ASSET.serialize_for_db()),
+            (0, 'BTC', '1.00', '178.44', BalanceType.ASSET.serialize_for_db()),
             (0, 'ETH', '0.50', '87', BalanceType.LIABILITY.serialize_for_db()),
             (1, 'BTC', '1.00', '178.44', BalanceType.ASSET.serialize_for_db()),
             (1, 'ETH', '1.00', '87', BalanceType.ASSET.serialize_for_db()),
             (2, 'BTC', '1.00', '178.44', BalanceType.ASSET.serialize_for_db()),
             (3, 'ETH', '1.00', '87', BalanceType.ASSET.serialize_for_db()),
+            # ts 4: high-precision amounts that are NOT float-exact, both present at the same
+            # timestamp. Locks in that the sum is computed with FVal (exact) and not via a
+            # float-coercing SQL SUM() over the TEXT columns.
+            (4, 'ETH', '0.1', '0', BalanceType.ASSET.serialize_for_db()),
+            (4, 'BTC', '0.2', '0', BalanceType.ASSET.serialize_for_db()),
+            # ts 5: a single high-precision source row, to ensure even unmerged rows keep their
+            # full precision instead of being truncated to a float.
+            (5, 'ETH', '123456789.123456789123456789', '0', BalanceType.ASSET.serialize_for_db()),
         ]
         write_cursor.executemany(
             'INSERT INTO timed_balances( '
@@ -1217,11 +1228,16 @@ def test_merge_assets_timed_balances(database: 'DBHandler') -> None:
 
     database.replace_asset_identifier(source_identifier='ETH', target_asset=Asset('BTC'))
     with database.conn.read_ctx() as cursor:
-        cursor.execute('SELECT timestamp, currency, amount, category FROM timed_balances')
+        cursor.execute(
+            'SELECT timestamp, currency, amount, category FROM timed_balances '
+            'ORDER BY timestamp, category',
+        )
         assert cursor.fetchall() == [
-            (0, 'BTC', '2.0', BalanceType.ASSET.serialize_for_db()),  # 1 ETH + 1 BTC
+            (0, 'BTC', '2', BalanceType.ASSET.serialize_for_db()),  # 1 ETH + 1 BTC, single row
             (0, 'BTC', '0.5', BalanceType.LIABILITY.serialize_for_db()),  # 0.5 ETH -> 0.5 BTC
-            (1, 'BTC', '2.0', BalanceType.ASSET.serialize_for_db()),  # 1 ETH + 1 BTC
-            (2, 'BTC', '1.0', BalanceType.ASSET.serialize_for_db()),  # 1 BTC = 1 BTC
-            (3, 'BTC', '1.0', BalanceType.ASSET.serialize_for_db()),  # 1 ETH -> 1 BTC
+            (1, 'BTC', '2', BalanceType.ASSET.serialize_for_db()),  # 1 ETH + 1 BTC
+            (2, 'BTC', '1', BalanceType.ASSET.serialize_for_db()),  # 1 BTC = 1 BTC
+            (3, 'BTC', '1', BalanceType.ASSET.serialize_for_db()),  # 1 ETH -> 1 BTC
+            (4, 'BTC', '0.3', BalanceType.ASSET.serialize_for_db()),  # 0.1 + 0.2 exactly, not 0.3000..04  # noqa: E501
+            (5, 'BTC', '123456789.123456789123456789', BalanceType.ASSET.serialize_for_db()),  # full precision kept  # noqa: E501
         ]


### PR DESCRIPTION
The asset merge in replace_asset_identifier summed amount/usd_value via SQL SUM() over TEXT (FVal) columns, coercing them to floats and corrupting stored balances. It also relied on an arbitrary GROUP BY bare-column pick, which left a stale target row (double-counting) or hit a UNIQUE constraint crash when both assets had a balance at the same timestamp. Merge in python with FVal, collapsing to one row per (category, timestamp). Extend the regression test to cover both the precision loss and the source-before-target ordering.
