### PR TITLE
Vendor what we need from coincurve and bip-utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "sqlcipher3==0.6.2",
     "rotki-sqlite==2025.8.1",
     "requests==2.33.1",
-    "coincurve==21.0.0",
     "bech32==1.2.0",
     "gql[requests]==3.5.2",
     "scalecodec==1.2.11",
@@ -59,7 +58,6 @@ dependencies = [
     "polyleven==0.9",
     # We used to only use this for packaging, but now use it for the version comparison functionality
     "packaging==25.0",
-    "bip-utils==2.12.1",
     # For Google Calendar integration
     "google-api-python-client==2.192.0",
     "google-auth==2.49.1",

--- a/rotkehlchen.spec
+++ b/rotkehlchen.spec
@@ -62,7 +62,7 @@ executable_name = 'rotki-core-{}-{}'.format(
     platform_name,
 )
 
-hiddenimports = ['cytoolz.utils', 'cytoolz._signatures', 'coincurve._cffi_backend']
+hiddenimports = ['cytoolz.utils', 'cytoolz._signatures']
 # Since the exchanges are loaded dynamically and some of them may not be detected
 # by pyinstaller (https://github.com/rotki/rotki/issues/602) make sure they are
 # all included as imports in the created executable

--- a/rotkehlchen/chain/bitcoin/bch/cashaddr.py
+++ b/rotkehlchen/chain/bitcoin/bch/cashaddr.py
@@ -1,0 +1,91 @@
+"""Minimal Bitcoin Cash CashAddr encoder/decoder.
+
+Implemented from the Bitcoin Cash CashAddr specification:
+https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md
+
+It reuses the bit-conversion helper from the existing `bech32` dependency, which packages
+Pieter Wuille's MIT-licensed BIP173 reference implementation.
+
+Added to rotki using Codex and ChatGPT 5.5.
+"""
+
+from typing import Final
+
+import bech32
+
+CHARSET: Final = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+GENERATOR: Final = (0x98f2bc8e61, 0x79b76d99e2, 0xf33e5fb3c4, 0xae2eabe2a8, 0x1e4f43e470)
+
+
+def _prefix_expand(prefix: str) -> list[int]:
+    """Expand a CashAddr prefix into checksum input values."""
+    return [ord(char) & 0x1f for char in prefix] + [0]
+
+
+def _polymod(values: list[int]) -> int:
+    """Return the CashAddr polymod checksum value."""
+    checksum = 1
+    for value in values:
+        top = checksum >> 35
+        checksum = ((checksum & 0x07ffffffff) << 5) ^ value
+        for idx, generator in enumerate(GENERATOR):
+            if top >> idx & 1:
+                checksum ^= generator
+
+    return checksum ^ 1
+
+
+def _create_checksum(prefix: str, payload: list[int]) -> list[int]:
+    """Create the 8-word CashAddr checksum for prefix and payload."""
+    polymod = _polymod(_prefix_expand(prefix) + payload + [0] * 8)
+    return [(polymod >> 5 * (7 - idx)) & 31 for idx in range(8)]
+
+
+def cashaddr_encode(prefix: str, version: bytes, data: bytes) -> str:
+    """Encode a BCH P2PKH/P2SH 20-byte hash as CashAddr."""
+    if len(prefix) == 0 or len(version) != 1 or version[0] not in {0, 8} or len(data) != 20:
+        raise ValueError('Invalid CashAddr data')
+    try:
+        payload = bech32.convertbits(version + data, 8, 5)
+    except ValueError as e:
+        raise ValueError('Invalid CashAddr data') from e
+    if payload is None:
+        raise ValueError('Invalid CashAddr data')
+
+    try:
+        checksum = _create_checksum(prefix, payload)
+    except ValueError as e:
+        raise ValueError('Invalid CashAddr data') from e
+    return prefix + ':' + ''.join(CHARSET[value] for value in payload + checksum)
+
+
+def cashaddr_decode(prefix: str, address: str) -> tuple[bytes, bytes]:
+    """Decode a BCH CashAddr into version byte and 20-byte hash."""
+    if len(prefix) == 0 or (address.upper() != address and address.lower() != address):
+        raise ValueError('Invalid CashAddr data')
+
+    address = address.lower()
+    if ':' not in address:
+        address = prefix + ':' + address
+
+    hrp, encoded = address.split(':', maxsplit=1)
+    if hrp != prefix or len(encoded) < 8 or not all(char in CHARSET for char in encoded):
+        raise ValueError('Invalid CashAddr data')
+
+    payload_with_checksum = [CHARSET.find(char) for char in encoded]
+    try:
+        is_valid_checksum = _polymod(_prefix_expand(hrp) + payload_with_checksum) == 0
+    except ValueError as e:
+        raise ValueError('Invalid CashAddr data') from e
+    if not is_valid_checksum:
+        raise ValueError('Invalid CashAddr data')
+
+    payload_5bit = payload_with_checksum[:-8]
+    try:
+        payload = bech32.convertbits(payload_5bit, 5, 8, False)
+    except ValueError as e:
+        raise ValueError('Invalid CashAddr data') from e
+    if len(payload_5bit) == 0 or payload is None or len(payload) != 21 or payload[0] not in {0, 8}:
+        raise ValueError('Invalid CashAddr data')
+
+    return bytes([payload[0]]), bytes(payload[1:])

--- a/rotkehlchen/chain/bitcoin/bch/constants.py
+++ b/rotkehlchen/chain/bitcoin/bch/constants.py
@@ -9,4 +9,4 @@ HASKOIN_BATCH_SIZE: Final = 100
 
 # Combined with the tx id to create the group identifiers for bitcoin cash transactions.
 BCH_GROUP_IDENTIFIER_PREFIX: Final = 'bch_'
-CASHADDR_PREFIX: Final = 'bitcoincash'  # standard prefix used by bip_utils and other APIs
+CASHADDR_PREFIX: Final = 'bitcoincash'  # standard prefix used by CashAddr APIs

--- a/rotkehlchen/chain/bitcoin/bch/utils.py
+++ b/rotkehlchen/chain/bitcoin/bch/utils.py
@@ -1,10 +1,10 @@
 from typing import Literal
 
 from base58 import b58decode_check, b58encode_check
-from bip_utils.bech32.bch_bech32 import BchBech32Decoder, BchBech32Encoder
 from eth_typing import ChecksumAddress
 from marshmallow import ValidationError
 
+from rotkehlchen.chain.bitcoin.bch.cashaddr import cashaddr_decode, cashaddr_encode
 from rotkehlchen.chain.bitcoin.bch.constants import CASHADDR_PREFIX
 from rotkehlchen.chain.bitcoin.bch.validation import is_valid_bitcoin_cash_address
 from rotkehlchen.chain.bitcoin.validation import is_valid_base58_address
@@ -34,7 +34,7 @@ def cash_to_legacy_address(address: str) -> BTCAddress | None:
         if not address.startswith(CASHADDR_PREFIX):
             address = CASHADDR_PREFIX + ':' + address
 
-        version, data = BchBech32Decoder.Decode(hrp=CASHADDR_PREFIX, addr=address)
+        version, data = cashaddr_decode(prefix=CASHADDR_PREFIX, address=address)
         legacy_version = convert_version(
             version=int.from_bytes(version),
             target_type='legacy',
@@ -71,9 +71,9 @@ def legacy_to_cash_address(address: str) -> BTCAddress | None:
     try:
         decoded = b58decode_check(address)
         cash_version = convert_version(version=decoded[0], target_type='cash')
-        return BTCAddress(BchBech32Encoder.Encode(
-            hrp=CASHADDR_PREFIX,
-            net_ver=bytes([cash_version]),
+        return BTCAddress(cashaddr_encode(
+            prefix=CASHADDR_PREFIX,
+            version=bytes([cash_version]),
             data=decoded[1:],
         ))
     except ValueError:

--- a/rotkehlchen/chain/bitcoin/bch/validation.py
+++ b/rotkehlchen/chain/bitcoin/bch/validation.py
@@ -1,5 +1,4 @@
-from bip_utils.bech32.bch_bech32 import BchBech32Decoder
-
+from rotkehlchen.chain.bitcoin.bch.cashaddr import cashaddr_decode
 from rotkehlchen.chain.bitcoin.bch.constants import CASHADDR_PREFIX
 
 
@@ -16,7 +15,7 @@ def is_valid_bitcoin_cash_address(address: str) -> bool:
         return False
 
     try:
-        BchBech32Decoder.Decode(hrp=CASHADDR_PREFIX, addr=address)
+        cashaddr_decode(prefix=CASHADDR_PREFIX, address=address)
     except ValueError:
         return False
 

--- a/rotkehlchen/chain/bitcoin/hdkey.py
+++ b/rotkehlchen/chain/bitcoin/hdkey.py
@@ -7,8 +7,7 @@ from dataclasses import dataclass
 from enum import auto
 from typing import NamedTuple, Optional, cast
 
-from coincurve import PrivateKey, PublicKey
-
+from rotkehlchen.chain.bitcoin.secp256k1 import PrivateKey, PublicKey
 from rotkehlchen.chain.bitcoin.utils import (
     BIP32_HARDEN,
     WitnessVersion,

--- a/rotkehlchen/chain/bitcoin/secp256k1.py
+++ b/rotkehlchen/chain/bitcoin/secp256k1.py
@@ -1,0 +1,178 @@
+"""Minimal secp256k1 public-key operations used for BIP32 xpub derivation.
+
+Implemented from public specifications:
+- SEC 2, section 2.4.1 for secp256k1 curve parameters.
+- BIP32 for non-hardened public child derivation.
+- BIP340/BIP341/BIP86 for x-only keys, tagged hashing, and Taproot output keys.
+
+Added to rotki using Codex and ChatGPT 5.5.
+"""
+
+import hashlib
+from dataclasses import dataclass
+from typing import Final, NamedTuple, Self
+
+P: Final = 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f
+N: Final = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+
+
+class Point(NamedTuple):
+    """Affine secp256k1 point."""
+
+    x: int
+    y: int
+
+
+G: Final = Point(
+    0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,
+    0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8,
+)
+
+
+def _inverse_mod(value: int) -> int:
+    """Return the inverse of value modulo the field prime."""
+    if value % P == 0:
+        raise ValueError('Cannot invert zero modulo secp256k1 field prime')
+
+    return pow(value, -1, P)
+
+
+def _is_on_curve(point: Point) -> bool:
+    """Return whether point satisfies the secp256k1 curve equation."""
+    return (point.y * point.y - point.x * point.x * point.x - 7) % P == 0
+
+
+def _point_add(first: Point | None, second: Point | None) -> Point | None:
+    """Add two curve points, returning None for the point at infinity."""
+    if first is None:
+        return second
+    if second is None:
+        return first
+    if first.x == second.x and (first.y != second.y or first.y == 0):
+        return None
+
+    if first == second:
+        slope = (3 * first.x * first.x * _inverse_mod(2 * first.y)) % P
+    else:
+        slope = ((second.y - first.y) * _inverse_mod(second.x - first.x)) % P
+
+    x = (slope * slope - first.x - second.x) % P
+    return Point(x=x, y=(slope * (first.x - x) - first.y) % P)
+
+
+def _point_mul(scalar: int, point: Point) -> Point | None:
+    """Multiply a curve point by a non-negative scalar."""
+    if scalar < 0:
+        raise ValueError('Invalid negative secp256k1 scalar')
+
+    result: Point | None = None
+    addend: Point | None = point
+    while scalar:
+        if scalar & 1:
+            result = _point_add(result, addend)
+        addend = _point_add(addend, addend)
+        scalar >>= 1
+
+    return result
+
+
+def _lift_x_even_y(x: int) -> Point:
+    """Lift an x coordinate to the even-y secp256k1 point."""
+    if not 0 <= x < P:
+        raise ValueError('Invalid secp256k1 public key')
+
+    y = pow((x * x * x + 7) % P, (P + 1) // 4, P)
+    if (y * y - x * x * x - 7) % P != 0:
+        raise ValueError('Invalid secp256k1 public key')
+    return Point(x=x, y=P - y if y % 2 == 1 else y)
+
+
+def _parse_public_key(data: bytes) -> Point:
+    """Parse a compressed SEC public key into a curve point."""
+    if len(data) != 33 or data[0] not in {2, 3}:
+        raise ValueError('Invalid secp256k1 compressed public key')
+
+    point = _lift_x_even_y(x=int.from_bytes(data[1:], byteorder='big'))
+    if point.y % 2 != data[0] & 1:
+        point = Point(x=point.x, y=P - point.y)
+    if not _is_on_curve(point):
+        raise ValueError('Invalid secp256k1 public key')
+
+    return point
+
+
+def _tagged_hash(tag: bytes, data: bytes) -> bytes:
+    """Return a BIP340 tagged SHA-256 hash."""
+    tag_hash = hashlib.sha256(tag).digest()
+    return hashlib.sha256(tag_hash + tag_hash + data).digest()
+
+
+@dataclass(frozen=True)
+class PublicKey:
+    """Small coincurve-compatible compressed secp256k1 public-key wrapper."""
+
+    _point: Point
+
+    def __init__(self, data: bytes | Point) -> None:
+        """Create a public key from a compressed SEC key or internal point."""
+        if isinstance(data, Point):
+            if not _is_on_curve(data):
+                raise ValueError('Invalid secp256k1 public key')
+            point = data
+        else:
+            point = _parse_public_key(data)
+
+        object.__setattr__(
+            self,
+            '_point',
+            point,
+        )
+
+    def format(self, compressed: bool = True) -> bytes:
+        """Serialize the key in compressed SEC format."""
+        if compressed is not True:
+            raise ValueError('Only compressed public keys are supported')
+
+        return bytes([2 + (self._point.y & 1)]) + self._point.x.to_bytes(32, byteorder='big')
+
+    def add(self, tweak: bytes) -> Self:
+        """Return this public key plus tweak * G."""
+        if len(tweak) != 32 or not 0 < (tweak_int := int.from_bytes(tweak, byteorder='big')) < N:
+            raise ValueError('Invalid secp256k1 tweak')
+        try:
+            tweak_point = _point_mul(tweak_int, G)
+            result = _point_add(self._point, tweak_point)
+        except ValueError as e:
+            raise ValueError('Invalid secp256k1 tweak') from e
+        if tweak_point is None or result is None:
+            raise ValueError('Invalid secp256k1 tweak')
+
+        try:
+            return type(self)(result)
+        except ValueError as e:
+            raise ValueError('Invalid secp256k1 tweak') from e
+
+    def taproot_output_key(self) -> bytes:
+        """Return the BIP86 tweaked x-only Taproot output key."""
+        internal_key = self._point.x.to_bytes(32, byteorder='big')
+        tweak = _tagged_hash(b'TapTweak', internal_key)
+        if not 0 <= (tweak_int := int.from_bytes(tweak, byteorder='big')) < N:
+            raise ValueError('Invalid taproot tweak')
+        try:
+            result = _point_add(
+                _lift_x_even_y(self._point.x),
+                _point_mul(tweak_int, G) if tweak_int != 0 else None,
+            )
+        except ValueError as e:
+            raise ValueError('Invalid taproot tweak') from e
+        if result is None:
+            raise ValueError('Invalid taproot tweak')
+
+        return result.x.to_bytes(32, byteorder='big')
+
+
+@dataclass(frozen=True)
+class PrivateKey:
+    """Compatibility container for existing type and `.secret` references."""
+
+    secret: bytes

--- a/rotkehlchen/chain/bitcoin/secp256k1.py
+++ b/rotkehlchen/chain/bitcoin/secp256k1.py
@@ -60,20 +60,70 @@ def _point_add(first: Point | None, second: Point | None) -> Point | None:
     return Point(x=x, y=(slope * (first.x - x) - first.y) % P)
 
 
+def _jacobian_double(x: int, y: int, z: int) -> tuple[int, int, int]:
+    """Double a Jacobian point, using (0, 1, 0) as infinity."""
+    if z == 0 or y == 0:
+        return 0, 1, 0
+
+    s = 4 * x * y % P * y % P
+    m = 3 * x * x % P
+    nx = (m * m - 2 * s) % P
+    y_sq = y * y % P
+    return nx, (m * (s - nx) - 8 * y_sq * y_sq) % P, 2 * y * z % P
+
+
+def _jacobian_add(
+        x1: int,
+        y1: int,
+        z1: int,
+        x2: int,
+        y2: int,
+        z2: int,
+) -> tuple[int, int, int]:
+    """Add two Jacobian points, using (0, 1, 0) as infinity."""
+    if z1 == 0:
+        return x2, y2, z2
+    if z2 == 0:
+        return x1, y1, z1
+
+    z1_sq, z2_sq = z1 * z1 % P, z2 * z2 % P
+    u1, u2 = x1 * z2_sq % P, x2 * z1_sq % P
+    s1, s2 = y1 * z2_sq % P * z2 % P, y2 * z1_sq % P * z1 % P
+    if u1 == u2:
+        if s1 != s2:
+            return 0, 1, 0
+        return _jacobian_double(x1, y1, z1)
+
+    h, r = (u2 - u1) % P, (s2 - s1) % P
+    h_sq = h * h % P
+    h_cb = h_sq * h % P
+    nx = (r * r - h_cb - 2 * u1 * h_sq) % P
+    return nx, (r * (u1 * h_sq - nx) - s1 * h_cb) % P, h * z1 % P * z2 % P
+
+
 def _point_mul(scalar: int, point: Point) -> Point | None:
-    """Multiply a curve point by a non-negative scalar."""
+    """Multiply a curve point by a non-negative scalar.
+
+    Uses Jacobian coordinates so the multiplication needs a single field inversion instead
+    of one per point addition/doubling.
+    """
     if scalar < 0:
         raise ValueError('Invalid negative secp256k1 scalar')
 
-    result: Point | None = None
-    addend: Point | None = point
+    rx, ry, rz = 0, 1, 0
+    ax, ay, az = point.x, point.y, 1
     while scalar:
         if scalar & 1:
-            result = _point_add(result, addend)
-        addend = _point_add(addend, addend)
+            rx, ry, rz = _jacobian_add(rx, ry, rz, ax, ay, az)
+        ax, ay, az = _jacobian_double(ax, ay, az)
         scalar >>= 1
 
-    return result
+    if rz == 0:
+        return None
+
+    z_inv = _inverse_mod(rz)
+    z_inv_sq = z_inv * z_inv % P
+    return Point(x=rx * z_inv_sq % P, y=ry * z_inv_sq % P * z_inv % P)
 
 
 def _lift_x_even_y(x: int) -> Point:

--- a/rotkehlchen/chain/bitcoin/segwit.py
+++ b/rotkehlchen/chain/bitcoin/segwit.py
@@ -67,7 +67,7 @@ def is_valid_bech32m_segwit_address(hrp: str, address: str) -> bool:
     address = address.lower()
     data = [CHARSET.find(char) for char in address[address.rfind('1') + 1:-6]]
     if (
-        not address.startswith(hrp + '1') or
+        address[:address.rfind('1')] != hrp or
         len(data) == 0 or
         data[0] > 16 or
         (decoded := bech32.convertbits(data[1:], 5, 8, False)) is None or

--- a/rotkehlchen/chain/bitcoin/segwit.py
+++ b/rotkehlchen/chain/bitcoin/segwit.py
@@ -1,0 +1,78 @@
+"""Small Bech32/Bech32m helpers for Bitcoin SegWit addresses.
+
+This module builds on the existing `bech32` dependency, which packages Pieter Wuille's
+MIT-licensed reference implementation for BIP173 Bech32. Bech32m handling is implemented
+from BIP350 by using the BIP350 checksum constant with the same polymod algorithm.
+
+Added to rotki using Codex and ChatGPT 5.5.
+"""
+
+from typing import Final
+
+import bech32
+
+CHARSET: Final = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+BECH32_CONST: Final = 1
+BECH32M_CONST: Final = 0x2bc830a3
+
+
+def _checksum_constant(address: str) -> int | None:
+    """Return the Bech32 checksum constant for address, if structurally valid."""
+    if (
+        any(ord(char) < 33 or ord(char) > 126 for char in address) or
+        (address.lower() != address and address.upper() != address)
+    ):
+        return None
+
+    address = address.lower()
+    if (pos := address.rfind('1')) < 1 or pos + 7 > len(address):
+        return None
+    if not all(char in CHARSET for char in address[pos + 1:]):
+        return None
+
+    values = [CHARSET.find(char) for char in address[pos + 1:]]
+    return bech32.bech32_polymod(bech32.bech32_hrp_expand(address[:pos]) + values)
+
+
+def encode_segwit_address(hrp: str, witness_version: int, witness_program: bytes) -> str:
+    """Encode a SegWit witness program as Bech32 or Bech32m."""
+    if (
+        len(hrp) == 0 or
+        not 0 <= witness_version <= 16 or
+        not 2 <= len(witness_program) <= 40 or
+        (witness_version == 0 and len(witness_program) not in {20, 32})
+    ):
+        raise ValueError('Invalid SegWit address data')
+
+    try:
+        converted = bech32.convertbits(witness_program, 8, 5)
+    except ValueError as e:
+        raise ValueError('Invalid SegWit address data') from e
+    if converted is None:
+        raise ValueError('Invalid SegWit address data')
+
+    data = [witness_version] + converted
+    const = BECH32_CONST if witness_version == 0 else BECH32M_CONST
+    values = bech32.bech32_hrp_expand(hrp) + data
+    polymod = bech32.bech32_polymod(values + [0, 0, 0, 0, 0, 0]) ^ const
+    checksum = [(polymod >> 5 * (5 - idx)) & 31 for idx in range(6)]
+    return hrp + '1' + ''.join(CHARSET[value] for value in data + checksum)
+
+
+def is_valid_bech32m_segwit_address(hrp: str, address: str) -> bool:
+    """Return whether address is a valid Bech32m SegWit address for hrp."""
+    if _checksum_constant(address) != BECH32M_CONST:
+        return False
+
+    address = address.lower()
+    data = [CHARSET.find(char) for char in address[address.rfind('1') + 1:-6]]
+    if (
+        not address.startswith(hrp + '1') or
+        len(data) == 0 or
+        data[0] > 16 or
+        (decoded := bech32.convertbits(data[1:], 5, 8, False)) is None or
+        not 2 <= len(decoded) <= 40
+    ):
+        return False
+
+    return data[0] != 0

--- a/rotkehlchen/chain/bitcoin/utils.py
+++ b/rotkehlchen/chain/bitcoin/utils.py
@@ -8,9 +8,10 @@ from typing import TYPE_CHECKING, Any
 
 import bech32
 import requests
-from bip_utils import P2TRAddrEncoder, P2WPKHAddrEncoder
 
 from rotkehlchen.chain.bitcoin.bch.validation import is_valid_bitcoin_cash_address
+from rotkehlchen.chain.bitcoin.secp256k1 import PublicKey
+from rotkehlchen.chain.bitcoin.segwit import encode_segwit_address
 from rotkehlchen.chain.bitcoin.validation import is_valid_btc_address
 from rotkehlchen.constants.timing import GLOBAL_REQUESTS_TIMEOUT
 from rotkehlchen.db.settings import CachedSettings
@@ -130,9 +131,9 @@ def pubkey_to_bech32_address(data: bytes, witver: WitnessVersion) -> BTCAddress:
     """
     try:
         if witver == WitnessVersion.BECH32:
-            result = P2WPKHAddrEncoder.EncodeKey(pub_key=data, hrp='bc')
+            result = encode_segwit_address('bc', 0, hash160(data))
         else:
-            result = P2TRAddrEncoder.EncodeKey(pub_key=data, hrp='bc')
+            result = encode_segwit_address('bc', 1, PublicKey(data).taproot_output_key())
     except ValueError as e:
         raise EncodingError('Could not derive Bech32 address from given public key') from e
     return BTCAddress(result)

--- a/rotkehlchen/chain/bitcoin/utils.py
+++ b/rotkehlchen/chain/bitcoin/utils.py
@@ -131,7 +131,7 @@ def pubkey_to_bech32_address(data: bytes, witver: WitnessVersion) -> BTCAddress:
     """
     try:
         if witver == WitnessVersion.BECH32:
-            result = encode_segwit_address('bc', 0, hash160(data))
+            result = encode_segwit_address('bc', 0, hash160(PublicKey(data).format()))
         else:
             result = encode_segwit_address('bc', 1, PublicKey(data).taproot_output_key())
     except ValueError as e:

--- a/rotkehlchen/chain/bitcoin/validation.py
+++ b/rotkehlchen/chain/bitcoin/validation.py
@@ -1,8 +1,8 @@
 import hashlib
 
 import bech32
-from bip_utils import Bech32ChecksumError, SegwitBech32Decoder
 
+from rotkehlchen.chain.bitcoin.segwit import is_valid_bech32m_segwit_address
 from rotkehlchen.utils.base58 import b58decode, b58encode
 
 
@@ -34,12 +34,7 @@ def is_valid_bech32_bip350_address(value: str) -> bool:
     This validation is based on BIP-350 which improves on a flaw in BIP-173
     https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
     """
-    try:
-        SegwitBech32Decoder.Decode('bc', value)
-    except (ValueError, Bech32ChecksumError):
-        return False
-    else:
-        return True
+    return is_valid_bech32m_segwit_address('bc', value)
 
 
 def is_valid_base58_address(value: str) -> bool:

--- a/rotkehlchen/tests/unit/test_bitcoin.py
+++ b/rotkehlchen/tests/unit/test_bitcoin.py
@@ -7,6 +7,7 @@ import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.chain.bitcoin.hdkey import HDKey, XpubType
+from rotkehlchen.chain.bitcoin.secp256k1 import PublicKey
 from rotkehlchen.chain.bitcoin.utils import (
     WitnessVersion,
     is_valid_derivation_path,
@@ -294,6 +295,23 @@ def test_from_bad_xpub():
         HDKey.from_xpub('xpriv68V4ZQQ62mea7ZUKn2urQu47Bdn2Wr7SxrBxBDDwE3kjytj361YBGSKDT4WoBrE5htrSB8eAMe59NPnKrcAbiv2veN5GQUmfdjRddD1Hxrk')
     with pytest.raises(XPUBError):
         HDKey.from_xpub('apfiv68V4ZQQ62mea7ZUKn2urQu47Bdn2Wr7SxrBxBDDwE3kjytj361YBGSKDT4WoBrE5htrSB8eAMe59NPnKrcAbiv2veN5GQUmfdjRddD1Hxrk')
+
+
+def test_secp256k1_public_key_validation_and_tweaks():
+    key = PublicKey(bytes.fromhex(
+        '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    ))
+    assert key.format(compressed=True) == bytes.fromhex(
+        '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+    )
+    assert key.add((1).to_bytes(32, byteorder='big')).format(compressed=True) == bytes.fromhex(
+        '02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5',
+    )
+
+    with pytest.raises(ValueError):
+        PublicKey(b'\x02' + b'\x00' * 32)
+    with pytest.raises(ValueError):
+        key.add(b'\x00' * 32)
 
 
 def test_xpub_data_comparison():

--- a/rotkehlchen/tests/unit/test_bitcoin.py
+++ b/rotkehlchen/tests/unit/test_bitcoin.py
@@ -86,6 +86,12 @@ def test_is_valid_btc_address():
     assert not is_valid_btc_address('BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R')  # noqa: E501
 
 
+def test_bech32m_hrp_must_match_exactly():
+    """A bech32m string whose hrp merely starts with bc1 is not a bitcoin address."""
+    assert is_valid_btc_address('bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0')  # BIP-350 valid vector  # noqa: E501
+    assert not is_valid_btc_address('bc1b1pqqqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0sed2y4h')  # hrp is bc1b, encoded with a valid bech32m checksum  # noqa: E501
+
+
 def test_pubkey_to_base58_address():
     """Test vectors from here: https://iancoleman.io/bip39/"""
     address = pubkey_to_base58_address(

--- a/uv.lock
+++ b/uv.lock
@@ -232,27 +232,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bip-utils"
-version = "2.12.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cbor2" },
-    { name = "coincurve" },
-    { name = "crcmod" },
-    { name = "ecdsa" },
-    { name = "ed25519-blake2b-fork" },
-    { name = "py-sr25519-bindings" },
-    { name = "pycryptodome" },
-    { name = "pynacl" },
-    { name = "pytoniq-core-fork" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/1b/417d040f1f31a9438eef1f874655db126662e7293c9bbaf28d056616cedd/bip_utils-2.12.1.tar.gz", hash = "sha256:23a88779620a981237227c7482bc316f8ce877a543c736fb00b1e4a7762d1978", size = 608036, upload-time = "2026-03-02T11:43:02.998Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/4d/d5be7df07e694d2a238808a9a8db20e0b2a722c087b63915d901a1dcb3db/bip_utils-2.12.1-py3-none-any.whl", hash = "sha256:167189f40bad8e747f35b54764eebdf9fabd3b165293149951e5ccbf5a624a2c", size = 634612, upload-time = "2026-03-02T11:43:01.304Z" },
-]
-
-[[package]]
 name = "bitarray"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -399,24 +378,6 @@ wheels = [
 ]
 
 [[package]]
-name = "coincurve"
-version = "21.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/a2/f2a38eb05b747ed3e54e1be33be339d4a14c1f5cc6a6e2b342b5e8160d51/coincurve-21.0.0.tar.gz", hash = "sha256:8b37ce4265a82bebf0e796e21a769e56fdbf8420411ccbe3fafee4ed75b6a6e5", size = 128986, upload-time = "2025-03-08T15:31:24.266Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/5a/9aaa096d830b5d1386335759e73038a5352f8cd670efed55d242f92d0bce/coincurve-21.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:65ec42cab9c60d587fb6275c71f0ebc580625c377a894c4818fb2a2b583a184b", size = 1390936, upload-time = "2025-03-08T15:30:14.716Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/e4/37dd30ed171432e32c075a03237915c0e69a5a524a807f380d910b276a2a/coincurve-21.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5828cd08eab928db899238874d1aab12fa1236f30fe095a3b7e26a5fc81df0a3", size = 1384762, upload-time = "2025-03-08T15:30:16.475Z" },
-    { url = "https://files.pythonhosted.org/packages/09/fd/78870f4babed4981feb9b97b3189aec0f01a1a24be8a1ac04807dc68aa0d/coincurve-21.0.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54de1cac75182de9f71ce41415faafcaf788303e21cbd0188064e268d61625e5", size = 1597025, upload-time = "2025-03-08T15:30:18.566Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/fb/b4850f8afc941655ef4c1204b50f9e21f841c6a64aa83a559277ca305cbd/coincurve-21.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07cda058d9394bea30d57a92fdc18ee3ca6b5bc8ef776a479a2ffec917105836", size = 1603987, upload-time = "2025-03-08T15:30:20.65Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/b7/df41dbcec3f70e383fa024949ce8956ff3b2a1b9eac330fba18c2115eece/coincurve-21.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9070804d7c71badfe4f0bf19b728cfe7c70c12e733938ead6b1db37920b745c0", size = 1604762, upload-time = "2025-03-08T15:30:22.271Z" },
-    { url = "https://files.pythonhosted.org/packages/70/84/1b2437fc22590073eefb3da0418648b2d5b768951ef851822be8c164b998/coincurve-21.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:669ab5db393637824b226de058bb7ea0cb9a0236e1842d7b22f74d4a8a1f1ff1", size = 1637469, upload-time = "2025-03-08T15:30:24.305Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/4b/893763b3964b3044071a450fdada4c5024dc16f7644258a7bd06cf41e2ba/coincurve-21.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3bcd538af097b3914ec3cb654262e72e224f95f2e9c1eb7fbd75d843ae4e528e", size = 1601177, upload-time = "2025-03-08T15:30:25.805Z" },
-    { url = "https://files.pythonhosted.org/packages/77/45/d2f42159cb461f5b070ff848244f1b83f3ea9ec3a3435368f9be33e4e276/coincurve-21.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45b6a5e6b5536e1f46f729829d99ce1f8f847308d339e8880fe7fa1646935c10", size = 1635597, upload-time = "2025-03-08T15:30:28.113Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/7c/528cff0aa17acd6c64b10c4bd8bb0adb6c96420be4e170916150537f36f6/coincurve-21.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:87597cf30dfc05fa74218810776efacf8816813ab9fa6ea1490f94e9f8b15e77", size = 1328626, upload-time = "2025-03-08T15:30:29.757Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/91/845b00da05b132e7bb3f3d1c4c301c195b39a9dc8f9962295ff340a27f18/coincurve-21.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:b992d1b1dac85d7f542d9acbcf245667438839484d7f2b032fd032256bcd778e", size = 1325365, upload-time = "2025-03-08T15:30:31.405Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -484,12 +445,6 @@ wheels = [
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
-
-[[package]]
-name = "crcmod"
-version = "1.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/b0/e595ce2a2527e169c3bcd6c33d2473c1918e0b7f6826a043ca1245dd4e5b/crcmod-1.7.tar.gz", hash = "sha256:dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e", size = 89670, upload-time = "2010-06-27T14:35:29.538Z" }
 
 [[package]]
 name = "cryptography"
@@ -601,24 +556,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
-]
-
-[[package]]
-name = "ed25519-blake2b-fork"
-version = "1.4.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/a1/ab4571f6aba346189658856e72a04a9383a62c6a20df2ffec2d04093b00a/ed25519_blake2b_fork-1.4.2.tar.gz", hash = "sha256:dd5d2f645b9a2f7e9834bae56ee348182e19f1528495e7186761384d8afd7f6f", size = 854701, upload-time = "2026-03-02T10:52:32.187Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/69/8fe3065861c4583445c11494a020f362da32519a073ec2e7bf6d907f8f51/ed25519_blake2b_fork-1.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ab18b99034de2de3750f0cd468e93767968dcd32f4431ca8f2c94f187e0ef069", size = 69230, upload-time = "2026-03-02T10:51:26.408Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/85/fcb77ce127c19525a34a806cee071b7af33aca2e8828d522af9b0823dd61/ed25519_blake2b_fork-1.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:246bff18ff0385469140fe17599c68f54df40e6ce84f65dd08df53e14ed19e48", size = 72274, upload-time = "2026-03-02T10:51:27.479Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/fe/d837e902115e494d8b09039ea16090cd9c7fbc69ce9a159ebd30ceaa69b2/ed25519_blake2b_fork-1.4.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a8dd2e94ce9483599effc534efe2e24738a9909a51d342b7d6ba176b47177a63", size = 123902, upload-time = "2026-03-02T10:51:28.625Z" },
-    { url = "https://files.pythonhosted.org/packages/96/90/97b651750d9b674ba829cd362b6c6732c867d219c2836eb7091585e20c24/ed25519_blake2b_fork-1.4.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a8c489b541bd3095a0aa485c4974ec3e9f64c1fda6e1f32787e5504747b66b26", size = 132489, upload-time = "2026-03-02T10:51:30.112Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1b/475f0a04e4483fabb7faa2829c4a22ed16f05fc03fef21b26a4b2d54752e/ed25519_blake2b_fork-1.4.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3cc0523703bd1e5ccb4ca332d75b1011e74ad5b4c89c0cc7098a2d8a9588979", size = 132496, upload-time = "2026-03-02T10:51:31.053Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/2b/208112c24450570643b33da1a40a1afbdb436a7f21d4f15cf49faf6bdd43/ed25519_blake2b_fork-1.4.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:681f0d377de5946f72c401470234bbb099bb5b4266737b0ae4c2d02b2a9a3383", size = 122110, upload-time = "2026-03-02T10:51:31.945Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/73/4f9e42929f85e0081c721e408e9a2dd94d5bb40e5e1c85c7336e0255bb65/ed25519_blake2b_fork-1.4.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e6816949ec401567e9f5fb731ad866ab9e37370d041c48d08f4d6ce1415183ef", size = 130755, upload-time = "2026-03-02T10:51:33.154Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/a6/5620fbbdf38ed6176896c5950e945536840d4b0f8e9504f4f9334650997e/ed25519_blake2b_fork-1.4.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:15c6bfcad5a4b9ef2c51b6b7596f3c61f5db02e99425b321ed72c73ad17a374b", size = 132685, upload-time = "2026-03-02T10:51:34.341Z" },
-    { url = "https://files.pythonhosted.org/packages/25/1b/9a6daedfb02df4b49f4253f287560bb3580f3beb6381811dc93fc8c88bdd/ed25519_blake2b_fork-1.4.2-cp311-cp311-win32.whl", hash = "sha256:15a3d6da858cf8b0400e33f38891be0c6428ddc3b06d50556e9d954d947bb5af", size = 74725, upload-time = "2026-03-02T10:51:35.23Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/bd/0ed119582a3ff84d25c3a9930bdb810b022596f4bdf5a95ab047f9736fab/ed25519_blake2b_fork-1.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:e988ff18c6d91a4d6d8cee108264af694d7bd6e2ff998fb5efdc128d0a39df2c", size = 71128, upload-time = "2026-03-02T10:51:36.795Z" },
 ]
 
 [[package]]
@@ -1965,23 +1902,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytoniq-core-fork"
-version = "0.1.48"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bitarray" },
-    { name = "pycryptodomex" },
-    { name = "pynacl" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-    { name = "x25519" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/73/aa/f345c0bdb04dc7f323fdf0708129e54ca95c0435ff57a4b404f8d628c9fd/pytoniq_core_fork-0.1.48.tar.gz", hash = "sha256:eeb22d5f3d9fb15daccc48df5b2faf53e45426503c51bf665b56138a6955ae4a", size = 115892, upload-time = "2026-02-27T10:38:53.432Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/5f/b967b7812438fd72b06c2a0d68299167d5d96147fb1af38ed65c91f00fbc/pytoniq_core_fork-0.1.48-py3-none-any.whl", hash = "sha256:248b0d0b2deffd6935599208ae587dc703fccf2756d735420e95804b5738177f", size = 106753, upload-time = "2026-02-27T10:38:52.047Z" },
-]
-
-[[package]]
 name = "pyunormalize"
 version = "16.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2113,9 +2033,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "beautifulsoup4" },
     { name = "bech32" },
-    { name = "bip-utils" },
     { name = "cbor2" },
-    { name = "coincurve" },
     { name = "content-hash" },
     { name = "cryptography" },
     { name = "eth-abi" },
@@ -2232,9 +2150,7 @@ requires-dist = [
     { name = "aiohttp", specifier = "==3.14.1" },
     { name = "beautifulsoup4", specifier = "==4.14.2" },
     { name = "bech32", specifier = "==1.2.0" },
-    { name = "bip-utils", specifier = "==2.12.1" },
     { name = "cbor2", specifier = "==5.9.0" },
-    { name = "coincurve", specifier = "==21.0.0" },
     { name = "content-hash", specifier = "==2.0.0" },
     { name = "cryptography", specifier = "==48.0.1" },
     { name = "eth-abi", specifier = "==5.2.0" },
@@ -3143,15 +3059,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/fa/9fb6e594f2ce03ef03eddbdb5f4f90acb1452221a5351116c7c4708ac865/wrapt-1.17.2-cp311-cp311-win32.whl", hash = "sha256:4afd5814270fdf6380616b321fd31435a462019d834f83c8611a0ce7484c7317", size = 36419, upload-time = "2025-01-14T10:33:53.551Z" },
     { url = "https://files.pythonhosted.org/packages/47/f8/fb1773491a253cbc123c5d5dc15c86041f746ed30416535f2a8df1f4a392/wrapt-1.17.2-cp311-cp311-win_amd64.whl", hash = "sha256:acc130bc0375999da18e3d19e5a86403667ac0c4042a094fefb7eec8ebac7cf3", size = 38773, upload-time = "2025-01-14T10:33:56.323Z" },
     { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594, upload-time = "2025-01-14T10:35:44.018Z" },
-]
-
-[[package]]
-name = "x25519"
-version = "0.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/b6/fca895aff0800cdf941f856df0685a5513094163664b904576e3e3ef1460/x25519-0.0.2.tar.gz", hash = "sha256:ed91d0aba7f4f4959ed8b37118c11d94f56d36c38bb6f2e6c20d0438d75b1556", size = 4833, upload-time = "2021-10-24T15:18:38.051Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/d1/66c637eb8e7a9601675bf7f04bb9a3015358a0f49e4c31d29a2b9a9d72d9/x25519-0.0.2-py3-none-any.whl", hash = "sha256:5c0833260a548bea9137a5a1b5c30334b751a59d148a62832df0c9e7b919ce99", size = 4907, upload-time = "2021-10-24T15:18:36.727Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The reason to vendor is that coincurve is not compatible with python 3.14 and bip-utils also depends on coincurve
