### PR TITLE
perf: build history-events accounting pot lazily

### DIFF
--- a/rotkehlchen/api/services/history.py
+++ b/rotkehlchen/api/services/history.py
@@ -403,15 +403,20 @@ class HistoryService:
                 entry_identifiers=event_identifiers,
             )
 
-        accountant_pot = AccountingPot(
-            database=self.rotkehlchen.data.db,
-            evm_accounting_aggregators=EVMAccountingAggregators([
-                self.rotkehlchen.chains_aggregator.get_evm_manager(x).accounting_aggregator
-                for x in EVM_CHAIN_IDS_WITH_TRANSACTIONS
-            ]),
-            msg_aggregator=self.rotkehlchen.msg_aggregator,
-            is_dummy_pot=True,
-        )
+        # The dummy pot is only needed when query_missing_accounting_rules misses its cache,
+        # so build it lazily to avoid the construction cost (settings reads + accounting
+        # machinery instantiation) on the common repeat/poll/back-pagination loads.
+        def build_dummy_pot() -> AccountingPot:
+            return AccountingPot(
+                database=self.rotkehlchen.data.db,
+                evm_accounting_aggregators=EVMAccountingAggregators([
+                    self.rotkehlchen.chains_aggregator.get_evm_manager(x).accounting_aggregator
+                    for x in EVM_CHAIN_IDS_WITH_TRANSACTIONS
+                ]),
+                msg_aggregator=self.rotkehlchen.msg_aggregator,
+                is_dummy_pot=True,
+            )
+
         result = {
             # entries are already serialized to JSON primitives, so wrap them to skip
             # the redundant process_result re-walk of the whole (potentially huge) list
@@ -420,8 +425,7 @@ class HistoryService:
                 aggregate_by_group_ids=aggregate_by_group_ids,
                 event_accounting_rule_statuses=query_missing_accounting_rules(
                     db=self.rotkehlchen.data.db,
-                    accounting_pot=accountant_pot,
-                    evm_accounting_aggregator=accountant_pot.events_accountant.evm_accounting_aggregators,
+                    pot_factory=build_dummy_pot,
                     events=events,
                     accountant=self.rotkehlchen.accountant,
                 ),

--- a/rotkehlchen/db/accounting_rules.py
+++ b/rotkehlchen/db/accounting_rules.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -34,7 +34,6 @@ from rotkehlchen.utils.misc import get_chunks
 if TYPE_CHECKING:
     from rotkehlchen.accounting.accountant import Accountant
     from rotkehlchen.accounting.pot import AccountingPot
-    from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregators
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.gevent import DBCursor
 
@@ -760,13 +759,16 @@ def _prefetch_accounting_treatments(
 def query_missing_accounting_rules(
         db: 'DBHandler',
         accountant: 'Accountant',
-        accounting_pot: 'AccountingPot',
-        evm_accounting_aggregator: 'EVMAccountingAggregators',
+        pot_factory: 'Callable[[], AccountingPot]',
         events: Sequence[HistoryBaseEntry],
 ) -> list[EventAccountingRuleStatus]:
     """
     For a list of events returns a list of the same length with boolean values where True
     means that the event won't be affected by any accounting rule or processed in accounting
+
+    pot_factory builds the (dummy) AccountingPot lazily so it is only constructed when the cache
+    fast path below misses. Building the pot is not free (it reads settings and instantiates the
+    accounting machinery) and is wasted work on the common repeat/poll/back-pagination loads.
     """
     # Fast path: if every event on the page is already resolved in the cache (repeat/poll/
     # back-pagination loads), return the cached statuses directly and skip re-querying and
@@ -775,6 +777,8 @@ def query_missing_accounting_rules(
     if all(status is not None for status in cached_statuses):
         return cached_statuses  # type: ignore  # all entries are non-None here
 
+    accounting_pot = pot_factory()
+    evm_accounting_aggregator = accounting_pot.events_accountant.evm_accounting_aggregators
     history_db = DBHistoryEvents(db)
     with db.conn.read_ctx() as cursor:
         # to know if an event will be processed or not in accounting we also need the related

--- a/rotkehlchen/tests/db/test_db_accounting_rules.py
+++ b/rotkehlchen/tests/db/test_db_accounting_rules.py
@@ -222,8 +222,7 @@ def test_missing_accounting_rules_accounting_treatment(
     events = store_and_retrieve_events([swap_event_spend, swap_event_receive, swap_event_fee], database)  # noqa: E501
     assert EventAccountingRuleStatus.NOT_PROCESSED not in query_missing_accounting_rules(
         db=database,
-        accounting_pot=accountant.pots[0],
-        evm_accounting_aggregator=accountant.pots[0].events_accountant.evm_accounting_aggregators,
+        pot_factory=lambda: accountant.pots[0],
         events=events,
         accountant=accountant,
     )
@@ -281,8 +280,7 @@ def test_events_affected_by_others_accounting_treatment(
     events = store_and_retrieve_events([return_wrapped, remove_asset], database)
     assert query_missing_accounting_rules(
         db=database,
-        accounting_pot=accountant.pots[0],
-        evm_accounting_aggregator=accountant.pots[0].events_accountant.evm_accounting_aggregators,
+        pot_factory=lambda: accountant.pots[0],
         events=events,
         accountant=accountant,
     ) == [
@@ -355,8 +353,7 @@ def test_events_affected_by_others_accounting_treatment_with_fee(
     events = store_and_retrieve_events([return_wrapped, fee_event, remove_asset], database)
     assert query_missing_accounting_rules(
         db=database,
-        accounting_pot=accountant.pots[0],
-        evm_accounting_aggregator=accountant.pots[0].events_accountant.evm_accounting_aggregators,
+        pot_factory=lambda: accountant.pots[0],
         events=events,
         accountant=accountant,
     ) == [
@@ -431,8 +428,7 @@ def test_correct_accounting_treatment_is_selected(
     events = store_and_retrieve_events([return_wrapped, remove_asset], database)
     assert query_missing_accounting_rules(
         db=database,
-        accounting_pot=accountant.pots[0],
-        evm_accounting_aggregator=accountant.pots[0].events_accountant.evm_accounting_aggregators,
+        pot_factory=lambda: accountant.pots[0],
         events=events,
         accountant=accountant,
     ) == [EventAccountingRuleStatus.HAS_RULE, EventAccountingRuleStatus.PROCESSED]


### PR DESCRIPTION
query_missing_accounting_rules now takes a pot_factory and only builds the dummy AccountingPot after its cache fast-path misses, so the pot's settings reads and accounting-machinery construction are skipped on the common repeat/poll/back-pagination events page loads.
