### PR TITLE
fix: scope protocol balance queries by address

### DIFF
--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -1015,7 +1015,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         eth_manager = self.get_chain_manager(blockchain=SupportedBlockchain.ETHEREUM)
         balances = eth_manager.query_evm_chain_balances(accounts=accounts)
         self._add_eth_protocol_balances(eth_balances=balances)
-        return eth_manager.query_protocols_with_balance(balances=balances)
+        return eth_manager.query_protocols_with_balance(balances=balances, addresses=accounts)
 
     def _add_eth_protocol_balances(self, eth_balances: defaultdict[ChecksumEvmAddress, BalanceSheet]) -> None:  # noqa: E501
         """Also count token balances that may come from various eth protocols"""

--- a/rotkehlchen/chain/arbitrum_one/modules/gmx/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/gmx/balances.py
@@ -44,7 +44,10 @@ class GmxBalances(ProtocolWithBalance):
         )
         self.gmx = A_GMX.resolve_to_evm_token()
 
-    def _extract_unique_deposits(self) -> dict['ChecksumEvmAddress', set[tuple[str, str, bool]]]:
+    def _extract_unique_deposits(
+            self,
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> dict['ChecksumEvmAddress', set[tuple[str, str, bool]]]:
         """
         fetch deposit events and remove duplicate positions. Since a user can modify the same
         position increasing or decreasing the collateral we want to remove duplicates to make
@@ -52,6 +55,7 @@ class GmxBalances(ProtocolWithBalance):
         """
         addresses_events = self.addresses_with_activity(
             event_types=self.deposit_event_types,
+            location_labels=addresses,
         )
         unique_deposits = {}
         for address, events in addresses_events.items():
@@ -73,7 +77,10 @@ class GmxBalances(ProtocolWithBalance):
             unique_deposits[address] = positions
         return unique_deposits
 
-    def query_position_balances(self) -> 'BalancesSheetType':
+    def query_position_balances(
+            self,
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> 'BalancesSheetType':
         """
         Query balances for GMX open positions and returns it.
 
@@ -91,7 +98,7 @@ class GmxBalances(ProtocolWithBalance):
         and the token amount is calculated by dividing the USD value by the token's USD price.
         """
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        unique_deposits = self._extract_unique_deposits()
+        unique_deposits = self._extract_unique_deposits(addresses=addresses)
         if len(unique_deposits) == 0:
             return balances
 
@@ -168,7 +175,11 @@ class GmxBalances(ProtocolWithBalance):
 
         return balances
 
-    def query_staking_balances(self, balances: 'BalancesSheetType') -> 'BalancesSheetType':
+    def query_staking_balances(
+            self,
+            balances: 'BalancesSheetType',
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> 'BalancesSheetType':
         """
         Query staked balances for GMX. It modifies the `balances` argument to include
         the staking balances and returns it.
@@ -180,6 +191,7 @@ class GmxBalances(ProtocolWithBalance):
         """
         addresses_events = self.addresses_with_activity(
             event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_FOR_WRAPPED)},
+            location_labels=addresses,
         )
         if len(addresses_events) == 0:
             return balances
@@ -203,7 +215,7 @@ class GmxBalances(ProtocolWithBalance):
 
         return balances
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query balances for GMX open positions"""
-        balances = self.query_position_balances()
-        return self.query_staking_balances(balances)
+        balances = self.query_position_balances(addresses=addresses)
+        return self.query_staking_balances(balances=balances, addresses=addresses)

--- a/rotkehlchen/chain/arbitrum_one/modules/thegraph/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/thegraph/balances.py
@@ -47,7 +47,10 @@ class ThegraphBalances(ProtocolWithBalance):
             deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
         )
 
-    def _get_delegations(self) -> list[tuple['ChecksumEvmAddress', 'ChecksumEvmAddress', 'ChecksumEvmAddress', 'ChecksumEvmAddress']]:  # noqa: E501
+    def _get_delegations(
+            self,
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> list[tuple['ChecksumEvmAddress', 'ChecksumEvmAddress', 'ChecksumEvmAddress', 'ChecksumEvmAddress']]:  # noqa: E501
         """Get staking events and process them to generate a unique set of delegations.
 
         Pre-Horizon upgrade events don't include the verifier in event logs, so we use the
@@ -71,6 +74,7 @@ class ThegraphBalances(ProtocolWithBalance):
                 return []
 
         delegations_unique = set()
+        queried_addresses = set(addresses)
         for event in events:
             if event.location_label is None or event.extra_data is None:
                 log.error(f'Skipping TheGraph deposit event {event} due to one or both of location_label and extra_data missing')  # noqa: E501
@@ -79,12 +83,18 @@ class ThegraphBalances(ProtocolWithBalance):
             verifier = event.extra_data.get('verifier', SUBGRAPH_DATA_SERVICE_ADDRESS)
             # simple staking where you just need to delegate to an indexer
             if (indexer := event.extra_data.get('indexer')) is not None:
+                if (
+                    (delegator := string_to_evm_address(event.location_label)) not in
+                    queried_addresses
+                ):
+                    continue
+
                 delegations_unique.add(
                     (
-                        string_to_evm_address(event.location_label),
+                        delegator,
                         string_to_evm_address(indexer),
                         verifier,
-                        string_to_evm_address(event.location_label),
+                        delegator,
                     ),
                 )
 
@@ -93,6 +103,9 @@ class ThegraphBalances(ProtocolWithBalance):
                 (delegator := event.extra_data.get('delegator_l2')) is not None and
                 (beneficiary := event.extra_data.get('beneficiary')) is not None
             ):
+                if beneficiary not in queried_addresses:
+                    continue
+
                 delegations_unique.add(
                     (
                         string_to_evm_address(delegator),
@@ -106,7 +119,7 @@ class ThegraphBalances(ProtocolWithBalance):
 
         return list(delegations_unique)
 
-    def query_balances(self) -> BalancesSheetType:
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> BalancesSheetType:
         """Query balances of GRT tokens delegated to indexers.
 
         Retrieves staking events and processes them to generate a unique set of delegations.
@@ -115,7 +128,7 @@ class ThegraphBalances(ProtocolWithBalance):
         rewards earned over time. Supports both simple and vested staking.
         """
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        if len(delegations := self._get_delegations()) == 0:  # user had no delegation events
+        if len(delegations := self._get_delegations(addresses=addresses)) == 0:  # user had no delegation events  # noqa: E501
             return balances
 
         chunk_size, call_order = get_rpc_first_chunk_size_call_order(self.evm_inquirer)

--- a/rotkehlchen/chain/arbitrum_one/modules/umami/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/umami/balances.py
@@ -52,7 +52,7 @@ class UmamiBalances(ProtocolWithBalance):
             deployed_block=176053511,
         )
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query both unstaked and staked balances for Umami vaults.
 
         For each user address with deposits:
@@ -69,7 +69,7 @@ class UmamiBalances(ProtocolWithBalance):
         if len(addresses_with_deposits := list(self.addresses_with_activity(event_types={
             (HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_FOR_WRAPPED),
             (HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET),
-        }))) == 0:
+        }, location_labels=addresses))) == 0:
             return balances
 
         gm_vault_addresses = [

--- a/rotkehlchen/chain/base/modules/morpho_blue/balances.py
+++ b/rotkehlchen/chain/base/modules/morpho_blue/balances.py
@@ -38,14 +38,17 @@ class MorphoBlueBalances(ProtocolWithBalance):
             },
         )
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        address_to_events = self.addresses_with_activity(event_types={
-            (HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_TO_PROTOCOL),
-            (HistoryEventType.WITHDRAWAL, HistoryEventSubType.WITHDRAW_FROM_PROTOCOL),
-            (HistoryEventType.RECEIVE, HistoryEventSubType.GENERATE_DEBT),
-            (HistoryEventType.SPEND, HistoryEventSubType.PAYBACK_DEBT),
-        })
+        address_to_events = self.addresses_with_activity(
+            event_types={
+                (HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_TO_PROTOCOL),
+                (HistoryEventType.WITHDRAWAL, HistoryEventSubType.WITHDRAW_FROM_PROTOCOL),
+                (HistoryEventType.RECEIVE, HistoryEventSubType.GENERATE_DEBT),
+                (HistoryEventType.SPEND, HistoryEventSubType.PAYBACK_DEBT),
+            },
+            location_labels=addresses,
+        )
         if len(address_to_events) == 0:
             return balances
 

