### PR TITLE
test: add API contract suite against a live backend

### DIFF
--- a/docs/designs/perf_and_integration_framework.md
+++ b/docs/designs/perf_and_integration_framework.md
@@ -339,21 +339,33 @@ fixture API is used, so `pytest-codspeed` stays a drop-in if we opt in later.
 
 ## 5. Stack B — Integration correctness
 
-### 5.1 API contract suite (phase 3 — cheap, high value)
+### 5.1 API contract suite (phase 5 — cheap, high value)
 
-A vitest suite (`frontend/app/tests/contract/`) pointed at a **live backend**
-booted on a golden profile — no browser:
+A vitest suite pointed at a **live backend** booted on a golden profile — no
+browser. Refined with frontend-maintainer input:
 
-- For every API module the frontend uses, perform the real HTTP call and
-  validate the response with the *frontend's own Zod schemas* (imported from
-  `src/modules/**`). The schemas are the contract; today they are only
-  enforced at user runtime.
-- Boot/teardown reuses `start-backend.ts` + profile builder; one backend per
-  profile, suite runs against `small` first, `whale` for pagination-shaped
-  endpoints.
-- Runs in regular PR CI (it is seconds-fast after boot) — any backend
-  serialization change that would break the frontend fails here, not in a
-  user's hands.
+- **Drive the frontend's API composables, not raw HTTP + `schema.parse()`.**
+  The fetch layer converts snake_case responses to camelCase before the Zod
+  schemas ever see them, so validating raw backend responses against the
+  schemas would test a shape the frontend never sees (and pass while the real
+  pipeline breaks). Invoking the composables (`use-*-api.ts`) against the
+  live backend exercises the whole real client pipeline — URL construction,
+  parameter serialization, the case transform and the schema parse — which is
+  the actual contract.
+- **Build path: port/parametrize the existing MSW-mocked API tests** rather
+  than writing a parallel suite. Those tests already encode, in
+  composable-driven form, what the frontend believes responses look like.
+  They become dual-mode: by default they keep running against their MSW
+  fixtures (fast, isolated, unchanged CI behavior); with a contract-mode
+  environment variable set, the same test bodies hit the profile-booted real
+  backend. A divergence between the two modes is precisely the
+  backend/frontend drift this suite exists to catch. Endpoints without MSW
+  coverage get new contract tests directly.
+- Boot/teardown reuses the profile builder + a backend-runner script; suite
+  runs against `small` first, `whale` for pagination-shaped endpoints.
+- Runs in regular PR CI as a non-required job at first (it is seconds-fast
+  after boot) — any backend serialization change that would break the
+  frontend fails here, not in a user's hands.
 
 ### 5.2 Golden-value e2e specs (phase 5)
 

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -31,6 +31,7 @@
     "test:e2e:debug": "playwright test --debug",
     "test:e2e:coverage": "E2E_COVERAGE=true VITE_COVERAGE=true playwright test",
     "test:e2e:coverage:report": "c8 report",
+    "test:contract": "tsx scripts/contract-tests.ts",
     "test:unit": "vitest --coverage",
     "test:unit:run": "vitest run --coverage",
     "typecheck": "vue-tsc --build --force",

