### PR TITLE
fix: don't drop block tag on indexer eth_call

### DIFF
--- a/rotkehlchen/chain/evm/node_inquirer.py
+++ b/rotkehlchen/chain/evm/node_inquirer.py
@@ -646,6 +646,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
             abi: ABI,
             method_name: str,
             arguments: list[Any] | None = None,
+            block_identifier: BlockIdentifier = 'latest',
     ) -> Any:
         """Performs an eth_call to an evm contract via the indexers.
 
@@ -660,6 +661,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
             chain_id=self.chain_id,
             to_address=contract_address,
             input_data=input_data,
+            block_identifier=block_identifier,
         ))) == '0x':
             raise BlockchainQueryError(
                 f'Error doing call on contract {contract_address} for {method_name} '
@@ -720,6 +722,7 @@ class EvmNodeInquirer(EVMRPCMixin, LockableQueryMixIn):
                 abi=abi,
                 method_name=method_name,
                 arguments=arguments,
+                block_identifier=block_identifier,
             )
 
         contract = web3.eth.contract(address=contract_address, abi=abi)

--- a/rotkehlchen/externalapis/blockscout.py
+++ b/rotkehlchen/externalapis/blockscout.py
@@ -56,6 +56,8 @@ log = RotkehlchenLogsAdapter(logger)
 class Blockscout(ExternalServiceWithApiKey, EtherscanLikeApi):
     """Blockscout API handler for the Blockscout PRO multichain endpoints."""
 
+    supports_historical_eth_call = True  # the json-rpc endpoint honors the eth_call block tag
+
     def __init__(
             self,
             database: 'DBHandler',

--- a/rotkehlchen/externalapis/etherscan_like.py
+++ b/rotkehlchen/externalapis/etherscan_like.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, overload
 import gevent
 import requests
 from requests import Response
+from web3.types import BlockIdentifier
 
 from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
 from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2ChainIdsWithL1FeesType
@@ -81,6 +82,11 @@ class HasChainActivity(Enum):
 
 class EtherscanLikeApi(ABC):
     """Base class for any APIs similar to etherscan."""
+
+    # Whether the indexer honors a block tag for eth_call. Etherscan silently ignores
+    # unrecognized tags and executes at the latest block, while routescan rejects the
+    # parameter, so only enable after verifying the indexer returns historical state.
+    supports_historical_eth_call: bool = False
 
     def __init__(
             self,
@@ -934,14 +940,23 @@ class EtherscanLikeApi(ABC):
             chain_id: SUPPORTED_CHAIN_IDS,
             to_address: ChecksumEvmAddress,
             input_data: str,
+            block_identifier: BlockIdentifier = 'latest',
     ) -> str:
         """Performs an eth_call on the given address and the given input data.
