### PR TITLE
fix: keep task scheduler alive on premium errors

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-
+* :bug:`-` A temporary premium server error no longer permanently stops all background tasks (balance snapshots, transaction querying and decoding, database sync) until the application is restarted.
 * :bug:`-` A failed Binance history query no longer marks the time range as queried, which permanently skipped the deposits and withdrawals of that range.
 * :bug:`-` Coinbase crypto-to-crypto conversions are no longer sometimes recorded as sales to fiat with the received asset missing.
 * :bug:`-` Solana events with a counterparty are no longer silently excluded from PnL reports.

--- a/rotkehlchen/premium/sync.py
+++ b/rotkehlchen/premium/sync.py
@@ -161,8 +161,12 @@ class PremiumSyncManager(LockableQueryMixIn):
         if self.premium is None:
             return False
 
-        if self.premium.get_capabilities()['max_backup_size_mb'] == 0:
-            log.debug('Skipping premium db backup because max size is zero')
+        try:
+            if self.premium.get_capabilities()['max_backup_size_mb'] == 0:
+                log.debug('Skipping premium db backup because max size is zero')
+                return False
+        except (RemoteError, PremiumAuthenticationError) as e:
+            log.error('Could not query premium capabilities during sync check due to %s', e)
             return False
 
         with self.data.db.conn.read_ctx() as cursor:

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -37,6 +37,7 @@ from rotkehlchen.db.utils import table_exists
 from rotkehlchen.errors.api import PremiumAuthenticationError, PremiumPermissionError
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.misc import RemoteError
+from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.externalapis.google_calendar import GoogleCalendarAPI
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.types import HistoricalPriceOracle
@@ -999,7 +1000,16 @@ class TaskManager:
                     break  # no more task slots left
                 if scheduling_fn in self.running_greenlets:
                     continue  # the specified task is already running
-                new_greenlets = scheduling_fn()
+                try:
+                    new_greenlets = scheduling_fn()
+                except (RemoteError, PremiumAuthenticationError, DeserializationError, UnknownAsset) as e:  # noqa: E501
+                    log.error(
+                        'Scheduling function %s failed due to %s. '
+                        'Skipping it for this scheduler tick',
+                        scheduling_fn.__name__,
+                        e,
+                    )
+                    continue
                 if new_greenlets is None:
                     continue  # The scheduling function for the specific task decided to not schedule it  # noqa: E501
                 self.running_greenlets[scheduling_fn] = new_greenlets

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -38,6 +38,7 @@ from rotkehlchen.premium.premium import (
     RemoteMetadata,
     SubscriptionStatus,
 )
+from rotkehlchen.premium.sync import PremiumSyncManager
 from rotkehlchen.serialization.deserialize import deserialize_timestamp
 from rotkehlchen.tasks.assets import _find_missing_tokens
 from rotkehlchen.tasks.manager import PREMIUM_STATUS_CHECK, TaskManager
@@ -1629,3 +1630,41 @@ def test_maybe_decode_transactions_checks_all_chains(task_manager: TaskManager) 
         mock_solana_tx.return_value.count_hashes_not_decoded.return_value = 5  # solana has work
         result = task_manager._maybe_decode_transactions()
         assert result is not None and len(result) == 1
+
+
+@pytest.mark.parametrize('max_tasks_num', [5])
+def test_schedule_survives_failing_task_check(task_manager: TaskManager) -> None:
+    """Test that a scheduling function raising during the schedule tick neither
+    propagates out of schedule() nor prevents the remaining tasks from being checked.
+
+    Regression test for the premium capabilities query in check_if_should_sync
+    raising RemoteError through TaskManager.schedule() into the main loop,
+    permanently killing the background task scheduler until app restart.
+    """
+    checked_after_failure = []
+
+    def failing_check() -> None:
+        raise RemoteError('rotki server unreachable')
+
+    def working_check() -> None:
+        checked_after_failure.append(True)
+
+    task_manager.potential_tasks = [failing_check, working_check]
+    with patch('rotkehlchen.tasks.manager.random.shuffle'):  # keep the failing task first
+        task_manager.schedule()
+
+    assert checked_after_failure == [True]
+
+
+def test_check_if_should_sync_survives_premium_errors() -> None:
+    """Test that a remote/auth error when querying premium capabilities makes the
+    db sync check return False instead of raising through the task scheduler.
+
+    Regression test for the main loop greenlet dying on a transient premium
+    server error (see test_schedule_survives_failing_task_check).
+    """
+    sync_manager = object.__new__(PremiumSyncManager)
+    sync_manager.premium = MagicMock()
+    for error in (RemoteError('connection timeout'), PremiumAuthenticationError('key rejected')):
+        sync_manager.premium.get_capabilities.side_effect = error
+        assert sync_manager.check_if_should_sync(force_upload=False) is False


### PR DESCRIPTION
A transient error from the premium server permanently killed the main scheduler greenlet, silently stopping all background tasks (balance snapshots, transaction querying and decoding, db sync, premium checks) until app restart. check_if_should_sync called get_capabilities() with no error handling, and the resulting RemoteError or PremiumAuthenticationError propagated through _maybe_schedule_db_upload and TaskManager.schedule() into main_loop, whose greenlet is spawned once and never respawned (its link_exception handler only logs).

The hourly premium status check made this a recurring risk: on every successful check it swaps in a freshly created Premium object whose limits cache is empty, so the scheduler performs a live HTTP request to rotki.com roughly once per hour on its synchronous tick path.

Fix in two layers: check_if_should_sync now catches the premium errors and skips the sync check, and _schedule guards each scheduling function so no single task check can ever kill the main loop. The latter also covers maybe_detect_new_tokens raising DeserializationError/UnknownAsset on a malformed history event row.