--- a/rotkehlchen/chain/base/modules/runmoney/balances.py
+++ b/rotkehlchen/chain/base/modules/runmoney/balances.py
@@ -20,6 +20,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 if TYPE_CHECKING:
     from rotkehlchen.chain.base.decoding.decoder import BaseTransactionDecoder
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
+    from rotkehlchen.types import ChecksumEvmAddress
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -44,9 +45,11 @@ class RunmoneyBalances(ProtocolWithBalance):
         )
         self.usdc_asset = Asset('eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913')
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        if len(addresses_with_deposits := list(self.addresses_with_deposits())) == 0:
+        if len(addresses_with_deposits := list(self.addresses_with_deposits(
+            location_labels=addresses,
+        ))) == 0:
             return balances
 
         try:

--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -90,6 +90,7 @@ class ProtocolWithBalance(abc.ABC):
     def addresses_with_activity(
             self,
             event_types: set[tuple[HistoryEventType, HistoryEventSubType]],
+            location_labels: list[ChecksumEvmAddress],
             assets: tuple['Asset', ...] | None = None,
     ) -> dict[ChecksumEvmAddress, list['EvmEvent']]:
         """
@@ -103,6 +104,7 @@ class ProtocolWithBalance(abc.ABC):
             location=Location.from_chain_id(self.evm_inquirer.chain_id),
             entry_types=IncludeExcludeFilterData(values=[HistoryBaseEntryType.EVM_EVENT]),
             excluded_addresses=self.excluded_addresses,
+            location_labels=[str(address) for address in location_labels],
         )
         with self.event_db.db.conn.read_ctx() as cursor:
             events = self.event_db.get_history_events_internal(
@@ -117,8 +119,14 @@ class ProtocolWithBalance(abc.ABC):
 
         return addresses_with_activity
 
-    def addresses_with_deposits(self) -> dict[ChecksumEvmAddress, list['EvmEvent']]:
-        return self.addresses_with_activity(event_types=self.deposit_event_types)
+    def addresses_with_deposits(
+            self,
+            location_labels: list[ChecksumEvmAddress],
+    ) -> dict[ChecksumEvmAddress, list['EvmEvent']]:
+        return self.addresses_with_activity(
+            event_types=self.deposit_event_types,
+            location_labels=location_labels,
+        )
 
     def _add_priced_balances(
             self,
@@ -149,7 +157,7 @@ class ProtocolWithBalance(abc.ABC):
     # --- Methods to be implemented by all subclasses
 
     @abc.abstractmethod
-    def query_balances(self) -> BalancesSheetType:
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> BalancesSheetType:
         """
         Common method for all the classes implementing this interface that returns a BalanceSheet
         with assets and liabilities as mappings of user addresses to their token balances. This is
@@ -178,8 +186,14 @@ class ProtocolWithGauges(ProtocolWithBalance):
         )
         self.gauge_deposit_event_types = gauge_deposit_event_types
 
-    def addresses_with_gauge_deposits(self) -> dict[ChecksumEvmAddress, list['EvmEvent']]:
-        return self.addresses_with_activity(event_types=self.gauge_deposit_event_types)
+    def addresses_with_gauge_deposits(
+            self,
+            location_labels: list[ChecksumEvmAddress],
+    ) -> dict[ChecksumEvmAddress, list['EvmEvent']]:
+        return self.addresses_with_activity(
+            event_types=self.gauge_deposit_event_types,
+            location_labels=location_labels,
+        )
 
     def _query_gauges_balances(
             self,
@@ -255,7 +269,7 @@ class ProtocolWithGauges(ProtocolWithBalance):
 
         return balances
 
-    def query_balances(self) -> BalancesSheetType:
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> BalancesSheetType:
         """
         Query gauge balances for the addresses that have interacted with known gauges.
         """
@@ -264,7 +278,9 @@ class ProtocolWithGauges(ProtocolWithBalance):
         entries: list[tuple[ChecksumEvmAddress, Asset, FVal]] = []
         # query addresses and gauges where they interacted
         chunk_size, call_order = get_rpc_first_chunk_size_call_order(self.evm_inquirer)
-        for address, events in self.addresses_with_gauge_deposits().items():
+        for address, events in self.addresses_with_gauge_deposits(
+            location_labels=addresses,
+        ).items():
             # Create a mapping of a gauge to its token
             for event in events:
                 if (

--- a/rotkehlchen/chain/ethereum/modules/aave/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/aave/balances.py
@@ -19,6 +19,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.types import ChecksumEvmAddress
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -37,7 +38,7 @@ class AaveBalances(ProtocolWithBalance):
             deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
         )
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Queries and returns the balances sheet for staking events.
 
         Retrieves deposit events and calls staking contract to get the total rewards balance.
@@ -45,7 +46,9 @@ class AaveBalances(ProtocolWithBalance):
         much AAVE is staked, that is the stkAAVE balance which should appear as
         part of balance queries and is 1-1 to AAVE."""
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        if len(addresses_with_deposits := list(self.addresses_with_deposits())) == 0:
+        if len(addresses_with_deposits := list(self.addresses_with_deposits(
+            location_labels=addresses,
+        ))) == 0:
             return balances
 
         staking_contract = self.evm_inquirer.contracts.contract(address=STK_AAVE_ADDR)

--- a/rotkehlchen/chain/ethereum/modules/blur/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/blur/balances.py
@@ -40,12 +40,14 @@ class BlurBalances(ProtocolWithBalance):
             deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
         )
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query balances of staked blur tokens if deposit events are found."""
         balances: BalancesSheetType = defaultdict(BalanceSheet)
 
         # fetch deposit events
-        if len(addresses_with_deposits := list(self.addresses_with_deposits())) == 0:
+        if len(addresses_with_deposits := list(self.addresses_with_deposits(
+            location_labels=addresses,
+        ))) == 0:
             return balances
 
         staking_contract = self.evm_inquirer.contracts.contract(BLUR_STAKING_CONTRACT)

--- a/rotkehlchen/chain/ethereum/modules/convex/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/balances.py
@@ -86,10 +86,11 @@ class ConvexBalances(ProtocolWithGauges):
 
         return None
 
-    def query_balances(self) -> 'BalancesSheetType':
-        balances = super().query_balances()  # Query the gauges
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
+        balances = super().query_balances(addresses=addresses)  # Query the gauges
         addresses_with_stake_mapping = self.addresses_with_activity(
             event_types=self.deposit_event_types,
+            location_labels=addresses,
             assets=(A_CVX,),
         )
         # addresses_with_deposits returns a mapping of address to evm event but since we will call

--- a/rotkehlchen/chain/ethereum/modules/curve/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/balances.py
@@ -55,15 +55,16 @@ class CurveBalances(ProtocolWithGauges):
     def get_gauge_address(self, event: 'EvmEvent') -> ChecksumEvmAddress | None:
         return event.address
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query gauge balances and CRV deposited in the veCRV contract"""
-        balances = super().query_balances()  # gauge balances
+        balances = super().query_balances(addresses=addresses)  # gauge balances
         db_filter = EvmEventFilterQuery.make(
             assets=(A_CRV,),
             counterparties=[self.counterparty],
             type_and_subtype_combinations=self.deposit_event_types,
             location=Location.from_chain_id(self.evm_inquirer.chain_id),
             addresses=[VOTING_ESCROW],
+            location_labels=[str(address) for address in addresses],
         )
         with self.event_db.db.conn.read_ctx() as cursor:
             events = self.event_db.get_history_events_internal(

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/balances.py
@@ -85,8 +85,12 @@ class EigenlayerBalances(ProtocolWithBalance):
         )
         self.evm_inquirer: EthereumInquirer
 
-    def _query_lst_deposits(self, balances: 'BalancesSheetType') -> 'BalancesSheetType':
-        addresses_with_deposits = self.addresses_with_deposits()
+    def _query_lst_deposits(
+            self,
+            balances: 'BalancesSheetType',
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> 'BalancesSheetType':
+        addresses_with_deposits = self.addresses_with_deposits(location_labels=addresses)
         # remap all events into a list that will contain all pairs (depositor, strategy)
         deposits = set()
         for depositor, event_list in addresses_with_deposits.items():
@@ -118,7 +122,11 @@ class EigenlayerBalances(ProtocolWithBalance):
         self._add_priced_balances(balances=balances, amounts=entries)
         return balances
 
-    def _query_token_pending_withdrawals(self, balances: 'BalancesSheetType') -> 'BalancesSheetType':  # noqa: E501
+    def _query_token_pending_withdrawals(
+            self,
+            balances: 'BalancesSheetType',
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> 'BalancesSheetType':
         """Query any balances that are being withdrawn from Eigenlayer and are on the fly"""
         # First find if there is any completed withdrawals unmatched,
         # as that would lead to double counting of balances
@@ -128,6 +136,7 @@ class EigenlayerBalances(ProtocolWithBalance):
             to_ts=ts_now(),
             event_types=[HistoryEventType.INFORMATIONAL],
             event_subtypes=[HistoryEventSubType.NONE],
+            location_labels=[str(address) for address in addresses],
         )
         with self.event_db.db.conn.read_ctx() as cursor:
             completed_withdrawal_events = self.event_db.get_history_events_internal(
@@ -151,6 +160,7 @@ class EigenlayerBalances(ProtocolWithBalance):
         # proceed with the counting of all pending withdrawals as balances
         addresses_with_withdrawals = self.addresses_with_activity(
             event_types={(HistoryEventType.INFORMATIONAL, HistoryEventSubType.REMOVE_ASSET)},
+            location_labels=addresses,
         )
         entries = []
         for address, event_list in addresses_with_withdrawals.items():
@@ -178,9 +188,18 @@ class EigenlayerBalances(ProtocolWithBalance):
         self._add_priced_balances(balances=balances, amounts=entries)
         return balances
 
-    def _query_eigenpod_balances(self, balances: 'BalancesSheetType') -> 'BalancesSheetType':
+    def _query_eigenpod_balances(
+            self,
+            balances: 'BalancesSheetType',
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> 'BalancesSheetType':
         """Queries the balance of ETH in the eigenpod and in the Delayed Withdrawal router"""
-        if len(eigenpod_to_owner := get_eigenpods_to_owners_mapping(self.event_db.db)) == 0:
+        eigenpod_to_owner = {
+            eigenpod: owner
+            for eigenpod, owner in get_eigenpods_to_owners_mapping(self.event_db.db).items()
+            if owner in addresses
+        }
+        if len(eigenpod_to_owner) == 0:
             return balances
 
         self._add_priced_balances(balances=balances, amounts=[  # query all eigenpod balances and add them  # noqa: E501
@@ -190,7 +209,7 @@ class EigenlayerBalances(ProtocolWithBalance):
         ])
         return balances
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """
         Query underlying balances for deposits in eigenlayer. Also for eigenpod
         owners and funds deposited in eigenpods. Also for any pending withdrawals
@@ -200,6 +219,6 @@ class EigenlayerBalances(ProtocolWithBalance):
         - RemoteError: Querying price of the deposited token
         """
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        balances = self._query_lst_deposits(balances)
-        balances = self._query_eigenpod_balances(balances)
-        return self._query_token_pending_withdrawals(balances)
+        balances = self._query_lst_deposits(balances=balances, addresses=addresses)
+        balances = self._query_eigenpod_balances(balances=balances, addresses=addresses)
+        return self._query_token_pending_withdrawals(balances=balances, addresses=addresses)

--- a/rotkehlchen/chain/ethereum/modules/hedgey/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/hedgey/balances.py
@@ -16,6 +16,7 @@ from .constants import (
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.types import ChecksumEvmAddress
 
 
 class HedgeyBalances(ProtocolWithBalance):
@@ -32,7 +33,7 @@ class HedgeyBalances(ProtocolWithBalance):
         )
         self.evm_inquirer: EthereumInquirer
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """
         Query underlying balances for deposits in eigenlayer. Also for eigenpod
         owners and funds deposited in eigenpods. Also for any pending withdrawals
@@ -47,6 +48,7 @@ class HedgeyBalances(ProtocolWithBalance):
                 (HistoryEventType.RECEIVE, HistoryEventSubType.REWARD),
                 (HistoryEventType.INFORMATIONAL, HistoryEventSubType.GOVERNANCE),
             },
