### PR TITLE
Isolate dev instances in electron and simplify dev env

### DIFF
--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -14,6 +14,20 @@ import { WindowManager } from '@electron/main/window-manager';
 import { checkIfDevelopment, startPromise } from '@shared/utils';
 import { app, protocol } from 'electron';
 
+/**
+ * Reads a dev-instance port override from the environment. `start-dev` sets
+ * these only when running an isolated instance so electron binds its backend +
+ * colibri on the instance's reserved ports instead of the shared defaults.
+ * Falls back to the default when unset or malformed.
+ */
+function instancePort(envKey: string, fallback: number): number {
+  const raw = process.env[envKey];
+  if (!raw)
+    return fallback;
+  const port = Number.parseInt(raw, 10);
+  return Number.isFinite(port) && port > 0 ? port : fallback;
+}
+
 export class Application {
   private readonly window: WindowManager;
   private readonly tray: TrayManager;
@@ -31,8 +45,8 @@ export class Application {
       colibriApiUrl: import.meta.env.VITE_COLIBRI_URL as string,
     },
     ports: {
-      colibriPort: DEFAULT_COLIBRI_PORT,
-      corePort: DEFAULT_PORT,
+      colibriPort: instancePort('ROTKI_INSTANCE_COLIBRI_PORT', DEFAULT_COLIBRI_PORT),
+      corePort: instancePort('ROTKI_INSTANCE_CORE_PORT', DEFAULT_PORT),
     },
   };
 

