### PR TITLE
Improve history event action picker UX

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3691,10 +3691,15 @@
       "out": "Out"
     },
     "picker": {
-      "empty": "No actions match your search.",
+      "empty_state": {
+        "hint": "Try a different word, or browse the groups.",
+        "no_query": "No actions available.",
+        "with_query": "No actions match \"{query}\"."
+      },
       "keyboard_hint": "↑↓ navigate · ↵ select · esc close",
       "label": "Action",
-      "placeholder": "Choose an action"
+      "placeholder": "Choose an action",
+      "recent": "Recent"
     }
   },
   "history_events_alert": {

--- a/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.spec.ts
+++ b/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.spec.ts
@@ -1,8 +1,8 @@
 import type { EventActionRow } from '@/modules/history/events/action-picker/use-event-action-picker';
 import { mount } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
-import { describe, expect, it, vi } from 'vitest';
-import { defineComponent, type VNode } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type PropType, type VNode } from 'vue';
 import HistoryEventActionPicker from '@/modules/history/events/action-picker/HistoryEventActionPicker.vue';
 
 function buildRow(): EventActionRow {
@@ -27,6 +27,16 @@ vi.mock('@/modules/history/events/action-picker/use-event-action-picker', () => 
   }),
 }));
 
+const recentRef = ref<string[]>([]);
+const record = vi.fn<(verbKey: string) => void>();
+
+vi.mock('@/modules/history/events/action-picker/use-recent-actions', () => ({
+  useRecentActions: (): unknown => ({
+    recent: recentRef,
+    record,
+  }),
+}));
+
 vi.mock('@/modules/history/events/mapping/use-history-event-mappings', () => ({
   useHistoryEventMappings: (): unknown => ({
     eventCategoryGroupsData: computed(() => ({
@@ -38,30 +48,62 @@ vi.mock('@/modules/history/events/mapping/use-history-event-mappings', () => ({
 }));
 
 const RuiAutoCompleteStub = defineComponent({
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'update:searchInput'],
   props: {
+    groupBy: { default: undefined, type: Function as unknown as PropType<(item: EventActionRow) => string> },
     label: { default: '', type: String },
     modelValue: { default: undefined, type: String },
     options: { required: true, type: Array as () => EventActionRow[] },
+    searchInput: { default: '', type: String },
   },
   setup(props, { emit, slots }) {
-    return (): VNode => h('div', { 'data-testid': 'autocomplete-stub' }, [
-      h('div', { 'data-testid': 'autocomplete-value' }, [props.modelValue ?? '']),
-      h('div', { 'data-testid': 'autocomplete-label' }, [props.label ?? '']),
-      ...props.options.map(item => h(
+    return (): VNode => {
+      const query = props.searchInput.trim().toLowerCase();
+      const visible = query
+        ? props.options.filter(item => item.label.toLowerCase().includes(query))
+        : props.options;
+
+      const groupBy = props.groupBy;
+      const groups: string[] = [];
+      for (const item of visible) {
+        const group = groupBy ? groupBy(item) : '';
+        if (!groups.includes(group))
+          groups.push(group);
+      }
+
+      const renderItem = (item: EventActionRow): VNode => h(
         'button',
         {
           'data-testid': `option-${item.verbKey}`,
           'onClick': (): void => emit('update:modelValue', item.verbKey),
         },
         slots.item ? [slots.item({ item })] : [item.label],
-      )),
-      slots.footer ? h('div', { 'data-testid': 'footer-slot' }, [slots.footer({})]) : null,
-    ]);
+      );
+
+      const renderGroup = (group: string): VNode => h('div', { 'data-testid': `group-${group}` }, [
+        slots['group-header'] ? slots['group-header']({ group }) : null,
+        ...visible.filter(item => (groupBy ? groupBy(item) : '') === group).map(renderItem),
+      ]);
+
+      return h('div', { 'data-testid': 'autocomplete-stub' }, [
+        h('div', { 'data-testid': 'autocomplete-value' }, [props.modelValue ?? '']),
+        h('div', { 'data-testid': 'autocomplete-label' }, [props.label ?? '']),
+        ...groups.map(renderGroup),
+        visible.length === 0 && slots['no-data']
+          ? h('div', { 'data-testid': 'no-data-slot' }, [slots['no-data']()])
+          : null,
+        slots.footer ? h('div', { 'data-testid': 'footer-slot' }, [slots.footer({})]) : null,
+      ]);
+    };
   },
 });
 
 describe('historyEventActionPicker', () => {
+  beforeEach(() => {
+    set(recentRef, []);
+    record.mockClear();
+  });
+
   function mountPicker(modelValue: { eventType: string; eventSubtype: string } | undefined = undefined): ReturnType<typeof mount<typeof HistoryEventActionPicker>> {
     return mount(HistoryEventActionPicker, {
       global: {
@@ -131,5 +173,91 @@ describe('historyEventActionPicker', () => {
     await flushPromises();
 
     expect(wrapper.find('[data-testid="footer-slot"]').exists()).toBe(true);
+  });
+
+  it('should not highlight any part of the label when the search is empty', async () => {
+    findRowByTypeSubtype.mockReturnValue(undefined);
+    const wrapper = mountPicker();
+    await flushPromises();
+
+    const rowEl = wrapper.find('[data-testid="event-action-picker-row-swap out"]');
+    expect(rowEl.find('.text-rui-primary').exists()).toBe(false);
+    expect(rowEl.text()).toContain('Swap out');
+  });
+
+  it('should highlight the matched substring of the label while searching', async () => {
+    findRowByTypeSubtype.mockReturnValue(undefined);
+    const wrapper = mountPicker();
+    await flushPromises();
+
+    wrapper.findComponent(RuiAutoCompleteStub).vm.$emit('update:searchInput', 'swap');
+    await flushPromises();
+
+    const highlighted = wrapper.find('[data-testid="event-action-picker-row-swap out"] .text-rui-primary');
+    expect(highlighted.exists()).toBe(true);
+    expect(highlighted.text()).toBe('Swap');
+  });
+
+  it('should show the empty state with the query when nothing matches', async () => {
+    findRowByTypeSubtype.mockReturnValue(undefined);
+    const wrapper = mountPicker();
+    await flushPromises();
+
+    wrapper.findComponent(RuiAutoCompleteStub).vm.$emit('update:searchInput', 'zzz');
+    await flushPromises();
+
+    const empty = wrapper.find('[data-testid="event-action-picker-empty"]');
+    expect(empty.exists()).toBe(true);
+    expect(empty.text()).toContain('zzz');
+  });
+
+  it('should hide the empty state when the search matches a row', async () => {
+    findRowByTypeSubtype.mockReturnValue(undefined);
+    const wrapper = mountPicker();
+    await flushPromises();
+
+    wrapper.findComponent(RuiAutoCompleteStub).vm.$emit('update:searchInput', 'swap');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="event-action-picker-empty"]').exists()).toBe(false);
+  });
+
+  it('should pin recent verbs to a synthetic recent group', async () => {
+    findRowByTypeSubtype.mockReturnValue(undefined);
+    set(recentRef, ['swap out']);
+    const wrapper = mountPicker();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="event-action-picker-recent-header"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="option-recent:swap out"]').exists()).toBe(true);
+    // The canonical row in its own group is still present.
+    expect(wrapper.find('[data-testid="option-swap out"]').exists()).toBe(true);
+  });
+
+  it('should not render the recent group while searching', async () => {
+    findRowByTypeSubtype.mockReturnValue(undefined);
+    set(recentRef, ['swap out']);
+    const wrapper = mountPicker();
+    await flushPromises();
+
+    wrapper.findComponent(RuiAutoCompleteStub).vm.$emit('update:searchInput', 'swap');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="event-action-picker-recent-header"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="option-recent:swap out"]').exists()).toBe(false);
+  });
+
+  it('should record the canonical verb key when a recent row is picked', async () => {
+    findRowByTypeSubtype.mockReturnValue(undefined);
+    set(recentRef, ['swap out']);
+    const wrapper = mountPicker();
+    await flushPromises();
+
+    await wrapper.find('[data-testid="option-recent:swap out"]').trigger('click');
+    await flushPromises();
+
+    expect(record).toHaveBeenCalledWith('swap out');
+    const updates = wrapper.emitted('update:modelValue') ?? [];
+    expect(updates[0][0]).toEqual({ eventSubtype: 'spend', eventType: 'trade' });
   });
 });

--- a/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.vue
+++ b/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import type { HistoryEventEntryType } from '@rotki/common';
+import { type HighlightSegment, splitHighlight } from '@/modules/history/events/action-picker/highlight-match';
 import HistoryEventActionDirectionBadge from '@/modules/history/events/action-picker/HistoryEventActionDirectionBadge.vue';
 import { type EventActionRow, useEventActionPicker } from '@/modules/history/events/action-picker/use-event-action-picker';
+import { useRecentActions } from '@/modules/history/events/action-picker/use-recent-actions';
 import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
 
 interface ModelValue {
@@ -10,7 +12,6 @@ interface ModelValue {
 }
 
 const modelValue = defineModel<ModelValue | undefined>({ required: true });
-
 const { entryType, disabled = false, label, errorMessages, required = false, hint } = defineProps<{
   entryType?: HistoryEventEntryType;
   disabled?: boolean;
@@ -19,10 +20,18 @@ const { entryType, disabled = false, label, errorMessages, required = false, hin
   required?: boolean;
   hint?: string;
 }>();
+// Synthetic group used to pin frequently picked verbs to the top. Recent rows
+// reuse a real row but carry a distinct key/group so RuiAutoComplete doesn't
+// collide with the canonical row that also lives in its taxonomy group.
+const RECENT_GROUP_ID = '__recent__';
+const RECENT_KEY_PREFIX = 'recent:';
 
 const { t } = useI18n({ useScope: 'global' });
 
+const search = ref<string>('');
+
 const { findRowByTypeSubtype, rows } = useEventActionPicker(() => entryType);
+const { recent, record } = useRecentActions(() => entryType);
 const { eventCategoryGroupsData, getHistoryEventSubTypeName, getHistoryEventTypeName } = useHistoryEventMappings();
 
 const selectedVerbKey = computed<string | undefined>(() => {
@@ -42,13 +51,61 @@ watch([selectedVerbKey, rows], ([verbKey, currentRows]) => {
 
 const triggerLabel = computed<string>(() => label ?? t('history_event_action.picker.label'));
 
+const trimmedSearch = computed<string>(() => get(search).trim());
+
+// Map the persisted recent verb keys back onto live rows (dropping any that the
+// current entry type filtered out), tagging them for the synthetic group.
+const recentRows = computed<EventActionRow[]>(() => {
+  const byKey = new Map(get(rows).map(row => [row.verbKey, row]));
+  const result: EventActionRow[] = [];
+
+  for (const verbKey of get(recent)) {
+    const row = byKey.get(verbKey);
+    if (row)
+      result.push({ ...row, groupId: RECENT_GROUP_ID, verbKey: `${RECENT_KEY_PREFIX}${verbKey}` });
+  }
+
+  return result;
+});
+
+// Recents only make sense while browsing; once a query is typed they'd just
+// duplicate the filtered results, so they're dropped.
+const displayRows = computed<EventActionRow[]>(() => {
+  const base = [...get(rows)];
+  if (get(trimmedSearch) || get(recentRows).length === 0)
+    return base;
+
+  return [...get(recentRows), ...base];
+});
+
+function highlightLabel(value: string): HighlightSegment[] {
+  return splitHighlight(value, get(search));
+}
+
 const FALLBACK_GROUP: Readonly<{ label: string; icon: string }> = {
   icon: 'lu-circle-question-mark',
   label: '',
 };
 
-function getGroupConfig(groupId: string): { label: string; icon: string } {
-  return get(eventCategoryGroupsData)[groupId] ?? FALLBACK_GROUP;
+interface GroupHeaderConfig {
+  label: string;
+  icon: string;
+  classes: string;
+  testId?: string;
+}
+
+function getGroupConfig(groupId: string): GroupHeaderConfig {
+  if (groupId === RECENT_GROUP_ID) {
+    return {
+      classes: 'text-rui-primary font-medium',
+      icon: 'lu-history',
+      label: t('history_event_action.picker.recent'),
+      testId: 'event-action-picker-recent-header',
+    };
+  }
+
+  const group = get(eventCategoryGroupsData)[groupId] ?? FALLBACK_GROUP;
+  return { classes: 'text-rui-text-secondary', icon: group.icon, label: group.label };
 }
 
 function rowEventTypes(row: EventActionRow): string {
@@ -83,16 +140,23 @@ function onUpdate(verbKey: string | undefined): void {
   if (!verbKey)
     return;
 
-  const row = get(rows).find(r => r.verbKey === verbKey);
-  if (!row)
-    return;
+  // A pick from the synthetic recent group carries the prefixed key; resolve it
+  // back to the canonical verb before touching the model or the recents store.
+  const realKey = verbKey.startsWith(RECENT_KEY_PREFIX) ? verbKey.slice(RECENT_KEY_PREFIX.length) : verbKey;
 
-  const current = get(modelValue);
-  if (current && row.combinations.some(c => c.eventType === current.eventType && c.eventSubtype === current.eventSubtype))
+  const row = get(rows).find(r => r.verbKey === realKey);
+  if (!row)
     return;
 
   const first = row.combinations[0];
   if (!first)
+    return;
+
+  // Record even when re-picking the current value so it bubbles back to the top.
+  record(realKey);
+
+  const current = get(modelValue);
+  if (current && row.combinations.some(c => c.eventType === current.eventType && c.eventSubtype === current.eventSubtype))
     return;
 
   set(modelValue, { eventSubtype: first.eventSubtype, eventType: first.eventType });
@@ -101,15 +165,15 @@ function onUpdate(verbKey: string | undefined): void {
 
 <template>
   <RuiAutoComplete
+    v-model:search-input="search"
     :model-value="selectedVerbKey"
-    :options="[...rows]"
+    :options="displayRows"
     key-attr="verbKey"
     text-attr="label"
     variant="outlined"
     :group-by="(row: EventActionRow) => row.groupId"
     :label="triggerLabel"
     :placeholder="t('history_event_action.picker.placeholder')"
-    :no-data-text="t('history_event_action.picker.empty')"
     :disabled="disabled"
     :required="required"
     :error-messages="errorMessages"
@@ -136,7 +200,11 @@ function onUpdate(verbKey: string | undefined): void {
       </div>
     </template>
     <template #group-header="{ group }">
-      <div class="flex items-center gap-2 px-3 py-2 text-xs uppercase tracking-wide text-rui-text-secondary">
+      <div
+        class="flex items-center gap-2 px-3 py-2 text-xs uppercase tracking-wide"
+        :class="getGroupConfig(group).classes"
+        :data-testid="getGroupConfig(group).testId"
+      >
         <RuiIcon
           :name="getGroupConfig(group).icon"
           size="14"
@@ -157,7 +225,13 @@ function onUpdate(verbKey: string | undefined): void {
         />
         <div class="flex-1 min-w-0">
           <div class="text-sm text-rui-text truncate">
-            {{ item.label }}
+            <span
+              v-for="(segment, index) in highlightLabel(item.label)"
+              :key="index"
+              :class="{ 'font-bold text-rui-primary': segment.matched }"
+            >
+              {{ segment.text }}
+            </span>
           </div>
           <div
             v-if="subtitleFor(item)"
@@ -170,6 +244,22 @@ function onUpdate(verbKey: string | undefined): void {
           :direction="item.direction"
           class="shrink-0"
         />
+      </div>
+    </template>
+    <template #no-data>
+      <div
+        class="flex flex-col gap-1 px-4 py-3 text-sm text-rui-text-secondary"
+        data-testid="event-action-picker-empty"
+      >
+        <span v-if="trimmedSearch">
+          {{ t('history_event_action.picker.empty_state.with_query', { query: trimmedSearch }) }}
+        </span>
+        <span v-else>
+          {{ t('history_event_action.picker.empty_state.no_query') }}
+        </span>
+        <span class="text-xs">
+          {{ t('history_event_action.picker.empty_state.hint') }}
+        </span>
       </div>
     </template>
     <template #footer>

--- a/frontend/app/src/modules/history/events/action-picker/highlight-match.spec.ts
+++ b/frontend/app/src/modules/history/events/action-picker/highlight-match.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { splitHighlight } from '@/modules/history/events/action-picker/highlight-match';
+
+describe('splitHighlight', () => {
+  it('should return a single unmatched segment for an empty query', () => {
+    expect(splitHighlight('Swap out', '')).toEqual([{ matched: false, text: 'Swap out' }]);
+  });
+
+  it('should return a single unmatched segment for a whitespace-only query', () => {
+    expect(splitHighlight('Swap out', '   ')).toEqual([{ matched: false, text: 'Swap out' }]);
+  });
+
+  it('should wrap a case-insensitive match at the start of the label', () => {
+    expect(splitHighlight('Swap out', 'swap')).toEqual([
+      { matched: true, text: 'Swap' },
+      { matched: false, text: ' out' },
+    ]);
+  });
+
+  it('should wrap a match in the middle of the label', () => {
+    expect(splitHighlight('Receive reward', 'eward')).toEqual([
+      { matched: false, text: 'Receive r' },
+      { matched: true, text: 'eward' },
+    ]);
+  });
+
+  it('should preserve the original casing of the matched span', () => {
+    expect(splitHighlight('Deposit Asset', 'DEPOSIT')).toEqual([
+      { matched: true, text: 'Deposit' },
+      { matched: false, text: ' Asset' },
+    ]);
+  });
+
+  it('should return the whole label unmatched when there is no contiguous match', () => {
+    expect(splitHighlight('Swap out', 'wapou')).toEqual([{ matched: false, text: 'Swap out' }]);
+  });
+});

--- a/frontend/app/src/modules/history/events/action-picker/highlight-match.ts
+++ b/frontend/app/src/modules/history/events/action-picker/highlight-match.ts
@@ -1,0 +1,37 @@
+export interface HighlightSegment {
+  readonly text: string;
+  readonly matched: boolean;
+}
+
+/**
+ * Splits a label into segments around the first case-insensitive occurrence of
+ * `query`, so the matched portion can be visually emphasised in the picker rows.
+ *
+ * RuiAutoComplete filters on a normalised token (lower-cased, non-alphanumerics
+ * stripped) that doesn't map back onto the visible label, so this performs a
+ * best-effort literal match instead: when the trimmed query appears contiguously
+ * in the label it is highlighted, otherwise the label is returned unsegmented
+ * (the row is still shown — the library filter already decided it matches).
+ */
+export function splitHighlight(label: string, query: string): HighlightSegment[] {
+  const trimmed = query.trim();
+  if (!trimmed)
+    return [{ matched: false, text: label }];
+
+  const index = label.toLowerCase().indexOf(trimmed.toLowerCase());
+  if (index === -1)
+    return [{ matched: false, text: label }];
+
+  const end = index + trimmed.length;
+  const segments: HighlightSegment[] = [];
+
+  if (index > 0)
+    segments.push({ matched: false, text: label.slice(0, index) });
+
+  segments.push({ matched: true, text: label.slice(index, end) });
+
+  if (end < label.length)
+    segments.push({ matched: false, text: label.slice(end) });
+
+  return segments;
+}

--- a/frontend/app/src/modules/history/events/action-picker/use-recent-actions.spec.ts
+++ b/frontend/app/src/modules/history/events/action-picker/use-recent-actions.spec.ts
@@ -1,0 +1,77 @@
+import { HistoryEventEntryType } from '@rotki/common';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useRecentActions } from '@/modules/history/events/action-picker/use-recent-actions';
+
+describe('useRecentActions', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should record a picked verb at the front', () => {
+    const { record, recent } = useRecentActions(() => HistoryEventEntryType.EVM_EVENT);
+
+    record('swap out');
+    record('receive');
+
+    expect(get(recent)).toEqual(['receive', 'swap out']);
+  });
+
+  it('should move a re-picked verb to the front without duplicating it', () => {
+    const { record, recent } = useRecentActions(() => HistoryEventEntryType.EVM_EVENT);
+
+    record('a');
+    record('b');
+    record('a');
+
+    expect(get(recent)).toEqual(['a', 'b']);
+  });
+
+  it('should rank a more frequently picked verb above a more recent one', () => {
+    const { record, recent } = useRecentActions(() => HistoryEventEntryType.EVM_EVENT);
+
+    record('a');
+    record('a');
+    record('b');
+
+    // 'b' was picked last, but 'a' was picked more often, so frequency wins.
+    expect(get(recent)).toEqual(['a', 'b']);
+  });
+
+  it('should display only the five top-ranked entries', () => {
+    const { record, recent } = useRecentActions(() => HistoryEventEntryType.EVM_EVENT);
+
+    for (const verb of ['a', 'b', 'c', 'd', 'e', 'f'])
+      record(verb);
+
+    expect(get(recent)).toEqual(['f', 'e', 'd', 'c', 'b']);
+  });
+
+  it('should persist recents across a fresh composable instance', async () => {
+    useRecentActions(() => HistoryEventEntryType.EVM_EVENT).record('swap out');
+    await nextTick();
+
+    const { recent } = useRecentActions(() => HistoryEventEntryType.EVM_EVENT);
+    expect(get(recent)).toEqual(['swap out']);
+  });
+
+  it('should scope recents per entry type', () => {
+    const evm = useRecentActions(() => HistoryEventEntryType.EVM_EVENT);
+    const block = useRecentActions(() => HistoryEventEntryType.ETH_BLOCK_EVENT);
+
+    evm.record('swap out');
+    block.record('block reward');
+
+    expect(get(evm.recent)).toEqual(['swap out']);
+    expect(get(block.recent)).toEqual(['block reward']);
+  });
+
+  it('should discard a persisted store with an incompatible schema version', () => {
+    localStorage.setItem(
+      'rotki.history.recent-actions',
+      JSON.stringify({ entries: { [HistoryEventEntryType.EVM_EVENT]: ['stale'] }, schemaVersion: 0 }),
+    );
+
+    const { recent } = useRecentActions(() => HistoryEventEntryType.EVM_EVENT);
+    expect(get(recent)).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/history/events/action-picker/use-recent-actions.ts
+++ b/frontend/app/src/modules/history/events/action-picker/use-recent-actions.ts
@@ -1,0 +1,96 @@
+import type { HistoryEventEntryType } from '@rotki/common';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+
+/**
+ * Phase 2 item 1 (frequently used actions).
+ *
+ * Persists the verbs a user picks per entry type so the picker can pin the ones
+ * they reach for most to the top. Ranking is frequency-first (how often a verb
+ * has been picked) with recency as the tiebreaker, so a long-favoured verb keeps
+ * its spot while ties resolve to whatever was touched last.
+ *
+ * Storage is a versioned envelope: bumping `RECENT_SCHEMA_VERSION` discards older
+ * shapes instead of trying to migrate them.
+ */
+
+const RECENT_SCHEMA_VERSION = 2;
+const RECENT_LIMIT = 5;
+const RECENT_TRACK_LIMIT = 20;
+const RECENT_STORAGE_KEY = 'rotki.history.recent-actions';
+const RECENT_SCOPE_FALLBACK = '__all__';
+
+interface RecentEntry {
+  verbKey: string;
+  count: number;
+}
+
+interface RecentActionsStore {
+  schemaVersion: number;
+  // Per-scope list of picked verbs, kept in most-recently-used-first order so the
+  // array position doubles as the recency tiebreaker for equal counts.
+  entries: Record<string, RecentEntry[]>;
+}
+
+interface UseRecentActionsReturn {
+  readonly recent: ComputedRef<readonly string[]>;
+  readonly record: (verbKey: string) => void;
+}
+
+function defaultStore(): RecentActionsStore {
+  return { entries: {}, schemaVersion: RECENT_SCHEMA_VERSION };
+}
+
+export function useRecentActions(
+  entryType?: MaybeRefOrGetter<HistoryEventEntryType | undefined>,
+): UseRecentActionsReturn {
+  const store = useLocalStorage<RecentActionsStore>(RECENT_STORAGE_KEY, defaultStore());
+
+  // useLocalStorage exposes a RemovableRef (the value can be null once the key is
+  // cleared), so always read through this guard to fall back to a fresh store.
+  function currentStore(): RecentActionsStore {
+    return get(store) ?? defaultStore();
+  }
+
+  // Discard incompatible persisted shapes rather than risk reading stale data.
+  if (currentStore().schemaVersion !== RECENT_SCHEMA_VERSION)
+    set(store, defaultStore());
+
+  const scopeKey = computed<string>(() => toValue(entryType) ?? RECENT_SCOPE_FALLBACK);
+
+  // Frequency-first ranking; the source array is recency-ordered, so a stable
+  // sort by descending count keeps the most-recent verb ahead on ties.
+  const recent = computed<readonly string[]>(() => {
+    const entries = currentStore().entries[get(scopeKey)] ?? [];
+    return entries
+      .slice()
+      .sort((a, b) => b.count - a.count)
+      .slice(0, RECENT_LIMIT)
+      .map(entry => entry.verbKey);
+  });
+
+  function record(verbKey: string): void {
+    const key = get(scopeKey);
+    const current = currentStore();
+    const existing = current.entries[key] ?? [];
+    const previous = existing.find(entry => entry.verbKey === verbKey);
+
+    // Move the picked verb to the front (recency) and bump its count (frequency).
+    const next: RecentEntry[] = [
+      { count: (previous?.count ?? 0) + 1, verbKey },
+      ...existing.filter(entry => entry.verbKey !== verbKey),
+    ].slice(0, RECENT_TRACK_LIMIT);
+
+    set(store, {
+      ...current,
+      entries: {
+        ...current.entries,
+        [key]: next,
+      },
+    });
+  }
+
+  return {
+    recent,
+    record,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 2 UX follow-ups for the history event action picker (verb selector in the history event form).

- **Highlight matched substring** — while searching, the matched portion of each action label is emphasised, via a new pure `splitHighlight()` helper (best-effort literal match, since RuiAutoComplete filters on a normalised token that doesn't map back to the visible label).
- **Useful empty state** — the dropdown now distinguishes "no actions match \"<query>\"" from "no actions available" and offers a hint to try another word or browse the groups, replacing the single static `no-data-text`.
- **Frequently used actions** — recently/often picked verbs are pinned to the top under a "Recent" group. Ranking is frequency-first (pick count) with recency as the tiebreaker, persisted per entry type in local storage under a versioned envelope.

## Notes

- Recents are scoped per `entryType` and hidden while a query is typed (they'd just duplicate filtered results).
- Recent rows reuse a real row but carry a distinct `recent:` key prefix + synthetic group so RuiAutoComplete doesn't collide with the canonical row; the prefix is stripped on selection.
- Storage uses `RECENT_SCHEMA_VERSION` (bumped to 2); incompatible persisted shapes are discarded rather than migrated.

## Testing

- New unit tests for `splitHighlight`, `useRecentActions` (frequency ranking, recency tiebreak, per-scope, schema discard), and the picker component (highlight, empty state, recent group, prefix round-trip).
- `pnpm run test:unit` (33 passed), `pnpm run typecheck`, and `lint-staged` all green.