### PR TITLE
perf: batch protocol balance price queries

### DIFF
--- a/rotkehlchen/chain/base/modules/morpho_blue/balances.py
+++ b/rotkehlchen/chain/base/modules/morpho_blue/balances.py
@@ -2,19 +2,19 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.accounting.structures.balance import BalanceSheet
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
 from rotkehlchen.chain.evm.decoding.morpho_blue.constants import CPT_MORPHO_BLUE
 from rotkehlchen.constants import ZERO
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset
     from rotkehlchen.chain.base.decoding.decoder import BaseTransactionDecoder
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
+    from rotkehlchen.types import ChecksumEvmAddress
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -49,6 +49,8 @@ class MorphoBlueBalances(ProtocolWithBalance):
         if len(address_to_events) == 0:
             return balances
 
+        asset_entries: list[tuple[ChecksumEvmAddress, Asset, FVal]] = []
+        liability_entries: list[tuple[ChecksumEvmAddress, Asset, FVal]] = []
         for address, events in address_to_events.items():
             assets_per_market: dict[tuple[str, Asset], FVal] = defaultdict(FVal)
             liabilities_per_market: dict[tuple[str, Asset], FVal] = defaultdict(FVal)
@@ -85,22 +87,19 @@ class MorphoBlueBalances(ProtocolWithBalance):
                 ):
                     liabilities_per_market[key] -= event.amount
 
-            for (_, asset), amount in assets_per_market.items():
-                if amount <= ZERO:
-                    continue
+            asset_entries.extend(
+                (address, asset, amount)
+                for (_, asset), amount in assets_per_market.items() if amount > ZERO
+            )
+            liability_entries.extend(
+                (address, asset, amount)
+                for (_, asset), amount in liabilities_per_market.items() if amount > ZERO
+            )
 
-                balances[address].assets[asset][self.counterparty] += Balance(
-                    amount=amount,
-                    value=amount * Inquirer.find_main_currency_price(asset),
-                )
-
-            for (_, asset), amount in liabilities_per_market.items():
-                if amount <= ZERO:
-                    continue
-
-                balances[address].liabilities[asset][self.counterparty] += Balance(
-                    amount=amount,
-                    value=amount * Inquirer.find_main_currency_price(asset),
-                )
-
+        self._add_priced_balances(balances=balances, amounts=asset_entries)
+        self._add_priced_balances(
+            balances=balances,
+            amounts=liability_entries,
+            category='liabilities',
+        )
         return balances

--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -10,6 +10,7 @@ from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.evm.tokens import get_rpc_first_chunk_size_call_order
 from rotkehlchen.chain.evm.types import WeightedNode, string_to_evm_address
+from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.db.filtering import EvmEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.misc import RemoteError
@@ -119,6 +120,32 @@ class ProtocolWithBalance(abc.ABC):
     def addresses_with_deposits(self) -> dict[ChecksumEvmAddress, list['EvmEvent']]:
         return self.addresses_with_activity(event_types=self.deposit_event_types)
 
+    def _add_priced_balances(
+            self,
+            balances: BalancesSheetType,
+            amounts: Sequence[tuple[ChecksumEvmAddress, 'Asset', FVal]],
+            category: Literal['assets', 'liabilities'] = 'assets',
+    ) -> None:
+        """Price all the given (address, asset, amount) entries in the user's main
+        currency with a single batched query and add them to the balances under the
+        protocol's counterparty.
+
+        Using one batched query instead of a per-asset one lets the inquirer serve
+        already-cached assets from the cache and query all the remaining ones from each
+        oracle in a single request. Assets for which no price could be found get a zero
+        value (price errors are logged by the inquirer).
+        """
+        if len(amounts) == 0:
+            return
+
+        prices = Inquirer.find_main_currency_prices(list({asset for _, asset, _ in amounts}))
+        for address, asset, amount in amounts:
+            sheet = balances[address].assets if category == 'assets' else balances[address].liabilities  # noqa: E501
+            sheet[asset][self.counterparty] += Balance(
+                amount=amount,
+                value=amount * prices.get(asset, ZERO_PRICE),
+            )
+
     # --- Methods to be implemented by all subclasses
 
     @abc.abstractmethod
