### PR TITLE
test: add e2e coverage for remaining settings subpages

### DIFF
--- a/frontend/app/src/modules/settings/data-security/oracle/OraclePenaltyDurationSetting.vue
+++ b/frontend/app/src/modules/settings/data-security/oracle/OraclePenaltyDurationSetting.vue
@@ -60,6 +60,7 @@ onMounted(() => {
         color="primary"
         :min="min"
         class="mt-2"
+        data-testid="oracle-penalty-duration"
         :label="t('oracle_cache_management.penalty.labels.oracle_penalty_duration')"
         type="number"
         :success-messages="success"

--- a/frontend/app/src/modules/settings/frontend/AnimationsEnabledSetting.vue
+++ b/frontend/app/src/modules/settings/frontend/AnimationsEnabledSetting.vue
@@ -31,6 +31,7 @@ function updateSetting(value: boolean, update: (newValue: any) => void) {
     <template #default="{ error, success, updateImmediate }">
       <RuiSwitch
         color="primary"
+        data-testid="animations-enabled"
         :model-value="!animationsEnabled"
         :label="t('frontend_settings.animations.animations_note')"
         :success-messages="success"

--- a/frontend/app/tests/e2e/helpers/utils.ts
+++ b/frontend/app/tests/e2e/helpers/utils.ts
@@ -15,6 +15,22 @@ const DISABLE_ANIMATIONS_CSS = `
 `;
 
 /**
+ * Opens a settings sub-page through the user menu, mirroring the path the rest
+ * of the e2e suite uses. Navigating straight to `/#/settings/<tab>` lands on a
+ * blank shell because the layout's data-bootstrapping never runs.
+ *
+ * @param page - the Playwright page
+ * @param tab - the settings tab id (e.g. `interface`, `modules`, `oracle`)
+ */
+export async function openSettingsTab(page: Page, tab: string): Promise<void> {
+  await page.locator('[data-cy=user-menu-button]').click();
+  await page.locator('[data-cy=user-dropdown]').waitFor({ state: 'visible' });
+  await page.locator('[data-cy=settings-button]').click();
+  await page.locator('[data-cy=user-dropdown]').waitFor({ state: 'detached' });
+  await page.locator(`[data-cy="settings__${tab}"]`).click();
+}
+
+/**
  * Disables CSS animations and transitions on the page for faster test execution.
  */
 export async function disableAnimations(page: Page): Promise<void> {

--- a/frontend/app/tests/e2e/pages/database-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/database-settings-page.ts
@@ -1,0 +1,20 @@
+import { expect, type Page } from '@playwright/test';
+import { TIMEOUT_MEDIUM } from '../helpers/constants';
+import { openSettingsTab } from '../helpers/utils';
+
+const SECTION_IDS = ['database_info', 'user_backups', 'manage_data', 'import_export', 'asset_database'] as const;
+
+export class DatabaseSettingsPage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await openSettingsTab(this.page, 'database');
+    // The manage-data section carries the one stable testid on this page.
+    await this.page.getByTestId('purge-source').waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+  }
+
+  async expectSectionsRendered(): Promise<void> {
+    for (const id of SECTION_IDS)
+      await expect(this.page.locator(`#${id}`)).toBeVisible();
+  }
+}

--- a/frontend/app/tests/e2e/pages/external-services-page.ts
+++ b/frontend/app/tests/e2e/pages/external-services-page.ts
@@ -1,0 +1,77 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { TIMEOUT_DIALOG, TIMEOUT_MEDIUM } from '../helpers/constants';
+import { RotkiApp } from './rotki-app';
+
+export class ExternalServicesPage {
+  private lastPutBody: unknown;
+
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await RotkiApp.navigateTo(this.page, 'api-keys', 'api-keys-external-services');
+    await this.page.locator('[data-cy=external-keys]').waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+  }
+
+  /**
+   * Stubs the external-services endpoints so no real key is persisted. GET
+   * starts empty; PUT captures the request body and echoes the saved key back
+   * in the backend-shaped response.
+   */
+  async setupMocks(): Promise<void> {
+    await this.page.route('**/api/1/external_services', async (route) => {
+      const method = route.request().method();
+      if (method === 'GET') {
+        await route.fulfill({
+          body: JSON.stringify({ message: '', result: {} }),
+          contentType: 'application/json',
+          status: 200,
+        });
+      }
+      else if (method === 'PUT') {
+        this.lastPutBody = route.request().postDataJSON();
+        const service = (route.request().postDataJSON()?.services ?? [])[0] ?? {};
+        await route.fulfill({
+          body: JSON.stringify({ message: '', result: { [service.name]: { api_key: service.api_key } } }),
+          contentType: 'application/json',
+          status: 200,
+        });
+      }
+      else {
+        await route.continue();
+      }
+    });
+  }
+
+  serviceTitle(title: string): Locator {
+    return this.page.locator('[data-cy=external-keys]').getByText(title, { exact: true });
+  }
+
+  async expectServicesRendered(titles: string[]): Promise<void> {
+    for (const title of titles)
+      await expect(this.serviceTitle(title)).toBeVisible();
+  }
+
+  async saveEtherscanKey(key: string): Promise<void> {
+    const card = this.page.locator('[data-cy=etherscan-api-keys]');
+    await card.getByRole('button', { name: 'Enter API key' }).click();
+
+    const dialog = this.page.locator('[data-cy=bottom-dialog]');
+    await dialog.waitFor({ state: 'visible', timeout: TIMEOUT_DIALOG });
+    await dialog.locator('[data-cy=service-key__api-key] input').fill(key);
+    await dialog.locator('[data-cy=confirm]').click();
+  }
+
+  async expectSaveSucceeded(key: string): Promise<void> {
+    await expect
+      .poll(() => JSON.stringify(this.lastPutBody ?? {}))
+      .toContain(key);
+    expect(JSON.stringify(this.lastPutBody)).toContain('etherscan');
+    await expect(this.page.locator('[data-cy=bottom-dialog]').getByText('Successfully updated the key')).toBeVisible();
+  }
+
+  async closeDialog(): Promise<void> {
+    const dialog = this.page.locator('[data-cy=bottom-dialog]');
+    await dialog.locator('[data-cy=cancel]').click();
+    await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_DIALOG });
+  }
+}

