### PR TITLE
dev: plain dev uses defaults; type VITE_ env vars

### DIFF
--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -41,8 +41,8 @@ export class Application {
     isDev: checkIfDevelopment(),
     isMac: process.platform === 'darwin',
     urls: {
-      coreApiUrl: import.meta.env.VITE_BACKEND_URL as string,
-      colibriApiUrl: import.meta.env.VITE_COLIBRI_URL as string,
+      coreApiUrl: import.meta.env.VITE_BACKEND_URL,
+      colibriApiUrl: import.meta.env.VITE_COLIBRI_URL,
     },
     ports: {
       colibriPort: instancePort('ROTKI_INSTANCE_COLIBRI_PORT', DEFAULT_COLIBRI_PORT),

--- a/frontend/app/env.d.ts
+++ b/frontend/app/env.d.ts
@@ -6,4 +6,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_WALLET_CONNECT_PROJECT_ID: string;
+  readonly VITE_BACKEND_URL: string;
+  readonly VITE_COLIBRI_URL: string;
+  readonly VITE_ROTKI_WEBSITE_URL: string | undefined;
 }

--- a/frontend/app/src/modules/core/api/api-urls.ts
+++ b/frontend/app/src/modules/core/api/api-urls.ts
@@ -2,7 +2,7 @@ import type { ApiUrls } from '@shared/ipc';
 
 function getDefaultCoreUrl(): string {
   if (import.meta.env.VITE_BACKEND_URL)
-    return import.meta.env.VITE_BACKEND_URL as string;
+    return import.meta.env.VITE_BACKEND_URL;
 
   if (import.meta.env.VITE_PUBLIC_PATH) {
     const pathname = window.location.pathname;
@@ -14,7 +14,7 @@ function getDefaultCoreUrl(): string {
 
 function getDefaultColibriUrl(): string {
   if (import.meta.env.VITE_COLIBRI_URL)
-    return import.meta.env.VITE_COLIBRI_URL as string;
+    return import.meta.env.VITE_COLIBRI_URL;
 
   if (import.meta.env.VITE_PUBLIC_PATH) {
     const pathname = window.location.pathname;

--- a/frontend/app/src/modules/integrations/monerium/MoneriumAuth.vue
+++ b/frontend/app/src/modules/integrations/monerium/MoneriumAuth.vue
@@ -24,7 +24,7 @@ const featureGate = computed<FeatureGate>(() => {
   return { allowed: get(allowed), message };
 });
 
-const websiteUrl = import.meta.env.VITE_ROTKI_WEBSITE_URL as string | undefined;
+const websiteUrl = import.meta.env.VITE_ROTKI_WEBSITE_URL;
 
 const isAuthorizing = ref<boolean>(false);
 const showTokenInput = ref<boolean>(false);

--- a/frontend/scripts/dev-instance/env-file.ts
+++ b/frontend/scripts/dev-instance/env-file.ts
@@ -12,10 +12,12 @@ export const MANAGED_ENV_KEYS = [
 ] as const;
 
 /**
- * Dev toggles that `pnpm dev` / `dev:web` keeps on by default. They live in the
- * managed block so a fresh checkout gets them without hand-editing, but a value
- * a developer has already set (in the env file or the shell) is preserved — see
- * `devFlagUpdates`. Never written for production builds (start-dev is dev-only).
+ * Dev toggles that instance runs (`pnpm dev --instance`) keep on by default.
+ * They live in the managed block so a fresh instance gets them without
+ * hand-editing, but a value a developer has already set (in the env file or the
+ * shell) is preserved (see `devFlagUpdates`). Plain `pnpm dev` / `dev:web` does
+ * NOT enable them; it strips the managed block and runs on the defaults. Never
+ * written for production builds (start-dev is dev-only).
  */
 export const MANAGED_DEV_FLAG_KEYS = [
   'ENABLE_DEV_TOOLS',
@@ -162,10 +164,12 @@ export function readManagedInstanceName(file: string): string | undefined {
 
 /**
  * Removes the dev:web-managed block (and any orphan managed keys) from `file`.
- * Leaves every unmanaged line untouched. Useful when an instance is cleaned and
- * we want to remove the env trail it wrote.
+ * Leaves every unmanaged line untouched. Useful when an instance is cleaned or a
+ * plain `pnpm dev` run wants the env trail gone. Defaults to stripping only the
+ * instance keys as orphans: a dev flag the developer set outside the block is
+ * their own line and is left in place (we don't touch or manage it).
  */
-export function clearManagedEnvBlock(file: string, opts: { managed: readonly string[] } = { managed: ALL_MANAGED_KEYS }): void {
+export function clearManagedEnvBlock(file: string, opts: { managed: readonly string[] } = { managed: MANAGED_ENV_KEYS }): void {
   if (!fs.existsSync(file))
     return;
   const managed = new Set(opts.managed);
@@ -220,28 +224,37 @@ function resolveDevFlag(existing: string | undefined): string {
 }
 
 /**
- * Resolved values for the always-on dev flags. Each defaults to on, but an
- * existing value is preserved so a developer who turns a flag off keeps it off
- * (`=false`, `=0`, `=off`, or empty all disable it). A value the developer wrote
- * OUTSIDE the managed block wins (their override, no matter where they put it —
- * it gets consolidated back into the block); else the current in-block value
- * carries over; else the flag defaults on.
+ * Resolved values for the default-on dev flags, to be written into the managed
+ * block. Each defaults to on, but an existing in-block value is preserved so a
+ * developer who turns a flag off keeps it off (`=false`, `=0`, `=off`, or empty
+ * all disable it). A flag the developer set OUTSIDE the managed block is their
+ * own line: we don't touch or manage it, so it's skipped here (never defaulted,
+ * never consolidated into the block).
  */
 export function devFlagUpdates(file: string): Record<string, string> {
   const { inBlock, outOfBlock } = readManagedSplit(file);
   const updates: Record<string, string> = {};
-  for (const key of MANAGED_DEV_FLAG_KEYS)
-    updates[key] = resolveDevFlag(outOfBlock[key] ?? inBlock[key]);
+  for (const key of MANAGED_DEV_FLAG_KEYS) {
+    if (key in outOfBlock)
+      continue;
+    updates[key] = resolveDevFlag(inBlock[key]);
+  }
   return updates;
 }
 
 /**
- * Writes the dev:web-managed block. The default-on dev flags are always
- * included; the instance keys only when running an instance (pass its computed
- * env as `instanceUpdates`, or omit for a non-instance run, which also strips
- * any stale instance keys). Call on every `pnpm dev` run so a fresh checkout
- * still gets the dev flags.
+ * Writes the dev:web-managed block for an instance run: the instance keys (pass
+ * its computed env as `instanceUpdates`) plus the default-on dev flags. Plain
+ * `pnpm dev` / `dev:web` does not call this: it strips the managed block via
+ * `clearManagedEnvBlock` and runs on the defaults.
+ *
+ * A dev flag the developer set outside the block is left in place: it's excluded
+ * from both the block content (via `devFlagUpdates`) and the managed key set, so
+ * writeEnvFile's orphan-strip doesn't remove their line.
  */
 export function writeManagedEnv(file: string, instanceUpdates: Record<string, string> = {}): void {
-  writeEnvFile(file, { ...instanceUpdates, ...devFlagUpdates(file) }, { managed: ALL_MANAGED_KEYS });
+  const { outOfBlock } = readManagedSplit(file);
+  const externalFlags = new Set(MANAGED_DEV_FLAG_KEYS.filter(key => key in outOfBlock));
+  const managed = ALL_MANAGED_KEYS.filter(key => !externalFlags.has(key));
+  writeEnvFile(file, { ...instanceUpdates, ...devFlagUpdates(file) }, { managed });
 }

--- a/frontend/scripts/dev-instance/env-file.ts
+++ b/frontend/scripts/dev-instance/env-file.ts
@@ -243,6 +243,26 @@ export function devFlagUpdates(file: string): Record<string, string> {
 }
 
 /**
+ * All managed KEY=VAL pairs currently INSIDE the block (instance keys + dev
+ * flags), for propagating into `process.env`. start-dev loads the env files into
+ * process.env before the instance block is (re)written, so a stale value from
+ * `app/.env` — e.g. the default `VITE_BACKEND_URL=...:4242` — can shadow the
+ * instance's real port. Vite gives process.env VITE_* vars priority over .env
+ * files, so the block must be pushed onto process.env to win. Dev flags a
+ * developer set outside the block are intentionally absent (not in-block), so
+ * their process.env value from the env-file load is left untouched.
+ */
+export function readManagedBlockEnv(file: string): Record<string, string> {
+  const { inBlock } = readManagedSplit(file);
+  const result: Record<string, string> = {};
+  for (const key of ALL_MANAGED_KEYS) {
+    if (key in inBlock)
+      result[key] = inBlock[key];
+  }
+  return result;
+}
+
+/**
  * Writes the dev:web-managed block for an instance run: the instance keys (pass
  * its computed env as `instanceUpdates`) plus the default-on dev flags. Plain
  * `pnpm dev` / `dev:web` does not call this: it strips the managed block via

--- a/frontend/scripts/dev-instance/index.ts
+++ b/frontend/scripts/dev-instance/index.ts
@@ -7,6 +7,7 @@ export {
   devFlagUpdates,
   loadEnvFile,
   MANAGED_ENV_KEYS,
+  readManagedBlockEnv,
   readManagedInstanceName,
   writeManagedEnv,
 } from './env-file';

--- a/frontend/scripts/start-dev.ts
+++ b/frontend/scripts/start-dev.ts
@@ -6,6 +6,7 @@ import { config } from 'dotenv';
 import {
   cleanAll,
   cleanInstance,
+  clearManagedEnvBlock,
   DEFAULT_PORTS,
   devFlagUpdates,
   type InstanceRuntime,
@@ -15,7 +16,6 @@ import {
   pruneInstances,
   readManagedInstanceName,
   repairRegistry,
-  writeManagedEnv,
 } from './dev-instance';
 import { errorMessage, formatPort } from './dev-instance/format';
 import { getCurrentGitBranch } from './dev-instance/git';
@@ -174,13 +174,9 @@ function readSlotHint(resolvedName: string): number | undefined {
 
 async function resolveInstance(options: DevCliOptions, useProxy: boolean): Promise<InstanceRuntime | null> {
   if (options.instance === false) {
-    // Explicit --no-instance: drop any stale instance keys from a prior instance
-    // run so Vite doesn't read INSTANCE_PORT_SLOT / VITE_BACKEND_URL pointing at
-    // a slot we're no longer using. The dev-flags block is still (re)written
-    // afterwards by writeManagedEnv, so this only strips the instance keys.
-    const staleOwner = readManagedInstanceName(ENV_FILE_RELATIVE);
-    if (staleOwner !== undefined)
-      logger.info(`--no-instance: dropping managed instance keys left over from "${staleOwner}"`);
+    // Explicit --no-instance: force default mode. runDevAction already stripped
+    // the managed block (via useDefaultDevEnv) before loading env, so there's
+    // nothing to do here beyond signalling default mode.
     return null;
   }
   const name = pickInstanceName(options.instance);
@@ -223,6 +219,50 @@ async function tearDownAndExit(error: unknown, exitCode: number): Promise<never>
   process.exit(exitCode);
 }
 
+/**
+ * Whether this run enters instance mode. True for an explicit `--instance [name]`,
+ * or when a wrapper has exported INSTANCE_NAME in the shell (the wt-managed case).
+ * `--no-instance` always forces default mode.
+ *
+ * MUST be evaluated BEFORE loadDevEnv, so process.env.INSTANCE_NAME reflects only
+ * a real shell export and not a stale managed block in the env file: plain
+ * `pnpm dev` / `dev:web` ignores a leftover file block rather than silently
+ * resuming the instance it names.
+ */
+function wantsInstanceMode(option: DevCliOptions['instance']): boolean {
+  if (option === false)
+    return false;
+  if (option === true || (typeof option === 'string' && option.length > 0))
+    return true;
+  return !!process.env.INSTANCE_NAME;
+}
+
+/**
+ * Plain `pnpm dev` / `dev:web`: ignore the managed block entirely. Strip it from
+ * `.env.development.local` BEFORE the env files are loaded, so the instance keys
+ * (ports, data dir, INSTANCE_NAME) never reach process.env. Otherwise Vite —
+ * which gives process.env VITE_* vars priority over .env files — would point the
+ * renderer at the instance backend, and resolveInstance would resume the
+ * instance. A dev flag a developer set outside the block is left in place.
+ */
+function useDefaultDevEnv(): void {
+  const staleOwner = readManagedInstanceName(ENV_FILE_RELATIVE);
+  clearManagedEnvBlock(ENV_FILE_RELATIVE);
+  if (staleOwner !== undefined)
+    logger.info(`Ignoring managed env block left over from "${staleOwner}"; using default dev env`);
+}
+
+/**
+ * Instance mode: propagate the resolved dev flags to this run's children
+ * (electron reads ENABLE_DEV_TOOLS from process.env; vite the VITE_* ones) so
+ * they take effect on the first run too, before the env file is re-read next
+ * time.
+ */
+function propagateInstanceEnv(): void {
+  for (const [key, value] of Object.entries(devFlagUpdates(ENV_FILE_RELATIVE)))
+    process.env[key] = value;
+}
+
 async function runDevAction(options: DevCliOptions): Promise<void> {
   try {
     if (await dispatchManagementSubcommand(options))
@@ -233,6 +273,11 @@ async function runDevAction(options: DevCliOptions): Promise<void> {
   }
 
   ensurePrerequisites();
+
+  // Decide instance vs default from CLI/shell before loading env, then for a
+  // default run strip the managed block first so it can't leak into process.env.
+  if (!wantsInstanceMode(options.instance))
+    useDefaultDevEnv();
   loadDevEnv();
 
   const useProxy = shouldUseProxy(options);
@@ -251,20 +296,8 @@ async function runDevAction(options: DevCliOptions): Promise<void> {
       `  ports: backend=${formatPort(instance.ports.restApi)} proxy=${formatPort(instance.ports.proxy)} `
       + `colibri=${formatPort(instance.ports.colibri)} dev=${formatPort(instance.ports.dev)}`,
     );
+    propagateInstanceEnv();
   }
-  else {
-    // Non-instance run: prepareInstance never ran, so write the managed block
-    // ourselves. It carries only the always-on dev flags (default on, existing
-    // values preserved) and strips any stale instance keys from a prior run.
-    writeManagedEnv(ENV_FILE_RELATIVE);
-  }
-
-  // Propagate the resolved dev flags to this run's children (electron reads
-  // ENABLE_DEV_TOOLS from process.env; vite the VITE_* ones) so they take effect
-  // on the first run too, before the env file is re-read next time. Read after
-  // the managed block was (re)written above so we pick up the consolidated values.
-  for (const [key, value] of Object.entries(devFlagUpdates(ENV_FILE_RELATIVE)))
-    process.env[key] = value;
 
   registerShutdownHandlers();
   setupProfilingEnvironment(options);

--- a/frontend/scripts/start-dev.ts
+++ b/frontend/scripts/start-dev.ts
@@ -8,12 +8,12 @@ import {
   cleanInstance,
   clearManagedEnvBlock,
   DEFAULT_PORTS,
-  devFlagUpdates,
   type InstanceRuntime,
   PortSlotAllocationError,
   prepareInstance,
   printInstanceList,
   pruneInstances,
+  readManagedBlockEnv,
   readManagedInstanceName,
   repairRegistry,
 } from './dev-instance';
@@ -253,13 +253,17 @@ function useDefaultDevEnv(): void {
 }
 
 /**
- * Instance mode: propagate the resolved dev flags to this run's children
- * (electron reads ENABLE_DEV_TOOLS from process.env; vite the VITE_* ones) so
- * they take effect on the first run too, before the env file is re-read next
- * time.
+ * Instance mode: prepareInstance wrote the managed block with this instance's
+ * ports, data-dir pointers and dev flags. Push the whole block onto process.env
+ * so it OVERRIDES what loadDevEnv seeded from `app/.env` — that load runs before
+ * the block is written, so on a fresh instance run the default `VITE_BACKEND_URL`
+ * (:4242) is already in process.env, and Vite prioritises process.env VITE_*
+ * over .env files. Without this the renderer would talk to 4242 instead of the
+ * instance's backend. Electron reads ENABLE_DEV_TOOLS / ROTKI_* from process.env;
+ * vite the VITE_* ones.
  */
 function propagateInstanceEnv(): void {
-  for (const [key, value] of Object.entries(devFlagUpdates(ENV_FILE_RELATIVE)))
+  for (const [key, value] of Object.entries(readManagedBlockEnv(ENV_FILE_RELATIVE)))
     process.env[key] = value;
 }
 


### PR DESCRIPTION
## Summary

Three related dev-environment / typing cleanups on top of the recent multi-instance dev launcher work.

### 1. Type `VITE_` env vars instead of casting
Add `VITE_BACKEND_URL`, `VITE_COLIBRI_URL` and `VITE_ROTKI_WEBSITE_URL` to the `ImportMetaEnv` interface in `env.d.ts` and drop the inline `as string` / `as string | undefined` casts at their use sites (`api-urls.ts`, `MoneriumAuth.vue`).

### 2. Plain dev uses the defaults; only `--instance` manages dev flags
Plain `pnpm dev` / `dev:web` now runs on the defaults and ignores the `dev:web`-managed block in `.env.development.local` entirely:
- The block is stripped **before** the env files are loaded, so its instance keys (ports, data dir, `INSTANCE_NAME`) never reach `process.env`. Otherwise Vite, which gives `process.env` `VITE_*` vars priority over `.env` files, would point the renderer at the instance backend, and a leftover `INSTANCE_NAME` would silently resume that instance.
- Instance mode is entered only on an explicit `--instance [name]` or a shell-exported `INSTANCE_NAME` (the wt-managed case), decided before the env load.
- Only instance mode enables the default-on dev flags (`ENABLE_DEV_TOOLS` / `VITE_DEV_LOGS` / `VITE_PERSIST_STORE`). A dev flag a developer set **outside** the managed block is left in place: never stripped, defaulted, or consolidated into the block.

### 3. Instance mode overrides stale `VITE_BACKEND_URL` from `app/.env`
Fixes a bug where, in electron instance mode, the renderer connected to the default backend port (`4242`) instead of the instance's reserved port. `start-dev` loads the env files into `process.env` before `prepareInstance` writes the managed block, so on a fresh instance run the default `VITE_BACKEND_URL` from `app/.env` lands in `process.env`, and Vite's `process.env > .env` precedence let it shadow the instance's real port. Instance mode now propagates the whole managed block onto `process.env` after it is written, overriding the stale seed.

## Test plan
- `pnpm dev --instance <name>` → renderer hits the instance backend port (e.g. `13031`), not `4242`.
- Plain `pnpm dev` → renderer hits the default `4242`; any leftover managed block is stripped, out-of-block dev flags preserved.
- Lint clean on the changed scripts; app `typecheck` passes.