### PR TITLE
fix: decode 1inch v5 Fusion orders as swaps

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` 1inch v5 Fusion limit orders will now be properly decoded.
 * :bug:`-` Clicking a dialog's save button several times while it is still saving (for example when editing a history event that is slow to save) no longer sends the same change repeatedly, so you no longer risk creating duplicate entries by double-clicking.
 * :feature:`12420` ZKsync Lite sunset claims are now decoded and balances are shown correctly.
 * :bug:`-` The asset and history-events export download endpoints now validate that the requested file lives in the export directory before serving it.

--- a/rotkehlchen/chain/evm/decoding/oneinch/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/decoder.py
@@ -31,11 +31,17 @@ class OneinchCommonDecoder(EvmDecoderInterface, ABC):
             router_address: 'ChecksumEvmAddress',
             swapped_signatures: list[bytes],
             counterparty: str = CPT_ONEINCH,
+            limit_order_topics: list[bytes] | None = None,
     ) -> None:
         super().__init__(evm_inquirer, base_tools, msg_aggregator)
         self.router_address = router_address
         self.swapped_signatures = swapped_signatures
         self.counterparty = counterparty
+        # Topics of the limit order protocol's OrderFilled event. These are emitted by the
+        # router when a 1inch limit order / Fusion order is settled. Such settlements may be
+        # submitted by a resolver (so the transaction initiator is not the order maker), which
+        # is why their swaps can't be paired through the initiator-based logic.
+        self.limit_order_topics = limit_order_topics if limit_order_topics is not None else []
 
     def _create_swapped_events(
             self,
@@ -94,6 +100,13 @@ class OneinchCommonDecoder(EvmDecoderInterface, ABC):
         """Decode the swapped log for the particular 1inch version"""
 
     def decode_action(self, context: DecoderContext) -> EvmDecodingOutput:
+        if context.tx_log.topics[0] in self.limit_order_topics:
+            # The OrderFilled log can appear before the token transfers (and the maker's
+            # transfer events don't exist yet at this point), so only flag the counterparty
+            # here to trigger the post-decoding rule which pairs the swap legs once all
+            # transfer events have been created.
+            return EvmDecodingOutput(matched_counterparty=self.counterparty)
+
         if context.tx_log.topics[0] in self.swapped_signatures:
             return self._decode_swapped(context=context)
 

--- a/rotkehlchen/chain/evm/decoding/oneinch/v4/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/v4/decoder.py
@@ -1,7 +1,9 @@
+import logging
 from abc import ABC
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.modules.oneinch.constants import CPT_ONEINCH_V4
@@ -18,7 +20,11 @@ from rotkehlchen.chain.evm.decoding.oneinch.v4.constants import (
     PANCAKE_SWAP_TOPIC,
     WOMBATV2_SWAPPED,
 )
-from rotkehlchen.chain.evm.decoding.structures import DecoderContext, EvmDecodingOutput
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_EVM_DECODING_OUTPUT,
+    DecoderContext,
+    EvmDecodingOutput,
+)
 from rotkehlchen.chain.evm.decoding.uniswap.v2.constants import UNISWAP_V2_SWAP_SIGNATURE
 from rotkehlchen.chain.evm.decoding.uniswap.v3.constants import (
     SWAP_SIGNATURE as UNISWAP_V3_SWAP_SIGNATURE,
@@ -27,6 +33,7 @@ from rotkehlchen.chain.evm.decoding.velodrome.decoder import SWAP_V2 as VELODROM
 from rotkehlchen.chain.evm.decoding.weth.decoder import WETH_WITHDRAW_TOPIC
 from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
 
 if TYPE_CHECKING:
@@ -34,6 +41,9 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class Oneinchv3n4DecoderBase(OneinchCommonDecoder, ABC):
@@ -46,6 +56,7 @@ class Oneinchv3n4DecoderBase(OneinchCommonDecoder, ABC):
             msg_aggregator: 'MessagesAggregator',
             counterparty: str,
             router_address: ChecksumEvmAddress,
+            limit_order_topics: list[bytes] | None = None,
     ) -> None:
         super().__init__(
             evm_inquirer=evm_inquirer,
@@ -66,7 +77,55 @@ class Oneinchv3n4DecoderBase(OneinchCommonDecoder, ABC):
                 WOMBATV2_SWAPPED,
             ],
             counterparty=counterparty,
+            limit_order_topics=limit_order_topics,
         )
+
+    def _decode_limit_order_swap(self, context: DecoderContext) -> EvmDecodingOutput:
+        """Decode a 1inch limit order / Fusion swap by pairing the maker's spend and receive
+        legs. Unlike _decode_swapped this does not rely on the transaction initiator, since
+        these orders can be settled by a resolver on the maker's behalf.
+
+        TODO: Handle resolver fees.
+        https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=137038891
+        """
+        if context.tx_log.topics[0] not in self.limit_order_topics:
+            return DEFAULT_EVM_DECODING_OUTPUT
+
+        out_event, in_event = None, None
+        for event in context.decoded_events:
+            if (
+                out_event is None and (
+                    (event.event_type == HistoryEventType.SPEND and event.event_subtype == HistoryEventSubType.NONE) or  # noqa: E501
+                    (event.event_type == HistoryEventType.TRADE and event.event_subtype == HistoryEventSubType.SPEND)  # noqa: E501
+                ) and event.counterparty != CPT_GAS
+            ):
+                out_event = event
+            elif (
+                in_event is None and (
+                    (event.event_type == HistoryEventType.RECEIVE and event.event_subtype == HistoryEventSubType.NONE) or  # noqa: E501
+                    (event.event_type == HistoryEventType.TRADE and event.event_subtype == HistoryEventSubType.RECEIVE)  # noqa: E501
+                )
+            ):
+                in_event = event
+
+        if out_event is None or in_event is None:
+            log.warning('Failed to find one leg of 1inch limit order swap in %s', context.transaction)  # noqa: E501
+            return DEFAULT_EVM_DECODING_OUTPUT
+
+        for event, new_event_subtype, notes in [
+            (out_event, HistoryEventSubType.SPEND, 'Swap {amount} {symbol} in a 1inch limit order'),  # noqa: E501
+            (in_event, HistoryEventSubType.RECEIVE, 'Receive {amount} {symbol} as the result of a 1inch limit order'),  # noqa: E501
+        ]:
+            event.notes = notes.format(amount=event.amount, symbol=event.asset.resolve_to_asset_with_symbol().symbol)  # noqa: E501
+            event.counterparty = self.counterparty
+            event.event_subtype = new_event_subtype
+            event.event_type = HistoryEventType.TRADE
+
+        maybe_reshuffle_events(
+            ordered_events=[out_event, in_event],
+            events_list=context.decoded_events,
+        )
+        return EvmDecodingOutput(process_swaps=True)
 
     def _handle_post_decoding(
             self,
@@ -83,6 +142,29 @@ class Oneinchv3n4DecoderBase(OneinchCommonDecoder, ABC):
         addresses_to_decoders mapping because the 1inch v4 router is not in the addresses of the
         logs of the transaction, and consequently it can't be extracted and mapped.
         """
+        for tx_log in all_logs:
+            # Limit order / Fusion settlements need to be handled first and independently of the
+            # transaction initiator, since the OrderFilled log may appear before the transfers
+            # and the order can be settled by a resolver rather than the maker themselves.
+            if tx_log.topics[0] in self.limit_order_topics:
+                if any(
+                    event.event_type == HistoryEventType.TRADE and
+                    event.counterparty == self.counterparty
+                    for event in decoded_events
+                ):
+                    # already paired during decoding (the OrderFilled log was processed after
+                    # the transfers via addresses_to_decoders), so there is nothing left to do.
+                    return decoded_events
+
+                self._decode_limit_order_swap(DecoderContext(
+                    tx_log=tx_log,
+                    transaction=transaction,
+                    decoded_events=decoded_events,
+                    all_logs=all_logs,
+                    action_items=[],
+                ))
+                return decoded_events
+
         tx_has_weth_transfer = False
         weth_transfer_tx_log = None
         for tx_log in all_logs:

--- a/rotkehlchen/chain/evm/decoding/oneinch/v5/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/v5/decoder.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
 from rotkehlchen.chain.ethereum.modules.oneinch.constants import CPT_ONEINCH_V5
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
     from rotkehlchen.user_messages import MessagesAggregator
 
 ONEINCH_V5_ROUTER = string_to_evm_address('0x1111111254EEB25477B68fb85Ed929f73A960582')
+# OrderFilled(address,bytes32,uint256) of the limit order protocol v3 embedded in the v5 router.
+# Emitted when a 1inch limit order / Fusion order is settled through the v5 router.
+ORDER_FILLED_TOPIC: Final = b'\xb9\xed\x02C\xfd\xf0\x0f\x05E\xc6:\n\xf8\x85\x0c\t\r\x86\xbbFh+\xae\xc4\xbf<Ih\x14\xfeO\x02'  # noqa: E501
 
 
 class Oneinchv5Decoder(Oneinchv3n4DecoderBase):
@@ -28,6 +31,7 @@ class Oneinchv5Decoder(Oneinchv3n4DecoderBase):
             msg_aggregator=msg_aggregator,
             router_address=ONEINCH_V5_ROUTER,
             counterparty=CPT_ONEINCH_V5,
+            limit_order_topics=[ORDER_FILLED_TOPIC],
         )
 
     # -- DecoderInterface methods

--- a/rotkehlchen/chain/evm/decoding/oneinch/v6/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/oneinch/v6/decoder.py
@@ -1,31 +1,20 @@
-import logging
 from typing import TYPE_CHECKING, Any, Final
 
-from rotkehlchen.accounting.entry_type_mappings import HistoryEventSubType, HistoryEventType
-from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.evm.decoding.balancer.v3.constants import (
     SWAP_TOPIC as BALANCER_V3_SWAP_TOPIC,
 )
 from rotkehlchen.chain.evm.decoding.oneinch.constants import CPT_ONEINCH_V6, ONEINCH_V6_ROUTER
 from rotkehlchen.chain.evm.decoding.oneinch.decoder import OneinchCommonDecoder
 from rotkehlchen.chain.evm.decoding.oneinch.v4.decoder import Oneinchv3n4DecoderBase
-from rotkehlchen.chain.evm.decoding.structures import (
-    DEFAULT_EVM_DECODING_OUTPUT,
-    EvmDecodingOutput,
-)
-from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChecksumEvmAddress
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
-    from rotkehlchen.chain.evm.decoding.decoder import DecoderContext
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.user_messages import MessagesAggregator
 
-logger = logging.getLogger(__name__)
-log = RotkehlchenLogsAdapter(logger)
+# OrderFilled(bytes32,uint256) of the limit order protocol v4 embedded in the v6 router.
 ORDER_FILLED_TOPIC: Final = b'\xfe\xc315\x0f\xcex\xbae\x8e\x08*q\xda \xac\x9f\x8dy\x8a\x99\xb3\xc7\x96\x81\xc8D\x0c\xbf\xe7~\x07'  # noqa: E501
 
 
@@ -42,56 +31,14 @@ class Oneinchv6Decoder(Oneinchv3n4DecoderBase):
             msg_aggregator=msg_aggregator,
             router_address=ONEINCH_V6_ROUTER,
             counterparty=CPT_ONEINCH_V6,
+            # The v6 router emits the OrderFilled log after the transfers, so it is paired
+            # during decoding via addresses_to_decoders below. The topic is still registered
+            # here so the post-decoding rule can recognize (and skip) the already-paired swap.
+            limit_order_topics=[ORDER_FILLED_TOPIC],
         )
         # Balancer V3 is reachable through 1inch Fusion routing, so its swap log can be the
         # only pool-side signature emitted in an otherwise opaque v6 swap transaction.
         self.swapped_signatures.append(BALANCER_V3_SWAP_TOPIC)
-
-    def _decode_limit_order_swap(self, context: 'DecoderContext') -> EvmDecodingOutput:
-        """Decode 1inch v6 limit order swap transactions.
-
-        TODO: Handle resolver fees.
-        https://github.com/orgs/rotki/projects/11/views/3?pane=issue&itemId=137038891
-        """
-        if context.tx_log.topics[0] != ORDER_FILLED_TOPIC:
-            return DEFAULT_EVM_DECODING_OUTPUT
-
-        out_event, in_event = None, None
-        for event in context.decoded_events:
-            if (
-                out_event is None and (
-                    (event.event_type == HistoryEventType.SPEND and event.event_subtype == HistoryEventSubType.NONE) or  # noqa: E501
-                    (event.event_type == HistoryEventType.TRADE and event.event_subtype == HistoryEventSubType.SPEND)  # noqa: E501
-                ) and event.counterparty != CPT_GAS
-            ):
-                out_event = event
-            elif (
-                in_event is None and (
-                    (event.event_type == HistoryEventType.RECEIVE and event.event_subtype == HistoryEventSubType.NONE) or  # noqa: E501
-                    (event.event_type == HistoryEventType.TRADE and event.event_subtype == HistoryEventSubType.RECEIVE)  # noqa: E501
-                )
-            ):
-                in_event = event
-
-        if out_event is None or in_event is None:
-            log.warning(f'Failed to find one leg of 1inch limit order swap in {context.transaction}')  # noqa: E501
-            return DEFAULT_EVM_DECODING_OUTPUT
-
-        for event, new_event_subtype, notes in [
-            (out_event, HistoryEventSubType.SPEND, 'Swap {amount} {symbol} in a 1inch limit order'),  # noqa: E501
-            (in_event, HistoryEventSubType.RECEIVE, 'Receive {amount} {symbol} as the result of a 1inch limit order'),  # noqa: E501
-        ]:
-            event.notes = notes.format(amount=event.amount, symbol=event.asset.resolve_to_asset_with_symbol().symbol)  # noqa: E501
-            event.counterparty = self.counterparty
-            event.event_subtype = new_event_subtype
-            event.event_type = HistoryEventType.TRADE
-
-        maybe_reshuffle_events(
-            ordered_events=[out_event, in_event],
-            events_list=context.decoded_events,
-        )
-
-        return EvmDecodingOutput(process_swaps=True)
 
     # -- DecoderInterface methods
 

--- a/rotkehlchen/tests/unit/decoders/test_1inch.py
+++ b/rotkehlchen/tests/unit/decoders/test_1inch.py
@@ -835,6 +835,46 @@ def test_half_decoded_1inch_v5_swap(ethereum_inquirer, ethereum_accounts):
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0x4d8E4c0ffA6e173Ed1c975ebE31616D1b29b1427']])
+def test_1inch_v5_fusion_order(ethereum_inquirer, ethereum_accounts):
+    """Test that a 1inch v5 Fusion order (EURS->USDC) is decoded as a swap for the order maker.
+
+    The settlement is submitted by a resolver, so the transaction initiator is not the tracked
+    maker, and the limit order protocol's OrderFilled log is emitted before the maker's token
+    transfers. The swap must still be paired from the maker's spend and receive legs.
+    """
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x47307e4efcb6b8b0a71e3e9b937b4e81235949fde189dd09939767720e356071')),  # noqa: E501
+    )
+    assert events == [EvmSwapEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1678547243000)),
+        location=Location.ETHEREUM,
+        event_subtype=HistoryEventSubType.SPEND,
+        asset=Asset('eip155:1/erc20:0xdB25f211AB05b1c97D595516F45794528a807ad8'),
+        amount=FVal(spend_amount := '39298.8'),
+        location_label=(user_address := ethereum_accounts[0]),
+        notes=f'Swap {spend_amount} EURS in a 1inch limit order',
+        counterparty=CPT_ONEINCH_V5,
+        address=(settlement_address := string_to_evm_address('0xBd4DBE0CB9136FFb4955ede88EBD5e92222aD09a')),  # noqa: E501
+    ), EvmSwapEvent(
+        tx_ref=tx_hash,
+        sequence_index=1,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_subtype=HistoryEventSubType.RECEIVE,
+        asset=A_USDC,
+        amount=FVal(receive_amount := '43520.618993'),
+        location_label=user_address,
+        notes=f'Receive {receive_amount} USDC as the result of a 1inch limit order',
+        counterparty=CPT_ONEINCH_V5,
+        address=settlement_address,
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('base_accounts', [['0xc37b40ABdB939635068d3c5f13E7faF686F03B65']])
 def test_1inch_base_v6_swap(base_inquirer, base_accounts):


### PR DESCRIPTION
1inch v5 Fusion/limit orders settled by a resolver were not decoded as a swap for the order maker. The v5 router emits the limit order protocol OrderFilled log (often before the maker's transfers) and the tx initiator is the resolver, so the from_address-based pairing in _decode_swapped never matched the maker's spend/receive legs.

Generalize the limit-order handling (previously v6 only) so v5 also pairs the maker's legs independently of the initiator, via a post-decoding rule that is robust to the OrderFilled log appearing before the transfers. v6 behavior is preserved (it still pairs during decoding; the post-decoding pass skips already-paired swaps).