### PR TITLE
Persist item caches across navigation

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/use-address-name-resolution.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-name-resolution.spec.ts
@@ -243,4 +243,26 @@ describe('useAddressNameResolution', () => {
       expect(get(result)).toStrictEqual([]);
     });
   });
+
+  describe('store-backed cache', () => {
+    it('should store resolved names in the shared store storage', async () => {
+      enableAliasNames(true);
+      const address = '0x4585FE77225b41b697C938B01232131231231233';
+      vi.mocked(api.getAddressesNames).mockResolvedValue([
+        { address, blockchain: Blockchain.ETH, name: 'stored_name' },
+      ]);
+
+      const name = resolution.useAddressName(() => address, () => Blockchain.ETH);
+      expect(get(name)).toBeUndefined();
+
+      vi.advanceTimersByTime(2500);
+      await flushPromises();
+
+      expect(get(name)).toBe('stored_name');
+
+      // The cache lives in the app-lifetime store, not a composable-scoped map.
+      const { addressNameStorage } = useAddressNamesStore();
+      expect(get(addressNameStorage.cache)[`${address}#${Blockchain.ETH}`]?.name).toBe('stored_name');
+    });
+  });
 });

--- a/frontend/app/src/modules/accounts/address-book/use-address-name-resolution.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-name-resolution.ts
@@ -43,6 +43,7 @@ interface UseAddressNameResolutionReturn {
 export const useAddressNameResolution = createSharedComposable((): UseAddressNameResolutionReturn => {
   const { enableAliasNames } = storeToRefs(useFrontendSettingsStore());
   const store = useAddressNamesStore();
+  const { addressNameStorage } = store;
   const { ensNames } = storeToRefs(store);
   const lastRefreshedAvatar = shallowRef<number>(Date.now());
   const { supportedChains } = useSupportedChains();
@@ -132,7 +133,7 @@ export const useAddressNameResolution = createSharedComposable((): UseAddressNam
     reset: resetAddressesNames,
     resolve,
     unknown,
-  } = createItemCache<AddressBookEntry | undefined>(async keys => fetchAddressesNames(keys));
+  } = createItemCache<AddressBookEntry | undefined>(async keys => fetchAddressesNames(keys), { storage: addressNameStorage });
 
   // Address name selectors
 

--- a/frontend/app/src/modules/accounts/address-book/use-address-names-store.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-names-store.ts
@@ -1,7 +1,12 @@
-import type { EthNames } from '@/modules/accounts/address-book/eth-names';
+import type { AddressBookEntry, EthNames } from '@/modules/accounts/address-book/eth-names';
+import { createItemCacheStorage } from '@/modules/core/common/use-item-cache';
 
 export const useAddressNamesStore = defineStore('blockchains/accounts/addresses-names', () => {
   const ensNames = shallowRef<EthNames>({});
+  // App-lifetime cache storage for resolved address names; the fetch/debounce/LRU
+  // logic lives in useAddressNameResolution, which binds to this so the cache
+  // survives composable teardown instead of being wiped at zero subscribers.
+  const addressNameStorage = createItemCacheStorage<AddressBookEntry | undefined>();
 
   function setEnsNames(newResult: Record<string, string | null>): void {
     set(ensNames, {
@@ -11,6 +16,7 @@ export const useAddressNamesStore = defineStore('blockchains/accounts/addresses-
   }
 
   return {
+    addressNameStorage,
     ensNames,
     setEnsNames,
   };

--- a/frontend/app/src/modules/assets/prices/use-historic-cache-price-store.ts
+++ b/frontend/app/src/modules/assets/prices/use-historic-cache-price-store.ts
@@ -1,7 +1,12 @@
-import type { CommonQueryStatusData, FailedHistoricalAssetPriceResponse } from '@rotki/common';
+import type { BigNumber, CommonQueryStatusData, FailedHistoricalAssetPriceResponse } from '@rotki/common';
 import type { StatsPriceQueryData } from '@/modules/core/messaging/types';
+import { createItemCacheStorage } from '@/modules/core/common/use-item-cache';
 
 export const useHistoricCachePriceStore = defineStore('prices/historic-cache', () => {
+  // App-lifetime cache storage for historic prices; the fetch/debounce/LRU logic
+  // lives in useHistoricPriceCache, which binds to this so the cache survives
+  // navigation (composable teardown) instead of being wiped at zero subscribers.
+  const historicStorage = createItemCacheStorage<BigNumber>();
   const statsPriceQueryStatus = shallowRef<Record<string, StatsPriceQueryData>>({});
   const historicalPriceStatus = shallowRef<CommonQueryStatusData>();
   const historicalDailyPriceStatus = shallowRef<CommonQueryStatusData>();
@@ -41,6 +46,7 @@ export const useHistoricCachePriceStore = defineStore('prices/historic-cache', (
   return {
     failedDailyPrices,
     getProtocolStatsPriceQueryStatus,
+    historicStorage,
     historicalDailyPriceStatus,
     historicalPriceStatus,
     resetProtocolStatsPriceQueryStatus,

--- a/frontend/app/src/modules/assets/prices/use-historic-price-cache.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-historic-price-cache.spec.ts
@@ -1,6 +1,7 @@
 import { bigNumberify } from '@rotki/common';
 import flushPromises from 'flush-promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope } from 'vue';
 import { usePriceApi } from '@/modules/balances/api/use-price-api';
 
 const runTaskMock = vi.fn();
@@ -114,6 +115,71 @@ describe('useHistoricPriceCache', () => {
     await flushPromises();
     expect(usePriceApi().queryHistoricalRates).toHaveBeenCalledTimes(2);
     expect(resolve(key)).toEqual(bigNumberify(mockPrice));
+  });
+
+  it('should store resolved prices in the shared store storage', async () => {
+    const { createKey, resolve } = useHistoricPriceCache();
+    const { useHistoricCachePriceStore } = await import('@/modules/assets/prices/use-historic-cache-price-store');
+    const { historicStorage } = useHistoricCachePriceStore();
+    const key = createKey(mockAsset, mockTimestamp);
+
+    runTaskMock.mockResolvedValue({
+      success: true,
+      result: {
+        targetAsset: 'USD',
+        assets: { [mockAsset]: { [mockTimestamp]: mockPrice } },
+      },
+    });
+
+    resolve(key);
+    vi.advanceTimersByTime(2500);
+    await flushPromises();
+
+    // The cache lives in the app-lifetime store, not a composable-scoped map, so
+    // the store's storage must hold the resolved value.
+    expect(get(historicStorage.cache)[key]).toEqual(bigNumberify(mockPrice));
+  });
+
+  it('should retain cached prices after the composable is torn down and re-created', async () => {
+    const key = `${mockAsset}#${mockTimestamp}`;
+    runTaskMock.mockResolvedValue({
+      success: true,
+      result: {
+        targetAsset: 'USD',
+        assets: { [mockAsset]: { [mockTimestamp]: mockPrice } },
+      },
+    });
+
+    // First subscriber resolves and populates the store-backed cache.
+    const scope1 = effectScope();
+    let first!: ReturnType<typeof useHistoricPriceCache>;
+    scope1.run(() => {
+      first = useHistoricPriceCache();
+    });
+    first.resolve(key);
+    vi.advanceTimersByTime(2500);
+    await flushPromises();
+    expect(first.resolve(key)).toEqual(bigNumberify(mockPrice));
+    expect(usePriceApi().queryHistoricalRates).toHaveBeenCalledOnce();
+
+    // Last subscriber unmounts -> createSharedComposable disposes the instance.
+    scope1.stop();
+
+    // A new subscriber re-creates the composable; the cache must come back from
+    // the store with no refetch.
+    const scope2 = effectScope();
+    let second!: ReturnType<typeof useHistoricPriceCache>;
+    scope2.run(() => {
+      second = useHistoricPriceCache();
+    });
+    // Confirm the shared instance was actually disposed and re-created.
+    expect(second).not.toBe(first);
+    expect(get(second.cache)[key]).toEqual(bigNumberify(mockPrice));
+    expect(second.resolve(key)).toEqual(bigNumberify(mockPrice));
+    vi.advanceTimersByTime(2500);
+    await flushPromises();
+    expect(usePriceApi().queryHistoricalRates).toHaveBeenCalledOnce();
+    scope2.stop();
   });
 
   it('should reset historical prices data', async () => {

--- a/frontend/app/src/modules/assets/prices/use-historic-price-cache.ts
+++ b/frontend/app/src/modules/assets/prices/use-historic-price-cache.ts
@@ -33,7 +33,9 @@ interface UseHistoricPriceCacheReturn {
 
 export const useHistoricPriceCache = createSharedComposable((): UseHistoricPriceCacheReturn => {
   const { currencySymbol } = storeToRefs(useGeneralSettingsStore());
-  const { failedDailyPrices, historicalDailyPriceStatus, resolvedFailedDailyPrices } = storeToRefs(useHistoricCachePriceStore());
+  const historicCachePriceStore = useHistoricCachePriceStore();
+  const { historicStorage } = historicCachePriceStore;
+  const { failedDailyPrices, historicalDailyPriceStatus, resolvedFailedDailyPrices } = storeToRefs(historicCachePriceStore);
   const { queryHistoricalRates } = usePriceApi();
   const { cancelTaskByTaskType, runTask } = useTaskHandler();
   const { t } = useI18n({ useScope: 'global' });
@@ -107,7 +109,7 @@ export const useHistoricPriceCache = createSharedComposable((): UseHistoricPrice
     reset,
     resolve,
     unknown,
-  } = createItemCache<BigNumber>(async keys => fetchHistoricPrices(keys));
+  } = createItemCache<BigNumber>(async keys => fetchHistoricPrices(keys), { storage: historicStorage });
 
   function getHistoricPrice(fromAsset: string, timestamp: number): BigNumber {
     const key = createKey(fromAsset, timestamp);

--- a/frontend/app/src/modules/assets/use-asset-info-cache-store.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-cache-store.ts
@@ -1,0 +1,21 @@
+import type { AssetCollection, AssetInfo } from '@rotki/common';
+import { createItemCacheStorage } from '@/modules/core/common/use-item-cache';
+
+/**
+ * Pure-state store for the asset-info cache. Holds only the persistent storage
+ * containers; the fetch/debounce/LRU logic lives in useAssetInfoCache, which
+ * binds to this so the cache survives composable teardown instead of being wiped
+ * at zero subscribers.
+ */
+export const useAssetInfoCacheStore = defineStore('assets/info-cache', () => {
+  const storage = createItemCacheStorage<AssetInfo>();
+  const fetchedAssetCollections = shallowRef<Record<string, AssetCollection>>({});
+
+  return {
+    fetchedAssetCollections,
+    storage,
+  };
+});
+
+if (import.meta.hot)
+  import.meta.hot.accept(acceptHMRUpdate(useAssetInfoCacheStore, import.meta.hot));

--- a/frontend/app/src/modules/assets/use-asset-info-cache.spec.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-cache.spec.ts
@@ -1,6 +1,7 @@
 import type { AssetMap } from '@/modules/assets/types';
 import flushPromises from 'flush-promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope } from 'vue';
 import { useAssetInfoApi } from '@/modules/assets/api/use-asset-info-api';
 
 describe('modules/assets/use-asset-info-cache', () => {
@@ -35,6 +36,51 @@ describe('modules/assets/use-asset-info-cache', () => {
     await flushPromises();
     expect(useAssetInfoApi().assetMapping).toHaveBeenCalledOnce();
     expect(cache.resolve('KEY')).toEqual(asset);
+  });
+
+  it('should retain cached assets after the composable is torn down and re-created', async () => {
+    const { useAssetInfoCache } = await import('./use-asset-info-cache');
+    const key = 'KEY';
+    const asset = {
+      isCustomAsset: false,
+      name: 'KEY Asset',
+      symbol: 'KEY',
+    };
+    vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue({
+      assetCollections: {},
+      assets: { [key]: asset },
+    });
+
+    // First subscriber resolves and populates the store-backed cache.
+    const scope1 = effectScope();
+    let first!: ReturnType<typeof useAssetInfoCache>;
+    scope1.run(() => {
+      first = useAssetInfoCache();
+    });
+    first.resolve(key);
+    vi.advanceTimersByTime(2500);
+    await flushPromises();
+    expect(first.resolve(key)).toEqual(asset);
+    expect(useAssetInfoApi().assetMapping).toHaveBeenCalledOnce();
+
+    // Last subscriber unmounts -> createSharedComposable disposes the instance.
+    scope1.stop();
+
+    // A new subscriber re-creates the composable; the cache must come back from
+    // the store with no refetch.
+    const scope2 = effectScope();
+    let second!: ReturnType<typeof useAssetInfoCache>;
+    scope2.run(() => {
+      second = useAssetInfoCache();
+    });
+    // Confirm the shared instance was actually disposed and re-created.
+    expect(second).not.toBe(first);
+    expect(get(second.cache)[key]).toEqual(asset);
+    expect(second.resolve(key)).toEqual(asset);
+    vi.advanceTimersByTime(2500);
+    await flushPromises();
+    expect(useAssetInfoApi().assetMapping).toHaveBeenCalledOnce();
+    scope2.stop();
   });
 
   it('should not request failed assets twice unless they expire', async () => {

--- a/frontend/app/src/modules/assets/use-asset-info-cache.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-cache.ts
@@ -2,6 +2,7 @@ import type { ShallowRef } from 'vue';
 import type { AssetMap } from '@/modules/assets/types';
 import { type AssetCollection, type AssetInfo, transformCase } from '@rotki/common';
 import { useAssetInfoApi } from '@/modules/assets/api/use-asset-info-api';
+import { useAssetInfoCacheStore } from '@/modules/assets/use-asset-info-cache-store';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
 import { createItemCache } from '@/modules/core/common/use-item-cache';
@@ -19,7 +20,9 @@ interface UseAssetInfoCacheReturn {
 }
 
 export const useAssetInfoCache = createSharedComposable((): UseAssetInfoCacheReturn => {
-  const fetchedAssetCollections = shallowRef<Record<string, AssetCollection>>({});
+  const assetInfoCacheStore = useAssetInfoCacheStore();
+  const { storage } = assetInfoCacheStore;
+  const { fetchedAssetCollections } = storeToRefs(assetInfoCacheStore);
 
   const { assetMapping } = useAssetInfoApi();
   const { t } = useI18n({ useScope: 'global' });
@@ -65,6 +68,7 @@ export const useAssetInfoCache = createSharedComposable((): UseAssetInfoCacheRet
     },
     {
       debounceInMs: 100,
+      storage,
     },
   );
 

--- a/frontend/app/src/modules/core/common/use-item-cache.spec.ts
+++ b/frontend/app/src/modules/core/common/use-item-cache.spec.ts
@@ -1,6 +1,6 @@
 import flushPromises from 'flush-promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createItemCache } from '@/modules/core/common/use-item-cache';
+import { createItemCache, createItemCacheStorage } from '@/modules/core/common/use-item-cache';
 
 interface TestEntry {
   key: string;
@@ -242,6 +242,98 @@ describe('createItemCache', () => {
       expect(calls).toHaveLength(1);
       expect(calls[0]).toEqual(expect.arrayContaining(['A', 'B', 'C']));
       expect(calls[0]).toHaveLength(3);
+    });
+  });
+
+  describe('storage injection', () => {
+    it('should create an empty storage container', () => {
+      const storage = createItemCacheStorage<string>();
+
+      expect(get(storage.cache)).toEqual({});
+      expect(storage.recent.size).toBe(0);
+      expect(storage.unknown.size).toBe(0);
+    });
+
+    it('should keep resolved values when a new cache binds to the same storage', async () => {
+      const storage = createItemCacheStorage<string>();
+      const { calls, fetch } = createMockFetch({ KEY: 'value' });
+
+      // First cache instance resolves and populates the shared storage.
+      const first = createItemCache(fetch, { storage });
+      first.resolve('KEY');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(first.resolve('KEY')).toBe('value');
+      expect(calls).toHaveLength(1);
+
+      // Simulate composable teardown + re-init: a brand new cache instance binds
+      // to the SAME storage. The value must already be there with no refetch.
+      const second = createItemCache(fetch, { storage });
+      expect(second.resolve('KEY')).toBe('value');
+
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(calls).toHaveLength(1);
+    });
+
+    it('should preserve the unknown (negative) cache across re-init', async () => {
+      const storage = createItemCacheStorage<string>();
+      const { calls, fetch } = createMockFetch({ KEY: null });
+
+      const first = createItemCache(fetch, { storage });
+      first.resolve('KEY');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(storage.unknown.has('KEY')).toBe(true);
+      expect(calls).toHaveLength(1);
+
+      // New instance on the same storage must not re-fetch a known-unknown key.
+      const second = createItemCache(fetch, { storage });
+      expect(second.resolve('KEY')).toBeNull();
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(calls).toHaveLength(1);
+    });
+
+    it('should start empty (and refetch) when no shared storage is provided', async () => {
+      const { calls, fetch } = createMockFetch({ KEY: 'value' });
+
+      const first = createItemCache(fetch);
+      first.resolve('KEY');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+      expect(calls).toHaveLength(1);
+
+      // Without injected storage each instance owns its own cache, so a fresh
+      // instance has nothing and must fetch again.
+      const second = createItemCache(fetch);
+      expect(second.resolve('KEY')).toBeNull();
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(calls).toHaveLength(2);
+    });
+
+    it('should reset shared storage when reset is called', async () => {
+      const storage = createItemCacheStorage<string>();
+      const { fetch } = createMockFetch({ KEY: 'value' });
+
+      const first = createItemCache(fetch, { storage });
+      first.resolve('KEY');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(get(storage.cache).KEY).toBe('value');
+
+      first.reset();
+
+      expect(Object.keys(get(storage.cache))).toHaveLength(0);
+      expect(storage.recent.size).toBe(0);
+      expect(storage.unknown.size).toBe(0);
     });
   });
 

--- a/frontend/app/src/modules/core/common/use-item-cache.ts
+++ b/frontend/app/src/modules/core/common/use-item-cache.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, DeepReadonly, MaybeRefOrGetter, Ref } from 'vue';
+import type { ComputedRef, DeepReadonly, MaybeRefOrGetter, Raw, Ref } from 'vue';
 import { assert } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -13,19 +13,57 @@ interface CacheEntry<T> {
 }
 
 /**
+ * The persistent storage of an item cache: the resolved values plus the
+ * bookkeeping required to decide validity. Decoupled from the cache logic so it
+ * can live in an app-lifetime Pinia store and survive composable teardown.
+ */
+export interface ItemCacheStorage<T> {
+  /** Resolved values keyed by identifier. */
+  cache: Ref<Record<string, T | null>>;
+  /** Per-key expiry timestamps backing the LRU + staleness checks. */
+  recent: Map<string, number>;
+  /** Identifiers that could not be resolved, with their expiry timestamps. */
+  unknown: Map<string, number>;
+}
+
+/**
+ * Creates a fresh {@link ItemCacheStorage} container.
+ *
+ * `markRaw` keeps it usable as plain state inside a Pinia store: the `cache` ref
+ * and the `Map`s are returned untouched (no reactive proxy that would unwrap the
+ * ref or wrap the maps). Reactivity for consumers flows through the `shallowRef`.
+ */
+export function createItemCacheStorage<T>(): Raw<ItemCacheStorage<T>> {
+  // Return the markRaw-branded type so a Pinia store holding this does not
+  // deeply unwrap `cache` (Ref) into a plain value — annotating it as the bare
+  // ItemCacheStorage<T> would strip the brand and reintroduce the unwrap.
+  return markRaw<ItemCacheStorage<T>>({
+    cache: shallowRef<Record<string, T | null>>({}),
+    recent: new Map<string, number>(),
+    unknown: new Map<string, number>(),
+  });
+}
+
+/**
  * A batch-fetch function that resolves multiple keys at once.
  * Returns a factory that yields {@link CacheEntry} items via an iterator,
  * allowing lazy consumption of potentially large result sets.
  */
 type CacheFetch<T> = (keys: string[]) => Promise<() => IterableIterator<CacheEntry<T>>>;
 
-interface CacheOptions {
+interface CacheOptions<T = unknown> {
   /** Debounce interval (ms) before a queued batch is fetched. @default 800 */
   debounceInMs?: number;
   /** Time-to-live (ms) for cached entries before they become stale. @default 600_000 (10 min) */
   expiry?: number;
   /** Maximum number of entries kept in the LRU cache. @default 500 */
   size?: number;
+  /**
+   * Persistent storage to bind to. When omitted a fresh in-scope storage is
+   * created (legacy behaviour). Pass a store-owned {@link ItemCacheStorage} to
+   * keep the cache alive across composable teardown.
+   */
+  storage?: ItemCacheStorage<T>;
 }
 
 interface ItemCacheReturn<T> {
@@ -67,12 +105,13 @@ interface ItemCacheReturn<T> {
  */
 export function createItemCache<T>(
   fetch: CacheFetch<T>,
-  options: CacheOptions = {},
+  options: CacheOptions<T> = {},
 ): ItemCacheReturn<T> {
   const { debounceInMs = DEBOUNCE_TIME, expiry = CACHE_EXPIRY, size = CACHE_SIZE } = options;
-  const recent: Map<string, number> = new Map();
-  const unknown: Map<string, number> = new Map();
-  const cache = shallowRef<Record<string, T | null>>({});
+  // Persistent storage is injected so it can outlive this factory instance
+  // (e.g. a Pinia store); when absent it falls back to in-scope storage.
+  const { cache, recent, unknown } = options.storage ?? createItemCacheStorage<T>();
+  // Transient in-flight state — intentionally factory-local, reset on re-init.
   const pending = shallowRef<Record<string, boolean>>({});
   const batch = new Set<string>();
 


### PR DESCRIPTION
## Problem

The three `createItemCache`-based caches (historic prices, address names, asset
info) had their cache map created **inside a `createSharedComposable` scope**.
`createSharedComposable` is subscriber-ref-counted: when the last component
unmounts, VueUse calls `scope.stop()` and the cache map is disposed. The next
subscriber re-runs the factory with an empty cache.

This is visible on the historic price cache, whose only consumers are the
snapshot/statistics screens: navigating **snapshot list → detail → back** passes
through a zero-subscriber instant, wipes the cache, and refires
`POST /api/1/assets/prices/historical` — every value blanks to a skeleton and
reloads. The other two caches carry the same latent bug but avoid it today only
because they always have a live subscriber.

## Fix

Decouple the cache's **permanent storage** from its **logic**. `createItemCache`
now accepts an injected `ItemCacheStorage<T>` (`cache` / `recent` / `unknown`)
via its options bag, while the transient in-flight state (`pending`, `batch`)
stays factory-local. The storage lives in a **pure-state Pinia store**
(app-lifetime), so it survives composable teardown; the factory and composable
keep all logic and their exact public APIs — call sites are unchanged.

`recent` is part of the persistent storage on purpose: it carries per-key expiry,
so without it surviving entries would be treated as stale and refetched.

The change is backward-compatible — when no `storage` is passed, the factory
creates its own (legacy behaviour), so the factory's own spec and any future
caller keep working.

### Commits (separable)
1. **Persist historic price cache across navigation** — factory storage injection + `useHistoricCachePriceStore`.
2. **Back address name cache with a store** — `useAddressNamesStore`.
3. **Back asset info cache with a store** — new `useAssetInfoCacheStore`. Kept isolated/last as `useAssetInfoCache` feeds nearly every asset name/icon render, so it can be reverted independently.

## Memory note

The caches are now app-lifetime (no auto-dispose). That is intended — the
underlying `createItemCache` already has an LRU bound (500) and 10-minute expiry,
so it is self-bounding.

## Tests
- **Factory** (`use-item-cache.spec.ts`): a new factory bound to the same storage
  sees resolved values with no refetch; negative cache persists; `reset()` clears
  shared storage; control case proves no-storage instances still refetch.
- **Composable-level re-bind** (historic + asset info): wrap the composable in an
  `effectScope`, stop it (forcing `createSharedComposable` to dispose), re-create
  it, and assert the cache comes back **from the store** with no refetch
  (`expect(second).not.toBe(first)` confirms a real teardown+recreate).
- Wiring tests confirm resolved data lands in the store-owned storage.

Verification: `typecheck` ✅, `lint-staged` ✅, cache specs 51/51, broader `assets/` 424/424, `address-book/` + aggregated-balances 86/86.