### PR TITLE
perf: skip balance cache update for account-less chains

### DIFF
--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -713,6 +713,10 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             if ignore_cache is True and chain.is_bitcoin():
                 xpub_manager.check_for_new_xpub_addresses(blockchain=chain)  # type: ignore[arg-type] # mypy doesn't understand is_bitcoin()
 
+            # on a full query skip chains with no accounts to avoid a needless write tx each
+            if (addresses is None or len(addresses) == 0) and len(self.accounts.get(chain)) == 0:
+                continue
+
             self._query_chain_balances(blockchain=chain, ignore_cache=ignore_cache, addresses=addresses)  # noqa: E501
             self._update_blockchain_balances_cache(blockchain=chain, addresses=addresses)
 

--- a/rotkehlchen/tests/unit/test_chains_aggregator.py
+++ b/rotkehlchen/tests/unit/test_chains_aggregator.py
@@ -396,3 +396,30 @@ def test_modify_blockchain_accounts_flushes_balance_cache(
     assert cached_keys.isdisjoint(blockchain.results_cache), (
         'adding an account must invalidate the cached chain balance query'
     )
+
+
+@pytest.mark.parametrize('ethereum_modules', [[]])
+@pytest.mark.parametrize('ethereum_accounts', [[]])
+def test_query_balances_skips_chains_without_accounts(
+        blockchain: 'ChainsAggregator',
+) -> None:
+    """Regression test: a full balance refresh must not touch the balances cache for
+    chains that have no tracked accounts.
+
+    Previously the refresh loop called `_update_blockchain_balances_cache` (which opens a
+    committed write transaction) for every supported chain on each refresh, even the ~14 a
+    typical user has no accounts on, deleting nothing each time.
+    """
+    with patch.object(
+        blockchain,
+        '_update_blockchain_balances_cache',
+        wraps=blockchain._update_blockchain_balances_cache,
+    ) as update_mock:
+        blockchain.query_balances(blockchain=None, ignore_cache=False)
+
+    updated_chains = {call.kwargs['blockchain'] for call in update_mock.call_args_list}
+    # with no accounts anywhere, only the beaconchain branch (handled before the guard)
+    # may update the cache; no account-less evm/bitcoin chain should.
+    assert updated_chains <= {SupportedBlockchain.ETHEREUM_BEACONCHAIN}, (
+        f'cache update ran for account-less chains: {updated_chains}'
+    )


### PR DESCRIPTION
A full balance refresh looped over all supported chains and called _update_blockchain_balances_cache for each, which opens a committed write transaction (bumping last_write_ts) even for chains the user has no accounts on - deleting nothing. Skip those chains so a typical user no longer does ~14 needless write transactions per refresh.
