### PR TITLE
fix: defer supported-chains fetch to post-login

### DIFF
--- a/frontend/app/src/modules/auth/unlock-flow/use-session-ready.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-session-ready.spec.ts
@@ -7,6 +7,7 @@ const {
   fetchTransactionStatusSummary,
   lastLoginRef,
   navigateToDashboard,
+  refreshSupportedChains,
   showGetPremiumButton,
   showReleaseNotesRef,
 } = vi.hoisted(() => {
@@ -16,10 +17,15 @@ const {
     fetchTransactionStatusSummary: vi.fn(),
     lastLoginRef: vueRef(''),
     navigateToDashboard: vi.fn(),
+    refreshSupportedChains: vi.fn(),
     showGetPremiumButton: vi.fn(),
     showReleaseNotesRef: vueRef(true),
   };
 });
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({ refreshSupportedChains })),
+}));
 
 vi.mock('@/modules/auth/account-management', () => ({
   lastLogin: lastLoginRef,
@@ -62,5 +68,14 @@ describe('useSessionReady', () => {
     expect(fetchTransactionStatusSummary).toHaveBeenCalled();
     expect(navigateToDashboard).toHaveBeenCalled();
     expect(get(showReleaseNotesRef)).toBe(false);
+  });
+
+  it('should load the supported chains before navigating to the dashboard', async () => {
+    await useSessionReady().handleSessionReady();
+
+    expect(refreshSupportedChains).toHaveBeenCalledOnce();
+    // chains must be populated before the dashboard (and its consumers) mount
+    expect(refreshSupportedChains.mock.invocationCallOrder[0])
+      .toBeLessThan(navigateToDashboard.mock.invocationCallOrder[0]);
   });
 });

--- a/frontend/app/src/modules/auth/unlock-flow/use-session-ready.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-session-ready.ts
@@ -1,5 +1,6 @@
 import { lastLogin } from '@/modules/auth/account-management';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useUpdateMessage } from '@/modules/core/messaging/use-update-message';
 import { useHistoryDataFetching } from '@/modules/history/use-history-data-fetching';
 import { usePremiumHelper } from '@/modules/premium/use-premium-helper';
