### PR TITLE
Multibugs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Editing a history event no longer silently erases internal metadata such as its link to a matched asset movement.
 * :bug:`-` A failed Coinbase history query no longer permanently loses the events of already queried accounts.
 * :bug:`-` A temporary premium server error no longer permanently stops all background tasks (balance snapshots, transaction querying and decoding, database sync) until the application is restarted.
 * :bug:`-` A failed Binance history query no longer marks the time range as queried, which permanently skipped the deposits and withdrawals of that range.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Removing an EVM account no longer fails while a transactions refresh of all accounts is running.
 * :bug:`-` Two quick successive login attempts can no longer run the account unlock logic concurrently.
 * :bug:`-` Editing a history event no longer silently erases internal metadata such as its link to a matched asset movement.
 * :bug:`-` A failed Coinbase history query no longer permanently loses the events of already queried accounts.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Two quick successive login attempts can no longer run the account unlock logic concurrently.
 * :bug:`-` Editing a history event no longer silently erases internal metadata such as its link to a matched asset movement.
 * :bug:`-` A failed Coinbase history query no longer permanently loses the events of already queried accounts.
 * :bug:`-` A temporary premium server error no longer permanently stops all background tasks (balance snapshots, transaction querying and decoding, database sync) until the application is restarted.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -315,6 +315,9 @@ def login_lock() -> Callable:
     """
     This is a decorator that uses the login lock at RestAPI to avoid a race condition between
     async tasks using the user unlock logic.
+
+    It has to be applied below async_api_call so that the lock is held while the wrapped
+    function actually runs in the spawned greenlet, and not just while it is dispatched.
     """
     def wrapper(func: Callable[..., Response]) -> Callable[..., Response]:
         def inner(rest_api: 'RestAPI', **kwargs: Any) -> Response:
@@ -899,8 +902,8 @@ class RestAPI:
         result_dict = _wrap_in_ok_result(result)
         return api_response(result_dict, status_code=HTTPStatus.OK)
 
-    @login_lock()
     @async_api_call()
+    @login_lock()
     def create_new_user(
             self,
             name: str,
@@ -983,8 +986,8 @@ class RestAPI:
             'status_code': HTTPStatus.OK,
         }
 
-    @login_lock()
     @async_api_call()
+    @login_lock()
     def user_login(
             self,
             name: str,

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -545,7 +545,10 @@ class DBHistoryEvents:
     ) -> None:
         """
         Edit a history entry to the DB with information provided by the user.
-        NOTE: It edits all the fields except the extra_data one.
+        NOTE: extra_data is preserved when the given event has none, since the edit
+        schemas of some entry types provide no control over it. The system-managed
+        matched_asset_movement key is also carried over to edits that do replace
+        extra_data, as only the unlink endpoint may remove it.
         Marks the event with the specified mapping state if provided.
         Only tracks modification for balance cache invalidation if balance-affecting
         fields change (timestamp, asset, amount, type, subtype, location_label).
@@ -554,11 +557,28 @@ class DBHistoryEvents:
             - InputError if an error occurred.
         """
         old_data = write_cursor.execute(
-            'SELECT timestamp, asset, amount, type, subtype, location_label, sequence_index '
-            'FROM history_events WHERE identifier=?',
+            'SELECT timestamp, asset, amount, type, subtype, location_label, sequence_index, '
+            'extra_data FROM history_events WHERE identifier=?',
             (event.identifier,),
         ).fetchone()
         assert event.identifier is not None
+
+        old_extra_data: dict[str, Any] | None = None
+        if old_data is not None:
+            old_extra_data = HistoryBaseEntry.deserialize_extra_data(
+                entry=old_data,
+                extra_data=old_data[7],
+            )
+        if old_extra_data is not None:
+            if event.extra_data is None and event.entry_type == HistoryBaseEntryType.HISTORY_EVENT:
+                # The edit schema of plain history events provides no extra_data control,
+                # so an edit must not wipe it (e.g. events matched to asset movements).
+                event.extra_data = old_extra_data
+            elif (
+                (matched := old_extra_data.get('matched_asset_movement')) is not None and
+                (event.extra_data is None or 'matched_asset_movement' not in event.extra_data)
+            ):  # tied to the history_event_links table, which user edits don't touch
+                event.extra_data = (event.extra_data or {}) | {'matched_asset_movement': matched}
 
         if save_backup:
             self.save_history_event_backup(write_cursor=write_cursor, identifier=event.identifier)

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -254,8 +254,10 @@ class Rotkehlchen:
                 )
                 if (
                         is_evm_tx_greenlet and
-                        greenlet.kwargs.get('only_cache', False) is False and
-                        account_data in greenlet.kwargs['accounts']
+                        # accounts is None when all tracked accounts are being refreshed,
+                        # which includes the address being removed
+                        ((accounts := greenlet.kwargs['accounts']) is None or
+                         account_data in accounts)
                 ):
                     greenlet.kill(exception=GreenletKilledError('Killed due to request for evm address removal'))  # noqa: E501
 

