### PR TITLE
fix: stop renderer requests before app quit

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 * :bug:`-` fix order of aave v3 token interest earnings for a specific subset of events.
 * :feature:`12499` Additional crypto.com CSV import transaction kinds such as van purchases, fiat wallet limit orders, and extra earn interest payments will now be properly imported.
 * :bug:`12507` The documented ``LOGFROMOTHERMODULES`` Docker environment variable is now honored again (it was misspelled internally) and accepts truthy string values such as ``true``, ``1``, ``yes`` and ``on``.
+* :bug:`-` Quitting the desktop app now stops it from querying the backend as it shuts down, so closing the app no longer logs spurious connection errors from requests that raced the backend termination.
 * :bug:`-` The rate-limit hint in the PnL report's missing prices dialog is now a warning icon next to the refresh button, so its tooltip no longer covers the price input or the buttons of nearby rows.
 * :bug:`-` The pending task shown while balances are queried now makes clear that a balance snapshot is being saved for statistics, and notes when query errors are being ignored.
 * :bug:`-` The "history out of sync" warning shown before generating a PnL report now lets you start the history sync right there, instead of only sending you to the history page.

--- a/frontend/app/electron/ipc-commands.ts
+++ b/frontend/app/electron/ipc-commands.ts
@@ -43,6 +43,9 @@ export const IpcCommands = {
   SYNC_GET_STARTUP_ERROR: 'SYNC_GET_STARTUP_ERROR',
   RENDERER_READY: 'RENDERER_READY',
   STARTUP_ERROR: 'STARTUP_ERROR',
+  // Graceful shutdown handshake
+  APP_CLOSING: 'APP_CLOSING',
+  APP_CLOSING_ACK: 'APP_CLOSING_ACK',
 } as const;
 
 export type IpcCommands = typeof IpcCommands[keyof typeof IpcCommands];

--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -1,18 +1,20 @@
 import type { AppConfig } from '@electron/main/app-config';
 import process from 'node:process';
+import { IpcCommands } from '@electron/ipc-commands';
 import { protectHtmlAssociation } from '@electron/main/html-mime-protection';
 import { IpcManager } from '@electron/main/ipc-setup';
 import { LogService } from '@electron/main/log-service';
 import { MenuManager } from '@electron/main/menu';
 import { parseToken } from '@electron/main/oauth-utils';
 import { DEFAULT_COLIBRI_PORT, DEFAULT_PORT } from '@electron/main/port-utils';
+import { notifyRendererOfShutdown } from '@electron/main/renderer-shutdown';
 import { resolveLogLevel } from '@electron/main/resolve-log-level';
 import { SettingsManager } from '@electron/main/settings-manager';
 import { SubprocessHandler } from '@electron/main/subprocess-handler';
 import { TrayManager } from '@electron/main/tray-manager';
 import { WindowManager } from '@electron/main/window-manager';
 import { checkIfDevelopment, startPromise } from '@shared/utils';
