### PR TITLE
fix: validate export download file path

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The asset and history-events export download endpoints now validate that the requested file lives in the export directory before serving it.
 * :feature:`-` Bitcoin transactions, addresses and blocks now open in the mempool.space explorer instead of blockchain.com.
 * :bug:`12416` Binance Simple Earn rewards history no longer fails to sync when the last successful sync was more than a month ago.
 * :bug:`-` Kraken trades where the bought and sold amounts happen to be equal are no longer skipped as failed transfers.

--- a/rotkehlchen/api/rest_helpers/downloads.py
+++ b/rotkehlchen/api/rest_helpers/downloads.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import tempfile
+from http import HTTPStatus
+from pathlib import Path
 
-from flask import Response, after_this_request
+from flask import Response, after_this_request, jsonify, make_response, send_file
 
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -23,3 +22,36 @@ def register_post_download_cleanup(temp_file: Path) -> None:
         except (FileNotFoundError, PermissionError, OSError) as e:
             log.warning(f'Failed to clean up after download of {temp_file}: {e!s}')
         return response
+
+
+def _is_within_temp_dir(path: Path) -> bool:
+    """Check that `path` resolves to a location inside the system temp directory."""
+    try:
+        resolved = path.resolve()
+    except (OSError, RuntimeError):  # RuntimeError: symlink loop while resolving
+        return False
+    return resolved.is_relative_to(Path(tempfile.gettempdir()).resolve())
+
+
+def make_download_response(file_path: str, mimetype: str) -> Response:
+    """Serve a freshly-exported file and delete it after the response is sent.
+
+    Exports are always created under the system temp directory, so the requested
+    path is validated to live within it before being served and cleaned up. Any
+    other path is rejected as invalid input.
+    """
+    if not _is_within_temp_dir(path := Path(file_path)):
+        return make_response(
+            (
+                jsonify({'result': None, 'message': f'Invalid file path: {file_path}'}),
+                HTTPStatus.BAD_REQUEST,
+            ),
+        )
+
+    register_post_download_cleanup(path)
+    return send_file(
+        path_or_file=file_path,
+        mimetype=mimetype,
+        as_attachment=True,
+        download_name=path.name,
+    )

--- a/rotkehlchen/api/services/assets.py
+++ b/rotkehlchen/api/services/assets.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Literal
 from zipfile import BadZipFile, ZipFile
 
-from flask import Response, make_response, send_file
+from flask import Response, make_response
 from marshmallow.exceptions import ValidationError
 from web3.exceptions import BadFunctionCallOutput
 
@@ -17,7 +17,7 @@ from rotkehlchen.accounting.constants import (
     EVENT_CATEGORY_MAPPINGS,
 )
 from rotkehlchen.accounting.entry_type_mappings import ENTRY_TYPE_MAPPINGS
-from rotkehlchen.api.rest_helpers.downloads import register_post_download_cleanup
+from rotkehlchen.api.rest_helpers.downloads import make_download_response
 from rotkehlchen.assets.asset import (
     Asset,
     AssetWithNameAndType,
@@ -349,13 +349,7 @@ class AssetsService:
         }
 
     def download_user_assets(self, file_path: str) -> Response:
-        register_post_download_cleanup(path := Path(file_path))
-        return send_file(
-            path_or_file=file_path,
-            mimetype='application/zip',
-            as_attachment=True,
-            download_name=path.name,
-        )
+        return make_download_response(file_path=file_path, mimetype='application/zip')
 
     def import_user_assets(self, path: Path) -> dict[str, Any]:
         try:

--- a/rotkehlchen/api/services/history.py
+++ b/rotkehlchen/api/services/history.py
@@ -16,7 +16,10 @@ from rotkehlchen.accounting.debugimporter.json import DebugHistoryImporter
 from rotkehlchen.accounting.export.csv import CSVWriteError, dict_to_csv_file
 from rotkehlchen.accounting.export.report import export_pnl_report_csv_from_db
 from rotkehlchen.accounting.pot import AccountingPot
-from rotkehlchen.api.rest_helpers.downloads import register_post_download_cleanup
+from rotkehlchen.api.rest_helpers.downloads import (
+    make_download_response,
+    register_post_download_cleanup,
+)
 from rotkehlchen.chain.ethereum.constants import CPT_KRAKEN
 from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregators
 from rotkehlchen.chain.structures import TimestampOrBlockRange
