### PR TITLE
perf(history): drop redundant per-event insert writes

### DIFF
--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -278,11 +278,16 @@ class DBHistoryEvents:
             event_type: HistoryEventType,
             notes: str | None,
             decoded_addresses: list[str] | None,
+            clear_existing: bool = True,
     ) -> None:
-        write_cursor.execute(
-            'DELETE FROM bitcoin_events_addresses WHERE event_identifier=?',
-            (identifier,),
-        )
+        # clear_existing is only needed when editing an event (its location/addresses may have
+        # changed). On a fresh insert the identifier is a brand new rowid and the FK to
+        # history_events is ON DELETE CASCADE, so there can never be pre-existing rows to delete.
+        if clear_existing:
+            write_cursor.execute(
+                'DELETE FROM bitcoin_events_addresses WHERE event_identifier=?',
+                (identifier,),
+            )
         if (
             location not in (Location.BITCOIN, Location.BITCOIN_CASH) or
             event_type not in (
@@ -317,6 +322,7 @@ class DBHistoryEvents:
             event: HistoryBaseEntry,
             mapping_values: dict[str, HistoryMappingState] | None = None,
             skip_tracking: bool = False,
+            ignored_assets: set[str] | None = None,
     ) -> int | None:
         """Insert a single history entry to the DB. Returns its identifier or
         None if it already exists. This function serializes the event depending
@@ -340,12 +346,22 @@ class DBHistoryEvents:
             else:
                 write_cursor.execute(f'INSERT OR IGNORE INTO {insertquery}', (identifier, *bindings))  # noqa: E501
 
-        write_cursor.execute(
-            'UPDATE history_events SET ignored=(CASE WHEN EXISTS '
-            "(SELECT 1 FROM multisettings WHERE name = 'ignored_asset' AND value = ?) "
-            'THEN 1 ELSE 0 END) WHERE identifier=?',
-            (event.asset.identifier, identifier),
-        )
+        # The `ignored` column defaults to 0 on insert. When the caller precomputes the
+        # ignored-asset set (e.g. add_history_events for a batch), only issue an UPDATE for the
+        # rare events whose asset is ignored, avoiding a per-event correlated subquery. Callers
+        # that don't pass the set fall back to determining the flag inline.
+        if ignored_assets is None:
+            write_cursor.execute(
+                'UPDATE history_events SET ignored=(CASE WHEN EXISTS '
+                "(SELECT 1 FROM multisettings WHERE name = 'ignored_asset' AND value = ?) "
+                'THEN 1 ELSE 0 END) WHERE identifier=?',
+                (event.asset.identifier, identifier),
+            )
+        elif event.asset.identifier in ignored_assets:
+            write_cursor.execute(
+                'UPDATE history_events SET ignored=1 WHERE identifier=?',
+                (identifier,),
+            )
 
         if mapping_values is not None:
             write_cursor.executemany(
@@ -362,6 +378,7 @@ class DBHistoryEvents:
             event_type=event.event_type,
             notes=event.notes,
             decoded_addresses=getattr(event, BITCOIN_COUNTERPARTY_ADDRESSES_METADATA_KEY, None),
+            clear_existing=False,  # fresh insert: no pre-existing rows can exist (see method)
         )
 
         # TODO (balances): add _mark_events_modified for event.timestamp if not skip_tracking
@@ -385,6 +402,9 @@ class DBHistoryEvents:
             return
 
         min_timestamp: TimestampMS | None = None
+        # Load the ignored-asset set once for the whole batch (the call is cached) so each event
+        # insert avoids a per-event correlated subquery to compute its `ignored` flag.
+        ignored_assets = self.db.get_ignored_asset_ids(cursor=write_cursor)
 
         # Add all events WITHOUT calling _mark_events_modified for each
         for event in history:
@@ -393,6 +413,7 @@ class DBHistoryEvents:
                     write_cursor=write_cursor,
                     event=event,
                     skip_tracking=True,  # Skip tracking per-event
+                    ignored_assets=ignored_assets,
                 ) is not None  # Only track if event was actually added (not a duplicate)
                 and (min_timestamp is None or event.timestamp < min_timestamp)
             ):

--- a/rotkehlchen/tests/unit/test_history_events.py
+++ b/rotkehlchen/tests/unit/test_history_events.py
@@ -27,6 +27,7 @@ from rotkehlchen.tests.utils.factories import (
 from rotkehlchen.types import ChecksumEvmAddress, Location, TimestampMS
 
 if TYPE_CHECKING:
+    from rotkehlchen.assets.asset import Asset
     from rotkehlchen.db.dbhandler import DBHandler
 
 
@@ -295,3 +296,38 @@ def test_edit_bitcoin_event_updates_counterparty_mappings(database: 'DBHandler')
             'SELECT COUNT(*) FROM bitcoin_events_addresses WHERE event_identifier=?',
             (event_id,),
         ).fetchone()[0] == 0
+
+
+def test_add_history_events_sets_ignored_flag(database: 'DBHandler') -> None:
+    """Batch insert must set the `ignored` flag from the precomputed ignored-asset set: 1 for
+    events whose asset is ignored, 0 (the column default) otherwise. Regression test for the
+    optimization that replaced the per-event correlated subquery with a once-per-batch lookup.
+    """
+    events_db = DBHistoryEvents(database)
+    with database.user_write() as write_cursor:
+        database.add_to_ignored_assets(write_cursor=write_cursor, asset=A_BTC)
+
+    def make_event(group_identifier: str, asset: 'Asset') -> HistoryEvent:
+        return HistoryEvent(
+            group_identifier=group_identifier,
+            sequence_index=0,
+            timestamp=TimestampMS(1710000000000),
+            location=Location.KRAKEN,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=asset,
+            amount=ONE,
+        )
+
+    with database.user_write() as write_cursor:
+        events_db.add_history_events(write_cursor=write_cursor, history=[
+            make_event('ignored_flag_test_btc', A_BTC),  # ignored asset -> ignored=1
+            make_event('ignored_flag_test_eth', A_ETH),  # not ignored -> stays 0
+        ])
+        ignored_by_asset = dict(write_cursor.execute(
+            'SELECT asset, ignored FROM history_events WHERE group_identifier IN (?, ?)',
+            ('ignored_flag_test_btc', 'ignored_flag_test_eth'),
+        ).fetchall())
+
+    assert ignored_by_asset[A_BTC.identifier] == 1
+    assert ignored_by_asset[A_ETH.identifier] == 0


### PR DESCRIPTION
On the batch event insert path (decoding/imports) each event ran an extra correlated-subquery UPDATE to set its ignored flag and an unconditional DELETE on bitcoin_events_addresses. The DELETE can never match on a fresh insert (new rowid + ON DELETE CASCADE FK), and the ignored flag can be set from a once-per-batch cached lookup, only updating the rare ignored assets. Keep the DELETE for the edit path and the inline flag for individual callers. Adds a regression test.

