### PR TITLE
fix: drop exchange unsupported-asset blocklist

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,9 @@
 Changelog
 =========
 
+
 * :feature:`12301` You can now reset all accounting rules back to rotki's defaults from the accounting rules settings, undoing any customizations in a single action.
+* :bug:`12348` User exchange balance queries should no longer hit the Unsupportedasset errors.
 * :bug:`-` A deposit or withdrawal manually matched to multiple on-chain transactions is no longer duplicated in the history view when filtering by chain.
 * :bug:`-` LP, wrapped and vault tokens are now reported as unpriced instead of at a too-low value when one of their underlying assets has no price.
 * :bug:`-` Merging assets now correctly combines their historical balances with exact precision, instead of failing or double-counting when both had a balance at the same timestamp.

--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -13,7 +13,7 @@ from rotkehlchen.accounting.types import EventAccountingRuleStatus, MissingPrice
 from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregators
 from rotkehlchen.db.reports import DBAccountingReports
 from rotkehlchen.db.settings import DBSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair
 from rotkehlchen.errors.misc import AccountingError, RemoteError
 from rotkehlchen.errors.price import NoPriceForGivenTimestamp, PriceQueryUnsupportedAsset
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -282,12 +282,6 @@ class Accountant:
         except UnknownAsset as e:
             self.msg_aggregator.add_warning(
                 f'At history processing found event with unknown asset {e.identifier}. '
-                f'Ignoring the event.',
-            )
-            return 1, prev_time
-        except UnsupportedAsset as e:
-            self.msg_aggregator.add_warning(
-                f'At history processing found event with unsupported asset {e.identifier}. '
                 f'Ignoring the event.',
             )
             return 1, prev_time