@@ -25,12 +26,17 @@ export function useSessionReady(): UseSessionReadyReturn {
   const { fetchTransactionStatusSummary } = useHistoryDataFetching();
   const { navigateToDashboard } = useAppNavigation();
   const { showReleaseNotes } = useUpdateMessage();
+  const { refreshSupportedChains } = useSupportedChains();
 
   async function handleSessionReady(): Promise<void> {
     clearUpgradeMessages();
     set(canRequestData, true);
     set(lastLogin, get(username));
     showGetPremiumButton();
+    // Load the supported chains before navigating: dashboard/accounts consumers read
+    // the chain list imperatively, so it must be populated before the destination mounts.
+    // Runs here (post-unlock) so the calls never fire on the login screen.
+    await refreshSupportedChains();
     await fetchTransactionStatusSummary();
     await navigateToDashboard();
     set(showReleaseNotes, false);

--- a/frontend/app/src/modules/core/common/use-supported-chains-store.ts
+++ b/frontend/app/src/modules/core/common/use-supported-chains-store.ts
@@ -1,0 +1,20 @@
+import type { EvmChainEntries, SupportedChains } from '@/modules/core/api/types/chains';
+
+/**
+ * State-only store for the supported chains data. Kept as a store (not composable
+ * state) so it is registered with `StoreTrackPlugin` and cleared automatically by
+ * `resetState()` on logout — no bespoke teardown watcher needed. The API call and
+ * all derived views live in the `useSupportedChains` composable that wraps this.
+ */
+export const useSupportedChainsStore = defineStore('core/supported-chains', () => {
+  const supportedChains = shallowRef<SupportedChains>([]);
+  const allEvmChains = shallowRef<EvmChainEntries>([]);
+
+  return {
+    allEvmChains,
+    supportedChains,
+  };
+});
+
+if (import.meta.hot)
+  import.meta.hot.accept(acceptHMRUpdate(useSupportedChainsStore, import.meta.hot));

--- a/frontend/app/src/modules/core/common/use-supported-chains.ts
+++ b/frontend/app/src/modules/core/common/use-supported-chains.ts
@@ -10,8 +10,8 @@ import {
 } from '@/modules/core/api/types/chains';
 import { isBlockchain } from '@/modules/core/common/chains';
 import { getPublicProtocolImagePath } from '@/modules/core/common/file/file';
-import { useMainStore } from '@/modules/core/common/use-main-store';
 import { useSupportedChainsApi } from '@/modules/core/common/use-supported-chains-api';
+import { useSupportedChainsStore } from '@/modules/core/common/use-supported-chains-store';
 import { Routes } from '@/router/routes';
 
 function isEvmChain(info: ChainInfo): info is EvmChainInfo {
@@ -62,15 +62,13 @@ interface UseSupportedChainsReturn {
   useBlockchainRedirectLink: (blockchain: MaybeRefOrGetter<string>) => ComputedRef<string>;
   useChainImageUrl: (chain: MaybeRefOrGetter<string>) => ComputedRef<string>;
   useChainName: (location: MaybeRefOrGetter<string | undefined>) => ComputedRef<string>;
+  refreshSupportedChains: () => Promise<void>;
 }
 
 export const useSupportedChains = createSharedComposable((): UseSupportedChainsReturn => {
   const { fetchAllEvmChains, fetchSupportedChains } = useSupportedChainsApi();
 
-  const { connected } = storeToRefs(useMainStore());
-
-  const supportedChains = shallowRef<SupportedChains>([]);
-  const allEvmChains = shallowRef<EvmChainEntries>([]);
+  const { allEvmChains, supportedChains } = storeToRefs(useSupportedChainsStore());
 
   // Derived filtered views
   const evmChainsData = computed<EvmChainInfo[]>(() =>
@@ -272,20 +270,16 @@ export const useSupportedChains = createSharedComposable((): UseSupportedChainsR
   const useBlockchainRedirectLink = (blockchain: MaybeRefOrGetter<string>): ComputedRef<string> =>
     computed<string>(() => getBlockchainRedirectLink(toValue(blockchain)));
 
-  watch(connected, async (isConnected) => {
-    if (isConnected) {
-      const [chains, evmChains] = await Promise.all([
-        fetchSupportedChains(),
-        fetchAllEvmChains(),
-      ]);
-      set(supportedChains, chains);
-      set(allEvmChains, evmChains);
-    }
-    else {
-      set(supportedChains, []);
-      set(allEvmChains, []);
-    }
-  }, { immediate: true });
+  // Loaded imperatively from the unlock flow (post-login), so the calls never fire
+  // on the login screen. The store state is cleared on logout by `resetState()`.
+  const refreshSupportedChains = async (): Promise<void> => {
+    const [chains, evmChains] = await Promise.all([
+      fetchSupportedChains(),
+      fetchAllEvmChains(),
+    ]);
+    set(supportedChains, chains);
+    set(allEvmChains, evmChains);
+  };
 
   return {
     allEvmChains,
@@ -311,6 +305,7 @@ export const useSupportedChains = createSharedComposable((): UseSupportedChainsR
     isEvmLikeChains,
     isSolanaChains,
     matchChain,
+    refreshSupportedChains,
     solanaChainsData,
     supportedChains,
     supportsTransactions,

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/DisabledChainQueriesSettings.spec.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/DisabledChainQueriesSettings.spec.ts
@@ -4,6 +4,7 @@ import { mount, type VueWrapper } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMainStore } from '@/modules/core/common/use-main-store';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import DisabledChainQueriesSettings from '@/modules/settings/general/disabled-chain-queries/DisabledChainQueriesSettings.vue';
 import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
 
@@ -56,7 +57,11 @@ describe('disabled-chain-queries-settings', () => {
   beforeEach(async (): Promise<void> => {
     setSettingsMock.mockClear();
     wrapper = createWrapper();
+    // The supported chains are no longer fetched from a `connected` watcher; the
+    // unlock flow loads them post-login. Populate them explicitly for the component.
+    await useSupportedChains().refreshSupportedChains();
     await flushPromises();
+    await nextTick();
   });
 
   it('should render the empty state when there are no rules', () => {


### PR DESCRIPTION
## Problem

`useSupportedChains` fetched `GET /blockchains/supported` and `GET /blockchains/evm/all` from a `watch(connected, …, { immediate: true })` on the main store. `connected` reflects **backend-process reachability** (set at app boot via `AppHost` → `setupBackend` → `attemptConnect`), not authentication — so both calls fired on the **login screen, before the user logged in**.

This is the remaining half from the login pre-auth hardening work: relocating the login flow's `connect` (PR #12501) didn't stop these, because the trigger is the boot-time backend connect flipping `connected`, independent of login.

## Change

- **State-only store** (`use-supported-chains-store.ts`) holds `supportedChains` / `allEvmChains`. Being a registered Pinia store, it is cleared automatically on logout by `resetState()`, no bespoke teardown watcher.
- **Composable wraps the store** and exposes an imperative `refreshSupportedChains()` (the API call + derived views stay in the composable). The `connected`/`logged` watcher is removed.
- **The unlock flow awaits it** in `handleSessionReady()`, the single post-unlock hook every path (login / create / resume) funnels through. **before `navigateToDashboard()`**, so the chain list is populated before the dashboard and its consumers mount. Several consumers (e.g. blockchain balance fetching) read the list imperatively, so ordering matters.

## Result

- No `/blockchains/*` calls on the login screen (gate-safe; no pre-auth 401s).
- Chains guaranteed loaded before navigation, so no empty-chain race in post-login balance fetching.
- Teardown handled by the existing session-reset path; the chains module no longer depends on auth state.

## Testing

- `use-session-ready.spec.ts`: added an assertion that `refreshSupportedChains` runs **before** `navigateToDashboard`.
- Typecheck, lint-staged, and affected unit specs (32 tests) pass.