### PR TITLE
Fix edge case on trade processing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Kraken trades where the bought and sold amounts happen to be equal are no longer skipped as failed transfers.
 * :bug:`-` Adding an EVM token no longer leaves the name, symbol and decimals fields disabled indefinitely when the token detail lookup cannot reach a working RPC node; the lookup now times out so you can fill in the details manually.
 * :bug:`-` Balance snapshots taken automatically when opening the app are no longer occasionally saved with a zero (or too-low) total while the blockchain balances are still being refreshed.
 * :bug:`-` Login no longer fails if the configured beacon node RPC endpoint returns an unexpected response.

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -1023,9 +1023,14 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                     )
 
                 fee_amount = deserialize_fval(raw_event['fee'])
-                # check for failed events (events that cancel each other out -- like failed
-                if (  # withdrawals). Compare if amounts cancel themselves out (also fee if exists)
+                # Check for failed events that cancel each other out, like failed withdrawals.
+                # Trades are excluded because equal absolute amounts in different assets can be a
+                # valid trade (e.g. buy 100 ONDO for 100 USD). Do not add an asset equality check
+                # here: Kraken staking transfer pairs can cancel out with different asset symbols,
+                # and the skipped-event reprocessing flow relies on keeping that behavior.
+                if (  # Compare if amounts cancel themselves out (also fee if exists)
                         len(events) == 2 and idx == 1 and
+                        event_type != HistoryEventType.TRADE and
                         events[0]['type'] == events[1]['type'] and
                         events[0]['subtype'] == events[1]['subtype'] and
                         abs(raw_amount) == group_events[0][1].amount and (

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -608,6 +608,82 @@ def test_kraken_trade_with_spend_receive(kraken):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_kraken_trade_with_same_spend_receive_amount(kraken):
+    """Test Kraken trade entries with equal spend/receive amounts are not skipped."""
+    test_trades = """{
+        "ledger": {
+            "FAKE1": {
+                "refid": "FAKE-TRADE-0001",
+                "time": 1747274044.753901,
+                "type": "trade",
+                "subtype": "tradespot",
+                "aclass": "currency",
+                "asset": "XETH",
+                "amount": "100.00000",
+                "fee": "0.00000",
+                "balance": "200.00000"
+            },
+            "FAKE2": {
+                "refid": "FAKE-TRADE-0001",
+                "time": 1747274044.753901,
+                "type": "trade",
+                "subtype": "tradespot",
+                "aclass": "currency",
+                "asset": "ZUSD",
+                "amount": "-100.0000",
+                "fee": "0.2500",
+                "balance": "102.2018"
+            }
+        },
+        "count": 2
+    }"""
+
+    with _patch_ledger(kraken, test_trades):
+        kraken.query_history_events()
+
+    with kraken.db.conn.read_ctx() as cursor:
+        assert DBHistoryEvents(kraken.db).get_history_events_internal(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(location=Location.KRAKEN),
+        ) == [SwapEvent(
+            identifier=1,
+            timestamp=(timestamp := TimestampMS(1747274044753)),
+            location=Location.KRAKEN,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_USD,
+            amount=FVal('100.0000'),
+            group_identifier=(group_identifier := create_group_identifier_from_unique_id(
+                location=Location.KRAKEN,
+                unique_id='FAKE-TRADE-00011747274044753',
+            )),
+            location_label=kraken.name,
+        ), SwapEvent(
+            identifier=2,
+            timestamp=timestamp,
+            location=Location.KRAKEN,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            asset=A_ETH,
+            amount=FVal('100.00000'),
+            group_identifier=group_identifier,
+            location_label=kraken.name,
+        ), SwapEvent(
+            identifier=3,
+            timestamp=timestamp,
+            location=Location.KRAKEN,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_USD,
+            amount=FVal('0.2500'),
+            group_identifier=group_identifier,
+            location_label=kraken.name,
+        )]
+
+    errors = kraken.msg_aggregator.consume_errors()
+    warnings = kraken.msg_aggregator.consume_warnings()
+    assert len(errors) == 0
+    assert len(warnings) == 0
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_kraken_trade_with_adjustment(kraken):
     """Test that trades based on adjustment events are processed"""
 


### PR DESCRIPTION
There is an edge case where if the asset is different but the amounts are the same the logic identifies it as an error and skips the entry.
