### PR TITLE
fix: link block number in MEV reward tx note

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The block number shown in a MEV reward transaction event's note is now a clickable link, like it already is for the related block production event.
 * :bug:`-` The net worth graph on the dashboard no longer smooths the line between points, so it now reflects your actual balance changes instead of curving past them.
 * :bug:`-` 1inch v5 Fusion limit orders will now be properly decoded.
 * :bug:`-` Clicking a dialog's save button several times while it is still saving (for example when editing a history event that is slow to save) no longer sends the same change repeatedly, so you no longer risk creating duplicate entries by double-clicking.

--- a/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.vue
@@ -61,6 +61,7 @@ const {
   validatorIndex,
 } = useHistoryEventItem({
   event: () => event,
+  groupEvents: () => completeGroupEvents,
   selection,
 });
 

--- a/frontend/app/src/modules/history/events/use-history-event-item.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-item.spec.ts
@@ -135,6 +135,25 @@ describe('useHistoryEventItem', () => {
       expect(get(blockNumber)).toBe(18000000);
     });
 
+    it('should recover blockNumber from a sibling group event when the event has none', () => {
+      const event = ref(createMockEvent({ groupIdentifier: 'BP1_18000000' }));
+      const groupEvents = ref<HistoryEventEntry[]>([
+        createMockEvent({ blockNumber: 18000000, groupIdentifier: 'BP1_18000000' }),
+        get(event),
+      ]);
+      const { blockNumber } = useHistoryEventItem({ event, groupEvents });
+
+      expect(get(blockNumber)).toBe(18000000);
+    });
+
+    it('should return undefined blockNumber when no sibling carries one', () => {
+      const event = ref(createMockEvent({ groupIdentifier: 'BP1_18000000' }));
+      const groupEvents = ref<HistoryEventEntry[]>([get(event)]);
+      const { blockNumber } = useHistoryEventItem({ event, groupEvents });
+
+      expect(get(blockNumber)).toBeUndefined();
+    });
+
     it('should return extraData from event', () => {
       const extraData = { key: 'value' };
       const event = ref(createMockEvent({

--- a/frontend/app/src/modules/history/events/use-history-event-item.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-item.ts
@@ -10,6 +10,12 @@ import { isEventMissingAccountingRule } from '@/modules/history/event-utils';
 export interface UseHistoryEventItemProps {
   event: MaybeRefOrGetter<HistoryEventEntry>;
   selection?: UseHistoryEventsSelectionModeReturn;
+  /**
+   * The other events that belong to the same group. Used to recover data that
+   * an event does not carry itself but a sibling does (e.g. the block number for
+   * MEV reward transaction events grouped under a block production event).
+   */
+  groupEvents?: MaybeRefOrGetter<HistoryEventEntry[]>;
 }
 
 export interface UseHistoryEventItemReturn {
@@ -36,7 +42,7 @@ export interface UseHistoryEventItemReturn {
 export function useHistoryEventItem(
   props: UseHistoryEventItemProps,
 ): UseHistoryEventItemReturn {
-  const { event, selection } = props;
+  const { event, groupEvents, selection } = props;
   const { getChain } = useSupportedChains();
   const { useAssetInfo } = useAssetInfoRetrieval();
   const { useIsAssetIgnored } = useAssetsStore();
@@ -92,7 +98,15 @@ export function useHistoryEventItem(
 
   const blockNumber = computed<number | undefined>(() => {
     const ev = toValue(event);
-    return 'blockNumber' in ev ? ev.blockNumber : undefined;
+    if ('blockNumber' in ev)
+      return ev.blockNumber;
+
+    // MEV reward transaction events are EVM events that get moved into a block
+    // production group. They don't carry a `blockNumber` field themselves, so
+    // recover it from a sibling block event in the same group to keep the note's
+    // block number linkable.
+    const sibling = toValue(groupEvents)?.find(other => 'blockNumber' in other);
+    return sibling && 'blockNumber' in sibling ? sibling.blockNumber : undefined;
   });
 
   const extraData = computed<Record<string, any> | undefined>(() => {

--- a/frontend/app/src/modules/history/events/use-history-event-note.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-note.spec.ts
@@ -434,6 +434,29 @@ describe('useHistoryEventNotes', () => {
     expect(formatted).toMatchObject(expected);
   });
 
+  it('should link the block number in a combined mev reward transaction note', () => {
+    // Note produced by the backend when a MEV reward transaction event is moved
+    // into a block production group (see db/eth2.py combine_block_with_tx_events).
+    // The event itself is an EVM event without a block number field; the block
+    // number is recovered from the group and passed in here.
+    const blockNumber = 17173975;
+    const txHash = '0xdb11f732bc83d29b52b20506cdd795196d3d0c5c42f9ad15b31bb4257c4990a5';
+    const notes = `Receive 0.05 ETH as mev reward for block ${blockNumber} in ${txHash}`;
+
+    const formatted = get(formatNotes({ notes, blockNumber, amount: bigNumberify(0.05), assetId: 'ETH' }));
+
+    expect(formatted).toContainEqual({
+      type: NoteType.BLOCK,
+      address: `${blockNumber}`,
+      showHashLink: true,
+    });
+    // the transaction hash should still be linked as a tx, not swallowed
+    expect(formatted).toContainEqual(expect.objectContaining({
+      type: NoteType.TX,
+      address: txHash,
+    }));
+  });
+
   it('should parse evm asset identifier', () => {
     const notes = 'Sell eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA';
 


### PR DESCRIPTION
## Problem

The block number in a **MEV reward transaction event**'s note was rendered as plain text instead of a clickable block link, even though the related **block production event** in the same group linked its block number fine.

## Root cause

MEV rewards arrive as two distinct events:

1. The `EthBlockEvent` (informational, *"Validator X produced block N. Relayer reported …"*) — carries a typed `blockNumber` field, so its note linkifies correctly.
2. The **actual MEV reward** — a regular EVM transaction event that `combine_block_with_tx_events` moves into the block production group (`BP1_<block>`) with a note like *"… as mev reward for block N in 0x…"*. This event is an `EvmHistoryEvent` and has **no** `blockNumber` field.

`processBlockNumber` only links a word when it equals the event's `blockNumber`. For the EVM MEV event that value was `undefined`, so the block number never linked.

## Fix

`useHistoryEventItem` now recovers the block number from a sibling event in the same group (the block production `EthBlockEvent`, which has the typed `blockNumber`). This relies only on the stable `blockNumber` field contract and the existing group, not on parsing the backend's `BP1_` group-identifier format. The note matcher itself is unchanged.

## Tests

- `use-history-event-item.spec.ts`: recovers `blockNumber` from a sibling group event when the event has none; returns `undefined` when no sibling carries one (regression guard — fails on the old code).
- `use-history-event-note.spec.ts`: the real combined note *"… as mev reward for block N in 0x…"* now links the block number while keeping the tx hash linked.