+            location_labels=addresses,
         )
         # gather the related tokens per address
         addresses_to_tokens = defaultdict(set)

--- a/rotkehlchen/chain/ethereum/modules/lido_csm/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/lido_csm/balances.py
@@ -27,6 +27,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.types import ChecksumEvmAddress
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -85,14 +86,16 @@ class LidoCsmBalances(ProtocolWithBalance):
         )
         return token_normalized_value_decimals(pooled_eth, 18)
 
-    def query_balances(self) -> BalancesSheetType:
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> BalancesSheetType:
         """Return the Lido CSM balances tracked in the DB for stETH.
 
         May raise:
             RemoteError: bubbled up from `_metrics_fetcher` when fetching rewards.
         """
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        if len(node_operators := self._node_operator_db.get_node_operators()) == 0:
+        if len(node_operators := self._node_operator_db.get_node_operators(
+            addresses=addresses,
+        )) == 0:
             return balances
 
         if (steth_price := Inquirer.find_price(

--- a/rotkehlchen/chain/ethereum/modules/octant/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/octant/balances.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.types import ChecksumEvmAddress
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -42,11 +43,13 @@ class OctantBalances(ProtocolWithBalance):
         )
         self.glm = A_GLM.resolve_to_evm_token()
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query balances of locked GLM in Octant"""
         balances: BalancesSheetType = defaultdict(BalanceSheet)
         # fetch deposit events
-        if len(addresses_with_deposits := list(self.addresses_with_deposits())) == 0:
+        if len(addresses_with_deposits := list(self.addresses_with_deposits(
+            location_labels=addresses,
+        ))) == 0:
             return balances
 
         deposits_contract = self.evm_inquirer.contracts.contract(OCTANT_DEPOSITS)

--- a/rotkehlchen/chain/ethereum/modules/pendle/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/pendle/balances.py
@@ -20,6 +20,7 @@ from .constants import PENDLE_TOKEN, VE_PENDLE_ABI, VE_PENDLE_CONTRACT_ADDRESS
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.decoding import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.types import ChecksumEvmAddress
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -45,10 +46,12 @@ class PendleBalances(ProtocolWithBalance):
             deployed_block=16032087,
         )
 
-    def query_balances(self) -> BalancesSheetType:
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> BalancesSheetType:
         """Query locked PENDLE balances."""
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        if len(addresses_with_deposits := list(self.addresses_with_deposits())) == 0:
+        if len(addresses_with_deposits := list(self.addresses_with_deposits(
+            location_labels=addresses,
+        ))) == 0:
             return balances
 
         call_order = get_rpc_first_chunk_size_call_order(self.evm_inquirer)[1]

--- a/rotkehlchen/chain/ethereum/modules/safe/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/safe/balances.py
@@ -134,18 +134,20 @@ class SafeBalances(ProtocolWithBalance):
 
         return entries
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query balances of locked and SafeNet-staked SAFE tokens if deposit events are found."""
         balances: BalancesSheetType = defaultdict(BalanceSheet)
         entries: list[tuple[ChecksumEvmAddress, Asset, FVal]] = []
         safe_asset = Asset(SAFE_TOKEN_ID)
         if len(locked := self.addresses_with_activity(
             event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_TO_PROTOCOL)},
+            location_labels=addresses,
         )) != 0:
             entries.extend(self._query_locked_safe(list(locked), safe_asset))
 
         if len(staked := self.addresses_with_activity(
             event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
+            location_labels=addresses,
         )) != 0:
             entries.extend(self._query_safenet_staked(list(staked), safe_asset))
 

--- a/rotkehlchen/chain/evm/decoding/compound/v3/balances.py
+++ b/rotkehlchen/chain/evm/decoding/compound/v3/balances.py
@@ -63,11 +63,15 @@ class Compoundv3Balances(ProtocolWithBalance):
             deposit_event_types=set(),
         )
 
-    def _extract_unique_collateral_tokens(self) -> dict[ChecksumEvmAddress, set[CompoundArguments]]:  # noqa: E501
+    def _extract_unique_collateral_tokens(
+            self,
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> dict[ChecksumEvmAddress, set[CompoundArguments]]:
         """Fetch the unique collateral tokens we need to query the comet contracts for"""
         unique_collaterals: dict[ChecksumEvmAddress, set[CompoundArguments]] = defaultdict(set)
         for user_address, events in self.addresses_with_activity(
             event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_TO_PROTOCOL)},
