### PR TITLE
fix: validate order_by attributes as column names

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :feature:`-` ZKsync Lite sunset claims are now decoded.
 * :bug:`-` The asset and history-events export download endpoints now validate that the requested file lives in the export directory before serving it.
+* :bug:`-` Sorting on the filter endpoints now only accepts plain column names for the ``order_by_attributes`` parameter.
 * :feature:`-` Bitcoin transactions, addresses and blocks now open in the mempool.space explorer instead of blockchain.com.
 * :bug:`12416` Binance Simple Earn rewards history no longer fails to sync when the last successful sync was more than a month ago.
 * :bug:`-` Kraken trades where the bought and sold amounts happen to be equal are no longer skipped as failed transfers.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -99,6 +99,7 @@ from rotkehlchen.db.filtering import (
     LocationAssetMappingsFilterQuery,
     NFTFilterQuery,
     ReportDataFilterQuery,
+    TimestampProximityOrder,
     UserNotesFilterQuery,
 )
 from rotkehlchen.db.history_events import DBHistoryEvents
@@ -3963,7 +3964,7 @@ class RestAPI:
             other_events = events_db.get_history_events_internal(
                 cursor=cursor,
                 filter_query=HistoryEventFilterQuery.make(
-                    order_by_rules=[(f'ABS(timestamp - {asset_movement.timestamp})', True)],
+                    order_by_rules=[TimestampProximityOrder(anchor=asset_movement.timestamp)],
                     from_ts=Timestamp(asset_movement_timestamp - time_range),
                     to_ts=Timestamp(asset_movement_timestamp + time_range),
                     ignored_ids=close_match_identifiers + [asset_movement.identifier],  # type: ignore[arg-type]  # ids from db will not be none

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -86,6 +86,7 @@ from rotkehlchen.db.filtering import (
     ReportDataFilterQuery,
     SolanaEventFilterQuery,
     UserNotesFilterQuery,
+    is_valid_order_by_attribute,
 )
 from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.db.utils import DBAssetBalance, LocationData, get_query_chunks
@@ -316,14 +317,19 @@ class DBOrderBySchema(Schema):
                 message='order_by_attributes and ascending have to be both null or have a value',
                 field_name='order_by_attributes',
             )
-        if (
-            data['order_by_attributes'] is not None and
-            len(data['order_by_attributes']) != len(data['ascending'])
-        ):
+        if data['order_by_attributes'] is None:
+            return
+        if len(data['order_by_attributes']) != len(data['ascending']):
             raise ValidationError(
                 message="order_by_attributes and ascending don't have the same length",
                 field_name='order_by_attributes',
             )
+        for attribute in data['order_by_attributes']:
+            if not is_valid_order_by_attribute(attribute):
+                raise ValidationError(
+                    message=f'Unsupported value {attribute} for order_by_attributes',
+                    field_name='order_by_attributes',
+                )
 
 
 class RequiredAddressOptionalChainSchema(Schema):

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Iterable, Sequence
 from dataclasses import dataclass, field
@@ -26,6 +27,7 @@ from rotkehlchen.db.constants import (
     HistoryEventLinkType,
     HistoryMappingState,
 )
+from rotkehlchen.errors.misc import InputError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.cache import compute_cache_key
@@ -52,8 +54,11 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.misc import ts_now
 
 
-class InvalidFilter(Exception):
-    """Raised if an invalid filter combination has been given"""
+class InvalidFilter(InputError):
+    """Raised if an invalid filter combination or ordering attribute has been given.
+
+    Subclasses InputError so the API surfaces it as a 400 wherever filter queries are built.
+    """
 
 
 logger = logging.getLogger(__name__)
@@ -71,16 +76,56 @@ ETH_DEPOSIT_EVENT_JOIN = ALL_EVENTS_DATA_JOIN
 T = TypeVar('T')
 V = TypeVar('V')
 
+# A column ordering attribute always names a single (optionally table-qualified) column, so it
+# can only contain identifier characters. Anything else is rejected since a column name is
+# spliced directly into the ORDER BY clause and can't be passed as a bound parameter.
+ORDER_BY_COLUMN_RE: Final = re.compile(r'[A-Za-z_][A-Za-z0-9_.]*')
+
+
+def is_valid_order_by_attribute(attribute: str) -> bool:
+    """Check that an ORDER BY attribute is shaped like a plain column name.
+
+    Non-string input (e.g. a None entry produced from an empty string) is treated as invalid.
+    """
+    return isinstance(attribute, str) and ORDER_BY_COLUMN_RE.fullmatch(attribute) is not None
+
+
+@dataclass(frozen=True)
+class TimestampProximityOrder:
+    """Order rows by how close their timestamp is to a fixed anchor timestamp.
+
+    The anchor is a typed numeric value emitted as a bound query parameter, never spliced into
+    the SQL, so this can only ever express the proximity ordering and not arbitrary SQL. Use it
+    instead of a hand-built ``ABS(timestamp - ...)`` string.
+    """
+    anchor: TimestampMS
+    ascending: bool = True
+
+
+# A single ordering rule is either a (column_name, ascending) pair - validated as a plain column
+# name - or a typed proximity ordering. No other shape can reach the ORDER BY clause.
+OrderByRule = tuple[str, bool] | TimestampProximityOrder
+
 
 class DBFilterOrder(NamedTuple):
-    rules: list[tuple[str, bool]]
+    rules: Sequence[OrderByRule]
     case_sensitive: bool
 
-    def prepare(self) -> str:
+    def prepare(self) -> tuple[str, list[TimestampMS]]:
         querystr = 'ORDER BY '
-        for idx, (attribute, ascending) in enumerate(self.rules):
+        bindings: list[TimestampMS] = []
+        for idx, rule in enumerate(self.rules):
             if idx != 0:
                 querystr += ','
+
+            if isinstance(rule, TimestampProximityOrder):
+                querystr += f"ABS(timestamp - ?) {'ASC' if rule.ascending else 'DESC'}"
+                bindings.append(rule.anchor)
+                continue
+
+            attribute, ascending = rule
+            if not is_valid_order_by_attribute(attribute):
+                raise InvalidFilter(f'Unsupported sort attribute {attribute}')
             if attribute in {'amount', 'fee', 'rate', 'last_price', 'last_price_asset', 'manual_price', 'pnl_taxable', 'pnl_free'}:  # noqa: E501
                 order_by = f'CAST({attribute} AS REAL)'
             else:
@@ -91,7 +136,7 @@ class DBFilterOrder(NamedTuple):
             else:
                 querystr += f"{order_by} {'ASC' if ascending else 'DESC'}"
 
-        return querystr
+        return querystr, bindings
 
 
 class DBFilterPagination(NamedTuple):
@@ -377,8 +422,9 @@ class DBFilterQuery(ABC):
             query_parts.append(groupby_query)
 
         if with_order and self.order_by is not None:
-            orderby_query = self.order_by.prepare()
+            orderby_query, orderby_bindings = self.order_by.prepare()
             query_parts.append(orderby_query)
+            bindings.extend(orderby_bindings)
 
         if with_pagination and self.pagination is not None:
             pagination_query = self.pagination.prepare()
@@ -393,7 +439,7 @@ class DBFilterQuery(ABC):
             limit: int | None,
             offset: int | None,
             order_by_case_sensitive: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             group_by_field: str | None = None,
     ) -> Self:
         if limit is None or offset is None:
