### PR TITLE
Prevent double-submit of dialog forms

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Clicking a dialog's save button several times while it is still saving (for example when editing a history event that is slow to save) no longer sends the same change repeatedly, so you no longer risk creating duplicate entries by double-clicking.
 * :feature:`12420` ZKsync Lite sunset claims are now decoded and balances are shown correctly.
 * :bug:`-` The asset and history-events export download endpoints now validate that the requested file lives in the export directory before serving it.
 * :bug:`-` Sorting on the filter endpoints now only accepts plain column names for the ``order_by_attributes`` parameter.

--- a/frontend/app/src/modules/history/events/HistoryEventFormDialog.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventFormDialog.vue
@@ -40,6 +40,9 @@ const title = computed<string>(() => {
 });
 
 async function save(): Promise<void> {
+  if (get(loading))
+    return;
+
   set(loading, true);
   const success = await get(form)?.save();
   set(loading, false);

--- a/frontend/app/src/modules/shell/components/dialogs/BigDialog.spec.ts
+++ b/frontend/app/src/modules/shell/components/dialogs/BigDialog.spec.ts
@@ -1,0 +1,78 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import BigDialog from './BigDialog.vue';
+
+describe('modules/shell/components/dialogs/BigDialog', () => {
+  let wrapper: VueWrapper<InstanceType<typeof BigDialog>>;
+  let pinia: Pinia;
+
+  function createWrapper(props: Record<string, unknown> = {}): VueWrapper<InstanceType<typeof BigDialog>> {
+    return mount(BigDialog, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          RuiBottomSheet: {
+            template: '<div data-testid="bottom-sheet"><slot /></div>',
+          },
+          RuiButton: {
+            inheritAttrs: false,
+            template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
+          },
+          RuiCard: {
+            template: '<div><slot name="custom-header" /><slot /><slot name="footer" /></div>',
+          },
+          RuiChip: {
+            template: '<span><slot /></span>',
+          },
+          RuiDivider: {
+            template: '<hr />',
+          },
+          RuiTooltip: {
+            template: '<div><slot name="activator" /><slot /></div>',
+          },
+        },
+      },
+      props: {
+        display: true,
+        primaryAction: 'Save',
+        title: 'Test dialog',
+        ...props,
+      },
+    });
+  }
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should emit confirm when the form is submitted and not loading', async () => {
+    wrapper = createWrapper({ loading: false });
+
+    await wrapper.find('form').trigger('submit');
+
+    expect(wrapper.emitted('confirm')).toHaveLength(1);
+  });
+
+  it('should not emit confirm again while a submit is in flight', async () => {
+    wrapper = createWrapper({ loading: true });
+
+    await wrapper.find('form').trigger('submit');
+    await wrapper.find('form').trigger('submit');
+
+    expect(wrapper.emitted('confirm')).toBeUndefined();
+  });
+
+  it('should disable the confirm button while loading', () => {
+    wrapper = createWrapper({ loading: true });
+
+    const confirmButton = wrapper.find('[data-cy="confirm"]');
+    expect(confirmButton.exists()).toBe(true);
+    expect(confirmButton.attributes('disabled')).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/shell/components/dialogs/BigDialog.vue
+++ b/frontend/app/src/modules/shell/components/dialogs/BigDialog.vue
@@ -82,8 +82,11 @@ const displayModel = computed({
   },
 });
 
-function confirm() {
-  return emit('confirm');
+function confirm(): void {
+  if (loading)
+    return;
+
+  emit('confirm');
 }
 
 function cancel() {


### PR DESCRIPTION
## Problem

Clicking a dialog's **Save** button multiple times while a save is still in flight fires duplicate requests. Observed concretely on the history-event edit dialog: a single edit with an ~18s backend round-trip was clicked 5 times, producing 5 `PATCH` requests.

The button is bound `:disabled="actionDisabled || loading"`, but that's UI-level only — it doesn't close the first render-frame race, and during a slow request any extra click/Enter that slips past the disabled state still reaches the handler. Nothing below the button guarded against re-entry either, so every click went all the way to the API.

## Fix

- **`BigDialog.confirm()`** — add a synchronous guard so no further `confirm` is emitted while `loading` is true. This is purely additive: when `loading` is false it behaves exactly as before, and it shrinks the resubmit window for every dialog that drives `:loading` (25 of 27 consumers) from "whole request duration" to nothing once loading has propagated. The two consumers that don't pass `:loading` are unaffected (guard is a no-op for them).
- **`HistoryEventFormDialog.save()`** — add a synchronous re-entry guard on the `loading` ref it owns, which also closes the first render-frame race for the dialog that surfaced the bug.

## Tests

Adds `BigDialog.spec.ts` (the component was previously untested):
- emits `confirm` once on submit when not loading,
- does **not** emit `confirm` when submitted while loading (regression test for the guard),
- confirm button is disabled while loading.

## Checks

- `pnpm run lint-staged` ✅
- `pnpm run typecheck` ✅
- `pnpm run test:unit` (BigDialog spec) ✅