### PR TITLE
Retag Gnosis Pay new-spender payments in migration 26

### DIFF
--- a/rotkehlchen/data_migrations/migrations/migration_26.py
+++ b/rotkehlchen/data_migrations/migrations/migration_26.py
@@ -1,18 +1,31 @@
+import logging
 from typing import TYPE_CHECKING
 
-from rotkehlchen.logging import enter_exit_debug_log
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.gnosis.modules.gnosis_pay.constants import (
+    CPT_GNOSIS_PAY,
+    GNOSIS_PAY_SPENDING_COLLECTOR,
+)
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.logging import RotkehlchenLogsAdapter, enter_exit_debug_log
+from rotkehlchen.types import Location
 from rotkehlchen.utils.progress import perform_userdb_migration_steps, progress_step
 
 if TYPE_CHECKING:
     from rotkehlchen.data_migrations.progress import MigrationProgressHandler
     from rotkehlchen.rotkehlchen import Rotkehlchen
 
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
 
 @enter_exit_debug_log()
 def data_migration_26(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgressHandler') -> None:
     """Introduced at v1.43.2
 
-    Clean up manually tracked balance tag mappings that were orphaned by the v51->v52 DB
+    - Clean up manually tracked balance tag mappings that were orphaned by the v51->v52 DB
     upgrade. That upgrade rebuilt manually_tracked_balances without preserving the id column,
     so rows above a deleted-id gap were renumbered and their tag_mappings (keyed by the old id)
     no longer point at any balance. Worse, since ids are now dense, a stale mapping can later
@@ -21,6 +34,9 @@ def data_migration_26(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgress
     The original association is unrecoverable, so we delete the orphaned mappings. Manual balance
     tags use a pure-integer object_reference (blockchain accounts use addresses and xpubs use the
     xpub string), so all-digit references that match no current balance id are the orphans.
+
+    - Retag Gnosis Pay card payments made through the new post-hack spender contract that were
+    decoded as plain token spends before the decoder learned the new spender address.
     """
     @progress_step(description='Removing orphaned manual balance tag mappings')
     def _remove_orphaned_manual_balance_tags(rotki: 'Rotkehlchen') -> None:
@@ -29,6 +45,61 @@ def data_migration_26(rotki: 'Rotkehlchen', progress_handler: 'MigrationProgress
                 'DELETE FROM tag_mappings WHERE '
                 "object_reference GLOB '[0-9]*' AND NOT object_reference GLOB '*[^0-9]*' AND "
                 'CAST(object_reference AS INTEGER) NOT IN (SELECT id FROM manually_tracked_balances)',  # noqa: E501
+            )
+
+    @progress_step(description='Tagging Gnosis Pay payments from the new spender contract')
+    def _retag_gnosis_pay_new_spender_payments(rotki: 'Rotkehlchen') -> None:
+        """Gnosis Pay payments made through the new post-hack spender contract were decoded as
+        plain token spends before the decoder learned the new spender address. They are missing
+        the gnosis_pay counterparty, so the Gnosis Pay refresh (which only enriches events that
+        already carry the counterparty) can never attach merchant data to them.
+
+        All Gnosis Pay card payments (old and new spender alike) send the spent token to the
+        spending collector, so we match outgoing transfers to it that are not yet attributed to
+        any counterparty and turn them into proper payment events. This lets a refresh pick them
+        up without a full redecode. Reproducing the decoder's notes is what makes the automatic
+        merchant backfill (which looks for 'Spend% via Gnosis Pay' notes) find them too.
+        """
+        updates: list[tuple[str, int]] = []
+        with rotki.data.db.conn.read_ctx() as cursor:
+            for identifier, amount, asset_id in cursor.execute(
+                'SELECT H.identifier, H.amount, H.asset FROM history_events H '
+                'INNER JOIN chain_events_info EI ON EI.identifier = H.identifier '
+                'WHERE H.location = ? AND H.type = ? AND H.subtype = ? AND '
+                'EI.address = ? AND EI.counterparty IS NULL',
+                (
+                    Location.GNOSIS.serialize_for_db(),
+                    HistoryEventType.SPEND.serialize(),
+                    HistoryEventSubType.NONE.serialize(),
+                    GNOSIS_PAY_SPENDING_COLLECTOR,
+                ),
+            ):
+                try:
+                    symbol = Asset(asset_id).resolve_to_asset_with_symbol().symbol
+                except (UnknownAsset, WrongAssetType) as e:
+                    log.error(
+                        'Could not resolve symbol for %s while tagging Gnosis Pay '
+                        'payment event %s due to %s. Skipping it',
+                        asset_id, identifier, e,
+                    )
+                    continue
+
+                updates.append((f'Spend {FVal(amount)} {symbol} via Gnosis Pay', identifier))
+
+        if len(updates) == 0:
+            return
+
+        with rotki.data.db.conn.write_ctx() as write_cursor:
+            write_cursor.executemany(
+                'UPDATE history_events SET subtype = ?, notes = ? WHERE identifier = ?',
+                [
+                    (HistoryEventSubType.PAYMENT.serialize(), notes, identifier)
+                    for notes, identifier in updates
+                ],
+            )
+            write_cursor.executemany(
+                'UPDATE chain_events_info SET counterparty = ? WHERE identifier = ?',
+                [(CPT_GNOSIS_PAY, identifier) for _, identifier in updates],
             )
 
     perform_userdb_migration_steps(rotki, progress_handler, should_vacuum=False)

--- a/rotkehlchen/tests/data_migrations/test_migration_26.py
+++ b/rotkehlchen/tests/data_migrations/test_migration_26.py
@@ -1,8 +1,24 @@
 """Test for data migration 26 - cleanup of orphaned manual balance tag mappings."""
 import pytest
 
+from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.chain.gnosis.modules.gnosis_pay.constants import (
+    CPT_GNOSIS_PAY,
+    GNOSIS_PAY_SPENDING_COLLECTOR,
+)
+from rotkehlchen.constants.assets import Asset
 from rotkehlchen.db.dbhandler import DBHandler
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.evm_event import EvmEvent
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.data_migrations import run_single_migration
+from rotkehlchen.tests.utils.factories import make_evm_tx_hash
+from rotkehlchen.types import ChecksumEvmAddress, EVMTxHash, Location, TimestampMS
+
+A_EURE = Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430')
+# An unrelated EURe recipient used to check that only transfers to the spending collector match.
+OTHER_ADDRESS = string_to_evm_address('0x9E0D8c9ff04F58e8D4053b78d33e582D8aCc8c44')
 
 
 @pytest.mark.parametrize('data_migration_version', [25])
@@ -42,3 +58,101 @@ def test_migration_26_orphaned_manual_balance_tags(database: DBHandler) -> None:
         assert set(cursor.execute(
             'SELECT object_reference FROM tag_mappings WHERE tag_name=?', ('public',),
         ).fetchall()) == {('5',), (address,), (xpub_ref,)}  # orphan '7' removed, rest kept
+
+
+@pytest.mark.parametrize('data_migration_version', [25])
+def test_migration_26_retag_gnosis_pay_new_spender_payments(database: DBHandler) -> None:
+    """A Gnosis Pay payment decoded as a plain spend (no counterparty) before the new spender
+    was supported is retagged as a gnosis_pay payment, so a refresh and the merchant backfill
+    can pick it up. Already-tagged payments and spends to other addresses are left untouched.
+    """
+    dbevents = DBHistoryEvents(database)
+
+    def make_spend(
+            tx_ref: EVMTxHash,
+            amount: str,
+            address: ChecksumEvmAddress,
+            subtype: HistoryEventSubType,
+            counterparty: str | None,
+            notes: str | None,
+    ) -> EvmEvent:
+        return EvmEvent(
+            tx_ref=tx_ref,
+            sequence_index=0,
+            timestamp=TimestampMS(1780902380000),
+            location=Location.GNOSIS,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=subtype,
+            asset=A_EURE,
+            amount=FVal(amount),
+            location_label=OTHER_ADDRESS,
+            notes=notes,
+            counterparty=counterparty,
+            address=address,
+        )
+
+    # the v2 payment decoded as a plain spend - should be retagged
+    target_event = make_spend(
+        tx_ref=(target_tx := make_evm_tx_hash()),
+        amount='2.1',
+        address=GNOSIS_PAY_SPENDING_COLLECTOR,
+        subtype=HistoryEventSubType.NONE,
+        counterparty=None,
+        notes='Send 2.1 EURe from gnosis address to gnosis address',
+    )
+    # an already correctly decoded payment - must not be touched
+    tagged_event = make_spend(
+        tx_ref=make_evm_tx_hash(),
+        amount='5',
+        address=GNOSIS_PAY_SPENDING_COLLECTOR,
+        subtype=HistoryEventSubType.PAYMENT,
+        counterparty=CPT_GNOSIS_PAY,
+        notes='Spend 5 EURe via Gnosis Pay',
+    )
+    # a plain spend to a different address - must not be touched
+    other_event = make_spend(
+        tx_ref=make_evm_tx_hash(),
+        amount='3',
+        address=OTHER_ADDRESS,
+        subtype=HistoryEventSubType.NONE,
+        counterparty=None,
+        notes='Send 3 EURe from gnosis address to gnosis address',
+    )
+    with database.user_write() as write_cursor:
+        target_id = dbevents.add_history_event(write_cursor, target_event)
+        tagged_id = dbevents.add_history_event(write_cursor, tagged_event)
+        other_id = dbevents.add_history_event(write_cursor, other_event)
+
+    assert target_id is not None and tagged_id is not None and other_id is not None
+
+    backfill_query = (
+        'SELECT EI.tx_ref FROM history_events H '
+        'INNER JOIN chain_events_info EI ON EI.identifier = H.identifier '
+        'WHERE H.location = ? AND EI.counterparty = ? AND H.notes LIKE ?'
+    )
+    backfill_bindings = (
+        Location.GNOSIS.serialize_for_db(),
+        CPT_GNOSIS_PAY,
+        'Spend% via Gnosis Pay',
+    )
+    with database.conn.read_ctx() as cursor:  # before migration the merchant backfill misses it
+        assert (bytes(target_tx),) not in cursor.execute(backfill_query, backfill_bindings).fetchall()  # noqa: E501
+
+    run_single_migration(database=database, migration=26)
+
+    with database.conn.read_ctx() as cursor:
+        assert set(cursor.execute(
+            'SELECT H.identifier, H.type, H.subtype, H.notes, EI.counterparty '
+            'FROM history_events H '
+            'INNER JOIN chain_events_info EI ON EI.identifier = H.identifier '
+            'WHERE H.identifier IN (?, ?, ?)',
+            (target_id, tagged_id, other_id),
+        ).fetchall()) == {
+            # the v2 payment got retagged as a gnosis pay payment
+            (target_id, HistoryEventType.SPEND.serialize(), HistoryEventSubType.PAYMENT.serialize(), 'Spend 2.1 EURe via Gnosis Pay', CPT_GNOSIS_PAY),  # noqa: E501
+            # the already tagged and the unrelated spend stay exactly as they were
+            (tagged_id, HistoryEventType.SPEND.serialize(), HistoryEventSubType.PAYMENT.serialize(), 'Spend 5 EURe via Gnosis Pay', CPT_GNOSIS_PAY),  # noqa: E501
+            (other_id, HistoryEventType.SPEND.serialize(), HistoryEventSubType.NONE.serialize(), 'Send 3 EURe from gnosis address to gnosis address', None),  # noqa: E501
+        }
+        # the merchant backfill now finds the retagged event
+        assert (bytes(target_tx),) in cursor.execute(backfill_query, backfill_bindings).fetchall()


### PR DESCRIPTION
Gnosis Pay card payments made through the new post-hack spender contract were decoded as plain token spends before the decoder learned the new spender address, so they lack the gnosis_pay counterparty and the refresh can never attach merchant data to them. Add a migration_26 step that retags outgoing transfers to the spending collector with no counterparty as gnosis_pay payments (counterparty, payment subtype and the decoder's notes), so a refresh and the merchant backfill pick them up without a full redecode. Includes a test.
