### PR TITLE
Unify login unlock-flow stage layouts

### DIFF
--- a/frontend/app/src/modules/auth/unlock-flow/LoginUnlockStage.vue
+++ b/frontend/app/src/modules/auth/unlock-flow/LoginUnlockStage.vue
@@ -66,7 +66,7 @@ watch(() => state, (current) => {
   <AssetUpdateMessage
     v-if="phase === UnlockPhase.updatePrompt"
     v-model:versions="versions"
-    class="max-w-[32rem] mx-auto"
+    class="max-w-[27.5rem] mx-auto"
     headless
     @confirm="emit('confirm', versions.upToVersion)"
     @dismiss="dismiss($event)"
@@ -92,7 +92,7 @@ watch(() => state, (current) => {
   <UpgradeProgressDisplay v-else-if="phase === UnlockPhase.unlocking && upgradeVisible" />
   <div
     v-else-if="busy"
-    class="flex flex-col gap-4 justify-center items-center py-12"
+    class="max-w-[27.5rem] mx-auto flex flex-col gap-4 justify-center items-center py-12"
   >
     <RuiProgress
       color="primary"
@@ -102,7 +102,7 @@ watch(() => state, (current) => {
     />
     <p
       v-if="busyMessage"
-      class="mb-0 text-rui-text-secondary"
+      class="mb-0 text-rui-text-secondary text-center"
     >
       {{ busyMessage }}
     </p>

--- a/frontend/app/src/modules/shell/app/AssetUpdateStatus.vue
+++ b/frontend/app/src/modules/shell/app/AssetUpdateStatus.vue
@@ -6,14 +6,14 @@ const { remoteVersion, status } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const title = computed(() => {
+const title = computed<string>(() => {
   if (status === 'checking')
     return t('asset_update_status.checking.title');
 
   return t('asset_update_status.applying.title');
 });
 
-const message = computed(() => {
+const message = computed<string>(() => {
   if (status === 'checking')
     return t('asset_update_status.checking.message');
 
@@ -24,22 +24,20 @@ const message = computed(() => {
 </script>
 
 <template>
-  <RuiCard
-    variant="flat"
-    class="max-w-[27.5rem] mx-auto !bg-transparent"
-  >
-    <template #header>
-      {{ title }}
-    </template>
-    <div class="flex items-center space-x-10">
-      <RuiProgress
-        color="primary"
-        variant="indeterminate"
-        circular
-      />
+  <div class="max-w-[27.5rem] mx-auto flex flex-col items-center gap-4 py-12 text-center">
+    <RuiProgress
+      color="primary"
+      variant="indeterminate"
+      circular
+      size="48"
+    />
+    <div>
+      <h5 class="text-h6 mb-1">
+        {{ title }}
+      </h5>
       <p class="mb-0 text-rui-text-secondary">
         {{ message }}
       </p>
     </div>
-  </RuiCard>
+  </div>
 </template>


### PR DESCRIPTION
## Summary

UI touch-ups for the login/unlock flow stages. Each asset-update / loading stage rendered with its own width and presentation, so the content shifted and resized as the flow advanced (login form → check → prompt → restart → unlock). This aligns them to a single layout system.

## Changes

- **Update prompt** capped at `27.5rem` (was `32rem`) to match the login form and status screens — removes the width jump.
- **Busy / restart / unlock spinner** gets a matching `27.5rem` centered, text-centered container so its message wraps and centers like the others.
- **Checking / applying status** now renders as the same centered spinner + title + message block as the other loading phases, dropping the flat card and its oversized spinner-to-text gap (`space-x-10`). This component is also reused by the manual asset-update page, where it still renders as a centered status block.

## Result

All four loading screens (checking / applying / restarting / unlocking) share one centered layout and one width, and the update prompt aligns to the same measure, so content stays put as the flow progresses. The `conflicts` full-screen dialog is unchanged by design.

## Testing

- `LoginUnlockStage.spec.ts` — 9 passed
- `lint-staged` and `typecheck` — clean