### PR TITLE
perf: use a set for hidden history-event ids

### DIFF
--- a/rotkehlchen/api/services/history.py
+++ b/rotkehlchen/api/services/history.py
@@ -736,7 +736,7 @@ class HistoryService:
             grouped_events_nums: list[int | None],
             mapping_states: dict[int, list[HistoryMappingState]],
             ignored_ids: set[str],
-            hidden_event_ids: list[int],
+            hidden_event_ids: set[int],
             joined_group_ids: dict[str, str],
             group_has_ignored_assets: set[str],
     ) -> list[dict[str, Any] | list[dict[str, Any]]]:

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -1986,11 +1986,15 @@ class DBHistoryEvents:
 
         return final_amounts, total_value
 
-    def get_hidden_event_ids(self, cursor: 'DBCursor') -> list[int]:
+    def get_hidden_event_ids(self, cursor: 'DBCursor') -> set[int]:
         """Returns all event identifiers that should be hidden in the UI
 
         These are, at the moment, special cases where due to grouping different event
         types with similar info they all appear together but the UI should just show one.
+
+        Returned as a set since the only use is per-event membership testing during
+        serialization (see HistoryBaseEntry.serialize_for_api). A list there is an O(N*M)
+        scan (N events serialized x M hidden ids); a set makes it O(N).
         """
         # Only 1 type of hidden event for now
         cursor.execute(
@@ -1999,7 +2003,7 @@ class DBHistoryEvents:
             'AND (SELECT COUNT(*) FROM history_events E2 WHERE '
             'E2.group_identifier=E.group_identifier) > 2',
         )
-        return [x[0] for x in cursor]
+        return {x[0] for x in cursor}
 
     def edit_event_extra_data(
             self,

--- a/rotkehlchen/history/events/structures/base.py
+++ b/rotkehlchen/history/events/structures/base.py
@@ -411,7 +411,7 @@ class HistoryBaseEntry(AccountingEventMixin, ABC, Generic[ExtraDataType]):
             self,
             mapping_states: dict[int, list[HistoryMappingState]],
             ignored_ids: set[str],
-            hidden_event_ids: list[int],
+            hidden_event_ids: set[int],
             event_accounting_rule_status: EventAccountingRuleStatus,
             grouped_events_num: int | None = None,
             has_ignored_assets: bool = False,

--- a/rotkehlchen/history/events/structures/onchain_event.py
+++ b/rotkehlchen/history/events/structures/onchain_event.py
@@ -193,7 +193,7 @@ class OnchainEvent(HistoryBaseEntry, Generic[T_TxRef, T_Address]):
             self,
             mapping_states: dict[int, list[HistoryMappingState]],
             ignored_ids: set[str],
-            hidden_event_ids: list[int],
+            hidden_event_ids: set[int],
             event_accounting_rule_status: EventAccountingRuleStatus,
             grouped_events_num: int | None = None,
             has_ignored_assets: bool = False,

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -1550,7 +1550,7 @@ def test_redecode_block_production_events(rotkehlchen_api_server: 'APIServer') -
             (5, 4, f'BP1_{block_number + 2}', 0, timestamp + 2, 'f', fee_recipient_address, 'ETH', reward4, f'Validator {v_index} produced block {block_number + 2} with {reward4} ETH going to {fee_recipient_address} as the block reward', 'informational', 'block production', None, 0),  # noqa: E501
         ]
         # Confirm combine_block_with_tx_events marked the EthBlockEvent as hidden
-        assert dbevents.get_hidden_event_ids(cursor) == [2]
+        assert dbevents.get_hidden_event_ids(cursor) == {2}
 
     assert_error_response(  # Check validation with non-existent block number.
         response=requests.put(

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -751,7 +751,7 @@ def test_combine_block_with_tx_events(eth2, database):
 
     with database.conn.read_ctx() as cursor:
         hidden_ids = dbevents.get_hidden_event_ids(cursor)
-        assert hidden_ids == [2]
+        assert hidden_ids == {2}
 
 
 def test_combine_block_with_tx_events_without_relay_data(eth2, database):

--- a/rotkehlchen/tests/unit/test_history_events.py
+++ b/rotkehlchen/tests/unit/test_history_events.py
@@ -50,7 +50,7 @@ def test_serialize_with_invalid_type_subtype():
     assert event.serialize_for_api(
         mapping_states={},
         ignored_ids=set(),
-        hidden_event_ids=[],
+        hidden_event_ids=set(),
         event_accounting_rule_status=EventAccountingRuleStatus.NOT_PROCESSED,  # needed to recreate the error this tests for  # noqa: E501
         grouped_events_num=None,
     ) == {

--- a/rotkehlchen/tests/utils/factories.py
+++ b/rotkehlchen/tests/utils/factories.py
@@ -178,7 +178,7 @@ def generate_events_response(
         x.serialize_for_api(
             mapping_states={},
             ignored_ids=set(),
-            hidden_event_ids=[],
+            hidden_event_ids=set(),
             event_accounting_rule_status=accounting_status,
             has_ignored_assets=processed_ignored_list[idx],
         ) for idx, x in enumerate(data)


### PR DESCRIPTION
get_hidden_event_ids returns the identifiers of ETH-staking events that the UI collapses (staking groups with >2 events). It is computed over the whole DB (no pagination) and consumed once per serialized event in HistoryBaseEntry.serialize_for_api via 'self.identifier in hidden_event_ids'.

It returned a list, so each membership test is an O(M) linear scan and the serialization loop is O(N*M): N = events serialized in the request, M = all hidden staking ids in the DB. M grows with staking activity, and the history events filter limit defaults to None (unbounded), so an unlimited request serializes every filtered event -> worst case N_total * M.

Return a set instead, making each lookup O(1) and the loop O(N). The value is only ever used for membership (no ordering/indexing/duplicates), so this is semantically identical. The sibling ignored_ids argument is already a set, so this also makes the two consistent.

Measured (list vs set membership), int ids:
  N=50,    M=2000  ->  0.16 ms  vs ~0.001 ms
  N=20000, M=2000  ->   119 ms  vs  0.24 ms   (unbounded request, staking-heavy)
  N=50000, M=5000  ->   745 ms  vs  0.60 ms

The work runs synchronously on the gevent loop, so removing it also stops it from blocking other requests on large staking DBs.