### PR TITLE
fix(history): dedupe movement in multi-match event view

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` A deposit or withdrawal manually matched to multiple on-chain transactions is no longer duplicated in the history view when filtering by chain.
 * :bug:`-` LP, wrapped and vault tokens are now reported as unpriced instead of at a too-low value when one of their underlying assets has no price.
 * :bug:`-` Merging assets now correctly combines their historical balances with exact precision, instead of failing or double-counting when both had a balance at the same timestamp.
 * :bug:`-` OKX withdrawal history is now queried correctly for accounts with more than 100 withdrawals, instead of failing and aborting the whole OKX history sync.

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -2408,18 +2408,30 @@ class DBHistoryEvents:
                     joined_events_result.ignored_group_identifiers,
                 )
 
-            # Include the newly loaded events with their associated groups.
+            # Include the newly loaded events with their associated groups. A movement can be
+            # matched with multiple events (manual multi-match), so the same joined group can be
+            # reachable from several groups present in the page. Track which joined groups have
+            # already been emitted to avoid adding their events more than once (e.g. the movement
+            # showing up twice when two of its matches are on the page but the movement isn't).
+            consumed_joined_groups: set[str] = set()
+
+            def extend_with_joined_group(events: list[HistoryBaseEntry], joined_group_id: str) -> None:  # noqa: E501
+                if joined_group_id in consumed_joined_groups:
+                    return
+                consumed_joined_groups.add(joined_group_id)
+                events.extend(joined_events_by_group[joined_group_id])
+
             for group_identifier, events in events_by_group.items():
                 if (match_info_list := movement_group_to_match_info.get(group_identifier)) is not None:  # noqa: E501
                     for _, matched_group_id, _ in match_info_list:
-                        events.extend(joined_events_by_group[matched_group_id])
+                        extend_with_joined_group(events, matched_group_id)
                 elif (movement_info := match_group_to_movement_info.get(group_identifier)) is not None:  # noqa: E501
-                    events.extend(joined_events_by_group[movement_group_id := movement_info[0]])
+                    extend_with_joined_group(events, movement_group_id := movement_info[0])
                     # also include all events from the groups of any other events that are
                     # matched with this movement.
                     if (match_info_list := movement_group_to_match_info.get(movement_group_id)) is not None:  # noqa: E501
                         for _, group_id, _ in match_info_list:
-                            events.extend(joined_events_by_group[group_id])
+                            extend_with_joined_group(events, group_id)
 
                 processed_events_result.extend(sorted(events, key=lambda event: event.timestamp))  # type: ignore  # will be a list of HistoryBaseEntry
 

--- a/rotkehlchen/tests/api/test_event_matching.py
+++ b/rotkehlchen/tests/api/test_event_matching.py
@@ -358,6 +358,24 @@ def test_multi_match_asset_movements(rotkehlchen_api_server: 'APIServer') -> Non
     assert len(result[3]) == 3  # movement and two matched events
     assert result[4]['entry']['group_identifier'] == before_event.group_identifier
 
+    # Regression test: non-aggregated filtering that returns several of the movement's matched
+    # events but not the movement itself must not duplicate the movement. Filtering by the
+    # ethereum location returns both matched onchain events but excludes the Kraken movement,
+    # which the join then pulls back in - previously once per matched event (i.e. twice).
+    result = assert_proper_response_with_result(
+        response=requests.post(
+            api_url_for(rotkehlchen_api_server, 'historyeventresource'),
+            json={'aggregate_by_group_ids': False, 'location': Location.ETHEREUM.serialize()},
+        ),
+        rotkehlchen_api_server=rotkehlchen_api_server,
+    )['entries']
+    flattened = [
+        sub for entry in result for sub in (entry if isinstance(entry, list) else [entry])
+    ]
+    assert sum(
+        1 for x in flattened if x['entry']['identifier'] == asset_movement.identifier
+    ) == 1, 'the matched movement must appear exactly once, not once per matched event on the page'
+
     # Check that unlinking a multi-match works properly
     assert_simple_ok_response(requests.delete(
         url=api_url_for(rotkehlchen_api_server, 'matchassetmovementsresource'),


### PR DESCRIPTION
In the non-aggregated history view a movement manually matched to multiple onchain events was pulled into each match group, so when a filter returned several matches but not the movement (e.g. filtering by chain) the movement event was shown once per match. Track already-emitted joined groups so each appears only once. Adds a regression test and changelog entry.

