### PR TITLE
fix: persist coinbase cursors after full query

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` A failed Coinbase history query no longer permanently loses the events of already queried accounts.
 * :bug:`-` A temporary premium server error no longer permanently stops all background tasks (balance snapshots, transaction querying and decoding, database sync) until the application is restarted.
 * :bug:`-` A failed Binance history query no longer marks the time range as queried, which permanently skipped the deposits and withdrawals of that range.
 * :bug:`-` Coinbase crypto-to-crypto conversions are no longer sometimes recorded as sales to fiat with the received asset missing.

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -415,6 +415,8 @@ class Coinbase(ExchangeInterface):
         self.staking_events = set()
         conversion_pairs: defaultdict[str, list[dict]] = defaultdict(list)
         all_events: list[HistoryBaseEntry] = []
+        cursor_updates: list[tuple[str, str]] = []
+        queried_account_ids: list[str] = []
         for account_id in account_info:
             if force_refresh:
                 last_id = None  # Bypass cache when force_refresh is True
@@ -439,25 +441,18 @@ class Coinbase(ExchangeInterface):
                     )) is not None:
                         last_id = str(result_id)
 
-            history_events, conversions = self._query_single_account_transactions(
+            history_events, conversions, last_queried_tx_id = self._query_single_account_transactions(  # noqa: E501
                 account_id=account_id,
-                account_last_id_name=f'{self.location}_{self.name}_{account_id}_last_query_id',
                 last_tx_id=last_id,
-                force_refresh=force_refresh,
             )
             conversion_pairs = combine_dicts(conversion_pairs, conversions)
             all_events.extend(history_events)
-
-            if not force_refresh:
-                with self.db.user_write() as write_cursor:
-                    self.db.set_dynamic_cache(
-                        write_cursor=write_cursor,
-                        name=DBCacheDynamic.LAST_QUERY_TS,
-                        value=ts_now(),
-                        location=self.location.serialize(),
-                        location_name=self.name,
-                        account_id=account_id,
-                    )
+            if last_queried_tx_id is not None:
+                cursor_updates.append((
+                    f'{self.location}_{self.name}_{account_id}_last_query_id',
+                    last_queried_tx_id,
+                ))
+            queried_account_ids.append(account_id)
 
         # Process conversions only after all accounts have been queried, since the two
         # legs of a conversion live in the wallets of the two involved assets. Processing
@@ -468,20 +463,44 @@ class Coinbase(ExchangeInterface):
                 transaction_pairs=conversion_pairs,
             ))
 
+        if not force_refresh:
+            # Only persist the per-account cursors now that all accounts have been
+            # queried successfully. The caller saves the returned events only after
+            # this function returns, so persisting a cursor earlier would permanently
+            # lose the in-memory events of the already queried accounts (and break
+            # cross-wallet conversion pairing) if a later account's query raises.
+            with self.db.user_write() as write_cursor:
+                write_cursor.executemany(
+                    'INSERT OR REPLACE INTO key_value_cache(name, value) VALUES(?, ?)',
+                    cursor_updates,
+                )
+                for account_id in queried_account_ids:
+                    self.db.set_dynamic_cache(
+                        write_cursor=write_cursor,
+                        name=DBCacheDynamic.LAST_QUERY_TS,
+                        value=ts_now(),
+                        location=self.location.serialize(),
+                        location_name=self.name,
+                        account_id=account_id,
+                    )
+
         return all_events
 
     def _query_single_account_transactions(
             self,
             account_id: str,
-            account_last_id_name: str,
             last_tx_id: str | None,
-            force_refresh: bool = False,
     ) -> tuple[
             list[HistoryEvent | AssetMovement | SwapEvent],
             defaultdict[str, list[dict]],
+            str | None,
         ]:
         """
-        Query all the transactions and save all newly generated events
+        Query all the transactions of an account and generate events from them.
+
+        Also returns the id of the last queried transaction (None if there was none)
+        so the caller can persist it as the account's cursor once the entire query
+        of all accounts has succeeded.
 
         May raise:
         - RemoteError
@@ -494,7 +513,7 @@ class Coinbase(ExchangeInterface):
         transaction_pairs: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)  # Maps every trade id to their two transactions  # noqa: E501
         if len(transactions) == 0:
             log.debug('Coinbase API query returned no transactions')
-            return history_events, transaction_pairs
+            return history_events, transaction_pairs, None
 
         for transaction in transactions:
             log.debug(f'Processing coinbase {transaction=}')
@@ -544,14 +563,7 @@ class Coinbase(ExchangeInterface):
             ):
                 log.warning(f'Found unknown coinbase transaction type: {transaction}')
 
-        if not force_refresh:  # Only update cache when not forcing refresh
-            with self.db.user_write() as write_cursor:  # Remember last transaction id for account
-                write_cursor.execute(
-                    'INSERT OR REPLACE INTO key_value_cache(name, value) VALUES(?, ?) ',
-                    (account_last_id_name, transactions[-1]['id']),  # -1 takes last transaction due to ascending order  # noqa: E501
-                )
-
-        return history_events, transaction_pairs
+        return history_events, transaction_pairs, transactions[-1]['id']  # -1 takes last transaction due to ascending order  # noqa: E501
 
     def _process_trades_from_conversion(
             self,

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -430,6 +430,74 @@ def test_coinbase_staking_events(
     )]
 
 
+def test_account_failure_does_not_advance_cursors(
+        database: 'DBHandler',
+        function_scope_coinbase: 'Coinbase',
+) -> None:
+    """Test that a failing account query persists no per-account cursors at all.
+
+    Events are only saved by the caller after all accounts have been queried, so
+    persisting a cursor for an already queried account earlier would permanently
+    lose its in-memory events: the retry would query only after the cursor."""
+    coinbase = function_scope_coinbase
+    failing = True
+
+    def mock_api_query(endpoint: str, options: dict | None = None, **kwargs: Any) -> list:
+        if endpoint == 'accounts':
+            return [{'id': 'account_a'}, {'id': 'account_b'}]
+        elif 'account_a/transactions' in endpoint:
+            if options is not None and options.get('starting_after') == 'tx_a_1':
+                return []  # the api honors the cursor: nothing after the last seen tx
+            return [{
+                'amount': {'amount': '5.5', 'currency': 'DOT'},
+                'created_at': '2024-01-01T16:19:24Z',
+                'id': 'tx_a_1',
+                'native_amount': {'amount': '46.68', 'currency': 'USD'},
+                'resource': 'transaction',
+                'resource_path': '/v2/accounts/account_a/transactions/tx_a_1',
+                'status': 'completed',
+                'type': 'staking_reward',
+            }]
+        elif 'account_b/transactions' in endpoint:
+            if failing:
+                raise RemoteError('Coinbase API request failed due to a transient error')
+            return []
+
+        raise AssertionError(f'Unexpected endpoint {endpoint} for test')
+
+    with (
+        patch.object(coinbase, '_api_query', side_effect=mock_api_query),
+        pytest.raises(RemoteError),
+    ):  # account_a succeeds but account_b's remote failure aborts the whole query
+        coinbase.query_history_events()
+
+    events_db = DBHistoryEvents(database)
+    with database.conn.read_ctx() as cursor:
+        assert cursor.execute(  # neither cursors nor query timestamps were persisted
+            "SELECT COUNT(*) FROM key_value_cache WHERE name LIKE '%last_query%'",
+        ).fetchone()[0] == 0
+        assert events_db.get_history_events_internal(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(location=Location.COINBASE),
+        ) == []
+
+    failing = False  # retry with the remote error resolved: account_a's event is recovered
+    with patch.object(coinbase, '_api_query', side_effect=mock_api_query):
+        coinbase.query_history_events()
+
+    with database.conn.read_ctx() as cursor:
+        events = events_db.get_history_events_internal(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(location=Location.COINBASE),
+        )
+        assert cursor.execute(  # and only now is the cursor persisted
+            'SELECT value FROM key_value_cache WHERE name=?',
+            (f'{coinbase.location}_{coinbase.name}_account_a_last_query_id',),
+        ).fetchone()[0] == 'tx_a_1'
+    assert len(events) == 1
+    assert events[0].group_identifier == 'CBE_tx_a_1'
+
+
 def test_coinbase_query_history_events(
         database,
         function_scope_coinbase,
@@ -1910,7 +1978,7 @@ def test_ignore_updated_at_ts(function_scope_coinbase):
         raise AssertionError(f'Unexpected url {url} for test')
 
     with (
-        patch.object(coinbase, '_query_single_account_transactions', return_value=([], [])) as tx_query_mock,  # noqa: E501
+        patch.object(coinbase, '_query_single_account_transactions', return_value=([], [], None)) as tx_query_mock,  # noqa: E501
         patch.object(coinbase.session, 'get', side_effect=_mock_query),
     ):
         coinbase.query_history_events()


### PR DESCRIPTION
Coinbase persisted each account's last_query_id cursor right after querying that account, while the generated events are only saved by the caller once all accounts have been queried. A remote failure on a later account therefore permanently lost the in-memory events of the already queried accounts, since their next query would start after the saved cursor. It could also break cross-wallet conversion pairing by re-fetching only one leg of a conversion.

Now all per-account cursors and last-query timestamps are persisted in a single transaction only after every account has been queried and the conversions have been processed, so a failed run leaves no cursor advanced and the retry re-fetches everything idempotently.
