### PR TITLE
feat: add globaldb v16->v17 upgrade dropping location_unsupported_assets

### DIFF
--- a/rotkehlchen/globaldb/minimized_schema.py
+++ b/rotkehlchen/globaldb/minimized_schema.py
@@ -22,7 +22,6 @@ MINIMIZED_GLOBAL_DB_SCHEMA = {
     "contract_data": "addressvarchar[42]notnull,chain_idintegernotnull,abiintegernotnull,deployed_blockinteger,foreignkey(abi)referencescontract_abi(id)onupdatecascadeondeletesetnull,primarykey(address,chain_id)",
     "default_rpc_nodes": "identifierintegernotnullprimarykey,nametextnotnull,endpointtextnotnull,ownedintegernotnullcheck(ownedin(0,1)),activeintegernotnullcheck(activein(0,1)),weighttextnotnull,blockchaintextnotnull",
     "location_asset_mappings": "locationtext,exchange_symboltextnotnull,local_idtextnotnullcollatenocase,unique(location,exchange_symbol)",
-    "location_unsupported_assets": "locationchar(1)notnull,exchange_symboltextnotnull,unique(location,exchange_symbol)",
     "counterparty_asset_mappings": "counterpartytextnotnull,symboltextnotnull,local_idtextnotnullcollatenocase,primarykey(counterparty,symbol)",
     "solana_tokens": "identifiertextprimarykeynotnullcollatenocase,token_kindchar(1)notnulldefault('d')referencestoken_kinds(token_kind),addressvarchar[44]notnull,decimalsinteger,protocoltext,foreignkey(identifier)referencesassets(identifier)onupdatecascadeondeletecascade",
 }

--- a/rotkehlchen/globaldb/schema.py
+++ b/rotkehlchen/globaldb/schema.py
@@ -346,14 +346,6 @@ CREATE TABLE IF NOT EXISTS counterparty_asset_mappings (
 );
 """
 
-DB_CREATE_LOCATION_UNSUPPORTED_ASSETS = """
-CREATE TABLE IF NOT EXISTS location_unsupported_assets (
-    location CHAR(1) NOT NULL,
-    exchange_symbol TEXT NOT NULL,
-    UNIQUE (location, exchange_symbol)
-);
-"""
-
 DB_CREATE_INDEXES = """
 CREATE INDEX IF NOT EXISTS idx_assets_identifier ON assets (identifier);
 CREATE INDEX IF NOT EXISTS idx_evm_tokens_identifier ON evm_tokens (identifier, chain, protocol);
@@ -395,7 +387,6 @@ BEGIN TRANSACTION;
 {DB_CREATE_CONTRACT_DATA}
 {DB_CREATE_DEFAULT_RPC_NODES}
 {DB_CREATE_LOCATION_ASSET_MAPPINGS}
-{DB_CREATE_LOCATION_UNSUPPORTED_ASSETS}
 {DB_CREATE_COUNTERPARTY_ASSET_MAPPINGS}
 {DB_CREATE_SOLANA_TOKENS}
 {DB_CREATE_INDEXES}

--- a/rotkehlchen/globaldb/upgrades/manager.py
+++ b/rotkehlchen/globaldb/upgrades/manager.py
@@ -36,6 +36,7 @@ from .v12_v13 import migrate_to_v13
 from .v13_v14 import migrate_to_v14
 from .v14_v15 import migrate_to_v15
 from .v15_v16 import migrate_to_v16
+from .v16_v17 import migrate_to_v17
 
 if TYPE_CHECKING:
     from rotkehlchen.db.drivers.gevent import DBConnection
@@ -62,6 +63,7 @@ UPGRADES_LIST = [
     UpgradeRecord(from_version=13, function=migrate_to_v14),
     UpgradeRecord(from_version=14, function=migrate_to_v15),
     UpgradeRecord(from_version=15, function=migrate_to_v16),
+    UpgradeRecord(from_version=16, function=migrate_to_v17),
 ]
 
 

