### PR TITLE
test: add unit specs for history and balances/accounts/assets

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/use-address-book-deletion.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-book-deletion.spec.ts
@@ -1,0 +1,58 @@
+import type { AddressBookEntry } from '@/modules/accounts/address-book/eth-names';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAddressBookDeletion } from './use-address-book-deletion';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    show: vi.fn(),
+    notifyError: vi.fn(),
+    deleteAddressBook: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): object => ({ show: spies.show }),
+}));
+vi.mock('@/modules/core/notifications/use-notifications', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
+  return { ...actual, useNotifications: (): object => ({ notifyError: spies.notifyError }) };
+});
+vi.mock('@/modules/accounts/address-book/use-address-book-operations', () => ({
+  useAddressBookOperations: (): object => ({ deleteAddressBook: spies.deleteAddressBook }),
+}));
+
+describe('useAddressBookDeletion', () => {
+  beforeEach(() => {
+    spies.deleteAddressBook.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should delete an entry and call the success callback', async () => {
+    const onSuccess = vi.fn();
+    const { deleteAddressBook } = useAddressBookDeletion('private', onSuccess);
+    await deleteAddressBook('0xabc', 'eth');
+    expect(spies.deleteAddressBook).toHaveBeenCalledWith('private', [{ address: '0xabc', blockchain: 'eth' }]);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it('should notify and skip the callback when deletion fails', async () => {
+    spies.deleteAddressBook.mockRejectedValue(new Error('boom'));
+    const onSuccess = vi.fn();
+    const { deleteAddressBook } = useAddressBookDeletion('global', onSuccess);
+    await deleteAddressBook('0xabc', null);
+    expect(spies.notifyError).toHaveBeenCalledOnce();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should delete through the confirmation dialog', async () => {
+    const { showDeleteConfirmation } = useAddressBookDeletion('private');
+    showDeleteConfirmation(createMock<AddressBookEntry>({ address: '0xdef', blockchain: 'optimism' }));
+    expect(spies.show).toHaveBeenCalledOnce();
+    await spies.show.mock.calls[0][1]();
+    expect(spies.deleteAddressBook).toHaveBeenCalledWith('private', [{ address: '0xdef', blockchain: 'optimism' }]);
+  });
+});

--- a/frontend/app/src/modules/accounts/use-blockchain-accounts-store.spec.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-accounts-store.spec.ts
@@ -1,0 +1,72 @@
+import type { BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBlockchainAccountsStore } from './use-blockchain-accounts-store';
+
+vi.mock('@/modules/accounts/account-utils', () => ({
+  getAccountAddress: (account: { data: { address: string } }): string => account.data.address,
+}));
+
+// real objects (not createMock) because the store spreads accounts `{ ...account }`.
+function account(address: string, tags: string[] = [], label = ''): BlockchainAccount {
+  return { chain: 'eth', data: { address, type: 'address' }, label, nativeAsset: 'ETH', tags };
+}
+
+describe('useBlockchainAccountsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should store and read accounts per chain', () => {
+    const store = useBlockchainAccountsStore();
+    store.updateAccounts('eth', [account('0x1')]);
+    expect(store.getAccounts('eth')).toHaveLength(1);
+    expect(store.getAccounts('missing')).toEqual([]);
+  });
+
+  it('should update the label and tags of the matching address', () => {
+    const store = useBlockchainAccountsStore();
+    store.updateAccounts('eth', [account('0x1'), account('0x2')]);
+    store.updateAccountData({ address: '0x1', label: 'Renamed', tags: ['vip'] });
+    const updated = store.getAccountByAddress('0x1', 'eth');
+    expect(updated?.label).toBe('Renamed');
+    expect(updated?.tags).toEqual(['vip']);
+    expect(store.getAccountByAddress('0x2', 'eth')?.label).toBe('');
+  });
+
+  it('should find an account by address with or without a chain hint', () => {
+    const store = useBlockchainAccountsStore();
+    store.updateAccounts('eth', [account('0x1')]);
+    store.updateAccounts('gnosis', [account('0x2')]);
+    expect(store.getAccountByAddress('0x2')).toBeDefined();
+    expect(store.getAccountByAddress('0x1', 'eth')).toBeDefined();
+    expect(store.getAccountByAddress('0x9')).toBeUndefined();
+  });
+
+  it('should remove a tag across all chains', () => {
+    const store = useBlockchainAccountsStore();
+    store.updateAccounts('eth', [account('0x1', ['keep', 'drop'])]);
+    store.removeTag('drop');
+    expect(store.getAccountByAddress('0x1', 'eth')?.tags).toEqual(['keep']);
+  });
+
+  it('should rename a tag across all chains', () => {
+    const store = useBlockchainAccountsStore();
+    store.updateAccounts('eth', [account('0x1', ['old'])]);
+    store.renameTag('old', 'new');
+    expect(store.getAccountByAddress('0x1', 'eth')?.tags).toEqual(['new']);
+  });
+
+  it('should track added addresses and forget them after the ttl', () => {
+    const store = useBlockchainAccountsStore();
+    store.trackAddedAddresses(['0xabc'], 1000);
+    expect(get(store.recentlyAddedAddresses).has('0xabc')).toBe(true);
+
+    vi.advanceTimersByTime(1000);
+    expect(get(store.recentlyAddedAddresses).has('0xabc')).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/assets/admin/use-managed-asset-operations.spec.ts
+++ b/frontend/app/src/modules/assets/admin/use-managed-asset-operations.spec.ts
@@ -1,0 +1,143 @@
+import type { SupportedAsset } from '@rotki/common';
+import type { Ref } from 'vue';
+import type { IgnoredAssetsHandlingType } from '@/modules/assets/types';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useManagedAssetOperations } from './use-managed-asset-operations';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    showErrorMessage: vi.fn(),
+    ignoreAssetWithConfirmation: vi.fn(),
+    ignoreAsset: vi.fn(),
+    unignoreAsset: vi.fn(),
+    isAssetIgnored: vi.fn(),
+    isAssetWhitelisted: vi.fn(),
+    useIsAssetWhitelisted: vi.fn(),
+    unWhitelistAsset: vi.fn(),
+    whitelistAsset: vi.fn(),
+    markAssetsAsSpam: vi.fn(),
+    removeAssetFromSpamList: vi.fn(),
+    refetchAssetInfo: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
+  return { ...actual, useNotifications: (): object => ({ showErrorMessage: spies.showErrorMessage }) };
+});
+vi.mock('@/modules/assets/use-ignored-asset-confirmation', () => ({
+  useIgnoredAssetConfirmation: (): object => ({ ignoreAssetWithConfirmation: spies.ignoreAssetWithConfirmation }),
+}));
+vi.mock('@/modules/assets/use-ignored-asset-operations', () => ({
+  useIgnoredAssetOperations: (): object => ({ ignoreAsset: spies.ignoreAsset, unignoreAsset: spies.unignoreAsset }),
+}));
+vi.mock('@/modules/assets/use-assets-store', () => ({
+  useAssetsStore: (): object => ({ isAssetIgnored: spies.isAssetIgnored, isAssetWhitelisted: spies.isAssetWhitelisted, useIsAssetWhitelisted: spies.useIsAssetWhitelisted }),
+}));
+vi.mock('@/modules/assets/use-whitelisted-asset-operations', () => ({
+  useWhitelistedAssetOperations: (): object => ({ unWhitelistAsset: spies.unWhitelistAsset, whitelistAsset: spies.whitelistAsset }),
+}));
+vi.mock('@/modules/assets/use-spam-asset', () => ({
+  useSpamAsset: (): object => ({ markAssetsAsSpam: spies.markAssetsAsSpam, removeAssetFromSpamList: spies.removeAssetFromSpamList }),
+}));
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: (): object => ({ refetchAssetInfo: spies.refetchAssetInfo }),
+}));
+
+function asset(overrides: Partial<SupportedAsset>): SupportedAsset {
+  return createMock<SupportedAsset>({ identifier: 'ETH', name: 'Ether', symbol: 'ETH', ...overrides });
+}
+
+function setup(handling: IgnoredAssetsHandlingType, selectedIds: string[] = []): {
+  ops: ReturnType<typeof useManagedAssetOperations>;
+  onRefresh: ReturnType<typeof vi.fn>;
+  selected: Ref<string[]>;
+} {
+  const onRefresh = vi.fn();
+  const ignoredFilter = ref({ ignoredAssetsHandling: handling, onlyShowOwned: false, onlyShowWhitelisted: false });
+  const selected = ref<string[]>(selectedIds);
+  const ops = useManagedAssetOperations(onRefresh, ignoredFilter, selected);
+  return { onRefresh, ops, selected };
+}
+
+describe('useManagedAssetOperations', () => {
+  beforeEach(() => {
+    spies.isAssetIgnored.mockReturnValue(false);
+    spies.isAssetWhitelisted.mockReturnValue(false);
+    spies.ignoreAsset.mockResolvedValue({ success: true });
+    spies.unignoreAsset.mockResolvedValue({ success: true });
+    spies.markAssetsAsSpam.mockResolvedValue({ success: true });
+    spies.removeAssetFromSpamList.mockResolvedValue({ success: true });
+    spies.whitelistAsset.mockResolvedValue(undefined);
+    spies.unWhitelistAsset.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should unignore an ignored asset and refresh when handling is active', async () => {
+    spies.isAssetIgnored.mockReturnValue(true);
+    const { onRefresh, ops } = setup('show_only');
+    await ops.toggleIgnoreAsset(asset({ identifier: 'A' }));
+    expect(spies.unignoreAsset).toHaveBeenCalledWith('A');
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(get(ops.loadingIgnore)).toBeUndefined();
+  });
+
+  it('should confirm before ignoring a new asset', async () => {
+    const { ops } = setup('none');
+    await ops.toggleIgnoreAsset(asset({ identifier: 'A', name: 'Asset A', symbol: '' }));
+    expect(spies.ignoreAssetWithConfirmation).toHaveBeenCalledWith('A', 'Asset A', expect.any(Function));
+  });
+
+  it('should toggle spam on and off', async () => {
+    const { onRefresh, ops } = setup('none');
+    await ops.toggleSpam(asset({ identifier: 'A', protocol: 'spam' }));
+    expect(spies.removeAssetFromSpamList).toHaveBeenCalledWith('A');
+
+    await ops.toggleSpam(asset({ identifier: 'B' }));
+    expect(spies.markAssetsAsSpam).toHaveBeenCalledWith(['B']);
+    expect(spies.refetchAssetInfo).toHaveBeenCalledWith('B');
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('should toggle whitelist state', async () => {
+    spies.isAssetWhitelisted.mockReturnValueOnce(true);
+    const { ops } = setup('none');
+    await ops.toggleWhitelistAsset('A');
+    expect(spies.unWhitelistAsset).toHaveBeenCalledWith('A');
+
+    await ops.toggleWhitelistAsset('B');
+    expect(spies.whitelistAsset).toHaveBeenCalledWith('B');
+  });
+
+  it('should mass-ignore the not-yet-ignored selection and clear it', async () => {
+    const { ops, selected } = setup('show_only', ['a', 'b', 'a']);
+    await ops.massIgnore(true);
+    expect(spies.ignoreAsset).toHaveBeenCalledWith(['a', 'b']);
+    expect(get(selected)).toEqual([]);
+  });
+
+  it('should warn when there is nothing to mass-ignore', async () => {
+    const { ops } = setup('none', []);
+    await ops.massIgnore(true);
+    expect(spies.showErrorMessage).toHaveBeenCalledOnce();
+    expect(spies.ignoreAsset).not.toHaveBeenCalled();
+  });
+
+  it('should mass-mark spam for the selection', async () => {
+    const { ops, selected } = setup('none', ['a', 'b']);
+    await ops.massSpam();
+    expect(spies.markAssetsAsSpam).toHaveBeenCalledWith(['a', 'b']);
+    expect(get(selected)).toEqual([]);
+  });
+
+  it('should warn when there is nothing to mass-spam', async () => {
+    const { ops } = setup('none', []);
+    await ops.massSpam();
+    expect(spies.showErrorMessage).toHaveBeenCalledOnce();
+    expect(spies.markAssetsAsSpam).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/assets/prices/use-currency-update.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-currency-update.spec.ts
@@ -1,0 +1,95 @@
+import type { AssetPrices } from '@/modules/assets/prices/price-types';
+import { bigNumberify } from '@rotki/common';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCurrencyUpdate } from './use-currency-update';
+
+const currencySymbol = ref<string>('USD');
+const previousCurrency = ref<string>();
+const exchangeRates = ref<Record<string, ReturnType<typeof bigNumberify>>>({});
+const prices = ref<AssetPrices>({});
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    updateFrontendSetting: vi.fn(),
+    adjustPrices: vi.fn(),
+    refreshPrices: vi.fn(),
+    fetchExchangeRates: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): object => ({ updateFrontendSetting: spies.updateFrontendSetting }),
+}));
+vi.mock('@/modules/assets/prices/use-price-refresh', () => ({
+  usePriceRefresh: (): object => ({ adjustPrices: spies.adjustPrices, refreshPrices: spies.refreshPrices }),
+}));
+vi.mock('@/modules/assets/prices/use-price-task-manager', () => ({
+  usePriceTaskManager: (): object => ({ fetchExchangeRates: spies.fetchExchangeRates }),
+}));
+vi.mock('@/modules/settings/use-general-settings-store', () => ({
+  useGeneralSettingsStore: vi.fn(() => ({ currencySymbol })),
+}));
+vi.mock('@/modules/balances/use-balance-prices-store', () => ({
+  useBalancePricesStore: vi.fn(() => ({ exchangeRates, previousCurrency, prices })),
+}));
+
+function price(value: number): AssetPrices[string] {
+  return { isManualPrice: false, oracle: 'coingecko', value: bigNumberify(value) };
+}
+
+describe('useCurrencyUpdate', () => {
+  beforeEach(() => {
+    set(currencySymbol, 'USD');
+    set(previousCurrency, undefined);
+    set(exchangeRates, { EUR: bigNumberify(0.9) });
+    set(prices, { ETH: price(100) });
+    spies.refreshPrices.mockResolvedValue(undefined);
+    spies.updateFrontendSetting.mockResolvedValue(undefined);
+    spies.fetchExchangeRates.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should seed the previous currency from the current symbol', () => {
+    useCurrencyUpdate();
+    expect(get(previousCurrency)).toBe('USD');
+  });
+
+  it('should refresh prices and reset the balance threshold on update', async () => {
+    const { onCurrencyUpdate } = useCurrencyUpdate();
+    await onCurrencyUpdate();
+    expect(spies.refreshPrices).toHaveBeenCalledWith(true);
+    expect(spies.updateFrontendSetting).toHaveBeenCalledWith({ balanceValueThreshold: {} });
+  });
+
+  it('should scale prices by the exchange-rate ratio when the currency changes', async () => {
+    const { onCurrencyUpdate } = useCurrencyUpdate();
+    set(currencySymbol, 'EUR');
+    await onCurrencyUpdate();
+    // USD (rate 1) -> EUR (rate 0.9): 100 * 0.9 = 90
+    expect(get(prices).ETH.value).toEqual(bigNumberify(90));
+    expect(spies.adjustPrices).toHaveBeenCalledOnce();
+    expect(get(previousCurrency)).toBe('EUR');
+  });
+
+  it('should fetch a missing exchange rate before scaling', async () => {
+    spies.fetchExchangeRates.mockImplementation(async (currency: string) => {
+      set(exchangeRates, { ...get(exchangeRates), [currency]: bigNumberify(0.5) });
+    });
+    const { onCurrencyUpdate } = useCurrencyUpdate();
+    set(currencySymbol, 'GBP');
+    await onCurrencyUpdate();
+    expect(spies.fetchExchangeRates).toHaveBeenCalledWith('GBP');
+    expect(get(prices).ETH.value).toEqual(bigNumberify(50)); // 100 * 0.5
+  });
+
+  it('should not scale non-positive prices', async () => {
+    set(prices, { ETH: price(0) });
+    const { onCurrencyUpdate } = useCurrencyUpdate();
+    set(currencySymbol, 'EUR');
+    await onCurrencyUpdate();
+    expect(get(prices).ETH.value).toEqual(bigNumberify(0));
+  });
+});

--- a/frontend/app/src/modules/assets/use-asset-locations-data.spec.ts
+++ b/frontend/app/src/modules/assets/use-asset-locations-data.spec.ts
@@ -1,0 +1,115 @@
+import type { AddressData, AssetBreakdown, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import { bigNumberify } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAssetLocationsData } from './use-asset-locations-data';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    getAssetBreakdown: vi.fn(),
+    getAccountByAddress: vi.fn(),
+    getAddressName: vi.fn(),
+    getAssetPriceInfo: vi.fn(),
+    getChainName: vi.fn(),
+    matchChain: vi.fn(),
+    getAccountAddress: vi.fn((account: { data: { address: string } }) => account.data.address),
+  },
+}));
+
+const currencySymbol = ref<string>('USD');
+const detailsLoading = ref<boolean>(false);
+
+vi.mock('@/modules/settings/use-general-settings-store', () => ({
+  useGeneralSettingsStore: vi.fn(() => ({ currencySymbol })),
+}));
+vi.mock('@/modules/core/common/use-status-store', () => ({
+  useStatusStore: vi.fn(() => ({ detailsLoading })),
+}));
+vi.mock('@/modules/accounts/use-blockchain-accounts-store', () => ({
+  useBlockchainAccountsStore: (): object => ({ getAccountByAddress: spies.getAccountByAddress }),
+}));
+vi.mock('@/modules/accounts/address-book/use-address-name-resolution', () => ({
+  useAddressNameResolution: (): object => ({ getAddressName: spies.getAddressName }),
+}));
+vi.mock('@/modules/balances/use-aggregated-balances', () => ({
+  useAggregatedBalances: (): object => ({ getAssetPriceInfo: spies.getAssetPriceInfo }),
+}));
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): object => ({ getChainName: spies.getChainName, matchChain: spies.matchChain }),
+}));
+vi.mock('@/modules/balances/use-asset-balances-breakdown', () => ({
+  useAssetBalancesBreakdown: (): object => ({ getAssetBreakdown: spies.getAssetBreakdown }),
+}));
+vi.mock('@/modules/accounts/account-utils', () => ({
+  getAccountAddress: spies.getAccountAddress,
+}));
+
+function breakdown(overrides: Partial<AssetBreakdown>): AssetBreakdown {
+  return { address: '0xabc', amount: bigNumberify(1), location: 'ethereum', value: bigNumberify(100), ...overrides };
+}
+
+function options(over: Partial<Parameters<typeof useAssetLocationsData>[0]> = {}): Parameters<typeof useAssetLocationsData>[0] {
+  return {
+    identifier: 'ETH',
+    locationFilter: ref(''),
+    onlyTags: ref([]),
+    selectedAccounts: ref([]),
+    ...over,
+  };
+}
+
+describe('useAssetLocationsData', () => {
+  beforeEach(() => {
+    spies.getAssetPriceInfo.mockReturnValue({ value: bigNumberify(500) });
+    spies.getAccountByAddress.mockReturnValue({ label: 'My Account' });
+    spies.getAddressName.mockReturnValue(null);
+    spies.getChainName.mockImplementation((location: string) => location);
+    spies.getAssetBreakdown.mockReturnValue([breakdown({})]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should expose the asset total value', () => {
+    const { totalValue } = useAssetLocationsData(options());
+    expect(get(totalValue)).toEqual(bigNumberify(500));
+  });
+
+  it('should attach the account and its label to each breakdown', () => {
+    const { assetLocations } = useAssetLocationsData(options());
+    const locations = get(assetLocations);
+    expect(locations).toHaveLength(1);
+    expect(spies.getAccountByAddress).toHaveBeenCalledWith('0xabc', 'ethereum');
+    expect(locations[0].label).toBe('My Account');
+  });
+
+  it('should filter visible locations by tag', () => {
+    spies.getAssetBreakdown.mockReturnValue([
+      breakdown({ address: '0x1', tags: ['tag-a'] }),
+      breakdown({ address: '0x2', tags: ['tag-b'] }),
+    ]);
+    const { visibleAssetLocations } = useAssetLocationsData(options({ onlyTags: ref(['tag-a']) }));
+    expect(get(visibleAssetLocations).map(l => l.address)).toEqual(['0x1']);
+  });
+
+  it('should filter visible locations by location name', () => {
+    spies.getAssetBreakdown.mockReturnValue([
+      breakdown({ address: '0x1', location: 'ethereum' }),
+      breakdown({ address: '0x2', location: 'gnosis' }),
+    ]);
+    spies.getChainName.mockImplementation((location: string) => location === 'ethereum' ? 'Ethereum' : 'Gnosis');
+    const { visibleAssetLocations } = useAssetLocationsData(options({ locationFilter: ref('ethereum') }));
+    expect(get(visibleAssetLocations).map(l => l.address)).toEqual(['0x1']);
+  });
+
+  it('should filter visible locations by selected account', () => {
+    spies.getAssetBreakdown.mockReturnValue([
+      breakdown({ address: '0x1' }),
+      breakdown({ address: '0x2' }),
+    ]);
+    const account = createMock<BlockchainAccount<AddressData>>({ data: { address: '0x2' } });
+    const { visibleAssetLocations } = useAssetLocationsData(options({ selectedAccounts: ref([account]) }));
+    expect(get(visibleAssetLocations).map(l => l.address)).toEqual(['0x2']);
+  });
+});

--- a/frontend/app/src/modules/balances/blockchain/use-blockchain-total-summary.spec.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-blockchain-total-summary.spec.ts
@@ -1,0 +1,58 @@
+import type { Balances } from '@/modules/accounts/blockchain-accounts';
+import { bigNumberify } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBlockchainTotalSummary } from './use-blockchain-total-summary';
+
+const balances = ref<Balances>({});
+
+vi.mock('@/modules/balances/use-balances-store', () => ({
+  useBalancesStore: vi.fn(() => ({ balances })),
+}));
+
+function chain(...assets: { amount: number; value: number }[]): Balances[string] {
+  const perAsset: Record<string, Record<string, { amount: ReturnType<typeof bigNumberify>; value: ReturnType<typeof bigNumberify> }>> = {};
+  assets.forEach(({ amount, value }, i) => {
+    perAsset[`ASSET_${i}`] = { protocol: { amount: bigNumberify(amount), value: bigNumberify(value) } };
+  });
+  return { '0xacc': { assets: perAsset, liabilities: {} } };
+}
+
+describe('useBlockchainTotalSummary', () => {
+  beforeEach(() => {
+    set(balances, {});
+  });
+
+  it('should return no totals for empty balances', () => {
+    const { blockchainTotals } = useBlockchainTotalSummary();
+    expect(get(blockchainTotals)).toEqual([]);
+  });
+
+  it('should sum every asset/protocol value per chain', () => {
+    set(balances, {
+      eth: chain({ amount: 1, value: 100 }, { amount: 2, value: 50 }),
+    });
+    const { blockchainTotals } = useBlockchainTotalSummary();
+    expect(get(blockchainTotals)).toEqual([
+      { chain: 'eth', loading: false, value: bigNumberify(150) },
+    ]);
+  });
+
+  it('should drop chains that sum to zero', () => {
+    set(balances, {
+      eth: chain({ amount: 1, value: 100 }),
+      gnosis: chain({ amount: 0, value: 0 }),
+    });
+    const { blockchainTotals } = useBlockchainTotalSummary();
+    expect(get(blockchainTotals).map(t => t.chain)).toEqual(['eth']);
+  });
+
+  it('should sort chains by descending value', () => {
+    set(balances, {
+      eth: chain({ amount: 1, value: 100 }),
+      gnosis: chain({ amount: 1, value: 300 }),
+      base: chain({ amount: 1, value: 200 }),
+    });
+    const { blockchainTotals } = useBlockchainTotalSummary();
+    expect(get(blockchainTotals).map(t => t.chain)).toEqual(['gnosis', 'base', 'eth']);
+  });
+});

