### PR TITLE
fix(assets): time out stalled ERC20 token lookup when adding an EVM asset

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Adding an EVM token no longer leaves the name, symbol and decimals fields disabled indefinitely when the token detail lookup cannot reach a working RPC node; the lookup now times out so you can fill in the details manually.
 * :bug:`-` Balance snapshots taken automatically when opening the app are no longer occasionally saved with a zero (or too-low) total while the blockchain balances are still being refreshed.
 * :bug:`-` Login no longer fails if the configured beacon node RPC endpoint returns an unexpected response.
 * :bug:`-` Removing an EVM account no longer fails while a transactions refresh of all accounts is running.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -328,6 +328,7 @@
       "erc20": {
         "error": {
           "description": "There was an error while retrieving token details: {message}",
+          "timeout": "Timed out while retrieving token details. You can enter the token information manually.",
           "title": "Retrieving token details for {address} ({evmChain})"
         },
         "task": {

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetForm.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetForm.vue
@@ -180,19 +180,23 @@ async function fetchTokenData(address: string, evmChain: string): Promise<void> 
   }
   set(fetching, true);
 
-  const tokenInfo = pick(get(modelValue), ['decimals', 'name', 'symbol']);
-  const tokenDetails = await fetchTokenDetails({ address, evmChain });
+  try {
+    const tokenInfo = pick(get(modelValue), ['decimals', 'name', 'symbol']);
+    const tokenDetails = await fetchTokenDetails({ address, evmChain });
 
-  const updateTokenInfo = {
-    decimals: tokenDetails.decimals ? tokenDetails.decimals : tokenInfo.decimals,
-    name: tokenDetails.name ? tokenDetails.name : tokenInfo.name,
-    symbol: tokenDetails.symbol ? tokenDetails.symbol : tokenInfo.symbol,
-  };
+    const updateTokenInfo = {
+      decimals: tokenDetails.decimals ? tokenDetails.decimals : tokenInfo.decimals,
+      name: tokenDetails.name ? tokenDetails.name : tokenInfo.name,
+      symbol: tokenDetails.symbol ? tokenDetails.symbol : tokenInfo.symbol,
+    };
 
-  set(modelValue, { ...get(modelValue), ...updateTokenInfo });
-
-  set(fetching, false);
-  clearFieldErrors(['decimals', 'name', 'symbol']);
+    set(modelValue, { ...get(modelValue), ...updateTokenInfo });
+    clearFieldErrors(['decimals', 'name', 'symbol']);
+  }
+  finally {
+    // Always re-enable the fields, even if the lookup throws, so the form never stays locked.
+    set(fetching, false);
+  }
 }
 
 async function refreshTokenData() {

--- a/frontend/app/src/modules/assets/use-asset-info-retrieval.spec.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-retrieval.spec.ts
@@ -5,8 +5,10 @@ import { CUSTOM_ASSET } from '@/modules/assets/types';
 import { useAssetInfoCache } from '@/modules/assets/use-asset-info-cache';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+import { TaskType } from '@/modules/core/tasks/task-type';
 
 const runTaskMock = vi.fn();
+const cancelTaskByTaskTypeMock = vi.fn();
 
 vi.mock('@/modules/assets/api/use-asset-info-api', () => ({
   useAssetInfoApi: vi.fn().mockReturnValue({
@@ -22,7 +24,7 @@ vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
       return runTaskMock(taskFn, ...rest);
     },
     cancelTask: vi.fn(),
-    cancelTaskByTaskType: vi.fn(),
+    cancelTaskByTaskType: async (...args: unknown[]): Promise<unknown> => cancelTaskByTaskTypeMock(...args),
   }),
 }));
 