--- a/frontend/app/electron/main/subprocess-handler.ts
+++ b/frontend/app/electron/main/subprocess-handler.ts
@@ -60,6 +60,14 @@ export class SubprocessHandler {
   }
 
   async checkForBackendProcess(): Promise<number[]> {
+    // In dev instance mode the backend runs against an isolated data dir on a
+    // reserved port, so a sibling rotki-core (the default dev backend or another
+    // instance) is a legitimately separate process, not a conflict. Skip the
+    // scan so it doesn't trip the "another backend is running" startup error.
+    if (process.env.ROTKI_INSTANCE_DATA_DIR) {
+      this.logger.info('Instance mode: skipping rotki-core process detection (isolated data dir)');
+      return [];
+    }
     try {
       this.logger.info('Checking for running rotki-core processes');
       const runningProcesses = await psList({ all: true });
@@ -103,6 +111,14 @@ export class SubprocessHandler {
     this.logger.info('Preparing to start processes');
     this.logger.updateLogDirectory(options.logDirectory);
     this.startupErrorReported = false;
+
+    // In dev instance mode the isolated data dir wins over any configured one so
+    // the backend + colibri run against the instance's seeded data.
+    const instanceDataDir = process.env.ROTKI_INSTANCE_DATA_DIR;
+    if (instanceDataDir) {
+      this.logger.info(`Instance mode: using data dir ${instanceDataDir}`);
+      options = { ...options, dataDirectory: instanceDataDir };
+    }
 
     // Wrap listener to track when errors are reported (so we can abort ping loop)
     const wrappedListener: SubprocessHandlerErrorListener = {

--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -146,7 +146,9 @@ export default defineConfig({
     {
       command: process.env.CI
         ? `vite preview --port ${FRONTEND_PORT}`
-        : `tsx scripts/serve.ts --web --port ${FRONTEND_PORT}`,
+        // --no-open: this is a test harness, don't pop a browser tab (serve.ts
+        // auto-opens in web mode by default) — Playwright drives its own browser.
+        : `tsx scripts/serve.ts --web --no-open --port ${FRONTEND_PORT}`,
       url: frontendUrl,
       reuseExistingServer: !process.env.CI,
       timeout: 180_000,

--- a/frontend/app/scripts/serve.ts
+++ b/frontend/app/scripts/serve.ts
@@ -27,6 +27,7 @@ interface ServeOptions {
   remoteDebuggingPort?: number;
   mode: string;
   port: number;
+  open: boolean;
 }
 
 async function getWatcher({ name, configFile, writeBundle }: WatcherConfig, mode: string): Promise<BuildOutput> {
@@ -113,15 +114,21 @@ async function setupPreloadPackageWatcher({ ws }: ViteDevServer, mode: string): 
 }
 
 async function serve(options: ServeOptions): Promise<void> {
-  const { web, remoteDebuggingPort, mode, port } = options;
+  const { web, remoteDebuggingPort, mode, port, open } = options;
 
   try {
+    // Only auto-open a browser tab in web mode: in electron mode the renderer is
+    // loaded inside the electron window, so a browser tab would be spurious. `open`
+    // is a plain boolean here (Vite opens the resolved server URL, honouring the
+    // instance's port), and CI never opens.
+    const openBrowser = web && open && !process.env.CI;
     const viteDevServer = await createServer({
       ...sharedConfig,
       mode: process.env.CI && process.env.VITE_TEST ? 'production' : mode,
       configFile: 'vite.config.ts',
       server: {
         port,
+        open: openBrowser,
       },
     });
 
@@ -163,12 +170,14 @@ cli.command('', 'Rotki frontend development server')
   .option('--remote-debugging-port <port>', 'Chrome remote debugging port')
   .option('--mode <mode>', 'Development mode', { default: 'development' })
   .option('--port <port>', 'Listening port', { default: 8080 })
+  .option('--open', 'Open the web app in the browser on start (web mode only, default: on; use --no-open to disable)', { default: true })
   .action(async (options) => {
     await serve({
       web: options.web ?? false,
       remoteDebuggingPort: options.remoteDebuggingPort ? Number(options.remoteDebuggingPort) : undefined,
       mode: options.mode,
       port: Number(options.port),
+      open: options.open ?? true,
     });
   });
 

--- a/frontend/scripts/dev-instance/env-file.ts
+++ b/frontend/scripts/dev-instance/env-file.ts
@@ -12,6 +12,21 @@ export const MANAGED_ENV_KEYS = [
 ] as const;
 
 /**
+ * Dev toggles that `pnpm dev` / `dev:web` keeps on by default. They live in the
+ * managed block so a fresh checkout gets them without hand-editing, but a value
+ * a developer has already set (in the env file or the shell) is preserved — see
+ * `devFlagUpdates`. Never written for production builds (start-dev is dev-only).
+ */
+export const MANAGED_DEV_FLAG_KEYS = [
+  'ENABLE_DEV_TOOLS',
+  'VITE_DEV_LOGS',
+  'VITE_PERSIST_STORE',
+] as const;
+
+/** Every key start-dev owns inside the managed block (instance + dev flags). */
+export const ALL_MANAGED_KEYS = [...MANAGED_ENV_KEYS, ...MANAGED_DEV_FLAG_KEYS] as const;
+
+/**
  * Sentinel comments wrapping the dev:web-managed block. The exact string is
  * load-bearing: writeEnvFile and clearManagedEnvBlock locate the block by
  * matching these lines. Changing the wording later would orphan blocks written
@@ -150,7 +165,7 @@ export function readManagedInstanceName(file: string): string | undefined {
  * Leaves every unmanaged line untouched. Useful when an instance is cleaned and
  * we want to remove the env trail it wrote.
  */
-export function clearManagedEnvBlock(file: string, opts: { managed: readonly string[] } = { managed: MANAGED_ENV_KEYS }): void {
+export function clearManagedEnvBlock(file: string, opts: { managed: readonly string[] } = { managed: ALL_MANAGED_KEYS }): void {
   if (!fs.existsSync(file))
     return;
   const managed = new Set(opts.managed);
@@ -160,4 +175,73 @@ export function clearManagedEnvBlock(file: string, opts: { managed: readonly str
   while (kept.length > 0 && kept.at(-1) === '')
     kept.pop();
   writeAtomic(file, kept.join('\n'));
+}
+
+/** Splits an env file's KEY=VAL lines into those inside vs outside the managed block. */
+function readManagedSplit(file: string): { inBlock: Record<string, string>; outOfBlock: Record<string, string> } {
+  const inBlock: Record<string, string> = {};
+  const outOfBlock: Record<string, string> = {};
+  if (!fs.existsSync(file))
+    return { inBlock, outOfBlock };
+  let within = false;
+  for (const rawLine of fs.readFileSync(file, 'utf-8').split('\n')) {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+    if (line === BLOCK_START) {
+      within = true;
+      continue;
+    }
+    if (line === BLOCK_END) {
+      within = false;
+      continue;
+    }
+    const key = envLineKey(line);
+    if (key === undefined)
+      continue;
+    const trimmed = line.trim();
+    const value = trimmed.slice(trimmed.indexOf('=') + 1).trim();
+    (within ? inBlock : outOfBlock)[key] = value;
+  }
+  return { inBlock, outOfBlock };
+}
+
+/** Values a developer might write to mean "off". */
+const OFF_VALUES = new Set(['', 'false', '0', 'no', 'off']);
+
+/**
+ * Normalises a dev-flag value to `'true'` (on) or `''` (off). The flags are read
+ * by their consumers as truthy strings (e.g. `if (import.meta.env.VITE_DEV_LOGS)`),
+ * so a literal `false` would otherwise still be on — we map any off-word to an
+ * empty (falsy) value that every consumer style reads as disabled. Absent = on.
+ */
+function resolveDevFlag(existing: string | undefined): string {
+  if (existing === undefined)
+    return 'true';
+  return OFF_VALUES.has(existing.trim().toLowerCase()) ? '' : 'true';
+}
+
+/**
+ * Resolved values for the always-on dev flags. Each defaults to on, but an
+ * existing value is preserved so a developer who turns a flag off keeps it off
+ * (`=false`, `=0`, `=off`, or empty all disable it). A value the developer wrote
+ * OUTSIDE the managed block wins (their override, no matter where they put it —
+ * it gets consolidated back into the block); else the current in-block value
+ * carries over; else the flag defaults on.
+ */
+export function devFlagUpdates(file: string): Record<string, string> {
+  const { inBlock, outOfBlock } = readManagedSplit(file);
+  const updates: Record<string, string> = {};
+  for (const key of MANAGED_DEV_FLAG_KEYS)
+    updates[key] = resolveDevFlag(outOfBlock[key] ?? inBlock[key]);
+  return updates;
+}
+
+/**
+ * Writes the dev:web-managed block. The default-on dev flags are always
+ * included; the instance keys only when running an instance (pass its computed
+ * env as `instanceUpdates`, or omit for a non-instance run, which also strips
+ * any stale instance keys). Call on every `pnpm dev` run so a fresh checkout
+ * still gets the dev flags.
+ */
+export function writeManagedEnv(file: string, instanceUpdates: Record<string, string> = {}): void {
+  writeEnvFile(file, { ...instanceUpdates, ...devFlagUpdates(file) }, { managed: ALL_MANAGED_KEYS });
 }

--- a/frontend/scripts/dev-instance/index.ts
+++ b/frontend/scripts/dev-instance/index.ts
@@ -4,10 +4,11 @@
 
 export {
   clearManagedEnvBlock,
+  devFlagUpdates,
   loadEnvFile,
   MANAGED_ENV_KEYS,
   readManagedInstanceName,
-  writeEnvFile,
+  writeManagedEnv,
 } from './env-file';
 
 export {

--- a/frontend/scripts/dev-instance/instance.ts
+++ b/frontend/scripts/dev-instance/instance.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import process from 'node:process';
 import consola from 'consola';
-import { loadEnvFile, MANAGED_ENV_KEYS, writeEnvFile } from './env-file';
+import { loadEnvFile, MANAGED_ENV_KEYS, writeManagedEnv } from './env-file';
 import { formatHostPort, formatPort, humanBytes } from './format';
 import { estimateSeedSize, freeDiskBytes, seedInstance } from './fs-walk';
 import { getCurrentGitBranch, getCurrentGitWorktree } from './git';
@@ -187,7 +187,7 @@ export async function prepareInstance(opts: PrepareInstanceOptions): Promise<Ins
   }
 
   ensureInstanceData(name, dir, opts.seed, opts.includeBackups === true);
-  writeEnvFile(opts.envFile, desiredEnv, { managed: MANAGED_ENV_KEYS });
+  writeManagedEnv(opts.envFile, desiredEnv);
 
   const meta = buildMeta(name, slot, existingMeta, alreadyConsented || opts.acceptManagedEnv || divergingKeys.length === 0);
   writeMetadata(dir, meta);

--- a/frontend/scripts/dev/services.ts
+++ b/frontend/scripts/dev/services.ts
@@ -179,7 +179,9 @@ async function startColibriService(opts: ColibriSpawnOptions): Promise<number> {
 
   startProcess('cargo run --locked -- ', colors.red(COLIBRI), COLIBRI, colibriArgs, {
     cwd: colibriCwd,
-    env: buildColibriEnv(),
+    // null (win32, Strawberry missing) and undefined both mean "inherit
+    // process.env" in startProcess; normalise so the env type matches.
+    env: buildColibriEnv() ?? undefined,
   });
   return chosenPort;
 }
@@ -260,6 +262,8 @@ export interface DevServerOptions {
   noElectron: boolean;
   devPort?: number;
   backendEnv?: BackendEnv;
+  /** Extra env forwarded to the serve child (electron instance ports/data dir). */
+  extraEnv?: Record<string, string>;
   onExit?: () => void;
 }
 
@@ -277,13 +281,17 @@ export function startDevServer(opts: DevServerOptions): void {
   const baseServeCmd = opts.noElectron ? 'pnpm run --filter rotki serve' : 'pnpm run --filter rotki electron:serve';
   // Forward `--port` to the serve script directly — no `--` separator. With
   // `--` cac inside serve.ts treats following flags as positional and ignores
-  // `--port`, so the dev server keeps listening on its default 8080.
-  const serveCmd = opts.noElectron && opts.devPort !== undefined
+  // `--port`, so the dev server keeps listening on its default 8080. Applies to
+  // both modes: in electron mode this runs the instance's Vite dev server on the
+  // instance `dev` port (serve.ts sets VITE_DEV_SERVER_URL from it, so electron
+  // loads the right origin); plain `pnpm dev` leaves devPort undefined → 8080.
+  const serveCmd = opts.devPort !== undefined
     ? `${baseServeCmd} --port ${opts.devPort}`
     : baseServeCmd;
 
+  const env = { ...opts.backendEnv, ...opts.extraEnv };
   const child = startProcess(`${serveCmd}${debuggerArgs}`, colors.magenta(ROTKI), ROTKI, [], {
-    env: opts.backendEnv ? { ...opts.backendEnv } : undefined,
+    env: Object.keys(env).length > 0 ? env : undefined,
   });
 
   child.on('exit', () => {
@@ -354,16 +362,35 @@ function spawnProxyForBackend(instance: InstanceRuntime | null, backendEnv: Back
   startDevProxy({ PORT: String(proxyPort), BACKEND: backendEnv.VITE_BACKEND_URL });
 }
 
-function spawnProxyForElectron(): void {
-  // Electron mode — electron's main process spawns its own backend; start-dev
-  // doesn't know the chosen port. Match the long-standing convention:
-  // backend defaults to DEFAULT_PORTS.restApi, proxy listens on DEFAULT_PORTS.proxy
-  // and forwards. Set VITE_BACKEND_URL so the Vite-served renderer hits the proxy.
-  process.env.VITE_BACKEND_URL = `http://127.0.0.1:${DEFAULT_PORTS.proxy}`;
+function spawnProxyForElectron(instance: InstanceRuntime | null): void {
+  // Electron mode — electron's main process spawns its own backend. In instance
+  // mode we tell electron which ports to bind (via instanceEnvForElectron), so
+  // the proxy fronts those same ports; otherwise fall back to the defaults
+  // (backend on restApi, proxy on proxy). Set VITE_BACKEND_URL so the
+  // Vite-served renderer hits the proxy.
+  const proxyPort = instance?.ports.proxy ?? DEFAULT_PORTS.proxy;
+  const backendPort = instance?.ports.restApi ?? DEFAULT_PORTS.restApi;
+  process.env.VITE_BACKEND_URL = `http://127.0.0.1:${proxyPort}`;
   startDevProxy({
-    PORT: String(DEFAULT_PORTS.proxy),
-    BACKEND: `http://127.0.0.1:${DEFAULT_PORTS.restApi}`,
+    PORT: String(proxyPort),
+    BACKEND: `http://127.0.0.1:${backendPort}`,
   });
+}
+
+/**
+ * Env handed to the electron child in instance mode. Electron spawns its own
+ * backend + colibri, so it needs the instance's reserved ports and data dir to
+ * bind there instead of the shared defaults. Returns undefined outside instance
+ * mode, leaving electron on its default ports / configured data dir.
+ */
+function instanceEnvForElectron(instance: InstanceRuntime | null): Record<string, string> | undefined {
+  if (!instance)
+    return undefined;
+  return {
+    ROTKI_INSTANCE_CORE_PORT: String(instance.ports.restApi),
+    ROTKI_INSTANCE_COLIBRI_PORT: String(instance.ports.colibri),
+    ROTKI_INSTANCE_DATA_DIR: instance.dir,
+  };
 }
 
 function pointFrontendAtBackend(backendEnv: BackendEnv): void {
@@ -377,25 +404,28 @@ export async function startDevelopmentEnvironment(opts: DevEnvironmentOptions): 
 
   let backendEnv: BackendEnv | undefined;
   let devPort: number | undefined;
+  let extraEnv: Record<string, string> | undefined;
 
   if (noElectron) {
     ({ backendEnv, devPort } = await startBackendForMode(instance, opts));
-  }
-
-  if (backendEnv) {
     if (useProxy)
       spawnProxyForBackend(instance, backendEnv);
     else
       pointFrontendAtBackend(backendEnv);
   }
-  else if (useProxy) {
-    // Electron mode + proxy: spawn it with defaults (electron's backend lands
-    // at 4242, proxy fronts it at 4243). This matches the pre-refactor
-    // behaviour triggered by VITE_BACKEND_URL being present in .env.
-    spawnProxyForElectron();
+  else {
+    // Electron mode: electron's main process spawns its own backend + colibri.
+    // In instance mode hand it the instance's reserved ports + data dir so it
+    // binds there rather than on the shared defaults, and run the Vite dev
+    // server on the instance's dev port (electron loads that origin). Plain
+    // `pnpm dev` leaves devPort undefined, keeping the default 8080.
+    extraEnv = instanceEnvForElectron(instance);
+    devPort = instance?.ports.dev;
+    if (useProxy)
+      spawnProxyForElectron(instance);
   }
 
-  startDevServer({ noElectron, devPort, backendEnv, onExit: onChildExit });
+  startDevServer({ noElectron, devPort, backendEnv, extraEnv, onExit: onChildExit });
 
   // win32 historically had no readiness wait — give hot-reload subscribers a
   // moment to attach before the first Vite compile.

--- a/frontend/scripts/start-dev.ts
+++ b/frontend/scripts/start-dev.ts
@@ -6,8 +6,8 @@ import { config } from 'dotenv';
 import {
   cleanAll,
   cleanInstance,
-  clearManagedEnvBlock,
   DEFAULT_PORTS,
+  devFlagUpdates,
   type InstanceRuntime,
   PortSlotAllocationError,
   prepareInstance,
@@ -15,6 +15,7 @@ import {
   pruneInstances,
   readManagedInstanceName,
   repairRegistry,
+  writeManagedEnv,
 } from './dev-instance';
 import { errorMessage, formatPort } from './dev-instance/format';
 import { getCurrentGitBranch } from './dev-instance/git';
@@ -23,6 +24,7 @@ import { registerShutdownHandlers, terminateSubprocesses } from './dev/process-p
 import { startDevelopmentEnvironment } from './dev/services';
 
 const ENV_FILE_RELATIVE = 'app/.env.development.local';
+const APP_ENV_RELATIVE = 'app/.env';
 
 const logger = consola.withTag('[36mdev[0m');
 
@@ -81,8 +83,16 @@ async function dispatchManagementSubcommand(options: DevCliOptions): Promise<boo
 }
 
 function loadDevEnv(): void {
+  // `.env.development.local` (instance/dev overrides) wins; `app/.env` is the
+  // base. dotenv never overrides an already-set var, so load the override
+  // first. This makes PREMIUM_COMPONENT_DIR — configured once in `app/.env` —
+  // visible to start-dev and the children it spawns (electron, proxy), so the
+  // dev-proxy no longer needs its own `frontend/dev-proxy/.env`.
   if (fs.existsSync(ENV_FILE_RELATIVE)) {
     config({ path: ENV_FILE_RELATIVE });
+  }
+  if (fs.existsSync(APP_ENV_RELATIVE)) {
+    config({ path: APP_ENV_RELATIVE });
   }
 }
 
@@ -164,14 +174,13 @@ function readSlotHint(resolvedName: string): number | undefined {
 
 async function resolveInstance(options: DevCliOptions, useProxy: boolean): Promise<InstanceRuntime | null> {
   if (options.instance === false) {
-    // Explicit --no-instance: erase any stale managed block from a prior
-    // instance run so Vite doesn't read INSTANCE_PORT_SLOT / VITE_BACKEND_URL
-    // pointing at a slot we're no longer using.
+    // Explicit --no-instance: drop any stale instance keys from a prior instance
+    // run so Vite doesn't read INSTANCE_PORT_SLOT / VITE_BACKEND_URL pointing at
+    // a slot we're no longer using. The dev-flags block is still (re)written
+    // afterwards by writeManagedEnv, so this only strips the instance keys.
     const staleOwner = readManagedInstanceName(ENV_FILE_RELATIVE);
-    if (staleOwner !== undefined) {
-      clearManagedEnvBlock(ENV_FILE_RELATIVE);
-      logger.info(`--no-instance: cleared managed env block left over from "${staleOwner}"`);
-    }
+    if (staleOwner !== undefined)
+      logger.info(`--no-instance: dropping managed instance keys left over from "${staleOwner}"`);
     return null;
   }
   const name = pickInstanceName(options.instance);
@@ -243,6 +252,19 @@ async function runDevAction(options: DevCliOptions): Promise<void> {
       + `colibri=${formatPort(instance.ports.colibri)} dev=${formatPort(instance.ports.dev)}`,
     );
   }
+  else {
+    // Non-instance run: prepareInstance never ran, so write the managed block
+    // ourselves. It carries only the always-on dev flags (default on, existing
+    // values preserved) and strips any stale instance keys from a prior run.
+    writeManagedEnv(ENV_FILE_RELATIVE);
+  }
+
+  // Propagate the resolved dev flags to this run's children (electron reads
+  // ENABLE_DEV_TOOLS from process.env; vite the VITE_* ones) so they take effect
+  // on the first run too, before the env file is re-read next time. Read after
+  // the managed block was (re)written above so we pick up the consolidated values.
+  for (const [key, value] of Object.entries(devFlagUpdates(ENV_FILE_RELATIVE)))
+    process.env[key] = value;
 
   registerShutdownHandlers();
   setupProfilingEnvironment(options);


### PR DESCRIPTION
## Summary

Makes the dev launcher honour isolated instances end to end (electron included) and drops the per-tool proxy config. No effect on production builds: everything here lives in the dev launcher / dev-only startup paths.

## Changes

- **Electron honours the instance.** In instance mode electron binds its backend + colibri on the instance's reserved ports (`ROTKI_INSTANCE_CORE_PORT` / `ROTKI_INSTANCE_COLIBRI_PORT`), uses the instance data dir (which wins over `rotki_config.json`), and runs the Vite dev server on the instance dev port. `rotki-core` process detection is a no-op in instance mode, so a sibling backend on a different data dir no longer trips the "another backend is running" startup error. The single-instance lock is unchanged.
- **Defaults unchanged.** Plain `pnpm dev` / `dev:web` (no `--instance`) keeps the same ports: backend 4242, colibri 4343, proxy 4243, dev server 8080.
- **Single-source proxy config.** Proxy settings (e.g. `PREMIUM_COMPONENT_DIR`) come from the one `app/.env`, loaded by start-dev and inherited by the proxy subprocess, so `frontend/dev-proxy/.env` is no longer needed and the electron proxy ports are no longer hardcoded.
- **`pnpm dev --web` opens the browser on start** (off in electron mode and CI; `--no-open` to disable, which the e2e webServer now passes so test runs don't pop a tab).
- **Managed dev flags.** `ENABLE_DEV_TOOLS` / `VITE_DEV_LOGS` / `VITE_PERSIST_STORE` are written on-by-default into the managed env block on every dev run so a fresh checkout gets them without hand-editing. A value a developer sets is respected — off-words (`false`/`0`/`no`/`off`/empty) map to a falsy value the truthy consumers read as disabled. A non-instance run also strips stale instance keys from the block.

## Test plan

- `pnpm dev` (no instance): backend/colibri/proxy/dev-server on the usual 4242/4343/4243/8080.
- `pnpm dev --instance <name>`: electron backend/colibri on the instance's reserved ports, isolated data dir, no false "another backend running" error.
- `pnpm dev --web`: app opens in the browser; local Playwright run does not.
- Lint, app typecheck, scripts typecheck, and the electron backend-handlers unit test pass.