### PR TITLE
fix: ignored LOGFROMOTHERMODULES docker env var

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`12499` Additional crypto.com CSV import transaction kinds such as van purchases, fiat wallet limit orders, and extra earn interest payments will now be properly imported.
+* :bug:`12507` The documented ``LOGFROMOTHERMODULES`` Docker environment variable is now honored again (it was misspelled internally) and accepts truthy string values such as ``true``, ``1``, ``yes`` and ``on``.
 * :bug:`-` The rate-limit hint in the PnL report's missing prices dialog is now a warning icon next to the refresh button, so its tooltip no longer covers the price input or the buttons of nearby rows.
 * :bug:`-` The pending task shown while balances are queried now makes clear that a balance snapshot is being saved for statistics, and notes when query errors are being ignored.
 * :bug:`-` The "history out of sync" warning shown before generating a PnL report now lets you start the history sync right there, instead of only sending you to the history page.

--- a/packaging/docker/entrypoint.py
+++ b/packaging/docker/entrypoint.py
@@ -108,9 +108,17 @@ def load_config_from_file() -> dict[str, Any] | None:
             return data
 
 
+def env_flag_is_set(value: str | None) -> bool:
+    """Interpret a string environment variable as a boolean flag.
+
+    Treats common truthy spellings (true/1/yes/on) as True, everything else as False.
+    """
+    return value is not None and value.strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
 def load_config_from_env() -> dict[str, Any]:
     loglevel = os.environ.get('LOGLEVEL')
-    logfromothermodules = os.environ.get('LOGFROMOTHERMODDULES')
+    logfromothermodules = env_flag_is_set(os.environ.get('LOGFROMOTHERMODULES'))
     max_size_in_mb_all_logs = os.environ.get('MAX_SIZE_IN_MB_ALL_LOGS')
     max_logfiles_num = os.environ.get('MAX_LOGFILES_NUM')
     sqlite_instructions = os.environ.get('SQLITE_INSTRUCTIONS')


### PR DESCRIPTION
## Problem

Closes #12507.

The Docker docs list `LOGFROMOTHERMODULES` as a supported environment variable, but `packaging/docker/entrypoint.py` never honored it because of two bugs:

1. The env lookup was misspelled `LOGFROMOTHERMODDULES` (double `D`), so the documented variable was always ignored.
2. Even with the correct name, environment variables arrive as strings, but the entrypoint only appended `--logfromothermodules` when the value was the boolean `True` — a string never matched.

## Fix

- Read the correctly spelled `LOGFROMOTHERMODULES`.
- Add an `env_flag_is_set()` helper that normalizes the value (`strip().lower()`) and treats `true`/`1`/`yes`/`on` as enabled.

File-config (JSON boolean `true`) behavior is unchanged and still overrides the env var. Default behavior is unchanged (unset → disabled).