### PR TITLE
Improve performance of transaction redecoding

### DIFF
--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -890,6 +890,55 @@ class DBHistoryEvents:
                 bindings += customized_bindings
             write_cursor.execute(query, bindings)
 
+    @staticmethod
+    def _get_customized_exclusions_for_tx_refs(
+            cursor: 'DBCursor',
+            tx_refs: Sequence[EVMTxHash | BTCTxId | Signature],
+            location: BLOCKCHAIN_LOCATIONS_TYPE,
+            customized_handling: Literal['preserve_events', 'preserve_transactions'],
+    ) -> list[int] | list[str]:
+        """Return customized event identifiers or group identifiers to preserve for tx deletions.
+
+        The lookup is scoped to the provided tx refs only, instead of scanning all customized
+        events for the location.
+        """
+        placeholders = ', '.join(['?'] * len(tx_refs))
+        customized_bindings = (
+            location.serialize_for_db(),
+            HISTORY_MAPPING_KEY_STATE,
+            HistoryMappingState.CUSTOMIZED.serialize_for_db(),
+        )
+        select_field = (
+            'group_identifier'
+            if customized_handling == 'preserve_transactions'
+            else 'identifier'
+        )
+        if location.is_bitcoin():
+            id_prefix = BTC_GROUP_IDENTIFIER_PREFIX if location == Location.BITCOIN else BCH_GROUP_IDENTIFIER_PREFIX  # noqa: E501
+            group_identifiers = [f'{id_prefix}{tx_hash}' for tx_hash in tx_refs]
+            query = (
+                f'SELECT DISTINCT h.{select_field} FROM history_events h '
+                'INNER JOIN history_events_mappings m ON h.identifier = m.parent_identifier '
+                f'WHERE h.group_identifier IN ({placeholders}) AND h.location = ? '
+                'AND m.name = ? AND m.value = ?'
+            )
+            bindings: tuple[Any, ...] = (*group_identifiers, *customized_bindings)
+        else:
+            if location == Location.SOLANA:
+                tx_ref_bindings = [x.to_bytes() for x in tx_refs]  # type: ignore[union-attr]  # solana signatures
+            else:
+                tx_ref_bindings = list(tx_refs)  # evm tx hashes
+            query = (
+                f'SELECT DISTINCT h.{select_field} FROM history_events h '
+                'INNER JOIN chain_events_info c ON h.identifier = c.identifier '
+                'INNER JOIN history_events_mappings m ON h.identifier = m.parent_identifier '
+                f'WHERE c.tx_ref IN ({placeholders}) AND h.location = ? '
+                'AND m.name = ? AND m.value = ?'
+            )
+            bindings = (*tx_ref_bindings, *customized_bindings)
+
+        return [row[0] for row in cursor.execute(query, bindings)]
+
     def delete_events_by_tx_ref(
             self,
             write_cursor: 'DBCursor',
@@ -926,23 +975,20 @@ class DBHistoryEvents:
             else:
                 bindings = list(tx_refs)  # type: ignore  # different type of elements in the list
 
-        if (
-            customized_handling != 'delete' and
-            (length := len(customized_event_ids := self.get_event_mapping_states(
+        if customized_handling != 'delete' and (
+            length := len(exclusions := self._get_customized_exclusions_for_tx_refs(
                 cursor=write_cursor,
+                tx_refs=tx_refs,
                 location=location,
-                mapping_state=HistoryMappingState.CUSTOMIZED,
-            ))) != 0
-        ):
+                customized_handling=customized_handling,
+            ))
+        ) != 0:
+            exclusion_placeholders = ', '.join(['?'] * length)
             if customized_handling == 'preserve_transactions':
-                where_str += (
-                    ' AND group_identifier NOT IN ('
-                    'SELECT group_identifier FROM history_events WHERE identifier IN ('
-                    + ', '.join(['?'] * length) + '))'
-                )
+                where_str += f' AND group_identifier NOT IN ({exclusion_placeholders})'
             else:  # preserve_events
-                where_str += f' AND identifier NOT IN ({", ".join(["?"] * length)})'
-            bindings.extend(customized_event_ids)  # type: ignore  # different type of elements in the list
+                where_str += f' AND identifier NOT IN ({exclusion_placeholders})'
+            bindings.extend(exclusions)  # type: ignore[arg-type]  # identifiers or group ids
 
         self.delete_events_and_track(
             write_cursor=write_cursor,

--- a/rotkehlchen/tests/benchmarks/test_hot_paths.py
+++ b/rotkehlchen/tests/benchmarks/test_hot_paths.py
@@ -12,19 +12,94 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
+from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.constants import ONE
 from rotkehlchen.constants.assets import A_ETH, A_USDC
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
+from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmEventFilterQuery
+from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.serialization.deserialize import deserialize_evm_tx_hash
-from rotkehlchen.types import Location, Timestamp, TimestampMS
+from rotkehlchen.tests.utils.factories import make_evm_tx_hash
+from rotkehlchen.types import (
+    ChainID,
+    ChecksumEvmAddress,
+    EvmTransaction,
+    Location,
+    Timestamp,
+    TimestampMS,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
+    from rotkehlchen.db.dbhandler import DBHandler
+
 N_EVENTS = 1_000
+N_CUSTOMIZED_TXS = 1_000
+N_DECODE_TXS = 50
+USDT_ADDRESS = string_to_evm_address('0xdAC17F958D2ee523a2206206994597C13D831ec7')
+
+
+def _address_topic(address: ChecksumEvmAddress) -> bytes:
+    """Left-pad a 20-byte address into a 32-byte log topic."""
+    return bytes(12) + bytes.fromhex(address[2:])
+
+
+def _make_decodable_transactions(
+        from_address: ChecksumEvmAddress,
+        to_address: ChecksumEvmAddress,
+) -> list[tuple[EvmTransaction, EvmTxReceipt]]:
+    """Build representative ERC20-transfer transactions decoded fully offline.
+
+    Each transaction carries a gas fee plus three USDT Transfer logs between two tracked
+    accounts, the most common shape the decoder processes. Both endpoints are tracked so the
+    transfer-decoding path actually emits events instead of bailing out early.
+    """
+    from_topic, to_topic = _address_topic(from_address), _address_topic(to_address)
+    transactions = []
+    for idx in range(N_DECODE_TXS):
+        tx_hash = deserialize_evm_tx_hash(idx.to_bytes(32, 'big'))
+        transactions.append((
+            EvmTransaction(
+                tx_hash=tx_hash,
+                chain_id=ChainID.ETHEREUM,
+                timestamp=Timestamp(1700000000 + idx),
+                block_number=18000000 + idx,
+                from_address=from_address,
+                to_address=USDT_ADDRESS,
+                value=0,
+                gas=45000,
+                gas_price=10000000000,
+                gas_used=45000,
+                input_data=b'',
+                nonce=idx,
+            ),
+            EvmTxReceipt(
+                tx_hash=tx_hash,
+                chain_id=ChainID.ETHEREUM,
+                contract_address=None,
+                status=True,
+                tx_type=0,
+                logs=[
+                    EvmTxReceiptLog(
+                        log_index=log_idx,
+                        data=((idx + log_idx + 1) * 1000000).to_bytes(32, 'big'),
+                        address=USDT_ADDRESS,
+                        topics=[ERC20_OR_ERC721_TRANSFER, from_topic, to_topic],
+                    )
+                    for log_idx in range(3)
+                ],
+            ),
+        ))
+
+    return transactions
 
 
 def _make_events() -> list[EvmEvent]:
@@ -76,6 +151,95 @@ def test_fval_arithmetic(benchmark: 'Callable') -> None:
         return total
 
     benchmark(aggregate)
+
+
+@pytest.mark.benchmark
+def test_redecode_delete_customized_lookup(benchmark: 'Callable', database: 'DBHandler') -> None:
+    """Per-transaction redecode delete path.
+
+    When redecoding, rotki calls `delete_events_by_tx_ref` once per transaction (see
+    `decoder._maybe_load_or_purge_events_from_db`). The customized-event exclusion lookup
+    used to scan the whole `history_events_mappings` table on every call, so its cost grew
+    with the user's total customized events rather than with the few txs being redecoded.
+
+    This seeds a heavy customized-events table and measures a single delete on a fully
+    customized tx. Such a tx is preserved by `preserve_transactions`, so the call deletes
+    nothing and stays repeatable across benchmark rounds while still exercising the lookup.
+    """
+    db = DBHistoryEvents(database)
+    tx_hashes = [make_evm_tx_hash() for _ in range(N_CUSTOMIZED_TXS)]
+    with database.user_write() as write_cursor:
+        for tx_hash in tx_hashes:
+            for seq_idx in range(2):
+                db.add_history_event(
+                    write_cursor=write_cursor,
+                    event=EvmEvent(
+                        tx_ref=tx_hash,
+                        sequence_index=seq_idx,
+                        timestamp=TimestampMS(1700000000000),
+                        location=Location.ETHEREUM,
+                        event_type=HistoryEventType.RECEIVE,
+                        event_subtype=HistoryEventSubType.NONE,
+                        asset=A_ETH,
+                        amount=ONE,
+                    ),
+                    mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
+                )
+
+    def run() -> None:
+        with database.user_write() as write_cursor:
+            db.delete_events_by_tx_ref(
+                write_cursor=write_cursor,
+                tx_refs=[tx_hashes[0]],
+                location=Location.ETHEREUM,
+                customized_handling='preserve_transactions',
+            )
+
+    benchmark(run)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize('ethereum_accounts', [[
+    '0x4bBa290826C253BD854121346c370a9886d1bC26',
+    '0x38C3f1Ab36BdCa29133d8AF7A19811D10B6CA3FC',
+]])
+def test_transaction_decoding(
+        benchmark: 'Callable',
+        database: 'DBHandler',
+        ethereum_accounts: list[ChecksumEvmAddress],
+        ethereum_transaction_decoder: 'EthereumTransactionDecoder',
+) -> None:
+    """Generic transaction-decoding hot path.
+
+    Measures `_decode_transaction` (gas event + per-log decoder dispatch + ERC20 transfer
+    decoding + post-decoding rules + event ordering), the backbone every redecode runs per
+    transaction. It is read-only (the event DB write is deferred to the caller), so decoding
+    the same batch each round is repeatable, deterministic and needs no network.
+    """
+    tx_data = _make_decodable_transactions(ethereum_accounts[0], ethereum_accounts[1])
+    with database.user_write() as write_cursor:
+        DBEvmTx(database).add_transactions(
+            write_cursor,
+            [tx for tx, _ in tx_data],
+            relevant_address=None,
+        )
+
+    # guard that the data actually exercises the decode path (1 gas + 3 transfer events)
+    # so the benchmark cannot silently degrade into decoding nothing
+    sample_events, _, _ = ethereum_transaction_decoder._decode_transaction(
+        transaction=tx_data[0][0],
+        tx_receipt=tx_data[0][1],
+    )
+    assert len(sample_events) == 4
+
+    def run() -> None:
+        for transaction, receipt in tx_data:
+            ethereum_transaction_decoder._decode_transaction(
+                transaction=transaction,
+                tx_receipt=receipt,
+            )
+
+    benchmark(run)
 
 
 @pytest.mark.benchmark

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -1586,6 +1586,84 @@ def test_delete_events_by_tx_ref_preserves_customized_transaction(database: DBHa
         assert len(group_ids) == 1  # only tx_a's group_identifier remains
 
 
+def test_delete_events_by_tx_ref_scopes_customized_lookup(database: DBHandler) -> None:
+    """Customized exclusions should only consider events from the deleted tx refs."""
+    tx_hash_a, tx_hash_b = _setup_two_evm_transactions(database)
+    tx_hash_c = make_evm_tx_hash()
+    db = DBHistoryEvents(database)
+    dbevmtx = DBEvmTx(database)
+
+    with database.user_write() as write_cursor:
+        dbevmtx.add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[EvmTransaction(
+                tx_hash=tx_hash_c,
+                chain_id=ChainID.ETHEREUM,
+                timestamp=Timestamp(3000),
+                block_number=3,
+                from_address=make_evm_address(),
+                to_address=make_evm_address(),
+                value=0,
+                gas=21000,
+                gas_price=1000000000,
+                gas_used=21000,
+                input_data=b'',
+                nonce=2,
+            )],
+            relevant_address=None,
+        )
+        for tx_hash, timestamp in (
+            (tx_hash_a, 1000000),
+            (tx_hash_b, 2000000),
+            (tx_hash_c, 3000000),
+        ):
+            for seq_idx in range(2):
+                db.add_history_event(
+                    write_cursor=write_cursor,
+                    event=EvmEvent(
+                        tx_ref=tx_hash,
+                        sequence_index=seq_idx,
+                        timestamp=TimestampMS(timestamp),
+                        location=Location.ETHEREUM,
+                        event_type=HistoryEventType.RECEIVE,
+                        event_subtype=HistoryEventSubType.NONE,
+                        asset=A_ETH,
+                        amount=ONE,
+                    ),
+                    mapping_values=(
+                        {HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED}
+                        if tx_hash in (tx_hash_a, tx_hash_c) and seq_idx == 0
+                        else None
+                    ),
+                )
+
+        assert write_cursor.execute('SELECT COUNT(*) FROM history_events').fetchone()[0] == 6
+        db.delete_events_by_tx_ref(
+            write_cursor=write_cursor,
+            tx_refs=[tx_hash_b],
+            location=Location.ETHEREUM,
+            customized_handling='preserve_transactions',
+        )
+        assert write_cursor.execute('SELECT COUNT(*) FROM history_events').fetchone()[0] == 4
+        remaining_tx_refs = {
+            row[0] for row in write_cursor.execute(
+                'SELECT DISTINCT tx_ref FROM chain_events_info',
+            )
+        }
+        assert remaining_tx_refs == {tx_hash_a, tx_hash_c}
+        db.delete_events_by_tx_ref(
+            write_cursor=write_cursor,
+            tx_refs=[tx_hash_a],
+            location=Location.ETHEREUM,
+            customized_handling='preserve_events',
+        )
+        assert write_cursor.execute('SELECT COUNT(*) FROM history_events').fetchone()[0] == 3
+        assert write_cursor.execute(
+            'SELECT COUNT(*) FROM history_events_mappings WHERE value=?',
+            (HistoryMappingState.CUSTOMIZED.serialize_for_db(),),
+        ).fetchone()[0] == 2
+
+
 def test_reset_events_for_redecode_preserves_customized_transaction(database: DBHandler) -> None:
     """Verifies that reset_events_for_redecode preserves all events in a transaction when
     any event is customized, and keeps the decoded status for that transaction.

--- a/tools/bench/__main__.py
+++ b/tools/bench/__main__.py
@@ -19,6 +19,7 @@ from tools.bench.harness import ensure_profile_cached, run_profile
 from tools.bench.output import (
     collect_meta,
     render_compare_table,
+    render_micro_compare_table,
     render_run_table,
     to_gha_benchmark,
 )
@@ -68,6 +69,7 @@ def compare_command(args: argparse.Namespace) -> None:
             profiles=args.profile,
             blocks=args.samples,
             work_dir=work_dir,
+            micro=args.micro,
         )
     finally:
         shutil.rmtree(work_dir, ignore_errors=True)
@@ -75,15 +77,21 @@ def compare_command(args: argparse.Namespace) -> None:
     result['meta'] = collect_meta(REPO_ROOT)
     args.output.write_text(json.dumps(result, indent=2), encoding='utf-8')
     table = render_compare_table(result['profiles'])
+    micro_table = render_micro_compare_table(result['micro'])
     if args.markdown is not None:
         header = (
             f'### Benchmark comparison\n\n'
             f'base `{result["base_commit"][:10]}` ({args.base}) vs head '
             f'`{result["head_commit"][:10]}` — {args.samples} interleaved block pairs\n\n'
         )
-        args.markdown.write_text(header + table + '\n', encoding='utf-8')
+        body = header + table + '\n'
+        if micro_table:
+            body += '\n' + micro_table + '\n'
+        args.markdown.write_text(body, encoding='utf-8')
     print(f'\nresults written to {args.output}\n')
     print(table)
+    if micro_table:
+        print('\n' + micro_table)
 
 
 def main() -> None:
@@ -107,7 +115,8 @@ def main() -> None:
     compare_parser.add_argument('--samples', type=int, default=5, help='Interleaved block pairs per profile')  # noqa: E501
     compare_parser.add_argument('--output', type=Path, default=Path('bench-compare.json'))
     compare_parser.add_argument('--markdown', type=Path, default=None, help='Also write the markdown table (with header) here')  # noqa: E501
-    compare_parser.set_defaults(func=compare_command)
+    compare_parser.add_argument('--no-micro', dest='micro', action='store_false', help='Skip the pytest-benchmark micro A/B (macro only)')  # noqa: E501
+    compare_parser.set_defaults(func=compare_command, micro=True)
 
     args = parser.parse_args()
     try:

--- a/tools/bench/compare.py
+++ b/tools/bench/compare.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from rotkehlchen.db.settings import ROTKEHLCHEN_DB_VERSION
 from tools.bench.harness import ensure_profile_cached, load_expected, run_block
+from tools.bench.micro_compare import run_micro_compare
 from tools.bench.runner import BenchError
 from tools.bench.stats import compare_samples
 
@@ -54,7 +55,9 @@ def _setup_worktree(repo_root: Path, base_commit: str) -> Path:
 
     env = {k: v for k, v in os.environ.items() if k != 'VIRTUAL_ENV'}
     sync = subprocess.run(
-        ['uv', 'sync'],  # noqa: S607
+        # --all-groups so the worktree gets the full test infra the micro suite needs
+        # (pytest-benchmark, and pylint which the test conftest imports eagerly)
+        ['uv', 'sync', '--all-groups'],  # noqa: S607
         cwd=worktree,
         env=env,
         capture_output=True,
@@ -83,8 +86,9 @@ def run_compare(
         profiles: list[str],
         blocks: int,
         work_dir: Path,
+        micro: bool = True,
 ) -> dict[str, Any]:
-    """Returns {base_commit, head_commit, profiles: {profile: {op: comparison}}}"""
+    """Returns {base_commit, head_commit, profiles: {profile: {op: comparison}}, micro}"""
     head_commit = _git(repo_root, 'rev-parse', 'HEAD')
     base_commit = _git(repo_root, 'merge-base', 'HEAD', base_ref)
     if base_commit == head_commit:
@@ -92,6 +96,7 @@ def run_compare(
 
     cached = {profile: ensure_profile_cached(repo_root, profile) for profile in profiles}
     worktree = _setup_worktree(repo_root, base_commit)
+    micro_comparison: dict[str, Any] = {}
     try:
         comparison: dict[str, Any] = {}
         for profile in profiles:
@@ -113,6 +118,10 @@ def run_compare(
                 op: compare_samples(base=base_samples, head=samples['head'][op])
                 for op, base_samples in samples['base'].items()
             }
+
+        if micro:  # pure-python micro suite, A/B'd against the same base worktree
+            micro_comparison = run_micro_compare(repo_root, worktree, work_dir)
+            print('  micro-benchmark comparison done')
     finally:
         _teardown_worktree(repo_root, worktree)
 
@@ -122,4 +131,5 @@ def run_compare(
         'head_commit': head_commit,
         'blocks': blocks,
         'profiles': comparison,
+        'micro': micro_comparison,
     }

--- a/tools/bench/launch_backend.py
+++ b/tools/bench/launch_backend.py
@@ -41,6 +41,21 @@ def _redirecting_send(self: Any, request: Any, **kwargs: Any) -> Any:
 
 requests.adapters.HTTPAdapter.send = _redirecting_send
 
+# Protocol on-chain caches (curve pools, gearbox lists, ...) refresh from chain whenever a
+# decode (or balances) runs and a cache looks stale -- which it always does on a fresh
+# profile. The mock serves no real protocol data, so those refreshes are meaningless and, for
+# calls returning complex tuples, the generic zero-word answer even breaks abi decoding. Force
+# every protocol cache "fresh" so decode/balances run entirely on the seeded data. Patched
+# before importing the app so the 14 modules that `from ... import` it bind the no-op version.
+import rotkehlchen.chain.ethereum.utils as _eth_utils
+
+
+def _never_update_protocol_cache(*_args: Any, **_kwargs: Any) -> bool:
+    return False
+
+
+_eth_utils.should_update_protocol_cache = _never_update_protocol_cache
+
 from rotkehlchen.__main__ import main
 
 main()

--- a/tools/bench/micro_compare.py
+++ b/tools/bench/micro_compare.py
@@ -1,0 +1,104 @@
+"""Micro-benchmark A/B: run the pytest-benchmark suite on base and head.
+
+The macro comparison can only exercise code reachable through the API with no
+network egress. Some optimizations live on paths that need the network and so
+are invisible to it -- e.g. the per-transaction redecode deletion
+(`delete_events_by_tx_ref`), which only the `test_redecode_delete_customized_lookup`
+micro-benchmark measures. This module runs the whole micro suite against both
+sides and compares, so such wins (and regressions) surface on the PR too.
+
+HEAD's benchmark files are used in both checkouts: the same measurement code
+runs against each side's backend, mirroring how the macro side shares HEAD's
+profile and operations. pytest-benchmark does its own repeated rounds, so a
+single suite run per side already yields a stable median/stddev.
+"""
+import json
+import shutil
+import subprocess  # noqa: S404
+from math import sqrt
+from pathlib import Path
+from typing import Any
+
+from tools.bench.runner import BenchError
+
+BENCH_DIR = Path('rotkehlchen') / 'tests' / 'benchmarks'
+
+
+def _run_micro_suite(side_root: Path, json_out: Path) -> dict[str, dict[str, float]]:
+    """Run the pytest-benchmark suite in side_root and return per-benchmark stats in ms.
+
+    Raises BenchError if the suite produced no json (import/collection failure), so the
+    caller can degrade gracefully instead of comparing against missing data.
+    """
+    result = subprocess.run(  # noqa: S603  # trusted args
+        [  # noqa: S607
+            'uv', 'run', 'python', 'pytestgeventwrapper.py',
+            '-m', 'benchmark', '--benchmark-only', '--benchmark-columns=median,min,stddev',
+            f'--benchmark-json={json_out}', str(BENCH_DIR),
+        ],
+        cwd=side_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if not json_out.exists() or json_out.stat().st_size == 0:
+        raise BenchError(
+            f'micro suite produced no json in {side_root}:\n'
+            f'{result.stdout[-2000:]}\n{result.stderr[-2000:]}',
+        )
+
+    try:
+        data = json.loads(json_out.read_text(encoding='utf-8'))
+    except json.JSONDecodeError as e:
+        raise BenchError(
+            f'micro suite json unreadable in {side_root}: {e}\n'
+            f'{result.stdout[-2000:]}\n{result.stderr[-2000:]}',
+        ) from e
+    return {
+        benchmark['name']: {
+            'median_ms': round(benchmark['stats']['median'] * 1000, 3),
+            'min_ms': round(benchmark['stats']['min'] * 1000, 3),
+            'stddev_ms': round(benchmark['stats']['stddev'] * 1000, 3),
+        }
+        for benchmark in data['benchmarks']
+    }
+
+
+def _compare_stats(base: dict[str, float], head: dict[str, float]) -> dict[str, Any]:
+    """Compare one benchmark's base/head stats. Same significance rule as the macro
+    side: the median delta must exceed 3x the pooled stddev of both runs."""
+    delta_ms = head['median_ms'] - base['median_ms']
+    pooled_stddev = sqrt((base['stddev_ms'] ** 2 + head['stddev_ms'] ** 2) / 2)
+    return {
+        'base': base,
+        'head': head,
+        'delta_ms': round(delta_ms, 3),
+        'delta_pct': round(100 * delta_ms / base['median_ms'], 2) if base['median_ms'] else 0.0,
+        'significant': pooled_stddev > 0 and abs(delta_ms) > 3 * pooled_stddev,
+    }
+
+
+def run_micro_compare(repo_root: Path, worktree: Path, work_dir: Path) -> dict[str, Any]:
+    """Run the micro suite on base (worktree) and head (repo_root) and compare.
+
+    Returns {'benchmarks': {name: comparison}} or {'error': reason} when the base side
+    cannot run the head benchmarks (e.g. a new benchmark references a head-only symbol),
+    so a benchmark-only change never fails the whole bench job.
+    """
+    head_bench, base_bench = repo_root / BENCH_DIR, worktree / BENCH_DIR
+    shutil.rmtree(base_bench, ignore_errors=True)
+    shutil.copytree(head_bench, base_bench, ignore=shutil.ignore_patterns('__pycache__'))
+
+    micro_dir = work_dir / 'micro'
+    micro_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        base_stats = _run_micro_suite(worktree, micro_dir / 'base.json')
+        head_stats = _run_micro_suite(repo_root, micro_dir / 'head.json')
+    except BenchError as e:
+        return {'error': str(e)}
+
+    return {'benchmarks': {
+        name: _compare_stats(base=base_stats[name], head=head_stats[name])
+        for name in base_stats
+        if name in head_stats
+    }}

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -79,6 +79,17 @@ def _blockchain_balances_eth(backend: 'BackendRunner', _expected: dict[str, Any]
     backend.request('POST', '/balances/blockchains/eth')
 
 
+def _redecode_transactions(backend: 'BackendRunner', _expected: dict[str, Any]) -> None:
+    # ignore_cache forces a full redecode of the profile's seeded ethereum transactions
+    # (the only ones with backing evm_transactions rows and receipts). Decoding runs from
+    # the stored receipts so the whole decode pipeline is measured without any network.
+    backend.request('POST', '/blockchains/transactions/decode', {
+        'async_query': False,
+        'ignore_cache': True,
+        'chain': 'eth',
+    })
+
+
 OPERATIONS: Final = (
     Operation(
         name='history_events_p1',
@@ -119,5 +130,10 @@ OPERATIONS: Final = (
         name='blockchain_balances_eth',
         profiles=('small', 'whale'),
         run=_blockchain_balances_eth,
+    ),
+    Operation(
+        name='redecode_transactions',
+        profiles=('small', 'whale'),
+        run=_redecode_transactions,
     ),
 )

--- a/tools/bench/output.py
+++ b/tools/bench/output.py
@@ -75,3 +75,32 @@ def render_compare_table(comparison: dict[str, dict[str, Any]]) -> str:
                 f'| {sign}{c["delta_ms"]} | {sign}{c["delta_pct"]}% | {marker} |',
             )
     return '\n'.join(lines)
+
+
+def render_micro_compare_table(micro: dict[str, Any]) -> str:
+    """Markdown section for the micro-benchmark A/B (`compare` result's 'micro' key).
+
+    Falls back to a note when the base side could not run the head benchmarks.
+    """
+    if 'error' in micro:
+        return (
+            '### Micro-benchmark comparison\n\n'
+            '_skipped: the base checkout could not run the head benchmark suite '
+            '(a new benchmark may reference a head-only symbol)._'
+        )
+    if not (benchmarks := micro.get('benchmarks')):
+        return ''
+
+    lines = [
+        '### Micro-benchmark comparison\n',
+        '| benchmark | base median ms | head median ms | Δ ms | Δ % | significant |',
+        '|---|---:|---:|---:|---:|:---:|',
+    ]
+    for name, c in benchmarks.items():
+        marker = '**yes**' if c['significant'] else 'no'
+        sign = '+' if c['delta_ms'] >= 0 else ''
+        lines.append(
+            f'| {name} | {c["base"]["median_ms"]} | {c["head"]["median_ms"]} '
+            f'| {sign}{c["delta_ms"]} | {sign}{c["delta_pct"]}% | {marker} |',
+        )
+    return '\n'.join(lines)

--- a/tools/scenarios/base.py
+++ b/tools/scenarios/base.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.accounts import BlockchainAccountData
     from rotkehlchen.db.settings import ModifiableDBSettings
     from rotkehlchen.history.events.structures.base import HistoryBaseEntry
+    from rotkehlchen.types import ChainID, ChecksumEvmAddress, EvmTransaction
 
 # Matches testEnv.PASSWORD in frontend/app/tests/e2e/fixtures/index.ts
 USER_PASSWORD: Final = '1234'
@@ -153,6 +154,38 @@ class ProfileBuilder:
         if len(missing := [x for x in identifiers if x not in existing]) != 0:
             print(f'WARNING: dropping assets missing from global DB: {missing}', file=sys.stderr)
         return [x for x in identifiers if x in existing]
+
+    def add_evm_transactions_with_receipts(
+            self,
+            chain_id: 'ChainID',
+            transactions: 'Sequence[EvmTransaction]',
+            receipts: 'Sequence[dict[str, Any]]',
+            relevant_address: 'ChecksumEvmAddress',
+    ) -> None:
+        """Seed EVM transactions and their receipts so a redecode operation can run fully
+        offline (the bench mock serves no receipts).
+
+        These are the only events with backing evm_transactions rows, so a location-wide
+        redecode only touches them and leaves the distribution events (which have no
+        transaction rows) intact.
+        """
+        from rotkehlchen.db.evmtx import DBEvmTx  # local import to keep base.py light
+        dbevmtx = DBEvmTx(self.db)
+        with self.db.user_write() as write_cursor:
+            dbevmtx.add_transactions(
+                write_cursor=write_cursor,
+                evm_transactions=list(transactions),
+                relevant_address=relevant_address,
+            )
+            for receipt in receipts:
+                dbevmtx.add_or_ignore_receipt_data(
+                    write_cursor=write_cursor,
+                    chain_id=chain_id,
+                    data=receipt,
+                )
+        self.stats['decodable_transactions'] = (
+            self.stats.get('decodable_transactions', 0) + len(transactions)
+        )
 
     def add_history_events(self, events: Iterable['HistoryBaseEntry']) -> None:
         """Bulk-insert history events with explicitly assigned identifiers.

--- a/tools/scenarios/profiles/common.py
+++ b/tools/scenarios/profiles/common.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 from eth_utils import to_checksum_address
 
+from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -19,10 +20,19 @@ if TYPE_CHECKING:
 
     from rotkehlchen.assets.asset import Asset
     from rotkehlchen.history.events.structures.base import HistoryBaseEntry
-    from rotkehlchen.types import ChecksumEvmAddress, Location, TimestampMS
+    from rotkehlchen.types import (
+        ChainID,
+        ChecksumEvmAddress,
+        EvmTransaction,
+        Location,
+        TimestampMS,
+    )
     from tools.scenarios.deterministic import DeterministicFactory
 
 GAS_COUNTERPARTY: Final = 'gas'
+
+# the ERC20 Transfer event topic as a hex string, for raw receipt-log seeding
+ERC20_TRANSFER_TOPIC: Final = '0x' + ERC20_OR_ERC721_TRANSFER.hex()
 
 # Fixed USD prices per symbol, seeded as manual latest prices so that any
 # balance valuation resolves locally instead of asking remote oracles.
@@ -271,6 +281,69 @@ def make_evm_tx_group(
         sequence_index += 1
 
     return events
+
+
+def _address_topic(address: 'ChecksumEvmAddress') -> str:
+    """Left-pad a 20-byte address into a 32-byte log-topic hex string."""
+    return '0x' + '0' * 24 + address[2:].lower()
+
+
+def make_decodable_evm_transactions(
+        factory: 'DeterministicFactory',
+        chain_id: 'ChainID',
+        from_address: 'ChecksumEvmAddress',
+        to_address: 'ChecksumEvmAddress',
+        token_address: str,
+        count: int,
+        logs_per_tx: int = 3,
+) -> tuple[list['EvmTransaction'], list[dict[str, Any]]]:
+    """Build ``count`` ERC20-transfer transactions plus their receipts, decodable offline.
+
+    The bench mock serves no receipts, so a redecode operation can only run if the
+    transactions and their receipts already live in the DB. Each transaction carries a gas
+    fee plus ``logs_per_tx`` Transfer logs between two tracked accounts (the most common
+    shape the decoder processes) so a redecode actually emits transfer events rather than
+    just gas. Returns ``(transactions, raw-receipt dicts)`` ready for
+    ``ProfileBuilder.add_evm_transactions_with_receipts``.
+    """
+    from rotkehlchen.types import EvmTransaction, Timestamp  # local import to avoid load cycle
+    from tools.scenarios.deterministic import SCENARIO_NOW
+
+    from_topic, to_topic = _address_topic(from_address), _address_topic(to_address)
+    transactions, receipts = [], []
+    for idx in range(count):
+        tx_hash = factory.evm_tx_hash()
+        transactions.append(EvmTransaction(
+            tx_hash=tx_hash,
+            chain_id=chain_id,
+            timestamp=Timestamp(SCENARIO_NOW - count + idx),
+            block_number=18000000 + idx,
+            from_address=from_address,
+            to_address=token_address,  # type: ignore[arg-type]  # the token contract
+            value=0,
+            gas=45000,
+            gas_price=10**10,
+            gas_used=45000,
+            input_data=b'',
+            nonce=idx,
+        ))
+        receipts.append({
+            'transactionHash': tx_hash.hex(),  # EVMTxHash.hex() already includes the 0x prefix
+            'type': '0x0',
+            'status': 1,
+            'contractAddress': None,
+            'logs': [
+                {
+                    'logIndex': log_idx,
+                    'data': '0x' + ((idx + log_idx + 1) * 1000000).to_bytes(32, 'big').hex(),
+                    'address': token_address,
+                    'topics': [ERC20_TRANSFER_TOPIC, from_topic, to_topic],
+                }
+                for log_idx in range(logs_per_tx)
+            ],
+        })
+
+    return transactions, receipts
 
 
 def make_exchange_swap(

--- a/tools/scenarios/profiles/small.py
+++ b/tools/scenarios/profiles/small.py
@@ -11,7 +11,7 @@ from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.accounts import BlockchainAccountData
 from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import Location, SupportedBlockchain
+from rotkehlchen.types import ChainID, Location, SupportedBlockchain
 from tools.scenarios.deterministic import DeterministicFactory, monthly_ramp_weights
 from tools.scenarios.profiles.common import (
     MODULE_TOKEN_PRICES,
@@ -20,6 +20,7 @@ from tools.scenarios.profiles.common import (
     erc20,
     make_asset_movement,
     make_chain_state,
+    make_decodable_evm_transactions,
     make_evm_tx_group,
     make_exchange_swap,
     make_snapshots,
@@ -42,6 +43,9 @@ SWAP_FEE_SHARE: Final = 0.3
 N_ASSET_MOVEMENTS: Final = 20
 MOVEMENT_FEE_SHARE: Final = 0.5
 N_STAKING_REWARDS: Final = 80
+# transactions seeded with receipts so the redecode benchmark operation can run offline
+N_DECODABLE_TXS: Final = 50
+USDT_ADDRESS: Final = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
 EXCHANGES: Final = (Location.KRAKEN, Location.BINANCE)
 EXCHANGE_WEIGHTS: Final = (0.6, 0.4)
@@ -202,4 +206,18 @@ def build(builder: 'ProfileBuilder') -> dict[str, Any] | None:
         return events
 
     builder.add_history_events(generate())
+    decodable_txs, decodable_receipts = make_decodable_evm_transactions(
+        factory=factory,
+        chain_id=ChainID.ETHEREUM,
+        from_address=eth_accounts[0],
+        to_address=eth_accounts[1],
+        token_address=USDT_ADDRESS,
+        count=N_DECODABLE_TXS,
+    )
+    builder.add_evm_transactions_with_receipts(
+        chain_id=ChainID.ETHEREUM,
+        transactions=decodable_txs,
+        receipts=decodable_receipts,
+        relevant_address=eth_accounts[0],
+    )
     return {'eth_accounts': eth_accounts}

--- a/tools/scenarios/profiles/whale.py
+++ b/tools/scenarios/profiles/whale.py
@@ -13,7 +13,7 @@ from rotkehlchen.balances.manual import ManuallyTrackedBalance
 from rotkehlchen.chain.accounts import BlockchainAccountData
 from rotkehlchen.constants.assets import A_BTC, A_ETH
 from rotkehlchen.fval import FVal
-from rotkehlchen.types import Location, SupportedBlockchain
+from rotkehlchen.types import ChainID, Location, SupportedBlockchain
 from tools.scenarios.deterministic import DeterministicFactory, monthly_ramp_weights
 from tools.scenarios.profiles.common import (
     MODULE_TOKEN_PRICES,
@@ -22,6 +22,7 @@ from tools.scenarios.profiles.common import (
     erc20,
     make_asset_movement,
     make_chain_state,
+    make_decodable_evm_transactions,
     make_evm_tx_group,
     make_exchange_swap,
     make_snapshots,
@@ -39,6 +40,9 @@ ACTIVE_MONTHS: Final = 72  # six years of history
 
 N_EVM_ACCOUNTS: Final = 20
 N_BTC_ACCOUNTS: Final = 5
+# transactions seeded with receipts so the redecode benchmark operation can run offline
+N_DECODABLE_TXS: Final = 300
+USDT_ADDRESS: Final = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 
 # Row-count targets per category (~400k total)
 EVM_ROWS_TARGET: Final = 300_000
@@ -273,4 +277,18 @@ def build(builder: 'ProfileBuilder') -> dict[str, Any] | None:
             )
 
     builder.add_history_events(generate())
+    decodable_txs, decodable_receipts = make_decodable_evm_transactions(
+        factory=factory,
+        chain_id=ChainID.ETHEREUM,
+        from_address=evm_accounts[0],
+        to_address=evm_accounts[1],
+        token_address=USDT_ADDRESS,
+        count=N_DECODABLE_TXS,
+    )
+    builder.add_evm_transactions_with_receipts(
+        chain_id=ChainID.ETHEREUM,
+        transactions=decodable_txs,
+        receipts=decodable_receipts,
+        relevant_address=evm_accounts[0],
+    )
     return {'evm_accounts': evm_accounts}


### PR DESCRIPTION
When rededocing a transaction we check if there are customized events by doing a full table search and then we filter. This PR adjusts the queried so we do a much more filtered query
