### PR TITLE
Fix missing-prices rate-limit tooltip overlap

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The rate-limit hint in the PnL report's missing prices dialog is now a warning icon next to the refresh button, so its tooltip no longer covers the price input or the buttons of nearby rows.
 * :bug:`-` The "history out of sync" warning shown before generating a PnL report now lets you start the history sync right there, instead of only sending you to the history page.
 * :bug:`-` Trying to add an ETH staking validator on a plan that doesn't include staking now shows a clear message saying your plan has no staking access, instead of a confusing "ETH staking limit of 0 ETH" error.
 * :bug:`12463` Querying price for custom asset under certain conditions no longer fails the task.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5062,7 +5062,7 @@
         "no_filled_prices": "No prices are filled",
         "price_is_saved": "Price is saved",
         "price_not_found": "Price not found",
-        "refresh_price_hint": "Rate limiting detected when rokti tried to fetch the historical price. You can either fetch the historical price again manually, or input manual price.",
+        "refresh_price_hint": "Rate limiting detected when rotki tried to fetch the historical price. You can either fetch the historical price again manually, or input manual price.",
         "regenerate_report_nudge": "click button below to re-generate the report.",
         "skipped_all_events_confirmation": "Are you sure you want to skip all events whose asset price is missing?",
         "title": "Missing Prices ({total})",

--- a/frontend/app/src/modules/reports/ReportMissingPrices.vue
+++ b/frontend/app/src/modules/reports/ReportMissingPrices.vue
@@ -233,32 +233,41 @@ onMounted(async () => {
           @blur="updatePrice(row)"
         >
           <template #append>
-            <RuiTooltip
+            <div
               v-if="row.rateLimited"
-              :popper="{ placement: 'top' }"
-              :open-delay="400"
-              tooltip-class="max-w-[16rem]"
-              :disabled="refreshing"
+              class="flex items-center gap-1"
             >
-              <template #activator>
-                <RuiButton
-                  :disabled="!!row.price || refreshing"
-                  :loading="refreshing"
-                  class="-mr-3 !py-[0.625rem] rounded-l-none"
-                  size="sm"
-                  color="primary"
-                  @click="refreshHistoricalPrice(row)"
-                >
+              <RuiTooltip
+                :popper="{ placement: 'right' }"
+                :open-delay="700"
+                tooltip-class="max-w-[16rem]"
+              >
+                <template #activator>
                   <RuiIcon
+                    class="mr-1"
                     size="20"
-                    name="lu-refresh-ccw"
+                    name="lu-triangle-alert"
+                    color="warning"
                   />
-                </RuiButton>
-              </template>
-              <span>
-                {{ t('profit_loss_report.actionable.missing_prices.refresh_price_hint') }}
-              </span>
-            </RuiTooltip>
+                </template>
+                <span>
+                  {{ t('profit_loss_report.actionable.missing_prices.refresh_price_hint') }}
+                </span>
+              </RuiTooltip>
+              <RuiButton
+                :disabled="!!row.price || refreshing"
+                :loading="refreshing"
+                class="-mr-3 !py-[0.625rem] rounded-l-none"
+                size="sm"
+                color="primary"
+                @click="refreshHistoricalPrice(row)"
+              >
+                <RuiIcon
+                  size="20"
+                  name="lu-refresh-ccw"
+                />
+              </RuiButton>
+            </div>
           </template>
         </AmountInput>
       </template>


### PR DESCRIPTION
## Problem

In the PnL report's **missing prices** dialog, the rate-limit hint was a tooltip attached to the per-row refresh button with `placement: 'top'`. On hover it rendered over the price input and over the refresh buttons of the rows above, making them hard to use. The message also had a typo (`rokti`).

## Fix

- Move the hint off the refresh button onto a dedicated **warning icon** (`lu-triangle-alert`, warning colour) placed next to it.
- The tooltip now opens to the **right** of the icon, so it can no longer cover the price input or nearby rows.
- Increased the open delay so the tooltip only shows when the user rests on the icon (a quick pass no longer triggers it).
- Fixed the `rokti` → `rotki` typo in the message.

## Visual

Warning icon sits just inside the input's right edge, followed by the refresh button flush to the edge.