+            location_labels=addresses,
         ).items():
             for event in events:
                 if event.address is None:
@@ -98,7 +102,10 @@ class Compoundv3Balances(ProtocolWithBalance):
 
         return unique_collaterals
 
-    def _extract_unique_borrowed_tokens(self) -> tuple[dict['EvmToken', set['ChecksumEvmAddress']], dict['ChecksumEvmAddress', 'EvmToken']]:  # noqa: E501
+    def _extract_unique_borrowed_tokens(
+            self,
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> tuple[dict['EvmToken', set['ChecksumEvmAddress']], dict['ChecksumEvmAddress', 'EvmToken']]:  # noqa: E501
         """
         Fetch unique borrow events from the userDB. Since a user can increase or decrease the same
         liability, we remove the duplicates to reduce the amount of queries. Returns a dict of
@@ -109,6 +116,7 @@ class Compoundv3Balances(ProtocolWithBalance):
         underlying_tokens: dict[ChecksumEvmAddress, EvmToken] = {}
         for address, events in self.addresses_with_activity(
             event_types={(HistoryEventType.RECEIVE, HistoryEventSubType.GENERATE_DEBT)},
+            location_labels=addresses,
         ).items():
             for event in events:
                 if event.address is None:
@@ -141,11 +149,15 @@ class Compoundv3Balances(ProtocolWithBalance):
 
         return unique_borrows, underlying_tokens
 
-    def query_collateral(self, balances: BalancesSheetType) -> 'BalancesSheetType':
+    def query_collateral(
+            self,
+            balances: BalancesSheetType,
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> 'BalancesSheetType':
         """Query for the collateral assets saved in the protocol that are in the
         COMET Contract and not as balanceOf in those contracts.
         """
-        unique_collaterals_mapping = self._extract_unique_collateral_tokens()
+        unique_collaterals_mapping = self._extract_unique_collateral_tokens(addresses=addresses)
         if len(unique_collaterals_mapping) == 0:
             return balances
 
@@ -199,7 +211,7 @@ class Compoundv3Balances(ProtocolWithBalance):
         self._add_priced_balances(balances=balances, amounts=entries)
         return balances
 
-    def query_liabilities(self) -> 'BalancesSheetType':
+    def query_liabilities(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """
         Query liabilities for Compound v3 open positions and return them.
 
@@ -207,7 +219,9 @@ class Compoundv3Balances(ProtocolWithBalance):
         tokens whose borrow history events are found in the userDB.
         """
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        unique_borrows, underlying_token = self._extract_unique_borrowed_tokens()
+        unique_borrows, underlying_token = self._extract_unique_borrowed_tokens(
+            addresses=addresses,
+        )
         if len(unique_borrows) == 0:
             return balances
 
@@ -261,6 +275,6 @@ class Compoundv3Balances(ProtocolWithBalance):
         self._add_priced_balances(balances=balances, amounts=entries, category='liabilities')
         return balances
 
-    def query_balances(self) -> 'BalancesSheetType':
-        balances = self.query_liabilities()
-        return self.query_collateral(balances)
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
+        balances = self.query_liabilities(addresses=addresses)
+        return self.query_collateral(balances=balances, addresses=addresses)

--- a/rotkehlchen/chain/evm/decoding/curve/lend/balances.py
+++ b/rotkehlchen/chain/evm/decoding/curve/lend/balances.py
@@ -55,12 +55,17 @@ class CurveControllerCommonBalances(ProtocolWithBalance, ABC):
     ) -> tuple['EvmToken', 'EvmToken'] | None:
         """Retrieve the collateral and borrowed tokens for the specified controller."""
 
-    def _get_controllers_with_balances(self) -> dict[ChecksumEvmAddress, set[ChecksumEvmAddress]]:
+    def _get_controllers_with_balances(
+            self,
+            addresses: 'list[ChecksumEvmAddress]',
+    ) -> dict[ChecksumEvmAddress, set[ChecksumEvmAddress]]:
         """Get addresses of controllers that the user may have balances on.
         Returns a dict of controller addresses -> set of user addresses with possible balances.
         """
         controllers: dict[ChecksumEvmAddress, set[ChecksumEvmAddress]] = defaultdict(set)
-        for address, events in self.addresses_with_deposits().items():
+        for address, events in self.addresses_with_deposits(
+            location_labels=addresses,
+        ).items():
             for event in events:
                 if event.extra_data is None or 'controller_address' not in event.extra_data:
                     continue  # skip any deposits without a controller address
@@ -69,13 +74,13 @@ class CurveControllerCommonBalances(ProtocolWithBalance, ABC):
 
         return controllers
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query balances for Curve lending loans and leveraged positions.
         Funds deposited in lending vaults are represented by cvcrvUSD tokens and
         do not need any special logic here.
         """
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        controllers_with_balances = self._get_controllers_with_balances()
+        controllers_with_balances = self._get_controllers_with_balances(addresses=addresses)
         if len(controllers_with_balances) == 0:
             return balances
 

--- a/rotkehlchen/chain/evm/decoding/extrafi/balances.py
+++ b/rotkehlchen/chain/evm/decoding/extrafi/balances.py
@@ -58,10 +58,10 @@ class ExtrafiCommonBalances(ProtocolWithBalance):
         )
         self.extrafi_token = extrafi_token
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query balances of lending pools and extra locking"""
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        address_to_deposits = self.addresses_with_deposits()
+        address_to_deposits = self.addresses_with_deposits(location_labels=addresses)
         for address, events in address_to_deposits.items():
             unique_reserves = set()
             farm_positions: set[tuple[int, int]] = set()
@@ -91,6 +91,7 @@ class ExtrafiCommonBalances(ProtocolWithBalance):
         if len(locked_extra_addresses := list(self.addresses_with_activity(
             event_types=self.deposit_event_types,
             assets=(self.extrafi_token,),
+            location_labels=addresses,
         ).keys())) != 0:
             self._query_locked_extra(addresses=locked_extra_addresses, balances=balances)
 

--- a/rotkehlchen/chain/evm/decoding/gearbox/balances.py
+++ b/rotkehlchen/chain/evm/decoding/gearbox/balances.py
@@ -40,10 +40,12 @@ class GearboxCommonBalances(ProtocolWithBalance):
         self.gear_token = gear_token
         self.staking_contract = staking_contract
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query balances of staked gear tokens if deposit events are found."""
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        if len(addresses_with_deposits := list(self.addresses_with_deposits())) == 0:
+        if len(addresses_with_deposits := list(self.addresses_with_deposits(
+            location_labels=addresses,
+        ))) == 0:
             return balances
 
         staking_contract = EvmContract(

--- a/rotkehlchen/chain/evm/decoding/giveth/balances.py
+++ b/rotkehlchen/chain/evm/decoding/giveth/balances.py
@@ -47,10 +47,10 @@ class GivethCommonBalances(ProtocolWithBalance):
         self.giv_token_id = giv_token_id
         self.query_method = query_method
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query balances of staked/locked GIV"""
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        address_to_deposits = self.addresses_with_deposits()
+        address_to_deposits = self.addresses_with_deposits(location_labels=addresses)
         staking_contract = EvmContract(
             address=self.staking_address,
             abi=DEPOSIT_BALANCE_ABI if self.query_method == 'depositTokenBalance' else self.evm_inquirer.contracts.abi('ERC20_TOKEN'),  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/hop/balances.py
+++ b/rotkehlchen/chain/evm/decoding/hop/balances.py
@@ -40,7 +40,7 @@ class HopBalances(ProtocolWithBalance):
             deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
         )
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Queries and returns the balance sheet for staking events.
 
         This method:
@@ -50,7 +50,9 @@ class HopBalances(ProtocolWithBalance):
         4. Converts balances and rewards to USD and updates the balance sheet.
         """
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        if len(addresses_with_deposits := self.addresses_with_deposits()) == 0:
+        if len(addresses_with_deposits := self.addresses_with_deposits(
+            location_labels=addresses,
+        )) == 0:
             return balances
 
         # Group addresses by staking contract
@@ -61,7 +63,7 @@ class HopBalances(ProtocolWithBalance):
                     staked_contracts[event.address].add(user_address)
 
         hop_abi = self.evm_inquirer.contracts.abi('HOP_STAKING')
-        for contract_address, addresses in staked_contracts.items():
+        for contract_address, staker_addresses in staked_contracts.items():
             staking_contract = EvmContract(
                 address=contract_address,
                 abi=hop_abi,
@@ -76,7 +78,7 @@ class HopBalances(ProtocolWithBalance):
                         method_name='balanceOf',
                         arguments=[user],
                     ),
-                ) for user in addresses],
+                ) for user in staker_addresses],
                 call_order=call_order,
                 calls_chunk_size=chunk_size,
             )) == 0:
@@ -119,14 +121,19 @@ class HopBalances(ProtocolWithBalance):
                 calls=[(
                     staking_contract.address,
                     staking_contract.encode(method_name='earned', arguments=[user]),
-                ) for user in addresses],
+                ) for user in staker_addresses],
                 call_order=call_order,
                 calls_chunk_size=chunk_size,
             )
             prices = Inquirer.find_main_currency_prices([staking_token, rewards_token])
             token_price = prices[staking_token]
             rewards_price = prices[rewards_token]
-            for user, lp, reward in zip(addresses, staked_lps, staked_rewards, strict=True):
+            for user, lp, reward in zip(
+                    staker_addresses,
+                    staked_lps,
+                    staked_rewards,
+                    strict=True,
+            ):
                 try:
                     if (balance := staking_contract.decode(
                         result=lp,

--- a/rotkehlchen/chain/evm/decoding/velodrome/balances.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/balances.py
@@ -59,10 +59,12 @@ class VelodromeLikeBalances(ProtocolWithGauges):
     def get_gauge_address(self, event: 'EvmEvent') -> ChecksumEvmAddress | None:
         return event.address if event.asset != self.protocol_token else None
 
-    def query_balances(self) -> BalancesSheetType:
-        balances = super().query_balances()
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> BalancesSheetType:
+        balances = super().query_balances(addresses=addresses)
         if (
-            len(addresses_with_deposits := self.addresses_with_deposits()) == 0 or
+            len(addresses_with_deposits := self.addresses_with_deposits(
+                location_labels=addresses,
+            )) == 0 or
             len(addresses_to_token_ids := {
                 address: list(token_ids_set) for address, events in addresses_with_deposits.items()
                 if len(token_ids_set := {event.extra_data['token_id'] for event in events if event.extra_data is not None}) != 0  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/woo_fi/balances.py
+++ b/rotkehlchen/chain/evm/decoding/woo_fi/balances.py
@@ -43,10 +43,12 @@ class WoofiBalances(ProtocolWithBalance):
             deposit_event_types={(HistoryEventType.STAKING, HistoryEventSubType.DEPOSIT_ASSET)},
         )
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query WOO and vault token staked balances."""
         balances: BalancesSheetType = defaultdict(BalanceSheet)
-        if len(address_to_deposits := self.addresses_with_deposits()) == 0:
+        if len(address_to_deposits := self.addresses_with_deposits(
+            location_labels=addresses,
+        )) == 0:
             return balances
 
         addresses_with_staked_woo_tokens = set()

--- a/rotkehlchen/chain/evm/manager.py
+++ b/rotkehlchen/chain/evm/manager.py
@@ -78,6 +78,7 @@ class EvmManager(
         """
         return self.query_protocols_with_balance(
             balances=self.query_evm_chain_balances(accounts=addresses),
+            addresses=addresses,
         )
 
     def query_transactions(
@@ -206,6 +207,7 @@ class EvmManager(
     def query_protocols_with_balance(
             self,
             balances: defaultdict[ChecksumEvmAddress, BalanceSheet],
+            addresses: Sequence[ChecksumEvmAddress],
     ) -> defaultdict[ChecksumEvmAddress, BalanceSheet]:
         """
         Query for balances of protocols in which tokens can be locked without returning a liquid
@@ -213,13 +215,16 @@ class EvmManager(
         needs to be added to the total balance of the account. Examples of such protocols are
         Legacy Curve gauges in ethereum, Convex and Velodrome.
         """
+        queried_addresses = list(addresses)
         for protocol in CHAIN_TO_BALANCE_PROTOCOLS[self.node_inquirer.chain_id]:
             protocol_with_balance: ProtocolWithBalance = protocol(
                 evm_inquirer=self.node_inquirer,  # type: ignore  # mypy can't match all possibilities here
                 tx_decoder=self.transactions_decoder,  # type: ignore  # mypy can't match all possibilities here
             )
             try:
-                protocol_balances = protocol_with_balance.query_balances()
+                protocol_balances = protocol_with_balance.query_balances(
+                    addresses=queried_addresses,
+                )
             except RemoteError as e:
                 log.error(f'Failed to query balances for {protocol} due to {e}. Skipping')
                 continue

--- a/rotkehlchen/chain/optimism/modules/walletconnect/balances.py
+++ b/rotkehlchen/chain/optimism/modules/walletconnect/balances.py
@@ -17,6 +17,7 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 if TYPE_CHECKING:
     from rotkehlchen.chain.optimism.decoding.decoder import OptimismTransactionDecoder
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
+    from rotkehlchen.types import ChecksumEvmAddress
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -38,12 +39,14 @@ class WalletconnectBalances(ProtocolWithBalance):
             },
         )
 
-    def query_balances(self) -> 'BalancesSheetType':
+    def query_balances(self, addresses: 'list[ChecksumEvmAddress]') -> 'BalancesSheetType':
         """Query balances of staked WalletConnect"""
         balances: BalancesSheetType = defaultdict(BalanceSheet)
         wct_token = Asset(WCT_TOKEN_ID)
         wct_price = Inquirer.find_main_currency_price(Asset(WCT_TOKEN_ID))
-        for address, events in self.addresses_with_deposits().items():
+        for address, events in self.addresses_with_deposits(
+            location_labels=addresses,
+        ).items():
             amount = ZERO
             for event in events:
                 if event.event_subtype == HistoryEventSubType.DEPOSIT_ASSET and event.asset == wct_token:  # noqa: E501

--- a/rotkehlchen/db/lido_csm.py
+++ b/rotkehlchen/db/lido_csm.py
@@ -83,27 +83,38 @@ class DBLidoCsm:
             metrics=metrics,
         )
 
-    def get_node_operators(self) -> tuple[LidoCsmNodeOperator, ...]:
+    def get_node_operators(
+            self,
+            addresses: list[ChecksumEvmAddress] | None = None,
+    ) -> tuple[LidoCsmNodeOperator, ...]:
         """Return all tracked node operators with their cached metrics, if any."""
+        if addresses == []:
+            return ()
+
+        query = """
+            SELECT
+                o.address,
+                o.node_operator_id,
+                m.operator_type_id,
+                m.bond_current,
+                m.bond_required,
+                m.bond_claimable,
+                m.total_deposited_validators,
+                m.rewards_pending
+            FROM lido_csm_node_operators AS o
+            LEFT JOIN lido_csm_node_operator_metrics AS m
+                ON o.node_operator_id = m.node_operator_id
+        """
+        bindings: tuple[ChecksumEvmAddress, ...] = ()
+        if addresses is not None:
+            query += f" WHERE o.address IN ({','.join('?' for _ in addresses)})"
+            bindings = tuple(addresses)
+        query += ' ORDER BY o.node_operator_id'
         with self.db.conn.read_ctx() as cursor:
-            rows = cursor.execute(
-                """
-                SELECT
-                    o.address,
-                    o.node_operator_id,
-                    m.operator_type_id,
-                    m.bond_current,
-                    m.bond_required,
-                    m.bond_claimable,
-                    m.total_deposited_validators,
-                    m.rewards_pending
-                FROM lido_csm_node_operators AS o
-                LEFT JOIN lido_csm_node_operator_metrics AS m
-                    ON o.node_operator_id = m.node_operator_id
-                ORDER BY o.node_operator_id
-                """,
-            ).fetchall()
-        return tuple(self._deserialize_entry(row) for row in rows)
+            return tuple(
+                self._deserialize_entry(row)
+                for row in cursor.execute(query, bindings)
+            )
 
     def add_node_operator(
             self,

--- a/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
+++ b/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
@@ -431,7 +431,7 @@ def test_lst_create_delayed_withdrawals(database, ethereum_inquirer, ethereum_ac
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    balances = balances_inquirer.query_balances()
+    balances = balances_inquirer.query_balances(addresses=ethereum_accounts)
     assert balances[ethereum_accounts[0]].assets[A_STETH.resolve_to_evm_token()][balances_inquirer.counterparty] == Balance(  # noqa: E501
         amount=FVal(amount),
         value=FVal('0.7720684677079537845'),
@@ -517,7 +517,7 @@ def test_lst_complete_delayed_withdrawals(database, ethereum_inquirer, ethereum_
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    balances = balances_inquirer.query_balances()
+    balances = balances_inquirer.query_balances(addresses=ethereum_accounts)
     assert balances[ethereum_accounts[0]].assets[cbeth][balances_inquirer.counterparty] == Balance()  # noqa: E501
 
 

--- a/rotkehlchen/tests/unit/test_blockchain_balances.py
+++ b/rotkehlchen/tests/unit/test_blockchain_balances.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -5,6 +6,7 @@ import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.aggregator import CHAIN_TO_BALANCE_PROTOCOLS
 from rotkehlchen.chain.balances import BlockchainBalances
 from rotkehlchen.chain.ethereum.modules.liquity.constants import CPT_LIQUITY
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -222,6 +224,31 @@ def test_partial_balance_refresh_keeps_other_accounts(blockchain: 'ChainsAggrega
 
     assert blockchain.balances.eth[refreshed_address] == refreshed_sheet
     assert blockchain.balances.eth[other_address] == other_sheet
+
+
+def test_protocol_balance_refresh_uses_requested_addresses(
+        blockchain: 'ChainsAggregator',
+) -> None:
+    requested_addresses = [make_evm_address()]
+
+    class ProtocolBalances:
+        def __init__(self, **kwargs) -> None:
+            pass
+
+        def query_balances(self, addresses: list[ChecksumEvmAddress]) -> dict:
+            assert addresses == requested_addresses
+            return {}
+
+    with patch.dict(
+        CHAIN_TO_BALANCE_PROTOCOLS,
+        {ChainID.ETHEREUM: (ProtocolBalances,)},
+    ):
+        blockchain.get_chain_manager(
+            blockchain=SupportedBlockchain.ETHEREUM,
+        ).query_protocols_with_balance(
+            balances=defaultdict(BalanceSheet),
+            addresses=requested_addresses,
+        )
 
 
 def test_blockchain_balances_cache_removes_spent_token(blockchain: 'ChainsAggregator') -> None:

--- a/rotkehlchen/tests/unit/test_lido_csm_balances.py
+++ b/rotkehlchen/tests/unit/test_lido_csm_balances.py
@@ -67,7 +67,7 @@ def test_lido_csm_balances_accumulates():
             evm_inquirer=_make_evm_inquirer(),
             tx_decoder=MagicMock(),
         )
-        result = balances.query_balances()
+        result = balances.query_balances(addresses=[entry.address])
 
     assert result[entry.address].assets[A_STETH][CPT_LIDO_CSM] == Balance(
         amount=FVal('1.5'),
@@ -108,7 +108,7 @@ def test_lido_csm_balances_skips_on_error():
             evm_inquirer=_make_evm_inquirer(),
             tx_decoder=MagicMock(),
         )
-        result = balances.query_balances()
+        result = balances.query_balances(addresses=[entry.address])
     assert len(result) == 0
 
 
@@ -139,7 +139,7 @@ def test_lido_csm_balances_real_data(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=ethereum_transaction_decoder,
     )
-    result = balances.query_balances()
+    result = balances.query_balances(addresses=[node_operator_address])
 
     operator_balance = result[node_operator_address].assets[A_STETH][CPT_LIDO_CSM]
     assert operator_balance.amount.is_close(FVal('26.318054536101981594'))

--- a/rotkehlchen/tests/unit/test_protocol_balances.py
+++ b/rotkehlchen/tests/unit/test_protocol_balances.py
@@ -99,6 +99,7 @@ from rotkehlchen.constants.assets import (
 )
 from rotkehlchen.constants.misc import ONE, ZERO
 from rotkehlchen.constants.resolver import evm_address_to_identifier
+from rotkehlchen.db.filtering import EvmEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.cache import (
@@ -171,7 +172,7 @@ def test_curve_balances(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    curve_balances = curve_balances_inquirer.query_balances()
+    curve_balances = curve_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = curve_balances[ethereum_accounts[0]]
     asset = EvmToken('eip155:1/erc20:0xC25a3A3b969415c80451098fa907EC722572917F')
     assert user_balance.assets[asset][CPT_CURVE] == Balance(
@@ -209,7 +210,7 @@ def test_curve_locked_crv_balances(
         curve_balances = CurveBalances(
             evm_inquirer=ethereum_inquirer,
             tx_decoder=ethereum_transaction_decoder,
-        ).query_balances()
+        ).query_balances(addresses=ethereum_accounts)
         user_balance = curve_balances[address]
         assert user_balance.assets[A_CRV][CPT_CURVE] == Balance(
             amount=locked_crv_amount,
@@ -234,7 +235,7 @@ def test_convex_gauges_balances(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    convex_balances = convex_balances_inquirer.query_balances()
+    convex_balances = convex_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = convex_balances[ethereum_accounts[0]]
     asset = EvmToken('eip155:1/erc20:0xF9835375f6b268743Ea0a54d742Aa156947f8C06')
     assert user_balance.assets[asset][CPT_CONVEX] == Balance(
@@ -261,7 +262,7 @@ def test_convex_staking_balances(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    convex_balances = convex_balances_inquirer.query_balances()
+    convex_balances = convex_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = convex_balances[ethereum_accounts[0]]
     # the amount here is the sum of the locked ~44 and the staked tokens ~333
     assert user_balance.assets[A_CVX.resolve_to_evm_token()][CPT_CONVEX] == Balance(
@@ -293,7 +294,7 @@ def test_convex_staking_balances_without_gauges(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    convex_balances = convex_balances_inquirer.query_balances()
+    convex_balances = convex_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = convex_balances[ethereum_accounts[0]]
     assert user_balance.assets[A_CVX.resolve_to_evm_token()][CPT_CONVEX] == Balance(
         amount=FVal('18229.934390350508148387'),
@@ -322,7 +323,7 @@ def test_velodrome_v2_staking_balances(
         evm_inquirer=optimism_inquirer,
         tx_decoder=tx_decoder,
     )
-    balances = balances_inquirer.query_balances()  # queries the gauge balance of the address if the address has interacted with a known gauge  # noqa: E501
+    balances = balances_inquirer.query_balances(addresses=optimism_accounts)  # queries the gauge balance of the address if the address has interacted with a known gauge  # noqa: E501
     user_balance = balances[optimism_accounts[0]]
     weth_op_lp_token = evm_address_to_identifier(
         address=string_to_evm_address('0xd25711EdfBf747efCE181442Cc1D8F5F8fc8a0D3'),
@@ -353,7 +354,7 @@ def test_thegraph_balances_arbitrum_one(
         evm_inquirer=arbitrum_one_inquirer,
         tx_decoder=tx_decoder,
     )
-    thegraph_balances = thegraph_balances_inquirer.query_balances()
+    thegraph_balances = thegraph_balances_inquirer.query_balances(addresses=arbitrum_one_accounts)
     user_balance = thegraph_balances[arbitrum_one_accounts[0]]
     assert user_balance.assets[A_GRT_ARB][CPT_THEGRAPH] == Balance(
         amount=amount,
@@ -387,16 +388,16 @@ def test_thegraph_balances_vested_arbitrum_one(
 
     original_get_delegations = ThegraphBalances._get_delegations
 
-    def mock_get_delegations(self):
+    def mock_get_delegations(self, addresses):
         """Mock _get_delegations to ensure deterministic ordering for VCR"""
-        delegations = original_get_delegations(self)
+        delegations = original_get_delegations(self, addresses=addresses)
         return sorted(delegations, key=operator.itemgetter(0, 1, 2, 3))
 
     with patch.object(ThegraphBalances, '_get_delegations', mock_get_delegations):
         thegraph_balances = ThegraphBalances(
             evm_inquirer=arbitrum_one_inquirer,
             tx_decoder=arbitrum_one_transaction_decoder,
-        ).query_balances()
+        ).query_balances(addresses=arbitrum_one_accounts)
     assert thegraph_balances[arbitrum_one_accounts[0]].assets[A_GRT_ARB][CPT_THEGRAPH] == Balance(
         amount=expected_grt_balance,
         value=expected_grt_balance * FVal(1.5),
@@ -421,7 +422,7 @@ def test_octant_balances(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    octant_balances = octant_balances_inquirer.query_balances()
+    octant_balances = octant_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = octant_balances[ethereum_accounts[0]]
     assert user_balance.assets[A_GLM.resolve_to_evm_token()][CPT_OCTANT] == Balance(amount=FVal('9849.361552045676790003'), value=FVal('14774.0423280685151850045'))  # noqa: E501
 
@@ -444,7 +445,7 @@ def test_octant_balances_v2(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    octant_balances = octant_balances_inquirer.query_balances()
+    octant_balances = octant_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = octant_balances[ethereum_accounts[0]]
     assert user_balance.assets[A_GLM.resolve_to_evm_token()][CPT_OCTANT] == Balance(
         amount=FVal('3767.190200498257727034'),
@@ -470,7 +471,7 @@ def test_eigenlayer_balances(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    balances = balances_inquirer.query_balances()
+    balances = balances_inquirer.query_balances(addresses=ethereum_accounts)
     assert balances[ethereum_accounts[0]].assets[A_STETH.resolve_to_evm_token()][CPT_EIGENLAYER] == Balance(  # noqa: E501
         amount=FVal('0.114063122816914142'),
         value=FVal('0.1710946842253712130'),
@@ -496,7 +497,7 @@ def test_eigenpod_balances(
         tx_decoder=tx_decoder,
     )
     eigenpod_balance = FVal('0.054506232')
-    balances = balances_inquirer.query_balances()
+    balances = balances_inquirer.query_balances(addresses=ethereum_accounts)
     assert balances[ethereum_accounts[0]].assets[A_ETH][CPT_EIGENLAYER] == Balance(
         amount=eigenpod_balance,
         value=FVal('1.5') * eigenpod_balance,
@@ -553,7 +554,9 @@ def test_gmx_balances(
             ('0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1', '0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f', False),  # noqa: E501
         ],
     }
-    actual_positions = balances_inquirer._extract_unique_deposits()
+    actual_positions = balances_inquirer._extract_unique_deposits(
+        addresses=arbitrum_one_accounts,
+    )
     for addr, positions in expected_positions.items():
         assert set(actual_positions[addr]) == set(positions)
 
@@ -561,7 +564,7 @@ def test_gmx_balances(
         'rotkehlchen.chain.arbitrum_one.modules.gmx.balances.GmxBalances._extract_unique_deposits',
         return_value=expected_positions,
     ):
-        balances = balances_inquirer.query_balances()
+        balances = balances_inquirer.query_balances(addresses=arbitrum_one_accounts)
 
     weth_arb = Asset('eip155:42161/erc20:0x82aF49447D8a07e3bd95BD0d56f35241523fBab1')
     assert balances[arbitrum_one_accounts[0]].assets[weth_arb][CPT_GMX] == Balance(
@@ -605,7 +608,7 @@ def test_gmx_balances_staking(
         evm_inquirer=arbitrum_one_inquirer,
         tx_decoder=tx_decoder,
     )
-    balances = balances_inquirer.query_balances()
+    balances = balances_inquirer.query_balances(addresses=arbitrum_one_accounts)
     assert balances[arbitrum_one_accounts[0]].assets[A_GMX][CPT_GMX] == Balance(
         amount=FVal('4.201981641893733976'),
         value=FVal('32.64939735751431299352'),
@@ -630,7 +633,7 @@ def test_aave_balances_staking(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    balances = balances_inquirer.query_balances()
+    balances = balances_inquirer.query_balances(addresses=ethereum_accounts)
     assert balances[ethereum_accounts[0]].assets[A_AAVE][CPT_AAVE] == Balance(
         amount=amount,
         value=amount * FVal(1.5),
@@ -738,14 +741,17 @@ def test_compound_v3_token_balances_liabilities(
         evm_inquirer=blockchain.ethereum.node_inquirer,
         tx_decoder=blockchain.ethereum.transactions_decoder,
     )
-    unique_borrows, underlying_tokens = compound_v3_balances._extract_unique_borrowed_tokens()
+    unique_borrows, underlying_tokens = compound_v3_balances._extract_unique_borrowed_tokens(
+        addresses=ethereum_accounts,
+    )
 
     def mock_extract_unique_borrowed_tokens(
             self: 'Compoundv3Balances',  # pylint: disable=unused-argument
+            addresses: list[ChecksumEvmAddress],  # pylint: disable=unused-argument
     ) -> tuple[dict[EvmToken, list['ChecksumEvmAddress']], dict['ChecksumEvmAddress', EvmToken]]:
         return {
-            token: sorted(addresses)  # cast set to list to avoid randomness in VCR
-            for token, addresses in unique_borrows.items()
+            token: sorted(borrowers)  # cast set to list to avoid randomness in VCR
+            for token, borrowers in unique_borrows.items()
         }, underlying_tokens
 
     def mock_query_tokens(addresses):
@@ -789,7 +795,7 @@ def test_blur_balances(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    blur_balances = blur_balances_inquirer.query_balances()
+    blur_balances = blur_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = blur_balances[ethereum_accounts[0]]
     assert user_balance.assets[Asset(BLUR_IDENTIFIER)][CPT_BLUR] == Balance(
         amount=amount,
@@ -815,7 +821,7 @@ def test_hop_balances_staking(
         evm_inquirer=arbitrum_one_inquirer,
         tx_decoder=tx_decoder,
     )
-    balances = balances_inquirer.query_balances()
+    balances = balances_inquirer.query_balances(addresses=arbitrum_one_accounts)
     hop_lp_token = Asset('eip155:42161/erc20:0x59745774Ed5EfF903e615F5A2282Cae03484985a')
     hop_reward_token = Asset('eip155:42161/erc20:0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC')
     assert balances[arbitrum_one_accounts[0]].assets[hop_lp_token][CPT_HOP] == Balance(
@@ -846,7 +852,7 @@ def test_hop_balances_staking_2(
         evm_inquirer=arbitrum_one_inquirer,
         tx_decoder=tx_decoder,
     )
-    balances = balances_inquirer.query_balances()
+    balances = balances_inquirer.query_balances(addresses=arbitrum_one_accounts)
     hop_lp_token = Asset('eip155:42161/erc20:0x59745774Ed5EfF903e615F5A2282Cae03484985a')
     assert balances[arbitrum_one_accounts[0]].assets[hop_lp_token][CPT_HOP] == Balance(
         amount=lp_amount,
@@ -876,7 +882,7 @@ def test_gearbox_balances(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = protocol_balances[ethereum_accounts[0]]
     assert user_balance.assets[GEAR_TOKEN][CPT_GEARBOX] == Balance(
         amount=amount,
@@ -902,7 +908,7 @@ def test_gearbox_balances_arb(
         evm_inquirer=arbitrum_one_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=arbitrum_one_accounts)
     user_balance = protocol_balances[arbitrum_one_accounts[0]]
     assert user_balance.assets[GEAR_TOKEN_ARB][CPT_GEARBOX] == Balance(
         amount=amount,
@@ -928,7 +934,7 @@ def test_safe_locked(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = protocol_balances[ethereum_accounts[0]]
     assert user_balance.assets[Asset(SAFE_TOKEN_ID)][CPT_SAFE] == Balance(
         amount=amount,
@@ -954,7 +960,7 @@ def test_safenet_staked(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = protocol_balances[ethereum_accounts[0]]
     assert user_balance.assets[Asset(SAFE_TOKEN_ID)][CPT_SAFE] == Balance(
         amount=amount,
@@ -989,7 +995,7 @@ def test_extrafi_lending_balances(
         evm_inquirer=optimism_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances, velo_amount, extra_amount = protocol_balances_inquirer.query_balances(), FVal('366399.179130825123704582'), FVal('6405.478041239509217895')  # noqa: E501
+    protocol_balances, velo_amount, extra_amount = protocol_balances_inquirer.query_balances(addresses=optimism_accounts), FVal('366399.179130825123704582'), FVal('6405.478041239509217895')  # noqa: E501
     assert protocol_balances[optimism_accounts[0]].assets[Asset('eip155:10/erc20:0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db')][CPT_EXTRAFI] == Balance(  # noqa: E501
         amount=velo_amount,
         value=velo_amount * FVal(1.5),
@@ -1029,7 +1035,7 @@ def test_extrafi_farm_balances(
         evm_inquirer=base_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=base_accounts)
     assert protocol_balances[base_accounts[0]].assets[Asset('eip155:8453/erc20:0x61366A4e6b1DB1b85DD701f2f4BFa275EF271197')][CPT_EXTRAFI] == Balance(  # noqa: E501
         amount=FVal('0.001146519712970269'),
         value=FVal('13715.96845367077767909372680774996'),
@@ -1048,7 +1054,7 @@ def test_extrafi_farm_balances(
         )]
 
     # query again to verify that it works as expected
-    assert (protocol_balances := protocol_balances_inquirer.query_balances())[base_accounts[0]].assets[Asset('eip155:8453/erc20:0x61366A4e6b1DB1b85DD701f2f4BFa275EF271197')][CPT_EXTRAFI] == Balance(  # noqa: E501
+    assert (protocol_balances := protocol_balances_inquirer.query_balances(addresses=base_accounts))[base_accounts[0]].assets[Asset('eip155:8453/erc20:0x61366A4e6b1DB1b85DD701f2f4BFa275EF271197')][CPT_EXTRAFI] == Balance(  # noqa: E501
         amount=FVal('0.001146519712970269'),
         value=FVal('13715.96845367077767909372680774996'),
     )
@@ -1124,7 +1130,7 @@ def test_umami_balances(
         evm_inquirer=arbitrum_one_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=arbitrum_one_accounts)
     user_balance = protocol_balances[arbitrum_one_accounts[0]]
     assert user_balance.assets[Asset('eip155:42161/erc20:0x5f851F67D24419982EcD7b7765deFD64fBb50a97')][CPT_UMAMI] == Balance(  # noqa: E501
         amount=FVal('46.422107'),
@@ -1151,7 +1157,7 @@ def test_walletconnect_staked_balances(
         evm_inquirer=optimism_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=optimism_accounts)
     user_balance = protocol_balances[optimism_accounts[0]]
     assert user_balance.assets[Asset(WCT_TOKEN_ID)][CPT_WALLETCONNECT] == Balance(
         amount=amount,
@@ -1177,7 +1183,7 @@ def test_curve_lend_balances(
         evm_inquirer=arbitrum_one_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=arbitrum_one_accounts)
     user_balance = protocol_balances[arbitrum_one_accounts[0]]
 
     assert user_balance.assets[A_WETH_ARB][CPT_CURVE] == Balance(
@@ -1209,7 +1215,7 @@ def test_curve_crvusd_balances(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = protocol_balances[ethereum_accounts[0]]
 
     assert user_balance.assets[A_WBTC][CPT_CURVE] == Balance(
@@ -1239,7 +1245,7 @@ def test_gnosis_giveth_staked_balances(
         evm_inquirer=gnosis_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=gnosis_accounts)
     user_balance = protocol_balances[gnosis_accounts[0]]
     giv_asset = Asset(protocol_balances_inquirer.giv_token_id)
 
@@ -1267,7 +1273,7 @@ def test_optimism_giveth_staked_balances(
         evm_inquirer=optimism_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=optimism_accounts)
     user_balance = protocol_balances[optimism_accounts[0]]
     giv_asset = Asset(protocol_balances_inquirer.giv_token_id)
 
@@ -1294,7 +1300,7 @@ def test_hedgey_locked_balances(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = protocol_balances[ethereum_accounts[0]]
 
     assert user_balance.assets[A_ENS][CPT_HEDGEY] == Balance(
@@ -1320,7 +1326,7 @@ def test_velodrome_locked_balances(
         evm_inquirer=optimism_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=optimism_accounts)
     user_balance = protocol_balances[optimism_accounts[0]]
     assert user_balance.assets[Asset('eip155:10/erc20:0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db')][CPT_VELODROME] == Balance(  # noqa: E501
         amount=FVal('215.817657296359655794'),
@@ -1345,7 +1351,7 @@ def test_aerodrome_locked_balances(
         evm_inquirer=base_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=base_accounts)
     user_balance = protocol_balances[base_accounts[0]]
     assert user_balance.assets[Asset('eip155:8453/erc20:0x940181a94A35A4569E4529A3CDfB74e38FD98631')][CPT_AERODROME] == Balance(  # noqa: E501
         amount=FVal('927'),
@@ -1381,6 +1387,25 @@ def test_all_balance_classes_used():
     assert unused_classes == set(), f'Found unused classes {unused_classes}'
 
 
+def test_protocol_activity_is_filtered_by_location_labels(
+        ethereum_inquirer: 'EthereumInquirer',
+        ethereum_transaction_decoder: 'EthereumTransactionDecoder',
+) -> None:
+    protocol_balances = Compoundv3Balances(
+        evm_inquirer=ethereum_inquirer,
+        tx_decoder=ethereum_transaction_decoder,
+    )
+    addresses = [address := make_evm_address()]
+
+    with patch.object(EvmEventFilterQuery, 'make', wraps=EvmEventFilterQuery.make) as make_filter:
+        protocol_balances.addresses_with_activity(
+            event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_TO_PROTOCOL)},
+            location_labels=addresses,
+        )
+
+    assert make_filter.call_args.kwargs['location_labels'] == [address]
+
+
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('should_mock_current_price_queries', [False])
 @pytest.mark.parametrize('ethereum_accounts', [['0x94F567bf71A4A7a88114aB679336522120EE3788']])
@@ -1397,7 +1422,7 @@ def test_pendle_locked_balances(
         evm_inquirer=ethereum_inquirer,
         tx_decoder=tx_decoder,
     )
-    protocol_balances = protocol_balances_inquirer.query_balances()
+    protocol_balances = protocol_balances_inquirer.query_balances(addresses=ethereum_accounts)
     user_balance = protocol_balances[ethereum_accounts[0]]
     assert user_balance.assets[PENDLE_TOKEN][CPT_PENDLE] == Balance(
         amount=FVal('367.772672118320474345'),
@@ -1421,7 +1446,7 @@ def test_runmoney_balances(
     protocol_balances = RunmoneyBalances(
         evm_inquirer=base_inquirer,
         tx_decoder=tx_decoder,
-    ).query_balances()
+    ).query_balances(addresses=base_accounts)
     user_balance = protocol_balances[base_accounts[0]]
     assert user_balance.assets[Asset('eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913')][CPT_RUNMONEY] == Balance(  # noqa: E501
         amount=FVal('102.973178'),
@@ -1518,7 +1543,7 @@ def test_morpho_blue_balances(
     protocol_balances = MorphoBlueBalances(
         evm_inquirer=base_inquirer,
         tx_decoder=base_transaction_decoder,
-    ).query_balances()
+    ).query_balances(addresses=base_accounts)
     user_balance = protocol_balances[user_address]
     assert user_balance.assets[usdc][CPT_MORPHO_BLUE] == Balance(
         amount=FVal('9'),
@@ -1546,7 +1571,7 @@ def test_woofi_stake_v2_balances(
     protocol_balances = WoofiBalances(
         evm_inquirer=optimism_inquirer,
         tx_decoder=tx_decoder,
-    ).query_balances()
+    ).query_balances(addresses=optimism_accounts)
     woo_token = Asset('eip155:10/erc20:0x871f2F2ff935FD1eD867842FF2a7bfD051A5E527')
     assert protocol_balances[optimism_accounts[0]].assets[woo_token][CPT_WOO_FI] == Balance(
         amount=FVal('1571.295767977009'),
@@ -1578,7 +1603,7 @@ def test_woofi_stake_vault_token_balances(
     protocol_balances = WoofiBalances(
         evm_inquirer=optimism_inquirer,
         tx_decoder=tx_decoder,
-    ).query_balances()
+    ).query_balances(addresses=optimism_accounts)
     vault_token = Asset('eip155:10/erc20:0xcA7184eA1cb4cF04d49Bf219c49a39231299dA26')
     assert protocol_balances[optimism_accounts[0]].assets[vault_token][CPT_WOO_FI] == Balance(
         amount=FVal('15923.160753145667983352'),


### PR DESCRIPTION
Partial EVM balance refreshes queried protocol balances for every tracked address, then discarded results outside the requested subset.

Pass the requested addresses through protocol balance inquirers and filter activity lookups and auxiliary queries before performing on-chain calls.
