### PR TITLE
Cached balances use manual current prices

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` A temporary premium server error no longer permanently stops all background tasks (balance snapshots, transaction querying and decoding, database sync) until the application is restarted.
+* :bug:`-` Cached blockchain balances now use your manual current prices when recalculating values, instead of falling back to older historical prices.
 * :bug:`-` A failed Binance history query no longer marks the time range as queried, which permanently skipped the deposits and withdrawals of that range.
 * :bug:`-` Coinbase crypto-to-crypto conversions are no longer sometimes recorded as sales to fiat with the received asset missing.
 * :bug:`-` Solana events with a counterparty are no longer silently excluded from PnL reports.

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -13,7 +13,7 @@ from web3.exceptions import BadFunctionCallOutput, Web3Exception
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.api.websockets.typedefs import WSMessageType
-from rotkehlchen.assets.asset import CryptoAsset
+from rotkehlchen.assets.asset import Asset, CryptoAsset
 from rotkehlchen.chain.accounts import BlockchainAccountData, BlockchainAccounts
 from rotkehlchen.chain.arbitrum_one.modules.gearbox.balances import (
     GearboxBalances as GearboxBalancesArbitrumOne,
@@ -67,7 +67,7 @@ from rotkehlchen.chain.optimism.modules.velodrome.balances import VelodromeBalan
 from rotkehlchen.chain.optimism.modules.walletconnect.balances import WalletconnectBalances
 from rotkehlchen.chain.substrate.manager import wait_until_a_node_is_available
 from rotkehlchen.chain.substrate.utils import SUBSTRATE_NODE_CONNECTION_TIMEOUT
-from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ZERO
+from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ONE, ZERO
 from rotkehlchen.constants.assets import A_BCH, A_BTC, A_DAI, A_ETH, A_ETH2
 from rotkehlchen.constants.timing import HOUR_IN_SECONDS
 from rotkehlchen.db.addressbook import DBAddressbook
@@ -87,6 +87,8 @@ from rotkehlchen.externalapis.etherscan_like import HasChainActivity
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.greenlets.manager import GreenletManager
+from rotkehlchen.history.deserialization import deserialize_price
+from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import Premium
 from rotkehlchen.types import (
@@ -109,6 +111,7 @@ from rotkehlchen.types import (
     Eth2PubKey,
     ListOfBlockchainAddresses,
     ModuleName,
+    Price,
     SupportedBlockchain,
     Timestamp,
 )
@@ -560,6 +563,43 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         with self.database.conn.read_ctx() as read_cursor:
             return self.get_blockchain_balances_last_query_ts(chain=chain, cursor=read_cursor)
 
+    @staticmethod
+    def get_price_for_cached_balances(
+            asset: CryptoAsset,
+            timestamp: Timestamp,
+            main_currency: Asset,
+            price_cache: dict[tuple[str, Timestamp], FVal],
+            manual_current_prices: dict[str, tuple[Asset, Price]],
+    ) -> FVal:
+        cache_key = (asset.identifier, timestamp)
+        if cache_key in price_cache:
+            return price_cache[cache_key]
+
+        if asset == main_currency:
+            price = ONE
+        elif (manual_current_result := manual_current_prices.get(asset.identifier)) is not None:
+            current_to_asset, current_price = manual_current_result
+            if current_to_asset == main_currency:
+                price = FVal(current_price)
+            else:
+                current_to_asset_price = Inquirer.find_price(
+                    from_asset=current_to_asset,
+                    to_asset=main_currency,
+                )
+                price = FVal(current_price * current_to_asset_price)
+        elif (price_entry := GlobalDBHandler.get_historical_price(
+            from_asset=asset,
+            to_asset=main_currency,
+            timestamp=timestamp,
+            max_seconds_distance=HOUR_IN_SECONDS,
+        )) is not None:
+            price = FVal(price_entry.price)
+        else:
+            price = ZERO
+
+        price_cache[cache_key] = price
+        return price
+
     def _populate_cached_balances_values(
             self,
             balances: BlockchainBalances,
@@ -567,26 +607,10 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
     ) -> None:
         main_currency = CachedSettings().main_currency
         price_cache: dict[tuple[str, Timestamp], FVal] = {}
-
-        def get_price(asset: CryptoAsset, timestamp: Timestamp) -> FVal:
-            cache_key = (asset.identifier, timestamp)
-            if cache_key in price_cache:
-                return price_cache[cache_key]
-
-            if asset == main_currency:
-                price = FVal(1)
-            elif (price_entry := GlobalDBHandler.get_historical_price(
-                from_asset=asset,
-                to_asset=main_currency,
-                timestamp=timestamp,
-                max_seconds_distance=HOUR_IN_SECONDS,
-            )) is not None:
-                price = FVal(price_entry.price)
-            else:
-                price = ZERO
-
-            price_cache[cache_key] = price
-            return price
+        manual_current_prices = {
+            from_asset: (Asset(to_asset), deserialize_price(price))
+            for from_asset, to_asset, price in GlobalDBHandler.get_all_manual_latest_prices()
+        }
 
         for chain, chain_balances in balances.chains_with_tokens():
             if (query_ts := last_query_ts.get(chain.serialize())) is None:
@@ -595,7 +619,13 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             for account_balances in chain_balances.values():
                 for category in (account_balances.assets, account_balances.liabilities):
                     for asset, labeled_balances in category.items():
-                        price = get_price(asset.resolve_to_crypto_asset(), query_ts)
+                        price = self.get_price_for_cached_balances(
+                            asset=asset.resolve_to_crypto_asset(),
+                            timestamp=query_ts,
+                            main_currency=main_currency,
+                            price_cache=price_cache,
+                            manual_current_prices=manual_current_prices,
+                        )
                         for balance in labeled_balances.values():
                             balance.value = balance.amount * price
 
@@ -606,7 +636,13 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             native_asset = (
                 A_BTC if chain == SupportedBlockchain.BITCOIN else A_BCH
             ).resolve_to_crypto_asset()
-            price = get_price(native_asset, query_ts)
+            price = self.get_price_for_cached_balances(
+                asset=native_asset,
+                timestamp=query_ts,
+                main_currency=main_currency,
+                price_cache=price_cache,
+                manual_current_prices=manual_current_prices,
+            )
 
             for balance in chain_balances.values():
                 balance.value = balance.amount * price

--- a/rotkehlchen/tests/unit/test_blockchain_balances.py
+++ b/rotkehlchen/tests/unit/test_blockchain_balances.py
@@ -9,12 +9,22 @@ from rotkehlchen.chain.balances import BlockchainBalances
 from rotkehlchen.chain.ethereum.modules.liquity.constants import CPT_LIQUITY
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.structures import EvmTokenDetectionData
-from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ONE
-from rotkehlchen.constants.assets import A_BCH, A_BTC, A_DAI, A_ETH, A_LQTY, A_POL
+from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ONE, ZERO
+from rotkehlchen.constants.assets import A_BCH, A_BTC, A_DAI, A_ETH, A_EUR, A_LQTY, A_POL
+from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.fval import FVal
+from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
 from rotkehlchen.tests.utils.factories import UNIT_BTC_ADDRESS1, make_evm_address
 from rotkehlchen.tests.utils.xpubs import setup_db_for_xpub_tests_impl
-from rotkehlchen.types import ChainID, ChecksumEvmAddress, SupportedBlockchain, TokenKind
+from rotkehlchen.types import (
+    ChainID,
+    ChecksumEvmAddress,
+    Price,
+    SupportedBlockchain,
+    Timestamp,
+    TokenKind,
+)
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.aggregator import ChainsAggregator
@@ -304,3 +314,73 @@ def test_native_token_balance(
             )},
             usdt: {DEFAULT_BALANCE_LABEL: Balance(amount=FVal('0.074222'), value=FVal(0.1113330))},
         }
+
+
+@pytest.mark.parametrize('number_of_eth_accounts', [0])
+@pytest.mark.parametrize('gnosis_accounts', [['0x586AD5760a2fe5847c58deEc2933e11B5f595dBF']])
+def test_cached_gnosis_balance_uses_manual_current_price(
+        blockchain: 'ChainsAggregator',
+        gnosis_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Regression test for cached GET repricing preferring manual current prices.
+
+    Reproduces issue 1 from the aGnoEURe investigation: when blockchain balances are
+    read from the DB cache, a manual current price must take precedence over any
+    historical price found at ``last_refresh_ts``.
+    """
+    assert len(gnosis_accounts) == 1
+    address = gnosis_accounts[0]
+    manual_price = FVal('5')
+    historical_price = FVal('1')
+    amount = FVal('65.748178097718409869')
+
+    gnosis_token = EvmToken.initialize(
+        address=string_to_evm_address('0xEdBC7449a9b594CA4E053D9737EC5Dc4CbCcBfb2'),
+        chain_id=ChainID.GNOSIS,
+        token_kind=TokenKind.ERC20,
+    )
+    blockchain.balances.gnosis[address] = BalanceSheet()
+    blockchain.balances.gnosis[address].assets[gnosis_token]['aave-v3'] = Balance(
+        amount=amount,
+        value=ZERO,
+    )
+    blockchain._update_blockchain_balances_cache(
+        blockchain=SupportedBlockchain.GNOSIS,
+        addresses=None,
+    )
+
+    refresh_ts = Timestamp(1_700_000_000)
+    with blockchain.database.user_write() as write_cursor:
+        blockchain.database.set_dynamic_cache(
+            write_cursor=write_cursor,
+            name=DBCacheDynamic.LAST_BLOCKCHAIN_BALANCES_QUERY_TS,
+            value=refresh_ts,
+            blockchain=SupportedBlockchain.GNOSIS.serialize(),
+        )
+
+    GlobalDBHandler.add_historical_prices([HistoricalPrice(
+        from_asset=gnosis_token,
+        to_asset=A_EUR,
+        source=HistoricalPriceOracle.MANUAL,
+        timestamp=refresh_ts,
+        price=Price(historical_price),
+    )])
+    GlobalDBHandler.add_manual_latest_price(
+        from_asset=gnosis_token,
+        to_asset=A_EUR,
+        price=Price(manual_price),
+    )
+    blockchain.balances.gnosis.clear()
+
+    with patch.object(
+        GlobalDBHandler,
+        'get_manual_current_price',
+        side_effect=AssertionError('cached balance repricing should prefetch manual prices'),
+    ):
+        balances_update = blockchain.get_balances_update(
+            chain=SupportedBlockchain.GNOSIS,
+            from_cache=True,
+        )
+
+    assert gnosis_token in balances_update.totals.assets
+    assert balances_update.totals.assets[gnosis_token]['aave-v3'].value == amount * manual_price


### PR DESCRIPTION
Previously we were checking for historical prices only ignoring manual current prices

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
