### PR TITLE
fix: invalidate chain balance cache on account changes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Adding or removing a blockchain account (or removing a spam token) now correctly invalidates the cached balances, so you no longer briefly see stale balances afterwards.
 * :bug:`-` Odos swaps now show the received amount before the router fee, so the fee no longer makes that asset go negative.
 * :bug:`-` rotki now notifies you when Blockscout is queried without an API key instead of silently skipping it.
 * :release:`1.43.2 <2026-06-18>`

--- a/rotkehlchen/api/services/assets.py
+++ b/rotkehlchen/api/services/assets.py
@@ -982,9 +982,7 @@ class AssetsService:
                     in_liabilities = balances.liabilities.pop(token, None)  # type: ignore
 
                     if in_assets is not None or in_liabilities is not None:
-                        self.rotkehlchen.chains_aggregator.flush_cache('query_balances')
-                        self.rotkehlchen.chains_aggregator.flush_cache(
-                            name='query_balances',
+                        self.rotkehlchen.chains_aggregator.flush_chain_balance_query_cache(
                             blockchain=blockchain,
                         )
 

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -388,12 +388,9 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
                 chain_manager.transactions_decoder.premium = None
 
         # Also flush the cache of anything that is touched by eth2 validators since
-        # without premium we have a limit
+        # without premium we have a limit. eth2 validator balances live in balances.eth2
+        # and are cached via query_eth2_balances (not _query_chain_balances).
         self.flush_cache('query_eth2_balances')
-        self.flush_cache('query_balances')
-        self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN)
-        self.flush_cache('query_balances', blockchain=None, ignore_cache=False, addresses=None)
-        self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN, ignore_cache=False, addresses=None)  # noqa: E501
 
     def process_new_modules_list(self, module_names: list[ModuleName]) -> None:
         """Processes a new list of active modules
@@ -754,6 +751,26 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             new_balances = {address: balance for address, balance in new_balances.items() if address in accounts}  # type: ignore[assignment]  # per-chain key/value types are preserved  # noqa: E501
         existing_balances.update(new_balances)  # type: ignore[arg-type]  # chain/balance types match per chain
 
+    def flush_chain_balance_query_cache(self, blockchain: SupportedBlockchain) -> None:
+        """Invalidate the cached full-chain balance query result for the given chain.
+
+        Must be called whenever a chain's tracked balances change out of band (e.g. an
+        account is added/removed or a spam token is removed) so that the next
+        non-ignore-cache balance query re-queries the chain instead of serving stale data.
+
+        The cached method is `_query_chain_balances`, which is always called per-chain with
+        addresses=None for a full query, so (blockchain, addresses=None) is the only key
+        that the cache-honoring read path consults. Referencing the method's `__name__`
+        (instead of a hardcoded string) keeps this correct if it is ever renamed - a rename
+        turns the attribute access into a loud AttributeError rather than a silent no-op,
+        which is exactly the failure mode this method exists to prevent.
+        """
+        self.flush_cache(
+            self._query_chain_balances.__name__,
+            blockchain=blockchain,
+            addresses=None,
+        )
+
     def _update_blockchain_balances_cache(
             self,
             blockchain: SupportedBlockchain,
@@ -924,7 +941,6 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         lock = getattr(self, f'{chain_key}_lock')
         balances = self.balances.get(chain=blockchain)
         with lock:
-            self.flush_cache(f'query_{chain_key}_balances')
             chain_modify_init = self.chain_modify_init.get(blockchain)
             if chain_modify_init is not None:
                 chain_modify_init(blockchain, append_or_remove)
@@ -941,12 +957,8 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
                     if chain_modify_remove is not None:
                         chain_modify_remove(blockchain, account)
 
-        # we are adding/removing accounts, make sure query cache is flushed
-        self.flush_cache('query_balances')
-        self.flush_cache('query_balances', blockchain=blockchain)
-        self.flush_cache('query_balances', blockchain=None, ignore_cache=False, addresses=None)
-        self.flush_cache('query_balances', blockchain=blockchain, ignore_cache=False, addresses=None)  # noqa: E501
-        self.flush_cache(f'query_{chain_key}_balances')
+        # we are adding/removing accounts, so invalidate the cached chain balance query
+        self.flush_chain_balance_query_cache(blockchain)
 
         # recalculate totals
         if append_or_remove == 'remove':  # at addition no balances are queried so no need
@@ -1125,10 +1137,6 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
                 ownership_proportion=ownership_proportion,
             )
         self.flush_cache('query_eth2_balances')
-        self.flush_cache('query_balances')
-        self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN)
-        self.flush_cache('query_balances', blockchain=None, ignore_cache=False, addresses=None)
-        self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN, ignore_cache=False, addresses=None)  # noqa: E501
 
     def add_eth2_validator(
             self,
@@ -1508,11 +1516,6 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         validators since it affects the balances and stats"""
         self.flush_cache('get_eth2_staking_details')
         self.flush_cache('query_eth2_balances')
