### PR TITLE
feat: add data issues inbox

### DIFF
--- a/frontend/app/env.d.ts
+++ b/frontend/app/env.d.ts
@@ -9,4 +9,5 @@ interface ImportMetaEnv {
   readonly VITE_BACKEND_URL: string;
   readonly VITE_COLIBRI_URL: string;
   readonly VITE_ROTKI_WEBSITE_URL: string | undefined;
+  readonly VITE_ACCOUNTING_UPDATE: string | undefined;
 }

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2548,6 +2548,102 @@
     "no_search_result": "Your search for \"{search}\" yielded no results.",
     "select_visible_columns": "Select visible columns"
   },
+  "data_issues": {
+    "action": {
+      "dismiss": {
+        "confirm": {
+          "message": "This hides the issue from the inbox and stops auto-remediation for it. You can still find it by filtering for dismissed issues.",
+          "title": "Dismiss this data issue?"
+        },
+        "error": "Could not dismiss issue",
+        "label": "Dismiss"
+      },
+      "resolve": {
+        "error": "Could not resolve issue",
+        "label": "Resolve manually"
+      },
+      "retry": {
+        "error": "Could not retry auto-remediation",
+        "label": "Retry auto-remediation"
+      }
+    },
+    "description": {
+      "current_balance_mismatch": "rotki's calculated {asset} balance ({derived}) doesn't match the actual on-chain balance ({observed}), a difference of {delta}. Some {asset} transactions are probably missing or were recorded incorrectly.",
+      "negative_balance": "An event spent more {asset} than rotki had tracked, so your balance went negative to {amount} (it was {before} just before). This usually means an earlier {asset} transaction is missing or was recorded incorrectly.",
+      "unknown": "rotki flagged a data issue. Open the details below to see what was recorded."
+    },
+    "detail": {
+      "detected": "Detected",
+      "no_attempts": "No automatic fixes have been attempted yet.",
+      "related_event": "Related history event: #{id}",
+      "remediation_history": "Auto-remediation history",
+      "resolution_note": "Resolution note",
+      "title": "Issue details",
+      "whats_wrong": "What's wrong"
+    },
+    "empty": {
+      "all_clear_subtitle": "Your accounting data looks healthy. rotki checks continuously and will flag anything here.",
+      "all_clear_title": "No data issues detected",
+      "clear_filters": "Clear filters",
+      "filtered": "No issues match these filters.",
+      "none": "No open issues. Everything rotki flagged has been handled."
+    },
+    "fetch": {
+      "error": {
+        "message": "Could not load data issues: {message}",
+        "title": "Data issues"
+      }
+    },
+    "filter": {
+      "account": "Account",
+      "asset": "Asset",
+      "end_date": "End date",
+      "kind": "Kind",
+      "start_date": "Start date",
+      "state": "State"
+    },
+    "headers": {
+      "detected": "Detected",
+      "kind": "Kind",
+      "protocol": "Protocol",
+      "state": "State"
+    },
+    "kind": {
+      "current_balance_mismatch": "Balance mismatch",
+      "negative_balance": "Negative balance"
+    },
+    "panel": {
+      "clear_selection": "Clear selection",
+      "goto_event": "Go to event",
+      "highlighting_event": "Highlighting the selected issue's event",
+      "pin": "Pin to sidebar",
+      "title": "Data issues",
+      "unpin": "Unpin",
+      "view_all": "View all"
+    },
+    "refresh_tooltip": "Reload the issues list.",
+    "resolve_dialog": {
+      "confirm": "Resolve",
+      "note_hint": "Visible later in the issue's resolution details.",
+      "note_label": "Note (optional)",
+      "notice": "Richer guided fixes are coming. Use this only if you've already corrected the underlying data yourself (for example, by adding a missing transaction). This marks the issue as resolved and records your note.",
+      "title": "Resolve manually"
+    },
+    "state": {
+      "auto_remediating": "Auto-remediating",
+      "dismissed": "Dismissed",
+      "open": "Open",
+      "resolved": "Resolved",
+      "unresolved": "Needs attention"
+    },
+    "summary": {
+      "all_clear": "All clear. No issues need your attention."
+    },
+    "toggle": {
+      "tooltip": "Data issues"
+    },
+    "view_details": "View details"
+  },
   "data_management": {
     "purge_data": {
       "confirm": {
@@ -4509,6 +4605,7 @@
     },
     "history": "History",
     "history_sub": {
+      "data_issues": "Data Issues",
       "events": "Events"
     },
     "import_data": "Import Data",

--- a/frontend/app/src/modules/history/data-issues/DataIssuesView.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/DataIssuesView.spec.ts
@@ -1,0 +1,134 @@
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import DataIssuesTable from '@/modules/history/data-issues/components/DataIssuesTable.vue';
+import DataIssuesView from '@/modules/history/data-issues/DataIssuesView.vue';
+import NoDataScreen from '@/modules/shell/components/NoDataScreen.vue';
+
+// Shared, per-test-mutable state backing the mocked composables. Plain values set
+// before each mount; the factories snapshot them into refs when the view mounts.
+interface MockState {
+  baselineTotal: number;
+  filters: Record<string, unknown>;
+  isLoading: boolean;
+  rows: DataIssue[];
+}
+
+const state = vi.hoisted((): MockState => ({
+  baselineTotal: 0,
+  filters: {},
+  isLoading: false,
+  rows: [],
+}));
+
+vi.mock('@/modules/core/table/use-pagination-filter', () => ({
+  usePaginationFilters: (): Record<string, unknown> => ({
+    fetchData: vi.fn().mockResolvedValue(undefined),
+    filters: ref(state.filters),
+    isLoading: ref(state.isLoading),
+    matchers: ref([]),
+    pagination: ref({}),
+    state: ref({ data: state.rows, found: state.rows.length, limit: 10, total: state.rows.length }),
+    updateFilter: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/history/data-issues/use-data-issues', () => ({
+  useDataIssues: (): Record<string, unknown> => ({
+    dismiss: vi.fn(),
+    fetchData: vi.fn(),
+    resolveManually: vi.fn(),
+    retry: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/history/data-issues/use-data-issues-summary', () => ({
+  useDataIssuesSummary: (): Record<string, unknown> => ({
+    actionableCount: ref(0),
+    baselineTotal: ref(state.baselineTotal),
+    counts: ref({}),
+    dismissInlinePanels: vi.fn(),
+    refreshSummary: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+async function createWrapper(): Promise<VueWrapper<InstanceType<typeof DataIssuesView>>> {
+  const wrapper = mount(DataIssuesView, {
+    global: {
+      plugins: [createPinia()],
+      stubs: {
+        DataIssueDetailDrawer: true,
+        DataIssuesTable: true,
+        DataIssueSummaryBar: true,
+        NoDataScreen: true,
+        ResolveManuallyDialog: true,
+        TableFilter: true,
+        TablePageLayout: { template: '<div><slot /></div>' },
+      },
+    },
+    props: {
+      mainPage: true,
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('data-issues view empty states', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    state.baselineTotal = 0;
+    state.filters = {};
+    state.isLoading = false;
+    state.rows = [];
+  });
+
+  it('should show the reassuring all-clear screen when no issues exist at all', async () => {
+    state.baselineTotal = 0;
+    const wrapper = await createWrapper();
+
+    expect(wrapper.findComponent(NoDataScreen).exists()).toBe(true);
+    expect(wrapper.findComponent(DataIssuesTable).exists()).toBe(false);
+  });
+
+  it('should keep the all-clear screen (not flash the table) while an empty inbox is refreshing', async () => {
+    state.baselineTotal = 0;
+    state.isLoading = true;
+    const wrapper = await createWrapper();
+
+    expect(wrapper.findComponent(NoDataScreen).exists()).toBe(true);
+    expect(wrapper.findComponent(DataIssuesTable).exists()).toBe(false);
+  });
+
+  it('should show the table (not the all-clear screen) once any issue exists', async () => {
+    state.baselineTotal = 4;
+    const wrapper = await createWrapper();
+
+    expect(wrapper.findComponent(NoDataScreen).exists()).toBe(false);
+    expect(wrapper.findComponent(DataIssuesTable).exists()).toBe(true);
+  });
+
+  it('should use the "no match" empty copy when filters are active but the list is empty', async () => {
+    state.baselineTotal = 4;
+    state.rows = [];
+    state.filters = { state: ['open'] };
+    const wrapper = await createWrapper();
+
+    const table = wrapper.findComponent(DataIssuesTable);
+    expect(table.props('emptyDescription')).toBe('data_issues.empty.filtered');
+    expect(table.props('showClearFilters')).toBe(true);
+  });
+
+  it('should use the "none" empty copy when there are no active filters', async () => {
+    state.baselineTotal = 4;
+    state.rows = [];
+    state.filters = {};
+    const wrapper = await createWrapper();
+
+    const table = wrapper.findComponent(DataIssuesTable);
+    expect(table.props('emptyDescription')).toBe('data_issues.empty.none');
+    expect(table.props('showClearFilters')).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/DataIssuesView.vue
+++ b/frontend/app/src/modules/history/data-issues/DataIssuesView.vue
@@ -1,0 +1,254 @@
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router';
+import type { DataIssue, DataIssuesRequestPayload } from '@/modules/history/data-issues/schemas';
+import { startPromise } from '@shared/utils';
+import TableFilter from '@/modules/core/table/TableFilter.vue';
+import { usePaginationFilters } from '@/modules/core/table/use-pagination-filter';
+import DataIssueDetailDrawer from '@/modules/history/data-issues/components/DataIssueDetailDrawer.vue';
+import DataIssuesTable from '@/modules/history/data-issues/components/DataIssuesTable.vue';
+import DataIssueSummaryBar from '@/modules/history/data-issues/components/DataIssueSummaryBar.vue';
+import ResolveManuallyDialog from '@/modules/history/data-issues/components/ResolveManuallyDialog.vue';
+import { DEFAULT_LIST_STATES, IssueState } from '@/modules/history/data-issues/constants';
+import { useDataIssueDetailActions } from '@/modules/history/data-issues/use-data-issue-detail-actions';
+import { useDataIssues } from '@/modules/history/data-issues/use-data-issues';
+import { type Filters, type Matcher, useDataIssuesFilter } from '@/modules/history/data-issues/use-data-issues-filter';
+import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
+import NoDataScreen from '@/modules/shell/components/NoDataScreen.vue';
+import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
+import { useSyncCompleted } from '@/modules/shell/sync-progress/use-sync-completed';
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+const { mainPage = false } = defineProps<{
+  mainPage?: boolean;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+const router = useRouter();
+
+const { fetchData } = useDataIssues();
+const { baselineTotal, counts, dismissInlinePanels, refreshSummary } = useDataIssuesSummary();
+const { syncCompleted } = useSyncCompleted();
+
+const {
+  fetchData: refresh,
+  filters,
+  isLoading,
+  matchers,
+  pagination,
+  state,
+  updateFilter,
+} = usePaginationFilters<DataIssue, DataIssuesRequestPayload, Filters, Matcher>(fetchData, {
+  defaultParams: computed(() => ({ state: [...DEFAULT_LIST_STATES] })),
+  filterSchema: useDataIssuesFilter,
+  history: mainPage ? 'router' : false,
+});
+
+// Tracks whether the first load has finished. The all-clear screen keys off this
+// (plus `hasAnyIssues`) instead of the list's transient `isLoading`, so a refresh
+// on an empty inbox does not briefly flash the table between loading states.
+const loadedOnce = ref<boolean>(false);
+
+async function reloadAll(): Promise<void> {
+  try {
+    await Promise.all([refresh(), refreshSummary()]);
+  }
+  finally {
+    set(loadedOnce, true);
+  }
+}
+
+const {
+  modelActionBusy,
+  modelDrawerOpen,
+  modelResolveOpen,
+  modelSelectedIssue,
+  onDismiss,
+  onResolveConfirm,
+  onResolveRequest,
+  onRetry,
+  openDetail,
+} = useDataIssueDetailActions(reloadAll);
+
+const activeStates = computed<string[]>(() => {
+  const value = get(filters).state;
+  if (Array.isArray(value))
+    return value.map(state => state.toString());
+  return value ? [value.toString()] : [];
+});
+
+const hasAnyIssues = computed<boolean>(() => get(baselineTotal) > 0);
+const hasActiveFilters = computed<boolean>(() => Object.keys(get(filters)).length > 0);
+const isEmpty = computed<boolean>(() => get(state).data.length === 0);
+
+const emptyDescription = computed<string>(() =>
+  get(hasActiveFilters)
+    ? t('data_issues.empty.filtered')
+    : t('data_issues.empty.none'),
+);
+
+const hasRemediatingRows = computed<boolean>(() =>
+  get(state).data.some(issue => issue.state === IssueState.AUTO_REMEDIATING),
+);
+
+// Show the loading indicator immediately, but keep it up for a minimum time so a
+// fetch that finishes almost instantly (or the 10s auto-remediation poll) does not
+// make the spinner flicker on and straight back off.
+const MIN_LOADING_MS = 500;
+const showLoading = ref<boolean>(false);
+const canHide = ref<boolean>(true);
+const { start: startMinLoading } = useTimeoutFn(() => {
+  set(canHide, true);
+  if (!get(isLoading))
+    set(showLoading, false);
+}, MIN_LOADING_MS, { immediate: false });
+
+watch(isLoading, (loading) => {
+  if (loading) {
+    set(showLoading, true);
+    set(canHide, false);
+    startMinLoading();
+  }
+  else if (get(canHide)) {
+    set(showLoading, false);
+  }
+  // else: finished within the minimum window, so the timer clears it.
+});
+
+function selectState(issueState: IssueState): void {
+  updateFilter({ ...get(filters), state: [issueState] });
+}
+
+function clearFilters(): void {
+  updateFilter({});
+}
+
+async function goToEvent(route: RouteLocationRaw): Promise<void> {
+  await router.push(route);
+}
+
+// Resolving reads the selected issue (the resolve dialog is shared), so a row-level
+// resolve selects the issue first, then opens the dialog.
+function onResolveFromRow(issue: DataIssue): void {
+  set(modelSelectedIssue, issue);
+  onResolveRequest();
+}
+
+const { pause, resume } = useIntervalFn(reloadAll, 10_000, { immediate: false });
+
+watch(hasRemediatingRows, (remediating) => {
+  if (remediating)
+    resume();
+  else
+    pause();
+});
+
+// Reload when the history sync finishes so the table and its all-clear shield reflect
+// the freshly detected issues without waiting for the slow poll or a manual refresh.
+watch(syncCompleted, () => {
+  startPromise(reloadAll());
+});
+
+onMounted(async () => {
+  // The dedicated page supersedes the overlay/pinned copies of the inbox; close
+  // them so the same list is not shown twice.
+  if (mainPage)
+    dismissInlinePanels();
+  await reloadAll();
+});
+</script>
+
+<template>
+  <TablePageLayout
+    :hide-header="!mainPage"
+    :child="!mainPage"
+    :title="[t('navigation_menu.history'), t('navigation_menu.history_sub.data_issues')]"
+    v-bind="$attrs"
+  >
+    <template #buttons>
+      <RuiTooltip :open-delay="400">
+        <template #activator>
+          <RuiButton
+            variant="outlined"
+            color="primary"
+            :loading="showLoading"
+            data-testid="data-issues-refresh"
+            @click="reloadAll()"
+          >
+            <template #prepend>
+              <RuiIcon name="lu-refresh-ccw" />
+            </template>
+            {{ t('common.refresh') }}
+          </RuiButton>
+        </template>
+        {{ t('data_issues.refresh_tooltip') }}
+      </RuiTooltip>
+    </template>
+
+    <NoDataScreen
+      v-if="loadedOnce && !hasAnyIssues"
+      full
+      variant="success"
+      icon="lu-shield-check"
+      data-testid="data-issues-all-clear"
+    >
+      <template #title>
+        {{ t('data_issues.empty.all_clear_title') }}
+      </template>
+      {{ t('data_issues.empty.all_clear_subtitle') }}
+    </NoDataScreen>
+
+    <div
+      v-else
+      class="flex flex-col gap-4"
+    >
+      <DataIssueSummaryBar
+        :counts="counts"
+        :active-states="activeStates"
+        @select="selectState($event)"
+      />
+
+      <RuiCard>
+        <div class="flex justify-end mb-4">
+          <div class="w-full sm:max-w-[30rem]">
+            <TableFilter
+              v-model:matches="filters"
+              :matchers="matchers"
+            />
+          </div>
+        </div>
+
+        <DataIssuesTable
+          v-model:pagination="pagination"
+          :rows="state.data"
+          :loading="showLoading"
+          :empty-description="emptyDescription"
+          :show-clear-filters="isEmpty && hasActiveFilters"
+          @open="openDetail($event)"
+          @goto="goToEvent($event)"
+          @dismiss="onDismiss($event.id)"
+          @retry="onRetry($event.id)"
+          @resolve="onResolveFromRow($event)"
+          @clear-filters="clearFilters()"
+        />
+      </RuiCard>
+    </div>
+
+    <DataIssueDetailDrawer
+      v-model="modelDrawerOpen"
+      :issue="modelSelectedIssue"
+      :busy="modelActionBusy"
+      @dismiss="onDismiss($event)"
+      @retry="onRetry($event)"
+      @resolve="onResolveRequest()"
+    />
+
+    <ResolveManuallyDialog
+      v-model="modelResolveOpen"
+      :loading="modelActionBusy"
+      @confirm="onResolveConfirm($event)"
+    />
+  </TablePageLayout>
+</template>

--- a/frontend/app/src/modules/history/data-issues/api/use-data-issues-api.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/api/use-data-issues-api.spec.ts
@@ -1,0 +1,68 @@
+import { server } from '@test/setup-files/server';
+import { http, HttpResponse } from 'msw';
+import { assert, describe, expect, it } from 'vitest';
+import { useDataIssuesApi } from '@/modules/history/data-issues/api/use-data-issues-api';
+
+const backendUrl = process.env.VITE_BACKEND_URL;
+const LIST_URL = `${backendUrl}/api/1/data_issues`;
+const DISMISS_URL = `${backendUrl}/api/1/data_issues/1/dismiss`;
+
+function listPayload(): { limit: number; offset: number } {
+  return { limit: 10, offset: 0 };
+}
+
+describe('useDataIssuesApi error classification', () => {
+  it('should classify a 404 as not-found', async () => {
+    server.use(http.get(LIST_URL, () => HttpResponse.json({ message: 'gone', result: null }, { status: 404 })));
+
+    const result = await useDataIssuesApi().listIssues(listPayload());
+
+    assert(!result.ok);
+    expect(result.error.type).toBe('not-found');
+  });
+
+  it('should classify a 400 as validation', async () => {
+    server.use(http.get(LIST_URL, () => HttpResponse.json({ message: 'bad request', result: null }, { status: 400 })));
+
+    const result = await useDataIssuesApi().listIssues(listPayload());
+
+    assert(!result.ok);
+    expect(result.error.type).toBe('validation');
+  });
+
+  it('should classify a 409 invalid transition as conflict', async () => {
+    server.use(http.get(LIST_URL, () => HttpResponse.json({ message: 'invalid transition', result: null }, { status: 409 })));
+
+    const result = await useDataIssuesApi().listIssues(listPayload());
+
+    assert(!result.ok);
+    expect(result.error.type).toBe('conflict');
+  });
+
+  it('should carry the backend message through to the error', async () => {
+    server.use(http.get(LIST_URL, () => HttpResponse.json({ message: 'gone', result: null }, { status: 404 })));
+
+    const result = await useDataIssuesApi().listIssues(listPayload());
+
+    assert(!result.ok);
+    expect(result.error.message).toContain('gone');
+  });
+
+  it('should classify a 409 invalid transition on a write action as conflict', async () => {
+    server.use(http.patch(DISMISS_URL, () => HttpResponse.json({ message: 'already resolved', result: null }, { status: 409 })));
+
+    const result = await useDataIssuesApi().dismissIssue(1);
+
+    assert(!result.ok);
+    expect(result.error.type).toBe('conflict');
+  });
+
+  it('should classify a 500 server error as network', async () => {
+    server.use(http.get(LIST_URL, () => HttpResponse.json({ message: 'boom', result: null }, { status: 500 })));
+
+    const result = await useDataIssuesApi().listIssues(listPayload());
+
+    assert(!result.ok);
+    expect(result.error.type).toBe('network');
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/api/use-data-issues-api.ts
+++ b/frontend/app/src/modules/history/data-issues/api/use-data-issues-api.ts
@@ -1,0 +1,98 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { DataIssueError } from '@/modules/history/data-issues/types';
+import { omit } from 'es-toolkit';
+import { FetchError } from 'ofetch';
+import { fromAsync, type ResultAsync } from 'plainfp/result-async';
+import { api } from '@/modules/core/api/rotki-api';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+import { HTTPStatus } from '@/modules/core/api/types/http';
+import { mapCollectionResponse } from '@/modules/core/common/data/collection-utils';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { type DataIssue, DataIssue as DataIssueSchema, DataIssuesCollectionResponse, type DataIssuesRequestPayload } from '@/modules/history/data-issues/schemas';
+
+const BASE = '/data_issues';
+
+// Keep 200 and 400 as "valid" statuses so a 400 still unwraps through the shared
+// wrapper into an ApiValidationError that carries the backend's structured
+// validation payload. 409 is deliberately excluded so it surfaces as a FetchError
+// with `status` (the wrapper would otherwise swallow it into a plain, status-less
+// Error), letting toDataIssueError tell a conflict apart from a network failure.
+const VALID_STATUSES = { validStatuses: [HTTPStatus.OK, HTTPStatus.BAD_REQUEST] } as const;
+
+/**
+ * Classifies a thrown API error into the typed {@link DataIssueError} domain.
+ *
+ * With {@link VALID_STATUSES}, a 400 arrives as an {@link ApiValidationError}
+ * (wrapping the backend validation data) and every other rejected status as a
+ * {@link FetchError} with `status`: 404 -> not-found, 409 (invalid state
+ * transition) -> conflict, 400 -> validation, anything else -> network.
+ */
+function toDataIssueError(cause: unknown): DataIssueError {
+  const message = getErrorMessage(cause);
+  if (cause instanceof FetchError && cause.status === 404)
+    return { message, type: 'not-found' };
+  if (cause instanceof FetchError && cause.status === 409)
+    return { message, type: 'conflict' };
+  // 400 validation errors arrive as ApiValidationError wrapping the backend's field data.
+  if (cause instanceof ApiValidationError || (cause instanceof FetchError && cause.status === 400))
+    return { message, type: 'validation' };
+  return { message, type: 'network' };
+}
+
+interface UseDataIssuesApiReturn {
+  listIssues: (payload: DataIssuesRequestPayload) => ResultAsync<Collection<DataIssue>, DataIssueError>;
+  getIssue: (id: number) => ResultAsync<DataIssue, DataIssueError>;
+  dismissIssue: (id: number) => ResultAsync<DataIssue, DataIssueError>;
+  resolveIssueManually: (id: number, note?: string) => ResultAsync<DataIssue, DataIssueError>;
+  retryAutoRemediation: (id: number) => ResultAsync<DataIssue, DataIssueError>;
+}
+
+export function useDataIssuesApi(): UseDataIssuesApiReturn {
+  const listIssues = async (
+    payload: DataIssuesRequestPayload,
+  ): ResultAsync<Collection<DataIssue>, DataIssueError> =>
+    fromAsync(async () => {
+      // The `/data_issues` endpoint orders rows server-side (ts_start desc) and
+      // its schema does not accept ordering params; strip the sort keys the shared
+      // pagination composable injects so the backend doesn't reject the request.
+      const query = omit(payload, ['orderByAttributes', 'ascending']);
+      const response = await api.get<unknown>(BASE, {
+        ...VALID_STATUSES,
+        filterEmptyProperties: { removeEmptyString: true },
+        query,
+      });
+      return mapCollectionResponse(DataIssuesCollectionResponse.parse(response));
+    }, toDataIssueError);
+
+  const getIssue = async (id: number): ResultAsync<DataIssue, DataIssueError> =>
+    fromAsync(async () => {
+      const response = await api.get<unknown>(`${BASE}/${id}`, VALID_STATUSES);
+      return DataIssueSchema.parse(response);
+    }, toDataIssueError);
+
+  const dismissIssue = async (id: number): ResultAsync<DataIssue, DataIssueError> =>
+    fromAsync(async () => {
+      const response = await api.patch<unknown>(`${BASE}/${id}/dismiss`, null, VALID_STATUSES);
+      return DataIssueSchema.parse(response);
+    }, toDataIssueError);
+
+  const resolveIssueManually = async (id: number, note?: string): ResultAsync<DataIssue, DataIssueError> =>
+    fromAsync(async () => {
+      const response = await api.patch<unknown>(`${BASE}/${id}/resolve_manually`, note ? { note } : null, VALID_STATUSES);
+      return DataIssueSchema.parse(response);
+    }, toDataIssueError);
+
+  const retryAutoRemediation = async (id: number): ResultAsync<DataIssue, DataIssueError> =>
+    fromAsync(async () => {
+      const response = await api.post<unknown>(`${BASE}/${id}/retry_auto_remediation`, null, VALID_STATUSES);
+      return DataIssueSchema.parse(response);
+    }, toDataIssueError);
+
+  return {
+    dismissIssue,
+    getIssue,
+    listIssues,
+    resolveIssueManually,
+    retryAutoRemediation,
+  };
+}

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueCardActions.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueCardActions.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router';
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import { canDismiss, canResolveManually, canRetry } from '@/modules/history/data-issues/constants';
+
+const { issue, eventRoute } = defineProps<{
+  issue: DataIssue;
+  eventRoute?: RouteLocationRaw;
+}>();
+
+const emit = defineEmits<{
+  goto: [route: RouteLocationRaw];
+  dismiss: [issue: DataIssue];
+  retry: [issue: DataIssue];
+  resolve: [issue: DataIssue];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+function onGoto(): void {
+  if (eventRoute)
+    emit('goto', eventRoute);
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-0.5">
+    <RuiTooltip
+      v-if="eventRoute"
+      :open-delay="300"
+    >
+      <template #activator>
+        <RuiButton
+          variant="text"
+          icon
+          size="sm"
+          :aria-label="t('data_issues.panel.goto_event')"
+          data-testid="data-issues-panel-goto-event"
+          @click.stop="onGoto()"
+        >
+          <RuiIcon
+            name="lu-arrow-up-right"
+            size="16"
+          />
+        </RuiButton>
+      </template>
+      {{ t('data_issues.panel.goto_event') }}
+    </RuiTooltip>
+    <RuiTooltip
+      v-if="canDismiss(issue.state)"
+      :open-delay="300"
+    >
+      <template #activator>
+        <RuiButton
+          variant="text"
+          icon
+          size="sm"
+          :aria-label="t('data_issues.action.dismiss.label')"
+          data-testid="data-issues-panel-dismiss"
+          @click.stop="emit('dismiss', issue)"
+        >
+          <RuiIcon
+            name="lu-archive"
+            size="16"
+          />
+        </RuiButton>
+      </template>
+      {{ t('data_issues.action.dismiss.label') }}
+    </RuiTooltip>
+    <RuiTooltip
+      v-if="canRetry(issue.state)"
+      :open-delay="300"
+    >
+      <template #activator>
+        <RuiButton
+          variant="text"
+          icon
+          size="sm"
+          :aria-label="t('data_issues.action.retry.label')"
+          data-testid="data-issues-panel-retry"
+          @click.stop="emit('retry', issue)"
+        >
+          <RuiIcon
+            name="lu-refresh-ccw"
+            size="16"
+          />
+        </RuiButton>
+      </template>
+      {{ t('data_issues.action.retry.label') }}
+    </RuiTooltip>
+    <RuiTooltip
+      v-if="canResolveManually(issue.state)"
+      :open-delay="300"
+    >
+      <template #activator>
+        <RuiButton
+          variant="text"
+          icon
+          size="sm"
+          color="primary"
+          :aria-label="t('data_issues.action.resolve.label')"
+          data-testid="data-issues-panel-resolve"
+          @click.stop="emit('resolve', issue)"
+        >
+          <RuiIcon
+            name="lu-check"
+            size="16"
+          />
+        </RuiButton>
+      </template>
+      {{ t('data_issues.action.resolve.label') }}
+    </RuiTooltip>
+  </div>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueDescription.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueDescription.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import type { BigNumber } from '@rotki/common';
+import type { FormatOptions } from '@/modules/assets/amount-display/types';
+import type { IssueDescription } from '@/modules/history/data-issues/types';
+import { ValueDisplay } from '@/modules/assets/amount-display/components';
+import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
+
+const { description, tag = 'span' } = defineProps<{
+  description: IssueDescription;
+  tag?: string;
+}>();
+
+const { useAssetField } = useAssetInfoRetrieval();
+
+// Resolve the asset identifier to its symbol so the sentence reads with a short
+// symbol (e.g. "USDC") instead of the raw `eip155:...` identifier. Falls back to
+// the identifier only when the asset cannot be resolved at all.
+const symbol = useAssetField(() => description.asset, 'symbol');
+const name = useAssetField(() => description.asset, 'name');
+
+// The sentence shows the symbol only; the hover title carries the fuller identity:
+// "Symbol (Name)" then the raw identifier on the next line. Native title so it stays
+// zero-cost across a list of cards.
+const assetTitle = computed<string>(() => {
+  const assetSymbol = get(symbol) || description.asset || '';
+  const assetName = get(name);
+  const header = assetName && assetName !== assetSymbol ? `${assetSymbol} (${assetName})` : assetSymbol;
+  return description.asset && description.asset !== header ? `${header}\n${description.asset}` : header;
+});
+
+// Render the exact amount (its own decimal count) so tiny values show in full
+// rather than the rounded "< 0.001" form, which reads awkwardly in the sentence.
+function exact(amount: BigNumber): FormatOptions {
+  return { decimals: amount.decimalPlaces() ?? undefined };
+}
+</script>
+
+<template>
+  <i18n-t
+    :keypath="description.messageKey"
+    :tag="tag"
+    scope="global"
+  >
+    <template #asset>
+      <span
+        class="font-medium cursor-help underline decoration-dotted decoration-rui-text-disabled underline-offset-2"
+        :title="assetTitle"
+      >
+        {{ symbol || description.asset }}
+      </span>
+    </template>
+    <template #amount>
+      <ValueDisplay
+        v-if="description.amounts.amount"
+        :value="description.amounts.amount"
+        :format="exact(description.amounts.amount)"
+        class="font-medium"
+      />
+    </template>
+    <template #before>
+      <ValueDisplay
+        v-if="description.amounts.before"
+        :value="description.amounts.before"
+        :format="exact(description.amounts.before)"
+        class="font-medium"
+      />
+    </template>
+    <template #derived>
+      <ValueDisplay
+        v-if="description.amounts.derived"
+        :value="description.amounts.derived"
+        :format="exact(description.amounts.derived)"
+        class="font-medium"
+      />
+    </template>
+    <template #observed>
+      <ValueDisplay
+        v-if="description.amounts.observed"
+        :value="description.amounts.observed"
+        :format="exact(description.amounts.observed)"
+        class="font-medium"
+      />
+    </template>
+    <template #delta>
+      <ValueDisplay
+        v-if="description.amounts.delta"
+        :value="description.amounts.delta"
+        :format="exact(description.amounts.delta)"
+        class="font-medium"
+      />
+    </template>
+  </i18n-t>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueDetailDrawer.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueDetailDrawer.spec.ts
@@ -1,0 +1,139 @@
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, type VNode } from 'vue';
+import DataIssueDetailDrawer from '@/modules/history/data-issues/components/DataIssueDetailDrawer.vue';
+import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const push = vi.fn();
+
+// Override the global vue-router mock with a stable `push` spy so the navigation
+// away from a related event can be asserted.
+vi.mock('vue-router', () => ({
+  useRouter: (): Record<string, unknown> => ({ push }),
+}));
+
+// Render the drawer's default slot inline so its content lands in the wrapper DOM
+// instead of a teleport target.
+const DrawerStub = defineComponent({
+  props: { modelValue: { default: false, type: Boolean } },
+  setup(_, { slots }): () => VNode {
+    return () => h('div', slots.default?.());
+  },
+});
+
+function createIssue(overrides: Partial<DataIssue> = {}): DataIssue {
+  return {
+    asset: 'ETH',
+    autoRemediationAttempts: [],
+    createdAt: 1710000100,
+    groupIdentifier: 'grp-1',
+    id: 1,
+    kind: IssueKind.NEGATIVE_BALANCE,
+    location: 'ethereum',
+    locationLabel: '0x0000000000000000000000000000000000000001',
+    payload: {
+      derivedBalanceBeforeEvent: '5',
+      eventIdentifier: 123,
+      inMemoryNegativeAmount: '-2',
+    },
+    protocol: null,
+    resolvedAt: null,
+    severity: IssueSeverity.WARNING,
+    state: IssueState.OPEN,
+    tsEnd: 1710000000,
+    tsStart: 1710000000,
+    ...overrides,
+  };
+}
+
+function createWrapper(issue?: DataIssue): VueWrapper<InstanceType<typeof DataIssueDetailDrawer>> {
+  return mount(DataIssueDetailDrawer, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        AssetDetails: true,
+        CounterpartyDisplay: true,
+        DataIssueDescription: true,
+        DataIssueDetectedTime: true,
+        DataIssueKindChip: true,
+        DataIssueRemediationTimeline: true,
+        DataIssueStateChip: true,
+        HistoryEventAccount: true,
+        LocationDisplay: true,
+        RuiNavigationDrawer: DrawerStub,
+      },
+    },
+    props: {
+      issue,
+      modelValue: true,
+    },
+  });
+}
+
+describe('dataIssueDetailDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render a related-event link for an issue that carries an event identifier', () => {
+    const wrapper = createWrapper(createIssue());
+
+    expect(wrapper.find('[data-testid="data-issue-related-event"]').exists()).toBe(true);
+  });
+
+  it('should not render a related-event link when the payload has no event identifier', () => {
+    const wrapper = createWrapper(createIssue({ kind: IssueKind.CURRENT_BALANCE_MISMATCH, payload: {} }));
+
+    expect(wrapper.find('[data-testid="data-issue-related-event"]').exists()).toBe(false);
+  });
+
+  it('should close the drawer and navigate to the related event on click', async () => {
+    const wrapper = createWrapper(createIssue());
+
+    await wrapper.find('[data-testid="data-issue-related-event"]').trigger('click');
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toStrictEqual([false]);
+    expect(push).toHaveBeenCalledWith(expect.objectContaining({
+      query: expect.objectContaining({
+        highlightedNegativeBalanceEvent: '123',
+        targetGroupIdentifier: 'grp-1',
+      }),
+    }));
+  });
+
+  it('should show the resolution note when the payload carries a string note', () => {
+    const wrapper = createWrapper(createIssue({
+      payload: { resolution: { note: 'fixed by hand' } },
+      state: IssueState.RESOLVED,
+    }));
+
+    expect(wrapper.text()).toContain('fixed by hand');
+  });
+
+  it('should ignore a non-string resolution note', () => {
+    const wrapper = createWrapper(createIssue({
+      payload: { resolution: { note: 42 } },
+      state: IssueState.RESOLVED,
+    }));
+
+    expect(wrapper.text()).not.toContain('data_issues.detail.resolution_note');
+  });
+
+  it('should not render a resolution note section when there is no resolution', () => {
+    const wrapper = createWrapper(createIssue({ payload: {}, state: IssueState.OPEN }));
+
+    expect(wrapper.text()).not.toContain('data_issues.detail.resolution_note');
+  });
+
+  it('should emit the action events with the issue id from the footer buttons', async () => {
+    const wrapper = createWrapper(createIssue({ id: 8 }));
+
+    await wrapper.find('[data-testid="data-issue-detail-dismiss"]').trigger('click');
+    await wrapper.find('[data-testid="data-issue-detail-resolve"]').trigger('click');
+
+    expect(wrapper.emitted('dismiss')?.[0]).toStrictEqual([8]);
+    expect(wrapper.emitted('resolve')?.[0]).toStrictEqual([8]);
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueDetailDrawer.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueDetailDrawer.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router';
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import AssetDetails from '@/modules/assets/AssetDetails.vue';
+import DataIssueDescription from '@/modules/history/data-issues/components/DataIssueDescription.vue';
+import DataIssueDetectedTime from '@/modules/history/data-issues/components/DataIssueDetectedTime.vue';
+import DataIssueKindChip from '@/modules/history/data-issues/components/DataIssueKindChip.vue';
+import DataIssueRemediationTimeline from '@/modules/history/data-issues/components/DataIssueRemediationTimeline.vue';
+import DataIssueStateChip from '@/modules/history/data-issues/components/DataIssueStateChip.vue';
+import { canDismiss, canResolveManually, canRetry } from '@/modules/history/data-issues/constants';
+import { describeIssue, relatedEventRoute, toTimelineItems } from '@/modules/history/data-issues/transforms';
+import HistoryEventAccount from '@/modules/history/events/HistoryEventAccount.vue';
+import LocationDisplay from '@/modules/history/LocationDisplay.vue';
+import CounterpartyDisplay from '@/modules/shell/components/display/CounterpartyDisplay.vue';
+
+const open = defineModel<boolean>({ required: true });
+
+const { issue, busy = false } = defineProps<{
+  issue?: DataIssue;
+  busy?: boolean;
+}>();
+
+const emit = defineEmits<{
+  dismiss: [id: number];
+  retry: [id: number];
+  resolve: [id: number];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+const router = useRouter();
+
+const description = computed(() => issue ? describeIssue(issue) : undefined);
+
+/** Deep-link to the offending history event (shared with the inbox panel). */
+const relatedEventLink = computed<RouteLocationRaw | undefined>(() =>
+  issue ? relatedEventRoute(issue.kind, get(description)?.eventIdentifier, issue.groupIdentifier, issue.asset) : undefined);
+
+async function goToRelatedEvent(): Promise<void> {
+  const link = get(relatedEventLink);
+  if (!link)
+    return;
+  set(open, false);
+  await router.push(link);
+}
+
+const timeline = computed(() => (issue ? toTimelineItems(issue) : []));
+
+const resolutionNote = computed<string | undefined>(() => {
+  const resolution = issue?.payload?.resolution;
+  if (resolution && typeof resolution === 'object' && 'note' in resolution) {
+    const note = resolution.note;
+    return typeof note === 'string' ? note : undefined;
+  }
+  return undefined;
+});
+</script>
+
+<template>
+  <RuiNavigationDrawer
+    v-model="open"
+    width="570px"
+    temporary
+    position="right"
+    class="flex flex-col"
+    content-class="flex flex-col"
+    data-testid="data-issue-detail-drawer"
+  >
+    <div
+      v-if="issue"
+      class="flex flex-col h-full"
+    >
+      <div class="flex items-start justify-between gap-2 p-4 border-b border-default">
+        <div class="flex flex-col gap-2">
+          <h5 class="text-h6">
+            {{ t('data_issues.detail.title') }}
+          </h5>
+          <div class="flex items-center gap-2 flex-wrap">
+            <DataIssueKindChip :kind="issue.kind" />
+            <DataIssueStateChip :state="issue.state" />
+          </div>
+        </div>
+        <RuiButton
+          variant="text"
+          icon
+          size="sm"
+          @click="open = false"
+        >
+          <RuiIcon name="lu-x" />
+        </RuiButton>
+      </div>
+
+      <div class="flex flex-col gap-6 p-4 overflow-y-auto grow">
+        <section>
+          <div class="text-overline text-rui-text-secondary mb-1">
+            {{ t('data_issues.detail.whats_wrong') }}
+          </div>
+          <DataIssueDescription
+            v-if="description"
+            :description="description"
+            tag="p"
+            class="text-body-1"
+          />
+          <RuiButton
+            v-if="description?.eventIdentifier !== undefined && relatedEventLink"
+            variant="text"
+            color="primary"
+            size="sm"
+            class="mt-1 !px-0"
+            data-testid="data-issue-related-event"
+            @click="goToRelatedEvent()"
+          >
+            <template #append>
+              <RuiIcon
+                name="lu-arrow-up-right"
+                size="16"
+              />
+            </template>
+            {{ t('data_issues.detail.related_event', { id: description.eventIdentifier }) }}
+          </RuiButton>
+        </section>
+
+        <section class="grid grid-cols-2 gap-x-4 gap-y-5">
+          <div class="flex flex-col gap-1">
+            <div class="text-overline text-rui-text-secondary">
+              {{ t('common.account') }}
+            </div>
+            <div class="flex items-center grow min-h-8">
+              <HistoryEventAccount
+                v-if="issue.locationLabel"
+                :location="issue.location"
+                :location-label="issue.locationLabel"
+              />
+              <span
+                v-else
+                class="text-body-2 text-rui-text-secondary"
+              >
+                -
+              </span>
+            </div>
+          </div>
+          <div class="flex flex-col gap-1">
+            <div class="text-overline text-rui-text-secondary">
+              {{ t('common.location') }}
+            </div>
+            <div class="flex items-center grow min-h-8">
+              <LocationDisplay
+                :identifier="issue.location"
+                horizontal
+                class="w-fit"
+              />
+            </div>
+          </div>
+          <div
+            v-if="issue.asset"
+            class="flex flex-col gap-1"
+          >
+            <div class="text-overline text-rui-text-secondary">
+              {{ t('common.asset') }}
+            </div>
+            <div class="flex items-center grow min-h-8">
+              <AssetDetails :asset="issue.asset" />
+            </div>
+          </div>
+          <div
+            v-if="issue.protocol"
+            class="flex flex-col gap-1"
+          >
+            <div class="text-overline text-rui-text-secondary">
+              {{ t('common.protocol') }}
+            </div>
+            <div class="flex items-center grow min-h-8">
+              <CounterpartyDisplay :counterparty="issue.protocol" />
+            </div>
+          </div>
+          <div class="flex flex-col gap-1">
+            <div class="text-overline text-rui-text-secondary">
+              {{ t('data_issues.detail.detected') }}
+            </div>
+            <div class="flex items-center grow min-h-8">
+              <DataIssueDetectedTime :timestamp="issue.createdAt" />
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div class="text-overline text-rui-text-secondary mb-2">
+            {{ t('data_issues.detail.remediation_history') }}
+          </div>
+          <DataIssueRemediationTimeline :items="timeline" />
+        </section>
+
+        <section v-if="resolutionNote">
+          <div class="text-overline text-rui-text-secondary mb-1">
+            {{ t('data_issues.detail.resolution_note') }}
+          </div>
+          <p class="text-body-2">
+            {{ resolutionNote }}
+          </p>
+        </section>
+      </div>
+
+      <div class="flex items-center justify-end gap-2 p-4 border-t border-default">
+        <RuiButton
+          variant="outlined"
+          :disabled="busy || !canDismiss(issue.state)"
+          data-testid="data-issue-detail-dismiss"
+          @click="emit('dismiss', issue.id)"
+        >
+          {{ t('data_issues.action.dismiss.label') }}
+        </RuiButton>
+        <RuiButton
+          variant="outlined"
+          color="primary"
+          :disabled="busy || !canRetry(issue.state)"
+          data-testid="data-issue-detail-retry"
+          @click="emit('retry', issue.id)"
+        >
+          {{ t('data_issues.action.retry.label') }}
+        </RuiButton>
+        <RuiButton
+          color="primary"
+          :disabled="busy || !canResolveManually(issue.state)"
+          data-testid="data-issue-detail-resolve"
+          @click="emit('resolve', issue.id)"
+        >
+          {{ t('data_issues.action.resolve.label') }}
+        </RuiButton>
+      </div>
+    </div>
+  </RuiNavigationDrawer>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueDetectedTime.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueDetectedTime.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
+
+const { timestamp } = defineProps<{
+  timestamp: number;
+}>();
+
+// rotki timestamps are in seconds; useTimeAgo expects milliseconds. The exact
+// date stays available on hover so the relative label never hides the real time.
+const timeAgo = useTimeAgo(() => timestamp * 1000);
+</script>
+
+<template>
+  <RuiTooltip :open-delay="300">
+    <template #activator>
+      <span class="whitespace-nowrap">{{ timeAgo }}</span>
+    </template>
+    <DateDisplay :timestamp="timestamp" />
+  </RuiTooltip>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueKindChip.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueKindChip.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { type IssueKind, KIND_META } from '@/modules/history/data-issues/constants';
+import { useDataIssuesFormat } from '@/modules/history/data-issues/use-data-issues-format';
+
+const { kind } = defineProps<{
+  kind: IssueKind;
+}>();
+
+const { kindLabel } = useDataIssuesFormat();
+
+const meta = computed(() => KIND_META[kind]);
+</script>
+
+<template>
+  <RuiChip
+    size="sm"
+    variant="outlined"
+    :color="meta.color"
+    data-testid="data-issue-kind-chip"
+  >
+    <div class="flex items-center gap-1.5">
+      <RuiIcon
+        :name="meta.icon"
+        size="14"
+      />
+      <span>{{ kindLabel(kind) }}</span>
+    </div>
+  </RuiChip>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuePanelCard.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuePanelCard.vue
@@ -1,0 +1,164 @@
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router';
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import type { IssueDescription } from '@/modules/history/data-issues/types';
+import { toHumanReadable } from '@rotki/common';
+import DataIssueCardActions from '@/modules/history/data-issues/components/DataIssueCardActions.vue';
+import DataIssueDescription from '@/modules/history/data-issues/components/DataIssueDescription.vue';
+import DataIssueDetectedTime from '@/modules/history/data-issues/components/DataIssueDetectedTime.vue';
+import DataIssueKindChip from '@/modules/history/data-issues/components/DataIssueKindChip.vue';
+import DataIssueStateChip from '@/modules/history/data-issues/components/DataIssueStateChip.vue';
+import HistoryEventAccount from '@/modules/history/events/HistoryEventAccount.vue';
+import LocationDisplay from '@/modules/history/LocationDisplay.vue';
+import AssetIcon from '@/modules/shell/components/AssetIcon.vue';
+import CounterpartyDisplay from '@/modules/shell/components/display/CounterpartyDisplay.vue';
+
+const { issue, eventRoute, active = false } = defineProps<{
+  issue: DataIssue;
+  description: IssueDescription;
+  eventRoute?: RouteLocationRaw;
+  active?: boolean;
+}>();
+
+const emit = defineEmits<{
+  open: [];
+  goto: [route: RouteLocationRaw];
+  dismiss: [issue: DataIssue];
+  retry: [issue: DataIssue];
+  resolve: [issue: DataIssue];
+}>();
+
+// The description is clamped to two lines; only show the full-text tooltip when it
+// actually overflows. Re-checked on resize and on content changes (the amounts and
+// resolved asset symbol arrive asynchronously and can change the height).
+const descriptionRef = useTemplateRef<HTMLElement>('descriptionRef');
+const descriptionTruncated = ref<boolean>(false);
+
+function checkTruncation(): void {
+  const el = get(descriptionRef);
+  set(descriptionTruncated, !!el && el.scrollHeight > el.clientHeight + 1);
+}
+
+onMounted(async () => {
+  await nextTick();
+  checkTruncation();
+});
+
+useResizeObserver(descriptionRef, checkTruncation);
+useMutationObserver(descriptionRef, checkTruncation, { characterData: true, childList: true, subtree: true });
+</script>
+
+<template>
+  <RuiCard
+    class="cursor-pointer transition-colors"
+    :class="active
+      ? '!border-rui-primary ring-1 ring-rui-primary bg-rui-primary/5'
+      : 'hover:bg-rui-grey-50 dark:hover:bg-rui-grey-900'"
+    no-padding
+    content-class="overflow-hidden"
+    data-testid="data-issues-panel-item"
+    :data-active="active"
+    @click="emit('open')"
+  >
+    <div class="flex items-stretch">
+      <div class="flex flex-col gap-2 p-3 grow min-w-0">
+        <div class="flex items-center gap-2">
+          <DataIssueKindChip :kind="issue.kind" />
+          <DataIssueStateChip :state="issue.state" />
+          <DataIssueDetectedTime
+            class="ml-auto shrink-0 text-caption text-rui-text-secondary"
+            :timestamp="issue.createdAt"
+          />
+        </div>
+
+        <RuiTooltip
+          :disabled="!descriptionTruncated"
+          :open-delay="400"
+        >
+          <template #activator>
+            <div
+              ref="descriptionRef"
+              class="text-body-2 text-rui-text-secondary line-clamp-3 leading-relaxed h-[3lh]"
+            >
+              <DataIssueDescription
+                :description="description"
+                tag="span"
+              />
+            </div>
+          </template>
+          <div class="max-w-xs">
+            <DataIssueDescription
+              :description="description"
+              tag="span"
+            />
+          </div>
+        </RuiTooltip>
+
+        <div class="flex items-center gap-2 text-caption text-rui-text-secondary">
+          <AssetIcon
+            v-if="issue.asset"
+            :identifier="issue.asset"
+            size="22px"
+            :show-chain="false"
+            class="shrink-0"
+          />
+          <RuiTooltip
+            class="shrink-0"
+            :open-delay="300"
+          >
+            <template #activator>
+              <LocationDisplay
+                :identifier="issue.location"
+                icon
+                size="20px"
+                :open-details="false"
+              />
+            </template>
+            <span class="capitalize">{{ issue.location }}</span>
+          </RuiTooltip>
+          <RuiTooltip
+            v-if="issue.protocol"
+            class="shrink-0"
+            :open-delay="300"
+          >
+            <template #activator>
+              <CounterpartyDisplay
+                :counterparty="issue.protocol"
+                icon
+                size="20px"
+              />
+            </template>
+            <span>{{ toHumanReadable(issue.protocol) }}</span>
+          </RuiTooltip>
+          <div
+            v-if="issue.locationLabel"
+            class="min-w-0"
+          >
+            <HistoryEventAccount
+              :location="issue.location"
+              :location-label="issue.locationLabel"
+              dense
+              class="min-w-0"
+            />
+          </div>
+          <DataIssueCardActions
+            class="ml-auto shrink-0"
+            :issue="issue"
+            :event-route="eventRoute"
+            @goto="emit('goto', $event)"
+            @dismiss="emit('dismiss', $event)"
+            @retry="emit('retry', $event)"
+            @resolve="emit('resolve', $event)"
+          />
+        </div>
+      </div>
+
+      <div class="flex items-center pr-2 text-rui-text-secondary opacity-50">
+        <RuiIcon
+          name="lu-chevron-right"
+          size="18"
+        />
+      </div>
+    </div>
+  </RuiCard>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueRemediationTimeline.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueRemediationTimeline.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type { RemediationTimelineItem } from '@/modules/history/data-issues/types';
+import { humanizeStrategy } from '@/modules/history/data-issues/transforms';
+import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
+
+const { items } = defineProps<{
+  items: RemediationTimelineItem[];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div data-testid="data-issue-timeline">
+    <div
+      v-if="items.length === 0"
+      class="text-body-2 text-rui-text-secondary"
+    >
+      {{ t('data_issues.detail.no_attempts') }}
+    </div>
+    <ol
+      v-else
+      class="flex flex-col gap-3"
+    >
+      <li
+        v-for="(item, index) in items"
+        :key="index"
+        class="flex items-start gap-3"
+      >
+        <RuiIcon
+          class="mt-0.5"
+          size="18"
+          :name="item.success === false ? 'lu-circle-x' : item.success ? 'lu-circle-check' : 'lu-circle-dot'"
+          :color="item.success === false ? 'error' : item.success ? 'success' : 'secondary'"
+        />
+        <div class="flex flex-col">
+          <span class="text-body-2 font-medium">{{ humanizeStrategy(item.strategy) }}</span>
+          <span
+            v-if="item.attribution"
+            class="text-caption text-rui-text-secondary"
+          >
+            {{ item.attribution }}
+          </span>
+          <DateDisplay
+            v-if="item.timestamp"
+            class="text-caption text-rui-text-secondary"
+            :timestamp="item.timestamp"
+          />
+        </div>
+      </li>
+    </ol>
+  </div>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueStateChip.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueStateChip.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { type IssueState, STATE_META } from '@/modules/history/data-issues/constants';
+import { useDataIssuesFormat } from '@/modules/history/data-issues/use-data-issues-format';
+
+const { state } = defineProps<{
+  state: IssueState;
+}>();
+
+const { stateLabel } = useDataIssuesFormat();
+
+const meta = computed(() => STATE_META[state]);
+</script>
+
+<template>
+  <RuiChip
+    size="sm"
+    variant="outlined"
+    :color="meta.color"
+    data-testid="data-issue-state-chip"
+  >
+    <div class="flex items-center gap-1.5">
+      <RuiIcon
+        :name="meta.icon"
+        size="14"
+        :class="{ 'animate-spin': meta.busy }"
+      />
+      <span>{{ stateLabel(state) }}</span>
+    </div>
+  </RuiChip>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueSummaryBar.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueSummaryBar.spec.ts
@@ -1,0 +1,66 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import DataIssueSummaryBar from '@/modules/history/data-issues/components/DataIssueSummaryBar.vue';
+import { IssueState } from '@/modules/history/data-issues/constants';
+import { emptyCounts, type StateCounts } from '@/modules/history/data-issues/use-data-issues-inbox-store';
+import { createRuiPlugin } from '@/plugins/rui';
+
+function counts(overrides: Partial<StateCounts> = {}): StateCounts {
+  return { ...emptyCounts(), ...overrides };
+}
+
+function createWrapper(props: { counts: StateCounts; activeStates: string[] }): VueWrapper<InstanceType<typeof DataIssueSummaryBar>> {
+  return mount(DataIssueSummaryBar, {
+    global: {
+      plugins: [createRuiPlugin({})],
+    },
+    props,
+  });
+}
+
+describe('dataIssueSummaryBar', () => {
+  it('should render one card per non-terminal summary state', () => {
+    const wrapper = createWrapper({ activeStates: [], counts: counts() });
+
+    expect(wrapper.find(`[data-testid="data-issue-summary-${IssueState.OPEN}"]`).exists()).toBe(true);
+    expect(wrapper.find(`[data-testid="data-issue-summary-${IssueState.AUTO_REMEDIATING}"]`).exists()).toBe(true);
+    expect(wrapper.find(`[data-testid="data-issue-summary-${IssueState.UNRESOLVED}"]`).exists()).toBe(true);
+    // terminal states never get a card.
+    expect(wrapper.find(`[data-testid="data-issue-summary-${IssueState.RESOLVED}"]`).exists()).toBe(false);
+  });
+
+  it('should show the per-state counts', () => {
+    const wrapper = createWrapper({ activeStates: [], counts: counts({ [IssueState.OPEN]: 4 }) });
+
+    expect(wrapper.find(`[data-testid="data-issue-summary-${IssueState.OPEN}"]`).text()).toContain('4');
+  });
+
+  it('should mark a card active only when it is the single selected state', () => {
+    const wrapper = createWrapper({ activeStates: [IssueState.OPEN], counts: counts() });
+
+    expect(wrapper.find(`[data-testid="data-issue-summary-${IssueState.OPEN}"]`).classes()).toContain('!border-rui-primary');
+    expect(wrapper.find(`[data-testid="data-issue-summary-${IssueState.UNRESOLVED}"]`).classes()).not.toContain('!border-rui-primary');
+  });
+
+  it('should not mark any card active when several states are selected', () => {
+    const wrapper = createWrapper({ activeStates: [IssueState.OPEN, IssueState.UNRESOLVED], counts: counts() });
+
+    expect(wrapper.find(`[data-testid="data-issue-summary-${IssueState.OPEN}"]`).classes()).not.toContain('!border-rui-primary');
+  });
+
+  it('should emit the state when a card is clicked', async () => {
+    const wrapper = createWrapper({ activeStates: [], counts: counts() });
+
+    await wrapper.find(`[data-testid="data-issue-summary-${IssueState.UNRESOLVED}"]`).trigger('click');
+
+    expect(wrapper.emitted('select')?.[0]).toStrictEqual([IssueState.UNRESOLVED]);
+  });
+
+  it('should show the all-clear hint only when every summary count is zero', async () => {
+    const wrapper = createWrapper({ activeStates: [], counts: counts() });
+    expect(wrapper.text()).toContain('data_issues.summary.all_clear');
+
+    await wrapper.setProps({ counts: counts({ [IssueState.OPEN]: 1 }) });
+    expect(wrapper.text()).not.toContain('data_issues.summary.all_clear');
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueSummaryBar.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueSummaryBar.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import type { StateCounts } from '@/modules/history/data-issues/use-data-issues-inbox-store';
+import { IssueState, STATE_META } from '@/modules/history/data-issues/constants';
+import { useDataIssuesFormat } from '@/modules/history/data-issues/use-data-issues-format';
+
+const { counts, activeStates } = defineProps<{
+  counts: StateCounts;
+  activeStates: string[];
+}>();
+
+const emit = defineEmits<{
+  select: [state: IssueState];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+const { stateLabel } = useDataIssuesFormat();
+
+const SUMMARY_STATES: IssueState[] = [
+  IssueState.OPEN,
+  IssueState.AUTO_REMEDIATING,
+  IssueState.UNRESOLVED,
+];
+
+const selectedStates = computed<string[]>(() => activeStates);
+
+const cards = computed(() => SUMMARY_STATES.map((state) => {
+  const meta = STATE_META[state];
+  return {
+    active: get(selectedStates).length === 1 && get(selectedStates)[0] === state,
+    busy: meta.busy === true,
+    color: meta.color === 'grey' ? undefined : meta.color,
+    count: counts[state],
+    icon: meta.icon,
+    label: stateLabel(state),
+    state,
+  };
+}));
+
+const allClear = computed<boolean>(() => SUMMARY_STATES.every(state => counts[state] === 0));
+</script>
+
+<template>
+  <div
+    class="grid grid-cols-1 sm:grid-cols-3 gap-3"
+    data-testid="data-issue-summary"
+  >
+    <RuiButton
+      v-for="card in cards"
+      :key="card.state"
+      variant="outlined"
+      class="!justify-start !p-3 !h-auto"
+      :class="{ '!border-rui-primary': card.active }"
+      :data-testid="`data-issue-summary-${card.state}`"
+      @click="emit('select', card.state)"
+    >
+      <div class="flex items-center gap-3 w-full">
+        <RuiIcon
+          :name="card.icon"
+          :color="card.color"
+          :class="{ 'animate-spin': card.busy && card.count > 0 }"
+        />
+        <div class="flex flex-col items-start">
+          <span class="text-h6 font-medium leading-none">{{ card.count }}</span>
+          <span class="text-caption text-rui-text-secondary">{{ card.label }}</span>
+        </div>
+      </div>
+    </RuiButton>
+
+    <div
+      v-if="allClear"
+      class="sm:col-span-3 text-caption text-rui-text-secondary flex items-center gap-1.5"
+    >
+      <RuiIcon
+        name="lu-circle-check"
+        color="success"
+        size="16"
+      />
+      {{ t('data_issues.summary.all_clear') }}
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesPanel.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesPanel.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
+import DataIssuesPanelContent from '@/modules/history/data-issues/components/DataIssuesPanelContent.vue';
+import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
+import { PinnedNames } from '@/modules/session/types';
+
+const { pinned } = storeToRefs(useAreaVisibilityStore());
+const { overlayVisible } = storeToRefs(useDataIssuesInboxStore());
+
+const subDialogOpen = ref<boolean>(false);
+
+/** Hand the panel off to the shared pinned rail so it slides in (and can be resized) like the other pinned panels. */
+function pin(): void {
+  set(pinned, { name: PinnedNames.DATA_ISSUES, props: {} });
+  set(overlayVisible, false);
+}
+
+// This overlay only exists within the history view; close it when the view unmounts so
+// it does not reappear elsewhere. A panel handed off to the pinned rail is unaffected.
+onUnmounted(() => {
+  set(overlayVisible, false);
+});
+</script>
+
+<template>
+  <RuiNavigationDrawer
+    v-model="overlayVisible"
+    width="450px"
+    position="right"
+    temporary
+    :stateless="subDialogOpen"
+  >
+    <DataIssuesPanelContent
+      v-model:sub-dialog-open="subDialogOpen"
+      :pinned="false"
+      @close="overlayVisible = false"
+      @toggle-pin="pin()"
+    />
+  </RuiNavigationDrawer>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesPanelContent.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesPanelContent.vue
@@ -1,0 +1,452 @@
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router';
+import type { DataIssue, DataIssuesRequestPayload } from '@/modules/history/data-issues/schemas';
+import type { IssueDescription } from '@/modules/history/data-issues/types';
+import { startPromise } from '@shared/utils';
+import TableFilter from '@/modules/core/table/TableFilter.vue';
+import DataIssueDetailDrawer from '@/modules/history/data-issues/components/DataIssueDetailDrawer.vue';
+import DataIssuePanelCard from '@/modules/history/data-issues/components/DataIssuePanelCard.vue';
+import ResolveManuallyDialog from '@/modules/history/data-issues/components/ResolveManuallyDialog.vue';
+import { IssueState, NON_TERMINAL_STATES } from '@/modules/history/data-issues/constants';
+import { describeIssue, relatedEventRoute } from '@/modules/history/data-issues/transforms';
+import { useDataIssueDetailActions } from '@/modules/history/data-issues/use-data-issue-detail-actions';
+import { useDataIssues } from '@/modules/history/data-issues/use-data-issues';
+import { type Filters, type Matcher, useDataIssuesFilter } from '@/modules/history/data-issues/use-data-issues-filter';
+import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
+import { HighlightTargetTypes, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
+import { useSyncCompleted } from '@/modules/shell/sync-progress/use-sync-completed';
+import { Routes } from '@/router/routes';
+
+/** Mirrors whether a stacked detail/resolve overlay is open, so the host drawer can stay stateless. */
+const subDialogOpen = defineModel<boolean>('subDialogOpen', { default: false });
+
+const { pinned = false } = defineProps<{
+  pinned?: boolean;
+}>();
+
+const emit = defineEmits<{
+  'close': [];
+  'toggle-pin': [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+const { isLgAndDown } = useBreakpoint();
+
+const issues = ref<DataIssue[]>([]);
+const loading = ref<boolean>(false);
+
+const { fetchData } = useDataIssues();
+const { refreshSummary } = useDataIssuesSummary();
+
+// Reuse the full-page filter matchers, but expose only the compact subset that fits
+// the preview: state, kind, asset and account. Protocol is intentionally absent (the
+// list endpoint does not accept a protocol filter).
+const PANEL_FILTER_KEYS: readonly string[] = ['state', 'kind', 'asset', 'account'];
+const { matchers } = useDataIssuesFilter();
+const panelMatchers = computed<Matcher[]>(() =>
+  get(matchers).filter(matcher => PANEL_FILTER_KEYS.includes(matcher.key)));
+const panelFilters = ref<Filters>({});
+const hasPanelFilters = computed<boolean>(() => Object.keys(get(panelFilters)).length > 0);
+
+// The filter's suggestion dropdown is a RuiMenu teleported to <body>, so clicking a
+// suggestion (e.g. an asset) reads as a click outside the floating drawer and would
+// dismiss it. Keep the drawer stateless while the filter is engaged, and hold that
+// state for a short grace period after focus leaves so the trailing click on a
+// teleported suggestion (which fires after the input blurs) is still ignored.
+const filterWrapper = useTemplateRef<HTMLElement>('filterWrapper');
+const { focused: filterFocused } = useFocusWithin(filterWrapper);
+const filterEngaged = ref<boolean>(false);
+const { start: scheduleDisengage, stop: cancelDisengage } = useTimeoutFn(() => {
+  set(filterEngaged, false);
+}, 300, { immediate: false });
+
+watch(filterFocused, (focused) => {
+  if (focused) {
+    cancelDisengage();
+    set(filterEngaged, true);
+  }
+  else {
+    scheduleDisengage();
+  }
+});
+
+// Filter values are typed `string | string[] | boolean`; our matchers only ever
+// produce strings/arrays, so narrow to the shapes the request payload accepts.
+type FilterValue = string | string[] | boolean | undefined;
+
+function asMulti(value: FilterValue): string | string[] | undefined {
+  return value === undefined || typeof value === 'boolean' ? undefined : value;
+}
+
+function asSingle(value: FilterValue): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+// The panel is a glanceable inbox preview: it loads one page at a time and appends
+// more as the user scrolls, rather than mounting the entire (possibly 100+) list at
+// once (each card resolves an asset icon/avatar and runs observers).
+const PAGE_SIZE = 25;
+const offset = ref<number>(0);
+const total = ref<number>(0);
+const loadingMore = ref<boolean>(false);
+const canLoadMore = computed<boolean>(() => get(issues).length < get(total));
+
+function buildPayload(): DataIssuesRequestPayload {
+  const filters = get(panelFilters);
+  return {
+    asset: asSingle(filters.asset),
+    kind: asMulti(filters.kind),
+    limit: PAGE_SIZE,
+    locationLabel: asSingle(filters.locationLabel),
+    offset: get(offset),
+    state: asMulti(filters.state) ?? [...NON_TERMINAL_STATES],
+  };
+}
+
+async function loadList(append: boolean): Promise<void> {
+  const busy = append ? loadingMore : loading;
+  set(busy, true);
+  try {
+    const collection = await fetchData(buildPayload());
+    set(issues, append ? [...get(issues), ...collection.data] : collection.data);
+    set(total, collection.found);
+  }
+  finally {
+    set(busy, false);
+  }
+}
+
+/** Reloads from the first page, replacing the current list (on mount, filter change, refresh). */
+async function refreshList(): Promise<void> {
+  set(offset, 0);
+  await loadList(false);
+}
+
+/** Appends the next page; guarded so overlapping scroll events do not double-fetch. */
+async function loadMore(): Promise<void> {
+  if (get(loading) || get(loadingMore) || !get(canLoadMore))
+    return;
+  set(offset, get(offset) + PAGE_SIZE);
+  await loadList(true);
+}
+
+async function reloadAll(): Promise<void> {
+  await Promise.all([refreshList(), refreshSummary()]);
+}
+
+const {
+  modelActionBusy,
+  modelDrawerOpen,
+  modelResolveOpen,
+  modelSelectedIssue,
+  onDismiss,
+  onResolveConfirm,
+  onResolveRequest,
+  onRetry,
+  openDetail,
+} = useDataIssueDetailActions(reloadAll);
+
+const isEmpty = computed<boolean>(() => get(issues).length === 0);
+
+const hasRemediatingRows = computed<boolean>(() =>
+  get(issues).some(issue => issue.state === IssueState.AUTO_REMEDIATING));
+
+interface PanelRow {
+  issue: DataIssue;
+  description: IssueDescription;
+  eventRoute: RouteLocationRaw | undefined;
+}
+
+const rows = computed<PanelRow[]>(() => get(issues).map((issue) => {
+  const description = describeIssue(issue);
+  return {
+    description,
+    eventRoute: relatedEventRoute(issue.kind, description.eventIdentifier, issue.groupIdentifier, issue.asset),
+    issue,
+  };
+}));
+
+const router = useRouter();
+const route = useRoute();
+const { clearHighlightTarget } = useHistoryEventNavigation();
+const { syncCompleted } = useSyncCompleted();
+
+async function goToEvent(target: RouteLocationRaw): Promise<void> {
+  await router.push(target);
+}
+
+// The route query is the single source of truth for the highlighted history event,
+// so the "source" card mirrors it: the card whose event is currently highlighted is
+// shown as active. This stays in sync automatically when the highlight is cleared
+// from the events view (the card simply stops matching).
+const activeEventIdentifier = computed<number | undefined>(() => {
+  const raw = get(route).query.highlightedNegativeBalanceEvent;
+  const value = Number(Array.isArray(raw) ? raw[0] : raw);
+  return Number.isInteger(value) && value > 0 ? value : undefined;
+});
+
+const hasActiveSelection = computed<boolean>(() => get(activeEventIdentifier) !== undefined);
+
+function isActiveRow(row: PanelRow): boolean {
+  const identifier = row.description.eventIdentifier;
+  return identifier !== undefined && identifier === get(activeEventIdentifier);
+}
+
+// Clear the selection: strip the highlight query params (which un-highlights both the
+// history row and the source card) and drop the paging target so a later filter change
+// does not re-navigate to the stale event. Mirrors clearHighlight() in the movement
+// matching pinned panel.
+async function clearSelection(): Promise<void> {
+  clearHighlightTarget(HighlightTargetTypes.NEGATIVE_BALANCE);
+  const { highlightedNegativeBalanceEvent, targetGroupIdentifier, ...remainingQuery } = get(route).query;
+  if (highlightedNegativeBalanceEvent || targetGroupIdentifier)
+    await router.replace({ query: remainingQuery });
+}
+
+// Resolving needs the issue selected first (the resolve dialog reads the selected
+// issue), so a card-triggered resolve selects then opens the dialog.
+function onResolveFromCard(issue: DataIssue): void {
+  set(modelSelectedIssue, issue);
+  onResolveRequest();
+}
+
+const { pause, resume } = useIntervalFn(reloadAll, 10_000, { immediate: false });
+
+watch(hasRemediatingRows, (remediating) => {
+  if (remediating)
+    resume();
+  else
+    pause();
+});
+
+// Reload when the history sync finishes so the inbox reflects the freshly detected
+// issues (or the all-clear shield) without waiting for the slow poll or a manual refresh.
+watch(syncCompleted, () => {
+  startPromise(reloadAll());
+});
+
+watch([modelDrawerOpen, modelResolveOpen, filterEngaged], ([drawer, resolve, filter]) => {
+  set(subDialogOpen, drawer || resolve || filter);
+});
+
+watchDebounced(panelFilters, () => {
+  startPromise(refreshList());
+}, { debounce: 300, deep: true });
+
+// Virtualise the loaded cards so only the visible window mounts (each card resolves an
+// asset icon/avatar and runs observers), and append the next page as the user nears the
+// end. Cards are a fixed height (the description reserves 3 lines), so the row height is
+// exact: 159px card + 8px gap.
+const ITEM_HEIGHT = 167;
+const { containerProps, list: visibleRows, wrapperProps } = useVirtualList(rows, {
+  itemHeight: ITEM_HEIGHT,
+  overscan: 4,
+});
+
+// Fetch the next page only when the user actually scrolls to the bottom of the loaded
+// cards (scroll-based, so it can't loop the way a "last visible index" watcher can).
+const { arrivedState } = useScroll(containerProps.ref);
+watch(() => arrivedState.bottom, (atBottom) => {
+  if (atBottom)
+    startPromise(loadMore());
+});
+
+onMounted(() => {
+  startPromise(reloadAll());
+});
+</script>
+
+<template>
+  <div class="h-full flex-1 min-h-0 overflow-hidden flex flex-col">
+    <div
+      class="flex justify-between items-center pl-4 pr-2 border-b border-default"
+      :class="pinned ? 'h-10 py-4' : 'py-2'"
+    >
+      <div
+        class="font-medium"
+        :class="pinned ? 'text-md' : 'text-xl'"
+      >
+        {{ t('data_issues.panel.title') }}
+      </div>
+      <div class="flex items-center gap-1">
+        <RuiTooltip
+          v-if="!isLgAndDown"
+          :open-delay="300"
+        >
+          <template #activator>
+            <RuiButton
+              variant="text"
+              icon
+              size="sm"
+              :active="pinned"
+              data-testid="data-issues-panel-pin"
+              @click="emit('toggle-pin')"
+            >
+              <RuiIcon
+                :name="pinned ? 'lu-pin-off' : 'lu-pin'"
+              />
+            </RuiButton>
+          </template>
+          {{ pinned ? t('data_issues.panel.unpin') : t('data_issues.panel.pin') }}
+        </RuiTooltip>
+        <RuiButton
+          variant="text"
+          icon
+          size="sm"
+          @click="emit('close')"
+        >
+          <RuiIcon
+            name="lu-x"
+          />
+        </RuiButton>
+      </div>
+    </div>
+
+    <div
+      ref="filterWrapper"
+      class="px-3 py-2 border-b border-default shrink-0"
+    >
+      <TableFilter
+        v-model:matches="panelFilters"
+        :matchers="panelMatchers"
+      />
+    </div>
+
+    <div
+      v-if="hasActiveSelection"
+      class="flex items-center justify-between gap-2 px-3 py-1.5 border-b border-default bg-rui-primary/5 text-caption"
+      data-testid="data-issues-panel-active-selection"
+    >
+      <span class="text-rui-text-secondary truncate">
+        {{ t('data_issues.panel.highlighting_event') }}
+      </span>
+      <RuiButton
+        variant="text"
+        color="primary"
+        size="sm"
+        class="shrink-0"
+        data-testid="data-issues-panel-clear-selection"
+        @click="clearSelection()"
+      >
+        {{ t('data_issues.panel.clear_selection') }}
+      </RuiButton>
+    </div>
+
+    <div
+      v-if="loading && isEmpty"
+      class="flex flex-1 items-center justify-center"
+    >
+      <RuiProgress
+        variant="indeterminate"
+        circular
+        size="32"
+        thickness="2"
+        color="primary"
+      />
+    </div>
+
+    <div
+      v-else-if="isEmpty && hasPanelFilters"
+      class="flex flex-col items-center justify-center flex-1 px-6 text-center gap-2 text-rui-text-secondary"
+    >
+      <RuiIcon
+        size="40px"
+        name="lu-funnel-x"
+      />
+      <div class="text-body-2">
+        {{ t('data_issues.empty.filtered') }}
+      </div>
+    </div>
+
+    <div
+      v-else-if="isEmpty"
+      class="flex flex-col items-center justify-center flex-1 px-6 text-center gap-2"
+    >
+      <RuiIcon
+        size="64px"
+        color="success"
+        name="lu-shield-check"
+      />
+      <div class="text-rui-text text-lg mt-2">
+        {{ t('data_issues.empty.all_clear_title') }}
+      </div>
+      <div class="text-rui-text-secondary text-body-2">
+        {{ t('data_issues.empty.all_clear_subtitle') }}
+      </div>
+    </div>
+
+    <div
+      v-else
+      v-bind="containerProps"
+      class="grow px-3 py-2"
+      data-testid="data-issues-panel-list"
+    >
+      <div v-bind="wrapperProps">
+        <div
+          v-for="{ data: row, index } in visibleRows"
+          :key="index"
+          :style="{ height: `${ITEM_HEIGHT}px` }"
+          class="pb-2"
+        >
+          <DataIssuePanelCard
+            :issue="row.issue"
+            :description="row.description"
+            :event-route="row.eventRoute"
+            :active="isActiveRow(row)"
+            @open="openDetail(row.issue)"
+            @goto="goToEvent($event)"
+            @dismiss="onDismiss($event.id)"
+            @retry="onRetry($event.id)"
+            @resolve="onResolveFromCard($event)"
+          />
+        </div>
+      </div>
+      <div
+        v-if="loadingMore"
+        class="sticky bottom-0 flex justify-center py-1"
+      >
+        <RuiProgress
+          variant="indeterminate"
+          circular
+          size="20"
+          thickness="2"
+          color="primary"
+        />
+      </div>
+    </div>
+
+    <div class="p-3 flex justify-end border-t border-default">
+      <RouterLink :to="Routes.HISTORY_DATA_ISSUES">
+        <RuiButton
+          variant="text"
+          color="primary"
+          data-testid="data-issues-panel-view-all"
+          @click="emit('close')"
+        >
+          <template #append>
+            <RuiIcon
+              name="lu-arrow-right"
+              size="18"
+            />
+          </template>
+          {{ t('data_issues.panel.view_all') }}
+        </RuiButton>
+      </RouterLink>
+    </div>
+
+    <DataIssueDetailDrawer
+      v-model="modelDrawerOpen"
+      :issue="modelSelectedIssue"
+      :busy="modelActionBusy"
+      @dismiss="onDismiss($event)"
+      @retry="onRetry($event)"
+      @resolve="onResolveRequest()"
+    />
+
+    <ResolveManuallyDialog
+      v-model="modelResolveOpen"
+      :loading="modelActionBusy"
+      @confirm="onResolveConfirm($event)"
+    />
+  </div>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesPinned.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesPinned.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
+import DataIssuesPanelContent from '@/modules/history/data-issues/components/DataIssuesPanelContent.vue';
+import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
+
+const { pinned } = storeToRefs(useAreaVisibilityStore());
+const { overlayVisible } = storeToRefs(useDataIssuesInboxStore());
+
+/** Hand the panel back to the floating overlay. */
+function unpin(): void {
+  set(pinned, null);
+  set(overlayVisible, true);
+}
+
+/** Dismiss the panel entirely. */
+function close(): void {
+  set(pinned, null);
+  set(overlayVisible, false);
+}
+</script>
+
+<template>
+  <RuiCard
+    no-padding
+    variant="flat"
+    class="!rounded-none h-full flex flex-col overflow-hidden"
+    content-class="h-full min-h-0"
+  >
+    <DataIssuesPanelContent
+      :pinned="true"
+      @close="close()"
+      @toggle-pin="unpin()"
+    />
+  </RuiCard>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesTable.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesTable.spec.ts
@@ -1,0 +1,129 @@
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { defineComponent, h, type VNode } from 'vue';
+import DataIssuesTable from '@/modules/history/data-issues/components/DataIssuesTable.vue';
+import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
+import CounterpartyDisplay from '@/modules/shell/components/display/CounterpartyDisplay.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+function createIssue(overrides: Partial<DataIssue> = {}): DataIssue {
+  return {
+    asset: 'ETH',
+    autoRemediationAttempts: [],
+    createdAt: 1710000100,
+    groupIdentifier: null,
+    id: 1,
+    kind: IssueKind.NEGATIVE_BALANCE,
+    location: 'ethereum',
+    locationLabel: '0x0000000000000000000000000000000000000001',
+    payload: {},
+    protocol: null,
+    resolvedAt: null,
+    severity: IssueSeverity.WARNING,
+    state: IssueState.OPEN,
+    tsEnd: 1710000000,
+    tsStart: 1710000000,
+    ...overrides,
+  };
+}
+
+function createWrapper(rows: DataIssue[]): VueWrapper<InstanceType<typeof DataIssuesTable>> {
+  return mount(DataIssuesTable, {
+    global: {
+      plugins: [createPinia(), createRuiPlugin({})],
+      stubs: {
+        AssetDetails: true,
+        CounterpartyDisplay: true,
+        DataIssueKindChip: true,
+        DataIssueStateChip: true,
+        DateDisplay: true,
+        HistoryEventAccount: true,
+        LocationDisplay: true,
+      },
+    },
+    props: {
+      emptyDescription: 'empty',
+      rows,
+    },
+  });
+}
+
+describe('data-issues table', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should render the protocol column between account and state', () => {
+    const headers = createWrapper([]).findAll('thead th').map(th => th.text());
+    const account = headers.indexOf('common.account');
+    const protocol = headers.indexOf('data_issues.headers.protocol');
+    const state = headers.indexOf('data_issues.headers.state');
+
+    expect(protocol).toBeGreaterThan(account);
+    expect(state).toBeGreaterThan(protocol);
+  });
+
+  it('should render a counterparty for a row that has a protocol', () => {
+    const wrapper = createWrapper([createIssue({ id: 1, protocol: 'uniswap-v3' })]);
+    const counterparty = wrapper.findComponent(CounterpartyDisplay);
+
+    expect(counterparty.exists()).toBe(true);
+    expect(counterparty.props('counterparty')).toBe('uniswap-v3');
+  });
+
+  it('should render a dash instead of a counterparty when the protocol is null', () => {
+    const wrapper = createWrapper([createIssue({ id: 1, protocol: null })]);
+
+    expect(wrapper.findComponent(CounterpartyDisplay).exists()).toBe(false);
+  });
+
+  it('should forward a row quick dismiss action', async () => {
+    const issue = createIssue({ id: 5, state: IssueState.OPEN });
+    const wrapper = createWrapper([issue]);
+
+    await wrapper.find('[data-testid="data-issues-panel-dismiss"]').trigger('click');
+
+    expect(wrapper.emitted('dismiss')?.[0]?.[0]).toStrictEqual(issue);
+  });
+
+  it('should emit open when the row action button is clicked', async () => {
+    const issue = createIssue({ id: 7 });
+    const wrapper = createWrapper([issue]);
+
+    await wrapper.find('[data-testid="data-issues-view-details"]').trigger('click');
+
+    expect(wrapper.emitted('open')?.[0]?.[0]).toStrictEqual(issue);
+  });
+
+  it('should emit open with the row when a row is clicked', async () => {
+    // A lightweight table stub whose button re-emits `click:row`, so we assert the
+    // component forwards it as `open` without depending on RuiDataTable internals.
+    const RuiDataTableStub = defineComponent({
+      emits: ['click:row'],
+      props: { rows: { default: () => [], type: Array } },
+      setup(props, { emit }): () => VNode {
+        return () => h('button', { onClick: () => emit('click:row', props.rows[0]) });
+      },
+    });
+    const issue = createIssue({ id: 42 });
+    const wrapper = mount(DataIssuesTable, {
+      global: {
+        plugins: [createPinia()],
+        stubs: {
+          CounterpartyDisplay: true,
+          RuiDataTable: RuiDataTableStub,
+        },
+      },
+      props: {
+        emptyDescription: 'empty',
+        rows: [issue],
+      },
+    });
+
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('open')?.[0]?.[0]).toStrictEqual(issue);
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesTable.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesTable.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import type { DataTableColumn, TablePaginationData } from '@rotki/ui-library';
+import type { RouteLocationRaw } from 'vue-router';
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import AssetDetails from '@/modules/assets/AssetDetails.vue';
+import DataIssueCardActions from '@/modules/history/data-issues/components/DataIssueCardActions.vue';
+import DataIssueDetectedTime from '@/modules/history/data-issues/components/DataIssueDetectedTime.vue';
+import DataIssueKindChip from '@/modules/history/data-issues/components/DataIssueKindChip.vue';
+import DataIssueStateChip from '@/modules/history/data-issues/components/DataIssueStateChip.vue';
+import { describeIssue, relatedEventRoute } from '@/modules/history/data-issues/transforms';
+import HistoryEventAccount from '@/modules/history/events/HistoryEventAccount.vue';
+import LocationDisplay from '@/modules/history/LocationDisplay.vue';
+import CounterpartyDisplay from '@/modules/shell/components/display/CounterpartyDisplay.vue';
+
+const pagination = defineModel<TablePaginationData>('pagination');
+
+const { emptyDescription, loading = false, rows, showClearFilters = false } = defineProps<{
+  rows: DataIssue[];
+  loading?: boolean;
+  emptyDescription: string;
+  showClearFilters?: boolean;
+}>();
+
+const emit = defineEmits<{
+  'open': [issue: DataIssue];
+  'goto': [route: RouteLocationRaw];
+  'dismiss': [issue: DataIssue];
+  'retry': [issue: DataIssue];
+  'resolve': [issue: DataIssue];
+  'clear-filters': [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+/** Deep-link to the offending history event for a row's quick "go to event" action. */
+function eventRouteFor(issue: DataIssue): RouteLocationRaw | undefined {
+  return relatedEventRoute(issue.kind, describeIssue(issue).eventIdentifier, issue.groupIdentifier, issue.asset);
+}
+
+const headers = computed<DataTableColumn<DataIssue>[]>(() => [
+  { key: 'kind', label: t('data_issues.headers.kind') },
+  { key: 'asset', label: t('common.asset') },
+  { key: 'account', label: t('common.account') },
+  { key: 'protocol', label: t('data_issues.headers.protocol') },
+  { key: 'state', label: t('data_issues.headers.state') },
+  { key: 'createdAt', label: t('data_issues.headers.detected') },
+  { align: 'end', key: 'actions', label: '' },
+]);
+</script>
+
+<template>
+  <RuiDataTable
+    v-model:pagination.external="pagination"
+    outlined
+    dense
+    :cols="headers"
+    :loading="loading"
+    :rows="rows"
+    row-attr="id"
+    :empty="{ description: emptyDescription }"
+    data-testid="data-issues-table"
+    @click:row="emit('open', $event)"
+  >
+    <template #item.kind="{ row }">
+      <DataIssueKindChip :kind="row.kind" />
+    </template>
+    <template #item.asset="{ row }">
+      <AssetDetails
+        v-if="row.asset"
+        :asset="row.asset"
+      />
+      <span
+        v-else
+        class="text-rui-text-secondary"
+      >
+        -
+      </span>
+    </template>
+    <template #item.account="{ row }">
+      <HistoryEventAccount
+        v-if="row.locationLabel"
+        :location="row.location"
+        :location-label="row.locationLabel"
+      />
+      <LocationDisplay
+        v-else
+        :identifier="row.location"
+      />
+    </template>
+    <template #item.protocol="{ row }">
+      <CounterpartyDisplay
+        v-if="row.protocol"
+        :counterparty="row.protocol"
+      />
+      <span
+        v-else
+        class="text-rui-text-secondary"
+      >
+        -
+      </span>
+    </template>
+    <template #item.state="{ row }">
+      <DataIssueStateChip :state="row.state" />
+    </template>
+    <template #item.createdAt="{ row }">
+      <DataIssueDetectedTime :timestamp="row.createdAt" />
+    </template>
+    <template #item.actions="{ row }">
+      <div class="flex items-center justify-end gap-0.5">
+        <DataIssueCardActions
+          :issue="row"
+          :event-route="eventRouteFor(row)"
+          @goto="emit('goto', $event)"
+          @dismiss="emit('dismiss', $event)"
+          @retry="emit('retry', $event)"
+          @resolve="emit('resolve', $event)"
+        />
+        <RuiTooltip :open-delay="300">
+          <template #activator>
+            <RuiButton
+              variant="text"
+              icon
+              size="sm"
+              :aria-label="t('data_issues.view_details')"
+              data-testid="data-issues-view-details"
+              @click.stop="emit('open', row)"
+            >
+              <RuiIcon
+                name="lu-chevron-right"
+                size="18"
+                class="text-rui-text-secondary"
+              />
+            </RuiButton>
+          </template>
+          {{ t('data_issues.view_details') }}
+        </RuiTooltip>
+      </div>
+    </template>
+
+    <template
+      v-if="showClearFilters"
+      #empty-description
+    >
+      <div class="flex flex-col items-center gap-2 py-2">
+        <span>{{ emptyDescription }}</span>
+        <RuiButton
+          size="sm"
+          variant="text"
+          color="primary"
+          @click="emit('clear-filters')"
+        >
+          {{ t('data_issues.empty.clear_filters') }}
+        </RuiButton>
+      </div>
+    </template>
+  </RuiDataTable>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesToggle.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesToggle.spec.ts
@@ -1,0 +1,119 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { get, set } from '@vueuse/core';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, ref } from 'vue';
+import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
+import DataIssuesToggle from '@/modules/history/data-issues/components/DataIssuesToggle.vue';
+import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
+import { PinnedNames } from '@/modules/session/types';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const refreshSummary = vi.fn();
+const actionableCount = ref<number>(0);
+const syncCompleted = ref<number>(0);
+
+vi.mock('@/modules/history/data-issues/use-data-issues-summary', () => ({
+  useDataIssuesSummary: (): Record<string, unknown> => ({ actionableCount, refreshSummary }),
+}));
+
+vi.mock('@/modules/shell/sync-progress/use-sync-completed', () => ({
+  useSyncCompleted: (): Record<string, unknown> => ({ syncCompleted }),
+}));
+
+let wrapper: VueWrapper<InstanceType<typeof DataIssuesToggle>> | undefined;
+
+function createWrapper(): VueWrapper<InstanceType<typeof DataIssuesToggle>> {
+  wrapper = mount(DataIssuesToggle, {
+    global: {
+      plugins: [createRuiPlugin({})],
+    },
+  });
+  return wrapper;
+}
+
+describe('dataIssuesToggle', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    refreshSummary.mockResolvedValue(undefined);
+    set(actionableCount, 0);
+    set(syncCompleted, 0);
+  });
+
+  afterEach(() => {
+    // Unmount so a component's syncCompleted watcher does not survive into the
+    // next test and fire on the shared ref.
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('should refresh the summary on mount', () => {
+    createWrapper();
+
+    expect(refreshSummary).toHaveBeenCalledOnce();
+  });
+
+  it('should open the overlay when toggled while hidden and unpinned', async () => {
+    const wrapper = createWrapper();
+    const { overlayVisible } = storeToRefs(useDataIssuesInboxStore());
+
+    await wrapper.find('[data-testid="data-issues-toggle"]').trigger('click');
+
+    expect(get(overlayVisible)).toBe(true);
+  });
+
+  it('should close the overlay when toggled while already open', async () => {
+    const wrapper = createWrapper();
+    const { overlayVisible } = storeToRefs(useDataIssuesInboxStore());
+    set(overlayVisible, true);
+
+    await wrapper.find('[data-testid="data-issues-toggle"]').trigger('click');
+
+    expect(get(overlayVisible)).toBe(false);
+  });
+
+  it('should unpin the panel instead of opening an overlay when it is pinned', async () => {
+    const wrapper = createWrapper();
+    const { overlayVisible } = storeToRefs(useDataIssuesInboxStore());
+    const { pinned } = storeToRefs(useAreaVisibilityStore());
+    set(pinned, { name: PinnedNames.DATA_ISSUES, props: {} });
+
+    await wrapper.find('[data-testid="data-issues-toggle"]').trigger('click');
+
+    expect(get(pinned)).toBeNull();
+    expect(get(overlayVisible)).toBe(false);
+  });
+
+  it('should mark the toggle active when the overlay is open', async () => {
+    const wrapper = createWrapper();
+    const { overlayVisible } = storeToRefs(useDataIssuesInboxStore());
+    const button = wrapper.find('[data-testid="data-issues-toggle"]');
+    expect(button.classes()).not.toContain('!bg-rui-primary');
+
+    set(overlayVisible, true);
+    await nextTick();
+
+    expect(button.classes()).toContain('!bg-rui-primary');
+  });
+
+  it('should mark the toggle active when the panel is pinned', async () => {
+    const wrapper = createWrapper();
+    const { pinned } = storeToRefs(useAreaVisibilityStore());
+
+    set(pinned, { name: PinnedNames.DATA_ISSUES, props: {} });
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="data-issues-toggle"]').classes()).toContain('!bg-rui-primary');
+  });
+
+  it('should refresh the summary again when a sync completes', async () => {
+    createWrapper();
+    expect(refreshSummary).toHaveBeenCalledTimes(1);
+
+    set(syncCompleted, get(syncCompleted) + 1);
+    await nextTick();
+
+    expect(refreshSummary).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesToggle.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesToggle.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { startPromise } from '@shared/utils';
+import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
+import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
+import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
+import { PinnedNames } from '@/modules/session/types';
+import { useSyncCompleted } from '@/modules/shell/sync-progress/use-sync-completed';
+
+const { t } = useI18n({ useScope: 'global' });
+
+const { actionableCount, refreshSummary } = useDataIssuesSummary();
+const { pinned } = storeToRefs(useAreaVisibilityStore());
+const { overlayVisible } = storeToRefs(useDataIssuesInboxStore());
+const { syncCompleted } = useSyncCompleted();
+
+const isPinned = computed<boolean>(() => get(pinned)?.name === PinnedNames.DATA_ISSUES);
+const active = computed<boolean>(() => get(overlayVisible) || get(isPinned));
+
+function toggle(): void {
+  // While the panel lives in the pinned rail, the toggle closes it there instead of
+  // opening a second overlay copy.
+  if (get(isPinned)) {
+    set(pinned, null);
+    return;
+  }
+  set(overlayVisible, !get(overlayVisible));
+}
+
+// Keep the badge count in step with the inbox: refresh when the history sync finishes.
+watch(syncCompleted, () => {
+  startPromise(refreshSummary());
+});
+
+onMounted(refreshSummary);
+</script>
+
+<template>
+  <RuiTooltip :open-delay="300">
+    <template #activator>
+      <RuiBadge
+        :model-value="actionableCount > 0"
+        :text="actionableCount.toString()"
+        color="error"
+        placement="top"
+        size="sm"
+        offset-y="6"
+        offset-x="-4"
+      >
+        <RuiButton
+          variant="outlined"
+          color="primary"
+          size="sm"
+          :class="{ '!bg-rui-primary !text-white': active }"
+          data-testid="data-issues-toggle"
+          @click="toggle()"
+        >
+          <RuiIcon
+            name="lu-shield-alert"
+            size="16"
+          />
+        </RuiButton>
+      </RuiBadge>
+    </template>
+    {{ t('data_issues.toggle.tooltip') }}
+  </RuiTooltip>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/ResolveManuallyDialog.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/components/ResolveManuallyDialog.spec.ts
@@ -1,0 +1,81 @@
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
+import ResolveManuallyDialog from '@/modules/history/data-issues/components/ResolveManuallyDialog.vue';
+
+async function mountDialog(open = true): Promise<VueWrapper<InstanceType<typeof ResolveManuallyDialog>>> {
+  const wrapper = mount(ResolveManuallyDialog, {
+    attachTo: document.body,
+    props: {
+      modelValue: open,
+    },
+    provide: libraryDefaults,
+  });
+  await flushPromises();
+  await nextTick();
+  return wrapper;
+}
+
+function queryNote(): HTMLTextAreaElement {
+  const note = document.body.querySelector<HTMLTextAreaElement>('[data-testid="data-issue-resolve-note"] textarea');
+  if (!note)
+    throw new Error('resolve note textarea not in DOM');
+  return note;
+}
+
+async function setNote(value: string): Promise<void> {
+  const note = queryNote();
+  note.value = value;
+  note.dispatchEvent(new Event('input'));
+  await nextTick();
+}
+
+function clickConfirm(): void {
+  const confirm = document.body.querySelector<HTMLButtonElement>('[data-testid="data-issue-resolve-confirm"]');
+  if (!confirm)
+    throw new Error('resolve confirm button not in DOM');
+  confirm.click();
+}
+
+describe('resolveManuallyDialog', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ResolveManuallyDialog>>;
+
+  beforeEach(async () => {
+    wrapper = await mountDialog();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    document.body.innerHTML = '';
+  });
+
+  it('should emit the trimmed note on confirm', async () => {
+    await setNote('  fixed externally  ');
+
+    clickConfirm();
+
+    expect(wrapper.emitted('confirm')?.[0]).toStrictEqual(['fixed externally']);
+  });
+
+  it('should emit undefined when the note is empty or whitespace only', async () => {
+    await setNote('   ');
+
+    clickConfirm();
+
+    expect(wrapper.emitted('confirm')?.[0]).toStrictEqual([undefined]);
+  });
+
+  it('should reset the note each time the dialog is reopened', async () => {
+    await setNote('stale note');
+    await wrapper.setProps({ modelValue: false });
+    await wrapper.setProps({ modelValue: true });
+    await flushPromises();
+    await nextTick();
+
+    clickConfirm();
+
+    expect(wrapper.emitted('confirm')?.[0]).toStrictEqual([undefined]);
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/components/ResolveManuallyDialog.vue
+++ b/frontend/app/src/modules/history/data-issues/components/ResolveManuallyDialog.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+const open = defineModel<boolean>({ required: true });
+
+const { loading = false } = defineProps<{
+  loading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  confirm: [note: string | undefined];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const note = ref<string>('');
+
+watch(open, (isOpen) => {
+  if (isOpen)
+    set(note, '');
+});
+
+function confirm(): void {
+  const trimmed = get(note).trim();
+  emit('confirm', trimmed.length > 0 ? trimmed : undefined);
+}
+</script>
+
+<template>
+  <RuiDialog
+    v-model="open"
+    max-width="500"
+  >
+    <RuiCard data-testid="data-issue-resolve-dialog">
+      <template #header>
+        {{ t('data_issues.resolve_dialog.title') }}
+      </template>
+
+      <RuiAlert
+        type="info"
+        class="mb-4"
+      >
+        {{ t('data_issues.resolve_dialog.notice') }}
+      </RuiAlert>
+
+      <RuiTextArea
+        v-model="note"
+        variant="outlined"
+        color="primary"
+        :label="t('data_issues.resolve_dialog.note_label')"
+        :hint="t('data_issues.resolve_dialog.note_hint')"
+        :rows="3"
+        data-testid="data-issue-resolve-note"
+      />
+
+      <template #footer>
+        <div class="grow" />
+        <RuiButton
+          variant="text"
+          color="primary"
+          @click="open = false"
+        >
+          {{ t('common.actions.cancel') }}
+        </RuiButton>
+        <RuiButton
+          color="primary"
+          :loading="loading"
+          data-testid="data-issue-resolve-confirm"
+          @click="confirm()"
+        >
+          {{ t('data_issues.resolve_dialog.confirm') }}
+        </RuiButton>
+      </template>
+    </RuiCard>
+  </RuiDialog>
+</template>

--- a/frontend/app/src/modules/history/data-issues/components/inbox.ts
+++ b/frontend/app/src/modules/history/data-issues/components/inbox.ts
@@ -1,0 +1,3 @@
+export { default as DataIssuesPanel } from './DataIssuesPanel.vue';
+
+export { default as DataIssuesToggle } from './DataIssuesToggle.vue';

--- a/frontend/app/src/modules/history/data-issues/constants.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/constants.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canDismiss,
+  canResolveManually,
+  canRetry,
+  DEFAULT_LIST_STATES,
+  IssueState,
+  NON_TERMINAL_STATES,
+} from '@/modules/history/data-issues/constants';
+
+describe('data-issues constants', () => {
+  describe('default filter states', () => {
+    it('should default the inbox list to open + unresolved (issues needing action)', () => {
+      expect(DEFAULT_LIST_STATES).toStrictEqual([IssueState.OPEN, IssueState.UNRESOLVED]);
+    });
+
+    it('should exclude the transient auto_remediating state from the default list', () => {
+      expect(DEFAULT_LIST_STATES).not.toContain(IssueState.AUTO_REMEDIATING);
+    });
+
+    it('should keep auto_remediating in the panel preview (non-terminal) states', () => {
+      expect(NON_TERMINAL_STATES).toStrictEqual([
+        IssueState.OPEN,
+        IssueState.AUTO_REMEDIATING,
+        IssueState.UNRESOLVED,
+      ]);
+    });
+
+    it('should never include terminal states in either default set', () => {
+      for (const set of [DEFAULT_LIST_STATES, NON_TERMINAL_STATES]) {
+        expect(set).not.toContain(IssueState.RESOLVED);
+        expect(set).not.toContain(IssueState.DISMISSED);
+      }
+    });
+  });
+
+  describe('transition guards', () => {
+    it.each([
+      [IssueState.OPEN, true],
+      [IssueState.AUTO_REMEDIATING, true],
+      [IssueState.UNRESOLVED, true],
+      [IssueState.RESOLVED, false],
+      [IssueState.DISMISSED, false],
+    ])('canDismiss(%s) === %s', (state, expected) => {
+      expect(canDismiss(state)).toBe(expected);
+    });
+
+    it.each([
+      [IssueState.OPEN, true],
+      [IssueState.AUTO_REMEDIATING, true],
+      [IssueState.UNRESOLVED, true],
+      [IssueState.RESOLVED, false],
+      [IssueState.DISMISSED, false],
+    ])('canResolveManually(%s) === %s', (state, expected) => {
+      expect(canResolveManually(state)).toBe(expected);
+    });
+
+    it.each([
+      [IssueState.OPEN, true],
+      [IssueState.AUTO_REMEDIATING, true],
+      [IssueState.UNRESOLVED, true],
+      [IssueState.RESOLVED, false],
+      [IssueState.DISMISSED, false],
+    ])('canRetry(%s) === %s', (state, expected) => {
+      expect(canRetry(state)).toBe(expected);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/constants.ts
+++ b/frontend/app/src/modules/history/data-issues/constants.ts
@@ -1,0 +1,91 @@
+import type { RuiIcons } from '@rotki/ui-library';
+
+/**
+ * Kinds of data issues the accounting engine can detect. Mirrors the backend
+ * `IssueKind` StrEnum (rotkehlchen/history/data_issues/constants.py).
+ */
+export enum IssueKind {
+  CURRENT_BALANCE_MISMATCH = 'current_balance_mismatch',
+  NEGATIVE_BALANCE = 'negative_balance',
+}
+
+/**
+ * Lifecycle states of a data issue. Mirrors the backend `IssueState` StrEnum.
+ * `open`, `auto_remediating` and `unresolved` are the non-terminal states the
+ * inbox shows by default; `resolved` and `dismissed` are terminal.
+ */
+export enum IssueState {
+  OPEN = 'open',
+  AUTO_REMEDIATING = 'auto_remediating',
+  UNRESOLVED = 'unresolved',
+  RESOLVED = 'resolved',
+  DISMISSED = 'dismissed',
+}
+
+/** Severity of a data issue. Only `warning` exists for now. */
+export enum IssueSeverity {
+  WARNING = 'warning',
+}
+
+/** Non-terminal states, used for the pinned/overlay panel preview. */
+export const NON_TERMINAL_STATES: readonly IssueState[] = [
+  IssueState.OPEN,
+  IssueState.AUTO_REMEDIATING,
+  IssueState.UNRESOLVED,
+] as const;
+
+/**
+ * Default state filter for the main inbox list (issue #12294): the issues the
+ * user still needs to act on, i.e. open plus auto-remediation that gave up.
+ * Auto-remediating rows are transient and excluded from the default view.
+ */
+export const DEFAULT_LIST_STATES: readonly IssueState[] = [
+  IssueState.OPEN,
+  IssueState.UNRESOLVED,
+] as const;
+
+export type ChipColor = 'grey' | 'primary' | 'secondary' | 'error' | 'warning' | 'info' | 'success';
+
+interface StateMeta {
+  readonly color: ChipColor;
+  readonly icon: RuiIcons;
+  /** Whether the state shows an in-progress spinner (auto-remediation running). */
+  readonly busy?: boolean;
+}
+
+export const STATE_META: Record<IssueState, StateMeta> = {
+  [IssueState.OPEN]: { color: 'warning', icon: 'lu-circle-dot' },
+  [IssueState.AUTO_REMEDIATING]: { busy: true, color: 'info', icon: 'lu-loader-circle' },
+  [IssueState.UNRESOLVED]: { color: 'error', icon: 'lu-circle-alert' },
+  [IssueState.RESOLVED]: { color: 'success', icon: 'lu-circle-check' },
+  [IssueState.DISMISSED]: { color: 'grey', icon: 'lu-circle-slash' },
+};
+
+interface KindMeta {
+  readonly color: ChipColor;
+  readonly icon: RuiIcons;
+}
+
+export const KIND_META: Record<IssueKind, KindMeta> = {
+  [IssueKind.NEGATIVE_BALANCE]: { color: 'error', icon: 'lu-trending-down' },
+  [IssueKind.CURRENT_BALANCE_MISMATCH]: { color: 'warning', icon: 'lu-scale' },
+};
+
+/**
+ * Whether each action is allowed from a given state, mirroring the backend
+ * transition rules (rotkehlchen/history/data_issues/manager.py):
+ *  - dismiss: any non-terminal state (terminal states are already closed).
+ *  - resolveManually: blocked once resolved or dismissed.
+ *  - retry: blocked once dismissed; a no-op (still allowed) for open/auto_remediating.
+ */
+export function canDismiss(state: IssueState): boolean {
+  return state !== IssueState.RESOLVED && state !== IssueState.DISMISSED;
+}
+
+export function canResolveManually(state: IssueState): boolean {
+  return state !== IssueState.RESOLVED && state !== IssueState.DISMISSED;
+}
+
+export function canRetry(state: IssueState): boolean {
+  return state !== IssueState.DISMISSED && state !== IssueState.RESOLVED;
+}

--- a/frontend/app/src/modules/history/data-issues/schemas.ts
+++ b/frontend/app/src/modules/history/data-issues/schemas.ts
@@ -1,0 +1,92 @@
+import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
+import { NumericString } from '@rotki/common';
+import { z } from 'zod/v4';
+import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
+
+/**
+ * A single auto-remediation attempt. The backend currently records at least the
+ * strategy and its outcome; timestamps/attributions may be added later, so the
+ * schema stays permissive (extra keys are preserved, rendered when present).
+ */
+export const AutoRemediationAttempt = z.looseObject({
+  strategy: z.string(),
+  success: z.boolean().optional(),
+  timestamp: z.number().optional(),
+  attribution: z.string().optional(),
+});
+
+export type AutoRemediationAttempt = z.infer<typeof AutoRemediationAttempt>;
+
+/**
+ * A persisted data quality issue, as served by `GET /data_issues`. The free-form
+ * `payload` differs per kind and is narrowed in transforms (see transforms.ts);
+ * here it is kept as a permissive record so backend payload additions don't break
+ * deserialization.
+ */
+export const DataIssue = z.object({
+  asset: z.string().nullable(),
+  autoRemediationAttempts: z.array(AutoRemediationAttempt).default([]),
+  createdAt: z.number(),
+  groupIdentifier: z.string().nullable().default(null),
+  id: z.number(),
+  kind: z.enum(IssueKind),
+  location: z.string(),
+  locationLabel: z.string().nullable(),
+  payload: z.record(z.string(), z.unknown()).default({}),
+  protocol: z.string().nullable(),
+  resolvedAt: z.number().nullable(),
+  severity: z.enum(IssueSeverity),
+  state: z.enum(IssueState),
+  tsEnd: z.number(),
+  tsStart: z.number(),
+});
+
+export type DataIssue = z.infer<typeof DataIssue>;
+
+/**
+ * `GET /data_issues` collection response. The backend only returns `entriesFound`
+ * and `entriesLimit`; we derive `entriesTotal` from `entriesFound` so the shape
+ * satisfies the shared `CollectionResponse`/`mapCollectionResponse` contract.
+ */
+export const DataIssuesCollectionResponse = z
+  .object({
+    entries: z.array(DataIssue),
+    entriesFound: z.number(),
+    entriesLimit: z.number().default(-1),
+  })
+  .transform(response => ({ ...response, entriesTotal: response.entriesFound }));
+
+export type DataIssuesCollectionResponse = z.infer<typeof DataIssuesCollectionResponse>;
+
+/** Request payload for listing data issues. Field names map 1:1 to the backend
+ * query params after snake_case transformation (e.g. `locationLabel` ->
+ * `location_label`). `state`/`kind` are multi-valued. */
+export interface DataIssuesRequestPayload extends PaginationRequestPayload<DataIssue> {
+  readonly state?: string | string[];
+  readonly kind?: string | string[];
+  readonly location?: string;
+  readonly locationLabel?: string;
+  readonly asset?: string;
+  readonly fromTimestamp?: number;
+  readonly toTimestamp?: number;
+}
+
+// --- Typed payload variants (narrowed by `kind` in transforms) ---
+
+export const NegativeBalancePayload = z.object({
+  derivedBalanceBeforeEvent: NumericString,
+  eventIdentifier: z.number(),
+  inMemoryNegativeAmount: NumericString,
+});
+
+export type NegativeBalancePayload = z.infer<typeof NegativeBalancePayload>;
+
+export const CurrentBalanceMismatchPayload = z.object({
+  delta: NumericString,
+  derivedBalance: NumericString,
+  latestEventIdentifier: z.number().nullable(),
+  observedBalance: NumericString,
+  queriedAtTs: z.number(),
+});
+
+export type CurrentBalanceMismatchPayload = z.infer<typeof CurrentBalanceMismatchPayload>;

--- a/frontend/app/src/modules/history/data-issues/transforms.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.spec.ts
@@ -1,0 +1,164 @@
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import { describe, expect, it } from 'vitest';
+import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
+import { describeIssue, humanizeStrategy, relatedEventRoute, toTimelineItems } from '@/modules/history/data-issues/transforms';
+import { Routes } from '@/router/routes';
+
+function createIssue(overrides: Partial<DataIssue> = {}): DataIssue {
+  return {
+    asset: 'ETH',
+    autoRemediationAttempts: [],
+    createdAt: 1710000100,
+    groupIdentifier: null,
+    id: 1,
+    kind: IssueKind.NEGATIVE_BALANCE,
+    location: 'ethereum',
+    locationLabel: '0x0000000000000000000000000000000000000001',
+    payload: {},
+    protocol: null,
+    resolvedAt: null,
+    severity: IssueSeverity.WARNING,
+    state: IssueState.OPEN,
+    tsEnd: 1710000000,
+    tsStart: 1710000000,
+    ...overrides,
+  };
+}
+
+describe('data-issues transforms', () => {
+  describe('humanizeStrategy', () => {
+    it('should turn a snake_case strategy into a readable label', () => {
+      expect(humanizeStrategy('reprocess_event')).toBe('Reprocess event');
+    });
+
+    it('should leave an empty string untouched', () => {
+      expect(humanizeStrategy('')).toBe('');
+    });
+  });
+
+  describe('describeIssue', () => {
+    it('should describe a negative balance issue and expose the event identifier', () => {
+      const issue = createIssue({
+        asset: 'ETH',
+        kind: IssueKind.NEGATIVE_BALANCE,
+        payload: {
+          derivedBalanceBeforeEvent: '0',
+          eventIdentifier: 42,
+          inMemoryNegativeAmount: '-1',
+        },
+      });
+
+      const result = describeIssue(issue);
+
+      expect(result.messageKey).toBe('data_issues.description.negative_balance');
+      expect(result.eventIdentifier).toBe(42);
+      expect(result.asset).toBe('ETH');
+      // amount keeps its sign; the i18n string no longer prepends a literal "-".
+      expect(result.amounts.amount?.toString()).toBe('-1');
+      expect(result.amounts.before?.toString()).toBe('0');
+    });
+
+    it('should describe a balance mismatch and link to the latest event when present', () => {
+      const issue = createIssue({
+        kind: IssueKind.CURRENT_BALANCE_MISMATCH,
+        payload: {
+          delta: '5',
+          derivedBalance: '10',
+          latestEventIdentifier: 7,
+          observedBalance: '15',
+          queriedAtTs: 1710000000,
+        },
+      });
+
+      const result = describeIssue(issue);
+
+      expect(result.messageKey).toBe('data_issues.description.current_balance_mismatch');
+      expect(result.eventIdentifier).toBe(7);
+      expect(result.amounts.delta?.toString()).toBe('5');
+    });
+
+    it('should leave the event identifier undefined when the mismatch has no latest event', () => {
+      const issue = createIssue({
+        kind: IssueKind.CURRENT_BALANCE_MISMATCH,
+        payload: {
+          delta: '5',
+          derivedBalance: '10',
+          latestEventIdentifier: null,
+          observedBalance: '15',
+          queriedAtTs: 1710000000,
+        },
+      });
+
+      expect(describeIssue(issue).eventIdentifier).toBeUndefined();
+    });
+
+    it('should fall back to an unknown description when the payload does not match the kind', () => {
+      const issue = createIssue({ kind: IssueKind.NEGATIVE_BALANCE, payload: { garbage: true } });
+
+      const result = describeIssue(issue);
+
+      expect(result.messageKey).toBe('data_issues.description.unknown');
+      expect(result.eventIdentifier).toBeUndefined();
+      expect(result.amounts).toEqual({});
+    });
+  });
+
+  describe('relatedEventRoute', () => {
+    it('should deep-link a negative balance to its highlighted event', () => {
+      expect(relatedEventRoute(IssueKind.NEGATIVE_BALANCE, 42)).toEqual({
+        path: Routes.HISTORY_EVENTS.toString(),
+        query: { highlightedNegativeBalanceEvent: '42' },
+      });
+    });
+
+    it('should also pass the group identifier so the events view can page to the event', () => {
+      expect(relatedEventRoute(IssueKind.NEGATIVE_BALANCE, 42, '0xabc')).toEqual({
+        path: Routes.HISTORY_EVENTS.toString(),
+        query: { highlightedNegativeBalanceEvent: '42', targetGroupIdentifier: '0xabc' },
+      });
+    });
+
+    it('should link a non negative-balance kind to the events page without a highlight', () => {
+      expect(relatedEventRoute(IssueKind.CURRENT_BALANCE_MISMATCH, 7)).toEqual({
+        path: Routes.HISTORY_EVENTS.toString(),
+      });
+    });
+
+    it('should also filter by asset when the issue carries one', () => {
+      expect(relatedEventRoute(IssueKind.NEGATIVE_BALANCE, 42, '0xabc', 'ETH')).toEqual({
+        path: Routes.HISTORY_EVENTS.toString(),
+        query: { asset: 'ETH', highlightedNegativeBalanceEvent: '42', targetGroupIdentifier: '0xabc' },
+      });
+    });
+
+    it('should filter a non negative-balance kind by asset alone', () => {
+      expect(relatedEventRoute(IssueKind.CURRENT_BALANCE_MISMATCH, 7, undefined, 'BTC')).toEqual({
+        path: Routes.HISTORY_EVENTS.toString(),
+        query: { asset: 'BTC' },
+      });
+    });
+
+    it('should return undefined when there is no event identifier', () => {
+      expect(relatedEventRoute(IssueKind.NEGATIVE_BALANCE, undefined)).toBeUndefined();
+    });
+  });
+
+  describe('toTimelineItems', () => {
+    it('should order attempts oldest-first by timestamp', () => {
+      const issue = createIssue({
+        autoRemediationAttempts: [
+          { strategy: 'second', success: true, timestamp: 200 },
+          { strategy: 'first', success: false, timestamp: 100 },
+        ],
+      });
+
+      const items = toTimelineItems(issue);
+
+      expect(items.map(item => item.strategy)).toEqual(['first', 'second']);
+    });
+
+    it('should return an empty array when there are no attempts', () => {
+      expect(toTimelineItems(createIssue())).toEqual([]);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/transforms.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.ts
@@ -1,0 +1,124 @@
+import type { RouteLocationRaw } from 'vue-router';
+import type { IssueDescription, RemediationTimelineItem } from '@/modules/history/data-issues/types';
+import { fromNullable, getOr } from 'plainfp/option';
+import { pipe } from 'plainfp/pipe';
+import { IssueKind } from '@/modules/history/data-issues/constants';
+import { type AutoRemediationAttempt, CurrentBalanceMismatchPayload, type DataIssue, NegativeBalancePayload } from '@/modules/history/data-issues/schemas';
+import { Routes } from '@/router/routes';
+
+/**
+ * Turns a raw strategy identifier (e.g. `reprocess_event`) into a human label
+ * (`Reprocess event`).
+ */
+export function humanizeStrategy(strategy: string): string {
+  const normalized = strategy.replaceAll(/[_-]+/g, ' ').trim();
+  if (normalized.length === 0)
+    return strategy;
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+/**
+ * Describes what is wrong with an issue, narrowed by its `kind`. Returns the i18n
+ * keypath and its interpolation values (the asset as an identifier, the numbers as
+ * `BigNumber`s) so the display can render the asset as a resolved symbol and the
+ * amounts with the user's decimals setting, rather than baking raw values into a
+ * string. Also exposes an optional `eventIdentifier` to deep-link the offending event.
+ */
+export function describeIssue(issue: DataIssue): IssueDescription {
+  if (issue.kind === IssueKind.NEGATIVE_BALANCE) {
+    const parsed = NegativeBalancePayload.safeParse(issue.payload);
+    if (parsed.success) {
+      const payload = parsed.data;
+      return {
+        amounts: {
+          // Signed value: the i18n string no longer prepends a literal "-", so
+          // ValueDisplay renders the sign (avoids awkward output like "-< 0.001").
+          amount: payload.inMemoryNegativeAmount,
+          before: payload.derivedBalanceBeforeEvent,
+        },
+        asset: issue.asset ?? undefined,
+        eventIdentifier: payload.eventIdentifier,
+        messageKey: 'data_issues.description.negative_balance',
+      };
+    }
+  }
+  else if (issue.kind === IssueKind.CURRENT_BALANCE_MISMATCH) {
+    const parsed = CurrentBalanceMismatchPayload.safeParse(issue.payload);
+    if (parsed.success) {
+      const payload = parsed.data;
+      return {
+        amounts: {
+          delta: payload.delta,
+          derived: payload.derivedBalance,
+          observed: payload.observedBalance,
+        },
+        asset: issue.asset ?? undefined,
+        eventIdentifier: pipe(
+          fromNullable(payload.latestEventIdentifier),
+          (option): number | undefined => getOr(option, undefined),
+        ),
+        messageKey: 'data_issues.description.current_balance_mismatch',
+      };
+    }
+  }
+
+  return { amounts: {}, messageKey: 'data_issues.description.unknown' };
+}
+
+/**
+ * Deep-link to the offending history event for an issue, or `undefined` when the
+ * issue carries no event identifier. For a negative-balance issue the events view
+ * needs both `highlightedNegativeBalanceEvent` (the event) and
+ * `targetGroupIdentifier` (its group) to page to and highlight the row, so we pass
+ * both when the backend supplied the group identifier. When the issue carries an
+ * asset we also add it to the query so the events view filters to that asset on
+ * arrival (the `asset` matcher key is read straight from the route). Shared by the
+ * detail drawer and the inbox panel so both navigate consistently.
+ */
+export function relatedEventRoute(
+  kind: IssueKind,
+  eventIdentifier: number | undefined,
+  groupIdentifier?: string | null,
+  asset?: string | null,
+): RouteLocationRaw | undefined {
+  if (eventIdentifier === undefined)
+    return undefined;
+
+  const path = Routes.HISTORY_EVENTS.toString();
+  const query: Record<string, string> = {};
+
+  if (kind === IssueKind.NEGATIVE_BALANCE) {
+    query.highlightedNegativeBalanceEvent = eventIdentifier.toString();
+    if (groupIdentifier)
+      query.targetGroupIdentifier = groupIdentifier;
+  }
+
+  if (asset)
+    query.asset = asset;
+
+  return Object.keys(query).length > 0 ? { path, query } : { path };
+}
+
+function toTimelineItem(attempt: AutoRemediationAttempt): RemediationTimelineItem {
+  return {
+    attribution: attempt.attribution,
+    strategy: attempt.strategy,
+    success: attempt.success,
+    timestamp: attempt.timestamp,
+  };
+}
+
+/**
+ * Maps the raw auto-remediation attempts into ordered timeline items. Attempts
+ * that carry a timestamp are shown oldest-first; the order of timestamp-less
+ * attempts (older backend rows) is preserved.
+ */
+export function toTimelineItems(issue: DataIssue): RemediationTimelineItem[] {
+  return issue.autoRemediationAttempts
+    .map(toTimelineItem)
+    .sort((a, b) => {
+      const left = pipe(fromNullable(a.timestamp), option => getOr(option, 0));
+      const right = pipe(fromNullable(b.timestamp), option => getOr(option, 0));
+      return left - right;
+    });
+}

--- a/frontend/app/src/modules/history/data-issues/types.ts
+++ b/frontend/app/src/modules/history/data-issues/types.ts
@@ -1,0 +1,43 @@
+import type { BigNumber } from '@rotki/common';
+
+/**
+ * Typed error domain for data-issue API calls, so the UI can branch on the
+ * failure kind (friendly copy, refetch on conflict) instead of matching error
+ * strings. Maps to the backend status codes: 404 -> not-found,
+ * 409 -> conflict (invalid state transition), 400 -> validation, else network.
+ */
+export type DataIssueError =
+  | { readonly type: 'not-found'; readonly message: string }
+  | { readonly type: 'conflict'; readonly message: string }
+  | { readonly type: 'validation'; readonly message: string }
+  | { readonly type: 'network'; readonly message: string };
+
+export function dataIssueErrorMessage(error: DataIssueError): string {
+  return error.message;
+}
+
+/** One entry in the auto-remediation timeline shown in the detail drawer. */
+export interface RemediationTimelineItem {
+  readonly strategy: string;
+  readonly success?: boolean;
+  readonly timestamp?: number;
+  readonly attribution?: string;
+}
+
+/**
+ * A description of what is wrong, derived from an issue payload. The sentence is
+ * kept as an i18n keypath plus its interpolation values (rather than a pre-built
+ * string) so the display can render the asset as a resolved symbol via `<i18n-t>`
+ * instead of embedding the raw asset identifier in the text.
+ */
+export interface IssueDescription {
+  /** i18n keypath for the "what's wrong" sentence. */
+  readonly messageKey: string;
+  /** Numeric interpolation values, keyed by placeholder name, rendered with the
+   * user's decimals setting (and a full-value tooltip) via `ValueDisplay`. */
+  readonly amounts: Record<string, BigNumber>;
+  /** Asset identifier for the `{asset}` placeholder, resolved to a symbol on render. */
+  readonly asset?: string;
+  /** Optional history-event identifier to deep-link to the offending event. */
+  readonly eventIdentifier?: number;
+}

--- a/frontend/app/src/modules/history/data-issues/use-data-issue-detail-actions.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issue-detail-actions.spec.ts
@@ -1,0 +1,159 @@
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import { get } from '@vueuse/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
+import { useDataIssueDetailActions } from '@/modules/history/data-issues/use-data-issue-detail-actions';
+
+const dismiss = vi.fn();
+const retry = vi.fn();
+const resolveManually = vi.fn();
+const show = vi.fn();
+
+vi.mock('@/modules/history/data-issues/use-data-issues', () => ({
+  useDataIssues: (): Record<string, unknown> => ({
+    dismiss,
+    fetchData: vi.fn(),
+    resolveManually,
+    retry,
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): Record<string, unknown> => ({ show }),
+}));
+
+/** Runs the onConfirm callback the composable handed to the confirm dialog. */
+async function confirmDismiss(): Promise<void> {
+  const onConfirm = show.mock.calls.at(-1)?.[1] as () => Promise<void>;
+  await onConfirm();
+}
+
+function createIssue(overrides: Partial<DataIssue> = {}): DataIssue {
+  return {
+    asset: 'ETH',
+    autoRemediationAttempts: [],
+    createdAt: 1710000100,
+    groupIdentifier: null,
+    id: 1,
+    kind: IssueKind.NEGATIVE_BALANCE,
+    location: 'ethereum',
+    locationLabel: '0x0000000000000000000000000000000000000001',
+    payload: {},
+    protocol: null,
+    resolvedAt: null,
+    severity: IssueSeverity.WARNING,
+    state: IssueState.OPEN,
+    tsEnd: 1710000000,
+    tsStart: 1710000000,
+    ...overrides,
+  };
+}
+
+describe('useDataIssueDetailActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should open the drawer with the selected issue', () => {
+    const { modelDrawerOpen, modelSelectedIssue, openDetail } = useDataIssueDetailActions(vi.fn());
+    const issue = createIssue();
+
+    openDetail(issue);
+
+    expect(get(modelSelectedIssue)).toStrictEqual(issue);
+    expect(get(modelDrawerOpen)).toBe(true);
+  });
+
+  it('should ask for confirmation before dismissing and not dismiss until confirmed', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const { onDismiss } = useDataIssueDetailActions(reload);
+
+    await onDismiss(1);
+
+    expect(show).toHaveBeenCalledOnce();
+    expect(dismiss).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('should close the drawer and reload after a confirmed dismiss', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    dismiss.mockResolvedValue(createIssue({ state: IssueState.DISMISSED }));
+    const { modelDrawerOpen, onDismiss, openDetail } = useDataIssueDetailActions(reload);
+    openDetail(createIssue());
+
+    await onDismiss(1);
+    await confirmDismiss();
+
+    expect(dismiss).toHaveBeenCalledWith(1);
+    expect(get(modelDrawerOpen)).toBe(false);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('should keep the drawer open and skip reload when a confirmed dismiss fails', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    dismiss.mockResolvedValue(undefined);
+    const { modelDrawerOpen, onDismiss, openDetail } = useDataIssueDetailActions(reload);
+    openDetail(createIssue());
+
+    await onDismiss(1);
+    await confirmDismiss();
+
+    expect(get(modelDrawerOpen)).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('should reset the busy flag even if a confirmed dismiss rejects', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    dismiss.mockRejectedValue(new Error('boom'));
+    const { modelActionBusy, onDismiss } = useDataIssueDetailActions(reload);
+
+    await onDismiss(1);
+    await expect(confirmDismiss()).rejects.toThrow('boom');
+    expect(get(modelActionBusy)).toBe(false);
+  });
+
+  it('should refresh the selected issue after a successful retry', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const updated = createIssue({ state: IssueState.AUTO_REMEDIATING });
+    retry.mockResolvedValue(updated);
+    const { modelSelectedIssue, onRetry } = useDataIssueDetailActions(reload);
+
+    await onRetry(1);
+
+    expect(get(modelSelectedIssue)).toStrictEqual(updated);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('should open the resolve dialog on request', () => {
+    const { modelResolveOpen, onResolveRequest } = useDataIssueDetailActions(vi.fn());
+
+    onResolveRequest();
+
+    expect(get(modelResolveOpen)).toBe(true);
+  });
+
+  it('should no-op resolve confirm when no issue is selected', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const { onResolveConfirm } = useDataIssueDetailActions(reload);
+
+    await onResolveConfirm('note');
+
+    expect(resolveManually).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('should resolve manually with the note, close both dialogs and reload', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    resolveManually.mockResolvedValue(createIssue({ state: IssueState.RESOLVED }));
+    const { modelDrawerOpen, modelResolveOpen, onResolveConfirm, onResolveRequest, openDetail } = useDataIssueDetailActions(reload);
+    openDetail(createIssue({ id: 7 }));
+    onResolveRequest();
+
+    await onResolveConfirm('fixed externally');
+
+    expect(resolveManually).toHaveBeenCalledWith(7, 'fixed externally');
+    expect(get(modelResolveOpen)).toBe(false);
+    expect(get(modelDrawerOpen)).toBe(false);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/use-data-issue-detail-actions.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issue-detail-actions.ts
@@ -1,0 +1,118 @@
+import type { Ref } from 'vue';
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useDataIssues } from '@/modules/history/data-issues/use-data-issues';
+
+interface UseDataIssueDetailActionsReturn {
+  modelSelectedIssue: Ref<DataIssue | undefined>;
+  modelDrawerOpen: Ref<boolean>;
+  modelResolveOpen: Ref<boolean>;
+  modelActionBusy: Ref<boolean>;
+  openDetail: (issue: DataIssue) => void;
+  onDismiss: (id: number) => Promise<void>;
+  onRetry: (id: number) => Promise<void>;
+  onResolveRequest: () => void;
+  onResolveConfirm: (note: string | undefined) => Promise<void>;
+}
+
+/**
+ * Detail-drawer and per-issue action orchestration shared by the inbox panel and
+ * the full page. Owns the selected issue, the drawer/resolve-dialog visibility,
+ * and a busy flag; each successful action triggers the caller-supplied `reload`
+ * so both the list and the badge summary refresh from a single place.
+ *
+ * The returned refs use the `model` prefix because they are two-way bindings the
+ * consumer drives via `v-model` / mutates, which the `composable-return-readonly`
+ * lint rule treats as writable-by-convention.
+ */
+export function useDataIssueDetailActions(
+  reload: () => Promise<void>,
+): UseDataIssueDetailActionsReturn {
+  const { t } = useI18n({ useScope: 'global' });
+  const { dismiss, resolveManually, retry } = useDataIssues();
+  const { show } = useConfirmStore();
+
+  const modelSelectedIssue = ref<DataIssue>();
+  const modelDrawerOpen = shallowRef<boolean>(false);
+  const modelResolveOpen = shallowRef<boolean>(false);
+  const modelActionBusy = shallowRef<boolean>(false);
+
+  function openDetail(issue: DataIssue): void {
+    set(modelSelectedIssue, issue);
+    set(modelDrawerOpen, true);
+  }
+
+  // Dismiss hides the issue and stops auto-remediation, so confirm first. The
+  // prompt is shown here (the single choke point) rather than per call site, so
+  // the drawer, panel cards and table quick actions all get it for free.
+  async function onDismiss(id: number): Promise<void> {
+    show(
+      {
+        message: t('data_issues.action.dismiss.confirm.message'),
+        title: t('data_issues.action.dismiss.confirm.title'),
+        type: 'warning',
+      },
+      async () => {
+        set(modelActionBusy, true);
+        try {
+          const updated = await dismiss(id);
+          if (updated) {
+            set(modelDrawerOpen, false);
+            await reload();
+          }
+        }
+        finally {
+          set(modelActionBusy, false);
+        }
+      },
+    );
+  }
+
+  async function onRetry(id: number): Promise<void> {
+    set(modelActionBusy, true);
+    try {
+      const updated = await retry(id);
+      if (updated) {
+        set(modelSelectedIssue, updated);
+        await reload();
+      }
+    }
+    finally {
+      set(modelActionBusy, false);
+    }
+  }
+
+  function onResolveRequest(): void {
+    set(modelResolveOpen, true);
+  }
+
+  async function onResolveConfirm(note: string | undefined): Promise<void> {
+    const issue = get(modelSelectedIssue);
+    if (!issue)
+      return;
+    set(modelActionBusy, true);
+    try {
+      const updated = await resolveManually(issue.id, note);
+      if (updated) {
+        set(modelResolveOpen, false);
+        set(modelDrawerOpen, false);
+        await reload();
+      }
+    }
+    finally {
+      set(modelActionBusy, false);
+    }
+  }
+
+  return {
+    modelActionBusy,
+    modelDrawerOpen,
+    modelResolveOpen,
+    modelSelectedIssue,
+    onDismiss,
+    onResolveConfirm,
+    onResolveRequest,
+    onRetry,
+    openDetail,
+  };
+}

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-filter.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-filter.ts
@@ -1,0 +1,128 @@
+import type { MatchedKeyword, SearchMatcher } from '@/modules/core/table/filtering';
+import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
+import { z } from 'zod/v4';
+import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
+import { arrayify } from '@/modules/core/common/data/array';
+import { dateDeserializer, dateRangeValidator, dateSerializer, getDateInputISOFormat } from '@/modules/core/common/data/date';
+import { assetSuggestions } from '@/modules/core/common/display/assets';
+import { IssueKind, IssueState } from '@/modules/history/data-issues/constants';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+
+enum DataIssuesFilterKeys {
+  STATE = 'state',
+  KIND = 'kind',
+  ASSET = 'asset',
+  ACCOUNT = 'account',
+  START = 'start',
+  END = 'end',
+}
+
+enum DataIssuesFilterValueKeys {
+  STATE = 'state',
+  KIND = 'kind',
+  ASSET = 'asset',
+  ACCOUNT = 'locationLabel',
+  START = 'fromTimestamp',
+  END = 'toTimestamp',
+}
+
+export type Matcher = SearchMatcher<DataIssuesFilterKeys, DataIssuesFilterValueKeys>;
+
+export type Filters = MatchedKeyword<DataIssuesFilterValueKeys>;
+
+const STATES: string[] = Object.values(IssueState);
+const KINDS: string[] = Object.values(IssueKind);
+
+export function useDataIssuesFilter(): FilterSchema<Filters, Matcher> {
+  const filters = ref<Filters>({});
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { assetSearch, getAssetInfo } = useAssetInfoRetrieval();
+  const { dateInputFormat } = storeToRefs(useFrontendSettingsStore());
+
+  const matchers = computed<Matcher[]>(() => [
+    {
+      description: t('data_issues.filter.state'),
+      key: DataIssuesFilterKeys.STATE,
+      keyValue: DataIssuesFilterValueKeys.STATE,
+      multiple: true,
+      string: true,
+      strictMatching: true,
+      suggestions: (): string[] => STATES,
+      suggestionsToShow: -1,
+      validate: (value: string): boolean => STATES.includes(value),
+    },
+    {
+      description: t('data_issues.filter.kind'),
+      key: DataIssuesFilterKeys.KIND,
+      keyValue: DataIssuesFilterValueKeys.KIND,
+      multiple: true,
+      string: true,
+      strictMatching: true,
+      suggestions: (): string[] => KINDS,
+      suggestionsToShow: -1,
+      validate: (value: string): boolean => KINDS.includes(value),
+    },
+    {
+      asset: true,
+      description: t('data_issues.filter.asset'),
+      deserializer: getAssetInfo,
+      key: DataIssuesFilterKeys.ASSET,
+      keyValue: DataIssuesFilterValueKeys.ASSET,
+      suggestions: assetSuggestions(assetSearch),
+    },
+    {
+      description: t('data_issues.filter.account'),
+      key: DataIssuesFilterKeys.ACCOUNT,
+      keyValue: DataIssuesFilterValueKeys.ACCOUNT,
+      string: true,
+      suggestions: (): string[] => [],
+      validate: (value: string): boolean => value.length > 0,
+    },
+    {
+      description: t('data_issues.filter.start_date'),
+      deserializer: dateDeserializer(dateInputFormat),
+      hint: t('transactions.filter.date_hint', {
+        format: getDateInputISOFormat(get(dateInputFormat)),
+      }),
+      key: DataIssuesFilterKeys.START,
+      keyValue: DataIssuesFilterValueKeys.START,
+      serializer: dateSerializer(dateInputFormat),
+      string: true,
+      suggestions: (): string[] => [],
+      validate: dateRangeValidator(dateInputFormat, () => get(filters)?.toTimestamp?.toString(), 'start'),
+    },
+    {
+      description: t('data_issues.filter.end_date'),
+      deserializer: dateDeserializer(dateInputFormat),
+      hint: t('transactions.filter.date_hint', {
+        format: getDateInputISOFormat(get(dateInputFormat)),
+      }),
+      key: DataIssuesFilterKeys.END,
+      keyValue: DataIssuesFilterValueKeys.END,
+      serializer: dateSerializer(dateInputFormat),
+      string: true,
+      suggestions: (): string[] => [],
+      validate: dateRangeValidator(dateInputFormat, () => get(filters)?.fromTimestamp?.toString(), 'end'),
+    },
+  ]);
+
+  const OptionalMultipleString = z.array(z.string()).or(z.string()).transform(arrayify).optional();
+  const OptionalString = z.string().optional();
+
+  const RouteFilterSchema = z.object({
+    [DataIssuesFilterValueKeys.ACCOUNT]: OptionalString,
+    [DataIssuesFilterValueKeys.ASSET]: OptionalString,
+    [DataIssuesFilterValueKeys.END]: OptionalString,
+    [DataIssuesFilterValueKeys.KIND]: OptionalMultipleString,
+    [DataIssuesFilterValueKeys.START]: OptionalString,
+    [DataIssuesFilterValueKeys.STATE]: OptionalMultipleString,
+  });
+
+  return {
+    // eslint-disable-next-line @rotki/composable-return-readonly -- usePaginationFilters writes back into this ref (set() on route changes and v-model)
+    filters,
+    matchers,
+    RouteFilterSchema,
+  };
+}

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-format.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-format.ts
@@ -1,0 +1,43 @@
+import { IssueKind, IssueState } from '@/modules/history/data-issues/constants';
+
+interface UseDataIssuesFormatReturn {
+  stateLabel: (state: IssueState) => string;
+  kindLabel: (kind: IssueKind) => string;
+}
+
+/**
+ * Maps issue enums to translated labels using explicit (non-dynamic) keys, so
+ * the i18n linter can statically verify every key is present.
+ */
+export function useDataIssuesFormat(): UseDataIssuesFormatReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  const stateLabel = (state: IssueState): string => {
+    switch (state) {
+      case IssueState.OPEN:
+        return t('data_issues.state.open');
+      case IssueState.AUTO_REMEDIATING:
+        return t('data_issues.state.auto_remediating');
+      case IssueState.UNRESOLVED:
+        return t('data_issues.state.unresolved');
+      case IssueState.RESOLVED:
+        return t('data_issues.state.resolved');
+      case IssueState.DISMISSED:
+        return t('data_issues.state.dismissed');
+    }
+  };
+
+  const kindLabel = (kind: IssueKind): string => {
+    switch (kind) {
+      case IssueKind.NEGATIVE_BALANCE:
+        return t('data_issues.kind.negative_balance');
+      case IssueKind.CURRENT_BALANCE_MISMATCH:
+        return t('data_issues.kind.current_balance_mismatch');
+    }
+  };
+
+  return {
+    kindLabel,
+    stateLabel,
+  };
+}

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-inbox-store.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-inbox-store.spec.ts
@@ -1,0 +1,74 @@
+import { get, set } from '@vueuse/core';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
+import { IssueState } from '@/modules/history/data-issues/constants';
+import { emptyCounts, type StateCounts, useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
+import { PinnedNames } from '@/modules/session/types';
+
+function counts(overrides: Partial<StateCounts> = {}): StateCounts {
+  return { ...emptyCounts(), ...overrides };
+}
+
+describe('useDataIssuesInboxStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should start with zeroed counts and a hidden overlay', () => {
+    const store = useDataIssuesInboxStore();
+
+    expect(get(store.counts)).toStrictEqual(emptyCounts());
+    expect(get(store.baselineTotal)).toBe(0);
+    expect(get(store.overlayVisible)).toBe(false);
+    expect(get(store.actionableCount)).toBe(0);
+  });
+
+  it('should count only open and unresolved issues as actionable', () => {
+    const store = useDataIssuesInboxStore();
+
+    store.setSummary(counts({
+      [IssueState.AUTO_REMEDIATING]: 4,
+      [IssueState.OPEN]: 3,
+      [IssueState.RESOLVED]: 7,
+      [IssueState.UNRESOLVED]: 2,
+    }), 16);
+
+    // auto-remediating, resolved and dismissed are excluded on purpose.
+    expect(get(store.actionableCount)).toBe(5);
+  });
+
+  it('should store the counts and baseline handed to setSummary', () => {
+    const store = useDataIssuesInboxStore();
+    const newCounts = counts({ [IssueState.OPEN]: 1 });
+
+    store.setSummary(newCounts, 42);
+
+    expect(get(store.counts)).toStrictEqual(newCounts);
+    expect(get(store.baselineTotal)).toBe(42);
+  });
+
+  it('should hide the overlay and clear the data-issues pin when dismissing inline panels', () => {
+    const store = useDataIssuesInboxStore();
+    const { overlayVisible } = storeToRefs(store);
+    const { pinned } = storeToRefs(useAreaVisibilityStore());
+    set(overlayVisible, true);
+    set(pinned, { name: PinnedNames.DATA_ISSUES, props: {} });
+
+    store.dismissInlinePanels();
+
+    expect(get(overlayVisible)).toBe(false);
+    expect(get(pinned)).toBeNull();
+  });
+
+  it('should leave an unrelated pin untouched when dismissing inline panels', () => {
+    const store = useDataIssuesInboxStore();
+    const { pinned } = storeToRefs(useAreaVisibilityStore());
+    const other = { name: PinnedNames.MATCH_ASSET_MOVEMENTS, props: {} };
+    set(pinned, other);
+
+    store.dismissInlinePanels();
+
+    expect(get(pinned)).toStrictEqual(other);
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-inbox-store.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-inbox-store.ts
@@ -1,0 +1,62 @@
+import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
+import { IssueState } from '@/modules/history/data-issues/constants';
+import { PinnedNames } from '@/modules/session/types';
+
+export type StateCounts = Record<IssueState, number>;
+
+export function emptyCounts(): StateCounts {
+  return {
+    [IssueState.OPEN]: 0,
+    [IssueState.AUTO_REMEDIATING]: 0,
+    [IssueState.UNRESOLVED]: 0,
+    [IssueState.RESOLVED]: 0,
+    [IssueState.DISMISSED]: 0,
+  };
+}
+
+/**
+ * Shared summary state for the data issues inbox. Both the top-bar indicator
+ * (badge) and the inbox panel read counts from here so the badge and the panel
+ * never disagree. The async refresh lives in `useDataIssuesSummary`; this store
+ * stays sync-only and just holds state and a setter.
+ */
+export const useDataIssuesInboxStore = defineStore('history/data-issues-inbox', () => {
+  const counts = ref<StateCounts>(emptyCounts());
+  const baselineTotal = ref<number>(0);
+
+  /** Whether the floating overlay panel is open. Kept here (not in the history view)
+   * so the pinned rail can hand the panel back to the overlay when it is unpinned. */
+  const overlayVisible = ref<boolean>(false);
+
+  /** Issues awaiting the user: open + needs-attention. Auto-remediating issues
+   * are in progress and need no action, so they are intentionally excluded. */
+  const actionableCount = computed<number>(() =>
+    get(counts)[IssueState.OPEN] + get(counts)[IssueState.UNRESOLVED]);
+
+  function setSummary(newCounts: StateCounts, baseline: number): void {
+    set(counts, newCounts);
+    set(baselineTotal, baseline);
+  }
+
+  /** Closes the overlay and pinned-rail copies of the inbox. Called when the
+   * dedicated data-issues page is shown, so the same list is not displayed twice.
+   * Only the data-issues pin is cleared; an unrelated pinned panel is left alone. */
+  function dismissInlinePanels(): void {
+    set(overlayVisible, false);
+    const { pinned } = storeToRefs(useAreaVisibilityStore());
+    if (get(pinned)?.name === PinnedNames.DATA_ISSUES)
+      set(pinned, null);
+  }
+
+  return {
+    actionableCount,
+    baselineTotal,
+    counts,
+    dismissInlinePanels,
+    overlayVisible,
+    setSummary,
+  };
+});
+
+if (import.meta.hot)
+  import.meta.hot.accept(acceptHMRUpdate(useDataIssuesInboxStore, import.meta.hot));

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-summary.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-summary.spec.ts
@@ -1,0 +1,65 @@
+import { get } from '@vueuse/core';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IssueState } from '@/modules/history/data-issues/constants';
+import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
+
+const listIssues = vi.fn();
+
+vi.mock('@/modules/history/data-issues/api/use-data-issues-api', () => ({
+  useDataIssuesApi: (): Record<string, unknown> => ({
+    listIssues,
+  }),
+}));
+
+// Per-state counts the mocked backend reports; the "all states" query is the baseline total.
+const FOUND: Record<string, number> = {
+  [IssueState.OPEN]: 3,
+  [IssueState.AUTO_REMEDIATING]: 2,
+  [IssueState.UNRESOLVED]: 5,
+};
+const BASELINE = 20;
+
+describe('useDataIssuesSummary', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    listIssues.mockImplementation(async ({ state }: { state: IssueState[] }) => {
+      const found = state.length === Object.values(IssueState).length
+        ? BASELINE
+        : FOUND[state[0]] ?? 0;
+      return { ok: true, value: { found } };
+    });
+  });
+
+  it('should aggregate per-state counts and the baseline total into the store', async () => {
+    const { baselineTotal, counts, refreshSummary } = useDataIssuesSummary();
+
+    await refreshSummary();
+
+    expect(get(counts)[IssueState.OPEN]).toBe(3);
+    expect(get(counts)[IssueState.AUTO_REMEDIATING]).toBe(2);
+    expect(get(counts)[IssueState.UNRESOLVED]).toBe(5);
+    expect(get(counts)[IssueState.RESOLVED]).toBe(0);
+    expect(get(counts)[IssueState.DISMISSED]).toBe(0);
+    expect(get(baselineTotal)).toBe(BASELINE);
+  });
+
+  it('should expose actionableCount as open + unresolved only', async () => {
+    const { actionableCount, refreshSummary } = useDataIssuesSummary();
+
+    await refreshSummary();
+
+    expect(get(actionableCount)).toBe(8);
+  });
+
+  it('should treat a failed query as a zero count', async () => {
+    listIssues.mockResolvedValue({ error: { message: 'boom' }, ok: false });
+    const { baselineTotal, counts, refreshSummary } = useDataIssuesSummary();
+
+    await refreshSummary();
+
+    expect(get(counts)[IssueState.OPEN]).toBe(0);
+    expect(get(baselineTotal)).toBe(0);
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-summary.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-summary.ts
@@ -1,0 +1,52 @@
+import type { Ref } from 'vue';
+import { useDataIssuesApi } from '@/modules/history/data-issues/api/use-data-issues-api';
+import { IssueState } from '@/modules/history/data-issues/constants';
+import { emptyCounts, type StateCounts, useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
+
+interface UseDataIssuesSummaryReturn {
+  counts: Ref<StateCounts>;
+  baselineTotal: Ref<number>;
+  actionableCount: Ref<number>;
+  refreshSummary: () => Promise<void>;
+  dismissInlinePanels: () => void;
+}
+
+/**
+ * Loads the inbox summary counts and writes them into the (sync-only) inbox
+ * store. Any consumer can read the shared counts from here and trigger a refresh
+ * after an action, keeping the badge and the panel in agreement.
+ */
+export function useDataIssuesSummary(): UseDataIssuesSummaryReturn {
+  const { listIssues } = useDataIssuesApi();
+  const store = useDataIssuesInboxStore();
+  const { actionableCount, baselineTotal, counts } = storeToRefs(store);
+
+  async function countForStates(states: IssueState[]): Promise<number> {
+    const result = await listIssues({ limit: 1, offset: 0, state: states });
+    return result.ok ? result.value.found : 0;
+  }
+
+  const refreshSummary = async (): Promise<void> => {
+    const [open, remediating, unresolved, baseline] = await Promise.all([
+      countForStates([IssueState.OPEN]),
+      countForStates([IssueState.AUTO_REMEDIATING]),
+      countForStates([IssueState.UNRESOLVED]),
+      countForStates(Object.values(IssueState)),
+    ]);
+
+    store.setSummary({
+      ...emptyCounts(),
+      [IssueState.OPEN]: open,
+      [IssueState.AUTO_REMEDIATING]: remediating,
+      [IssueState.UNRESOLVED]: unresolved,
+    }, baseline);
+  };
+
+  return {
+    actionableCount,
+    baselineTotal,
+    counts,
+    dismissInlinePanels: store.dismissInlinePanels,
+    refreshSummary,
+  };
+}

--- a/frontend/app/src/modules/history/data-issues/use-data-issues.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues.spec.ts
@@ -1,0 +1,151 @@
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
+import { useDataIssues } from '@/modules/history/data-issues/use-data-issues';
+
+const listIssues = vi.fn();
+const dismissIssue = vi.fn();
+const resolveIssueManually = vi.fn();
+const retryAutoRemediation = vi.fn();
+const notifyError = vi.fn();
+const setMessage = vi.fn();
+
+vi.mock('@/modules/history/data-issues/api/use-data-issues-api', () => ({
+  useDataIssuesApi: (): Record<string, unknown> => ({
+    dismissIssue,
+    resolveIssueManually,
+    retryAutoRemediation,
+    listIssues,
+  }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: (): Record<string, unknown> => ({ notifyError }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+function createIssue(overrides: Partial<DataIssue> = {}): DataIssue {
+  return {
+    asset: 'ETH',
+    autoRemediationAttempts: [],
+    createdAt: 1710000100,
+    groupIdentifier: null,
+    id: 1,
+    kind: IssueKind.NEGATIVE_BALANCE,
+    location: 'ethereum',
+    locationLabel: '0x0000000000000000000000000000000000000001',
+    payload: {},
+    protocol: null,
+    resolvedAt: null,
+    severity: IssueSeverity.WARNING,
+    state: IssueState.OPEN,
+    tsEnd: 1710000000,
+    tsStart: 1710000000,
+    ...overrides,
+  };
+}
+
+describe('useDataIssues', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return the collection on a successful fetch', async () => {
+    const collection = { data: [createIssue()], found: 1, limit: 10, total: 1 };
+    listIssues.mockResolvedValue({ ok: true, value: collection });
+    const { fetchData } = useDataIssues();
+
+    const result = await fetchData({ limit: 10, offset: 0 });
+
+    expect(result).toStrictEqual(collection);
+    expect(notifyError).not.toHaveBeenCalled();
+  });
+
+  it('should notify and return an empty collection on a failed fetch', async () => {
+    listIssues.mockResolvedValue({ error: { message: 'boom' }, ok: false });
+    const { fetchData } = useDataIssues();
+
+    const result = await fetchData({ limit: 10, offset: 0 });
+
+    expect(notifyError).toHaveBeenCalledOnce();
+    expect(result.data).toStrictEqual([]);
+    expect(result.found).toBe(0);
+  });
+
+  it('should resolve the payload to a plain value before querying', async () => {
+    listIssues.mockResolvedValue({ ok: true, value: { data: [], found: 0, limit: 10, total: 0 } });
+    const { fetchData } = useDataIssues();
+
+    await fetchData(ref({ limit: 10, offset: 0 }));
+
+    expect(listIssues).toHaveBeenCalledWith({ limit: 10, offset: 0 });
+  });
+
+  it('should return the updated issue on a successful dismiss', async () => {
+    const updated = createIssue({ state: IssueState.DISMISSED });
+    dismissIssue.mockResolvedValue({ ok: true, value: updated });
+    const { dismiss } = useDataIssues();
+
+    const result = await dismiss(1);
+
+    expect(dismissIssue).toHaveBeenCalledWith(1);
+    expect(result).toStrictEqual(updated);
+    expect(setMessage).not.toHaveBeenCalled();
+  });
+
+  it('should set an error message and return undefined when dismiss fails', async () => {
+    dismissIssue.mockResolvedValue({ error: { message: 'nope' }, ok: false });
+    const { dismiss } = useDataIssues();
+
+    const result = await dismiss(1);
+
+    expect(result).toBeUndefined();
+    expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({
+      description: 'nope',
+      success: false,
+    }));
+  });
+
+  it('should pass the note through when resolving manually', async () => {
+    resolveIssueManually.mockResolvedValue({ ok: true, value: createIssue({ state: IssueState.RESOLVED }) });
+    const { resolveManually } = useDataIssues();
+
+    await resolveManually(3, 'fixed externally');
+
+    expect(resolveIssueManually).toHaveBeenCalledWith(3, 'fixed externally');
+  });
+
+  it('should set an error message when a manual resolve fails', async () => {
+    resolveIssueManually.mockResolvedValue({ error: { message: 'bad state' }, ok: false });
+    const { resolveManually } = useDataIssues();
+
+    const result = await resolveManually(3);
+
+    expect(result).toBeUndefined();
+    expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ description: 'bad state' }));
+  });
+
+  it('should return the updated issue on a successful retry', async () => {
+    const updated = createIssue({ state: IssueState.AUTO_REMEDIATING });
+    retryAutoRemediation.mockResolvedValue({ ok: true, value: updated });
+    const { retry } = useDataIssues();
+
+    const result = await retry(9);
+
+    expect(retryAutoRemediation).toHaveBeenCalledWith(9);
+    expect(result).toStrictEqual(updated);
+  });
+
+  it('should set an error message when a retry fails', async () => {
+    retryAutoRemediation.mockResolvedValue({ error: { message: 'conflict' }, ok: false });
+    const { retry } = useDataIssues();
+
+    const result = await retry(9);
+
+    expect(result).toBeUndefined();
+    expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ description: 'conflict' }));
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/use-data-issues.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues.ts
@@ -1,0 +1,67 @@
+import type { MaybeRef } from 'vue';
+import type { Collection } from '@/modules/core/common/collection';
+import type { DataIssue, DataIssuesRequestPayload } from '@/modules/history/data-issues/schemas';
+import { defaultCollectionState } from '@/modules/core/common/data/collection-utils';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useNotifications } from '@/modules/core/notifications/use-notifications';
+import { useDataIssuesApi } from '@/modules/history/data-issues/api/use-data-issues-api';
+
+interface UseDataIssuesReturn {
+  fetchData: (payload: MaybeRef<DataIssuesRequestPayload>) => Promise<Collection<DataIssue>>;
+  dismiss: (id: number) => Promise<DataIssue | undefined>;
+  resolveManually: (id: number, note?: string) => Promise<DataIssue | undefined>;
+  retry: (id: number) => Promise<DataIssue | undefined>;
+}
+
+export function useDataIssues(): UseDataIssuesReturn {
+  const { t } = useI18n({ useScope: 'global' });
+  const { dismissIssue, listIssues, resolveIssueManually, retryAutoRemediation } = useDataIssuesApi();
+  const { notifyError } = useNotifications();
+  const { setMessage } = useMessageStore();
+
+  const fetchData = async (
+    payload: MaybeRef<DataIssuesRequestPayload>,
+  ): Promise<Collection<DataIssue>> => {
+    const result = await listIssues(get(payload));
+    if (result.ok)
+      return result.value;
+
+    notifyError(
+      t('data_issues.fetch.error.title'),
+      t('data_issues.fetch.error.message', { message: result.error.message }),
+    );
+    return defaultCollectionState<DataIssue>();
+  };
+
+  async function runAction(
+    action: Promise<{ ok: true; value: DataIssue } | { ok: false; error: { message: string } }>,
+    errorTitle: string,
+  ): Promise<DataIssue | undefined> {
+    const result = await action;
+    if (result.ok)
+      return result.value;
+
+    setMessage({
+      description: result.error.message,
+      success: false,
+      title: errorTitle,
+    });
+    return undefined;
+  }
+
+  const dismiss = async (id: number): Promise<DataIssue | undefined> =>
+    runAction(dismissIssue(id), t('data_issues.action.dismiss.error'));
+
+  const resolveManually = async (id: number, note?: string): Promise<DataIssue | undefined> =>
+    runAction(resolveIssueManually(id, note), t('data_issues.action.resolve.error'));
+
+  const retry = async (id: number): Promise<DataIssue | undefined> =>
+    runAction(retryAutoRemediation(id), t('data_issues.action.retry.error'));
+
+  return {
+    dismiss,
+    fetchData,
+    resolveManually,
+    retry,
+  };
+}

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -6,6 +6,7 @@ import AccountingOverlayToggle from '@/modules/history/balances/AccountingOverla
 import { OverlayMode, type OverlayPair, useAccountingOverlay } from '@/modules/history/balances/use-accounting-overlay';
 import { provideAccountingOverlay } from '@/modules/history/balances/use-accounting-overlay-context';
 import { useHistoricalBalancesStore } from '@/modules/history/balances/use-historical-balances-store';
+import { DataIssuesPanel, DataIssuesToggle } from '@/modules/history/data-issues/components/inbox';
 import { HISTORY_EVENT_ACTIONS, type HistoryEventAction } from '@/modules/history/events/action-types';
 import HistoryEventsVirtualTable from '@/modules/history/events/components/HistoryEventsVirtualTable.vue';
 import {
@@ -323,75 +324,79 @@ watchDebounced(route, async () => {
           @open:internal-tx-conflicts="dialogContainer?.show({ type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS })"
         />
 
-        <RuiCard>
-          <template
-            v-if="!mainPage"
-            #header
-          >
-            <div class="flex items-center gap-x-1">
-              <RefreshButton
-                :disabled="refreshing"
-                :tooltip="t('transactions.refresh_tooltip')"
-                @refresh="actions.refresh.all(true)"
-              />
-              {{ usedTitle }}
+        <div class="flex gap-4 items-start">
+          <RuiCard class="flex-1 min-w-0">
+            <template
+              v-if="!mainPage"
+              #header
+            >
+              <div class="flex items-center gap-x-1">
+                <RefreshButton
+                  :disabled="refreshing"
+                  :tooltip="t('transactions.refresh_tooltip')"
+                  @refresh="actions.refresh.all(true)"
+                />
+                {{ usedTitle }}
+              </div>
+            </template>
+
+            <HistoryEventsTableActions
+              ref="tableActions"
+              v-model:filters="filters"
+              v-model:toggles="toggles"
+              :location-labels="locationLabels"
+              :processing="processing"
+              :matchers="matchers"
+              :export-params="pageParams"
+              :hide-redecode-buttons="!mainPage"
+              :hide-account-selector="useExternalAccountFilter"
+              :selection="selectionMode.state.value"
+              :ignore-status="ignoreStatus"
+              @update:location-labels="onLocationLabelsChanged($event)"
+              @redecode="actions.redecode.by($event)"
+              @selection:action="handleSelectionAction($event)"
+            />
+
+            <div
+              v-if="overlayAvailable"
+              class="flex items-center justify-end gap-2 px-2 pt-2 mb-1"
+            >
+              <AccountingOverlayToggle v-model="overlayMode" />
+              <DataIssuesToggle />
             </div>
-          </template>
 
-          <HistoryEventsTableActions
-            ref="tableActions"
-            v-model:filters="filters"
-            v-model:toggles="toggles"
-            :location-labels="locationLabels"
-            :processing="processing"
-            :matchers="matchers"
-            :export-params="pageParams"
-            :hide-redecode-buttons="!mainPage"
-            :hide-account-selector="useExternalAccountFilter"
-            :selection="selectionMode.state.value"
-            :ignore-status="ignoreStatus"
-            @update:location-labels="onLocationLabelsChanged($event)"
-            @redecode="actions.redecode.by($event)"
-            @selection:action="handleSelectionAction($event)"
-          />
+            <HistoryEventsFiltersChips
+              ref="filtersChips"
+              :group-identifiers="groupIdentifiers"
+              :duplicate-handling-status="duplicateHandlingStatus"
+              @refresh="actions.fetch.dataAndLocations()"
+            />
 
-          <div
-            v-if="overlayAvailable"
-            class="flex items-center justify-end px-2 pt-2 mb-1"
-          >
-            <AccountingOverlayToggle v-model="overlayMode" />
-          </div>
-
-          <HistoryEventsFiltersChips
-            ref="filtersChips"
-            :group-identifiers="groupIdentifiers"
-            :duplicate-handling-status="duplicateHandlingStatus"
-            @refresh="actions.fetch.dataAndLocations()"
-          />
-
-          <HistoryEventsVirtualTable
-            v-model:sort="sort"
-            v-model:pagination="pagination"
-            :table-height-offset="tableHeightOffset"
-            :group-loading="groupLoading"
-            :groups="groups"
-            :page-params="toggles.matchExactEvents ? pageParams : undefined"
-            :exclude-ignored="!toggles.showIgnoredAssets"
-            :has-active-filters="hasActiveFilters"
-            :identifiers="identifiers"
-            :highlighted-group-identifier="highlightedGroupIdentifier"
-            :highlighted-identifiers="highlightedIdentifiers"
-            :highlight-types="highlightTypes"
-            :selection="selectionMode"
-            :duplicate-handling-status="duplicateHandlingStatus"
-            @clear-filters="clearFilters()"
-            @show:dialog="dialogContainer?.show($event)"
-            @refresh="handleRedecode($event)"
-            @refresh:block-event="actions.redecode.blocks($event)"
-            @set-page="setPage($event)"
-            @update-event-ids="handleUpdateEventIds($event)"
-          />
-        </RuiCard>
+            <HistoryEventsVirtualTable
+              v-model:sort="sort"
+              v-model:pagination="pagination"
+              :table-height-offset="tableHeightOffset"
+              :group-loading="groupLoading"
+              :groups="groups"
+              :page-params="toggles.matchExactEvents ? pageParams : undefined"
+              :exclude-ignored="!toggles.showIgnoredAssets"
+              :has-active-filters="hasActiveFilters"
+              :identifiers="identifiers"
+              :highlighted-group-identifier="highlightedGroupIdentifier"
+              :highlighted-identifiers="highlightedIdentifiers"
+              :highlight-types="highlightTypes"
+              :selection="selectionMode"
+              :duplicate-handling-status="duplicateHandlingStatus"
+              @clear-filters="clearFilters()"
+              @show:dialog="dialogContainer?.show($event)"
+              @refresh="handleRedecode($event)"
+              @refresh:block-event="actions.redecode.blocks($event)"
+              @set-page="setPage($event)"
+              @update-event-ids="handleUpdateEventIds($event)"
+            />
+          </RuiCard>
+          <DataIssuesPanel v-if="overlayAvailable" />
+        </div>
 
         <HistoryEventsDialogContainer
           ref="dialogContainer"

--- a/frontend/app/src/modules/history/events/use-history-event-navigation-consumer.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-navigation-consumer.spec.ts
@@ -501,6 +501,75 @@ describe('use-history-event-navigation-consumer', () => {
       });
     });
 
+    it('should keep the asset filter and compute the page within the filtered view', async () => {
+      setupMockRoute('/history/events', {
+        asset: 'ETH',
+        highlightedNegativeBalanceEvent: '500',
+        targetGroupIdentifier: 'group-route',
+      });
+      mockGetHistoryEventGroupPosition.mockResolvedValue(10);
+
+      const { useHistoryEventNavigationConsumer } = await importFresh();
+      const pagination = createPagination(10);
+
+      scope.run(() => {
+        useHistoryEventNavigationConsumer(pagination);
+      });
+
+      await flushPromises();
+
+      expect(mockGetHistoryEventGroupPosition).toHaveBeenCalledWith('group-route', { asset: 'ETH' });
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        force: true,
+        path: '/history/events',
+        query: {
+          asset: 'ETH',
+          highlightedNegativeBalanceEvent: '500',
+          limit: '10',
+          page: '2',
+        },
+      });
+    });
+
+    it('should wait for the loading cycle and preserve the asset filter when navigating with an asset', async () => {
+      setupMockRoute('/history/events', {
+        asset: 'ETH',
+        highlightedNegativeBalanceEvent: '500',
+        targetGroupIdentifier: 'group-route',
+      });
+      mockGetHistoryEventGroupPosition.mockResolvedValue(10);
+
+      const { useHistoryEventNavigationConsumer } = await importFresh();
+      const pagination = createPagination(10);
+      const loading = ref<boolean>(false);
+
+      scope.run(() => {
+        useHistoryEventNavigationConsumer(pagination, undefined, loading);
+      });
+
+      await nextTick();
+      // Position is computed within the asset-filtered view.
+      expect(mockGetHistoryEventGroupPosition).toHaveBeenCalledWith('group-route', { asset: 'ETH' });
+      // The push is deferred until the pagination refetch settles.
+      expect(mockRouterPush).not.toHaveBeenCalled();
+
+      // Simulate the pagination system loading cycle.
+      set(loading, true);
+      await nextTick();
+      set(loading, false);
+      await flushPromises();
+
+      expect(mockRouterPush).toHaveBeenCalledWith({
+        force: true,
+        path: '/history/events',
+        query: expect.objectContaining({
+          asset: 'ETH',
+          highlightedNegativeBalanceEvent: '500',
+          page: '2',
+        }),
+      });
+    });
+
     it('should not trigger navigation when targetGroupIdentifier is missing', async () => {
       setupMockRoute('/history/events', {
         highlightedNegativeBalanceEvent: '500',

--- a/frontend/app/src/modules/history/events/use-history-event-navigation-consumer.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-navigation-consumer.ts
@@ -32,13 +32,14 @@ export function useHistoryEventNavigationConsumer(
 
   // Watch for route-based navigation from external packages
   watchImmediate(route, ({ query }) => {
-    const { targetGroupIdentifier, highlightedNegativeBalanceEvent } = query;
+    const { targetGroupIdentifier, highlightedNegativeBalanceEvent, asset } = query;
     if (targetGroupIdentifier && highlightedNegativeBalanceEvent) {
       setHighlightTarget(HighlightTargetTypes.NEGATIVE_BALANCE, {
         groupIdentifier: targetGroupIdentifier.toString(),
         identifier: Number(highlightedNegativeBalanceEvent),
       });
       requestNavigation({
+        assetFilter: typeof asset === 'string' ? asset : undefined,
         highlightedNegativeBalanceEvent: Number(highlightedNegativeBalanceEvent),
         targetGroupIdentifier: targetGroupIdentifier.toString(),
       });
@@ -73,6 +74,9 @@ export function useHistoryEventNavigationConsumer(
     if (request.highlightedInternalTxConflict)
       query.highlightedInternalTxConflict = request.highlightedInternalTxConflict;
 
+    if (request.assetFilter)
+      query.asset = request.assetFilter;
+
     return query;
   }
 
@@ -85,7 +89,12 @@ export function useHistoryEventNavigationConsumer(
 
     try {
       while (currentRequest) {
-        const filterPayload = currentRequest.preserveFilters && pageParams ? get(pageParams) : undefined;
+        const basePayload = currentRequest.preserveFilters && pageParams ? get(pageParams) : undefined;
+        // Compute the target's position within the asset-filtered view so the page number
+        // matches the filter that will be applied on arrival.
+        const filterPayload = currentRequest.assetFilter
+          ? { ...basePayload, asset: currentRequest.assetFilter }
+          : basePayload;
         const position = await getHistoryEventGroupPosition(currentRequest.targetGroupIdentifier, filterPayload);
 
         // Check if this request is still current after the await
@@ -108,7 +117,11 @@ export function useHistoryEventNavigationConsumer(
         const page = Math.floor(position / limit) + 1;
         const highlightQuery = buildHighlightQuery(currentRequest, page);
 
-        if (currentRequest.preserveFilters && groupLoading) {
+        // An asset filter navigation changes a real filter, so it must wait for the
+        // pagination system's refetch to settle before pushing (the same coordination
+        // preserveFilters uses). Without this the highlight push races the filter refetch
+        // and the "clear highlights on filter change" watcher can wipe the highlight.
+        if ((currentRequest.preserveFilters || currentRequest.assetFilter) && groupLoading) {
           /**
            * Wait for the pagination system's loading cycle to complete.
            * The loading may not have started yet (fetchDebounce), so wait for it to start first.

--- a/frontend/app/src/modules/history/events/use-history-event-navigation.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-navigation.ts
@@ -33,6 +33,10 @@ export interface HistoryEventNavigationRequest {
   highlightedNegativeBalanceEvent?: number;
   /** Tx hash for internal tx conflict highlight (warning/yellow, group-based) */
   highlightedInternalTxConflict?: string;
+  /** Asset identifier to keep as a filter on the events page. The target's page is
+   *  computed within this asset-filtered view and the param is preserved in the final
+   *  route query, so the highlight and the asset filter coexist. */
+  assetFilter?: string;
   /** When true, preserve current route filters and calculate position within filtered view */
   preserveFilters?: boolean;
   /** Fallback requests to try when the target is not found in filtered results */

--- a/frontend/app/src/modules/session/types.ts
+++ b/frontend/app/src/modules/session/types.ts
@@ -26,6 +26,7 @@ export enum PrivacyMode {
 }
 
 export const PinnedNames = {
+  DATA_ISSUES: 'data-issues-pinned',
   INTERNAL_TX_CONFLICTS: 'internal-tx-conflicts-pinned',
   MATCH_ASSET_MOVEMENTS: 'match-asset-movements-pinned',
   REPORT_ACTIONABLE_CARD: 'report-actionable-card',

--- a/frontend/app/src/modules/shell/components/NoDataScreen.vue
+++ b/frontend/app/src/modules/shell/components/NoDataScreen.vue
@@ -1,10 +1,29 @@
 <script setup lang="ts">
+import type { RuiIcons } from '@rotki/ui-library';
 import FullSizeContent from '@/modules/shell/components/FullSizeContent.vue';
 import RotkiLogo from '@/modules/shell/components/RotkiLogo.vue';
 
-const { full = false } = defineProps<{ full?: boolean }>();
+const { full = false, icon, variant = 'default' } = defineProps<{
+  full?: boolean;
+  /** When set (and no `logo` slot is provided), renders this icon instead of the rotki logo. */
+  icon?: RuiIcons;
+  /** Tints the circle + icon. `success` signals a healthy/all-clear state. */
+  variant?: 'default' | 'success';
+}>();
 
 const { isMdAndUp } = useBreakpoint();
+
+const circleClasses = computed<string>(() => {
+  if (icon) {
+    const tint = variant === 'success'
+      ? 'bg-rui-success/10 dark:bg-rui-success/15'
+      : 'bg-rui-grey-200 dark:bg-rui-grey-900';
+    return `${tint} ${get(isMdAndUp) ? 'size-40' : 'size-32'}`;
+  }
+  return `bg-rui-grey-200 dark:bg-rui-grey-900 ${get(isMdAndUp) ? 'size-64 p-16' : 'size-48 p-8'}`;
+});
+
+const iconColor = computed<'secondary' | 'success'>(() => variant === 'success' ? 'success' : 'secondary');
 </script>
 
 <template>
@@ -12,13 +31,20 @@ const { isMdAndUp } = useBreakpoint();
     class="gap-4"
     :class="{ '!h-auto !mt-20': !full }"
   >
-    <div class="flex items-center justify-center">
+    <div class="flex items-center justify-center mb-8">
       <div
-        class="bg-rui-grey-200 dark:bg-rui-grey-900 rounded-full mb-8"
-        :class="[isMdAndUp ? 'size-64 p-16' : 'size-48 p-8']"
+        class="rounded-full flex items-center justify-center"
+        :class="circleClasses"
       >
         <slot name="logo">
+          <RuiIcon
+            v-if="icon"
+            :name="icon"
+            :size="isMdAndUp ? 64 : 48"
+            :color="iconColor"
+          />
           <RotkiLogo
+            v-else
             :size="isMdAndUp ? 8 : 4"
             unique-key="3"
           />
@@ -33,7 +59,7 @@ const { isMdAndUp } = useBreakpoint();
     </div>
     <div
       v-if="$slots.default"
-      class="text-subtitle-2 text-rui-text-secondary"
+      class="text-subtitle-2 text-rui-text-secondary max-w-md mx-auto"
     >
       <slot />
     </div>

--- a/frontend/app/src/modules/shell/components/navigation/NavigationMenu.vue
+++ b/frontend/app/src/modules/shell/components/navigation/NavigationMenu.vue
@@ -33,8 +33,41 @@ const { isMini = false } = defineProps<{
 }>();
 
 const { appRoutes } = useAppRoutes();
+
+// The data-issues inbox is part of the accounting refactor and only served in builds where the
+// backend exposes it (ROTKI_ACCOUNTING_UPDATE, mirrored into VITE_ACCOUNTING_UPDATE in
+// vite.config.ts). When enabled, History becomes a group [Events, Data Issues]; otherwise it stays
+// a single item linking straight to Events.
+const dataIssuesEnabled = !!import.meta.env.VITE_ACCOUNTING_UPDATE;
+
 const navItems = computed<MenuItem[]>(() => {
   const Routes = get(appRoutes);
+
+  const history: MenuItem = dataIssuesEnabled
+    ? {
+        class: 'history',
+        type: 'group',
+        ...Routes.HISTORY,
+        items: [
+          {
+            class: 'history-events',
+            type: 'item',
+            ...Routes.HISTORY_EVENTS,
+          },
+          {
+            class: 'history-data-issues',
+            type: 'item',
+            ...Routes.HISTORY_DATA_ISSUES,
+          },
+        ],
+      }
+    : {
+        class: 'history',
+        type: 'item',
+        ...Routes.HISTORY,
+        route: Routes.HISTORY_EVENTS.route,
+      };
+
   return [
     {
       class: 'dashboard',
@@ -95,12 +128,7 @@ const navItems = computed<MenuItem[]>(() => {
         },
       ],
     },
-    {
-      class: 'history',
-      type: 'item',
-      ...Routes.HISTORY,
-      route: Routes.HISTORY_EVENTS.route,
-    },
+    history,
     {
       class: 'onchain',
       type: 'group',

--- a/frontend/app/src/modules/shell/components/navigation/PinnedSidebar.vue
+++ b/frontend/app/src/modules/shell/components/navigation/PinnedSidebar.vue
@@ -6,12 +6,13 @@ import { useSidebarResize } from '@/modules/shell/layout/use-sidebar-resize';
 const ReportActionableCard = defineAsyncComponent(() => import('@/modules/reports/ReportActionableCard.vue'));
 const MatchAssetMovementsPinned = defineAsyncComponent(() => import('@/modules/history/events/MatchAssetMovementsPinned.vue'));
 const InternalTxConflictsPinned = defineAsyncComponent(() => import('@/modules/history/internal-tx-conflicts/InternalTxConflictsPinned.vue'));
+const DataIssuesPinned = defineAsyncComponent(() => import('@/modules/history/data-issues/components/DataIssuesPinned.vue'));
 
 const { pinned, showPinned } = storeToRefs(useAreaVisibilityStore());
 
 const { isLgAndDown } = useBreakpoint();
 
-const component = computed<typeof ReportActionableCard | typeof MatchAssetMovementsPinned | typeof InternalTxConflictsPinned | undefined>(() => {
+const component = computed<typeof ReportActionableCard | typeof MatchAssetMovementsPinned | typeof InternalTxConflictsPinned | typeof DataIssuesPinned | undefined>(() => {
   const pinnedValue = get(pinned);
   if (pinnedValue && pinnedValue.name === PinnedNames.REPORT_ACTIONABLE_CARD)
     return ReportActionableCard;
@@ -21,6 +22,9 @@ const component = computed<typeof ReportActionableCard | typeof MatchAssetMoveme
 
   if (pinnedValue && pinnedValue.name === PinnedNames.INTERNAL_TX_CONFLICTS)
     return InternalTxConflictsPinned;
+
+  if (pinnedValue && pinnedValue.name === PinnedNames.DATA_ISSUES)
+    return DataIssuesPinned;
 
   return undefined;
 });

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-completed.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-completed.spec.ts
@@ -1,0 +1,68 @@
+import { get, set } from '@vueuse/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, type Ref, ref } from 'vue';
+import { SyncPhase } from '@/modules/shell/sync-progress/types';
+
+const phase = ref<SyncPhase>(SyncPhase.IDLE);
+
+vi.mock('@/modules/shell/sync-progress/use-sync-progress', () => ({
+  useSyncProgress: (): Record<string, unknown> => ({ phase }),
+}));
+
+/**
+ * Imports a fresh copy of the shared composable. `createSharedComposable` caches
+ * its instance for the module's lifetime, so each test resets modules to get an
+ * isolated counter and watcher.
+ */
+async function freshUseSyncCompleted(): Promise<() => { syncCompleted: Ref<number> }> {
+  vi.resetModules();
+  const mod = await import('@/modules/shell/sync-progress/use-sync-completed');
+  return mod.useSyncCompleted;
+}
+
+describe('useSyncCompleted', () => {
+  beforeEach(() => {
+    set(phase, SyncPhase.IDLE);
+  });
+
+  it('should start the completion counter at zero', async () => {
+    const useSyncCompleted = await freshUseSyncCompleted();
+    const { syncCompleted } = useSyncCompleted();
+
+    expect(get(syncCompleted)).toBe(0);
+  });
+
+  it('should bump the counter when the sync phase reaches complete', async () => {
+    const useSyncCompleted = await freshUseSyncCompleted();
+    const { syncCompleted } = useSyncCompleted();
+
+    set(phase, SyncPhase.COMPLETE);
+    await nextTick();
+
+    expect(get(syncCompleted)).toBe(1);
+  });
+
+  it('should not bump the counter for non-complete phase transitions', async () => {
+    const useSyncCompleted = await freshUseSyncCompleted();
+    const { syncCompleted } = useSyncCompleted();
+
+    set(phase, SyncPhase.SYNCING);
+    await nextTick();
+
+    expect(get(syncCompleted)).toBe(0);
+  });
+
+  it('should bump once per transition into complete', async () => {
+    const useSyncCompleted = await freshUseSyncCompleted();
+    const { syncCompleted } = useSyncCompleted();
+
+    set(phase, SyncPhase.COMPLETE);
+    await nextTick();
+    set(phase, SyncPhase.SYNCING);
+    await nextTick();
+    set(phase, SyncPhase.COMPLETE);
+    await nextTick();
+
+    expect(get(syncCompleted)).toBe(2);
+  });
+});

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-completed.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-completed.ts
@@ -1,0 +1,25 @@
+import type { Ref } from 'vue';
+import { SyncPhase } from '@/modules/shell/sync-progress/types';
+import { useSyncProgress } from '@/modules/shell/sync-progress/use-sync-progress';
+
+interface UseSyncCompletedReturn {
+  /** Bumped once each time the aggregate history sync finishes; watch it to react. */
+  syncCompleted: Ref<number>;
+}
+
+/**
+ * Emits a signal every time the aggregate history sync (tx query + exchange events +
+ * decoding) transitions to complete. Shared so any number of consumers react off a
+ * single, centrally checked completion instead of each watching the sync phase itself.
+ */
+export const useSyncCompleted = createSharedComposable((): UseSyncCompletedReturn => {
+  const { phase } = useSyncProgress();
+  const syncCompleted = ref<number>(0);
+
+  watch(phase, (current) => {
+    if (current === SyncPhase.COMPLETE)
+      set(syncCompleted, get(syncCompleted) + 1);
+  });
+
+  return { syncCompleted };
+});

--- a/frontend/app/src/pages/history/data-issues/index.vue
+++ b/frontend/app/src/pages/history/data-issues/index.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { NoteLocation } from '@/modules/core/common/notes';
+import DataIssuesView from '@/modules/history/data-issues/DataIssuesView.vue';
+
+definePage({
+  meta: {
+    canNavigateBack: true,
+    noteLocation: NoteLocation.HISTORY,
+  },
+  name: 'history-data-issues',
+});
+</script>
+
+<template>
+  <DataIssuesView main-page />
+</template>

--- a/frontend/app/src/route-map.d.ts
+++ b/frontend/app/src/route-map.d.ts
@@ -252,6 +252,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    'history-data-issues': RouteRecordInfo<
+      'history-data-issues',
+      '/history/data-issues',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     'history-events': RouteRecordInfo<
       'history-events',
       '/history/events',
@@ -766,6 +773,14 @@ declare module 'vue-router/auto-routes' {
     'src/pages/history/index.vue': {
       routes:
         | '/history/'
+      views:
+        | never
+      pathParamNames:
+        | never
+    }
+    'src/pages/history/data-issues/index.vue': {
+      routes:
+        | 'history-data-issues'
       views:
         | never
       pathParamNames:

--- a/frontend/app/src/router/routes.ts
+++ b/frontend/app/src/router/routes.ts
@@ -38,6 +38,7 @@ export const Routes = {
   CALENDAR: ensureRoute('/calendar'),
   DASHBOARD: ensureRoute('/dashboard'),
   HISTORY: ensureRoute('/history'),
+  HISTORY_DATA_ISSUES: ensureRoute('/history/data-issues'),
   HISTORY_EVENTS: ensureRoute('/history/events'),
   IMPORT: ensureRoute('/import'),
   LOCATIONS: ensureRoute('/locations/:identifier'),
@@ -217,6 +218,11 @@ export const useAppRoutes = createSharedComposable(() => {
       icon: 'lu-history' as const,
       route: Routes.HISTORY,
       text: t('navigation_menu.history'),
+    },
+    HISTORY_DATA_ISSUES: {
+      icon: 'lu-shield-alert' as const,
+      route: Routes.HISTORY_DATA_ISSUES,
+      text: t('navigation_menu.history_sub.data_issues'),
     },
     HISTORY_EVENTS: {
       icon: 'lu-list' as const,

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -115,6 +115,8 @@ export default defineConfig({
       'viem',
       'plainfp',
       'plainfp/result-async',
+      'plainfp/option',
+      'plainfp/pipe',
       '@rotki/ui-library/components',
       'vue-echarts',
     ],


### PR DESCRIPTION
## Summary

Adds a frontend "Data issues" inbox that surfaces the backend Data Issues API
(merged in #12476). It provides a full-page list, a detail drawer, a manual
resolution flow, a pinnable/floating side panel on the History events view, and a
summary badge. The whole feature is gated behind the accounting-refactor build flag
(`VITE_ACCOUNTING_UPDATE`), so it only appears in builds where the backend serves it.

Refs #12294.

## Running

The feature is gated behind the accounting-refactor flag, so a plain dev build will
not show it. Start dev with the flag enabled:

```
ROTKI_ACCOUNTING_UPDATE=true pnpm run dev
```

## What's included

- **Data issues page** (`/history/data-issues`): columns kind, asset, account,
  protocol, state, detected, plus per-row quick actions (go to event, dismiss,
  retry, resolve manually) and view details. Filter by state, kind, asset, account
  and time range. Default view is open + unresolved. Reassuring "all clear" empty
  state, distinct from "no match for these filters".
- **Navigation**: History becomes a group [Events, Data Issues], gated behind
  `VITE_ACCOUNTING_UPDATE`.
- **Detail drawer**: parsed payload, full auto-remediation timeline with per-attempt
  outcomes, and dismiss / retry / resolve-manually actions. Dismiss is confirmation
  gated.
- **Side panel** on the History events view (pinnable into the shared rail, or a
  floating overlay): a compact filter (state, kind, asset, account), a virtualized
  card list that lazily fetches the next page as you scroll (only the visible cards
  mount), relative "time ago" with the exact time on hover, and all-clear / filtered
  empty states.
- **Summary badge** in the history toolbar, backed by a shared sync-only Pinia store
  so the badge and panel never disagree, with auto-polling while any issue is
  auto-remediating.
- **Go to event**: negative-balance issues deep-link to the offending history event,
  paging to it and highlighting the row (uses the backend `group_identifier` via
  `targetGroupIdentifier`).

## Tests

Co-located specs for the constants, transforms (incl. the highlight route), API error
classification (msw), detail actions (incl. the dismiss confirmation), summary,
table, and the view empty states. 60 unit tests; `typecheck` and `lint` green.

## Notes

- Frontend-only; the backend API landed in #12476 and the `group_identifier`
  addition in the data-issues work already on develop.
- Deferred follow-ups (backend-dependent): column sorting (needs `order_by`
  support on the list endpoint) and a protocol filter (the list endpoint does not
  accept one).