--- a/rotkehlchen/globaldb/upgrades/v16_v17.py
+++ b/rotkehlchen/globaldb/upgrades/v16_v17.py
@@ -1,0 +1,29 @@
+import logging
+from typing import TYPE_CHECKING
+
+from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
+from rotkehlchen.utils.progress import perform_globaldb_upgrade_steps, progress_step
+
+if TYPE_CHECKING:
+    from rotkehlchen.db.drivers.gevent import DBConnection, DBCursor
+    from rotkehlchen.db.upgrade_manager import DBUpgradeProgressHandler
+
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+@enter_exit_debug_log(name='globaldb v16->v17 upgrade')
+def migrate_to_v17(
+        connection: 'DBConnection',
+        progress_handler: 'DBUpgradeProgressHandler',
+) -> None:
+    """This upgrade takes place in v1.44.0."""
+
+    @progress_step('Drop the unused location_unsupported_assets table.')
+    def _drop_location_unsupported_assets_table(write_cursor: 'DBCursor') -> None:
+        """The exchange unsupported-asset blocklist was removed, so the table that backed
+        it is no longer used. Drop it."""
+        write_cursor.execute('DROP TABLE IF EXISTS location_unsupported_assets')
+
+    perform_globaldb_upgrade_steps(connection, progress_handler)

--- a/rotkehlchen/globaldb/utils.py
+++ b/rotkehlchen/globaldb/utils.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 # 1. Go to assets repo and tweak the min/max schema of the updates
 # 2. Tweak ASSETS_FILE_IMPORT_ACCEPTED_GLOBALDB_VERSIONS
 # 3. Add the previous version to GLOBAL_DB_ASSETS_BREAKING_VERSIONS if it breaks asset updates compatibility  # noqa: E501
-GLOBAL_DB_VERSION = 16
+GLOBAL_DB_VERSION = 17
 ASSETS_FILE_IMPORT_ACCEPTED_GLOBALDB_VERSIONS = (3, GLOBAL_DB_VERSION)
 MIN_SUPPORTED_GLOBAL_DB_VERSION = 2
 # Global DB versions that break compatibility with existing asset updates.

--- a/rotkehlchen/tests/exchanges/test_gate.py
+++ b/rotkehlchen/tests/exchanges/test_gate.py
@@ -13,7 +13,7 @@ from rotkehlchen.constants.assets import A_BTC, A_ETH, A_USDT
 from rotkehlchen.constants.timing import DAY_IN_SECONDS
 from rotkehlchen.db.constants import GATE_LOCATION_KEY
 from rotkehlchen.db.ranges import DBQueryRanges
-from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.exchanges.gate import (
     GATE_BASE_URL,
     GATE_MAX_MOVEMENT_WINDOW,
@@ -27,7 +27,6 @@ from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.swap import SwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.tests.utils.globaldb import is_asset_symbol_unsupported
 from rotkehlchen.types import Location, Timestamp, TimestampMS
 from rotkehlchen.utils.misc import ts_now
 
@@ -173,7 +172,7 @@ def test_validate_api_key(gate_exchange: Gate):
     assert msg == ''
 
 
-def test_assets_are_known(gate_exchange: Gate, globaldb):
+def test_assets_are_known(gate_exchange: Gate):
     mock_fn = gate_account_mock(calls={
         '/spot/accounts': [(None, [])],
     })
@@ -188,12 +187,6 @@ def test_assets_are_known(gate_exchange: Gate, globaldb):
                     f'Found unknown asset {e.identifier} in Gate. '
                     f'Support for it has to be added',
                 ))
-            except UnsupportedAsset as e:
-                if is_asset_symbol_unsupported(globaldb, Location.GATE, symbol) is False:
-                    test_warnings.warn(UserWarning(
-                        f'Found unsupported asset {e.identifier} in Gate. '
-                        f'Support for it has to be added',
-                    ))
 
 
 def test_deposit_withdrawals(gate_exchange: Gate) -> None:

