### PR TITLE
Fix duplicate nginx Host header rejected by uvicorn

### DIFF
--- a/packaging/docker/nginx.conf
+++ b/packaging/docker/nginx.conf
@@ -20,7 +20,6 @@
         proxy_pass_header Set-Cookie;
         proxy_pass http://localhost:4242/api/1/;
         proxy_ssl_session_reuse off;
-        proxy_set_header Host $http_host;
         proxy_cache_bypass $http_upgrade;
         proxy_redirect off;
     }
@@ -37,7 +36,6 @@
         proxy_pass_header Set-Cookie;
         proxy_pass http://localhost:4242$request_uri;
         proxy_ssl_session_reuse off;
-        proxy_set_header Host $http_host;
         proxy_cache_bypass $http_upgrade;
         proxy_redirect off;
     }
@@ -50,7 +48,6 @@
         proxy_pass_header Set-Cookie;
         proxy_pass http://localhost:4343/;
         proxy_ssl_session_reuse off;
-        proxy_set_header Host $http_host;
         proxy_cache_bypass $http_upgrade;
         proxy_redirect off;
     }


### PR DESCRIPTION
Every `/api` and `/colibri` request in the Docker deployment 400s with `Invalid HTTP request received.`, so the frontend can't reach the backend.

Each proxied nginx location sets `proxy_set_header Host` twice (`$host` and `$http_host`), forwarding two `Host` headers. gevent's WSGI server tolerated this; the uvicorn server (after the gevent-removal flip) rejects duplicate `Host` headers per the HTTP spec. Fix: keep a single `Host` per location, matching `/ws`.