### PR TITLE
fix: don't mark failed binance query ranges as done

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 
+* :bug:`-` A failed Binance history query no longer marks the time range as queried, which permanently skipped the deposits and withdrawals of that range.
 * :bug:`-` Coinbase crypto-to-crypto conversions are no longer sometimes recorded as sales to fiat with the received asset missing.
 * :bug:`-` Solana events with a counterparty are no longer silently excluded from PnL reports.
 * :bug:`-` Refreshing the balances of a single blockchain account no longer makes other accounts' wallet balances disappear from the dashboard and net worth totals when those accounts have DeFi protocol positions on the same chain.

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -1536,6 +1536,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             force_refresh: bool = False,
     ) -> tuple[Sequence['HistoryBaseEntry'], Timestamp]:
         events: list[HistoryBaseEntry] = []
+        with_errors = False
         for query_func in (
             self._query_online_asset_movements,
             self._query_online_trade_history,
@@ -1543,13 +1544,17 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             try:
                 events.extend(query_func(start_ts=start_ts, end_ts=end_ts, force_refresh=force_refresh))  # noqa: E501
             except (RemoteError, BinancePermissionError) as e:
+                with_errors = True
                 log.error(
                     f'Failed to call {self.name} {query_func.__name__} '
                     f'between {start_ts} and {end_ts} due to {e!s}',
                 )
                 continue
 
-        return events, end_ts
+        # Don't claim the range as queried if any sub-query failed, otherwise the base class
+        # marks it as done and the failed window's events are never fetched again. Mirrors
+        # kraken's behavior and the query_online_history_events contract.
+        return events, start_ts if with_errors else end_ts
 
     def _query_online_asset_movements(
             self,

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -462,6 +462,43 @@ def test_binance_query_trade_history(function_scope_binance: 'Binance'):
     )]
 
 
+def test_binance_query_history_events_failure_keeps_range(function_scope_binance):
+    """Test that a failing sub-query makes query_online_history_events report no progress,
+    so the base class does not mark the range as queried.
+
+    Regression test for end_ts being returned unconditionally even when a sub-query
+    raised: the failed window was saved as queried and its deposits/withdrawals/fiat
+    movements were never fetched again.
+    """
+    def query_success(**kwargs):
+        return []
+
+    def query_failure(**kwargs):
+        raise RemoteError('boom')
+
+    binance = function_scope_binance
+    end_ts = Timestamp(1638529919)
+    with (
+        patch.object(binance, '_query_online_asset_movements', query_success),
+        patch.object(binance, '_query_online_trade_history', query_failure),
+    ):
+        _, actual_end_ts = binance.query_online_history_events(
+            start_ts=Timestamp(0),
+            end_ts=end_ts,
+        )
+    assert actual_end_ts == Timestamp(0)
+
+    with (  # and when nothing fails the full range is reported as queried
+        patch.object(binance, '_query_online_asset_movements', query_success),
+        patch.object(binance, '_query_online_trade_history', query_success),
+    ):
+        _, actual_end_ts = binance.query_online_history_events(
+            start_ts=Timestamp(0),
+            end_ts=end_ts,
+        )
+    assert actual_end_ts == end_ts
+
+
 def test_binance_query_trade_history_unexpected_data(function_scope_binance):
     """Test that turning a binance trade that contains unexpected data is handled gracefully"""
     binance = function_scope_binance


### PR DESCRIPTION
binance's query_online_history_events swallows RemoteError and BinancePermissionError from its two sub-queries (asset movements and trade history) but unconditionally returned end_ts. The base class saves the returned timestamp as the successfully queried range, so any transient failure -- e.g. exhausted rate-limit retries on one sapi endpoint -- marked the whole window as done. Deposits, withdrawals and fiat orders are queried strictly by these saved ranges, so the failed window's movements were silently lost for good (trades partially self-heal through the per-pair last-id cursor, movements do not).

This violates the query_online_history_events contract, which says the returned timestamp should differ from end_ts when an error prevented full coverage; kraken already implements it correctly by returning start_ts on failure. Do the same: track sub-query failures and return start_ts when any occurred, so the base class retries the range on the next refresh. Already-fetched events are still returned and saved; re-querying them is harmless since insertion deduplicates.