--- a/frontend/app/src/modules/balances/manual/use-manual-balance-pagination.spec.ts
+++ b/frontend/app/src/modules/balances/manual/use-manual-balance-pagination.spec.ts
@@ -1,0 +1,56 @@
+import type { ManualBalanceRequestPayload, ManualBalanceWithPrice } from '@/modules/balances/types/manual-balances';
+import type { Collection } from '@/modules/core/common/collection';
+import { bigNumberify } from '@rotki/common';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useManualBalancePagination } from './use-manual-balance-pagination';
+
+const manualBalances = ref<{ id: number }[]>([{ id: 1 }]);
+const manualLiabilities = ref<{ id: number }[]>([{ id: 2 }]);
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    sortAndFilterManualBalance: vi.fn(),
+    getAssetPrice: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/balances/use-balances-store', () => ({
+  useBalancesStore: vi.fn(() => ({ manualBalances, manualLiabilities })),
+}));
+vi.mock('@/modules/assets/prices/use-price-utils', () => ({
+  usePriceUtils: (): object => ({ getAssetPrice: spies.getAssetPrice }),
+}));
+vi.mock('@/modules/balances/manual-balances', () => ({
+  sortAndFilterManualBalance: spies.sortAndFilterManualBalance,
+}));
+
+const payload = { limit: 10, offset: 0 } as unknown as ManualBalanceRequestPayload;
+
+describe('useManualBalancePagination', () => {
+  beforeEach(() => {
+    spies.sortAndFilterManualBalance.mockReturnValue({ data: [], found: 0, limit: 10, total: 0 } satisfies Collection<ManualBalanceWithPrice>);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should sort and filter the manual balances', async () => {
+    const result = await useManualBalancePagination().fetchBalances(payload);
+    expect(spies.sortAndFilterManualBalance).toHaveBeenCalledWith(get(manualBalances), payload, expect.any(Object));
+    expect(result).toEqual({ data: [], found: 0, limit: 10, total: 0 });
+  });
+
+  it('should sort and filter the manual liabilities', async () => {
+    await useManualBalancePagination().fetchLiabilities(payload);
+    expect(spies.sortAndFilterManualBalance).toHaveBeenCalledWith(get(manualLiabilities), payload, expect.any(Object));
+  });
+
+  it('should resolve asset prices through the price utils', async () => {
+    spies.getAssetPrice.mockReturnValue(bigNumberify(42));
+    await useManualBalancePagination().fetchBalances(payload);
+    const resolvers = spies.sortAndFilterManualBalance.mock.calls[0][2];
+    expect(resolvers.resolveAssetPrice('ETH')).toEqual(bigNumberify(42));
+    expect(spies.getAssetPrice).toHaveBeenCalledWith('ETH');
+  });
+});

