### PR TITLE
Avoid double counted balance with Hyperliquid perps

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
 * :bug:`-` Tags on manually tracked balances are no longer dropped (or shown on the wrong balance) after updating, for users who had previously deleted a manual balance. The faulty cleanup that orphaned those tags is also reverted.
 * :bug:`-` A temporary node/indexer failure during token detection no longer wipes the previously detected tokens for an address. The cached token list is now kept intact until a successful detection can replace it, so balances no longer silently go missing after a transient RPC error.
 * :bug:`-` HTX balances are no longer under-reported. Funds locked in open orders (and balances of an asset held across multiple HTX account types) are now summed instead of overwriting each other.
+* :bug:`-` Hyperliquid balances with open perp positions no longer count the reserved USDC margin twice, so your account value should match Hyperliquid more closely.
 * :bug:`12329` ENS domain extensions made through the renewal wrapper are now decoded as renewal events.
 * :bug:`12323` rotki no longer hijacks the system's default browser for HTML files on Linux (GNOME with older xdg-utils) when registering its ``rotki://`` link handler, and restores the association for users already affected by a previous version.
 * :bug:`-` Special-cased asset prices are no longer shown in USD by mistake for non-USD main currencies when the exchange rate is temporarily unavailable.

--- a/rotkehlchen/externalapis/hyperliquid.py
+++ b/rotkehlchen/externalapis/hyperliquid.py
@@ -344,8 +344,9 @@ class HyperliquidAPI:
     ) -> None:
         """Query spot and perp balances for one Hyperliquid DEX context."""
         dex_display = dex_name if dex_name is not None else 'main'
+        spot_usdc_hold = ZERO
         if include_spot is True:
-            self._query_spot_balances_for_dex(
+            spot_usdc_hold = self._query_spot_balances_for_dex(
                 address=address,
                 dex_name=dex_name,
                 dex_display=dex_display,
@@ -365,9 +366,15 @@ class HyperliquidAPI:
             )
         else:
             try:
-                balances[self.arb_usdc] += deserialize_fval(
-                    value=perp_data.get('crossMarginSummary', {}).get('accountValue', 0),
+                perp_summary = perp_data.get('crossMarginSummary', {})
+                perp_account_value = deserialize_fval(
+                    value=perp_summary.get('accountValue', 0),
                     name='clearinghouseState total balances',
+                    location='hyperliquid',
+                )
+                perp_margin_used = deserialize_fval(
+                    value=perp_summary.get('totalMarginUsed', 0),
+                    name='clearinghouseState total margin used',
                     location='hyperliquid',
                 )
             except DeserializationError as e:
@@ -375,6 +382,11 @@ class HyperliquidAPI:
                     f'Failed to read hyperliquid crossMarginSummary '
                     f'for dex={dex_display} due to {e}',
                 )
+            else:
+                if (duplicated_spot_margin := min(spot_usdc_hold, perp_margin_used)) > ZERO:
+                    balances[self.arb_usdc] -= duplicated_spot_margin
+
+                balances[self.arb_usdc] += perp_account_value
 
     def _query_spot_balances_for_dex(
             self,
@@ -382,7 +394,7 @@ class HyperliquidAPI:
             dex_name: str | None,
             dex_display: str,
             balances: defaultdict[Asset, FVal],
-    ) -> None:
+    ) -> FVal:
         """Query and aggregate spot balances for one Hyperliquid DEX context."""
         try:
             data = self._query(
@@ -395,8 +407,9 @@ class HyperliquidAPI:
                 f'Skipping spotClearinghouseState balances in hyperliquid '
                 f'for {address} and dex={dex_display} due to {e}',
             )
-            return
+            return ZERO
 
+        usdc_hold = ZERO
         for asset_entry in data.get('balances', []):
             try:
                 if (
@@ -423,6 +436,23 @@ class HyperliquidAPI:
                 continue
 
             balances[asset] += balance
+            if asset == self.arb_usdc:
+                try:
+                    usdc_hold += deserialize_fval(
+                        value=asset_entry.get('hold', 0),
+                        name='spotClearinghouseState held USDC balance',
+                        location='hyperliquid',
+                    )
+                except DeserializationError as e:
+                    log.error(
+                        'Failed to read held USDC balance %s from hyperliquid '
+                        'for dex=%s due to %s. Skipping hold deduction',
+                        asset_entry,
+                        dex_display,
+                        e,
+                    )
+
+        return usdc_hold
 
     @staticmethod
     def _entry_strict_unique_id(entry: dict[str, Any]) -> str | None:

--- a/rotkehlchen/tests/unit/test_hyperliquid_core_balances.py
+++ b/rotkehlchen/tests/unit/test_hyperliquid_core_balances.py
@@ -128,6 +128,57 @@ def test_query_balances_core_failure_returns_evm_only(
     assert len(result[ADDR_A].assets) == 1
 
 
+def test_query_balances_does_not_double_count_open_perp_margin(globaldb) -> None:
+    """Regression test for the reported HYPE/USDC perp double count.
+
+    Hyperliquid reports the USDC margin used by an open perp as held spot USDC and
+    in the perp account value. Rotki should replace the duplicated margin with perp
+    equity, not add both on top of each other.
+    """
+    api = HyperliquidAPI()
+    with patch.object(api, '_query', side_effect=[
+        {
+            'balances': [{
+                'coin': 'USDC',
+                'token': 0,
+                'total': '31.79386159',
+                'hold': '1.22538',
+                'entryNtl': '0.0',
+            }],
+        }, {
+            'marginSummary': {
+                'accountValue': '1.20604',
+                'totalNtlPos': '12.2476',
+                'totalRawUsd': '-11.04156',
+                'totalMarginUsed': '1.22476',
+            },
+            'crossMarginSummary': {
+                'accountValue': '1.20604',
+                'totalNtlPos': '12.2476',
+                'totalRawUsd': '-11.04156',
+                'totalMarginUsed': '1.22476',
+            },
+            'assetPositions': [{
+                'type': 'oneWay',
+                'position': {
+                    'coin': 'HYPE',
+                    'szi': '0.2',
+                    'positionValue': '12.2476',
+                    'unrealizedPnl': '-0.0204',
+                    'marginUsed': '1.22476',
+                },
+            }],
+        },
+    ]):
+        result = api.query_balances(
+            address=string_to_evm_address('0x48Bf3df773B557e8068Dd3FC76E13301b8a0De22'),
+            include_discovered_dexs=False,
+        )
+
+    double_counted_balance = FVal('31.79386159') + FVal('1.20604')
+    assert result[api.arb_usdc] == double_counted_balance - FVal('1.22476')
+
+
 @pytest.mark.vcr(match_on=['uri', 'method', 'body'], record_mode='once')
 def test_query_balances_fetches_core_balances_with_vcr(
         globaldb,


### PR DESCRIPTION
Before
<img width="1468" height="523" alt="Screenshot 2026-06-08 at 13 33 42" src="https://github.com/user-attachments/assets/f0414358-2e7a-4828-bbbe-6da504acaf6e" />


After
<img width="1468" height="461" alt="Screenshot 2026-06-08 at 13 22 31" src="https://github.com/user-attachments/assets/310418e0-0de6-422d-ae34-9491132a116e" />

The 1.2 USDC difference is the collateral in the long position