### PR TITLE
Add useSetting read primitive and settings facade layer

### DIFF
--- a/frontend/app/src/modules/assets/amount-display/use-amount-display-settings.ts
+++ b/frontend/app/src/modules/assets/amount-display/use-amount-display-settings.ts
@@ -1,78 +1,52 @@
-import type { ComputedRef, Ref } from 'vue';
+import type { Ref } from 'vue';
 import type { Currency } from '@/modules/assets/amount-display/currencies';
 import type { RoundingMode } from '@/modules/settings/types/frontend-settings';
-import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
-import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
+import { useSetting } from '@/modules/settings/use-setting';
 
 export interface AmountDisplaySettings {
   // General settings
-  floatingPrecision: Ref<number>;
-  currency: Ref<Currency>;
-  currencySymbol: Ref<string>;
+  floatingPrecision: Readonly<Ref<number>>;
+  currency: Readonly<Ref<Currency>>;
+  currencySymbol: Readonly<Ref<string>>;
 
   // Frontend settings - formatting
-  thousandSeparator: Ref<string>;
-  decimalSeparator: Ref<string>;
-  currencyLocation: Ref<'before' | 'after'>;
-  abbreviateNumber: Ref<boolean>;
-  minimumDigitToBeAbbreviated: Ref<number>;
-  subscriptDecimals: Ref<boolean>;
+  thousandSeparator: Readonly<Ref<string>>;
+  decimalSeparator: Readonly<Ref<string>>;
+  currencyLocation: Readonly<Ref<'before' | 'after'>>;
+  abbreviateNumber: Readonly<Ref<boolean>>;
+  minimumDigitToBeAbbreviated: Readonly<Ref<number>>;
+  subscriptDecimals: Readonly<Ref<boolean>>;
 
   // Frontend settings - rounding
-  amountRoundingMode: Ref<RoundingMode>;
-  valueRoundingMode: Ref<RoundingMode>;
+  amountRoundingMode: Readonly<Ref<RoundingMode>>;
+  valueRoundingMode: Readonly<Ref<RoundingMode>>;
 
   // Frontend settings - privacy
-  scrambleData: Ref<boolean>;
-  scrambleMultiplier: Ref<number | undefined>;
-  shouldShowAmount: ComputedRef<boolean>;
+  scrambleData: Readonly<Ref<boolean>>;
+  scrambleMultiplier: Readonly<Ref<number | undefined>>;
+  shouldShowAmount: Readonly<Ref<boolean>>;
 }
 
 /**
- * Consolidates all settings needed for AmountDisplay into a single composable.
- * This reduces duplicate store access calls and provides a clean API for settings.
- *
- * Note: Pinia stores are already singletons per pinia instance, so calling this
- * multiple times is efficient - no additional caching is needed.
+ * Domain facade bundling the settings needed for amount display. Each entry reads through
+ * `useSetting`, so this composable knows nothing about which store owns each key and no store is
+ * imported here. This is the "several settings consumed together" layer over the per-key primitive.
  */
 export function useAmountDisplaySettings(): AmountDisplaySettings {
-  const generalSettingsStore = useGeneralSettingsStore();
-  const frontendSettingsStore = useFrontendSettingsStore();
-
-  const {
-    currency,
-    currencySymbol,
-    floatingPrecision,
-  } = storeToRefs(generalSettingsStore);
-
-  const {
-    abbreviateNumber,
-    amountRoundingMode,
-    currencyLocation,
-    decimalSeparator,
-    minimumDigitToBeAbbreviated,
-    scrambleData,
-    scrambleMultiplier,
-    shouldShowAmount,
-    subscriptDecimals,
-    thousandSeparator,
-    valueRoundingMode,
-  } = storeToRefs(frontendSettingsStore);
-
   return {
-    abbreviateNumber,
-    amountRoundingMode,
-    currency,
-    currencyLocation,
-    currencySymbol,
-    decimalSeparator,
-    floatingPrecision,
-    minimumDigitToBeAbbreviated,
-    scrambleData,
-    scrambleMultiplier,
-    shouldShowAmount,
-    subscriptDecimals,
-    thousandSeparator,
-    valueRoundingMode,
+    abbreviateNumber: useSetting('abbreviateNumber'),
+    amountRoundingMode: useSetting('amountRoundingMode'),
+    currency: useSetting('currency'),
+    currencyLocation: useSetting('currencyLocation'),
+    currencySymbol: useSetting('currencySymbol'),
+    decimalSeparator: useSetting('decimalSeparator'),
+    floatingPrecision: useSetting('floatingPrecision'),
+    minimumDigitToBeAbbreviated: useSetting('minimumDigitToBeAbbreviated'),
+    scrambleData: useSetting('scrambleData'),
+    scrambleMultiplier: useSetting('scrambleMultiplier'),
+    shouldShowAmount: useSetting('shouldShowAmount'),
+    subscriptDecimals: useSetting('subscriptDecimals'),
+    thousandSeparator: useSetting('thousandSeparator'),
+    valueRoundingMode: useSetting('valueRoundingMode'),
   };
 }

