### PR TITLE
Add MCP get_balances and query_history_events tools

### DIFF
--- a/rotkehlchen/mcp/__main__.py
+++ b/rotkehlchen/mcp/__main__.py
@@ -30,8 +30,34 @@ def main(argv: Sequence[str] | None = None) -> None:
         choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
         help='MCP server log level. Defaults to %(default)s',
     )
+    parser.add_argument(
+        '--privacy-mode',
+        default=os.environ.get('ROTKI_MCP_PRIVACY_MODE', 'balanced'),
+        choices=('balanced', 'strict', 'raw'),
+        help=(
+            'How aggressively to strip identifiers before data reaches the LLM. '
+            '"raw" disables all filtering and must be chosen explicitly. '
+            'Defaults to %(default)s'
+        ),
+    )
+    parser.add_argument(
+        '--max-events',
+        default=os.environ.get('ROTKI_MCP_MAX_EVENTS'),
+        type=int,
+        help=(
+            'Cap how many history events a single analytics load pulls in. By default '
+            'there is no cap, so the complete (time-scoped) set is loaded. Set this only '
+            'to bound load time on a very large history.'
+        ),
+    )
     args = parser.parse_args(argv)
-    run_server(backend_url=args.backend_url, timeout=args.timeout, log_level=args.log_level)
+    run_server(
+        backend_url=args.backend_url,
+        timeout=args.timeout,
+        log_level=args.log_level,
+        privacy_mode=args.privacy_mode,
+        max_events=args.max_events,
+    )
 
 
 if __name__ == '__main__':

