### PR TITLE
Gate MCP access behind Basic premium tier and up

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -686,7 +686,7 @@ Querying premium capabilities
      - `enabled` (Boolean): Enables automatic matching of exchange asset movements with onchain events when triggering the matching task.
      - `minimum_tier` (String): The minimum tier required to unlock this capability.
    - `minimum_tier` can be `null` if the key is not present in the unlocks response from the server.
-   - `current_tier`: String. Current user tier name (for example `Free`, `lite`, `Basic`, `Advanced`).
+   - `current_tier`: String. Current user tier name. As of this writing the possible values are `Free` (no active subscription), `Supporter`, `Basic` and `Advanced`. The tier names are defined server-side, not in this repository, so the authoritative and up-to-date list can be fetched with an unauthenticated ``GET`` at ``https://rotki.com/webapi/2/available-tiers`` (the ``tier_name`` field of each entry). Paid tiers are ordered `Supporter` < `Basic` < `Advanced`.
    - `limit_of_devices`: Integer. Maximum number of connected devices.
    - `history_events_limit`: Integer. Maximum number of history events.
    - `pnl_events_limit`: Integer. Maximum number of PnL events.

--- a/rotkehlchen/mcp/premium.py
+++ b/rotkehlchen/mcp/premium.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Final
+
+from rotkehlchen.mcp.backend import BackendQueryError, get_backend_config, request_api
+
+DEFAULT_TIER: Final = 'Free'
+# Tiers that do NOT grant MCP access. Everything else (Basic and up) does. The tier
+# names are defined server-side, not here; the authoritative list can be fetched from
+# https://rotki.com/webapi/2/available-tiers (the `tier_name` of each entry). As of this
+# writing the paid tiers are ordered Supporter < Basic < Advanced.
+NON_MCP_TIERS: Final = frozenset({DEFAULT_TIER, 'Supporter'})
+PREMIUM_CACHE_TTL: Final = 60.0
+UPGRADE_URL: Final = 'https://rotki.com/products/'
+
+_premium_cache: tuple[float, bool] | None = None
+
+
+def _query_mcp_access() -> bool:
+    backend_config = get_backend_config()
+    payload = request_api(
+        base_url=backend_config.base_url,
+        endpoint='premium/capabilities',
+        timeout=backend_config.timeout,
+    )
+    if not isinstance(result := payload.get('result'), dict):
+        raise BackendQueryError(
+            'rotki backend returned an unexpected premium capabilities response',
+        )
+    return result.get('current_tier', DEFAULT_TIER) not in NON_MCP_TIERS
+
+
+def has_mcp_access() -> bool:
+    """Return whether the unlocked backend's subscription tier grants MCP access.
+
+    MCP is available to the Basic tier and up; the Free and Supporter tiers are excluded.
+    The result is cached for PREMIUM_CACHE_TTL seconds so gated tools don't hit the
+    backend on every call, while still noticing a subscription that lapses or starts
+    mid-session.
+    """
+    global _premium_cache  # noqa: PLW0603 -- short-lived MCP premium status cache
+    now = time.monotonic()
+    if _premium_cache is not None and now - _premium_cache[0] < PREMIUM_CACHE_TTL:
+        return _premium_cache[1]
+
+    allowed = _query_mcp_access()
+    _premium_cache = (now, allowed)
+    return allowed
+
+
+def reset_premium_cache() -> None:
+    """Clear the cached premium status. Mainly useful for tests."""
+    global _premium_cache  # noqa: PLW0603 -- short-lived MCP premium status cache
+    _premium_cache = None
+
+
+def premium_gate() -> dict[str, Any] | None:
+    """Return a structured error if MCP access should be blocked, otherwise None.
+
+    A backend that cannot be reached or queried is treated as ineligible so gated
+    tools fail closed rather than leaking data.
+    """
+    try:
+        if has_mcp_access():
+            return None
+    except BackendQueryError as e:
+        return {
+            'error': 'premium_check_failed',
+            'message': f'Could not verify rotki premium subscription: {e!s}',
+            'upgrade_url': UPGRADE_URL,
+        }
+
+    return {
+        'error': 'premium_required',
+        'message': 'This tool requires a rotki Basic subscription or higher.',
+        'upgrade_url': UPGRADE_URL,
+    }

--- a/rotkehlchen/mcp/registry.py
+++ b/rotkehlchen/mcp/registry.py
@@ -12,10 +12,17 @@ def register_tool(
         fn: Callable[..., Any] | None = None,
         *,
         name: str | None = None,
+        premium: bool = True,
 ) -> Callable[..., Any]:
