### PR TITLE
Use mempool.space explorer for Bitcoin

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` Bitcoin transactions, addresses and blocks now open in the mempool.space explorer instead of blockchain.com.
 * :bug:`12416` Binance Simple Earn rewards history no longer fails to sync when the last successful sync was more than a month ago.
 * :bug:`-` Kraken trades where the bought and sold amounts happen to be equal are no longer skipped as failed transfers.
 * :bug:`-` Adding an EVM token no longer leaves the name, symbol and decimals fields disabled indefinitely when the token detail lookup cannot reach a working RPC node; the lookup now times out so you can fill in the details manually.

--- a/frontend/app/src/modules/assets/asset-urls.ts
+++ b/frontend/app/src/modules/assets/asset-urls.ts
@@ -44,9 +44,9 @@ export const explorerUrls: AssetExplorerUrls = {
     transaction: 'https://bscscan.com/tx/',
   },
   [Blockchain.BTC]: {
-    address: 'https://www.blockchain.com/explorer/addresses/btc/',
-    block: 'https://www.blockchain.com/explorer/blocks/btc/',
-    transaction: 'https://www.blockchain.com/explorer/transactions/btc/',
+    address: 'https://mempool.space/address/',
+    block: 'https://mempool.space/block/',
+    transaction: 'https://mempool.space/tx/',
   },
   [Blockchain.DOT]: {
     address: 'https://polkadot.subscan.io/account/',


### PR DESCRIPTION
## Summary

Switches the Bitcoin explorer links (address, block, transaction) from blockchain.com to mempool.space.

- BTC `address` → `https://mempool.space/address/`
- BTC `block` → `https://mempool.space/block/`
- BTC `transaction` → `https://mempool.space/tx/`

BCH is left on blockchain.com, since mempool.space is Bitcoin-only and has no Bitcoin Cash explorer.

## Changes
- `frontend/app/src/modules/assets/asset-urls.ts` — updated BTC entry.
- `docs/changelog.rst` — user-facing changelog entry.

## Checks
- `lint-staged` ✅
- `typecheck` ✅
- No unit tests cover this static URL map.