### PR TITLE
Clarify ETH staking plan-limit validator error

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Trying to add an ETH staking validator on a plan that doesn't include staking now shows a clear message saying your plan has no staking access, instead of a confusing "ETH staking limit of 0 ETH" error.
 * :bug:`12463` Querying price for custom asset under certain conditions no longer fails the task.
 * :bug:`-` Tables shown inside dialogs (such as the PnL report "issues found" dialog with missing acquisitions/prices, and the snapshot editor) are scrollable again, so rows past the visible area are no longer cut off.
 * :bug:`-` The desktop app no longer accesses the OS keyring (triggering a keychain/keyring unlock prompt) when you create or open an account, unless you have chosen to save your password.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1729,7 +1729,8 @@
     "add_account": "Add Account",
     "add_validator_premium": "Adding ETH staking validators is a premium feature. Upgrade to rotki Premium to add validators.",
     "binance_warning": "Binance Smart Chain accounts can only be detected with a paid Etherscan key.",
-    "eth_staking_limit_error": "Adding this validator would exceed your {currentTier} plan's ETH staking limit of {limit} ETH. Upgrade your plan via {link} or contact us for a custom plan to increase your limit.",
+    "eth_staking_limit_error": "Adding this validator would put you over your {currentTier} plan's ETH staking limit of {limit} ETH. Upgrade your plan via {link} or contact us for a custom plan to raise your limit.",
+    "eth_staking_no_access": "Your {currentTier} plan doesn't include ETH staking. Upgrade your plan via {link} or contact us for a custom plan to get access.",
     "evm_detection": {
       "title": "Detect EVM accounts",
       "tooltip": "Detect activities of all registered EVM accounts in other EVM chains, and register them."

--- a/frontend/app/src/modules/accounts/management/AccountDialog.vue
+++ b/frontend/app/src/modules/accounts/management/AccountDialog.vue
@@ -134,6 +134,7 @@ watch(model, (model, oldModel) => {
     >
       <template v-if="saveErrorIsPremium">
         <i18n-t
+          v-if="ethStakedLimit > 0"
           scope="global"
           keypath="blockchain_balances.eth_staking_limit_error"
           tag="span"
@@ -141,6 +142,24 @@ watch(model, (model, oldModel) => {
           <template #limit>
             {{ ethStakedLimit }}
           </template>
+          <template #currentTier>
+            {{ currentTier }}
+          </template>
+          <template #link>
+            <ExternalLink
+              :text="upgradeLinkText"
+              :url="upgradeLinkUrl"
+              premium
+              color="primary"
+            />
+          </template>
+        </i18n-t>
+        <i18n-t
+          v-else
+          scope="global"
+          keypath="blockchain_balances.eth_staking_no_access"
+          tag="span"
+        >
           <template #currentTier>
             {{ currentTier }}
           </template>


### PR DESCRIPTION
## Problem

Adding an ETH staking validator that's rejected for plan reasons always showed:

> Adding this validator would exceed your {currentTier} plan's ETH staking limit of {limit} ETH.

When the plan's staked-ETH limit is `0`, that means the plan has **no** staking access at all — but the message framed it as a quantity limit ("limit of 0 ETH"), which read as confusing/misleading rather than "your plan doesn't include staking."

## Change

Split the message in two, chosen by `ethStakedLimit` in `AccountDialog.vue`:

- **`0` (no access):** new key `eth_staking_no_access` — "Your {currentTier} plan doesn't include ETH staking. Upgrade ... to get access."
- **`> 0` (limit reached):** reworded `eth_staking_limit_error` — "Adding this validator would put you over your {currentTier} plan's ETH staking limit of {limit} ETH. Upgrade ... to raise your limit."

Both use **static** `keypath` literals (toggled with `v-if`/`v-else`) rather than a dynamic `:keypath` ternary, so the vue-i18n eslint key detection keeps working. Only `en.json` is touched (other locales sync externally). Changelog entry added.

## Notes

- Out of scope: `currentTier` falls back to `'Free'` in `use-premium-helper.ts`, so the message may name the wrong tier for some plans — left for a separate change.