-import { app, protocol } from 'electron';
+import { app, ipcMain, protocol } from 'electron';
 
 export class Application {
   private readonly window: WindowManager;
@@ -23,6 +25,7 @@ export class Application {
   private readonly menu: MenuManager;
   private readonly settings: SettingsManager;
   private protocolRegistrationFailed: boolean = false;
+  private shuttingDown: boolean = false;
   private readonly appConfig: AppConfig = {
     isDev: checkIfDevelopment(),
     isMac: process.platform === 'darwin',
@@ -217,25 +220,62 @@ export class Application {
     app.removeAllListeners('before-quit');
   }
 
+  /**
+   * Notifies the renderer that we are quitting so it can stop polling and
+   * cancel in-flight requests before the backend goes down. Bounded: it can
+   * never block quit for more than the internal timeout.
+   */
+  private async notifyRendererShutdown(): Promise<void> {
+    await notifyRendererOfShutdown({
+      send: () => this.window.notifyClosing(),
+      waitForAck: (onAck) => {
+        ipcMain.once(IpcCommands.APP_CLOSING_ACK, onAck);
+        return () => ipcMain.removeListener(IpcCommands.APP_CLOSING_ACK, onAck);
+      },
+      logger: this.logger,
+    });
+  }
+
   private async quit() {
-    this.cleanup();
-    this.menu.cleanup();
-    this.window.cleanup();
-    this.tray.cleanup();
-    this.ipc.cleanup();
+    // Absolute backstop: whatever happens below, force the process to exit so a
+    // hung renderer, subprocess, or socket can never wedge the quit indefinitely.
+    const failsafe = setTimeout(() => {
+      this.logger.warn('Quit watchdog fired; forcing exit');
+      app.exit();
+    }, 5000);
+    failsafe.unref?.();
+
     try {
-      await this.processHandler.terminateProcesses();
+      // Give the renderer a bounded chance to halt outbound traffic. Must run
+      // before window.cleanup() nulls the webContents. Guarded so the multiple
+      // quit entry points only notify once.
+      if (!this.shuttingDown) {
+        this.shuttingDown = true;
+        await this.notifyRendererShutdown();
+      }
+
+      this.cleanup();
+      this.menu.cleanup();
+      this.window.cleanup();
+      this.tray.cleanup();
+      this.ipc.cleanup();
+      try {
+        await this.processHandler.terminateProcesses();
+      }
+      finally {
+        // In some cases the app object might be already disposed
+        try {
+          if (process.platform !== 'win32')
+            app.exit();
+        }
+        catch (error: any) {
+          if (error.message !== 'Object has been destroyed')
+            console.error(error);
+        }
+      }
     }
     finally {
-      // In some cases the app object might be already disposed
-      try {
-        if (process.platform !== 'win32')
-          app.exit();
-      }
-      catch (error: any) {
-        if (error.message !== 'Object has been destroyed')
-          console.error(error);
-      }
+      clearTimeout(failsafe);
     }
   }
 }

--- a/frontend/app/electron/main/renderer-shutdown.spec.ts
+++ b/frontend/app/electron/main/renderer-shutdown.spec.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { notifyRendererOfShutdown, type RendererShutdownDeps } from './renderer-shutdown';
+
+function createLogger(): RendererShutdownDeps['logger'] {
+  return { debug: vi.fn(), warn: vi.fn() };
+}
+
+describe('electron/main/renderer-shutdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should resolve via ack before the timeout and clean up the listener', async () => {
+    let ack: (() => void) | undefined;
+    const unregister = vi.fn();
+    const deps: RendererShutdownDeps = {
+      send: vi.fn(() => true),
+      waitForAck: vi.fn((onAck) => {
+        ack = onAck;
+        return unregister;
+      }),
+      logger: createLogger(),
+    };
+
+    const promise = notifyRendererOfShutdown(deps, 750);
+    // Renderer acknowledges quickly, well before the timeout.
+    ack?.();
+    await expect(promise).resolves.toBeUndefined();
+
+    expect(deps.send).toHaveBeenCalledOnce();
+    expect(unregister).toHaveBeenCalledOnce();
+  });
+
+  it('should resolve via timeout when no ack arrives', async () => {
+    const unregister = vi.fn();
+    const deps: RendererShutdownDeps = {
+      send: vi.fn(() => true),
+      waitForAck: vi.fn(() => unregister),
+      logger: createLogger(),
+    };
+
+    let settled = false;
+    const promise = notifyRendererOfShutdown(deps, 750).then(() => {
+      settled = true;
+    });
+
+    // Not yet: still within the timeout window.
+    await vi.advanceTimersByTimeAsync(749);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+    expect(settled).toBe(true);
+    expect(unregister).toHaveBeenCalledOnce();
+  });
+
+  it('should resolve immediately without waiting when there is no renderer', async () => {
+    const deps: RendererShutdownDeps = {
+      send: vi.fn(() => false),
+      waitForAck: vi.fn(),
+      logger: createLogger(),
+    };
+
+    await expect(notifyRendererOfShutdown(deps, 750)).resolves.toBeUndefined();
+    expect(deps.waitForAck).not.toHaveBeenCalled();
+  });
+
+  it('should resolve when send throws and never register a listener', async () => {
+    const deps: RendererShutdownDeps = {
+      send: vi.fn(() => {
+        throw new Error('webContents destroyed');
+      }),
+      waitForAck: vi.fn(),
+      logger: createLogger(),
+    };
+
+    await expect(notifyRendererOfShutdown(deps, 750)).resolves.toBeUndefined();
+    expect(deps.waitForAck).not.toHaveBeenCalled();
+    expect(deps.logger.warn).toHaveBeenCalled();
+  });
+
+  it('should resolve when registering the ack listener throws', async () => {
+    const deps: RendererShutdownDeps = {
+      send: vi.fn(() => true),
+      waitForAck: vi.fn(() => {
+        throw new Error('ipcMain gone');
+      }),
+      logger: createLogger(),
+    };
+
+    await expect(notifyRendererOfShutdown(deps, 750)).resolves.toBeUndefined();
+    expect(deps.logger.warn).toHaveBeenCalled();
+  });
+
+  it('should ignore a late ack after the timeout has resolved', async () => {
+    let ack: (() => void) | undefined;
+    const unregister = vi.fn();
+    const deps: RendererShutdownDeps = {
+      send: vi.fn(() => true),
+      waitForAck: vi.fn((onAck) => {
+        ack = onAck;
+        return unregister;
+      }),
+      logger: createLogger(),
+    };
+
+    const promise = notifyRendererOfShutdown(deps, 750);
+    await vi.advanceTimersByTimeAsync(750);
+    await promise;
+
+    // A stray ack arriving after resolution must not throw or double-cleanup.
+    expect(() => ack?.()).not.toThrow();
+    expect(unregister).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/electron/main/renderer-shutdown.ts
+++ b/frontend/app/electron/main/renderer-shutdown.ts
@@ -1,0 +1,64 @@
+import type { LogService } from '@electron/main/log-service';
+
+export interface RendererShutdownDeps {
+  /** Send the "app closing" notice to the renderer. Returns false if there is no live window to notify. */
+  send: () => boolean;
+  /** Register a one-shot ack listener. Returns a function that unregisters it. */
+  waitForAck: (onAck: () => void) => () => void;
+  logger: Pick<LogService, 'debug' | 'warn'>;
+}
+
+/**
+ * Notifies the renderer that the app is about to quit and waits for it to
+ * acknowledge (after halting its outbound traffic).
+ *
+ * Invariant: this resolves in at most `timeoutMs`, no matter what the renderer
+ * does. The ack can only ever shorten the wait; it can never block or extend
+ * shutdown. Resolves early when there is no renderer to notify. Never rejects.
+ */
+export async function notifyRendererOfShutdown(
+  deps: RendererShutdownDeps,
+  timeoutMs = 750,
+): Promise<void> {
+  let sent = false;
+  try {
+    sent = deps.send();
+  }
+  catch (error) {
+    deps.logger.warn('Failed to notify renderer of shutdown', error);
+    return;
+  }
+
+  if (!sent) {
+    deps.logger.debug('No renderer to notify of shutdown; proceeding');
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    let unregister = (): void => {};
+    let timer: ReturnType<typeof setTimeout>;
+
+    const finish = (reason: 'ack' | 'timeout'): void => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timer);
+      unregister();
+      deps.logger.debug(`Renderer shutdown wait finished: ${reason}`);
+      resolve();
+    };
+
+    // Arm the timeout unconditionally so a dead or unresponsive renderer can
+    // never keep us waiting past timeoutMs.
+    timer = setTimeout(() => finish('timeout'), timeoutMs);
+
+    try {
+      unregister = deps.waitForAck(() => finish('ack'));
+    }
+    catch (error) {
+      deps.logger.warn('Failed to register shutdown ack listener', error);
+      finish('timeout');
+    }
+  });
+}

--- a/frontend/app/electron/main/window-manager.ts
+++ b/frontend/app/electron/main/window-manager.ts
@@ -316,6 +316,26 @@ export class WindowManager {
     }
   }
 