--- a/rotkehlchen/tests/api/test_users.py
+++ b/rotkehlchen/tests/api/test_users.py
@@ -17,7 +17,11 @@ from rotkehlchen.constants.misc import USERDB_NAME, USERSDIR_NAME
 from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.drivers.gevent import DBConnection, DBConnectionType
 from rotkehlchen.db.settings import ROTKEHLCHEN_DB_VERSION, DBSettings
-from rotkehlchen.errors.api import PremiumAuthenticationError, PremiumPermissionError
+from rotkehlchen.errors.api import (
+    AuthenticationError,
+    PremiumAuthenticationError,
+    PremiumPermissionError,
+)
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.inquirer import Inquirer
@@ -85,6 +89,32 @@ def test_loggedin_user_querying(
     assert result[username] == 'loggedin'
     assert result['another_user'] == 'loggedout'
     assert len(result) == 2
+
+
+@pytest.mark.parametrize('start_with_logged_in_user', [False])
+def test_async_login_holds_login_lock(rotkehlchen_api_server: 'APIServer') -> None:
+    """Test that the login lock is held while an async login actually runs the unlock
+    logic, and not just while the async task is dispatched. Otherwise two quick
+    successive login/create-user requests can run the unlock logic concurrently."""
+    rest_api = rotkehlchen_api_server.rest_api
+    lock_states: list[bool] = []
+
+    def mock_unlock(*args: Any, **kwargs: Any) -> None:
+        lock_states.append(rest_api.login_lock.locked())
+        raise AuthenticationError('end the login here')
+
+    with (
+        patch.object(rest_api.rotkehlchen, 'unlock_user', side_effect=mock_unlock),
+        patch.object(rest_api.rotkehlchen, 'reset_after_failed_account_creation_or_login'),
+    ):
+        response = requests.post(
+            api_url_for(rotkehlchen_api_server, 'usersbynameresource', name='someuser'),
+            json={'password': '123', 'sync_approval': 'unknown', 'async_query': True},
+        )
+        task_id = assert_ok_async_response(response)
+        wait_for_async_task(rotkehlchen_api_server, task_id)
+
+    assert lock_states == [True]
 
 
 @pytest.mark.parametrize('start_with_logged_in_user', [False])

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Mapping
 from typing import Any
 from unittest.mock import patch
@@ -285,6 +286,72 @@ def test_read_write_events_from_db(database):
                         address=data_entry[4],
                     )
                     assert event == expected_event
+
+
+def test_edit_history_event_extra_data_preservation(database: DBHandler) -> None:
+    """Test that editing events does not wipe extra_data the edit schemas cannot provide.
+
+    Plain history events keep their whole extra_data when the edited event has none
+    (their edit schema has no extra_data field), the system-managed
+    matched_asset_movement key survives edits that replace extra_data (the asset
+    movement form rebuilds it from its fields), and the normal overwrite semantics
+    stay intact for evm events whose form round-trips extra_data."""
+    db = DBHistoryEvents(database)
+    matched = {'group_identifier': 'whatever', 'exchange': 'kraken'}
+    plain_event = HistoryEvent(
+        group_identifier='TEST1',
+        sequence_index=1,
+        timestamp=TimestampMS(1),
+        location=Location.BITCOIN,
+        event_type=HistoryEventType.EXCHANGE_TRANSFER,
+        event_subtype=HistoryEventSubType.SPEND,
+        asset=A_BTC,
+        amount=ONE,
+        extra_data={'matched_asset_movement': matched, 'other': 1},
+    )
+    movement_event = AssetMovement(
+        timestamp=TimestampMS(2),
+        location=Location.KRAKEN,
+        event_subtype=HistoryEventSubType.SPEND,
+        asset=A_BTC,
+        amount=ONE,
+        extra_data={'address': 'old_address', 'matched_asset_movement': matched},  # set by the asset movement matching task  # noqa: E501
+    )
+    evm_event = EvmEvent(
+        tx_ref=make_evm_tx_hash(),
+        sequence_index=1,
+        timestamp=TimestampMS(3),
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.TRADE,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_ETH,
+        amount=ONE,
+        extra_data={'airdrop': 'uniswap'},
+    )
+    with db.db.user_write() as write_cursor:
+        for event in (plain_event, movement_event, evm_event):
+            event.identifier = db.add_history_event(write_cursor=write_cursor, event=event)
+
+    def edited_extra_data(event: HistoryBaseEntry) -> dict | None:
+        with db.db.user_write() as write_cursor:
+            db.edit_history_event(write_cursor=write_cursor, event=event, mapping_state=None)
+            raw = write_cursor.execute(
+                'SELECT extra_data FROM history_events WHERE identifier=?',
+                (event.identifier,),
+            ).fetchone()[0]
+        return json.loads(raw) if raw is not None else None
+
+    plain_event.extra_data = None  # the plain event edit schema produces no extra_data
+    assert edited_extra_data(plain_event) == {'matched_asset_movement': matched, 'other': 1}
+
+    movement_event.extra_data = {'address': 'new_address'}  # rebuilt from the form fields
+    assert edited_extra_data(movement_event) == {
+        'address': 'new_address',
+        'matched_asset_movement': matched,
+    }
+
+    evm_event.extra_data = None  # deliberate clearing keeps working for evm events
+    assert edited_extra_data(evm_event) is None
 
 
 def test_history_events_count_with_chain_filters(database: DBHandler) -> None:

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import gevent
 import pytest