--- a/frontend/app/src/modules/settings/use-setting.spec.ts
+++ b/frontend/app/src/modules/settings/use-setting.spec.ts
@@ -1,0 +1,40 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAccountingSettingsStore } from '@/modules/settings/use-accounting-settings-store';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
+import { useSessionSettingsStore } from '@/modules/settings/use-session-settings-store';
+import { settingStore, type SettingStoreTag, useSetting } from '@/modules/settings/use-setting';
+
+const stores: Record<SettingStoreTag, () => object> = {
+  accounting: useAccountingSettingsStore,
+  frontend: useFrontendSettingsStore,
+  general: useGeneralSettingsStore,
+  session: useSessionSettingsStore,
+};
+
+describe('useSetting routing', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should route every key to a store that actually exposes it', () => {
+    for (const [key, tag] of Object.entries(settingStore)) {
+      const store = stores[tag]();
+      expect(key in store, `${key} is not exposed by the ${tag} store`).toBe(true);
+    }
+  });
+
+  it('should return a readonly ref reflecting the current store value', () => {
+    const store = useGeneralSettingsStore();
+    const format = useSetting('dateDisplayFormat');
+    expect(get(format)).toBe(store.dateDisplayFormat);
+  });
+
+  it('should stay in sync when the owning store updates', () => {
+    const store = useFrontendSettingsStore();
+    const separator = useSetting('thousandSeparator');
+    store.update({ thousandSeparator: '_' });
+    expect(get(separator)).toBe('_');
+  });
+});

