### PR TITLE
Adjust page limit for etherscan

### DIFF
--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
-ETHERSCAN_PAGINATION_LIMIT: Final = 10000
+ETHERSCAN_PAGINATION_LIMIT: Final = 1000
 ETHERSCAN_BASE_URL: Final = 'https://api.etherscan.io/v2/api'
 ROTKI_PACKAGED_KEY: Final = ApiKey('W9CEV6QB9NIPUEHD6KNEYM4PDX6KBPRVVR')
 


### PR DESCRIPTION
Adjusts the max page size to 1000 in anticipation of the changes in https://docs.etherscan.io/changelog#upcoming-change-reduced-maximum-records-per-request-on-the-free-api-tier

Checked that all the endpoints that we use are listed on the announcement so I changed the global limit.