### PR TITLE
Use historic FX rate in the balance snapshot editor

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`12277` If your main currency is not USD, editing a balance snapshot now shows and saves each value converted at the exchange rate from that snapshot's own date. Previously it used today's exchange rate, so the values you saw and saved were off, especially for assets pegged to a fiat currency such as EUR stablecoins.
 * :bug:`12306` Chain locations (e.g. ``ethereum``, ``optimism``) with on-chain balances are now reachable via global search, even when no manual balance is tagged with that label.
 * :bug:`12304` Opening a location breakdown page for a blockchain (e.g. ``/locations/ethereum``) now shows that chain's on-chain assets and total — previously the page rendered as 0 value with an empty/loading table whenever the location identifier was a chain alias.
 * :feature:`12049` rotki now runs a DB integrity check before uploading a cloud backup or replacing the local DB with a downloaded copy

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.spec.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.spec.ts
@@ -1,0 +1,123 @@
+import { bigNumberify } from '@rotki/common';
+import { updateGeneralSettings } from '@test/utils/general-settings';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, ref } from 'vue';
+import { useCurrencies } from '@/modules/assets/amount-display/currencies';
+import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
+import EditBalancesSnapshotAssetPriceForm from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue';
+import TwoFieldsAmountInput from '@/modules/shell/components/inputs/TwoFieldsAmountInput.vue';
+
+// ETH priced at $2000 and €1800 at the timestamp -> historic USD->EUR rate 0.9.
+const ETH_USD = 2000;
+const ETH_EUR = 1800;
+
+vi.mock('@/modules/assets/prices/use-price-task-manager', () => ({
+  usePriceTaskManager: vi.fn().mockReturnValue({
+    getHistoricPrice: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: vi.fn().mockReturnValue({
+    addHistoricalPrice: vi.fn(),
+  }),
+}));
+
+// Direct USD->EUR forex rate 0.9 (matches ETH's 1800/2000 ratio).
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: vi.fn(() => ({
+    createKey: (fromAsset: string, ts: number): string => `${fromAsset}#${ts}`,
+    getHistoricPrice: (): unknown => bigNumberify(0.9),
+    getIsPending: (): boolean => false,
+    resetHistoricalPricesData: vi.fn(),
+  })),
+}));
+
+type FormInstance = InstanceType<typeof EditBalancesSnapshotAssetPriceForm>;
+
+describe('edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<FormInstance>;
+
+  const timestamp = 1700000000;
+
+  function setCurrency(symbol: string): void {
+    const { findCurrency } = useCurrencies();
+    updateGeneralSettings({ mainCurrency: findCurrency(symbol) });
+  }
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.mocked(usePriceTaskManager().getHistoricPrice).mockImplementation(
+      async ({ toAsset }: { toAsset: string }) => bigNumberify(toAsset === 'USD' ? ETH_USD : ETH_EUR),
+    );
+    vi.mocked(useAssetPricesApi().addHistoricalPrice).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function createWrapper(amount = '1.5', usdValue = '0'): VueWrapper<FormInstance> {
+    const model = ref({ amount, asset: 'ETH', usdValue });
+    return mount(EditBalancesSnapshotAssetPriceForm, {
+      global: { plugins: [pinia] },
+      props: {
+        'amount': model.value.amount,
+        'asset': model.value.asset,
+        timestamp,
+        'usdValue': model.value.usdValue,
+        'onUpdate:amount': (v: string) => { model.value.amount = v; },
+        'onUpdate:asset': (v: string) => { model.value.asset = v; },
+        'onUpdate:usdValue': (v: string) => { model.value.usdValue = v; },
+      },
+    });
+  }
+
+  function lastUsdValue(): string | undefined {
+    const updates = wrapper.emitted<[string]>('update:usdValue');
+    return updates?.at(-1)?.[0];
+  }
+
+  it('should keep the fetched USD value on load in a non-USD currency', async () => {
+    setCurrency('EUR');
+    wrapper = createWrapper();
+    await flushPromises();
+    await nextTick();
+
+    // fiatValue = 1.5 * 1800 = 2700; usdValue = 2700 / 0.9 = 3000 (consistent)
+    expect(lastUsdValue()).toBe('3000');
+  });
+
+  it('should back-propagate a fiat value edit to the stored USD value', async () => {
+    setCurrency('EUR');
+    wrapper = createWrapper();
+    await flushPromises();
+    await nextTick();
+
+    const twoFields = wrapper.findComponent(TwoFieldsAmountInput);
+    // user focuses the value (secondary) field, then types a new fiat value
+    twoFields.vm.$emit('update:reversed', true);
+    twoFields.vm.$emit('update:secondaryValue', '3600');
+    await flushPromises();
+    await nextTick();
+
+    // 3600 EUR / 0.9 = 4000 USD
+    expect(lastUsdValue()).toBe('4000');
+  });
+
+  it('should not touch the historic FX path in a USD main currency', async () => {
+    setCurrency('USD');
+    wrapper = createWrapper();
+    await flushPromises();
+    await nextTick();
+
+    // usdValue = amount * asset USD price = 1.5 * 2000
+    expect(lastUsdValue()).toBe('3000');
+  });
+});

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue
@@ -1,18 +1,8 @@
 <script setup lang="ts">
