### PR TITLE
fix: chunk Binance Simple Earn rewards history into 30-day windows

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`12416` Binance Simple Earn rewards history no longer fails to sync when the last successful sync was more than a month ago.
 * :bug:`-` Kraken trades where the bought and sold amounts happen to be equal are no longer skipped as failed transfers.
 * :bug:`-` Adding an EVM token no longer leaves the name, symbol and decimals fields disabled indefinitely when the token detail lookup cannot reach a working RPC node; the lookup now times out so you can fill in the details manually.
 * :bug:`-` Balance snapshots taken automatically when opening the app are no longer occasionally saved with a zero (or too-low) total while the blockchain balances are still being refreshed.

--- a/rotkehlchen/exchanges/binance.py
+++ b/rotkehlchen/exchanges/binance.py
@@ -90,6 +90,10 @@ API_TIME_INTERVAL_CONSTRAINT_TS: Final = 7689600  # 89 days
 
 # this determines the length of the data returned, 100 is the maximum value possible.
 BINANCE_SIMPLE_EARN_HISTORY_PAGE_SIZE: Final = 100
+# Simple Earn rewards history endpoints (flexible & locked) only allow a 30-day range between
+# startTime and endTime. A larger range fails with error code -6021 "Query time range too large".
+# https://developers.binance.com/docs/simple_earn/flexible-locked/history/Get-Flexible-Rewards-History
+BINANCE_SIMPLE_EARN_TIME_INTERVAL_CONSTRAINT_TS: Final = 30 * DAY_IN_SECONDS
 
 # Convert API has 30-day max interval constraint
 CONVERT_API_TIME_DELTA: Final = 30 * DAY_IN_SECONDS
@@ -664,8 +668,9 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
         "REALTIME" -> Real-time APR.
         "REWARDS" -> Historical rewards.
 
-        `end_ts` - `start_ts` <= 89 days. This is handled using `_api_query_list_within_time_delta`
-        using `API_TIME_INTERVAL_CONSTRAINT_TS` as the timedelta.
+        `end_ts` - `start_ts` <= 30 days. This is handled using `_api_query_list_within_time_delta`
+        using `BINANCE_SIMPLE_EARN_TIME_INTERVAL_CONSTRAINT_TS` as the timedelta, since the rewards
+        history endpoints reject larger ranges with error -6021 "Query time range too large".
 
         Lending Interest History Documentation:
         https://binance-docs.github.io/apidocs/spot/en/#get-flexible-rewards-history-user_data
@@ -698,7 +703,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                     response = self._api_query_list_within_time_delta(
                         api_type='sapi',
                         start_ts=query_start_ts,
-                        time_delta=API_TIME_INTERVAL_CONSTRAINT_TS,
+                        time_delta=BINANCE_SIMPLE_EARN_TIME_INTERVAL_CONSTRAINT_TS,
                         end_ts=query_end_ts,
                         method='simple-earn/flexible/history/rewardsRecord',
                         additional_options={
@@ -769,7 +774,7 @@ class Binance(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 response = self._api_query_list_within_time_delta(
                     api_type='sapi',
                     start_ts=query_start_ts,
-                    time_delta=API_TIME_INTERVAL_CONSTRAINT_TS,
+                    time_delta=BINANCE_SIMPLE_EARN_TIME_INTERVAL_CONSTRAINT_TS,
                     end_ts=query_end_ts,
                     method='simple-earn/locked/history/rewardsRecord',
                     additional_options={'size': BINANCE_SIMPLE_EARN_HISTORY_PAGE_SIZE},

--- a/rotkehlchen/tests/exchanges/test_binance.py
+++ b/rotkehlchen/tests/exchanges/test_binance.py
@@ -22,6 +22,7 @@ from rotkehlchen.exchanges.binance import (
     API_TIME_INTERVAL_CONSTRAINT_TS,
     BINANCE_ASSETS_STARTING_WITH_LD,
     BINANCE_LAUNCH_TS,
+    BINANCE_SIMPLE_EARN_TIME_INTERVAL_CONSTRAINT_TS,
     Binance,
     trade_from_binance,
 )
@@ -1126,6 +1127,58 @@ def test_binance_query_lending_interests_history(
                 'SELECT COUNT(*) FROM history_events WHERE subtype="reward" AND location=?;',
                 (location.serialize_for_db(),),
             ).fetchone()[0] == count
+
+    assert len(binance.msg_aggregator.consume_errors()) == 0
+    assert len(binance.msg_aggregator.consume_warnings()) == 0
+
+
+@pytest.mark.parametrize('default_mock_price_value', [ONE])
+def test_binance_query_lending_interests_history_chunks_30_days(
+        function_scope_binance: 'Binance',
+        price_historian: 'PriceHistorian',  # pylint: disable=unused-argument
+):
+    """Regression test for https://github.com/rotki/rotki/issues/12416
+
+    The Simple Earn rewards history endpoints (flexible & locked) reject ranges larger than
+    30 days with error -6021 "Query time range too large". A range larger than 30 days must be
+    split into chunks of at most 30 days, otherwise the very first request fails.
+    """
+    binance = function_scope_binance
+    binance.db.add_exchange(
+        name='binance',
+        location=Location.BINANCE,
+        api_key=ApiKey('binance_api_key'),
+        api_secret=ApiSecret(b'binance_api_secret'),
+    )
+    requested_windows: list[tuple[int, int]] = []
+    max_window_ms = BINANCE_SIMPLE_EARN_TIME_INTERVAL_CONSTRAINT_TS * 1000
+
+    def mock_my_lendings(url, params, *args, **kwargs):  # pylint: disable=unused-argument
+        if 'simple-earn' in url and 'rewardsRecord' in url:
+            window = params['endTime'] - params['startTime']
+            requested_windows.append((params['startTime'], params['endTime']))
+            # mimic Binance: reject anything wider than the 30-day limit
+            if window > max_window_ms:
+                return MockResponse(
+                    400,
+                    '{"code": -6021, "msg": "Query time range too large"}',
+                )
+        return MockResponse(200, '{"rows": [], "total": 0}')
+
+    # query a range spanning ~89 days, which previously was sent as a single request
+    with (
+        patch.object(binance.session, 'request', side_effect=mock_my_lendings),
+        binance.db.conn.read_ctx() as cursor,
+    ):
+        assert binance.query_lending_interests_history(
+            cursor=cursor,
+            start_ts=BINANCE_LAUNCH_TS,
+            end_ts=Timestamp(BINANCE_LAUNCH_TS + API_TIME_INTERVAL_CONSTRAINT_TS),
+        ) is False
+
+    assert len(requested_windows) > 1  # the range had to be chunked
+    for start_time, end_time in requested_windows:
+        assert end_time - start_time <= max_window_ms
 
     assert len(binance.msg_aggregator.consume_errors()) == 0
     assert len(binance.msg_aggregator.consume_warnings()) == 0


### PR DESCRIPTION
Fix #12416 