### PR TITLE
chore: CodeQL parse-error fix + http-proxy-middleware v4

### DIFF
--- a/frontend/app/electron/main/app-server.ts
+++ b/frontend/app/electron/main/app-server.ts
@@ -1,10 +1,10 @@
 import type { LogService } from '@electron/main/log-service';
 import fs from 'node:fs/promises';
 import http, { type Server } from 'node:http';
+import net from 'node:net';
 import path from 'node:path';
 import { getMimeType } from '@electron/main/create-protocol';
 import { sanitizePath } from '@electron/main/path-sanitizer';
-import httpProxy from 'http-proxy';
 
 const HttpStatus = {
   OK: 200,
@@ -34,8 +34,12 @@ export class AppServer {
   }
 
   private async startDevelopmentProxy(port: number, devServerUrl: string, initialRoute?: string): Promise<void> {
+    // httpxy is a dev-only dependency, dynamically imported so it stays out of
+    // the production main bundle (it is marked external in vite.config.main.ts).
+    const { createProxyServer } = await import('httpxy');
+
     return new Promise((resolve, reject) => {
-      const proxy = httpProxy.createProxyServer({
+      const proxy = createProxyServer({
         target: devServerUrl,
         changeOrigin: true,
       });
@@ -43,23 +47,25 @@ export class AppServer {
       const server = http.createServer((req, res) => {
         this.logger.debug(`Proxy request: ${req.method} ${req.url}`);
 
-        proxy.web(req, res, {}, (err: Error | null) => {
-          if (err) {
-            this.logger.error('Proxy error:', err);
-            res.writeHead(HttpStatus.INTERNAL_SERVER_ERROR, { 'Content-Type': 'text/plain' });
-            res.end('Proxy error');
-          }
+        proxy.web(req, res).catch((error: Error) => {
+          this.logger.error('Proxy error:', error);
+          res.writeHead(HttpStatus.INTERNAL_SERVER_ERROR, { 'Content-Type': 'text/plain' });
+          res.end('Proxy error');
         });
       });
 
       // Handle WebSocket upgrade requests (for HMR)
       server.on('upgrade', (req, socket, head) => {
         this.logger.debug(`WebSocket upgrade request: ${req.url}`);
-        proxy.ws(req, socket, head, {}, (err: Error | null) => {
-          if (err) {
-            this.logger.error('WebSocket proxy error:', err);
-            socket.destroy();
-          }
+        // Node types the upgrade socket as Duplex, but HTTP/1.1 upgrades are
+        // always net.Socket, which is what httpxy expects.
+        if (!(socket instanceof net.Socket)) {
+          socket.destroy();
+          return;
+        }
+        proxy.ws(req, socket, {}, head).catch((error: Error) => {
+          this.logger.error('WebSocket proxy error:', error);
+          socket.destroy();
         });
       });
 

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -101,6 +101,7 @@
     "fake-indexeddb": "catalog:",
     "flush-promises": "catalog:",
     "happy-dom": "catalog:",
+    "httpxy": "catalog:",
     "msw": "catalog:",
     "npm-run-all2": "catalog:",
     "postcss": "catalog:",

--- a/frontend/app/src/modules/staking/kraken/KrakenStaking.vue
+++ b/frontend/app/src/modules/staking/kraken/KrakenStaking.vue
@@ -25,7 +25,9 @@ const { getAssetPrice } = usePriceUtils();
 const { getProtocolStatsPriceQueryStatus } = useHistoricCachePriceStore();
 const krakenHistoricPriceStatus = getProtocolStatsPriceQueryStatus('kraken');
 
-const earnedAssetsData = computed<[boolean, AssetBalance[]]>(() => {
+type EarnedAssetsData = [boolean, AssetBalance[]];
+
+const earnedAssetsData = computed<EarnedAssetsData>(() => {
   const earned = get(events).received;
 
   if (get(selection) === 'historical') {

--- a/frontend/app/vite.config.main.ts
+++ b/frontend/app/vite.config.main.ts
@@ -64,7 +64,9 @@ export default defineConfig({
       formats: ['es'],
     },
     rolldownOptions: {
-      external: ['electron', ...builtinModules.flatMap(p => [p, `node:${p}`])],
+      // httpxy is only loaded via dynamic import on the dev proxy path
+      // (see AppServer.startDevelopmentProxy); keep it out of the production bundle.
+      external: ['electron', 'httpxy', ...builtinModules.flatMap(p => [p, `node:${p}`])],
       output: {
         entryFileNames: 'main.js',
         manualChunks(id) {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -172,8 +172,11 @@ catalogs:
       specifier: 20.10.2
       version: 20.10.2
     http-proxy-middleware:
-      specifier: 3.0.6
-      version: 3.0.6
+      specifier: 4.1.0
+      version: 4.1.0
+    httpxy:
+      specifier: 0.5.3
+      version: 0.5.3
     husky:
       specifier: 9.1.7
       version: 9.1.7
@@ -538,6 +541,9 @@ importers:
       happy-dom:
         specifier: 'catalog:'
         version: 20.10.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      httpxy:
+        specifier: 'catalog:'
+        version: 0.5.3
       msw:
         specifier: 'catalog:'
         version: 2.14.6(@types/node@24.12.2)(typescript@6.0.3)
@@ -627,7 +633,7 @@ importers:
         version: 5.2.1
       http-proxy-middleware:
         specifier: 'catalog:'
-        version: 3.0.6
+        version: 4.1.0
     devDependencies:
       '@types/body-parser':
         specifier: 'catalog:'
@@ -2510,9 +2516,6 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
-  '@types/http-proxy@1.17.17':
-    resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
-
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
@@ -4190,9 +4193,6 @@ packages:
     resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
     engines: {node: '>=14.0.0'}
 
-  eventemitter3@4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -4570,13 +4570,9 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
-  http-proxy-middleware@3.0.6:
-    resolution: {integrity: sha512-jhO3QfahaHWfQjEnyGW0vpYIYaXcnA6FEfehrBthOokGppvmI6zcV+1yb6TWn3vyeh8yQUoEqH51DNHOCjivxg==}
-    engines: {node: ^14.18.0 || ^16.10.0 || >=18.0.0}
-
-  http-proxy@1.18.1:
-    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
-    engines: {node: '>=8.0.0'}
+  http-proxy-middleware@4.1.0:
+    resolution: {integrity: sha512-XUOAjKncPZjsrgDTTem+CUED6A+piUAKTOwBM8g1gAublBX/GdxTHP8mO+og1EW1evYP8wd0G2c111tExwo/jw==}
+    engines: {node: ^22.15.0 || ^24.0.0 || >=26.0.0}
 
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
@@ -4585,6 +4581,9 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  httpxy@0.5.3:
+    resolution: {integrity: sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -4718,9 +4717,9 @@ packages:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
 
-  is-plain-object@5.0.0:
-    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
-    engines: {node: '>=0.10.0'}
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -5951,9 +5950,6 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
-
-  requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
@@ -9464,10 +9460,6 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
-  '@types/http-proxy@1.17.17':
-    dependencies:
-      '@types/node': 24.12.2
-
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/jsesc@2.5.1': {}
@@ -10618,7 +10610,7 @@ snapshots:
 
   axios@1.16.0:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -11754,8 +11746,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  eventemitter3@4.0.7: {}
-
   eventemitter3@5.0.1: {}
 
   eventemitter3@5.0.4: {}
@@ -11905,9 +11895,8 @@ snapshots:
 
   flush-promises@1.0.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
-    optionalDependencies:
-      debug: 4.4.3
+  follow-redirects@1.16.0:
+    optional: true
 
   foreground-child@3.3.1:
     dependencies:
@@ -12205,24 +12194,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@3.0.6:
+  http-proxy-middleware@4.1.0:
     dependencies:
-      '@types/http-proxy': 1.17.17
       debug: 4.4.3
-      http-proxy: 1.18.1(debug@4.4.3)
+      httpxy: 0.5.3
       is-glob: 4.0.3
-      is-plain-object: 5.0.0
+      is-plain-obj: 4.1.0
       micromatch: 4.0.8
     transitivePeerDependencies:
       - supports-color
-
-  http-proxy@1.18.1(debug@4.4.3):
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.3)
-      requires-port: 1.0.0
-    transitivePeerDependencies:
-      - debug
 
   http2-wrapper@1.0.3:
     dependencies:
@@ -12235,6 +12215,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  httpxy@0.5.3: {}
 
   husky@9.1.7: {}
 
@@ -12333,7 +12315,7 @@ snapshots:
 
   is-path-inside@4.0.0: {}
 
-  is-plain-object@5.0.0: {}
+  is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
 
@@ -13718,8 +13700,6 @@ snapshots:
   require-from-string@2.0.2: {}
 
   require-main-filename@2.0.0: {}
-
-  requires-port@1.0.0: {}
 
   resedit@1.7.2:
     dependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -88,7 +88,8 @@ catalog:
   flag-icons: 7.5.0
   flush-promises: 1.0.2
   happy-dom: 20.10.2
-  http-proxy-middleware: 3.0.6
+  http-proxy-middleware: 4.1.0
+  httpxy: 0.5.3
   husky: 9.1.7
   imask: 7.6.1
   lint-staged: 17.0.7


### PR DESCRIPTION
Small maintenance batch.

### `fix: avoid CodeQL parse error in KrakenStaking`
CodeQL's JS analysis transpiles each Vue SFC into a virtual `.ts` file and parses it with its bundled TypeScript compiler. It mis-parses the inline tuple-with-nested-array generic argument `computed<[boolean, AssetBalance[]]>`, emitting a spurious `']' expected` extraction diagnostic ("The affected file is not located within the code being analyzed").

Extracting the tuple into a named type alias sidesteps it; behaviour is unchanged. Verified by reproducing against the exact CI bundle (CodeQL 2.25.6) — the diagnostic is present before the change and gone after.

### `chore(deps): bump http-proxy-middleware to 4.1.0`
Major bump from 3.0.6 (only `dev-proxy` consumes it). None of the v4 breaking changes apply:
- **ESM-only** — `dev-proxy` is already `"type": "module"`
- **Drops Node ≤20** (engines `^22.15 || ^24 || >=26`) — project requires Node 22+
- **Removes `legacyCreateProxyMiddleware()`** — code uses `createProxyMiddleware` with the v3-style `on: {}` event API, unchanged in v4

Pinned to 4.1.0 rather than the latest 4.1.1, which is still inside the repo's 7-day `minimumReleaseAge` window.