### PR TITLE
fix: restore scrolling for in-dialog tables

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`12463` Querying price for custom asset under certain conditions no longer fails the task.
+* :bug:`-` Tables shown inside dialogs (such as the PnL report "issues found" dialog with missing acquisitions/prices, and the snapshot editor) are scrollable again, so rows past the visible area are no longer cut off.
 * :bug:`-` The desktop app no longer accesses the OS keyring (triggering a keychain/keyring unlock prompt) when you create or open an account, unless you have chosen to save your password.
 * :bug:`-` PnL reports no longer fail for accounts with a very very large history.
 * :bug:`-` Adding or removing a blockchain account (or removing a spam token) now correctly invalidates the cached balances, so you no longer briefly see stale balances afterwards.

--- a/frontend/app/src/modules/core/table/ScrollableDialogContent.spec.ts
+++ b/frontend/app/src/modules/core/table/ScrollableDialogContent.spec.ts
@@ -1,0 +1,86 @@
+import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
+
+describe('scrollable-dialog-content', () => {
+  function createWrapper(options: ComponentMountingOptions<typeof ScrollableDialogContent> = {}): VueWrapper {
+    return mount(ScrollableDialogContent, {
+      ...options,
+      slots: {
+        default: '<div data-testid="body">body</div>',
+        ...options.slots,
+      },
+    });
+  }
+
+  function bodyRegion(wrapper: VueWrapper): Element {
+    const body = wrapper.find('[data-testid=body]').element.parentElement;
+    if (!body)
+      throw new Error('body region not found');
+    return body;
+  }
+
+  it('should make the body region the scroll container', () => {
+    // The whole point of the component: the scrollable region must carry
+    // `flex-1 min-h-0 overflow-y-auto`. `min-h-0` is load-bearing — without it a
+    // flex child will not shrink below its content and never scrolls. Guard it.
+    const region = bodyRegion(createWrapper());
+    expect(region.className).toContain('flex-1');
+    expect(region.className).toContain('min-h-0');
+    expect(region.className).toContain('overflow-y-auto');
+  });
+
+  it('should bound the column so the body can absorb leftover space', () => {
+    const root = createWrapper().element;
+    expect(root.className).toContain('flex');
+    expect(root.className).toContain('flex-col');
+    expect(root.className).toContain('max-h-[90vh]');
+  });
+
+  it('should grow within a flex-column parent when `fill` is set', () => {
+    const root = createWrapper({ props: { fill: true } }).element;
+    expect(root.className).toContain('flex-1');
+    expect(root.className).toContain('min-h-0');
+    expect(root.className).not.toContain('max-h-[90vh]');
+  });
+
+  it('should apply an explicit cap when `maxHeight` is set', () => {
+    const root = createWrapper({ props: { maxHeight: 'calc(100vh - 10rem)' } }).element;
+    expect(root.className).not.toContain('max-h-[90vh]');
+    expect(root.getAttribute('style')).toContain('max-height: calc(100vh - 10rem)');
+  });
+
+  it('should prefer `fill` over `maxHeight`', () => {
+    const root = createWrapper({ props: { fill: true, maxHeight: 'calc(100vh - 10rem)' } }).element;
+    expect(root.className).toContain('flex-1');
+    expect(root.getAttribute('style') ?? '').not.toContain('max-height');
+  });
+
+  it('should pin the header above the scroll area', () => {
+    const wrapper = createWrapper({
+      slots: {
+        header: '<div data-testid="header">header</div>',
+        default: '<div data-testid="body">body</div>',
+      },
+    });
+    const header = wrapper.find('[data-testid=header]').element.parentElement;
+    expect(header?.className).toContain('shrink-0');
+  });
+
+  it('should pin the footer below the scroll area', () => {
+    const wrapper = createWrapper({
+      slots: {
+        default: '<div data-testid="body">body</div>',
+        footer: '<div data-testid="footer">footer</div>',
+      },
+    });
+    const footer = wrapper.find('[data-testid=footer]').element.parentElement;
+    expect(footer?.className).toContain('shrink-0');
+  });
+
+  it('should not render header/footer wrappers when those slots are absent', () => {
+    const wrapper = createWrapper();
+    // only the body wrapper should exist as a direct child
+    expect(wrapper.element.children).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/core/table/ScrollableDialogContent.vue
+++ b/frontend/app/src/modules/core/table/ScrollableDialogContent.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+/**
+ * Layout primitive for dialogs (and the pinned sidebar) that hold a table or
+ * other long content which must scroll while the surrounding chrome stays put.
+ *
+ * It establishes a bounded flex column so the body region absorbs the leftover
+ * space and scrolls on its own — no per-dialog `max-h-[calc(100vh - …)]` magic
+ * numbers, and no fighting a child component's own `overflow` rules.
+ *
+ * The `min-h-0` on the body is load-bearing: without it a flex child refuses to
+ * shrink below its content and would never scroll. Keeping it here means callers
+ * cannot forget it.
+ *
+ * The root `max-h-[90vh]` matches RuiDialog's own content cap so the dialog's
+ * scrollbar never doubles up with ours; `fill` swaps it for `h-full` when the
+ * host already provides a fixed height (e.g. the pinned sidebar).
+ */
+const { fill = false, maxHeight } = defineProps<{
+  /**
+   * Grow to fill the remaining space of a bounded flex-column parent instead of
+   * capping at the dialog's `90vh`. The immediate parent must be `flex flex-col`
+   * with a bounded height (e.g. the report card body, the pinned sidebar). Use
+   * this for the truly magic-number-free layout.
+   */
+  fill?: boolean;
+  /**
+   * Explicit cap for the column, e.g. `calc(100vh - 21.25rem)`. Use when the
+   * host can't propagate a flex height down to here (e.g. content nested inside
+   * `RuiTabItems`). Ignored when `fill` is set.
+   */
+  maxHeight?: string;
+}>();
+
+defineSlots<{
+  /** Pinned above the scroll area (title bar, stepper, …). */
+  header?: () => any;
+  /** The scrollable region (usually a table). */
+  default: () => any;
+  /** Pinned below the scroll area (action buttons, hints, …). */
+  footer?: () => any;
+}>();
+
+const boundClass = computed<string>(() => {
+  if (fill)
+    return 'flex-1';
+
+  return maxHeight ? '' : 'max-h-[90vh]';
+});
+
+const boundStyle = computed<Record<string, string> | undefined>(() =>
+  (!fill && maxHeight) ? { maxHeight } : undefined,
+);
+</script>
+
+<template>
+  <div
+    class="flex flex-col min-h-0"
+    :class="[boundClass]"
+    :style="boundStyle"
+  >
+    <div
+      v-if="$slots.header"
+      class="shrink-0"
+    >
+      <slot name="header" />
+    </div>
+    <div class="flex-1 min-h-0 overflow-y-auto scroll-smooth">
+      <slot />
+    </div>
+    <div
+      v-if="$slots.footer"
+      class="shrink-0"
+    >
+      <slot name="footer" />
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotTable.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotTable.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+/* eslint-disable @rotki/max-dependencies -- already at the dependency cap; the shared scroll layout pushes it over. The edit-snapshot tables are slated for a rewrite, so suppress rather than churn imports about to change. */
 import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
 import type { BalanceSnapshot, BalanceSnapshotPayload, Snapshot } from '@/modules/dashboard/snapshots';
 import { assert, type BigNumber, bigNumberify, One, toSentenceCase, Zero } from '@rotki/common';
@@ -10,6 +11,7 @@ import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
 import NftDetails from '@/modules/balances/nft/NftDetails.vue';
 import { BalanceType } from '@/modules/balances/types/balances';
 import { bigNumberSum } from '@/modules/core/common/data/calculation';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import ConfirmSnapshotConflictReplacementDialog
   from '@/modules/dashboard/ConfirmSnapshotConflictReplacementDialog.vue';
@@ -21,6 +23,8 @@ import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 import ConfirmDialog from '@/modules/shell/components/dialogs/ConfirmDialog.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 import RowActions from '@/modules/shell/components/RowActions.vue';
+
+/* eslint-enable @rotki/max-dependencies */
 
 const modelValue = defineModel<Snapshot>({ required: true });
 
@@ -381,53 +385,54 @@ function confirmDelete(): void {
         :label="t('dashboard.snapshot.search_asset')"
       />
     </div>
-    <RuiDataTable
-      v-model:sort="sort"
-      class="table-inside-dialog !max-h-[calc(100vh-26.25rem)]"
-      :cols="tableHeaders"
-      :rows="filteredData"
-      row-attr="assetIdentifier"
-      dense
-    >
-      <template #item.categoryLabel="{ row }">
-        <span>{{ toSentenceCase(row.categoryLabel) }}</span>
-      </template>
+    <ScrollableDialogContent max-height="calc(100vh - 26.25rem)">
+      <RuiDataTable
+        v-model:sort="sort"
+        :cols="tableHeaders"
+        :rows="filteredData"
+        row-attr="assetIdentifier"
+        dense
+      >
+        <template #item.categoryLabel="{ row }">
+          <span>{{ toSentenceCase(row.categoryLabel) }}</span>
+        </template>
 
-      <template #item.assetIdentifier="{ row }">
-        <AssetDetails
-          v-if="!isNft(row.assetIdentifier)"
-          class="[&_.avatar]:ml-1.5 [&_.avatar]:mr-2"
-          :asset="row.assetIdentifier"
-          :enable-association="false"
-        />
-        <NftDetails
-          v-else
-          :identifier="row.assetIdentifier"
-        />
-      </template>
+        <template #item.assetIdentifier="{ row }">
+          <AssetDetails
+            v-if="!isNft(row.assetIdentifier)"
+            class="[&_.avatar]:ml-1.5 [&_.avatar]:mr-2"
+            :asset="row.assetIdentifier"
+            :enable-association="false"
+          />
+          <NftDetails
+            v-else
+            :identifier="row.assetIdentifier"
+          />
+        </template>
 
-      <template #item.amount="{ row }">
-        <ValueDisplay :value="row.amount" />
-      </template>
+        <template #item.amount="{ row }">
+          <ValueDisplay :value="row.amount" />
+        </template>
 
-      <template #item.usdValue="{ row }">
-        <AssetValueDisplay
-          :asset="row.assetIdentifier"
-          :amount="row.amount"
-          :value="row.usdValue"
-          :timestamp="{ ms: timestamp }"
-        />
-      </template>
+        <template #item.usdValue="{ row }">
+          <AssetValueDisplay
+            :asset="row.assetIdentifier"
+            :amount="row.amount"
+            :value="row.usdValue"
+            :timestamp="{ ms: timestamp }"
+          />
+        </template>
 
-      <template #item.action="{ row }">
-        <RowActions
-          :edit-tooltip="t('dashboard.snapshot.edit.dialog.actions.edit_item')"
-          :delete-tooltip="t('dashboard.snapshot.edit.dialog.actions.delete_item')"
-          @edit-click="editClick(row)"
-          @delete-click="deleteClick(row)"
-        />
-      </template>
-    </RuiDataTable>
+        <template #item.action="{ row }">
+          <RowActions
+            :edit-tooltip="t('dashboard.snapshot.edit.dialog.actions.edit_item')"
+            :delete-tooltip="t('dashboard.snapshot.edit.dialog.actions.delete_item')"
+            @edit-click="editClick(row)"
+            @delete-click="deleteClick(row)"
+          />
+        </template>
+      </RuiDataTable>
+    </ScrollableDialogContent>
     <div
       class="border-t-2 border-rui-grey-300 dark:border-rui-grey-800 relative z-[2] flex items-center justify-between gap-4 p-2"
     >

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotTable.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotTable.vue
@@ -6,6 +6,7 @@ import { AssetValueDisplay, FiatDisplay } from '@/modules/assets/amount-display/
 import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
 import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import EditLocationDataSnapshotForm from '@/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
@@ -194,37 +195,38 @@ function showDeleteConfirmation(item: IndexedLocationDataSnapshot) {
 
 <template>
   <div>
-    <RuiDataTable
-      v-model:sort="sort"
-      class="table-inside-dialog !max-h-[calc(100vh-26.25rem)]"
-      :cols="tableHeaders"
-      :rows="data"
-      row-attr="location"
-      dense
-    >
-      <template #item.location="{ row }">
-        <LocationDisplay
-          :opens-details="false"
-          :identifier="row.location"
-        />
-      </template>
+    <ScrollableDialogContent max-height="calc(100vh - 26.25rem)">
+      <RuiDataTable
+        v-model:sort="sort"
+        :cols="tableHeaders"
+        :rows="data"
+        row-attr="location"
+        dense
+      >
+        <template #item.location="{ row }">
+          <LocationDisplay
+            :opens-details="false"
+            :identifier="row.location"
+          />
+        </template>
 
-      <template #item.usdValue="{ row }">
-        <FiatDisplay
-          :value="row.usdValue"
-          from="USD"
-        />
-      </template>
+        <template #item.usdValue="{ row }">
+          <FiatDisplay
+            :value="row.usdValue"
+            from="USD"
+          />
+        </template>
 
-      <template #item.action="{ row }">
-        <RowActions
-          :edit-tooltip="t('dashboard.snapshot.edit.dialog.actions.edit_item')"
-          :delete-tooltip="t('dashboard.snapshot.edit.dialog.actions.delete_item')"
-          @edit-click="editClick(row)"
-          @delete-click="showDeleteConfirmation(row)"
-        />
-      </template>
-    </RuiDataTable>
+        <template #item.action="{ row }">
+          <RowActions
+            :edit-tooltip="t('dashboard.snapshot.edit.dialog.actions.edit_item')"
+            :delete-tooltip="t('dashboard.snapshot.edit.dialog.actions.delete_item')"
+            @edit-click="editClick(row)"
+            @delete-click="showDeleteConfirmation(row)"
+          />
+        </template>
+      </RuiDataTable>
+    </ScrollableDialogContent>
     <div
       class="border-t-2 border-rui-grey-300 dark:border-rui-grey-800 relative z-[2] flex items-center justify-between gap-4 p-2"
     >

--- a/frontend/app/src/modules/history/balances/NegativeBalancesDialog.vue
+++ b/frontend/app/src/modules/history/balances/NegativeBalancesDialog.vue
@@ -3,6 +3,7 @@ import type { DataTableColumn } from '@rotki/ui-library';
 import type { NegativeBalanceDetectedData } from '@/modules/core/messaging/types/status-types';
 import { AssetAmountDisplay } from '@/modules/assets/amount-display/components';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import { Routes } from '@/router/routes';
@@ -78,52 +79,53 @@ async function navigateToEvent(row: NegativeBalanceDetectedData): Promise<void> 
         <DateDisplay :timestamp="lastRunTs" />
       </div>
 
-      <RuiDataTable
-        :cols="headers"
-        :rows="negativeBalances"
-        row-attr="eventIdentifier"
-        outlined
-        dense
-        class="table-inside-dialog"
-      >
-        <template #item.asset="{ row }">
-          <AssetDetails
-            :asset="row.asset"
-            :dense="true"
-          />
-        </template>
-        <template #item.balanceBefore="{ row }">
-          <AssetAmountDisplay
-            :amount="row.balanceBefore"
-            :asset="row.asset"
-          />
-        </template>
-        <template #item.actions="{ row }">
-          <RuiTooltip
-            :popper="{ placement: 'top' }"
-            :open-delay="400"
-            tooltip-class="max-w-80"
-          >
-            <template #activator>
-              <RuiButton
-                variant="text"
-                size="sm"
-                color="primary"
-                @click="navigateToEvent(row)"
-              >
-                <template #prepend>
-                  <RuiIcon
-                    name="lu-external-link"
-                    size="16"
-                  />
-                </template>
-                {{ t('historical_balances.negative_balances.view_event') }}
-              </RuiButton>
-            </template>
-            {{ t('historical_balances.negative_balances.view_event_tooltip') }}
-          </RuiTooltip>
-        </template>
-      </RuiDataTable>
+      <ScrollableDialogContent max-height="calc(100vh - 21.25rem)">
+        <RuiDataTable
+          :cols="headers"
+          :rows="negativeBalances"
+          row-attr="eventIdentifier"
+          outlined
+          dense
+        >
+          <template #item.asset="{ row }">
+            <AssetDetails
+              :asset="row.asset"
+              :dense="true"
+            />
+          </template>
+          <template #item.balanceBefore="{ row }">
+            <AssetAmountDisplay
+              :amount="row.balanceBefore"
+              :asset="row.asset"
+            />
+          </template>
+          <template #item.actions="{ row }">
+            <RuiTooltip
+              :popper="{ placement: 'top' }"
+              :open-delay="400"
+              tooltip-class="max-w-80"
+            >
+              <template #activator>
+                <RuiButton
+                  variant="text"
+                  size="sm"
+                  color="primary"
+                  @click="navigateToEvent(row)"
+                >
+                  <template #prepend>
+                    <RuiIcon
+                      name="lu-external-link"
+                      size="16"
+                    />
+                  </template>
+                  {{ t('historical_balances.negative_balances.view_event') }}
+                </RuiButton>
+              </template>
+              {{ t('historical_balances.negative_balances.view_event_tooltip') }}
+            </RuiTooltip>
+          </template>
+        </RuiDataTable>
+      </ScrollableDialogContent>
     </RuiCard>
   </RuiDialog>
 </template>

--- a/frontend/app/src/modules/history/events/CustomizedEventDuplicatesList.vue
+++ b/frontend/app/src/modules/history/events/CustomizedEventDuplicatesList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DataTableColumn } from '@rotki/ui-library';
 import type { DuplicateRow } from '@/modules/history/events/use-customized-event-duplicates';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import HistoryEventAccount from '@/modules/history/events/HistoryEventAccount.vue';
 import HistoryEventsIdentifier from '@/modules/history/events/HistoryEventsIdentifier.vue';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
@@ -67,48 +68,49 @@ const columns = computed<DataTableColumn<DuplicateRow>[]>(() => [
         {{ t('customized_event_duplicates.actions.show_in_history') }}
       </RuiButton>
     </div>
-    <RuiDataTable
-      v-model="selected"
-      :cols="columns"
-      :rows="rows"
-      row-attr="groupIdentifier"
-      outlined
-      dense
-      multi-page-select
-      :loading="loading"
-      class="max-h-[calc(100vh-23rem)] table-inside-dialog"
-      :empty="{ description: t('customized_event_duplicates.no_items') }"
-    >
-      <template #item.timestamp="{ row }">
-        <DateDisplay
-          :timestamp="row.timestamp"
-          milliseconds
-        />
-      </template>
-      <template #item.txHash="{ row }">
-        <div class="flex flex-col gap-1">
-          <HistoryEventsIdentifier :event="row.entry" />
-          <HistoryEventAccount
-            v-if="row.locationLabel"
-            :location="row.location"
-            :location-label="row.locationLabel"
-            class="text-sm min-w-0"
+    <ScrollableDialogContent max-height="calc(100vh - 23rem)">
+      <RuiDataTable
+        v-model="selected"
+        :cols="columns"
+        :rows="rows"
+        row-attr="groupIdentifier"
+        outlined
+        dense
+        multi-page-select
+        :loading="loading"
+        :empty="{ description: t('customized_event_duplicates.no_items') }"
+      >
+        <template #item.timestamp="{ row }">
+          <DateDisplay
+            :timestamp="row.timestamp"
+            milliseconds
           />
-        </div>
-      </template>
-      <template #item.location="{ row }">
-        <LocationDisplay
-          size="24px"
-          horizontal
-          :identifier="row.location"
-        />
-      </template>
-      <template #item.actions="{ row }">
-        <slot
-          name="actions"
-          :row="row"
-        />
-      </template>
-    </RuiDataTable>
+        </template>
+        <template #item.txHash="{ row }">
+          <div class="flex flex-col gap-1">
+            <HistoryEventsIdentifier :event="row.entry" />
+            <HistoryEventAccount
+              v-if="row.locationLabel"
+              :location="row.location"
+              :location-label="row.locationLabel"
+              class="text-sm min-w-0"
+            />
+          </div>
+        </template>
+        <template #item.location="{ row }">
+          <LocationDisplay
+            size="24px"
+            horizontal
+            :identifier="row.location"
+          />
+        </template>
+        <template #item.actions="{ row }">
+          <slot
+            name="actions"
+            :row="row"
+          />
+        </template>
+      </RuiDataTable>
+    </ScrollableDialogContent>
   </div>
 </template>

--- a/frontend/app/src/modules/history/events/PotentialMatchesList.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesList.vue
@@ -5,6 +5,7 @@ import type {
   PotentialMatchRow,
   UnmatchedAssetMovement,
 } from '@/modules/history/events/use-unmatched-asset-movements';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import HistoryEventAccount from '@/modules/history/events/HistoryEventAccount.vue';
@@ -121,17 +122,11 @@ const movementEntry = computed<HistoryEventEntry>(() => {
 const searchControlsEl = useTemplateRef<HTMLElement>('searchControls');
 const { height: searchControlsHeight } = useElementSize(searchControlsEl);
 
-const tableClass = computed<string>(() => {
-  if (isPinned)
-    return '!overflow-auto !max-h-none';
-  return 'table-inside-dialog !max-h-[calc(100vh-33rem)]';
-});
-
-const pinnedTableStyle = computed<Record<string, string> | undefined>(() => {
-  if (!isPinned)
-    return undefined;
-  return { height: `calc(100vh - 28.4rem - ${get(searchControlsHeight)}px)` };
-});
+const tableMaxHeight = computed<string>(() =>
+  isPinned
+    ? `calc(100vh - 28.4rem - ${get(searchControlsHeight)}px)`
+    : 'calc(100vh - 33rem)',
+);
 
 watchDebounced(onlyExpectedAssets, () => {
   emit('search');
@@ -361,98 +356,98 @@ watchDebounced(onlyExpectedAssets, () => {
         {{ t('asset_movement_matching.dialog.matching_hint') }}
       </p>
 
-      <RuiDataTable
-        :cols="columns"
-        :rows="matches"
-        row-attr="identifier"
-        :class="tableClass"
-        :style="pinnedTableStyle"
-        :item-class="getRowClass"
-        dense
-        outlined
-        :empty="{ label: t('asset_movement_matching.dialog.no_matches_found') }"
-        :loading="loading"
-      >
-        <template #item.timestamp="{ row }">
-          <div class="flex flex-col gap-1">
-            <DateDisplay
-              :timestamp="row.entry.timestamp"
-              milliseconds
-            />
-            <div
-              v-if="isPinned"
-              class="font-bold"
-            >
-              {{ getHistoryEventTypeName(row.entry.eventType) }} -
-              {{ getHistoryEventSubTypeName(row.entry.eventSubtype) }}
+      <ScrollableDialogContent :max-height="tableMaxHeight">
+        <RuiDataTable
+          :cols="columns"
+          :rows="matches"
+          row-attr="identifier"
+          :item-class="getRowClass"
+          dense
+          outlined
+          :empty="{ label: t('asset_movement_matching.dialog.no_matches_found') }"
+          :loading="loading"
+        >
+          <template #item.timestamp="{ row }">
+            <div class="flex flex-col gap-1">
+              <DateDisplay
+                :timestamp="row.entry.timestamp"
+                milliseconds
+              />
+              <div
+                v-if="isPinned"
+                class="font-bold"
+              >
+                {{ getHistoryEventTypeName(row.entry.eventType) }} -
+                {{ getHistoryEventSubTypeName(row.entry.eventSubtype) }}
+              </div>
             </div>
-          </div>
-        </template>
-        <template #item.eventTypeAndSubtype="{ row }">
-          <div>{{ getHistoryEventTypeName(row.entry.eventType) }} -</div>
-          <div>{{ getHistoryEventSubTypeName(row.entry.eventSubtype) }}</div>
-        </template>
-        <template #item.txRef="{ row }">
-          <div
-            v-if="'txRef' in row.entry && row.entry.txRef"
-            class="flex items-center"
-            :class="isPinned ? 'gap-2' : 'gap-1'"
-          >
-            <LocationIcon
-              horizontal
-              icon
-              size="1.25rem"
-              :item="row.entry.location"
-              :class="{ '!text-xs': isPinned }"
-            />
-            <HashLink
-              :text="row.entry.txRef"
-              type="transaction"
-              :location="row.entry.location"
-              :class="{ '!text-[10px]': isPinned }"
-            />
-          </div>
-          <div>
-            <span v-if="!row.entry.locationLabel">-</span>
-            <HistoryEventAccount
-              v-else
-              :dense="isPinned"
-              :location="row.entry.location"
-              :location-label="row.entry.locationLabel"
-            />
-          </div>
-        </template>
-        <template #item.asset="{ row }">
-          <div class="flex items-center gap-2">
-            <HistoryEventAsset
-              :dense="isPinned"
-              :class="{ '-mt-2 -mb-1': isPinned }"
-              disable-options
-              :event="row.entry"
-            />
-            <RuiTooltip
-              v-if="row.isCloseMatch && isPinned"
-              :open-delay="200"
+          </template>
+          <template #item.eventTypeAndSubtype="{ row }">
+            <div>{{ getHistoryEventTypeName(row.entry.eventType) }} -</div>
+            <div>{{ getHistoryEventSubTypeName(row.entry.eventSubtype) }}</div>
+          </template>
+          <template #item.txRef="{ row }">
+            <div
+              v-if="'txRef' in row.entry && row.entry.txRef"
+              class="flex items-center"
+              :class="isPinned ? 'gap-2' : 'gap-1'"
             >
-              <template #activator>
-                <RuiIcon
-                  name="lu-thumbs-up"
-                  size="16"
-                  color="success"
-                />
-              </template>
-              {{ t('asset_movement_matching.dialog.recommended') }}
-            </RuiTooltip>
-          </div>
-          <ReuseRowActions
-            v-if="isPinned"
-            :row="row"
-          />
-        </template>
-        <template #item.actions="{ row }">
-          <ReuseRowActions :row="row" />
-        </template>
-      </RuiDataTable>
+              <LocationIcon
+                horizontal
+                icon
+                size="1.25rem"
+                :item="row.entry.location"
+                :class="{ '!text-xs': isPinned }"
+              />
+              <HashLink
+                :text="row.entry.txRef"
+                type="transaction"
+                :location="row.entry.location"
+                :class="{ '!text-[10px]': isPinned }"
+              />
+            </div>
+            <div>
+              <span v-if="!row.entry.locationLabel">-</span>
+              <HistoryEventAccount
+                v-else
+                :dense="isPinned"
+                :location="row.entry.location"
+                :location-label="row.entry.locationLabel"
+              />
+            </div>
+          </template>
+          <template #item.asset="{ row }">
+            <div class="flex items-center gap-2">
+              <HistoryEventAsset
+                :dense="isPinned"
+                :class="{ '-mt-2 -mb-1': isPinned }"
+                disable-options
+                :event="row.entry"
+              />
+              <RuiTooltip
+                v-if="row.isCloseMatch && isPinned"
+                :open-delay="200"
+              >
+                <template #activator>
+                  <RuiIcon
+                    name="lu-thumbs-up"
+                    size="16"
+                    color="success"
+                  />
+                </template>
+                {{ t('asset_movement_matching.dialog.recommended') }}
+              </RuiTooltip>
+            </div>
+            <ReuseRowActions
+              v-if="isPinned"
+              :row="row"
+            />
+          </template>
+          <template #item.actions="{ row }">
+            <ReuseRowActions :row="row" />
+          </template>
+        </RuiDataTable>
+      </ScrollableDialogContent>
     </div>
   </div>
 </template>

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsList.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsList.vue
@@ -2,6 +2,7 @@
 import type { DataTableColumn } from '@rotki/ui-library';
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
@@ -129,11 +130,11 @@ const emptyDescription = computed<string>(() =>
 const descriptionEl = useTemplateRef<HTMLElement>('description');
 const { height: descriptionHeight } = useElementSize(descriptionEl);
 
-const pinnedTableStyle = computed<Record<string, string> | undefined>(() => {
-  if (!isPinned)
-    return undefined;
-  return { height: `calc(100vh - 15.4rem - ${get(descriptionHeight)}px)` };
-});
+const tableMaxHeight = computed<string>(() =>
+  isPinned
+    ? `calc(100vh - 15.4rem - ${get(descriptionHeight)}px)`
+    : 'calc(100vh - 23rem)',
+);
 
 function getRowClass(row: UnmatchedMovementRow): string {
   const classes = ['transition-all'];
@@ -169,184 +170,129 @@ function getRowClass(row: UnmatchedMovementRow): string {
         {{ t('asset_movement_matching.actions_pin.pin_section') }}
       </RuiButton>
     </div>
-    <RuiDataTable
-      v-model="selected"
-      :cols="columns"
-      :rows="rows"
-      row-attr="groupIdentifier"
-      :item-class="getRowClass"
-      outlined
-      dense
-      multi-page-select
-      :loading="loading"
-      :style="pinnedTableStyle"
-      :class="!isPinned ? 'max-h-[calc(100vh-23rem)]' : '!max-h-none'"
-      class="table-inside-dialog"
-      :empty="{ description: emptyDescription }"
-    >
-      <template
-        v-if="matchDisabled"
-        #body.prepend
+    <ScrollableDialogContent :max-height="tableMaxHeight">
+      <RuiDataTable
+        v-model="selected"
+        :cols="columns"
+        :rows="rows"
+        row-attr="groupIdentifier"
+        :item-class="getRowClass"
+        outlined
+        dense
+        multi-page-select
+        :loading="loading"
+        :empty="{ description: emptyDescription }"
       >
-        <tr>
-          <td :colspan="columns.length + 1">
-            <RuiAlert
-              type="warning"
-              size="sm"
-              class="whitespace-break-spaces !py-0.5 !rounded-none"
-            >
-              <i18n-t
-                v-if="premium"
-                scope="global"
-                keypath="asset_movement_matching.premium.premium_tooltip"
-              >
-                <template #tier>
-                  <strong>{{ matchMinimumTier }}</strong>
-                </template>
-                <template #currentTier>
-                  <strong>{{ currentTier }}</strong>
-                </template>
-                <template #link>
-                  <ExternalLink
-                    premium
-                    color="primary"
-                  >
-                    {{ t('asset_movement_matching.premium.link') }}
-                  </ExternalLink>
-                </template>
-              </i18n-t>
-              <i18n-t
-                v-else
-                scope="global"
-                keypath="asset_movement_matching.premium.free_tooltip"
-              >
-                <template #tier>
-                  <strong>{{ matchMinimumTier }}</strong>
-                </template>
-                <template #link>
-                  <ExternalLink
-                    premium
-                    color="primary"
-                  >
-                    {{ t('asset_movement_matching.premium.link') }}
-                  </ExternalLink>
-                </template>
-              </i18n-t>
-            </RuiAlert>
-          </td>
-        </tr>
-      </template>
-      <template #item.asset="{ row }">
-        <div class="flex items-center gap-2">
-          <HistoryEventAsset
-            :dense="isPinned"
-            disable-options
-            :event="row.entry"
-          />
-          <RuiTooltip
-            v-if="row.isFiat"
-            :open-delay="400"
-            :popper="{ placement: 'top' }"
-            tooltip-class="max-w-80"
-          >
-            <template #activator>
-              <RuiChip
-                size="sm"
-                color="warning"
-              >
-                {{ t('asset_movement_matching.fiat_hint.label') }}
-              </RuiChip>
-            </template>
-            {{ t('asset_movement_matching.fiat_hint.tooltip') }}
-          </RuiTooltip>
-        </div>
-      </template>
-      <template #item.eventSubtype="{ row }">
-        <BadgeDisplay>
-          {{ getAssetMovementsType(row.eventSubtype) }}
-        </BadgeDisplay>
-      </template>
-      <template #item.location="{ row }">
-        <LocationDisplay
-          size="24px"
-          :identifier="row.location"
-        />
-      </template>
-      <template #item.timestamp="{ row }">
-        <DateDisplay
-          :timestamp="row.timestamp"
-          milliseconds
-        />
-        <div
-          v-if="isPinned"
-          class="flex flex-wrap items-center gap-x-1.5"
+        <template
+          v-if="matchDisabled"
+          #body.prepend
         >
-          <BadgeDisplay class="!leading-6 my-1">
-            {{ getAssetMovementsType(row.eventSubtype) }}
-          </BadgeDisplay>
-          <LocationDisplay
-            class="[&_div]:!justify-start"
-            size="16px"
-            :identifier="row.location"
-            horizontal
-          />
-        </div>
-      </template>
-      <template #item.actions="{ row }">
-        <div class="flex items-center gap-2">
-          <RuiTooltip
-            :open-delay="400"
-            :popper="{ placement: 'top' }"
-          >
-            <template #activator>
-              <RuiButton
+          <tr>
+            <td :colspan="columns.length + 1">
+              <RuiAlert
+                type="warning"
                 size="sm"
-                variant="outlined"
-                icon
-                color="primary"
-                class="!px-2 h-[30px]"
-                @click="emit('show-in-events', row.original)"
+                class="whitespace-break-spaces !py-0.5 !rounded-none"
               >
-                <RuiIcon
-                  size="16"
-                  name="lu-external-link"
-                />
-              </RuiButton>
-            </template>
-            {{ t('asset_movement_matching.dialog.show_in_events') }}
-          </RuiTooltip>
-          <template v-if="showRestore">
+                <i18n-t
+                  v-if="premium"
+                  scope="global"
+                  keypath="asset_movement_matching.premium.premium_tooltip"
+                >
+                  <template #tier>
+                    <strong>{{ matchMinimumTier }}</strong>
+                  </template>
+                  <template #currentTier>
+                    <strong>{{ currentTier }}</strong>
+                  </template>
+                  <template #link>
+                    <ExternalLink
+                      premium
+                      color="primary"
+                    >
+                      {{ t('asset_movement_matching.premium.link') }}
+                    </ExternalLink>
+                  </template>
+                </i18n-t>
+                <i18n-t
+                  v-else
+                  scope="global"
+                  keypath="asset_movement_matching.premium.free_tooltip"
+                >
+                  <template #tier>
+                    <strong>{{ matchMinimumTier }}</strong>
+                  </template>
+                  <template #link>
+                    <ExternalLink
+                      premium
+                      color="primary"
+                    >
+                      {{ t('asset_movement_matching.premium.link') }}
+                    </ExternalLink>
+                  </template>
+                </i18n-t>
+              </RuiAlert>
+            </td>
+          </tr>
+        </template>
+        <template #item.asset="{ row }">
+          <div class="flex items-center gap-2">
+            <HistoryEventAsset
+              :dense="isPinned"
+              disable-options
+              :event="row.entry"
+            />
             <RuiTooltip
+              v-if="row.isFiat"
               :open-delay="400"
               :popper="{ placement: 'top' }"
+              tooltip-class="max-w-80"
             >
               <template #activator>
-                <RuiButton
+                <RuiChip
                   size="sm"
-                  color="primary"
-                  :loading="ignoreLoading"
-                  @click="emit('restore', row.original)"
+                  color="warning"
                 >
-                  {{ t('asset_movement_matching.dialog.restore') }}
-                </RuiButton>
+                  {{ t('asset_movement_matching.fiat_hint.label') }}
+                </RuiChip>
               </template>
-              {{ t('asset_movement_matching.dialog.restore_tooltip') }}
+              {{ t('asset_movement_matching.fiat_hint.tooltip') }}
             </RuiTooltip>
-          </template>
+          </div>
+        </template>
+        <template #item.eventSubtype="{ row }">
+          <BadgeDisplay>
+            {{ getAssetMovementsType(row.eventSubtype) }}
+          </BadgeDisplay>
+        </template>
+        <template #item.location="{ row }">
+          <LocationDisplay
+            size="24px"
+            :identifier="row.location"
+          />
+        </template>
+        <template #item.timestamp="{ row }">
+          <DateDisplay
+            :timestamp="row.timestamp"
+            milliseconds
+          />
           <div
-            v-else
-            class="flex"
-            :class="isPinned ? 'flex-wrap gap-1' : 'gap-2'"
+            v-if="isPinned"
+            class="flex flex-wrap items-center gap-x-1.5"
           >
-            <RuiButton
-              size="sm"
-              color="primary"
-              :class="{ '!py-0.5': isPinned }"
-              :disabled="matchDisabled"
-              @click="emit('select', row.original)"
-            >
-              {{ t('asset_movement_matching.dialog.find_match') }}
-            </RuiButton>
+            <BadgeDisplay class="!leading-6 my-1">
+              {{ getAssetMovementsType(row.eventSubtype) }}
+            </BadgeDisplay>
+            <LocationDisplay
+              class="[&_div]:!justify-start"
+              size="16px"
+              :identifier="row.location"
+              horizontal
+            />
+          </div>
+        </template>
+        <template #item.actions="{ row }">
+          <div class="flex items-center gap-2">
             <RuiTooltip
               :open-delay="400"
               :popper="{ placement: 'top' }"
@@ -355,18 +301,72 @@ function getRowClass(row: UnmatchedMovementRow): string {
                 <RuiButton
                   size="sm"
                   variant="outlined"
-                  :class="{ '!py-0.5': isPinned }"
-                  :loading="ignoreLoading"
-                  @click="emit('ignore', row.original)"
+                  icon
+                  color="primary"
+                  class="!px-2 h-[30px]"
+                  @click="emit('show-in-events', row.original)"
                 >
-                  {{ t('asset_movement_matching.dialog.ignore') }}
+                  <RuiIcon
+                    size="16"
+                    name="lu-external-link"
+                  />
                 </RuiButton>
               </template>
-              {{ t('asset_movement_matching.dialog.ignore_tooltip') }}
+              {{ t('asset_movement_matching.dialog.show_in_events') }}
             </RuiTooltip>
+            <template v-if="showRestore">
+              <RuiTooltip
+                :open-delay="400"
+                :popper="{ placement: 'top' }"
+              >
+                <template #activator>
+                  <RuiButton
+                    size="sm"
+                    color="primary"
+                    :loading="ignoreLoading"
+                    @click="emit('restore', row.original)"
+                  >
+                    {{ t('asset_movement_matching.dialog.restore') }}
+                  </RuiButton>
+                </template>
+                {{ t('asset_movement_matching.dialog.restore_tooltip') }}
+              </RuiTooltip>
+            </template>
+            <div
+              v-else
+              class="flex"
+              :class="isPinned ? 'flex-wrap gap-1' : 'gap-2'"
+            >
+              <RuiButton
+                size="sm"
+                color="primary"
+                :class="{ '!py-0.5': isPinned }"
+                :disabled="matchDisabled"
+                @click="emit('select', row.original)"
+              >
+                {{ t('asset_movement_matching.dialog.find_match') }}
+              </RuiButton>
+              <RuiTooltip
+                :open-delay="400"
+                :popper="{ placement: 'top' }"
+              >
+                <template #activator>
+                  <RuiButton
+                    size="sm"
+                    variant="outlined"
+                    :class="{ '!py-0.5': isPinned }"
+                    :loading="ignoreLoading"
+                    @click="emit('ignore', row.original)"
+                  >
+                    {{ t('asset_movement_matching.dialog.ignore') }}
+                  </RuiButton>
+                </template>
+                {{ t('asset_movement_matching.dialog.ignore_tooltip') }}
+              </RuiTooltip>
+            </div>
           </div>
-        </div>
-      </template>
-    </RuiDataTable>
+        </template>
+      </RuiDataTable>
+    </ScrollableDialogContent>
   </div>
 </template>

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DataTableColumn } from '@rotki/ui-library';
 import { startPromise } from '@shared/utils';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import TableFilter from '@/modules/core/table/TableFilter.vue';
 import CopyButton from '@/modules/shell/components/CopyButton.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
@@ -236,9 +237,9 @@ defineExpose({
       />
     </div>
 
-    <div
-      class="flex-1 overflow-auto"
-      :class="compact && 'px-1'"
+    <ScrollableDialogContent
+      fill
+      :class="{ 'px-1': compact }"
     >
       <RuiDataTable
         v-model:sort.external="sort"
@@ -249,7 +250,6 @@ defineExpose({
         row-attr="txHash"
         outlined
         dense
-        class="table-inside-dialog"
       >
         <template #header.selection>
           <RuiCheckbox
@@ -388,6 +388,6 @@ defineExpose({
           </div>
         </template>
       </RuiDataTable>
-    </div>
+    </ScrollableDialogContent>
   </div>
 </template>

--- a/frontend/app/src/modules/reports/ReportActionableCard.vue
+++ b/frontend/app/src/modules/reports/ReportActionableCard.vue
@@ -202,11 +202,12 @@ function closePinnedSidebar() {
 <template>
   <RuiCard
     no-padding
-    class="overflow-hidden"
-    :class="{ '!rounded-none': isPinned }"
+    class="overflow-hidden flex flex-col"
+    :class="isPinned ? 'h-full !rounded-none' : 'max-h-[90vh]'"
+    content-class="flex flex-col flex-1 min-h-0 overflow-hidden"
     variant="flat"
   >
-    <div class="flex bg-rui-primary text-white p-2">
+    <div class="flex bg-rui-primary text-white p-2 shrink-0">
       <RuiButton
         v-if="!isPinned"
         variant="text"
@@ -284,75 +285,74 @@ function closePinnedSidebar() {
     <RuiStepper
       :steps="stepperContents"
       :step="step"
-      class="border-b-2 border-default"
+      class="border-b-2 border-default shrink-0"
       :class="{ 'py-2': isPinned, 'py-4': !isPinned }"
     />
 
-    <div
-      v-for="(content, index) of stepperContents"
-      :key="content.key"
-    >
-      <Component
-        :is="content.selector"
-        v-if="step === index + 1"
-        :items="content.items"
-        :is-pinned="isPinned"
-        @pin="pinSection()"
+    <div class="flex-1 min-h-0 flex flex-col">
+      <template
+        v-for="(content, index) of stepperContents"
+        :key="content.key"
       >
-        <template
+        <Component
+          :is="content.selector"
           v-if="step === index + 1"
-          #actions="{ items }"
+          :items="content.items"
+          :is-pinned="isPinned"
+          @pin="pinSection()"
         >
-          <div
-            class="border-t-2 border-rui-grey-300 dark:border-rui-grey-800 relative z-[2] flex items-center justify-between gap-4"
-            :class="isPinned ? 'p-2' : 'p-4'"
-          >
+          <template #actions="{ items }">
             <div
-              v-if="content.hint"
-              class="text-caption"
+              class="border-t-2 border-rui-grey-300 dark:border-rui-grey-800 relative z-[2] flex items-center justify-between gap-4"
+              :class="isPinned ? 'p-2' : 'p-4'"
             >
-              {{ content.hint }}
-            </div>
+              <div
+                v-if="content.hint"
+                class="text-caption"
+              >
+                {{ content.hint }}
+              </div>
 
-            <div class="flex gap-2">
-              <RuiButton
-                v-if="step > 1"
-                :size="isPinned ? 'sm' : undefined"
-                variant="text"
-                @click="step = step - 1"
-              >
-                {{ t('common.actions.back') }}
-              </RuiButton>
-              <RuiButton
-                v-if="step < stepperContents.length"
-                color="primary"
-                :size="isPinned ? 'sm' : undefined"
-                @click="step = step + 1"
-              >
-                {{ t('common.actions.next') }}
-              </RuiButton>
-              <template v-if="step === stepperContents.length">
+              <div class="flex gap-2">
                 <RuiButton
-                  v-if="!isPinned && content.key === 'missingAcquisitions'"
-                  color="primary"
+                  v-if="step > 1"
                   :size="isPinned ? 'sm' : undefined"
-                  @click="setDialog(false)"
+                  variant="text"
+                  @click="step = step - 1"
                 >
-                  {{ t('common.actions.close') }}
+                  {{ t('common.actions.back') }}
                 </RuiButton>
                 <RuiButton
-                  v-else-if="content.key !== 'missingAcquisitions'"
+                  v-if="step < stepperContents.length"
                   color="primary"
                   :size="isPinned ? 'sm' : undefined"
-                  @click="submitActionableItems(items)"
+                  @click="step = step + 1"
                 >
-                  {{ t('common.actions.finish') }}
+                  {{ t('common.actions.next') }}
                 </RuiButton>
-              </template>
+                <template v-if="step === stepperContents.length">
+                  <RuiButton
+                    v-if="!isPinned && content.key === 'missingAcquisitions'"
+                    color="primary"
+                    :size="isPinned ? 'sm' : undefined"
+                    @click="setDialog(false)"
+                  >
+                    {{ t('common.actions.close') }}
+                  </RuiButton>
+                  <RuiButton
+                    v-else-if="content.key !== 'missingAcquisitions'"
+                    color="primary"
+                    :size="isPinned ? 'sm' : undefined"
+                    @click="submitActionableItems(items)"
+                  >
+                    {{ t('common.actions.finish') }}
+                  </RuiButton>
+                </template>
+              </div>
             </div>
-          </div>
-        </template>
-      </Component>
+          </template>
+        </Component>
+      </template>
     </div>
   </RuiCard>
 </template>

--- a/frontend/app/src/modules/reports/ReportMissingAcquisitions.vue
+++ b/frontend/app/src/modules/reports/ReportMissingAcquisitions.vue
@@ -7,6 +7,7 @@ import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { useAssetsStore } from '@/modules/assets/use-assets-store';
 import { useIgnoredAssetOperations } from '@/modules/assets/use-ignored-asset-operations';
 import { bigNumberSum } from '@/modules/core/common/data/calculation';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
@@ -162,14 +163,10 @@ async function showInHistoryEvent(identifier: number) {
       <DateDisplay :timestamp="row.endDate" />
     </template>
   </CreateDate>
-  <div>
+  <ScrollableDialogContent fill>
     <RuiDataTable
       v-model:sort="sort"
       v-model:expanded="expanded"
-      class="table-inside-dialog"
-      :class="{
-        'max-h-full h-[calc(100vh-245px)]': isPinned,
-      }"
       :cols="headers"
       :rows="groupedMissingAcquisitions"
       row-attr="asset"
@@ -287,6 +284,8 @@ async function showInHistoryEvent(identifier: number) {
         </RuiDataTable>
       </template>
     </RuiDataTable>
-    <slot name="actions" />
-  </div>
+    <template #footer>
+      <slot name="actions" />
+    </template>
+  </ScrollableDialogContent>
 </template>

--- a/frontend/app/src/modules/reports/ReportMissingPrices.vue
+++ b/frontend/app/src/modules/reports/ReportMissingPrices.vue
@@ -9,6 +9,7 @@ import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-pric
 import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
 import { ApiValidationError } from '@/modules/core/api/types/errors';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import { PriceOracle } from '@/modules/settings/types/price-oracle';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
@@ -172,13 +173,9 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div>
+  <ScrollableDialogContent fill>
     <RuiDataTable
       v-model:sort="sort"
-      class="table-inside-dialog"
-      :class="{
-        'max-h-full h-[calc(100vh-245px)]': isPinned,
-      }"
       :cols="headers"
       :rows="formattedItems"
       :dense="isPinned"
@@ -266,9 +263,11 @@ onMounted(async () => {
         </AmountInput>
       </template>
     </RuiDataTable>
-    <slot
-      name="actions"
-      :items="formattedItems"
-    />
-  </div>
+    <template #footer>
+      <slot
+        name="actions"
+        :items="formattedItems"
+      />
+    </template>
+  </ScrollableDialogContent>
 </template>

--- a/frontend/app/tailwind.config.ts
+++ b/frontend/app/tailwind.config.ts
@@ -49,10 +49,6 @@ const componentsPlugin = plugin((pluginAPI: PluginAPI) => {
       '@apply px-4': {},
       'maxWidth': '1500px',
     },
-    '.table-inside-dialog': {
-      '@apply scroll-smooth overflow-auto': {},
-      'maxHeight': 'calc(100vh - 21.25rem)',
-    },
   });
   pluginAPI.addUtilities({
     '.blur': {


### PR DESCRIPTION
## Problem

Tables shown inside dialogs were capped in height but **not scrollable** — rows past the visible area were clipped and unreachable. Most visible on the PnL report **"issues found"** dialog (missing acquisitions / missing prices), but it affected every dialog using the shared `.table-inside-dialog` class.

## Root cause

These tables applied the `.table-inside-dialog` Tailwind **component** class (`overflow-auto` + `max-height`) to `RuiDataTable`'s root element. After the ui-library data-table refactor (first shipped in **v2.16.0**), that root carries an `overflow-hidden` Tailwind **utility**. Utilities win over the `addComponents()` layer, so `overflow-hidden` overrode our `overflow-auto` and the `max-height` clipped the content with no scrollbar.

## Fix

Introduce a small layout primitive, `ScrollableDialogContent`, that owns the scroll region on an **app-owned** element instead of fighting the library on its own root:

- bounded flex column; `shrink-0` header/footer slots; `flex-1 min-h-0 overflow-y-auto` body
- `min-h-0` (the easy-to-forget, load-bearing bit) lives in one place so it can't drift
- `fill` mode (grow within a flex column) for the report card; `max-height` mode (self-bounding, parent-agnostic) for the rest

All dialogs are converted to it and the `.table-inside-dialog` class is removed entirely — no `!important`, no per-dialog magic-number drift.

## What gets better for users

In-dialog tables scroll again, so long lists (missing acquisitions/prices, snapshot rows, conflicts, asset-movement matches…) are fully reachable instead of cut off.

## Test plan / what to check

- [x] **PnL report → "Show issues"** dialog: Missing Acquisitions and Missing Prices tables scroll; title, stepper and the action bar stay pinned. Pin it to the sidebar → still scrolls.
- [x] **Dashboard → snapshot → edit**: Balances and Location tables scroll; the totals/action footer stays pinned; tab switching still works.
- [ ] **Negative balances** dialog: table scrolls.
- [x] **Internal tx conflicts**: both the dialog and the pinned-sidebar view scroll.
- [x] **Asset movement matching**: unmatched movements list and potential matches list scroll, in both dialog and pinned views.
- [ ] **Customized event duplicates** dialog: table scrolls.

## Notes

- New unit test `ScrollableDialogContent.spec.ts` guards the pattern (body keeps `flex-1 min-h-0 overflow-y-auto`, header/footer keep `shrink-0`).
- `EditBalancesSnapshotTable` was already at the import-dependency cap, so the shared component pushed it over; suppressed there with a comment since the snapshot editor is slated for a rewrite.