### PR TITLE
perf: cache asset existence and enum serialization

### DIFF
--- a/rotkehlchen/assets/resolver.py
+++ b/rotkehlchen/assets/resolver.py
@@ -39,6 +39,9 @@ class AssetResolver:
     # Maps asset identifier -> collection main_asset identifier (or None if not in a collection).
     # None is a valid cached value so presence must be tested with `identifier.lower() in cache`.
     collection_main_asset_cache: LRUCacheLowerKey[str | None] = LRUCacheLowerKey(maxsize=512)
+    # Maps asset identifier -> its normalized identifier for existence checks. Lets
+    # check_existence avoid a globaldb query for every event row during deserialization.
+    existence_cache: LRUCacheLowerKey[str] = LRUCacheLowerKey(maxsize=512)
 
     def __new__(  # noqa: PYI034 # singleton pattern should not get Self
             cls,
@@ -67,10 +70,12 @@ class AssetResolver:
             AssetResolver.__instance.assets_cache.remove(identifier)
             AssetResolver.__instance.types_cache.remove(identifier)
             AssetResolver.__instance.collection_main_asset_cache.remove(identifier)
+            AssetResolver.__instance.existence_cache.remove(identifier)
         else:
             AssetResolver.__instance.assets_cache.clear()
             AssetResolver.__instance.types_cache.clear()
             AssetResolver.__instance.collection_main_asset_cache.clear()
+            AssetResolver.__instance.existence_cache.clear()
 
     @staticmethod
     def get_collection_main_asset(identifier: str) -> str | None:
@@ -125,6 +130,12 @@ class AssetResolver:
         if (cached_data := AssetResolver.types_cache.get(identifier)) is not None:
             return cached_data
 
+        # If the asset was already fully resolved its type is known, so reuse it
+        # instead of issuing a fresh `SELECT type` query against the globaldb.
+        if (resolved := AssetResolver.assets_cache.get(identifier)) is not None:
+            AssetResolver.types_cache.add(identifier, resolved.asset_type)
+            return resolved.asset_type
+
         try:
             asset_type = AssetResolver._globaldb.get_asset_type(identifier)
         except UnknownAsset:
@@ -150,6 +161,8 @@ class AssetResolver:
         """
         if (cached_data := AssetResolver.assets_cache.get(identifier)) is not None:
             return cached_data.identifier
+        if (normalized_id := AssetResolver.existence_cache.get(identifier)) is not None:
+            return normalized_id
 
         try:
             normalized_id = AssetResolver._globaldb.asset_id_exists(identifier)
@@ -163,6 +176,7 @@ class AssetResolver:
                 use_packaged_db=True,
             )
 
+        AssetResolver.existence_cache.add(identifier, normalized_id)
         return normalized_id
 
     @staticmethod
@@ -183,6 +197,9 @@ class AssetResolver:
             if (cached_data := AssetResolver.assets_cache.get(identifier)) is not None:
                 normalized_map[identifier] = cached_data.identifier
                 continue
+            if (normalized_id := AssetResolver.existence_cache.get(identifier)) is not None:
+                normalized_map[identifier] = normalized_id
+                continue
             to_check.add(identifier)
 
         found_ids: set[str] = set()
@@ -197,6 +214,8 @@ class AssetResolver:
                     found_ids.update(row[0] for row in cursor)
 
         normalized_map.update({identifier: identifier for identifier in found_ids})
+        for identifier in found_ids:
+            AssetResolver.existence_cache.add(identifier, identifier)
 
         if len(missing_ids := to_check - found_ids) == 0:
             return normalized_map, set()
@@ -218,6 +237,8 @@ class AssetResolver:
                     packaged_found.update(row[0] for row in cursor)
 
         normalized_map.update({identifier: identifier for identifier in packaged_found})
+        for identifier in packaged_found:
+            AssetResolver.existence_cache.add(identifier, identifier)
         unknown_ids = missing_non_constant | (missing_constant - packaged_found)
         return normalized_map, unknown_ids
 

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb.py
@@ -2,6 +2,7 @@ import itertools
 from pathlib import Path
 from shutil import copyfile
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -269,6 +270,28 @@ def test_check_asset_exists(globaldb):
         symbol='EUR',
     ))
     assert globaldb.check_asset_exists(FiatAsset.initialize(identifier='mieur', name='Euro', symbol='EUR')) == ['EUR', '4']  # noqa: E501
+
+
+def test_check_existence_caches_db_lookups(globaldb):
+    """check_existence should hit the globaldb only once per asset and reuse the
+    cache afterwards. This is the per-event-row hot path during deserialization, so
+    repeated/identical identifiers must not re-query the globaldb."""
+    AssetResolver.clean_memory_cache()
+    with patch.object(
+            GlobalDBHandler,
+            'asset_id_exists',
+            wraps=GlobalDBHandler.asset_id_exists,
+    ) as mock_exists:
+        # case-insensitive variants of the same asset should all normalize and only query once
+        assert AssetResolver.check_existence('eTh') == 'ETH'
+        assert AssetResolver.check_existence('ETH') == 'ETH'
+        assert AssetResolver.check_existence('eth') == 'ETH'
+        assert mock_exists.call_count == 1
+
+        # invalidating the cache for that asset forces exactly one fresh lookup
+        AssetResolver.clean_memory_cache('ETH')
+        assert AssetResolver.check_existence('ETH') == 'ETH'
+        assert mock_exists.call_count == 2
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])

--- a/rotkehlchen/utils/mixins/enums.py
+++ b/rotkehlchen/utils/mixins/enums.py
@@ -64,14 +64,33 @@ class DBEnumMixIn(SerializableEnumMixin, metaclass=ABCEnumMeta):
         -May raise a DeserializationError if something is wrong with the DB data"""
 
 
+# Caches for the serialized string of each enum member. Members are immortal singletons,
+# so memoizing avoids recomputing the same split/lower/join on every call - these run
+# multiple times per history event while serializing them for the api.
+_name_words_cache: dict[Enum, str] = {}
+_value_words_cache: dict[Enum, str] = {}
+
+
+def _name_to_words(member: Enum) -> str:
+    if (cached := _name_words_cache.get(member)) is None:
+        _name_words_cache[member] = cached = ' '.join(word.lower() for word in member.name.split('_'))  # noqa: E501
+    return cached
+
+
+def _value_to_words(member: Enum) -> str:
+    if (cached := _value_words_cache.get(member)) is None:
+        _value_words_cache[member] = cached = ' '.join(word.lower() for word in member.value.split('_'))  # noqa: E501
+    return cached
+
+
 class SerializableEnumNameMixin(SerializableEnumMixin):
     """An enum that uses the name of the enum to serialize/deserialize"""
 
     def __str__(self) -> str:
-        return ' '.join(word.lower() for word in self.name.split('_'))  # pylint: disable=no-member
+        return _name_to_words(self)
 
     def serialize(self) -> str:
-        return str(self)
+        return _name_to_words(self)
 
     @classmethod
     def deserialize(cls, value: str) -> Self:
@@ -92,10 +111,10 @@ class SerializableEnumValueMixin(SerializableEnumMixin):
     """An enum that uses lowercase value for serialization but uses name for __str__"""
 
     def __str__(self) -> str:
-        return ' '.join(word.lower() for word in self.name.split('_'))  # pylint: disable=no-member
+        return _name_to_words(self)
 
     def serialize(self) -> str:
-        return ' '.join(word.lower() for word in self.value.split('_'))  # pylint: disable=no-member
+        return _value_to_words(self)
 
     @classmethod
     def deserialize(cls, value: str) -> Self:
@@ -117,10 +136,10 @@ class SerializableEnumIntValueMixin(SerializableEnumMixin):
     For serialization to/from DB the int value is used"""
 
     def __str__(self) -> str:
-        return ' '.join(word.lower() for word in self.name.split('_'))  # pylint: disable=no-member
+        return _name_to_words(self)
 
     def serialize(self) -> str:
-        return ' '.join(word.lower() for word in self.value.split('_'))  # pylint: disable=no-member
+        return _value_to_words(self)
 
     @classmethod
     def deserialize(cls, value: str) -> Self:


### PR DESCRIPTION
Avoid a globaldb query per event row by caching AssetResolver check_existence results, and let get_asset_type reuse an already resolved asset's type. Memoize enum __str__/serialize so the same string is not recomputed for every serialized history event.


