### PR TITLE
perf: stop polluting the price cache with collection members

### DIFF
--- a/rotkehlchen/assets/resolver.py
+++ b/rotkehlchen/assets/resolver.py
@@ -39,8 +39,6 @@ class AssetResolver:
     # Maps asset identifier -> collection main_asset identifier (or None if not in a collection).
     # None is a valid cached value so presence must be tested with `identifier.lower() in cache`.
     collection_main_asset_cache: LRUCacheLowerKey[str | None] = LRUCacheLowerKey(maxsize=512)
-    # Maps asset identifier -> all assets in its collection (or just itself if in no collection).
-    collection_assets_cache: LRUCacheLowerKey[tuple['Asset', ...]] = LRUCacheLowerKey(maxsize=512)
 
     def __new__(  # noqa: PYI034 # singleton pattern should not get Self
             cls,
@@ -69,12 +67,10 @@ class AssetResolver:
             AssetResolver.__instance.assets_cache.remove(identifier)
             AssetResolver.__instance.types_cache.remove(identifier)
             AssetResolver.__instance.collection_main_asset_cache.remove(identifier)
-            AssetResolver.__instance.collection_assets_cache.remove(identifier)
         else:
             AssetResolver.__instance.assets_cache.clear()
             AssetResolver.__instance.types_cache.clear()
             AssetResolver.__instance.collection_main_asset_cache.clear()
-            AssetResolver.__instance.collection_assets_cache.clear()
 
     @staticmethod
     def get_collection_main_asset(identifier: str) -> str | None:
@@ -91,23 +87,6 @@ class AssetResolver:
         main_asset = AssetResolver._globaldb.get_collection_main_asset(identifier)
         cache.add(identifier, main_asset)
         return main_asset
-
-    @staticmethod
-    def get_assets_in_same_collection(identifier: str) -> tuple['Asset', ...]:
-        """Return all assets in the same collection as identifier, memoized.
-
-        Mirrors GlobalDBHandler.get_assets_in_same_collection but caches the result to avoid
-        re-running the collection JOIN on hot paths (e.g. Inquirer.set_cached_price, called once
-        per priced asset on every balance refresh). Returns (Asset(identifier),) when the asset
-        is in no collection. The value is never None, so a None get() result means a cache miss.
-        """
-        cache = AssetResolver.collection_assets_cache
-        if (cached := cache.get(identifier)) is not None:
-            return cached
-
-        result = AssetResolver._globaldb.get_assets_in_same_collection(identifier)
-        cache.add(identifier, result)
-        return result
 
     @staticmethod
     def resolve_asset(identifier: str) -> 'AssetWithNameAndType':

--- a/rotkehlchen/inquirer.py
+++ b/rotkehlchen/inquirer.py
@@ -525,10 +525,15 @@ class Inquirer:
 
     @staticmethod
     def set_cached_price(cache_key: tuple[Asset, Asset], cached_price: CachedPriceEntry) -> None:
-        """Save cached price for the key provided and all the assets in the same collection"""
-        related_assets = AssetResolver.get_assets_in_same_collection(cache_key[0].identifier)
-        for related_asset in related_assets:
-            Inquirer._cached_current_price.add((related_asset, cache_key[1]), cached_price)
+        """Save cached price for the key provided.
+
+        The price hot path (_preprocess_assets_to_query) always normalizes a collection member
+        to its collection main asset via _maybe_replace_asset before reading the cache, and every
+        set_cached_price call site is downstream of that normalization, so cache_key[0] is already
+        the collection main asset. Storing extra entries for the other collection members would
+        therefore never be read and only evict useful entries from the LRU.
+        """
+        Inquirer._cached_current_price.add(cache_key, cached_price)
 
     @staticmethod
     def _try_oracle_price_query(

--- a/rotkehlchen/tests/unit/test_inquirer.py
+++ b/rotkehlchen/tests/unit/test_inquirer.py
@@ -1104,7 +1104,12 @@ def test_find_yearn_v1_vault_token_price(inquirer_defi):
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 def test_cache_is_hit_for_collection(inquirer: Inquirer):
-    """Test that the price for a collection is saved to cache and not query for every asset"""
+    """Test that the price for a collection is saved to cache and not queried for every asset.
+
+    Querying one member of a multi-chain collection (wstETH on mainnet) and then another member
+    (wstETH on optimism) must return the same price with only a single oracle query, since every
+    member normalizes to the collection main asset on cache lookup.
+    """
     wsteth = Asset('eip155:1/erc20:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0')
     wsteth_op = Asset('eip155:10/erc20:0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb')
     with mock.patch.object(
@@ -1112,30 +1117,12 @@ def test_cache_is_hit_for_collection(inquirer: Inquirer):
         '_query_oracle_instances',
         wraps=inquirer._query_oracle_instances,
     ) as oracle_query:
-        inquirer.find_usd_price(wsteth)
-        assert (wsteth_op, A_USD) in inquirer._cached_current_price.cache
-        inquirer.find_usd_price(wsteth_op)
+        wsteth_price = inquirer.find_usd_price(wsteth)
+        wsteth_op_price = inquirer.find_usd_price(wsteth_op)
 
+    assert wsteth_price != ZERO_PRICE
+    assert wsteth_op_price == wsteth_price
     assert oracle_query.call_count == 1
-
-
-@pytest.mark.parametrize('should_mock_current_price_queries', [False])
-def test_collection_assets_query_is_memoized(inquirer: Inquirer):
-    """Test that get_assets_in_same_collection is memoized so set_cached_price (called once per
-    priced asset on every balance refresh) does not re-run the collection JOIN every time."""
-    wsteth = Asset('eip155:1/erc20:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0')
-    AssetResolver.clean_memory_cache(wsteth.identifier)
-    with mock.patch.object(
-        GlobalDBHandler,
-        'get_assets_in_same_collection',
-        wraps=GlobalDBHandler.get_assets_in_same_collection,
-    ) as collection_query:
-        first = AssetResolver.get_assets_in_same_collection(wsteth.identifier)
-        second = AssetResolver.get_assets_in_same_collection(wsteth.identifier)
-
-    assert collection_query.call_count == 1, 'collection JOIN must be memoized across calls'
-    assert first == second
-    assert wsteth in first  # sanity: wstETH belongs to a multi-chain collection
 
 
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])


### PR DESCRIPTION
set_cached_price wrote a cache entry for every asset in the same collection as cache_key[0]. But the price hot path (_preprocess_assets_to_query) always normalizes a collection member to its main asset before reading the cache, and every set_cached_price call site is downstream of that normalization, so only the (main_asset, to_asset) entry is ever read. The extra per-member entries were never hit and only evicted useful entries from the 1024-slot LRU (10-30 dead writes per set for multi-chain assets like USDC/USDT/WETH).

Write a single entry instead, and drop the now-dead get_assets_in_same_collection memoization wrapper and collection_assets_cache that existed solely for that loop.