@@ -161,12 +188,12 @@ class ProtocolWithGauges(ProtocolWithBalance):
             call_order: list[WeightedNode],
             chunk_size: int,
             balances_contract: Callable,
-    ) -> BalanceSheet:
+    ) -> dict[EvmToken, FVal]:
         """
-        Query the set of gauges in gauges_to_token and return the balances for each
-        lp token deposited in all gauges.
+        Query the set of gauges in gauges_to_token and return the deposited amount
+        of each lp token in all gauges.
         """
-        balances = BalanceSheet()
+        amounts: defaultdict[EvmToken, FVal] = defaultdict(FVal)
         gauge_chunks = get_chunks(list(gauges_to_token.keys()), n=chunk_size)
         for gauge_chunk in gauge_chunks:
             tokens = [gauges_to_token[staking_addr] for staking_addr in gauge_chunk]
@@ -179,13 +206,9 @@ class ProtocolWithGauges(ProtocolWithBalance):
 
             # Now map the gauge to the underlying token
             for lp_token, balance in gauges_balances.items():
-                lp_token_price = Inquirer.find_main_currency_price(lp_token)
-                balances.assets[lp_token][self.counterparty] += Balance(
-                    amount=balance,
-                    value=lp_token_price * balance,
-                )
+                amounts[lp_token] += balance
 