--- a/frontend/app/tests/e2e/pages/interface-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/interface-settings-page.ts
@@ -1,0 +1,26 @@
+import { expect, type Page } from '@playwright/test';
+import { TIMEOUT_MEDIUM } from '../helpers/constants';
+import { confirmInlineSuccess, openSettingsTab } from '../helpers/utils';
+
+const SECTION_IDS = ['interface_only', 'graph', 'alias', 'newly_detected_tokens', 'theme'] as const;
+
+export class InterfaceSettingsPage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await openSettingsTab(this.page, 'interface');
+    await this.page.locator('#interface_only').waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+  }
+
+  async expectSectionsRendered(): Promise<void> {
+    for (const id of SECTION_IDS)
+      await expect(this.page.locator(`#${id}`)).toBeVisible();
+  }
+
+  async toggleAnimations(): Promise<void> {
+    const control = this.page.getByTestId('animations-enabled');
+    await control.scrollIntoViewIfNeeded();
+    await control.locator('input').click();
+    await confirmInlineSuccess(this.page, '[data-testid=animations-enabled]');
+  }
+}

--- a/frontend/app/tests/e2e/pages/modules-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/modules-settings-page.ts
@@ -1,0 +1,38 @@
+import { expect, type Page } from '@playwright/test';
+import { TIMEOUT_MEDIUM } from '../helpers/constants';
+import { openSettingsTab } from '../helpers/utils';
+
+export class ModulesSettingsPage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await openSettingsTab(this.page, 'modules');
+    await this.moduleSwitch('makerdao_dsr').waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+  }
+
+  private moduleSwitch(identifier: string) {
+    return this.page.locator(`[data-cy="${identifier}-module-switch"]`);
+  }
+
+  private moduleCheckbox(identifier: string) {
+    return this.moduleSwitch(identifier).locator('input');
+  }
+
+  async isModuleEnabled(identifier: string): Promise<boolean> {
+    return this.moduleCheckbox(identifier).isChecked();
+  }
+
+  async toggleModule(identifier: string): Promise<void> {
+    const before = await this.isModuleEnabled(identifier);
+    await this.moduleSwitch(identifier).click();
+    await expect(this.moduleCheckbox(identifier)).toBeChecked({ checked: !before });
+  }
+
+  async expectModuleEnabled(identifier: string, enabled: boolean): Promise<void> {
+    await expect(this.moduleCheckbox(identifier)).toBeChecked({ checked: enabled });
+  }
+
+  async enableAll(): Promise<void> {
+    await this.page.locator('[data-cy=modules_enable_all]').click();
+  }
+}

