### PR TITLE
fix: apply accounting rule fallback to solana events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 
+* :bug:`-` Solana events with a counterparty are no longer silently excluded from PnL reports.
 * :bug:`-` Refreshing the balances of a single blockchain account no longer makes other accounts' wallet balances disappear from the dashboard and net worth totals when those accounts have DeFi protocol positions on the same chain.
 * :feature:`12301` You can now reset all accounting rules back to rotki's defaults from the accounting rules settings, undoing any customizations in a single action.
 * :bug:`-` Gnosis Pay card payments made through the new post-hack contract are now decoded correctly as payments instead of plain token spends.

--- a/rotkehlchen/accounting/rules.py
+++ b/rotkehlchen/accounting/rules.py
@@ -5,7 +5,7 @@ from rotkehlchen.db.accounting_rules import DBAccountingRules
 from rotkehlchen.db.filtering import AccountingRulesFilterQuery
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.history.events.structures.base import HistoryBaseEntry, get_event_type_identifier
-from rotkehlchen.history.events.structures.evm_event import EvmEvent
+from rotkehlchen.history.events.structures.onchain_event import OnchainEvent
 
 if TYPE_CHECKING:
     from rotkehlchen.accounting.pot import AccountingPot
@@ -71,7 +71,7 @@ class AccountingRulesManager:
         else:
             callback = None
 
-        if isinstance(event, EvmEvent) is False or rule is not None:
+        if isinstance(event, OnchainEvent) is False or rule is not None:
             return rule, callback
 
         event_id_no_cpt = event.get_type_identifier(include_counterparty=False)

--- a/rotkehlchen/tests/unit/accounting/test_default_settings.py
+++ b/rotkehlchen/tests/unit/accounting/test_default_settings.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 from more_itertools import peekable
+from solders.solders import Signature
 
 from rotkehlchen.accounting.accountant import Accountant
 from rotkehlchen.accounting.cost_basis.base import (
@@ -23,6 +24,7 @@ from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
+from rotkehlchen.history.events.structures.solana_swap import SolanaSwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
 from rotkehlchen.types import Location, Price, Timestamp, TimestampMS
@@ -392,6 +394,48 @@ def test_accounting_swap_settings(accounting_pot: 'AccountingPot', counterparty:
     expected_receive_event.count_cost_basis_pnl = False
     assert accounting_pot.processed_events[1:] == [expected_spend_event, expected_receive_event]
     assert accounting_pot.pnls.taxable == ETH_PRICE_TS_1 + expected_spend_event.pnl.taxable
+
+
+@pytest.mark.parametrize('mocked_price_queries', [MOCKED_PRICES])
+def test_accounting_solana_swap_counterparty_fallback(accounting_pot: 'AccountingPot') -> None:
+    """Test that solana swap events with a counterparty that has no specific accounting
+    rule fall back to the default swap treatment instead of being silently skipped.
+
+    Regression test for the no-counterparty rule fallback being gated on EvmEvent,
+    which excluded all counterparty-tagged solana events (e.g. jupiter swaps) from
+    PnL reports.
+    """
+    _gain_one_ether(events_accountant=accounting_pot.events_accountant)
+    signature = Signature.default()
+    swap_spend_event = SolanaSwapEvent(
+        tx_ref=signature,
+        sequence_index=1,
+        timestamp=TIMESTAMP_2_MS,
+        event_subtype=HistoryEventSubType.SPEND,
+        asset=A_ETH,
+        amount=ONE,
+        notes='Swap 1 ETH in Jupiter',
+        counterparty='jupiter',
+    )
+    swap_receive_event = SolanaSwapEvent(
+        tx_ref=signature,
+        sequence_index=2,
+        timestamp=TIMESTAMP_2_MS,
+        event_subtype=HistoryEventSubType.RECEIVE,
+        asset=A_DAI,
+        amount=FVal(3000),
+        notes='Receive 3000 DAI as the result of a swap in Jupiter',
+        counterparty='jupiter',
+    )
+    assert accounting_pot.events_accountant.process(
+        event=swap_spend_event,
+        events_iterator=peekable([swap_receive_event]),
+    ) == 2
+    assert len(accounting_pot.processed_events) == 3  # initial ETH gain + both swap legs
+    assert accounting_pot.processed_events[-2].asset == A_ETH
+    assert accounting_pot.processed_events[-2].pnl.taxable == ETH_PRICE_TS_2 - ETH_PRICE_TS_1
+    assert accounting_pot.processed_events[-1].asset == A_DAI
+    assert accounting_pot.processed_events[-1].free_amount == FVal(3000)
 
 
 # --- BASIS_TRANSFER tests ---


### PR DESCRIPTION
When no accounting rule matches an event's (type, subtype, counterparty) combination, AccountingRulesManager.get_event_settings falls back to looking up a rule without the counterparty. That fallback was gated on isinstance(event, EvmEvent), but solana events extend OnchainEvent directly, so any counterparty-tagged solana event (all jupiter/jito/pump.fun decoded events) missed the fallback and got no rule at all. The accountant then skipped them with only a debug log: solana swaps contributed nothing to PnL reports, spent assets kept their cost basis lots and received assets acquired none, causing missing acquisitions errors down the line.

The shipped accounting rules data (v1-v12) has no solana counterparty rules, only the generic (trade, spend, no counterparty) swap rule, so every counterparty-tagged solana event was affected. The UI-side rule resolution in db/accounting_rules.py applies the no-counterparty fallback for all event types, so the history view even showed these events as having a rule while the report path dropped them.

Gate the fallback on OnchainEvent instead, which covers both evm and solana events. Includes a regression test that fails on the unfixed code.