### PR TITLE
Reload dev page on locale change

### DIFF
--- a/frontend/app/src/i18n.ts
+++ b/frontend/app/src/i18n.ts
@@ -29,12 +29,3 @@ export async function loadLocaleMessages(locale: string): Promise<void> {
   loadedLocales.add(locale);
   return nextTick();
 }
-
-// Hot-reload the base (en) locale: the JSON is registered once at startup, so
-// without this an edit to en.json only takes effect after a full dev restart.
-if (import.meta.hot) {
-  import.meta.hot.accept('./locales/en.json', (updated) => {
-    if (updated?.default)
-      i18n.global.setLocaleMessage('en', updated.default);
-  });
-}

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -1,6 +1,7 @@
 import type { ComponentResolver } from 'unplugin-vue-components';
+import type { Plugin } from 'vite';
 import { builtinModules } from 'node:module';
-import { join, resolve } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 import process from 'node:process';
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite';
 import { ruiIconsPlugin } from '@rotki/ui-library/vite-plugin';
@@ -32,6 +33,30 @@ const hmrEnabled = isDevelopment && !(process.env.CI && isTest);
 // the raw value would let e.g. `=1` enable the frontend while the backend stays off.
 if (process.env.ROTKI_ACCOUNTING_UPDATE === 'True')
   process.env.VITE_ACCOUNTING_UPDATE = 'true';
+
+/**
+ * Force a full page reload when a locale JSON changes. @intlify/unplugin-vue-i18n
+ * precompiles the messages and self-accepts the compiled module, so edits to
+ * src/locales are silently swallowed (no reload, stale text) and an
+ * `import.meta.hot.accept` + `setLocaleMessage` fallback no-ops. A full reload
+ * re-fetches the recompiled messages and re-initialises i18n from scratch.
+ */
+function reloadOnLocaleChange(): Plugin {
+  const localeDir = resolve(PACKAGE_ROOT, './src/locales');
+  return {
+    name: 'rotki:reload-on-locale-change',
+    handleHotUpdate({ file, server }) {
+      if (file.startsWith(localeDir) && file.endsWith('.json')) {
+        server.config.logger.info(
+          `[locale] ${relative(PACKAGE_ROOT, file)} changed, reloading page...`,
+          { clear: true, timestamp: true },
+        );
+        server.ws.send({ path: '*', type: 'full-reload' });
+        return [];
+      }
+    },
+  };
+}
 
 function RuiComponentResolver(): ComponentResolver {
   return {
@@ -167,6 +192,7 @@ export default defineConfig({
     VueI18nPlugin({
       include: [resolve(PACKAGE_ROOT, './src/locales/**')],
     }),
+    reloadOnLocaleChange(),
     ...(!isTest && process.env.ENABLE_DEV_TOOLS ? [vueDevTools()] : []),
   ],
   server: {


### PR DESCRIPTION
## Problem

Editing a `frontend/app/src/locales/*.json` file during development does not update the running app. The text stays stale until the dev server is restarted manually.

The cause is `@intlify/unplugin-vue-i18n`: it precompiles the locale JSON into message functions and self-accepts the compiled module, so Vite treats the change as a handled HMR update and never reloads. The existing `import.meta.hot.accept('./locales/en.json', ...)` + `setLocaleMessage` fallback in `i18n.ts` does not help either, because the precompiled messages and the components' already-compiled global scope keep the old text. This is a known limitation (intlify/bundle-tools#299).

## Fix

Add a small Vite plugin (`rotki:reload-on-locale-change`) that forces a full page reload whenever a file under `src/locales` changes, so the recompiled messages are re-fetched and i18n re-initialises from scratch. Remove the dead `import.meta.hot.accept` hook from `i18n.ts`.

Dev only; no effect on production builds.

## Testing

Verified in the running dev app: editing a locale string now triggers an immediate full page reload and the new text shows up without a manual restart.