--- a/frontend/app/tests/e2e/pages/oracle-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/oracle-settings-page.ts
@@ -1,0 +1,29 @@
+import { expect, type Page } from '@playwright/test';
+import { TIMEOUT_MEDIUM } from '../helpers/constants';
+import { confirmInlineSuccess, openSettingsTab } from '../helpers/utils';
+
+export class OracleSettingsPage {
+  constructor(private readonly page: Page) {}
+
+  async visit(): Promise<void> {
+    await openSettingsTab(this.page, 'oracle');
+    await this.page.locator('#price_oracle').waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
+  }
+
+  async expectSectionsRendered(): Promise<void> {
+    await expect(this.page.locator('#price_oracle')).toBeVisible();
+    await expect(this.page.locator('#penalty')).toBeVisible();
+  }
+
+  async setPenaltyDuration(value: string): Promise<void> {
+    const input = this.page.getByTestId('oracle-penalty-duration').locator('input');
+    await input.scrollIntoViewIfNeeded();
+    await input.fill(value);
+    await input.blur();
+    await confirmInlineSuccess(this.page, '[data-testid=oracle-penalty-duration]');
+  }
+
+  async expectPenaltyDuration(value: string): Promise<void> {
+    await expect(this.page.getByTestId('oracle-penalty-duration').locator('input')).toHaveValue(value);
+  }
+}

--- a/frontend/app/tests/e2e/specs/app/external-services.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/external-services.spec.ts
@@ -1,0 +1,29 @@
+import { test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { ExternalServicesPage } from '../../pages/external-services-page';
+
+test.describe.serial('api-keys::external-services', () => {
+  let ctx: SharedTestContext;
+  let page: ExternalServicesPage;
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request, { disableModules: true });
+    page = new ExternalServicesPage(ctx.sharedPage);
+    await page.setupMocks();
+    await page.visit();
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('lists the external service providers', async () => {
+    await page.expectServicesRendered(['Etherscan', 'CoinGecko', 'CryptoCompare']);
+  });
+
+  test('saves an etherscan api key', async () => {
+    await page.saveEtherscanKey('DUMMY_ETHERSCAN_KEY');
+    await page.expectSaveSucceeded('DUMMY_ETHERSCAN_KEY');
+    await page.closeDialog();
+  });
+});

--- a/frontend/app/tests/e2e/specs/settings/database.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/database.spec.ts
@@ -1,0 +1,22 @@
+import { test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { DatabaseSettingsPage } from '../../pages/database-settings-page';
+
+test.describe.serial('settings::database', () => {
+  let ctx: SharedTestContext;
+  let page: DatabaseSettingsPage;
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request, { disableModules: true });
+    page = new DatabaseSettingsPage(ctx.sharedPage);
+    await page.visit();
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('renders every database settings section', async () => {
+    await page.expectSectionsRendered();
+  });
+});