--- a/frontend/app/scripts/contract-tests.ts
+++ b/frontend/app/scripts/contract-tests.ts
@@ -1,0 +1,144 @@
+import { type ChildProcess, spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { cac } from 'cac';
+import consola from 'consola';
+
+/**
+ * Contract test runner (measurement framework §5.1).
+ *
+ * Builds a golden user profile (tools/scenarios), boots the real backend on
+ * it, then runs the contract vitest suite (vitest.contract.config.ts) with
+ * the backend url and the profile's expected values in the environment.
+ */
+
+const appDir = path.resolve(import.meta.dirname, '..');
+const repoRoot = path.resolve(appDir, '..', '..');
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('could not allocate a port'));
+        return;
+      }
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+function buildProfile(profile: string, dataDir: string): void {
+  consola.start(`Building golden profile '${profile}'`);
+  const result = spawnSync(
+    'uv',
+    ['run', 'python', '-m', 'tools.scenarios', 'build', '--profile', profile, '--output', dataDir],
+    { cwd: repoRoot, encoding: 'utf8' },
+  );
+  if (result.status !== 0)
+    throw new Error(`profile build failed:\n${result.stderr}\n${result.stdout}`);
+  consola.success(`Profile ready at ${dataDir}`);
+}
+
+async function startBackend(dataDir: string, logDir: string, port: number): Promise<ChildProcess> {
+  fs.mkdirSync(logDir, { recursive: true });
+  const log = fs.openSync(path.join(logDir, 'stdout.log'), 'a');
+  const backend = spawn(
+    'uv',
+    [
+      'run',
+      'python',
+      '-m',
+      'rotkehlchen',
+      '--rest-api-port',
+      port.toString(),
+      '--api-cors',
+      'http://localhost:*',
+      '--data-dir',
+      dataDir,
+      '--logfile',
+      path.join(logDir, 'rotki.log'),
+    ],
+    { cwd: repoRoot, stdio: ['ignore', log, log] },
+  );
+
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (backend.exitCode !== null)
+      throw new Error(`backend exited with code ${backend.exitCode}; see ${logDir}`);
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/api/1/ping`);
+      if (response.ok) {
+        consola.success(`Backend answering on port ${port}`);
+        return backend;
+      }
+    }
+    catch {
+      // not up yet
+    }
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+  backend.kill('SIGKILL');
+  throw new Error('backend did not answer ping within 120s');
+}
+
+async function main(profile: string): Promise<void> {
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rotki-contract-'));
+  const dataDir = path.join(workDir, 'data');
+  const logDir = path.join(workDir, 'logs');
+  let backend: ChildProcess | undefined;
+  let status = 1;
+
+  try {
+    buildProfile(profile, dataDir);
+    const expected = fs.readFileSync(
+      path.join(dataDir, 'users', profile, 'expected.json'),
+      'utf8',
+    );
+    const port = await freePort();
+    backend = await startBackend(dataDir, logDir, port);
+
+    consola.start('Running contract tests');
+    const vitest = spawnSync(
+      'pnpm',
+      ['exec', 'vitest', 'run', '--config', 'vitest.contract.config.ts'],
+      {
+        cwd: appDir,
+        env: {
+          ...process.env,
+          CONTRACT_BACKEND_URL: `http://127.0.0.1:${port}`,
+          CONTRACT_EXPECTED: expected,
+          CONTRACT_USERNAME: profile,
+        },
+        stdio: 'inherit',
+      },
+    );
+    status = vitest.status ?? 1;
+  }
+  finally {
+    if (backend && backend.exitCode === null) {
+      backend.kill('SIGTERM');
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      if (backend.exitCode === null)
+        backend.kill('SIGKILL');
+    }
+    fs.rmSync(workDir, { force: true, recursive: true });
+  }
+  process.exit(status);
+}
+
+const cli = cac();
+
+cli.command('', 'Run the API contract tests against a live backend')
+  .option('--profile <name>', 'Golden profile to boot', { default: 'small' })
+  .action(async (options: { profile: string }) => {
+    await main(options.profile);
+  });
+
+cli.help();
+cli.parse();