@@ -86,6 +88,28 @@ describe('useAssetRetrieval', () => {
       expect(result).toEqual({});
 
       expect(useNotificationDispatcher().notify).toHaveBeenCalled();
+    });
+
+    it('should time out and cancel the task when the lookup never resolves', async () => {
+      // Regression: a stalled ERC20 lookup (e.g. no RPC node answers) must not leave the
+      // caller awaiting forever, which would keep the asset form fields disabled indefinitely.
+      vi.useFakeTimers();
+      cancelTaskByTaskTypeMock.mockClear();
+      // Backend task that never settles.
+      runTaskMock.mockReturnValue(new Promise<never>(() => {}));
+
+      try {
+        const resultPromise = assetInfoRetrieval.fetchTokenDetails(payload);
+
+        await vi.advanceTimersByTimeAsync(15_000);
+
+        await expect(resultPromise).resolves.toEqual({});
+        expect(cancelTaskByTaskTypeMock).toHaveBeenCalledWith(TaskType.ERC20_DETAILS);
+        expect(useNotificationDispatcher().notify).toHaveBeenCalled();
+      }
+      finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/frontend/app/src/modules/assets/use-asset-info-retrieval.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-retrieval.ts
@@ -30,6 +30,13 @@ export interface AssetResolutionOptions {
 
 export const NO_COLLECTION_RESOLVE: AssetResolutionOptions = { collectionParent: false } as const;
 
+/**
+ * Upper bound for the ERC20 token detail lookup. The backend queries live RPC nodes, which
+ * can stall under rate limiting; past this we give up, cancel the task and let the user type
+ * the token information manually.
+ */
+const ERC20_DETAILS_TIMEOUT_MS = 15_000;
+
 interface AssetWithResolutionStatus extends AssetInfoWithId {
   resolved: boolean;
 }
@@ -69,7 +76,7 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
   const { assetSearch: assetSearchCaller, erc20details } = useAssetInfoApi();
   const { fetchedAssetCollections, queueIdentifier, resolve: resolveAsset } = useAssetInfoCache();
   const { notify, notifyError } = useNotifications();
-  const { runTask } = useTaskHandler();
+  const { cancelTaskByTaskType, runTask } = useTaskHandler();
 
   const { getChain } = useSupportedChains();
 
@@ -194,20 +201,44 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
     computed<string>(() => getTokenAddress(toValue(identifier), toValue(options)));
 
   const fetchTokenDetails = async (payload: EvmChainAddress): Promise<ERC20Token> => {
-    const outcome = await runTask<ERC20Token, TaskMeta>(
+    const timedOut = Symbol('timed-out');
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<typeof timedOut>((resolve) => {
+      // Cleared in the finally block below, so it never outlives this call.
+      // eslint-disable-next-line @rotki/composable-require-cleanup
+      timer = setTimeout(() => resolve(timedOut), ERC20_DETAILS_TIMEOUT_MS);
+    });
+
+    const task = runTask<ERC20Token, TaskMeta>(
       async () => erc20details(payload),
       { type: TaskType.ERC20_DETAILS, meta: { title: t('actions.assets.erc20.task.title', payload) } },
     );
 
-    if (outcome.success) {
-      return outcome.result;
+    try {
+      const outcome = await Promise.race([task, timeout]);
+
+      // The lookup can stall when no RPC node answers (e.g. rate limiting). Bail out
+      // instead of leaving the caller awaiting indefinitely, and cancel the backend task.
+      if (outcome === timedOut) {
+        await cancelTaskByTaskType(TaskType.ERC20_DETAILS);
+        notifyError(t('actions.assets.erc20.error.title', payload), t('actions.assets.erc20.error.timeout'));
+        return {};
+      }
+
+      if (outcome.success) {
+        return outcome.result;
+      }
+      else if (isActionableFailure(outcome)) {
+        notifyError(t('actions.assets.erc20.error.title', payload), t('actions.assets.erc20.error.description', {
+          message: outcome.message,
+        }));
+      }
+      return {};
     }
-    else if (isActionableFailure(outcome)) {
-      notifyError(t('actions.assets.erc20.error.title', payload), t('actions.assets.erc20.error.description', {
-        message: outcome.message,
-      }));
+    finally {
+      if (timer !== undefined)
+        clearTimeout(timer);
     }
-    return {};
   };
 
   const assetSearch = async (params: AssetSearchParams): Promise<AssetsWithId> => {

--- a/frontend/app/tests/e2e/specs/app/assets.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/assets.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
 import { apiEnsureSymbolsNotIgnored } from '../../helpers/api';
+import { apiConfigureRpcMock } from '../../helpers/rpc-mock';
 import { AssetsManagerPage } from '../../pages/assets-manager-page';
 import { CustomAssetsPage } from '../../pages/custom-assets-page';
 import { LatestPricePage } from '../../pages/price-manager-page';
@@ -73,6 +74,10 @@ test.describe('assets', () => {
       otherAssetSymbol = `OTH${uniqueId}`;
 
       ctx = await createLoggedInContext(browser, request);
+
+      // Point Ethereum at the mock RPC so the ERC20 token-detail lookup resolves locally
+      // instead of querying live public nodes (which rate-limit and stall the dialog).
+      await apiConfigureRpcMock(request, 'ETH');
 
       // Navigate to assets page once
       assetsPage = new AssetsManagerPage(ctx.sharedPage);


### PR DESCRIPTION
## Problem

When adding an EVM asset, entering the contract address triggers a token-detail lookup (`erc20details`) that **disables** the Name / Symbol / Decimals fields until it resolves. The lookup runs as an async backend task that reads `name`/`symbol`/`decimals` from the chain's RPC nodes.

If that query stalls — e.g. the configured public RPC nodes rate-limit the request (`429 Too Many Requests`) — the backend keeps retrying (`read_timeout` 30s × `query_retry_limit`) and the frontend `await`s it indefinitely. `fetching` never flips back, so the fields stay **disabled forever** and the user can't even type the values manually.

This also surfaced as a consistently-failing e2e (`assets.spec.ts › adds an EVM asset`): the test entered a synthetic address, the lookup hit live RPC, and the dialog hung until the 60s test timeout.

## Fix

**Product (`fix(assets)`):**
- `fetchTokenDetails` now races the task against a **15s timeout**. On timeout it calls `cancelTaskByTaskType(ERC20_DETAILS)` (real backend `DELETE`), notifies the user, and returns `{}`.
- `fetchTokenData` is wrapped in `try/finally` so `fetching` is always reset — the form can never stay locked, even if the lookup throws.
- New fake-timers unit test asserts a never-resolving lookup times out, cancels the task, and resolves (regression guard against the stuck-disabled state).

**Test reliability (`test(e2e)`):**
- The `add asset` spec now calls `apiConfigureRpcMock(request, 'ETH')` in `beforeAll`, so the token-detail lookup resolves against the local mock RPC instead of live public nodes (which rate-limit CI runners). This is the same pattern the balance specs already use.

## Validation

- Unit: `use-asset-info-retrieval.spec.ts` 9/9 pass (new timeout test runs in ~20ms via fake timers).
- E2E: `adds an EVM asset` passes locally (38.9s) — mock RPC responds instantly instead of stalling on live nodes.
- `lint-staged` + `typecheck` clean.

## Notes

The e2e half explains why this test was recently failing across multiple branches (the public RPC rate-limiting is environmental/time-correlated, not branch-specific). User-facing changelog entry included.