### PR TITLE
perf: inline pagination into history events query

### DIFF
--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -1481,7 +1481,10 @@ class DBHistoryEvents:
             include_entries_with_limit_count=include_entries_with_limit_count,
         )
         if filter_query.pagination is not None:
-            base_query = f'SELECT * FROM ({base_query}) {filter_query.pagination.prepare()}'
+            # Append LIMIT/OFFSET to the same SELECT as the ORDER BY instead of wrapping
+            # in an outer query, so sqlite's sorter keeps only the page rows rather than
+            # sorting all grouped rows into a temp b-tree first.
+            base_query = f'{base_query} {filter_query.pagination.prepare()}'
 
         ethereum_tracked_accounts: set[ChecksumEvmAddress] | None = None
         cursor.execute(base_query, filters_bindings)

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -767,6 +767,74 @@ def test_get_history_events_free_filter(database: 'DBHandler'):
                     assert free_event.identifier > 3, 'Free sub-events should be from the latest 3 event groups'  # noqa: E501
 
 
+def test_pagination_with_entries_limit(database: 'DBHandler') -> None:
+    """Test that LIMIT/OFFSET pagination composes correctly with the subscription
+    entries limit. The limit restricts the visible universe to the newest N event
+    groups and pagination pages within it: pages inside the cap fill normally, the
+    boundary page truncates and pages beyond it are empty.
+
+    Regression test for the pagination living in the same SELECT as the ORDER BY
+    instead of an outer wrapping query.
+    """
+    history_events = DBHistoryEvents(database)
+    with database.user_write() as write_cursor:
+        history_events.add_history_events(
+            write_cursor=write_cursor,
+            history=[HistoryEvent(
+                group_identifier=f'group_{group}',
+                sequence_index=sequence_index,
+                timestamp=TimestampMS(group * 1000),
+                location=Location.KRAKEN,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_ETH,
+                amount=ONE,
+            ) for group in range(1, 11) for sequence_index in range(2)],
+        )
+
+    def paginated_filter(limit: int, offset: int) -> HistoryEventFilterQuery:
+        return HistoryEventFilterQuery.make(
+            order_by_rules=[('timestamp', False), ('sequence_index', True)],
+            limit=limit,
+            offset=offset,
+        )
+
+    with database.conn.read_ctx() as cursor:
+        # with entries_limit=5 only the 5 newest groups (group_10..group_6) are visible
+        assert [(num, event.group_identifier) for num, event in history_events.get_history_events(
+            cursor=cursor,
+            filter_query=paginated_filter(limit=2, offset=0),
+            entries_limit=5,
+            aggregate_by_group_ids=True,
+        )] == [(2, 'group_10'), (2, 'group_9')]
+        assert [(num, event.group_identifier) for num, event in history_events.get_history_events(
+            cursor=cursor,
+            filter_query=paginated_filter(limit=2, offset=4),  # page straddling the cap
+            entries_limit=5,
+            aggregate_by_group_ids=True,
+        )] == [(2, 'group_6')]
+        assert history_events.get_history_events(
+            cursor=cursor,
+            filter_query=paginated_filter(limit=2, offset=6),  # page beyond the cap
+            entries_limit=5,
+            aggregate_by_group_ids=True,
+        ) == []
+
+        # when not grouping the 5 visible groups contain 10 events
+        assert [event.group_identifier for event in history_events.get_history_events(
+            cursor=cursor,
+            filter_query=paginated_filter(limit=4, offset=8),
+            entries_limit=5,
+            aggregate_by_group_ids=False,
+        )] == ['group_6', 'group_6']
+        assert history_events.get_history_events(
+            cursor=cursor,
+            filter_query=paginated_filter(limit=4, offset=12),
+            entries_limit=5,
+            aggregate_by_group_ids=False,
+        ) == []
+
+
 def test_history_events_with_ignored_groups_excluding_assets(database: 'DBHandler') -> None:
     db = DBHistoryEvents(database)
     group_identifier = 'group_with_ignored_asset'


### PR DESCRIPTION
The paginated history events query wrapped LIMIT/OFFSET in an outer SELECT * FROM (...) around the grouped and ordered subquery. With the LIMIT in a different SELECT than the ORDER BY, sqlite's sorter cannot apply its ORDER BY LIMIT optimization and materializes a temp b-tree sort of every grouped row on each page load, only to discard all but one page of them.

Appending the pagination to the same SELECT as the ORDER BY is semantically identical (LIMIT applies after grouping and ordering either way) but lets the sorter keep only offset+limit rows in a priority queue.

Benchmarked with the real query builder against 250k events in 100k groups, matching the frontend history page request (aggregated by group ids, timestamp DESC, page size 10):

- page 1: 257ms -> 114ms (2.25x)
- offset 1000: 260ms -> 136ms (1.9x)

Results verified byte-identical between the old and new query shape.
