### PR TITLE
perf: read cached settings on more hot DB paths

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -3148,7 +3148,9 @@ class DBHandler:
             to_ts = ts_now()
 
         if settings is None:
-            settings = self.get_settings(cursor)
+            # cached settings are kept in sync on write, so avoid a full settings DB
+            # read + deserialization on every per-asset timed-balances query
+            settings = CachedSettings().get_settings()
         querystr = (
             'SELECT timestamp, amount, usd_value, category FROM timed_balances '
             'WHERE timestamp BETWEEN ? AND ? AND currency=?'
@@ -3478,7 +3480,7 @@ class DBHandler:
         """
         with self.conn.read_ctx() as cursor:
             ignored_asset_ids = self.get_ignored_asset_ids(cursor)
-            treat_eth2_as_eth = self.get_settings(cursor).treat_eth2_as_eth
+            treat_eth2_as_eth = CachedSettings().get_settings().treat_eth2_as_eth
             cursor.execute(
                 'SELECT timestamp, currency, amount, usd_value, category FROM timed_balances '
                 'WHERE timestamp=(SELECT MAX(timestamp) from timed_balances) AND category = ? '
@@ -4359,8 +4361,9 @@ class DBHandler:
     def get_chains_to_detect_evm_accounts(self) -> list[SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE]:
         """Reads the DB for the excluding chains and calculate which chains to
         perform EVM account detection on"""
-        with self.conn.read_ctx() as cursor:
-            excluded_chains = self.get_settings(cursor).evmchains_to_skip_detection
+        # cached settings are kept in sync on write, so read the excluded chains from there
+        # to avoid a full settings DB read + deserialization (and an extra read_ctx)
+        excluded_chains = CachedSettings().get_settings().evmchains_to_skip_detection
         return list(set(SUPPORTED_EVM_EVMLIKE_CHAINS) - set(excluded_chains))
 
     def _insert_into_credentials_mappings(


### PR DESCRIPTION
query_timed_balances, get_latest_location_value_distribution and get_chains_to_detect_evm_accounts each rebuilt the full DBSettings object (a settings SELECT + ~70-row deserialization) just to read a single attribute. CachedSettings is kept in sync on every write, so read these from it instead, matching the existing swap in query_collection_timed_balances. Also drops a now-unneeded read_ctx in get_chains_to_detect_evm_accounts.