--- a/frontend/app/tests/e2e/specs/settings/interface.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/interface.spec.ts
@@ -1,0 +1,26 @@
+import { test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { InterfaceSettingsPage } from '../../pages/interface-settings-page';
+
+test.describe.serial('settings::interface', () => {
+  let ctx: SharedTestContext;
+  let page: InterfaceSettingsPage;
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request, { disableModules: true });
+    page = new InterfaceSettingsPage(ctx.sharedPage);
+    await page.visit();
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('renders every interface settings section', async () => {
+    await page.expectSectionsRendered();
+  });
+
+  test('toggles the animations setting and shows inline success', async () => {
+    await page.toggleAnimations();
+  });
+});

--- a/frontend/app/tests/e2e/specs/settings/modules.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/modules.spec.ts
@@ -1,0 +1,32 @@
+import { test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { ModulesSettingsPage } from '../../pages/modules-settings-page';
+
+test.describe.serial('settings::modules', () => {
+  let ctx: SharedTestContext;
+  let page: ModulesSettingsPage;
+  const testModule = 'makerdao_dsr';
+  let expectedState: boolean;
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request, { disableModules: true });
+    page = new ModulesSettingsPage(ctx.sharedPage);
+    await page.visit();
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('toggles a module and reflects the new state', async () => {
+    const before = await page.isModuleEnabled(testModule);
+    await page.toggleModule(testModule);
+    expectedState = !before;
+  });
+
+  test('persists the module state after re-login', async () => {
+    await ctx.app.relogin(ctx.username);
+    await page.visit();
+    await page.expectModuleEnabled(testModule, expectedState);
+  });
+});

--- a/frontend/app/tests/e2e/specs/settings/oracle.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/oracle.spec.ts
@@ -1,0 +1,33 @@
+import { test } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { OracleSettingsPage } from '../../pages/oracle-settings-page';
+
+test.describe.serial('settings::oracle', () => {
+  let ctx: SharedTestContext;
+  let page: OracleSettingsPage;
+  const penaltyDuration = '3600';
+
+  test.beforeAll(async ({ browser, request }) => {
+    ctx = await createLoggedInContext(browser, request, { disableModules: true });
+    page = new OracleSettingsPage(ctx.sharedPage);
+    await page.visit();
+  });
+
+  test.afterAll(async () => {
+    await cleanupContext(ctx);
+  });
+
+  test('renders the price oracle and penalty sections', async () => {
+    await page.expectSectionsRendered();
+  });
+
+  test('changes the oracle penalty duration and shows inline success', async () => {
+    await page.setPenaltyDuration(penaltyDuration);
+  });
+
+  test('persists the penalty duration after re-login', async () => {
+    await ctx.app.relogin(ctx.username);
+    await page.visit();
+    await page.expectPenaltyDuration(penaltyDuration);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Playwright e2e coverage for the P2 items from the coverage audit (#11252): the settings subpages and external-services page that previously had zero coverage.

- **Interface** (`/settings/interface`) — every section renders; toggling the animations setting shows inline "Setting saved".
- **Modules** (`/settings/modules`) — toggle a module and verify the new state persists after re-login.
- **Oracle** (`/settings/oracle`) — both sections render; the penalty-duration setting saves inline and persists after re-login.
- **Database** (`/settings/database`) — every section renders (non-destructive; the purge flow is already covered by `exchange-purge.spec.ts`).
- **API Keys > External Services** (`/api-keys/external`) — lists the providers and saves an Etherscan key through a mocked endpoint (no real key persisted).

## Notes

- Adds a shared `openSettingsTab` helper (the four settings page objects share the user-menu → settings → tab path).
- Adds two `data-testid` hooks for stable selectors: the animations switch and the oracle penalty-duration input. New selectors use `data-testid` per the ongoing `data-cy` → `data-testid` migration.

## Test

`pnpm run test:e2e specs/settings/interface.spec.ts specs/settings/modules.spec.ts specs/settings/oracle.spec.ts specs/settings/database.spec.ts specs/app/external-services.spec.ts` — 10 passed.