@@ -583,13 +586,7 @@ class HistoryService:
         return {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
 
     def download_history_events_csv(self, file_path: str) -> Response:
-        register_post_download_cleanup(path := Path(file_path))
-        return send_file(
-            path_or_file=file_path,
-            mimetype='text/csv',
-            as_attachment=True,
-            download_name=path.name,
-        )
+        return make_download_response(file_path=file_path, mimetype='text/csv')
 
     def _get_exchange_staking_or_savings_history(
             self,

--- a/rotkehlchen/tests/api/test_history_events_export.py
+++ b/rotkehlchen/tests/api/test_history_events_export.py
@@ -183,6 +183,37 @@ def test_history_export_download_csv(
     assert_csv_export_response(response, temp_csv_file, is_download=True)
 
 
+def test_history_export_download_path_traversal(
+        rotkehlchen_api_server_with_exchanges: APIServer,
+) -> None:
+    """The csv download endpoint only serves files from the export (temp) directory.
+
+    A path pointing elsewhere must be rejected as invalid input, and the file it
+    points to must be left untouched (not served and not deleted by the cleanup).
+    """
+    # sentinel lives outside the system temp dir (next to this test file)
+    sentinel = Path(__file__).parent / 'traversal_sentinel_csv.txt'
+    sentinel.write_text('do-not-delete', encoding='utf-8')
+    try:
+        for path in (str(sentinel), '/root/config.json'):
+            response = requests.get(
+                api_url_for(
+                    rotkehlchen_api_server_with_exchanges,
+                    'exporthistorydownloadresource',
+                ),
+                json={'file_path': path},
+            )
+            assert_error_response(
+                response=response,
+                contained_in_msg='Invalid file path',
+                status_code=HTTPStatus.BAD_REQUEST,
+            )
+        # the rejected path must not have been deleted by the cleanup hook
+        assert sentinel.exists()
+    finally:
+        sentinel.unlink(missing_ok=True)
+
+
 @pytest.mark.vcr(filter_query_parameters=['api_key'])
 @pytest.mark.parametrize('db_settings', [{'csv_export_delimiter': ';'}])
 @pytest.mark.freeze_time('2025-04-30')

--- a/rotkehlchen/tests/api/test_user_assets.py
+++ b/rotkehlchen/tests/api/test_user_assets.py
@@ -963,6 +963,33 @@ def test_replace_asset_edge_cases(
             )
 
 
+@pytest.mark.parametrize('start_with_logged_in_user', [True])
+def test_download_user_assets_path_traversal(rotkehlchen_api_server: APIServer) -> None:
+    """The download endpoint only serves files from the export (temp) directory.
+
+    A path pointing elsewhere must be rejected as invalid input, and the file it
+    points to must be left untouched (not served and not deleted by the cleanup).
+    """
+    # sentinel lives outside the system temp dir (next to this test file)
+    sentinel = Path(__file__).parent / 'traversal_sentinel.txt'
+    sentinel.write_text('do-not-delete', encoding='utf-8')
+    try:
+        for path in (str(sentinel), '/root/config.json'):
+            response = requests.get(
+                api_url_for(rotkehlchen_api_server, 'userassetsexportdownloadresource'),
+                json={'file_path': path},
+            )
+            assert_error_response(
+                response=response,
+                contained_in_msg='Invalid file path',
+                status_code=HTTPStatus.BAD_REQUEST,
+            )
+        # the rejected path must not have been deleted by the cleanup hook
+        assert sentinel.exists()
+    finally:
+        sentinel.unlink(missing_ok=True)
+
+
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('start_with_logged_in_user', [True])
 @pytest.mark.parametrize('with_custom_path', [False, True])


### PR DESCRIPTION
The asset export and history-events export download endpoints passed the
`file_path` from the request straight to `send_file` and registered it for
post-response deletion, without checking where it pointed.

Both endpoints now go through a shared `make_download_response` helper that
confirms the requested file resolves inside the system temp directory (where
all exports are created) before serving and cleaning it up. Any other path is
rejected as invalid input.

The DB-backup download already had its own containment check; the PnL report
and DB-snapshot downloads use server-generated paths and were unaffected.

## Tests
- `test_download_user_assets_path_traversal`
- `test_history_export_download_path_traversal`

Both verify a path outside the export directory is rejected and the target
file is left untouched. Existing positive download tests still pass.