-        May raise RemoteError if there are problems contacting the indexer.
+        May raise RemoteError if there are problems contacting the indexer or if the
+        call is for a past block and the indexer can't execute it at historical state.
         """
+        options = {'to': to_address, 'data': input_data}
+        if block_identifier != 'latest':
+            if self.supports_historical_eth_call is False:
+                raise RemoteError(f'{self.name} does not support eth_call at a past block')
+
+            options['tag'] = hex(block_identifier) if isinstance(block_identifier, int) else str(block_identifier)  # noqa: E501
+
         return self._query_rpc_method(
             chain_id=chain_id,
             method='eth_call',
-            options={'to': to_address, 'data': input_data},
+            options=options,
         )
 
     def get_logs(

--- a/rotkehlchen/tests/external_apis/test_blockscout.py
+++ b/rotkehlchen/tests/external_apis/test_blockscout.py
@@ -346,3 +346,20 @@ def test_pro_api_urls_for_v1_v2_and_rpc(blockscout: Blockscout) -> None:
                     'params': [],
                 },
             )
+
+
+def test_eth_call_historical_block_passes_tag(blockscout: Blockscout) -> None:
+    """Blockscout honors the eth_call block tag, so historical calls should forward it"""
+    with patch.object(blockscout, '_query_rpc_method', return_value='0x1') as query_mock:
+        assert blockscout.eth_call(
+            chain_id=ChainID.ETHEREUM,
+            to_address=(dai := string_to_evm_address('0x6B175474E89094C44Da98b954EedeAC495271d0F')),  # noqa: E501
+            input_data='0x18160ddd',
+            block_identifier=10000000,
+        ) == '0x1'
+
+    query_mock.assert_called_once_with(
+        chain_id=ChainID.ETHEREUM,
+        method='eth_call',
+        options={'to': dai, 'data': '0x18160ddd', 'tag': '0x989680'},
+    )

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -307,3 +307,28 @@ def test_has_activity(temp_etherscan: 'Etherscan') -> None:
     assert temp_etherscan.has_activity(ChainID.ETHEREUM, string_to_evm_address('0x3C69Bc9B9681683890ad82953Fe67d13Cd91D5EE')) == HasChainActivity.BALANCE  # noqa: E501
     assert temp_etherscan.has_activity(ChainID.ETHEREUM, string_to_evm_address('0x014cd0535b2Ea668150a681524392B7633c8681c')) == HasChainActivity.TOKENS  # noqa: E501
     assert temp_etherscan.has_activity(ChainID.ETHEREUM, string_to_evm_address('0x6c66149E65c517605e0a2e4F707550ca342f9c1B')) == HasChainActivity.NONE  # noqa: E501
+
+
+def test_eth_call_historical_block_refused(temp_etherscan: 'Etherscan') -> None:
+    """Etherscan silently executes eth_call at the latest block when given a block tag,
+    so historical calls must be refused instead of returning wrong data"""
+    with (
+        patch.object(temp_etherscan, '_query_rpc_method') as query_mock,
+        pytest.raises(RemoteError, match='does not support eth_call at a past block'),
+    ):
+        temp_etherscan.eth_call(
+            chain_id=ChainID.ETHEREUM,
+            to_address=string_to_evm_address('0x6B175474E89094C44Da98b954EedeAC495271d0F'),
+            input_data='0x18160ddd',
+            block_identifier=10000000,
+        )
+
+    assert query_mock.call_count == 0
+    with patch.object(temp_etherscan, '_query_rpc_method', return_value='0x1') as query_mock:
+        assert temp_etherscan.eth_call(  # latest is still queried, without a tag
+            chain_id=ChainID.ETHEREUM,
+            to_address=(dai := string_to_evm_address('0x6B175474E89094C44Da98b954EedeAC495271d0F')),  # noqa: E501
+            input_data='0x18160ddd',
+        ) == '0x1'
+
+    assert query_mock.call_args.kwargs['options'] == {'to': dai, 'data': '0x18160ddd'}

--- a/rotkehlchen/tests/unit/test_evm_indexer_order.py
+++ b/rotkehlchen/tests/unit/test_evm_indexer_order.py
@@ -7,7 +7,7 @@ import pytest
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
 from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
-from rotkehlchen.chain.evm.types import EvmIndexer
+from rotkehlchen.chain.evm.types import EvmIndexer, string_to_evm_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import NoAvailableIndexers, RemoteError
@@ -151,3 +151,29 @@ def test_try_indexers_sends_ws_notification_when_no_indexers() -> None:
         message_type=WSMessageType.NO_AVAILABLE_INDEXERS,
         data={'chain': SupportedBlockchain.ETHEREUM.value},
     )
+
+
+def test_call_contract_indexers_forwards_block_identifier() -> None:
+    """Regression test for historical eth_call via indexers executing at the latest block.
+
+    _call_contract used to drop block_identifier when falling back to the indexers, so
+    historical contract queries silently returned state from the latest block instead.
+    """
+    inquirer = DummyEvmNodeInquirer()
+    seen_kwargs: dict[str, Any] = {}
+
+    def eth_call(**kwargs: Any) -> str:
+        seen_kwargs.update(kwargs)
+        return '0x' + '1'.zfill(64)
+
+    for indexer in (inquirer.etherscan, inquirer.blockscout, inquirer.routescan):
+        indexer.eth_call = eth_call  # type: ignore[assignment,method-assign]
+
+    assert inquirer._call_contract(
+        web3=None,
+        contract_address=string_to_evm_address('0x6B175474E89094C44Da98b954EedeAC495271d0F'),
+        abi=[{'inputs': [], 'name': 'totalSupply', 'outputs': [{'name': '', 'type': 'uint256'}], 'stateMutability': 'view', 'type': 'function'}],  # noqa: E501
+        method_name='totalSupply',
+        block_identifier=10000000,
+    ) == 1
+    assert seen_kwargs['block_identifier'] == 10000000


### PR DESCRIPTION
_call_contract dropped block_identifier when falling back to the indexers, so historical contract calls silently executed at the latest block. The archive-node guard in _query never applies to the indexers pseudo-node (its rpc_node is always None), and multicall even falls back to the indexers explicitly, so users without a reachable archive node got current pool state for historical Uniswap LP valuations and Uniswap-oracle price queries. The wrong prices were then persisted to the global price cache, permanently corrupting PnL.

Tested live: blockscout's json-rpc honors the eth_call block tag, etherscan v2 silently ignores it (even tag=0x1 returns latest state) and routescan rejects the parameter. So thread block_identifier through to the indexers with a supports_historical_eth_call capability flag: blockscout forwards the tag, while etherscan and routescan raise RemoteError for past blocks so _try_indexers falls through to an indexer that can serve them instead of returning wrong data with a success status.