### PR TITLE
perf: reuse daily price oracle results for whole day

### DIFF
--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -29,8 +29,14 @@ from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import Price, Timestamp
+from rotkehlchen.utils.misc import timestamp_to_daystart_timestamp
 
-from .types import HistoricalPrice, HistoricalPriceOracle, HistoricalPriceOracleInstance
+from .types import (
+    DAILY_GRANULARITY_ORACLES,
+    HistoricalPrice,
+    HistoricalPriceOracle,
+    HistoricalPriceOracleInstance,
+)
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.oracles.uniswap import UniswapV2Oracle, UniswapV3Oracle
@@ -329,6 +335,17 @@ class PriceHistorian:
         )) is not None:
             return cached_price_entry.price
 
+        # Daily-granularity oracles have a single price per UTC day, cached at the
+        # day-start timestamp, so any same-day query can reuse it without a remote call
+        if (cached_price_entry := GlobalDBHandler.get_historical_price(
+            from_asset=from_asset,
+            to_asset=to_asset,
+            timestamp=timestamp_to_daystart_timestamp(timestamp),
+            max_seconds_distance=0,
+            sources=tuple(source for source in sources if source in DAILY_GRANULARITY_ORACLES),
+        )) is not None:
+            return cached_price_entry.price
+
         # else cryptocompare also has historical fiat to fiat data
         rate_limited = False
         for oracle, oracle_instance in zip(oracles, oracle_instances, strict=True):
@@ -368,7 +385,12 @@ class PriceHistorian:
                 from_asset=from_asset,
                 to_asset=to_asset,
                 source=oracle,
-                timestamp=timestamp,
+                # daily-granularity sources return the same price for the whole UTC
+                # day, so cache at day start to make it reusable by same-day queries
+                timestamp=(
+                    timestamp_to_daystart_timestamp(timestamp)
+                    if oracle in DAILY_GRANULARITY_ORACLES else timestamp
+                ),
                 price=price,
             )])
             return price

--- a/rotkehlchen/history/types.py
+++ b/rotkehlchen/history/types.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, NamedTuple, Union
+from typing import TYPE_CHECKING, Final, NamedTuple, Union
 
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.types import OracleSource, Price, Timestamp
@@ -39,6 +39,12 @@ DEFAULT_HISTORICAL_PRICE_ORACLES_ORDER = (
     HistoricalPriceOracle.UNISWAPV3,
     HistoricalPriceOracle.UNISWAPV2,
 )
+
+# Oracles whose historical endpoint has daily granularity: one price per UTC day.
+# Coingecko's coins/{id}/history takes only a date and returns the 00:00 UTC snapshot.
+# Prices from these sources are cached at the day-start timestamp so that any other
+# query within the same UTC day is served from the cache instead of the remote oracle.
+DAILY_GRANULARITY_ORACLES: Final = {HistoricalPriceOracle.COINGECKO}
 
 
 class HistoricalPrice(NamedTuple):

--- a/rotkehlchen/tests/unit/test_price_historian.py
+++ b/rotkehlchen/tests/unit/test_price_historian.py
@@ -9,6 +9,7 @@ from rotkehlchen.chain.ethereum.oracles.uniswap import UniswapV2Oracle, UniswapV
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V2, CPT_UNISWAP_V3
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.polygon_pos.constants import POLYGON_POS_POL_HARDFORK
+from rotkehlchen.constants import HOUR_IN_SECONDS
 from rotkehlchen.constants.assets import (
     A_AAVE,
     A_BTC,
@@ -43,6 +44,7 @@ from rotkehlchen.types import (
     Timestamp,
     TokenKind,
 )
+from rotkehlchen.utils.misc import timestamp_to_daystart_timestamp
 
 if TYPE_CHECKING:
     from rotkehlchen.assets.asset import FiatAsset
@@ -293,6 +295,53 @@ def test_disabled_historical_oracle_cache_is_ignored(
             to_asset=A_USD,
             timestamp=query_timestamp,
         )
+
+
+def test_daily_oracle_price_reused_for_whole_day(
+        globaldb,
+        fake_price_historian,
+        inquirer,  # pylint: disable=unused-argument
+):
+    """Prices from daily-granularity oracles (coingecko) are cached at the UTC
+    day-start timestamp and reused by any other query in the same UTC day,
+    instead of re-querying the remote oracle for every distinct timestamp.
+    """
+    price_historian = fake_price_historian
+    price_historian.set_oracles_order([HistoricalPriceOracle.COINGECKO])
+    coingecko = price_historian._oracle_instances[0]
+    coingecko.can_query_history.return_value = True
+    coingecko.query_historical_price.return_value = (expected_price := Price(FVal('2080')))
+
+    morning_ts = Timestamp(1611567600)  # 25/01/2021 09:00 UTC
+    assert price_historian.query_historical_price(
+        from_asset=A_BTC,
+        to_asset=A_USD,
+        timestamp=morning_ts,
+    ) == expected_price
+    assert coingecko.query_historical_price.call_count == 1
+    assert globaldb.get_historical_price(  # the price got stored at the day start
+        from_asset=A_BTC,
+        to_asset=A_USD,
+        timestamp=timestamp_to_daystart_timestamp(morning_ts),
+        max_seconds_distance=0,
+    ).price == expected_price
+
+    # queries at other times of the same UTC day are served from the cache
+    for hours_later in (4, 13):
+        assert price_historian.query_historical_price(
+            from_asset=A_BTC,
+            to_asset=A_USD,
+            timestamp=Timestamp(morning_ts + hours_later * HOUR_IN_SECONDS),
+        ) == expected_price
+    assert coingecko.query_historical_price.call_count == 1
+
+    # while a query on the next day hits the remote oracle again
+    assert price_historian.query_historical_price(
+        from_asset=A_BTC,
+        to_asset=A_USD,
+        timestamp=Timestamp(morning_ts + DAY_IN_SECONDS),
+    ) == expected_price
+    assert coingecko.query_historical_price.call_count == 2
 
 
 def test_get_historical_prices(globaldb: 'GlobalDBHandler') -> None:


### PR DESCRIPTION
Coingecko's historical endpoint has daily granularity: it only takes a date and returns the 00:00 UTC snapshot. rotki however cached the result at the exact query timestamp and reused it only within one hour, so a PnL run needing prices for the same asset on the same day at different times re-queried the oracle 3-5 times for the same daily value, burning through the ~30 req/min free tier and stalling report generation on rate limits.

Now prices from daily-granularity oracles are cached at the day-start timestamp and a same-UTC-day cache lookup is done before hitting the network, so each asset-day is fetched at most once. Precise sources (manual, cryptocompare hourly, defillama, alchemy 1h interval) keep the existing exact-timestamp behavior via the primary lookup, which still runs first.

