### PR TITLE
fix: keep other accounts on partial balance query

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 
+* :bug:`-` Refreshing the balances of a single blockchain account no longer makes other accounts' wallet balances disappear from the dashboard and net worth totals when those accounts have DeFi protocol positions on the same chain.
 * :feature:`12301` You can now reset all accounting rules back to rotki's defaults from the accounting rules settings, undoing any customizations in a single action.
 * :bug:`-` Gnosis Pay card payments made through the new post-hack contract are now decoded correctly as payments instead of plain token spends.
 * :bug:`-` Older Gnosis Pay safes frozen by Gnosis Pay's post-hack migration can now be re-authenticated again, instead of failing with "No Gnosis Pay safe accounts are registered in rotki".

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -697,20 +697,26 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
     ) -> None:
         existing_balances = self.balances.get(chain=blockchain)
         if addresses is None or len(addresses) == 0:
+            full_query = True
             existing_balances.clear()
             if len(accounts := self.accounts.get(blockchain)) == 0:
                 return
         else:
+            full_query = False
             accounts = addresses  # type: ignore  # they are both sequences.
             for account in accounts:
                 existing_balances.pop(account, None)  # type: ignore[arg-type]
 
-        existing_balances.update(
-            (  # Ethereum balances are handled differently to include eth module balances.
-                self.query_eth_balances(accounts) if blockchain == SupportedBlockchain.ETHEREUM  # type: ignore[arg-type]  # will be checksum addresses
-                else self.get_chain_manager(blockchain).query_balances(accounts)
-            ),
+        new_balances = (  # Ethereum balances are handled differently to include eth module balances.  # noqa: E501
+            self.query_eth_balances(accounts) if blockchain == SupportedBlockchain.ETHEREUM  # type: ignore[arg-type]  # will be checksum addresses
+            else self.get_chain_manager(blockchain).query_balances(accounts)
         )
+        if full_query is False:
+            # Protocol balance queries return entries for any tracked address with protocol
+            # activity, not only the queried ones. Keep only the requested addresses so the
+            # other accounts' full balance sheets don't get replaced by protocol-only data.
+            new_balances = {address: balance for address, balance in new_balances.items() if address in accounts}  # type: ignore[assignment]  # per-chain key/value types are preserved  # noqa: E501
+        existing_balances.update(new_balances)  # type: ignore[arg-type]  # chain/balance types match per chain
 
     def _update_blockchain_balances_cache(
             self,
@@ -980,7 +986,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         if (vaults_module := self.get_module('makerdao_vaults')) is not None:
             vault_balances = vaults_module.get_balances()
             for address, entry in vault_balances.items():
-                if address not in eth_balances:
+                if address not in self.accounts.eth:
                     self.msg_aggregator.add_error(
                         f'The owner of a vault {address} was not in the tracked addresses.'
                         f' This should not happen and is probably a bug. Please report it.',

--- a/rotkehlchen/tests/unit/test_blockchain_balances.py
+++ b/rotkehlchen/tests/unit/test_blockchain_balances.py
@@ -177,6 +177,43 @@ def test_protocol_balances(blockchain: 'ChainsAggregator') -> None:
     assert blockchain.balances.eth[ETH_ADDRESS2].assets == {}
 
 
+def test_partial_balance_refresh_keeps_other_accounts(blockchain: 'ChainsAggregator') -> None:
+    """Test that refreshing balances for a subset of addresses does not replace the
+    balance sheets of the other tracked accounts.
+
+    Protocol balance queries (query_protocols_with_balance/_add_eth_protocol_balances)
+    return entries for any tracked address with protocol activity, not only the queried
+    ones. Before the fix those entries replaced the other accounts' full balance sheets
+    with protocol-only data.
+    """
+    refreshed_address, other_address = make_evm_address(), make_evm_address()
+    other_sheet = BalanceSheet()
+    other_sheet.assets[A_ETH][DEFAULT_BALANCE_LABEL] = Balance(amount=ONE, value=ONE)
+    other_sheet.assets[A_DAI][DEFAULT_BALANCE_LABEL] = Balance(amount=FVal('100'), value=FVal('100'))  # noqa: E501
+    blockchain.balances.eth[other_address] = other_sheet
+
+    refreshed_sheet = BalanceSheet()
+    refreshed_sheet.assets[A_ETH][DEFAULT_BALANCE_LABEL] = Balance(amount=FVal('2'), value=FVal('2'))  # noqa: E501
+    protocol_only_sheet = BalanceSheet()  # what a protocol query returns for the non-queried address  # noqa: E501
+    protocol_only_sheet.assets[A_LQTY][CPT_LIQUITY] = Balance(amount=ONE, value=ONE)
+
+    with patch.object(
+        blockchain,
+        'query_eth_balances',
+        return_value={
+            refreshed_address: refreshed_sheet,
+            other_address: protocol_only_sheet,
+        },
+    ):
+        blockchain._query_chain_balances(
+            blockchain=SupportedBlockchain.ETHEREUM,
+            addresses=[refreshed_address],
+        )
+
+    assert blockchain.balances.eth[refreshed_address] == refreshed_sheet
+    assert blockchain.balances.eth[other_address] == other_sheet
+
+
 def test_blockchain_balances_cache_removes_spent_token(blockchain: 'ChainsAggregator') -> None:
     """Test that refreshing an address removes token balances no longer returned."""
     address = make_evm_address()


### PR DESCRIPTION
Refreshing balances for a subset of addresses corrupted the in-memory balances of all other tracked accounts with protocol activity on the same chain. The protocol balance queries (query_protocols_with_balance and _add_eth_protocol_balances) return entries for any tracked address with activity -- they never filter by the queried accounts -- and _query_chain_balances merged the result with dict.update(), which replaced the full balance sheets (native + tokens) of non-queried accounts with protocol-only data. recalculate_totals() then propagated the corruption to the net worth totals until the next full refresh.

Fix by keeping only the requested addresses from the query result before merging, so a partial refresh can never touch other accounts' balance sheets.

Also check the makerdao vault owner against the tracked eth accounts instead of the partial result dict. This removes the spurious 'owner of a vault was not in the tracked addresses' error during partial refreshes, and no longer drops the vault balance of a tracked owner that has zero native/token balances on a full refresh.

Includes a regression test that fails on the unfixed code.