+import requests
 from freezegun import freeze_time
 
 from rotkehlchen.assets.asset import EvmToken, UnderlyingToken
@@ -47,6 +48,7 @@ from rotkehlchen.tasks.utils import (
     should_run_periodic_task,
 )
 from rotkehlchen.tests.fixtures.websockets import WebsocketReader
+from rotkehlchen.tests.utils.api import api_url_for, assert_ok_async_response
 from rotkehlchen.tests.utils.ethereum import (
     TEST_ADDR1,
     TEST_ADDR2,
@@ -713,6 +715,41 @@ def test_maybe_kill_running_tx_query_tasks(rotkehlchen_api_server, ethereum_acco
         rotki.task_manager.potential_tasks = []
         rotki.task_manager.schedule()
         assert len(rotki.task_manager.running_greenlets) == 0
+
+
+@pytest.mark.parametrize('ethereum_accounts', [[make_evm_address()]])
+def test_maybe_kill_tx_query_tasks_all_accounts_refresh(
+        rotkehlchen_api_server,
+        ethereum_accounts,
+):
+    """Test that an api transactions refresh task without specific accounts (refresh all)
+    is killed when one of the tracked addresses is removed, instead of raising a
+    TypeError on the None accounts kwarg which made account removal fail."""
+    rest_api = rotkehlchen_api_server.rest_api
+    rotki = rest_api.rotkehlchen
+
+    def blocking_refresh(**kwargs):  # pylint: disable=unused-argument
+        while True:  # busy wait :D just for the test
+            gevent.sleep(1)
+
+    with patch.object(
+        rest_api.transactions_service,
+        'refresh_transactions',
+        side_effect=blocking_refresh,
+    ):
+        response = requests.post(
+            api_url_for(rotkehlchen_api_server, 'blockchaintransactionsresource'),
+            json={'async_query': True},  # no accounts given: refresh all tracked accounts
+        )
+        task_id = assert_ok_async_response(response)
+        greenlet = next(g for g in rotki.api_task_greenlets if g.task_id == task_id)
+        gevent.sleep(.1)  # give the greenlet a chance to start
+        assert greenlet.dead is False
+        rotki.maybe_kill_running_tx_query_tasks(
+            blockchain=SupportedBlockchain.ETHEREUM,
+            addresses=[ethereum_accounts[0]],
+        )
+        assert greenlet.dead is True
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[


### PR DESCRIPTION
[fix: keep extra data when editing history events](https://github.com/rotki/rotki/commit/ea9d23862e30168d5ee594e54c266b7320256d2f) 

Editing a history event wrote the edited event's extra_data to the DB
even though some edit schemas provide no control over it, silently
erasing stored metadata. Plain history events (e.g. bitcoin events
matched to an exchange asset movement) lost their whole extra_data on
any edit, and asset movement edits rebuilt extra_data from the form
fields, dropping the matched_asset_movement key while the link row
survived, leaving the match metadata inconsistent.

Now an edit preserves the existing extra_data when the edited event has
none and its type offers no way to edit it, and the system-managed
matched_asset_movement key is carried over into edits that replace
extra_data, since only the unlink endpoint may remove it. Deliberately
overwriting or clearing extra_data of evm events keeps working.
@[LefterisJP](https://github.com/rotki/rotki/commits?author=LefterisJP)
LefterisJP committed 1 minute ago
[fix: hold login lock during async user unlock](https://github.com/rotki/rotki/commit/cb15f93685c08d1544ec20a318cfdfbbd9996989) 

The login_lock decorator was applied above async_api_call on the user
login and creation endpoints, so for async queries the lock was only
held while the task greenlet was spawned and the actual unlock logic
ran unlocked. Two quick successive login or create-user requests could
therefore run the unlock logic concurrently, which is exactly the race
the lock was introduced to prevent.

Swap the decorator order so the lock wraps the function that executes
inside the spawned greenlet, and document the ordering requirement in
the decorator.
@[LefterisJP](https://github.com/rotki/rotki/commits?author=LefterisJP)
LefterisJP committed 1 minute ago
[fix: kill all-accounts tx query on account removal](https://github.com/rotki/rotki/commit/16eb8c03e0756f703ee4bdbac8b360dac1113d6d) 

When removing an EVM account, rotki kills any running api transactions
query tasks for that address. A refresh of all accounts however passes
accounts as None, and checking membership in it raised a TypeError
which made the account removal fail with an internal error while such
a refresh was running.

Treat None as matching every address, since an all-accounts refresh
also queries the address being removed, and drop the dead only_cache
check since refresh_transactions has no such argument anymore.