--- a/frontend/app/src/modules/balances/manual/use-manual-balances-or-liabilities.spec.ts
+++ b/frontend/app/src/modules/balances/manual/use-manual-balances-or-liabilities.spec.ts
@@ -1,0 +1,64 @@
+import type { ManualBalanceWithValue } from '@/modules/balances/types/manual-balances';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useManualBalancesOrLiabilities } from './use-manual-balances-or-liabilities';
+
+function balance(location: string): ManualBalanceWithValue {
+  return createMock<ManualBalanceWithValue>({ location });
+}
+
+const manualBalances = ref<ManualBalanceWithValue[]>([]);
+const manualLiabilities = ref<ManualBalanceWithValue[]>([]);
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    fetchBalances: vi.fn(),
+    fetchLiabilities: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/balances/use-balances-store', () => ({
+  useBalancesStore: vi.fn(() => ({ manualBalances, manualLiabilities })),
+}));
+vi.mock('@/modules/balances/manual/use-manual-balance-pagination', () => ({
+  useManualBalancePagination: (): object => ({ fetchBalances: spies.fetchBalances, fetchLiabilities: spies.fetchLiabilities }),
+}));
+
+describe('useManualBalancesOrLiabilities', () => {
+  beforeEach(() => {
+    set(manualBalances, [balance('kraken'), balance('ethereum')]);
+    set(manualLiabilities, [balance('ethereum'), balance('aave')]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should expose balances or liabilities based on the type', () => {
+    expect(get(useManualBalancesOrLiabilities('balances').dataSource)).toBe(get(manualBalances));
+    expect(get(useManualBalancesOrLiabilities('liabilities').dataSource)).toBe(get(manualLiabilities));
+  });
+
+  it('should collect the unique locations across both lists', () => {
+    const { locations } = useManualBalancesOrLiabilities('balances');
+    expect(get(locations)).toEqual(['kraken', 'ethereum', 'aave']);
+  });
+
+  it('should fetch balances or liabilities based on the type', async () => {
+    const payload = {} as never;
+    await useManualBalancesOrLiabilities('balances').fetch(payload);
+    expect(spies.fetchBalances).toHaveBeenCalledOnce();
+    expect(spies.fetchLiabilities).not.toHaveBeenCalled();
+
+    await useManualBalancesOrLiabilities('liabilities').fetch(payload);
+    expect(spies.fetchLiabilities).toHaveBeenCalledOnce();
+  });
+
+  it('should react to a getter type', () => {
+    const type = ref<'balances' | 'liabilities'>('balances');
+    const { dataSource } = useManualBalancesOrLiabilities(() => get(type));
+    expect(get(dataSource)).toBe(get(manualBalances));
+    set(type, 'liabilities');
+    expect(get(dataSource)).toBe(get(manualLiabilities));
+  });
+});

--- a/frontend/app/src/modules/balances/nft/use-nft-gallery-data.spec.ts
+++ b/frontend/app/src/modules/balances/nft/use-nft-gallery-data.spec.ts
@@ -1,0 +1,92 @@
+import type { Nft } from '@/modules/assets/nfts';
+import type { NftPrice } from '@/modules/assets/prices/price-types';
+import { bigNumberify } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useNftGalleryData } from './use-nft-gallery-data';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    fetchNfts: vi.fn(),
+    fetchNftsPrices: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/assets/use-asset-nft', () => ({
+  useNfts: (): object => ({ fetchNfts: spies.fetchNfts }),
+}));
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: (): object => ({ fetchNftsPrices: spies.fetchNftsPrices }),
+}));
+
+// these nfts are spread (`{ ...nft }`) by the composable, so they must be real objects.
+function nft(tokenIdentifier: string): Nft {
+  return {
+    backgroundColor: null,
+    collection: { bannerImage: null, description: null, largeImage: null, name: 'Collection' },
+    externalLink: undefined,
+    imageUrl: null,
+    name: tokenIdentifier,
+    permalink: null,
+    price: bigNumberify(1),
+    priceAsset: 'USD',
+    priceInAsset: bigNumberify(1),
+    tokenIdentifier,
+  };
+}
+
+describe('useNftGalleryData', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should store the fetched nfts and stop loading', async () => {
+    spies.fetchNfts.mockResolvedValue({ result: { addresses: { '0x1': [] }, entriesFound: 3, entriesLimit: 10 } });
+    const data = useNftGalleryData();
+    await data.fetchNfts();
+    expect(get(data.total)).toBe(3);
+    expect(get(data.limit)).toBe(10);
+    expect(get(data.perAccount)).toEqual({ '0x1': [] });
+    expect(get(data.loading)).toBe(false);
+  });
+
+  it('should record the error message on a failed fetch', async () => {
+    spies.fetchNfts.mockResolvedValue({ message: 'entries limit reached' });
+    const data = useNftGalleryData();
+    await data.fetchNfts();
+    expect(get(data.error)).toBe('entries limit reached');
+    expect(get(data.nftLimited)).toBe(true);
+  });
+
+  it('should flatten per-account nfts and attach the address', () => {
+    const data = useNftGalleryData();
+    set(data.perAccount, { '0xabc': [nft('t1'), nft('t2')] });
+    const nfts = get(data.nfts);
+    expect(nfts).toHaveLength(2);
+    expect(nfts[0]).toMatchObject({ address: '0xabc', tokenIdentifier: 't1' });
+  });
+
+  it('should apply a manually-entered price to the matching nft', () => {
+    const data = useNftGalleryData();
+    set(data.perAccount, { '0xabc': [nft('t1')] });
+    set(data.prices, {
+      t1: createMock<NftPrice>({ manuallyInput: true, price: bigNumberify(5), priceAsset: 'ETH', priceInAsset: bigNumberify(2) }),
+    });
+    const nfts = get(data.nfts);
+    expect(nfts[0]).toMatchObject({ price: bigNumberify(5), priceAsset: 'ETH' });
+  });
+
+  it('should key fetched prices by asset', async () => {
+    spies.fetchNftsPrices.mockResolvedValue([createMock<NftPrice>({ asset: 't1' })]);
+    const data = useNftGalleryData();
+    await data.fetchPrices();
+    expect(get(data.prices)).toHaveProperty('t1');
+  });
+
+  it('should capture a price fetch error', async () => {
+    spies.fetchNftsPrices.mockRejectedValue(new Error('price boom'));
+    const data = useNftGalleryData();
+    await data.fetchPrices();
+    expect(get(data.priceError)).toBe('price boom');
+  });
+});

--- a/frontend/app/src/modules/balances/nft/use-nft-gallery-filters.spec.ts
+++ b/frontend/app/src/modules/balances/nft/use-nft-gallery-filters.spec.ts
@@ -1,0 +1,90 @@
+import type { ComputedRef } from 'vue';
+import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import type { GalleryNft, Nfts } from '@/modules/assets/nfts';
+import { bigNumberify } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNftGalleryFilters } from './use-nft-gallery-filters';
+
+vi.mock('@/modules/accounts/account-utils', () => ({
+  getAccountAddress: (account: { data: { address: string } }): string => account.data.address,
+}));
+
+function nft(overrides: { address?: string; name?: string; price?: number; collection?: string }): GalleryNft {
+  return createMock<GalleryNft>({
+    address: overrides.address ?? '0xabc',
+    collection: createMock({ name: overrides.collection ?? 'Punks' }),
+    name: overrides.name ?? 'NFT',
+    price: bigNumberify(overrides.price ?? 1),
+  });
+}
+
+function account(address: string): BlockchainAccount<AddressData> {
+  return createMock<BlockchainAccount<AddressData>>({ data: { address } });
+}
+
+describe('useNftGalleryFilters', () => {
+  let nfts: ComputedRef<GalleryNft[]>;
+  let list: GalleryNft[];
+
+  beforeEach(() => {
+    list = [];
+    nfts = computed<GalleryNft[]>(() => list);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should list available addresses from the per-account map', () => {
+    const perAccount = ref<Nfts | null>({ '0x1': [], '0x2': [] });
+    const { availableAddresses } = useNftGalleryFilters(nfts, perAccount);
+    expect(get(availableAddresses)).toEqual(['0x1', '0x2']);
+  });
+
+  it('should return no addresses when the per-account map is null', () => {
+    const { availableAddresses } = useNftGalleryFilters(nfts, ref(null));
+    expect(get(availableAddresses)).toEqual([]);
+  });
+
+  it('should collect the unique collection names', () => {
+    list = [nft({ collection: 'Punks' }), nft({ collection: 'Apes' }), nft({ collection: 'Punks' })];
+    const { collections } = useNftGalleryFilters(nfts, ref(null));
+    expect(get(collections)).toEqual(['Punks', 'Apes']);
+  });
+
+  it('should sort by name ascending by default', () => {
+    list = [nft({ name: 'Zed' }), nft({ name: 'Alpha' })];
+    const { items } = useNftGalleryFilters(nfts, ref(null));
+    expect(get(items).map(n => n.name)).toEqual(['Alpha', 'Zed']);
+  });
+
+  it('should sort by price descending', () => {
+    list = [nft({ name: 'a', price: 1 }), nft({ name: 'b', price: 9 })];
+    const { items, sortBy, sortDescending } = useNftGalleryFilters(nfts, ref(null));
+    set(sortBy, 'price');
+    set(sortDescending, true);
+    expect(get(items).map(n => n.name)).toEqual(['b', 'a']);
+  });
+
+  it('should filter by the selected collection', () => {
+    list = [nft({ name: 'a', collection: 'Punks' }), nft({ name: 'b', collection: 'Apes' })];
+    const { items, selectedCollection } = useNftGalleryFilters(nfts, ref(null));
+    set(selectedCollection, 'Apes');
+    expect(get(items).map(n => n.name)).toEqual(['b']);
+  });
+
+  it('should filter by the selected accounts', () => {
+    list = [nft({ address: '0x1', name: 'a' }), nft({ address: '0x2', name: 'b' })];
+    const { items, selectedAccounts } = useNftGalleryFilters(nfts, ref(null));
+    set(selectedAccounts, [account('0x2')]);
+    expect(get(items).map(n => n.name)).toEqual(['b']);
+  });
+
+  it('should validate the sort key on update', () => {
+    const { sortBy, updateSortBy } = useNftGalleryFilters(nfts, ref(null));
+    updateSortBy('collection');
+    expect(get(sortBy)).toBe('collection');
+    expect(() => updateSortBy('bogus')).toThrow();
+  });
+});

