### PR TITLE
fix: avoid keyring access without saved password

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The desktop app no longer accesses the OS keyring (triggering a keychain/keyring unlock prompt) when you create or open an account, unless you have chosen to save your password.
 * :bug:`-` PnL reports no longer fail for accounts with a very very large history.
 * :bug:`-` Adding or removing a blockchain account (or removing a spam token) now correctly invalidates the cached balances, so you no longer briefly see stale balances afterwards.
 * :bug:`-` Odos swaps now show the received amount before the router fee, so the fee no longer makes that asset go negative.

--- a/frontend/app/electron/main/password-manager.spec.ts
+++ b/frontend/app/electron/main/password-manager.spec.ts
@@ -1,0 +1,127 @@
+import { Buffer } from 'node:buffer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PasswordManager } from './password-manager';
+
+const ENCODING = 'latin1';
+
+const { isEncryptionAvailable, encryptString, decryptString, backing } = vi.hoisted(() => ({
+  isEncryptionAvailable: vi.fn<() => boolean>(),
+  encryptString: vi.fn<(value: string) => Buffer>(),
+  decryptString: vi.fn<(buffer: Buffer) => string>(),
+  backing: { data: {} as Record<string, string> },
+}));
+
+vi.mock('electron', () => ({
+  safeStorage: { isEncryptionAvailable, encryptString, decryptString },
+}));
+
+vi.mock('electron-store', () => ({
+  default: class {
+    get store(): Record<string, string> {
+      return backing.data;
+    }
+
+    set(key: string, value: string): void {
+      backing.data[key] = value;
+    }
+
+    clear(): void {
+      backing.data = {};
+    }
+  },
+}));
+
+describe('passwordManager', () => {
+  let manager: PasswordManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backing.data = {};
+    manager = new PasswordManager();
+  });
+
+  describe('retrievePassword', () => {
+    it('should not touch safeStorage when no password is stored for the user', async () => {
+      // Regression: creating/using an account without opting in to "save password"
+      // must never trigger an OS keyring prompt. With nothing stored, safeStorage
+      // (including isEncryptionAvailable, which is what prompts on macOS) must not
+      // be accessed at all.
+      const password = await manager.retrievePassword('alice');
+
+      expect(password).toBe('');
+      expect(isEncryptionAvailable).not.toHaveBeenCalled();
+      expect(decryptString).not.toHaveBeenCalled();
+    });
+
+    it('should not touch safeStorage when a different user has a stored password', async () => {
+      backing.data.bob = 'encrypted-blob-for-bob';
+
+      const password = await manager.retrievePassword('alice');
+
+      expect(password).toBe('');
+      expect(isEncryptionAvailable).not.toHaveBeenCalled();
+      expect(decryptString).not.toHaveBeenCalled();
+    });
+
+    it('should decrypt the stored password when one exists', async () => {
+      backing.data.alice = 'encrypted-blob';
+      isEncryptionAvailable.mockReturnValue(true);
+      decryptString.mockReturnValue('s3cret');
+
+      const password = await manager.retrievePassword('alice');
+
+      expect(password).toBe('s3cret');
+      expect(isEncryptionAvailable).toHaveBeenCalledOnce();
+      expect(decryptString).toHaveBeenCalledWith(Buffer.from('encrypted-blob', ENCODING));
+    });
+
+    it('should not decrypt when encryption is unavailable even if a password is stored', async () => {
+      backing.data.alice = 'encrypted-blob';
+      isEncryptionAvailable.mockReturnValue(false);
+
+      const password = await manager.retrievePassword('alice');
+
+      expect(password).toBe('');
+      expect(decryptString).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('storePassword', () => {
+    it('should encrypt and store the password when encryption is available', async () => {
+      isEncryptionAvailable.mockReturnValue(true);
+      encryptString.mockReturnValue(Buffer.from('encrypted', ENCODING));
+
+      const success = await manager.storePassword({ username: 'alice', password: 's3cret' });
+
+      expect(success).toBe(true);
+      expect(encryptString).toHaveBeenCalledWith('s3cret');
+      expect(backing.data.alice).toBe('encrypted');
+    });
+
+    it('should not store the password when encryption is unavailable', async () => {
+      isEncryptionAvailable.mockReturnValue(false);
+
+      const success = await manager.storePassword({ username: 'alice', password: 's3cret' });
+
+      expect(success).toBe(false);
+      expect(encryptString).not.toHaveBeenCalled();
+      expect(backing.data.alice).toBeUndefined();
+    });
+  });
+
+  describe('clearPasswords', () => {
+    it('should not touch safeStorage when there is nothing stored', async () => {
+      await manager.clearPasswords();
+
+      expect(isEncryptionAvailable).not.toHaveBeenCalled();
+    });
+
+    it('should clear stored passwords when present', async () => {
+      backing.data.alice = 'encrypted-blob';
+
+      await manager.clearPasswords();
+
+      expect(backing.data).toStrictEqual({});
+    });
+  });
+});

--- a/frontend/app/electron/main/password-manager.ts
+++ b/frontend/app/electron/main/password-manager.ts
@@ -19,6 +19,10 @@ export class PasswordManager {
     this.store.clear();
   };
 
+  private readonly hasStoredPassword = (key: string): boolean => Boolean(this.store.store?.[key]);
+
+  private readonly hasAnyStoredPassword = (): boolean => Object.keys(this.store.store ?? {}).length > 0;
+
   private readonly getPassword = (key: string) => {
     const buffer = this.store.store?.[key];
     if (buffer)
@@ -37,15 +41,22 @@ export class PasswordManager {
   }
 
   async retrievePassword(username: string): Promise<string> {
-    let password = '';
-    if (this.getEncryptionAvailability())
-      password = this.getPassword(username);
+    // Never touch safeStorage (which triggers an OS keyring prompt) unless a
+    // password was actually saved for this user. If nothing is stored, the user
+    // never opted in to saving the password, so there is nothing to decrypt.
+    if (!this.hasStoredPassword(username))
+      return '';
 
-    return password;
+    if (!this.getEncryptionAvailability())
+      return '';
+
+    return this.getPassword(username);
   }
 
   async clearPasswords(): Promise<void> {
-    if (this.getEncryptionAvailability())
+    // Clearing the on-disk store does not require safeStorage; only access the
+    // keyring when there is actually a saved password to clear.
+    if (this.hasAnyStoredPassword())
       this.clearPassword();
   }
 }


### PR DESCRIPTION
## Problem

On macOS, the first `safeStorage` access in a session — **including `safeStorage.isEncryptionAvailable()`** — triggers an OS keychain unlock prompt. `PasswordManager` called it unconditionally in `retrievePassword` and `clearPasswords`, so creating or opening an account prompted for the keyring **even when the user never opted in to saving their password** (and there was nothing stored to read).

## Fix

Only interact with `safeStorage` when there is actually a stored password:

- `retrievePassword` returns early (no `safeStorage` access) when no password is stored for that user.
- `clearPasswords` only runs when something is actually stored (clearing the on-disk store never needed `safeStorage`).
- `storePassword` (the opt-in path, only called when "save password" is checked) is unchanged.

## Tests

Adds `password-manager.spec.ts` (mocking `electron`'s `safeStorage` and `electron-store`) with regression coverage:

- `retrievePassword` does **not** touch `safeStorage` when nothing is stored for the user, nor when only a *different* user has a saved password.
- It still decrypts correctly when a password exists, and returns `''` without decrypting when encryption is unavailable.
- `clearPasswords` does **not** touch `safeStorage` when nothing is stored.
- `storePassword` encrypts/stores only when encryption is available.