### PR TITLE
perf: batch exchange balance price queries

### DIFF
--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -14,7 +14,6 @@ import gevent
 import requests
 from rsqlite import IntegrityError
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.assets.converters import asset_from_binance
@@ -54,7 +53,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -486,10 +484,10 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
     def _add_balances(
             self,
-            balances: defaultdict[AssetWithOracles, Balance],
+            balances: defaultdict[AssetWithOracles, FVal],
             new_balances: list[dict],
-    ) -> defaultdict[AssetWithOracles, Balance]:
-        """Add new balances to balances dict"""
+    ) -> defaultdict[AssetWithOracles, FVal]:
+        """Add new balance amounts to the balances dict"""
         for entry in new_balances:
             try:
                 # force string https://github.com/rotki/rotki/issues/2342
@@ -530,23 +528,14 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 )
                 continue
 
-            try:
-                price = Inquirer.find_main_currency_price(asset)
-            except RemoteError as e:
-                log.error(
-                    f'Error processing {self.name} balance entry due to inability to '
-                    f'query price: {e!s}. Skipping balance entry',
-                )
-                continue
-
-            balances[asset] += Balance(amount=amount, value=amount * price)
+            balances[asset] += amount
 
         return balances
 
     def _query_spot_balances(
             self,
-            balances: defaultdict[AssetWithOracles, Balance],
-    ) -> defaultdict[AssetWithOracles, Balance]:
+            balances: defaultdict[AssetWithOracles, FVal],
+    ) -> defaultdict[AssetWithOracles, FVal]:
         try:
             account_data = self.api_query_dict(api_type='api', method='account')
         except (RemoteError, BinancePermissionError) as e:
@@ -563,8 +552,8 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
     def _query_funding_balances(
             self,
-            balances: defaultdict[AssetWithOracles, Balance],
-    ) -> defaultdict[AssetWithOracles, Balance]:
+            balances: defaultdict[AssetWithOracles, FVal],
+    ) -> defaultdict[AssetWithOracles, FVal]:
         """Query the balances of funding wallet in binance.
         Docs: https://binance-docs.github.io/apidocs/spot/en/#funding-wallet-user_data
 
@@ -588,8 +577,8 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
     def _query_lending_balances(
             self,
-            balances: defaultdict[AssetWithOracles, Balance],
-    ) -> defaultdict[AssetWithOracles, Balance]:
+            balances: defaultdict[AssetWithOracles, FVal],
+    ) -> defaultdict[AssetWithOracles, FVal]:
         """Queries binance lending balances and if any found adds them to `balances`
 
         May raise:
@@ -658,19 +647,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                     )
                     continue
 
-                try:
-                    price = Inquirer.find_main_currency_price(asset)
-                except RemoteError as e:
-                    log.error(
-                        f'Error processing {self.name} balance entry due to inability to '
-                        f'query price: {e!s}. Skipping balance entry',
-                    )
-                    continue
-
-                balances[asset] += Balance(
-                    amount=amount,
-                    value=amount * price,
-                )
+                balances[asset] += amount
 
         return balances
 
@@ -865,8 +842,8 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
     def _query_cross_collateral_futures_balances(
             self,
-            balances: defaultdict[AssetWithOracles, Balance],
-    ) -> defaultdict[AssetWithOracles, Balance]:
+            balances: defaultdict[AssetWithOracles, FVal],
+    ) -> defaultdict[AssetWithOracles, FVal]:
         """Queries binance collateral future balances and if any found adds them to `balances`
 
         May raise:
@@ -895,19 +872,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                     )
                     continue
 
-                try:
-                    price = Inquirer.find_main_currency_price(asset)
-                except RemoteError as e:
-                    log.error(
-                        f'Error processing {self.name} balance entry due to inability to '
-                        f'query price: {e!s}. Skipping balance entry',
-                    )
-                    continue
-
-                balances[asset] += Balance(
-                    amount=amount,
-                    value=amount * price,
-                )
+                balances[asset] += amount
 
         except KeyError as e:
             self.msg_aggregator.add_error(
@@ -917,19 +882,19 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
         return balances
 
-    def _query_margined_fapi(self, balances: defaultdict[AssetWithOracles, Balance]) -> defaultdict[AssetWithOracles, Balance]:  # noqa: E501
+    def _query_margined_fapi(self, balances: defaultdict[AssetWithOracles, FVal]) -> defaultdict[AssetWithOracles, FVal]:  # noqa: E501
         """Only a convenience function to give same interface as other query methods"""
         return self._query_margined_futures_balances('fapi', balances)
 
-    def _query_margined_dapi(self, balances: defaultdict[AssetWithOracles, Balance]) -> defaultdict[AssetWithOracles, Balance]:  # noqa: E501
+    def _query_margined_dapi(self, balances: defaultdict[AssetWithOracles, FVal]) -> defaultdict[AssetWithOracles, FVal]:  # noqa: E501
         """Only a convenience function to give same interface as other query methods"""
         return self._query_margined_futures_balances('dapi', balances)
 
     def _query_margined_futures_balances(
             self,
             api_type: Literal['fapi', 'dapi'],
-            balances: defaultdict[AssetWithOracles, Balance],
-    ) -> defaultdict[AssetWithOracles, Balance]:
+            balances: defaultdict[AssetWithOracles, FVal],
+    ) -> defaultdict[AssetWithOracles, FVal]:
         """Queries binance margined future balances and if any found adds them to `balances`
 
         May raise:
@@ -965,19 +930,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                     )
                     continue
 
