### PR TITLE
perf: skip redundant re-walk of serialized history events

### DIFF
--- a/rotkehlchen/api/services/history.py
+++ b/rotkehlchen/api/services/history.py
@@ -51,6 +51,7 @@ from rotkehlchen.premium.premium import (
     has_premium_capability,
     has_premium_check,
 )
+from rotkehlchen.serialization.serialize import PreSerializedList
 from rotkehlchen.types import (
     EVM_CHAIN_IDS_WITH_TRANSACTIONS,
     EVM_CHAINS_WITH_TRANSACTIONS,
@@ -405,7 +406,9 @@ class HistoryService:
             ([None] * len(processed_events_result), processed_events_result)
         )
         result = {
-            'entries': self._serialize_and_group_history_events(
+            # entries are already serialized to JSON primitives, so wrap them to skip
+            # the redundant process_result re-walk of the whole (potentially huge) list
+            'entries': PreSerializedList(self._serialize_and_group_history_events(
                 events=events,
                 aggregate_by_group_ids=aggregate_by_group_ids,
                 event_accounting_rule_statuses=query_missing_accounting_rules(
@@ -421,7 +424,7 @@ class HistoryService:
                 hidden_event_ids=hidden_event_ids,
                 joined_group_ids=joined_group_ids,
                 group_has_ignored_assets=group_has_ignored_assets,
-            ),
+            )),
             'entries_found': entries_with_limit,
             'entries_limit': entries_limit,
             'entries_total': entries_total,

--- a/rotkehlchen/serialization/serialize.py
+++ b/rotkehlchen/serialization/serialize.py
@@ -63,6 +63,18 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.version_check import VersionCheckResult
 
 
+class PreSerializedList(list):  # noqa: FURB189  # we want a genuine list subclass (not UserList) so json.dumps serializes it natively and isinstance(x, list) holds; it adds no methods, just acts as a marker type
+    """A list whose elements are already plain JSON primitives (produced by the
+    objects' own ``serialize()``). ``process_result`` returns it untouched instead
+    of recursively re-walking and rebuilding it, which for large payloads (e.g. a
+    full page of history events) avoids a redundant deep copy of the whole list.
+
+    It subclasses ``list`` so that even on a code path that does not pass through
+    ``process_result`` ``json.dumps`` still serializes it correctly as a normal
+    array rather than raising.
+    """
+
+
 def _process_dict(entry: dict) -> dict:
     new_dict = {}
     for k, v in entry.items():
@@ -156,6 +168,8 @@ HANDLERS.update(dict.fromkeys((
     DefiProtocolBalances,
     BlockchainAccountData,
 ), lambda x: _process_dict(x._asdict())))
+# already JSON-ready: return as-is and skip the (expensive) recursive re-walk
+HANDLERS[PreSerializedList] = lambda x: x
 
 
 def _process_entry(entry: Any) -> str | (list[Any] | (dict[str, Any] | Any)):

--- a/rotkehlchen/tests/unit/test_serialization.py
+++ b/rotkehlchen/tests/unit/test_serialization.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,6 +20,7 @@ from rotkehlchen.serialization.deserialize import (
     deserialize_int_from_hex_or_int,
 )
 from rotkehlchen.serialization.schemas import ExportedAssetsSchema
+from rotkehlchen.serialization.serialize import PreSerializedList, process_result
 from rotkehlchen.types import (
     ChainID,
     EvmTransaction,
@@ -47,6 +49,29 @@ def test_rlk_jsondumps():
         '{"a": "5.4", "b": "foo", "c": "32.1", "d": 5, '
         '"e": [1, "a", "5.1"], "f": "ETH", "BTC": "test_with_asset_key"}'
     )
+
+
+def test_pre_serialized_list_skips_rewalk() -> None:
+    """A PreSerializedList must be returned untouched by process_result (no deep
+    re-walk) while producing byte-identical json to walking a plain list. This guards
+    the history-events hot path where the entries are already JSON primitives -- note
+    extra_data can hold floats (it is json.loads'd from the DB), so the output must
+    match plain json.dumps and not go through an FVal-only encoder.
+    """
+    entries = [
+        {'entry': {'identifier': 1, 'asset': 'BTC', 'amount': '0.5', 'extra_data': {'ratio': 1.5, 'x': None}}, 'hidden': True},  # noqa: E501
+        [  # a grouped sub-list of events
+            {'entry': {'identifier': 2, 'asset': 'ETH', 'amount': '3'}, 'states': [0, 1]},
+            {'entry': {'identifier': 3, 'asset': 'ETH', 'amount': '1', 'extra_data': {'n': 2}}},
+        ],
+    ]
+    marker = PreSerializedList(entries)
+    processed = process_result({'result': {'entries': marker, 'entries_found': 2}, 'message': ''})
+    # the wrapped list is the very same object -> no rebuild/deep copy happened
+    assert processed['result']['entries'] is marker
+    # and the emitted json is identical to re-walking a plain list
+    plain = process_result({'result': {'entries': entries, 'entries_found': 2}, 'message': ''})
+    assert json.dumps(plain) == json.dumps(processed)
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])


### PR DESCRIPTION
The history-events response (GET /history/events) builds its 'entries' list from each event's serialize()/serialize_for_api(), which already produces plain JSON primitives. The response path then runs process_result over the whole response, recursively re-walking and rebuilding every event dict, before api_response json.dumps it -- a second full pass over data that is already JSON-ready. For large pages/exports this is a redundant deep copy of the entire list (benchmarked ~7x serialization cost on a 5k-event payload).

Add PreSerializedList, a list subclass marker registered in process_result's HANDLERS so it is returned untouched (no deep re-walk), and wrap the history events 'entries' in it. The sibling count fields still go through process_result normally. Both the sync (make_response_from_dict) and async (task outcome) paths funnel through process_result, so both benefit.

Note plain json.dumps is kept (not RKLEncoder): extra_data is json.loads'd from the DB and can contain floats, which RKLEncoder rejects but process_result and plain json.dumps pass through. Output is byte-identical to before.

PreSerializedList subclasses list (not UserList) on purpose so json.dumps serializes it natively and isinstance(x, list) still holds even on a path that skips process_result.

Verified byte-identical output (incl. extra_data floats and nested groups), object identity (no rebuild), and end-to-end via the history events API tests.