--- a/rotkehlchen/tests/unit/globaldb/test_upgrades.py
+++ b/rotkehlchen/tests/unit/globaldb/test_upgrades.py
@@ -29,10 +29,7 @@ from rotkehlchen.globaldb.cache import (
     globaldb_get_unique_cache_value,
 )
 from rotkehlchen.globaldb.handler import GlobalDBHandler
-from rotkehlchen.globaldb.schema import (
-    DB_CREATE_LOCATION_ASSET_MAPPINGS,
-    DB_CREATE_LOCATION_UNSUPPORTED_ASSETS,
-)
+from rotkehlchen.globaldb.schema import DB_CREATE_LOCATION_ASSET_MAPPINGS
 from rotkehlchen.globaldb.upgrades.manager import maybe_upgrade_globaldb
 from rotkehlchen.globaldb.upgrades.v2_v3 import OTHER_EVM_CHAINS_ASSETS
 from rotkehlchen.globaldb.upgrades.v3_v4 import (
@@ -582,7 +579,11 @@ def test_upgrade_v6_v7(globaldb: GlobalDBHandler, messages_aggregator):
         assert table_exists(
             cursor=cursor,
             name='location_unsupported_assets',
-            schema=DB_CREATE_LOCATION_UNSUPPORTED_ASSETS,
+            schema="""CREATE TABLE IF NOT EXISTS location_unsupported_assets (
+                location CHAR(1) NOT NULL,
+                exchange_symbol TEXT NOT NULL,
+                UNIQUE (location, exchange_symbol)
+            );""",
         ) is True
 
         # check that correct number of exchanges mappings are present.
@@ -1776,6 +1777,35 @@ def test_upgrade_v15_v16(
                 1262304000,
             ),
         ).fetchall() == [(1262304000, '0.7')]
+
+
+@pytest.mark.parametrize('globaldb_upgrades', [[]])
+@pytest.mark.parametrize('custom_globaldb', ['v14_global.db'])
+@pytest.mark.parametrize('target_globaldb_version', [14])
+@pytest.mark.parametrize('reload_user_assets', [False])
+@pytest.mark.parametrize('use_in_memory_globaldb', [False])
+def test_upgrade_v16_v17(
+        globaldb: GlobalDBHandler,
+        messages_aggregator: MessagesAggregator,
+) -> None:
+    """Test the global DB upgrade from v16 to v17 that drops the now-unused
+    location_unsupported_assets table."""
+    assert globaldb.get_setting_value('version', 0) == 14
+    with globaldb.conn.read_ctx() as cursor:
+        assert table_exists(cursor=cursor, name='location_unsupported_assets') is True
+
+    with ExitStack() as stack:
+        patch_for_globaldb_upgrade_to(stack, 17)
+        maybe_upgrade_globaldb(
+            connection=globaldb.conn,
+            global_dir=globaldb._data_directory / GLOBALDIR_NAME,  # type: ignore
+            db_filename=GLOBALDB_NAME,
+            msg_aggregator=messages_aggregator,
+        )
+
+    assert globaldb.get_setting_value('version', 0) == 17
+    with globaldb.conn.read_ctx() as cursor:
+        assert table_exists(cursor=cursor, name='location_unsupported_assets') is False
 
 
 @pytest.mark.parametrize('custom_globaldb', ['v2_global.db'])

--- a/rotkehlchen/tests/utils/globaldb.py
+++ b/rotkehlchen/tests/utils/globaldb.py
@@ -81,7 +81,7 @@ USER_TOKEN3 = EvmToken.initialize(
 
 def patch_for_globaldb_upgrade_to(
         stack: ExitStack,
-        version: Literal[2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        version: Literal[2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
 ) -> ExitStack:
     stack.enter_context(
         patch(


### PR DESCRIPTION
Add a new global DB upgrade (v16->v17, taking place in v1.44.0) that drops the now-unused location_unsupported_assets table, finishing the removal of the exchange unsupported-asset blocklist started in PR #12350. Remove the table from schema.py and minimized_schema.py, bump GLOBAL_DB_VERSION to 17, and drop the table from the packaged global.db. Also clean up the leftover is_asset_symbol_unsupported reference in test_gate.py missed by #12350.