--- a/rotkehlchen/mcp/analytics.py
+++ b/rotkehlchen/mcp/analytics.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import hmac
+import json
+import re
+import secrets
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import TYPE_CHECKING, Any, Final
+
+import polars as pl
+
+from rotkehlchen.mcp.backend import (
+    BackendQueryError,
+    get_backend_config,
+    query_all_balances,
+    query_history_events_page,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from rotkehlchen.mcp.constants import PrivacyMode
+
+PAGE_SIZE: Final = 1000
+DEFAULT_MAX_RESULT_ROWS: Final = 500
+MAX_RESULT_ROWS: Final = 5_000
+REDACTED_TEXT: Final = '[redacted]'
+DEFAULT_TABLES: Final = ('history_events',)
+AVAILABLE_TABLES: Final = ('history_events', 'balances')
+# Any real unix-seconds timestamp is well below this (1e11 s ~= year 5138), while a
+# millisecond timestamp is ~1.7e12. Used to accept either unit for the time-range filter:
+# the event ``timestamp`` column is in ms, so an LLM naturally passes ms here too.
+MS_THRESHOLD: Final = 10**11
+
+# --- privacy classification -------------------------------------------------------------
+# Free-text columns: never emitted verbatim outside ``raw`` mode (only a ``has_<col>``
+# flag). ``auto_notes`` is rotki's decoded description and routinely embeds addresses, so
+# it is treated as free text rather than a safe value.
+TEXT_COLUMN_NAMES: Final = frozenset({'notes', 'user_notes', 'auto_notes'})
+# Identifier columns that are always personally identifying: hashed (never raw) outside
+# ``raw`` mode. ``location_label`` is special-cased in ``balanced`` (see _sanitize_identifier).
+PII_COLUMN_NAMES: Final = frozenset({
+    'account',
+    'address',
+    'group_identifier',
+    'event_identifier',
+    'location_label',
+    'tx_hash',
+})
+# In ``strict`` mode, user-authored labels and names are treated as identifiers too.
+STRICT_IDENTIFIER_COLUMN_NAMES: Final = PII_COLUMN_NAMES | frozenset({'label', 'name', 'tag'})
+# The ONLY columns allowed through verbatim outside ``raw`` mode. This is the core of the
+# fail-closed design: anything whose base name is not here, and that is not handled by the
+# text/identifier paths above, is hashed (if a string) rather than leaked. Adding a new
+# nested field upstream therefore defaults to "hidden", not "exposed".
+SAFE_PASSTHROUGH_COLUMN_NAMES: Final = frozenset({
+    'amount',
+    'asset',
+    'balance',
+    'category',
+    'counterparty',
+    'entry_type',
+    'event_subtype',
+    'event_type',
+    'ignored_asset',
+    'location',
+    'percentage_of_net_value',
+    'price',
+    'product',
+    'sequence_index',
+    'timestamp',
+    'usd_value',
+    'value',
+})
+
+ALLOWED_SQL_PREFIXES: Final = ('select ', 'with ')
+DENIED_SQL_TOKENS: Final = frozenset({
+    'alter', 'attach', 'copy', 'create', 'delete', 'drop',
+    'insert', 'replace', 'truncate', 'update',
+})
+SQL_ERROR_HINT: Final = (
+    'Use list_tables() and describe_table(table) to inspect the schema, then query, e.g. '
+    '`select * from history_events limit 1`.'
+)
+# Detects bare crypto identifiers embedded in otherwise-safe strings (defence in depth on
+# top of the column allowlist; catches e.g. an address inside a counterparty product url).
+SENSITIVE_IDENTIFIER_RE: Final = re.compile(
+    r'(?:'
+    r'0x[a-fA-F0-9]{40}|'           # EVM address
+    r'0x[a-fA-F0-9]{64}|'           # EVM tx/hash
+    r'(?:bc1|tb1)[ac-hj-np-z02-9]{20,90}|'  # bech32 BTC
+    r'[13][a-km-zA-HJ-NP-Z1-9]{25,34}|'     # base58 BTC
+    r'[1-9A-HJ-NP-Za-km-z]{32,44}'  # base58 (Solana etc.)
+    r')',
+)
+
+# Per-process random seed so the same identifier hashes consistently within a session
+# (GROUP BY / joins over the hash still work) but is not linkable across sessions or back
+# to the real value.
+_session_seed: Final = secrets.token_bytes(32)
+
+
+@dataclass(frozen=True)
+class TableData:
+    frame: pl.DataFrame
+    source: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AnalyticsScope:
+    from_timestamp: int | None
+    to_timestamp: int | None
+    include_ignored_assets: bool
+    privacy_mode: PrivacyMode
+
+
+def _hash_identifier(value: Any) -> str | None:
+    if value is None:
+        return None
+    return f'anon_{hmac.new(_session_seed, str(value).encode(), sha256).hexdigest()[:16]}'
+
+
+_KNOWN_COLUMN_NAMES: Final = tuple(sorted(
+    TEXT_COLUMN_NAMES | STRICT_IDENTIFIER_COLUMN_NAMES | SAFE_PASSTHROUGH_COLUMN_NAMES,
+    key=len,
+    reverse=True,
+))
+
+
+def _base_column_name(column: str) -> str:
+    """The flattener prefixes nested keys (``extra_data_address``). Resolve a flattened
+    column to the known base name it carries (longest match wins, so ``location_label``
+    stays ``location_label`` rather than collapsing to ``label``); unknown columns return
+    themselves and thus fall through to the fail-closed branch.
+    """
+    for known in _KNOWN_COLUMN_NAMES:
+        if column == known or column.endswith(f'_{known}'):
+            return known
+    return column
+
+
+def _to_float(value: Any) -> float | None:
+    if value in (None, ''):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _json_scalar(value: Any) -> Any:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    return json.dumps(value, default=str, sort_keys=True)
+
+
+def _flatten(value: dict[str, Any], prefix: str = '') -> dict[str, Any]:
+    """Recursively flatten a nested mapping into ``parent_child`` keyed scalars. Numeric
+    strings additionally get a ``<col>_float`` companion so SQL can do arithmetic directly.
+    """
+    row: dict[str, Any] = {}
+    for key, nested in value.items():
+        column = f'{prefix}_{key}' if prefix else str(key)
+        if isinstance(nested, dict):
+            row.update(_flatten(nested, prefix=column))
+            continue
+        scalar = _json_scalar(nested)
+        row[column] = scalar
+        if isinstance(scalar, str) and (as_float := _to_float(scalar)) is not None:
+            row[f'{column}_float'] = as_float
+    return row
+
+
+def _sanitize_row(row: dict[str, Any], privacy_mode: PrivacyMode) -> dict[str, Any]:
+    """Strip identifiers from one flattened row according to ``privacy_mode``.
+
+    Fail-closed: a column is emitted verbatim only if it is explicitly allowlisted (or we
+    are in ``raw`` mode). Every other string is hashed rather than passed through, so a
+    field we have never seen before defaults to hidden. Numbers/bools are the analytic
+    payload and are kept (they carry no identifier on their own).
+    """
+    if privacy_mode == 'raw':
+        return row
+
+    identifier_columns = (
+        STRICT_IDENTIFIER_COLUMN_NAMES if privacy_mode == 'strict' else PII_COLUMN_NAMES
+    )
+    sanitized: dict[str, Any] = {}
+    for column, value in row.items():
+        base = _base_column_name(column)
+        if base in TEXT_COLUMN_NAMES:
+            has_value = value not in (None, '')
+            sanitized[f'has_{column}'] = has_value
+            sanitized[column] = REDACTED_TEXT if has_value else None
+        elif base in identifier_columns:
+            sanitized[f'{column}_hash'] = _hash_identifier(value)
+            # In balanced mode a human-friendly account label (e.g. "Kraken main") that is
+            # not itself an address stays readable; anything address-shaped is hashed only.
+            if (
+                privacy_mode == 'balanced' and
+                base == 'location_label' and
+                isinstance(value, str) and
+                SENSITIVE_IDENTIFIER_RE.search(value) is None
+            ):
+                sanitized[column] = value
+        elif base in SAFE_PASSTHROUGH_COLUMN_NAMES:
+            sanitized[column] = value
+        elif isinstance(value, str):
+            # Unrecognized string: never leak it. Keep a numeric companion if it is really
+            # a number, otherwise hash it so it can still be grouped/joined on.
+            if (as_float := _to_float(value)) is not None:
+                sanitized[f'{column}_float'] = as_float
+            else:
+                sanitized[f'{column}_hash'] = _hash_identifier(value)
+        else:
+            sanitized[column] = value  # int / float / bool / None: safe analytic payload
+    return sanitized
+
+
+def _promote_entry(raw: dict[str, Any]) -> dict[str, Any]:
+    """The history/events API wraps each event's fields in an ``entry`` sub-object next to
+    sibling metadata. Promote those fields to the top level so SQL columns read as
+    ``timestamp``/``location``/``asset`` rather than ``entry_timestamp`` etc.
+    """
+    if not isinstance(inner := raw.get('entry'), dict):
+        return raw
+    return {**{key: value for key, value in raw.items() if key != 'entry'}, **inner}
+
+
+def _load_history_events(scope: AnalyticsScope) -> TableData:
+    # No cap by default: load the complete (time-scoped) set so the user gets complete data
+    # unless they explicitly bound it with --max-events to limit load time on a huge history.
+    max_events = get_backend_config().max_events
+    rows: list[dict[str, Any]] = []
+    offset = 0
+    entries_found: int | None = None
+    entries_total: int | None = None
+    entries_limit: int | None = None
+    while max_events is None or len(rows) < max_events:
+        result = query_history_events_page(
+            limit=PAGE_SIZE,
+            offset=offset,
+            from_timestamp=scope.from_timestamp,
+            to_timestamp=scope.to_timestamp,
+            exclude_ignored_assets=scope.include_ignored_assets is False,
+        )
+        entries_found = result.get('entries_found')
+        entries_total = result.get('entries_total')
+        entries_limit = result.get('entries_limit')
+        if not isinstance(entries := result.get('entries'), list) or len(entries) == 0:
+            break
+
+        rows.extend(
+            _sanitize_row(_flatten(_promote_entry(entry)), scope.privacy_mode)
+            for entry in entries if isinstance(entry, dict)
+        )
+        offset += PAGE_SIZE
+        if isinstance(entries_found, int) and offset >= entries_found:
+            break
+
+    if max_events is not None and len(rows) > max_events:
+        rows = rows[:max_events]
+    cache_truncated = (
+        max_events is not None and
+        isinstance(entries_found, int) and
+        entries_found > len(rows)
+    )
+    frame = pl.DataFrame(rows, infer_schema_length=None) if rows else pl.DataFrame()
+    if 'timestamp' in frame.columns and frame.schema['timestamp'].is_integer():
+        # Add readable date columns derived from the ms timestamp so an LLM can filter on
+        # `year` / `datetime` instead of computing error-prone unix-millisecond bounds.
+        frame = frame.with_columns(
+            _dt=pl.from_epoch(pl.col('timestamp'), time_unit='ms'),
+        ).with_columns(
+            datetime=pl.col('_dt').dt.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            year=pl.col('_dt').dt.year(),
+        ).drop('_dt')
+
+    return TableData(
+        frame=frame,
+        source={
+            'endpoint': 'history/events',
+            'range_scoped': True,
+            'cached_rows': len(rows),
+            'cache_truncated': cache_truncated,
+            'entries_found': entries_found,
+            'entries_total': entries_total,
+            'entries_limit': entries_limit,
+            'privacy_mode': scope.privacy_mode,
+        },
+    )
+
+
+def _load_balances(scope: AnalyticsScope) -> TableData:
+    # Never force a refresh here: recalculating balances is slow and should stay an explicit
+    # user action in the app. The analytics layer reads the latest cached snapshot.
+    result = query_all_balances(refresh=False, timeout=get_backend_config().timeout)
+    rows: list[dict[str, Any]] = []
+    for category in ('assets', 'liabilities'):
+        holdings = result.get(category)
+        if not isinstance(holdings, dict):
+            continue
+        for asset, data in holdings.items():
+            if not isinstance(data, dict):
+                continue
+            rows.append(_sanitize_row(
+                _flatten({'category': category[:-1], 'asset': asset, **data}),
+                scope.privacy_mode,
+            ))
+
+    return TableData(
+        frame=pl.DataFrame(rows, infer_schema_length=None) if rows else pl.DataFrame(),
+        source={
+            'endpoint': 'balances',
+            'range_scoped': False,
+            'cached_rows': len(rows),
+            'net_value': result.get('net_value'),
+            'privacy_mode': scope.privacy_mode,
+        },
+    )
+
+
+TABLE_LOADERS: Final[dict[str, Callable[[AnalyticsScope], TableData]]] = {
+    'history_events': _load_history_events,
+    'balances': _load_balances,
+}
+
+
+def _normalize_tables(tables: list[str] | None) -> list[str]:
+    return sorted(set(tables)) if tables else list(DEFAULT_TABLES)
+
+
+def _filter_seconds(timestamp: int) -> int | None:
+    """Normalize a time-range bound to unix seconds for the backend filter. 0 means no
+    bound; a millisecond value (the unit of the ``timestamp`` column) is accepted and
+    converted, so callers can pass milliseconds consistently.
+    """
+    if not timestamp:
+        return None
+    return timestamp // 1000 if timestamp >= MS_THRESHOLD else timestamp
+
+
+def _validate_sql(sql: str) -> str | None:
+    normalized = ' '.join(sql.strip().lower().split())
+    if not normalized.startswith(ALLOWED_SQL_PREFIXES):
+        return 'Only read-only SELECT/WITH queries over analytics tables are allowed'
+    if ';' in normalized.rstrip(';'):
+        return 'Only a single SQL statement is allowed'
+    tokens = set(normalized.replace(',', ' ').replace('(', ' ').replace(')', ' ').split())
+    if disallowed := tokens & DENIED_SQL_TOKENS:
+        return f'Disallowed SQL token(s): {", ".join(sorted(disallowed))}'
+    return None
+
+
+def _error(error_type: str, message: str, **details: Any) -> dict[str, Any]:
+    return {'error': {'type': error_type, 'message': message, 'hint': SQL_ERROR_HINT, **details}}
+
+
+def _summary(table: str, table_data: TableData) -> dict[str, Any]:
+    return {'table': table, 'rows': table_data.frame.height, 'source': table_data.source}
+
+
+class AnalyticsSession:
+    """In-memory, privacy-filtered table store queried with Polars SQL. One instance lives
+    for the lifetime of the MCP server process and is shared across tool calls.
+    """
+
+    def __init__(self) -> None:
+        self._tables: dict[str, TableData] = {}
+        self._last_scope: AnalyticsScope | None = None
+
+    def _current_scope(
+            self,
+            from_timestamp: int,
+            to_timestamp: int,
+            include_ignored_assets: bool,
+    ) -> AnalyticsScope:
+        return AnalyticsScope(
+            from_timestamp=_filter_seconds(from_timestamp),
+            to_timestamp=_filter_seconds(to_timestamp),
+            include_ignored_assets=include_ignored_assets,
+            privacy_mode=get_backend_config().privacy_mode,
+        )
+
+    def refresh(
+            self,
+            tables: list[str] | None,
+            from_timestamp: int,
+            to_timestamp: int,
+            include_ignored_assets: bool,
+    ) -> dict[str, Any]:
+        scope = self._current_scope(from_timestamp, to_timestamp, include_ignored_assets)
+        loaded: dict[str, Any] = {}
+        errors: dict[str, str] = {}
+        for table in _normalize_tables(tables):
+            if (loader := TABLE_LOADERS.get(table)) is None:
+                errors[table] = f'Unknown table {table!r}. Available: {list(AVAILABLE_TABLES)}'
+                continue
+            try:
+                self._tables[table] = (table_data := loader(scope))
+            except BackendQueryError as e:
+                errors[table] = str(e)
+            except (KeyError, TypeError, pl.exceptions.PolarsError) as e:
+                errors[table] = str(e)
+            else:
+                loaded[table] = _summary(table, table_data)
+
+        self._last_scope = scope
+        return {'tables': loaded, 'errors': errors, 'privacy_mode': scope.privacy_mode}
+
+    def list_tables(self) -> dict[str, Any]:
+        return {
+            'loaded': {t: _summary(t, d) for t, d in sorted(self._tables.items())},
+            'default_tables': list(DEFAULT_TABLES),
+            'available_tables': list(AVAILABLE_TABLES),
+            'privacy_mode': get_backend_config().privacy_mode,
+        }
+
+    def describe_table(self, table: str) -> dict[str, Any]:
+        if (table_data := self._tables.get(table)) is None:
+            return _error(
+                'unknown_table',
+                f'Table {table!r} is not loaded. Call refresh_analytics_data first.',
+                available_tables=list(AVAILABLE_TABLES),
+            )
+        return {
+            'table': table,
+            'columns': [
+                {'name': name, 'dtype': str(dtype)}
+                for name, dtype in table_data.frame.schema.items()
+            ],
+            'rows': table_data.frame.height,
+            'source': table_data.source,
+        }
+
+    def query_sql(self, sql: str, max_rows: int) -> dict[str, Any]:
+        if (error := _validate_sql(sql)) is not None:
+            return _error('validation_error', error)
+        if len(self._tables) == 0:
+            return _error(
+                'no_tables_loaded',
+                'No analytics tables are loaded yet. Call refresh_analytics_data first.',
+            )
+
+        context = pl.SQLContext()
+        for table, table_data in self._tables.items():
+            context.register(table, table_data.frame)
+        try:
+            result_frame = context.execute(sql, eager=True)
+        except pl.exceptions.PolarsError as e:
+            return _error(
+                'sql_execution_error',
+                str(e),
+                available_columns={t: d.frame.columns for t, d in self._tables.items()},
+            )
+
+        bounded = min(max(max_rows, 1), MAX_RESULT_ROWS)
+        result_rows = result_frame.head(bounded).to_dicts()
+        return {
+            'columns': result_frame.columns,
+            'rows': result_rows,
+            'row_count': result_frame.height,
+            'returned_rows': len(result_rows),
+            'result_truncated': result_frame.height > bounded,
+            'privacy_mode': get_backend_config().privacy_mode,
+        }
+
+    def clear(self) -> None:
+        self._tables.clear()
+        self._last_scope = None
+
+
+_analytics_session = AnalyticsSession()
+
+
+def get_analytics_session() -> AnalyticsSession:
+    return _analytics_session

--- a/rotkehlchen/mcp/backend.py
+++ b/rotkehlchen/mcp/backend.py
@@ -2,19 +2,28 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final, Literal
 
 import requests
+
+if TYPE_CHECKING:
+    from rotkehlchen.mcp.constants import PrivacyMode
 
 DEFAULT_BACKEND_HOST: Final = '127.0.0.1'
 DEFAULT_BACKEND_PORT: Final = 4242
 DEFAULT_BACKEND_URL: Final = f'http://{DEFAULT_BACKEND_HOST}:{DEFAULT_BACKEND_PORT}/api/1'
+DEFAULT_PRIVACY_MODE: Final[PrivacyMode] = 'balanced'
 
 
 @dataclass(frozen=True)
 class BackendConfig:
     base_url: str
     timeout: int
+    privacy_mode: PrivacyMode = DEFAULT_PRIVACY_MODE
+    # Optional cap on how many history events a single analytics load pulls in. None means
+    # no cap (load the complete set) so users get complete data by default; set it only to
+    # bound load time/cost on a very large history.
+    max_events: int | None = None
 
 
 _backend_config = BackendConfig(base_url=DEFAULT_BACKEND_URL, timeout=5)
@@ -24,9 +33,19 @@ class BackendQueryError(Exception):
     """Raised when the local rotki backend cannot be queried."""
 
 
-def configure_backend(base_url: str, timeout: int) -> None:
+def configure_backend(
+        base_url: str,
+        timeout: int,
+        privacy_mode: PrivacyMode = DEFAULT_PRIVACY_MODE,
+        max_events: int | None = None,
+) -> None:
     global _backend_config  # noqa: PLW0603  -- MCP server startup config for registered tools
-    _backend_config = BackendConfig(base_url=base_url, timeout=timeout)
+    _backend_config = BackendConfig(
+        base_url=base_url,
+        timeout=timeout,
+        privacy_mode=privacy_mode,
+        max_events=max_events,
+    )
 
 
 def get_backend_config() -> BackendConfig:
@@ -42,10 +61,20 @@ def request_api(
         endpoint: str,
         timeout: int,
         params: dict[str, Any] | None = None,
+        json_data: dict[str, Any] | None = None,
+        method: Literal['GET', 'POST'] = 'GET',
 ) -> dict[str, Any]:
+    """Query the local rotki REST API and return its decoded ``{result, message}`` payload.
+
+    ``method`` selects the verb: plain reads use ``GET`` (with ``params`` for the query
+    string), while endpoints that take a filter body (e.g. ``/history/events``) use
+    ``POST`` with ``json_data``. Any failure to reach, or make sense of, the backend is
+    surfaced as a ``BackendQueryError`` so tools can fail closed.
+    """
     url = _api_url(base_url=base_url, endpoint=endpoint)
+    request = requests.post if method == 'POST' else requests.get
     try:
-        response = requests.get(url=url, params=params, timeout=timeout)
+        response = request(url=url, params=params, json=json_data, timeout=timeout)
     except requests.exceptions.RequestException as e:
         raise BackendQueryError(f'Could not connect to rotki backend at {url}: {e!s}') from e
 
@@ -63,3 +92,49 @@ def request_api(
         raise BackendQueryError(f'rotki backend returned an unexpected response for {url}')
 
     return payload
+
+
+def query_history_events_page(
+        limit: int,
+        offset: int,
+        from_timestamp: int | None = None,
+        to_timestamp: int | None = None,
+        exclude_ignored_assets: bool = True,
+) -> dict[str, Any]:
+    """Fetch one page of decoded history events. Used by the analytics loader to page the
+    full (time-scoped) set into a local frame. Returns the backend ``result`` dict.
+    """
+    backend_config = get_backend_config()
+    body: dict[str, Any] = {
+        'limit': limit,
+        'offset': offset,
+        'exclude_ignored_assets': exclude_ignored_assets,
+    }
+    if from_timestamp is not None:
+        body['from_timestamp'] = from_timestamp
+    if to_timestamp is not None:
+        body['to_timestamp'] = to_timestamp
+
+    payload = request_api(
+        base_url=backend_config.base_url,
+        endpoint='history/events',
+        timeout=backend_config.timeout,
+        json_data=body,
+        method='POST',
+    )
+    return payload['result']
+
+
+def query_all_balances(refresh: bool, timeout: int) -> dict[str, Any]:
+    """Return the current balances snapshot. ``refresh=True`` forces a slow live query of
+    every exchange and chain; otherwise the cached snapshot is returned. Read-only: never
+    persists. Returns the backend ``result`` dict.
+    """
+    backend_config = get_backend_config()
+    payload = request_api(
+        base_url=backend_config.base_url,
+        endpoint='balances',
+        timeout=timeout,
+        params={'ignore_cache': 'true'} if refresh else None,
+    )
+    return payload['result']

--- a/rotkehlchen/mcp/constants.py
+++ b/rotkehlchen/mcp/constants.py
@@ -1,5 +1,11 @@
 from typing import Final, Literal
 
 LogLevel = Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+# How aggressively the analytics layer strips identifiers before data reaches the LLM:
+# - ``strict``:   hash every identifier, label and name; redact all free text.
+# - ``balanced``: hash addresses/tx hashes/group ids, but keep human-friendly account
+#                 labels (e.g. exchange-account names) that are not themselves addresses.
+# - ``raw``:      no filtering. Must be opted into explicitly at server start.
+PrivacyMode = Literal['balanced', 'strict', 'raw']
 
 SERVICE_NAME: Final = 'rotki MCP'

--- a/rotkehlchen/mcp/server.py
+++ b/rotkehlchen/mcp/server.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from mcp.server.fastmcp import FastMCP
 
 from rotkehlchen.mcp.backend import configure_backend
-from rotkehlchen.mcp.constants import SERVICE_NAME, LogLevel
+from rotkehlchen.mcp.constants import SERVICE_NAME, LogLevel, PrivacyMode
 from rotkehlchen.mcp.premium import premium_gate
 from rotkehlchen.mcp.registry import discover_tools
 
@@ -30,8 +30,19 @@ def _gate_with_premium(tool_function: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-def setup_server(backend_url: str, timeout: int, log_level: LogLevel) -> FastMCP:
-    configure_backend(base_url=backend_url, timeout=timeout)
+def setup_server(
+        backend_url: str,
+        timeout: int,
+        log_level: LogLevel,
+        privacy_mode: PrivacyMode,
+        max_events: int | None = None,
+) -> FastMCP:
+    configure_backend(
+        base_url=backend_url,
+        timeout=timeout,
+        privacy_mode=privacy_mode,
+        max_events=max_events,
+    )
     server = FastMCP(name=SERVICE_NAME, log_level=log_level)
 
     for tool_function in discover_tools():
@@ -47,9 +58,17 @@ def setup_server(backend_url: str, timeout: int, log_level: LogLevel) -> FastMCP
     return server
 
 
-def run_server(backend_url: str, timeout: int, log_level: LogLevel) -> None:
+def run_server(
+        backend_url: str,
+        timeout: int,
+        log_level: LogLevel,
+        privacy_mode: PrivacyMode,
+        max_events: int | None = None,
+) -> None:
     setup_server(
         backend_url=backend_url,
         timeout=timeout,
         log_level=log_level,
+        privacy_mode=privacy_mode,
+        max_events=max_events,
     ).run(transport='stdio')

--- a/rotkehlchen/mcp/tools/analytics.py
+++ b/rotkehlchen/mcp/tools/analytics.py
@@ -1,0 +1,78 @@
+import asyncio
+from typing import Any
+
+from rotkehlchen.mcp.analytics import DEFAULT_MAX_RESULT_ROWS, get_analytics_session
+from rotkehlchen.mcp.registry import register_tool
+
+
+@register_tool(name='refresh_analytics_data')
+async def refresh_analytics_data(
+        tables: list[str] | None = None,
+        from_timestamp: int = 0,
+        to_timestamp: int = 0,
+        include_ignored_assets: bool = False,
+) -> dict[str, Any]:
+    """Load the user's rotki data into the local, privacy-filtered analytics session.
+
+    This pulls data from the running rotki backend, flattens it into tables and applies
+    privacy filtering, so that ``query_sql`` can then run SQL over it. Call this first (or
+    again, to change the loaded time range / tables).
+
+    - ``tables``: which tables to load. Defaults to ``["history_events"]``. ``"balances"``
+      is available but opt-in because refreshing it can be slow. See ``list_tables`` for
+      the full set.
+    - ``from_timestamp`` / ``to_timestamp``: time range bounding ``history_events`` (0 means
+      unbounded). Either unix seconds or milliseconds are accepted, so you can pass the same
+      millisecond unit used by the ``timestamp`` column. Large histories are capped; the
+      returned source metadata reports ``cache_truncated`` when that happens — narrow the
+      range to load everything.
+    - ``include_ignored_assets``: include events for assets the user has marked ignored.
+
+    Returns the per-table row counts and source metadata, plus the active ``privacy_mode``.
+    """
+    return await asyncio.to_thread(
+        get_analytics_session().refresh,
+        tables=tables,
+        from_timestamp=from_timestamp,
+        to_timestamp=to_timestamp,
+        include_ignored_assets=include_ignored_assets,
+    )
+
+
+@register_tool(name='list_tables')
+async def list_tables() -> dict[str, Any]:
+    """List the analytics tables: which are loaded now, the defaults, and all available."""
+    return await asyncio.to_thread(get_analytics_session().list_tables)
+
+
+@register_tool(name='describe_table')
+async def describe_table(table: str) -> dict[str, Any]:
+    """Describe a loaded analytics table: its columns (name + dtype), row count and source.
+
+    Use this to discover the schema before writing SQL. Note that identifier columns are
+    privacy-filtered: addresses/hashes appear as ``<col>_hash`` (consistent within a
+    session so you can still GROUP BY / JOIN on them) and free-text ``notes`` are redacted
+    to a ``has_notes`` flag, unless the server was started in ``raw`` privacy mode.
+    """
+    return await asyncio.to_thread(get_analytics_session().describe_table, table=table)
+
+
+@register_tool(name='query_sql')
+async def query_sql(sql: str, max_rows: int = DEFAULT_MAX_RESULT_ROWS) -> dict[str, Any]:
+    """Run a read-only SQL query over the loaded, privacy-filtered analytics tables.
+
+    Polars SQL runs the query, so aggregations, joins, grouping, ordering and window
+    functions are all available and computed exactly — use it for the math (sums, cost
+    basis candidates, rolling balances, per-asset/per-counterparty rollups, fee totals)
+    rather than doing arithmetic yourself. Only a single ``SELECT``/``WITH`` statement is
+    allowed; writes and DDL are rejected.
+
+    Call ``refresh_analytics_data`` first to load data, and ``describe_table`` to learn the
+    columns. The default table is ``history_events``. ``max_rows`` caps returned rows; the
+    result reports ``result_truncated`` and the true ``row_count`` when more matched.
+    """
+    return await asyncio.to_thread(
+        get_analytics_session().query_sql,
+        sql=sql,
+        max_rows=max_rows,
+    )

--- a/rotkehlchen/tests/mcp/conftest.py
+++ b/rotkehlchen/tests/mcp/conftest.py
@@ -9,4 +9,9 @@ from rotkehlchen.mcp.backend import configure_backend, get_backend_config
 def restore_backend_config() -> Generator[None]:
     backend_config = get_backend_config()
     yield
-    configure_backend(base_url=backend_config.base_url, timeout=backend_config.timeout)
+    configure_backend(
+        base_url=backend_config.base_url,
+        timeout=backend_config.timeout,
+        privacy_mode=backend_config.privacy_mode,
+        max_events=backend_config.max_events,
+    )

--- a/rotkehlchen/tests/mcp/test_analytics.py
+++ b/rotkehlchen/tests/mcp/test_analytics.py
@@ -1,0 +1,239 @@
+from typing import Any
+
+import pytest
+
+from rotkehlchen.mcp import analytics
+from rotkehlchen.mcp.analytics import (
+    AnalyticsSession,
+    _flatten,
+    _sanitize_row,
+    _validate_sql,
+)
+from rotkehlchen.mcp.backend import configure_backend
+
+ADDRESS = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65'
+TX_HASH = '0x' + 'ab' * 32
+
+
+def test_flatten_should_recurse_and_add_float_companions() -> None:
+    row = _flatten({
+        'identifier': 1,
+        'amount': '1.5',
+        'extra_data': {'address': ADDRESS, 'depth': 2},
+    })
+    assert row == {
+        'identifier': 1,
+        'amount': '1.5',
+        'amount_float': 1.5,
+        'extra_data_address': ADDRESS,
+        'extra_data_depth': 2,
+    }
+
+
+def test_sanitize_should_fail_closed_on_unknown_string_columns() -> None:
+    """The crux of the design: a column we have never classified must NOT leak its value.
+
+    ``ens_name`` and ``memo`` are neither allowlisted nor address-shaped, so a naive
+    regex-only filter would pass them straight through. Fail-closed hashing must hide them.
+    """
+    sanitized = _sanitize_row(
+        {
+            'amount': '1.5',          # allowlisted -> kept verbatim (+ float companion)
+            'amount_float': 1.5,
+            'ens_name': 'vitalik.eth',  # unknown string -> must be hidden
+            'memo': 'pay rent to bob',  # unknown string -> must be hidden
+            'sequence_index': 3,        # allowlisted
+            'random_count': 7,          # unknown int -> safe analytic payload, kept
+        },
+        privacy_mode='balanced',
+    )
+    assert sanitized['amount'] == '1.5'
+    assert sanitized['sequence_index'] == 3
+    assert sanitized['random_count'] == 7
+    # the unknown strings never appear verbatim, only as opaque session hashes
+    assert 'ens_name' not in sanitized
+    assert 'memo' not in sanitized
+    assert sanitized['ens_name_hash'].startswith('anon_')
+    assert sanitized['memo_hash'].startswith('anon_')
+    assert 'vitalik.eth' not in str(sanitized)
+    assert 'bob' not in str(sanitized)
+
+
+def test_sanitize_should_hash_identifiers_and_redact_notes() -> None:
+    sanitized = _sanitize_row(
+        {'address': ADDRESS, 'group_identifier': TX_HASH, 'notes': 'Burned ETH for gas'},
+        privacy_mode='balanced',
+    )
+    assert ADDRESS not in str(sanitized)
+    assert TX_HASH not in str(sanitized)
+    assert sanitized['address_hash'].startswith('anon_')
+    assert sanitized['group_identifier_hash'].startswith('anon_')
+    assert sanitized['notes'] == analytics.REDACTED_TEXT
+    assert sanitized['has_notes'] is True
+
+
+def test_sanitize_balanced_keeps_named_label_but_strict_hashes_it() -> None:
+    row = {'location_label': 'Kraken main', 'label': 'my tag'}
+    balanced = _sanitize_row(row, privacy_mode='balanced')
+    # a human-friendly account name (not address-shaped) stays readable in balanced mode
+    assert balanced['location_label'] == 'Kraken main'
+    # but an address-shaped location_label is hashed even in balanced mode
+    assert 'location_label' not in _sanitize_row({'location_label': ADDRESS}, 'balanced')
+
+    strict = _sanitize_row(row, privacy_mode='strict')
+    assert 'location_label' not in strict
+    assert strict['location_label_hash'].startswith('anon_')
+    assert 'label' not in strict  # user-authored label is an identifier in strict mode
+
+
+def test_sanitize_raw_passes_everything_through() -> None:
+    row = {'address': ADDRESS, 'notes': 'secret', 'ens_name': 'vitalik.eth'}
+    assert _sanitize_row(row, privacy_mode='raw') == row
+
+
+def test_hash_is_stable_within_session_for_grouping() -> None:
+    first = _sanitize_row({'address': ADDRESS}, 'balanced')['address_hash']
+    second = _sanitize_row({'address': ADDRESS}, 'balanced')['address_hash']
+    assert first == second  # GROUP BY / JOIN on the hash works across rows
+    other = _sanitize_row({'address': TX_HASH}, 'balanced')['address_hash']
+    assert first != other
+
+
+@pytest.mark.parametrize(('sql', 'valid'), [
+    ('select * from history_events', True),
+    ('WITH t as (select 1) select * from t', True),
+    ('delete from history_events', False),
+    ('drop table history_events', False),
+    ('select 1; select 2', False),
+    ('update history_events set amount = 0', False),
+])
+def test_validate_sql(sql: str, valid: bool) -> None:
+    assert (_validate_sql(sql) is None) is valid
+
+
+def _mock_history_pages(monkeypatch, entries: list[dict[str, Any]]) -> None:
+    def fake_page(limit, offset, **kwargs):
+        page = entries[offset:offset + limit]
+        return {
+            'entries': page,
+            'entries_found': len(entries),
+            'entries_total': len(entries),
+            'entries_limit': -1,
+        }
+    monkeypatch.setattr(analytics, 'query_history_events_page', fake_page)
+
+
+def test_session_refresh_then_query_sql_roundtrip(monkeypatch) -> None:
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'identifier': 1, 'asset': 'ETH', 'amount': '2', 'event_type': 'spend', 'notes': 'a'},
+        {'identifier': 2, 'asset': 'ETH', 'amount': '3', 'event_type': 'spend', 'notes': 'b'},
+        {'identifier': 3, 'asset': 'BTC', 'amount': '1', 'event_type': 'receive'},
+    ])
+    session = AnalyticsSession()
+
+    refreshed = session.refresh(tables=None, from_timestamp=0, to_timestamp=0,
+                                include_ignored_assets=False)
+    assert refreshed['errors'] == {}
+    assert refreshed['tables']['history_events']['rows'] == 3
+
+    result = session.query_sql(
+        'select asset, sum(amount_float) as total from history_events group by asset '
+        'order by asset',
+        max_rows=500,
+    )
+    assert result['columns'] == ['asset', 'total']
+    assert result['rows'] == [
+        {'asset': 'BTC', 'total': 1.0},
+        {'asset': 'ETH', 'total': 5.0},
+    ]
+    assert result['result_truncated'] is False
+
+
+def test_history_events_promote_entry_and_redact_auto_notes(monkeypatch) -> None:
+    """The API wraps fields in an ``entry`` envelope; columns must read as ``timestamp``/
+    ``location`` (not ``entry_timestamp``), and ``auto_notes`` must be redacted, not raw.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {
+            'entry': {
+                'timestamp': 1614556800000,
+                'location': 'ethereum',
+                'asset': 'ETH',
+                'amount': '1.5',
+                'auto_notes': f'Send 1.5 ETH to {ADDRESS}',
+            },
+            'has_ignored_assets': False,
+        },
+    ])
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False)
+
+    columns = session.describe_table('history_events')['columns']
+    names = {column['name'] for column in columns}
+    assert {'timestamp', 'location', 'asset', 'amount'} <= names  # promoted, no entry_ prefix
+    assert 'entry_timestamp' not in names
+    assert 'auto_notes' in names and 'has_auto_notes' in names
+    # readable date columns are derived so the LLM can filter without unix math
+    assert {'year', 'datetime'} <= names
+    row = session.query_sql('select * from history_events', max_rows=10)['rows'][0]
+    assert row['year'] == 2021  # 1614556800000 ms -> 2021-03-01
+    assert row['datetime'] == '2021-03-01T00:00:00Z'
+    # the address embedded in auto_notes never leaks
+    assert row['auto_notes'] == analytics.REDACTED_TEXT
+    assert ADDRESS not in str(row)
+
+
+def test_refresh_accepts_millisecond_timestamps(monkeypatch) -> None:
+    """An LLM passing ms (the unit of the timestamp column) must not silently load 0 rows:
+    ms bounds are normalized to the seconds the backend filter expects.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    captured: dict[str, Any] = {}
+
+    def fake_page(limit, offset, from_timestamp=None, to_timestamp=None, **kwargs):
+        captured['from_timestamp'] = from_timestamp
+        captured['to_timestamp'] = to_timestamp
+        return {'entries': [], 'entries_found': 0, 'entries_total': 0, 'entries_limit': -1}
+    monkeypatch.setattr(analytics, 'query_history_events_page', fake_page)
+
+    AnalyticsSession().refresh(
+        tables=None,
+        from_timestamp=1709423608000,  # ms -> must become seconds
+        to_timestamp=1735689600,       # already seconds -> unchanged
+        include_ignored_assets=False,
+    )
+    assert captured['from_timestamp'] == 1709423608
+    assert captured['to_timestamp'] == 1735689600
+
+
+def test_load_is_uncapped_by_default_and_respects_max_events(monkeypatch) -> None:
+    """Complete data by default; --max-events only caps when explicitly set."""
+    entries = [
+        {'identifier': i, 'asset': 'ETH', 'amount': str(i), 'event_type': 'spend'}
+        for i in range(5)
+    ]
+    _mock_history_pages(monkeypatch, entries)
+
+    configure_backend(base_url='http://backend/api/1', timeout=5)  # max_events defaults to None
+    full = AnalyticsSession().refresh(tables=None, from_timestamp=0, to_timestamp=0,
+                                      include_ignored_assets=False)
+    assert full['tables']['history_events']['rows'] == 5
+    assert full['tables']['history_events']['source']['cache_truncated'] is False
+
+    configure_backend(base_url='http://backend/api/1', timeout=5, max_events=3)
+    capped = AnalyticsSession().refresh(tables=None, from_timestamp=0, to_timestamp=0,
+                                        include_ignored_assets=False)
+    assert capped['tables']['history_events']['rows'] == 3
+    assert capped['tables']['history_events']['source']['cache_truncated'] is True
+
+
+def test_query_sql_without_loaded_tables_errors() -> None:
+    assert AnalyticsSession().query_sql('select 1', max_rows=10)['error']['type'] == (
+        'no_tables_loaded'
+    )
+
+
+def test_describe_unknown_table_errors() -> None:
+    assert AnalyticsSession().describe_table('nope')['error']['type'] == 'unknown_table'

