### PR TITLE
fix: recover Gnosis Pay admins for frozen old safes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 
 * :feature:`12301` You can now reset all accounting rules back to rotki's defaults from the accounting rules settings, undoing any customizations in a single action.
+* :bug:`-` Older Gnosis Pay safes frozen by Gnosis Pay's post-hack migration can now be re-authenticated again, instead of failing with "No Gnosis Pay safe accounts are registered in rotki".
 * :bug:`12348` User exchange balance queries should no longer hit the Unsupportedasset errors.
 * :bug:`-` A deposit or withdrawal manually matched to multiple on-chain transactions is no longer duplicated in the history view when filtering by chain.
 * :bug:`-` LP, wrapped and vault tokens are now reported as unpriced instead of at a too-low value when one of their underlying assets has no price.

--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -734,6 +734,42 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
             ) from e
         return result
 
+    def get_storage_at(
+            self,
+            account_address: ChecksumEvmAddress,
+            position: int,
+            call_order: Sequence[WeightedNode] | None = None,
+    ) -> bytes:
+        """Read the raw 32-byte storage word at the given slot of an address.
+
+        May raise:
+        - RemoteError if none of the nodes could return a result
+        """
+        return self._query(
+            method=self._get_storage_at,
+            call_order=call_order,
+            account_address=account_address,
+            position=position,
+        )
+
+    def _get_storage_at(
+            self,
+            web3: Web3 | None,
+            account_address: ChecksumEvmAddress,
+            position: int,
+    ) -> bytes:
+        """Read the raw 32-byte storage word at the given slot of an address.
+
+        May raise:
+        - RemoteError if web3 is None, since indexers can't read raw storage and we need to
+          fail over to an rpc node
+        - Web3Exception/ValueError propagated by web3 if the rpc call itself fails, which
+          _query() turns into a RemoteError so the next node is tried
+        """
+        if web3 is None:  # indexers can't read raw storage, fail over to an rpc node
+            raise RemoteError('Reading contract storage requires an rpc node')
+        return bytes(web3.eth.get_storage_at(account_address, position))
+
     def _get_transaction_receipt(
             self,
             web3: Web3 | None,

--- a/rotkehlchen/chain/gnosis/node_inquirer.py
+++ b/rotkehlchen/chain/gnosis/node_inquirer.py
@@ -3,20 +3,22 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Final, Literal
 
 from eth_typing.abi import ABI
+from web3 import Web3
 
 from rotkehlchen.chain.constants import DEFAULT_RPC_TIMEOUT
-from rotkehlchen.chain.evm.constants import BALANCE_SCANNER_ADDRESS
+from rotkehlchen.chain.evm.constants import BALANCE_SCANNER_ADDRESS, ZERO_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants.assets import A_XDAI
-from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.errors.misc import BlockchainQueryError, RemoteError
+from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.greenlets.manager import GreenletManager
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EVMTxHash, SupportedBlockchain
-from rotkehlchen.utils.misc import get_chunks
+from rotkehlchen.utils.misc import bytes_to_address, get_chunks
 
 from .constants import (
     ARCHIVE_NODE_CHECK_ADDRESS,
@@ -37,6 +39,16 @@ log = RotkehlchenLogsAdapter(logger)
 GNOSIS_PAY_SAFE_ADMINS_CONTRACT: Final = string_to_evm_address('0x5De882ac4c220f69ADC18Ab242e5F0b834e302A2')  # noqa: E501
 GNOSIS_PAY_SAFE_ADMINS_ABI: Final[ABI] = [{'inputs': [{'name': 'addresses', 'type': 'address[]'}], 'name': 'get_admins', 'outputs': [{'name': '', 'type': 'address[][]'}], 'stateMutability': 'view', 'type': 'function'}]  # noqa: E501
 GNOSIS_PAY_SAFE_QUERY_CHUNK_SIZE: Final[int] = 64  # defined in the contract
+# Gnosis Pay's post-hack migration re-points a compromised safe's singleton to a frozen
+# implementation whose getOwners()/getModulesPaginated() return empty, so the helper above
+# can't see the admins. The data still lives in the proxy's own storage though, so we recover
+# it from there (Safe storage layout: `modules` mapping at slot 1, `owners` mapping at slot 2)
+# and query the first (Delay) module directly, since the module proxy itself is not frozen.
+SAFE_MODULES_STORAGE_SLOT: Final = 1
+SAFE_OWNERS_STORAGE_SLOT: Final = 2
+SAFE_SENTINEL_ADDRESS: Final = string_to_evm_address('0x0000000000000000000000000000000000000001')
+SAFE_MODULE_CONTROLLED_OWNER: Final = string_to_evm_address('0x0000000000000000000000000000000000000002')  # noqa: E501
+SAFE_MODULES_PAGINATED_ABI: Final[ABI] = [{'inputs': [{'name': 'start', 'type': 'address'}, {'name': 'pageSize', 'type': 'uint256'}], 'name': 'getModulesPaginated', 'outputs': [{'name': 'array', 'type': 'address[]'}, {'name': 'next', 'type': 'address'}], 'stateMutability': 'view', 'type': 'function'}]  # noqa: E501
 
 
 class GnosisInquirer(EvmNodeInquirer):
@@ -107,6 +119,10 @@ class GnosisInquirer(EvmNodeInquirer):
 
             for address, admins in zip(chunk_list, admins_result, strict=True):
                 if not admins:
+                    # helper sees no admins. The safe's singleton may have been frozen by
+                    # Gnosis Pay's post-hack migration, hiding its modules. Recover from storage.
+                    if len(recovered := self._recover_admins_from_frozen_safe(address)) != 0:
+                        result[address] = recovered
                     continue
 
                 if not isinstance(admins, (tuple, list)):
@@ -116,3 +132,61 @@ class GnosisInquirer(EvmNodeInquirer):
                 result[address] = [deserialize_evm_address(admin) for admin in admins]
 
         return result
+
+    def _read_safe_mapping_address(
+            self,
+            safe_address: ChecksumEvmAddress,
+            base_slot: int,
+            key: ChecksumEvmAddress,
+    ) -> ChecksumEvmAddress:
+        """Read mapping(address => address)[key] directly from a Safe proxy's own storage.
+
+        Used to recover data that a frozen safe singleton no longer returns via its view
+        functions. May raise RemoteError or DeserializationError.
+        """
+        return bytes_to_address(self.get_storage_at(
+            account_address=safe_address,
+            position=int.from_bytes(Web3.keccak(
+                int(key, 16).to_bytes(32) + base_slot.to_bytes(32),
+            )),
+        ))
+
+    def _recover_admins_from_frozen_safe(
+            self,
+            safe_address: ChecksumEvmAddress,
+    ) -> list[ChecksumEvmAddress]:
+        """Recover a Gnosis Pay safe's admins when its singleton has been frozen by Gnosis
+        Pay's post-hack migration so that getOwners()/getModulesPaginated() return empty.
+
+        The module list still lives in the proxy's own storage, so we read the first module
+        (the Zodiac Delay module) from there and query that live module for its enabled
+        modules, which are the admins. Returns an empty list for anything that is not a
+        module-controlled Gnosis Pay safe.
+
+        Best-effort: any failure (e.g. no rpc node able to read storage) is swallowed and
+        returns [] so it can never break detection for the other queried safes.
+        """
+        try:
+            if self._read_safe_mapping_address(  # only module-controlled safes (owner == 0x..02)
+                safe_address=safe_address,
+                base_slot=SAFE_OWNERS_STORAGE_SLOT,
+                key=SAFE_SENTINEL_ADDRESS,
+            ) != SAFE_MODULE_CONTROLLED_OWNER:
+                return []
+
+            if (delay_module := self._read_safe_mapping_address(  # modules[SENTINEL] is modules[0]
+                safe_address=safe_address,
+                base_slot=SAFE_MODULES_STORAGE_SLOT,
+                key=SAFE_SENTINEL_ADDRESS,
+            )) in (ZERO_ADDRESS, SAFE_SENTINEL_ADDRESS):
+                return []
+
+            return [deserialize_evm_address(admin) for admin in self.call_contract(
+                contract_address=delay_module,  # the Delay module proxy itself is not frozen
+                abi=SAFE_MODULES_PAGINATED_ABI,
+                method_name='getModulesPaginated',
+                arguments=[SAFE_SENTINEL_ADDRESS, GNOSIS_PAY_SAFE_QUERY_CHUNK_SIZE],
+            )[0]]
+        except (RemoteError, BlockchainQueryError, DeserializationError) as e:
+            log.error('Failed to recover gnosis pay admins for frozen safe %s: %s', safe_address, e)  # noqa: E501
+            return []

--- a/rotkehlchen/tests/unit/test_gnosis_inquirer.py
+++ b/rotkehlchen/tests/unit/test_gnosis_inquirer.py
@@ -2,8 +2,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from rotkehlchen.chain.evm.types import NodeName, WeightedNode, string_to_evm_address
+from rotkehlchen.constants.misc import ONE
 from rotkehlchen.tests.utils.ethereum import wait_until_all_nodes_connected
 from rotkehlchen.tests.utils.gnosis import GNOSIS_NODES_PARAMETERS_WITH_PRUNED_AND_NOT_ARCHIVED
+from rotkehlchen.types import SupportedBlockchain
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
@@ -39,3 +42,52 @@ def test_gnosis_nodes_prune_and_archive_status(
             raise AssertionError(f'Unknown node {node_name} encountered.')
 
     assert len(gnosis_inquirer.rpc_mapping) == len(gnosis_manager_connect_at_start)
+
+
+# pin to a single live node so the request order is deterministic and VCR-able
+GNOSIS_SINGLE_NODE: list[WeightedNode] = [WeightedNode(
+    node_info=NodeName(
+        name='gnosis official',
+        endpoint='https://rpc.gnosischain.com',
+        owned=False,
+        blockchain=SupportedBlockchain.GNOSIS,
+    ),
+    active=True,
+    weight=ONE,
+)]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('gnosis_manager_connect_at_start', [GNOSIS_SINGLE_NODE])
+@pytest.mark.parametrize('gnosis_accounts', [[
+    '0xaCFEb570426e260Eb930971FE528c8014f1002a0',  # old GP safe, singleton frozen post-hack
+    '0x9E0D8c9ff04F58e8D4053b78d33e582D8aCc8c44',  # new GP safe
+]])
+def test_gnosis_pay_safe_admins_recovers_frozen_safe(
+        gnosis_manager_connect_at_start: list[tuple],
+        gnosis_inquirer: 'GnosisInquirer',
+        gnosis_accounts: list[str],
+) -> None:
+    """Both a new Gnosis Pay safe and an old one whose singleton was frozen by Gnosis Pay's
+    post-hack migration must be recognized. The frozen old safe's getOwners()/
+    getModulesPaginated() return empty, so the on-chain helper sees no admins and we have to
+    recover them from the proxy's own storage. Hits the real chain on purpose - to be VCR'd
+    later.
+    """
+    gnosis_inquirer.maybe_connect_to_nodes(when_tracked_accounts=True)
+    wait_until_all_nodes_connected(
+        connect_at_start=gnosis_manager_connect_at_start,
+        evm_inquirer=gnosis_inquirer,
+    )
+    old_safe, new_safe = gnosis_accounts
+    admins = gnosis_inquirer.get_safe_admins_for_addresses(
+        [string_to_evm_address(old_safe), string_to_evm_address(new_safe)],
+    )
+    assert {address: sorted(found) for address, found in admins.items()} == {
+        old_safe: sorted([  # recovered from proxy storage since the singleton is frozen
+            '0x34f40d7BdbFC99d27B3a596F0D1F3891DB415B03',
+            '0x37f18A82493cdF80675fF01e58c1A1b39637cf50',
+            '0xc37b40ABdB939635068d3c5f13E7faF686F03B65',
+        ]),
+        new_safe: ['0x34f40d7BdbFC99d27B3a596F0D1F3891DB415B03'],  # resolved by the helper
+    }

--- a/tools/lint_new_logging_fstrings.py
+++ b/tools/lint_new_logging_fstrings.py
@@ -11,9 +11,12 @@ lands on a line ADDED relative to a base git ref. Legacy lines are grandfathered
 Base ref resolution order:
   1. --base <ref> argument
   2. LINT_DIFF_BASE environment variable (CI passes the PR base sha here)
-  3. first existing of origin/develop, develop, origin/main, main
+  3. local autodetect: of the known base branches that exist (origin/ and local
+     develop, main, bugfixes), pick the one whose merge-base with HEAD is the most
+     recent - i.e. the branch this one actually stems from - so a feature branch off
+     bugfixes is diffed against bugfixes, not against a stale develop.
 
-If no base can be resolved (e.g. a local checkout without the upstream branch), the
+If no base can be resolved (e.g. a local checkout without any of those branches), the
 check prints a notice and exits 0 so it never blocks local `make lint`.
 """
 
@@ -25,7 +28,11 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_BASE_CANDIDATES = ('origin/develop', 'develop', 'origin/main', 'main')
+# base branch names to look for locally, in preference order (origin/<name> first for each)
+BASE_BRANCH_NAMES = ('develop', 'main', 'bugfixes')
+DEFAULT_BASE_CANDIDATES = tuple(
+    f'{prefix}{name}' for name in BASE_BRANCH_NAMES for prefix in ('origin/', '')
+)
 HUNK_RE = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
 
 
@@ -39,6 +46,30 @@ def _git(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+def _autodetect_base() -> str | None:
+    """Pick the existing base branch closest to HEAD (the one HEAD branched off).
+
+    For each candidate we take its merge-base with HEAD and keep the candidate whose
+    merge-base is the most recent commit. Candidates whose merge-base IS HEAD (the
+    currently checked-out branch's own ref, or any descendant) are skipped, since
+    diffing against them would yield no changes and silently pass.
+    """
+    head = _git('rev-parse', 'HEAD').stdout.strip()
+    current_branch = _git('symbolic-ref', '--quiet', '--short', 'HEAD').stdout.strip()
+    best_ref: str | None = None
+    best_ts = -1
+    for ref in DEFAULT_BASE_CANDIDATES:
+        if ref == current_branch:  # the checked-out branch itself is not a useful base
+            continue
+        if _git('rev-parse', '--verify', '--quiet', ref).returncode != 0:
+            continue  # ref does not exist in this checkout
+        if (merge_base := _git('merge-base', 'HEAD', ref).stdout.strip()) in ('', head):
+            continue  # unrelated history, or ref is at/ahead of HEAD (empty diff)
+        if (ts := int(_git('show', '-s', '--format=%ct', merge_base).stdout.strip() or -1)) > best_ts:  # noqa: E501
+            best_ts, best_ref = ts, ref
+    return best_ref
+
+
 def resolve_base() -> str | None:
     """Resolve the git ref to diff against, or None if none is available."""
     args = sys.argv[1:]
@@ -46,10 +77,7 @@ def resolve_base() -> str | None:
         return args[args.index('--base') + 1]
     if (env_base := os.environ.get('LINT_DIFF_BASE')):
         return env_base
-    for ref in DEFAULT_BASE_CANDIDATES:
-        if _git('rev-parse', '--verify', '--quiet', ref).returncode == 0:
-            return ref
-    return None
+    return _autodetect_base()
 
 
 def added_lines(base: str) -> dict[str, set[int]]:


### PR DESCRIPTION
Gnosis Pay's post-hack migration re-points a compromised safe's singleton to a frozen implementation whose getOwners()/getModulesPaginated() return empty, so the on-chain admins helper sees no admins and reauth dead-ends with 'No registered accounts'.

Recover the data from the safe proxy's own storage: read modules[0] (the Zodiac Delay module) and query that live module for its enabled modules (the admins). Adds a generic EvmNodeInquirer.get_storage_at primitive and a best-effort recovery in GnosisInquirer.get_safe_admins_for_addresses that degrades to [] on failure so it can't break detection for other safes.