--- a/frontend/app/src/modules/balances/nft/use-nft-gallery-layout.spec.ts
+++ b/frontend/app/src/modules/balances/nft/use-nft-gallery-layout.spec.ts
@@ -1,0 +1,77 @@
+import type { ComputedRef } from 'vue';
+import type { GalleryNft } from '@/modules/assets/nfts';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNftGalleryLayout } from './use-nft-gallery-layout';
+
+const breakpoint = {
+  is2xl: ref<boolean>(false),
+  isMd: ref<boolean>(false),
+  isSm: ref<boolean>(false),
+  isSmAndDown: ref<boolean>(false),
+};
+
+vi.mock('@rotki/ui-library', async () => {
+  const actual = await vi.importActual<typeof import('@rotki/ui-library')>('@rotki/ui-library');
+  return { ...actual, useBreakpoint: (): typeof breakpoint => breakpoint };
+});
+
+function nftList(count: number): ComputedRef<GalleryNft[]> {
+  const items = Array.from({ length: count }, (_, i) => createMock<GalleryNft>({ tokenIdentifier: `nft-${i}` }));
+  return computed<GalleryNft[]>(() => items);
+}
+
+describe('useNftGalleryLayout', () => {
+  beforeEach(() => {
+    set(breakpoint.is2xl, false);
+    set(breakpoint.isMd, false);
+    set(breakpoint.isSm, false);
+    set(breakpoint.isSmAndDown, false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['isSmAndDown', 1],
+    ['isSm', 2],
+    ['isMd', 6],
+    ['is2xl', 10],
+  ] as const)('should pick the first limit for %s', (key, expected) => {
+    set(breakpoint[key], true);
+    const { firstLimit, itemsPerPage } = useNftGalleryLayout(nftList(0));
+    expect(get(firstLimit)).toBe(expected);
+    // watchImmediate syncs itemsPerPage to the first limit
+    expect(get(itemsPerPage)).toBe(expected);
+  });
+
+  it('should default the first limit to 8', () => {
+    const { firstLimit } = useNftGalleryLayout(nftList(0));
+    expect(get(firstLimit)).toBe(8);
+  });
+
+  it('should derive the page-size limits from the first limit', () => {
+    set(breakpoint.isMd, true); // first = 6
+    const { limits } = useNftGalleryLayout(nftList(0));
+    expect(get(limits)).toEqual([6, 12, 24]);
+  });
+
+  it('should page the visible nfts by items-per-page', () => {
+    const { visibleNfts, page } = useNftGalleryLayout(nftList(20));
+    // default first limit 8
+    expect(get(visibleNfts)).toHaveLength(8);
+    expect(get(visibleNfts)[0].tokenIdentifier).toBe('nft-0');
+
+    set(page, 2);
+    expect(get(visibleNfts)[0].tokenIdentifier).toBe('nft-8');
+  });
+
+  it('should expose and update pagination data', () => {
+    const { paginationData } = useNftGalleryLayout(nftList(20));
+    expect(get(paginationData)).toMatchObject({ limit: 8, page: 1, total: 20 });
+
+    set(paginationData, { limit: 4, limits: [4, 8, 16], page: 3, total: 20 });
+    expect(get(paginationData)).toMatchObject({ limit: 4, page: 3 });
+  });
+});

--- a/frontend/app/src/modules/balances/non-fungible/use-nft-asset-ignoring.spec.ts
+++ b/frontend/app/src/modules/balances/non-fungible/use-nft-asset-ignoring.spec.ts
@@ -1,0 +1,84 @@
+import type { NonFungibleBalance } from '@/modules/balances/types/nfbalances';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNftAssetIgnoring } from './use-nft-asset-ignoring';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    showErrorMessage: vi.fn(),
+    ignoreAssetWithConfirmation: vi.fn(),
+    ignoreAsset: vi.fn(),
+    unignoreAsset: vi.fn(),
+    isAssetIgnored: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
+  return { ...actual, useNotifications: (): object => ({ showErrorMessage: spies.showErrorMessage }) };
+});
+vi.mock('@/modules/assets/use-ignored-asset-confirmation', () => ({
+  useIgnoredAssetConfirmation: (): object => ({ ignoreAssetWithConfirmation: spies.ignoreAssetWithConfirmation }),
+}));
+vi.mock('@/modules/assets/use-ignored-asset-operations', () => ({
+  useIgnoredAssetOperations: (): object => ({ ignoreAsset: spies.ignoreAsset, unignoreAsset: spies.unignoreAsset }),
+}));
+vi.mock('@/modules/assets/use-assets-store', () => ({
+  useAssetsStore: (): object => ({ isAssetIgnored: spies.isAssetIgnored }),
+}));
+
+function balance(id: string): NonFungibleBalance {
+  return createMock<NonFungibleBalance>({ id, name: id });
+}
+
+describe('useNftAssetIgnoring', () => {
+  const fetchData = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    spies.isAssetIgnored.mockReturnValue(false);
+    spies.ignoreAsset.mockResolvedValue({ success: true });
+    spies.unignoreAsset.mockResolvedValue({ success: true });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should refresh only when ignored assets are being shown', () => {
+    useNftAssetIgnoring(fetchData, 'none').refreshCallback();
+    expect(fetchData).not.toHaveBeenCalled();
+
+    useNftAssetIgnoring(fetchData, 'show_only').refreshCallback();
+    expect(fetchData).toHaveBeenCalledOnce();
+  });
+
+  it('should unignore an already-ignored asset on toggle', async () => {
+    spies.isAssetIgnored.mockReturnValue(true);
+    await useNftAssetIgnoring(fetchData, 'show_only').toggleIgnoreAsset(balance('nft-1'));
+    expect(spies.unignoreAsset).toHaveBeenCalledWith('nft-1');
+    expect(spies.ignoreAssetWithConfirmation).not.toHaveBeenCalled();
+  });
+
+  it('should confirm before ignoring a new asset on toggle', async () => {
+    await useNftAssetIgnoring(fetchData, 'none').toggleIgnoreAsset(balance('nft-2'));
+    expect(spies.ignoreAssetWithConfirmation).toHaveBeenCalledWith('nft-2', 'nft-2', expect.any(Function));
+  });
+
+  it('should mass-ignore the not-yet-ignored selection and clear it', async () => {
+    const { massIgnore, selected } = useNftAssetIgnoring(fetchData, 'show_only');
+    set(selected, ['a', 'b', 'a']);
+    await massIgnore(true);
+    expect(spies.ignoreAsset).toHaveBeenCalledWith(['a', 'b']);
+    expect(get(selected)).toEqual([]);
+    expect(fetchData).toHaveBeenCalledOnce();
+  });
+
+  it('should warn when there is nothing to mass-ignore', async () => {
+    spies.isAssetIgnored.mockReturnValue(true); // all already ignored
+    const { massIgnore, selected } = useNftAssetIgnoring(fetchData, 'none');
+    set(selected, ['a']);
+    await massIgnore(true);
+    expect(spies.showErrorMessage).toHaveBeenCalledOnce();
+    expect(spies.ignoreAsset).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/balances/non-fungible/use-nft-price-management.spec.ts
+++ b/frontend/app/src/modules/balances/non-fungible/use-nft-price-management.spec.ts
@@ -1,0 +1,66 @@
+import type { NonFungibleBalance } from '@/modules/balances/types/nfbalances';
+import { bigNumberify } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNftPriceManagement } from './use-nft-price-management';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    notifyError: vi.fn(),
+    deleteLatestPrice: vi.fn(),
+    show: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
+  return { ...actual, useNotifications: (): object => ({ notifyError: spies.notifyError }) };
+});
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: (): object => ({ deleteLatestPrice: spies.deleteLatestPrice }),
+}));
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): object => ({ show: spies.show }),
+}));
+
+function nftBalance(): NonFungibleBalance {
+  return createMock<NonFungibleBalance>({ id: 'nft-1', name: 'Cool NFT', priceAsset: 'ETH', priceInAsset: bigNumberify(2) });
+}
+
+describe('useNftPriceManagement', () => {
+  const fetchData = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    spies.deleteLatestPrice.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should delete a price and refresh', async () => {
+    await useNftPriceManagement(fetchData).deletePrice(nftBalance());
+    expect(spies.deleteLatestPrice).toHaveBeenCalledWith('nft-1');
+    expect(fetchData).toHaveBeenCalledOnce();
+  });
+
+  it('should notify when deletion fails', async () => {
+    spies.deleteLatestPrice.mockRejectedValue(new Error('boom'));
+    await useNftPriceManagement(fetchData).deletePrice(nftBalance());
+    expect(spies.notifyError).toHaveBeenCalledOnce();
+  });
+
+  it('should populate the price form and open the dialog', () => {
+    const { customPrice, openPriceDialog, setPriceForm } = useNftPriceManagement(fetchData);
+    setPriceForm(nftBalance());
+    expect(get(customPrice)).toEqual({ fromAsset: 'nft-1', price: '2', toAsset: 'ETH' });
+    expect(get(openPriceDialog)).toBe(true);
+  });
+
+  it('should delete through the confirmation dialog', async () => {
+    useNftPriceManagement(fetchData).showDeleteConfirmation(nftBalance());
+    expect(spies.show).toHaveBeenCalledOnce();
+    await spies.show.mock.calls[0][1]();
+    expect(spies.deleteLatestPrice).toHaveBeenCalledWith('nft-1');
+  });
+});

--- a/frontend/app/src/modules/balances/protocols/use-protocol-data.spec.ts
+++ b/frontend/app/src/modules/balances/protocols/use-protocol-data.spec.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProtocolData } from './use-protocol-data';
+
+interface LocationInfo { name?: string; image?: string; icon?: string }
+
+interface DefiInfo { icon: string; name: string }
+
+interface CounterpartyInfo { image: string; label?: string }
+
+const locationData = ref<LocationInfo | undefined>();
+const defiData = ref<DefiInfo | undefined>();
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    getBaseCounterpartyData: vi.fn(),
+    getProtocolImageUrl: vi.fn((name: string, icon: string) => `url:${name}:${icon}`),
+  },
+}));
+
+vi.mock('@/modules/core/common/use-locations', () => ({
+  useLocations: (): object => ({ useLocationData: () => locationData }),
+}));
+vi.mock('@/modules/balances/protocols/use-protocol-metadata', () => ({
+  useProtocolMetadata: (): object => ({ getProtocolData: () => defiData, getProtocolImageUrl: spies.getProtocolImageUrl }),
+}));
+vi.mock('@/modules/history/events/mapping/use-history-event-counterparty-mappings', () => ({
+  useHistoryEventCounterpartyMappings: (): object => ({ getBaseCounterpartyData: spies.getBaseCounterpartyData }),
+}));
+
+describe('useProtocolData', () => {
+  beforeEach(() => {
+    set(locationData, undefined);
+    set(defiData, undefined);
+    spies.getBaseCounterpartyData.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the wallet icon for the address pseudo-protocol', () => {
+    const { protocolData } = useProtocolData('address');
+    expect(get(protocolData)).toEqual({ icon: 'lu-wallet', name: 'Address', type: 'icon' });
+  });
+
+  it('should prefer a location image', () => {
+    set(locationData, { image: 'kraken.svg', name: 'Kraken' });
+    const { protocolData } = useProtocolData('kraken');
+    expect(get(protocolData)).toEqual({ image: 'kraken.svg', name: 'Kraken', type: 'image' });
+  });
+
+  it('should fall back to a location icon and the display name', () => {
+    set(locationData, { icon: 'lu-bank' });
+    const { protocolData } = useProtocolData('somebank');
+    expect(get(protocolData)).toEqual({ icon: 'lu-bank', name: 'Somebank', type: 'icon' });
+  });
+
+  it('should use counterparty data when there is no location', () => {
+    spies.getBaseCounterpartyData.mockReturnValue({ image: 'uni.svg', label: 'Uniswap V3' } satisfies CounterpartyInfo);
+    const { protocolData } = useProtocolData('uniswap-v3');
+    expect(get(protocolData)).toEqual({ image: 'uni.svg', name: 'Uniswap V3', type: 'image' });
+  });
+
+  it('should build a defi protocol image url as a last resort', () => {
+    set(defiData, { icon: 'aave.png', name: 'Aave' });
+    const { protocolData } = useProtocolData('aave');
+    expect(get(protocolData)).toEqual({ image: 'url:aave:aave.png', name: 'Aave', type: 'image' });
+    expect(spies.getProtocolImageUrl).toHaveBeenCalledWith('aave', 'aave.png');
+  });
+
+  it('should return undefined when nothing matches', () => {
+    const { protocolData } = useProtocolData('mystery');
+    expect(get(protocolData)).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/balances/protocols/use-protocol-metadata.spec.ts
+++ b/frontend/app/src/modules/balances/protocols/use-protocol-metadata.spec.ts
@@ -1,0 +1,87 @@
+import type { ProtocolMetadata } from '@/modules/balances/protocols/types';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const connected = ref<boolean>(true);
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    fetchDefiMetadata: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/airdrops/use-defi-api', () => ({
+  useDefiApi: (): object => ({ fetchDefiMetadata: spies.fetchDefiMetadata }),
+}));
+vi.mock('@/modules/core/common/use-main-store', () => ({
+  useMainStore: vi.fn(() => ({ connected })),
+}));
+vi.mock('@/modules/core/common/file/file', () => ({
+  getPublicProtocolImagePath: (path: string): string => `img:${path}`,
+}));
+
+// createSharedComposable caches the instance, so reset the module per test.
+async function load(): Promise<typeof import('./use-protocol-metadata')> {
+  vi.resetModules();
+  return import('./use-protocol-metadata');
+}
+
+const metadata: ProtocolMetadata[] = [
+  { icon: 'aave.svg', identifier: 'aave', name: 'Aave' },
+  { icon: 'uni.svg', identifier: 'uniswap-v2', name: 'Uniswap V2' },
+];
+
+describe('useProtocolMetadata', () => {
+  beforeEach(() => {
+    set(connected, true);
+    spies.fetchDefiMetadata.mockResolvedValue(metadata);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should build a protocol image url from an icon or the identifier', async () => {
+    const { useProtocolMetadata } = await load();
+    const { getProtocolImageUrl } = useProtocolMetadata();
+    expect(getProtocolImageUrl('aave', 'custom.png')).toBe('img:custom.png');
+    expect(getProtocolImageUrl('aave', undefined)).toBe('img:aave.svg');
+  });
+
+  it('should load metadata when connected and look it up case-insensitively', async () => {
+    const { useProtocolMetadata } = await load();
+    const { findProtocolData } = useProtocolMetadata();
+    await flushPromises();
+    expect(spies.fetchDefiMetadata).toHaveBeenCalled();
+    expect(findProtocolData('aave')?.name).toBe('Aave');
+    // camelCase comparison ignores separators/casing
+    expect(findProtocolData('uniswapV2')?.identifier).toBe('uniswap-v2');
+    expect(findProtocolData('unknown')).toBeUndefined();
+  });
+
+  it('should not fetch metadata while disconnected', async () => {
+    set(connected, false);
+    const { useProtocolMetadata } = await load();
+    const { findProtocolData, metadata: meta } = useProtocolMetadata();
+    await flushPromises();
+    expect(spies.fetchDefiMetadata).not.toHaveBeenCalled();
+    expect(get(meta)).toEqual([]);
+    expect(findProtocolData('aave')).toBeUndefined();
+  });
+
+  it('should resolve a protocol name and fall back to the identifier', async () => {
+    const { useProtocolMetadata } = await load();
+    const { findProtocolName } = useProtocolMetadata();
+    await flushPromises();
+    expect(findProtocolName('aave')).toBe('Aave');
+    expect(findProtocolName('mystery')).toBe('mystery');
+  });
+
+  it('should look up a protocol identifier by name', async () => {
+    const { useProtocolMetadata } = await load();
+    const { getProtocolIdentifierByName } = useProtocolMetadata();
+    await flushPromises();
+    expect(get(getProtocolIdentifierByName('Aave'))).toBe('aave');
+    expect(get(getProtocolIdentifierByName('Nope'))).toBe('Nope');
+  });
+});

--- a/frontend/app/src/modules/balances/use-balance-loading.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-loading.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskType as Task, type TaskType } from '@/modules/core/tasks/task-type';
+import { useBalancesLoading } from './use-balance-loading';
+
+const running = ref<Set<TaskType>>(new Set());
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: (): object => ({
+    useIsTaskRunning: (type: TaskType) => computed<boolean>(() => get(running).has(type)),
+  }),
+}));
+
+describe('useBalancesLoading', () => {
+  beforeEach(() => {
+    set(running, new Set());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should not be loading when no relevant task runs', () => {
+    const { loadingBalances, loadingBalancesAndDetection } = useBalancesLoading();
+    expect(get(loadingBalances)).toBe(false);
+    expect(get(loadingBalancesAndDetection)).toBe(false);
+  });
+
+  it.each([
+    Task.QUERY_BALANCES,
+    Task.QUERY_BLOCKCHAIN_BALANCES,
+    Task.QUERY_EXCHANGE_BALANCES,
+    Task.MANUAL_BALANCES,
+  ])('should flag loading when %s runs', (task) => {
+    const { loadingBalances, loadingBalancesAndDetection } = useBalancesLoading();
+    set(running, new Set([task]));
+    expect(get(loadingBalances)).toBe(true);
+    expect(get(loadingBalancesAndDetection)).toBe(true);
+  });
+
+  it('should include token detection only in the detection flag', () => {
+    const { loadingBalances, loadingBalancesAndDetection } = useBalancesLoading();
+    set(running, new Set([Task.FETCH_DETECTED_TOKENS]));
+    expect(get(loadingBalances)).toBe(false);
+    expect(get(loadingBalancesAndDetection)).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/balances/use-balance-prices-store.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-prices-store.spec.ts
@@ -1,0 +1,27 @@
+import { bigNumberify } from '@rotki/common';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useBalancePricesStore } from './use-balance-prices-store';
+
+describe('useBalancePricesStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should start with empty prices and rates and no previous currency', () => {
+    const store = useBalancePricesStore();
+    expect(get(store.prices)).toEqual({});
+    expect(get(store.exchangeRates)).toEqual({});
+    expect(get(store.previousCurrency)).toBeUndefined();
+  });
+
+  it('should hold the assigned prices, rates and previous currency', () => {
+    const { exchangeRates, prices, previousCurrency } = storeToRefs(useBalancePricesStore());
+    set(prices, { ETH: { isManualPrice: false, oracle: 'coingecko', value: bigNumberify(1000) } });
+    set(exchangeRates, { EUR: bigNumberify(0.9) });
+    set(previousCurrency, 'EUR');
+
+    expect(get(prices).ETH.value).toEqual(bigNumberify(1000));
+    expect(get(exchangeRates).EUR).toEqual(bigNumberify(0.9));
+    expect(get(previousCurrency)).toBe('EUR');
+  });
+});

--- a/frontend/app/src/modules/history/balances/use-historical-balances-store.spec.ts
+++ b/frontend/app/src/modules/history/balances/use-historical-balances-store.spec.ts
@@ -1,0 +1,74 @@
+import type { HistoricalBalanceProcessingData, NegativeBalanceDetectedData } from '@/modules/core/messaging/types/status-types';
+import { bigNumberify } from '@rotki/common';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useHistoricalBalancesStore } from './use-historical-balances-store';
+
+function progress(processed: number, total: number): HistoricalBalanceProcessingData {
+  return { processed, total };
+}
+
+function negative(lastRunTs: number, eventIdentifier = 1): NegativeBalanceDetectedData {
+  return {
+    asset: 'ETH',
+    balanceBefore: bigNumberify('-1'),
+    bucket: { asset: 'ETH', location: 'ethereum', locationLabel: null, protocol: null },
+    eventIdentifier,
+    groupIdentifier: '0x1',
+    lastRunTs,
+  };
+}
+
+describe('useHistoricalBalancesStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should report processing state and percentage', () => {
+    const store = useHistoricalBalancesStore();
+    expect(get(store.isProcessing)).toBe(false);
+    expect(get(store.processingPercentage)).toBe(0);
+
+    store.setProcessingProgress(progress(25, 100));
+    expect(get(store.isProcessing)).toBe(true);
+    expect(get(store.processingPercentage)).toBe(25);
+
+    store.setProcessingProgress(progress(100, 100));
+    expect(get(store.isProcessing)).toBe(false);
+    expect(get(store.processingPercentage)).toBe(100);
+  });
+
+  it('should treat a zero total as not processing', () => {
+    const store = useHistoricalBalancesStore();
+    store.setProcessingProgress(progress(0, 0));
+    expect(get(store.isProcessing)).toBe(false);
+    expect(get(store.processingPercentage)).toBe(0);
+  });
+
+  it('should reset negative balances when a new processing cycle starts', () => {
+    const store = useHistoricalBalancesStore();
+    store.setProcessingProgress(progress(50, 100));
+    store.addNegativeBalance(negative(1000));
+    expect(get(store.negativeBalances)).toHaveLength(1);
+
+    // processed drops below the previous value -> new cycle -> reset
+    store.setProcessingProgress(progress(10, 100));
+    expect(get(store.negativeBalances)).toEqual([]);
+  });
+
+  it('should accumulate negative balances sharing a run timestamp', () => {
+    const store = useHistoricalBalancesStore();
+    store.addNegativeBalance(negative(1000, 1));
+    store.addNegativeBalance(negative(1000, 2));
+    expect(get(store.negativeBalances)).toHaveLength(2);
+  });
+
+  it('should start a fresh list when the run timestamp changes', () => {
+    const store = useHistoricalBalancesStore();
+    store.addNegativeBalance(negative(1000, 1));
+    store.addNegativeBalance(negative(2000, 2));
+    const result = get(store.negativeBalances);
+    expect(result).toHaveLength(1);
+    expect(result[0].lastRunTs).toBe(2000);
+    expect(result[0].eventIdentifier).toBe(2);
+  });
+});

