### PR TITLE
Sync history from PnL out-of-sync warning

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The "history out of sync" warning shown before generating a PnL report now lets you start the history sync right there, instead of only sending you to the history page.
 * :bug:`-` Trying to add an ETH staking validator on a plan that doesn't include staking now shows a clear message saying your plan has no staking access, instead of a confusing "ETH staking limit of 0 ETH" error.
 * :bug:`12463` Querying price for custom asset under certain conditions no longer fails the task.
 * :bug:`-` Tables shown inside dialogs (such as the PnL report "issues found" dialog with missing acquisitions/prices, and the snapshot editor) are scrollable again, so rows past the visible area are no longer cut off.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5076,14 +5076,14 @@
       "title": "Profit and Loss Report Generation"
     },
     "go_to_exchanges": "Go to Exchange Settings",
-    "go_to_history": "Go to History Events",
     "loading": "Please wait while your PnL report is loading",
     "loading_hint": "Your report generation might take a while depending on the amount of trades and actions you performed during the selected period.",
     "loading_message": "Please wait while your report is generated...",
     "out_of_sync_alert": "Your history events data is out of sync. Please update your history events before generating a report.",
-    "processing_alert": "History events are currently being processed. Please wait until processing is complete.",
+    "processing_alert": "History events are currently being processed ({percentage}%). Please wait until processing is complete.",
     "report_period": "Report starting from {start} to {end}",
-    "settings_tooltip": "Open the accounting settings"
+    "settings_tooltip": "Open the accounting settings",
+    "sync_history": "Sync history now"
   },
   "profit_loss_reports": {
     "columns": {

--- a/frontend/app/src/modules/reports/ReportGenerator.vue
+++ b/frontend/app/src/modules/reports/ReportGenerator.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import type { ProfitLossReportPeriod } from '@/modules/reports/report-types';
+import { startPromise } from '@shared/utils';
 import { useExchangeApi } from '@/modules/balances/api/use-exchange-api';
 import { useTransactionStatusCheck } from '@/modules/dashboard/progress/use-transaction-status-check';
+import { useHistoryTransactions } from '@/modules/history/events/tx/use-history-transactions';
 import RangeSelector from '@/modules/reports/RangeSelector.vue';
 import { useSessionSettingsStore } from '@/modules/settings/use-session-settings-store';
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
+import { useSyncProgress } from '@/modules/shell/sync-progress/use-sync-progress';
 import { Routes } from '@/router/routes';
 
 const emit = defineEmits<{
@@ -15,7 +18,9 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { isOutOfSync, navigateToHistory, processing } = useTransactionStatusCheck();
+const { isOutOfSync, processing } = useTransactionStatusCheck();
+const { overallProgress } = useSyncProgress();
+const { refreshTransactions } = useHistoryTransactions();
 const { queryBinanceUserMarkets } = useExchangeApi();
 const { connectedExchanges } = storeToRefs(useSessionSettingsStore());
 
@@ -57,6 +62,10 @@ function toReportPeriod(): ProfitLossReportPeriod {
 
 function generate(): void {
   emit('generate', toReportPeriod());
+}
+
+function syncHistory(): void {
+  startPromise(refreshTransactions());
 }
 
 function exportReportData(): void {
@@ -110,22 +119,21 @@ onMounted(async () => {
       type="warning"
       class="mt-6"
     >
-      <template v-if="processing">
-        {{ t('profit_loss_report.processing_alert') }}
-      </template>
-      <template v-else>
-        <div class="flex flex-col items-start gap-2">
-          <div>{{ t('profit_loss_report.out_of_sync_alert') }}</div>
-          <RuiButton
-            size="sm"
-            color="primary"
-            variant="outlined"
-            @click="navigateToHistory()"
-          >
-            {{ t('profit_loss_report.go_to_history') }}
-          </RuiButton>
+      <div class="flex flex-col items-start gap-2">
+        <div>
+          {{ processing ? t('profit_loss_report.processing_alert', { percentage: overallProgress }) : t('profit_loss_report.out_of_sync_alert') }}
         </div>
-      </template>
+        <RuiButton
+          size="sm"
+          color="primary"
+          variant="outlined"
+          :loading="processing"
+          :disabled="processing"
+          @click="syncHistory()"
+        >
+          {{ t('profit_loss_report.sync_history') }}
+        </RuiButton>
+      </div>
     </RuiAlert>
     <RuiAlert
       v-if="hasBinanceWithoutMarkets"


### PR DESCRIPTION
## Problem

When you open the PnL report generator and your history events are out of sync (typically because you haven't visited the history page in a while), a warning is shown with a button that only **navigates** to the history page. The user is dropped onto the history view and has to wait there for the sync, rather than being able to refresh from where they already are.

## Change

The button in the "history out of sync" warning now triggers the history sync **in place** instead of navigating away:

- Clicking it calls `refreshTransactions()` (via `useHistoryTransactions`). No `userInitiated` flag is needed — on a fresh session the history section status is `NONE`, so `fetchDisabled` is false and the sync runs, exactly like navigating to history does (`refresh.all()` on mount).
- While syncing, the button shows a loading state and the warning text shows the overall sync progress percentage.
- The percentage reuses `useSyncProgress().overallProgress` — the same weighted figure (tx / events / decoding) shown by the history page's `SyncProgressPanel` — so the number is consistent with what the history page displays. (The dashboard's older `useHistoryQueryProgress` metric is query-only and reads an inflated value early in a sync, so it was not used here.)

## Notes

- i18n: removed the now-unused `profit_loss_report.go_to_history` key and added `profit_loss_report.sync_history`; `processing_alert` now includes the percentage. Only `en.json` is edited.
- Changelog entry added.