### PR TITLE
perf: skip idle periodic tx receipt/decode scans

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -67,6 +67,7 @@ from rotkehlchen.db.filtering import UserNotesFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.loopring import DBLoopring
 from rotkehlchen.db.misc import detect_sqlcipher_version
+from rotkehlchen.db.pending_transactions import PendingTransactionsTracker
 from rotkehlchen.db.schema import DB_SCRIPT_CREATE_TABLES
 from rotkehlchen.db.schema_transient import DB_SCRIPT_CREATE_TRANSIENT_TABLES
 from rotkehlchen.db.settings import (
@@ -251,6 +252,9 @@ class DBHandler:
         self.get_or_create_token_lock = Semaphore()
         self.match_asset_movements_lock = Semaphore()
         self._ignored_asset_ids_cache: dict[bool, set[str]] = {}
+        # tracks, in memory, which chains may have transactions pending receipt fetching or
+        # decoding so the periodic scheduler can skip its full-table "is there work?" scans
+        self.pending_txs_tracker = PendingTransactionsTracker()
         self.password = password
         self._connect()
         self._check_unfinished_upgrades(resume_from_backup=resume_from_backup)

--- a/rotkehlchen/db/evmtx.py
+++ b/rotkehlchen/db/evmtx.py
@@ -89,6 +89,7 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
         newly_inserted: list[EVMTxHash] = []
+        dirty_chains: set[ChainID] = set()
         for tx in evm_transactions:
             row_id, is_new = self.db.write_single_tuple(
                 write_cursor=write_cursor,
@@ -112,6 +113,7 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
             )
             if is_new:
                 newly_inserted.append(tx.tx_hash)
+                dirty_chains.add(tx.chain_id)
             if row_id is not None and tx.authorization_list is not None:
                 self.db.write_tuples(
                     write_cursor=write_cursor,
@@ -122,6 +124,8 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
                         for auth in tx.authorization_list
                     ],
                 )