--- a/frontend/app/src/modules/history/events/dialog-manager/use-history-events-dialog-manager.spec.ts
+++ b/frontend/app/src/modules/history/events/dialog-manager/use-history-events-dialog-manager.spec.ts
@@ -1,0 +1,101 @@
+import type { GroupEventData } from '@/modules/history/management/forms/form-types';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRouter } from 'vue-router';
+import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
+import { DIALOG_TYPES } from '@/modules/history/events/dialog-types';
+import { PinnedNames } from '@/modules/session/types';
+import { useHistoryEventsDialogManager } from './use-history-events-dialog-manager';
+
+const push = vi.fn();
+
+describe('useHistoryEventsDialogManager', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    push.mockClear();
+    vi.mocked(useRouter).mockReturnValue(createMock<ReturnType<typeof useRouter>>({ push }));
+  });
+
+  it('should start closed', () => {
+    const { currentDialog } = useHistoryEventsDialogManager();
+    expect(get(currentDialog)).toEqual({ type: 'closed' });
+  });
+
+  it('should open the event form with its data', async () => {
+    const { currentDialog, show } = useHistoryEventsDialogManager();
+    const data = createMock<GroupEventData>();
+    await show({ data, type: DIALOG_TYPES.EVENT_FORM });
+    const dialog = get(currentDialog);
+    expect(dialog.type).toBe(DIALOG_TYPES.EVENT_FORM);
+    if (dialog.type === DIALOG_TYPES.EVENT_FORM)
+      expect(dialog.data).toBe(data);
+  });
+
+  it('should default the transaction form data when none is given', async () => {
+    const { currentDialog, show } = useHistoryEventsDialogManager();
+    await show({ type: DIALOG_TYPES.TRANSACTION_FORM });
+    expect(get(currentDialog)).toEqual({
+      data: { associatedAddress: '', blockchain: '', txRef: '' },
+      type: DIALOG_TYPES.TRANSACTION_FORM,
+    });
+  });
+
+  it('should map add-transaction to an empty transaction form', async () => {
+    const { currentDialog, show } = useHistoryEventsDialogManager();
+    await show({ type: DIALOG_TYPES.ADD_TRANSACTION });
+    expect(get(currentDialog)).toEqual({
+      data: { associatedAddress: '', blockchain: '', txRef: '' },
+      type: DIALOG_TYPES.TRANSACTION_FORM,
+    });
+  });
+
+  it('should carry the persistent flag into the decoding-status dialog', async () => {
+    const { currentDialog, show } = useHistoryEventsDialogManager();
+    await show({ persistent: true, type: DIALOG_TYPES.DECODING_STATUS });
+    expect(get(currentDialog)).toEqual({ data: { persistent: true }, type: DIALOG_TYPES.DECODING_STATUS });
+  });
+
+  it('should open dataless dialogs', async () => {
+    const { currentDialog, show } = useHistoryEventsDialogManager();
+    await show({ type: DIALOG_TYPES.PROTOCOL_CACHE });
+    expect(get(currentDialog)).toEqual({ data: undefined, type: DIALOG_TYPES.PROTOCOL_CACHE });
+  });
+
+  it('should navigate to the accounting settings for add-missing-rule', async () => {
+    const { show } = useHistoryEventsDialogManager();
+    await show({
+      data: { counterparty: 'cp', eventIds: [5], eventSubtype: 'sub', eventType: 'type' },
+      type: DIALOG_TYPES.ADD_MISSING_RULE,
+    });
+    expect(push).toHaveBeenCalledWith({
+      path: '/settings/accounting',
+      query: { 'add-rule': 'true', 'counterparty': 'cp', 'eventId': '5', 'eventSubtype': 'sub', 'eventType': 'type' },
+    });
+  });
+
+  it('should reveal the pinned panel instead of opening the conflicts dialog when already pinned', async () => {
+    const { pinned, showPinned } = storeToRefs(useAreaVisibilityStore());
+    set(pinned, { name: PinnedNames.INTERNAL_TX_CONFLICTS, props: {} });
+    set(showPinned, false);
+
+    const { currentDialog, show } = useHistoryEventsDialogManager();
+    await show({ type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS });
+
+    expect(get(showPinned)).toBe(true);
+    expect(get(currentDialog)).toEqual({ type: 'closed' });
+  });
+
+  it('should open the conflicts dialog when not pinned', async () => {
+    const { currentDialog, show } = useHistoryEventsDialogManager();
+    await show({ type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS });
+    expect(get(currentDialog)).toEqual({ data: undefined, type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS });
+  });
+
+  it('should close an open dialog', async () => {
+    const { closeDialog, currentDialog, show } = useHistoryEventsDialogManager();
+    await show({ type: DIALOG_TYPES.PROTOCOL_CACHE });
+    expect(get(currentDialog).type).toBe(DIALOG_TYPES.PROTOCOL_CACHE);
+    closeDialog();
+    expect(get(currentDialog)).toEqual({ type: 'closed' });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-deletion-strategies.spec.ts
+++ b/frontend/app/src/modules/history/events/use-deletion-strategies.spec.ts
@@ -1,0 +1,88 @@
+import type { SwapGroup, TransactionGroup } from './use-event-analysis';
+import { mockT } from '@test/i18n';
+import { createMock } from '@test/utils/create-mock';
+import { describe, expect, it } from 'vitest';
+import { buildDeletionConfirmationMessage, DELETION_STRATEGY_TYPE } from './use-deletion-strategies';
+
+// `buildDeletionConfirmationMessage` takes `t` as a parameter (it is not a
+// composable), so we hand it the same shared mock the global `useI18n` uses.
+// mockT returns `key` alone, or `key::<comma-joined arg values>` when given params.
+const t = mockT;
+
+function txGroups(count: number): Map<string, TransactionGroup> {
+  const map = new Map<string, TransactionGroup>();
+  // only the map size is read, so an empty stub per entry is enough.
+  for (let i = 0; i < count; i++)
+    map.set(`0x${i}`, createMock<TransactionGroup>());
+  return map;
+}
+
+describe('buildDeletionConfirmationMessage', () => {
+  it('should build a single-transaction delete message', () => {
+    const result = buildDeletionConfirmationMessage(
+      { transactions: txGroups(1), type: DELETION_STRATEGY_TYPE.DELETE_TRANSACTIONS },
+      t,
+    );
+    expect(result.message).toContain('transactions.events.confirmation.delete.complete_transaction_single');
+    expect(result.message).toContain('transactions.events.confirmation.delete.complete_transaction_options');
+    expect(result.primaryAction).toBe('transactions.events.confirmation.delete.delete_transaction');
+    expect(result.secondaryAction).toBe('transactions.events.confirmation.ignore.action_short');
+    expect(result.title).toBe('transactions.events.confirmation.delete.complete_transaction_title');
+  });
+
+  it('should switch to the plural transaction key with the count', () => {
+    const result = buildDeletionConfirmationMessage(
+      { transactions: txGroups(3), type: DELETION_STRATEGY_TYPE.DELETE_TRANSACTIONS },
+      t,
+    );
+    expect(result.message).toContain('complete_transaction_multiple::3');
+  });
+
+  it('should build a delete-events message with the event count', () => {
+    const result = buildDeletionConfirmationMessage(
+      { eventIds: [1, 2, 3], type: DELETION_STRATEGY_TYPE.DELETE_EVENTS },
+      t,
+    );
+    expect(result.message).toBe('transactions.events.confirmation.delete.message_multiple::3');
+    expect(result.primaryAction).toBe('common.actions.confirm');
+    expect(result.secondaryAction).toBeUndefined();
+  });
+
+  it('should aggregate totals across partial swap groups', () => {
+    const partialSwapGroups: SwapGroup[] = [
+      { groupIds: [1, 2, 3], selectedIds: [1] },
+      { groupIds: [4, 5], selectedIds: [4, 5] },
+    ];
+    const result = buildDeletionConfirmationMessage(
+      { partialSwapGroups, type: DELETION_STRATEGY_TYPE.DELETE_PARTIAL_SWAP },
+      t,
+    );
+    // mockT joins arg values in insertion order: groupCount, selectedCount, totalCount
+    expect(result.message).toBe('transactions.events.confirmation.delete.partial_swap_warning::2, 3, 5');
+    expect(result.title).toBe('transactions.events.confirmation.delete.partial_swap_title');
+  });
+
+  it('should build an ignore-events message from the transaction size', () => {
+    const result = buildDeletionConfirmationMessage(
+      { transactions: txGroups(2), type: DELETION_STRATEGY_TYPE.IGNORE_EVENTS },
+      t,
+    );
+    expect(result.message).toBe('transactions.events.confirmation.ignore.message_multiple::2');
+    expect(result.primaryAction).toBe('transactions.events.confirmation.ignore.confirm');
+  });
+
+  it('should default counts to zero when collections are missing', () => {
+    const result = buildDeletionConfirmationMessage(
+      { type: DELETION_STRATEGY_TYPE.DELETE_EVENTS },
+      t,
+    );
+    expect(result.message).toContain('message_multiple::0');
+  });
+
+  it('should throw on an unknown strategy type', () => {
+    expect(() => buildDeletionConfirmationMessage(
+      { type: 'nonsense' as never },
+      t,
+    )).toThrow('Unknown deletion strategy');
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-events-auto-fetch.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-auto-fetch.spec.ts
@@ -1,0 +1,94 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type Ref } from 'vue';
+import { useHistoryEventsAutoFetch } from './use-history-events-auto-fetch';
+
+const REFRESH_INTERVAL = 60_000;
+
+function mountAutoFetch(shouldFetch: Ref<boolean>, fetchFunction: () => Promise<void>): VueWrapper {
+  return mount(defineComponent({
+    render: () => null,
+    setup() {
+      useHistoryEventsAutoFetch(shouldFetch, fetchFunction);
+      return {};
+    },
+  }));
+}
+
+describe('useHistoryEventsAutoFetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should call the fetch function on each interval while enabled', async () => {
+    const fetchFunction = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountAutoFetch(ref(true), fetchFunction);
+
+    expect(fetchFunction).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL);
+    expect(fetchFunction).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL);
+    expect(fetchFunction).toHaveBeenCalledTimes(2);
+
+    wrapper.unmount();
+  });
+
+  it('should skip a tick while a previous fetch is still in flight', async () => {
+    let resolve: () => void = () => {};
+    const fetchFunction = vi.fn().mockImplementation(async () => new Promise<void>((res) => {
+      resolve = res;
+    }));
+    const wrapper = mountAutoFetch(ref(true), fetchFunction);
+
+    await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL);
+    expect(fetchFunction).toHaveBeenCalledTimes(1);
+
+    // second tick fires while the first fetch is unresolved -> guarded
+    await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL);
+    expect(fetchFunction).toHaveBeenCalledTimes(1);
+
+    // once the in-flight fetch resolves, the next tick runs again
+    resolve();
+    await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL);
+    expect(fetchFunction).toHaveBeenCalledTimes(2);
+
+    wrapper.unmount();
+  });
+
+  it('should pause and resume when the enabled flag toggles', async () => {
+    const shouldFetch = ref<boolean>(true);
+    const fetchFunction = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountAutoFetch(shouldFetch, fetchFunction);
+
+    await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL);
+    expect(fetchFunction).toHaveBeenCalledTimes(1);
+
+    set(shouldFetch, false);
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL * 3);
+    expect(fetchFunction).toHaveBeenCalledTimes(1); // paused
+
+    set(shouldFetch, true);
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL);
+    expect(fetchFunction).toHaveBeenCalledTimes(2); // resumed
+
+    wrapper.unmount();
+  });
+
+  it('should stop fetching after the component unmounts', async () => {
+    const fetchFunction = vi.fn().mockResolvedValue(undefined);
+    const wrapper = mountAutoFetch(ref(true), fetchFunction);
+
+    await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL);
+    expect(fetchFunction).toHaveBeenCalledTimes(1);
+
+    wrapper.unmount();
+    await vi.advanceTimersByTimeAsync(REFRESH_INTERVAL * 3);
+    expect(fetchFunction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-events-deletion.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-deletion.spec.ts
@@ -1,0 +1,171 @@
+import type { TransactionGroup } from './use-event-analysis';
+import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
+import type { HistoryEventRow } from '@/modules/history/events/schemas';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHistoryEventsDeletion } from './use-history-events-deletion';
+import { useHistoryEventsSelectionMode } from './use-selection-mode';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    showConfirm: vi.fn(),
+    showErrorMessage: vi.fn(),
+    showSuccessMessage: vi.fn(),
+    deleteHistoryEventApi: vi.fn(),
+    deleteTransactions: vi.fn(),
+    deleteHistoryEvent: vi.fn(),
+    ignoreSingle: vi.fn(),
+    getChain: vi.fn((chain: string) => chain),
+    analyzeSelectedEvents: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): object => ({ show: spies.showConfirm }),
+}));
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): object => ({ getChain: spies.getChain }),
+}));
+vi.mock('@/modules/core/notifications/use-notifications', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
+  return { ...actual, useNotifications: (): object => ({ showErrorMessage: spies.showErrorMessage, showSuccessMessage: spies.showSuccessMessage }) };
+});
+vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
+  useHistoryEventsApi: (): object => ({ deleteHistoryEvent: spies.deleteHistoryEventApi, deleteTransactions: spies.deleteTransactions }),
+}));
+vi.mock('@/modules/history/events/use-history-events', () => ({
+  useHistoryEvents: (): object => ({ deleteHistoryEvent: spies.deleteHistoryEvent }),
+}));
+vi.mock('@/modules/history/use-ignore', () => ({
+  useIgnore: (): object => ({ ignoreSingle: spies.ignoreSingle }),
+}));
+vi.mock('./use-event-analysis', () => ({
+  analyzeSelectedEvents: spies.analyzeSelectedEvents,
+}));
+
+function txGroup(chain: string, groupIdentifier: string, events: number[]): TransactionGroup {
+  return { chain, events, groupIdentifier };
+}
+
+function setup(pageParams?: HistoryEventRequestPayload): {
+  deletion: ReturnType<typeof useHistoryEventsDeletion>;
+  selectionMode: ReturnType<typeof useHistoryEventsSelectionMode>;
+  refreshCallback: ReturnType<typeof vi.fn>;
+} {
+  const selectionMode = useHistoryEventsSelectionMode();
+  const refreshCallback = vi.fn().mockResolvedValue(undefined);
+  const deletion = useHistoryEventsDeletion(
+    selectionMode,
+    ref<Record<string, HistoryEventRow[]>>({}),
+    ref<HistoryEventRow[]>([]),
+    refreshCallback,
+    pageParams ? computed<HistoryEventRequestPayload>(() => pageParams) : undefined,
+  );
+  return { deletion, refreshCallback, selectionMode };
+}
+
+// `deleteSelected` blocks on a confirm dialog whose callback resolves the inner
+// promise, so we start it, invoke the callback (index 1 = primary), then await it.
+async function drive(run: Promise<void>, index = 1): Promise<void> {
+  await spies.showConfirm.mock.calls[0][index]();
+  await run;
+}
+
+describe('useHistoryEventsDeletion', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    spies.deleteHistoryEvent.mockResolvedValue({ success: true });
+    spies.deleteHistoryEventApi.mockResolvedValue(true);
+    spies.deleteTransactions.mockResolvedValue(undefined);
+    spies.analyzeSelectedEvents.mockReturnValue({ completeTransactions: new Map(), partialEventIds: [], partialSwapGroups: [] });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should do nothing when the selection is empty', async () => {
+    const { deletion } = setup();
+    await deletion.deleteSelected();
+    expect(spies.showConfirm).not.toHaveBeenCalled();
+    expect(get(deletion.isDeleting)).toBe(false);
+  });
+
+  it('should delete by filter when select-all-matching is active', async () => {
+    const { deletion, refreshCallback, selectionMode } = setup({
+      ascending: [true],
+      limit: 10,
+      offset: 0,
+      onlyCache: true,
+      groupByEventIds: true,
+    } as unknown as HistoryEventRequestPayload);
+    selectionMode.actions.toggleSelectAllMatching();
+    selectionMode.setTotalMatchingCount(42);
+
+    const run = deletion.deleteSelected();
+    expect(spies.showConfirm).toHaveBeenCalledOnce();
+
+    await drive(run);
+    // pagination/sort keys are stripped before the filter delete
+    expect(spies.deleteHistoryEventApi).toHaveBeenCalledWith({ groupByEventIds: true }, true);
+    expect(spies.showSuccessMessage).toHaveBeenCalledOnce();
+    expect(refreshCallback).toHaveBeenCalledOnce();
+    expect(get(deletion.isDeleting)).toBe(false);
+  });
+
+  it('should delete partial events through the confirmation', async () => {
+    spies.analyzeSelectedEvents.mockReturnValue({ completeTransactions: new Map(), partialEventIds: [1, 2], partialSwapGroups: [] });
+    const { deletion, refreshCallback, selectionMode } = setup();
+    selectionMode.actions.toggleEvent(1);
+    selectionMode.actions.toggleEvent(2);
+
+    await drive(deletion.deleteSelected());
+
+    expect(spies.deleteHistoryEvent).toHaveBeenCalledWith([1, 2], false);
+    expect(spies.showSuccessMessage).toHaveBeenCalledOnce();
+    expect(refreshCallback).toHaveBeenCalledOnce();
+  });
+
+  it('should surface an error when partial event deletion fails', async () => {
+    spies.deleteHistoryEvent.mockResolvedValue({ message: 'nope', success: false });
+    spies.analyzeSelectedEvents.mockReturnValue({ completeTransactions: new Map(), partialEventIds: [1], partialSwapGroups: [] });
+    const { deletion, refreshCallback, selectionMode } = setup();
+    selectionMode.actions.toggleEvent(1);
+
+    await drive(deletion.deleteSelected());
+
+    expect(spies.showErrorMessage).toHaveBeenCalledOnce();
+    expect(refreshCallback).not.toHaveBeenCalled();
+  });
+
+  it('should delete complete transactions and expose a secondary ignore option', async () => {
+    const transactions = new Map([['0xabc', txGroup('ethereum', 'g1', [1, 2])]]);
+    spies.analyzeSelectedEvents.mockReturnValue({ completeTransactions: transactions, partialEventIds: [], partialSwapGroups: [] });
+    const { deletion, refreshCallback, selectionMode } = setup();
+    selectionMode.actions.toggleEvent(1);
+
+    const run = deletion.deleteSelected();
+    // primary + secondary callbacks are both registered
+    expect(spies.showConfirm.mock.calls[0]).toHaveLength(3);
+
+    await drive(run);
+    expect(spies.deleteTransactions).toHaveBeenCalledWith('ethereum', '0xabc');
+    expect(spies.showSuccessMessage).toHaveBeenCalledOnce();
+    expect(refreshCallback).toHaveBeenCalledOnce();
+  });
+
+  it('should delete partial swap groups plus remaining events', async () => {
+    spies.analyzeSelectedEvents.mockReturnValue({
+      completeTransactions: new Map(),
+      partialEventIds: [9],
+      partialSwapGroups: [{ groupIds: [1, 2], selectedIds: [1] }],
+    });
+    const { deletion, refreshCallback, selectionMode } = setup();
+    selectionMode.actions.toggleEvent(1);
+
+    await drive(deletion.deleteSelected());
+
+    // full swap group ids (1,2) plus remaining event (9)
+    expect(spies.deleteHistoryEvent).toHaveBeenCalledWith([1, 2, 9], false);
+    expect(refreshCallback).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-events-operations.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-operations.spec.ts
@@ -1,0 +1,187 @@
+import type { PullEventPayload } from '@/modules/history/events/event-payloads';
+import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
+import type { HistoryEventsTableEmitFn } from '@/modules/history/events/types';
+import { HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHistoryEventsOperations } from './use-history-events-operations';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    show: vi.fn(),
+    notifyError: vi.fn(),
+    getChain: vi.fn((location: string) => location),
+    deleteTransactions: vi.fn(),
+    unlinkAssetMovement: vi.fn(),
+    refreshUnmatchedAssetMovements: vi.fn(),
+    deleteHistoryEvent: vi.fn(),
+    ignoreSingle: vi.fn(),
+    toggle: vi.fn(),
+    getGroupEvents: vi.fn(() => [] as HistoryEventEntry[]),
+    isAssetMovementEvent: vi.fn(() => false),
+    isCustomizedEvent: vi.fn(() => false),
+  },
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): object => ({ show: spies.show }),
+}));
+vi.mock('@/modules/core/notifications/use-notifications', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
+  return { ...actual, useNotifications: (): object => ({ notifyError: spies.notifyError }) };
+});
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): object => ({ getChain: spies.getChain }),
+}));
+vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
+  useHistoryEventsApi: (): object => ({ deleteTransactions: spies.deleteTransactions }),
+}));
+vi.mock('@/modules/history/api/events/use-asset-movement-matching-api', () => ({
+  useAssetMovementMatchingApi: (): object => ({ unlinkAssetMovement: spies.unlinkAssetMovement }),
+}));
+vi.mock('@/modules/history/events/use-unmatched-asset-movements', () => ({
+  useUnmatchedAssetMovements: (): object => ({ refreshUnmatchedAssetMovements: spies.refreshUnmatchedAssetMovements }),
+}));
+vi.mock('@/modules/history/events/use-history-events', () => ({
+  useHistoryEvents: (): object => ({ deleteHistoryEvent: spies.deleteHistoryEvent }),
+}));
+vi.mock('@/modules/history/use-ignore', () => ({
+  useIgnore: (): object => ({ ignoreSingle: spies.ignoreSingle, toggle: spies.toggle }),
+}));
+vi.mock('@/modules/history/events/use-complete-events', () => ({
+  useCompleteEvents: (): object => ({ getGroupEvents: spies.getGroupEvents }),
+}));
+vi.mock('@/modules/history/event-utils', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/history/event-utils')>('@/modules/history/event-utils');
+  return { ...actual, isAssetMovementEvent: spies.isAssetMovementEvent, isCustomizedEvent: spies.isCustomizedEvent };
+});
+
+const emit = vi.fn() as unknown as HistoryEventsTableEmitFn;
+
+function setup(flattened: HistoryEventEntry[] = []): ReturnType<typeof useHistoryEventsOperations> {
+  return useHistoryEventsOperations({
+    completeEventsMapped: computed<Record<string, HistoryEventRow[]>>(() => ({})),
+    flattenedEvents: computed<HistoryEventEntry[]>(() => flattened),
+  }, emit);
+}
+
+const evmPayload: PullEventPayload = { data: { location: 'ethereum', txRef: '0x1' }, type: HistoryEventEntryType.EVM_EVENT };
+const blockPayload: PullEventPayload = { data: [123], type: HistoryEventEntryType.ETH_BLOCK_EVENT };
+
+describe('useHistoryEventsOperations', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    spies.getChain.mockImplementation((location: string) => location);
+    spies.getGroupEvents.mockReturnValue([]);
+    spies.isAssetMovementEvent.mockReturnValue(false);
+    spies.isCustomizedEvent.mockReturnValue(false);
+  });
+
+  it('should dim ignored events via the item class', () => {
+    const ops = setup();
+    expect(ops.getItemClass(createMock<HistoryEventEntry>({ ignoredInAccounting: true }))).toBe('opacity-50');
+    expect(ops.getItemClass(createMock<HistoryEventEntry>({ ignoredInAccounting: false }))).toBe('');
+  });
+
+  it('should suggest the next sequence id from the group max', () => {
+    const flattened = [
+      createMock<HistoryEventEntry>({ groupIdentifier: 'g1', hidden: false, sequenceIndex: 2 }),
+      createMock<HistoryEventEntry>({ groupIdentifier: 'g1', hidden: false, sequenceIndex: 5 }),
+      createMock<HistoryEventEntry>({ groupIdentifier: 'g1', hidden: true, sequenceIndex: 9 }), // hidden ignored
+      createMock<HistoryEventEntry>({ groupIdentifier: 'other', hidden: false, sequenceIndex: 20 }),
+    ];
+    const ops = setup(flattened);
+    expect(ops.suggestNextSequenceId(createMock<HistoryEventEntry>({ groupIdentifier: 'g1', sequenceIndex: 0 }))).toBe('6');
+  });
+
+  it('should fall back to group sequence + 1 when nothing is flattened', () => {
+    const ops = setup([]);
+    expect(ops.suggestNextSequenceId(createMock<HistoryEventEntry>({ groupIdentifier: 'g1', sequenceIndex: 7 }))).toBe('8');
+  });
+
+  it('should emit a block-event refresh when redecoding a block payload', () => {
+    setup().redecode(blockPayload, 'g1');
+    expect(emit).toHaveBeenCalledWith('refresh:block-event', { blockNumbers: [123] });
+  });
+
+  it('should open the confirmation dialog when the group has custom events', () => {
+    spies.getGroupEvents.mockReturnValue([createMock<HistoryEventEntry>({})]);
+    spies.isCustomizedEvent.mockReturnValue(true);
+    const ops = setup();
+    ops.redecode(evmPayload, 'g1');
+    expect(get(ops.hasCustomEvents)).toBe(true);
+    expect(get(ops.showRedecodeConfirmation)).toBe(true);
+    expect(get(ops.redecodePayload)).toEqual(evmPayload);
+    expect(emit).not.toHaveBeenCalledWith('refresh', expect.anything());
+  });
+
+  it('should redecode directly when there are no custom events', () => {
+    spies.getGroupEvents.mockReturnValue([createMock<HistoryEventEntry>({})]);
+    setup().redecode(evmPayload, 'g1');
+    expect(emit).toHaveBeenCalledWith('refresh', {
+      deleteCustom: false,
+      linkedMovement: undefined,
+      transactions: [evmPayload.data],
+    });
+  });
+
+  it('should show indexer options for EVM redecode-with-options', () => {
+    spies.getGroupEvents.mockReturnValue([createMock<HistoryEventEntry>({})]);
+    const ops = setup();
+    ops.redecodeWithOptions(evmPayload, 'g1');
+    expect(get(ops.showIndexerOptions)).toBe(true);
+    expect(get(ops.showRedecodeConfirmation)).toBe(true);
+    expect(get(ops.redecodePayload)).toEqual(evmPayload);
+  });
+
+  it('should emit refresh and reset payload on confirm-redecode', () => {
+    const ops = setup();
+    ops.confirmRedecode({ deleteCustom: true, payload: evmPayload });
+    expect(emit).toHaveBeenCalledWith('refresh', expect.objectContaining({
+      deleteCustom: true,
+      transactions: [evmPayload.data],
+    }));
+    expect(get(ops.redecodePayload)).toBeUndefined();
+  });
+
+  it('should delete events through the confirmation callback', async () => {
+    spies.deleteHistoryEvent.mockResolvedValue({ success: true });
+    setup().confirmDelete({ ids: [1, 2], type: 'delete' });
+    expect(spies.show).toHaveBeenCalledOnce();
+    await spies.show.mock.calls[0][1]();
+    expect(spies.deleteHistoryEvent).toHaveBeenCalledWith([1, 2]);
+    expect(emit).toHaveBeenCalledWith('refresh');
+  });
+
+  it('should ignore an event through the confirmation callback', async () => {
+    const event = createMock<HistoryEventEntry>({ identifier: 1 });
+    setup().confirmDelete({ event, type: 'ignore' });
+    await spies.show.mock.calls[0][1]();
+    expect(spies.ignoreSingle).toHaveBeenCalledWith(event, true);
+    expect(spies.deleteHistoryEvent).not.toHaveBeenCalled();
+  });
+
+  it('should delete a transaction and its events, notifying on error', async () => {
+    setup().confirmTxAndEventsDelete({ location: 'ethereum', txRef: '0x1' });
+    await spies.show.mock.calls[0][1]();
+    expect(spies.deleteTransactions).toHaveBeenCalledWith('ethereum', '0x1');
+    expect(emit).toHaveBeenCalledWith('refresh');
+
+    spies.deleteTransactions.mockRejectedValueOnce(new Error('boom'));
+    setup().confirmTxAndEventsDelete({ location: 'ethereum', txRef: '0x2' });
+    await spies.show.mock.calls[1][1]();
+    expect(spies.notifyError).toHaveBeenCalledOnce();
+  });
+
+  it('should unlink an asset movement through the confirmation callback', async () => {
+    setup().confirmUnlink({ identifier: 9 });
+    await spies.show.mock.calls[0][1]();
+    expect(spies.unlinkAssetMovement).toHaveBeenCalledWith(9);
+    expect(spies.refreshUnmatchedAssetMovements).toHaveBeenCalledOnce();
+    expect(emit).toHaveBeenCalledWith('refresh');
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-events-selection-actions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-selection-actions.spec.ts
@@ -1,0 +1,135 @@
+import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHistoryEventsSelectionActions } from './use-history-events-selection-actions';
+import { useHistoryEventsSelectionMode } from './use-selection-mode';
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    showConfirm: vi.fn(),
+    ignore: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): object => ({ show: spies.showConfirm }),
+}));
+
+vi.mock('@/modules/history/use-ignore', () => ({
+  useIgnore: (): object => ({ ignore: spies.ignore }),
+}));
+
+function historyEvent(overrides: Partial<HistoryEventEntry>): HistoryEventEntry {
+  return createMock<HistoryEventEntry>({ eventSubtype: 'fee', eventType: 'spend', ignoredInAccounting: false, ...overrides });
+}
+
+function setup(events: HistoryEventEntry[]): {
+  actions: ReturnType<typeof useHistoryEventsSelectionActions>;
+  selectionMode: ReturnType<typeof useHistoryEventsSelectionMode>;
+  deleteSelected: ReturnType<typeof vi.fn>;
+  refreshCallback: ReturnType<typeof vi.fn>;
+} {
+  const selectionMode = useHistoryEventsSelectionMode();
+  const deleteSelected = vi.fn().mockResolvedValue(undefined);
+  const refreshCallback = vi.fn().mockResolvedValue(undefined);
+  const originalGroups = ref<HistoryEventRow[]>(events);
+  const actions = useHistoryEventsSelectionActions({
+    deletion: { deleteSelected },
+    originalGroups,
+    refreshCallback,
+    selectionMode,
+  });
+  return { actions, deleteSelected, refreshCallback, selectionMode };
+}
+
+function select(selectionMode: ReturnType<typeof useHistoryEventsSelectionMode>, ...ids: number[]): void {
+  ids.forEach(id => selectionMode.actions.toggleEvent(id));
+}
+
+describe('useHistoryEventsSelectionActions', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should delegate the delete action to the deletion handler', async () => {
+    const { actions, deleteSelected } = setup([]);
+    await actions.handleSelectionAction('delete');
+    expect(deleteSelected).toHaveBeenCalledOnce();
+  });
+
+  it('should drive selection-mode toggles', async () => {
+    const { actions, selectionMode } = setup([]);
+    await actions.handleSelectionAction('toggle-mode');
+    expect(get(selectionMode.isSelectionMode)).toBe(true);
+    await actions.handleSelectionAction('exit');
+    expect(get(selectionMode.isSelectionMode)).toBe(false);
+    await actions.handleSelectionAction('toggle-select-all-matching');
+    expect(get(selectionMode.isSelectAllMatching)).toBe(true);
+  });
+
+  it('should report the ignored/not-ignored split of the selection', () => {
+    const events = [
+      historyEvent({ identifier: 1, ignoredInAccounting: true }),
+      historyEvent({ identifier: 2, ignoredInAccounting: false }),
+      historyEvent({ identifier: 3, ignoredInAccounting: false }),
+    ];
+    const { actions, selectionMode } = setup(events);
+    select(selectionMode, 1, 2, 3);
+    expect(get(actions.ignoreStatus)).toEqual({ ignoredCount: 1, notIgnoredCount: 2 });
+  });
+
+  it('should warn when creating a rule with no selected events', async () => {
+    const { actions } = setup([]);
+    await actions.handleSelectionAction('create-rule');
+    expect(spies.showConfirm).toHaveBeenCalledOnce();
+    expect(get(actions.accountingRuleToEdit)).toBeUndefined();
+  });
+
+  it('should warn when the selected events have differing types', async () => {
+    const events = [
+      historyEvent({ eventSubtype: 'fee', eventType: 'spend', identifier: 1 }),
+      historyEvent({ eventSubtype: 'reward', eventType: 'receive', identifier: 2 }),
+    ];
+    const { actions, selectionMode } = setup(events);
+    select(selectionMode, 1, 2);
+    await actions.handleSelectionAction('create-rule');
+    expect(spies.showConfirm).toHaveBeenCalledOnce();
+    expect(get(actions.accountingRuleToEdit)).toBeUndefined();
+  });
+
+  it('should seed an accounting rule when the selection shares a type', async () => {
+    const events = [
+      historyEvent({ eventSubtype: 'fee', eventType: 'spend', identifier: 1 }),
+      historyEvent({ eventSubtype: 'fee', eventType: 'spend', identifier: 2 }),
+    ];
+    const { actions, selectionMode } = setup(events);
+    select(selectionMode, 1, 2);
+    await actions.handleSelectionAction('create-rule');
+    expect(spies.showConfirm).not.toHaveBeenCalled();
+    expect(get(actions.selectedEventIds)).toEqual([1, 2]);
+    expect(get(actions.accountingRuleToEdit)).toMatchObject({ eventSubtype: 'fee', eventType: 'spend' });
+  });
+
+  it('should ignore and unignore the selected events', async () => {
+    const events = [historyEvent({ identifier: 1 })];
+    const { actions, selectionMode } = setup(events);
+    select(selectionMode, 1);
+
+    await actions.handleSelectionAction('ignore');
+    expect(spies.ignore).toHaveBeenLastCalledWith(true);
+
+    await actions.handleSelectionAction('unignore');
+    expect(spies.ignore).toHaveBeenLastCalledWith(false);
+  });
+
+  it('should exit selection mode after an accounting-rule refresh', () => {
+    const { actions, selectionMode } = setup([]);
+    selectionMode.actions.toggle();
+    actions.handleAccountingRuleRefresh();
+    expect(get(selectionMode.isSelectionMode)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/history/events/use-selection-mode.spec.ts
+++ b/frontend/app/src/modules/history/events/use-selection-mode.spec.ts
@@ -1,0 +1,121 @@
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import { createMock } from '@test/utils/create-mock';
+import { describe, expect, it } from 'vitest';
+import { useHistoryEventsSelectionMode } from './use-selection-mode';
+
+// selection mode only reads `identifier`, so a minimal stub is enough here.
+function event(identifier: number): HistoryEventEntry {
+  return createMock<HistoryEventEntry>({ identifier });
+}
+
+describe('useHistoryEventsSelectionMode', () => {
+  it('should start inactive with an empty selection', () => {
+    const { state } = useHistoryEventsSelectionMode();
+    expect(get(state)).toMatchObject({
+      hasAvailableEvents: false,
+      isActive: false,
+      isAllSelected: false,
+      isPartiallySelected: false,
+      selectAllMatching: false,
+      selectedCount: 0,
+    });
+    expect(get(state).selectedIds.size).toBe(0);
+  });
+
+  it('should toggle selection mode on and off, clearing on exit', () => {
+    const { actions, isSelectionMode, state } = useHistoryEventsSelectionMode();
+    actions.toggle();
+    expect(get(isSelectionMode)).toBe(true);
+
+    actions.toggleEvent(1);
+    expect(get(state).selectedCount).toBe(1);
+
+    // toggling off clears the selection
+    actions.toggle();
+    expect(get(isSelectionMode)).toBe(false);
+    expect(get(state).selectedCount).toBe(0);
+  });
+
+  it('should toggle individual events', () => {
+    const { actions, isEventSelected, getSelectedIds } = useHistoryEventsSelectionMode();
+    actions.toggleEvent(1);
+    actions.toggleEvent(2);
+    expect(getSelectedIds().sort()).toEqual([1, 2]);
+    expect(isEventSelected(1)).toBe(true);
+
+    actions.toggleEvent(1);
+    expect(getSelectedIds()).toEqual([2]);
+    expect(isEventSelected(1)).toBe(false);
+  });
+
+  it('should report all/partial selection against the available ids', () => {
+    const { actions, setAvailableIds, state } = useHistoryEventsSelectionMode();
+    setAvailableIds([event(1), event(2), event(3)]);
+    expect(get(state).hasAvailableEvents).toBe(true);
+
+    actions.toggleEvent(1);
+    expect(get(state).isPartiallySelected).toBe(true);
+    expect(get(state).isAllSelected).toBe(false);
+
+    actions.toggleAll();
+    expect(get(state).isAllSelected).toBe(true);
+    expect(get(state).isPartiallySelected).toBe(false);
+    expect(get(state).selectedCount).toBe(3);
+
+    // toggleAll again clears when everything is selected
+    actions.toggleAll();
+    expect(get(state).selectedCount).toBe(0);
+  });
+
+  it('should toggle a swap group as a unit', () => {
+    const { actions, getSelectedIds } = useHistoryEventsSelectionMode();
+    actions.toggleSwap([1, 2, 3]);
+    expect(getSelectedIds().sort()).toEqual([1, 2, 3]);
+
+    // all present -> removes the whole group
+    actions.toggleSwap([1, 2, 3]);
+    expect(getSelectedIds()).toEqual([]);
+
+    // partial presence -> adds the missing ones
+    actions.toggleEvent(1);
+    actions.toggleSwap([1, 2]);
+    expect(getSelectedIds().sort()).toEqual([1, 2]);
+  });
+
+  it('should handle select-all-matching and disable it on manual toggles', () => {
+    const { actions, isSelectAllMatching, setTotalMatchingCount, state } = useHistoryEventsSelectionMode();
+    setTotalMatchingCount(42);
+    actions.toggleSelectAllMatching();
+    expect(get(isSelectAllMatching)).toBe(true);
+    expect(get(state).selectedCount).toBe(42);
+
+    // manually toggling an event turns off select-all-matching
+    actions.toggleEvent(1);
+    expect(get(isSelectAllMatching)).toBe(false);
+  });
+
+  it('should treat every event as selected while select-all-matching is on', () => {
+    const { actions, isEventSelected } = useHistoryEventsSelectionMode();
+    actions.toggleSelectAllMatching();
+    expect(isEventSelected(999)).toBe(true);
+  });
+
+  it('should clear select-all-matching when toggled off', () => {
+    const { actions, isSelectAllMatching, getSelectedIds } = useHistoryEventsSelectionMode();
+    actions.toggleEvent(1);
+    actions.toggleSelectAllMatching();
+    actions.toggleSelectAllMatching();
+    expect(get(isSelectAllMatching)).toBe(false);
+    expect(getSelectedIds()).toEqual([]);
+  });
+
+  it('should exit and reset every piece of state', () => {
+    const { actions, setAvailableIds, isSelectionMode, state } = useHistoryEventsSelectionMode();
+    setAvailableIds([event(1)]);
+    actions.toggle();
+    actions.toggleEvent(1);
+    actions.exit();
+    expect(get(isSelectionMode)).toBe(false);
+    expect(get(state).selectedCount).toBe(0);
+  });
+});

--- a/frontend/app/src/modules/history/use-events-query-status-store.spec.ts
+++ b/frontend/app/src/modules/history/use-events-query-status-store.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type HistoryEventsQueryData, HistoryEventsQueryStatus } from '@/modules/core/messaging/types';
+import { useEventsQueryStatusStore } from './use-events-query-status-store';
+
+function data(
+  location: string,
+  name: string,
+  status: HistoryEventsQueryStatus,
+): HistoryEventsQueryData {
+  return { eventType: '', location, name, period: [0, 100], status };
+}
+
+describe('useEventsQueryStatusStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should mark started/finished statuses correctly', () => {
+    const store = useEventsQueryStatusStore();
+    expect(store.isStatusFinished(data('eth', 'a', HistoryEventsQueryStatus.QUERYING_EVENTS_STARTED))).toBe(false);
+    expect(store.isStatusFinished(data('eth', 'a', HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED))).toBe(true);
+    expect(store.isStatusFinished(data('eth', 'a', HistoryEventsQueryStatus.CANCELLED))).toBe(true);
+  });
+
+  it('should initialize a started status for each location and begin syncing', () => {
+    const store = useEventsQueryStatusStore();
+    store.initializeQueryStatus([{ location: 'eth', name: 'a' }, { location: 'btc', name: 'b' }]);
+
+    expect(get(store.syncing)).toBe(true);
+    const status = get(store.queryStatus);
+    expect(Object.keys(status)).toHaveLength(2);
+    expect(status.etha.status).toBe(HistoryEventsQueryStatus.QUERYING_EVENTS_STARTED);
+    expect(store.isAllFinished).toBeDefined();
+    expect(get(store.isAllFinished)).toBe(false);
+  });
+
+  it('should ignore status updates while not syncing', () => {
+    const store = useEventsQueryStatusStore();
+    store.setQueryStatus(data('eth', 'a', HistoryEventsQueryStatus.QUERYING_EVENTS_STARTED));
+    expect(get(store.queryStatus)).toEqual({});
+  });
+
+  it('should merge status updates while syncing', () => {
+    const store = useEventsQueryStatusStore();
+    store.initializeQueryStatus([{ location: 'eth', name: 'a' }]);
+    store.setQueryStatus(data('eth', 'a', HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED));
+    expect(get(store.queryStatus).etha.status).toBe(HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED);
+    expect(get(store.isAllFinished)).toBe(true);
+  });
+
+  it('should not overwrite a cancelled entry', () => {
+    const store = useEventsQueryStatusStore();
+    store.initializeQueryStatus([{ location: 'eth', name: 'a' }]);
+    store.markLocationCancelled({ location: 'eth', name: 'a' });
+    expect(get(store.queryStatus).etha.status).toBe(HistoryEventsQueryStatus.CANCELLED);
+
+    store.setQueryStatus(data('eth', 'a', HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED));
+    expect(get(store.queryStatus).etha.status).toBe(HistoryEventsQueryStatus.CANCELLED);
+  });
+
+  it('should reset the query status', () => {
+    const store = useEventsQueryStatusStore();
+    store.initializeQueryStatus([{ location: 'eth', name: 'a' }]);
+    store.resetQueryStatus();
+    expect(get(store.queryStatus)).toEqual({});
+  });
+});

