### PR TITLE
Disable net worth graph line smoothing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The net worth graph on the dashboard no longer smooths the line between points, so it now reflects your actual balance changes instead of curving past them.
 * :bug:`-` 1inch v5 Fusion limit orders will now be properly decoded.
 * :bug:`-` Clicking a dialog's save button several times while it is still saving (for example when editing a history event that is slow to save) no longer sends the same change repeatedly, so you no longer risk creating duplicate entries by double-clicking.
 * :feature:`12420` ZKsync Lite sunset claims are now decoded and balances are shown correctly.

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-chart-config.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-chart-config.ts
@@ -87,7 +87,7 @@ export function useNetValueChartConfig(chartData: MaybeRefOrGetter<NetValueChart
     itemStyle: { color: get(baseColor) },
     lineStyle: { color: get(baseColor) },
     showSymbol: false,
-    smooth: true,
+    smooth: false,
     symbol: 'circle',
     symbolSize: 8,
     type: 'line',


### PR DESCRIPTION
## Description

The dashboard net worth graph rendered its line with `smooth: true`, which interpolates a curve between data points. This makes the line bend past the actual values and can misrepresent balance changes (e.g. curving above/below real net worth between snapshots).

This disables smoothing so the line connects points directly and reflects actual balance changes.

## Changes

- Set `smooth: false` in `use-net-value-chart-config.ts`.
- Added a user-facing changelog entry.