+  /**
+   * Sends the "app closing" notice to the renderer.
+   * @returns true if the message was dispatched to a live renderer, false if
+   * there is no window/webContents to notify (nothing to wait for).
+   */
+  notifyClosing(): boolean {
+    const webContents = this.window?.webContents;
+    if (!webContents || webContents.isDestroyed())
+      return false;
+
+    try {
+      webContents.send(IpcCommands.APP_CLOSING);
+      return true;
+    }
+    catch (error) {
+      this.logger.error('Failed to notify renderer of shutdown:', error);
+      return false;
+    }
+  }
+
   async openOAuthWindow(url: string): Promise<void> {
     try {
       const oauthWindow = new BrowserWindow({

--- a/frontend/app/electron/preload/index.ts
+++ b/frontend/app/electron/preload/index.ts
@@ -49,6 +49,17 @@ contextBridge.exposeInMainWorld('interop', {
       });
     }
 
+    // Graceful shutdown: let the renderer halt outbound traffic, then always
+    // acknowledge so the main process is never blocked, even if the handler throws.
+    ipcRenderer.on(IpcCommands.APP_CLOSING, () => {
+      try {
+        listeners.onAppClosing?.();
+      }
+      finally {
+        ipcRenderer.send(IpcCommands.APP_CLOSING_ACK);
+      }
+    });
+
     // Signal to main process that renderer is ready for async messages
     ipcRenderer.send(IpcCommands.RENDERER_READY);
   },

--- a/frontend/app/shared/ipc.ts
+++ b/frontend/app/shared/ipc.ts
@@ -104,6 +104,12 @@ export interface Listeners {
   onRestart: () => void;
   onProcessDetected: (pids: string[]) => void;
   onOAuthCallback?: (oAuthResult: OAuthResult) => void;
+  /**
+   * Invoked when the main process is about to quit, before the backend
+   * subprocesses are terminated. Gives the renderer a chance to stop polling
+   * and cancel in-flight requests so they don't hit a dying backend.
+   */
+  onAppClosing?: () => void;
 }
 
 export interface Interop {

--- a/frontend/app/src/modules/core/api/rotki-api.spec.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.spec.ts
@@ -2,6 +2,7 @@ import { server } from '@test/setup-files/server';
 import { http, HttpResponse } from 'msw';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defaultApiUrls } from '@/modules/core/api/api-urls';
+import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
 import { RotkiApi } from '@/modules/core/api/rotki-api';
 import { ApiValidationError } from '@/modules/core/api/types/errors';
 import { HTTPStatus } from '@/modules/core/api/types/http';
@@ -888,6 +889,48 @@ describe('modules/api/rotki-api', () => {
       );
 
       await expect(api.get('test')).rejects.toThrow();
+    });
+  });
+
+  describe('stopRequests', () => {
+    it('should reject new fetches with RequestCancelledError once stopped', async () => {
+      let hit = false;
+      server.use(
+        http.get(`${backendUrl}/api/1/test`, () => {
+          hit = true;
+          return HttpResponse.json({ result: true, message: '' });
+        }),
+      );
+
+      api.stopRequests();
+
+      await expect(api.get('test')).rejects.toThrow(RequestCancelledError);
+      expect(hit).toBe(false);
+    });
+
+    it('should reject skipQueue fetches once stopped', async () => {
+      api.stopRequests();
+      await expect(api.get('test', { skipQueue: true })).rejects.toThrow(RequestCancelledError);
+    });
+
+    it('should reject headStatus and fetchBlob once stopped', async () => {
+      api.stopRequests();
+      await expect(api.headStatus('test')).rejects.toThrow(RequestCancelledError);
+      await expect(api.fetchBlob('test')).rejects.toThrow(RequestCancelledError);
+    });
+
+    it('should accept requests again after setup re-enables the api', async () => {
+      server.use(
+        http.get(`${backendUrl}/api/1/test`, () =>
+          HttpResponse.json({ result: { ok: true }, message: '' })),
+      );
+
+      api.stopRequests();
+      await expect(api.get('test')).rejects.toThrow(RequestCancelledError);
+
+      api.setup(backendUrl!);
+      const result = await api.get<{ ok: boolean }>('test');
+      expect(result).toEqual({ ok: true });
     });
   });
 });