--- a/frontend/app/src/modules/history/use-history-store.spec.ts
+++ b/frontend/app/src/modules/history/use-history-store.spec.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useHistoryStore } from './use-history-store';
+
+describe('useHistoryStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should track unprocessed modifications via version counters', () => {
+    const store = useHistoryStore();
+    expect(get(store.hasUnprocessedModifications)).toBe(false);
+
+    store.signalEventsModified();
+    expect(get(store.eventsVersion)).toBe(1);
+    expect(get(store.hasUnprocessedModifications)).toBe(true);
+
+    store.acknowledgeModifications();
+    expect(get(store.hasUnprocessedModifications)).toBe(false);
+  });
+
+  it('should keep flagging modifications while newer signals arrive', () => {
+    const store = useHistoryStore();
+    store.signalEventsModified();
+    store.signalEventsModified();
+    store.acknowledgeModifications();
+    expect(get(store.hasUnprocessedModifications)).toBe(false);
+
+    store.signalEventsModified();
+    expect(get(store.hasUnprocessedModifications)).toBe(true);
+  });
+
+  it('should store associated locations, labels and the transaction summary', () => {
+    const store = useHistoryStore();
+    const labels = [{ location: 'kraken', locationLabel: 'Kraken' }];
+    const summary = {
+      evmLastQueriedTs: 100,
+      exchangesLastQueriedTs: 200,
+      hasEvmAccounts: true,
+      hasExchangesAccounts: false,
+      undecodedTxCount: 3,
+    };
+    store.setAssociatedLocations(['kraken', 'binance']);
+    store.setLocationLabels(labels);
+    store.setTransactionStatusSummary(summary);
+
+    expect(get(store.associatedLocations)).toEqual(['kraken', 'binance']);
+    expect(get(store.locationLabels)).toEqual(labels);
+    expect(get(store.transactionStatusSummary)).toEqual(summary);
+  });
+});

