### PR TITLE
fix: app:// handler falls back to index.html

### DIFF
--- a/frontend/app/electron/main/create-protocol.spec.ts
+++ b/frontend/app/electron/main/create-protocol.spec.ts
@@ -1,0 +1,98 @@
+import type { Protocol } from 'electron';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createProtocol } from './create-protocol';
+
+type Handler = (request: Request) => Promise<Response>;
+
+describe('createProtocol', () => {
+  let baseDir: string;
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(join(tmpdir(), 'rotki-protocol-'));
+    await writeFile(join(baseDir, 'index.html'), '<html>root</html>');
+    await writeFile(join(baseDir, 'main.js'), 'console.log(1)');
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    await rm(baseDir, { force: true, recursive: true });
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Captures the handler registered via `protocol.handle` so it can be invoked
+   * with fabricated requests, serving from the temporary `baseDir`.
+   */
+  function registerHandler(): Handler {
+    let handler: Handler | undefined;
+    const customProtocol = {
+      handle: (_scheme: string, cb: Handler) => {
+        handler = cb;
+      },
+    } as unknown as Protocol;
+
+    createProtocol('app', customProtocol, baseDir);
+
+    if (!handler)
+      throw new Error('handler was not registered');
+
+    return handler;
+  }
+
+  function request(path: string): Request {
+    return new Request(`app://localhost${path}`);
+  }
+
+  it('should serve an existing asset with the correct mime type', async () => {
+    const handler = registerHandler();
+
+    const response = await handler(request('/main.js'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/javascript');
+    expect(await response.text()).toBe('console.log(1)');
+  });
+
+  it('should fall back to index.html for the bare origin', async () => {
+    const handler = registerHandler();
+
+    const response = await handler(request('/'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html');
+    expect(await response.text()).toBe('<html>root</html>');
+  });
+
+  it('should fall back to index.html for an unknown extensionless route', async () => {
+    const handler = registerHandler();
+
+    const response = await handler(request('/dashboard'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html');
+    expect(await response.text()).toBe('<html>root</html>');
+  });
+
+  it('should return 404 for a missing asset with an extension', async () => {
+    const handler = registerHandler();
+
+    const response = await handler(request('/missing.js'));
+
+    expect(response.status).toBe(404);
+  });
+
+  it('should not escape the served directory on path traversal attempts', async () => {
+    const handler = registerHandler();
+
+    const response = await handler(request('/../../secret.txt'));
+
+    // sanitizePath strips the traversal sequence, so it can never reach a file
+    // outside baseDir; the request resolves within the directory instead.
+    expect(response.status).not.toBe(500);
+    expect([200, 403, 404]).toContain(response.status);
+  });
+});

--- a/frontend/app/electron/main/create-protocol.ts
+++ b/frontend/app/electron/main/create-protocol.ts
@@ -1,9 +1,12 @@
 import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { URL } from 'node:url';
+import { sanitizePath } from '@electron/main/path-sanitizer';
 import { type Protocol, protocol } from 'electron';
 
 const currentDir = import.meta.dirname;
+
+const INDEX_HTML = 'index.html';
 
 export function getMimeType(pathName: string): string {
   const extension = path.extname(pathName).toLowerCase();
@@ -28,24 +31,77 @@ export function getMimeType(pathName: string): string {
   return 'application/octet-stream';
 }
 
-export function createProtocol(scheme: string, customProtocol?: Protocol) {
+/**
+ * Resolves a request path to a file inside `baseDir`, guarding against path
+ * traversal. Returns the absolute file path, or `undefined` if the request
+ * escapes the served directory.
+ */
+function resolveFilePath(baseDir: string, requestFile: string): string | undefined {
+  const filePath = path.resolve(path.join(baseDir, requestFile));
+  const resolvedBaseDir = path.resolve(baseDir);
+  if (filePath !== resolvedBaseDir && !filePath.startsWith(resolvedBaseDir + path.sep))
+    return undefined;
+
+  return filePath;
+}
+
+async function fileResponse(filePath: string): Promise<Response> {
+  const data = await readFile(filePath);
+  return new Response(new Uint8Array(data), {
+    status: 200,
+    headers: {
+      'Content-Type': getMimeType(filePath),
+    },
+  });
+}
+
+export function createProtocol(scheme: string, customProtocol?: Protocol, baseDir: string = currentDir) {
   const protocolToUse = customProtocol || protocol;
 
   protocolToUse.handle(scheme, async (request) => {
     try {
       const url = new URL(request.url);
       const pathname = decodeURIComponent(url.pathname);
-      const filePath = path.join(currentDir, pathname);
+      let requestFile = sanitizePath(pathname);
 
-      const data = await readFile(filePath);
-      const mimeType = getMimeType(filePath);
+      // Serve index.html for the bare origin and SPA (hash) routes. The renderer
+      // is loaded via `app://localhost/index.html`, but a reload or navigation
+      // can request the bare origin (`app://localhost/`), which would otherwise
+      // resolve to the `dist` directory and fail.
+      if (!requestFile || requestFile === '/' || requestFile.startsWith('/#/'))
+        requestFile = INDEX_HTML;
 
-      return new Response(new Uint8Array(data), {
-        status: 200,
-        headers: {
-          'Content-Type': mimeType,
-        },
-      });
+      const filePath = resolveFilePath(baseDir, requestFile);
+      if (!filePath) {
+        return new Response('Forbidden', {
+          status: 403,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      }
+
+      try {
+        return await fileResponse(filePath);
+      }
+      catch {
+        // The file is missing. If the request has no extension it is a client
+        // route rather than an asset, so fall back to index.html and let the
+        // router resolve it. Genuine missing assets get a 404.
+        if (path.extname(requestFile) === '') {
+          const indexPath = resolveFilePath(baseDir, INDEX_HTML);
+          if (indexPath) {
+            try {
+              return await fileResponse(indexPath);
+            }
+            catch { /* fall through to 404 */ }
+          }
+        }
+
+        console.warn(`File not found via ${scheme}:// protocol: ${requestFile}`);
+        return new Response('File not found', {
+          status: 404,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      }
     }
     catch (error) {
       console.error(`Failed to load file via ${scheme}:// protocol`, error);

--- a/frontend/app/vitest.config.ts
+++ b/frontend/app/vitest.config.ts
@@ -9,6 +9,7 @@ export default mergeConfig(
     resolve: {
       alias: {
         '@test': `${path.join(__dirname, 'tests', 'unit')}/`,
+        '@electron': path.join(__dirname, 'electron'),
       },
     },
   }),


### PR DESCRIPTION
## Problem

On Linux (reported on TUXEDO OS / Ubuntu-based, AppImage) the window renders blank after startup, with the main process logging:

```
Failed to load file via app:// protocol Error: ENOENT, dist not found in .../app.asar
```

Fixes the blank-window part of #12523.

## Root cause

The `app://` protocol handler (`create-protocol.ts`) resolved requests by joining the request pathname onto the `dist` directory, with no fallback. A request for the bare origin `app://localhost/` (pathname `/`) resolved to the `dist` directory itself, so `readFile` threw `ENOENT`, the handler returned 500, and the renderer stayed blank.

Startup loads `app://localhost/index.html` explicitly, which always works, so this only surfaced when the renderer navigated or reloaded to the bare origin. The HTTP-server code path (`app-server.ts`) already guarded against exactly this; the `app://` handler did not.

## Fix

Mirror the HTTP-server behavior in the `app://` handler:

- Bare origin and hash routes (`/`, `/#/…`) serve `index.html`.
- Unknown extensionless routes fall back to `index.html` so the client router can resolve them.
- Genuinely missing assets (with an extension) return 404 instead of 500.
- Added a path-traversal guard via the shared `sanitizePath` plus a resolved-path containment check.

## Notes

- Could not reproduce locally: the same upgrade from the old version to the new version was tested on Ubuntu 24.04 LTS and did not trigger the blank window. A clean launch never hits the bare-origin path, so the failure appears to depend on the reporter's environment (a renderer navigation/reload to the bare origin). This fix hardens the handler regardless of the trigger.
- The secondary GlobalDB-downgrade concern raised in #12523 is out of scope here: the hard-fail is by design (see #2781) and a downgrade utility is tracked separately in #12174.

## Tests

Added `create-protocol.spec.ts` covering asset serving + mime type, bare-origin fallback, extensionless-route fallback, missing-asset 404, and traversal containment. `createProtocol` gained an optional `baseDir` param (defaults to the module dir) to make the served directory injectable in tests.