--- a/frontend/app/src/modules/core/api/rotki-api.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.ts
@@ -4,6 +4,7 @@ import type { RotkiFetchOptions } from '@/modules/core/api/types';
 import { ofetch } from 'ofetch';
 import { defaultApiUrls } from '@/modules/core/api/api-urls';
 import { DEFAULT_TIMEOUT } from '@/modules/core/api/constants';
+import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
 import { RequestQueue } from '@/modules/core/api/request-queue/queue';
 import { RequestPriority } from '@/modules/core/api/request-queue/request-priority';
 import { transformRequestBody, transformRequestQuery } from '@/modules/core/api/request-transformers';
@@ -21,6 +22,7 @@ export class RotkiApi {
   private authFailureAction?: () => void;
   private _requestQueue: RequestQueue;
   private _colibriRequestQueue: RequestQueue;
+  private _stopped: boolean = false;
 
   constructor() {
     this._serverUrl = defaultApiUrls.coreApiUrl;
@@ -64,6 +66,18 @@ export class RotkiApi {
     this._colibriRequestQueue.cancelAll();
   }
 
+  /**
+   * Puts the api into a quitting state: rejects any new request, cancels
+   * everything queued, and aborts in-flight direct requests. Used on app
+   * shutdown so nothing keeps hitting a backend that is going down. Reset by
+   * {@link setup} if the backend is later restarted.
+   */
+  stopRequests(): void {
+    this._stopped = true;
+    this.cancelAllQueued();
+    this.cancel();
+  }
+
   getQueueMetrics(): QueueState {
     return this._requestQueue.getMetrics();
   }
@@ -96,6 +110,8 @@ export class RotkiApi {
     this._serverUrl = serverUrl;
     this._baseURL = `${serverUrl}/api/1/`;
     this.abortController = new AbortController();
+    // A fresh backend (e.g. after a restart) can accept requests again.
+    this._stopped = false;
   }
 
   setOnAuthFailure(action: () => void): void {
@@ -114,6 +130,9 @@ export class RotkiApi {
   }
 
   async fetch<T>(url: string, options: RotkiFetchOptions<'json', T> = {}): Promise<T> {
+    if (this._stopped)
+      throw new RequestCancelledError('Application is quitting');
+
     const {
       skipQueue,
       priority,
@@ -242,6 +261,9 @@ export class RotkiApi {
     url: string,
     options: Omit<RotkiFetchOptions, 'method' | 'retry'> = {},
   ): Promise<number> {
+    if (this._stopped)
+      throw new RequestCancelledError('Application is quitting');
+
     const { validStatuses, skipSnakeCase, query: rawQuery, baseURL, timeout } = options;
     const query = transformRequestQuery(rawQuery as Record<string, unknown> | undefined, { skipSnakeCase });
 
@@ -270,6 +292,9 @@ export class RotkiApi {
     url: string,
     options: Omit<RotkiFetchOptions, 'skipCamelCase' | 'skipRootCamelCase' | 'skipResultUnwrap'> = {},
   ): Promise<Blob> {
+    if (this._stopped)
+      throw new RequestCancelledError('Application is quitting');
+
     const { validStatuses, skipSnakeCase, ...fetchOptions } = options;
     const body = transformRequestBody(fetchOptions.body, { skipSnakeCase });
     const query = transformRequestQuery(fetchOptions.query as Record<string, unknown> | undefined, { skipSnakeCase });

--- a/frontend/app/src/modules/shell/app/use-backend-messages.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-messages.ts
@@ -2,6 +2,7 @@ import type { Ref } from 'vue';
 import { BackendCode, type OAuthResult } from '@shared/ipc';
 import { checkIfDevelopment, startPromise } from '@shared/utils';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { api } from '@/modules/core/api';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
 import { useMainStore } from '@/modules/core/common/use-main-store';
@@ -40,17 +41,24 @@ function useBackendMessagesInternal(): UseBackendMessagesInternalReturn {
   const { connectionEnabled } = storeToRefs(useMainStore());
 
   /**
+   * Halts all outbound activity against the backend: stops the connection ping
+   * loop and disables future attempts, stops all monitoring (periodic tasks,
+   * websocket, etc.), and disables websocket reconnection. Used whenever the
+   * backend is unavailable or about to become unavailable.
+   */
+  function haltBackendActivity(): void {
+    stopConnectionAttempts();
+    stopMonitoring();
+    setWsConnectionEnabled(false);
+  }
+
+  /**
    * Handle a startup error by logging it and updating the appropriate state.
    * Also stops all monitoring, connection attempts, and WebSocket connections since the backend is unavailable.
    */
   function handleStartupError(message: string, code: BackendCode): void {
     logger.error(message, code);
-    // Stop connection ping loop and disable future connection attempts
-    stopConnectionAttempts();
-    // Stop all monitoring (periodic tasks, websocket, etc.) - backend is not available
-    stopMonitoring();
-    // Also explicitly disable websocket reconnection
-    setWsConnectionEnabled(false);
+    haltBackendActivity();
 
     if (code === BackendCode.TERMINATED) {
       set(startupErrorMessage, message);
@@ -99,11 +107,15 @@ function useBackendMessagesInternal(): UseBackendMessagesInternalReturn {
           handler(oAuthResult);
         });
       },
+      onAppClosing: () => {
+        // The app is quitting: stop polling and cancel in-flight requests so
+        // nothing hits the backend while it is being torn down.
+        haltBackendActivity();
+        api.stopRequests();
+      },
       onProcessDetected: (pids) => {
         // Stop all connection attempts and monitoring - another backend process is running
-        stopConnectionAttempts();
-        stopMonitoring();
-        setWsConnectionEnabled(false);
+        haltBackendActivity();
         set(
           startupErrorMessage,
           t('error.process_running', {


### PR DESCRIPTION
## Problem

On quit, `Application.quit()` terminated the backend/colibri subprocesses while the renderer was still alive. Its polling loops (task/periodic/balance/evm-status/password-check schedulers + websocket) and already-queued requests kept firing at a backend that was already going down, producing spurious connection errors during the shutdown window.

## Fix

A bounded shutdown handshake:

- **Main** sends `APP_CLOSING` to the renderer at the top of `quit()` (before the window is torn down) and waits for `APP_CLOSING_ACK` **or** a short timeout before terminating the subprocesses.
- **Renderer** halts all monitoring, disables websocket reconnection, and puts the api into a quitting state (`api.stopRequests()`) that rejects new requests and cancels in-flight/queued ones.

### The wait can never wedge quit
`notifyRendererOfShutdown` resolves on ack, on timeout (default 750ms), or immediately when there is no live renderer, and never rejects. A 5s watchdog in `quit()` force-exits as an absolute backstop (covers a hung renderer *or* a hung subprocess/socket).

## ⚠️ Needs manual testing

Draft: the end-to-end quit behavior has **not** been exercised in a real Electron build yet. Before this comes out of draft please verify:

- Quit via window close (X), app/menu Quit, tray Quit, and the renderer "close app" buttons — all shut down cleanly with no request errors in the logs.
- macOS: window close still hides to dock; a real Quit exits.
- Windows: still exits (final `app.exit()` is skipped on win32 as before; the watchdog covers the edge).
- No regression in normal quit latency (the ack path should be well under the 750ms timeout).
- Backend restart still works (the api quitting-state resets on `setup()`).

## Tests included

- `renderer-shutdown.spec.ts` — ack path, timeout path, no-window fast path, send-throws, register-throws, late-ack no-op.
- `rotki-api.spec.ts` — `stopRequests()` gates new `fetch`/`skipQueue`/`headStatus`/`fetchBlob`, and re-enables after `setup()`.

A unit spec for the `use-backend-messages` `onAppClosing` handler was intentionally omitted: that composable is a `createGlobalState` singleton whose listeners register in `onBeforeMount`, which does not bind under the current test harness (no precedent spec exists). The handler is trivial glue over the same `setupListeners` path that already delivers `onError`/`onAbout` in production. Can be added via a small refactor to make the wiring injectable if desired.