### PR TITLE
Suggest tracking missing Gnosis Pay Safe after migration

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3063,6 +3063,16 @@
         "signature_rejected": "Signature request was rejected by user",
         "unknown": "An unknown error occurred"
       },
+      "safe_migration": {
+        "account_label": "Gnosis Pay Safe",
+        "add_action": "Add to rotki",
+        "add_error": "Failed to add the Safe: {error}",
+        "add_success": "Added {address} as a Gnosis Chain account.",
+        "missing_new": "Gnosis Pay replaced your Safe. You track only the previous one; add the new active Safe {address} to track future activity.",
+        "missing_old": "Gnosis Pay replaced your Safe. You track only the new one; add the previous Safe {address} to keep its historical activity.",
+        "never_action": "Never show again",
+        "title": "Gnosis Pay Safe migration"
+      },
       "siwe": {
         "checking_accounts": "Checking for registered Gnosis Pay accounts...",
         "connected_address": "Connected Address",
@@ -4579,6 +4589,11 @@
       "title": "CSV Import Result: {sourceName}"
     },
     "deserialization_error": "We could not deserialize {count} assets for your accounts, please check the application logs for more information.",
+    "gnosis_pay_safe_migration": {
+      "message_new": "Gnosis Pay replaced your Safe in its security migration. You track only the previous Safe. Add the new active Safe {address} to track future activity.",
+      "message_old": "Gnosis Pay replaced your Safe in its security migration. You track only the new Safe. Add the previous Safe {address} to keep its historical activity.",
+      "title": "Gnosis Pay Safe migration"
+    },
     "gnosis_pay_session_key_expired": {
       "title": "Gnosis Pay session key expired"
     },

--- a/frontend/app/src/modules/auth/unlock-flow/use-session-ready.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-session-ready.spec.ts
@@ -47,6 +47,10 @@ vi.mock('@/modules/core/messaging/use-update-message', () => ({
   useUpdateMessage: vi.fn(() => ({ showReleaseNotes: showReleaseNotesRef })),
 }));
 
