### PR TITLE
perf: batch periodic-task timestamp reads per scheduler tick

### DIFF
--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -1,7 +1,7 @@
 import logging
 import random
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, NamedTuple
 
 import gevent
@@ -58,7 +58,10 @@ from rotkehlchen.tasks.calendar import (
 from rotkehlchen.tasks.internal_tx_conflicts import (
     repull_internal_tx_conflicts,
 )
-from rotkehlchen.tasks.utils import should_run_periodic_task
+from rotkehlchen.tasks.utils import (
+    prefetch_scheduler_task_timestamps,
+    should_run_periodic_task,
+)
 from rotkehlchen.types import (
     CHAINS_WITH_TRANSACTION_DECODERS,
     EVM_CHAINS_WITH_TRANSACTIONS,
@@ -141,6 +144,9 @@ class TaskManager:
         self.last_exchange_query_ts: defaultdict[ExchangeLocationID, int] = defaultdict(int)
         self.prepared_cryptocompare_query = False
         self.running_greenlets: dict[Callable, list[gevent.Greenlet]] = {}
+        # Per-tick snapshot of periodic-task last-run timestamps, set for the duration of a
+        # _schedule pass so each task's should_run check reads from memory instead of the DB.
+        self._scheduler_task_timestamps: Mapping[str, str] | None = None
         self.deactivate_premium = deactivate_premium
         self.activate_premium = activate_premium
         self.query_balances = query_balances
@@ -660,6 +666,7 @@ class TaskManager:
                 database=self.database,
                 key_name=DBCacheStatic.LAST_ETH2_EVENTS_PROCESSING_TS,
                 refresh_period=HOUR_IN_SECONDS,
+                cached_timestamps=self._scheduler_task_timestamps,
             ) is False
         ):
             return None
@@ -678,7 +685,7 @@ class TaskManager:
         Function that schedules the data update task if either there is no data update
         cache yet or this cache is older than `DATA_UPDATES_REFRESH`
         """
-        if should_run_periodic_task(self.database, DBCacheStatic.LAST_DATA_UPDATES_TS, DATA_UPDATES_REFRESH) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCacheStatic.LAST_DATA_UPDATES_TS, DATA_UPDATES_REFRESH, cached_timestamps=self._scheduler_task_timestamps) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(
@@ -693,7 +700,7 @@ class TaskManager:
         Function that schedules the EVM accounts detection task if there has been more than
         EVM_ACCOUNTS_DETECTION_REFRESH seconds since the last time it ran.
         """
