### PR TITLE
Avoid zero-value balance snapshot on app startup

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Balance snapshots taken automatically when opening the app are no longer occasionally saved with a zero (or too-low) total while the blockchain balances are still being refreshed.
 * :bug:`-` Removing an EVM account no longer fails while a transactions refresh of all accounts is running.
 * :bug:`-` Two quick successive login attempts can no longer run the account unlock logic concurrently.
 * :bug:`-` Editing a history event no longer silently erases internal metadata such as its link to a matched asset movement.

--- a/frontend/app/src/modules/auth/use-session-load.spec.ts
+++ b/frontend/app/src/modules/auth/use-session-load.spec.ts
@@ -102,7 +102,7 @@ describe('composables::session::load', () => {
     set(mockShouldFetchData, true);
 
     mockFetchCached.mockResolvedValue(undefined);
-    mockRefreshFromChain.mockReturnValue(undefined);
+    mockRefreshFromChain.mockResolvedValue(undefined);
     mockFetchIgnoredAssets.mockResolvedValue(undefined);
     mockFetchWhitelistedAssets.mockResolvedValue(undefined);
     mockFetchNetValue.mockResolvedValue(undefined);

--- a/frontend/app/src/modules/auth/use-session-load.ts
+++ b/frontend/app/src/modules/auth/use-session-load.ts
@@ -46,7 +46,7 @@ export function useDataLoader(): UseDataLoaderReturn {
     ]);
     await seedFromHistoric();
     startPromise(refreshPrices());
-    refreshFromChain();
+    startPromise(refreshFromChain());
     onBalancesLoaded();
     sigilBus.emit('balances:loaded');
   };

--- a/frontend/app/src/modules/balances/use-balance-fetching.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-fetching.spec.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useBalanceFetching } from './use-balance-fetching';
 import '@test/i18n';
 
+const { queryBalancesAsync, refreshBlockchainBalances } = vi.hoisted(() => ({
+  queryBalancesAsync: vi.fn().mockResolvedValue({ taskId: 1 }),
+  refreshBlockchainBalances: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useTaskHandler: vi.fn().mockReturnValue({
@@ -14,7 +19,13 @@ vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
 
 vi.mock('@/modules/balances/api/use-balances-api', () => ({
   useBalancesApi: vi.fn().mockReturnValue({
-    queryBalancesAsync: vi.fn().mockResolvedValue({ taskId: 1 }),
+    queryBalancesAsync,
+  }),
+}));
+
+vi.mock('@/modules/balances/use-blockchain-balances', () => ({
+  useBlockchainBalances: vi.fn().mockReturnValue({
+    refreshBlockchainBalances,
   }),
 }));
 
@@ -57,6 +68,8 @@ vi.mock('@/modules/assets/prices/use-price-refresh', () => ({
 describe('useBalanceFetching', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    queryBalancesAsync.mockClear();
+    refreshBlockchainBalances.mockClear();
   });
 
   describe('fetchBalances', () => {
@@ -70,6 +83,20 @@ describe('useBalanceFetching', () => {
     it('should coordinate fetching of all balance types', async () => {
       const { fetch } = useBalanceFetching();
       await expect(fetch()).resolves.not.toThrow();
+    });
+  });
+
+  describe('refreshFromChain', () => {
+    it('should query all balances only after the chain refresh completes', async () => {
+      const { refreshFromChain } = useBalanceFetching();
+      await refreshFromChain();
+
+      expect(refreshBlockchainBalances).toHaveBeenCalledOnce();
+      expect(queryBalancesAsync).toHaveBeenCalledOnce();
+      // the all-balances query (which may persist a snapshot) must run strictly
+      // after the per-chain refresh to avoid snapshotting transient cleared state
+      expect(refreshBlockchainBalances.mock.invocationCallOrder[0])
+        .toBeLessThan(queryBalancesAsync.mock.invocationCallOrder[0]);
     });
   });
 

--- a/frontend/app/src/modules/balances/use-balance-fetching.ts
+++ b/frontend/app/src/modules/balances/use-balance-fetching.ts
@@ -46,14 +46,20 @@ export const useBalanceFetching = createSharedComposable(() => {
     await Promise.allSettled([fetchManualBalances(), refreshAccounts(), fetchConnectedExchangeBalances()]);
   };
 
-  const refreshFromChain = (): void => {
-    startPromise(refreshBlockchainBalances());
-    startPromise(fetchBalances());
+  const refreshFromChain = async (): Promise<void> => {
+    // Refresh the blockchain balances fully before triggering the all-balances
+    // query. GET /balances reads the shared in-memory balances and may persist a
+    // snapshot; a per-chain refresh clears a chain's balances before repopulating
+    // them, so running both concurrently can let the snapshot observe the transient
+    // cleared state and save a 0-value snapshot while the balances recover right
+    // after.
+    await refreshBlockchainBalances();
+    await fetchBalances();
   };
 
   const fetch = async (): Promise<void> => {
     await fetchCached();
-    refreshFromChain();
+    startPromise(refreshFromChain());
   };
 
   const autoRefresh = async (): Promise<void> => {


### PR DESCRIPTION
## Problem

When opening the app, a balance snapshot could occasionally be saved with a **zero (or too-low) total**, even though the balances showed their correct value moments later.

## Root cause

On startup, `refreshFromChain()` fired two backend calls **concurrently** (both fire-and-forget):

1. the per-chain blockchain refresh (`POST /balances/blockchains/*`)
2. the all-balances query (`GET /balances`), whose result the frontend discards but which causes the backend to (interval-permitting) persist a balance snapshot

The per-chain refresh clears a chain's in-memory balances before repopulating them (`existing_balances.clear()` in `ChainsAggregator._query_chain_balances`). Because the all-balances query reads the shared in-memory balances and recomputes the totals, running it concurrently with the refresh could let it observe the transient cleared state and snapshot a zero/too-low total.

## Fix

`refreshFromChain()` now **awaits** the blockchain refresh before issuing the all-balances query, so the snapshot is always taken against fully populated balances. The two callers (`fetch()` and the session loader) keep it fire-and-forget via `startPromise`, so the cached balances still paint immediately.

## Test

Added an ordering test asserting `refreshBlockchainBalances` is invoked strictly before `queryBalancesAsync` (via `invocationCallOrder`), guarding against a regression back to the concurrent pattern.

## Note / follow-up

This closes the **frontend-triggered** path. The underlying backend window — where a concurrent `query_balances` with a different `ignore_cache` argument bypasses the outer per-call lock and reads `self.balances` mid-clear — still exists for any other caller and may warrant a separate backend-side fix.