### PR TITLE
feat: rank assets page search by levenshtein

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`-` Add support for Bit2me exchange.
+* :feature:`9316` Searching for an asset in the asset manager now shows the closest matches first, so the asset you are looking for appears at the top instead of being buried under similarly-named or spam tokens.
 * :feature:`12219` Add Moralis as a price Oracle.
 * :bug:`12277` If your main currency is not USD, editing a balance snapshot now shows and saves each value converted at the exchange rate from that snapshot's own date. Previously it used today's exchange rate, so the values you saw and saved were off, especially for assets pegged to a fiat currency such as EUR stablecoins.
 * :bug:`12306` Chain locations (e.g. ``ethereum``, ``optimism``) with on-chain balances are now reachable via global search, even when no manual balance is tagged with that label.

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2790,6 +2790,10 @@ class AssetsPostSchema(DBPaginationSchema, DBOrderBySchema):
             show_user_owned_assets_only=data['show_user_owned_assets_only'],
             show_whitelisted_assets_only=data['show_whitelisted_assets_only'],
             ignored_assets_handling=data['ignored_assets_handling'],
+            # when a name/symbol search is active, always rank by fuzzy closeness first so the
+            # best matches lead (like the asset search dropdown). The requested/default column
+            # sort is kept as the tiebreaker. Only takes effect when name or symbol is set.
+            rank_by_levenshtein=True,
         )
         return {'filter_query': filter_query}
 

--- a/rotkehlchen/db/drivers/gevent.py
+++ b/rotkehlchen/db/drivers/gevent.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 import gevent
 import rsqlite
+from polyleven import levenshtein
 from sqlcipher3 import dbapi2 as sqlcipher
 
 from rotkehlchen.db.checks import sanity_check_impl
@@ -277,6 +278,10 @@ class DBConnection:
                 isolation_level=None,
             )
         self._set_progress_handler()
+        if connection_type == DBConnectionType.GLOBAL:
+            # Register a fuzzy-match helper so asset search/ranking can ORDER BY Levenshtein
+            # distance directly in SQL instead of pulling every matching row into memory.
+            self._conn.create_function('levenshtein', 2, levenshtein, deterministic=True)
         self.minimized_schema = None
         self.minimized_indexes = None
         if connection_type == DBConnectionType.USER:

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -102,18 +102,33 @@ class TimestampProximityOrder:
     ascending: bool = True
 
 
+@dataclass(frozen=True)
+class LevenshteinOrder:
+    """Order rows by the Levenshtein distance of their name/symbol to a search term.
+
+    The term is emitted as bound query parameters, never spliced into the SQL, so this can only
+    ever express the fuzzy ordering and not arbitrary SQL. Requires the ``levenshtein`` scalar
+    function to be registered on the connection (done for the global DB connection in
+    rotkehlchen/db/drivers/gevent.py).
+    """
+    term: str
+    name_field: str = 'name'
+    symbol_field: str = 'symbol'
+    ascending: bool = True
+
+
 # A single ordering rule is either a (column_name, ascending) pair - validated as a plain column
-# name - or a typed proximity ordering. No other shape can reach the ORDER BY clause.
-OrderByRule = tuple[str, bool] | TimestampProximityOrder
+# name - or a typed proximity/levenshtein ordering. No other shape can reach the ORDER BY clause.
+OrderByRule = tuple[str, bool] | TimestampProximityOrder | LevenshteinOrder
 
 
 class DBFilterOrder(NamedTuple):
     rules: Sequence[OrderByRule]
     case_sensitive: bool
 
-    def prepare(self) -> tuple[str, list[TimestampMS]]:
+    def prepare(self) -> tuple[str, list[Any]]:
         querystr = 'ORDER BY '
-        bindings: list[TimestampMS] = []
+        bindings: list[Any] = []
         for idx, rule in enumerate(self.rules):
             if idx != 0:
                 querystr += ','
@@ -121,6 +136,21 @@ class DBFilterOrder(NamedTuple):
             if isinstance(rule, TimestampProximityOrder):
                 querystr += f"ABS(timestamp - ?) {'ASC' if rule.ascending else 'DESC'}"
                 bindings.append(rule.anchor)
+                continue
+
+            if isinstance(rule, LevenshteinOrder):
+                if not (
+                    is_valid_order_by_attribute(rule.name_field) and
+                    is_valid_order_by_attribute(rule.symbol_field)
+                ):
+                    raise InvalidFilter(f'Invalid levenshtein order fields {rule.name_field}, {rule.symbol_field}')  # noqa: E501
+                querystr += (
+                    'MIN('
+                    f"levenshtein(?, lower(COALESCE({rule.name_field}, ''))), "
+                    f"levenshtein(?, lower(COALESCE({rule.symbol_field}, '')))"
+                    f") {'ASC' if rule.ascending else 'DESC'}"
+                )
+                bindings.extend((rule.term, rule.term))
                 continue
 
             attribute, ascending = rule
