### PR TITLE
perf: scope history-event state/hidden lookups to the page

### DIFF
--- a/rotkehlchen/api/services/history.py
+++ b/rotkehlchen/api/services/history.py
@@ -362,11 +362,6 @@ class HistoryService:
                 entries_table='history_events',
                 group_by='group_identifier' if aggregate_by_group_ids else None,
             )
-            event_mapping_states = dbevents.get_event_mapping_states(
-                cursor=cursor,
-                location=filter_query.location,
-            )
-            hidden_event_ids = dbevents.get_hidden_event_ids(cursor)
             ignored_ids = self.rotkehlchen.data.db.get_ignored_action_ids(cursor=cursor)
             # entries_total is the unfiltered row/group count for the whole table. If it is
             # already at or below the tier limit then the filtered count must also be, so the
@@ -388,6 +383,25 @@ class HistoryService:
                 joined_group_ids.get(group_identifier, group_identifier)
                 for group_identifier in ignored_group_identifiers
             }
+            grouped_events_nums: list[int | None]
+            events: list[HistoryBaseEntry]
+            grouped_events_nums, events = (
+                zip(*processed_events_result, strict=False)  # type: ignore
+                if aggregate_by_group_ids is True and len(processed_events_result) != 0 else
+                ([None] * len(processed_events_result), processed_events_result)
+            )
+            # mapping states and hidden ids are only needed for the events of this page, so
+            # scope the lookups to them instead of scanning those tables for the whole DB
+            event_identifiers = [event.identifier for event in events if event.identifier is not None]  # noqa: E501
+            event_mapping_states = dbevents.get_event_mapping_states(
+                cursor=cursor,
+                location=filter_query.location,
+                entry_identifiers=event_identifiers,
+            )
+            hidden_event_ids = dbevents.get_hidden_event_ids(
+                cursor=cursor,
+                entry_identifiers=event_identifiers,
+            )
 
         accountant_pot = AccountingPot(
             database=self.rotkehlchen.data.db,
@@ -397,13 +411,6 @@ class HistoryService:
             ]),
             msg_aggregator=self.rotkehlchen.msg_aggregator,
             is_dummy_pot=True,
-        )
-        grouped_events_nums: list[int | None]
-        events: list[HistoryBaseEntry]
-        grouped_events_nums, events = (
-            zip(*processed_events_result, strict=False)  # type: ignore
-            if aggregate_by_group_ids is True and len(processed_events_result) != 0 else
-            ([None] * len(processed_events_result), processed_events_result)
         )
         result = {
             # entries are already serialized to JSON primitives, so wrap them to skip

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -936,6 +936,7 @@ class DBHistoryEvents:
             cursor: 'DBCursor',
             location: Location | None,
             mapping_state: HistoryMappingState,
+            entry_identifiers: Sequence[int] | None = None,
     ) -> list[int]:
         ...
 
@@ -945,6 +946,7 @@ class DBHistoryEvents:
             cursor: 'DBCursor',
             location: Location | None,
             mapping_state: None = None,
+            entry_identifiers: Sequence[int] | None = None,
     ) -> dict[int, list[HistoryMappingState]]:
         ...
 
@@ -953,10 +955,29 @@ class DBHistoryEvents:
             cursor: 'DBCursor',
             location: Location | None,
             mapping_state: HistoryMappingState | None = None,
+            entry_identifiers: Sequence[int] | None = None,
     ) -> dict[int, list[HistoryMappingState]] | list[int]:
         """Get the mapping states of each event in the database that has a mapping state,
-        optionally filtered by Location or
+        optionally filtered by Location.
+
+        If entry_identifiers is given the lookup is scoped to those events (e.g. a single
+        page) instead of scanning the whole name='state' mappings table, which can grow
+        large (matched asset movements, customized and csv-imported events all live there).
+        Only supported for the dict (mapping_state is None) variant.
         """
+        if entry_identifiers is not None:
+            assert mapping_state is None, 'entry_identifiers scoping is only for the dict variant'
+            scoped_states: dict[int, list[HistoryMappingState]] = defaultdict(list)
+            for chunk, placeholders in get_query_chunks(entry_identifiers):
+                for identifier, state_value in cursor.execute(
+                    f'SELECT parent_identifier, value FROM history_events_mappings '
+                    f'WHERE name=? AND parent_identifier IN ({placeholders})',
+                    (HISTORY_MAPPING_KEY_STATE, *chunk),
+                ):
+                    scoped_states[identifier].append(HistoryMappingState(state_value))
+
+            return scoped_states
+
         where_str = 'A.name = ? '
         bindings: list[Any] = [HISTORY_MAPPING_KEY_STATE]
         if mapping_state is not None:
@@ -1986,24 +2007,43 @@ class DBHistoryEvents:
 
         return final_amounts, total_value
 
-    def get_hidden_event_ids(self, cursor: 'DBCursor') -> set[int]:
-        """Returns all event identifiers that should be hidden in the UI
+    def get_hidden_event_ids(
+            self,
+            cursor: 'DBCursor',
+            entry_identifiers: Sequence[int] | None = None,
+    ) -> set[int]:
+        """Returns the event identifiers that should be hidden in the UI
 
         These are, at the moment, special cases where due to grouping different event
         types with similar info they all appear together but the UI should just show one.
+
+        If entry_identifiers is given the search is scoped to those events (e.g. a single
+        page) instead of the whole DB; otherwise every hidden event in the DB is returned.
 
         Returned as a set since the only use is per-event membership testing during
         serialization (see HistoryBaseEntry.serialize_for_api). A list there is an O(N*M)
         scan (N events serialized x M hidden ids); a set makes it O(N).
         """
-        # Only 1 type of hidden event for now
-        cursor.execute(
+        # Only 1 type of hidden event for now: the sequence_index=1 eth staking event of a
+        # staking group with more than 2 events. The COUNT subquery is over the whole group
+        # (correct regardless of scoping) since group membership does not depend on the page.
+        base_query = (
             'SELECT E.identifier FROM history_events E LEFT JOIN eth_staking_events_info S '
-            'ON E.identifier=S.identifier WHERE E.sequence_index=1 AND S.identifier IS NOT NULL '
-            'AND (SELECT COUNT(*) FROM history_events E2 WHERE '
-            'E2.group_identifier=E.group_identifier) > 2',
+            'ON E.identifier=S.identifier WHERE {extra}E.sequence_index=1 '
+            'AND S.identifier IS NOT NULL AND (SELECT COUNT(*) FROM history_events E2 WHERE '
+            'E2.group_identifier=E.group_identifier) > 2'
         )
-        return {x[0] for x in cursor}
+        if entry_identifiers is None:
+            return {x[0] for x in cursor.execute(base_query.format(extra=''))}
+
+        hidden: set[int] = set()
+        for chunk, placeholders in get_query_chunks(entry_identifiers):
+            hidden.update(x[0] for x in cursor.execute(
+                base_query.format(extra=f'E.identifier IN ({placeholders}) AND '),
+                tuple(chunk),
+            ))
+
+        return hidden
 
     def edit_event_extra_data(
             self,


### PR DESCRIPTION
On every GET /history/events request, get_event_mapping_states and get_hidden_event_ids were run over the whole DB before the page was even fetched. get_event_mapping_states built a dict of every event carrying a name='state' mapping (CUSTOMIZED, PROFIT_ADJUSTMENT, MATCHED and IMPORTED_FROM_CSV all live there, so this grows large on csv-imported or asset-movement-heavy DBs) and get_hidden_event_ids scanned all eth staking events with a per-row COUNT subquery -- yet only the current page's ~10-50 identifiers are ever consulted during serialization.

Reorder get_history_events to fetch the page first, then look up mapping states and hidden ids scoped to that page's event identifiers via an added optional entry_identifiers argument (chunked with get_query_chunks for unbounded pages). The full-DB paths are kept as the default for the other callers and tests. The group-membership COUNT in the hidden-ids query stays over the whole group, so scoping by the page's ids is correct (a hidden event must be on the page to be serialized and need the flag).

Synthetic benchmark (50-event page, building the state dict):
   5000 state-rows ->  2.25 ms full  vs 0.045 ms scoped (~50x)
  50000 state-rows -> 26.30 ms full  vs 0.047 ms scoped (~565x)
 200000 state-rows -> 113.5 ms full  vs 0.048 ms scoped (~2353x)

The scoped lookups are page-size bound (roughly constant) instead of growing with total DB size, and this work runs synchronously on the gevent loop.

Validated end-to-end via test_query_transactions_check_decoded_events (asserts a customized event's 'states' appears in the response) plus the history events and db mapping-state tests.