+vi.mock('@/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration', () => ({
+  useGnosisPaySafeMigration: vi.fn(() => ({ checkAndNotify: vi.fn().mockResolvedValue(undefined) })),
+}));
+
 describe('useSessionReady', () => {
   beforeEach(() => {
     setActivePinia(createPinia());

--- a/frontend/app/src/modules/auth/unlock-flow/use-session-ready.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-session-ready.ts
@@ -1,8 +1,10 @@
+import { startPromise } from '@shared/utils';
 import { lastLogin } from '@/modules/auth/account-management';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useUpdateMessage } from '@/modules/core/messaging/use-update-message';
 import { useHistoryDataFetching } from '@/modules/history/use-history-data-fetching';
+import { useGnosisPaySafeMigration } from '@/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration';
 import { usePremiumHelper } from '@/modules/premium/use-premium-helper';
 import { useAppNavigation } from '@/modules/shell/layout/use-navigation';
 
@@ -27,6 +29,7 @@ export function useSessionReady(): UseSessionReadyReturn {
   const { navigateToDashboard } = useAppNavigation();
   const { showReleaseNotes } = useUpdateMessage();
   const { refreshSupportedChains } = useSupportedChains();
+  const { checkAndNotify: checkGnosisPaySafeMigration } = useGnosisPaySafeMigration();
 
   async function handleSessionReady(): Promise<void> {
     clearUpgradeMessages();
@@ -40,6 +43,8 @@ export function useSessionReady(): UseSessionReadyReturn {
     await fetchTransactionStatusSummary();
     await navigateToDashboard();
     set(showReleaseNotes, false);
+    // Fire-and-forget: a premium-gated network check that must not block navigation.
+    startPromise(checkGnosisPaySafeMigration());
   }
 
   return { handleSessionReady };

--- a/frontend/app/src/modules/integrations/gnosis-pay/components/GnosisPayAuth.vue
+++ b/frontend/app/src/modules/integrations/gnosis-pay/components/GnosisPayAuth.vue
@@ -6,11 +6,13 @@ import { useMessageStore } from '@/modules/core/common/use-message-store';
 import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { useExternalApiKeys } from '@/modules/settings/api-keys/external/use-external-api-keys';
 import ServiceKeyCard, { type FeatureGate } from '@/modules/settings/api-keys/ServiceKeyCard.vue';
+import AccountDisplay from '@/modules/shell/components/display/AccountDisplay.vue';
 import { useUnifiedProviders } from '@/modules/wallet/providers/use-unified-providers';
 import ProviderSelectionDialog from '@/modules/wallet/ProviderSelectionDialog.vue';
 import { useWalletStore } from '@/modules/wallet/use-wallet-store';
 import { AuthStep, GnosisPayError } from '../types';
 import { useGnosisPayAuthState, useGnosisPayAuthSteps } from '../use-gnosis-pay-auth-state';
+import { useGnosisPaySafeMigration } from '../use-gnosis-pay-safe-migration';
 import { useGnosisPaySigning } from '../use-gnosis-pay-signing';
 import { useGnosisPayWallet } from '../use-gnosis-pay-wallet';
 import GnosisPayAddressValidation from './GnosisPayAddressValidation.vue';
@@ -24,6 +26,12 @@ const name = 'gnosis_pay';
 const GNOSIS_CHAIN_ID = 100;
 const { useApiKey, confirmDelete, load, loading } = useExternalApiKeys();
 const key = useApiKey(name);
+
+const { addMissingSafe, adding, checkMigration, hasUntrackedSafe, untrackedAccount, untrackedSafe } = useGnosisPaySafeMigration();
+
+const safeMigrationKeypath = computed<string>(() => get(untrackedSafe)?.type === 'new'
+  ? 'external_services.gnosispay.safe_migration.missing_new'
+  : 'external_services.gnosispay.safe_migration.missing_old');
 
 const { allowed, minimumTier, premium } = useFeatureAccess(PremiumFeature.GNOSIS_PAY);
 const featureGate = computed<FeatureGate>(() => {
@@ -90,6 +98,7 @@ const signing = useGnosisPaySigning({
   errorType,
   onSignInComplete: async () => {
     await load();
+    await checkMigration();
   },
   setError,
   signingInProgress,
@@ -232,6 +241,14 @@ watch(connectedAddress, async (address) => {
   }
 });
 
+// Check for a Safe left untracked by the Gnosis Pay migration whenever the token changes.
+watchImmediate(key, async (apiKey) => {
+  if (apiKey)
+    await checkMigration();
+  else
+    set(untrackedSafe, undefined);
+});
+
 // When authentication is complete, close dialog and show success message
 watch(() => isStepComplete(AuthStep.SIGN_MESSAGE), (complete) => {
   if (!complete) {
@@ -261,6 +278,48 @@ watch(() => isStepComplete(AuthStep.SIGN_MESSAGE), (complete) => {
       :image-src="getPublicServiceImagePath('gnosispay.png')"
       hide-action
     >
+      <template
+        v-if="key && hasUntrackedSafe"
+        #banner
+      >
+        <RuiAlert
+          type="warning"
+          :title="t('external_services.gnosispay.safe_migration.title')"
+        >
+          <div class="flex flex-col items-start gap-2">
+            <i18n-t
+              v-if="untrackedAccount"
+              scope="global"
+              tag="div"
+              class="text-body-2 break-words"
+              :keypath="safeMigrationKeypath"
+            >
+              <template #address>
+                <AccountDisplay
+                  class="inline-flex align-middle max-w-full"
+                  hide-chain-icon
+                  :account="untrackedAccount"
+                />
+              </template>
+            </i18n-t>
+            <RuiButton
+              size="sm"
+              color="primary"
+              :loading="adding"
+              @click="addMissingSafe()"
+            >
+              <template #prepend>
+                <RuiIcon
+                  name="lu-plus"
+                  size="16"
+                />
+              </template>
+              {{ t('external_services.gnosispay.safe_migration.add_action') }}
+            </RuiButton>
+          </div>
+        </RuiAlert>
+      </template>
+
       <template
         v-if="key"
         #left-buttons

--- a/frontend/app/src/modules/integrations/gnosis-pay/types.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/types.ts
@@ -25,3 +25,17 @@ export interface GnosisPayErrorContext {
 export const GnosisPayAdminsMappingSchema = z.record(z.string(), z.array(z.string()));
 
 export type GnosisPayAdminsMapping = z.infer<typeof GnosisPayAdminsMappingSchema>;
+
+export const GnosisPayUntrackedSafeSchema = z.object({
+  address: z.string(),
+  type: z.enum(['new', 'old']),
+});
+
+export type GnosisPayUntrackedSafe = z.infer<typeof GnosisPayUntrackedSafeSchema>;
+
+export const GnosisPaySafeMigrationSchema = z.object({
+  migrationId: z.string(),
+  untrackedAddresses: z.array(GnosisPayUntrackedSafeSchema),
+});
+
+export type GnosisPaySafeMigration = z.infer<typeof GnosisPaySafeMigrationSchema>;

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-api.spec.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-api.spec.ts
@@ -46,6 +46,53 @@ describe('useGnosisPaySiweApi', () => {
     });
   });
 
+  describe('fetchGnosisPaySafeMigration', () => {
+    it('should GET the migration and camelCase the untracked address', async () => {
+      server.use(
+        http.get(`${backendUrl}/api/1/services/gnosispay/migration`, () =>
+          HttpResponse.json({
+            result: {
+              migration_id: 'safe-replacement-2026-06',
+              untracked_addresses: [{
+                address: '0xabcdef1234567890abcdef1234567890abcdef12',
+                type: 'new',
+              }],
+            },
+            message: '',
+          })),
+      );
+
+      const { fetchGnosisPaySafeMigration } = useGnosisPaySiweApi();
+      const result = await fetchGnosisPaySafeMigration();
+
+      expect(result).toEqual({
+        migrationId: 'safe-replacement-2026-06',
+        untrackedAddresses: [{
+          address: '0xabcdef1234567890abcdef1234567890abcdef12',
+          type: 'new',
+        }],
+      });
+    });
+
+    it('should return an empty untracked list when nothing is missing', async () => {
+      server.use(
+        http.get(`${backendUrl}/api/1/services/gnosispay/migration`, () =>
+          HttpResponse.json({
+            result: {
+              migration_id: 'safe-replacement-2026-06',
+              untracked_addresses: [],
+            },
+            message: '',
+          })),
+      );
+
+      const { fetchGnosisPaySafeMigration } = useGnosisPaySiweApi();
+      const result = await fetchGnosisPaySafeMigration();
+
+      expect(result.untrackedAddresses).toEqual([]);
+    });
+  });
+
   describe('fetchNonce', () => {
     it('should send GET request with async_query param and returns pending task', async () => {
       let capturedUrl: URL | undefined;

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-api.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-api.ts
@@ -1,9 +1,15 @@
 import { api } from '@/modules/core/api/rotki-api';
 import { type PendingTask, PendingTaskSchema } from '@/modules/core/tasks/types';
-import { type GnosisPayAdminsMapping, GnosisPayAdminsMappingSchema } from '@/modules/integrations/gnosis-pay/types';
+import {
+  type GnosisPayAdminsMapping,
+  GnosisPayAdminsMappingSchema,
+  type GnosisPaySafeMigration,
+  GnosisPaySafeMigrationSchema,
+} from '@/modules/integrations/gnosis-pay/types';
 
 interface GnosisPaySiweApiReturn {
   fetchGnosisPayAdmins: () => Promise<GnosisPayAdminsMapping>;
+  fetchGnosisPaySafeMigration: () => Promise<GnosisPaySafeMigration>;
   fetchNonce: () => Promise<PendingTask>;
   verifySiweSignature: (message: string, signature: string) => Promise<PendingTask>;
 }
@@ -12,6 +18,11 @@ export function useGnosisPaySiweApi(): GnosisPaySiweApiReturn {
   const fetchGnosisPayAdmins = async (): Promise<GnosisPayAdminsMapping> => {
     const response = await api.get<GnosisPayAdminsMapping>('/services/gnosispay/admins');
     return GnosisPayAdminsMappingSchema.parse(response);
+  };
+
+  const fetchGnosisPaySafeMigration = async (): Promise<GnosisPaySafeMigration> => {
+    const response = await api.get<GnosisPaySafeMigration>('/services/gnosispay/migration');
+    return GnosisPaySafeMigrationSchema.parse(response);
   };
 
   const fetchNonce = async (): Promise<PendingTask> => {
@@ -42,6 +53,7 @@ export function useGnosisPaySiweApi(): GnosisPaySiweApiReturn {
 
   return {
     fetchGnosisPayAdmins,
+    fetchGnosisPaySafeMigration,
     fetchNonce,
     verifySiweSignature,
   };

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.spec.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.spec.ts
@@ -1,0 +1,211 @@
+import type { GnosisPaySafeMigration } from '@/modules/integrations/gnosis-pay/types';
+import { Blockchain } from '@rotki/common';
+import dayjs from 'dayjs';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+const NEW_SAFE = '0xabcdef1234567890abcdef1234567890abcdef12';
+const OLD_SAFE = '0x1234567890abcdef1234567890abcdef12345678';
+
+const fetchGnosisPaySafeMigration = vi.fn();
+const addAccounts = vi.fn();
+const notify = vi.fn();
+const showErrorMessage = vi.fn();
+const showSuccessMessage = vi.fn();
+const updateFrontendSetting = vi.fn();
+const getApiKey = vi.fn();
+const loadExternalKeys = vi.fn();
+const externalKeys = ref<Record<string, unknown> | undefined>({ gnosis_pay: { apiKey: 'gpay-token' } });
+
+vi.mock('@/modules/integrations/gnosis-pay/use-gnosis-pay-api', () => ({
+  useGnosisPaySiweApi: vi.fn().mockImplementation(() => ({ fetchGnosisPaySafeMigration })),
+}));
+
+vi.mock('@/modules/accounts/use-blockchain-account-management', () => ({
+  useBlockchainAccountManagement: vi.fn().mockImplementation(() => ({ addAccounts })),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn().mockImplementation(() => ({ notify, showErrorMessage, showSuccessMessage })),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: vi.fn().mockImplementation(() => ({ updateFrontendSetting })),
+}));
+
+vi.mock('@/modules/settings/api-keys/external/use-external-api-keys', () => ({
+  useExternalApiKeys: vi.fn().mockImplementation(() => ({ getApiKey, keys: externalKeys, load: loadExternalKeys })),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+function migration(untracked: GnosisPaySafeMigration['untrackedAddresses']): GnosisPaySafeMigration {
+  return { migrationId: 'safe-replacement-2026-06', untrackedAddresses: untracked };
+}
+
+async function setup(settings?: Record<string, unknown>): Promise<{
+  composable: Awaited<ReturnType<typeof import('./use-gnosis-pay-safe-migration')['useGnosisPaySafeMigration']>>;
+}> {
+  if (settings) {
+    const { useFrontendSettingsStore } = await import('@/modules/settings/use-frontend-settings-store');
+    useFrontendSettingsStore().update(settings);
+  }
+  const { useGnosisPaySafeMigration } = await import('./use-gnosis-pay-safe-migration');
+  return { composable: useGnosisPaySafeMigration() };
+}
+
+describe('useGnosisPaySafeMigration', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setActivePinia(createPinia());
+    fetchGnosisPaySafeMigration.mockReset();
+    addAccounts.mockReset().mockResolvedValue(undefined);
+    notify.mockReset();
+    showErrorMessage.mockReset();
+    showSuccessMessage.mockReset();
+    updateFrontendSetting.mockReset().mockResolvedValue(undefined);
+    getApiKey.mockReset().mockReturnValue('gpay-token');
+    loadExternalKeys.mockReset().mockResolvedValue(undefined);
+    set(externalKeys, { gnosis_pay: { apiKey: 'gpay-token' } });
+  });
+
+  it('should expose the first untracked safe after checking', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: NEW_SAFE, type: 'new' }]));
+    const { composable } = await setup();
+
+    await composable.checkMigration();
+
+    expect(get(composable.untrackedSafe)).toEqual({ address: NEW_SAFE, type: 'new' });
+    expect(get(composable.hasUntrackedSafe)).toBe(true);
+  });
+
+  it('should skip the request entirely when Gnosis Pay is not configured', async () => {
+    getApiKey.mockReturnValue('');
+    const { composable } = await setup();
+
+    await composable.checkMigration();
+
+    expect(fetchGnosisPaySafeMigration).not.toHaveBeenCalled();
+    expect(get(composable.untrackedSafe)).toBeUndefined();
+  });
+
+  it('should load the external keys first when they are not loaded yet', async () => {
+    set(externalKeys, undefined);
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: NEW_SAFE, type: 'new' }]));
+    const { composable } = await setup();
+
+    await composable.checkMigration();
+
+    expect(loadExternalKeys).toHaveBeenCalled();
+    expect(fetchGnosisPaySafeMigration).toHaveBeenCalled();
+  });
+
+  it('should clear the untracked safe when the migration has none', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([]));
+    const { composable } = await setup();
+
+    await composable.checkMigration();
+
+    expect(get(composable.untrackedSafe)).toBeUndefined();
+    expect(get(composable.hasUntrackedSafe)).toBe(false);
+  });
+
+  it('should fail silently when the endpoint errors (not configured / not premium)', async () => {
+    fetchGnosisPaySafeMigration.mockRejectedValue(new Error('Gnosis Pay credentials are not configured'));
+    const { composable } = await setup();
+
+    await expect(composable.checkMigration()).resolves.toBeUndefined();
+    expect(get(composable.untrackedSafe)).toBeUndefined();
+  });
+
+  it('should add the missing safe to Gnosis Chain and report success', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: NEW_SAFE, type: 'new' }]));
+    const { composable } = await setup();
+    await composable.checkMigration();
+
+    await composable.addMissingSafe();
+
+    expect(addAccounts).toHaveBeenCalledWith(
+      Blockchain.GNOSIS,
+      { payload: [{ address: NEW_SAFE, label: expect.any(String), tags: null }] },
+      { wait: true },
+    );
+    expect(get(composable.untrackedSafe)).toBeUndefined();
+    expect(showSuccessMessage).toHaveBeenCalled();
+    expect(showErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('should surface an error and keep the safe when adding fails', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: OLD_SAFE, type: 'old' }]));
+    addAccounts.mockRejectedValue(new Error('boom'));
+    const { composable } = await setup();
+    await composable.checkMigration();
+
+    await composable.addMissingSafe();
+
+    expect(showErrorMessage).toHaveBeenCalled();
+    expect(get(composable.untrackedSafe)).toEqual({ address: OLD_SAFE, type: 'old' });
+  });
+
+  it('should notify once and record the timestamp when never shown before', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: NEW_SAFE, type: 'new' }]));
+    const { composable } = await setup({ gnosisPaySafeMigrationLastNotified: 0, gnosisPaySafeMigrationNeverNotify: false });
+
+    await composable.checkAndNotify();
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    const payload = notify.mock.calls[0][0];
+    expect(payload.message).toContain('message_new');
+    expect(payload.message).toContain(NEW_SAFE);
+    expect(updateFrontendSetting).toHaveBeenCalledWith(
+      expect.objectContaining({ gnosisPaySafeMigrationLastNotified: expect.any(Number) }),
+    );
+  });
+
+  it('should not notify when the user chose never to be reminded', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: NEW_SAFE, type: 'new' }]));
+    const { composable } = await setup({ gnosisPaySafeMigrationNeverNotify: true });
+
+    await composable.checkAndNotify();
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('should not notify again within a week', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: NEW_SAFE, type: 'new' }]));
+    const { composable } = await setup({ gnosisPaySafeMigrationLastNotified: dayjs().unix() - 10 });
+
+    await composable.checkAndNotify();
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('should notify again once a week has passed', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: OLD_SAFE, type: 'old' }]));
+    const { composable } = await setup({ gnosisPaySafeMigrationLastNotified: dayjs().unix() - WEEK_IN_SECONDS - 10 });
+
+    await composable.checkAndNotify();
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0].message).toContain('message_old');
+  });
+
+  it('should wire the notification actions to add and to never-show-again', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: NEW_SAFE, type: 'new' }]));
+    const { composable } = await setup({ gnosisPaySafeMigrationLastNotified: 0 });
+
+    await composable.checkAndNotify();
+
+    const actions = notify.mock.calls[0][0].action;
+    expect(actions).toHaveLength(2);
+
+    await actions[0].action();
+    expect(addAccounts).toHaveBeenCalled();
+
+    await actions[1].action();
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ gnosisPaySafeMigrationNeverNotify: true });
+  });
+});

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.ts
@@ -1,0 +1,158 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { GnosisPaySafeMigration, GnosisPayUntrackedSafe } from '@/modules/integrations/gnosis-pay/types';
+import { type Account, Blockchain, NotificationCategory, Priority, Severity } from '@rotki/common';
+import dayjs from 'dayjs';
+import { useBlockchainAccountManagement } from '@/modules/accounts/use-blockchain-account-management';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useNotifications } from '@/modules/core/notifications/use-notifications';
+import { useGnosisPaySiweApi } from '@/modules/integrations/gnosis-pay/use-gnosis-pay-api';
+import { useExternalApiKeys } from '@/modules/settings/api-keys/external/use-external-api-keys';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
+
+const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+const GNOSIS_PAY_SERVICE = 'gnosis_pay';
+
+interface UseGnosisPaySafeMigrationReturn {
+  untrackedSafe: Ref<GnosisPayUntrackedSafe | undefined>;
+  untrackedAccount: ComputedRef<Account | undefined>;
+  hasUntrackedSafe: ComputedRef<boolean>;
+  adding: Ref<boolean>;
+  checkMigration: () => Promise<void>;
+  addMissingSafe: () => Promise<void>;
+  checkAndNotify: () => Promise<void>;
+}
+
+/**
+ * Consumes the backend `/services/gnosispay/migration` endpoint, which reports the
+ * Safe address a user is missing after the Gnosis Pay Safe security migration (when
+ * exactly one of the two migration Safes is tracked). The request is skipped unless
+ * Gnosis Pay is configured, and it is premium-gated, so a failed fetch is swallowed.
+ */
+export const useGnosisPaySafeMigration = createSharedComposable((): UseGnosisPaySafeMigrationReturn => {
+  const untrackedSafe = ref<GnosisPayUntrackedSafe>();
+  const adding = ref<boolean>(false);
+
+  const hasUntrackedSafe = computed<boolean>(() => isDefined(untrackedSafe));
+
+  const untrackedAccount = computed<Account | undefined>(() => {
+    const safe = get(untrackedSafe);
+    return safe ? { address: safe.address, chain: Blockchain.GNOSIS } : undefined;
+  });
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { fetchGnosisPaySafeMigration } = useGnosisPaySiweApi();
+  const { addAccounts } = useBlockchainAccountManagement();
+  const { notify, showErrorMessage, showSuccessMessage } = useNotifications();
+  const { updateFrontendSetting } = useSettingsOperations();
+  const settingsStore = useFrontendSettingsStore();
+  const { getApiKey, keys, load } = useExternalApiKeys();
+
+  const isGnosisPayConfigured = async (): Promise<boolean> => {
+    if (!isDefined(keys)) // external service keys not loaded yet (e.g. right after login)
+      await load();
+
+    return Boolean(getApiKey(GNOSIS_PAY_SERVICE));
+  };
+
+  const checkMigration = async (): Promise<void> => {
+    // Skip the (premium-gated) request entirely when Gnosis Pay is not configured.
+    if (!await isGnosisPayConfigured()) {
+      set(untrackedSafe, undefined);
+      return;
+    }
+
+    try {
+      const migration: GnosisPaySafeMigration = await fetchGnosisPaySafeMigration();
+      set(untrackedSafe, migration.untrackedAddresses[0]);
+    }
+    catch (error: unknown) {
+      // Not premium / remote error: nothing to suggest.
+      logger.debug(`Failed to fetch Gnosis Pay Safe migration: ${getErrorMessage(error)}`);
+      set(untrackedSafe, undefined);
+    }
+  };
+
+  const addMissingSafe = async (): Promise<void> => {
+    const safe = get(untrackedSafe);
+    if (!safe)
+      return;
+
+    set(adding, true);
+    try {
+      await addAccounts(Blockchain.GNOSIS, {
+        payload: [{
+          address: safe.address,
+          label: t('external_services.gnosispay.safe_migration.account_label'),
+          tags: null,
+        }],
+      }, { wait: true });
+      set(untrackedSafe, undefined);
+      showSuccessMessage(
+        t('external_services.gnosispay.safe_migration.title'),
+        t('external_services.gnosispay.safe_migration.add_success', { address: safe.address }),
+      );
+    }
+    catch (error: unknown) {
+      showErrorMessage(
+        t('external_services.gnosispay.safe_migration.title'),
+        t('external_services.gnosispay.safe_migration.add_error', { error: getErrorMessage(error) }),
+      );
+    }
+    finally {
+      set(adding, false);
+    }
+  };
+
+  const notifyIfNeeded = async (): Promise<void> => {
+    const safe = get(untrackedSafe);
+    if (!safe || settingsStore.gnosisPaySafeMigrationNeverNotify)
+      return;
+
+    const lastNotified = settingsStore.gnosisPaySafeMigrationLastNotified;
+    const now = dayjs().unix();
+    if (lastNotified !== 0 && (now - lastNotified) <= WEEK_IN_SECONDS)
+      return;
+
+    notify({
+      action: [
+        {
+          action: async (): Promise<void> => addMissingSafe(),
+          label: t('external_services.gnosispay.safe_migration.add_action'),
+        },
+        {
+          action: async (): Promise<void> => {
+            await updateFrontendSetting({ gnosisPaySafeMigrationNeverNotify: true });
+          },
+          label: t('external_services.gnosispay.safe_migration.never_action'),
+        },
+      ],
+      category: NotificationCategory.DEFAULT,
+      display: true,
+      message: safe.type === 'new'
+        ? t('notification_messages.gnosis_pay_safe_migration.message_new', { address: safe.address })
+        : t('notification_messages.gnosis_pay_safe_migration.message_old', { address: safe.address }),
+      priority: Priority.ACTION,
+      severity: Severity.WARNING,
+      title: t('notification_messages.gnosis_pay_safe_migration.title'),
+    });
+
+    await updateFrontendSetting({ gnosisPaySafeMigrationLastNotified: now });
+  };
+
+  const checkAndNotify = async (): Promise<void> => {
+    await checkMigration();
+    await notifyIfNeeded();
+  };
+
+  return {
+    addMissingSafe,
+    adding,
+    checkAndNotify,
+    checkMigration,
+    hasUntrackedSafe,
+    untrackedAccount,
+    untrackedSafe,
+  };
+});