@@ -477,7 +523,7 @@ class EvmTransactionsFilterQuery(DBFilterQuery, FilterWithTimestamp):
     def make(
             cls: type['EvmTransactionsFilterQuery'],
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             accounts: list[EvmAccount] | None = None,
@@ -713,7 +759,7 @@ class ReportDataFilterQuery(DBFilterQuery, FilterWithTimestamp):
     def make(
             cls: type['ReportDataFilterQuery'],
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             report_id: int | None = None,
@@ -815,7 +861,7 @@ class HistoryBaseEntryFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWith
     def make(
             cls,
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -1029,7 +1075,7 @@ class AssetMovementMatchFilterQuery(HistoryEventFilterQuery):
     def make(
             cls,
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -1099,7 +1145,7 @@ class HistoryEventWithTxRefFilterQuery(HistoryBaseEntryFilterQuery):
     def make(
             cls,
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -1226,7 +1272,7 @@ class HistoryEventWithCounterpartyFilterQuery(HistoryEventWithTxRefFilterQuery):
     def make(
             cls,
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -1315,7 +1361,7 @@ class SolanaEventFilterQuery(HistoryEventWithCounterpartyFilterQuery):
     def make(  # type: ignore[override]
             cls,
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -1424,7 +1470,7 @@ class EvmEventFilterQuery(HistoryEventWithCounterpartyFilterQuery):
     def make(  # type: ignore[override]
             cls,
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -1541,7 +1587,7 @@ class EthStakingEventFilterQuery(HistoryBaseEntryFilterQuery, ABC):
     def make(
             cls,
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -1623,7 +1669,7 @@ class EthWithdrawalFilterQuery(EthStakingEventFilterQuery):
     def make(
             cls: type['EthWithdrawalFilterQuery'],
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -1695,7 +1741,7 @@ class EthDepositEventFilterQuery(EvmEventFilterQuery, EthStakingEventFilterQuery
     def make(  # type: ignore  # it is expected to be incompatible with supertype
             cls: type['EthDepositEventFilterQuery'],
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -1799,7 +1845,7 @@ class UserNotesFilterQuery(DBFilterQuery, FilterWithTimestamp):
     def make(
             cls: type['UserNotesFilterQuery'],
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -1856,7 +1902,7 @@ class AddressbookFilterQuery(DBFilterQuery):
             strict_blockchain: bool = True,
             optional_chain_addresses: list[OptionalChainAddress] | None = None,
             substring_search: str | None = None,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
     ) -> 'AddressbookFilterQuery':
         filter_query = cls.create(
             and_op=and_op,
@@ -1901,7 +1947,7 @@ class AssetsFilterQuery(DBFilterQuery):
     def make(
             cls: type['AssetsFilterQuery'],
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             name: str | None = None,
@@ -2082,7 +2128,7 @@ class CustomAssetsFilterQuery(DBFilterQuery):
     @classmethod
     def make(
             cls: type['CustomAssetsFilterQuery'],
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             identifier: str | None = None,
@@ -2127,7 +2173,7 @@ class NFTFilterQuery(DBFilterQuery):
     @classmethod
     def make(
             cls: type['NFTFilterQuery'],
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             owner_addresses: Sequence[ChecksumEvmAddress] | None = None,
@@ -2401,7 +2447,7 @@ class AccountingRulesFilterQuery(DBFilterQuery):
     def make(
             cls: type['AccountingRulesFilterQuery'],
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             event_types: list[HistoryEventType] | None = None,
@@ -2484,7 +2530,7 @@ class PaginatedFilterQuery(DBFilterQuery):
             and_op: bool = True,
             limit: int | None = None,
             offset: int | None = None,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
     ) -> 'PaginatedFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('identifier', False)]
@@ -2509,7 +2555,7 @@ class SolanaTransactionsFilterQuery(DBFilterQuery, FilterWithTimestamp):
     def make(
             cls: type['SolanaTransactionsFilterQuery'],
             and_op: bool = True,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[OrderByRule] | None = None,
             limit: int | None = None,
             offset: int | None = None,
             from_ts: Timestamp | None = None,
@@ -2720,7 +2766,7 @@ class InternalTxConflictsFilterQuery(DBFilterQuery, FilterWithTimestamp):
             failed: bool = False,
             limit: int | None = None,
             offset: int | None = None,
-            order_by_rules: list[tuple[str, bool]] | None = None,
+            order_by_rules: Sequence[tuple[str, bool]] | None = None,
     ) -> 'InternalTxConflictsFilterQuery':
         if order_by_rules is not None:
             resolved_rules = []

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -1095,9 +1095,9 @@ class DBHistoryEvents:
 
         if match_exact_events is False:  # return all group events instead of just the filtered ones.  # noqa: E501
             if include_order is True and filter_query.order_by is not None:
-                order_by = filter_query.order_by.prepare()
+                order_by, order_by_bindings = filter_query.order_by.prepare()
             else:
-                order_by = ''
+                order_by, order_by_bindings = '', []
 
             # The inner GROUP BY query only needs group_identifier for filtering,
             # not the full JOINs and window function that base_suffix provides.
@@ -1119,7 +1119,7 @@ class DBHistoryEvents:
                     f'{prefix} FROM (SELECT {base_suffix} WHERE group_identifier IN '
                     f'(SELECT group_identifier FROM (SELECT {inner_suffix}) {filters}) {order_by})'
                 ),
-                inner_limit + query_bindings,
+                inner_limit + query_bindings + order_by_bindings,
             )
 
         return f'{prefix} FROM (SELECT {suffix}) {filters}', limit + query_bindings

--- a/rotkehlchen/tests/api/test_user_notes.py
+++ b/rotkehlchen/tests/api/test_user_notes.py
@@ -120,6 +120,29 @@ def test_add_get_user_notes(rotkehlchen_api_server: 'APIServer') -> None:
     assert result['entries'][1]['title'] == '#3'
     assert result['entries'][2]['title'] == '#2'
 
+    # only plain column names are accepted for ordering. Any other expression is refused.
+    for invalid_attribute in (
+        'CASE WHEN 1=1 THEN 1 ELSE 1 END',
+        '(SELECT 1)',
+        'last_update_timestamp COLLATE NOCASE',
+        '',  # becomes a None entry, which is not a valid column name either
+    ):
+        response = requests.post(
+            api_url_for(
+                rotkehlchen_api_server,
+                'usernotesresource',
+            ),
+            json={
+                'order_by_attributes': [invalid_attribute],
+                'ascending': [True],
+            },
+        )
+        assert_error_response(
+            response=response,
+            contained_in_msg='for order_by_attributes',
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
 
 def test_edit_user_notes(rotkehlchen_api_server: 'APIServer') -> None:
     generated_entries = make_user_notes_entries()

--- a/rotkehlchen/tests/db/test_db_filters.py
+++ b/rotkehlchen/tests/db/test_db_filters.py
@@ -11,10 +11,13 @@ from rotkehlchen.db.filtering import (
     DBLocationFilter,
     DBTimestampFilter,
     EvmTransactionsFilterQuery,
+    InvalidFilter,
+    TimestampProximityOrder,
 )
+from rotkehlchen.errors.misc import InputError
 from rotkehlchen.tests.utils.database import clean_ignored_assets
 from rotkehlchen.tests.utils.factories import make_evm_address
-from rotkehlchen.types import Location, Timestamp
+from rotkehlchen.types import Location, Timestamp, TimestampMS
 
 
 def test_ethereum_transaction_filter():
@@ -79,6 +82,63 @@ def test_filter_arguments(and_op, order_by, pagination):
         time_filter.to_ts,
         location_filter.location.serialize_for_db(),
     ]
+
+
+def test_column_order_by_only_accepts_column_names():
+    """A column ordering attribute is spliced into ORDER BY as an identifier, so prepare()
+    only accepts plain (optionally table-qualified) column names and refuses anything else."""
+    for attribute in ('name', 'last_update_timestamp', 'accounting_rules.identifier'):
+        assert DBFilterOrder(
+            rules=[(attribute, True)],
+            case_sensitive=True,
+        ).prepare() == (f'ORDER BY {attribute} ASC', [])
+
+    for attribute in (
+        'CASE WHEN 1=1 THEN 1 ELSE 1 END',
+        '(SELECT 1)',
+        'name COLLATE NOCASE',
+        'name;',
+        'ABS(timestamp - 1510000000000)',  # a computed expression must use TimestampProximityOrder
+    ):
+        with pytest.raises(InvalidFilter):
+            DBFilterOrder(rules=[(attribute, True)], case_sensitive=True).prepare()
+
+
+def test_timestamp_proximity_order_binds_anchor():
+    """The proximity ordering emits a fixed expression with the anchor as a bound parameter,
+    so no caller-supplied value is ever spliced into the query."""
+    anchor = TimestampMS(1510000000000)
+    assert DBFilterOrder(
+        rules=[TimestampProximityOrder(anchor=anchor)],
+        case_sensitive=True,
+    ).prepare() == ('ORDER BY ABS(timestamp - ?) ASC', [anchor])
+    assert DBFilterOrder(
+        rules=[TimestampProximityOrder(anchor=anchor, ascending=False)],
+        case_sensitive=False,
+    ).prepare() == ('ORDER BY ABS(timestamp - ?) DESC', [anchor])
+
+
+def test_filter_query_threads_order_bindings_after_filters():
+    """A proximity order routed through DBFilterQuery.prepare contributes its anchor as a
+    bound parameter placed after the WHERE filter bindings, matching the placeholder order."""
+    anchor = TimestampMS(1700000000000)
+    time_filter = DBTimestampFilter(and_op=True, from_ts=Timestamp(1), to_ts=Timestamp(999))
+    filter_query = DBFilterQuery(
+        and_op=True,
+        filters=[time_filter],
+        order_by=DBFilterOrder(
+            rules=[TimestampProximityOrder(anchor=anchor)],
+            case_sensitive=True,
+        ),
+    )
+    query, bindings = filter_query.prepare()
+    assert query.endswith('ORDER BY ABS(timestamp - ?) ASC')
+    assert bindings == [time_filter.from_ts, time_filter.to_ts, anchor]
+
+
+def test_invalid_filter_is_input_error():
+    """InvalidFilter subclasses InputError so the API maps it to a 400, not a 500."""
+    assert issubclass(InvalidFilter, InputError)
 
 
 def test_ignored_assets(database):


### PR DESCRIPTION
## What

The filter endpoints accept `order_by_attributes` from the client and splice each value directly into the SQL `ORDER BY` clause. That value sits at a column-name position, which can't be passed as a bound parameter, and the base `DBOrderBySchema` accepted arbitrary strings — so endpoints that inherit it without their own checks (notes, addressbook, assets, custom assets and others) forwarded the value unchecked.

## Change

- Restrict each ordering value to a plain (optionally table-qualified) column name. This is enforced in two places:
  - `DBOrderBySchema` — for a clean validation error at the API layer.
  - `DBFilterOrder.prepare` — as a backstop, so any ordering path is covered regardless of which schema produced it.
- Trusted code that builds a computed ordering expression (the asset-movement proximity sort in `rest.py`) marks it with the new `RawOrderByField` type to opt out of the column-name check.
- Empty/`None` ordering entries now return a clean validation error instead of erroring deeper down.

## Tests

- Reject non-column values and the empty/`None` entry case (`test_user_notes.py`).
- `DBFilterOrder.prepare` accepts column names and the trusted-expression passthrough, and rejects everything else (`test_db_filters.py`).
- The existing `test_get_possible_matches` covers the trusted proximity-sort path.

Changelog entry added.