--- a/frontend/app/src/modules/history/use-ignore.spec.ts
+++ b/frontend/app/src/modules/history/use-ignore.spec.ts
@@ -1,0 +1,137 @@
+import type { Ref } from 'vue';
+import type { EntryMeta } from '@/modules/history/meta';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useIgnore } from '@/modules/history/use-ignore';
+
+interface TestItem extends EntryMeta {
+  groupIdentifier: string;
+  ignoredInAccounting: boolean;
+}
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    ignoreActions: vi.fn(),
+    unignoreActions: vi.fn(),
+    showErrorMessage: vi.fn(),
+  },
+}));
+
+vi.mock('@/modules/history/api/use-history-ignoring-api', () => ({
+  useHistoryIgnoringApi: (): object => ({
+    ignoreActions: spies.ignoreActions,
+    unignoreActions: spies.unignoreActions,
+  }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>(
+    '@/modules/core/notifications/use-notifications',
+  );
+  return {
+    ...actual,
+    useNotifications: (): object => ({
+      showErrorMessage: spies.showErrorMessage,
+    }),
+  };
+});
+
+function item(groupIdentifier: string, ignoredInAccounting = false): TestItem {
+  return { groupIdentifier, ignoredInAccounting };
+}
+
+function setup(items: TestItem[]): {
+  ignore: (ignored: boolean) => Promise<void>;
+  ignoreSingle: (item: TestItem, ignored: boolean) => Promise<void>;
+  toggle: (item: TestItem) => Promise<void>;
+  refresh: ReturnType<typeof vi.fn>;
+  selected: Ref<TestItem[]>;
+} {
+  const selected = shallowRef<TestItem[]>(items);
+  const refresh = vi.fn();
+  const api = useIgnore<TestItem>({ toData: i => i.groupIdentifier }, selected, refresh);
+  return { ...api, refresh, selected };
+}
+
+describe('useIgnore', () => {
+  beforeEach(() => {
+    spies.ignoreActions.mockResolvedValue(true);
+    spies.unignoreActions.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should ignore only the not-yet-ignored items and dedupe payload', async () => {
+    const { ignore, refresh, selected } = setup([
+      item('a'),
+      item('a'), // duplicate group identifier
+      item('b'),
+      item('c', true), // already ignored -> excluded when ignoring
+    ]);
+
+    await ignore(true);
+
+    expect(spies.ignoreActions).toHaveBeenCalledWith({ data: ['a', 'b'] });
+    expect(spies.unignoreActions).not.toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(get(selected)).toEqual([]);
+  });
+
+  it('should unignore only the currently-ignored items', async () => {
+    const { ignore, refresh, selected } = setup([
+      item('a', true),
+      item('b', false), // not ignored -> excluded when unignoring
+    ]);
+
+    await ignore(false);
+
+    expect(spies.unignoreActions).toHaveBeenCalledWith({ data: ['a'] });
+    expect(spies.ignoreActions).not.toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(get(selected)).toEqual([]);
+  });
+
+  it('should warn and skip the api when nothing matches', async () => {
+    const { ignore, refresh, selected } = setup([item('a', true)]);
+
+    await ignore(true); // all already ignored
+
+    expect(spies.showErrorMessage).toHaveBeenCalledOnce();
+    expect(spies.ignoreActions).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+    expect(get(selected)).toHaveLength(1); // selection preserved
+  });
+
+  it('should surface an error and keep the selection when the api throws', async () => {
+    spies.ignoreActions.mockRejectedValue(new Error('boom'));
+    const { ignore, refresh, selected } = setup([item('a')]);
+
+    await ignore(true);
+
+    expect(spies.showErrorMessage).toHaveBeenCalledOnce();
+    expect(refresh).not.toHaveBeenCalled();
+    expect(get(selected)).toHaveLength(1);
+  });
+
+  it('should toggle a single item based on its current state', async () => {
+    const { toggle, selected } = setup([]);
+
+    await toggle(item('x', false));
+    expect(spies.ignoreActions).toHaveBeenCalledWith({ data: ['x'] });
+
+    await toggle(item('y', true));
+    expect(spies.unignoreActions).toHaveBeenCalledWith({ data: ['y'] });
+    expect(get(selected)).toEqual([]);
+  });
+
+  it('should ignore or unignore a single item explicitly', async () => {
+    const { ignoreSingle } = setup([]);
+
+    await ignoreSingle(item('x', false), true);
+    expect(spies.ignoreActions).toHaveBeenCalledWith({ data: ['x'] });
+
+    await ignoreSingle(item('z', true), false);
+    expect(spies.unignoreActions).toHaveBeenCalledWith({ data: ['z'] });
+  });
+});


### PR DESCRIPTION
Part of the frontend unit-coverage effort for #11252.

Adds co-located unit specs for 28 previously untested composables and Pinia stores. No production code changes; test files only.

### History (11)
`use-selection-mode`, `use-deletion-strategies`, `use-ignore`, `use-history-events-selection-actions`, `use-history-events-operations`, `use-history-events-deletion`, `use-history-events-auto-fetch`, `use-history-events-dialog-manager`, and the `use-history-store`, `use-events-query-status-store` and `use-historical-balances-store` stores.

### Balances / accounts / assets (17)
`use-balance-prices-store`, `use-blockchain-accounts-store`, `use-balance-loading`, `use-blockchain-total-summary`, `use-manual-balance-pagination`, `use-manual-balances-or-liabilities`, `use-protocol-data`, `use-protocol-metadata`, `use-nft-gallery-layout`, `use-nft-gallery-filters`, `use-nft-gallery-data`, `use-nft-asset-ignoring`, `use-nft-price-management`, `use-address-book-deletion`, `use-managed-asset-operations`, `use-currency-update`, `use-asset-locations-data`.

### Verification
- Full unit suite green (448 files, 4348 tests).
- `vue-tsc` typecheck clean.
- eslint clean on the new specs.

Specs follow existing conventions: co-located `*.spec.ts`, the shared `createMock`/`mockT` helpers, and `it('should ...')` descriptions.