### PR TITLE
perf: read cached settings on hot balance/exchange paths

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -3954,7 +3954,10 @@ class DBHandler:
         Returns whether we should save a balance snapshot depending on whether the last snapshot
         and last query timestamps are older than the period defined by the save frequency setting.
         """
-        settings = self.get_settings(cursor)
+        # balance_save_frequency is a cached setting kept in sync on every write, so read it from
+        # the in-memory cache instead of doing a full settings DB read (this runs on every
+        # scheduler tick and balance query).
+        settings = CachedSettings().get_settings()
         # Setting is saved in hours, convert to seconds here
         period = settings.balance_save_frequency * 60 * 60
         now = ts_now()

--- a/rotkehlchen/exchanges/manager.py
+++ b/rotkehlchen/exchanges/manager.py
@@ -14,6 +14,7 @@ from rotkehlchen.db.constants import (
     OKX_LOCATION_KEY,
 )
 from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import InputError
 from rotkehlchen.exchanges.binance import BINANCE_BASE_URL, BINANCEUS_BASE_URL
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeWithExtras
@@ -72,8 +73,9 @@ class ExchangeManager:
 
     def iterate_exchanges(self) -> Iterator[ExchangeInterface]:
         """Iterate all connected and syncing exchanges"""
-        with self.database.conn.read_ctx() as cursor:
-            excluded = self.database.get_settings(cursor).non_syncing_exchanges
+        # non_syncing_exchanges is a cached setting kept in sync on every write, so read it
+        # from the in-memory cache instead of doing a full settings DB read on every call.
+        excluded = CachedSettings().get_settings().non_syncing_exchanges
         for exchanges in self.connected_exchanges.values():
             for exchange in exchanges:
                 # We are not yielding excluded exchanges

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -80,6 +80,7 @@ from rotkehlchen.db.settings import (
     DEFAULT_UI_FLOATING_PRECISION,
     DEFAULT_USE_ASSET_COLLECTIONS_IN_COST_BASIS,
     ROTKEHLCHEN_DB_VERSION,
+    CachedSettings,
     DBSettings,
     ModifiableDBSettings,
 )
@@ -641,6 +642,10 @@ def test_balance_save_frequency_check(data_dir, username, sql_vm_instructions_cb
     msg_aggregator = MessagesAggregator()
     data = DataHandler(data_dir, msg_aggregator, sql_vm_instructions_cb)
     data.unlock(username, '123', create_new=True, resume_from_backup=False)
+    # should_save_balances reads balance_save_frequency from CachedSettings, so initialize it
+    # from the DB here (DataHandler.unlock does not, unlike the full Rotkehlchen.unlock_user).
+    with data.db.conn.read_ctx() as cursor:
+        CachedSettings().initialize(data.db.get_settings(cursor))
 
     now = int(time.time())
     data_save_ts = now - 24 * 60 * 60 + 20


### PR DESCRIPTION
should_save_balances (every scheduler tick + balance query) and iterate_exchanges (every balance/history/exchange query) did a full uncached settings DB read for a single field. Read those fields from the in-sync CachedSettings instead; iterate_exchanges no longer needs a DB read_ctx at all. Initialize CachedSettings in the affected DataHandler test since it does not go through Rotkehlchen.unlock_user.