--- a/rotkehlchen/tests/mcp/test_backend.py
+++ b/rotkehlchen/tests/mcp/test_backend.py
@@ -55,3 +55,28 @@ def test_request_api_should_return_payload(monkeypatch) -> None:
         'result': True,
         'message': '',
     }
+
+
+def test_request_api_should_post_json_body(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def mock_post(url: str, **kwargs: Any) -> MockResponse:
+        captured['url'] = url
+        captured['json'] = kwargs.get('json')
+        return MockResponse({'result': {'entries': []}, 'message': ''})
+
+    def mock_get(url: str, **kwargs: Any) -> MockResponse:
+        raise AssertionError('POST request must not fall back to GET')
+
+    monkeypatch.setattr(requests, 'post', mock_post)
+    monkeypatch.setattr(requests, 'get', mock_get)
+
+    assert request_api(
+        base_url='http://backend/api/1',
+        endpoint='history/events',
+        timeout=5,
+        json_data={'limit': 10},
+        method='POST',
+    ) == {'result': {'entries': []}, 'message': ''}
+    assert captured['url'] == 'http://backend/api/1/history/events'
+    assert captured['json'] == {'limit': 10}

--- a/rotkehlchen/tests/mcp/test_server.py
+++ b/rotkehlchen/tests/mcp/test_server.py
@@ -37,6 +37,7 @@ def test_setup_server_should_register_discovered_tools(monkeypatch) -> None:
         backend_url='http://backend/api/1',
         timeout=3,
         log_level='DEBUG',
+        privacy_mode='balanced',
     )
 
     assert init_args == {'name': SERVICE_NAME, 'log_level': 'DEBUG'}
@@ -67,7 +68,12 @@ def test_setup_server_should_gate_premium_tools(monkeypatch) -> None:
     gated_tool.__mcp_premium__ = True  # type: ignore[attr-defined]
 
     monkeypatch.setattr(server, 'discover_tools', lambda: [gated_tool])
-    server.setup_server(backend_url='http://backend/api/1', timeout=3, log_level='DEBUG')
+    server.setup_server(
+        backend_url='http://backend/api/1',
+        timeout=3,
+        log_level='DEBUG',
+        privacy_mode='balanced',
+    )
 
     name, description, wrapped = tools[0]
     assert name == 'gated_tool'


### PR DESCRIPTION
Extend the MCP backend client with POST support and add two premium-gated data tools wrapping the rotki REST API:
- get_balances: current balances snapshot (assets/liabilities/location/net_value)
- query_history_events: filtered decoded history events query

