### PR TITLE
perf: cache eth2 validator statuses during accounting

### DIFF
--- a/rotkehlchen/accounting/pot.py
+++ b/rotkehlchen/accounting/pot.py
@@ -31,6 +31,7 @@ from rotkehlchen.utils.data_structures import LRUCacheWithRemove
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.modules.eth2.structures import ValidatorDetailsWithStatus
     from rotkehlchen.chain.evm.accounting.aggregator import EVMAccountingAggregators
     from rotkehlchen.db.dbhandler import DBHandler
 
@@ -95,6 +96,26 @@ class AccountingPot(CustomizableDateMixin):
         # duration of a report so keying on (asset identifier, timestamp) is enough.
         # Only successful lookups are cached so error paths keep being retried.
         self._profit_currency_rates: LRUCacheWithRemove[tuple[str, Timestamp], Price] = LRUCacheWithRemove(maxsize=PROFIT_CURRENCY_RATE_CACHE_SIZE)  # noqa: E501
+        # memoize validator statuses per report. Validators don't change while processing a
+        # fixed event set, so we load them once (on first eth2 withdrawal/exit event) instead
+        # of re-scanning the whole eth2_validators table per event. None means not yet loaded.
+        self._validators_with_status: dict[int, ValidatorDetailsWithStatus] | None = None
+
+    def get_validator_with_status(self, validator_index: int) -> 'ValidatorDetailsWithStatus | None':  # noqa: E501
+        """Return the status details for a tracked validator, loading and caching all
+        validators on the first call of a report. Returns None if the index is not tracked."""
+        if self._validators_with_status is None:
+            with self.database.conn.read_ctx() as cursor:
+                self._validators_with_status = {
+                    validator.validator_index: validator
+                    for validator in self.dbeth2.get_validators_with_status(
+                        cursor=cursor,
+                        validator_indices=None,
+                    )
+                    if validator.validator_index is not None
+                }
+
+        return self._validators_with_status.get(validator_index)
 
     def _add_processed_event(self, event: ProcessedAccountingEvent) -> None:
         self.processed_events.append(event)
@@ -172,6 +193,7 @@ class AccountingPot(CustomizableDateMixin):
         self.report_id = report_id
         self.profit_currency = self.settings.main_currency.resolve_to_asset_with_oracles()
         self._profit_currency_rates.clear()
+        self._validators_with_status = None
         self.query_start_ts = start_ts
         self.query_end_ts = end_ts
         self.pnls.reset()

--- a/rotkehlchen/history/events/structures/eth2.py
+++ b/rotkehlchen/history/events/structures/eth2.py
@@ -222,20 +222,13 @@ class EthWithdrawalEvent(EthStakingEvent):
             accounting: 'AccountingPot',
             events_iterator: Iterator['AccountingEventMixin'],  # pylint: disable=unused-argument
     ) -> int:
-        with accounting.database.conn.read_ctx() as cursor:
-            validators_info = accounting.dbeth2.get_validators_with_status(
-                cursor=cursor,
-                validator_indices={self.validator_index},
-            )
-
-        if len(validators_info) == 0:
+        if (validator_info := accounting.get_validator_with_status(self.validator_index)) is None:
             log.error(
                 f'Could not find validator {self.validator_index} in the DB while processing '
                 f'{self} for accounting. Skipping the event.',
             )
             return 1
 
-        validator_info = validators_info[0]
         event_ts, is_exit = self.get_timestamp_in_sec(), self.is_exit_or_blocknumber != 0
         name = 'Exit' if is_exit else 'Withdrawal'
         if validator_info.validator_type != ValidatorType.ACCUMULATING:

--- a/rotkehlchen/tests/unit/accounting/test_staking.py
+++ b/rotkehlchen/tests/unit/accounting/test_staking.py
@@ -1,4 +1,6 @@
 
+from unittest.mock import patch
+
 import pytest
 
 from rotkehlchen.accounting.accountant import Accountant
@@ -360,6 +362,66 @@ def test_eth_withdrawal_processing(accountant: Accountant, ethereum_accounts: li
 
     assert processed_events[4].notes == f'Exit of 60 ETH from validator {v_accum_2}. Loss of -4 incurred'  # noqa: E501
     assert processed_events[4].pnl.taxable == FVal(-4) * 3000  # $6000 taxable
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b']])
+@pytest.mark.parametrize('should_mock_price_queries', [True])
+@pytest.mark.parametrize('default_mock_price_value', [FVal(3000)])  # ETH price at $3000
+@pytest.mark.parametrize('db_settings', [{
+    'eth_staking_taxable_after_withdrawal_enabled': True,
+}])
+def test_eth_withdrawal_processing_queries_validators_once(
+        accountant: Accountant,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Validators don't change while processing a report, so their statuses must be loaded
+    once and cached on the pot rather than re-queried (a full eth2_validators scan plus a
+    consolidation history scan) for every withdrawal event. Regression test for that N+1:
+    the validators query must run exactly once across N withdrawal events, not N times.
+    """
+    v_1, v_2 = 2001, 2002
+    withdraw_address = ethereum_accounts[0]
+    events = [EthWithdrawalEvent(
+        validator_index=v_1 if idx % 2 == 0 else v_2,
+        timestamp=TimestampMS(1689000000000 + idx * 1000000),
+        amount=FVal(2),
+        withdrawal_address=withdraw_address,
+        is_exit=False,
+    ) for idx in range(4)]
+
+    with accountant.db.conn.write_ctx() as write_cursor:
+        DBEth2(accountant.db).add_or_update_validators(write_cursor, [
+            ValidatorDetails(
+                validator_index=v_1,
+                public_key=Eth2PubKey('0x' + 'a' * 96),
+                validator_type=ValidatorType.DISTRIBUTING,
+            ),
+            ValidatorDetails(
+                validator_index=v_2,
+                public_key=Eth2PubKey('0x' + 'b' * 96),
+                validator_type=ValidatorType.DISTRIBUTING,
+            ),
+        ])
+        DBHistoryEvents(accountant.db).add_history_events(write_cursor, events)
+
+    pot = accountant.pots[0]
+    with patch.object(
+        pot.dbeth2,
+        'get_validators_with_status',
+        wraps=pot.dbeth2.get_validators_with_status,
+    ) as validators_mock:
+        accountant.process_history(
+            start_ts=Timestamp(0),
+            end_ts=ts_now(),
+            events=events,
+        )
+
+    # all withdrawals were processed correctly (behavior preserved) ...
+    processed_events = pot.processed_events
+    assert len(processed_events) == 4
+    assert all(event.pnl.taxable == FVal(2) * 3000 for event in processed_events)
+    # ... but the validators table was queried once, not once per withdrawal event
+    assert validators_mock.call_count == 1
 
 
 @pytest.mark.parametrize('ethereum_accounts', [['0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b']])


### PR DESCRIPTION
EthWithdrawalEvent.process re-queried get_validators_with_status per event, each time scanning the whole eth2_validators table (plus a consolidation history scan) and discarding all but one validator. Since validators don't change while processing a report, load them once and cache them on the pot (cleared in reset), turning the per-event O(N*M) into O(M).