-    """Register a decorated function as an MCP tool."""
+    """Register a decorated function as an MCP tool.
+
+    Tools require an active premium subscription by default. Pass ``premium=False`` for
+    tools that must stay available to everyone (e.g. ``info``), so a new tool can never
+    leak data for free by forgetting to opt in.
+    """
     def _decorate(function: Callable[..., Any]) -> Callable[..., Any]:
         function.__mcp_tool_name__ = name or function.__name__  # type: ignore[attr-defined]
+        function.__mcp_premium__ = premium  # type: ignore[attr-defined]
         AVAILABLE_TOOLS.append(function)
         return function
 

--- a/rotkehlchen/mcp/server.py
+++ b/rotkehlchen/mcp/server.py
@@ -1,10 +1,33 @@
 from __future__ import annotations
 
+import asyncio
+import functools
+from typing import TYPE_CHECKING, Any
+
 from mcp.server.fastmcp import FastMCP
 
 from rotkehlchen.mcp.backend import configure_backend
 from rotkehlchen.mcp.constants import SERVICE_NAME, LogLevel
+from rotkehlchen.mcp.premium import premium_gate
 from rotkehlchen.mcp.registry import discover_tools
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _gate_with_premium(tool_function: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a tool so it returns a structured error unless the backend has premium.
+
+    ``functools.wraps`` keeps the original signature and docstring so FastMCP still
+    derives the correct input schema from the wrapped tool.
+    """
+    @functools.wraps(tool_function)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if (error := await asyncio.to_thread(premium_gate)) is not None:
+            return error
+        return await tool_function(*args, **kwargs)
+
+    return wrapper
 
 
 def setup_server(backend_url: str, timeout: int, log_level: LogLevel) -> FastMCP:
@@ -15,7 +38,8 @@ def setup_server(backend_url: str, timeout: int, log_level: LogLevel) -> FastMCP
         default_name = getattr(tool_function, '__name__', 'unknown')
         tool_name = getattr(tool_function, '__mcp_tool_name__', default_name)
         server.add_tool(
-            tool_function,
+            _gate_with_premium(tool_function)
+            if getattr(tool_function, '__mcp_premium__', True) else tool_function,
             name=tool_name,
             description=tool_function.__doc__,
         )

--- a/rotkehlchen/mcp/tools/info.py
+++ b/rotkehlchen/mcp/tools/info.py
@@ -69,7 +69,7 @@ def get_info() -> dict[str, Any]:
     }
 
 
-@register_tool(name='info')
+@register_tool(name='info', premium=False)
 async def info() -> dict[str, Any]:
     """Return rotki version and verify connectivity to the unlocked backend."""
     return await asyncio.to_thread(get_info)

--- a/rotkehlchen/tests/mcp/test_premium.py
+++ b/rotkehlchen/tests/mcp/test_premium.py
@@ -1,0 +1,90 @@
+from collections.abc import Generator
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+import requests
+
+from rotkehlchen.mcp import premium
+from rotkehlchen.mcp.backend import configure_backend
+
+
+class MockResponse:
+    def __init__(
+            self,
+            payload: dict[str, Any],
+            status_code: HTTPStatus = HTTPStatus.OK,
+            text: str = '',
+    ) -> None:
+        self.payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+
+@pytest.fixture(autouse=True)
+def reset_cache() -> Generator[None]:
+    premium.reset_premium_cache()
+    yield
+    premium.reset_premium_cache()
+
+
+def _mock_tier(monkeypatch, tier: str) -> list[str]:
+    """Patch requests.get to return the given premium tier, tracking each call."""
+    calls: list[str] = []
+
+    def mock_get(url: str, **kwargs: Any) -> MockResponse:
+        calls.append(url)
+        return MockResponse({'result': {'current_tier': tier}, 'message': ''})
+
+    monkeypatch.setattr(requests, 'get', mock_get)
+    configure_backend(base_url='http://backend/api/1', timeout=5)
+    return calls
+
+
+@pytest.mark.parametrize('tier', ['Basic', 'Advanced'])
+def test_has_mcp_access_should_be_true_for_basic_and_up(monkeypatch, tier: str) -> None:
+    _mock_tier(monkeypatch, tier)
+    assert premium.has_mcp_access() is True
+
+
+@pytest.mark.parametrize('tier', ['Free', 'Supporter'])
+def test_has_mcp_access_should_be_false_for_free_and_supporter(monkeypatch, tier: str) -> None:
+    _mock_tier(monkeypatch, tier)
+    assert premium.has_mcp_access() is False
+
+
+def test_has_mcp_access_should_cache_result(monkeypatch) -> None:
+    calls = _mock_tier(monkeypatch, 'Advanced')
+    assert premium.has_mcp_access() is True
+    assert premium.has_mcp_access() is True
+    assert len(calls) == 1  # second call served from the cache, no extra backend hit
+
+
+def test_premium_gate_should_allow_basic_backend(monkeypatch) -> None:
+    _mock_tier(monkeypatch, 'Basic')
+    assert premium.premium_gate() is None
+
+
+@pytest.mark.parametrize('tier', ['Free', 'Supporter'])
+def test_premium_gate_should_block_free_and_supporter(monkeypatch, tier: str) -> None:
+    _mock_tier(monkeypatch, tier)
+    error = premium.premium_gate()
+    assert error is not None
+    assert error['error'] == 'premium_required'
+    assert error['upgrade_url'] == premium.UPGRADE_URL
+
+
+def test_premium_gate_should_fail_closed_when_backend_unreachable(monkeypatch) -> None:
+    def mock_get(url: str, **kwargs: Any) -> MockResponse:
+        raise requests.exceptions.ConnectionError('connection refused')
+
+    monkeypatch.setattr(requests, 'get', mock_get)
+    configure_backend(base_url='http://backend/api/1', timeout=5)
+
+    error = premium.premium_gate()
+    assert error is not None
+    assert error['error'] == 'premium_check_failed'
+    assert 'Could not verify rotki premium subscription' in error['message']

--- a/rotkehlchen/tests/mcp/test_server.py
+++ b/rotkehlchen/tests/mcp/test_server.py
@@ -1,3 +1,5 @@
+import asyncio
+import selectors
 from typing import Any
 
 from rotkehlchen.mcp import server
@@ -27,6 +29,7 @@ def test_setup_server_should_register_discovered_tools(monkeypatch) -> None:
         return {'result': 'ok'}
 
     fake_tool.__mcp_tool_name__ = 'fake_tool'  # type: ignore[attr-defined]
+    fake_tool.__mcp_premium__ = False  # type: ignore[attr-defined]
 
     monkeypatch.setattr(server, 'discover_tools', lambda: [fake_tool])
 
@@ -38,3 +41,49 @@ def test_setup_server_should_register_discovered_tools(monkeypatch) -> None:
 
     assert init_args == {'name': SERVICE_NAME, 'log_level': 'DEBUG'}
     assert tools == [('fake_tool', None, fake_tool)]
+
+
+def test_setup_server_should_gate_premium_tools(monkeypatch) -> None:
+    """A premium-gated tool is wrapped so it can't run without an active subscription."""
+    tools = []
+
+    class MockFastMCP:
+        def __init__(self, name: str, log_level: str) -> None:
+            pass
+
+        def add_tool(self, fn: Any, name: str, description: str | None = None) -> None:
+            tools.append((name, description, fn))
+
+    monkeypatch.setattr(server, 'FastMCP', MockFastMCP)
+
+    calls = []
+
+    async def gated_tool() -> dict[str, Any]:  # noqa: RUF029  -- mimics an async MCP tool
+        """A gated tool."""
+        calls.append('ran')
+        return {'result': 'ok'}
+
+    gated_tool.__mcp_tool_name__ = 'gated_tool'  # type: ignore[attr-defined]
+    gated_tool.__mcp_premium__ = True  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(server, 'discover_tools', lambda: [gated_tool])
+    server.setup_server(backend_url='http://backend/api/1', timeout=3, log_level='DEBUG')
+
+    name, description, wrapped = tools[0]
+    assert name == 'gated_tool'
+    assert description == 'A gated tool.'  # docstring preserved through the wrapper
+    assert wrapped is not gated_tool  # the gated tool got wrapped
+
+    loop = asyncio.SelectorEventLoop(selectors.SelectSelector())
+    try:
+        # backend reports no premium -> wrapper short-circuits with an error
+        monkeypatch.setattr(server, 'premium_gate', lambda: {'error': 'premium_required'})
+        assert loop.run_until_complete(wrapped()) == {'error': 'premium_required'}
+        assert calls == []  # the underlying tool never ran
+
+        # backend reports premium -> wrapper delegates to the real tool
+        monkeypatch.setattr(server, 'premium_gate', lambda: None)
+        assert loop.run_until_complete(wrapped()) == {'result': 'ok'}
+        assert calls == ['ran']
+    finally:
+        loop.close()


### PR DESCRIPTION
The MCP server gated all tools equally (none, actually) regardless of subscription. Gate every tool except info behind the premium check, with MCP available to the Basic tier and up while Free and Supporter are excluded.

Part of https://github.com/rotki/rotki/issues/12171
