### PR TITLE
fix: warn on missing Blockscout API key

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` rotki now notifies you when Blockscout is queried without an API key instead of silently skipping it.
 * :release:`1.43.2 <2026-06-18>`
 * :bug:`-` Manually refetching Hyperliquid transactions now also refetches Hyperliquid Core history, so missed Core events can be recovered.
 * :bug:`-` EUR pegged assets are now valued correctly for users whose main currency is BTC, instead of causing balance queries to fail.

--- a/frontend/app/shared/external-links.ts
+++ b/frontend/app/shared/external-links.ts
@@ -18,7 +18,7 @@ export const etherscanLink = 'https://etherscan.io/myapikey';
 
 export const heliusLink = 'https://dev.helius.xyz/dashboard/app';
 
-export const blockscoutLink = 'https://api.blockscout.com/account/api-key';
+export const blockscoutLink = 'https://dev.blockscout.com/';
 
 export const externalLinks = {
   premium: `${BASE_URL}products${UTM_PARAMS}`,

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -4337,6 +4337,10 @@
         "message": "If you have a Beaconcha.in API key, you can add it to retrieve block production history and improved staking analytics. Press @.quote:notification_messages.missing_api_key.action to add it in the app.",
         "title": "{service} API key"
       },
+      "blockscout": {
+        "message": "rotki is using {service} as a transaction indexer but it requires an API key, so its queries are being skipped. Add an API key for {service}, or adjust the indexer order to prioritize a different service.",
+        "title": "{service} API key"
+      },
       "change_indexer_order": "Change indexer order",
       "do_not_show_again": "Do not show again",
       "etherscan": {

--- a/frontend/app/src/modules/core/common/helpers/url.ts
+++ b/frontend/app/src/modules/core/common/helpers/url.ts
@@ -1,5 +1,5 @@
 import type { RouteLocationRaw } from 'vue-router';
-import { etherscanLink, externalLinks } from '@shared/external-links';
+import { blockscoutLink, etherscanLink, externalLinks } from '@shared/external-links';
 import { logger } from '@/modules/core/common/logging/logging';
 import { pslSuffixes } from '@/modules/core/common/psl';
 import { Routes } from '@/router/routes';
@@ -48,6 +48,16 @@ function getEtherScanRegisterUrl(): ExternalUrl | undefined {
   };
 }
 
+function getBlockscoutRegisterUrl(): ExternalUrl {
+  return {
+    external: blockscoutLink,
+    route: {
+      path: Routes.API_KEYS_EXTERNAL_SERVICES.toString(),
+      query: { service: 'blockscout' },
+    },
+  };
+}
+
 function getTheGraphRegisterUrl(): ExternalUrl {
   return {
     external: externalLinks.applyTheGraphApiKey,
@@ -87,6 +97,8 @@ export function getServiceRegisterUrl(service: string): ExternalUrl | undefined 
   switch (service) {
     case 'etherscan':
       return getEtherScanRegisterUrl();
+    case 'blockscout':
+      return getBlockscoutRegisterUrl();
     case 'thegraph':
       return getTheGraphRegisterUrl();
     case 'helius':

--- a/frontend/app/src/modules/core/messaging/handlers/missing-api-key.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/missing-api-key.ts
@@ -29,6 +29,7 @@ export function createMissingApiKeyHandler(t: ReturnType<typeof useI18n>['t'], r
     const actions: NotificationAction[] = [];
 
     const isEtherscan = service === SuppressibleMissingKeyService.ETHERSCAN;
+    const isBlockscout = service === SuppressibleMissingKeyService.BLOCKSCOUT;
 
     if (route) {
       actions.push({
@@ -38,7 +39,8 @@ export function createMissingApiKeyHandler(t: ReturnType<typeof useI18n>['t'], r
       });
     }
 
-    if (isEtherscan) {
+    // Both etherscan and blockscout are transaction indexers, so offer to change the order.
+    if (isEtherscan || isBlockscout) {
       actions.push({
         action: async () => router.push({ path: Routes.SETTINGS_EVM.toString(), hash: '#indexer' }),
         icon: 'lu-settings',
@@ -46,7 +48,10 @@ export function createMissingApiKeyHandler(t: ReturnType<typeof useI18n>['t'], r
         persist: true,
       });
     }
-    else if (external) {
+
+    // Unlike etherscan (which ships with a packaged fallback key), blockscout has no
+    // default key and its PRO endpoints reject keyless queries, so also offer to get one.
+    if (external && !isEtherscan) {
       actions.push({
         action: async () => openUrl(external),
         icon: 'lu-external-link',
@@ -93,6 +98,11 @@ export function createMissingApiKeyHandler(t: ReturnType<typeof useI18n>['t'], r
         category: NotificationCategory.BEACONCHAIN,
         messageKey: 'notification_messages.missing_api_key.beaconchain.message',
         titleKey: 'notification_messages.missing_api_key.beaconchain.title',
+      },
+      [SuppressibleMissingKeyService.BLOCKSCOUT]: {
+        category: NotificationCategory.BLOCKSCOUT,
+        messageKey: 'notification_messages.missing_api_key.blockscout.message',
+        titleKey: 'notification_messages.missing_api_key.blockscout.title',
       },
       [SuppressibleMissingKeyService.ETHERSCAN]: {
         category: NotificationCategory.ETHERSCAN,

--- a/frontend/app/src/modules/settings/general/external-services/SuppressMissingKeyServicesSetting.vue
+++ b/frontend/app/src/modules/settings/general/external-services/SuppressMissingKeyServicesSetting.vue
@@ -13,6 +13,7 @@ const { suppressMissingKeyMsgServices } = storeToRefs(useGeneralSettingsStore())
 
 const SERVICE_ICONS: Record<SuppressibleMissingKeyService, string> = {
   [SuppressibleMissingKeyService.BEACONCHAIN]: getPublicServiceImagePath('beaconchain.svg'),
+  [SuppressibleMissingKeyService.BLOCKSCOUT]: getPublicServiceImagePath('blockscout.svg'),
   [SuppressibleMissingKeyService.ETHERSCAN]: getPublicServiceImagePath('etherscan.svg'),
   [SuppressibleMissingKeyService.HELIUS]: getPublicServiceImagePath('helius.svg'),
   [SuppressibleMissingKeyService.THEGRAPH]: getPublicServiceImagePath('thegraph.svg'),

--- a/frontend/app/src/modules/settings/types/user-settings.ts
+++ b/frontend/app/src/modules/settings/types/user-settings.ts
@@ -21,6 +21,7 @@ export type OtherSettings = z.infer<typeof OtherSettings>;
 
 export const SuppressibleMissingKeyService = {
   BEACONCHAIN: 'beaconchain',
+  BLOCKSCOUT: 'blockscout',
   ETHERSCAN: 'etherscan',
   HELIUS: 'helius',
   THEGRAPH: 'thegraph',
@@ -28,6 +29,7 @@ export const SuppressibleMissingKeyService = {
 
 export const SuppressibleMissingKeyServiceEnum = z.enum([
   SuppressibleMissingKeyService.BEACONCHAIN,
+  SuppressibleMissingKeyService.BLOCKSCOUT,
   SuppressibleMissingKeyService.ETHERSCAN,
   SuppressibleMissingKeyService.HELIUS,
   SuppressibleMissingKeyService.THEGRAPH,

--- a/frontend/common/src/messages/index.ts
+++ b/frontend/common/src/messages/index.ts
@@ -30,6 +30,7 @@ export enum NotificationGroup {
 export const NotificationCategory = {
   ADDRESS_MIGRATION: 'address_migration',
   BEACONCHAIN: 'beaconchain',
+  BLOCKSCOUT: 'blockscout',
   CALENDAR_REMINDER: 'calendar_reminder',
   DEFAULT: 'default',
   ETHERSCAN: 'etherscan',

--- a/rotkehlchen/externalapis/blockscout.py
+++ b/rotkehlchen/externalapis/blockscout.py
@@ -15,7 +15,7 @@ from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import ChainNotSupported, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.externalapis.etherscan_like import EtherscanLikeApi, HasChainActivity
-from rotkehlchen.externalapis.interface import ExternalServiceWithApiKey
+from rotkehlchen.externalapis.interface import ExternalServiceWithRecommendedApiKey
 from rotkehlchen.externalapis.utils import get_earliest_ts, maybe_read_integer
 from rotkehlchen.history.events.structures.eth2 import EthWithdrawalEvent
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -53,8 +53,12 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class Blockscout(ExternalServiceWithApiKey, EtherscanLikeApi):
-    """Blockscout API handler for the Blockscout PRO multichain endpoints."""
+class Blockscout(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
+    """Blockscout API handler for the Blockscout PRO multichain endpoints.
+
+    The PRO endpoints require an API key (they return 401 without one), so we use the
+    recommended-key base to warn the user once via a websocket message when it's missing.
+    """
 
     supports_historical_eth_call = True  # the json-rpc endpoint honors the eth_call block tag
 
@@ -63,7 +67,7 @@ class Blockscout(ExternalServiceWithApiKey, EtherscanLikeApi):
             database: 'DBHandler',
             msg_aggregator: MessagesAggregator,
     ) -> None:
-        ExternalServiceWithApiKey.__init__(
+        ExternalServiceWithRecommendedApiKey.__init__(
             self,
             database=database,
             service_name=ExternalService.BLOCKSCOUT,

--- a/rotkehlchen/tests/external_apis/test_blockscout.py
+++ b/rotkehlchen/tests/external_apis/test_blockscout.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, patch
 
 import pytest
 
+from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.optimism.constants import OP_BEDROCK_BLOCK, OP_BEDROCK_UPGRADE
 from rotkehlchen.chain.structures import TimestampOrBlockRange
@@ -15,9 +16,10 @@ from rotkehlchen.externalapis.blockscout import Blockscout
 from rotkehlchen.externalapis.etherscan_like import HasChainActivity
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.eth2 import EthWithdrawalEvent
+from rotkehlchen.tests.fixtures.messages import MockRotkiNotifier
 from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
 from rotkehlchen.tests.utils.mock import MockResponse
-from rotkehlchen.types import ApiKey, ChainID, Timestamp, TimestampMS
+from rotkehlchen.types import ApiKey, ChainID, ExternalService, Timestamp, TimestampMS
 
 
 @pytest.fixture(name='blockscout')
@@ -363,3 +365,17 @@ def test_eth_call_historical_block_passes_tag(blockscout: Blockscout) -> None:
         method='eth_call',
         options={'to': dai, 'data': '0x18160ddd', 'tag': '0x989680'},
     )
+
+
+@pytest.mark.parametrize('include_blockscout_key', [False])
+def test_missing_api_key_warns_once(blockscout: Blockscout) -> None:
+    """Blockscout's PRO endpoints require an api key, so a missing one should emit a
+    MISSING_API_KEY websocket message (once) instead of silently skipping the query."""
+    blockscout.db.msg_aggregator.rotki_notifier = (notifier := MockRotkiNotifier())  # type: ignore[assignment]
+    assert blockscout._get_api_key_for_chain(ChainID.ETHEREUM) is None
+    assert (message := notifier.pop_message()) is not None
+    assert message.message_type == WSMessageType.MISSING_API_KEY
+    assert message.data == {'service': ExternalService.BLOCKSCOUT.serialize()}
+    # querying again must not re-warn, as the warning is given only once per session
+    assert blockscout._get_api_key_for_chain(ChainID.ETHEREUM) is None
+    assert notifier.pop_message() is None


### PR DESCRIPTION
Blockscout's PRO endpoints now require an API key (return 401 without one), but the client silently fell through the indexer chain. Switch Blockscout to ExternalServiceWithRecommendedApiKey so it emits a MISSING_API_KEY websocket message once, like etherscan, and wire the notification through the frontend.