-        self.flush_cache('query_balances')
-        self.flush_cache('query_balances', blockchain=None, ignore_cache=False, addresses=None)
-        self.flush_cache('query_balances', blockchain=None, ignore_cache=True, addresses=None)
-        self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN, ignore_cache=False, addresses=None)  # noqa: E501
-        self.flush_cache('query_balances', blockchain=SupportedBlockchain.ETHEREUM_BEACONCHAIN, ignore_cache=True, addresses=None)  # noqa: E501
         with self.database.user_write() as write_cursor:
             self.database.delete_blockchain_balances_cache(
                 write_cursor=write_cursor,

--- a/rotkehlchen/tests/unit/test_chains_aggregator.py
+++ b/rotkehlchen/tests/unit/test_chains_aggregator.py
@@ -362,3 +362,37 @@ def test_detect_spammed_transaction_new_token(
         assert base_manager.transactions.address_has_been_spammed(
             address=base_accounts[0],
         ) is True
+
+
+@pytest.mark.parametrize('ethereum_modules', [[]])
+@pytest.mark.parametrize('ethereum_accounts', [[]])
+def test_modify_blockchain_accounts_flushes_balance_cache(
+        blockchain: 'ChainsAggregator',
+) -> None:
+    """Regression test for balance result-cache invalidation on account changes.
+
+    The cached per-chain balance method was renamed to `_query_chain_balances` in commit
+    8fe3fdd874, but the `flush_cache` calls in `modify_blockchain_accounts` kept using the
+    old `query_balances` name, so the cache key never matched and the entry was never
+    invalidated. A non-ignore-cache balance query within the cache TTL would then return
+    stale balances (e.g. missing a newly added account).
+    """
+    chain = SupportedBlockchain.ETHEREUM
+    keys_before = set(blockchain.results_cache)
+    # Populate the cached full-chain balance query the way a non-ignore-cache query does.
+    # With no accounts the method short-circuits (no network) but still caches its result.
+    blockchain._query_chain_balances(blockchain=chain, ignore_cache=False, addresses=None)
+    cached_keys = set(blockchain.results_cache) - keys_before
+    assert len(cached_keys) == 1, 'the full-chain balance query should have been cached'
+
+    with blockchain.database.user_write() as write_cursor:
+        blockchain.modify_blockchain_accounts(
+            write_cursor=write_cursor,
+            blockchain=chain,
+            accounts=[make_evm_address()],
+            append_or_remove='append',
+        )
+
+    assert cached_keys.isdisjoint(blockchain.results_cache), (
+        'adding an account must invalidate the cached chain balance query'
+    )


### PR DESCRIPTION
The per-chain balance result cache is keyed by the cached method name (_query_chain_balances). The flush_cache calls used the pre-rename name 'query_balances' (renamed in 8fe3fdd874), so they never matched a real key and the cache was never invalidated. A non-ignore-cache balance query within the cache TTL could then serve stale balances, e.g. a newly added account would be missing.

Add a single flush_chain_balance_query_cache helper that derives the key from _query_chain_balances.__name__ (so a future rename fails loudly instead of silently no-op'ing) and use it wherever a chain's balances change out of band. Drop the dead query_balances flushes from the eth2/premium paths, whose live query_eth2_balances flush already covers the intended invalidation.