-        return balances
+        return amounts
 
     def _get_staking_contract_balances(
             self,
@@ -238,6 +261,7 @@ class ProtocolWithGauges(ProtocolWithBalance):
         """
         balances: BalancesSheetType = defaultdict(BalanceSheet)
         gauges_to_token: dict[ChecksumEvmAddress, EvmToken] = {}
+        entries: list[tuple[ChecksumEvmAddress, Asset, FVal]] = []
         # query addresses and gauges where they interacted
         chunk_size, call_order = get_rpc_first_chunk_size_call_order(self.evm_inquirer)
         for address, events in self.addresses_with_gauge_deposits().items():
@@ -251,14 +275,15 @@ class ProtocolWithGauges(ProtocolWithBalance):
 
                 gauges_to_token[gauge_address] = event.asset.resolve_to_evm_token()
 
-            balances[address] = self._query_gauges_balances(
+            entries.extend((address, lp_token, amount) for lp_token, amount in self._query_gauges_balances(  # noqa: E501
                 user_address=address,
                 gauges_to_token=gauges_to_token,
                 call_order=call_order,
                 chunk_size=chunk_size,
                 balances_contract=self._get_staking_contract_balances,
-            )
+            ).items())
 
+        self._add_priced_balances(balances=balances, amounts=entries)
         return balances
 
     # --- Methods to be implemented by all subclasses

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/balances.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Final
 
 from eth_typing.abi import ABI
 
-from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.accounting.structures.balance import BalanceSheet
 from rotkehlchen.assets.utils import asset_normalized_value, get_or_create_evm_token
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
 from rotkehlchen.chain.ethereum.modules.eigenlayer.utils import get_eigenpods_to_owners_mapping
@@ -15,7 +15,6 @@ from rotkehlchen.db.filtering import EvmEventFilterQuery
 from rotkehlchen.errors.misc import NotERC20Conformant, RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, Location
 from rotkehlchen.utils.misc import ts_now
@@ -100,6 +99,7 @@ class EigenlayerBalances(ProtocolWithBalance):
         if len(deposits) == 0:  # user had no related events
             return balances
 
+        entries = []
         for depositor, strategy in deposits:
             try:
                 amount, token = _read_underlying_assets(
@@ -113,12 +113,9 @@ class EigenlayerBalances(ProtocolWithBalance):
                 )
                 continue
 
-            token_price = Inquirer.find_main_currency_price(token)
-            balances[depositor].assets[token][self.counterparty] += Balance(
-                amount=amount,
-                value=token_price * amount,
-            )
+            entries.append((depositor, token, amount))
 
+        self._add_priced_balances(balances=balances, amounts=entries)
         return balances
 
     def _query_token_pending_withdrawals(self, balances: 'BalancesSheetType') -> 'BalancesSheetType':  # noqa: E501
@@ -155,6 +152,7 @@ class EigenlayerBalances(ProtocolWithBalance):
         addresses_with_withdrawals = self.addresses_with_activity(
             event_types={(HistoryEventType.INFORMATIONAL, HistoryEventSubType.REMOVE_ASSET)},
         )
+        entries = []
         for address, event_list in addresses_with_withdrawals.items():
             for event in event_list:
                 if event.asset == A_ETH:
@@ -175,12 +173,9 @@ class EigenlayerBalances(ProtocolWithBalance):
                     log.error(f'Unexpected eigenlayer withdrawal queueing event {event}. Missing amount from extra data. Skipping.')  # noqa: E501
                     continue
 
-                token_price = Inquirer.find_main_currency_price(event.asset)
-                balances[withdrawer].assets[event.asset][self.counterparty] += Balance(
-                    amount=(amount := FVal(str_amount)),
-                    value=token_price * amount,
-                )
+                entries.append((withdrawer, event.asset, FVal(str_amount)))
 
+        self._add_priced_balances(balances=balances, amounts=entries)
         return balances
 
     def _query_eigenpod_balances(self, balances: 'BalancesSheetType') -> 'BalancesSheetType':
@@ -188,14 +183,11 @@ class EigenlayerBalances(ProtocolWithBalance):
         if len(eigenpod_to_owner := get_eigenpods_to_owners_mapping(self.event_db.db)) == 0:
             return balances
 
-        eth_price = Inquirer.find_main_currency_price(A_ETH)  # now query all eigenpod balances and add it  # noqa: E501
-        for eigenpod_address, amount in self.evm_inquirer.get_multi_balance(accounts=list(eigenpod_to_owner.keys())).items():  # noqa: E501
-            if amount > ZERO:
-                balances[eigenpod_to_owner[eigenpod_address]].assets[A_ETH][self.counterparty] += Balance(  # noqa: E501
-                    amount=amount,
-                    value=eth_price * amount,
-                )
-
+        self._add_priced_balances(balances=balances, amounts=[  # query all eigenpod balances and add them  # noqa: E501
+            (eigenpod_to_owner[eigenpod_address], A_ETH, amount)
+            for eigenpod_address, amount in self.evm_inquirer.get_multi_balance(accounts=list(eigenpod_to_owner.keys())).items()  # noqa: E501
+            if amount > ZERO
+        ])
         return balances
 
     def query_balances(self) -> 'BalancesSheetType':

--- a/rotkehlchen/chain/ethereum/modules/hedgey/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/hedgey/balances.py
@@ -1,12 +1,11 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.accounting.structures.balance import BalanceSheet
 from rotkehlchen.assets.utils import token_normalized_value
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.inquirer import Inquirer
 
 from .constants import (
     CPT_HEDGEY,
@@ -67,10 +66,11 @@ class HedgeyBalances(ProtocolWithBalance):
             method_name='lockedBalances',
             arguments=call_args,
         )
-        for idx, entry in enumerate(result):
-            token = args[idx][1]
-            balances[args[idx][0]].assets[token][self.counterparty] += Balance(
-                amount=(amount := token_normalized_value(token_amount=entry[0], token=token)),
-                value=amount * Inquirer.find_main_currency_price(token),
-            )
+        self._add_priced_balances(balances=balances, amounts=[
+            ((address_and_token := args[idx])[0], address_and_token[1], token_normalized_value(
+                token_amount=entry[0],
+                token=address_and_token[1],
+            ))
+            for idx, entry in enumerate(result)
+        ])
         return balances

--- a/rotkehlchen/chain/evm/decoding/compound/v3/balances.py
+++ b/rotkehlchen/chain/evm/decoding/compound/v3/balances.py
@@ -2,18 +2,16 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, NamedTuple
 
-from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.accounting.structures.balance import BalanceSheet
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContract
-from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, TokenKind
 
@@ -175,6 +173,7 @@ class Compoundv3Balances(ProtocolWithBalance):
             log.error(f'Failed to query Compound v3 collateral due to {e!s}')
             return balances
 
+        entries = []
         for idx, result in enumerate(call_output):
             raw_amount = comet_contract.decode(
                 result=result,
@@ -188,23 +187,16 @@ class Compoundv3Balances(ProtocolWithBalance):
                 continue
 
             collateral_asset = calls_arguments[idx].compound_asset
-            collateral_balance = token_normalized_value_decimals(
-                token_amount=raw_amount,
-                token_decimals=collateral_asset.decimals,
-            )
+            entries.append((
+                calls_arguments[idx].user_address,
+                collateral_asset,
+                token_normalized_value_decimals(
+                    token_amount=raw_amount,
+                    token_decimals=collateral_asset.decimals,
+                ),
+            ))
 
-            if (asset_price := Inquirer.find_main_currency_price(collateral_asset)) == ZERO:
-                log.error(
-                    f'Failed to query price of {collateral_asset!s} '
-                    'while fetching the collateral balances of Compound v3',
-                )
-                continue
-
-            balances[calls_arguments[idx].user_address].assets[collateral_asset][self.counterparty] += Balance(  # noqa: E501
-                amount=collateral_balance,
-                value=collateral_balance * asset_price,
-            )
-
+        self._add_priced_balances(balances=balances, amounts=entries)
         return balances
 
     def query_liabilities(self) -> 'BalancesSheetType':
@@ -247,6 +239,7 @@ class Compoundv3Balances(ProtocolWithBalance):
             log.error(f'Failed to query Compound v3 liabilities due to {e!s}')
             return balances
 
+        entries = []
         for idx, result in enumerate(call_output):
             raw_amount = token_contract.decode(
                 result=result,
@@ -256,24 +249,16 @@ class Compoundv3Balances(ProtocolWithBalance):
             if raw_amount <= 0:
                 continue
 
-            borrow_balance = token_normalized_value_decimals(
-                token_amount=raw_amount,
-                token_decimals=calls_arguments[idx].compound_asset.decimals,
-            )
+            entries.append((
+                calls_arguments[idx].user_address,
+                underlying_token[calls[idx][0]],
+                token_normalized_value_decimals(
+                    token_amount=raw_amount,
+                    token_decimals=calls_arguments[idx].compound_asset.decimals,
+                ),
+            ))
 
-            # query the current price of the underlying asset
-            if (asset_price := Inquirer.find_main_currency_price(underlying_token[calls[idx][0]])) == ZERO:  # noqa: E501
-                log.error(
-                    f'Failed to query price of {underlying_token[calls[idx][0]]!s} '
-                    'while fetching the liability balances of Compound v3',
-                )
-                continue
-
-            balances[calls_arguments[idx].user_address].liabilities[underlying_token[calls[idx][0]]][self.counterparty] += Balance(  # noqa: E501
-                amount=borrow_balance,
-                value=borrow_balance * asset_price,
-            )
-
+        self._add_priced_balances(balances=balances, amounts=entries, category='liabilities')
         return balances
 
     def query_balances(self) -> 'BalancesSheetType':

--- a/rotkehlchen/chain/evm/decoding/curve/lend/balances.py
+++ b/rotkehlchen/chain/evm/decoding/curve/lend/balances.py
@@ -3,18 +3,16 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
+from rotkehlchen.accounting.structures.balance import BalanceSheet
 from rotkehlchen.assets.utils import get_or_create_evm_token, token_normalized_value
 from rotkehlchen.chain.ethereum.interfaces.balances import BalancesSheetType, ProtocolWithBalance
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.curve.constants import CPT_CURVE
 from rotkehlchen.chain.evm.decoding.curve.lend.constants import CURVE_VAULT_CONTROLLER_ABI
-from rotkehlchen.constants import ZERO
 from rotkehlchen.errors.misc import NotERC20Conformant, NotERC721Conformant, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.serialization.deserialize import deserialize_evm_address
 from rotkehlchen.types import ChecksumEvmAddress
@@ -23,7 +21,6 @@ if TYPE_CHECKING:
     from rotkehlchen.assets.asset import EvmToken
     from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
-    from rotkehlchen.types import Price
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -71,24 +68,6 @@ class CurveControllerCommonBalances(ProtocolWithBalance, ABC):
                 controllers[event.extra_data['controller_address']].add(address)
 
         return controllers
-
-    @staticmethod
-    def _get_token_balance(
-            token: 'EvmToken',
-            amount: int,
-            token_prices: dict['EvmToken', 'Price'],
-    ) -> Balance | None:
-        """Return a Balance using the specified amount, token, and prices."""
-        if amount == 0 or token not in token_prices:
-            return None
-
-        return Balance(
-            amount=(normalized_amount := token_normalized_value(
-                token_amount=amount,
-                token=token,
-            )),
-            value=normalized_amount * token_prices[token],
-        )
 
     def query_balances(self) -> 'BalancesSheetType':
         """Query balances for Curve lending loans and leveraged positions.
@@ -160,30 +139,16 @@ class CurveControllerCommonBalances(ProtocolWithBalance, ABC):
                 liabilities.append((user_address, borrowed_token, debt_amount))
                 unique_tokens.add(borrowed_token)
 
-        # Fetch prices for tokens
-        token_prices: dict[EvmToken, Price] = {}
-        for token in unique_tokens:
-            if (price := Inquirer.find_main_currency_price(token)) == ZERO:
-                log.error(f'Failed to query price of {token!s} while fetching Curve lending balances.')  # noqa: E501
-
-            token_prices[token] = price
-
-        # Add assets and liabilities balances
-        for user_address, token, amount in assets:
-            if (balance := self._get_token_balance(
-                    token=token,
-                    amount=amount,
-                    token_prices=token_prices,
-            )):
-                balances[user_address].assets[token][self.counterparty] += balance
-
-        for user_address, token, amount in liabilities:
-            if (balance := self._get_token_balance(
-                    token=token,
-                    amount=amount,
-                    token_prices=token_prices,
-            )):
-                balances[user_address].liabilities[token][self.counterparty] += balance
+        # Price all tokens in one batched query and add the asset/liability balances
+        for entries, category in ((assets, 'assets'), (liabilities, 'liabilities')):
+            self._add_priced_balances(
+                balances=balances,
+                amounts=[
+                    (user_address, token, token_normalized_value(token_amount=amount, token=token))
+                    for user_address, token, amount in entries if amount != 0
+                ],
+                category=category,  # type: ignore[arg-type]  # is a valid literal
+            )
 
         return balances
 

--- a/rotkehlchen/chain/evm/decoding/extrafi/balances.py
+++ b/rotkehlchen/chain/evm/decoding/extrafi/balances.py
@@ -76,13 +76,10 @@ class ExtrafiCommonBalances(ProtocolWithBalance):
                     )
 
             if len(unique_reserves) != 0:
-                lending_reserves = self.query_lending_reserves(address, list(unique_reserves))
-                for reserve_token, balance_amount in lending_reserves.items():
-                    price = Inquirer.find_main_currency_price(reserve_token)
-                    balances[address].assets[reserve_token][self.counterparty] += Balance(
-                        amount=balance_amount,
-                        value=balance_amount * price,
-                    )
+                self._add_priced_balances(balances=balances, amounts=[
+                    (address, reserve_token, balance_amount)
+                    for reserve_token, balance_amount in self.query_lending_reserves(address, list(unique_reserves)).items()  # noqa: E501
+                ])
 
             if len(farm_positions) != 0:
                 self._query_farm_positions(
@@ -122,6 +119,8 @@ class ExtrafiCommonBalances(ProtocolWithBalance):
             log.error(f'Failed to query {self.evm_inquirer.chain_name} extrafi locked balances due to {e!s}')  # noqa: E501
             return
 
+        asset_entries: list[tuple[ChecksumEvmAddress, EvmToken, FVal]] = []
+        liability_entries: list[tuple[ChecksumEvmAddress, EvmToken, FVal]] = []
         for idx, result in enumerate(results):
             staked_amount_raw = farm_contract.decode(
                 result=result,
@@ -140,23 +139,19 @@ class ExtrafiCommonBalances(ProtocolWithBalance):
                 evm_inquirer=self.evm_inquirer,
             )
 
-            lp_amount = token_normalized_value(lp_amount_raw, lp_token)
-            lp_price = Inquirer.find_main_currency_price(lp_token)
-            balances[address].assets[lp_token][self.counterparty] += Balance(
-                amount=lp_amount,
-                value=lp_amount * lp_price,
+            asset_entries.append((address, lp_token, token_normalized_value(lp_amount_raw, lp_token)))  # noqa: E501
+            liability_entries.extend(
+                (address, debt_token, token_normalized_value(debt_amount, debt_token))
+                for debt_token, debt_amount in ((token_0, debt_0_amount), (token_1, debt_1_amount))
+                if debt_amount != 0
             )
 
-            for debt_token, debt_amount in ((token_0, debt_0_amount), (token_1, debt_1_amount)):
-                if debt_amount == 0:
-                    continue
-
-                amount = token_normalized_value(debt_amount, debt_token)
-                price = Inquirer.find_main_currency_price(debt_token)
-                balances[address].liabilities[debt_token][self.counterparty] += Balance(
-                    amount=amount,
-                    value=amount * price,
-                )
+        self._add_priced_balances(balances=balances, amounts=asset_entries)
+        self._add_priced_balances(
+            balances=balances,
+            amounts=liability_entries,
+            category='liabilities',
+        )
 
     def _query_locked_extra(
             self,

--- a/rotkehlchen/chain/evm/decoding/woo_fi/balances.py
+++ b/rotkehlchen/chain/evm/decoding/woo_fi/balances.py
@@ -177,6 +177,7 @@ class WoofiBalances(ProtocolWithBalance):
                 )
                 return balances
 
+            entries = []
             for (pool_id, vault_token), result in zip(pool_info_list, results, strict=False):
                 raw_balance, _ = master_chef_contract.decode(
                     result=result,
@@ -186,12 +187,11 @@ class WoofiBalances(ProtocolWithBalance):
                 if raw_balance == 0:
                     continue
 
-                balances[address].assets[vault_token][self.counterparty] += Balance(
-                    amount=(balance := asset_normalized_value(
-                        amount=raw_balance,
-                        asset=vault_token.resolve_to_crypto_asset(),
-                    )),
-                    value=balance * Inquirer.find_main_currency_price(vault_token),
-                )
+                entries.append((address, vault_token, asset_normalized_value(
+                    amount=raw_balance,
+                    asset=vault_token.resolve_to_crypto_asset(),
+                )))
+
+            self._add_priced_balances(balances=balances, amounts=entries)
 
         return balances


### PR DESCRIPTION
Add ProtocolWithBalance._add_priced_balances which prices a list of (address, asset, amount) entries in the user's main currency with a single batched inquirer query and adds them to the balance sheets under the protocol's counterparty. Assets already priced (e.g. by a previously queried protocol or exchange) are served from the price cache.

Use it to replace the per-asset price queries in the balance modules that priced inside loops: the gauges interface (curve, convex, velodrome, aerodrome etc, now one batch per module across all addresses), eigenlayer, morpho blue, compound v3, curve lend, extrafi, hedgey and woo-fi vaults.

Modules that price a single asset once outside their loop are left unchanged, as is GMX positions where the price is needed to derive the position amount. Compound v3 entries whose price cannot be found are now included with a zero value instead of being skipped, matching the behavior of the other modules. Curve lend's now unneeded _get_token_balance helper is removed.