-        if should_run_periodic_task(self.database, DBCacheStatic.LAST_EVM_ACCOUNTS_DETECT_TS, EVMLIKE_ACCOUNTS_DETECTION_REFRESH) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCacheStatic.LAST_EVM_ACCOUNTS_DETECT_TS, EVMLIKE_ACCOUNTS_DETECTION_REFRESH, cached_timestamps=self._scheduler_task_timestamps) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(
@@ -726,7 +733,7 @@ class TaskManager:
         This function queries the globaldb looking for assets that look like spam tokens
         and ignores them in addition to marking them as spam tokens
         """
-        if should_run_periodic_task(self.database, DBCacheStatic.LAST_SPAM_ASSETS_DETECT_KEY, SPAM_ASSETS_DETECTION_REFRESH) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCacheStatic.LAST_SPAM_ASSETS_DETECT_KEY, SPAM_ASSETS_DETECTION_REFRESH, cached_timestamps=self._scheduler_task_timestamps) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(
@@ -747,6 +754,7 @@ class TaskManager:
             database=self.database,
             key_name=DBCacheStatic.LAST_INTERNAL_TX_CONFLICTS_REPULL_TS,
             refresh_period=cached_settings.internal_tx_conflict_repull_frequency,
+            cached_timestamps=self._scheduler_task_timestamps,
         ) is False:
             return None
 
@@ -766,7 +774,7 @@ class TaskManager:
         This task is required to have a fresh status on the assets searches when the filter for
         owned assets is used.
         """
-        if should_run_periodic_task(self.database, DBCacheStatic.LAST_OWNED_ASSETS_UPDATE, OWNED_ASSETS_UPDATE) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCacheStatic.LAST_OWNED_ASSETS_UPDATE, OWNED_ASSETS_UPDATE, cached_timestamps=self._scheduler_task_timestamps) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(
@@ -782,7 +790,7 @@ class TaskManager:
         This function runs the logic to query the aave v3 contracts to get all the
         underlying assets supported by them and save them in the globaldb.
         """
-        if should_run_periodic_task(self.database, DBCacheStatic.LAST_AAVE_V3_ASSETS_UPDATE, AAVE_V3_ASSETS_UPDATE) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCacheStatic.LAST_AAVE_V3_ASSETS_UPDATE, AAVE_V3_ASSETS_UPDATE, cached_timestamps=self._scheduler_task_timestamps) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(
@@ -801,6 +809,7 @@ class TaskManager:
             database=self.database,
             refresh_period=WEEK_IN_SECONDS,
             key_name=DBCacheStatic.LAST_SPARK_ASSETS_UPDATE,
+            cached_timestamps=self._scheduler_task_timestamps,
         ) is False:
             return None
 
@@ -820,6 +829,7 @@ class TaskManager:
                 database=self.database,
                 key_name=DBCacheStatic.LAST_CREATE_REMINDER_CHECK_TS,
                 refresh_period=DAY_IN_SECONDS,
+                cached_timestamps=self._scheduler_task_timestamps,
             ) is False
         ):
             return None
@@ -876,7 +886,7 @@ class TaskManager:
         Delete old calendar events if the setting for deleting them allows it and if they haven't
         been marked to not be deleted.
         """
-        if should_run_periodic_task(self.database, DBCacheStatic.LAST_DELETE_PAST_CALENDAR_EVENTS, DAY_IN_SECONDS) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCacheStatic.LAST_DELETE_PAST_CALENDAR_EVENTS, DAY_IN_SECONDS, cached_timestamps=self._scheduler_task_timestamps) is False:  # noqa: E501
             return None
 
         return [self.greenlet_manager.spawn_and_track(
@@ -933,7 +943,7 @@ class TaskManager:
         particularly, search for DelegationTransferredToL2 event. If not found, it decodes
         and adds them.
         """
-        if should_run_periodic_task(self.database, DBCacheStatic.LAST_GRAPH_DELEGATIONS_CHECK_TS, DAY_IN_SECONDS) is False:  # noqa: E501
+        if should_run_periodic_task(self.database, DBCacheStatic.LAST_GRAPH_DELEGATIONS_CHECK_TS, DAY_IN_SECONDS, cached_timestamps=self._scheduler_task_timestamps) is False:  # noqa: E501
             return None
 
         if len(self.chains_aggregator.accounts.get(SupportedBlockchain.ETHEREUM)) == 0:
@@ -969,17 +979,23 @@ class TaskManager:
         random.shuffle(self.potential_tasks)
         max_tasks = min(self.max_tasks_num - current_greenlets, len(self.potential_tasks))
 
-        spawned_new = 0
-        for scheduling_fn in self.potential_tasks:
-            if spawned_new >= max_tasks:
-                break  # no more task slots left
-            if scheduling_fn in self.running_greenlets:
-                continue  # the specified task is already running
-            new_greenlets = scheduling_fn()
-            if new_greenlets is None:
-                continue  # The scheduling function for the specific task decided to not schedule it  # noqa: E501
-            self.running_greenlets[scheduling_fn] = new_greenlets
-            spawned_new += 1
+        # Read all periodic-task last-run timestamps once for this pass so the should_run checks
+        # below hit this snapshot instead of each issuing its own key_value_cache query.
+        self._scheduler_task_timestamps = prefetch_scheduler_task_timestamps(self.database)
+        try:
+            spawned_new = 0
+            for scheduling_fn in self.potential_tasks:
+                if spawned_new >= max_tasks:
+                    break  # no more task slots left
+                if scheduling_fn in self.running_greenlets:
+                    continue  # the specified task is already running
+                new_greenlets = scheduling_fn()
+                if new_greenlets is None:
+                    continue  # The scheduling function for the specific task decided to not schedule it  # noqa: E501
+                self.running_greenlets[scheduling_fn] = new_greenlets
+                spawned_new += 1
+        finally:
+            self._scheduler_task_timestamps = None
 
     def schedule(self) -> None:
         """Schedules background task while holding the scheduling lock

--- a/rotkehlchen/tasks/utils.py
+++ b/rotkehlchen/tasks/utils.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Literal
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Final, Literal
 
 from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -11,6 +12,39 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
+
+# The last-run timestamp keys that the task scheduler checks on every tick via
+# should_run_periodic_task. Prefetching them all in a single query lets one scheduling pass
+# avoid a separate key_value_cache read per task. This list is only an optimization hint: a key
+# missing from it (or not yet set) still works, should_run_periodic_task falls back to a single
+# DB read for it, so correctness never depends on this being complete.
+SCHEDULER_PERIODIC_TASK_KEYS: Final = (
+    DBCacheStatic.LAST_DATA_UPDATES_TS,
+    DBCacheStatic.LAST_EVM_ACCOUNTS_DETECT_TS,
+    DBCacheStatic.LAST_SPAM_ASSETS_DETECT_KEY,
+    DBCacheStatic.LAST_OWNED_ASSETS_UPDATE,
+    DBCacheStatic.LAST_AAVE_V3_ASSETS_UPDATE,
+    DBCacheStatic.LAST_SPARK_ASSETS_UPDATE,
+    DBCacheStatic.LAST_CREATE_REMINDER_CHECK_TS,
+    DBCacheStatic.LAST_DELETE_PAST_CALENDAR_EVENTS,
+    DBCacheStatic.LAST_GRAPH_DELEGATIONS_CHECK_TS,
+    DBCacheStatic.LAST_ETH2_EVENTS_PROCESSING_TS,
+    DBCacheStatic.LAST_INTERNAL_TX_CONFLICTS_REPULL_TS,
+)
+
+
+def prefetch_scheduler_task_timestamps(database: 'DBHandler') -> dict[str, str]:
+    """Read all periodic-task last-run timestamps the scheduler needs in a single query.
+
+    The returned mapping is meant to be passed to should_run_periodic_task as cached_timestamps
+    so a scheduling pass does not issue one key_value_cache read per task.
+    """
+    placeholders = ','.join('?' * len(SCHEDULER_PERIODIC_TASK_KEYS))
+    with database.conn.read_ctx() as cursor:
+        return dict(cursor.execute(
+            f'SELECT name, value FROM key_value_cache WHERE name IN ({placeholders})',
+            [key.value for key in SCHEDULER_PERIODIC_TASK_KEYS],
+        ))
 
 
 def should_run_periodic_task(
@@ -33,11 +67,20 @@ def should_run_periodic_task(
             DBCacheStatic.LAST_INTERNAL_TX_CONFLICTS_REPULL_TS,
         ],
         refresh_period: int,
+        cached_timestamps: Mapping[str, str] | None = None,
 ) -> bool:
     """
     Checks if enough time has elapsed since the last run of a periodic task in order to run
     it again.
+
+    cached_timestamps is an optional name -> value map of already-read key_value_cache entries
+    (see prefetch_scheduler_task_timestamps). When the key is present there the in-memory value
+    is used; otherwise we fall back to a single DB read so correctness does not depend on the
+    prefetch containing every key.
     """
+    if cached_timestamps is not None and (last_update_str := cached_timestamps.get(key_name.value)) is not None:  # noqa: E501
+        return ts_now() - deserialize_timestamp(last_update_str) >= refresh_period
+
     with database.conn.read_ctx() as cursor:
         cursor.execute('SELECT value FROM key_value_cache WHERE name=?', (key_name.value,))
         timestamp_in_db = cursor.fetchone()

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -41,7 +41,10 @@ from rotkehlchen.premium.premium import (
 from rotkehlchen.serialization.deserialize import deserialize_timestamp
 from rotkehlchen.tasks.assets import _find_missing_tokens
 from rotkehlchen.tasks.manager import PREMIUM_STATUS_CHECK, TaskManager
-from rotkehlchen.tasks.utils import should_run_periodic_task
+from rotkehlchen.tasks.utils import (
+    prefetch_scheduler_task_timestamps,
+    should_run_periodic_task,
+)
 from rotkehlchen.tests.fixtures.websockets import WebsocketReader
 from rotkehlchen.tests.utils.ethereum import (
     TEST_ADDR1,
@@ -590,6 +593,36 @@ def test_should_run_periodic_task(database: 'DBHandler') -> None:
         database=database,
         key_name=DBCacheStatic.LAST_DATA_UPDATES_TS,
         refresh_period=DATA_UPDATES_REFRESH,
+    ) is True
+
+
+def test_should_run_periodic_task_cached_timestamps(database: 'DBHandler') -> None:
+    """When the key is present in the prefetched timestamps map its value is used (over the DB);
+    when it is missing we fall back to a single DB read."""
+    old_ts = str(ts_now() - DATA_UPDATES_REFRESH * 2)  # value stored in the DB -> would say "run"
+    with database.user_write() as write_cursor:
+        write_cursor.execute(
+            'INSERT INTO key_value_cache(name, value) VALUES (?, ?)',
+            (DBCacheStatic.LAST_DATA_UPDATES_TS.value, old_ts),
+        )
+
+    # the prefetch helper reads the stored value
+    assert prefetch_scheduler_task_timestamps(database) == {DBCacheStatic.LAST_DATA_UPDATES_TS.value: old_ts}  # noqa: E501
+
+    # a recent value in the cache map wins over the (old) DB value -> should not run
+    assert should_run_periodic_task(
+        database=database,
+        key_name=DBCacheStatic.LAST_DATA_UPDATES_TS,
+        refresh_period=DATA_UPDATES_REFRESH,
+        cached_timestamps={DBCacheStatic.LAST_DATA_UPDATES_TS.value: str(ts_now())},
+    ) is False
+
+    # key absent from the cache map -> falls back to the DB read (old ts -> should run)
+    assert should_run_periodic_task(
+        database=database,
+        key_name=DBCacheStatic.LAST_DATA_UPDATES_TS,
+        refresh_period=DATA_UPDATES_REFRESH,
+        cached_timestamps={},
     ) is True
 
 


### PR DESCRIPTION
Each scheduler tick checked ~10 periodic tasks, every one issuing its own key_value_cache read via should_run_periodic_task. Prefetch those last-run timestamps once per _schedule pass and pass them in. Keys not in the prefetch (or unset) still fall back to a single DB read, so correctness does not depend on the prefetch being complete.