-                try:
-                    price = Inquirer.find_main_currency_price(asset)
-                except RemoteError as e:
-                    log.error(
-                        f'Error processing {self.name} balance entry due to inability to '
-                        f'query price: {e!s}. Skipping margined futures balance entry',
-                    )
-                    continue
-
-                balances[asset] += Balance(
-                    amount=amount,
-                    value=amount * price,
-                )
+                balances[asset] += amount
 
         except KeyError as e:
             self.msg_aggregator.add_error(
@@ -989,8 +942,8 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
 
     def _query_pools_balances(
             self,
-            balances: defaultdict[AssetWithOracles, Balance],
-    ) -> defaultdict[AssetWithOracles, Balance]:
+            balances: defaultdict[AssetWithOracles, FVal],
+    ) -> defaultdict[AssetWithOracles, FVal]:
         """Queries binance pool balances and if any found adds them to `balances`
 
         May raise:
@@ -1016,19 +969,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 )
                 return None
 
-            try:
-                price = Inquirer.find_main_currency_price(asset)
-            except RemoteError as e:
-                log.error(
-                    f'Error processing {self.name} balance entry due to inability to '
-                    f'query price: {e!s}. Skipping {self.name} pool balance entry',
-                )
-                return None
-
-            balances[asset] += Balance(
-                amount=asset_amount,
-                value=asset_amount * price,
-            )
+            balances[asset] += asset_amount
             return None
 
         try:
@@ -1065,9 +1006,9 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
     def query_balances(self) -> ExchangeQueryBalances:
         try:
             self.first_connection()
-            returned_balances: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
-            returned_balances = self._query_spot_balances(returned_balances)
-            returned_balances = self._query_funding_balances(returned_balances)
+            amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
+            amounts = self._query_spot_balances(amounts)
+            amounts = self._query_funding_balances(amounts)
             if self.location != Location.BINANCEUS:
                 for method in (
                         self._query_lending_balances,
@@ -1077,7 +1018,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                         self._query_pools_balances,
                 ):
                     try:
-                        returned_balances = method(returned_balances)
+                        amounts = method(amounts)
                     except RemoteError as e:  # errors in any of these methods should not be fatal
                         log.warning(f'Failed to query binance method {method.__name__} due to {e!s}')  # noqa: E501
 
@@ -1089,6 +1030,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             self.msg_aggregator.add_error(msg)
             return None, msg
 
+        returned_balances = self.balances_from_amounts(amounts)
         log.debug(
             f'{self.name} balance query result',
             balances=returned_balances,

--- a/rotkehlchen/exchanges/bitcoinde.py
+++ b/rotkehlchen/exchanges/bitcoinde.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from collections import defaultdict
 from collections.abc import Sequence
 from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Literal
@@ -8,7 +9,6 @@ from urllib.parse import urlencode
 
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.assets.converters import asset_from_bitcoinde
 from rotkehlchen.constants.assets import A_EUR
@@ -18,9 +18,9 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import Location, MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.swap import SwapEvent, create_swap_events
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -173,7 +173,7 @@ class Bitcoinde(ExchangeInterface, SignatureGeneratorMixin):
             return True, ''
 
     def query_balances(self, **kwargs: Any) -> ExchangeQueryBalances:
-        assets_balance: dict[AssetWithOracles, Balance] = {}
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         try:
             resp_info = self._api_query('get', 'account')
         except RemoteError as e:
@@ -195,15 +195,6 @@ class Bitcoinde(ExchangeInterface, SignatureGeneratorMixin):
                 )
                 continue
             try:
-                price = Inquirer.find_main_currency_price(asset)
-            except RemoteError as e:
-                self.msg_aggregator.add_error(
-                    f'Error processing Bitcoin.de balance entry due to inability to '
-                    f'query price: {e!s}. Skipping balance entry',
-                )
-                continue
-
-            try:
                 amount = deserialize_fval(balance['total_amount'])
             except DeserializationError as e:
                 self.msg_aggregator.add_error(
@@ -212,12 +203,9 @@ class Bitcoinde(ExchangeInterface, SignatureGeneratorMixin):
                 )
                 continue
 
-            assets_balance[asset] = Balance(
-                amount=amount,
-                value=amount * price,
-            )
+            amounts[asset] += amount
 
-        return assets_balance, ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def _deserialize_trade(self, raw_trade: dict) -> list[SwapEvent]:
         """Convert bitcoin.de raw trade data to a list of SwapEvents.

--- a/rotkehlchen/exchanges/bitfinex.py
+++ b/rotkehlchen/exchanges/bitfinex.py
@@ -14,7 +14,6 @@ import requests
 from gevent.lock import Semaphore
 from requests.adapters import Response
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import BITFINEX_EXCHANGE_TEST_ASSETS, asset_from_bitfinex
 from rotkehlchen.assets.utils import symbol_to_asset_or_token
 from rotkehlchen.constants import ZERO