--- a/frontend/app/src/modules/settings/api-keys/ServiceKeyCard.vue
+++ b/frontend/app/src/modules/settings/api-keys/ServiceKeyCard.vue
@@ -43,6 +43,7 @@ const emit = defineEmits<{
 defineSlots<{
   'default': () => any;
   'left-buttons': () => any;
+  'banner': () => any;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
@@ -113,6 +114,12 @@ defineExpose({
           {{ subtitle }}
         </template>
       </RuiCardHeader>
+      <div
+        v-if="$slots.banner"
+        class="px-6 pb-2"
+      >
+        <slot name="banner" />
+      </div>
     </div>
     <div
       v-if="featureBlocked"

--- a/frontend/app/src/modules/settings/types/frontend-settings.ts
+++ b/frontend/app/src/modules/settings/types/frontend-settings.ts
@@ -200,6 +200,8 @@ export const FrontendSettings = z.object({
     Defaults.DEFAULT_EVM_QUERY_INDICATOR_MIN_OUT_OF_SYNC_PERIOD,
   ),
   explorers: ExplorersSettings.default({}),
+  gnosisPaySafeMigrationLastNotified: z.number().int().nonnegative().default(0),
+  gnosisPaySafeMigrationNeverNotify: z.boolean().default(false),
   graphZeroBased: z.boolean().default(false),
   ignoreSnapshotError: z.boolean().default(false),
   itemsPerPage: z.number().positive().int().default(10),

--- a/frontend/app/src/modules/settings/types/user-settings.spec.ts
+++ b/frontend/app/src/modules/settings/types/user-settings.spec.ts
@@ -100,6 +100,8 @@ describe('user-types', () => {
       autoDetectTokensCooldownHours: 24,
       autoDetectTokensOnLogin: false,
       lastAutoDetectAt: 0,
+      gnosisPaySafeMigrationLastNotified: 0,
+      gnosisPaySafeMigrationNeverNotify: false,
     };
 
     const raw = {

--- a/frontend/app/src/modules/settings/use-frontend-settings-store.spec.ts
+++ b/frontend/app/src/modules/settings/use-frontend-settings-store.spec.ts
@@ -135,6 +135,8 @@ describe('useFrontendSettingsStore', () => {
       autoDetectTokensCooldownHours: 24,
       autoDetectTokensOnLogin: false,
       lastAutoDetectAt: 0,
+      gnosisPaySafeMigrationLastNotified: 0,
+      gnosisPaySafeMigrationNeverNotify: false,
     };
 
     store.update(state);

--- a/frontend/app/src/modules/settings/use-frontend-settings-store.ts
+++ b/frontend/app/src/modules/settings/use-frontend-settings-store.ts
@@ -31,6 +31,8 @@ export const useFrontendSettingsStore = defineStore('settings/frontend', () => {
   const newlyDetectedTokensTtlDays = useComputedRef(settings, 'newlyDetectedTokensTtlDays');
   const refreshPeriod = useComputedRef(settings, 'refreshPeriod');
   const explorers = useComputedRef(settings, 'explorers');
+  const gnosisPaySafeMigrationLastNotified = useComputedRef(settings, 'gnosisPaySafeMigrationLastNotified');
+  const gnosisPaySafeMigrationNeverNotify = useComputedRef(settings, 'gnosisPaySafeMigrationNeverNotify');
   const itemsPerPage = useComputedRef(settings, 'itemsPerPage');
   const amountRoundingMode = useComputedRef(settings, 'amountRoundingMode');
   const valueRoundingMode = useComputedRef(settings, 'valueRoundingMode');
@@ -111,6 +113,8 @@ export const useFrontendSettingsStore = defineStore('settings/frontend', () => {
     evmQueryIndicatorDismissalThreshold,
     evmQueryIndicatorMinOutOfSyncPeriod,
     explorers,
+    gnosisPaySafeMigrationLastNotified,
+    gnosisPaySafeMigrationNeverNotify,
     graphZeroBased,
     ignoreSnapshotError,
     itemsPerPage,


### PR DESCRIPTION
Frontend for #12505. Backend shipped in #12506, which exposes `GET /services/gnosispay/migration` returning the Safe address a user is missing when they track exactly one of the two migration Safes:

```json
{ "migration_id": "safe-replacement-2026-06", "untracked_addresses": [{ "address": "0x…", "type": "new" | "old" }] }
```

## What this does

- **API + schema** (`use-gnosis-pay-api.ts`, `types.ts`): `fetchGnosisPaySafeMigration()` calls the endpoint, parsed with a new zod schema.
- **Shared composable** (`use-gnosis-pay-safe-migration.ts`): fetches the migration (fails silently on the 409/non-premium responses), builds the target `Account`, adds the missing Safe to Gnosis Chain, and owns the throttled notification.
- **Card** (`GnosisPayAuth.vue`): the Gnosis Pay card in the external-services area shows the untracked Safe (blockie + address via `AccountDisplay`) with a one-click "Add to rotki" action, distinguishing the previous vs new Safe. A `banner` slot was added to `ServiceKeyCard.vue` so the alert renders on the card face.
- **Notification**: a once-per-week, per-user prompt (with a **Never show again** option) fired post-login from `handleSessionReady()`. Throttled via two new frontend settings (`gnosisPaySafeMigrationLastNotified`, `gnosisPaySafeMigrationNeverNotify`), following the `usePasswordConfirmation` pattern.
- Added EN translations (alphabetically sorted).

## Tests

- `use-gnosis-pay-safe-migration.spec.ts` — check/clear, silent-fail on error, add success/error, weekly throttle, never-show gating, and notification action wiring.
- `use-gnosis-pay-api.spec.ts` — migration GET + snake→camel transform, empty list.
- Updated the full-settings fixtures for the two new keys.

`typecheck`, `lint`, and unit tests pass. Changelog entry for #12505 already landed with the backend PR.