+        for chain_id in dirty_chains:  # newly added txs have no receipt yet -> pending receipts
+            self.db.pending_txs_tracker.mark_receipts_dirty(chain_id.to_blockchain())
         return newly_inserted
 
     def add_evm_internal_transactions(
@@ -384,6 +388,8 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
                 raise
             return tx_id  # otherwise something else added the receipt so we continue
 
+        # a new receipt was just added, so this tx is now pending decoding
+        self.db.pending_txs_tracker.mark_decoding_dirty(chain_id.to_blockchain())
         for log_entry in data['logs']:
             write_cursor.execute(
                 'INSERT INTO evmtx_receipt_logs (tx_id, log_index, data, address) '
@@ -559,6 +565,8 @@ class DBEvmTx(DBCommonTx[ChecksumEvmAddress, EvmTransaction, EVMTxHash, EvmTrans
             'DELETE FROM evm_tx_mappings WHERE tx_id=? AND value IN (?, ?, ?)',
             [(x, TX_DECODED, TX_SPAM, TX_INTERNALS_QUERIED) for x in tx_ids],
         )
+        # remaining txs had their decoded marker removed -> pending decoding again
+        self.db.pending_txs_tracker.mark_decoding_dirty(chain)
         # Delete any key_value_cache entries
         write_cursor.executemany(
             'DELETE FROM key_value_cache WHERE name LIKE ?',

--- a/rotkehlchen/db/pending_transactions.py
+++ b/rotkehlchen/db/pending_transactions.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from rotkehlchen.types import SupportedBlockchain, Timestamp
+
+# Safety net: even if some invalidation site is ever missed, re-scan a chain that was
+# marked clean once this many seconds have passed. Event-based invalidation
+# (mark_*_dirty) keeps the common "new transactions arrived" case responsive; this only
+# bounds the worst-case latency so a pending queue can never get permanently stuck.
+PENDING_TX_RESCAN_AFTER: Final = 300
+
+
+class PendingTransactionsTracker:
+    """In-memory, per-chain signal of whether transactions may be pending receipt
+    fetching or decoding.
+
+    The periodic task scheduler probes the DB every few seconds to decide whether to
+    schedule receipt fetching / transaction decoding. Those probes are full-table scans
+    (there is no chain_id index on evm_transactions), so re-running them on every tick of
+    an already synced wallet is pure waste. This tracker lets a probe skip the scan for a
+    chain that was found empty on a recent scan and has not been touched since.
+
+    Semantics: a chain whose last clean scan is recent (and that has not been invalidated
+    since) is skipped. Inserts/deletes that can create pending work invalidate the chain so
+    the next tick scans it again. State starts empty, so every chain is scanned until
+    proven clean (conservative - never skips work that may exist).
+
+    Lives on the (per-user) DBHandler so both the DB write paths that create work and the
+    scheduler that drains it share a single instance without the DB layer depending on the
+    task manager.
+    """
+
+    def __init__(self) -> None:
+        # chain -> timestamp of the most recent scan that found no pending work
+        self.receipts_clean_ts: dict[SupportedBlockchain, Timestamp] = {}
+        self.decoding_clean_ts: dict[SupportedBlockchain, Timestamp] = {}
+
+    def should_scan_receipts(self, blockchain: SupportedBlockchain, now: Timestamp) -> bool:
+        return now - self.receipts_clean_ts.get(blockchain, 0) > PENDING_TX_RESCAN_AFTER
+
+    def should_scan_decoding(self, blockchain: SupportedBlockchain, now: Timestamp) -> bool:
+        return now - self.decoding_clean_ts.get(blockchain, 0) > PENDING_TX_RESCAN_AFTER
+
+    def mark_receipts_clean(self, blockchain: SupportedBlockchain, now: Timestamp) -> None:
+        self.receipts_clean_ts[blockchain] = now
+
+    def mark_decoding_clean(self, blockchain: SupportedBlockchain, now: Timestamp) -> None:
+        self.decoding_clean_ts[blockchain] = now
+
+    def mark_receipts_dirty(self, blockchain: SupportedBlockchain) -> None:
+        """Signal that `blockchain` may now have transactions missing their receipt."""
+        self.receipts_clean_ts.pop(blockchain, None)
+
+    def mark_decoding_dirty(self, blockchain: SupportedBlockchain) -> None:
+        """Signal that `blockchain` may now have transactions pending decoding."""
+        self.decoding_clean_ts.pop(blockchain, None)

--- a/rotkehlchen/db/solanatx.py
+++ b/rotkehlchen/db/solanatx.py
@@ -14,7 +14,7 @@ from rotkehlchen.db.filtering import (
 )
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.utils import get_query_chunks
-from rotkehlchen.types import Location, SolanaAddress, Timestamp
+from rotkehlchen.types import Location, SolanaAddress, SupportedBlockchain, Timestamp
 
 if TYPE_CHECKING:
     from rotkehlchen.db.drivers.gevent import DBCursor
@@ -109,6 +109,8 @@ class DBSolanaTx(DBCommonTx[SolanaAddress, SolanaTransaction, Signature, SolanaT
                         ],
                     )
 
+        if len(newly_inserted) != 0:  # new solana txs are not decoded yet -> pending decoding
+            self.db.pending_txs_tracker.mark_decoding_dirty(SupportedBlockchain.SOLANA)
         return newly_inserted
 
     @staticmethod

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -387,14 +387,20 @@ class TaskManager:
         lock acquired.
         """
         dbevmtx = DBEvmTx(self.database)
+        tracker = self.database.pending_txs_tracker
+        now = ts_now()
         shuffled_chains = list(EVM_CHAINS_WITH_TRANSACTIONS)
         random.shuffle(shuffled_chains)
         for blockchain in shuffled_chains:
+            if tracker.should_scan_receipts(blockchain, now) is False:
+                continue  # recently scanned with no missing receipts, untouched since -> skip scan
+
             hash_results = dbevmtx.get_transaction_hashes_no_receipt(
                 tx_filter_query=EvmTransactionsFilterQuery.make(chain_id=blockchain.to_chain_id()),
                 limit=TX_RECEIPTS_QUERY_LIMIT,
             )
             if len(hash_results) == 0:
+                tracker.mark_receipts_clean(blockchain, now)
                 continue
 
             evm_inquirer = self.chains_aggregator.get_chain_manager(blockchain)
@@ -449,9 +455,14 @@ class TaskManager:
         lock acquired.
         """
 
+        tracker = self.database.pending_txs_tracker
+        now = ts_now()
         shuffled_chains = list(CHAINS_WITH_TRANSACTION_DECODERS)
         random.shuffle(shuffled_chains)
         for blockchain in shuffled_chains:
+            if tracker.should_scan_decoding(blockchain, now) is False:
+                continue  # recently scanned with nothing to decode, untouched since -> skip scan
+
             if blockchain == SupportedBlockchain.SOLANA:
                 number_of_tx_to_decode = DBSolanaTx(self.database).count_hashes_not_decoded(
                     filter_query=SolanaTransactionsNotDecodedFilterQuery.make(),
@@ -462,6 +473,7 @@ class TaskManager:
                 )
 
             if number_of_tx_to_decode == 0:
+                tracker.mark_decoding_clean(blockchain, now)
                 continue
 
             chain_inquirer = self.chains_aggregator.get_chain_manager(blockchain)

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -55,7 +55,11 @@ from rotkehlchen.tests.utils.ethereum import (
     get_decoded_events_of_transaction,
     setup_ethereum_transactions_test,
 )
-from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
+from rotkehlchen.tests.utils.factories import (
+    make_ethereum_transaction,
+    make_evm_address,
+    make_evm_tx_hash,
+)
 from rotkehlchen.tests.utils.mock import mock_evm_chains_with_transactions
 from rotkehlchen.tests.utils.premium import VALID_PREMIUM_KEY, VALID_PREMIUM_SECRET
 from rotkehlchen.types import (
@@ -308,6 +312,35 @@ def test_maybe_schedule_txreceipts_checks_all_chains(task_manager: TaskManager) 
         ]
         result = task_manager._maybe_schedule_evm_txreceipts()
         assert result is not None and len(result) == 1
+
+
+@pytest.mark.parametrize('max_tasks_num', [5])
+def test_maybe_schedule_txreceipts_skips_recently_clean_chain(task_manager: TaskManager) -> None:
+    """A chain found to have no transactions missing receipts must not be re-scanned on the
+    next tick, and must be scanned again once an insert invalidates it.
+
+    Guards the per-tick full-table scan from running every scheduler tick on an idle wallet.
+    """
+    with (
+        patch(
+            'rotkehlchen.tasks.manager.EVM_CHAINS_WITH_TRANSACTIONS',
+            new=(SupportedBlockchain.ETHEREUM,),
+        ),
+        patch('rotkehlchen.tasks.manager.DBEvmTx') as mock_evm_tx,
+    ):
+        scan = mock_evm_tx.return_value.get_transaction_hashes_no_receipt
+        scan.return_value = []  # no transactions missing receipts
+
+        assert task_manager._maybe_schedule_evm_txreceipts() is None
+        assert scan.call_count == 1  # scanned once, then marked clean
+
+        assert task_manager._maybe_schedule_evm_txreceipts() is None
+        assert scan.call_count == 1, 'recently-clean chain should not be scanned again'
+
+        # a newly added transaction invalidates the chain -> next tick scans again
+        task_manager.database.pending_txs_tracker.mark_receipts_dirty(SupportedBlockchain.ETHEREUM)
+        assert task_manager._maybe_schedule_evm_txreceipts() is None
+        assert scan.call_count == 2
 
 
 @pytest.mark.parametrize('max_tasks_num', [7])
@@ -1641,6 +1674,9 @@ def test_maybe_decode_transactions(task_manager: TaskManager) -> None:
             new=(SupportedBlockchain.SOLANA,),
         ),
     ):
+        # the previous block marked solana clean; new work appearing in production always
+        # goes through an invalidating DB write, so simulate that here
+        task_manager.database.pending_txs_tracker.mark_decoding_dirty(SupportedBlockchain.SOLANA)
         mock_solana_tx.return_value.count_hashes_not_decoded.return_value = 5
         result = task_manager._maybe_decode_transactions()
         assert result is not None and len(result) == 1
@@ -1669,6 +1705,64 @@ def test_maybe_decode_transactions_checks_all_chains(task_manager: TaskManager) 
         mock_solana_tx.return_value.count_hashes_not_decoded.return_value = 5  # solana has work
         result = task_manager._maybe_decode_transactions()
         assert result is not None and len(result) == 1
+
+
+@pytest.mark.parametrize('max_tasks_num', [5])
+def test_maybe_decode_transactions_skips_recently_clean_chain(task_manager: TaskManager) -> None:
+    """A chain found to have nothing to decode must not be re-scanned on the next tick, and
+    must be scanned again once an insert/redecode invalidates it.
+
+    Guards the per-tick COUNT(DISTINCT) join scan from running every scheduler tick.
+    """
+    task_manager.should_schedule = True
+    with (
+        patch(
+            'rotkehlchen.tasks.manager.CHAINS_WITH_TRANSACTION_DECODERS',
+            new=(SupportedBlockchain.ETHEREUM,),
+        ),
+        patch('rotkehlchen.tasks.manager.DBEvmTx') as mock_evm_tx,
+    ):
+        count = mock_evm_tx.return_value.count_hashes_not_decoded
+        count.return_value = 0  # nothing to decode
+
+        assert task_manager._maybe_decode_transactions() is None
+        assert count.call_count == 1  # scanned once, then marked clean
+
+        assert task_manager._maybe_decode_transactions() is None
+        assert count.call_count == 1, 'recently-clean chain should not be scanned again'
+
+        # a new receipt / redecode invalidates the chain -> next tick scans again
+        task_manager.database.pending_txs_tracker.mark_decoding_dirty(SupportedBlockchain.ETHEREUM)
+        assert task_manager._maybe_decode_transactions() is None
+        assert count.call_count == 2
+
+
+def test_pending_txs_tracker_invalidated_on_db_writes(database: 'DBHandler') -> None:
+    """The DB write paths that create pending work must invalidate the tracker, so the
+    scheduler picks the work up on the next tick rather than only after the safety-net TTL.
+    """
+    tracker = database.pending_txs_tracker
+    dbevmtx = DBEvmTx(database)
+    now = ts_now()
+
+    # adding a transaction (which has no receipt yet) marks the chain pending receipts
+    tracker.mark_receipts_clean(SupportedBlockchain.ETHEREUM, now)
+    tx = make_ethereum_transaction()
+    with database.user_write() as write_cursor:
+        dbevmtx.add_transactions(write_cursor, [tx], relevant_address=None)
+    assert tracker.should_scan_receipts(SupportedBlockchain.ETHEREUM, now) is True
+
+    # adding its receipt marks the chain pending decoding
+    tracker.mark_decoding_clean(SupportedBlockchain.ETHEREUM, now)
+    with database.user_write() as write_cursor:
+        dbevmtx.add_or_ignore_receipt_data(write_cursor, ChainID.ETHEREUM, {
+            'transactionHash': tx.tx_hash.hex(),
+            'type': '0x0',
+            'status': 1,
+            'contractAddress': None,
+            'logs': [],
+        })
+    assert tracker.should_scan_decoding(SupportedBlockchain.ETHEREUM, now) is True
 
 
 @pytest.mark.parametrize('max_tasks_num', [5])


### PR DESCRIPTION
The scheduler ran _maybe_schedule_evm_txreceipts and _maybe_decode_transactions every ~10s tick, and each performed a full-table scan per chain (evm_transactions has no chain_id index) just to decide whether to schedule work. On an already-synced wallet this is ~20 scans every tick that find nothing (~78ms/tick at 30k txs, scaling linearly with table size).

Add an in-memory per-chain PendingTransactionsTracker on the DBHandler. A probe skips the scan for a chain it recently found empty and that has not been touched since. The DB write paths that create pending work invalidate the relevant chain so the next tick scans it again: add_transactions -> pending receipts; add_or_ignore_receipt_data and the redecode mapping delete -> pending decoding; solana tx adds -> pending decoding. A 300s safety-net rescan bounds the worst case so a queue can never get stuck if an invalidation site is ever missed.

