### PR TITLE
cache special/protocol prices for non-USD target currencies

### DIFF
--- a/rotkehlchen/assets/resolver.py
+++ b/rotkehlchen/assets/resolver.py
@@ -39,6 +39,8 @@ class AssetResolver:
     # Maps asset identifier -> collection main_asset identifier (or None if not in a collection).
     # None is a valid cached value so presence must be tested with `identifier.lower() in cache`.
     collection_main_asset_cache: LRUCacheLowerKey[str | None] = LRUCacheLowerKey(maxsize=512)
+    # Maps asset identifier -> all assets in its collection (or just itself if in no collection).
+    collection_assets_cache: LRUCacheLowerKey[tuple['Asset', ...]] = LRUCacheLowerKey(maxsize=512)
 
     def __new__(  # noqa: PYI034 # singleton pattern should not get Self
             cls,
@@ -67,10 +69,12 @@ class AssetResolver:
             AssetResolver.__instance.assets_cache.remove(identifier)
             AssetResolver.__instance.types_cache.remove(identifier)
             AssetResolver.__instance.collection_main_asset_cache.remove(identifier)
+            AssetResolver.__instance.collection_assets_cache.remove(identifier)
         else:
             AssetResolver.__instance.assets_cache.clear()
             AssetResolver.__instance.types_cache.clear()
             AssetResolver.__instance.collection_main_asset_cache.clear()
+            AssetResolver.__instance.collection_assets_cache.clear()
 
     @staticmethod
     def get_collection_main_asset(identifier: str) -> str | None:
@@ -87,6 +91,23 @@ class AssetResolver:
         main_asset = AssetResolver._globaldb.get_collection_main_asset(identifier)
         cache.add(identifier, main_asset)
         return main_asset
+
+    @staticmethod
+    def get_assets_in_same_collection(identifier: str) -> tuple['Asset', ...]:
+        """Return all assets in the same collection as identifier, memoized.
+
+        Mirrors GlobalDBHandler.get_assets_in_same_collection but caches the result to avoid
+        re-running the collection JOIN on hot paths (e.g. Inquirer.set_cached_price, called once
+        per priced asset on every balance refresh). Returns (Asset(identifier),) when the asset
+        is in no collection. The value is never None, so a None get() result means a cache miss.
+        """
+        cache = AssetResolver.collection_assets_cache
+        if (cached := cache.get(identifier)) is not None:
+            return cached
+
+        result = AssetResolver._globaldb.get_assets_in_same_collection(identifier)
+        cache.add(identifier, result)
+        return result
 
     @staticmethod
     def resolve_asset(identifier: str) -> 'AssetWithNameAndType':

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -526,7 +526,7 @@ class Inquirer:
     @staticmethod
     def set_cached_price(cache_key: tuple[Asset, Asset], cached_price: CachedPriceEntry) -> None:
         """Save cached price for the key provided and all the assets in the same collection"""
-        related_assets = GlobalDBHandler.get_assets_in_same_collection(cache_key[0].identifier)
+        related_assets = AssetResolver.get_assets_in_same_collection(cache_key[0].identifier)
         for related_asset in related_assets:
             Inquirer._cached_current_price.add((related_asset, cache_key[1]), cached_price)
 

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -726,6 +726,18 @@ class Inquirer:
                     for from_asset in eur_collection_assets:
                         found_prices[from_asset] = eur_to_target, CurrentPriceOracle.FIAT
 
+        # Cache the resolved prices under the actual target currency so a subsequent query
+        # short-circuits in _preprocess_assets_to_query. Otherwise non-USD targets always miss
+        # the cache (only the USD price is cached in _maybe_get_evm_token_usd_price) and re-run
+        # the underlying onchain price query (e.g. the curve/yearn multicall) on every refresh.
+        now = ts_now()
+        for from_asset, (price, oracle) in found_prices.items():
+            if price != ZERO_PRICE:
+                Inquirer.set_cached_price(
+                    cache_key=(from_asset, to_asset),
+                    cached_price=CachedPriceEntry(price=price, time=now, oracle=oracle),
+                )
+
         return assets_without_special_price, found_prices
 
     @staticmethod

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -1068,6 +1068,25 @@ def test_cache_is_hit_for_collection(inquirer: Inquirer):
 
 
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
+def test_collection_assets_query_is_memoized(inquirer: Inquirer):
+    """Test that get_assets_in_same_collection is memoized so set_cached_price (called once per
+    priced asset on every balance refresh) does not re-run the collection JOIN every time."""
+    wsteth = Asset('eip155:1/erc20:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0')
+    AssetResolver.clean_memory_cache(wsteth.identifier)
+    with mock.patch.object(
+        GlobalDBHandler,
+        'get_assets_in_same_collection',
+        wraps=GlobalDBHandler.get_assets_in_same_collection,
+    ) as collection_query:
+        first = AssetResolver.get_assets_in_same_collection(wsteth.identifier)
+        second = AssetResolver.get_assets_in_same_collection(wsteth.identifier)
+
+    assert collection_query.call_count == 1, 'collection JOIN must be memoized across calls'
+    assert first == second
+    assert wsteth in first  # sanity: wstETH belongs to a multi-chain collection
+
+
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
 @requires_env([TestEnvironment.NIGHTLY])
 def test_usd_price(inquirer: Inquirer, globaldb: GlobalDBHandler):
     """Check that price is queried for tokens in different chains using defillama"""

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -772,6 +772,32 @@ def test_special_price_unpriced_when_target_rate_unavailable(inquirer: 'Inquirer
     assert found_prices[A_KFEE][0] == Price(FVal('0.009'))  # 0.01 USD * 0.9 USD/EUR
 
 
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
+def test_special_price_cached_for_non_usd_target(inquirer: 'Inquirer') -> None:
+    """Regression test: for a non-USD target currency the underlying onchain USD price of a
+    protocol/LP token must be queried only once and then served from cache (converted to the
+    target currency). Previously only the USD price was cached while lookups used the
+    (asset, target) key, so every balance refresh re-ran the underlying onchain price query
+    (e.g. a curve/yearn multicall) for non-USD main currencies.
+    """
+    token = A_CRV  # a plain evm token that reaches the _maybe_get_evm_token_usd_price branch
+    with (
+        patch.object(
+            Inquirer,
+            '_maybe_get_evm_token_usd_price',
+            return_value=(Price(FVal('1.05')), CurrentPriceOracle.BLOCKCHAIN),
+        ) as usd_price_mock,
+        patch.object(Inquirer, 'find_price', return_value=Price(FVal('0.9'))),  # USD->EUR rate
+    ):
+        first = Inquirer.find_prices(from_assets=[token], to_asset=A_EUR, ignore_cache=True)
+        second = Inquirer.find_prices(from_assets=[token], to_asset=A_EUR)
+
+    # the second (normal) refresh must hit the cache instead of re-querying the onchain price
+    assert usd_price_mock.call_count == 1, 'onchain USD price must be queried only once across refreshes'  # noqa: E501
+    assert first[token].is_close(FVal('1.05') * FVal('0.9'))  # 1.05 USD * 0.9 USD/EUR
+    assert second[token] == first[token]
+
+
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_find_asset_with_no_api_oracles(inquirer_defi):


### PR DESCRIPTION
_get_special_prices now caches the resolved target-currency price so a subsequent balance refresh short-circuits in _preprocess_assets_to_query instead of re-running the underlying onchain price query (e.g. curve/yearn multicall) for every protocol/LP token. Previously only the USD price was cached while lookups used the (asset, target) key, so non-USD main currency users re-queried onchain on every refresh. Adds a regression test.