--- a/frontend/app/src/modules/settings/use-setting.ts
+++ b/frontend/app/src/modules/settings/use-setting.ts
@@ -1,0 +1,70 @@
+import { type Ref, toRef } from 'vue';
+import { useAccountingSettingsStore } from '@/modules/settings/use-accounting-settings-store';
+import { useFrontendSettingsStore } from '@/modules/settings/use-frontend-settings-store';
+import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
+import { useSessionSettingsStore } from '@/modules/settings/use-session-settings-store';
+
+const storeFactories = {
+  accounting: useAccountingSettingsStore,
+  frontend: useFrontendSettingsStore,
+  general: useGeneralSettingsStore,
+  session: useSessionSettingsStore,
+} as const;
+
+export type SettingStoreTag = keyof typeof storeFactories;
+
+/**
+ * Explicit routing from a logical setting key to the store that owns it. This is the single place
+ * that knows where a setting lives: `useSetting` and every domain facade built on it read through
+ * here, so when the backing store is later replaced the routing changes in exactly one spot.
+ *
+ * The table grows as consumers migrate onto `useSetting` — add a key here the first time a consumer
+ * needs it. Keys are grouped by their owning store and kept alphabetical within each group. A key
+ * must exist on the store it is mapped to; `use-setting.spec.ts` asserts this at runtime.
+ */
+export const settingStore = {
+  // general
+  currency: 'general',
+  currencySymbol: 'general',
+  dateDisplayFormat: 'general',
+  displayDateInLocaltime: 'general',
+  floatingPrecision: 'general',
+  // frontend
+  abbreviateNumber: 'frontend',
+  amountRoundingMode: 'frontend',
+  currencyLocation: 'frontend',
+  decimalSeparator: 'frontend',
+  minimumDigitToBeAbbreviated: 'frontend',
+  scrambleData: 'frontend',
+  scrambleMultiplier: 'frontend',
+  shouldShowAmount: 'frontend',
+  subscriptDecimals: 'frontend',
+  thousandSeparator: 'frontend',
+  valueRoundingMode: 'frontend',
+} as const satisfies Record<string, SettingStoreTag>;
+
+export type SettingKey = keyof typeof settingStore;
+
+type StoreInstance<T extends SettingStoreTag> = ReturnType<(typeof storeFactories)[T]>;
+
+/** The value the owning store exposes for `key`, read through the store proxy (already unwrapped). */
+export type SettingValue<K extends SettingKey> =
+  StoreInstance<(typeof settingStore)[K]>[K & keyof StoreInstance<(typeof settingStore)[K]>];
+
+/**
+ * Reads a single setting by its logical key and returns a readonly ref to it, without the caller
+ * having to know or import the owning store. This is the read primitive of the settings surface;
+ * domain facades (e.g. `useAmountDisplaySettings`) bundle several of these for settings that are
+ * consumed together.
+ *
+ * The returned ref is a getter ref (no per-key reactive effect) and stays in sync when the store
+ * replaces its whole settings object, mirroring `toSettingsRefs`.
+ */
+export function useSetting<K extends SettingKey>(key: K): Readonly<Ref<SettingValue<K>>> {
+  const store = storeFactories[settingStore[key]]();
+  // `store` is the union of the four store instance types; the routing table guarantees `key`
+  // indexes the resolved member, but TS cannot prove that for a generic `K`. Read through a getter
+  // ref and assert the element type once, behind this typed facade (same pattern as toSettingsRefs).
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- routing table guarantees key exists on the resolved store
+  return toRef(() => (store as unknown as Record<K, SettingValue<K>>)[key]);
+}

--- a/frontend/app/src/modules/shell/components/display/DateDisplay.vue
+++ b/frontend/app/src/modules/shell/components/display/DateDisplay.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { displayDateFormatter } from '@/modules/core/common/date-formatter';
-import { useGeneralSettingsStore } from '@/modules/settings/use-general-settings-store';
 import { useScramble } from '@/modules/settings/use-scramble';
+import { useSetting } from '@/modules/settings/use-setting';
 import CopyTooltip from '@/modules/shell/components/CopyTooltip.vue';
 
 const { hideTooltip = false, milliseconds = false, noTime = false, showTimezone = false, timestamp } = defineProps<{
@@ -12,7 +12,7 @@ const { hideTooltip = false, milliseconds = false, noTime = false, showTimezone 
   hideTooltip?: boolean;
 }>();
 
-const { dateDisplayFormat } = storeToRefs(useGeneralSettingsStore());
+const dateDisplayFormat = useSetting('dateDisplayFormat');
 
 const dateFormat = computed<string>(() => {
   const display = showTimezone


### PR DESCRIPTION
Internal refactor, no user-facing change (no issue to close). Follow-up to #12536.

## What

Introduce a read surface over the settings stores so components stop importing the stores directly to read a value.

**`useSetting(key)` — per-key read primitive.** A typed accessor that routes a logical setting key to its owning store via an explicit table and returns a `Readonly<Ref<Value>>` getter ref. The routing table is the single place that knows where a setting lives, so a later change of backing store touches one spot instead of every consumer.

**Domain facades on top.** For settings that are consumed together, a facade bundles several `useSetting` calls:
- `useAmountDisplaySettings` is rebuilt to read every entry through `useSetting` (no store import, no `storeToRefs`).
- `DateDisplay`, a leaf reading a single key, is migrated to a direct `useSetting('dateDisplayFormat')` call (no facade needed for one key).

The routing table currently holds the keys these two consumers need and grows as more consumers migrate.

## Safety

`use-setting.spec.ts` asserts every mapped key is actually exposed by the store it routes to, and that the returned ref tracks store updates. Verified: `typecheck` clean, unit specs green (routing + store-shape + AmountDisplay component), `lint-staged` clean.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

  N/A: no user-facing behavior change; nothing to document.