### PR TITLE
Attach to running backend on refresh and unify auto-login

### DIFF
--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -168,6 +168,7 @@ export class Application {
       },
       updateDownloadProgress: progress => this.window.updateProgress(progress),
       getRunningCorePIDs: async () => this.processHandler.checkForBackendProcess(),
+      isCoreRunning: () => this.processHandler.isCoreRunning,
       getProtocolRegistrationFailed: () => this.protocolRegistrationFailed,
       openOAuthInWindow: async (url: string) => this.window.openOAuthWindow(url),
       sendIpcMessage: (channel: string, ...args: any[]) => this.window.sendIpcMessage(channel, ...args),

--- a/frontend/app/electron/main/ipc-handlers/backend-handlers.spec.ts
+++ b/frontend/app/electron/main/ipc-handlers/backend-handlers.spec.ts
@@ -1,0 +1,78 @@
+import type { LogService } from '@electron/main/log-service';
+import type { BackendOptions } from '@shared/ipc';
+import { IpcCommands } from '@electron/ipc-commands';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { BackendHandlers } from './backend-handlers';
+
+describe('backendHandlers', () => {
+  let handlers: BackendHandlers;
+  let restartSubprocesses: Mock<(options: Partial<BackendOptions>) => Promise<void>>;
+  let getRunningCorePIDs: Mock<() => Promise<number[]>>;
+  let sendIpcMessage: Mock<(channel: string, ...args: any[]) => void>;
+  let coreRunning: boolean;
+
+  const options: Partial<BackendOptions> = { dataDirectory: '/tmp/rotki-data' };
+
+  beforeEach(() => {
+    coreRunning = false;
+    restartSubprocesses = vi.fn<(options: Partial<BackendOptions>) => Promise<void>>().mockResolvedValue(undefined);
+    getRunningCorePIDs = vi.fn<() => Promise<number[]>>().mockResolvedValue([]);
+    sendIpcMessage = vi.fn<(channel: string, ...args: any[]) => void>();
+
+    handlers = new BackendHandlers(createMock<LogService>());
+    handlers.initialize({
+      restartSubprocesses,
+      getRunningCorePIDs,
+      isCoreRunning: () => coreRunning,
+      sendIpcMessage,
+    });
+  });
+
+  it('should start the backend on first load when none is running', async () => {
+    coreRunning = false;
+
+    const success = await handlers.restartBackend(options);
+
+    expect(success).toBe(true);
+    expect(restartSubprocesses).toHaveBeenCalledWith(options);
+  });
+
+  it('should attach instead of restarting when a backend is already running (refresh)', async () => {
+    // first call performs the initial start
+    await handlers.restartBackend(options);
+    restartSubprocesses.mockClear();
+    coreRunning = true;
+
+    // second call simulates a page refresh: not forced, backend already up
+    const success = await handlers.restartBackend(options);
+
+    expect(success).toBe(true);
+    expect(restartSubprocesses).not.toHaveBeenCalled();
+  });
+
+  it('should restart a running backend when forceRestart is true', async () => {
+    await handlers.restartBackend(options);
+    restartSubprocesses.mockClear();
+    coreRunning = true;
+
+    const success = await handlers.restartBackend(options, true);
+
+    expect(success).toBe(true);
+    expect(restartSubprocesses).toHaveBeenCalledWith(options);
+  });
+
+  it('should detect and report an existing backend process only on first start', async () => {
+    getRunningCorePIDs.mockResolvedValue([4242]);
+    const send = vi.fn<Electron.WebContents['send']>();
+    const event = createMock<Electron.IpcMainInvokeEvent>({ sender: { send } });
+
+    await handlers.restartBackend(options, false, event);
+    expect(getRunningCorePIDs).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(IpcCommands.BACKEND_PROCESS_DETECTED, [4242]);
+
+    // subsequent calls must not re-run PID detection
+    await handlers.restartBackend(options, false, event);
+    expect(getRunningCorePIDs).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/electron/main/ipc-handlers/backend-handlers.ts
+++ b/frontend/app/electron/main/ipc-handlers/backend-handlers.ts
@@ -6,6 +6,7 @@ import { assert } from '@rotki/common';
 interface BackendHandlersCallbacks {
   restartSubprocesses: (options: Partial<BackendOptions>) => Promise<void>;
   getRunningCorePIDs: () => Promise<number[]>;
+  isCoreRunning: () => boolean;
   sendIpcMessage: (channel: string, ...args: any[]) => void;
 }
 
@@ -26,8 +27,12 @@ export class BackendHandlers {
     this.callbacks = callbacks;
   }
 
-  restartBackend = async (options: Partial<BackendOptions>, event?: Electron.IpcMainInvokeEvent): Promise<boolean> => {
-    this.logger.info(`Restarting backend with options: ${JSON.stringify(options)}`);
+  restartBackend = async (
+    options: Partial<BackendOptions>,
+    forceRestart: boolean = false,
+    event?: Electron.IpcMainInvokeEvent,
+  ): Promise<boolean> => {
+    this.logger.info(`Restarting backend with options: ${JSON.stringify(options)} (forceRestart: ${forceRestart})`);
 
     if (this.firstStart) {
       this.firstStart = false;
@@ -41,6 +46,14 @@ export class BackendHandlers {
       else {
         this.logger.debug('No existing backend process detected');
       }
+    }
+
+    // On a plain renderer (re)load the request is not a forced restart. If the
+    // managed backend is already running (e.g. the page was just refreshed),
+    // attach to it instead of tearing it down and spawning a new process.
+    if (!forceRestart && this.requireCallbacks.isCoreRunning()) {
+      this.logger.info('Backend already running; attaching instead of restarting');
+      return true;
     }
 
     let success = false;

--- a/frontend/app/electron/main/ipc-setup.ts
+++ b/frontend/app/electron/main/ipc-setup.ts
@@ -25,6 +25,7 @@ interface Callbacks {
   restartSubprocesses: (options: Partial<BackendOptions>) => Promise<void>;
   terminateSubprocesses: (update?: boolean) => Promise<void>;
   getRunningCorePIDs: () => Promise<number[]>;
+  isCoreRunning: () => boolean;
   updateDownloadProgress: (progress: number) => void;
   getProtocolRegistrationFailed: () => boolean;
   openOAuthInWindow: (url: string) => Promise<void>;
@@ -94,6 +95,7 @@ export class IpcManager {
     this.backendHandlers.initialize({
       restartSubprocesses: callbacks.restartSubprocesses,
       getRunningCorePIDs: callbacks.getRunningCorePIDs,
+      isCoreRunning: callbacks.isCoreRunning,
       sendIpcMessage: callbacks.sendIpcMessage,
     });
 
@@ -135,7 +137,7 @@ export class IpcManager {
     });
 
     // Backend handlers
-    ipcMain.handle(IpcCommands.INVOKE_SUBPROCESS_START, async (event, options) => this.backendHandlers.restartBackend(options, event));
+    ipcMain.handle(IpcCommands.INVOKE_SUBPROCESS_START, async (event, options, forceRestart) => this.backendHandlers.restartBackend(options, forceRestart, event));
 
     // Update handlers
     ipcMain.handle(IpcCommands.INVOKE_UPDATE_CHECK, this.updateHandlers.checkForUpdates);

--- a/frontend/app/electron/main/subprocess-handler.ts
+++ b/frontend/app/electron/main/subprocess-handler.ts
@@ -43,6 +43,15 @@ export class SubprocessHandler {
     );
   }
 
+  /**
+   * Whether the managed rotki-core process is currently running. Used to decide
+   * whether a renderer (re)load should attach to the existing backend instead of
+   * tearing it down and spawning a new one (e.g. on a page refresh).
+   */
+  get isCoreRunning(): boolean {
+    return this.coreManager.isRunning;
+  }
+
   private matchProcess(processName?: string): boolean {
     if (this.config.isDev) {
       return processName?.includes('-m rotkehlchen') ?? false;

--- a/frontend/app/electron/preload/index.ts
+++ b/frontend/app/electron/preload/index.ts
@@ -56,7 +56,7 @@ contextBridge.exposeInMainWorld('interop', {
   apiUrls: (): ApiUrls => ipcRenderer.sendSync(IpcCommands.SYNC_API_URL),
   metamaskImport: async () => ipcRenderer.invoke(IpcCommands.INVOKE_WALLET_IMPORT),
   openWalletConnectBridge: async () => ipcRenderer.invoke(IpcCommands.OPEN_WALLET_CONNECT_BRIDGE),
-  restartBackend: async options => ipcRenderer.invoke(IpcCommands.INVOKE_SUBPROCESS_START, options),
+  restartBackend: async (options, forceRestart = false) => ipcRenderer.invoke(IpcCommands.INVOKE_SUBPROCESS_START, options, forceRestart),
   checkForUpdates: async () => ipcRenderer.invoke(IpcCommands.INVOKE_UPDATE_CHECK),
   downloadUpdate: async (progress) => {
     ipcRenderer.on(IpcCommands.DOWNLOAD_PROGRESS, (event, args) => {

--- a/frontend/app/shared/ipc.ts
+++ b/frontend/app/shared/ipc.ts
@@ -119,7 +119,7 @@ export interface Interop {
   checkForUpdates: () => Promise<boolean>;
   downloadUpdate: (progress: (percentage: number) => void) => Promise<boolean>;
   installUpdate: () => Promise<boolean | Error>;
-  restartBackend: (options: Partial<BackendOptions>) => Promise<boolean>;
+  restartBackend: (options: Partial<BackendOptions>, forceRestart?: boolean) => Promise<boolean>;
   setSelectedTheme: (selectedTheme: number) => Promise<boolean>;
   version: () => Promise<SystemVersion>;
   isMac: () => Promise<boolean>;

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2073,6 +2073,8 @@
     "title": "Connection failure"
   },
   "connection_loading": {
+    "logging_in": "Signing in…",
+    "logging_out": "Signing out…",
     "message": "Connecting to rotki backend",
     "restarting": "Restarting the rotki backend"
   },

--- a/frontend/app/src/modules/auth/ConnectionLoading.vue
+++ b/frontend/app/src/modules/auth/ConnectionLoading.vue
@@ -1,33 +1,36 @@
 <script setup lang="ts">
-const { connected, restarting = false } = defineProps<{
+const { connected, loggingIn = false, restarting = false } = defineProps<{
   connected: boolean;
   restarting?: boolean;
+  loggingIn?: boolean;
 }>();
 const { t } = useI18n({ useScope: 'global' });
 
-const message = computed<string>(() =>
-  restarting ? t('connection_loading.restarting') : t('connection_loading.message'),
-);
+const message = computed<string>(() => {
+  if (restarting)
+    return t('connection_loading.restarting');
+  if (loggingIn)
+    return t('connection_loading.logging_in');
+  return t('connection_loading.message');
+});
 </script>
 
 <template>
-  <RuiCard
+  <div
     v-if="!connected"
-    variant="flat"
-    class="max-w-[27.5rem] mx-auto !bg-transparent"
+    class="max-w-[27.5rem] mx-auto flex flex-col gap-4 justify-center items-center py-12"
   >
-    <div class="flex items-center space-x-10">
-      <RuiProgress
-        color="primary"
-        variant="indeterminate"
-        circular
-      />
-      <h5
-        class="text-rui-text-secondary text-h5"
-        data-cy="connection-loading__content"
-      >
-        {{ message }}
-      </h5>
-    </div>
-  </RuiCard>
+    <RuiProgress
+      color="primary"
+      variant="indeterminate"
+      circular
+      size="48"
+    />
+    <p
+      class="mb-0 text-rui-text-secondary text-center"
+      data-cy="connection-loading__content"
+    >
+      {{ message }}
+    </p>
+  </div>
 </template>

--- a/frontend/app/src/modules/auth/UserHost.vue
+++ b/frontend/app/src/modules/auth/UserHost.vue
@@ -18,13 +18,16 @@ const { connected, connectionFailure, dockerRiskAccepted } = storeToRefs(useMain
 
 const isDocker = import.meta.env.VITE_DOCKER;
 const showDockerWarning = logicAnd(isDocker, logicNot(dockerRiskAccepted));
-const displayRouter = logicAnd(connected, logicNot(showDockerWarning), logicNot(restarting));
+// Hide the login form while an auto-unlock is running — the ConnectionLoading card is the
+// single loading state for the whole attempt, so the empty form never shows behind it.
+const displayRouter = logicAnd(connected, logicNot(autolog), logicNot(showDockerWarning), logicNot(restarting));
 </script>
 
 <template>
   <ConnectionLoading
     v-if="!connectionFailure"
     :connected="connected && !autolog"
+    :logging-in="autolog"
     :restarting="restarting"
   />
   <ConnectionFailureMessage v-else />
@@ -39,18 +42,18 @@ const displayRouter = logicAnd(connected, logicNot(showDockerWarning), logicNot(
 
   <DockerWarning v-else-if="showDockerWarning" />
   <div
-    v-else-if="connected"
-    class="w-full h-full flex flex-col gap-4 items-center justify-center"
+    v-else-if="connected && !autolog"
+    class="max-w-[27.5rem] mx-auto flex flex-col gap-4 justify-center items-center py-12"
   >
     <RuiProgress
-      thickness="2"
       color="primary"
       variant="indeterminate"
       circular
+      size="48"
     />
     <p
       v-if="restarting"
-      class="mb-0 text-rui-text-secondary"
+      class="mb-0 text-rui-text-secondary text-center"
     >
       {{ t('connection_loading.restarting') }}
     </p>

--- a/frontend/app/src/modules/auth/login/LoginForm.vue
+++ b/frontend/app/src/modules/auth/login/LoginForm.vue
@@ -99,7 +99,7 @@ const v$ = useVuelidate(
   },
 );
 
-const { clearPassword, getPassword, isPackaged, storePassword } = useInterop();
+const { clearPassword, isPackaged, storePassword } = useInterop();
 
 watch([username, password], ([username, password], [oldUsername, oldPassword]) => {
   // touched should not be emitted when restoring from local storage
@@ -197,7 +197,11 @@ function checkRememberUsername() {
   set(rememberUsername, !!get(savedRememberUsername) || !!get(savedRememberPassword) || !isDocker);
 }
 
-async function loadSettings() {
+// Pre-fills the form and remember toggles for a manual login. The saved-password
+// auto-unlock is NOT driven from here anymore — it is a single flow started by
+// `useAutoLogin` on backend connect (see use-auto-login.ts / startAuto), so this
+// component can never race that flow.
+function loadSettings(): void {
   set(rememberPassword, !!get(savedRememberPassword));
   checkRememberUsername();
   if (!get(username))
@@ -207,18 +211,6 @@ async function loadSettings() {
   set(customBackendUrl, url);
   set(customBackendSessionOnly, sessionOnly);
   set(customBackendSaved, !!url);
-
-  if (errors.length > 0)
-    return;
-
-  if (isPackaged && get(rememberPassword) && get(username)) {
-    const savedPassword = await getPassword(get(username));
-
-    if (savedPassword) {
-      set(password, savedPassword);
-      await login();
-    }
-  }
 }
 
 onBeforeMount(async () => {
@@ -227,7 +219,7 @@ onBeforeMount(async () => {
     newAccount();
     return;
   }
-  await loadSettings();
+  loadSettings();
 });
 
 onMounted(() => {

--- a/frontend/app/src/modules/auth/unlock-flow/use-stored-credentials.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-stored-credentials.spec.ts
@@ -1,0 +1,82 @@
+import { none, some } from 'plainfp';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useStoredCredentials } from './use-stored-credentials';
+
+const { getPassword, isPackagedRef, lastLoginRef, savedRememberPasswordRef } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref: vueRef } = require('vue');
+  return {
+    getPassword: vi.fn(),
+    isPackagedRef: vueRef(false),
+    lastLoginRef: vueRef(''),
+    savedRememberPasswordRef: vueRef(null),
+  };
+});
+
+vi.mock('@/modules/auth/account-management', () => ({ lastLogin: lastLoginRef }));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: vi.fn(() => ({ getPassword, isPackaged: isPackagedRef.value })),
+}));
+
+vi.mock('@/modules/auth/use-remember-settings', () => ({
+  useRememberSettings: vi.fn(() => ({ savedRememberPassword: savedRememberPasswordRef })),
+}));
+
+describe('useStoredCredentials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(lastLoginRef, '');
+    set(isPackagedRef, false);
+    set(savedRememberPasswordRef, null);
+  });
+
+  it('should return none when there is no last login', async () => {
+    const { resolveStoredCredentials } = useStoredCredentials();
+    expect(await resolveStoredCredentials()).toEqual(none);
+  });
+
+  it('should return an empty password when not packaged', async () => {
+    set(lastLoginRef, 'alice');
+    set(isPackagedRef, false);
+
+    const { resolveStoredCredentials } = useStoredCredentials();
+
+    expect(await resolveStoredCredentials()).toEqual(some({ password: '', username: 'alice' }));
+    expect(getPassword).not.toHaveBeenCalled();
+  });
+
+  it('should read the saved password when packaged and remember-password is on', async () => {
+    set(lastLoginRef, 'alice');
+    set(isPackagedRef, true);
+    set(savedRememberPasswordRef, 'true');
+    getPassword.mockResolvedValue('secret');
+
+    const { resolveStoredCredentials } = useStoredCredentials();
+
+    expect(await resolveStoredCredentials()).toEqual(some({ password: 'secret', username: 'alice' }));
+    expect(getPassword).toHaveBeenCalledWith('alice');
+  });
+
+  it('should fall back to an empty password when the keychain has none', async () => {
+    set(lastLoginRef, 'alice');
+    set(isPackagedRef, true);
+    set(savedRememberPasswordRef, 'true');
+    getPassword.mockResolvedValue(undefined);
+
+    const { resolveStoredCredentials } = useStoredCredentials();
+
+    expect(await resolveStoredCredentials()).toEqual(some({ password: '', username: 'alice' }));
+  });
+
+  it('should not read the password when remember-password is off', async () => {
+    set(lastLoginRef, 'alice');
+    set(isPackagedRef, true);
+    set(savedRememberPasswordRef, null);
+
+    const { resolveStoredCredentials } = useStoredCredentials();
+
+    expect(await resolveStoredCredentials()).toEqual(some({ password: '', username: 'alice' }));
+    expect(getPassword).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/auth/unlock-flow/use-stored-credentials.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-stored-credentials.ts
@@ -1,0 +1,33 @@
+import type { UnlockCredentials } from './use-unlock-flow';
+import { none, type OptionType as Option, some } from 'plainfp';
+import { lastLogin } from '@/modules/auth/account-management';
+import { useRememberSettings } from '@/modules/auth/use-remember-settings';
+import { useInterop } from '@/modules/shell/app/use-electron-interop';
+
+export interface UseStoredCredentialsReturn {
+  resolveStoredCredentials: () => Promise<Option<UnlockCredentials>>;
+}
+
+/**
+ * Resolves the credentials for a background auto-unlock from local state only: the username
+ * from the last login, and the password from the OS keychain when the app is packaged and
+ * remember-password is on. Returns `none` when there is no saved profile — the flow then
+ * shows the manual login form. Kept separate from the flow steps so the keychain/remember
+ * sourcing is unit-testable on its own.
+ */
+export function useStoredCredentials(): UseStoredCredentialsReturn {
+  const { getPassword, isPackaged } = useInterop();
+  const { savedRememberPassword } = useRememberSettings();
+
+  const resolveStoredCredentials = async (): Promise<Option<UnlockCredentials>> => {
+    const username = get<string>(lastLogin);
+    if (!username)
+      return none;
+    const password = isPackaged && get(savedRememberPassword)
+      ? (await getPassword(username)) ?? ''
+      : '';
+    return some({ password, username });
+  };
+
+  return { resolveStoredCredentials };
+}

--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow-controller.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow-controller.spec.ts
@@ -24,12 +24,15 @@ const h = vi.hoisted(() => ({
   checkUpdate: vi.fn(),
   connect: vi.fn(),
   createCheckUpdate: vi.fn(),
-  createUnlock: vi.fn(),
+  createLogin: vi.fn(),
   disconnectWallet: vi.fn(),
   handleSessionReady: vi.fn(),
   loadSession: vi.fn(),
+  login: vi.fn(),
+  probeSession: vi.fn(),
   requestRestart: vi.fn(),
-  unlock: vi.fn(),
+  resolveCredentials: vi.fn(),
+  resume: vi.fn(),
   updateFrontendSetting: vi.fn(),
   waitReady: vi.fn(),
 }));
@@ -42,8 +45,11 @@ vi.mock('./use-unlock-steps', () => ({
       checkUpdate: h.createCheckUpdate,
       connect: h.connect,
       loadSession: h.loadSession,
+      login: h.createLogin,
+      probeSession: async () => ok(false),
       requestRestart: h.requestRestart,
-      unlock: h.createUnlock,
+      resolveCredentials: async () => ok(none),
+      resume: async () => ok(undefined),
       waitReady: h.waitReady,
     })),
     loginSteps: {
@@ -52,8 +58,11 @@ vi.mock('./use-unlock-steps', () => ({
       checkUpdate: h.checkUpdate,
       connect: h.connect,
       loadSession: h.loadSession,
+      login: h.login,
+      probeSession: h.probeSession,
       requestRestart: h.requestRestart,
-      unlock: h.unlock,
+      resolveCredentials: h.resolveCredentials,
+      resume: h.resume,
       waitReady: h.waitReady,
     },
   }),
@@ -96,13 +105,16 @@ describe('useUnlockFlowController', () => {
     vi.clearAllMocks();
     h.authenticate.mockResolvedValue(ok(undefined));
     h.connect.mockResolvedValue(ok(undefined));
+    h.probeSession.mockResolvedValue(ok(false)); // default: no live session ⇒ fresh-login branch
     h.checkUpdate.mockResolvedValue(ok(none));
     h.createCheckUpdate.mockResolvedValue(ok(none));
     h.applyUpdate.mockResolvedValue(ok({ kind: 'done' }));
     h.requestRestart.mockResolvedValue(ok(undefined));
     h.waitReady.mockResolvedValue(ok(undefined));
-    h.unlock.mockResolvedValue(ok(undefined));
-    h.createUnlock.mockResolvedValue(ok(undefined));
+    h.resume.mockResolvedValue(ok(undefined));
+    h.login.mockResolvedValue(ok(undefined));
+    h.createLogin.mockResolvedValue(ok(undefined));
+    h.resolveCredentials.mockResolvedValue(ok(some({ password: 'p', username: 'alice' })));
     setUsernameOnLoad('alice');
 
     scope = effectScope();
@@ -116,11 +128,12 @@ describe('useUnlockFlowController', () => {
     scope.stop();
   });
 
-  it('should drive a fresh login to ready and run login-mode side-effects', async () => {
+  it('should drive a fresh login to ready and run fresh-login side-effects', async () => {
     await controller.startLogin({ password: 'p', username: 'alice' });
     await flushPromises();
 
     expect(get(controller.state).kind).toBe(UnlockPhase.ready);
+    expect(h.login).toHaveBeenCalled();
     expect(h.handleSessionReady).toHaveBeenCalled();
     expect(h.updateFrontendSetting).toHaveBeenCalled();
     expect(h.disconnectWallet).toHaveBeenCalled();
@@ -133,29 +146,72 @@ describe('useUnlockFlowController', () => {
     await flushPromises();
 
     expect(get(controller.state).kind).toBe(UnlockPhase.ready);
-    expect(h.createUnlock).toHaveBeenCalled();
+    expect(h.createLogin).toHaveBeenCalled();
     expect(h.handleSessionReady).toHaveBeenCalled();
     expect(h.updateFrontendSetting).not.toHaveBeenCalled();
     expect(h.disconnectWallet).not.toHaveBeenCalled();
   });
 
-  it('should fall back to idle when a resume finds no live session', async () => {
-    h.unlock.mockResolvedValue({ error: { kind: UnlockErrorKind.unknown, message: '' }, ok: false });
+  it('should resume a live session on auto-unlock and run resume-only effects', async () => {
+    h.probeSession.mockResolvedValue(ok(true));
 
-    await controller.startResume();
-    await flushPromises();
-
-    // a failed background resume must not park the flow in error — it returns to a clean form
-    expect(get(controller.state).kind).toBe(UnlockPhase.idle);
-  });
-
-  it('should skip the asset-update prompt on resume even when an update exists', async () => {
-    h.checkUpdate.mockResolvedValue(ok(some({ upToVersion: 9 })));
-
-    await controller.startResume();
+    await controller.startAuto();
     await flushPromises();
 
     expect(get(controller.state).kind).toBe(UnlockPhase.ready);
+    expect(h.resume).toHaveBeenCalled();
+    expect(h.login).not.toHaveBeenCalled();
+    // resume effects: password confirmation, but no lastPasswordConfirmed write / wallet disconnect
+    expect(h.checkIfPasswordConfirmationNeeded).toHaveBeenCalled();
+    expect(h.updateFrontendSetting).not.toHaveBeenCalled();
+    expect(h.disconnectWallet).not.toHaveBeenCalled();
+  });
+
+  it('should fresh-login with the saved password on auto-unlock when no live session exists', async () => {
+    h.probeSession.mockResolvedValue(ok(false));
+    h.resolveCredentials.mockResolvedValue(ok(some({ password: 'saved', username: 'alice' })));
+
+    await controller.startAuto();
+    await flushPromises();
+
+    expect(get(controller.state).kind).toBe(UnlockPhase.ready);
+    expect(h.login).toHaveBeenCalled();
+    expect(h.updateFrontendSetting).toHaveBeenCalled();
+    expect(h.disconnectWallet).toHaveBeenCalled();
+    expect(h.checkIfPasswordConfirmationNeeded).not.toHaveBeenCalled();
+  });
+
+  it('should return to idle on auto-unlock with no live session and no saved password', async () => {
+    h.probeSession.mockResolvedValue(ok(false));
+    h.resolveCredentials.mockResolvedValue(ok(some({ password: '', username: 'alice' })));
+
+    await controller.startAuto();
+    await flushPromises();
+
+    // deterministic: no doomed empty-password login, just back to the form
+    expect(get(controller.state).kind).toBe(UnlockPhase.idle);
+    expect(h.login).not.toHaveBeenCalled();
+  });
+
+  it('should return to idle on auto-unlock when nothing is stored', async () => {
+    h.resolveCredentials.mockResolvedValue(ok(none));
+
+    await controller.startAuto();
+    await flushPromises();
+
+    expect(get(controller.state).kind).toBe(UnlockPhase.idle);
+    expect(h.probeSession).not.toHaveBeenCalled();
+  });
+
+  it('should skip the asset-update prompt when auto-unlock resumes a live session', async () => {
+    h.probeSession.mockResolvedValue(ok(true));
+    h.checkUpdate.mockResolvedValue(ok(some({ upToVersion: 9 })));
+
+    await controller.startAuto();
+    await flushPromises();
+
+    expect(get(controller.state).kind).toBe(UnlockPhase.ready);
+    expect(h.checkUpdate).not.toHaveBeenCalled(); // resume branch never reaches checkUpdate
     expect(h.checkIfPasswordConfirmationNeeded).toHaveBeenCalled();
     expect(h.updateFrontendSetting).not.toHaveBeenCalled();
   });
@@ -181,8 +237,8 @@ describe('useUnlockFlowController', () => {
     await flushPromises();
     expect(get(controller.state).kind).toBe(UnlockPhase.updatePrompt);
 
-    // a resume firing mid-flow (e.g. an auto-login watcher) must be ignored
-    await controller.startResume();
+    // an auto-unlock firing mid-flow (e.g. the connected watcher) must be ignored
+    await controller.startAuto();
     await flushPromises();
 
     expect(get(controller.state).kind).toBe(UnlockPhase.updatePrompt);
@@ -190,7 +246,7 @@ describe('useUnlockFlowController', () => {
   });
 
   it('should expose an unknown unlock error as a message in errors', async () => {
-    h.unlock.mockResolvedValue({ error: { kind: UnlockErrorKind.unknown, message: 'boom' }, ok: false });
+    h.login.mockResolvedValue({ error: { kind: UnlockErrorKind.unknown, message: 'boom' }, ok: false });
 
     await controller.startLogin({ password: 'p', username: 'alice' });
     await flushPromises();
@@ -199,6 +255,16 @@ describe('useUnlockFlowController', () => {
     expect(get(controller.errors)).toEqual(['boom']);
     expect(get(controller.loading)).toBe(false);
     expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  });
+
+  it('should not park an auto-unlock in error (falls back to idle)', async () => {
+    h.login.mockResolvedValue({ error: { kind: UnlockErrorKind.wrongPassword }, ok: false });
+
+    await controller.startAuto();
+    await flushPromises();
+
+    // a stale saved password shouldn't leave the login screen stuck in error
+    expect(get(controller.state).kind).toBe(UnlockPhase.idle);
   });
 
   it('should wire a session-gated 401 handler on the api', () => {
@@ -214,7 +280,7 @@ describe('useUnlockFlowController', () => {
   });
 
   it('should keep errors empty for a sync conflict (the alert is store-driven)', async () => {
-    h.unlock.mockResolvedValue({ error: { kind: UnlockErrorKind.syncConflict, payload: {} }, ok: false });
+    h.login.mockResolvedValue({ error: { kind: UnlockErrorKind.syncConflict, payload: {} }, ok: false });
 
     await controller.startLogin({ password: 'p', username: 'alice' });
     await flushPromises();
@@ -261,6 +327,6 @@ describe('useUnlockFlowController', () => {
 
     expect(get(controller.state).kind).toBe(UnlockPhase.ready);
     expect(h.applyUpdate).not.toHaveBeenCalled();
-    expect(h.unlock).toHaveBeenCalled();
+    expect(h.login).toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow-controller.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow-controller.ts
@@ -2,7 +2,6 @@ import type { ComputedRef, Ref } from 'vue';
 import type { CreateAccountPayload } from '@/modules/auth/login';
 import { startPromise, wait } from '@shared/utils';
 import dayjs from 'dayjs';
-import { none, ok } from 'plainfp';
 import { usePasswordConfirmation } from '@/modules/auth/use-password-confirmation';
 import { useRememberSettings } from '@/modules/auth/use-remember-settings';
 import { useRestartingStatus } from '@/modules/auth/use-restarting-status';
@@ -23,13 +22,15 @@ import {
 } from './use-unlock-flow';
 import { useUnlockSteps } from './use-unlock-steps';
 
-type UnlockMode = 'login' | 'create' | 'resume';
+type UnlockMode = 'login' | 'create' | 'auto';
 
 // Phases where the form must show a busy state (the asset-update prompt/conflict phases
 // are excluded — they wait on the user, not on us).
 const IN_FLIGHT: ReadonlySet<string> = new Set([
+  UnlockPhase.resolving,
   UnlockPhase.authenticating,
   UnlockPhase.connecting,
+  UnlockPhase.probing,
   UnlockPhase.checkingUpdate,
   UnlockPhase.applyingUpdate,
   UnlockPhase.restarting,
@@ -45,7 +46,7 @@ export interface UseUnlockFlowControllerReturn {
   upgradeVisible: Readonly<Ref<boolean>>;
   startLogin: (credentials: UnlockCredentials) => Promise<void>;
   startCreate: (payload: CreateAccountPayload) => Promise<void>;
-  startResume: () => Promise<void>;
+  startAuto: () => Promise<void>;
   applyUpdate: (resolution?: Resolution, version?: number) => Promise<void>;
   skipUpdate: () => Promise<void>;
   reset: () => void;
@@ -77,10 +78,6 @@ export function createUnlockFlowController(): UseUnlockFlowControllerReturn {
   const { checkIfPasswordConfirmationNeeded } = usePasswordConfirmation();
   const { restarting } = useRestartingStatus();
 
-  // Resume (auto-login/reload) must NOT pop an asset-update prompt — applying it would
-  // restart the backend and kill the live session it just re-attached to.
-  const resumeSteps: UnlockSteps = { ...loginSteps, checkUpdate: async () => ok(none) };
-
   const mode = ref<UnlockMode>('login');
   // The step-set the proxy currently delegates to; swapped synchronously before each start.
   let active: UnlockSteps = loginSteps;
@@ -93,17 +90,20 @@ export function createUnlockFlowController(): UseUnlockFlowControllerReturn {
     checkUpdate: async () => active.checkUpdate(),
     connect: async () => active.connect(),
     loadSession: async () => active.loadSession(),
+    login: async credentials => active.login(credentials),
+    probeSession: async credentials => active.probeSession(credentials),
     requestRestart: async () => active.requestRestart(),
-    unlock: async credentials => active.unlock(credentials),
+    resolveCredentials: async () => active.resolveCredentials(),
+    resume: async credentials => active.resume(credentials),
     waitReady: async () => active.waitReady(),
   };
 
   const flow = useUnlockFlow(proxy);
 
-  // Auto-login/resume runs in the background — it must not flip the login form into its
-  // disabled "loading" state (the disable→enable toggle on the autocomplete would otherwise
-  // fire a spurious empty-username validation on first open).
-  const loading = computed<boolean>(() => get(mode) !== 'resume' && IN_FLIGHT.has(get(flow.state).kind));
+  // Auto-unlock runs in the background — it must not flip the login form into its disabled
+  // "loading" state (the disable→enable toggle on the autocomplete would otherwise fire a
+  // spurious empty-username validation on first open).
+  const loading = computed<boolean>(() => get(mode) !== 'auto' && IN_FLIGHT.has(get(flow.state).kind));
 
   const errors = computed<string[]>(() => {
     const current = get(flow.state);
@@ -128,23 +128,32 @@ export function createUnlockFlowController(): UseUnlockFlowControllerReturn {
 
   async function onReady(): Promise<void> {
     const current = get(mode);
+    const state = get(flow.state);
+    // The flow owns the resume-vs-fresh-login branch, so `ready.resumed` — not the caller's
+    // mode — decides which post-unlock effects apply (a saved-password auto-unlock can end
+    // in either branch).
+    const resumed = state.kind === UnlockPhase.ready && state.resumed;
 
     // Pad only a *fast* create+upgrade so the progress bar is actually seen — a long upgrade
     // is already visible long enough and shouldn't tack on a needless delay before navigating.
     if (current === 'create' && get(upgradeVisible) && (dayjs().valueOf() - createStartedAt) / 1000 < 10)
       await wait(3000);
-    // A manual login proves the password; record the confirmation timestamp.
-    if (current === 'login')
+    // A fresh login (manual or saved-password auto-unlock) proves the password; record it.
+    if (!resumed && current !== 'create')
       await updateFrontendSetting({ lastPasswordConfirmed: dayjs().unix() });
     if (current === 'create')
       set(savedUsername, get(username));
 
     await handleSessionReady();
 
-    if (current === 'login')
-      await disconnectWallet();
-    else if (current === 'resume')
+    if (current === 'create')
+      return;
+    // A resumed session hasn't re-proven the password, so it may still need confirmation; a
+    // fresh login just did, and disconnects any wallet lingering from the previous session.
+    if (resumed)
       await checkIfPasswordConfirmationNeeded(get(username));
+    else
+      await disconnectWallet();
   }
 
   watch(flow.state, (current) => {
@@ -183,15 +192,15 @@ export function createUnlockFlowController(): UseUnlockFlowControllerReturn {
     await flow.start(payload.credentials);
   }
 
-  async function startResume(): Promise<void> {
+  async function startAuto(): Promise<void> {
     if (!canStart())
       return;
-    set(mode, 'resume');
-    active = resumeSteps;
-    await flow.start({ password: '', username: '' });
-    // A resume that found no live session ends in `error` with no message — fall back to a
-    // clean idle form. Guarded by the canStart() check above so it can never clear another
-    // in-flight flow (e.g. an asset-update restart that briefly drops the connection).
+    set(mode, 'auto');
+    active = loginSteps;
+    await flow.startAuto();
+    // A background auto-unlock that hit a real failure (e.g. a stale saved password) ends in
+    // `error` — fall back to a clean idle form rather than parking the login screen in error.
+    // Guarded by the canStart() check above so it can never clear another in-flight flow.
     if (get(flow.state).kind === UnlockPhase.error)
       flow.reset();
   }
@@ -202,9 +211,9 @@ export function createUnlockFlowController(): UseUnlockFlowControllerReturn {
     loading,
     reset: flow.reset,
     skipUpdate: flow.skipUpdate,
+    startAuto,
     startCreate,
     startLogin,
-    startResume,
     state: flow.state,
     upgradeVisible,
   };

--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow.spec.ts
@@ -18,8 +18,11 @@ function makeSteps(overrides: Partial<UnlockSteps> = {}): UnlockSteps {
     checkUpdate: vi.fn(async () => ok(none)),
     connect: vi.fn(async () => ok(undefined)),
     loadSession: vi.fn(async () => ok({})),
+    login: vi.fn(async () => ok(undefined)),
+    probeSession: vi.fn(async () => ok(false)),
     requestRestart: vi.fn(async () => ok(undefined)),
-    unlock: vi.fn(async () => ok(undefined)),
+    resolveCredentials: vi.fn(async () => ok(some(CREDENTIALS))),
+    resume: vi.fn(async () => ok(undefined)),
     waitReady: vi.fn(async () => ok(undefined)),
     ...overrides,
   };
@@ -36,7 +39,7 @@ describe('useUnlockFlow', () => {
     phases = [];
   });
 
-  it('should walk authenticate → check → unlock → ready when no update exists', async () => {
+  it('should walk authenticate → probe → check → login → ready when no session/update exists', async () => {
     const steps = makeSteps();
     const flow = useUnlockFlow(steps);
     track(flow);
@@ -47,14 +50,40 @@ describe('useUnlockFlow', () => {
       UnlockPhase.idle,
       UnlockPhase.authenticating,
       UnlockPhase.connecting,
+      UnlockPhase.probing,
       UnlockPhase.checkingUpdate,
       UnlockPhase.unlocking,
       UnlockPhase.loadingSession,
       UnlockPhase.ready,
     ]);
-    expect(steps.authenticate).toHaveBeenCalledTimes(1);
-    expect(steps.connect).toHaveBeenCalledTimes(1);
+    expect(steps.login).toHaveBeenCalledTimes(1);
+    expect(steps.resume).not.toHaveBeenCalled();
     expect(steps.requestRestart).not.toHaveBeenCalled();
+  });
+
+  it('should skip checkUpdate and resume when the backend has a live session', async () => {
+    const steps = makeSteps({
+      checkUpdate: vi.fn(async () => ok(some({ changes: 5, local: 37, remote: 42, upToVersion: 42 }))),
+      probeSession: vi.fn(async () => ok(true)),
+    });
+    const flow = useUnlockFlow(steps);
+    track(flow);
+
+    await flow.start(CREDENTIALS);
+
+    expect(phases).toEqual([
+      UnlockPhase.idle,
+      UnlockPhase.authenticating,
+      UnlockPhase.connecting,
+      UnlockPhase.probing,
+      UnlockPhase.unlocking,
+      UnlockPhase.loadingSession,
+      UnlockPhase.ready,
+    ]);
+    expect(steps.checkUpdate).not.toHaveBeenCalled();
+    expect(steps.resume).toHaveBeenCalledTimes(1);
+    expect(steps.login).not.toHaveBeenCalled();
+    expect(flow.state.value).toMatchObject({ kind: UnlockPhase.ready, resumed: true });
   });
 
   it('should suspend at update-prompt, then apply → restart → re-auth → ready', async () => {
@@ -67,7 +96,7 @@ describe('useUnlockFlow', () => {
     await flow.start(CREDENTIALS);
     // suspended waiting for the user's decision
     expect(flow.state.value.kind).toBe(UnlockPhase.updatePrompt);
-    expect(steps.unlock).not.toHaveBeenCalled();
+    expect(steps.login).not.toHaveBeenCalled();
 
     await flow.applyUpdate();
 
@@ -75,6 +104,7 @@ describe('useUnlockFlow', () => {
       UnlockPhase.idle,
       UnlockPhase.authenticating,
       UnlockPhase.connecting,
+      UnlockPhase.probing,
       UnlockPhase.checkingUpdate,
       UnlockPhase.updatePrompt,
       UnlockPhase.applyingUpdate,
@@ -87,6 +117,8 @@ describe('useUnlockFlow', () => {
     // re-authenticated and reconnected after the restart (initial + post-restart)
     expect(steps.authenticate).toHaveBeenCalledTimes(2);
     expect(steps.connect).toHaveBeenCalledTimes(2);
+    // the session was not resumable, so a fresh login runs after the restart
+    expect(flow.state.value).toMatchObject({ kind: UnlockPhase.ready, resumed: false });
   });
 
   it('should surface conflicts and resume on resolution', async () => {
@@ -109,7 +141,7 @@ describe('useUnlockFlow', () => {
     expect(applyUpdate).toHaveBeenLastCalledWith(7, { 'eip155:1/erc20:0xabc': 'remote' });
   });
 
-  it('should skip straight to unlock when the user declines the update', async () => {
+  it('should skip straight to login when the user declines the update', async () => {
     const steps = makeSteps({
       checkUpdate: vi.fn(async () => ok(some({ changes: 1, local: 2, remote: 3, upToVersion: 3 }))),
     });
@@ -122,9 +154,10 @@ describe('useUnlockFlow', () => {
     expect(flow.state.value.kind).toBe(UnlockPhase.ready);
     expect(steps.applyUpdate).not.toHaveBeenCalled();
     expect(steps.requestRestart).not.toHaveBeenCalled();
+    expect(steps.login).toHaveBeenCalledTimes(1);
   });
 
-  it('should land in error on a wrong password without unlocking', async () => {
+  it('should land in error on a wrong password without probing or unlocking', async () => {
     const steps = makeSteps({
       authenticate: vi.fn(async () => err({ kind: UnlockErrorKind.wrongPassword })),
     });
@@ -137,7 +170,69 @@ describe('useUnlockFlow', () => {
       error: { kind: UnlockErrorKind.wrongPassword },
       kind: UnlockPhase.error,
     });
+    expect(steps.probeSession).not.toHaveBeenCalled();
     expect(steps.checkUpdate).not.toHaveBeenCalled();
-    expect(steps.unlock).not.toHaveBeenCalled();
+    expect(steps.login).not.toHaveBeenCalled();
+  });
+
+  describe('startAuto', () => {
+    it('should resolve stored credentials then resume a live session', async () => {
+      const steps = makeSteps({ probeSession: vi.fn(async () => ok(true)) });
+      const flow = useUnlockFlow(steps);
+      track(flow);
+
+      await flow.startAuto();
+
+      expect(phases).toEqual([
+        UnlockPhase.idle,
+        UnlockPhase.resolving,
+        UnlockPhase.authenticating,
+        UnlockPhase.connecting,
+        UnlockPhase.probing,
+        UnlockPhase.unlocking,
+        UnlockPhase.loadingSession,
+        UnlockPhase.ready,
+      ]);
+      expect(steps.resume).toHaveBeenCalledTimes(1);
+      expect(steps.login).not.toHaveBeenCalled();
+    });
+
+    it('should resolve stored credentials then fresh-login when no live session exists', async () => {
+      const steps = makeSteps(); // probeSession → false, resolveCredentials → some(CREDENTIALS)
+      const flow = useUnlockFlow(steps);
+      track(flow);
+
+      await flow.startAuto();
+
+      expect(flow.state.value).toMatchObject({ kind: UnlockPhase.ready, resumed: false });
+      expect(steps.login).toHaveBeenCalledTimes(1);
+      expect(steps.resume).not.toHaveBeenCalled();
+    });
+
+    it('should return to idle when nothing is stored', async () => {
+      const steps = makeSteps({ resolveCredentials: vi.fn(async () => ok(none)) });
+      const flow = useUnlockFlow(steps);
+      track(flow);
+
+      await flow.startAuto();
+
+      expect(flow.state.value.kind).toBe(UnlockPhase.idle);
+      expect(steps.probeSession).not.toHaveBeenCalled();
+    });
+
+    it('should return to idle when there is no live session and no saved password', async () => {
+      const steps = makeSteps({
+        probeSession: vi.fn(async () => ok(false)),
+        resolveCredentials: vi.fn(async () => ok(some({ password: '', username: 'alice' }))),
+      });
+      const flow = useUnlockFlow(steps);
+      track(flow);
+
+      await flow.startAuto();
+
+      // no doomed empty-password login — straight back to the idle form
+      expect(flow.state.value.kind).toBe(UnlockPhase.idle);
+      expect(steps.login).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow.ts
@@ -6,14 +6,16 @@ import { flatMap } from 'plainfp/result-async';
 
 /**
  * The single source of truth the login/unlock UI renders from. The whole
- * authenticate → asset-update → unlock sequence is one flow with one phase, so
- * the asset-update + restart steps never fall back to the global
- * "disconnected/connecting" UI — they are just phases here.
+ * resolve → authenticate → probe → (resume | asset-update + fresh-login) sequence
+ * is one flow with one phase, so a background auto-unlock and a manual login share
+ * the same machine and can never race each other.
  */
 export const UnlockPhase = {
   idle: 'idle',
+  resolving: 'resolving',
   authenticating: 'authenticating',
   connecting: 'connecting',
+  probing: 'probing',
   checkingUpdate: 'checking-update',
   updatePrompt: 'update-prompt',
   applyingUpdate: 'applying-update',
@@ -71,8 +73,10 @@ export type ApplyOutcome =
 
 export type UnlockState =
   | { kind: typeof UnlockPhase.idle }
+  | { kind: typeof UnlockPhase.resolving }
   | { kind: typeof UnlockPhase.authenticating }
   | { kind: typeof UnlockPhase.connecting }
+  | { kind: typeof UnlockPhase.probing }
   | { kind: typeof UnlockPhase.checkingUpdate }
   | { kind: typeof UnlockPhase.updatePrompt; changes: UpdateChanges }
   | { kind: typeof UnlockPhase.applyingUpdate }
@@ -80,28 +84,36 @@ export type UnlockState =
   | { kind: typeof UnlockPhase.restarting }
   | { kind: typeof UnlockPhase.unlocking }
   | { kind: typeof UnlockPhase.loadingSession }
-  | { kind: typeof UnlockPhase.ready; session: SessionModel }
+  | { kind: typeof UnlockPhase.ready; session: SessionModel; resumed: boolean }
   | { kind: typeof UnlockPhase.error; error: UnlockError };
 
 /**
  * The fallible steps the flow orchestrates. Injected so the flow is unit-testable
  * in isolation (mock the steps, assert phase transitions). `authenticate` is a
  * no-op when no session key is configured, so it is always safe to run first.
+ *
+ * `probeSession` decides resume-vs-fresh-login up front (part of the flow), so the
+ * resume branch structurally skips `checkUpdate` and the fresh-login branch keeps it.
+ * `resolveCredentials` gathers the stored credentials for a background auto-unlock.
  */
 export interface UnlockSteps {
+  resolveCredentials: () => ResultAsync<Option<UnlockCredentials>, UnlockError>;
   authenticate: (credentials: UnlockCredentials) => ResultAsync<void, UnlockError>;
   connect: () => ResultAsync<void, UnlockError>;
+  probeSession: (credentials: UnlockCredentials) => ResultAsync<boolean, UnlockError>;
   checkUpdate: () => ResultAsync<Option<UpdateChanges>, UnlockError>;
   applyUpdate: (upToVersion: number, resolution?: Resolution) => ResultAsync<ApplyOutcome, UnlockError>;
   requestRestart: () => ResultAsync<void, UnlockError>;
   waitReady: () => ResultAsync<void, UnlockError>;
-  unlock: (credentials: UnlockCredentials) => ResultAsync<void, UnlockError>;
+  resume: (credentials: UnlockCredentials) => ResultAsync<void, UnlockError>;
+  login: (credentials: UnlockCredentials) => ResultAsync<void, UnlockError>;
   loadSession: () => ResultAsync<SessionModel, UnlockError>;
 }
 
 export interface UseUnlockFlowReturn {
   state: Readonly<Ref<UnlockState>>;
   start: (credentials: UnlockCredentials) => Promise<void>;
+  startAuto: () => Promise<void>;
   applyUpdate: (resolution?: Resolution, version?: number) => Promise<void>;
   skipUpdate: () => Promise<void>;
   reset: () => void;
@@ -112,15 +124,43 @@ export function useUnlockFlow(steps: UnlockSteps): UseUnlockFlowReturn {
   // Lives only for the duration of one flow (needed to re-authenticate after an
   // asset-update restart) and is dropped the moment we reach `ready`.
   let credentials: UnlockCredentials | undefined;
+  // True for a background auto-unlock: a failure (or nothing to resume/log in with)
+  // silently returns to the idle form instead of parking in `error`.
+  let auto = false;
   let pendingVersion = 0;
 
   const toPhase = (next: UnlockState): void => set(state, next);
   const fail = (error: UnlockError): void => toPhase({ kind: UnlockPhase.error, error });
 
-  // authenticate (no-op without sessions) → open the WS (so migration progress can
-  // stream) → look for an asset update
+  // Manual login/create: credentials come from the form/payload.
   async function start(creds: UnlockCredentials): Promise<void> {
+    auto = false;
     credentials = creds;
+    await runPipeline();
+  }
+
+  // Background auto-unlock: resolve the stored credentials first. Nothing stored ⇒
+  // there is nothing to auto-unlock with, so drop back to the idle login form.
+  async function startAuto(): Promise<void> {
+    auto = true;
+    toPhase({ kind: UnlockPhase.resolving });
+    const resolved = await steps.resolveCredentials();
+    if (!resolved.ok)
+      return fail(resolved.error);
+    if (!resolved.value.some)
+      return reset();
+
+    credentials = resolved.value.value;
+    await runPipeline();
+  }
+
+  // authenticate (no-op without sessions) → open the WS (so migration progress can
+  // stream) → probe whether the backend already has a live session for this user.
+  async function runPipeline(): Promise<void> {
+    const creds = credentials;
+    if (!creds)
+      return fail({ kind: UnlockErrorKind.unknown, message: 'unlock without an active flow' });
+
     toPhase({ kind: UnlockPhase.authenticating });
     const connected = await pipe(
       steps.authenticate(creds),
@@ -131,6 +171,21 @@ export function useUnlockFlow(steps: UnlockSteps): UseUnlockFlowReturn {
     );
     if (!connected.ok)
       return fail(connected.error);
+
+    toPhase({ kind: UnlockPhase.probing });
+    const resumable = await steps.probeSession(creds);
+    if (!resumable.ok)
+      return fail(resumable.error);
+
+    // Live session ⇒ resume directly, never touching the asset-update prompt (applying
+    // it would restart the backend and kill the session we just re-attached to).
+    if (resumable.value)
+      return finishUnlock(true);
+
+    // No live session and nothing to log in with (background auto-unlock without a saved
+    // password) ⇒ show the form for manual entry instead of a doomed empty-password login.
+    if (auto && !creds.password)
+      return reset();
 
     await checkUpdate();
   }
@@ -147,7 +202,7 @@ export function useUnlockFlow(steps: UnlockSteps): UseUnlockFlowReturn {
       return toPhase({ kind: UnlockPhase.updatePrompt, changes: found.value.value });
     }
 
-    await finishUnlock();
+    await finishUnlock(false);
   }
 
   // user accepted the update (optionally resolving conflicts). `version` lets the prompt
@@ -168,13 +223,14 @@ export function useUnlockFlow(steps: UnlockSteps): UseUnlockFlowReturn {
   }
 
   async function skipUpdate(): Promise<void> {
-    await finishUnlock();
+    await finishUnlock(false);
   }
 
   // The restart is a phase WITHIN this flow — it never tears the app down to the
   // global "connecting" state. requestRestart hits the (initially no-op) HTTP
   // control endpoint; waitReady polls /ping; then we re-authenticate with the
-  // password still held in this closure.
+  // password still held in this closure. An asset update only ever happens on the
+  // fresh-login branch, so after the restart we always do a fresh login.
   async function restart(): Promise<void> {
     const creds = credentials;
     if (!creds)
@@ -190,17 +246,17 @@ export function useUnlockFlow(steps: UnlockSteps): UseUnlockFlowReturn {
     if (!result.ok)
       return fail(result.error);
 
-    await finishUnlock();
+    await finishUnlock(false);
   }
 
-  async function finishUnlock(): Promise<void> {
+  async function finishUnlock(resumed: boolean): Promise<void> {
     const creds = credentials;
     if (!creds)
       return fail({ kind: UnlockErrorKind.unknown, message: 'unlock without an active flow' });
 
     toPhase({ kind: UnlockPhase.unlocking });
     const result = await pipe(
-      steps.unlock(creds),
+      resumed ? steps.resume(creds) : steps.login(creds),
       flatMap(async () => {
         toPhase({ kind: UnlockPhase.loadingSession });
         return steps.loadSession();
@@ -210,11 +266,12 @@ export function useUnlockFlow(steps: UnlockSteps): UseUnlockFlowReturn {
       return fail(result.error);
 
     credentials = undefined; // drop the password once we are in
-    toPhase({ kind: UnlockPhase.ready, session: result.value });
+    toPhase({ kind: UnlockPhase.ready, session: result.value, resumed });
   }
 
   function reset(): void {
     credentials = undefined;
+    auto = false;
     pendingVersion = 0;
     toPhase({ kind: UnlockPhase.idle });
   }
@@ -222,6 +279,7 @@ export function useUnlockFlow(steps: UnlockSteps): UseUnlockFlowReturn {
   return {
     state: computed<UnlockState>(() => get(state)),
     start,
+    startAuto,
     applyUpdate,
     skipUpdate,
     reset,

--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-steps.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-steps.spec.ts
@@ -1,4 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia';
+import { none, some } from 'plainfp';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type CreateAccountPayload, IncompleteUpgradeError, SyncConflictError } from '@/modules/auth/login';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
@@ -19,6 +20,7 @@ const {
   migrateSettingsIfNeeded,
   monitorStart,
   requestRestart,
+  resolveStoredCredentials,
   runTask,
   setSettings,
   sigilEmit,
@@ -40,6 +42,7 @@ const {
     migrateSettingsIfNeeded: vi.fn(),
     monitorStart: vi.fn(),
     requestRestart: vi.fn(),
+    resolveStoredCredentials: vi.fn(),
     runTask: vi.fn(),
     setSettings: vi.fn(),
     sigilEmit: vi.fn(),
@@ -62,6 +65,10 @@ vi.mock('@/modules/settings/api/use-settings-api', () => ({
 
 vi.mock('@/modules/balances/api/use-exchange-api', () => ({
   useExchangeApi: vi.fn(() => ({ getExchanges })),
+}));
+
+vi.mock('./use-stored-credentials', () => ({
+  useStoredCredentials: vi.fn(() => ({ resolveStoredCredentials })),
 }));
 
 vi.mock('@/modules/core/tasks/use-task-handler', () => ({
@@ -114,18 +121,64 @@ describe('useUnlockSteps', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     set(lastLoginRef, '');
+    resolveStoredCredentials.mockResolvedValue(none);
     migrateSettingsIfNeeded.mockReturnValue(undefined);
   });
 
-  describe('loginSteps.unlock', () => {
-    it('should resume from an existing session when already logged in and no conflict', async () => {
+  describe('loginSteps.probeSession', () => {
+    it('should report resumable when already logged in and no conflict', async () => {
       setupStore();
       checkIfLogged.mockResolvedValue(true);
+
+      const { loginSteps } = useUnlockSteps();
+      expect(await loginSteps.probeSession(credentials)).toEqual({ ok: true, value: true });
+    });
+
+    it('should not be resumable when a conflict exists', async () => {
+      const store = setupStore();
+      checkIfLogged.mockResolvedValue(true);
+      set(storeToRefs(store).syncConflict, { message: 'x', payload: { localLastModified: 1, remoteLastModified: 2 } });
+
+      const { loginSteps } = useUnlockSteps();
+      expect(await loginSteps.probeSession(credentials)).toEqual({ ok: true, value: false });
+    });
+
+    it('should not be resumable when not logged in', async () => {
+      setupStore();
+      checkIfLogged.mockResolvedValue(false);
+
+      const { loginSteps } = useUnlockSteps();
+      expect(await loginSteps.probeSession(credentials)).toEqual({ ok: true, value: false });
+    });
+
+    it('should fall back to lastLogin when credentials.username is empty', async () => {
+      setupStore();
+      set(lastLoginRef, 'remembered');
+      checkIfLogged.mockResolvedValue(true);
+
+      const { loginSteps } = useUnlockSteps();
+      await loginSteps.probeSession({ password: 'p', username: '' });
+
+      expect(checkIfLogged).toHaveBeenCalledWith('remembered');
+    });
+
+    it('should map an unexpected throw to err(unknown)', async () => {
+      setupStore();
+      checkIfLogged.mockRejectedValue(new Error('boom'));
+
+      const { loginSteps } = useUnlockSteps();
+      expect(await loginSteps.probeSession(credentials)).toEqual({ error: { kind: UnlockErrorKind.unknown, message: 'boom' }, ok: false });
+    });
+  });
+
+  describe('loginSteps.resume', () => {
+    it('should resume from settings + exchanges without running the login task', async () => {
+      setupStore();
       getRawSettings.mockResolvedValue({ frontendSettings: '{}' });
       getExchanges.mockResolvedValue([{ location: 'kraken', name: 'kraken' }]);
 
       const { loginSteps } = useUnlockSteps();
-      const result = await loginSteps.unlock(credentials);
+      const result = await loginSteps.resume(credentials);
 
       expect(result).toEqual({ ok: true, value: undefined });
       expect(getRawSettings).toHaveBeenCalled();
@@ -133,29 +186,54 @@ describe('useUnlockSteps', () => {
       expect(runTask).not.toHaveBeenCalled();
     });
 
-    it('should fall back to lastLogin when credentials.username is empty', async () => {
-      setupStore();
-      set(lastLoginRef, 'remembered');
-      checkIfLogged.mockResolvedValue(true);
-      getRawSettings.mockResolvedValue({ frontendSettings: '{}' });
-      getExchanges.mockResolvedValue([]);
+    it('should map SyncConflictError onto the store and return err(syncConflict)', async () => {
+      const store = setupStore();
+      const { syncConflict } = storeToRefs(store);
+      const payload = { localLastModified: 1, remoteLastModified: 2 };
+      getRawSettings.mockRejectedValueOnce(new SyncConflictError('conflict!', payload));
 
       const { loginSteps } = useUnlockSteps();
-      await loginSteps.unlock({ password: 'p', username: '' });
+      const result = await loginSteps.resume(credentials);
 
-      expect(checkIfLogged).toHaveBeenCalledWith('remembered');
+      expect(result).toEqual({ error: { kind: UnlockErrorKind.syncConflict, payload }, ok: false });
+      expect(get(syncConflict)).toEqual({ message: 'conflict!', payload });
     });
 
-    it('should run the login task path when not currently logged in', async () => {
+    it('should map IncompleteUpgradeError onto the store and return err(incompleteUpgrade)', async () => {
+      const store = setupStore();
+      const { incompleteUpgradeConflict } = storeToRefs(store);
+      getRawSettings.mockRejectedValueOnce(new IncompleteUpgradeError('upgrade!'));
+
+      const { loginSteps } = useUnlockSteps();
+      const result = await loginSteps.resume(credentials);
+
+      expect(result).toEqual({ error: { kind: UnlockErrorKind.incompleteUpgrade }, ok: false });
+      expect(get(incompleteUpgradeConflict)).toEqual({ message: 'upgrade!' });
+    });
+
+    it('should persist migrated frontend settings on resume', async () => {
       setupStore();
-      checkIfLogged.mockResolvedValue(false);
+      getRawSettings.mockResolvedValue({ frontendSettings: 'OLD' });
+      getExchanges.mockResolvedValue([]);
+      migrateSettingsIfNeeded.mockReturnValue('NEW');
+
+      const { loginSteps } = useUnlockSteps();
+      await loginSteps.resume(credentials);
+
+      expect(setSettings).toHaveBeenCalledWith({ frontendSettings: 'NEW' });
+    });
+  });
+
+  describe('loginSteps.login', () => {
+    it('should run the login task path and colibri login', async () => {
+      setupStore();
       runTask.mockResolvedValue({
         result: { exchanges: [], settings: { frontendSettings: '{}' } },
         success: true,
       });
 
       const { loginSteps } = useUnlockSteps();
-      const result = await loginSteps.unlock({ password: 'p', username: 'bob' });
+      const result = await loginSteps.login({ password: 'p', username: 'bob' });
 
       expect(result).toEqual({ ok: true, value: undefined });
       expect(runTask).toHaveBeenCalled();
@@ -164,95 +242,60 @@ describe('useUnlockSteps', () => {
 
     it('should return err(wrongPassword) on a non-actionable login failure', async () => {
       setupStore();
-      checkIfLogged.mockResolvedValue(false);
       runTask.mockResolvedValue({ message: '', success: false });
 
       const { loginSteps } = useUnlockSteps();
-      const result = await loginSteps.unlock({ password: 'p', username: 'bob' });
+      const result = await loginSteps.login({ password: 'p', username: 'bob' });
 
       expect(result).toEqual({ error: { kind: UnlockErrorKind.wrongPassword }, ok: false });
       expect(colibriLogin).not.toHaveBeenCalled();
     });
 
-    it('should return a silent unknown err when no username and not logged in', async () => {
+    it('should return a silent unknown err when no username is available', async () => {
       setupStore();
-      checkIfLogged.mockResolvedValue(false);
 
       const { loginSteps } = useUnlockSteps();
-      const result = await loginSteps.unlock({ password: 'p', username: '' });
+      const result = await loginSteps.login({ password: 'p', username: '' });
 
       expect(result).toEqual({ error: { kind: UnlockErrorKind.unknown, message: '' }, ok: false });
       expect(runTask).not.toHaveBeenCalled();
     });
 
-    it('should map SyncConflictError onto the store and return err(syncConflict)', async () => {
-      const store = setupStore();
-      const { syncConflict } = storeToRefs(store);
-      checkIfLogged.mockResolvedValue(true);
-      const payload = { localLastModified: 1, remoteLastModified: 2 };
-      getRawSettings.mockRejectedValueOnce(new SyncConflictError('conflict!', payload));
-
-      const { loginSteps } = useUnlockSteps();
-      const result = await loginSteps.unlock(credentials);
-
-      expect(result).toEqual({ error: { kind: UnlockErrorKind.syncConflict, payload }, ok: false });
-      expect(get(syncConflict)).toEqual({ message: 'conflict!', payload });
-    });
-
     it('should map a SyncConflictError carried by an actionable login-task failure', async () => {
       const store = setupStore();
       const { syncConflict } = storeToRefs(store);
-      checkIfLogged.mockResolvedValue(false);
       const payload = { localLastModified: 1, remoteLastModified: 2 };
       // the task monitor forwards the original error on the failed outcome
       runTask.mockResolvedValue({ error: new SyncConflictError('conflict!', payload), message: 'conflict!', success: false });
 
       const { loginSteps } = useUnlockSteps();
-      const result = await loginSteps.unlock({ password: 'p', username: 'bob' });
+      const result = await loginSteps.login({ password: 'p', username: 'bob' });
 
       expect(result).toEqual({ error: { kind: UnlockErrorKind.syncConflict, payload }, ok: false });
       expect(get(syncConflict)).toEqual({ message: 'conflict!', payload });
       expect(colibriLogin).not.toHaveBeenCalled();
     });
+  });
 
-    it('should map IncompleteUpgradeError onto the store and return err(incompleteUpgrade)', async () => {
-      const store = setupStore();
-      const { incompleteUpgradeConflict } = storeToRefs(store);
-      checkIfLogged.mockResolvedValue(true);
-      getRawSettings.mockRejectedValueOnce(new IncompleteUpgradeError('upgrade!'));
+  describe('loginSteps.resolveCredentials', () => {
+    it('should wrap the resolved stored credentials in ok', async () => {
+      setupStore();
+      resolveStoredCredentials.mockResolvedValue(some({ password: 'secret', username: 'alice' }));
 
       const { loginSteps } = useUnlockSteps();
-      const result = await loginSteps.unlock(credentials);
-
-      expect(result).toEqual({ error: { kind: UnlockErrorKind.incompleteUpgrade }, ok: false });
-      expect(get(incompleteUpgradeConflict)).toEqual({ message: 'upgrade!' });
+      expect(await loginSteps.resolveCredentials()).toEqual({ ok: true, value: some({ password: 'secret', username: 'alice' }) });
     });
 
-    it('should return err(unknown) with the message when an unexpected error is thrown', async () => {
+    it('should map a resolution throw to err(unknown)', async () => {
       setupStore();
-      checkIfLogged.mockRejectedValue(new Error('boom'));
+      resolveStoredCredentials.mockRejectedValue(new Error('keychain boom'));
 
       const { loginSteps } = useUnlockSteps();
-      const result = await loginSteps.unlock(credentials);
-
-      expect(result).toEqual({ error: { kind: UnlockErrorKind.unknown, message: 'boom' }, ok: false });
-    });
-
-    it('should persist migrated frontend settings on resume', async () => {
-      setupStore();
-      checkIfLogged.mockResolvedValue(true);
-      getRawSettings.mockResolvedValue({ frontendSettings: 'OLD' });
-      getExchanges.mockResolvedValue([]);
-      migrateSettingsIfNeeded.mockReturnValue('NEW');
-
-      const { loginSteps } = useUnlockSteps();
-      await loginSteps.unlock(credentials);
-
-      expect(setSettings).toHaveBeenCalledWith({ frontendSettings: 'NEW' });
+      expect(await loginSteps.resolveCredentials()).toEqual({ error: { kind: UnlockErrorKind.unknown, message: 'keychain boom' }, ok: false });
     });
   });
 
-  describe('createSteps(payload).unlock', () => {
+  describe('createSteps(payload)', () => {
     const payload: CreateAccountPayload = {
       credentials: { password: 'pw', username: 'new-user' },
       initialSettings: { submitUsageAnalytics: true },
@@ -266,7 +309,7 @@ describe('useUnlockSteps', () => {
       });
 
       const { createSteps } = useUnlockSteps();
-      const result = await createSteps(payload).unlock(payload.credentials);
+      const result = await createSteps(payload).login(payload.credentials);
 
       expect(result).toEqual({ ok: true, value: undefined });
       expect(colibriLogin).toHaveBeenCalledWith({ password: 'pw', username: 'new-user' });
@@ -277,19 +320,19 @@ describe('useUnlockSteps', () => {
       runTask.mockResolvedValue({ message: 'nope', success: false });
 
       const { createSteps } = useUnlockSteps();
-      const result = await createSteps(payload).unlock(payload.credentials);
+      const result = await createSteps(payload).login(payload.credentials);
 
       expect(result).toEqual({ error: { kind: UnlockErrorKind.unknown, message: 'nope' }, ok: false });
       expect(colibriLogin).not.toHaveBeenCalled();
     });
 
-    it('should report no update for a fresh account', async () => {
+    it('should never be resumable and never prompt for an update', async () => {
       setupStore();
 
       const { createSteps } = useUnlockSteps();
-      const result = await createSteps(payload).checkUpdate();
-
-      expect(result).toEqual({ ok: true, value: { some: false } });
+      const steps = createSteps(payload);
+      expect(await steps.probeSession(payload.credentials)).toEqual({ ok: true, value: false });
+      expect(await steps.checkUpdate()).toEqual({ ok: true, value: { some: false } });
       expect(checkUpdate).not.toHaveBeenCalled();
     });
   });
@@ -297,12 +340,11 @@ describe('useUnlockSteps', () => {
   describe('loadSession', () => {
     it('should hydrate the store and emit session:ready after a successful unlock', async () => {
       const store = setupStore();
-      checkIfLogged.mockResolvedValue(true);
       getRawSettings.mockResolvedValue({ frontendSettings: '{}' });
       getExchanges.mockResolvedValue([]);
 
       const { loginSteps } = useUnlockSteps();
-      await loginSteps.unlock(credentials);
+      await loginSteps.resume(credentials);
       const result = await loginSteps.loadSession();
 
       expect(result).toEqual({ ok: true, value: { username: 'alice' } });
@@ -325,13 +367,12 @@ describe('useUnlockSteps', () => {
 
     it('should map an initialize failure to a typed err', async () => {
       setupStore();
-      checkIfLogged.mockResolvedValue(true);
       getRawSettings.mockResolvedValue({ frontendSettings: '{}' });
       getExchanges.mockResolvedValue([]);
       initialize.mockRejectedValueOnce(new Error('init failed'));
 
       const { loginSteps } = useUnlockSteps();
-      await loginSteps.unlock(credentials);
+      await loginSteps.resume(credentials);
       const result = await loginSteps.loadSession();
 
       expect(result).toEqual({ error: { kind: UnlockErrorKind.unknown, message: 'init failed' }, ok: false });

--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-steps.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-steps.ts
@@ -1,7 +1,6 @@
 import type { Exchange } from '@/modules/balances/types/exchanges';
 import type { TaskMeta } from '@/modules/core/tasks/types';
-import { objectPick } from '@vueuse/shared';
-import { err, none, ok, pipe, type ResultType as Result, ResultAsync } from 'plainfp';
+import { err, none, ok, type OptionType as Option, type ResultType as Result } from 'plainfp';
 import { lastLogin } from '@/modules/auth/account-management';
 import { type CreateAccountPayload, IncompleteUpgradeError, SyncConflictError } from '@/modules/auth/login';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
@@ -17,6 +16,7 @@ import { migrateSettingsIfNeeded } from '@/modules/settings/types/frontend-setti
 import { type SettingsUpdate, UserAccount, UserSettingsModel } from '@/modules/settings/types/user-settings';
 import { useMonitorService } from '@/modules/shell/app/use-monitor-service';
 import { useAssetUpdateSteps } from './use-asset-update-steps';
+import { useStoredCredentials } from './use-stored-credentials';
 import {
   type SessionModel,
   type UnlockCredentials,
@@ -51,6 +51,7 @@ export function useUnlockSteps(): UseUnlockStepsReturn {
   const { checkIfLogged, colibriLogin, createAccount: callCreateAccount, login: callLogin } = useUsersApi();
   const { getRawSettings, setSettings } = useSettingsApi();
   const { getExchanges } = useExchangeApi();
+  const { resolveStoredCredentials } = useStoredCredentials();
   const assetSteps = useAssetUpdateSteps();
 
   // the account produced by `unlock`, consumed by `loadSession` (one flow at a time)
@@ -124,7 +125,7 @@ export function useUnlockSteps(): UseUnlockStepsReturn {
       return err({ kind: UnlockErrorKind.wrongPassword });
     }
 
-    await colibriLogin(objectPick(credentials, ['username', 'password']));
+    await colibriLogin({ password: credentials.password, username: credentials.username });
     outcome.result.settings.frontendSettings = await migrateAndSaveSettings(outcome.result.settings.frontendSettings);
     const account = UserAccount.parse(outcome.result);
     return ok({ exchanges: account.exchanges, fetchData: true, settings: account.settings, username: name });
@@ -157,26 +158,45 @@ export function useUnlockSteps(): UseUnlockStepsReturn {
     }
   };
 
-  // checkIfLogged → (resume | freshLogin) → stash the loaded account. Every async op is
-  // behind `fromPromise`/`guarded`, so a throw from any stage is mapped to a typed `err`
+  // Resolve the stored credentials for a background auto-unlock (delegated to
+  // useStoredCredentials); `none` ⇒ nothing to auto-unlock with, so the flow drops back to
+  // the manual login form. `guarded` maps any throw to a typed err.
+  const resolveCredentials = async (): Promise<Result<Option<UnlockCredentials>, UnlockError>> =>
+    guarded<Option<UnlockCredentials>>(async () => ok(await resolveStoredCredentials()));
+
+  // The "auto-login check": does the backend already hold a live session for this user
+  // (and no conflict is pending)? Decided up front so the resume branch skips the
+  // asset-update prompt and the fresh-login branch keeps it.
+  const probeSession = async (credentials: UnlockCredentials): Promise<Result<boolean, UnlockError>> =>
+    guarded(async () => {
+      const name = credentials.username || get<string>(lastLogin);
+      const alreadyLogged = await checkIfLogged(name);
+      return ok(alreadyLogged && !get(conflictExist));
+    });
+
+  // Resume an already-live server-side session — no login task, no colibri login.
+  const resumeUnlock = async (credentials: UnlockCredentials): Promise<Result<void, UnlockError>> =>
+    guarded(async () => {
+      const name = credentials.username || get<string>(lastLogin);
+      const account = await resumeSession(name);
+      if (!account.ok)
+        return account;
+      loaded = account.value;
+      return ok(undefined);
+    });
+
+  // Fresh login with credentials (manual or saved-password auto-unlock). Every async op is
+  // behind `guarded`, so a throw from any stage is mapped to a typed `err`
   // (single-boundary safety) instead of rejecting the flow.
-  const loginUnlock = async (credentials: UnlockCredentials): Promise<Result<void, UnlockError>> => {
-    const name = credentials.username || get<string>(lastLogin);
-    return pipe(
-      ResultAsync.fromPromise(checkIfLogged(name), failWith),
-      ResultAsync.flatMap(async (alreadyLogged): Promise<Result<void, UnlockError>> =>
-        guarded(async () => {
-          const account = alreadyLogged && !get(conflictExist)
-            ? await resumeSession(name)
-            : await freshLogin(credentials, name);
-          if (!account.ok)
-            return account;
-          loaded = account.value;
-          return ok(undefined);
-        }),
-      ),
-    );
-  };
+  const loginUnlock = async (credentials: UnlockCredentials): Promise<Result<void, UnlockError>> =>
+    guarded(async () => {
+      const name = credentials.username || get<string>(lastLogin);
+      const account = await freshLogin(credentials, name);
+      if (!account.ok)
+        return account;
+      loaded = account.value;
+      return ok(undefined);
+    });
 
   const createUnlock = (payload: CreateAccountPayload) => async (): Promise<Result<void, UnlockError>> =>
     guarded(async () => {
@@ -188,7 +208,7 @@ export function useUnlockSteps(): UseUnlockStepsReturn {
         return err({ kind: UnlockErrorKind.unknown, message: outcome.message });
 
       const { exchanges, settings } = UserAccount.parse(outcome.result);
-      await colibriLogin(objectPick(payload.credentials, ['username', 'password']));
+      await colibriLogin({ password: payload.credentials.password, username: payload.credentials.username });
       loaded = {
         exchanges,
         fetchData: payload.premiumSetup?.syncDatabase ?? false,
@@ -211,13 +231,19 @@ export function useUnlockSteps(): UseUnlockStepsReturn {
       ...shared,
       applyUpdate: assetSteps.applyUpdate,
       checkUpdate: async () => ok(none), // a fresh account is always current
-      unlock: createUnlock(payload),
+      login: createUnlock(payload),
+      probeSession: async () => ok(false), // a new account is never resumable
+      resolveCredentials: async () => ok(none), // create is never a background auto-unlock
+      resume: async () => ok(undefined), // never reached for create
     }),
     loginSteps: {
       ...shared,
       applyUpdate: assetSteps.applyUpdate,
       checkUpdate: assetSteps.checkUpdate,
-      unlock: loginUnlock,
+      login: loginUnlock,
+      probeSession,
+      resolveCredentials,
+      resume: resumeUnlock,
     },
   };
 }

--- a/frontend/app/src/modules/auth/use-account-management.spec.ts
+++ b/frontend/app/src/modules/auth/use-account-management.spec.ts
@@ -1,12 +1,12 @@
 import dayjs from 'dayjs';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccountManagement } from '@/modules/auth/use-account-management';
-import { useAutoLogin } from '@/modules/auth/use-auto-login';
+import { createAutoLogin } from '@/modules/auth/use-auto-login';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { Constraints } from '@/modules/core/common/constraints';
 import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
 
-const { controllerErrors, controllerLoading, controllerState, reset, startCreate, startLogin, startResume } = vi.hoisted(() => {
+const { controllerErrors, controllerLoading, controllerState, reset, startCreate, startLogin, startAuto } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { ref: vueRef } = require('vue');
   return {
@@ -16,7 +16,7 @@ const { controllerErrors, controllerLoading, controllerState, reset, startCreate
     reset: vi.fn(),
     startCreate: vi.fn(),
     startLogin: vi.fn(),
-    startResume: vi.fn(),
+    startAuto: vi.fn(),
   };
 });
 
@@ -29,7 +29,7 @@ vi.mock('@/modules/auth/unlock-flow/use-unlock-flow-controller', () => ({
     skipUpdate: vi.fn(),
     startCreate,
     startLogin,
-    startResume,
+    startAuto,
     state: controllerState,
   })),
 }));
@@ -64,7 +64,8 @@ describe('useAccount', () => {
     set(controllerState, { kind: 'idle' });
     startLogin.mockReset();
     startCreate.mockReset();
-    startResume.mockReset();
+    startAuto.mockReset();
+    reset.mockReset();
   });
 
   describe('login', () => {
@@ -92,6 +93,31 @@ describe('useAccount', () => {
       await userLogin({ password: '1234', resumeFromBackup: true, syncApproval: 'yes', username: 'test' });
 
       expect(startLogin).toHaveBeenCalledWith({ password: '1234', resumeFromBackup: true, syncApproval: 'yes', username: 'test' });
+    });
+  });
+
+  describe('clearErrors', () => {
+    it('should reset the flow to dismiss a terminal error', () => {
+      const { clearErrors } = useAccountManagement();
+      set(controllerState, { kind: 'error' });
+
+      clearErrors();
+
+      expect(reset).toHaveBeenCalled();
+    });
+
+    it('should not reset an in-flight flow (a background auto-unlock must survive `touched`)', () => {
+      // A background auto-unlock can be in flight while the form is interactive; `touched` →
+      // clearErrors must not reset it, or it would drop the flow's credentials and abort with
+      // "unlock without an active flow".
+      const { clearErrors } = useAccountManagement();
+
+      for (const kind of ['authenticating', 'connecting', 'checking-update', 'unlocking', 'idle'] as const) {
+        set(controllerState, { kind });
+        clearErrors();
+      }
+
+      expect(reset).not.toHaveBeenCalled();
     });
   });
 
@@ -150,7 +176,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: Constraints.PASSWORD_CONFIRMATION_MIN_SECONDS,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(false);
@@ -173,7 +199,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: Constraints.PASSWORD_CONFIRMATION_MIN_SECONDS,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(false);
@@ -195,7 +221,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: Constraints.PASSWORD_CONFIRMATION_MIN_SECONDS,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(true);
@@ -216,7 +242,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: Constraints.PASSWORD_CONFIRMATION_MIN_SECONDS,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(false);
@@ -238,7 +264,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: Constraints.PASSWORD_CONFIRMATION_MIN_SECONDS,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       // Should not set needsPasswordConfirmation because no stored password
@@ -259,7 +285,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: Constraints.PASSWORD_CONFIRMATION_MIN_SECONDS,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(false);
@@ -282,7 +308,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: Constraints.PASSWORD_CONFIRMATION_MIN_SECONDS,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(true);
@@ -304,7 +330,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: interval,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(true);
@@ -326,7 +352,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: interval,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(false);
@@ -348,7 +374,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: sevenDaysInSeconds,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(true);
@@ -369,7 +395,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: Constraints.PASSWORD_CONFIRMATION_MAX_SECONDS,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(true);
@@ -390,7 +416,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: Constraints.PASSWORD_CONFIRMATION_MIN_SECONDS,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
 
       expect(get(needsPasswordConfirmation)).toBe(false);
@@ -412,7 +438,7 @@ describe('useAccount', () => {
         passwordConfirmationInterval: Constraints.PASSWORD_CONFIRMATION_MIN_SECONDS,
       });
 
-      const { checkIfPasswordConfirmationNeeded } = useAutoLogin();
+      const { checkIfPasswordConfirmationNeeded } = createAutoLogin();
       await checkIfPasswordConfirmationNeeded('testUser');
       const afterTime = dayjs().unix();
 
@@ -424,7 +450,7 @@ describe('useAccount', () => {
     });
 
     it('should return true when password is correct', async () => {
-      const { confirmPassword } = useAutoLogin();
+      const { confirmPassword } = createAutoLogin();
       const correctPassword = 'mySecurePassword123';
 
       vi.mocked(mockInterop.getPassword).mockResolvedValue(correctPassword);
@@ -436,7 +462,7 @@ describe('useAccount', () => {
     });
 
     it('should return false when password is incorrect', async () => {
-      const { confirmPassword } = useAutoLogin();
+      const { confirmPassword } = createAutoLogin();
 
       vi.mocked(mockInterop.getPassword).mockResolvedValue('correctPassword');
 
@@ -446,7 +472,7 @@ describe('useAccount', () => {
     });
 
     it('should return false when password is empty', async () => {
-      const { confirmPassword } = useAutoLogin();
+      const { confirmPassword } = createAutoLogin();
 
       vi.mocked(mockInterop.getPassword).mockResolvedValue('somePassword');
 
@@ -457,7 +483,7 @@ describe('useAccount', () => {
 
     it('should update lastPasswordConfirmed timestamp when password is correct', async () => {
       const frontendStore = useFrontendSettingsStore();
-      const { confirmPassword } = useAutoLogin();
+      const { confirmPassword } = createAutoLogin();
       const correctPassword = 'testPassword';
 
       vi.mocked(mockInterop.getPassword).mockResolvedValue(correctPassword);
@@ -473,7 +499,7 @@ describe('useAccount', () => {
 
     it('should not update timestamp when password is incorrect', async () => {
       const frontendStore = useFrontendSettingsStore();
-      const { confirmPassword } = useAutoLogin();
+      const { confirmPassword } = createAutoLogin();
 
       const initialTimestamp = frontendStore.lastPasswordConfirmed;
       vi.mocked(mockInterop.getPassword).mockResolvedValue('correctPassword');
@@ -486,7 +512,7 @@ describe('useAccount', () => {
     it('should set needsPasswordConfirmation to false when password is correct', async () => {
       const authStore = useSessionAuthStore();
       const { needsPasswordConfirmation } = storeToRefs(authStore);
-      const { confirmPassword } = useAutoLogin();
+      const { confirmPassword } = createAutoLogin();
       const correctPassword = 'test123';
 
       set(needsPasswordConfirmation, true);
@@ -498,7 +524,7 @@ describe('useAccount', () => {
     });
 
     it('should handle special characters in password', async () => {
-      const { confirmPassword } = useAutoLogin();
+      const { confirmPassword } = createAutoLogin();
       const specialPassword = 'p@$$w0rd!#$%^&*()';
 
       vi.mocked(mockInterop.getPassword).mockResolvedValue(specialPassword);
@@ -509,7 +535,7 @@ describe('useAccount', () => {
     });
 
     it('should compare passwords case-sensitively', async () => {
-      const { confirmPassword } = useAutoLogin();
+      const { confirmPassword } = createAutoLogin();
 
       vi.mocked(mockInterop.getPassword).mockResolvedValue('Password123');
 
@@ -521,7 +547,7 @@ describe('useAccount', () => {
     });
 
     it('should handle getPassword rejection', async () => {
-      const { confirmPassword } = useAutoLogin();
+      const { confirmPassword } = createAutoLogin();
 
       vi.mocked(mockInterop.getPassword).mockRejectedValue(new Error('Failed to get password'));
 

--- a/frontend/app/src/modules/auth/use-account-management.ts
+++ b/frontend/app/src/modules/auth/use-account-management.ts
@@ -52,8 +52,17 @@ export function useAccountManagement(): UseAccountManagementReturn {
     });
   };
 
+  // Dismissing the form's error alert (fired on field `touched`, and before each login attempt)
+  // must only clear a terminal error — never reset an in-flight unlock. A background auto-unlock
+  // can be running while the form is interactive; a full `controller.reset()` here would drop the
+  // flow's credentials and abort it with "unlock without an active flow".
+  const clearErrors = (): void => {
+    if (get(controller.state).kind === UnlockPhase.error)
+      controller.reset();
+  };
+
   return {
-    clearErrors: controller.reset,
+    clearErrors,
     createNewAccount,
     error,
     errors: controller.errors,

--- a/frontend/app/src/modules/auth/use-auto-login.spec.ts
+++ b/frontend/app/src/modules/auth/use-auto-login.spec.ts
@@ -3,25 +3,26 @@ import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type EffectScope, effectScope } from 'vue';
 import { useMainStore } from '@/modules/core/common/use-main-store';
-import { useAutoLogin } from './use-auto-login';
+import { createAutoLogin } from './use-auto-login';
 
-const { checkIfPasswordConfirmationNeeded, confirmPassword, lastLoginRef, needsPasswordConfirmationRef, resetSessionBackend, startResume } = vi.hoisted(() => {
+const { checkIfPasswordConfirmationNeeded, confirmPassword, controllerStateRef, lastLoginRef, needsPasswordConfirmationRef, resetSessionBackend, startAuto } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { ref: vueRef } = require('vue');
   return {
     checkIfPasswordConfirmationNeeded: vi.fn(),
     confirmPassword: vi.fn(),
+    controllerStateRef: vueRef({ kind: 'idle' }),
     lastLoginRef: vueRef(''),
     needsPasswordConfirmationRef: vueRef(false),
     resetSessionBackend: vi.fn().mockResolvedValue(undefined),
-    startResume: vi.fn().mockResolvedValue(undefined),
+    startAuto: vi.fn().mockResolvedValue(undefined),
   };
 });
 
 vi.mock('@/modules/auth/account-management', () => ({ lastLogin: lastLoginRef }));
 
 vi.mock('@/modules/auth/unlock-flow/use-unlock-flow-controller', () => ({
-  useUnlockFlowController: vi.fn(() => ({ startResume })),
+  useUnlockFlowController: vi.fn(() => ({ startAuto, state: controllerStateRef })),
 }));
 
 vi.mock('@/modules/auth/use-password-confirmation', () => ({
@@ -40,13 +41,14 @@ function connect(value: boolean): void {
   set(storeToRefs(useMainStore()).connected, value);
 }
 
-describe('useAutoLogin', () => {
+describe('createAutoLogin', () => {
   let scope: EffectScope;
 
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
     set(lastLoginRef, '');
+    set(controllerStateRef, { kind: 'idle' });
     scope = effectScope();
   });
 
@@ -56,37 +58,49 @@ describe('useAutoLogin', () => {
 
   it('should resume the session when the backend connects and a profile is saved', async () => {
     set(lastLoginRef, 'alice');
-    const autoLogin = scope.run(() => useAutoLogin());
+    const autoLogin = scope.run(() => createAutoLogin());
 
     connect(true);
     await flushPromises();
 
     expect(resetSessionBackend).toHaveBeenCalled();
-    expect(startResume).toHaveBeenCalledTimes(1);
+    expect(startAuto).toHaveBeenCalledTimes(1);
     expect(get(autoLogin!.autolog)).toBe(false);
   });
 
+  it('should keep the loader up on a successful auto-unlock while navigation is pending', async () => {
+    set(lastLoginRef, 'alice');
+    // success ⇒ the flow ends in `ready` and navigation runs asynchronously
+    startAuto.mockImplementation(async () => set(controllerStateRef, { kind: 'ready' }));
+    const autoLogin = scope.run(() => createAutoLogin());
+
+    connect(true);
+    await flushPromises();
+
+    expect(get(autoLogin!.autolog)).toBe(true);
+  });
+
   it('should not resume when there is no saved profile', async () => {
-    scope.run(() => useAutoLogin());
+    scope.run(() => createAutoLogin());
 
     connect(true);
     await flushPromises();
 
     expect(resetSessionBackend).toHaveBeenCalled();
-    expect(startResume).not.toHaveBeenCalled();
+    expect(startAuto).not.toHaveBeenCalled();
   });
 
   it('should ignore the disconnect transition', async () => {
     set(lastLoginRef, 'alice');
-    scope.run(() => useAutoLogin());
+    scope.run(() => createAutoLogin());
 
     connect(true);
     await flushPromises();
-    startResume.mockClear();
+    startAuto.mockClear();
 
     connect(false);
     await flushPromises();
 
-    expect(startResume).not.toHaveBeenCalled();
+    expect(startAuto).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/modules/auth/use-auto-login.ts
+++ b/frontend/app/src/modules/auth/use-auto-login.ts
@@ -1,5 +1,6 @@
 import type { Ref } from 'vue';
 import { lastLogin } from '@/modules/auth/account-management';
+import { UnlockPhase } from '@/modules/auth/unlock-flow/use-unlock-flow';
 import { useUnlockFlowController } from '@/modules/auth/unlock-flow/use-unlock-flow-controller';
 import { usePasswordConfirmation } from '@/modules/auth/use-password-confirmation';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
@@ -15,12 +16,19 @@ interface UseAutoLoginReturn {
 }
 
 /**
- * Auto-login on backend (re)connection: when a saved profile exists, resume the session
- * through the shared unlock-flow controller. Resume uses the `resume` step-set (no
- * asset-update prompt) and the post-unlock side-effects — including the password-confirmation
- * check — run in the controller's `ready` handler, so this only kicks the flow off.
+ * Auto-unlock on backend (re)connection — the single trigger for it. When a saved profile
+ * exists it kicks off `controller.startAuto()`, which resolves the stored credentials and
+ * drives the ONE shared flow: the flow probes for a live session and either resumes it or
+ * does a fresh login with the saved password. Post-unlock side-effects run in the
+ * controller's `ready` handler, so this only starts the flow.
+ *
+ * Exposed as a shared singleton (see `useAutoLogin` below): `autolog` and the `connected`
+ * watch MUST be shared so every consumer (UserHost, AppMessages) reads the same loading flag
+ * and there is exactly one watcher. With a per-instance copy the "loser" of the `canStart`
+ * race flips its own `autolog` back to false while the winner's flow is still running, so the
+ * login form flashes instead of the loader.
  */
-export function useAutoLogin(): UseAutoLoginReturn {
+export function createAutoLogin(): UseAutoLoginReturn {
   const autolog = shallowRef<boolean>(false);
 
   const controller = useUnlockFlowController();
@@ -29,20 +37,33 @@ export function useAutoLogin(): UseAutoLoginReturn {
   const { resetSessionBackend } = useBackendManagement();
   const { checkIfPasswordConfirmationNeeded, confirmPassword, needsPasswordConfirmation } = usePasswordConfirmation();
 
+  // `immediate` so it also fires when this is created after the backend already connected
+  // (e.g. the login screen mounts post-connect) rather than only on a false→true transition.
   watch(connected, async (isConnected) => {
     if (!isConnected)
       return;
 
+    // Flag the auto-unlock immediately — before resetSessionBackend and before the flow
+    // starts — so the connection loader covers the whole attempt and the login form never
+    // flashes empty (with a disabled button and no spinner) in the gap.
+    set(autolog, true);
+
     await resetSessionBackend();
 
-    // No saved credentials ⇒ nothing to resume; show the login form.
-    if (!get(lastLogin))
+    // No saved profile ⇒ nothing to auto-unlock; drop the loader and show the login form.
+    if (!get(lastLogin)) {
+      set(autolog, false);
       return;
+    }
 
-    set(autolog, true);
-    await controller.startResume();
-    set(autolog, false);
-  });
+    await controller.startAuto();
+
+    // On success the flow is `ready` and navigation to the dashboard is under way (onReady still
+    // has an async settings write + nav to run) — keep the loader up until the route changes so
+    // the form doesn't reappear. Only drop it when startAuto fell back to the idle login form.
+    if (get(controller.state).kind !== UnlockPhase.ready)
+      set(autolog, false);
+  }, { immediate: true });
 
   return {
     autolog: readonly(autolog),
@@ -52,3 +73,5 @@ export function useAutoLogin(): UseAutoLoginReturn {
     username,
   };
 }
+
+export const useAutoLogin = createSharedComposable(createAutoLogin);

--- a/frontend/app/src/modules/shell/app/AppCore.vue
+++ b/frontend/app/src/modules/shell/app/AppCore.vue
@@ -13,6 +13,8 @@ import { useCoreScroll } from '@/modules/shell/layout/use-core-scroll';
 import { initGraph } from '@/modules/statistics/init-graph';
 import { useStatisticsStore } from '@/modules/statistics/use-statistics-store';
 
+const { t } = useI18n({ useScope: 'global' });
+
 const visibilityStore = useAreaVisibilityStore();
 const { expanded, isMini, pinnedDragging, pinnedWidth, showPinned } = storeToRefs(visibilityStore);
 const { overall } = storeToRefs(useStatisticsStore());
@@ -96,12 +98,17 @@ onBeforeMount(() => {
               v-if="!logged"
               class="fixed top-0 left-0 w-full h-full bg-white dark:bg-rui-grey-900 z-[999] flex items-center justify-center"
             >
-              <RuiProgress
-                thickness="2"
-                color="primary"
-                variant="indeterminate"
-                circular
-              />
+              <div class="flex flex-col gap-4 justify-center items-center">
+                <RuiProgress
+                  color="primary"
+                  variant="indeterminate"
+                  circular
+                  size="48"
+                />
+                <p class="mb-0 text-rui-text-secondary text-center">
+                  {{ t('connection_loading.logging_out') }}
+                </p>
+              </div>
             </div>
             <component
               :is="Component"

--- a/frontend/app/src/modules/shell/app/use-backend-management.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-management.spec.ts
@@ -141,6 +141,33 @@ describe('useBackendManagement', () => {
     });
   });
 
+  describe('forceRestart intent', () => {
+    it('should attach (forceRestart=false) when setupBackend runs on a page refresh', async () => {
+      const { useBackendManagement } = await importModule();
+      const { setupBackend } = scope.run(() => useBackendManagement())!;
+      await setupBackend();
+
+      expect(mockRestartBackend).toHaveBeenCalledWith(expect.anything(), false);
+    });
+
+    it('should force a restart when applying changed user options', async () => {
+      const config = { dataDirectory: '/tmp/rotki-data' };
+      const { useBackendManagement } = await importModule();
+      const { applyUserOptions } = scope.run(() => useBackendManagement())!;
+      await applyUserOptions(config, false);
+
+      expect(mockRestartBackend).toHaveBeenCalledWith(config, true);
+    });
+
+    it('should force a restart when resetting options', async () => {
+      const { useBackendManagement } = await importModule();
+      const { resetOptions } = scope.run(() => useBackendManagement())!;
+      await resetOptions();
+
+      expect(mockRestartBackend).toHaveBeenCalledWith(expect.anything(), true);
+    });
+  });
+
   describe('backendChanged', () => {
     it('should re-enable connections when restarting due to a null url', async () => {
       const store = useMainStore();

--- a/frontend/app/src/modules/shell/app/use-backend-management.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-management.ts
@@ -18,7 +18,7 @@ interface UseBackendManagementReturn {
   fileConfig: Ref<Partial<BackendOptions>>;
   saveOptions: (opts: Partial<BackendOptions>) => Promise<void>;
   resetOptions: () => Promise<void>;
-  restartBackend: () => Promise<void>;
+  restartBackend: (forceRestart?: boolean) => Promise<void>;
   resetSessionBackend: () => Promise<void>;
   setupBackend: () => Promise<void>;
   backendChanged: (url: string | null) => Promise<void>;
@@ -42,9 +42,9 @@ export function useBackendManagement(loaded: () => void = () => {}): UseBackendM
     ...get(fileConfig),
   }));
 
-  const restartBackendWithOptions = async (options: Partial<BackendOptions>): Promise<void> => {
+  const restartBackendWithOptions = async (options: Partial<BackendOptions>, forceRestart = false): Promise<void> => {
     setConnected(false);
-    await interop.restartBackend(options);
+    await interop.restartBackend(options, forceRestart);
     // Re-enable connections in case a prior process termination disabled them
     // (e.g. on Windows, taskkill exits the core process with a non-zero code, which
     // is reported as a TERMINATED startup error and disables connection attempts).
@@ -73,7 +73,7 @@ export function useBackendManagement(loaded: () => void = () => {}): UseBackendM
       interop.setLogLevel(resolvedLevel);
     }
     if (!skipRestart) {
-      await restartBackendWithOptions(get(options));
+      await restartBackendWithOptions(get(options), true);
     }
   };
 
@@ -91,29 +91,29 @@ export function useBackendManagement(loaded: () => void = () => {}): UseBackendM
   const resetOptions = async (): Promise<void> => {
     clearUserOptions();
     set(userOptions, {});
-    await restartBackendWithOptions(get(options));
+    await restartBackendWithOptions(get(options), true);
   };
 
-  const restartBackend = async (): Promise<void> => {
+  const restartBackend = async (forceRestart = false): Promise<void> => {
     if (!interop.isPackaged)
       return;
 
     await load();
-    await restartBackendWithOptions(get(options));
+    await restartBackendWithOptions(get(options), forceRestart);
   };
 
   const resetSessionBackend = async (): Promise<void> => {
     const { sessionOnly } = getBackendUrl();
     if (sessionOnly) {
       deleteBackendUrl();
-      await restartBackend();
+      await restartBackend(true);
     }
   };
 
   const backendChanged = async (url: string | null): Promise<void> => {
     setConnected(false);
     if (!url)
-      await restartBackend();
+      await restartBackend(true);
 
     connect(url);
   };

--- a/frontend/app/src/modules/shell/app/use-electron-interop.ts
+++ b/frontend/app/src/modules/shell/app/use-electron-interop.ts
@@ -19,7 +19,7 @@ interface UseInteropReturn {
   premiumUserLoggedIn: (premiumUser: boolean) => void;
   closeApp: () => Promise<void>;
   metamaskImport: () => Promise<string[]>;
-  restartBackend: (options: Partial<BackendOptions>) => Promise<boolean>;
+  restartBackend: (options: Partial<BackendOptions>, forceRestart?: boolean) => Promise<boolean>;
   config: (defaults: boolean) => Promise<Partial<BackendOptions>>;
   version: () => Promise<SystemVersion | WebVersion>;
   isMac: () => Promise<boolean>;
@@ -167,9 +167,9 @@ const interop: UseInteropReturn = {
     window.interop?.updateTray({});
   },
 
-  restartBackend: async (options: Partial<BackendOptions>): Promise<boolean> => {
+  restartBackend: async (options: Partial<BackendOptions>, forceRestart = false): Promise<boolean> => {
     assert(window.interop);
-    return window.interop.restartBackend(options);
+    return window.interop.restartBackend(options, forceRestart);
   },
 
   setSelectedTheme: async (selectedTheme: Theme): Promise<void> => {

--- a/frontend/app/tests/unit/utils/create-mock.ts
+++ b/frontend/app/tests/unit/utils/create-mock.ts
@@ -1,0 +1,72 @@
+import { vi } from 'vitest';
+
+/**
+ * Deeply-partial shape accepted as overrides. Every property is optional and
+ * recursively partial; function properties keep their call signature so a
+ * `vi.fn()` (or any implementation) can be supplied directly.
+ */
+export type DeepPartial<T> = T extends (...args: infer A) => infer R
+  ? (...args: A) => R
+  : T extends object
+    ? { [K in keyof T]?: DeepPartial<T[K]> }
+    : T;
+
+// Properties that must never be auto-mocked: `then`/`catch`/`finally` would make
+// the mock look thenable (so `await mock` hangs), and the inspection hooks would
+// break `console.log(mock)` / util.inspect. Returning undefined for them keeps
+// the proxy inert to the runtime.
+const passthroughUndefined = new Set<PropertyKey>([
+  'then',
+  'catch',
+  'finally',
+  'asymmetricMatch',
+  'inspect',
+  Symbol.iterator,
+  Symbol.asyncIterator,
+  Symbol.toPrimitive,
+  Symbol.for('nodejs.util.inspect.custom'),
+]);
+
+function createProxy(overrides: Record<PropertyKey, unknown>): unknown {
+  const cache = new Map<PropertyKey, unknown>();
+
+  return new Proxy(vi.fn(), {
+    get(target, prop, receiver) {
+      if (prop in overrides)
+        return overrides[prop];
+
+      if (passthroughUndefined.has(prop))
+        return undefined;
+
+      // Expose the underlying vi.fn()'s own members (mock, mockReturnValue, …)
+      // so the returned value behaves as a real Vitest mock function.
+      if (prop in target)
+        return Reflect.get(target, prop, receiver);
+
+      // Lazily materialise (and cache) a nested mock so deep access such as
+      // `event.sender.send` resolves to a callable mock as well.
+      if (!cache.has(prop))
+        cache.set(prop, createProxy({}));
+
+      return cache.get(prop);
+    },
+  });
+}
+
+/**
+ * Creates a deeply-mocked stand-in for `T` for use in unit tests.
+ *
+ * Every accessed property resolves to a `vi.fn()` (callable and further
+ * proxyable), so class or branded types that cannot be constructed in a unit
+ * test — e.g. `LogService` or `Electron.IpcMainInvokeEvent` — can be supplied
+ * where the real type is expected. Pass `overrides` to pin specific
+ * properties/implementations.
+ *
+ * The single assertion below is unavoidable and intentionally contained here:
+ * a runtime `Proxy` cannot be statically proven to be `T`. Keeping it in this
+ * one helper means test files stay assertion-free.
+ */
+export function createMock<T>(overrides?: DeepPartial<T>): T {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- a runtime Proxy cannot be proven to satisfy the branded/class type T; contained to this helper
+  return createProxy(overrides ?? {}) as T;
+}

--- a/frontend/app/tsconfig.app.json
+++ b/frontend/app/tsconfig.app.json
@@ -33,6 +33,7 @@
     "**/.*",
     "tests/**/*",
     "src/**/__tests__/*",
-    "src/**/*.spec.ts"
+    "src/**/*.spec.ts",
+    "electron/**/*.spec.ts"
   ]
 }

--- a/frontend/app/tsconfig.vitest.json
+++ b/frontend/app/tsconfig.vitest.json
@@ -18,6 +18,7 @@
     "src/**/*",
     "src/**/*.vue",
     "src/**/*.spec.ts",
+    "electron/**/*",
     "tests/unit/**/*",
     "tests/contract/**/*",
     "shared/**/*"

--- a/frontend/app/vitest.config.ts
+++ b/frontend/app/vitest.config.ts
@@ -8,6 +8,7 @@ export default mergeConfig(
     resolve: {
       alias: {
         '@test': `${path.join(__dirname, 'tests', 'unit')}/`,
+        '@electron': `${path.join(__dirname, 'electron')}/`,
       },
     },
   }),


### PR DESCRIPTION
## What

Two related changes to the login and startup flow.

1. Attach to a running backend on refresh instead of respawning it.
On a renderer reload the main process now checks whether rotki-core is already
running (SubprocessHandler.isCoreRunning) and attaches to it, rather than always
terminating and restarting it. Explicit user actions (option changes, reset, URL
switch) still force a full restart, via a forceRestart intent threaded through the
restartBackend IPC.

2. Unify auto-login into the unlock flow.
The recent login rework left two independent triggers driving the shared unlock
flow: an empty-credential resume in useAutoLogin, and a saved-password login in
LoginForm. Only one can run at a time, so on a cold start they raced: auto-login
could end up stuck at the login form, or fail with "unlock without an active
flow". Both triggers are now a single startAuto() entry, and the resume vs login
decision is a probe phase at the front of the state machine.

## Details

- Probe-first flow: resolveCredentials, authenticate, connect, probe. A live
session resumes and skips the asset-update prompt; no session does a fresh login
with the saved password and keeps the prompt.
- useAutoLogin is a shared singleton now (one autolog flag, one connected watch),
so every consumer reads the same loading state instead of a per-instance flag that
the losing caller flipped back to false.
- clearErrors only clears a terminal error, never an in-flight flow.
- One loading state covers the whole auto-unlock, and the connecting, signing-in,
signing-out and restart spinners now match the login-stage layouts.

## Tests

- Full frontend unit suite passes; added specs for the probe flow, the
stored-credential resolver, and the shared auto-login trigger.
- Typecheck and lint clean.

## Checklist

- [ ] The PR modified the frontend, and updated the user guide to reflect the changes.