@@ -26,6 +25,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin
+from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.asset_movement import (
@@ -39,7 +39,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -846,7 +845,7 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
         # Wallet items indices
         currency_index = 1
         balance_index = 2
-        assets_balance: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for wallet in response_list:
             if len(wallet) < API_WALLET_MIN_RESULT_LENGTH:
                 log.error(
@@ -873,15 +872,6 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
                 continue
 
             try:
-                price = Inquirer.find_main_currency_price(asset)
-            except RemoteError as e:
-                self.msg_aggregator.add_error(
-                    f'Error processing {self.name} {asset.name} balance result due to inability '
-                    f'to query price: {e!s}. Skipping balance result.',
-                )
-                continue
-
-            try:
                 amount = deserialize_fval(wallet[balance_index])
             except DeserializationError as e:
                 self.msg_aggregator.add_error(
@@ -890,12 +880,9 @@ class Bitfinex(ExchangeInterface, SignatureGeneratorMixin):
                 )
                 continue
 
-            assets_balance[asset] += Balance(
-                amount=amount,
-                value=amount * price,
-            )
+            amounts[asset] += amount
 
-        return dict(assets_balance), ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def query_online_history_events(
             self,

--- a/rotkehlchen/exchanges/bitmex.py
+++ b/rotkehlchen/exchanges/bitmex.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from collections import defaultdict
 from collections.abc import Sequence
 from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Literal, overload
@@ -7,7 +8,6 @@ from urllib.parse import urlencode
 
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.assets.utils import normalized_fval_value_decimals, symbol_to_asset_or_token
 from rotkehlchen.constants.assets import A_BTC, A_ETH
@@ -28,7 +28,6 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.events.structures.asset_movement import create_asset_movement_with_fee
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_fval, deserialize_fval_or_zero
 from rotkehlchen.types import (
@@ -274,7 +273,7 @@ class Bitmex(ExchangeInterface, SignatureGeneratorMixin):
     @cache_response_timewise()
     def query_balances(self, **kwargs: Any) -> ExchangeQueryBalances:
         self.first_connection()
-        returned_balances: dict[AssetWithOracles, Balance] = {}
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         try:
             resp = self._api_query('user/wallet', {'currency': 'all'})
         except RemoteError as e:
@@ -295,25 +294,9 @@ class Bitmex(ExchangeInterface, SignatureGeneratorMixin):
                 log.error(f'Unknown decimals for asset balance {balance} in bitmex. Skipping')
                 continue
 
-            amount = normalized_fval_value_decimals(amount=FVal(raw_amount), decimals=decimals)
-            try:
-                price = Inquirer.find_main_currency_price(asset)
-            except RemoteError as e:
-                self.msg_aggregator.add_error(
-                    f'Error processing {self.name} balance entry due to inability to '
-                    f'query price: {e!s}. Skipping balance entry',
-                )
-                continue
+            amounts[asset] += normalized_fval_value_decimals(amount=FVal(raw_amount), decimals=decimals)  # noqa: E501
 
-            returned_balances[asset] = Balance(amount=amount, value=(value := amount * price))
-            log.debug(
-                'Bitmex balance query result',
-                currency=currency,
-                amount=amount,
-                value=value,
-            )
-
-        return returned_balances, ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def query_online_margin_history(
             self,

--- a/rotkehlchen/exchanges/bitpanda.py
+++ b/rotkehlchen/exchanges/bitpanda.py
@@ -9,7 +9,6 @@ from urllib.parse import urlencode
 import gevent
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_bitpanda
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_BEST
@@ -23,6 +22,7 @@ from rotkehlchen.exchanges.exchange import (
     ExchangeQueryBalances,
     ExchangeWithoutApiSecret,
 )
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
@@ -35,7 +35,6 @@ from rotkehlchen.history.events.structures.swap import (
     get_swap_spend_receive,
 )
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_movement_event_type,
@@ -452,7 +451,7 @@ class Bitpanda(ExchangeWithoutApiSecret):
             msg = f'Failed to query Bitpanda balances. {e!s}'
             return None, msg
 
-        assets_balance: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         wallets_len = len(wallets)
         for idx, entry in enumerate(wallets + fiat_wallets):
 
@@ -488,20 +487,9 @@ class Bitpanda(ExchangeWithoutApiSecret):
             if amount == ZERO:
                 continue
 
-            try:
-                price = Inquirer.find_main_currency_price(asset)
-            except RemoteError as e:
-                self.msg_aggregator.add_error(
-                    f'Error processing Bitpanda balance entry due to inability to '
-                    f'query price: {e!s}. Skipping balance entry',
-                )
-                continue
-            assets_balance[asset] += Balance(
-                amount=amount,
-                value=amount * price,
-            )
+            amounts[asset] += amount
 
-        return dict(assets_balance), ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def query_online_history_events(
             self,

--- a/rotkehlchen/exchanges/bitstamp.py
+++ b/rotkehlchen/exchanges/bitstamp.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from collections import defaultdict
 from collections.abc import Sequence
 from http import HTTPStatus
 from json.decoder import JSONDecodeError
@@ -9,7 +10,6 @@ from urllib.parse import urlencode
 import requests
 from requests.adapters import Response
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.assets.converters import asset_from_bitstamp
 from rotkehlchen.constants import ZERO
@@ -23,6 +23,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
@@ -36,7 +37,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -62,7 +62,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from rotkehlchen.db.dbhandler import DBHandler
-    from rotkehlchen.fval import FVal
     from rotkehlchen.history.events.structures.base import HistoryBaseEntry
 
 logger = logging.getLogger(__name__)
@@ -185,7 +184,7 @@ class Bitstamp(ExchangeInterface, SignatureGeneratorMixin):
             log.error(msg)
             raise RemoteError(msg) from e
 
-        assets_balance: dict[AssetWithOracles, Balance] = {}
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for entry, raw_amount in response_dict.items():
             if not entry.endswith('_balance'):
                 continue
@@ -213,22 +212,9 @@ class Bitstamp(ExchangeInterface, SignatureGeneratorMixin):
                     details='balance query',
                 )
                 continue
-            try:
-                price = Inquirer.find_main_currency_price(asset)
-            except RemoteError as e:
-                log.error(str(e))
-                self.msg_aggregator.add_error(
-                    f'Error processing Bitstamp balance result due to inability to '
-                    f'query price: {e!s}. Skipping balance entry.',
-                )
-                continue
+            amounts[asset] += amount
 
-            assets_balance[asset] = Balance(
-                amount=amount,
-                value=amount * price,
-            )
-
-        return assets_balance, ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def _get_since_id_option(
             self,

--- a/rotkehlchen/exchanges/bybit.py
+++ b/rotkehlchen/exchanges/bybit.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Final, Literal
 import gevent
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.assets.converters import asset_from_bybit
 from rotkehlchen.constants.misc import ZERO
@@ -23,6 +22,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
@@ -36,7 +36,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_fval
 from rotkehlchen.types import (
@@ -438,12 +437,12 @@ class Bybit(ExchangeInterface, SignatureGeneratorMixin):
     def _process_wallet_balances(
             self,
             entries: Sequence[dict[str, Any]],
-    ) -> dict[AssetWithOracles, Balance]:
-        """Common logic to process balances from the funding and wallet endpoints
+    ) -> dict[AssetWithOracles, FVal]:
+        """Common logic to process balance amounts from the funding and wallet endpoints
         May raise:
         - DeserializationError
         """
-        assets_balance: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for coin_data in entries:
             try:
                 asset = asset_from_bybit(coin_data['coin'])
@@ -453,8 +452,6 @@ class Bybit(ExchangeInterface, SignatureGeneratorMixin):
                     location='bybit',
                 )) == ZERO:
                     continue
-
-                value = amount * Inquirer.find_main_currency_price(asset)
 
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
@@ -469,16 +466,16 @@ class Bybit(ExchangeInterface, SignatureGeneratorMixin):
                     msg = f'Missing key entry for {msg}.'
                 raise DeserializationError(f'Error processing Bybit balance entry {coin_data}. {msg}') from e  # noqa: E501
 
-            assets_balance[asset] += Balance(amount=amount, value=value)
+            amounts[asset] += amount
 
-        return assets_balance
+        return amounts
 
-    def _query_account_balances(self) -> tuple[dict[AssetWithOracles, Balance], str | None]:
+    def _query_account_balances(self) -> tuple[dict[AssetWithOracles, FVal], str | None]:
         """
-        Query balances in wallet. It queries the unified and spot accounts.
+        Query balance amounts in wallet. It queries the unified and spot accounts.
         This call assumes that the first connection has been made to identify the account type.
 
-        Returns a tuple of balances and None if there wasn't any error or a string
+        Returns a tuple of balance amounts and None if there wasn't any error or a string
         message with a description of what went wrong.
         """
         asset_balances = {}
@@ -502,15 +499,15 @@ class Bybit(ExchangeInterface, SignatureGeneratorMixin):
 
         return asset_balances, None
 
-    def _query_funding_balances(self) -> tuple[dict[AssetWithOracles, Balance], str | None]:
+    def _query_funding_balances(self) -> tuple[dict[AssetWithOracles, FVal], str | None]:
         """
-        Query balances in the funding wallet.
+        Query balance amounts in the funding wallet.
         This call assumes that the first connection has been made to identify the account type.
 
-        Returns a tuple of balances and None if there wasn't any error or a string
+        Returns a tuple of balance amounts and None if there wasn't any error or a string
         message with a description of what went wrong.
         """
-        asset_balances: dict[AssetWithOracles, Balance] = {}
+        asset_balances: dict[AssetWithOracles, FVal] = {}
         response, error = self._query_balances_or_error(
             path='asset/transfer/query-account-coins-balance',
             options={'accountType': 'FUND'},
@@ -542,7 +539,9 @@ class Bybit(ExchangeInterface, SignatureGeneratorMixin):
         if err is not None:
             return None, err
 
-        return combine_dicts(a=account_assets_balance, b=account_funding_balance), ''
+        return dict(self.balances_from_amounts(
+            combine_dicts(a=account_assets_balance, b=account_funding_balance),
+        )), ''
 
     def _query_deposits_withdrawals(
             self,

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -16,7 +16,6 @@ import requests
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_coinbase
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.timing import HOUR_IN_SECONDS
@@ -29,6 +28,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import deserialize_asset_movement_address, get_key_if_has_val
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     create_asset_movement_with_fee,
@@ -42,7 +42,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -68,7 +67,6 @@ from rotkehlchen.utils.serialization import jsonloads_dict
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import AssetWithOracles
     from rotkehlchen.db.dbhandler import DBHandler
-    from rotkehlchen.fval import FVal
     from rotkehlchen.history.events.structures.base import HistoryBaseEntry
     from rotkehlchen.types import Asset, TimestampMS
 
@@ -362,7 +360,7 @@ class Coinbase(ExchangeInterface):
             log.error(f'{msg_prefix} Could not reach coinbase due to {e}')
             return None, f'{msg_prefix} Check logs for more details'
 
-        returned_balances: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for account in resp:
             try:
                 if (balance := account.get('balance')) is None:
@@ -381,17 +379,7 @@ class Coinbase(ExchangeInterface):
                 if amount == ZERO:
                     continue
 
-                asset = asset_from_coinbase(account['balance']['currency'])
-                try:
-                    price = Inquirer.find_main_currency_price(asset)
-                except RemoteError as e:
-                    log.error(
-                        f'Error processing coinbase balance for {asset.identifier} due to'
-                        f' inability to query price: {e!s}. Skipping balance entry',
-                    )
-                    continue
-
-                returned_balances[asset] += Balance(amount=amount, value=amount * price)
+                amounts[asset_from_coinbase(account['balance']['currency'])] += amount
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
@@ -409,7 +397,7 @@ class Coinbase(ExchangeInterface):
                 )
                 continue
 
-        return dict(returned_balances), ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     @protect_with_lock()
     def _query_transactions(self, force_refresh: bool = False) -> list['HistoryBaseEntry']:

--- a/rotkehlchen/exchanges/coinbaseprime.py
+++ b/rotkehlchen/exchanges/coinbaseprime.py
@@ -9,7 +9,6 @@ from urllib.parse import urlparse
 
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_coinbase
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
@@ -19,6 +18,7 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     create_asset_movement_with_fee,
@@ -30,7 +30,6 @@ from rotkehlchen.history.events.structures.base import (
 )
 from rotkehlchen.history.events.structures.swap import SwapEvent, create_swap_events
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_movement_event_type,
@@ -471,7 +470,7 @@ class Coinbaseprime(ExchangeInterface):
             log.error(f'{msg_prefix} Could not reach coinbase due to {e}')
             return None, f'{msg_prefix} Check logs for more details'
 
-        returned_balances: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for account_id in portfolio_ids:
             try:
                 balances_query: dict[str, list[dict[str, Any]]] = self._api_query(
@@ -500,20 +499,7 @@ class Coinbaseprime(ExchangeInterface):
                     if total_balance == ZERO:
                         continue
 
-                    asset = asset_from_coinbase(balance_entry['symbol'])
-                    try:
-                        price = Inquirer.find_main_currency_price(asset)
-                    except RemoteError as e:
-                        log.error(
-                            f'Error processing coinbase balance entry due to inability to '
-                            f'query price: {e!s}. Skipping balance entry',
-                        )
-                        continue
-
-                    returned_balances[asset] += Balance(
-                        amount=total_balance,
-                        value=total_balance * price,
-                    )
+                    amounts[asset_from_coinbase(balance_entry['symbol'])] += total_balance
                 except UnknownAsset as e:
                     self.send_unknown_asset_message(
                         asset_identifier=e.identifier,
@@ -529,7 +515,7 @@ class Coinbaseprime(ExchangeInterface):
                         error=msg,
                     )
 
-        return dict(returned_balances), ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def query_online_history_events(
             self,

--- a/rotkehlchen/exchanges/cryptocom.py
+++ b/rotkehlchen/exchanges/cryptocom.py
@@ -8,7 +8,6 @@ import requests
 from gevent.lock import Semaphore
 from requests.adapters import Response
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_cryptocom
 from rotkehlchen.constants import MONTH_IN_MILLISECONDS, WEEK_IN_MILLISECONDS, ZERO
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
@@ -19,6 +18,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     AssetMovementExtraData,
@@ -31,7 +31,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -298,8 +297,8 @@ class Cryptocom(ExchangeInterface, SignatureGeneratorMixin):
             self,
             new_balance_data: dict[str, Any],
             balance_key: str,
-            existing_balances: defaultdict['AssetWithOracles', Balance],
-    ) -> defaultdict['AssetWithOracles', Balance]:
+            existing_balances: defaultdict['AssetWithOracles', FVal],
+    ) -> defaultdict['AssetWithOracles', FVal]:
         """Deserialize a balance dict using the amount from the specified balance_key.
         Returns the updated existing_balances.
         """
@@ -309,11 +308,7 @@ class Cryptocom(ExchangeInterface, SignatureGeneratorMixin):
 
         try:
             if (amount := deserialize_fval(new_balance_data[balance_key])) > ZERO:
-                asset = asset_from_cryptocom(instrument_name)
-                existing_balances[asset] += Balance(
-                    amount=amount,
-                    value=amount * Inquirer.find_main_currency_price(asset),
-                )
+                existing_balances[asset_from_cryptocom(instrument_name)] += amount
         except UnknownAsset as e:
             self.send_unknown_asset_message(
                 asset_identifier=e.identifier,
@@ -323,11 +318,6 @@ class Cryptocom(ExchangeInterface, SignatureGeneratorMixin):
             self.msg_aggregator.add_error(
                 f'Error processing {self.name} {instrument_name} balance result due to inability '
                 f'to deserialize asset amount due to {e!s}. Skipping balance result.',
-            )
-        except RemoteError as e:
-            self.msg_aggregator.add_error(
-                f'Error processing {self.name} {instrument_name} balance result due to inability '
-                f'to query price: {e!s}. Skipping balance result.',
             )
 
         return existing_balances
@@ -344,7 +334,7 @@ class Cryptocom(ExchangeInterface, SignatureGeneratorMixin):
         if result.code != API_SUCCESS_CODE:
             return None, f'{self.name} balance query failed: {result.message}'
 
-        assets_balance: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        assets_balance: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
 
         if result.result is not None:
             balance_data = result.result.get('data', [])
@@ -366,7 +356,7 @@ class Cryptocom(ExchangeInterface, SignatureGeneratorMixin):
                     existing_balances=assets_balance,
                 )
 
-        return dict(assets_balance), ''
+        return dict(self.balances_from_amounts(assets_balance)), ''
 
     def _query_deposits_withdrawals(
             self,

--- a/rotkehlchen/exchanges/exchange.py
+++ b/rotkehlchen/exchanges/exchange.py
@@ -1,5 +1,6 @@
 import logging
 from abc import abstractmethod
+from collections import defaultdict
 from collections.abc import Callable, Sequence
 from http.client import RemoteDisconnected
 from typing import TYPE_CHECKING, Any
@@ -15,10 +16,13 @@ from rotkehlchen.api.websockets.typedefs import (
     WSMessageType,
 )
 from rotkehlchen.assets.asset import AssetWithOracles
+from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.ranges import DBQueryRanges
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.exchanges.data_structures import MarginPosition
+from rotkehlchen.fval import FVal
+from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import (
     ApiKey,
@@ -258,6 +262,28 @@ class ExchangeWithoutApiSecret(CacheableMixIn, LockableQueryMixIn):
         The name must be the canonical name used by rotkehlchen
         """
         raise NotImplementedError('query_balances should only be implemented by subclasses')
+
+    @staticmethod
+    def balances_from_amounts(
+            amounts: dict[AssetWithOracles, FVal],
+    ) -> defaultdict[AssetWithOracles, Balance]:
+        """Price all the given asset amounts in the user's main currency with a single
+        batched query and return the corresponding balances mapping.
+
+        Using one batched query instead of a per-asset one lets the inquirer serve
+        already-cached assets from the cache and query all the remaining ones from each
+        oracle in a single request. Assets for which no price could be found get a zero
+        value (price errors are logged by the inquirer).
+        """
+        prices = Inquirer.find_main_currency_prices(list(amounts))
+        balances: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        for asset, amount in amounts.items():
+            balances[asset] = Balance(
+                amount=amount,
+                value=amount * prices.get(asset, ZERO_PRICE),
+            )
+
+        return balances
 
     def query_exchange_specific_history(
             self,

--- a/rotkehlchen/exchanges/gemini.py
+++ b/rotkehlchen/exchanges/gemini.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 import gevent
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.assets.converters import asset_from_gemini
 from rotkehlchen.constants import ZERO
@@ -27,6 +26,7 @@ from rotkehlchen.exchanges.utils import (
     deserialize_asset_movement_address,
     get_key_if_has_val,
 )
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.swap import (
@@ -36,7 +36,6 @@ from rotkehlchen.history.events.structures.swap import (
     get_swap_spend_receive,
 )
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_movement_event_type,
@@ -328,7 +327,7 @@ class Gemini(ExchangeInterface, SignatureGeneratorMixin):
             log.error(msg)
             return None, msg
 
-        returned_balances: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for entry in balances:
             try:
                 balance_type = entry['type']
@@ -340,20 +339,7 @@ class Gemini(ExchangeInterface, SignatureGeneratorMixin):
                 if amount == ZERO:
                     continue
 
-                asset = asset_from_gemini(entry['currency'])
-                try:
-                    price = Inquirer.find_main_currency_price(asset)
-                except RemoteError as e:
-                    self.msg_aggregator.add_error(
-                        f'Error processing gemini {balance_type} balance result due to '
-                        f'inability to query price: {e!s}. Skipping balance entry',
-                    )
-                    continue
-
-                returned_balances[asset] += Balance(
-                    amount=amount,
-                    value=amount * price,
-                )
+                amounts[asset_from_gemini(entry['currency'])] += amount
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
@@ -371,7 +357,7 @@ class Gemini(ExchangeInterface, SignatureGeneratorMixin):
                 log.error('Error processing a gemini balance', error=msg)
                 continue
 
-        return returned_balances, ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def _get_paginated_query(
             self,

--- a/rotkehlchen/exchanges/htx.py
+++ b/rotkehlchen/exchanges/htx.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Final, Literal
 
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_htx
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.constants.timing import DAY_IN_SECONDS
@@ -18,6 +17,7 @@ from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin, get_key_if_has_val
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
@@ -31,7 +31,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -159,7 +158,7 @@ class Htx(ExchangeInterface, SignatureGeneratorMixin):
 
     def query_balances(self, **kwargs: Any) -> ExchangeQueryBalances:
         """Query balances for the accounts linked to the api key"""
-        returned_balances: dict[AssetWithOracles, Balance] = defaultdict(Balance)
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for account in self.get_accounts():
             account_id = account['id']
             path = f'/v1/account/accounts/{account_id}/balance'
@@ -168,7 +167,7 @@ class Htx(ExchangeInterface, SignatureGeneratorMixin):
             except RemoteError as e:
                 error_prefix = 'Failed to query HTX'
                 log.error(f'{error_prefix} balances due to {e}')
-                return returned_balances, f'{error_prefix} due to a remote error. Check logs for more details'  # noqa: E501
+                return dict(self.balances_from_amounts(amounts)), f'{error_prefix} due to a remote error. Check logs for more details'  # noqa: E501
 
             if (account_balance_type := data['type']) is None:
                 log.error(f'Response for balances does not contain the type key {data}. Skipping')
@@ -211,21 +210,9 @@ class Htx(ExchangeInterface, SignatureGeneratorMixin):
                     log.error(f'HTX balance does not contain the key {e}. Skipping')
                     continue
 
-                try:
-                    price = Inquirer.find_main_currency_price(asset)
-                except RemoteError as e:
-                    self.msg_aggregator.add_error(
-                        f'Error processing HTX balance entry due to inability to '
-                        f'query price: {e!s}. Skipping balance entry',
-                    )
-                    continue
+                amounts[asset] += amount
 
-                returned_balances[asset] += Balance(
-                    amount=amount,
-                    value=amount * price,
-                )
-
-        return returned_balances, ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def _paginated_query(
             self,

--- a/rotkehlchen/exchanges/iconomi.py
+++ b/rotkehlchen/exchanges/iconomi.py
@@ -3,13 +3,13 @@ import hashlib
 import json
 import logging
 import time
+from collections import defaultdict
 from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
 
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_iconomi
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_AUST
@@ -19,6 +19,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import Location, MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.swap import create_swap_events
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
 from rotkehlchen.inquirer import Inquirer
@@ -153,7 +154,7 @@ class Iconomi(ExchangeInterface, SignatureGeneratorMixin):
             return True, ''
 
     def query_balances(self, **kwargs: Any) -> ExchangeQueryBalances:
-        assets_balance: dict[AssetWithOracles, Balance] = {}
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         try:
             resp_info = self._api_query('get', 'user/balance')
         except RemoteError as e:
@@ -183,19 +184,7 @@ class Iconomi(ExchangeInterface, SignatureGeneratorMixin):
                     )
                     continue
 
-                try:
-                    price = Inquirer.find_main_currency_price(asset)
-                except RemoteError as e:
-                    self.msg_aggregator.add_error(
-                        f'Error processing Iconomi balance entry due to inability to '
-                        f'query price: {e!s}. Skipping balance entry',
-                    )
-                    continue
-
-                assets_balance[asset] = Balance(
-                    amount=amount,
-                    value=amount * price,
-                )
+                amounts[asset] += amount
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
@@ -237,27 +226,14 @@ class Iconomi(ExchangeInterface, SignatureGeneratorMixin):
                     )
                     continue
 
-                amount = usd_value / aust_usd_price
-                try:
-                    price = Inquirer.find_main_currency_price(self.aust)
-                except RemoteError as e:
-                    self.msg_aggregator.add_error(
-                        f'Error processing Iconomi balance entry due to inability to '
-                        f'query price: {e!s}. Skipping balance entry',
-                    )
-                    continue
-
-                assets_balance[self.aust] = Balance(
-                    amount=amount,
-                    value=amount * price,
-                )
+                amounts[self.aust] += usd_value / aust_usd_price
             else:
                 self.msg_aggregator.add_warning(
                     f'Found unsupported ICONOMI strategy {ticker}. '
                     f' Ignoring its balance query.',
                 )
 
-        return assets_balance, ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def query_online_history_events(
             self,

--- a/rotkehlchen/exchanges/independentreserve.py
+++ b/rotkehlchen/exchanges/independentreserve.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from collections.abc import Sequence
 from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Literal
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Literal
 import gevent
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.assets.utils import symbol_to_asset_or_token
 from rotkehlchen.constants import ZERO
@@ -32,7 +31,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_asset_movement_event_type,
@@ -242,7 +240,7 @@ class Independentreserve(ExchangeInterface, SignatureGeneratorMixin):
             return True, ''
 
     def query_balances(self, **kwargs: Any) -> ExchangeQueryBalances:
-        assets_balance: dict[AssetWithOracles, Balance] = {}
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         try:
             response = self._api_query(verb='post', method_type='Private', path='GetAccounts')
         except RemoteError as e:
@@ -255,19 +253,12 @@ class Independentreserve(ExchangeInterface, SignatureGeneratorMixin):
         for entry in response:
             try:
                 asset = independentreserve_asset(entry['CurrencyCode'])
-                price = Inquirer.find_main_currency_price(asset)
                 amount = deserialize_fval(entry['TotalBalance'])
                 account_guids.append(entry['AccountGuid'])
             except UnknownAsset as e:
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
                     details='balance query',
-                )
-                continue
-            except RemoteError as e:  # raised only by find_price
-                self.msg_aggregator.add_error(
-                    f'Error processing IndependentReserve balance entry due to inability to '
-                    f'query price: {e!s}. Skipping balance entry',
                 )
                 continue
             except (DeserializationError, KeyError) as e:
@@ -279,13 +270,10 @@ class Independentreserve(ExchangeInterface, SignatureGeneratorMixin):
             if amount == ZERO:
                 continue
 
-            assets_balance[asset] = Balance(
-                amount=amount,
-                value=amount * price,
-            )
+            amounts[asset] += amount
 
         self.account_guids = account_guids
-        return assets_balance, ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def _gather_paginated_data(self, path: str, extra_options: dict | None = None) -> list[dict[str, Any]]:  # noqa: E501
         """May raise KeyError"""

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -42,6 +42,7 @@ from rotkehlchen.exchanges.exchange import (
     ExchangeWithExtras,
 )
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     create_asset_movement_with_fee,
@@ -58,7 +59,6 @@ from rotkehlchen.history.events.structures.swap import (
     create_swap_events_multi_fee,
 )
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_fval
 from rotkehlchen.types import (
@@ -477,7 +477,8 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
         return kraken_balances, ''
 
     def deserialize_kraken_balance(self, kraken_balances: dict) -> tuple[dict, str]:
-        assets_balance: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        kfee_amount = ZERO
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for kraken_name, amount_ in kraken_balances.items():
             log.debug(
                 f'deserializing kraken balance for {kraken_name} with amount: {amount_}')
@@ -507,27 +508,14 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 )
                 continue
 
-            balance = Balance(amount=amount)
-            if our_asset.identifier != 'KFEE':
-                # There is no price value for KFEE
-                try:
-                    price = Inquirer.find_main_currency_price(our_asset)
-                except RemoteError as e:
-                    self.msg_aggregator.add_error(
-                        f'Error processing kraken balance entry due to inability to '
-                        f'query price: {e!s}. Skipping balance entry',
-                    )
-                    continue
+            if our_asset.identifier == 'KFEE':
+                kfee_amount += amount  # There is no price value for KFEE
+            else:
+                amounts[our_asset] += amount
 
-                balance.value = balance.amount * price
-
-            assets_balance[our_asset] += balance
-            log.debug(
-                'kraken balance query result',
-                currency=our_asset,
-                amount=balance.amount,
-                value=balance.value,
-            )
+        assets_balance = self.balances_from_amounts(amounts)
+        if kfee_amount != ZERO:
+            assets_balance[asset_from_kraken('KFEE')] += Balance(amount=kfee_amount)
 
         return dict(assets_balance), ''
 

--- a/rotkehlchen/exchanges/kucoin.py
+++ b/rotkehlchen/exchanges/kucoin.py
@@ -25,6 +25,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
@@ -38,7 +39,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -447,7 +447,7 @@ class Kucoin(ExchangeInterface, SignatureGeneratorMixin):
             log.error(msg, response_dict)
             raise RemoteError(msg) from e
 
-        assets_balance: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for raw_result in accounts_data:
             try:
                 amount = deserialize_fval(raw_result['balance'])
@@ -488,21 +488,10 @@ class Kucoin(ExchangeInterface, SignatureGeneratorMixin):
                     details='balance deserialization',
                 )
                 continue
-            try:
-                price = Inquirer.find_main_currency_price(asset)
-            except RemoteError:
-                self.msg_aggregator.add_error(
-                    f'Failed to deserialize a kucoin balance after failing to '
-                    f'request the price of {asset.identifier}. Ignoring it.',
-                )
-                continue
 
-            assets_balance[asset] += Balance(
-                amount=amount,
-                value=amount * price,
-            )
+            amounts[asset] += amount
 
-        return dict(assets_balance)
+        return dict(self.balances_from_amounts(amounts))
 
     def _deserialize_asset_movement(
             self,

--- a/rotkehlchen/exchanges/okx.py
+++ b/rotkehlchen/exchanges/okx.py
@@ -8,7 +8,6 @@ from urllib.parse import urlencode, urljoin
 
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_okx
 from rotkehlchen.constants import ZERO
 from rotkehlchen.data_import.utils import maybe_set_transaction_extra_data
@@ -24,6 +23,7 @@ from rotkehlchen.exchanges.exchange import (
     ExchangeWithExtras,
 )
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin, deserialize_asset_movement_address
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
@@ -37,7 +37,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_fval, deserialize_fval_or_zero
 from rotkehlchen.types import (
@@ -282,7 +281,7 @@ class Okx(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             return None, msg
 
         currencies_data.extend(self._api_query_list(endpoint=OkxEndpoint.FUNDING_BALANCE))
-        assets_balance: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for currency_data in currencies_data:
             try:
                 asset = asset_from_okx(okx_name=currency_data['ccy'])
@@ -290,15 +289,6 @@ class Okx(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 self.send_unknown_asset_message(
                     asset_identifier=e.identifier,
                     details='balance query',
-                )
-                continue
-
-            try:
-                price = Inquirer.find_main_currency_price(asset)
-            except RemoteError as e:
-                self.msg_aggregator.add_error(
-                    f'Error processing {self.name} {asset.name} balance result due to inability '
-                    f'to query price: {e!s}. Skipping balance result.',
                 )
                 continue
 
@@ -311,12 +301,9 @@ class Okx(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 )
                 continue
 
-            assets_balance[asset] += Balance(
-                amount=amount,
-                value=amount * price,
-            )
+            amounts[asset] += amount
 
-        return dict(assets_balance), ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def query_online_margin_history(
             self,

--- a/rotkehlchen/exchanges/poloniex.py
+++ b/rotkehlchen/exchanges/poloniex.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 import operator
+from collections import defaultdict
 from collections.abc import Sequence
 from json.decoder import JSONDecodeError
 from typing import TYPE_CHECKING, Any, Final, Literal
@@ -10,7 +11,6 @@ from urllib.parse import urlencode
 import gevent
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_poloniex
 from rotkehlchen.constants import DAY_IN_SECONDS, ZERO
 from rotkehlchen.constants.assets import A_LEND
@@ -26,6 +26,7 @@ from rotkehlchen.exchanges.utils import (
     deserialize_asset_movement_address,
     get_key_if_has_val,
 )
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
@@ -39,7 +40,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -376,7 +376,7 @@ class Poloniex(ExchangeInterface, SignatureGeneratorMixin):
             log.error(msg)
             return None, msg
 
-        assets_balance: dict[AssetWithOracles, Balance] = {}
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for account_info in resp:
             try:
                 balances = account_info['balances']
@@ -422,29 +422,9 @@ class Poloniex(ExchangeInterface, SignatureGeneratorMixin):
                     if asset == A_LEND:  # poloniex mistakenly returns LEND balances
                         continue  # https://github.com/rotki/rotki/issues/2530
 
-                    try:
-                        price = Inquirer.find_main_currency_price(asset)
-                    except RemoteError as e:
-                        self.msg_aggregator.add_error(
-                            f'Error processing poloniex balance entry due to inability to '
-                            f'query price: {e!s}. Skipping balance entry',
-                        )
-                        continue
+                    amounts[asset] += available + on_orders
 
-                    amount = available + on_orders
-                    value = amount * price
-                    assets_balance[asset] = Balance(
-                        amount=amount,
-                        value=value,
-                    )
-                    log.debug(
-                        'Poloniex balance query',
-                        currency=asset,
-                        amount=amount,
-                        value=value,
-                    )
-
-        return assets_balance, ''
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def _deserialize_trade(
             self,

--- a/rotkehlchen/exchanges/woo.py
+++ b/rotkehlchen/exchanges/woo.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
 
 import requests
 
-from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import AssetWithOracles
 from rotkehlchen.assets.converters import asset_from_woo
 from rotkehlchen.constants import ZERO
@@ -20,6 +19,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.exchanges.data_structures import MarginPosition
 from rotkehlchen.exchanges.exchange import ExchangeInterface, ExchangeQueryBalances
 from rotkehlchen.exchanges.utils import SignatureGeneratorMixin
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.deserialization import deserialize_price
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
@@ -33,7 +33,6 @@ from rotkehlchen.history.events.structures.swap import (
 )
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import (
     deserialize_fval,
@@ -128,13 +127,12 @@ class Woo(ExchangeInterface, SignatureGeneratorMixin):
             log.error(msg, response)
             raise RemoteError(msg) from e
 
-        assets_balance: defaultdict[AssetWithOracles, Balance] = defaultdict(Balance)
+        amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
         for entry in balances:
             try:
                 if (amount := deserialize_fval(entry['holding'] + entry['staked'])) == ZERO:
                     continue
                 asset = asset_from_woo(entry['token'])
-                price = Inquirer.find_main_currency_price(asset)
             except (DeserializationError, KeyError) as e:
                 log.error('Error processing a Woo balance.', entry=entry, error=str(e))
                 self.msg_aggregator.add_error(
@@ -148,18 +146,10 @@ class Woo(ExchangeInterface, SignatureGeneratorMixin):
                     details='balance query',
                 )
                 continue
-            except RemoteError as e:
-                self.msg_aggregator.add_error(
-                    f'Error processing Woo balance result due to inability to '
-                    f'query price: {e}. Skipping balance entry.',
-                )
-                continue
-            assets_balance[asset] += Balance(
-                amount=amount,
-                value=amount * price,
-            )
 
-        return dict(assets_balance), ''
+            amounts[asset] += amount
+
+        return dict(self.balances_from_amounts(amounts)), ''
 
     def _deserialize_trade(self, trade: dict[str, Any]) -> list[SwapEvent]:
         """

--- a/rotkehlchen/tests/exchanges/test_bitstamp.py
+++ b/rotkehlchen/tests/exchanges/test_bitstamp.py
@@ -9,6 +9,7 @@ import requests
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.converters import asset_from_bitstamp
+from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_LINK, A_USD, A_USDC
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.asset import UnknownAsset
@@ -200,21 +201,22 @@ def test_query_balances_skipped_not_asset_entry(mock_bitstamp):
         assert mock_bitstamp.query_balances() == ({}, '')
 
 
-def test_query_balances_skips_inquirer_error(mock_bitstamp):
-    """Test an entry that can't get its USD price because of a remote error is
-    skipped
-    """
+def test_query_balances_includes_unpriceable_entry(mock_bitstamp):
+    """Test an entry whose price can't be found is included with a zero value"""
     def mock_api_query_response(endpoint):  # pylint: disable=unused-argument
         return MockResponse(HTTPStatus.OK, '{"link_balance": "1.00000000"}')
 
     with (
         patch(
-            'rotkehlchen.exchanges.bitstamp.Inquirer.find_price',
-            side_effect=RemoteError('test'),
+            'rotkehlchen.exchanges.exchange.Inquirer.find_main_currency_prices',
+            return_value={},  # no price could be found for any asset
         ),
         patch.object(mock_bitstamp, '_api_query', side_effect=mock_api_query_response),
     ):
-        assert mock_bitstamp.query_balances() == ({}, '')
+        assert mock_bitstamp.query_balances() == (
+            {A_LINK.resolve_to_asset_with_oracles(): Balance(amount=ONE, value=ZERO)},
+            '',
+        )
 
 
 @pytest.mark.parametrize('should_mock_current_price_queries', [True])

--- a/rotkehlchen/tests/exchanges/test_cryptocom.py
+++ b/rotkehlchen/tests/exchanges/test_cryptocom.py
@@ -75,8 +75,11 @@ def test_query_balances(mock_cryptocom):
         attribute='_api_query',
         return_value=MockResponse(HTTPStatus.OK, text=json.dumps(BALANCES_RESPONSE)),
     ), patch(
-        target='rotkehlchen.inquirer.Inquirer.find_main_currency_price',
-        side_effect=lambda from_asset: (FVal(112000) if from_asset == A_BTC else ONE),
+        target='rotkehlchen.exchanges.exchange.Inquirer.find_main_currency_prices',
+        side_effect=lambda from_assets: {
+            from_asset: (FVal(112000) if from_asset == A_BTC else ONE)
+            for from_asset in from_assets
+        },
     )):
         balances, msg = mock_cryptocom.query_balances()
         assert msg == ''

--- a/rotkehlchen/tests/exchanges/test_exchange.py
+++ b/rotkehlchen/tests/exchanges/test_exchange.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+import pytest
+
+from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.constants import ONE
+from rotkehlchen.constants.assets import A_BTC, A_ETH, A_USDC
+from rotkehlchen.exchanges.exchange import ExchangeWithoutApiSecret
+from rotkehlchen.fval import FVal
+from rotkehlchen.types import Price
+
+
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
+def test_balances_from_amounts_batches_and_uses_cache(inquirer):
+    """Test that the exchange pricing helper queries all asset prices in a single
+    batched oracle query and that subsequent calls (e.g. from the next exchange in
+    a balance refresh) get the already priced assets from the price cache, querying
+    the oracle only for the new ones"""
+    oracle_queries = []
+
+    def mock_oracle_batch(from_assets, to_asset):
+        oracle_queries.append(set(from_assets))
+        return {from_asset: Price(FVal(100)) for from_asset in from_assets}
+
+    eth, btc, usdc = (x.resolve_to_asset_with_oracles() for x in (A_ETH, A_BTC, A_USDC))
+    with patch.object(
+        inquirer._coingecko,
+        'query_multiple_current_prices',
+        side_effect=mock_oracle_batch,
+    ):
+        balances = ExchangeWithoutApiSecret.balances_from_amounts({eth: FVal(2), btc: ONE})
+        assert oracle_queries == [{eth, btc}]  # one batched query for all assets
+        assert balances == {
+            eth: Balance(amount=FVal(2), value=FVal(200)),
+            btc: Balance(amount=ONE, value=FVal(100)),
+        }
+
+        balances = ExchangeWithoutApiSecret.balances_from_amounts({btc: FVal(3), usdc: FVal(4)})
+        assert oracle_queries == [{eth, btc}, {usdc}]  # btc was served from the cache
+        assert balances == {
+            btc: Balance(amount=FVal(3), value=FVal(300)),
+            usdc: Balance(amount=FVal(4), value=FVal(400)),
+        }


### PR DESCRIPTION
Replace the per-asset Inquirer.find_main_currency_price calls in the balance queries of all 19 exchange connectors with a single batched find_main_currency_prices call per exchange, via the new ExchangeInterface.balances_from_amounts helper. Each exchange now parses its API response into asset amounts first and prices them in one oracle request; assets already priced (e.g. by a previously queried exchange) are served from the inquirer price cache.

Also changes failure semantics: assets whose price cannot be found are now included with a zero value instead of being silently skipped.