### PR TITLE
perf: skip repeat evm queried-range reads per scheduler tick

### DIFF
--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -344,9 +344,19 @@ class TaskManager:
 
                 queriable_accounts: list[ChecksumEvmAddress] = []
                 for account in accounts:
+                    # Skip the queried-range DB read when the in-memory timestamp already shows
+                    # the account was queried within the refresh period. It is set when we
+                    # schedule a query (below) or, in the else branch, when we confirm the
+                    # account is already up to date - so later ticks avoid re-reading the range.
+                    last_queried = self.last_evm_tx_query_ts[account, blockchain]
+                    if now - last_queried <= EVM_TX_QUERY_FREQUENCY:
+                        continue
+
                     _, end_ts = dbevmtx.get_queried_range(cursor, account, blockchain)
-                    if now - max(self.last_evm_tx_query_ts[account, blockchain], end_ts) > EVM_TX_QUERY_FREQUENCY:  # noqa: E501
+                    if now - max(last_queried, end_ts) > EVM_TX_QUERY_FREQUENCY:
                         queriable_accounts.append(account)
+                    else:  # up to date: memoize so subsequent ticks skip the queried-range read
+                        self.last_evm_tx_query_ts[account, blockchain] = max(last_queried, end_ts)
 
                 if len(queriable_accounts) == 0:
                     continue

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -136,6 +136,29 @@ def test_maybe_query_ethereum_transactions(task_manager, ethereum_accounts):
         raise AssertionError(f'The transaction query was not scheduled within {timeout} seconds') from e  # noqa: E501
 
 
+@pytest.mark.parametrize('number_of_eth_accounts', [1])
+@pytest.mark.parametrize('max_tasks_num', [5])
+def test_maybe_query_evm_transactions_skips_repeat_range_reads(task_manager, ethereum_accounts):
+    """An up-to-date account's queried range is read once and then remembered in memory, so
+    subsequent scheduler ticks skip the per-account queried-range DB read."""
+    task_manager.potential_tasks = [task_manager._maybe_query_evm_transactions]
+    # return a recent end_ts so every account is considered up to date (not queriable)
+    range_patch = patch.object(
+        DBEvmTx,
+        'get_queried_range',
+        return_value=(Timestamp(0), Timestamp(ts_now())),
+    )
+    with range_patch as range_mock:
+        task_manager.schedule()
+        gevent.sleep(.2)
+        first_tick_reads = range_mock.call_count
+        assert first_tick_reads >= 1, 'first tick reads the queried range from the DB'
+
+        task_manager.schedule()
+        gevent.sleep(.2)
+        assert range_mock.call_count == first_tick_reads, 'later ticks skip the read (memoized)'
+
+
 @pytest.mark.parametrize('max_tasks_num', [5])
 def test_maybe_schedule_xpub_derivation(task_manager, database):
     xpub = 'xpub68V4ZQQ62mea7ZUKn2urQu47Bdn2Wr7SxrBxBDDwE3kjytj361YBGSKDT4WoBrE5htrSB8eAMe59NPnKrcAbiv2veN5GQUmfdjRddD1Hxrk'  # noqa: E501


### PR DESCRIPTION
_maybe_query_evm_transactions read each account's queried range (3 used_query_ranges seeks) on every tick. Gate the read on the in-memory last_evm_tx_query_ts first, and memoize the range end when an account is found up to date, so later ticks skip the read until the refresh period elapses. Behavior is unchanged since the stored timestamp is never lowered (max), only fewer DB reads are issued.
