### PR TITLE
fix: correct PnL report greenlet-yield throttle

### DIFF
--- a/rotkehlchen/accounting/accountant.py
+++ b/rotkehlchen/accounting/accountant.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Sequence
 from pathlib import Path
+from time import monotonic
 from typing import TYPE_CHECKING
 
 import gevent
@@ -160,6 +161,7 @@ class Accountant:
             actions_length = len(events)
             prev_time = last_event_ts = Timestamp(0)
             ignored_ids = self.db.get_ignored_action_ids(cursor=cursor)
+            last_yield = monotonic()
 
         events_iter = peekable(events)
         while True:
@@ -210,11 +212,17 @@ class Accountant:
                 break  # we reached the period end
 
             last_event_ts = prev_time
-            if count % 500 == 0:
+            if monotonic() - last_yield > 0.1:
                 # This loop can take a very long time depending on the amount of events
-                # to process. We need to yield to other greenlets or else calls to the
-                # API may time out
-                gevent.sleep(0.5)
+                # to process. We need to periodically yield to other greenlets or else
+                # calls to the API may time out. A positive sleep value is required: it
+                # forces a full event-loop cycle (including the I/O poll) so greenlets
+                # blocked on socket I/O -- like the API server -- actually get to run.
+                # gevent.sleep(0) does NOT guarantee this and starves the API. The
+                # wall-clock cadence (vs an event count) keeps the overhead a fixed
+                # fraction of report time regardless of how long individual events take.
+                gevent.sleep(0.01)
+                last_yield = monotonic()
             count += processed_events_num
             if not active_premium and count >= FREE_PNL_EVENTS_LIMIT:
                 log.debug(


### PR DESCRIPTION
The accounting per-event loop yields to other greenlets so the API stays responsive during long PnL reports. The throttle regressed: in 2020 it was 'if count % 500 == 0: gevent.sleep(0.5)' with 'count += 1', firing exactly every 500 events. In 2022 'count += 1' became 'count += processed_events_num' (needed for the free-tier event limit), so count jumps in steps of 2-4 and rarely lands on a multiple of 500 -> the yield fires erratically and the loop under-yields, risking API timeouts during big reports.

Replace the event-count throttle with a wall-clock one: yield when >100ms have elapsed since the last yield, sleeping 0.01s. A positive sleep is required -- it forces a full event-loop cycle (incl. the I/O poll) so greenlets blocked on socket I/O (the API server) actually run; gevent.sleep(0) does not guarantee this. Wall-clock cadence keeps the overhead a fixed fraction of report time regardless of how long individual events take.

Measured (60k events, ~6s pure processing, real gevent server + report greenlet sharing one hub, probed by an independent OS thread):

  strategy              report   api_p50  api_p99  api_max  served
  idle baseline            -       0.4ms    0.8ms    0.8ms     40
  none (never yield)      6.02s     -        -        -      0 reqs
  sleep(0)   every 500    6.35s  2515ms   2723ms   2723ms   2 reqs
  sleep(0.5) every 500   66.3s     0.4ms   41ms     46ms    2400
  sleep(0.05) every 500  12.2s    41ms     59ms     61ms     240
  sleep(0.01) every 500   7.38s   31ms     47ms     47ms     120
  sleep(0)   timed@100ms  6.59s  5100ms   5100ms   5100ms   1 req
  sleep(0.01) timed@100ms 6.73s   80ms     81ms     95ms      60

- gevent.sleep(0) starves the API (1-2 reqs served in 6s, multi-second latency) -> a positive value is required.
- sleep(0.5) is an 11x report slowdown for no gain over sleep(0.01).
- wall-clock sleep(0.01)@100ms: ~12% overhead, API p99 ~81ms, 0 timeouts.