--- a/frontend/app/tests/contract/api.contract.ts
+++ b/frontend/app/tests/contract/api.contract.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-accounts-api';
+import { useUsersApi } from '@/modules/auth/use-users-api';
+import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { useSettingsApi } from '@/modules/settings/api/use-settings-api';
+import { contractExpected, contractUsername } from './contract-env';
+
+/**
+ * Contract tests (measurement framework §5.1): the frontend's own api
+ * composables against a live backend booted on a golden profile. Each call
+ * exercises the full client pipeline — URL construction, parameter
+ * serialization, snake_case<->camelCase transforms and zod schema parsing —
+ * so a passing test means the real frontend understands the real backend.
+ * Assertions compare against the profile generator's expected.json, never
+ * against hand-written fixtures that could drift.
+ */
+
+describe('users api contract', () => {
+  it('should list the profile user', async () => {
+    const profiles = await useUsersApi().getUserProfiles();
+    expect(profiles).toContain(contractUsername());
+  });
+
+  it('should report the profile user as logged in', async () => {
+    const logged = await useUsersApi().loggedUsers();
+    expect(logged).toContain(contractUsername());
+  });
+});
+
+describe('settings api contract', () => {
+  it('should fetch and parse the user settings', async () => {
+    const settings = await useSettingsApi().getSettings();
+    // camelCase fields with meaningful values prove the response went
+    // through the case transform and the UserSettingsModel zod parse
+    expect(settings.data.version).toBeGreaterThan(0);
+    expect(settings.general.mainCurrency.tickerSymbol).toBeTruthy();
+  });
+});
+
+describe('blockchain accounts api contract', () => {
+  it('should return exactly the seeded ethereum accounts', async () => {
+    const accounts = await useBlockchainAccountsApi().queryAccounts('eth');
+    const addresses = accounts.map(account => account.address).sort();
+    const seeded = [...contractExpected().eth_accounts].sort();
+    expect(addresses).toEqual(seeded);
+  });
+});
+
+describe('history events api contract', () => {
+  it('should page through history events with the seeded totals', async () => {
+    const expected = contractExpected();
+    const result = await useHistoryEventsApi().fetchHistoryEvents({
+      aggregateByGroupIds: false,
+      ascending: [false],
+      limit: 10,
+      offset: 0,
+      orderByAttributes: ['timestamp'],
+    });
+
+    expect(result.entriesTotal).toBe(expected.total_events);
+    expect(result.entries.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/app/tests/contract/contract-env.ts
+++ b/frontend/app/tests/contract/contract-env.ts
@@ -1,0 +1,23 @@
+import process from 'node:process';
+
+export function contractBackendUrl(): string {
+  const url = process.env.CONTRACT_BACKEND_URL;
+  if (!url)
+    throw new Error('CONTRACT_BACKEND_URL is not set. Run the contract tests through `pnpm run test:contract`, which boots a backend on a golden profile.');
+  return url;
+}
+
+export function contractUsername(): string {
+  return process.env.CONTRACT_USERNAME ?? 'small';
+}
+
+/**
+ * The expected values emitted by the profile generator
+ * (users/<profile>/expected.json), forwarded by the runner script.
+ */
+export function contractExpected(): Record<string, any> {
+  const raw = process.env.CONTRACT_EXPECTED;
+  if (!raw)
+    throw new Error('CONTRACT_EXPECTED is not set. Run the contract tests through `pnpm run test:contract`.');
+  return JSON.parse(raw);
+}

--- a/frontend/app/tests/contract/setup.ts
+++ b/frontend/app/tests/contract/setup.ts
@@ -1,0 +1,43 @@
+import process from 'node:process';
+import { mockT } from '@test/i18n';
+import { beforeAll, vi } from 'vitest';
+import { ref } from 'vue';
+import { api } from '@/modules/core/api/rotki-api';
+import { contractBackendUrl, contractUsername } from './contract-env';
+
+// i18n is a UI concern, not part of the API contract, but some zod schema
+// transforms reach for useI18n — mock it the same way the unit setup does.
+vi.mock('vue-i18n', () => ({
+  createI18n: () => ({}),
+  useI18n: () => ({
+    locale: ref(''),
+    t: mockT,
+    te: mockT,
+  }),
+}));
+
+/**
+ * Points the api singleton at the live contract backend and unlocks the
+ * profile user. Runs once per test file; the unlock is idempotent (an
+ * already-logged-in response is accepted).
+ */
+beforeAll(async () => {
+  api.setup(contractBackendUrl());
+
+  const username = contractUsername();
+  const response = await fetch(`${contractBackendUrl()}/api/1/users/${username}`, {
+    body: JSON.stringify({
+      password: process.env.CONTRACT_PASSWORD ?? '1234',
+      resume_from_backup: false,
+      sync_approval: 'no',
+    }),
+    headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    if (!body.includes('logged'))
+      throw new Error(`contract setup: failed to unlock user ${username}: ${response.status} ${body}`);
+  }
+});

--- a/frontend/app/tsconfig.node.json
+++ b/frontend/app/tsconfig.node.json
@@ -12,6 +12,7 @@
   "include": [
     "vite.config.*",
     "vitest.config.*",
+    "vitest.contract.config.*",
     "playwright.config.*",
     "tailwind.config.*",
     "scripts/**/*",

--- a/frontend/app/tsconfig.vitest.json
+++ b/frontend/app/tsconfig.vitest.json
@@ -19,6 +19,7 @@
     "src/**/*.vue",
     "src/**/*.spec.ts",
     "tests/unit/**/*",
+    "tests/contract/**/*",
     "shared/**/*"
   ],
   "exclude": []

--- a/frontend/app/vitest.contract.config.ts
+++ b/frontend/app/vitest.contract.config.ts
@@ -1,0 +1,43 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { merge } from 'es-toolkit';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+/**
+ * Contract test mode (measurement framework §5.1).
+ *
+ * Runs the API-composable contract tests against a LIVE backend booted on a
+ * golden user profile, exercising the full real client pipeline (URL
+ * construction, snake_case<->camelCase transforms and zod parsing) instead of
+ * MSW fixtures. Run through `pnpm run test:contract`, which boots the backend
+ * and provides CONTRACT_BACKEND_URL.
+ *
+ * Deliberately separate from vitest.config.ts: no MSW setup file, no fake
+ * timers (real HTTP needs real timers) and no parallelism (the backend is a
+ * single-user process).
+ */
+export default mergeConfig(
+  merge(viteConfig, {
+    resolve: {
+      alias: {
+        '@test': `${path.join(__dirname, 'tests', 'unit')}/`,
+      },
+    },
+  }),
+  defineConfig({
+    test: {
+      globals: true,
+      environment: 'happy-dom',
+      testTimeout: 30_000,
+      env: {
+        TZ: 'UTC',
+        VITE_TEST: 'true',
+      },
+      include: ['tests/contract/**/*.contract.ts'],
+      fileParallelism: false,
+      root: fileURLToPath(new URL('./', import.meta.url)),
+      setupFiles: ['tests/contract/setup.ts'],
+    },
+  }),
+);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "dev": "tsx scripts/start-dev.ts",
     "preview": "pnpm run --filter rotki preview",
     "test": "pnpm run test:unit && pnpm run test:e2e",
+    "test:contract": "pnpm run --filter rotki test:contract",
     "test:unit": "pnpm run --filter rotki test:unit:run",
     "test:unit:watch": "pnpm run --filter rotki test:unit",
     "test:e2e": "pnpm run --filter rotki test:e2e",


### PR DESCRIPTION
Phase 5 of the measurement framework: contract tests that run the frontend's own api composables against a real backend booted on a golden user profile (tools/scenarios). Each call exercises the full client pipeline - URL construction, parameter serialization, the snake_case/camelCase transforms and the zod schema parsing - so a passing run means the actual frontend understands the actual backend, catching serialization drift in CI instead of at runtime.

- pnpm run test:contract (frontend/ or app/) builds the profile, boots the backend, runs vitest with vitest.contract.config.ts and tears everything down
- tests assert against the profile generator's expected.json, never hand-written fixtures that could drift; first slice covers users, settings, blockchain accounts and history events apis
- separate vitest config: no MSW, no fake timers, no parallelism (single-user backend); contract files use the .contract.ts suffix so the unit suite never picks them up