-import type { BigNumber } from '@rotki/common';
-import type { HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
 import useVuelidate from '@vuelidate/core';
 import { helpers, required } from '@vuelidate/validators';
-import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
-import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
-import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
-import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
-import { bigNumberifyFromRef } from '@/modules/core/common/data/bignumbers';
 import { toMessages } from '@/modules/core/common/validation/validation';
-import { TaskType } from '@/modules/core/tasks/task-type';
-import { useTaskStore } from '@/modules/core/tasks/use-task-store';
-import { PriceOracle } from '@/modules/settings/types/price-oracle';
-import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
+import { useSnapshotAssetPrice } from '@/modules/dashboard/snapshots/composables/use-snapshot-asset-price';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 import TwoFieldsAmountInput from '@/modules/shell/components/inputs/TwoFieldsAmountInput.vue';
@@ -31,30 +21,17 @@ const { disableAsset = false, nft = false, timestamp } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const fiatValue = ref<string>('');
-const assetToUsdPrice = ref<string>('');
-const assetToFiatPrice = ref<string>('');
-
-const fiatValueFocused = ref<boolean>(false);
-const fetchedAssetToUsdPrice = ref<string>('');
-const fetchedAssetToFiatPrice = ref<string>('');
-
-const { resetHistoricalPricesData } = useHistoricPriceCache();
-const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
-const { useIsTaskRunning } = useTaskStore();
-
-const { getHistoricPrice } = usePriceTaskManager();
-const { addHistoricalPrice } = useAssetPricesApi();
-
-const isCurrentCurrencyUsd = computed<boolean>(() => get(currencySymbol) === CURRENCY_USD);
-const fetching = useIsTaskRunning(TaskType.FETCH_HISTORIC_PRICE);
-
-const numericAssetToUsdPrice = bigNumberifyFromRef(assetToUsdPrice);
-const numericAssetToFiatPrice = bigNumberifyFromRef(assetToFiatPrice);
-const numericFiatValue = bigNumberifyFromRef(fiatValue);
-
-const numericAmount = bigNumberifyFromRef(amount);
-const numericUsdValue = bigNumberifyFromRef(usdValue);
+const {
+  assetToFiatPrice,
+  assetToUsdPrice,
+  currencySymbol,
+  fetching,
+  fiatValue,
+  fiatValueFocused,
+  isCurrentCurrencyUsd,
+  reset,
+  submitPrice,
+} = useSnapshotAssetPrice({ amount, asset, timestamp: () => timestamp, usdValue });
 
 const rules = {
   amount: {
@@ -79,160 +56,6 @@ const v$ = useVuelidate(
     $autoDirty: true,
   },
 );
-
-async function savePrice(payload: HistoricalPriceFormPayload) {
-  await addHistoricalPrice(payload);
-  resetHistoricalPricesData([payload]);
-}
-
-function onAssetToUsdPriceChange(forceUpdate = false) {
-  if (get(amount) && get(assetToUsdPrice) && (!get(fiatValueFocused) || forceUpdate))
-    set(usdValue, get(numericAmount).multipliedBy(get(numericAssetToUsdPrice)).toFixed());
-}
-
-function onAssetToFiatPriceChanged(forceUpdate = false) {
-  if (get(amount) && get(assetToFiatPrice) && (!get(fiatValueFocused) || forceUpdate))
-    set(fiatValue, get(numericAmount).multipliedBy(get(numericAssetToFiatPrice)).toFixed());
-}
-
-function onUsdValueChange() {
-  if (get(amount) && get(fiatValueFocused))
-    set(assetToUsdPrice, get(numericUsdValue).div(get(numericAmount)).toFixed());
-}
-
-function onFiatValueChange() {
-  if (get(amount) && get(fiatValueFocused))
-    set(assetToFiatPrice, get(numericFiatValue).div(get(numericAmount)).toFixed());
-}
-
-async function fetchHistoricPrices() {
-  const assetVal = get(asset);
-  if (!timestamp || !assetVal)
-    return;
-
-  const oldUsdPrice = get(numericUsdValue).dividedBy(get(numericAmount));
-
-  if (assetVal === CURRENCY_USD) {
-    set(fetchedAssetToUsdPrice, '1');
-  }
-  else {
-    const price: BigNumber = await getHistoricPrice({
-      fromAsset: assetVal,
-      timestamp,
-      toAsset: CURRENCY_USD,
-    });
-
-    if (price.gt(0)) {
-      set(fetchedAssetToUsdPrice, price.toFixed());
-    }
-    else {
-      set(assetToUsdPrice, oldUsdPrice.toFixed());
-    }
-  }
-
-  if (!get(isCurrentCurrencyUsd)) {
-    const currentCurrency = get(currencySymbol);
-
-    if (assetVal === currentCurrency) {
-      set(fetchedAssetToFiatPrice, '1');
-      return;
-    }
-
-    const price = await getHistoricPrice({
-      fromAsset: assetVal,
-      timestamp,
-      toAsset: currentCurrency,
-    });
-
-    if (price.gt(0)) {
-      set(fetchedAssetToFiatPrice, price.toFixed());
-    }
-    else {
-      set(assetToFiatPrice, oldUsdPrice.toFixed());
-    }
-  }
-}
-
-async function submitPrice(): Promise<void> {
-  const assetVal = get(asset);
-
-  if (!assetVal)
-    return;
-
-  if (get(isCurrentCurrencyUsd)) {
-    if (get(assetToUsdPrice) !== get(fetchedAssetToUsdPrice)) {
-      await savePrice({
-        fromAsset: assetVal,
-        price: get(assetToUsdPrice),
-        sourceType: PriceOracle.MANUAL,
-        timestamp,
-        toAsset: CURRENCY_USD,
-      });
-    }
-  }
-  else if (get(assetToFiatPrice) !== get(fetchedAssetToFiatPrice)) {
-    await savePrice({
-      fromAsset: assetVal,
-      price: get(assetToFiatPrice),
-      sourceType: PriceOracle.MANUAL,
-      timestamp,
-      toAsset: get(currencySymbol),
-    });
-  }
-}
-
-function reset() {
-  set(fetchedAssetToUsdPrice, '');
-  set(fetchedAssetToFiatPrice, '');
-  set(assetToUsdPrice, '');
-  set(assetToFiatPrice, '');
-  set(fiatValue, '');
-  set(usdValue, '');
-}
-
-watchImmediate(
-  [() => timestamp, asset],
-  async ([timestamp, asset], [oldTimestamp, oldAsset]) => {
-    if (timestamp !== oldTimestamp || asset !== oldAsset)
-      await fetchHistoricPrices();
-  },
-);
-
-watchImmediate(fetchedAssetToUsdPrice, (price) => {
-  set(assetToUsdPrice, price);
-  onAssetToUsdPriceChange(true);
-});
-
-watchImmediate(assetToUsdPrice, () => {
-  onAssetToUsdPriceChange();
-});
-
-watchImmediate(usdValue, () => {
-  onUsdValueChange();
-});
-
-watchImmediate(fetchedAssetToFiatPrice, (price) => {
-  set(assetToFiatPrice, price);
-  onAssetToFiatPriceChanged(true);
-});
-
-watchImmediate(assetToFiatPrice, () => {
-  onAssetToFiatPriceChanged();
-});
-
-watchImmediate(fiatValue, () => {
-  onFiatValueChange();
-});
-
-watchImmediate(amount, () => {
-  if (!get(isCurrentCurrencyUsd)) {
-    onAssetToFiatPriceChanged();
-    onFiatValueChange();
-  }
-
-  onAssetToUsdPriceChange();
-  onUsdValueChange();
-});
 
 defineExpose({
   reset,

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotDeleteDialog.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotDeleteDialog.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import type { Snapshot } from '@/modules/dashboard/snapshots';
+import EditBalancesSnapshotLocationSelector from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue';
+import { locationBalanceAfterDelete, type LocationBalancePreview } from '@/modules/dashboard/snapshots/lib/snapshot-location-balance';
+import { rebuildSnapshotAfterBalanceChange } from '@/modules/dashboard/snapshots/lib/snapshot-mutations';
+import ConfirmDialog from '@/modules/shell/components/dialogs/ConfirmDialog.vue';
+
+const modelValue = defineModel<Snapshot>({ required: true });
+
+const { index, locations, timestamp } = defineProps<{
+  /** Index of the balance to delete, or null when the dialog is closed. */
+  index: number | null;
+  locations: string[];
+  timestamp: number;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const locationToDelete = ref<string>('');
+
+const display = computed<boolean>(() => index !== null);
+
+const previewDeleteLocationBalance = computed<LocationBalancePreview | null>(() => {
+  const location = get(locationToDelete);
+
+  if (index === null || !location)
+    return null;
+
+  return locationBalanceAfterDelete({ index, location, snapshot: get(modelValue) });
+});
+
+watch(() => index, () => {
+  set(locationToDelete, '');
+});
+
+function confirm(): void {
+  if (index === null)
+    return;
+
+  const balancesSnapshot = [...get(modelValue).balancesSnapshot];
+  balancesSnapshot.splice(index, 1);
+
+  set(modelValue, rebuildSnapshotAfterBalanceChange({
+    balancesSnapshot,
+    location: get(locationToDelete),
+    locationBalance: get(previewDeleteLocationBalance),
+    snapshot: get(modelValue),
+    timestamp,
+  }));
+
+  emit('close');
+}
+</script>
+
+<template>
+  <ConfirmDialog
+    :display="display"
+    :title="t('dashboard.snapshot.edit.dialog.balances.delete_title')"
+    :message="t('dashboard.snapshot.edit.dialog.balances.delete_confirmation')"
+    max-width="700"
+    @cancel="emit('close')"
+    @confirm="confirm()"
+  >
+    <div class="mt-4">
+      <EditBalancesSnapshotLocationSelector
+        v-model="locationToDelete"
+        :locations="locations"
+        :preview-location-balance="previewDeleteLocationBalance"
+        :timestamp="timestamp"
+      />
+    </div>
+  </ConfirmDialog>
+</template>

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotEntryDialog.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotEntryDialog.vue
@@ -1,0 +1,199 @@
+<script setup lang="ts">
+import type { BalanceSnapshot, BalanceSnapshotPayload, Snapshot } from '@/modules/dashboard/snapshots';
+import { assert, bigNumberify } from '@rotki/common';
+import { BalanceType } from '@/modules/balances/types/balances';
+import ConfirmSnapshotConflictReplacementDialog
+  from '@/modules/dashboard/ConfirmSnapshotConflictReplacementDialog.vue';
+import EditBalancesSnapshotForm from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue';
+import { locationBalanceAfterEdit, type LocationBalancePreview } from '@/modules/dashboard/snapshots/lib/snapshot-location-balance';
+import { rebuildSnapshotAfterBalanceChange } from '@/modules/dashboard/snapshots/lib/snapshot-mutations';
+import { TOTAL_LOCATION } from '@/modules/dashboard/snapshots/lib/snapshot-totals';
+import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
+
+type EditableBalance = BalanceSnapshot & { index: number };
+
+const modelValue = defineModel<Snapshot>({ required: true });
+
+const { timestamp } = defineProps<{
+  timestamp: number;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const open = ref<boolean>(false);
+const stateUpdated = ref<boolean>(false);
+const submitting = ref<boolean>(false);
+const editIndex = ref<number | null>(null);
+const formModel = ref<(BalanceSnapshotPayload & { location: string }) | null>(null);
+const conflictedBalanceSnapshot = ref<BalanceSnapshot | null>(null);
+
+const form = useTemplateRef<InstanceType<typeof EditBalancesSnapshotForm>>('form');
+
+const existingLocations = computed<string[]>(() =>
+  get(modelValue).locationDataSnapshot.filter(item => item.location !== TOTAL_LOCATION).map(item => item.location),
+);
+
+const previewLocationBalance = computed<LocationBalancePreview | null>(() => {
+  const formVal = get(formModel);
+
+  if (!formVal?.amount || !formVal.usdValue || !formVal.location)
+    return null;
+
+  // `formVal.usdValue` is already in USD (derived from the historic asset→USD
+  // price); the user-currency conversion happens at the UI level, so no FX here.
+  return locationBalanceAfterEdit({
+    category: formVal.category,
+    editIndex: get(editIndex),
+    location: formVal.location,
+    snapshot: get(modelValue),
+    usdValue: bigNumberify(formVal.usdValue),
+  });
+});
+
+function openAdd(): void {
+  set(editIndex, null);
+  set(formModel, {
+    amount: '',
+    assetIdentifier: '',
+    category: BalanceType.ASSET,
+    location: '',
+    timestamp,
+    usdValue: '',
+  });
+  set(open, true);
+}
+
+function openEdit(item: EditableBalance): void {
+  set(editIndex, item.index);
+
+  // Snapshots store USD. The asset-price form re-derives the display value from
+  // the historic asset->USD price, so pre-fill the raw USD value (no FX). This
+  // is also the form's fallback when the historic price fetch fails, where a
+  // main-currency-converted value would be persisted as USD and corrupt it.
+  set(formModel, {
+    ...item,
+    amount: item.amount.toFixed(),
+    location: '',
+    usdValue: item.usdValue.toFixed(),
+  });
+
+  set(open, true);
+}
+
+function checkAssetExist(asset: string): void {
+  const assetFound = get(modelValue).balancesSnapshot.find(item => item.assetIdentifier === asset);
+  set(conflictedBalanceSnapshot, assetFound ?? null);
+}
+
+function closeConflictDialog(): void {
+  set(conflictedBalanceSnapshot, null);
+}
+
+function cancelConvertToEdit(): void {
+  const currentFormModel = get(formModel);
+  if (currentFormModel) {
+    set(formModel, {
+      ...currentFormModel,
+      assetIdentifier: '',
+    });
+  }
+
+  closeConflictDialog();
+}
+
+function convertToEdit(): void {
+  assert(conflictedBalanceSnapshot);
+  const assetIdentifier = get(conflictedBalanceSnapshot)?.assetIdentifier;
+  const index = get(modelValue).balancesSnapshot.findIndex(item => item.assetIdentifier === assetIdentifier);
+
+  if (index > -1)
+    openEdit({ ...get(modelValue).balancesSnapshot[index], index });
+
+  closeConflictDialog();
+}
+
+function close(): void {
+  set(open, false);
+  set(editIndex, null);
+  set(formModel, null);
+}
+
+async function save(): Promise<void> {
+  const formRef = get(form);
+  const valid = await formRef?.validate();
+  if (!valid)
+    return;
+
+  const formData = get(formModel);
+  if (!formData)
+    return;
+
+  set(submitting, true);
+  const index = get(editIndex);
+
+  const balancesSnapshot = [...get(modelValue).balancesSnapshot];
+  const payload = {
+    amount: bigNumberify(formData.amount),
+    assetIdentifier: formData.assetIdentifier,
+    category: formData.category,
+    timestamp,
+    usdValue: bigNumberify(formData.usdValue),
+  };
+
+  if (index !== null)
+    balancesSnapshot[index] = payload;
+  else balancesSnapshot.unshift(payload);
+
+  set(submitting, false);
+
+  set(modelValue, rebuildSnapshotAfterBalanceChange({
+    balancesSnapshot,
+    location: formData.location,
+    locationBalance: get(previewLocationBalance),
+    snapshot: get(modelValue),
+    timestamp,
+  }));
+
+  formRef?.submitPrice();
+  close();
+}
+
+defineExpose({
+  openAdd,
+  openEdit,
+});
+</script>
+
+<template>
+  <BigDialog
+    :display="open"
+    :title="
+      editIndex !== null
+        ? t('dashboard.snapshot.edit.dialog.balances.edit_title')
+        : t('dashboard.snapshot.edit.dialog.balances.add_title')
+    "
+    :primary-action="t('common.actions.save')"
+    :loading="submitting"
+    :prompt-on-close="stateUpdated"
+    @confirm="save()"
+    @cancel="close()"
+  >
+    <EditBalancesSnapshotForm
+      v-if="formModel"
+      ref="form"
+      v-model="formModel"
+      v-model:state-updated="stateUpdated"
+      :edit="editIndex !== null"
+      :preview-location-balance="previewLocationBalance"
+      :locations="editIndex !== null ? existingLocations : []"
+      :timestamp="timestamp"
+      @update:asset="checkAssetExist($event)"
+    />
+
+    <ConfirmSnapshotConflictReplacementDialog
+      :snapshot="conflictedBalanceSnapshot"
+      @cancel="cancelConvertToEdit()"
+      @confirm="convertToEdit()"
+    />
+  </BigDialog>
+</template>

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { BigNumber } from '@rotki/common';
 import type { BalanceSnapshotPayload } from '@/modules/dashboard/snapshots';
+import type { LocationBalancePreview } from '@/modules/dashboard/snapshots/lib/snapshot-location-balance';
 import useVuelidate from '@vuelidate/core';
 import { helpers, required } from '@vuelidate/validators';
 import { isNft } from '@/modules/assets/nft-utils';
@@ -17,7 +17,7 @@ const model = defineModel<BalanceSnapshotPayloadAndLocation>({ required: true })
 const { locations, previewLocationBalance = null, timestamp } = defineProps<{
   edit?: boolean;
   locations: string[];
-  previewLocationBalance?: Record<string, BigNumber> | null;
+  previewLocationBalance?: LocationBalancePreview | null;
   timestamp: number;
 }>();
 
@@ -135,6 +135,7 @@ defineExpose({
       optional-show-existing
       :locations="locations"
       :preview-location-balance="previewLocationBalance"
+      :timestamp="timestamp"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
-import type { BigNumber } from '@rotki/common';
-import { FiatDisplay } from '@/modules/assets/amount-display/components';
+import type { LocationBalancePreview } from '@/modules/dashboard/snapshots/lib/snapshot-location-balance';
 import LocationSelector from '@/modules/balances/LocationSelector.vue';
+import SnapshotFiatDisplay from '@/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue';
 
 const model = defineModel<string>({ default: '', required: true });
 
-const { locations = [], optionalShowExisting = false, previewLocationBalance = null } = defineProps<{
+const { locations = [], optionalShowExisting = false, previewLocationBalance = null, timestamp } = defineProps<{
   locations?: string[];
-  previewLocationBalance?: Record<string, BigNumber> | null;
+  previewLocationBalance?: LocationBalancePreview | null;
   optionalShowExisting?: boolean;
+  timestamp: number;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
@@ -58,9 +59,9 @@ const showOnlyExisting = ref<boolean>(true);
           <div class="text-overline text-rui-text-secondary -mb-2">
             {{ t('dashboard.snapshot.edit.dialog.balances.preview.from') }}
           </div>
-          <FiatDisplay
+          <SnapshotFiatDisplay
             :value="previewLocationBalance.before"
-            from="USD"
+            :timestamp="timestamp"
           />
         </div>
         <div class="px-8 text-rui-text-secondary">
@@ -70,9 +71,9 @@ const showOnlyExisting = ref<boolean>(true);
           <div class="text-overline text-rui-text-secondary -mb-2">
             {{ t('dashboard.snapshot.edit.dialog.balances.preview.to') }}
           </div>
-          <FiatDisplay
+          <SnapshotFiatDisplay
             :value="previewLocationBalance.after"
-            from="USD"
+            :timestamp="timestamp"
           />
         </div>
       </div>

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotTable.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotTable.vue
@@ -1,24 +1,17 @@
 <script setup lang="ts">
 import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
-import type { BalanceSnapshot, BalanceSnapshotPayload, Snapshot } from '@/modules/dashboard/snapshots';
-import { assert, type BigNumber, bigNumberify, One, toSentenceCase, Zero } from '@rotki/common';
-import { AssetValueDisplay, ValueDisplay } from '@/modules/assets/amount-display/components';
-import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
+import type { BalanceSnapshot, Snapshot } from '@/modules/dashboard/snapshots';
+import { type BigNumber, toSentenceCase } from '@rotki/common';
+import { ValueDisplay } from '@/modules/assets/amount-display/components';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { isNft } from '@/modules/assets/nft-utils';
-import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
 import NftDetails from '@/modules/balances/nft/NftDetails.vue';
-import { BalanceType } from '@/modules/balances/types/balances';
-import { bigNumberSum } from '@/modules/core/common/data/calculation';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
-import ConfirmSnapshotConflictReplacementDialog
-  from '@/modules/dashboard/ConfirmSnapshotConflictReplacementDialog.vue';
-import EditBalancesSnapshotForm from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue';
-import EditBalancesSnapshotLocationSelector
-  from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue';
+import EditBalancesSnapshotDeleteDialog from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotDeleteDialog.vue';
+import EditBalancesSnapshotEntryDialog from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotEntryDialog.vue';
+import SnapshotFiatDisplay from '@/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue';
+import { getTotalValue, TOTAL_LOCATION } from '@/modules/dashboard/snapshots/lib/snapshot-totals';
 import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
-import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
-import ConfirmDialog from '@/modules/shell/components/dialogs/ConfirmDialog.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 import RowActions from '@/modules/shell/components/RowActions.vue';
 
@@ -36,25 +29,14 @@ const { t } = useI18n({ useScope: 'global' });
 
 type IndexedBalanceSnapshot = BalanceSnapshot & { index: number; categoryLabel: string };
 
-const openDialog = ref<boolean>(false);
-const stateUpdated = ref<boolean>(false);
-const submitting = ref<boolean>(false);
-
 const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
-const showDeleteConfirmation = ref<boolean>(false);
-const indexToEdit = ref<number | null>(null);
 const indexToDelete = ref<number | null>(null);
-const locationToDelete = ref<string>('');
-const formModel = ref<(BalanceSnapshotPayload & { location: string }) | null>(null);
 const sort = ref<DataTableSortData<BalanceSnapshot>>({
   column: 'usdValue',
   direction: 'desc',
 });
 const assetSearch = ref<string>('');
-const form = useTemplateRef<InstanceType<typeof EditBalancesSnapshotForm>>('form');
-
-const { getExchangeRate } = usePriceUtils();
-const fiatExchangeRate = computed<BigNumber>(() => getExchangeRate(get(currencySymbol), One));
+const entryDialog = useTemplateRef<InstanceType<typeof EditBalancesSnapshotEntryDialog>>('entryDialog');
 
 const data = computed<IndexedBalanceSnapshot[]>(() =>
   get(modelValue).balancesSnapshot.map((item: BalanceSnapshot, index: number) => ({
@@ -75,14 +57,7 @@ const filteredData = computed<IndexedBalanceSnapshot[]>(() => {
   return allData.filter(({ assetIdentifier }) => assetIdentifier === search);
 });
 
-const total = computed<BigNumber>(() => {
-  const totalEntry = get(modelValue).locationDataSnapshot.find(item => item.location === 'total');
-
-  if (!totalEntry)
-    return Zero;
-
-  return totalEntry.usdValue;
-});
+const total = computed<BigNumber>(() => getTotalValue(get(modelValue).locationDataSnapshot));
 
 const tableHeaders = computed<DataTableColumn<IndexedBalanceSnapshot>[]>(() => [
   {
@@ -124,249 +99,20 @@ function updateStep(step: number): void {
   emit('update:step', step);
 }
 
-const conflictedBalanceSnapshot = ref<BalanceSnapshot | null>(null);
-
-function checkAssetExist(asset: string): void {
-  const assetFound = get(modelValue).balancesSnapshot.find((item: BalanceSnapshot) => item.assetIdentifier === asset);
-  set(conflictedBalanceSnapshot, assetFound || null);
-}
-
-function closeConvertToEditDialog(): void {
-  set(conflictedBalanceSnapshot, null);
-}
-
-function cancelConvertToEdit(): void {
-  const currentFormModel = get(formModel);
-  if (currentFormModel) {
-    set(formModel, {
-      ...currentFormModel,
-      assetIdentifier: '',
-    });
-  }
-
-  closeConvertToEditDialog();
-}
-
-function convertToEdit(): void {
-  assert(conflictedBalanceSnapshot);
-  const item = get(data).find(
-    ({ assetIdentifier }) => assetIdentifier === get(conflictedBalanceSnapshot)?.assetIdentifier,
-  );
-
-  if (item)
-    editClick(item);
-
-  closeConvertToEditDialog();
-}
+const existingLocations = computed<string[]>(() =>
+  get(modelValue).locationDataSnapshot.filter(item => item.location !== TOTAL_LOCATION).map(item => item.location),
+);
 
 function editClick(item: IndexedBalanceSnapshot): void {
-  set(indexToEdit, item.index);
-
-  const convertedFiatValue
-    = get(currencySymbol) === CURRENCY_USD
-      ? item.usdValue.toFixed()
-      : item.usdValue.multipliedBy(get(fiatExchangeRate)).toFixed();
-
-  set(formModel, {
-    ...item,
-    amount: item.amount.toFixed(),
-    location: '',
-    usdValue: convertedFiatValue,
-  });
-
-  set(openDialog, true);
+  get(entryDialog)?.openEdit(item);
 }
-
-const existingLocations = computed<string[]>(() =>
-  get(modelValue).locationDataSnapshot.filter(item => item.location !== 'total').map(item => item.location),
-);
 
 function deleteClick(item: IndexedBalanceSnapshot): void {
   set(indexToDelete, item.index);
-  set(showDeleteConfirmation, true);
-  set(locationToDelete, '');
 }
 
 function add(): void {
-  set(indexToEdit, null);
-  set(formModel, {
-    amount: '',
-    assetIdentifier: '',
-    category: BalanceType.ASSET,
-    location: '',
-    timestamp,
-    usdValue: '',
-  });
-  set(openDialog, true);
-}
-
-const previewLocationBalance = computed<Record<string, BigNumber> | null>(() => {
-  const formVal = get(formModel);
-
-  if (!formVal?.amount || !formVal.usdValue || !formVal.location)
-    return null;
-
-  const index = get(indexToEdit);
-  const val = get(modelValue);
-
-  const locationData = val.locationDataSnapshot.find(item => item.location === formVal.location);
-
-  const usdValueInBigNumber = bigNumberify(formVal.usdValue);
-  const convertedUsdValue
-    = get(currencySymbol) === CURRENCY_USD ? usdValueInBigNumber : usdValueInBigNumber.dividedBy(get(fiatExchangeRate));
-
-  if (!locationData) {
-    return {
-      after: convertedUsdValue,
-      before: Zero,
-    };
-  }
-
-  const isCurrentLiability = formVal.category === 'liability';
-  const currentFactor = bigNumberify(isCurrentLiability ? -1 : 1);
-  let usdValueDiff = convertedUsdValue.multipliedBy(currentFactor);
-
-  const balancesSnapshot = val.balancesSnapshot;
-
-  if (index !== null) {
-    const isPrevLiability = balancesSnapshot[index].category === 'liability';
-    const prevFactor = bigNumberify(isPrevLiability ? -1 : 1);
-    usdValueDiff = usdValueDiff.minus(balancesSnapshot[index].usdValue.multipliedBy(prevFactor));
-  }
-
-  return {
-    after: locationData.usdValue.plus(usdValueDiff),
-    before: locationData.usdValue,
-  };
-});
-
-const previewDeleteLocationBalance = computed<Record<string, BigNumber> | null>(() => {
-  const index = get(indexToDelete);
-  const location = get(locationToDelete);
-
-  if (index === null || !location)
-    return null;
-
-  const val = get(modelValue);
-  const locationData = val.locationDataSnapshot.find(item => item.location === location);
-  const balanceData = val.balancesSnapshot[index];
-
-  if (!locationData || !balanceData)
-    return null;
-
-  const isCurrentLiability = balanceData.category === 'liability';
-  const currentFactor = bigNumberify(isCurrentLiability ? 1 : -1);
-  const usdValueDiff = balanceData.usdValue.multipliedBy(currentFactor);
-
-  return {
-    after: locationData.usdValue.plus(usdValueDiff),
-    before: locationData.usdValue,
-  };
-});
-
-function updateData(
-  balancesSnapshot: BalanceSnapshot[],
-  location = '',
-  calculatedBalance: Record<string, BigNumber> | null = null,
-): void {
-  const val = get(modelValue);
-  const locationDataSnapshot = [...val.locationDataSnapshot];
-
-  if (location) {
-    const locationDataIndex = locationDataSnapshot.findIndex(item => item.location === location);
-    if (locationDataIndex > -1) {
-      locationDataSnapshot[locationDataIndex].usdValue = calculatedBalance!.after;
-    }
-    else {
-      locationDataSnapshot.push({
-        location,
-        timestamp,
-        usdValue: calculatedBalance!.after,
-      });
-    }
-  }
-
-  const assetsValue = balancesSnapshot.map((item: BalanceSnapshot) => {
-    if (item.category === 'asset')
-      return item.usdValue;
-
-    return item.usdValue.negated();
-  });
-
-  const totalValue = bigNumberSum(assetsValue);
-
-  const totalDataIndex = locationDataSnapshot.findIndex(item => item.location === 'total');
-
-  locationDataSnapshot[totalDataIndex].usdValue = totalValue;
-
-  set(modelValue, {
-    balancesSnapshot,
-    locationDataSnapshot,
-  });
-}
-
-async function save(): Promise<boolean> {
-  const formRef = get(form);
-  const valid = await formRef?.validate();
-  if (!valid)
-    return false;
-
-  const formData = get(formModel);
-
-  if (!formData)
-    return false;
-
-  set(submitting, true);
-  const index = get(indexToEdit);
-  const val = get(modelValue);
-  const timestampVal = timestamp;
-
-  const balancesSnapshot = [...val.balancesSnapshot];
-  const payload = {
-    amount: bigNumberify(formData.amount),
-    assetIdentifier: formData.assetIdentifier,
-    category: formData.category,
-    timestamp: timestampVal,
-    usdValue: bigNumberify(formData.usdValue),
-  };
-
-  if (index !== null)
-    balancesSnapshot[index] = payload;
-  else balancesSnapshot.unshift(payload);
-
-  set(submitting, false);
-
-  updateData(balancesSnapshot, formData.location, get(previewLocationBalance));
-  formRef?.submitPrice();
-  clearEditDialog();
-  return true;
-}
-
-function clearEditDialog(): void {
-  set(openDialog, false);
-  set(indexToEdit, null);
-  set(formModel, null);
-}
-
-function clearDeleteDialog(): void {
-  set(indexToDelete, null);
-  set(showDeleteConfirmation, false);
-  set(locationToDelete, '');
-}
-
-function confirmDelete(): void {
-  const index = get(indexToDelete);
-  const val = get(modelValue);
-  const location = get(locationToDelete);
-
-  if (index === null)
-    return;
-
-  const balancesSnapshot = [...val.balancesSnapshot];
-  balancesSnapshot.splice(index, 1);
-
-  updateData(balancesSnapshot, location, get(previewDeleteLocationBalance));
-  clearDeleteDialog();
+  get(entryDialog)?.openAdd();
 }
 </script>
 
@@ -411,11 +157,9 @@ function confirmDelete(): void {
       </template>
 
       <template #item.usdValue="{ row }">
-        <AssetValueDisplay
-          :asset="row.assetIdentifier"
-          :amount="row.amount"
+        <SnapshotFiatDisplay
           :value="row.usdValue"
-          :timestamp="{ ms: timestamp }"
+          :timestamp="timestamp"
         />
       </template>
 
@@ -436,11 +180,9 @@ function confirmDelete(): void {
           {{ t('common.total') }}:
         </div>
         <div class="font-bold text-h6 -mt-1">
-          <AssetValueDisplay
-            :asset="CURRENCY_USD"
-            :amount="total"
+          <SnapshotFiatDisplay
             :value="total"
-            :timestamp="{ ms: timestamp }"
+            :timestamp="timestamp"
           />
         </div>
       </div>
@@ -469,53 +211,18 @@ function confirmDelete(): void {
       </div>
     </div>
 
-    <BigDialog
-      :display="openDialog"
-      :title="
-        indexToEdit !== null
-          ? t('dashboard.snapshot.edit.dialog.balances.edit_title')
-          : t('dashboard.snapshot.edit.dialog.balances.add_title')
-      "
-      :primary-action="t('common.actions.save')"
-      :loading="submitting"
-      :prompt-on-close="stateUpdated"
-      @confirm="save()"
-      @cancel="clearEditDialog()"
-    >
-      <EditBalancesSnapshotForm
-        v-if="formModel"
-        ref="form"
-        v-model="formModel"
-        v-model:state-updated="stateUpdated"
-        :edit="!!indexToEdit"
-        :preview-location-balance="previewLocationBalance"
-        :locations="indexToEdit !== null ? existingLocations : []"
-        :timestamp="timestamp"
-        @update:asset="checkAssetExist($event)"
-      />
+    <EditBalancesSnapshotEntryDialog
+      ref="entryDialog"
+      v-model="modelValue"
+      :timestamp="timestamp"
+    />
 
-      <ConfirmSnapshotConflictReplacementDialog
-        :snapshot="conflictedBalanceSnapshot"
-        @cancel="cancelConvertToEdit()"
-        @confirm="convertToEdit()"
-      />
-    </BigDialog>
-
-    <ConfirmDialog
-      :display="showDeleteConfirmation"
-      :title="t('dashboard.snapshot.edit.dialog.balances.delete_title')"
-      :message="t('dashboard.snapshot.edit.dialog.balances.delete_confirmation')"
-      max-width="700"
-      @cancel="clearDeleteDialog()"
-      @confirm="confirmDelete()"
-    >
-      <div class="mt-4">
-        <EditBalancesSnapshotLocationSelector
-          v-model="locationToDelete"
-          :locations="existingLocations"
-          :preview-location-balance="previewDeleteLocationBalance"
-        />
-      </div>
-    </ConfirmDialog>
+    <EditBalancesSnapshotDeleteDialog
+      v-model="modelValue"
+      :index="indexToDelete"
+      :locations="existingLocations"
+      :timestamp="timestamp"
+      @close="indexToDelete = null"
+    />
   </div>
 </template>

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotTable.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotTable.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
 import type { LocationDataSnapshot, LocationDataSnapshotPayload } from '@/modules/dashboard/snapshots';
-import { type BigNumber, bigNumberify, One, Zero } from '@rotki/common';
-import { AssetValueDisplay, FiatDisplay } from '@/modules/assets/amount-display/components';
-import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
-import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
+import { type BigNumber, bigNumberify } from '@rotki/common';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import EditLocationDataSnapshotForm from '@/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue';
+import SnapshotFiatDisplay from '@/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue';
+import { useHistoricFiatConversion } from '@/modules/dashboard/snapshots/composables/use-historic-fiat-conversion';
+import { convertFiatToUsd, convertUsdToFiat } from '@/modules/dashboard/snapshots/lib/snapshot-fx';
+import { getTotalValue, TOTAL_LOCATION } from '@/modules/dashboard/snapshots/lib/snapshot-totals';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
@@ -66,11 +67,12 @@ const tableHeaders = computed<DataTableColumn<IndexedLocationDataSnapshot>[]>(()
 
 useRememberTableSorting<LocationDataSnapshot>(TableId.EDIT_LOCATION_DATA_SNAPSHOT, sort, tableHeaders);
 
-const { getExchangeRate } = usePriceUtils();
-const fiatExchangeRate = computed<BigNumber>(() => getExchangeRate(get(currencySymbol), One));
+// Snapshots are stored in USD; editing in the user's fiat must use the
+// historic USD -> fiat rate at the snapshot's timestamp, not today's (#12277).
+const { isUsd, loading: fetchingRate, rate, rateReady } = useHistoricFiatConversion(() => timestamp);
 
 const data = computed<IndexedLocationDataSnapshot[]>(() =>
-  get(modelValue).map((item: LocationDataSnapshot, index: number) => ({ ...item, index })).filter((item: IndexedLocationDataSnapshot) => item.location !== 'total'),
+  get(modelValue).map((item: LocationDataSnapshot, index: number) => ({ ...item, index })).filter((item: IndexedLocationDataSnapshot) => item.location !== TOTAL_LOCATION),
 );
 
 function updateStep(step: number): void {
@@ -81,9 +83,9 @@ function editClick(item: IndexedLocationDataSnapshot): void {
   set(editedIndex, item.index);
 
   const convertedFiatValue
-    = get(currencySymbol) === CURRENCY_USD
+    = get(isUsd)
       ? item.usdValue.toFixed()
-      : item.usdValue.multipliedBy(get(fiatExchangeRate)).toFixed();
+      : convertUsdToFiat(item.usdValue, get(rate)).toFixed();
 
   set(formModel, {
     ...item,
@@ -129,9 +131,9 @@ async function save(): Promise<boolean> {
   const timestampVal = timestamp;
 
   const convertedUsdValue
-    = get(currencySymbol) === CURRENCY_USD
+    = get(isUsd)
       ? bigNumberify(formData.usdValue)
-      : bigNumberify(formData.usdValue).dividedBy(get(fiatExchangeRate));
+      : convertFiatToUsd(bigNumberify(formData.usdValue), get(rate));
 
   const newValue = [...val];
   const payload = {
@@ -170,14 +172,7 @@ function confirmDelete(index: number): void {
   set(modelValue, newValue);
 }
 
-const total = computed<BigNumber>(() => {
-  const totalEntry = get(modelValue).find((item: LocationDataSnapshot) => item.location === 'total');
-
-  if (!totalEntry)
-    return Zero;
-
-  return totalEntry.usdValue;
-});
+const total = computed<BigNumber>(() => getTotalValue(get(modelValue)));
 
 const { show } = useConfirmStore();
 
@@ -210,14 +205,15 @@ function showDeleteConfirmation(item: IndexedLocationDataSnapshot) {
       </template>
 
       <template #item.usdValue="{ row }">
-        <FiatDisplay
+        <SnapshotFiatDisplay
           :value="row.usdValue"
-          from="USD"
+          :timestamp="timestamp"
         />
       </template>
 
       <template #item.action="{ row }">
         <RowActions
+          :edit-disabled="!rateReady"
           :edit-tooltip="t('dashboard.snapshot.edit.dialog.actions.edit_item')"
           :delete-tooltip="t('dashboard.snapshot.edit.dialog.actions.delete_item')"
           @edit-click="editClick(row)"
@@ -233,11 +229,9 @@ function showDeleteConfirmation(item: IndexedLocationDataSnapshot) {
           {{ t('common.total') }}:
         </div>
         <div class="font-bold text-h6 -mt-1">
-          <AssetValueDisplay
-            :asset="CURRENCY_USD"
-            :amount="total"
+          <SnapshotFiatDisplay
             :value="total"
-            :timestamp="{ ms: timestamp }"
+            :timestamp="timestamp"
           />
         </div>
       </div>
@@ -246,6 +240,8 @@ function showDeleteConfirmation(item: IndexedLocationDataSnapshot) {
         <RuiButton
           variant="text"
           color="primary"
+          :disabled="!rateReady"
+          :loading="fetchingRate"
           @click="add()"
         >
           <template #prepend>

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditSnapshotTotal.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditSnapshotTotal.vue
@@ -1,15 +1,10 @@
 <script setup lang="ts">
 import type { BalanceSnapshot, LocationDataSnapshot } from '@/modules/dashboard/snapshots';
-import { assert, type BigNumber, bigNumberify, One, Zero } from '@rotki/common';
 import useVuelidate from '@vuelidate/core';
 import { helpers, required } from '@vuelidate/validators';
-import { FiatDisplay } from '@/modules/assets/amount-display/components';
-import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
-import { isNft } from '@/modules/assets/nft-utils';
-import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
-import { bigNumberSum } from '@/modules/core/common/data/calculation';
 import { toMessages } from '@/modules/core/common/validation/validation';
-import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
+import SnapshotFiatDisplay from '@/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue';
+import { type TotalSuggestionKey, useSnapshotTotalInput } from '@/modules/dashboard/snapshots/composables/use-snapshot-total-input';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 
 const modelValue = defineModel<LocationDataSnapshot[]>({ required: true });
@@ -23,108 +18,21 @@ const emit = defineEmits<{
   'update:step': [step: number];
 }>();
 
-const total = ref<string>('');
-
 const { t } = useI18n({ useScope: 'global' });
-const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
-const { createKey, getHistoricPrice, isPending } = useHistoricPriceCache();
 
-const isCurrencyCurrencyUsd = computed<boolean>(() => get(currencySymbol) === CURRENCY_USD);
-
-const rate = computed<BigNumber>(() => {
-  if (get(isCurrencyCurrencyUsd))
-    return One;
-  return getHistoricPrice(CURRENCY_USD, timestamp);
+const {
+  applyTotal,
+  fetchingRate,
+  nftsExcludedTotal,
+  rateReady,
+  setTotal,
+  suggestions,
+  total,
+} = useSnapshotTotalInput({
+  balancesSnapshot: () => balancesSnapshot,
+  modelValue,
+  timestamp: () => timestamp,
 });
-
-const fetchingRate = isPending(createKey(CURRENCY_USD, timestamp));
-
-const assetTotal = computed<BigNumber>(() => {
-  const numbers = balancesSnapshot.map((item: BalanceSnapshot) => {
-    if (item.category === 'asset')
-      return item.usdValue;
-
-    return item.usdValue.negated();
-  });
-
-  return bigNumberSum(numbers);
-});
-
-const locationTotal = computed<BigNumber>(() => {
-  const numbers = get(modelValue).map((item: LocationDataSnapshot) => {
-    if (item.location === 'total')
-      return Zero;
-
-    return item.usdValue;
-  });
-
-  return bigNumberSum(numbers);
-});
-
-const nftsTotal = computed<BigNumber>(() => {
-  const numbers = balancesSnapshot.map((item: BalanceSnapshot) => {
-    if (!isNft(item.assetIdentifier))
-      return Zero;
-
-    if (item.category === 'asset')
-      return item.usdValue;
-
-    return item.usdValue.negated();
-  });
-
-  return bigNumberSum(numbers);
-});
-
-const numericTotal = computed<BigNumber>(() => {
-  const value = get(total);
-
-  if (value === '')
-    return Zero;
-
-  return get(isCurrencyCurrencyUsd)
-    ? bigNumberify(value)
-    : bigNumberify(value).dividedBy(get(rate));
-});
-
-const nftsExcludedTotal = computed<BigNumber>(() => get(numericTotal).minus(get(nftsTotal)));
-
-const suggestions = computed(() => {
-  const assetTotalValue = get(assetTotal);
-  const locationTotalValue = get(locationTotal);
-
-  if (assetTotalValue.minus(locationTotalValue).abs().lt(1e-8) || !get(isCurrencyCurrencyUsd)) {
-    return {
-      total: assetTotalValue,
-    };
-  }
-  return {
-    asset: assetTotalValue,
-    location: locationTotalValue,
-  };
-});
-
-watchImmediate(rate, (rate) => {
-  const totalEntry = get(modelValue).find((item: LocationDataSnapshot) => item.location === 'total');
-
-  if (totalEntry) {
-    const convertedFiatValue
-      = get(isCurrencyCurrencyUsd)
-        ? totalEntry.usdValue.toFixed()
-        : totalEntry.usdValue.multipliedBy(get(rate)).toFixed();
-
-    set(total, convertedFiatValue);
-  }
-});
-
-function updateStep(step: number): void {
-  emit('update:step', step);
-}
-
-function setTotal(number?: BigNumber) {
-  assert(number);
-  const convertedFiatValue = number.multipliedBy(get(rate)).toFixed();
-  set(total, convertedFiatValue);
-}
 
 const rules = {
   total: {
@@ -132,17 +40,13 @@ const rules = {
   },
 };
 
-const states = {
-  total,
-};
-
 const v$ = useVuelidate(
   rules,
-  states,
+  { total },
   { $autoDirty: true },
 );
 
-const suggestionsLabel = computed(() => ({
+const suggestionsLabel = computed<Record<TotalSuggestionKey, string>>(() => ({
   asset: t('dashboard.snapshot.edit.dialog.total.use_calculated_asset', {
     length: balancesSnapshot.length,
   }),
@@ -152,18 +56,15 @@ const suggestionsLabel = computed(() => ({
   total: t('dashboard.snapshot.edit.dialog.total.use_calculated_total'),
 }));
 
+function updateStep(step: number): void {
+  emit('update:step', step);
+}
+
 async function save(): Promise<void> {
   if (!(await get(v$).$validate()))
     return;
 
-  const val = get(modelValue);
-  const index = val.findIndex((item: LocationDataSnapshot) => item.location === 'total')!;
-
-  const newValue = [...val];
-
-  newValue[index].usdValue = get(numericTotal);
-
-  set(modelValue, newValue);
+  applyTotal();
 }
 </script>
 
@@ -178,7 +79,7 @@ async function save(): Promise<void> {
           v-model="total"
           variant="outlined"
           :error-messages="toMessages(v$.total)"
-          :disabled="fetchingRate"
+          :disabled="fetchingRate || !rateReady"
         >
           <template
             v-if="fetchingRate"
@@ -200,9 +101,9 @@ async function save(): Promise<void> {
             keypath="dashboard.snapshot.edit.dialog.total.warning"
           >
             <template #amount>
-              <FiatDisplay
+              <SnapshotFiatDisplay
                 :value="nftsExcludedTotal"
-                from="USD"
+                :timestamp="timestamp"
               />
             </template>
           </i18n-t>
@@ -216,17 +117,17 @@ async function save(): Promise<void> {
           <RuiButton
             color="primary"
             class="mb-4 w-full"
+            :disabled="!rateReady"
             @click="setTotal(number)"
           >
             <div class="flex flex-col items-center">
               <span>
                 {{ suggestionsLabel[key] }}
               </span>
-              <FiatDisplay
+              <SnapshotFiatDisplay
                 v-if="number"
                 :value="number"
-                :timestamp="{ ms: timestamp }"
-                from="USD"
+                :timestamp="timestamp"
                 class="text-2xl"
               />
             </div>

--- a/frontend/app/src/modules/dashboard/snapshots.ts
+++ b/frontend/app/src/modules/dashboard/snapshots.ts
@@ -8,7 +8,6 @@ export const BalanceSnapshot = z.object({
   category: z.enum(BalanceType),
   timestamp: z.number(),
   usdValue: NumericString,
-  value: NumericString.optional(),
 });
 
 export type BalanceSnapshot = z.infer<typeof BalanceSnapshot>;

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import type { BigNumber } from '@rotki/common';
+import { FiatDisplay } from '@/modules/assets/amount-display/components';
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+/**
+ * Displays a USD-denominated snapshot value in the user's currency, converted
+ * at the *historic* rate of the snapshot's timestamp.
+ *
+ * Why this wrapper exists
+ * -----------------------
+ * Every value stored in a snapshot is USD. Showing it in a non-USD main
+ * currency must use the FX rate that applied *at the snapshot's time*, not
+ * today's rate (#12277). With `FiatDisplay` that means always pairing
+ * `from="USD"` with the snapshot timestamp.
+ *
+ * Two foot-guns made this worth centralising:
+ *  - Forgetting the timestamp entirely falls back to today's FX rate — a silent
+ *    correctness bug that looks fine on screen.
+ *  - The snapshot `timestamp` is in **seconds**. `FiatDisplay`/`normalizeTimestamp`
+ *    treat a raw number as seconds but `{ ms }` as milliseconds, so passing
+ *    `{ ms: timestamp }` floors it to a near-zero key, the historic price is
+ *    never found, and the value renders as 0.
+ *
+ * This component is the single correct spelling: pass a USD `value` and the
+ * snapshot `timestamp` (seconds), and historic conversion is guaranteed. Prefer
+ * it over `FiatDisplay from="USD"` anywhere in the snapshot editor.
+ */
+const { value, timestamp } = defineProps<{
+  /** The value to display, denominated in USD. */
+  value: BigNumber;
+  /** The snapshot timestamp, in seconds (used for the historic FX lookup). */
+  timestamp: number;
+}>();
+</script>
+
+<template>
+  <FiatDisplay
+    :value="value"
+    from="USD"
+    :timestamp="timestamp"
+    v-bind="$attrs"
+  />
+</template>

--- a/frontend/app/src/modules/dashboard/snapshots/composables/use-historic-fiat-conversion.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/composables/use-historic-fiat-conversion.spec.ts
@@ -1,0 +1,75 @@
+import { bigNumberify, NoPrice } from '@rotki/common';
+import { updateGeneralSettings } from '@test/utils/general-settings';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCurrencies } from '@/modules/assets/amount-display/currencies';
+import { useHistoricFiatConversion } from '@/modules/dashboard/snapshots/composables/use-historic-fiat-conversion';
+
+const getHistoricPrice = vi.fn();
+const getIsPending = vi.fn();
+
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: vi.fn(() => ({
+    createKey: (fromAsset: string, timestamp: number): string => `${fromAsset}#${timestamp}`,
+    getHistoricPrice,
+    getIsPending,
+  })),
+}));
+
+describe('modules/dashboard/snapshots/composables/use-historic-fiat-conversion', () => {
+  // Snapshot timestamps are in seconds, matching the historic-price cache key.
+  const timestamp = 1_600_000_000;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    getHistoricPrice.mockReturnValue(NoPrice);
+    getIsPending.mockReturnValue(false);
+  });
+
+  function setCurrency(symbol: string): void {
+    const { findCurrency } = useCurrencies();
+    updateGeneralSettings({ mainCurrency: findCurrency(symbol) });
+  }
+
+  it('should short-circuit to a rate of one when the display currency is USD', () => {
+    setCurrency('USD');
+    const { isUsd, loading, rate, rateReady } = useHistoricFiatConversion(timestamp);
+
+    expect(get(isUsd)).toBe(true);
+    expect(get(rate).toNumber()).toBe(1);
+    expect(get(loading)).toBe(false);
+    expect(get(rateReady)).toBe(true);
+    expect(getHistoricPrice).not.toHaveBeenCalled();
+  });
+
+  it('should resolve the historic USD rate for a non-USD currency', () => {
+    setCurrency('EUR');
+    getHistoricPrice.mockReturnValue(bigNumberify(0.85));
+    const { isUsd, rate, rateReady } = useHistoricFiatConversion(timestamp);
+
+    expect(get(isUsd)).toBe(false);
+    expect(get(rate).toNumber()).toBe(0.85);
+    expect(get(rateReady)).toBe(true);
+    expect(getHistoricPrice).toHaveBeenCalledWith('USD', timestamp);
+  });
+
+  it('should report loading and a not-ready rate while the lookup is pending', () => {
+    setCurrency('EUR');
+    getHistoricPrice.mockReturnValue(NoPrice);
+    getIsPending.mockReturnValue(true);
+    const { loading, rateReady } = useHistoricFiatConversion(timestamp);
+
+    expect(get(loading)).toBe(true);
+    expect(get(rateReady)).toBe(false);
+  });
+
+  it('should accept a getter for the timestamp', () => {
+    setCurrency('EUR');
+    getHistoricPrice.mockReturnValue(bigNumberify(0.9));
+    const ts = ref<number>(timestamp);
+    const { rate } = useHistoricFiatConversion(() => get(ts));
+
+    expect(get(rate).toNumber()).toBe(0.9);
+    expect(getHistoricPrice).toHaveBeenCalledWith('USD', timestamp);
+  });
+});

--- a/frontend/app/src/modules/dashboard/snapshots/composables/use-historic-fiat-conversion.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/composables/use-historic-fiat-conversion.ts
@@ -1,0 +1,58 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import { type BigNumber, One } from '@rotki/common';
+import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
+import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
+import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
+
+interface UseHistoricFiatConversionReturn {
+  /** Whether the user's display currency is USD (no conversion needed). */
+  isUsd: ComputedRef<boolean>;
+  /** Whether the historic rate lookup is still in progress. */
+  loading: ComputedRef<boolean>;
+  /** The USD -> display-currency rate at the given timestamp (One when USD). */
+  rate: ComputedRef<BigNumber>;
+  /** Whether `rate` is usable (USD, or a positive resolved historic rate). */
+  rateReady: ComputedRef<boolean>;
+}
+
+/**
+ * Resolves the historic USD -> display-currency rate at a snapshot's
+ * timestamp (#12277). Snapshots are stored in USD; displaying or editing them
+ * in the user's fiat must use the rate that applied *at the snapshot's time*,
+ * not today's exchange rate.
+ *
+ * Backed by the lazy historic-price cache: accessing the rate triggers the
+ * fetch and `loading` reflects the pending state so callers can guard inputs.
+ *
+ * @param timestamp the snapshot timestamp in SECONDS (the historic-price cache
+ *   key unit) — plain value, ref or getter. Do not pass milliseconds.
+ */
+export function useHistoricFiatConversion(timestamp: MaybeRefOrGetter<number>): UseHistoricFiatConversionReturn {
+  const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
+  const { createKey, getHistoricPrice, getIsPending } = useHistoricPriceCache();
+
+  const isUsd = computed<boolean>(() => get(currencySymbol) === CURRENCY_USD);
+
+  const rate = computed<BigNumber>(() => {
+    if (get(isUsd))
+      return One;
+
+    return getHistoricPrice(CURRENCY_USD, toValue(timestamp));
+  });
+
+  const loading = computed<boolean>(() => {
+    if (get(isUsd))
+      return false;
+
+    return getIsPending(createKey(CURRENCY_USD, toValue(timestamp)));
+  });
+
+  const rateReady = computed<boolean>(() => get(isUsd) || get(rate).isPositive());
+
+  return {
+    isUsd,
+    loading,
+    rate,
+    rateReady,
+  };
+}

--- a/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-asset-price.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-asset-price.spec.ts
@@ -1,0 +1,134 @@
+import { bigNumberify } from '@rotki/common';
+import { updateGeneralSettings } from '@test/utils/general-settings';
+import flushPromises from 'flush-promises';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type EffectScope, nextTick, ref, type Ref } from 'vue';
+import { useCurrencies } from '@/modules/assets/amount-display/currencies';
+import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
+import { useSnapshotAssetPrice } from '@/modules/dashboard/snapshots/composables/use-snapshot-asset-price';
+
+// ETH priced at $2000 and €1800 at the timestamp -> historic USD->EUR rate 0.9.
+const ETH_USD = 2000;
+const ETH_EUR = 1800;
+
+// The direct USD -> display-currency forex rate (the one SnapshotFiatDisplay uses).
+const directHistoricPrice = vi.fn();
+
+vi.mock('@/modules/assets/prices/use-price-task-manager', () => ({
+  usePriceTaskManager: vi.fn().mockReturnValue({ getHistoricPrice: vi.fn() }),
+}));
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: vi.fn().mockReturnValue({ addHistoricalPrice: vi.fn() }),
+}));
+
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: vi.fn(() => ({
+    createKey: (fromAsset: string, ts: number): string => `${fromAsset}#${ts}`,
+    getHistoricPrice: directHistoricPrice,
+    getIsPending: (): boolean => false,
+    resetHistoricalPricesData: vi.fn(),
+  })),
+}));
+
+describe('modules/dashboard/snapshots/composables/use-snapshot-asset-price', () => {
+  const timestamp = 1700000000;
+  let scope: EffectScope;
+
+  function setCurrency(symbol: string): void {
+    const { findCurrency } = useCurrencies();
+    updateGeneralSettings({ mainCurrency: findCurrency(symbol) });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.mocked(usePriceTaskManager().getHistoricPrice).mockImplementation(
+      async ({ toAsset }: { toAsset: string }) => bigNumberify(toAsset === 'USD' ? ETH_USD : ETH_EUR),
+    );
+    vi.mocked(useAssetPricesApi().addHistoricalPrice).mockResolvedValue(true);
+    // Direct USD->EUR forex rate 0.9 (matches ETH's 1800/2000 ratio here).
+    directHistoricPrice.mockReturnValue(bigNumberify(0.9));
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  async function setup(amountValue = '1.5', usdValueValue = '0'): Promise<{
+    amount: Ref<string>;
+    api: ReturnType<typeof useSnapshotAssetPrice>;
+    asset: Ref<string>;
+    usdValue: Ref<string>;
+  }> {
+    const amount = ref<string>(amountValue);
+    const usdValue = ref<string>(usdValueValue);
+    const asset = ref<string>('ETH');
+    let api!: ReturnType<typeof useSnapshotAssetPrice>;
+    scope = effectScope();
+    scope.run(() => {
+      api = useSnapshotAssetPrice({ amount, asset, timestamp: () => timestamp, usdValue });
+    });
+    await flushPromises();
+    await nextTick();
+    return { amount, api, asset, usdValue };
+  }
+
+  it('should derive a consistent USD value on load in a non-USD currency', async () => {
+    setCurrency('EUR');
+    const { usdValue } = await setup();
+    // fiatValue = 1.5 * 1800 = 2700; usdValue = 2700 / 0.9 = 3000
+    expect(get(usdValue)).toBe('3000');
+  });
+
+  it('should back-propagate a fiat value edit to the stored USD value', async () => {
+    setCurrency('EUR');
+    const { api, usdValue } = await setup();
+
+    set(api.fiatValueFocused, true);
+    set(api.fiatValue, '3600');
+    await nextTick();
+
+    // 3600 EUR / 0.9 = 4000 USD
+    expect(get(usdValue)).toBe('4000');
+  });
+
+  it('should derive the USD value from the asset USD price in a USD currency', async () => {
+    setCurrency('USD');
+    const { api, usdValue } = await setup();
+    expect(get(api.isCurrentCurrencyUsd)).toBe(true);
+    // usdValue = 1.5 * 2000
+    expect(get(usdValue)).toBe('3000');
+  });
+
+  it('should store usdValue against the direct forex rate, not the asset price ratio', async () => {
+    setCurrency('EUR');
+    // EUR-pegged asset: oracle says $1.25 / €1.00 (ratio 0.8), but the forex
+    // USD->EUR rate is 1.0 — the divergence that bit aGnoEURe.
+    vi.mocked(usePriceTaskManager().getHistoricPrice).mockImplementation(
+      async ({ toAsset }: { toAsset: string }) => bigNumberify(toAsset === 'USD' ? 1.25 : 1),
+    );
+    directHistoricPrice.mockReturnValue(bigNumberify(1));
+
+    const { usdValue } = await setup('1000');
+
+    // fiatValue = 1000 * 1 = 1000 EUR; stored = 1000 / 1.0 (direct) = 1000,
+    // NOT 1000 / 0.8 (asset ratio) = 1250.
+    expect(get(usdValue)).toBe('1000');
+  });
+
+  it('should apply the same direct-rate logic for any non-USD currency (GBP-pegged)', async () => {
+    setCurrency('GBP');
+    // GBP-pegged asset: oracle $1.25 / £1.00 (ratio 0.8), forex USD->GBP = 1.0.
+    vi.mocked(usePriceTaskManager().getHistoricPrice).mockImplementation(
+      async ({ toAsset }: { toAsset: string }) => bigNumberify(toAsset === 'USD' ? 1.25 : 1),
+    );
+    directHistoricPrice.mockReturnValue(bigNumberify(1));
+
+    const { usdValue } = await setup('1000');
+
+    // 1000 GBP / 1.0 (direct) = 1000, not 1000 / 0.8 (ratio) = 1250.
+    expect(get(usdValue)).toBe('1000');
+  });
+});

--- a/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-asset-price.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-asset-price.ts
@@ -1,0 +1,285 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
+import { Zero } from '@rotki/common';
+import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
+import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
+import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
+import { bigNumberifyFromRef } from '@/modules/core/common/data/bignumbers';
+import { TaskType } from '@/modules/core/tasks/task-type';
+import { useTaskStore } from '@/modules/core/tasks/use-task-store';
+import { useHistoricFiatConversion } from '@/modules/dashboard/snapshots/composables/use-historic-fiat-conversion';
+import { PriceOracle } from '@/modules/settings/types/price-oracle';
+import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
+
+interface UseSnapshotAssetPriceOptions {
+  /** The asset amount (two-way; the form's v-model). */
+  amount: Ref<string>;
+  /** The stored USD value (two-way; the form's v-model). Always USD. */
+  usdValue: Ref<string>;
+  /** The asset identifier (two-way; the form's v-model). */
+  asset: Ref<string>;
+  /** The snapshot timestamp, in SECONDS. */
+  timestamp: MaybeRefOrGetter<number>;
+}
+
+interface UseSnapshotAssetPriceReturn {
+  /** Asset price in USD (bound to the USD-mode primary field). */
+  assetToUsdPrice: Ref<string>;
+  /** Asset price in the user's display currency (non-USD primary field). */
+  assetToFiatPrice: Ref<string>;
+  /** Asset value in the user's display currency (non-USD secondary field). */
+  fiatValue: Ref<string>;
+  /** Whether the user is editing the secondary (value) field. */
+  fiatValueFocused: Ref<boolean>;
+  /** Whether the user's main currency is USD (no conversion needed). */
+  isCurrentCurrencyUsd: ComputedRef<boolean>;
+  /** The user's main currency symbol. */
+  currencySymbol: Ref<string>;
+  /** Whether a historic-price fetch is in flight. */
+  fetching: ComputedRef<boolean>;
+  /** Persist a user-edited manual price (USD or fiat) for the timestamp. */
+  submitPrice: () => Promise<void>;
+  /** Clear all derived/fetched price state. */
+  reset: () => void;
+}
+
+/**
+ * Owns the asset <-> USD <-> display-currency price-sync state machine used by
+ * the snapshot balance edit form.
+ *
+ * Snapshots are stored in USD. In a non-USD main currency the user edits the
+ * fiat price/value, so the stored `usdValue` must be kept in sync via the
+ * historic USD -> fiat rate at the snapshot's timestamp (#12277). That rate is
+ * derived from the two fetched asset prices (asset->fiat / asset->USD): it is
+ * the rate that applied then and is stable across the user's edits.
+ *
+ * Extracted from EditBalancesSnapshotAssetPriceForm so this bidirectional,
+ * rounding-sensitive logic can be unit-tested without mounting the component.
+ */
+export function useSnapshotAssetPrice(
+  options: UseSnapshotAssetPriceOptions,
+): UseSnapshotAssetPriceReturn {
+  const { amount, asset, timestamp, usdValue } = options;
+
+  const fiatValue = shallowRef<string>('');
+  const assetToUsdPrice = shallowRef<string>('');
+  const assetToFiatPrice = shallowRef<string>('');
+
+  const fiatValueFocused = shallowRef<boolean>(false);
+  const fetchedAssetToUsdPrice = shallowRef<string>('');
+  const fetchedAssetToFiatPrice = shallowRef<string>('');
+
+  const { resetHistoricalPricesData } = useHistoricPriceCache();
+  const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
+  const { useIsTaskRunning } = useTaskStore();
+  const { getHistoricPrice } = usePriceTaskManager();
+  const { addHistoricalPrice } = useAssetPricesApi();
+
+  const isCurrentCurrencyUsd = computed<boolean>(() => get(currencySymbol) === CURRENCY_USD);
+  const fetching = useIsTaskRunning(TaskType.FETCH_HISTORIC_PRICE);
+
+  // The historic USD -> display-currency rate, fetched directly — the SAME rate
+  // every snapshot display (SnapshotFiatDisplay) uses to convert the stored USD
+  // value back. Driving the fiat->USD storage off this rate (rather than the
+  // asset's own USD/fiat price ratio) makes the round-trip exact even for
+  // EUR-pegged assets, whose oracle USD price diverges from the forex rate.
+  const { rate: usdToFiatRate } = useHistoricFiatConversion(timestamp);
+
+  const numericAssetToUsdPrice = bigNumberifyFromRef(assetToUsdPrice);
+  const numericAssetToFiatPrice = bigNumberifyFromRef(assetToFiatPrice);
+  const numericFiatValue = bigNumberifyFromRef(fiatValue);
+  const numericAmount = bigNumberifyFromRef(amount);
+  const numericUsdValue = bigNumberifyFromRef(usdValue);
+
+  async function savePrice(payload: HistoricalPriceFormPayload): Promise<void> {
+    await addHistoricalPrice(payload);
+    resetHistoricalPricesData([payload]);
+  }
+
+  function onAssetToUsdPriceChange(forceUpdate = false): void {
+    // USD main currency only: in a non-USD currency the stored USD value is
+    // driven from the fiat value via the direct rate (see syncUsdValueFromFiat),
+    // so this must not also write it from the asset's USD price.
+    if (get(isCurrentCurrencyUsd) && get(amount) && get(assetToUsdPrice) && (!get(fiatValueFocused) || forceUpdate))
+      set(usdValue, get(numericAmount).multipliedBy(get(numericAssetToUsdPrice)).toFixed());
+  }
+
+  function onAssetToFiatPriceChanged(forceUpdate = false): void {
+    if (get(amount) && get(assetToFiatPrice) && (!get(fiatValueFocused) || forceUpdate))
+      set(fiatValue, get(numericAmount).multipliedBy(get(numericAssetToFiatPrice)).toFixed());
+  }
+
+  function onUsdValueChange(): void {
+    if (get(amount) && get(fiatValueFocused))
+      set(assetToUsdPrice, get(numericUsdValue).div(get(numericAmount)).toFixed());
+  }
+
+  // Keep the stored USD value in sync with the fiat value, using the direct
+  // historic USD->fiat rate so it round-trips exactly through the display
+  // (#12277). Without this the user's fiat edit is dropped, or (for EUR-pegged
+  // assets) stored against the wrong rate.
+  function syncUsdValueFromFiat(): void {
+    if (get(isCurrentCurrencyUsd) || !get(amount))
+      return;
+
+    const rate = get(usdToFiatRate);
+    if (rate.isPositive())
+      set(usdValue, get(numericFiatValue).div(rate).toFixed());
+  }
+
+  function onFiatValueChange(): void {
+    if (!get(amount))
+      return;
+
+    if (get(fiatValueFocused))
+      set(assetToFiatPrice, get(numericFiatValue).div(get(numericAmount)).toFixed());
+
+    syncUsdValueFromFiat();
+  }
+
+  async function fetchHistoricPrices(): Promise<void> {
+    const assetVal = get(asset);
+    const ts = toValue(timestamp);
+    if (!ts || !assetVal)
+      return;
+
+    // Fallback price (used when a historic lookup is unavailable). Guard the
+    // division: an empty/zero amount would otherwise yield NaN/Infinity and
+    // poison the price fields.
+    const currentAmount = get(numericAmount);
+    const oldUsdPrice = currentAmount.isPositive()
+      ? get(numericUsdValue).dividedBy(currentAmount)
+      : Zero;
+
+    if (assetVal === CURRENCY_USD) {
+      set(fetchedAssetToUsdPrice, '1');
+    }
+    else {
+      const price = await getHistoricPrice({ fromAsset: assetVal, timestamp: ts, toAsset: CURRENCY_USD });
+
+      if (price.gt(0))
+        set(fetchedAssetToUsdPrice, price.toFixed());
+      else
+        set(assetToUsdPrice, oldUsdPrice.toFixed());
+    }
+
+    if (!get(isCurrentCurrencyUsd)) {
+      const currentCurrency = get(currencySymbol);
+
+      if (assetVal === currentCurrency) {
+        set(fetchedAssetToFiatPrice, '1');
+        return;
+      }
+
+      const price = await getHistoricPrice({ fromAsset: assetVal, timestamp: ts, toAsset: currentCurrency });
+
+      if (price.gt(0))
+        set(fetchedAssetToFiatPrice, price.toFixed());
+      else
+        set(assetToFiatPrice, oldUsdPrice.toFixed());
+    }
+  }
+
+  async function submitPrice(): Promise<void> {
+    const assetVal = get(asset);
+    if (!assetVal)
+      return;
+
+    if (get(isCurrentCurrencyUsd)) {
+      if (get(assetToUsdPrice) !== get(fetchedAssetToUsdPrice)) {
+        await savePrice({
+          fromAsset: assetVal,
+          price: get(assetToUsdPrice),
+          sourceType: PriceOracle.MANUAL,
+          timestamp: toValue(timestamp),
+          toAsset: CURRENCY_USD,
+        });
+      }
+    }
+    else if (get(assetToFiatPrice) !== get(fetchedAssetToFiatPrice)) {
+      await savePrice({
+        fromAsset: assetVal,
+        price: get(assetToFiatPrice),
+        sourceType: PriceOracle.MANUAL,
+        timestamp: toValue(timestamp),
+        toAsset: get(currencySymbol),
+      });
+    }
+  }
+
+  function reset(): void {
+    set(fetchedAssetToUsdPrice, '');
+    set(fetchedAssetToFiatPrice, '');
+    set(assetToUsdPrice, '');
+    set(assetToFiatPrice, '');
+    set(fiatValue, '');
+    set(usdValue, '');
+  }
+
+  // Re-fetch whenever the timestamp or asset changes (fetchHistoricPrices
+  // no-ops when there is no asset yet).
+  watchImmediate([(): number => toValue(timestamp), asset], async (): Promise<void> => {
+    await fetchHistoricPrices();
+  });
+
+  watchImmediate(fetchedAssetToUsdPrice, (price) => {
+    set(assetToUsdPrice, price);
+    onAssetToUsdPriceChange(true);
+  });
+
+  watchImmediate(assetToUsdPrice, () => {
+    onAssetToUsdPriceChange();
+  });
+
+  watchImmediate(usdValue, () => {
+    onUsdValueChange();
+  });
+
+  watchImmediate(fetchedAssetToFiatPrice, (price) => {
+    set(assetToFiatPrice, price);
+    onAssetToFiatPriceChanged(true);
+  });
+
+  watchImmediate(assetToFiatPrice, () => {
+    onAssetToFiatPriceChanged();
+  });
+
+  watchImmediate(fiatValue, () => {
+    onFiatValueChange();
+  });
+
+  watchImmediate(amount, () => {
+    if (!get(isCurrentCurrencyUsd)) {
+      onAssetToFiatPriceChanged();
+      onFiatValueChange();
+    }
+
+    onAssetToUsdPriceChange();
+    onUsdValueChange();
+  });
+
+  // The direct rate resolves asynchronously; re-derive the stored USD value once
+  // it is available so a freshly-opened form isn't left with a stale value.
+  watch(usdToFiatRate, () => {
+    syncUsdValueFromFiat();
+  });
+
+  return {
+    // These refs are two-way bound (v-model) by the consuming form, so they
+    // must stay writable rather than be wrapped in readonly().
+    // eslint-disable-next-line @rotki/composable-return-readonly
+    assetToFiatPrice,
+    // eslint-disable-next-line @rotki/composable-return-readonly
+    assetToUsdPrice,
+    currencySymbol,
+    fetching,
+    // eslint-disable-next-line @rotki/composable-return-readonly
+    fiatValue,
+    // eslint-disable-next-line @rotki/composable-return-readonly
+    fiatValueFocused,
+    isCurrentCurrencyUsd,
+    reset,
+    submitPrice,
+  };
+}

--- a/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-total-input.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-total-input.spec.ts
@@ -1,0 +1,119 @@
+import { bigNumberify } from '@rotki/common';
+import { updateGeneralSettings } from '@test/utils/general-settings';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type EffectScope, nextTick, ref, type Ref } from 'vue';
+import { useCurrencies } from '@/modules/assets/amount-display/currencies';
+import { BalanceType } from '@/modules/balances/types/balances';
+import { BalanceSnapshot, LocationDataSnapshot } from '@/modules/dashboard/snapshots';
+import { useSnapshotTotalInput } from '@/modules/dashboard/snapshots/composables/use-snapshot-total-input';
+
+const getHistoricPrice = vi.fn();
+const getIsPending = vi.fn();
+
+// USD -> EUR historic rate of 0.9 at the snapshot timestamp.
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: vi.fn(() => ({
+    createKey: (fromAsset: string, timestamp: number): string => `${fromAsset}#${timestamp}`,
+    getHistoricPrice,
+    getIsPending,
+  })),
+}));
+
+function balance(usdValue: string, category: BalanceType = BalanceType.ASSET, assetIdentifier = 'ETH'): BalanceSnapshot {
+  return BalanceSnapshot.parse({ amount: '1', assetIdentifier, category, timestamp: 1700000000, usdValue });
+}
+
+function location(loc: string, usdValue: string): LocationDataSnapshot {
+  return LocationDataSnapshot.parse({ location: loc, timestamp: 1700000000, usdValue });
+}
+
+describe('modules/dashboard/snapshots/composables/use-snapshot-total-input', () => {
+  const timestamp = 1700000000;
+  let scope: EffectScope;
+
+  function setCurrency(symbol: string): void {
+    const { findCurrency } = useCurrencies();
+    updateGeneralSettings({ mainCurrency: findCurrency(symbol) });
+  }
+
+  function setup(modelValue: Ref<LocationDataSnapshot[]>, balances: BalanceSnapshot[] = []): ReturnType<typeof useSnapshotTotalInput> {
+    let api!: ReturnType<typeof useSnapshotTotalInput>;
+    scope = effectScope();
+    scope.run(() => {
+      api = useSnapshotTotalInput({ balancesSnapshot: () => balances, modelValue, timestamp: () => timestamp });
+    });
+    return api;
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    getHistoricPrice.mockReturnValue(bigNumberify(0.9));
+    getIsPending.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  it('should seed the field from the stored USD total at the historic rate', () => {
+    setCurrency('EUR');
+    const model = ref([location('total', '1000')]);
+    const { total } = setup(model);
+    // 1000 USD * 0.9 = 900 EUR
+    expect(get(total)).toBe('900');
+  });
+
+  it('should convert the entered fiat total back to USD in numericTotal', () => {
+    setCurrency('EUR');
+    const model = ref([location('total', '0')]);
+    const { numericTotal, total } = setup(model);
+    set(total, '900');
+    // 900 EUR / 0.9 = 1000 USD
+    expect(get(numericTotal).toNumber()).toBe(1000);
+  });
+
+  it('should treat the entered total as USD in a USD currency', () => {
+    setCurrency('USD');
+    const model = ref([location('total', '0')]);
+    const { numericTotal, total } = setup(model);
+    set(total, '1000');
+    expect(get(numericTotal).toNumber()).toBe(1000);
+  });
+
+  it('should seed the field from a USD value via setTotal', () => {
+    setCurrency('EUR');
+    const model = ref([location('total', '0')]);
+    const { setTotal, total } = setup(model);
+    setTotal(bigNumberify(1000));
+    expect(get(total)).toBe('900');
+  });
+
+  it('should persist numericTotal into the total row via applyTotal', async () => {
+    setCurrency('EUR');
+    const model = ref([location('blockchain', '700'), location('total', '0')]);
+    const { applyTotal, total } = setup(model);
+    set(total, '900');
+    await nextTick();
+    applyTotal();
+    const totalRow = get(model).find(item => item.location === 'total');
+    expect(totalRow?.usdValue.toNumber()).toBe(1000);
+  });
+
+  it('should suggest a single total when asset and location totals agree', () => {
+    setCurrency('USD');
+    const model = ref([location('blockchain', '100'), location('total', '100')]);
+    const { suggestions } = setup(model, [balance('100')]);
+    expect(get(suggestions)).toEqual({ total: expect.anything() });
+    expect(get(suggestions).total?.toNumber()).toBe(100);
+  });
+
+  it('should suggest asset and location separately when they disagree (USD)', () => {
+    setCurrency('USD');
+    const model = ref([location('blockchain', '70'), location('total', '70')]);
+    const { suggestions } = setup(model, [balance('100')]);
+    expect(get(suggestions).asset?.toNumber()).toBe(100);
+    expect(get(suggestions).location?.toNumber()).toBe(70);
+  });
+});

--- a/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-total-input.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-total-input.ts
@@ -1,0 +1,134 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { BalanceSnapshot, LocationDataSnapshot } from '@/modules/dashboard/snapshots';
+import { assert, type BigNumber, bigNumberify, Zero } from '@rotki/common';
+import { useHistoricFiatConversion } from '@/modules/dashboard/snapshots/composables/use-historic-fiat-conversion';
+import { convertFiatToUsd, convertUsdToFiat } from '@/modules/dashboard/snapshots/lib/snapshot-fx';
+import {
+  assetsTotal,
+  getTotalEntry,
+  locationsTotal,
+  nftsTotal as sumNftsTotal,
+} from '@/modules/dashboard/snapshots/lib/snapshot-totals';
+
+export type TotalSuggestionKey = 'asset' | 'location' | 'total';
+
+interface UseSnapshotTotalInputOptions {
+  /** The location-data rows (two-way; the total step's v-model). */
+  modelValue: Ref<LocationDataSnapshot[]>;
+  /** The balance rows the snapshot's total reconciles against. */
+  balancesSnapshot: MaybeRefOrGetter<BalanceSnapshot[]>;
+  /** The snapshot timestamp, in SECONDS. */
+  timestamp: MaybeRefOrGetter<number>;
+}
+
+interface UseSnapshotTotalInputReturn {
+  /** The total the user enters, in their display currency (the form field). */
+  total: Ref<string>;
+  /** The stored USD total derived from `total` at the historic rate. */
+  numericTotal: ComputedRef<BigNumber>;
+  /** Net USD total excluding NFTs (shown in the warning text). */
+  nftsExcludedTotal: ComputedRef<BigNumber>;
+  /** Calculated totals offered as one-click suggestions. */
+  suggestions: ComputedRef<Partial<Record<TotalSuggestionKey, BigNumber>>>;
+  /** Whether the historic rate lookup is in flight. */
+  fetchingRate: ComputedRef<boolean>;
+  /** Whether the rate is usable (USD, or a positive resolved historic rate). */
+  rateReady: ComputedRef<boolean>;
+  /** Seed the field from a USD value, converting to the display currency. */
+  setTotal: (value?: BigNumber) => void;
+  /** Persist `numericTotal` into the snapshot's `total` location row. */
+  applyTotal: () => void;
+}
+
+/**
+ * Owns the snapshot total-step input: the user enters the grand total in their
+ * display currency, and it is stored in USD using the historic USD -> fiat rate
+ * at the snapshot's timestamp (#12277). Also computes the asset/location
+ * calculated suggestions. Extracted from EditSnapshotTotal so the rate-gated
+ * conversion can be unit-tested without mounting the component.
+ */
+export function useSnapshotTotalInput(
+  options: UseSnapshotTotalInputOptions,
+): UseSnapshotTotalInputReturn {
+  const { balancesSnapshot, modelValue, timestamp } = options;
+
+  const total = shallowRef<string>('');
+
+  const { isUsd, loading: fetchingRate, rate, rateReady } = useHistoricFiatConversion(timestamp);
+
+  const assetTotal = computed<BigNumber>(() => assetsTotal(toValue(balancesSnapshot)));
+  const locationTotal = computed<BigNumber>(() => locationsTotal(get(modelValue)));
+  const nftsTotal = computed<BigNumber>(() => sumNftsTotal(toValue(balancesSnapshot)));
+
+  const numericTotal = computed<BigNumber>(() => {
+    const value = get(total);
+
+    if (value === '')
+      return Zero;
+
+    if (get(isUsd))
+      return bigNumberify(value);
+
+    const currentRate = get(rate);
+    if (!currentRate.isPositive())
+      return Zero;
+
+    return convertFiatToUsd(bigNumberify(value), currentRate);
+  });
+
+  const nftsExcludedTotal = computed<BigNumber>(() => get(numericTotal).minus(get(nftsTotal)));
+
+  const suggestions = computed<Partial<Record<TotalSuggestionKey, BigNumber>>>(() => {
+    const assetTotalValue = get(assetTotal);
+    const locationTotalValue = get(locationTotal);
+
+    if (assetTotalValue.minus(locationTotalValue).abs().lt(1e-8) || !get(isUsd)) {
+      return { total: assetTotalValue };
+    }
+    return { asset: assetTotalValue, location: locationTotalValue };
+  });
+
+  function setTotal(value?: BigNumber): void {
+    assert(value);
+    if (!get(rateReady))
+      return;
+
+    set(total, convertUsdToFiat(value, get(rate)).toFixed());
+  }
+
+  function applyTotal(): void {
+    const newValue = [...get(modelValue)];
+    const totalEntry = getTotalEntry(newValue);
+
+    if (totalEntry)
+      totalEntry.usdValue = get(numericTotal);
+
+    set(modelValue, newValue);
+  }
+
+  // Seed the field from the stored total whenever the rate resolves.
+  watchImmediate(rate, (currentRate): void => {
+    if (!get(rateReady))
+      return;
+
+    const totalEntry = getTotalEntry(get(modelValue));
+    if (totalEntry) {
+      set(total, get(isUsd)
+        ? totalEntry.usdValue.toFixed()
+        : convertUsdToFiat(totalEntry.usdValue, currentRate).toFixed());
+    }
+  });
+
+  return {
+    applyTotal,
+    fetchingRate,
+    nftsExcludedTotal,
+    numericTotal,
+    rateReady,
+    setTotal,
+    suggestions,
+    // Two-way bound (v-model) by the consuming form, so it stays writable.
+    // eslint-disable-next-line @rotki/composable-return-readonly
+    total,
+  };
+}

--- a/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-fx.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-fx.spec.ts
@@ -1,0 +1,38 @@
+import { bigNumberify, One } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { convertFiatToUsd, convertUsdToFiat } from '@/modules/dashboard/snapshots/lib/snapshot-fx';
+
+describe('modules/dashboard/snapshots/lib/snapshot-fx', () => {
+  describe('convertUsdToFiat', () => {
+    it('should multiply the USD value by the rate', () => {
+      expect(convertUsdToFiat(bigNumberify(100), bigNumberify(0.85)).toNumber()).toBe(85);
+    });
+
+    it('should be the identity when the rate is one', () => {
+      expect(convertUsdToFiat(bigNumberify(123.45), One).toNumber()).toBe(123.45);
+    });
+
+    it('should return zero for a zero value', () => {
+      expect(convertUsdToFiat(bigNumberify(0), bigNumberify(0.85)).toNumber()).toBe(0);
+    });
+  });
+
+  describe('convertFiatToUsd', () => {
+    it('should divide the fiat value by the rate', () => {
+      expect(convertFiatToUsd(bigNumberify(85), bigNumberify(0.85)).toNumber()).toBe(100);
+    });
+
+    it('should be the identity when the rate is one', () => {
+      expect(convertFiatToUsd(bigNumberify(123.45), One).toNumber()).toBe(123.45);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('should recover the original USD value', () => {
+      const rate = bigNumberify(0.9234);
+      const usd = bigNumberify(1234.56);
+      const back = convertFiatToUsd(convertUsdToFiat(usd, rate), rate);
+      expect(back.toNumber()).toBeCloseTo(1234.56, 8);
+    });
+  });
+});

--- a/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-fx.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-fx.ts
@@ -1,0 +1,33 @@
+import type { BigNumber } from '@rotki/common';
+
+/**
+ * Snapshot FX helpers.
+ *
+ * Snapshots are stored USD-denominated. Converting to/from the user's display
+ * currency is purely a display/input concern and must use the historic
+ * USD -> fiat rate at the snapshot's timestamp (see #12277), not today's rate.
+ *
+ * These functions are pure: rate in, value out. The caller is responsible for
+ * supplying an appropriate (historic) rate and for short-circuiting when the
+ * display currency already is USD.
+ */
+
+/**
+ * Converts a USD-denominated value into the user's fiat currency.
+ *
+ * @param usdValue the stored USD value
+ * @param rate the USD -> fiat rate at the relevant timestamp
+ */
+export function convertUsdToFiat(usdValue: BigNumber, rate: BigNumber): BigNumber {
+  return usdValue.multipliedBy(rate);
+}
+
+/**
+ * Converts a fiat value entered by the user back into USD for storage.
+ *
+ * @param fiatValue the value in the user's display currency
+ * @param rate the USD -> fiat rate at the relevant timestamp
+ */
+export function convertFiatToUsd(fiatValue: BigNumber, rate: BigNumber): BigNumber {
+  return fiatValue.dividedBy(rate);
+}

--- a/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-location-balance.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-location-balance.spec.ts
@@ -1,0 +1,140 @@
+import type { BalanceSnapshot as BalanceSnapshotType, LocationDataSnapshot as LocationDataSnapshotType, Snapshot } from '@/modules/dashboard/snapshots';
+import { bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { BalanceType } from '@/modules/balances/types/balances';
+import { BalanceSnapshot, LocationDataSnapshot } from '@/modules/dashboard/snapshots';
+import {
+  locationBalanceAfterDelete,
+  locationBalanceAfterEdit,
+} from '@/modules/dashboard/snapshots/lib/snapshot-location-balance';
+
+interface BalanceOptions {
+  usdValue: string;
+  category?: BalanceType;
+  assetIdentifier?: string;
+  amount?: string;
+}
+
+function balance(options: BalanceOptions): BalanceSnapshotType {
+  return BalanceSnapshot.parse({
+    amount: options.amount ?? '1',
+    assetIdentifier: options.assetIdentifier ?? 'ETH',
+    category: options.category ?? BalanceType.ASSET,
+    timestamp: 1700000000,
+    usdValue: options.usdValue,
+  });
+}
+
+function location(loc: string, usdValue: string): LocationDataSnapshotType {
+  return LocationDataSnapshot.parse({ location: loc, timestamp: 1700000000, usdValue });
+}
+
+function snapshot(balances: BalanceSnapshotType[], locations: LocationDataSnapshotType[]): Snapshot {
+  return { balancesSnapshot: balances, locationDataSnapshot: locations };
+}
+
+describe('modules/dashboard/snapshots/lib/snapshot-location-balance', () => {
+  describe('locationBalanceAfterEdit', () => {
+    it('should add a new asset to the existing subtotal', () => {
+      const snap = snapshot([], [location('kraken', '100')]);
+      const result = locationBalanceAfterEdit({
+        category: BalanceType.ASSET,
+        editIndex: null,
+        location: 'kraken',
+        snapshot: snap,
+        usdValue: bigNumberify(40),
+      });
+      expect(result.before.toNumber()).toBe(100);
+      expect(result.after.toNumber()).toBe(140);
+    });
+
+    it('should subtract a new liability from the subtotal', () => {
+      const snap = snapshot([], [location('kraken', '100')]);
+      const result = locationBalanceAfterEdit({
+        category: BalanceType.LIABILITY,
+        editIndex: null,
+        location: 'kraken',
+        snapshot: snap,
+        usdValue: bigNumberify(40),
+      });
+      expect(result.after.toNumber()).toBe(60);
+    });
+
+    it('should start from zero when the location has no row yet', () => {
+      const snap = snapshot([], [location('kraken', '100')]);
+      const result = locationBalanceAfterEdit({
+        category: BalanceType.ASSET,
+        editIndex: null,
+        location: 'binance',
+        snapshot: snap,
+        usdValue: bigNumberify(40),
+      });
+      expect(result.before.toNumber()).toBe(0);
+      expect(result.after.toNumber()).toBe(40);
+    });
+
+    it('should remove the previous balance then add the edited one', () => {
+      // existing asset of 40 in kraken, edited up to 70
+      const snap = snapshot(
+        [balance({ category: BalanceType.ASSET, usdValue: '40' })],
+        [location('kraken', '100')],
+      );
+      const result = locationBalanceAfterEdit({
+        category: BalanceType.ASSET,
+        editIndex: 0,
+        location: 'kraken',
+        snapshot: snap,
+        usdValue: bigNumberify(70),
+      });
+      // 100 - 40 (old) + 70 (new) = 130
+      expect(result.after.toNumber()).toBe(130);
+    });
+
+    it('should handle editing an asset into a liability', () => {
+      const snap = snapshot(
+        [balance({ category: BalanceType.ASSET, usdValue: '40' })],
+        [location('kraken', '100')],
+      );
+      const result = locationBalanceAfterEdit({
+        category: BalanceType.LIABILITY,
+        editIndex: 0,
+        location: 'kraken',
+        snapshot: snap,
+        usdValue: bigNumberify(40),
+      });
+      // 100 - 40 (old asset) - 40 (new liability) = 20
+      expect(result.after.toNumber()).toBe(20);
+    });
+  });
+
+  describe('locationBalanceAfterDelete', () => {
+    it('should remove a deleted asset from the subtotal', () => {
+      const snap = snapshot(
+        [balance({ category: BalanceType.ASSET, usdValue: '40' })],
+        [location('kraken', '100')],
+      );
+      const result = locationBalanceAfterDelete({ index: 0, location: 'kraken', snapshot: snap });
+      expect(result?.before.toNumber()).toBe(100);
+      expect(result?.after.toNumber()).toBe(60);
+    });
+
+    it('should add a deleted liability back to the subtotal', () => {
+      const snap = snapshot(
+        [balance({ category: BalanceType.LIABILITY, usdValue: '40' })],
+        [location('kraken', '100')],
+      );
+      const result = locationBalanceAfterDelete({ index: 0, location: 'kraken', snapshot: snap });
+      expect(result?.after.toNumber()).toBe(140);
+    });
+
+    it('should return null when the location row is missing', () => {
+      const snap = snapshot([balance({ usdValue: '40' })], [location('kraken', '100')]);
+      expect(locationBalanceAfterDelete({ index: 0, location: 'binance', snapshot: snap })).toBeNull();
+    });
+
+    it('should return null when the balance is missing', () => {
+      const snap = snapshot([], [location('kraken', '100')]);
+      expect(locationBalanceAfterDelete({ index: 5, location: 'kraken', snapshot: snap })).toBeNull();
+    });
+  });
+});

--- a/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-location-balance.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-location-balance.ts
@@ -1,0 +1,82 @@
+import type { Snapshot } from '@/modules/dashboard/snapshots';
+import { type BigNumber, bigNumberify, Zero } from '@rotki/common';
+import { BalanceType } from '@/modules/balances/types/balances';
+import { isLiability } from '@/modules/dashboard/snapshots/lib/snapshot-totals';
+
+/**
+ * Snapshot location-balance preview helpers.
+ *
+ * Adding, editing or deleting a balance shifts the subtotal of the location it
+ * belongs to. These pure helpers compute the resulting `{ before, after }`
+ * subtotal so the edit dialog can preview it. The liability sign is the easy
+ * thing to get wrong (an edit subtracts the old contribution then adds the new;
+ * a delete is the inverse of an add), so it lives here under test. All USD.
+ */
+
+export interface LocationBalancePreview {
+  before: BigNumber;
+  after: BigNumber;
+}
+
+/** Sign a balance contributes to a subtotal: +1 for assets, -1 for liabilities. */
+function contributionFactor(category: BalanceType): BigNumber {
+  return bigNumberify(isLiability(category) ? -1 : 1);
+}
+
+/**
+ * The subtotal of `location` after adding or editing a balance there.
+ *
+ * `usdValue`/`category` describe the new balance (USD). When `editIndex` is a
+ * number, the previous balance at that index is removed from the subtotal first
+ * (an edit = remove old + add new). When the location has no row yet, the
+ * preview starts from zero.
+ */
+export function locationBalanceAfterEdit(params: {
+  snapshot: Snapshot;
+  location: string;
+  usdValue: BigNumber;
+  category: BalanceType;
+  editIndex: number | null;
+}): LocationBalancePreview {
+  const { category, editIndex, location, snapshot, usdValue } = params;
+  const locationData = snapshot.locationDataSnapshot.find(item => item.location === location);
+
+  if (!locationData)
+    return { after: usdValue, before: Zero };
+
+  let usdValueDiff = usdValue.multipliedBy(contributionFactor(category));
+
+  const previous = editIndex === null ? undefined : snapshot.balancesSnapshot[editIndex];
+  if (previous)
+    usdValueDiff = usdValueDiff.minus(previous.usdValue.multipliedBy(contributionFactor(previous.category)));
+
+  return {
+    after: locationData.usdValue.plus(usdValueDiff),
+    before: locationData.usdValue,
+  };
+}
+
+/**
+ * The subtotal of `location` after deleting the balance at `index`. Removal is
+ * the inverse of an add, so the contribution sign is negated. Returns `null`
+ * when the location row or the balance is missing.
+ */
+export function locationBalanceAfterDelete(params: {
+  snapshot: Snapshot;
+  location: string;
+  index: number;
+}): LocationBalancePreview | null {
+  const { index, location, snapshot } = params;
+  const locationData = snapshot.locationDataSnapshot.find(item => item.location === location);
+  const balanceData = snapshot.balancesSnapshot[index];
+
+  if (!locationData || !balanceData)
+    return null;
+
+  const usdValueDiff = balanceData.usdValue.multipliedBy(contributionFactor(balanceData.category).negated());
+
+  return {
+    after: locationData.usdValue.plus(usdValueDiff),
+    before: locationData.usdValue,
+  };
+}

--- a/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-mutations.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-mutations.spec.ts
@@ -1,0 +1,89 @@
+import { bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { BalanceType } from '@/modules/balances/types/balances';
+import { BalanceSnapshot, LocationDataSnapshot, type Snapshot } from '@/modules/dashboard/snapshots';
+import { rebuildSnapshotAfterBalanceChange } from '@/modules/dashboard/snapshots/lib/snapshot-mutations';
+
+function balance(usdValue: string, category: BalanceType = BalanceType.ASSET): BalanceSnapshot {
+  return BalanceSnapshot.parse({ amount: '1', assetIdentifier: 'ETH', category, timestamp: 1700000000, usdValue });
+}
+
+function location(loc: string, usdValue: string): LocationDataSnapshot {
+  return LocationDataSnapshot.parse({ location: loc, timestamp: 1700000000, usdValue });
+}
+
+function snapshot(balances: BalanceSnapshot[], locations: LocationDataSnapshot[]): Snapshot {
+  return { balancesSnapshot: balances, locationDataSnapshot: locations };
+}
+
+describe('modules/dashboard/snapshots/lib/snapshot-mutations', () => {
+  it('should update the affected location subtotal and recompute the total', () => {
+    const snap = snapshot(
+      [balance('100')],
+      [location('kraken', '40'), location('total', '40')],
+    );
+    const result = rebuildSnapshotAfterBalanceChange({
+      balancesSnapshot: [balance('100'), balance('70')],
+      location: 'kraken',
+      locationBalance: { after: bigNumberify(110), before: bigNumberify(40) },
+      snapshot: snap,
+      timestamp: 1700000000,
+    });
+
+    expect(result.locationDataSnapshot.find(i => i.location === 'kraken')?.usdValue.toNumber()).toBe(110);
+    // total recomputed from net balances 100 + 70
+    expect(result.locationDataSnapshot.find(i => i.location === 'total')?.usdValue.toNumber()).toBe(170);
+  });
+
+  it('should append a new location row when the location does not exist', () => {
+    const snap = snapshot([balance('100')], [location('total', '100')]);
+    const result = rebuildSnapshotAfterBalanceChange({
+      balancesSnapshot: [balance('100'), balance('50')],
+      location: 'binance',
+      locationBalance: { after: bigNumberify(50), before: bigNumberify(0) },
+      snapshot: snap,
+      timestamp: 1700000000,
+    });
+
+    expect(result.locationDataSnapshot.find(i => i.location === 'binance')?.usdValue.toNumber()).toBe(50);
+    expect(result.locationDataSnapshot.find(i => i.location === 'total')?.usdValue.toNumber()).toBe(150);
+  });
+
+  it('should net liabilities into the recomputed total', () => {
+    const snap = snapshot([], [location('total', '0')]);
+    const result = rebuildSnapshotAfterBalanceChange({
+      balancesSnapshot: [balance('100'), balance('30', BalanceType.LIABILITY)],
+      location: '',
+      locationBalance: null,
+      snapshot: snap,
+      timestamp: 1700000000,
+    });
+
+    expect(result.locationDataSnapshot.find(i => i.location === 'total')?.usdValue.toNumber()).toBe(70);
+  });
+
+  it('should skip the location update when location is empty', () => {
+    const snap = snapshot([balance('100')], [location('kraken', '40'), location('total', '40')]);
+    const result = rebuildSnapshotAfterBalanceChange({
+      balancesSnapshot: [balance('100')],
+      location: '',
+      locationBalance: null,
+      snapshot: snap,
+      timestamp: 1700000000,
+    });
+
+    expect(result.locationDataSnapshot.find(i => i.location === 'kraken')?.usdValue.toNumber()).toBe(40);
+    expect(result.locationDataSnapshot.find(i => i.location === 'total')?.usdValue.toNumber()).toBe(100);
+  });
+
+  it('should not throw when there is no total row', () => {
+    const snap = snapshot([balance('100')], [location('kraken', '40')]);
+    expect(() => rebuildSnapshotAfterBalanceChange({
+      balancesSnapshot: [balance('100')],
+      location: '',
+      locationBalance: null,
+      snapshot: snap,
+      timestamp: 1700000000,
+    })).not.toThrow();
+  });
+});

--- a/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-mutations.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-mutations.ts
@@ -1,0 +1,41 @@
+import type { LocationBalancePreview } from '@/modules/dashboard/snapshots/lib/snapshot-location-balance';
+import type { BalanceSnapshot, Snapshot } from '@/modules/dashboard/snapshots';
+import { assetsTotal, TOTAL_LOCATION } from '@/modules/dashboard/snapshots/lib/snapshot-totals';
+
+/**
+ * Rebuilds a snapshot after its balance rows change (add / edit / delete).
+ *
+ * The affected `location` subtotal is updated to `locationBalance.after` (a new
+ * location row is appended when it doesn't exist yet), and the synthetic
+ * `total` row is recomputed from the net of all balances. All values are USD.
+ *
+ * @param params.snapshot the current snapshot (read for its location rows)
+ * @param params.balancesSnapshot the new balance rows to store
+ * @param params.location the location whose subtotal changed ('' to skip)
+ * @param params.locationBalance the `{ before, after }` for that location
+ * @param params.timestamp the snapshot timestamp (for a newly created row)
+ */
+export function rebuildSnapshotAfterBalanceChange(params: {
+  snapshot: Snapshot;
+  balancesSnapshot: BalanceSnapshot[];
+  location: string;
+  locationBalance: LocationBalancePreview | null;
+  timestamp: number;
+}): Snapshot {
+  const { balancesSnapshot, location, locationBalance, snapshot, timestamp } = params;
+  const locationDataSnapshot = [...snapshot.locationDataSnapshot];
+
+  if (location && locationBalance) {
+    const locationDataIndex = locationDataSnapshot.findIndex(item => item.location === location);
+    if (locationDataIndex > -1)
+      locationDataSnapshot[locationDataIndex].usdValue = locationBalance.after;
+    else
+      locationDataSnapshot.push({ location, timestamp, usdValue: locationBalance.after });
+  }
+
+  const totalDataIndex = locationDataSnapshot.findIndex(item => item.location === TOTAL_LOCATION);
+  if (totalDataIndex > -1)
+    locationDataSnapshot[totalDataIndex].usdValue = assetsTotal(balancesSnapshot);
+
+  return { balancesSnapshot, locationDataSnapshot };
+}

--- a/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-totals.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-totals.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { BalanceType } from '@/modules/balances/types/balances';
+import { BalanceSnapshot, LocationDataSnapshot } from '@/modules/dashboard/snapshots';
+import {
+  assetsTotal,
+  getTotalEntry,
+  getTotalValue,
+  locationsTotal,
+  nftsTotal,
+  signedUsdValue,
+  TOTAL_LOCATION,
+} from '@/modules/dashboard/snapshots/lib/snapshot-totals';
+
+interface BalanceOptions {
+  usdValue: string;
+  category?: BalanceType;
+  assetIdentifier?: string;
+  amount?: string;
+}
+
+function balance(options: BalanceOptions): BalanceSnapshot {
+  return BalanceSnapshot.parse({
+    amount: options.amount ?? '1',
+    assetIdentifier: options.assetIdentifier ?? 'ETH',
+    category: options.category ?? BalanceType.ASSET,
+    timestamp: 1700000000,
+    usdValue: options.usdValue,
+  });
+}
+
+function location(loc: string, usdValue: string): LocationDataSnapshot {
+  return LocationDataSnapshot.parse({ location: loc, timestamp: 1700000000, usdValue });
+}
+
+describe('modules/dashboard/snapshots/lib/snapshot-totals', () => {
+  it('should add assets and subtract liabilities in signedUsdValue', () => {
+    expect(signedUsdValue(balance({ category: BalanceType.ASSET, usdValue: '100' })).toNumber()).toBe(100);
+    expect(signedUsdValue(balance({ category: BalanceType.LIABILITY, usdValue: '30' })).toNumber()).toBe(-30);
+  });
+
+  it('should net assets against liabilities in assetsTotal', () => {
+    const snapshot = [
+      balance({ category: BalanceType.ASSET, usdValue: '100' }),
+      balance({ category: BalanceType.ASSET, usdValue: '50' }),
+      balance({ category: BalanceType.LIABILITY, usdValue: '30' }),
+    ];
+    expect(assetsTotal(snapshot).toNumber()).toBe(120);
+  });
+
+  it('should return zero from assetsTotal for an empty snapshot', () => {
+    expect(assetsTotal([]).toNumber()).toBe(0);
+  });
+
+  it('should only count NFT balances in nftsTotal', () => {
+    const snapshot = [
+      balance({ assetIdentifier: 'ETH', usdValue: '100' }),
+      balance({ assetIdentifier: '_nft_0xabc_1', usdValue: '40' }),
+      balance({ assetIdentifier: '_nft_0xabc_2', category: BalanceType.LIABILITY, usdValue: '10' }),
+    ];
+    expect(nftsTotal(snapshot).toNumber()).toBe(30);
+  });
+
+  it('should sum only non-total rows in locationsTotal', () => {
+    const rows = [
+      location('blockchain', '70'),
+      location('kraken', '50'),
+      location(TOTAL_LOCATION, '120'),
+    ];
+    expect(locationsTotal(rows).toNumber()).toBe(120);
+  });
+
+  it('should find the total entry and read its value', () => {
+    const rows = [location('kraken', '50'), location(TOTAL_LOCATION, '120')];
+    expect(getTotalEntry(rows)?.usdValue.toNumber()).toBe(120);
+    expect(getTotalValue(rows).toNumber()).toBe(120);
+  });
+
+  it('should return zero from getTotalValue when there is no total row', () => {
+    expect(getTotalValue([location('kraken', '50')]).toNumber()).toBe(0);
+    expect(getTotalEntry([location('kraken', '50')])).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-totals.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/lib/snapshot-totals.ts
@@ -1,0 +1,68 @@
+import type { BalanceSnapshot, LocationDataSnapshot } from '@/modules/dashboard/snapshots';
+import { type BigNumber, Zero } from '@rotki/common';
+import { isNft } from '@/modules/assets/nft-utils';
+import { BalanceType } from '@/modules/balances/types/balances';
+import { bigNumberSum } from '@/modules/core/common/data/calculation';
+
+/**
+ * Snapshot total helpers.
+ *
+ * Snapshots are USD-denominated. A snapshot's location rows include a synthetic
+ * `total` row that must equal the sum of the real location rows (and of the
+ * net balances). These helpers centralise that aggregation — previously
+ * re-implemented inline in the balances table, the location table and the
+ * total step — so the "subtotals sum to the total" invariant lives in one
+ * tested place. All returned values are USD.
+ */
+
+/**
+ * The synthetic location row holding the snapshot's grand total. It is excluded
+ * from location aggregations and is what real location rows must sum to.
+ */
+export const TOTAL_LOCATION = 'total';
+
+/** Whether a balance subtracts from (rather than adds to) a net total. */
+export function isLiability(category: BalanceType): boolean {
+  return category === BalanceType.LIABILITY;
+}
+
+/**
+ * Signed USD contribution of a balance to a net total: assets add, liabilities
+ * subtract.
+ */
+export function signedUsdValue(item: Pick<BalanceSnapshot, 'category' | 'usdValue'>): BigNumber {
+  return isLiability(item.category) ? item.usdValue.negated() : item.usdValue;
+}
+
+/** Net USD total of all balances (assets minus liabilities). */
+export function assetsTotal(balancesSnapshot: BalanceSnapshot[]): BigNumber {
+  return bigNumberSum(balancesSnapshot.map(signedUsdValue));
+}
+
+/** Net USD total of the NFT balances only (assets minus liabilities). */
+export function nftsTotal(balancesSnapshot: BalanceSnapshot[]): BigNumber {
+  return bigNumberSum(
+    balancesSnapshot.map(item => (isNft(item.assetIdentifier) ? signedUsdValue(item) : Zero)),
+  );
+}
+
+/** Sum of the real (non-`total`) location rows, in USD. */
+export function locationsTotal(locationDataSnapshot: LocationDataSnapshot[]): BigNumber {
+  return bigNumberSum(
+    locationDataSnapshot
+      .filter(item => item.location !== TOTAL_LOCATION)
+      .map(item => item.usdValue),
+  );
+}
+
+/** The synthetic `total` location row, if present. */
+export function getTotalEntry(
+  locationDataSnapshot: LocationDataSnapshot[],
+): LocationDataSnapshot | undefined {
+  return locationDataSnapshot.find(item => item.location === TOTAL_LOCATION);
+}
+
+/** USD value of the `total` location row, or `Zero` when it is absent. */
+export function getTotalValue(locationDataSnapshot: LocationDataSnapshot[]): BigNumber {
+  return getTotalEntry(locationDataSnapshot)?.usdValue ?? Zero;
+}


### PR DESCRIPTION
Fixes #12277.

## What

When editing a balance snapshot in a **non-USD main currency**, the editor now converts every value using the historic exchange rate of the snapshot's own date instead of today's rate, both for what is **displayed** and what is **saved**.

## Why it mattered

Snapshots are stored USD-denominated, so showing/editing them in a non-USD currency requires the rate that applied *at the snapshot's time*. The editor was using today's rate, so the values you saw and saved were wrong. A related divergence affected **fiat-pegged assets** (e.g. EUR stablecoins like aGnoEURe): their oracle USD price differs from the direct forex rate by a small basis, and that wrong value was being **persisted** into the location subtotal and total. The editor now stores/displays through the single direct historic `USD -> main-currency` rate, so the round-trip is exact for any pegged asset in any non-USD currency.

## Changes

- Convert at the historic rate across the balances rows/total, location rows/total, the total step (suggestions + warning), and the location-balance previews.
- Drive the stored USD value from the fiat input via the same direct rate the display uses (fixes the pegged-asset divergence).
- Extract the FX logic into tested units: `snapshot-fx`, `snapshot-totals`, `snapshot-location-balance`, `snapshot-mutations`, `use-historic-fiat-conversion`, `use-snapshot-asset-price`, `use-snapshot-total-input`, plus a `SnapshotFiatDisplay` wrapper.
- Split the ~466-line balance table into focused add/edit (`EditBalancesSnapshotEntryDialog`) and delete (`EditBalancesSnapshotDeleteDialog`) dialog components.
- Remove a vestigial unused `value` field from the `BalanceSnapshot` schema (backend never sends it; nothing reads it).

## Testing

- Unit tests added for all new libs/composables (incl. EUR-pegged and GBP-pegged round-trip cases); full frontend unit suite green.
- Manually verified in the running app against the live API: e.g. 15000 aGnoEURe entered in EUR persists as the correct USD value that round-trips back to the entered EUR.
- The existing `snapshot-edit.spec.ts` e2e covers the USD edit/save path (runs in CI).

## Notes

- A sub-1e-22 decimal drift from the USD round-trip remains (inherent to storing USD + converting back via division); it is below any meaningful precision and only visible under ROUND_DOWN at high display precision. Deliberately not "fixed" by rounding stored values, to keep subtotals reconciling with the total.