--- a/rotkehlchen/assets/converters.py
+++ b/rotkehlchen/assets/converters.py
@@ -86,7 +86,6 @@ def asset_from_kraken(kraken_name: str) -> AssetWithOracles:
 def asset_from_poloniex(poloniex_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(poloniex_name, str):
@@ -102,7 +101,6 @@ def asset_from_poloniex(poloniex_name: str) -> AssetWithOracles:
 def asset_from_bitfinex(bitfinex_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
 
     Currency map fetched in `<Bitfinex>._query_currency_map()` is already
@@ -121,7 +119,6 @@ def asset_from_bitfinex(bitfinex_name: str) -> AssetWithOracles:
 def asset_from_bitstamp(bitstamp_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(bitstamp_name, str):
@@ -138,7 +135,6 @@ def asset_from_bitstamp(bitstamp_name: str) -> AssetWithOracles:
 def asset_from_bittrex(bittrex_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(bittrex_name, str):
@@ -154,7 +150,6 @@ def asset_from_bittrex(bittrex_name: str) -> AssetWithOracles:
 def asset_from_coinbasepro(coinbase_pro_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(coinbase_pro_name, str):
@@ -172,7 +167,6 @@ def asset_from_coinbasepro(coinbase_pro_name: str) -> AssetWithOracles:
 def asset_from_binance(binance_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(binance_name, str):
@@ -220,7 +214,6 @@ def asset_from_coinbase(cb_name: str, time: Timestamp | None = None) -> AssetWit
 def asset_from_kucoin(kucoin_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(kucoin_name, str):
@@ -236,7 +229,6 @@ def asset_from_kucoin(kucoin_name: str) -> AssetWithOracles:
 def asset_from_gemini(symbol: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(symbol, str):
@@ -268,7 +260,6 @@ def asset_from_blockfi(symbol: str) -> AssetWithOracles:
 def asset_from_iconomi(symbol: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(symbol, str):
@@ -285,7 +276,6 @@ def asset_from_iconomi(symbol: str) -> AssetWithOracles:
 def asset_from_uphold(symbol: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(symbol, str):
@@ -301,7 +291,6 @@ def asset_from_uphold(symbol: str) -> AssetWithOracles:
 def asset_from_nexo(nexo_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(nexo_name, str):
@@ -320,7 +309,6 @@ def asset_from_nexo(nexo_name: str) -> AssetWithOracles:
 def asset_from_bitpanda(bitpanda_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(bitpanda_name, str):
@@ -336,7 +324,6 @@ def asset_from_bitpanda(bitpanda_name: str) -> AssetWithOracles:
 def asset_from_cryptocom(cryptocom_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(cryptocom_name, str):
@@ -354,7 +341,6 @@ def asset_from_cryptocom(cryptocom_name: str) -> AssetWithOracles:
 def asset_from_okx(okx_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(okx_name, str):
@@ -370,7 +356,6 @@ def asset_from_okx(okx_name: str) -> AssetWithOracles:
 def asset_from_ftx(ftx_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(ftx_name, str):
@@ -390,7 +375,6 @@ def asset_from_ftx(ftx_name: str) -> AssetWithOracles:
 def asset_from_bybit(name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(name, str):
@@ -443,7 +427,6 @@ def asset_from_common_identifier(common_identifier: str) -> AssetWithOracles:
 def asset_from_htx(htx_name: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     if not isinstance(htx_name, str):
@@ -460,7 +443,6 @@ def asset_from_htx(htx_name: str) -> AssetWithOracles:
 def asset_from_bitcoinde(bitcoinde: str) -> AssetWithOracles:
     """May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     """
     bitcoinde = bitcoinde.upper()

--- a/rotkehlchen/data_import/importers/binance.py
+++ b/rotkehlchen/data_import/importers/binance.py
@@ -12,7 +12,7 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.data_import.utils import BaseExchangeImporter, UnsupportedCSVEntry, hash_csv_row
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.price import NoPriceForGivenTimestamp
 from rotkehlchen.errors.serialization import DeserializationError
@@ -725,7 +725,7 @@ class BinanceImporter(BaseExchangeImporter):
                     is_error=True,
                 )
                 skipped_count += 1
-            except (DeserializationError, UnsupportedAsset) as e:
+            except DeserializationError as e:
                 self.send_message(
                     row_index=index,
                     csv_row=csv_row,

--- a/rotkehlchen/data_import/importers/bitcoin_tax.py
+++ b/rotkehlchen/data_import/importers/bitcoin_tax.py
@@ -12,7 +12,7 @@ from rotkehlchen.data_import.utils import (
     hash_csv_row,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.base import HistoryEvent
@@ -262,13 +262,6 @@ class BitcoinTaxImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/bitstamp.py
+++ b/rotkehlchen/data_import/importers/bitstamp.py
@@ -7,7 +7,7 @@ from rotkehlchen.assets.converters import asset_from_bitstamp
 from rotkehlchen.data_import.importers.constants import BITSTAMP_EVENT_PREFIX
 from rotkehlchen.data_import.utils import BaseExchangeImporter
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import (
@@ -118,13 +118,6 @@ class BitstampTransactionsImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/bittrex.py
+++ b/rotkehlchen/data_import/importers/bittrex.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from rotkehlchen.assets.converters import asset_from_bittrex
 from rotkehlchen.data_import.utils import BaseExchangeImporter, maybe_set_transaction_extra_data
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.utils import deserialize_asset_movement_address, get_key_if_has_val
@@ -250,13 +249,6 @@ class BittrexImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Deserialization error: {e!s}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except KeyError as e:

--- a/rotkehlchen/data_import/importers/blockfi_trades.py
+++ b/rotkehlchen/data_import/importers/blockfi_trades.py
@@ -7,7 +7,7 @@ from rotkehlchen.assets.converters import asset_from_blockfi
 from rotkehlchen.constants import ZERO
 from rotkehlchen.data_import.utils import BaseExchangeImporter, SkippedCSVEntry
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events
@@ -93,13 +93,6 @@ class BlockfiTradesImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/blockfi_transactions.py
+++ b/rotkehlchen/data_import/importers/blockfi_transactions.py
@@ -12,7 +12,7 @@ from rotkehlchen.data_import.utils import (
     hash_csv_row,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -143,13 +143,6 @@ class BlockfiTransactionsImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/blockpit.py
+++ b/rotkehlchen/data_import/importers/blockpit.py
@@ -11,7 +11,7 @@ from rotkehlchen.constants.assets import A_USD
 from rotkehlchen.data_import.importers.constants import BLOCKPIT_EVENT_PREFIX
 from rotkehlchen.data_import.utils import BaseExchangeImporter, UnsupportedCSVEntry, hash_csv_row
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -224,13 +224,6 @@ class BlockpitImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/coinbasepro.py
+++ b/rotkehlchen/data_import/importers/coinbasepro.py
@@ -8,7 +8,7 @@ from rotkehlchen.assets.converters import asset_from_coinbasepro
 from rotkehlchen.data_import.importers.constants import COINBASEPRO_EVENT_PREFIX
 from rotkehlchen.data_import.utils import BaseExchangeImporter
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -178,11 +178,6 @@ class CoinbaseProImporter(BaseExchangeImporter):
                     row_index=index, csv_row=row,
                     msg=f'Unknown asset {e.identifier}.', is_error=True,
                 )
-            except UnsupportedAsset as e:
-                self.send_message(
-                    row_index=index, csv_row=row,
-                    msg=str(e), is_error=True,
-                )
             except DeserializationError as e:
                 self.send_message(
                     row_index=index, csv_row=row,
@@ -201,12 +196,6 @@ class CoinbaseProImporter(BaseExchangeImporter):
                 self.send_message(
                     row_index=0, csv_row=rows[0],
                     msg=f'Unknown asset {e.identifier} in trade {trade_id}.',
-                    is_error=True,
-                )
-            except UnsupportedAsset as e:
-                self.send_message(
-                    row_index=0, csv_row=rows[0],
-                    msg=f'{e!s} (trade {trade_id}).',
                     is_error=True,
                 )
             except (DeserializationError, ValueError) as e:

--- a/rotkehlchen/data_import/importers/coinledger.py
+++ b/rotkehlchen/data_import/importers/coinledger.py
@@ -12,7 +12,7 @@ from rotkehlchen.data_import.utils import (
     maybe_set_transaction_extra_data,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -225,13 +225,6 @@ class CoinledgerImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/cointracking.py
+++ b/rotkehlchen/data_import/importers/cointracking.py
@@ -17,7 +17,7 @@ from rotkehlchen.data_import.utils import (
     hash_csv_row,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import (
@@ -240,13 +240,6 @@ class CointrackingImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except (IndexError, ValueError):

--- a/rotkehlchen/data_import/importers/cryptocom.py
+++ b/rotkehlchen/data_import/importers/cryptocom.py
@@ -15,7 +15,7 @@ from rotkehlchen.data_import.utils import (
     hash_csv_row,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -568,8 +568,6 @@ class CryptocomImporter(BaseExchangeImporter):
                 raise InputError(f'Crypto.com csv missing entry for {e!s}') from e
             except UnknownAsset as e:
                 raise InputError(f'Encountered unknown asset {e!s} at crypto.com csv import') from e  # noqa: E501
-            except UnsupportedAsset as e:
-                raise InputError(f'Encountered unsupported asset at crypto.com csv import: {e!s}') from e  # noqa: E501
 
             for index, row in enumerate(data, start=1):
                 try:
@@ -581,13 +579,6 @@ class CryptocomImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/kucoin.py
+++ b/rotkehlchen/data_import/importers/kucoin.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.assets.converters import asset_from_kucoin
 from rotkehlchen.data_import.utils import BaseExchangeImporter, hash_csv_row
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnsupportedAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.utils import get_key_if_has_val
@@ -108,13 +107,6 @@ class KucoinImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Deserialization error: {e!s}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except KeyError as e:

--- a/rotkehlchen/data_import/importers/nexo.py
+++ b/rotkehlchen/data_import/importers/nexo.py
@@ -12,7 +12,7 @@ from rotkehlchen.data_import.utils import (
     hash_csv_row,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -218,13 +218,6 @@ class NexoImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/rotki_events.py
+++ b/rotkehlchen/data_import/importers/rotki_events.py
@@ -10,7 +10,7 @@ from rotkehlchen.data_import.utils import (
     process_rotki_generic_import_csv_fields,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.base import HistoryBaseEntry, HistoryEvent
@@ -101,13 +101,6 @@ class RotkiGenericEventsImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=f'{e!s} for location {row.get("Location", "")}.',
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/rotki_trades.py
+++ b/rotkehlchen/data_import/importers/rotki_trades.py
@@ -8,7 +8,7 @@ from rotkehlchen.data_import.utils import (
     process_rotki_generic_import_csv_fields,
 )
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events
@@ -74,13 +74,6 @@ class RotkiGenericTradesImporter(BaseExchangeImporter):
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=f'{e!s} for location {row.get("Location", "")}.',
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/shapeshift_trades.py
+++ b/rotkehlchen/data_import/importers/shapeshift_trades.py
@@ -8,7 +8,7 @@ from rotkehlchen.constants.assets import A_DAI, A_SAI
 from rotkehlchen.constants.timing import SAI_DAI_MIGRATION_TS
 from rotkehlchen.data_import.utils import BaseExchangeImporter, SkippedCSVEntry, hash_csv_row
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.swap import create_swap_events
@@ -112,13 +112,6 @@ Trade from ShapeShift with ShapeShift Deposit Address:
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/data_import/importers/uphold_transactions.py
+++ b/rotkehlchen/data_import/importers/uphold_transactions.py
@@ -6,7 +6,7 @@ from rotkehlchen.assets.converters import asset_from_uphold
 from rotkehlchen.constants import ZERO
 from rotkehlchen.data_import.utils import BaseExchangeImporter, SkippedCSVEntry, hash_csv_row
 from rotkehlchen.db.drivers.gevent import DBCursor
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
@@ -198,13 +198,6 @@ Activity from uphold with uphold transaction id:
                         row_index=index,
                         csv_row=row,
                         msg=f'Unknown asset {e.identifier}.',
-                        is_error=True,
-                    )
-                except UnsupportedAsset as e:
-                    self.send_message(
-                        row_index=index,
-                        csv_row=row,
-                        msg=str(e),
                         is_error=True,
                     )
                 except DeserializationError as e:

--- a/rotkehlchen/db/constants.py
+++ b/rotkehlchen/db/constants.py
@@ -64,7 +64,6 @@ class UpdateType(Enum):
     ACCOUNTING_RULES = 'accounting_rules'
     LOCATION_ASSET_MAPPINGS = 'location_asset_mappings'
     COUNTERPARTY_ASSET_MAPPINGS = 'counterparty_asset_mappings'
-    LOCATION_UNSUPPORTED_ASSETS = 'location_unsupported_assets'
 
     def serialize(self) -> str:
         """Serializes the update type for the DB and API"""

--- a/rotkehlchen/db/updates.py
+++ b/rotkehlchen/db/updates.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Literal
 import requests
 from packaging import version as pversion
 from packaging.version import Version
-from rsqlite import OperationalError
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import Asset
@@ -95,7 +94,6 @@ class RotkiDataUpdater:
             UpdateType.GLOBAL_ADDRESSBOOK: self.update_global_addressbook,
             UpdateType.ACCOUNTING_RULES: self.update_accounting_rules,
             UpdateType.LOCATION_ASSET_MAPPINGS: self.update_location_asset_mappings,
-            UpdateType.LOCATION_UNSUPPORTED_ASSETS: self.update_location_unsupported_assets,
             UpdateType.COUNTERPARTY_ASSET_MAPPINGS: self.update_counterparty_asset_mappings,
         }  # If we ever change this also change tests/unit/test_data_updates::reset_update_type_mappings  # noqa: E501
         self.version = get_current_version().our_version
@@ -497,32 +495,6 @@ class RotkiDataUpdater:
                     log.error(f'Could not deserialize {entry_type.__name__} {raw_entry!s}: {e!s}')
 
             update_function(entries=entries, skip_errors=True)
-
-    def update_location_unsupported_assets(self, data: dict[str, dict[str, list[str]]], version: int) -> None:  # noqa: E501
-        """Applies location unsupported assets updates in the global DB"""
-        log.info(f'Applying update for location unsupported assets to v{version}')
-        for raw_data_key, update_query in (
-            ('insert', 'INSERT OR IGNORE INTO location_unsupported_assets(location, exchange_symbol) VALUES(?, ?);'),  # noqa: E501
-            ('remove', 'DELETE FROM location_unsupported_assets WHERE location = ? AND exchange_symbol = ?;'),  # noqa: E501
-        ):
-            raw_data: dict[str, list[str]] | None = data.get(raw_data_key)
-            if raw_data is None:
-                continue  # no data to update
-
-            for raw_location, exchange_symbols in raw_data.items():
-                try:
-                    location = Location.deserialize(raw_location).serialize_for_db()
-                except DeserializationError as e:
-                    log.error(f'Could not deserialize a valid location from {raw_location}: {e!s}')
-                    continue
-
-                try:
-                    with GlobalDBHandler().conn.write_ctx() as write_cursor:
-                        write_cursor.executemany(
-                            update_query, [(location, symbol) for symbol in exchange_symbols],
-                        )
-                except OperationalError as e:
-                    log.error(f'Could not {raw_data_key} location unsupported asset for {raw_location} due to: {e!s}')  # noqa: E501
 
     def check_for_updates(self, updates: Sequence[UpdateType] = tuple(UpdateType)) -> None:
         """Retrieve the information about the latest available update"""

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -25,7 +25,7 @@ from rotkehlchen.db.constants import BINANCE_MARKETS_KEY
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.ranges import DBQueryRanges
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import BinancePair, MarginPosition
@@ -143,7 +143,6 @@ def trade_from_binance(
 
     Returns a tuple containing the unique_id and list of SwapEvents for this trade.
     May raise:
-        - UnsupportedAsset due to asset_from_binance
         - DeserializationError due to unexpected format of dict entries
         - KeyError due to dict entries missing an expected entry
     """
@@ -518,13 +517,6 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
             try:
                 asset = asset_from_binance(asset_symbol)
-            except UnsupportedAsset as e:
-                log.error(
-                    'Found unsupported %s asset %s. Ignoring its balance query.',
-                    self.name,
-                    e.identifier,
-                )
-                continue
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
@@ -650,12 +642,6 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                         continue
 
                     asset = asset_from_binance(entry['asset'])
-                except UnsupportedAsset as e:
-                    log.error(
-                        f'Found unsupported {self.name} asset {e.identifier}. '
-                        'Ignoring its lending balance query.',
-                    )
-                    continue
                 except UnknownAsset as e:
                     self.send_unknown_asset_message(
                         asset_identifier=e.identifier,
@@ -774,12 +760,6 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
                     try:
                         asset = asset_from_binance(entry['asset'])
-                    except UnsupportedAsset as e:
-                        log.error(
-                            f'Found unsupported {self.name} asset {e.identifier}. '
-                            f'Ignoring its lending interest history query.',
-                        )
-                        continue
                     except UnknownAsset as e:
                         self.send_unknown_asset_message(
                             asset_identifier=e.identifier,
@@ -848,12 +828,6 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
                 try:
                     asset = asset_from_binance(entry['asset'])
-                except UnsupportedAsset as e:
-                    log.error(
-                        f'Found unsupported {self.name} asset {e.identifier}. '
-                        f'Ignoring its lending interest history query.',
-                    )
-                    continue
                 except UnknownAsset as e:
                     self.send_unknown_asset_message(
                         asset_identifier=e.identifier,
@@ -908,12 +882,6 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
                 try:
                     asset = asset_from_binance(entry['collateralCoin'])
-                except UnsupportedAsset as e:
-                    log.error(
-                        f'Found unsupported {self.name} asset {e.identifier}. '
-                        f'Ignoring its futures balance query.',
-                    )
-                    continue
                 except UnknownAsset as e:
                     self.send_unknown_asset_message(
                         asset_identifier=e.identifier,
@@ -984,12 +952,6 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
                 try:
                     asset = asset_from_binance(entry['asset'])
-                except UnsupportedAsset as e:
-                    log.error(
-                        f'Found unsupported {self.name} asset {e.identifier}. '
-                        f'Ignoring its margined futures balance query.',
-                    )
-                    continue
                 except UnknownAsset as e:
                     self.send_unknown_asset_message(
                         asset_identifier=e.identifier,
@@ -1041,12 +1003,6 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
             try:
                 asset = asset_from_binance(asset_name)
-            except UnsupportedAsset as e:
-                log.error(
-                    f'Found unsupported {self.name} asset {asset_name}. '
-                    f'Ignoring its {self.name} pool balance query. {e!s}',
-                )
-                return None
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
@@ -1232,12 +1188,6 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                     details='trade',
                 )
                 continue
-            except UnsupportedAsset as e:
-                log.error(
-                    f'Found {self.name} trade with unsupported asset '
-                    f'{e.identifier}. Ignoring it.',
-                )
-                continue
             except (DeserializationError, KeyError) as e:
                 msg = str(e)
                 if isinstance(e, KeyError):
@@ -1360,11 +1310,6 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                     self.send_unknown_asset_message(
                         asset_identifier=e.identifier,
                         details=operation_type,
-                    )
-                except UnsupportedAsset as e:
-                    log.error(
-                        f'Found {self.location!s} {operation_type} with unsupported asset '
-                        f'{e.identifier}. Ignoring it.',
                     )
                 except (DeserializationError, KeyError) as e:
                     msg = str(e)

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -520,8 +520,9 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 asset = asset_from_binance(asset_symbol)
             except UnsupportedAsset as e:
                 log.error(
-                    f'Found unsupported {self.name} asset {e.identifier}. '
-                    f'Ignoring its balance query.',
+                    'Found unsupported %s asset %s. Ignoring its balance query.',
+                    self.name,
+                    e.identifier,
                 )
                 continue
             except UnknownAsset as e:

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -519,11 +519,10 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             try:
                 asset = asset_from_binance(asset_symbol)
             except UnsupportedAsset as e:
-                if e.identifier != 'ETF':
-                    log.error(
-                        f'Found unsupported {self.name} asset {e.identifier}. '
-                        f'Ignoring its balance query.',
-                    )
+                log.error(
+                    f'Found unsupported {self.name} asset {e.identifier}. '
+                    f'Ignoring its balance query.',
+                )
                 continue
             except UnknownAsset as e:
                 self.send_unknown_asset_message(

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -20,7 +20,7 @@ from rotkehlchen.assets.utils import symbol_to_asset_or_token
 from rotkehlchen.constants import ZERO
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
@@ -414,13 +414,6 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
                     f'Failed to deserialize a {self.name} {case} result. '
                     f'Check logs for details. Ignoring it.',
                 )
-            except UnsupportedAsset as e:
-                msg = (
-                    f'Found {self.name} {case} with unsupported '
-                    f'asset {e.identifier}'
-                )
-                log.warning(f'{msg}. raw_data={raw_result}')
-                self.msg_aggregator.add_warning(f'{msg}. Ignoring {case}')
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
@@ -444,7 +437,6 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
         Can raise:
          - DeserializationError.
          - UnknownAsset
-         - UnsupportedAsset
 
         Schema reference in:
         https://docs.bitfinex.com/reference#rest-auth-movements
@@ -494,7 +486,6 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
         Can raise:
          - DeserializationError.
          - UnknownAsset
-         - UnsupportedAsset
 
         Schema reference in:
         https://docs.bitfinex.com/reference#rest-auth-trades
@@ -874,12 +865,6 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
 
             try:
                 asset = asset_from_bitfinex(bitfinex_name=wallet[currency_index])
-            except UnsupportedAsset as e:
-                self.msg_aggregator.add_warning(
-                    f'Found unsupported {self.name} asset {e.identifier} due to: {e!s}. '
-                    f'Ignoring its balance query.',
-                )
-                continue
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -634,9 +634,6 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
                     ]:
                         try:
                             asset = get_asset_func(param)  # type: ignore[operator]
-                        except UnsupportedAsset:
-                            log.warning(f'Found unsupported asset {bfx_symbol} in Bitfinex. Support for it has to be added.')  # noqa: E501
-                            break  # Don't try fallbacks; this asset is explicitly unsupported
                         except UnknownAsset:
                             continue
 
@@ -645,8 +642,6 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
                                 bfx_db_serialized,
                                 bfx_symbol,
                                 asset.serialize(),
-                                bfx_db_serialized,
-                                bfx_symbol,
                             ))
 
                         break
@@ -654,12 +649,11 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
                         log.warning(f'Found new asset symbol {bfx_symbol} for {symbol} in Bitfinex. Support for it has to be added.')  # noqa: E501
                         continue  # skip unknown assets
 
-                # insert the mapping, and skip unsupported assets
+                # insert the fetched mappings
                 with GlobalDBHandler().conn.write_ctx() as write_cursor:
                     write_cursor.executemany(
                         'INSERT OR IGNORE INTO location_asset_mappings (location, '
-                        'exchange_symbol, local_id) SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 '
-                        'FROM location_unsupported_assets WHERE location=? AND exchange_symbol=?)',
+                        'exchange_symbol, local_id) VALUES(?, ?, ?)',
                         bindings,
                     )
 

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -17,7 +17,7 @@ from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
@@ -205,12 +205,6 @@ class Bitstamp(ExchangeInterface, SignatureGeneratorMixin):
                 self.msg_aggregator.add_error(
                     'Failed to deserialize a Bitstamp balance. '
                     'Check logs for details. Ignoring it.',
-                )
-                continue
-            except UnsupportedAsset as e:
-                log.error(str(e))
-                self.msg_aggregator.add_warning(
-                    f'Found unsupported Bistamp asset {e.identifier}. Ignoring its balance query.',
                 )
                 continue
             except UnknownAsset as e:
@@ -866,7 +860,7 @@ class Bitstamp(ExchangeInterface, SignatureGeneratorMixin):
         try:
             base_asset = asset_from_bitstamp(base_asset_symbol)
             quote_asset = asset_from_bitstamp(quote_asset_symbol)
-        except (UnknownAsset, UnsupportedAsset) as e:
+        except UnknownAsset as e:
             log.error(str(e))
             asset_tag = 'Unknown' if isinstance(e, UnknownAsset) else 'Unsupported'
             raise DeserializationError(

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -23,7 +23,7 @@ from rotkehlchen.constants.timing import HOUR_IN_SECONDS
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
@@ -398,12 +398,6 @@ class Coinbase(ExchangeInterface):
                     details='balance query',
                 )
                 continue
-            except UnsupportedAsset as e:
-                log.warning(
-                    f'Found coinbase balance result with unsupported asset '
-                    f'{e.identifier}. Ignoring it.',
-                )
-                continue
             except (DeserializationError, KeyError) as e:
                 msg = str(e)
                 if isinstance(e, KeyError):
@@ -588,12 +582,6 @@ class Coinbase(ExchangeInterface):
                     details='conversion',
                 )
                 continue
-            except UnsupportedAsset as e:
-                self.msg_aggregator.add_warning(
-                    f'Found coinbase conversion with unsupported asset '
-                    f'{e.identifier}. Ignoring it.',
-                )
-                continue
             except (DeserializationError, KeyError) as e:
                 msg = str(e)
                 if isinstance(e, KeyError):
@@ -759,11 +747,6 @@ class Coinbase(ExchangeInterface):
             self.send_unknown_asset_message(
                 asset_identifier=e.identifier,
                 details='transaction',
-            )
-        except UnsupportedAsset as e:
-            self.msg_aggregator.add_warning(
-                f'Found coinbase trade with unsupported asset '
-                f'{e.identifier}. Ignoring it.',
             )
         except (DeserializationError, KeyError, IndexError, ZeroDivisionError) as e:
             msg = str(e)
@@ -999,11 +982,6 @@ class Coinbase(ExchangeInterface):
                 asset_identifier=e.identifier,
                 details='deposit/withdrawal',
             )
-        except UnsupportedAsset as e:
-            self.msg_aggregator.add_warning(
-                f'Found coinbase deposit/withdrawal with unsupported asset '
-                f'{e.identifier}. Ignoring it.',
-            )
         except (DeserializationError, KeyError) as e:
             msg = str(e)
             if isinstance(e, KeyError):
@@ -1121,11 +1099,6 @@ class Coinbase(ExchangeInterface):
             self.send_unknown_asset_message(
                 asset_identifier=e.identifier,
                 details='transaction',
-            )
-        except UnsupportedAsset as e:
-            self.msg_aggregator.add_warning(
-                f'Found coinbase transaction with unsupported asset '
-                f'{e.identifier}. Ignoring it.',
             )
         except (DeserializationError, KeyError) as e:
             msg = str(e)

--- a/rotkehlchen/exchanges/coinbaseprime.py
+++ b/rotkehlchen/exchanges/coinbaseprime.py
@@ -14,7 +14,7 @@ from rotkehlchen.assets.converters import asset_from_coinbase
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
@@ -518,11 +518,6 @@ class Coinbaseprime(ExchangeInterface):
                     self.send_unknown_asset_message(
                         asset_identifier=e.identifier,
                         details='balance query',
-                    )
-                except UnsupportedAsset as e:
-                    log.warning(
-                        f'Found coinbase prime balance result with unsupported asset '
-                        f'{e.identifier}. Ignoring it.',
                     )
                 except (DeserializationError, KeyError) as e:
                     msg = str(e)

--- a/rotkehlchen/exchanges/cryptocom.py
+++ b/rotkehlchen/exchanges/cryptocom.py
@@ -13,7 +13,7 @@ from rotkehlchen.assets.converters import asset_from_cryptocom
 from rotkehlchen.constants import MONTH_IN_MILLISECONDS, WEEK_IN_MILLISECONDS, ZERO
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
@@ -229,7 +229,6 @@ class Cryptocom(ExchangeInterface, SignatureGeneratorMixin):
         Can raise:
          - DeserializationError
          - UnknownAsset
-         - UnsupportedAsset
          - KeyError
         """
         raw_fee = raw_result.get('fee')
@@ -261,7 +260,6 @@ class Cryptocom(ExchangeInterface, SignatureGeneratorMixin):
         Can raise:
          - DeserializationError
          - UnknownAsset
-         - UnsupportedAsset
          - KeyError
         """
         # Parse the instrument name (e.g., "BTC_USDT")
@@ -316,11 +314,6 @@ class Cryptocom(ExchangeInterface, SignatureGeneratorMixin):
                     amount=amount,
                     value=amount * Inquirer.find_main_currency_price(asset),
                 )
-        except UnsupportedAsset as e:
-            self.msg_aggregator.add_warning(
-                f'Found unsupported {self.name} asset {e.identifier} due to: {e!s}. '
-                f'Ignoring its balance query.',
-            )
         except UnknownAsset as e:
             self.send_unknown_asset_message(
                 asset_identifier=e.identifier,
@@ -477,7 +470,7 @@ class Cryptocom(ExchangeInterface, SignatureGeneratorMixin):
                 for raw_asset_movement in (raw_list := result.result.get(result_key, [])):
                     try:
                         events.extend(deserialize_fn(raw_asset_movement))
-                    except (DeserializationError, UnsupportedAsset, UnknownAsset, KeyError) as e:
+                    except (DeserializationError, UnknownAsset, KeyError) as e:
                         msg = f'missing key: {e!s}' if isinstance(e, KeyError) else str(e)
                         log.error(
                             f'Error processing {self.name} {query_type}: '

--- a/rotkehlchen/exchanges/data_structures.py
+++ b/rotkehlchen/exchanges/data_structures.py
@@ -304,7 +304,6 @@ class BinancePair(NamedTuple):
     def deserialize_from_db(cls, entry: BINANCE_PAIR_DB_TUPLE) -> 'BinancePair':
         """Create a BinancePair from data in the database. May raise:
         - DeserializationError
-        - UnsupportedAsset
         - UnknownAsset
         """
         return BinancePair(

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -17,7 +17,7 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.timing import GLOBAL_REQUESTS_TIMEOUT
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
@@ -360,12 +360,6 @@ class Gemini(ExchangeInterface, SignatureGeneratorMixin):
                     details='balance query',
                 )
                 continue
-            except UnsupportedAsset as e:
-                self.msg_aggregator.add_warning(
-                    f'Found gemini balance result with unsupported '
-                    f'asset {e.identifier}. Ignoring it.',
-                )
-                continue
             except (DeserializationError, KeyError) as e:
                 msg = str(e)
                 if isinstance(e, KeyError):
@@ -565,12 +559,6 @@ class Gemini(ExchangeInterface, SignatureGeneratorMixin):
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
                     details='deposit/withdrawal',
-                )
-                continue
-            except UnsupportedAsset as e:
-                self.msg_aggregator.add_warning(
-                    f'Found gemini deposit/withdrawal with unsupported asset '
-                    f'{e.identifier}. Ignoring it.',
                 )
                 continue
             except (DeserializationError, KeyError) as e:

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -13,7 +13,7 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_iconomi
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_AUST
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import Location, MarginPosition
@@ -196,12 +196,6 @@ class Iconomi(ExchangeInterface, SignatureGeneratorMixin):
                     amount=amount,
                     value=amount * price,
                 )
-            except UnsupportedAsset:
-                self.msg_aggregator.add_warning(
-                    f'Found unsupported ICONOMI asset {ticker}. '
-                    f' Ignoring its balance query.',
-                )
-                continue
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -16,7 +16,7 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_BTC
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import Location, MarginPosition
@@ -61,7 +61,6 @@ def independentreserve_asset(symbol: str) -> AssetWithOracles:
     """Returns the asset corresponding to the independentreserve symbol
 
     May raise:
-    - UnsupportedAsset
     - UnknownAsset
     """
     return symbol_to_asset_or_token(GlobalDBHandler.get_assetid_from_exchange_name(
@@ -77,7 +76,6 @@ def _asset_movement_from_independentreserve(raw_tx: dict) -> AssetMovement | Non
     https://www.independentreserve.com/products/api#GetTransactions
     May raise:
     - DeserializationError
-    - UnsupportedAsset
     - UnknownAsset
     - KeyError
     """
@@ -260,12 +258,6 @@ class Independentreserve(ExchangeInterface, SignatureGeneratorMixin):
                 price = Inquirer.find_main_currency_price(asset)
                 amount = deserialize_fval(entry['TotalBalance'])
                 account_guids.append(entry['AccountGuid'])
-            except UnsupportedAsset as e:
-                log.error(
-                    f'Found unsupported {self.name} asset {e.identifier}. '
-                    f'Ignoring its balance query.',
-                )
-                continue
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
@@ -365,11 +357,6 @@ class Independentreserve(ExchangeInterface, SignatureGeneratorMixin):
                         unique_id=str(raw_trade['TradeGuid']),
                     ),
                 ))
-            except UnsupportedAsset as e:
-                log.error(
-                    f'Found unsupported {self.name} asset {e.identifier}. '
-                    f'Ignoring this trade entry {raw_trade}.',
-                )
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
@@ -427,12 +414,6 @@ class Independentreserve(ExchangeInterface, SignatureGeneratorMixin):
                     movement = _asset_movement_from_independentreserve(entry)
                     if movement:
                         movements.append(movement)
-                except UnsupportedAsset as e:
-                    log.error(
-                        f'Found unsupported {self.name} asset {e.identifier}. '
-                        f'Ignoring this asset movement entry {entry}.',
-                    )
-                    continue
                 except UnknownAsset as e:
                     self.send_unknown_asset_message(
                         asset_identifier=e.identifier,

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -19,7 +19,7 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.timing import MONTH_IN_SECONDS, WEEK_IN_SECONDS
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
@@ -132,7 +132,6 @@ def deserialize_trade_pair(trade_pair_symbol: str) -> tuple[AssetWithOracles, As
     """May raise:
     - UnprocessableTradePair
     - UnknownAsset
-    - UnsupportedAsset
     """
     try:
         base_asset_symbol, quote_asset_symbol = trade_pair_symbol.split('-')
@@ -401,7 +400,6 @@ class Kucoin(ExchangeInterface, SignatureGeneratorMixin):
                     DeserializationError,
                     KeyError,
                     UnprocessableTradePair,
-                    UnsupportedAsset,
                 ) as e:
                     error_msg = f'Missing key: {e!s}.' if isinstance(e, KeyError) else str(e)
                     log.error(
@@ -409,9 +407,6 @@ class Kucoin(ExchangeInterface, SignatureGeneratorMixin):
                         error=error_msg,
                         raw_result=raw_result,
                     )
-                    if isinstance(e, UnsupportedAsset):
-                        error_msg = f'Found unsupported kucoin asset {e.identifier}'
-
                     self.msg_aggregator.add_error(
                         f'Failed to deserialize a kucoin {case} result. {error_msg}. Ignoring it. '
                         f'Check logs for more details')
@@ -487,12 +482,6 @@ class Kucoin(ExchangeInterface, SignatureGeneratorMixin):
                     'Failed to deserialize a kucoin balance. Ignoring it.',
                 )
                 continue
-            except UnsupportedAsset as e:
-                self.msg_aggregator.add_warning(
-                    f'Found unsupported kucoin asset {e.identifier} while deserializing '
-                    f'a balance. Ignoring it.',
-                )
-                continue
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
@@ -525,7 +514,6 @@ class Kucoin(ExchangeInterface, SignatureGeneratorMixin):
         May raise:
         - DeserializationError
         - UnknownAsset
-        - UnsupportedAsset
         """
         event_subtype: Literal[HistoryEventSubType.RECEIVE, HistoryEventSubType.SPEND]
         if case == KucoinCase.DEPOSITS:
@@ -578,7 +566,6 @@ class Kucoin(ExchangeInterface, SignatureGeneratorMixin):
         - DeserializationError
         - UnknownAsset
         - UnprocessableTradePair
-        - UnsupportedAsset
         """
         try:
             timestamp = deserialize_timestamp(raw_result['createdAt'])

--- a/rotkehlchen/exchanges/okx.py
+++ b/rotkehlchen/exchanges/okx.py
@@ -14,7 +14,7 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.constants import OKX_LOCATION_KEY
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
@@ -292,12 +292,6 @@ class Okx(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                     details='balance query',
                 )
                 continue
-            except UnsupportedAsset as e:
-                self.msg_aggregator.add_warning(
-                    f'Found {self.name} balance with unsupported asset '
-                    f'{e.identifier}. Ignoring it.',
-                )
-                continue
 
             try:
                 price = Inquirer.find_main_currency_price(asset)
@@ -416,11 +410,6 @@ class Okx(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 asset_identifier=e.identifier,
                 details='trade',
             )
-        except UnsupportedAsset as e:
-            self.msg_aggregator.add_warning(
-                f'Found {self.name} trade with unsupported asset '
-                f'{e.identifier}. Ignoring it.',
-            )
         except (DeserializationError, KeyError) as e:
             self.msg_aggregator.add_error(
                 f'Unexpected data encountered during deserialization of {self.name}'
@@ -480,11 +469,6 @@ class Okx(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             self.send_unknown_asset_message(
                 asset_identifier=e.identifier,
                 details='deposit/withdrawal',
-            )
-        except UnsupportedAsset as e:
-            self.msg_aggregator.add_warning(
-                f'Found {self.name} deposit/withdrawal with unsupported asset '
-                f'{e.identifier}. Ignoring it.',
             )
         except (DeserializationError, KeyError) as e:
             self.msg_aggregator.add_error(

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -16,7 +16,7 @@ from rotkehlchen.constants import DAY_IN_SECONDS, ZERO
 from rotkehlchen.constants.assets import A_LEND
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
@@ -77,7 +77,6 @@ def trade_from_poloniex(exchange_name: str, poloniex_trade: dict[str, Any]) -> l
     """Convert a poloniex trade returned from poloniex trade history into a list of SwapEvents.
 
     Throws:
-        - UnsupportedAsset due to asset_from_poloniex()
         - DeserializationError due to the data being in unexpected format
         - UnprocessableTradePair due to the pair data being in an unexpected format
     """
@@ -403,12 +402,6 @@ class Poloniex(ExchangeInterface, SignatureGeneratorMixin):
                 if available != ZERO or on_orders != ZERO:
                     try:
                         asset = asset_from_poloniex(poloniex_asset)
-                    except UnsupportedAsset as e:
-                        self.msg_aggregator.add_warning(
-                            f'Found unsupported poloniex asset {e.identifier}. '
-                            f'Ignoring its balance query.',
-                        )
-                        continue
                     except UnknownAsset as e:
                         self.send_unknown_asset_message(
                             asset_identifier=e.identifier,
@@ -473,11 +466,6 @@ class Poloniex(ExchangeInterface, SignatureGeneratorMixin):
                     f'Error deserializing a poloniex trade. Unknown trade '
                     f'accountType {account_type} found.',
                 )
-        except UnsupportedAsset as e:
-            self.msg_aggregator.add_warning(
-                f'Found poloniex trade with unsupported asset'
-                f' {e.identifier}. Ignoring it.',
-            )
         except UnknownAsset as e:
             self.send_unknown_asset_message(asset_identifier=e.identifier, details='trade')
         except (UnprocessableTradePair, DeserializationError) as e:
@@ -541,11 +529,6 @@ class Poloniex(ExchangeInterface, SignatureGeneratorMixin):
                     address=deserialize_asset_movement_address(movement_data, 'address', asset),
                     transaction_id=transaction_id,
                 ),
-            )
-        except UnsupportedAsset as e:
-            self.msg_aggregator.add_warning(
-                f'Found {movement_type!s} of unsupported poloniex asset '
-                f'{e.identifier}. Ignoring it.',
             )
         except UnknownAsset as e:
             self.send_unknown_asset_message(

--- a/rotkehlchen/exchanges/utils.py
+++ b/rotkehlchen/exchanges/utils.py
@@ -16,7 +16,7 @@ from rotkehlchen.assets.converters import asset_from_binance
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.timing import DAY_IN_SECONDS
 from rotkehlchen.db.settings import CachedSettings
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.exchanges.data_structures import BinancePair
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.binance import GlobalDBBinance
@@ -174,7 +174,7 @@ def create_binance_symbols_to_pair(
                 quote_asset=asset_from_binance(symbol['quoteAsset']),
                 location=location,
             )
-        except (UnknownAsset, UnsupportedAsset) as e:
+        except UnknownAsset as e:
             log.debug(f'Found binance pair with no processable asset. {e!s}')
     return result
 

--- a/rotkehlchen/globaldb/binance.py
+++ b/rotkehlchen/globaldb/binance.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import rsqlite
 
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import BinancePair
@@ -59,7 +59,7 @@ class GlobalDBBinance:
             for pair in cursor:
                 try:
                     pairs.append(BinancePair.deserialize_from_db(pair))
-                except (DeserializationError, UnsupportedAsset, UnknownAsset) as e:
+                except (DeserializationError, UnknownAsset) as e:
                     log.debug(f'Failed to deserialize binance pair {pair}. {e!s}')
 
         return pairs

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -39,7 +39,7 @@ from rotkehlchen.constants.misc import (
 from rotkehlchen.constants.resolver import evm_address_to_identifier, tokenid_to_collectible_id
 from rotkehlchen.db.drivers.gevent import DBConnection, DBConnectionType, DBCursor
 from rotkehlchen.db.utils import get_query_chunks
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset, WrongAssetType
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.deserialization import deserialize_price
@@ -2401,12 +2401,6 @@ class GlobalDBHandler:
         location_asset_mappings table. Use exchange=None to get the common id for all exchanges.
         If the mapping is not present returns default."""
         with GlobalDBHandler().conn.read_ctx() as cursor:
-            if exchange is not None and cursor.execute(
-                'SELECT COUNT(*) FROM location_unsupported_assets WHERE location=? AND exchange_symbol=?',  # noqa: E501
-                (exchange.serialize_for_db(), symbol),
-            ).fetchone()[0] > 0:
-                raise UnsupportedAsset(symbol)
-
             location_filter, bindings = '', [symbol]
             if exchange is not None:
                 location_filter = 'location IS ? OR'

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -141,18 +141,28 @@ def test_query_history(rotkehlchen_api_server_with_exchanges: 'APIServer', start
     assert len(events_result['entries']) == entries_length
 
     # And now make sure that messages have also been generated for the query of
-    # the unsupported/unknown assets
+    # the assets that can't be mapped to a known asset
     websocket_connection.wait_until_messages_num(num=20, timeout=10)
-    assert [msg for msg in websocket_connection.messages if msg['type'] != 'history_events_status'][::-1] == [  # noqa: E501
-        {'type': 'exchange_unknown_asset', 'data': {'location': 'poloniex', 'name': 'poloniex', 'identifier': 'IDONTEXIST', 'details': 'asset movement'}},  # noqa: E501
-        {'type': 'legacy', 'data': {'verbosity': 'warning', 'value': 'Found withdrawal of unsupported poloniex asset BALLS. Ignoring it.'}},  # noqa: E501
-        {'type': 'exchange_unknown_asset', 'data': {'location': 'poloniex', 'name': 'poloniex', 'identifier': 'IDONTEXIST', 'details': 'asset movement'}},  # noqa: E501
-        {'type': 'legacy', 'data': {'verbosity': 'warning', 'value': 'Found deposit of unsupported poloniex asset EBT. Ignoring it.'}},  # noqa: E501
-        {'type': 'exchange_unknown_asset', 'data': {'location': 'poloniex', 'name': 'poloniex', 'identifier': 'NOEXISTINGASSET', 'details': 'trade'}},  # noqa: E501
-        {'type': 'legacy', 'data': {'verbosity': 'warning', 'value': 'Found poloniex trade with unsupported asset BALLS. Ignoring it.'}},  # noqa: E501
-        {'type': 'legacy', 'data': {'verbosity': 'error', 'value': "Failed to read ledger event from kraken {'refid': 'D3', 'time': 1408994442, 'type': 'deposit', 'subtype': '', 'aclass': 'currency', 'asset': 'IDONTEXISTEITHER', 'amount': '10', 'fee': '0', 'balance': '100'} due to Unknown asset IDONTEXISTEITHER provided."}},  # noqa: E501
-        {'type': 'legacy', 'data': {'verbosity': 'error', 'value': "Failed to read ledger event from kraken {'refid': 'W3', 'time': 1408994442, 'type': 'withdrawal', 'subtype': '', 'aclass': 'currency', 'asset': 'IDONTEXISTEITHER', 'amount': '-10', 'fee': '0.11', 'balance': '100'} due to Unknown asset IDONTEXISTEITHER provided."}},  # noqa: E501
-    ]
+    non_status_messages = [msg for msg in websocket_connection.messages if msg['type'] != 'history_events_status']  # noqa: E501
+    # poloniex assets that can't be mapped produce unknown-asset messages
+    assert sorted(
+        (msg['data']['identifier'], msg['data']['details'])
+        for msg in non_status_messages if msg['type'] == 'exchange_unknown_asset'
+    ) == sorted([
+        ('NOEXISTINGASSET', 'trade'),
+        ('NOTAREALASSET', 'trade'),
+        ('EBT', 'asset movement'),
+        ('IDONTEXIST', 'asset movement'),
+        ('NOTAREALASSET', 'asset movement'),
+        ('IDONTEXIST', 'asset movement'),
+    ])
+    # kraken ledger entries with unknown assets remain legacy error messages
+    assert sorted(
+        msg['data']['value'] for msg in non_status_messages if msg['type'] == 'legacy'
+    ) == sorted([
+        "Failed to read ledger event from kraken {'refid': 'D3', 'time': 1408994442, 'type': 'deposit', 'subtype': '', 'aclass': 'currency', 'asset': 'IDONTEXISTEITHER', 'amount': '10', 'fee': '0', 'balance': '100'} due to Unknown asset IDONTEXISTEITHER provided.",  # noqa: E501
+        "Failed to read ledger event from kraken {'refid': 'W3', 'time': 1408994442, 'type': 'withdrawal', 'subtype': '', 'aclass': 'currency', 'asset': 'IDONTEXISTEITHER', 'amount': '-10', 'fee': '0.11', 'balance': '100'} due to Unknown asset IDONTEXISTEITHER provided.",  # noqa: E501
+    ])
 
     response = requests.get(
         api_url_for(

--- a/rotkehlchen/tests/api/test_messages.py
+++ b/rotkehlchen/tests/api/test_messages.py
@@ -26,8 +26,8 @@ def test_query_messages(
     rotki = rotkehlchen_api_server_with_exchanges.rest_api.rotkehlchen
     setup = mock_history_processing_and_exchanges(rotki)
 
-    # Query polo trades of to get them saved in the DB. This generates
-    # warnings due to unsupported assets found during querying
+    # Query polo trades of to get them saved in the DB. This generates unknown
+    # asset messages for the assets that can't be mapped during querying
     with setup.polo_patch:
         response = requests.post(
             api_url_for(rotkehlchen_api_server_with_exchanges, 'exchangeeventsqueryresource'),
@@ -41,14 +41,18 @@ def test_query_messages(
     )
     assert_proper_sync_response_with_result(response)
     websocket_connection.wait_until_messages_num(num=9, timeout=10)
-    assert [msg for msg in websocket_connection.messages if msg['type'] != 'history_events_status'] == [  # noqa: E501
-        {'type': 'legacy', 'data': {'verbosity': 'warning', 'value': 'Found poloniex trade with unsupported asset BALLS. Ignoring it.'}},  # noqa: E501
-        {'type': 'exchange_unknown_asset', 'data': {'location': 'poloniex', 'name': 'poloniex', 'identifier': 'NOEXISTINGASSET', 'details': 'trade'}},  # noqa: E501
-        {'type': 'legacy', 'data': {'verbosity': 'warning', 'value': 'Found deposit of unsupported poloniex asset EBT. Ignoring it.'}},  # noqa: E501
-        {'type': 'exchange_unknown_asset', 'data': {'location': 'poloniex', 'name': 'poloniex', 'identifier': 'IDONTEXIST', 'details': 'asset movement'}},  # noqa: E501
-        {'type': 'legacy', 'data': {'verbosity': 'warning', 'value': 'Found withdrawal of unsupported poloniex asset BALLS. Ignoring it.'}},  # noqa: E501
-        {'type': 'exchange_unknown_asset', 'data': {'location': 'poloniex', 'name': 'poloniex', 'identifier': 'IDONTEXIST', 'details': 'asset movement'}},  # noqa: E501
-    ]
+    non_status_messages = [msg for msg in websocket_connection.messages if msg['type'] != 'history_events_status']  # noqa: E501
+    assert all(msg['type'] == 'exchange_unknown_asset' for msg in non_status_messages)
+    assert sorted(
+        (msg['data']['identifier'], msg['data']['details']) for msg in non_status_messages
+    ) == sorted([
+        ('NOEXISTINGASSET', 'trade'),
+        ('NOTAREALASSET', 'trade'),
+        ('EBT', 'asset movement'),
+        ('IDONTEXIST', 'asset movement'),
+        ('NOTAREALASSET', 'asset movement'),
+        ('IDONTEXIST', 'asset movement'),
+    ])
 
     # now query for the messages again and make sure that nothing is return, since
     # our previous query should have popped all the messages in the queue

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -528,13 +528,6 @@ def test_binance_query_trade_history_unexpected_data(function_scope_binance):
     )
     query_binance_and_test(input_str)
 
-    # unsupported fee currency
-    input_str = BINANCE_MYTRADES_RESPONSE.replace(
-        '"commissionAsset": "BNB"',
-        '"commissionAsset": "BTCB"',
-    )
-    query_binance_and_test(input_str)
-
     # unknown fee currency
     input_str = BINANCE_MYTRADES_RESPONSE.replace(
         '"commissionAsset": "BNB"',
@@ -683,20 +676,6 @@ def test_binance_query_deposits_withdrawals_unexpected_data(function_scope_binan
         else:
             new_deposits = deposits
             new_withdrawals = withdrawals.replace('"ETH"', '"dasdsDSDSAD"')
-        mock_binance_and_query(
-            new_deposits,
-            new_withdrawals,
-            expected_warnings_num=1,
-            expected_errors_num=0,
-        )
-
-        # Unsupported Asset
-        if testing_deposits:
-            new_deposits = deposits.replace('"ETH"', '"BTCB"')
-            new_withdrawals = withdrawals
-        else:
-            new_deposits = deposits
-            new_withdrawals = withdrawals.replace('"ETH"', '"BTCB"')
         mock_binance_and_query(
             new_deposits,
             new_withdrawals,

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -16,7 +16,7 @@ from rotkehlchen.constants.assets import A_BNB, A_BTC, A_DOT, A_ETH, A_EUR, A_US
 from rotkehlchen.constants.misc import ONE
 from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.db.constants import BINANCE_MARKETS_KEY
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.exchanges.binance import (
     API_TIME_INTERVAL_CONSTRAINT_TS,
@@ -41,10 +41,8 @@ from rotkehlchen.tests.utils.exchanges import (
     BINANCE_MYTRADES_RESPONSE,
     BINANCE_WITHDRAWALS_HISTORY_RESPONSE,
     assert_binance_asset_movements_result,
-    get_exchange_asset_symbols,
     mock_binance_balance_response,
 )
-from rotkehlchen.tests.utils.globaldb import is_asset_symbol_unsupported
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import ApiKey, ApiSecret, Timestamp, TimestampMS
 from rotkehlchen.utils.misc import ts_now_in_ms
@@ -268,10 +266,7 @@ def test_trade_from_binance(function_scope_binance):
     reason='https://twitter.com/LefterisJP/status/1598107187184037888',
 )
 @pytest.mark.asset_test
-def test_binance_assets_are_known(inquirer, globaldb):  # pylint: disable=unused-argument
-    for asset in get_exchange_asset_symbols(Location.BINANCE):
-        assert is_asset_symbol_unsupported(globaldb, Location.BINANCE, asset) is False, f'Binance assets {asset} should not be unsupported'  # noqa: E501
-
+def test_binance_assets_are_known(inquirer):  # pylint: disable=unused-argument
     exchange_data = requests.get('https://api3.binance.com/api/v3/exchangeInfo').json()
     binance_assets = set()
     assets_starting_with_ld = set()
@@ -290,8 +285,6 @@ def test_binance_assets_are_known(inquirer, globaldb):  # pylint: disable=unused
     for binance_asset in sorted_assets:
         try:
             _ = asset_from_binance(binance_asset)
-        except UnsupportedAsset:
-            assert is_asset_symbol_unsupported(globaldb, Location.BINANCE, binance_asset)
         except UnknownAsset as e:
             if binance_asset not in missing_assets:
                 test_warnings.warn(UserWarning(

--- a/rotkehlchen/tests/exchanges/test_binance_us.py
+++ b/rotkehlchen/tests/exchanges/test_binance_us.py
@@ -7,7 +7,7 @@ import requests
 from rotkehlchen.assets.converters import asset_from_binance
 from rotkehlchen.constants import HOUR_IN_SECONDS
 from rotkehlchen.constants.assets import A_BNB, A_BTC
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.exchanges.binance import BINANCEUS_BASE_URL, Binance
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.swap import SwapEvent
@@ -19,7 +19,6 @@ from rotkehlchen.tests.utils.exchanges import (
     BINANCE_WITHDRAWALS_HISTORY_RESPONSE,
     assert_binance_asset_movements_result,
 )
-from rotkehlchen.tests.utils.globaldb import is_asset_symbol_unsupported
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Location, Timestamp, TimestampMS
 from rotkehlchen.utils.misc import ts_now
@@ -32,7 +31,7 @@ def test_name():
 
 
 @pytest.mark.asset_test
-def test_binance_assets_are_known(inquirer, globaldb):  # pylint: disable=unused-argument
+def test_binance_assets_are_known(inquirer):  # pylint: disable=unused-argument
     exchange_data = requests.get('https://api.binance.us/api/v3/exchangeInfo').json()
     binance_assets = set()
     for pair_symbol in exchange_data['symbols']:
@@ -43,8 +42,6 @@ def test_binance_assets_are_known(inquirer, globaldb):  # pylint: disable=unused
     for binance_asset in sorted_assets:
         try:
             _ = asset_from_binance(binance_asset)
-        except UnsupportedAsset:
-            assert is_asset_symbol_unsupported(globaldb, Location.BINANCE, binance_asset)
         except UnknownAsset as e:
             test_warnings.warn(UserWarning(
                 f'Found unknown asset {e.identifier} in binanceus. '

--- a/rotkehlchen/tests/exchanges/test_bitfinex.py
+++ b/rotkehlchen/tests/exchanges/test_bitfinex.py
@@ -13,7 +13,7 @@ from rotkehlchen.assets.converters import BITFINEX_EXCHANGE_TEST_ASSETS, asset_f
 from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_GLM, A_LINK, A_USD, A_USDT, A_WBTC
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.exchanges.bitfinex import (
     API_ERR_AUTH_NONCE_CODE,
@@ -29,8 +29,6 @@ from rotkehlchen.history.events.structures.swap import SwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
 from rotkehlchen.tests.utils.constants import A_NEO
-from rotkehlchen.tests.utils.exchanges import get_exchange_asset_symbols
-from rotkehlchen.tests.utils.globaldb import is_asset_symbol_unsupported
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import (
     ChainID,
@@ -134,12 +132,9 @@ def test_name():
 
 
 @pytest.mark.asset_test
-def test_assets_are_known(mock_bitfinex, globaldb):
+def test_assets_are_known(mock_bitfinex):
     """This tests only exchange (trades) assets (not margin, nor futures ones).
     """
-    for asset in get_exchange_asset_symbols(Location.BITFINEX):
-        assert is_asset_symbol_unsupported(globaldb, Location.BITFINEX, asset) is False, f'Bitfinex assets {asset} should not be unsupported'  # noqa: E501
-
     currencies_response = mock_bitfinex._query_currencies()
     if currencies_response.success is False:
         response = currencies_response.response
@@ -182,12 +177,6 @@ def test_assets_are_known(mock_bitfinex, globaldb):
     for symbol in symbols:
         try:
             asset_from_bitfinex(bitfinex_name=symbol)
-        except UnsupportedAsset:
-            assert is_asset_symbol_unsupported(globaldb, Location.BITFINEX, symbol)
-            test_warnings.warn(UserWarning(
-                f'Found unsupported asset with symbol {symbol} in '
-                f'{mock_bitfinex.name}. Support for it has to be added',
-            ))
         except UnknownAsset as e:
             test_warnings.warn(UserWarning(
                 f'Found unknown asset {e.identifier} with symbol {symbol} in '
@@ -220,14 +209,6 @@ def test_first_connection(mock_bitfinex, globaldb):
 
     new_mappings = mappings_after - mappings_before
     assert len(new_mappings) > 0
-
-    with globaldb.conn.read_ctx() as cursor:
-        for bfx_symbol, _ in new_mappings:
-            assert cursor.execute(
-                'SELECT COUNT(*) FROM location_unsupported_assets '
-                'WHERE location=? AND exchange_symbol=?;',
-                (bitfinex_db_serialized, bfx_symbol),
-            ).fetchone()[0] == 0  # no new mapping added for unsupported assets
 
     assert mock_bitfinex.pair_bfx_symbols_map['BTCUST'] == ('BTC', 'UST')
     assert mock_bitfinex.pair_bfx_symbols_map['UDCUSD'] == ('UDC', 'USD')
@@ -287,7 +268,7 @@ def test_query_balances_asset_balance(
     Also test the following logic:
       - An asset balance is the result of aggregating its balances per wallet
       type (i.e. exchange, margin and funding).
-      - The balance of an asset in location_unsupported_assets is skipped.
+      - The balance of an asset that can't be mapped to a known asset is skipped.
       - The asset ticker is standardized (e.g. WBT to WBTC, UST to USDT).
     """
     mock_bitfinex.first_connection = MagicMock()  # type: ignore

--- a/rotkehlchen/tests/exchanges/test_gemini.py
+++ b/rotkehlchen/tests/exchanges/test_gemini.py
@@ -11,7 +11,7 @@ from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_BCH, A_BTC, A_ETH, A_GUSD, A_LINK, A_USD
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
-from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset, UnprocessableTradePair
 from rotkehlchen.exchanges.gemini import gemini_symbol_to_base_quote
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -23,8 +23,6 @@ from rotkehlchen.tests.fixtures.exchanges.gemini import (
     SANDBOX_GEMINI_WP_API_SECRET,
 )
 from rotkehlchen.tests.utils.constants import A_LTC, A_PAXG, A_ZEC
-from rotkehlchen.tests.utils.exchanges import get_exchange_asset_symbols
-from rotkehlchen.tests.utils.globaldb import is_asset_symbol_unsupported
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Location, Timestamp, TimestampMS
 from rotkehlchen.utils.misc import ts_now
@@ -72,14 +70,11 @@ def test_gemini_wrong_key(sandbox_gemini):
 @pytest.mark.asset_test
 @pytest.mark.skipif('CI' in os.environ, reason='temporarily skip gemini in CI')
 @pytest.mark.parametrize('gemini_test_base_uri', ['https://api.gemini.com'])
-def test_gemini_all_symbols_are_known(sandbox_gemini, globaldb):
+def test_gemini_all_symbols_are_known(sandbox_gemini):
     """Test that the gemini trade pairs are all supported by rotki
 
     Use the real gemini API
     """
-    for asset in get_exchange_asset_symbols(Location.GEMINI):
-        assert is_asset_symbol_unsupported(globaldb, Location.GEMINI, asset) is False, f'Gemini assets {asset} should not be unsupported'  # noqa: E501
-
     symbols = sandbox_gemini._public_api_query('symbols')
     for symbol in symbols:
         try:
@@ -96,8 +91,6 @@ def test_gemini_all_symbols_are_known(sandbox_gemini, globaldb):
             test_warnings.warn(UserWarning(
                 f'Unknown Gemini asset detected. {e} Symbol: {symbol}',
             ))
-        except UnsupportedAsset as e:
-            assert globaldb.is_asset_symbol_unsupported(globaldb, Location.GEMINI, str(e).split(' ')[2])  # noqa: PT017, E501
 
 
 @pytest.mark.skipif('CI' in os.environ, reason='temporarily skip gemini in CI')

--- a/rotkehlchen/tests/exchanges/test_htx.py
+++ b/rotkehlchen/tests/exchanges/test_htx.py
@@ -11,7 +11,7 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import asset_from_htx
 from rotkehlchen.constants.assets import A_CRV, A_DAI, A_USDT, A_ZRX
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.exchanges.htx import PAGINATION_LIMIT, Htx
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -19,7 +19,6 @@ from rotkehlchen.history.events.structures.swap import SwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
 from rotkehlchen.tests.utils.constants import A_DOGE
-from rotkehlchen.tests.utils.globaldb import is_asset_symbol_unsupported
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Location, Timestamp, TimestampMS
 
@@ -80,7 +79,7 @@ def test_balances(htx_exchange: Htx):
     }
 
 
-def test_assets_are_known(htx_exchange: Htx, globaldb):
+def test_assets_are_known(htx_exchange: Htx):
     with patch('rotkehlchen.exchanges.htx.Htx._sign_request', return_value={}):
         tickers = htx_exchange._query('/v2/settings/common/symbols')
     for ticker in tickers:
@@ -93,12 +92,6 @@ def test_assets_are_known(htx_exchange: Htx, globaldb):
                 f'Found unknown asset {e.identifier} in HTX. '
                 f'Support for it has to be added',
             ))
-        except UnsupportedAsset as e:
-            if is_asset_symbol_unsupported(globaldb, Location.HTX, ticker['bcdn']) is False:
-                test_warnings.warn(UserWarning(
-                    f'Found unsupported asset {e.identifier} in HTX. '
-                    f'Support for it has to be added',
-                ))
 
 
 def test_deposit_withdrawals(htx_exchange: Htx) -> None:

--- a/rotkehlchen/tests/exchanges/test_iconomi.py
+++ b/rotkehlchen/tests/exchanges/test_iconomi.py
@@ -11,9 +11,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.swap import SwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.tests.utils.exchanges import get_exchange_asset_symbols
 from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret
-from rotkehlchen.tests.utils.globaldb import is_asset_symbol_unsupported
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Location, Timestamp, TimestampMS
 from rotkehlchen.user_messages import MessagesAggregator
@@ -124,11 +122,7 @@ def test_query_trade_history(function_scope_iconomi):
 def test_iconomi_assets_are_known(
         database,
         inquirer,  # pylint: disable=unused-argument
-        globaldb,
 ):
-    for asset in get_exchange_asset_symbols(Location.ICONOMI):
-        assert is_asset_symbol_unsupported(globaldb, Location.ICONOMI, asset) is False, f'Iconomi assets {asset} should not be unsupported'  # noqa: E501
-
     # use a real Iconomi instance so that we always get the latest data
     iconomi = Iconomi(
         name='iconomi1',
@@ -140,15 +134,7 @@ def test_iconomi_assets_are_known(
     supported_tickers = []
     resp = iconomi._api_query('get', 'assets', authenticated=False)
     for asset_info in resp:
-        if (
-            asset_info['supported'] is False or
-            asset_info['status'] == 'OFFLINE' or
-            is_asset_symbol_unsupported(
-                globaldb=globaldb,
-                location=Location.ICONOMI,
-                asset_symbol=asset_info['ticker'],
-            ) is True
-        ):
+        if asset_info['supported'] is False or asset_info['status'] == 'OFFLINE':
             continue
 
         supported_tickers.append(asset_info['ticker'])

--- a/rotkehlchen/tests/exchanges/test_kucoin.py
+++ b/rotkehlchen/tests/exchanges/test_kucoin.py
@@ -13,7 +13,7 @@ from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_kucoin
 from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_BNB, A_BTC, A_ETH, A_LINK, A_USDC, A_USDT
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.exchanges.kucoin import Kucoin, KucoinCase
 from rotkehlchen.fval import FVal
@@ -22,8 +22,6 @@ from rotkehlchen.history.events.structures.swap import SwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
 from rotkehlchen.tests.utils.constants import A_BSV, A_KCS, A_NANO, A_SOL
-from rotkehlchen.tests.utils.exchanges import get_exchange_asset_symbols
-from rotkehlchen.tests.utils.globaldb import is_asset_symbol_unsupported
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Location, Timestamp, TimestampMS
 from rotkehlchen.utils.serialization import jsonloads_dict
@@ -46,7 +44,7 @@ def test_name():
 
 
 @pytest.mark.asset_test
-def test_kucoin_exchange_assets_are_known(mock_kucoin, globaldb):
+def test_kucoin_exchange_assets_are_known(mock_kucoin):
     request_url = f'{mock_kucoin.base_uri}/api/v1/currencies'
     try:
         response = requests.get(request_url)
@@ -65,9 +63,6 @@ def test_kucoin_exchange_assets_are_known(mock_kucoin, globaldb):
     except JSONDecodeError as e:
         raise RemoteError(f'Kucoin returned invalid JSON response: {response.text}') from e
 
-    for asset in get_exchange_asset_symbols(Location.KUCOIN):
-        assert is_asset_symbol_unsupported(globaldb, Location.KUCOIN, asset) is False, f'Kucoin assets {asset} should not be unsupported'  # noqa: E501
-
     missing_assets = {
         'ZEUSCC8',  # no information about this token
         'SNAKES',  # no information found
@@ -77,8 +72,6 @@ def test_kucoin_exchange_assets_are_known(mock_kucoin, globaldb):
         symbol = entry['currency']
         try:
             asset_from_kucoin(symbol)
-        except UnsupportedAsset:
-            assert is_asset_symbol_unsupported(globaldb, Location.KUCOIN, symbol)
         except UnknownAsset as e:
             if symbol not in missing_assets:
                 test_warnings.warn(UserWarning(

--- a/rotkehlchen/tests/exchanges/test_okx.py
+++ b/rotkehlchen/tests/exchanges/test_okx.py
@@ -6,7 +6,7 @@ import pytest
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import asset_from_okx
 from rotkehlchen.constants.assets import A_ETH, A_USDC, A_USDT
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.exchanges.okx import Okx, OkxEndpoint
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -14,7 +14,6 @@ from rotkehlchen.history.events.structures.swap import SwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
 from rotkehlchen.tests.utils.constants import A_SOL, A_XMR
-from rotkehlchen.tests.utils.globaldb import is_asset_symbol_unsupported
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Location, Timestamp, TimestampMS
 
@@ -26,7 +25,7 @@ def test_name():
 
 
 @pytest.mark.asset_test
-def test_assets_are_known(mock_okx: Okx, globaldb):
+def test_assets_are_known(mock_okx: Okx):
     currencies = mock_okx._api_query(OkxEndpoint.CURRENCIES)
     okx_assets = {currency['ccy'] for currency in currencies['data']}
 
@@ -38,12 +37,6 @@ def test_assets_are_known(mock_okx: Okx, globaldb):
                 f'Found unknown asset {e.identifier} in OKX. '
                 f'Support for it has to be added',
             ))
-        except UnsupportedAsset as e:
-            if is_asset_symbol_unsupported(globaldb, Location.OKX, okx_asset) is False:
-                test_warnings.warn(UserWarning(
-                    f'Found unsupported asset {e.identifier} in OKX. '
-                    f'Support for it has to be added',
-                ))
 
 
 def test_okx_api_signature(mock_okx: Okx):

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -309,9 +309,9 @@ def test_query_trade_history_unexpected_data(poloniex):
     given_input = input_trades.replace('"ETH_BTC"', '"0"')
     mock_poloniex_and_query(given_input, expected_warnings_num=0, expected_errors_num=1)
 
-    # symbol with unsupported asset
-    given_input = input_trades.replace('"ETH_BTC"', '"ETH_BALLS"')
-    mock_poloniex_and_query(given_input, expected_warnings_num=1, expected_errors_num=0)
+    # symbol with an asset that can't be mapped to a known asset
+    given_input = input_trades.replace('"ETH_BTC"', '"ETH_NOTAREALASSET"')
+    mock_poloniex_and_query(given_input, expected_warnings_num=0, expected_errors_num=0)
 
     # invalid price
     given_input = input_trades.replace('"0.00003432"', 'null')
@@ -350,8 +350,8 @@ def test_poloniex_assets_are_known(poloniex: 'Poloniex'):
 @pytest.mark.parametrize('function_scope_initialize_mock_rotki_notifier', [True])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_poloniex_query_balances_unknown_asset(poloniex):
-    """Test that if a poloniex balance query returns unknown asset no exception
-    is raised and a warning is generated. Same for unsupported assets"""
+    """Test that if a poloniex balance query returns an asset that can't be mapped
+    no exception is raised and an unknown asset message is generated"""
 
     def mock_unknown_asset_return(url, **kwargs):  # pylint: disable=unused-argument
         return MockResponse(200, POLONIEX_BALANCES_RESPONSE)
@@ -369,15 +369,14 @@ def test_poloniex_query_balances_unknown_asset(poloniex):
 
     messages = poloniex.msg_aggregator.rotki_notifier.messages
     assert len(messages) == 2
-    assert messages[0].message_type == WSMessageType.EXCHANGE_UNKNOWN_ASSET
-    assert 'unsupported poloniex asset CNOTE' in messages[1].data['value']
+    assert all(m.message_type == WSMessageType.EXCHANGE_UNKNOWN_ASSET for m in messages)
 
 
 @pytest.mark.parametrize('function_scope_initialize_mock_rotki_notifier', [True])
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_poloniex_deposits_withdrawal_unknown_asset(poloniex: 'Poloniex') -> None:
-    """Test that if a poloniex asset movement query returns unknown asset no exception
-    is raised and a warning is generated. Same for unsupported assets"""
+    """Test that if a poloniex asset movement query returns an asset that can't be
+    mapped no exception is raised and an unknown asset message is generated"""
 
     def mock_api_return(url, **kwargs):  # pylint: disable=unused-argument
         if '/trades' in url:
@@ -460,10 +459,7 @@ def test_poloniex_deposits_withdrawal_unknown_asset(poloniex: 'Poloniex') -> Non
 
     messages = cast('MockRotkiNotifier', poloniex.msg_aggregator.rotki_notifier).messages
     assert len(messages) == 4
-    assert messages[0].message_type == WSMessageType.EXCHANGE_UNKNOWN_ASSET
-    assert 'Found withdrawal of unsupported poloniex asset BALLS' in messages[1].data['value']  # type: ignore
-    assert messages[2].message_type == WSMessageType.EXCHANGE_UNKNOWN_ASSET
-    assert 'Found deposit of unsupported poloniex asset EBT' in messages[3].data['value']  # type: ignore
+    assert all(m.message_type == WSMessageType.EXCHANGE_UNKNOWN_ASSET for m in messages)
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])

--- a/rotkehlchen/tests/exchanges/test_poloniex.py
+++ b/rotkehlchen/tests/exchanges/test_poloniex.py
@@ -10,7 +10,7 @@ from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import asset_from_poloniex
 from rotkehlchen.constants.assets import A_BCH, A_BTC, A_ETH
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.poloniex import Poloniex, trade_from_poloniex
 from rotkehlchen.fval import FVal
@@ -23,14 +23,11 @@ from rotkehlchen.tests.utils.exchanges import (
     POLONIEX_BALANCES_RESPONSE,
     POLONIEX_MOCK_DEPOSIT_WITHDRAWALS_RESPONSE,
     POLONIEX_TRADES_RESPONSE,
-    get_exchange_asset_symbols,
 )
-from rotkehlchen.tests.utils.globaldb import is_asset_symbol_unsupported
 from rotkehlchen.tests.utils.mock import MockResponse
 from rotkehlchen.types import Location, Timestamp, TimestampMS
 
 if TYPE_CHECKING:
-    from rotkehlchen.globaldb.handler import GlobalDBHandler
     from rotkehlchen.tests.fixtures.messages import MockRotkiNotifier
 
 
@@ -338,17 +335,12 @@ def test_query_trade_history_unexpected_data(poloniex):
 
 
 @pytest.mark.asset_test
-def test_poloniex_assets_are_known(poloniex: 'Poloniex', globaldb: 'GlobalDBHandler'):
-    for asset in get_exchange_asset_symbols(Location.POLONIEX):
-        assert is_asset_symbol_unsupported(globaldb, Location.POLONIEX, asset) is False, f'Poloniex assets {asset} should not be unsupported'  # noqa: E501
-
+def test_poloniex_assets_are_known(poloniex: 'Poloniex'):
     currencies = poloniex.api_query_list('/currencies')
     for asset_data in currencies:
         for poloniex_asset in asset_data:
             try:
                 _ = asset_from_poloniex(poloniex_asset)
-            except UnsupportedAsset:
-                assert is_asset_symbol_unsupported(globaldb, Location.POLONIEX, poloniex_asset)
             except UnknownAsset as e:
                 test_warnings.warn(UserWarning(
                     f'Found unknown asset {e.identifier} with symbol {poloniex_asset} in Poloniex. Support for it has to be added',  # noqa: E501

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py
@@ -466,7 +466,6 @@ def test_remote_updates_consistency_with_packaged_db(
     """Test that the remote updates are consistent with the packaged db for:
     - Location asset mappings
     - Counterparty asset mappings
-    - Location unsupported assets
     """
     temp_data_dir = Path(tmpdir_factory.mktemp(GLOBALDIR_NAME))
     (old_db_dir := temp_data_dir / GLOBALDIR_NAME).mkdir(parents=True, exist_ok=True)
@@ -482,7 +481,6 @@ def test_remote_updates_consistency_with_packaged_db(
     )
     data_updater.check_for_updates(updates=[
         UpdateType.LOCATION_ASSET_MAPPINGS,
-        UpdateType.LOCATION_UNSUPPORTED_ASSETS,
         UpdateType.COUNTERPARTY_ASSET_MAPPINGS,
     ])
 
@@ -491,8 +489,8 @@ def test_remote_updates_consistency_with_packaged_db(
         globaldb.packaged_db_conn().read_ctx() as packaged_db_cursor,
     ):
         (
-            (updated_location_asset_mappings, updated_counterparty_asset_mappings, updated_location_unsupported_assets),  # noqa: E501
-            (packaged_location_asset_mappings, packaged_counterparty_asset_mappings, packaged_location_unsupported_assets),  # noqa: E501
+            (updated_location_asset_mappings, updated_counterparty_asset_mappings),
+            (packaged_location_asset_mappings, packaged_counterparty_asset_mappings),
         ) = (
             (
                 {
@@ -506,9 +504,7 @@ def test_remote_updates_consistency_with_packaged_db(
                     for counterparty, symbol, identifier in cursor.execute(
                         'SELECT counterparty, symbol, local_id FROM counterparty_asset_mappings',
                     )
-                }, set(cursor.execute(
-                    'SELECT location, exchange_symbol FROM location_unsupported_assets',
-                ).fetchall()),
+                },
             )
             for cursor in (old_db_cursor, packaged_db_cursor)
         )
@@ -571,22 +567,6 @@ def test_remote_updates_consistency_with_packaged_db(
             for (field1, field2), identifier in packaged_mappings.items()
             if (field1, field2) in updated_mappings and updated_mappings[field1, field2] != identifier  # noqa: E501
         ])
-
-    # find all the location_unsupported_assets that are present in remote updates but not in packaged db  # noqa: E501
-    missing_in_packaged_db.extend([
-        f"INSERT INTO location_unsupported_assets(location, exchange_symbol) VALUES('{location}', '{symbol}');"  # noqa: E501
-        for location, symbol in updated_location_unsupported_assets
-        if (location, symbol) not in packaged_location_unsupported_assets
-    ])
-
-    # find all the location_unsupported_assets that are present in packaged db but not in remote updates  # noqa: E501
-    missing_unsupported_assets = defaultdict(list)
-    for location, symbol in packaged_location_unsupported_assets:
-        if (location, symbol) not in updated_location_unsupported_assets:
-            missing_unsupported_assets[Location.deserialize_from_db(location).serialize()].append(symbol)
-
-    if len(missing_unsupported_assets) > 0:
-        missing_in_remote_updates.append(missing_unsupported_assets)
 
     if len(missing_in_packaged_db) > 0:
         # warning here instead of failing because we generally keep adding remote updates without

--- a/rotkehlchen/tests/unit/test_data_import_utils.py
+++ b/rotkehlchen/tests/unit/test_data_import_utils.py
@@ -59,18 +59,18 @@ def test_detect_duplicate_event_escapes_like(database) -> None:
         ) is False
 
 
-def test_rotki_generic_trades_unsupported_asset(database, tmp_path) -> None:
+def test_rotki_generic_trades_unknown_asset(database, tmp_path) -> None:
     """Regression for https://github.com/rotki/rotki/issues/12233.
 
-    An UnsupportedAsset on a row (GLD on Bittrex is blacklisted in
-    location_unsupported_assets) must not crash the import task — it should be
-    surfaced as a per-row error and the rest of the file should import fine.
+    An asset on a row that can't be mapped to a known asset must not crash the
+    import task — it should be surfaced as a per-row error and the rest of the
+    file should import fine.
     """
     filepath = tmp_path / 'rotki_generic_trades.csv'
     filepath.write_text(
         'Location,Spend Currency,Receive Currency,Receive Amount,Spend Amount,'
         'Fee,Fee Currency,Description,Timestamp\n'
-        'bittrex,GLD,BTC,0.01,100,,,Trade GLD for BTC,1545575255000\n'
+        'bittrex,ZZZFAKE,BTC,0.01,100,,,Trade ZZZFAKE for BTC,1545575255000\n'
         'kraken,LTC,BTC,4.3241,392.8870,,,Trade LTC for BTC,1659171600000\n',
     )
 
@@ -82,17 +82,16 @@ def test_rotki_generic_trades_unsupported_asset(database, tmp_path) -> None:
     assert importer.imported_entries == 1
     error_msgs = [m for m in importer.import_msgs if m.get('is_error')]
     assert len(error_msgs) == 1
-    assert 'GLD' in error_msgs[0]['msg']
-    assert 'not supported' in error_msgs[0]['msg']
-    assert 'bittrex' in error_msgs[0]['msg']
+    assert 'ZZZFAKE' in error_msgs[0]['msg']
+    assert 'Unknown asset' in error_msgs[0]['msg']
 
 
-def test_rotki_generic_events_unsupported_asset(database, tmp_path) -> None:
+def test_rotki_generic_events_unknown_asset(database, tmp_path) -> None:
     """Same regression for the rotki generic events importer."""
     filepath = tmp_path / 'rotki_generic_events.csv'
     filepath.write_text(
         'Type,Location,Currency,Amount,Fee,Fee Currency,Description,Timestamp\n'
-        'Deposit,bittrex,GLD,100,,,Deposit GLD,1545575255000\n'
+        'Deposit,bittrex,ZZZFAKE,100,,,Deposit ZZZFAKE,1545575255000\n'
         'Deposit,kraken,LTC,5,,,Deposit LTC,1659171600000\n',
     )
 
@@ -104,6 +103,5 @@ def test_rotki_generic_events_unsupported_asset(database, tmp_path) -> None:
     assert importer.imported_entries == 1
     error_msgs = [m for m in importer.import_msgs if m.get('is_error')]
     assert len(error_msgs) == 1
-    assert 'GLD' in error_msgs[0]['msg']
-    assert 'not supported' in error_msgs[0]['msg']
-    assert 'bittrex' in error_msgs[0]['msg']
+    assert 'ZZZFAKE' in error_msgs[0]['msg']
+    assert 'Unknown asset' in error_msgs[0]['msg']

--- a/rotkehlchen/tests/unit/test_data_updates.py
+++ b/rotkehlchen/tests/unit/test_data_updates.py
@@ -222,19 +222,6 @@ COUNTERPARTY_ASSET_MAPPINGS_DATA: dict[str, dict[str, list[dict[str, Any]]]] = {
     },
 }
 
-LOCATION_UNSUPPORTED_ASSETS_DATA: dict[str, dict[str, dict[str, list[str]]]] = {
-    'location_unsupported_assets': {
-        'insert': {
-            'binance': ['OJ', '123'],  # 123 already exists
-            'kucoin': ['OJ', 'NAKA'],  # NAKA already exists
-        },
-        'remove': {
-            'bitfinex': ['OJ', 'IDX'],  # OJ does not exist
-            'bittrex': ['OJ', 'SLV'],  # OJ does not exist
-        },
-    },
-}
-
 
 def make_single_mock_github_data_response(target: UpdateType):
     """Creates a mocking function for a single update type for github requests."""
@@ -248,7 +235,6 @@ def make_single_mock_github_data_response(target: UpdateType):
                 'accounting_rules': {'latest': 1 if target == UpdateType.ACCOUNTING_RULES else 0},
                 'location_asset_mappings': {'latest': 1 if target == UpdateType.LOCATION_ASSET_MAPPINGS else 0},  # noqa: E501
                 'counterparty_asset_mappings': {'latest': 1 if target == UpdateType.COUNTERPARTY_ASSET_MAPPINGS else 0},  # noqa: E501
-                'location_unsupported_assets': {'latest': 1 if target == UpdateType.LOCATION_UNSUPPORTED_ASSETS else 0},  # noqa: E501
             }
         elif 'spam_assets/v' in url:
             data = SPAM_ASSET_MOCK_DATA
@@ -262,8 +248,6 @@ def make_single_mock_github_data_response(target: UpdateType):
             data = ACCOUNTING_RULES_DATA
         elif 'location_asset_mappings/v' in url:
             data = LOCATION_ASSET_MAPPINGS_DATA
-        elif 'location_unsupported_assets/v' in url:
-            data = LOCATION_UNSUPPORTED_ASSETS_DATA
         elif 'counterparty_asset_mappings/v' in url:
             data = COUNTERPARTY_ASSET_MAPPINGS_DATA
         else:
@@ -303,8 +287,6 @@ def make_mock_github_response(latest: int, min_version: str | None = None, max_v
             result = ACCOUNTING_RULES_DATA
         elif 'location_asset_mappings/v' in url:
             result = LOCATION_ASSET_MAPPINGS_DATA
-        elif 'location_unsupported_assets/v' in url:
-            result = LOCATION_UNSUPPORTED_ASSETS_DATA
         elif 'counterparty_asset_mappings/v' in url:
             result = COUNTERPARTY_ASSET_MAPPINGS_DATA
         else:
@@ -324,7 +306,6 @@ def reset_update_type_mappings(data_updater: RotkiDataUpdater) -> None:
         UpdateType.GLOBAL_ADDRESSBOOK: data_updater.update_global_addressbook,
         UpdateType.ACCOUNTING_RULES: data_updater.update_accounting_rules,
         UpdateType.LOCATION_ASSET_MAPPINGS: data_updater.update_location_asset_mappings,
-        UpdateType.LOCATION_UNSUPPORTED_ASSETS: data_updater.update_location_unsupported_assets,
         UpdateType.COUNTERPARTY_ASSET_MAPPINGS: data_updater.update_counterparty_asset_mappings,
     }
 
@@ -403,7 +384,6 @@ def test_no_update_due_to_update_version(data_updater: RotkiDataUpdater) -> None
                 (UpdateType.GLOBAL_ADDRESSBOOK.serialize(), 999),
                 (UpdateType.ACCOUNTING_RULES.serialize(), 999),
                 (UpdateType.LOCATION_ASSET_MAPPINGS.serialize(), 999),
-                (UpdateType.LOCATION_UNSUPPORTED_ASSETS.serialize(), 999),
                 (UpdateType.COUNTERPARTY_ASSET_MAPPINGS.serialize(), 999),
             ],
         )
@@ -808,43 +788,6 @@ def test_counterparty_asset_mappings_updates(
 
     with globaldb.conn.read_ctx() as cursor:
         _check_counterparty_asset_mappings(cursor, after_upgrade=True)
-
-
-def _check_location_unsupported_assets(cursor: 'DBCursor', after_upgrade: bool) -> None:
-    """Auxiliary function to check the db values before and after the upgrade"""
-    assert cursor.execute('SELECT COUNT(*) FROM location_asset_mappings').fetchone()[0] == NUM_PACKAGED_ASSETS_MAPPINGS  # noqa: E501
-
-    for operation, expected_count in (
-        ('insert', lambda symbol: 0 if after_upgrade is False and symbol == 'OJ' else 1),
-        ('remove', lambda symbol: 1 if after_upgrade is False and symbol != 'OJ' else 0),
-    ):
-        for location, symbols in LOCATION_UNSUPPORTED_ASSETS_DATA['location_unsupported_assets'][operation].items():  # noqa: E501
-            for symbol in symbols:
-                assert cursor.execute(
-                    'SELECT COUNT(*) FROM location_unsupported_assets '
-                    'WHERE location = ? AND exchange_symbol = ?;', (
-                        Location.deserialize(location).serialize_for_db(), symbol,
-                    ),
-                ).fetchone()[0] == expected_count(symbol)  # type: ignore[no-untyped-call]
-
-
-def test_location_unsupported_assets_updates(
-        data_updater: RotkiDataUpdater,
-        globaldb: 'GlobalDBHandler',
-) -> None:
-    """Test that remote updates for location unsupported assets work"""
-    # check state of the location asset mappings before updating
-    with globaldb.conn.read_ctx() as cursor:
-        _check_location_unsupported_assets(cursor, after_upgrade=False)
-
-    with patch(
-        'requests.get',
-        wraps=make_single_mock_github_data_response(UpdateType.LOCATION_UNSUPPORTED_ASSETS),
-    ):
-        data_updater.check_for_updates()
-
-    with globaldb.conn.read_ctx() as cursor:
-        _check_location_unsupported_assets(cursor, after_upgrade=True)
 
 
 def test_version_used_in_updates(database: 'DBHandler', monkeypatch: pytest.MonkeyPatch) -> None:

--- a/rotkehlchen/tests/utils/exchanges.py
+++ b/rotkehlchen/tests/utils/exchanges.py
@@ -82,7 +82,7 @@ POLONIEX_MOCK_DEPOSIT_WITHDRAWALS_RESPONSE: Final = """{
       "withdrawalRequestsId": 3,
       "status": "COMPLETE: 0xbd4da74e1a0b81c21d056c6f58a5b306de85d21ddf89992693b812bb117eace4"
     }, {
-      "currency": "BALLS",
+      "currency": "NOTAREALASSET",
       "timestamp": 1478994442,
       "amount": "10.0",
       "fee": "0.1",
@@ -181,10 +181,6 @@ BINANCE_BALANCES_RESPONSE: Final = """
       "locked": "0.00000000"
     }, {
       "asset": "IDONTEXIST",
-      "free": "5.0",
-      "locked": "0.0"
-    }, {
-      "asset": "ETF",
       "free": "5.0",
       "locked": "0.0"
 }]}"""

--- a/rotkehlchen/tests/utils/globaldb.py
+++ b/rotkehlchen/tests/utils/globaldb.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from contextlib import ExitStack
 from copy import deepcopy
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 from unittest.mock import patch
 
 from rotkehlchen.assets.asset import EvmToken, UnderlyingToken
@@ -12,10 +12,6 @@ from rotkehlchen.globaldb.cache import compute_cache_key
 from rotkehlchen.globaldb.upgrades.manager import UPGRADES_LIST
 from rotkehlchen.tests.utils.factories import make_evm_address
 from rotkehlchen.types import CacheType, ChainID, Timestamp, TokenKind
-
-if TYPE_CHECKING:
-    from rotkehlchen.globaldb.handler import GlobalDBHandler
-    from rotkehlchen.types import Location
 
 underlying_address1 = make_evm_address()
 underlying_address2 = make_evm_address()
@@ -134,12 +130,3 @@ def globaldb_get_general_cache_last_queried_ts(
     if result is None:
         return None
     return Timestamp(result[0])
-
-
-def is_asset_symbol_unsupported(globaldb: 'GlobalDBHandler', location: 'Location', asset_symbol: str) -> bool:  # noqa: E501
-    """Returns if the asset with the given symbol is not supported in the given location."""
-    with globaldb.conn.read_ctx() as cursor:
-        return cursor.execute(
-            'SELECT COUNT(*) FROM location_unsupported_assets WHERE location=? AND exchange_symbol=?',  # noqa: E501
-            (location.serialize_for_db(), asset_symbol),
-        ).fetchone()[0] > 0

--- a/rotkehlchen/tests/utils/history.py
+++ b/rotkehlchen/tests/utils/history.py
@@ -388,7 +388,7 @@ def mock_exchange_responses(rotki: Rotkehlchen, remote_errors: bool):
                     "type": "LIMIT",
                     "accountType": "SPOT"
                 }, {
-                    "symbol": "ETH_BALLS",
+                    "symbol": "ETH_NOTAREALASSET",
                     "id": 394131419,
                     "createTime": 1539713237000,
                     "price": "0.06935244",

--- a/tools/assets_database/main.py
+++ b/tools/assets_database/main.py
@@ -133,7 +133,6 @@ def populate_location_mappings():
         print(f'Applying remote updates from data branch: {rotki_updater.branch}')
         rotki_updater.check_for_updates(updates=[
             UpdateType.LOCATION_ASSET_MAPPINGS,
-            UpdateType.LOCATION_UNSUPPORTED_ASSETS,
             UpdateType.COUNTERPARTY_ASSET_MAPPINGS,
             UpdateType.RPC_NODES,
         ])


### PR DESCRIPTION
Remove the location_unsupported_assets blocklist mechanism that shadowed user/API CEX mappings (e.g. Bitfinex GTX->GT, issue #12348). Exchange ticker resolution now falls through to location_asset_mappings and UnknownAsset, so unmapped tickers surface in the missing-mappings UI instead of being silently blocked. Retire the LOCATION_UNSUPPORTED_ASSETS remote-update type. The table is left defined (no DB upgrade on bugfixes) but is now inert. Clean up the exchange asset-tests and the is_asset_symbol_unsupported helper.

Fix #12348
