### PR TITLE
fix: handle custom assets without price oracles in inquirer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`12463` Querying price for custom asset under certain conditions no longer fails the task.
 * :bug:`-` PnL reports no longer fail for accounts with a very very large history.
 * :bug:`-` Adding or removing a blockchain account (or removing a spam token) now correctly invalidates the cached balances, so you no longer briefly see stale balances afterwards.
 * :bug:`-` Odos swaps now show the received amount before the router fee, so the fee no longer makes that asset go negative.

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -592,7 +592,14 @@ class Inquirer:
         # Resolve assets to AssetWithOracles and set
         # the price of any assets without oracles to ZERO_PRICE
         found_prices, unpriced_assets = {}, []
-        to_asset = to_asset.resolve_to_asset_with_oracles()
+        try:
+            to_asset = to_asset.resolve_to_asset_with_oracles()
+        except WrongAssetType:
+            # The target currency has no oracles (e.g. a custom asset). Any from_asset that
+            # could be priced against it via a manual price was already handled earlier in
+            # _find_prices, so the remaining ones are unpriceable by the oracles here.
+            return dict.fromkeys(from_assets, (ZERO_PRICE, CurrentPriceOracle.BLOCKCHAIN))
+
         for from_asset in from_assets:
             if from_asset.is_asset_with_oracles():
                 unpriced_assets.append(from_asset.resolve_to_asset_with_oracles())

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -902,6 +902,28 @@ def test_price_for_custom_assets(inquirer, database, globaldb):
 
 
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
+def test_price_with_custom_asset_as_target(inquirer, database):
+    """Regression test for a custom asset used as the price target (to_asset).
+
+    A custom asset has no oracles, so resolving the target to an AssetWithOracles inside
+    _query_oracle_instances used to raise WrongAssetType and crash the query task. The
+    leftover from_assets (which already missed the manual price layer) should instead be
+    reported as unpriced (ZERO_PRICE) without raising.
+    """
+    DBCustomAssets(database).add_custom_asset(CustomAsset.initialize(
+        identifier='custom-target-id',
+        name='my custom target',
+        custom_asset_type='oh my type',
+    ))
+    custom_target = Asset('custom-target-id')
+    # BTC has no manual price into the custom asset, so it reaches _query_oracle_instances
+    inquirer._oracle_instances = [MagicMock() for _ in inquirer._oracles]
+    assert inquirer.find_price(from_asset=A_BTC, to_asset=custom_target) == ZERO_PRICE
+    for oracle_instance in inquirer._oracle_instances:
+        assert oracle_instance.query_current_price.call_count == 0
+
+
+@pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_coingecko_handles_rate_limit(inquirer):
     """
     Test that the mechanism to ignore coingecko when the user gets rate limited works as expected


### PR DESCRIPTION
Fixes #12463

## Description

This PR fixes a backend crash that occurs when the Inquirer attempts to resolve a custom asset (which is a `CustomAsset` and not an `AssetWithOracles`) during balance or snapshot query tasks.

### Changes:

- Caught `WrongAssetType` in `Inquirer._query_oracle_instances` when resolving `to_asset` or `from_assets` to `AssetWithOracles`.
- When `WrongAssetType` is caught, we gracefully fall back to returning `ZERO_PRICE` and `CurrentPriceOracle.BLOCKCHAIN` for these assets instead of crashing the task greenlet.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
