### PR TITLE
fix: release address tx locks on account removal error

### DIFF
--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -195,17 +195,22 @@ class EvmTransactions(ABC):  # noqa: B024
 
     @contextmanager
     def wait_until_no_query_for(self, addresses: list[ChecksumEvmAddress]) -> Iterator[None]:
-        """Will acquire all locks relevant to an address and yield to the caller"""
+        """Will acquire all locks relevant to an address and yield to the caller
+
+        The locks are released even if the caller's body raises, since leaking an
+        acquired address lock would permanently block all transaction querying for
+        that address (and with it the periodic tx query task) until restart.
+        """
         locks = []
-        for address in addresses:
-            lock = self.address_tx_locks[address]
-            lock.acquire()
-            locks.append(lock)
+        try:
+            for address in addresses:
+                (lock := self.address_tx_locks[address]).acquire()
+                locks.append(lock)
 
-        yield  # yield to caller since all locks are now acquired
-
-        for lock in locks:  # clean up
-            lock.release()
+            yield  # yield to caller since all locks are now acquired
+        finally:  # release even on error, also covering a partially acquired list
+            for lock in locks:
+                lock.release()
 
     @with_tx_status_messaging
     def single_address_query_transactions(

--- a/rotkehlchen/tests/unit/test_evm_transactions.py
+++ b/rotkehlchen/tests/unit/test_evm_transactions.py
@@ -33,6 +33,7 @@ from rotkehlchen.types import (
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.manager import EthereumManager
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
     from rotkehlchen.chain.optimism.manager import OptimismManager
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.types import ChecksumEvmAddress
@@ -772,3 +773,28 @@ def test_all_indexers_get_same_tx_results(
     for idx, internal_tx_list in enumerate(txlistinteral_results):
         txlistinteral_results[idx] = [x._replace(trace_id=0) for x in internal_tx_list]
     assert all(x == txlistinteral_results[0] for x in txlistinteral_results[1:])
+
+
+def test_wait_until_no_query_for_releases_locks_on_error(
+        eth_transactions: 'EthereumTransactions',
+) -> None:
+    """Test that the address tx locks are released when the caller's body raises.
+
+    Regression test for account removal failing while holding the locks
+    (remove_single_blockchain_accounts enters the context manager via ExitStack,
+    which throws the body's exception into the generator at the yield point),
+    leaking the locks forever and permanently blocking all transaction querying
+    for those addresses - and with it the periodic tx query task - until restart.
+    """
+    addresses = [make_evm_address(), make_evm_address()]
+
+    def removal_that_fails() -> None:
+        with ExitStack() as stack:
+            stack.enter_context(eth_transactions.wait_until_no_query_for(addresses))
+            raise ValueError('simulated error during account removal')
+
+    with pytest.raises(ValueError, match='simulated'):
+        removal_that_fails()
+
+    for address in addresses:
+        assert eth_transactions.address_tx_locks[address].locked() is False


### PR DESCRIPTION
wait_until_no_query_for acquired the per-address transaction locks and only released them after its yield, with no try/finally. Its sole caller is blockchain account removal, which enters it through an ExitStack: when anything later in that block raises (InputError from a concurrent removal of the same account, a DB write failure, or the greenlet being killed mid-removal), the exception is thrown into the generator at the yield point and the release loop never runs.

The leaked semaphores live for the whole session, so the first tx query that touches such an address blocks forever. Since the periodic evm tx query task spawns one greenlet per tick and the scheduler skips a task whose greenlets are not dead, one stuck greenlet silently freezes periodic transaction querying for all chains and addresses until restart. API-triggered queries for the address hang as well.

Wrap acquisition and yield in try/finally, also covering a kill while blocked on acquiring a later lock in the list, which previously leaked the already-acquired ones.
