### PR TITLE
Disable reown/appkit analytics

### DIFF
--- a/frontend/app/src/modules/wallet/use-wallet-connect.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-connect.ts
@@ -31,7 +31,7 @@ function buildAppKit(): AppKit {
     adapters: [new EthersAdapter()],
     allowUnsupportedChain: true,
     features: {
-      analytics: true,
+      analytics: false,
       email: false,
       onramp: false,
       socials: false,


### PR DESCRIPTION
Disables analytics collection in the reown/appkit (WalletConnect) configuration by setting `features.analytics` to `false` in `use-wallet-connect.ts`.