@@ -1963,9 +1993,16 @@ class AssetsFilterQuery(DBFilterQuery):
             chain_id: ChainID | None = None,
             identifier_column_name: str = 'identifier',
             ignored_assets_handling: IgnoredAssetsHandling = IgnoredAssetsHandling.NONE,
+            rank_by_levenshtein: bool = False,
     ) -> 'AssetsFilterQuery':
         if order_by_rules is None:
             order_by_rules = [('name', True)]
+
+        # When a name/symbol search is active, rank the (already LIKE-prefiltered) matches by
+        # levenshtein closeness so the best matches lead, mirroring the assets search dropdown.
+        # The requested/default column sort is kept as the tiebreaker.
+        if rank_by_levenshtein and (term := name if name is not None else symbol) is not None:
+            order_by_rules = [LevenshteinOrder(term=term.casefold()), *order_by_rules]
 
         filter_query = cls.create(
             and_op=and_op,

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -440,7 +440,9 @@ class GlobalDBHandler:
             # get `entries_found`. In the case of handling the ignored assets we need to manually
             # count the assets found since the information needed is both in the
             # userdb (ignored assets) and the globaldb (filtered identifiers)
-            query, bindings = filter_query.prepare(with_pagination=False)
+            # skip ORDER BY for the count: sorting (and the per-row levenshtein calls it may add)
+            # is pointless for COUNT(*)/identifier collection and would only add cost + bindings.
+            query, bindings = filter_query.prepare(with_pagination=False, with_order=False)
             if filter_query.ignored_assets_handling == IgnoredAssetsHandling.NONE:
                 total_found_query = f'SELECT COUNT(*) FROM ({parent_query}) ' + query
                 entries_found = cursor.execute(total_found_query, bindings).fetchone()[0]

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -82,6 +82,16 @@ def assert_asset_at_top_position(
             assert index <= max_position_index
 
 
+def _min_levenshtein(entry: dict[str, Any], term: str) -> int:
+    """Mirror the backend's min-over-name/symbol levenshtein scoring for an asset entry."""
+    distances = [100]
+    if entry.get('name') is not None:
+        distances.append(levenshtein(term, entry['name'].casefold()))
+    if entry.get('symbol') is not None:
+        distances.append(levenshtein(term, entry['symbol'].casefold()))
+    return min(distances)
+
+
 @pytest.mark.freeze_time('2026-06-05 04:27:20 GMT', tick=True)
 @pytest.mark.vcr
 @pytest.mark.parametrize('number_of_eth_accounts', [2])
@@ -344,7 +354,10 @@ def test_get_all_assets(rotkehlchen_api_server: 'APIServer') -> None:
         assert 'uniswap' in entry['name'].lower()
         if entry['asset_type'] == AssetType.EVM_TOKEN.serialize():
             assert entry['evm_chain'] in [x.to_name() for x in ChainID]
-    assert_asset_result_order(data=result['entries'], is_ascending=False, order_field='symbol')
+    # a name/symbol search is now relevance-ranked (levenshtein), so the page is ordered by
+    # non-decreasing distance to the term, with the requested symbol sort only as tiebreaker
+    distances = [_min_levenshtein(entry, 'uniswap') for entry in result['entries']]
+    assert distances == sorted(distances)
 
     # test that ignored assets filter works
     with rotkehlchen_api_server.rest_api.rotkehlchen.data.db.user_write() as write_cursor:
@@ -581,6 +594,81 @@ def test_get_all_assets(rotkehlchen_api_server: 'APIServer') -> None:
         contained_in_msg='Given value xxxxxxxxx is not a valid EVM or Solana address',
         status_code=HTTPStatus.BAD_REQUEST,
     )
+
+
+def test_get_all_assets_levenshtein_ranking(rotkehlchen_api_server: 'APIServer') -> None:
+    """Test that the paginated assets endpoint ranks name/symbol searches by levenshtein
+    closeness (like the asset search dropdown) instead of an alphabetical LIKE match, while
+    keeping pagination correct. Regression test for https://github.com/rotki/rotki/issues/9316
+    """
+    globaldb = GlobalDBHandler()
+    # seed deterministic assets whose symbols all contain the search term `zztop` (so they pass
+    # the LIKE prefilter) but at increasing levenshtein distance. Names are kept far from the
+    # term so the symbol distance drives the ranking.
+    exact_id, coin_id, spam_id = str(uuid4()), str(uuid4()), str(uuid4())
+    globaldb.add_asset(CryptoAsset.initialize(
+        identifier=spam_id,
+        asset_type=AssetType.OWN_CHAIN,
+        name='Asset Gamma',
+        symbol='MYZZTOPSPAM',  # alphabetically first, but the furthest match
+    ))
+    globaldb.add_asset(CryptoAsset.initialize(
+        identifier=coin_id,
+        asset_type=AssetType.OWN_CHAIN,
+        name='Asset Beta',
+        symbol='ZZTOPCOIN',
+    ))
+    globaldb.add_asset(CryptoAsset.initialize(
+        identifier=exact_id,
+        asset_type=AssetType.OWN_CHAIN,
+        name='Asset Alpha',
+        symbol='ZZTOP',  # exact match, must rank first
+    ))
+
+    # search by symbol without an explicit sort -> results ranked by levenshtein closeness
+    result = assert_proper_sync_response_with_result(requests.post(
+        api_url_for(rotkehlchen_api_server, 'allassetsresource'),
+        json={'limit': 50, 'offset': 0, 'symbol': 'zztop'},
+    ))
+    entries = result['entries']
+    assert {e['identifier'] for e in entries} == {exact_id, coin_id, spam_id}
+    # the exact symbol match must be first, despite being alphabetically last
+    assert entries[0]['identifier'] == exact_id
+    # the whole page is ordered by non-decreasing levenshtein distance
+    distances = [_min_levenshtein(e, 'zztop') for e in entries]
+    assert distances == sorted(distances)
+    assert distances[0] == 0
+
+    # pagination must stay correct (disjoint, contiguous) under the levenshtein ordering
+    page1 = assert_proper_sync_response_with_result(requests.post(
+        api_url_for(rotkehlchen_api_server, 'allassetsresource'),
+        json={'limit': 2, 'offset': 0, 'symbol': 'zztop'},
+    ))
+    page2 = assert_proper_sync_response_with_result(requests.post(
+        api_url_for(rotkehlchen_api_server, 'allassetsresource'),
+        json={'limit': 2, 'offset': 2, 'symbol': 'zztop'},
+    ))
+    assert page1['entries_found'] == 3
+    paged_ids = [e['identifier'] for e in page1['entries']] + [e['identifier'] for e in page2['entries']]  # noqa: E501
+    assert paged_ids == [e['identifier'] for e in entries]  # same order, no dupes/gaps
+    assert len(set(paged_ids)) == 3
+
+    # an explicit column sort does NOT opt out of relevance ranking: the closest match still
+    # leads, with the requested column only acting as the tiebreaker between equal distances
+    result = assert_proper_sync_response_with_result(requests.post(
+        api_url_for(rotkehlchen_api_server, 'allassetsresource'),
+        json={
+            'limit': 50,
+            'offset': 0,
+            'symbol': 'zztop',
+            'order_by_attributes': ['symbol'],
+            'ascending': [False],
+        },
+    ))
+    # exact match still first despite the explicit symbol sort, and overall still by distance
+    assert result['entries'][0]['identifier'] == exact_id
+    distances = [_min_levenshtein(e, 'zztop') for e in result['entries']]
+    assert distances == sorted(distances)
 
 
 def test_get_assets_mappings(rotkehlchen_api_server: 'APIServer') -> None:

--- a/rotkehlchen/tests/api/test_user_evm_tokens.py
+++ b/rotkehlchen/tests/api/test_user_evm_tokens.py
@@ -765,8 +765,10 @@ def test_adding_evm_token_with_underlying_token(
     )
     result = assert_proper_sync_response_with_result(response)
     assert result['entries_found'] == 2
-    assert result['entries'][1]['underlying_tokens'] == underlying_tokens
-    assert len(result['entries'][0]['underlying_tokens']) == 2
+    # the search is now relevance-ranked, so the exact match 'my balancer token' leads and
+    # 'my balancer token b' follows
+    assert result['entries'][0]['underlying_tokens'] == underlying_tokens
+    assert len(result['entries'][1]['underlying_tokens']) == 2
 
     response = requests.post(
         api_url_for(


### PR DESCRIPTION
## Abstract

Fixes #9316.

The paginated assets page search (`/assets/all`) used a plain `symbol/name LIKE %value%` ordered alphabetically, so exact matches got buried under spam/LP tokens (e.g. searching `dai` surfaced `fdai.xyz` spam before DAI). Unlike the asset search dropdown, it had no relevance ranking because the levenshtein implementation lived in memory and the endpoint is paginated.

## Specification

Ranking is now done **in SQL** so pagination stays correct without pulling rows into memory:

- Register `polyleven.levenshtein` as a deterministic 2-arg SQL function on the global DB connection (`rsqlite` supports `create_function`).
- Add a typed `LevenshteinOrder` ordering rule (mirrors the existing `TimestampProximityOrder`; the search term is always a bound parameter, never spliced into SQL).
- `AssetsPostSchema`/`AssetsFilterQuery` enable it when a `name`/`symbol` search is active: the LIKE prefilter still selects candidates, and the survivors are ordered by `MIN(levenshtein(term, name), levenshtein(term, symbol))`. The requested/default column sort is kept as the tiebreaker, so the closest matches always lead.
- The `entries_found` count query skips `ORDER BY` (`with_order=False`) to avoid the per-row UDF cost.

Benchmarked at ~15ms to rank the full ~13k-asset global DB, so a native SQLite extension wasn't needed.

## Tests

- New `test_get_all_assets_levenshtein_ranking`: exact match ranks first despite being alphabetically last, the full page is ordered by non-decreasing distance, **pagination stays disjoint/contiguous** under the new ordering, and an explicit column sort still relevance-leads with the column as tiebreaker.
- Updated the `name='Uniswap'` assertion in `test_get_all_assets` to reflect relevance ranking.