### PR TITLE
fix: migrate roboto fonts to fontsource

### DIFF
--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -38,6 +38,8 @@
     "traces": "vue-tsc --build --force --generateTrace traces"
   },
   "dependencies": {
+    "@fontsource/roboto": "catalog:",
+    "@fontsource/roboto-mono": "catalog:",
     "@rotki/common": "workspace:*",
     "@rotki/ui-library": "catalog:",
     "@types/ws": "catalog:",
@@ -64,9 +66,7 @@
     "plainfp": "catalog:",
     "ps-list": "catalog:",
     "qrcode": "catalog:",
-    "roboto-fontface": "catalog:",
     "theme-colors": "catalog:",
-    "typeface-roboto-mono": "catalog:",
     "utf-8-validate": "catalog:",
     "vanilla-jsoneditor": "catalog:",
     "viem": "catalog:",

--- a/frontend/app/src/main.css
+++ b/frontend/app/src/main.css
@@ -1,5 +1,13 @@
-@import 'roboto-fontface/css/roboto/roboto-fontface.css';
-@import 'typeface-roboto-mono/index.css';
+@import '@fontsource/roboto/300.css';
+@import '@fontsource/roboto/400.css';
+@import '@fontsource/roboto/400-italic.css';
+@import '@fontsource/roboto/500.css';
+@import '@fontsource/roboto/600.css';
+@import '@fontsource/roboto/700.css';
+@import '@fontsource/roboto/900.css';
+@import '@fontsource/roboto-mono/400.css';
+@import '@fontsource/roboto-mono/500.css';
+@import '@fontsource/roboto-mono/700.css';
 @import 'flag-icons/css/flag-icons.min.css';
 
 @tailwind base;

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -12,6 +12,12 @@ catalogs:
     '@electron/notarize':
       specifier: 3.1.1
       version: 3.1.1
+    '@fontsource/roboto':
+      specifier: 5.2.10
+      version: 5.2.10
+    '@fontsource/roboto-mono':
+      specifier: 5.2.9
+      version: 5.2.9
     '@intlify/eslint-plugin-vue-i18n':
       specifier: 4.5.1
       version: 4.5.1
@@ -216,9 +222,6 @@ catalogs:
     rimraf:
       specifier: 6.1.3
       version: 6.1.3
-    roboto-fontface:
-      specifier: '*'
-      version: 0.10.0
     semver:
       specifier: 7.8.5
       version: 7.8.5
@@ -243,9 +246,6 @@ catalogs:
     tsx:
       specifier: 4.22.4
       version: 4.22.4
-    typeface-roboto-mono:
-      specifier: 1.1.13
-      version: 1.1.13
     typescript:
       specifier: 6.0.3
       version: 6.0.3
@@ -361,6 +361,12 @@ importers:
 
   app:
     dependencies:
+      '@fontsource/roboto':
+        specifier: 'catalog:'
+        version: 5.2.10
+      '@fontsource/roboto-mono':
+        specifier: 'catalog:'
+        version: 5.2.9
       '@rotki/common':
         specifier: workspace:*
         version: link:../common
@@ -439,15 +445,9 @@ importers:
       qrcode:
         specifier: 'catalog:'
         version: 1.5.4
-      roboto-fontface:
-        specifier: 'catalog:'
-        version: 0.10.0
       theme-colors:
         specifier: 'catalog:'
         version: 0.1.0
-      typeface-roboto-mono:
-        specifier: 'catalog:'
-        version: 1.1.13
       utf-8-validate:
         specifier: 'catalog:'
         version: 6.0.6
@@ -1393,6 +1393,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/roboto-mono@5.2.9':
+    resolution: {integrity: sha512-iIeSyrRGoM15uIWqXslW1K9UFnUYfnCFNrNoWjXE0huO1L+hM0Jst0KNLuRc7P21xPpGL0bZouzYSX0Em9eyWg==}
+
+  '@fontsource/roboto@5.2.10':
+    resolution: {integrity: sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==}
 
   '@fortawesome/fontawesome-common-types@7.2.0':
     resolution: {integrity: sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==}
@@ -5467,9 +5473,6 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
-  roboto-fontface@0.10.0:
-    resolution: {integrity: sha512-OlwfYEgA2RdboZohpldlvJ1xngOins5d7ejqnIBWr9KaMxsnBqotpptRXTyfNRLnFpqzX6sTDt+X+a+6udnU8g==}
-
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5960,9 +5963,6 @@ packages:
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
-
-  typeface-roboto-mono@1.1.13:
-    resolution: {integrity: sha512-pnzDc70b7ywJHin/BUFL7HZX8DyOTBLT2qxlJ92eH1UJOFcENIBXa9IZrxsJX/gEKjbEDKhW5vz/TKRBNk/ufQ==}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -7291,6 +7291,10 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/roboto-mono@5.2.9': {}
+
+  '@fontsource/roboto@5.2.10': {}
 
   '@fortawesome/fontawesome-common-types@7.2.0': {}
 
@@ -11985,8 +11989,6 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
-  roboto-fontface@0.10.0: {}
-
   rolldown@1.0.3:
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -12555,8 +12557,6 @@ snapshots:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
-
-  typeface-roboto-mono@1.1.13: {}
 
   typescript@6.0.3: {}
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -37,6 +37,8 @@ patchedDependencies:
 catalog:
   '@clack/prompts': 1.6.0
   '@electron/notarize': 3.1.1
+  '@fontsource/roboto': 5.2.10
+  '@fontsource/roboto-mono': 5.2.9
   '@intlify/eslint-plugin-vue-i18n': 4.5.1
   '@intlify/unplugin-vue-i18n': 11.2.4
   '@pinia/testing': 1.0.3
@@ -105,7 +107,6 @@ catalog:
   ps-list: 9.0.0
   qrcode: 1.5.4
   rimraf: 6.1.3
-  roboto-fontface: '*'
   semver: 7.8.5
   source-map-support: 0.5.21
   stylelint: 17.13.0
@@ -114,7 +115,6 @@ catalog:
   tailwindcss: 3.4.19
   theme-colors: 0.1.0
   tsx: 4.22.4
-  typeface-roboto-mono: 1.1.13
   typescript: 6.0.3
   unplugin-auto-import: 21.0.0
   unplugin-vue-components: 32.1.0


### PR DESCRIPTION
## Summary

Replaces the deprecated `roboto-fontface` and `typeface-roboto-mono` font packages with the actively maintained `@fontsource/roboto` and `@fontsource/roboto-mono`.

The motivation was dependency pinning: the `roboto-fontface` catalog entry was an unpinned wildcard (`roboto-fontface: '*'`), the only unpinned dependency in the frontend. Rather than pin the stale package, this migrates both Roboto families to Fontsource, which is pinned in the catalog.

## Details

- **Catalog** (`pnpm-workspace.yaml`): drop `roboto-fontface: '*'` and `typeface-roboto-mono: 1.1.13`; add `@fontsource/roboto: 5.2.10` and `@fontsource/roboto-mono: 5.2.9`.
- **`app/package.json`**: swap both deps to the catalog entries.
- **`app/src/main.css`**: replace the two all-in-one bundle imports with per-weight imports covering only the weights actually used across the app and `@rotki/ui-library`:
  - Roboto: 300, 400, 400-italic, 500, 600, 700, 900
  - Roboto Mono: 400, 500, 700
- Unused Thin (100) and the non-functional extra italics are dropped.

Font-family names are unchanged (`Roboto`, `Roboto Mono`), so the base family from `@rotki/ui-library` and the Tailwind `mono` config resolve exactly as before.

## Notes

- With Roboto 600 now available and imported, `font-semibold` renders as a true 600 instead of the previous fallback to 700 (the old package shipped no 600 face). This is the only intentional visual change.

## Testing

- `pnpm install` regenerates the lockfile (Fontsource in, old packages out).
- `pnpm run build` succeeds; the built output emits the expected Roboto/Roboto Mono woff2/woff files and the CSS references the correct families.