### PR TITLE
test: add frontend unit specs for core/session/settings/dashboard/shell

### DIFF
--- a/frontend/app/src/modules/core/common/async/async-utilities.spec.ts
+++ b/frontend/app/src/modules/core/common/async/async-utilities.spec.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { delay, waitForCondition } from './async-utilities';
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+describe('delay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should resolve after the given time', async () => {
+    let resolved = false;
+    const promise = delay(1000).then(() => {
+      resolved = true;
+    });
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+    expect(resolved).toBe(true);
+  });
+
+  it('should reject immediately when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(delay(1000, controller.signal)).rejects.toThrow('aborted');
+  });
+
+  it('should reject when the signal aborts mid-flight', async () => {
+    const controller = new AbortController();
+    const promise = delay(1000, controller.signal);
+    const assertion = expect(promise).rejects.toThrow('aborted');
+    controller.abort();
+    await assertion;
+  });
+});
+
+describe('waitForCondition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should resolve as soon as the condition is met', async () => {
+    const checkFn = vi.fn().mockResolvedValue('ready');
+    const result = await waitForCondition(checkFn, r => r === 'ready', { name: 'op' });
+    expect(result).toBe('ready');
+    expect(checkFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep polling until the condition becomes true', async () => {
+    const checkFn = vi.fn()
+      .mockResolvedValueOnce('pending')
+      .mockResolvedValueOnce('done');
+    const promise = waitForCondition(checkFn, r => r === 'done', { name: 'op', interval: 500 });
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(promise).resolves.toBe('done');
+    expect(checkFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should retry after a failed check', async () => {
+    const checkFn = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('done');
+    const promise = waitForCondition(checkFn, r => r === 'done', { name: 'op', interval: 500 });
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(promise).resolves.toBe('done');
+    expect(checkFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reject with a timeout error when the condition never holds', async () => {
+    const checkFn = vi.fn().mockResolvedValue('never');
+    const promise = waitForCondition(checkFn, () => false, { name: 'op', interval: 500, timeout: 1000 });
+    const assertion = expect(promise).rejects.toThrow(/Timeout waiting for op/);
+    await vi.advanceTimersByTimeAsync(1000);
+    await assertion;
+  });
+
+  it('should reject immediately when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      waitForCondition(vi.fn().mockResolvedValue('x'), () => true, { name: 'op', signal: controller.signal }),
+    ).rejects.toThrow('aborted');
+  });
+});

--- a/frontend/app/src/modules/core/common/async/async-utilities.ts
+++ b/frontend/app/src/modules/core/common/async/async-utilities.ts
@@ -65,12 +65,8 @@ export async function waitForCondition<T>(checkFn: () => Promise<T>, condition: 
   const combinedSignal = signal ? AbortSignal.any([signal, abortController.signal]) : abortController.signal;
 
   return new Promise((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      abortController.abort();
-      reject(new TimeoutError(name, timeout));
-    }, timeout);
-
     let isCompleted = false;
+    let timeoutId: ReturnType<typeof setTimeout>;
 
     const cleanup = (): void => {
       isCompleted = true;
@@ -85,6 +81,14 @@ export async function waitForCondition<T>(checkFn: () => Promise<T>, condition: 
       cleanup();
       reject(new AbortedError(name));
     }
+
+    // cleanup() removes the abort listener before aborting, so the TimeoutError
+    // below is the rejection callers observe (aborting first would fire onAbort
+    // and reject with an AbortedError instead).
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new TimeoutError(name, timeout));
+    }, timeout);
 
     combinedSignal.addEventListener('abort', onAbort, { once: true });
 

--- a/frontend/app/src/modules/core/common/data/collection-utils.spec.ts
+++ b/frontend/app/src/modules/core/common/data/collection-utils.spec.ts
@@ -1,0 +1,111 @@
+import type { Collection, CollectionResponse } from '@/modules/core/common/collection';
+import { bigNumberify, Zero } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  defaultCollectionState,
+  getCollectionData,
+  mapCollectionResponse,
+  setupEntryLimit,
+} from './collection-utils';
+
+const premium = ref<boolean>(false);
+
+vi.mock('@/modules/premium/use-premium', () => ({
+  usePremium: (): typeof premium => premium,
+}));
+
+describe('mapCollectionResponse', () => {
+  it('should rename entry fields and keep the rest', () => {
+    const response: CollectionResponse<number> & { extra: string } = {
+      entries: [1, 2],
+      entriesFound: 2,
+      entriesLimit: 10,
+      entriesTotal: 5,
+      extra: 'keep',
+    };
+    expect(mapCollectionResponse(response)).toEqual({
+      data: [1, 2],
+      found: 2,
+      limit: 10,
+      total: 5,
+      extra: 'keep',
+    });
+  });
+});
+
+describe('defaultCollectionState', () => {
+  it('should return an empty collection with a zero total value', () => {
+    const state = defaultCollectionState<string>();
+    expect(state).toEqual({ data: [], found: 0, limit: 0, total: 0, totalValue: Zero });
+  });
+});
+
+describe('getCollectionData', () => {
+  it('should expose each collection field as a computed', () => {
+    const collection: Collection<number> = {
+      data: [1, 2, 3],
+      limit: 10,
+      found: 3,
+      total: 8,
+      entriesFoundTotal: 12,
+      totalValue: bigNumberify(100),
+    };
+    const { data, entriesFoundTotal, found, limit, total, totalValue } = getCollectionData(collection);
+    expect(get(data)).toEqual([1, 2, 3]);
+    expect(get(limit)).toBe(10);
+    expect(get(found)).toBe(3);
+    expect(get(total)).toBe(8);
+    expect(get(entriesFoundTotal)).toBe(12);
+    expect(get(totalValue)).toEqual(bigNumberify(100));
+  });
+
+  it('should react to a source ref changing', () => {
+    const source = ref<Collection<number>>(defaultCollectionState<number>());
+    const { found } = getCollectionData(source);
+    expect(get(found)).toBe(0);
+    set(source, { ...defaultCollectionState<number>(), found: 4 });
+    expect(get(found)).toBe(4);
+  });
+});
+
+describe('setupEntryLimit', () => {
+  beforeEach(() => {
+    set(premium, false);
+  });
+
+  it('should cap the item length at the limit for non-premium users', () => {
+    const { itemLength } = setupEntryLimit(ref(10), ref(50), ref(50));
+    expect(get(itemLength)).toBe(10);
+  });
+
+  it('should return the full found count for premium users', () => {
+    set(premium, true);
+    const { itemLength } = setupEntryLimit(ref(10), ref(50), ref(50));
+    expect(get(itemLength)).toBe(50);
+  });
+
+  it('should treat a -1 limit as unlimited', () => {
+    const { itemLength } = setupEntryLimit(ref(-1), ref(50), ref(50));
+    expect(get(itemLength)).toBe(50);
+  });
+
+  it('should show the upgrade row when the limit is reached', () => {
+    const { showUpgradeRow } = setupEntryLimit(ref(10), ref(50), ref(50));
+    expect(get(showUpgradeRow)).toBe(true);
+  });
+
+  it('should hide the upgrade row when the limit exceeds the total', () => {
+    const { showUpgradeRow } = setupEntryLimit(ref(100), ref(50), ref(50));
+    expect(get(showUpgradeRow)).toBe(false);
+  });
+
+  it('should compare found against entryFoundTotal when provided', () => {
+    const { showUpgradeRow } = setupEntryLimit(ref(10), ref(5), ref(50), ref(8));
+    expect(get(showUpgradeRow)).toBe(true);
+  });
+
+  it('should hide the upgrade row when found matches entryFoundTotal', () => {
+    const { showUpgradeRow } = setupEntryLimit(ref(10), ref(8), ref(50), ref(8));
+    expect(get(showUpgradeRow)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/core/common/helpers/attrs.spec.ts
+++ b/frontend/app/src/modules/core/common/helpers/attrs.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { getNonRootAttrs, getRootAttrs } from './attrs';
+
+describe('getRootAttrs', () => {
+  it('should pick class and all data-* attributes by default', () => {
+    const attrs = { 'class': 'my-class', 'data-testid': 'foo', 'data-id': '1', 'onClick': (): void => {} };
+    expect(getRootAttrs(attrs)).toEqual({ 'class': 'my-class', 'data-testid': 'foo', 'data-id': '1' });
+  });
+
+  it('should honour a custom include list', () => {
+    const attrs = { 'id': 'root', 'class': 'x', 'data-testid': 'foo' };
+    expect(getRootAttrs(attrs, ['id'])).toEqual({ 'id': 'root', 'data-testid': 'foo' });
+  });
+
+  it('should return only data-* attributes when nothing else matches', () => {
+    const attrs = { 'data-a': '1', 'onClick': (): void => {} };
+    expect(getRootAttrs(attrs, [])).toEqual({ 'data-a': '1' });
+  });
+});
+
+describe('getNonRootAttrs', () => {
+  it('should omit class and all data-* attributes by default', () => {
+    const onClick = (): void => {};
+    const attrs = { 'class': 'my-class', 'data-testid': 'foo', onClick };
+    expect(getNonRootAttrs(attrs)).toEqual({ onClick });
+  });
+
+  it('should honour a custom exclude list', () => {
+    const onClick = (): void => {};
+    const attrs = { 'id': 'root', 'class': 'x', 'data-testid': 'foo', onClick };
+    expect(getNonRootAttrs(attrs, ['id'])).toEqual({ class: 'x', onClick });
+  });
+
+  it('should be the complement of getRootAttrs', () => {
+    const attrs = { 'class': 'x', 'data-a': '1', 'title': 'hello' };
+    expect(getNonRootAttrs(attrs)).toEqual({ title: 'hello' });
+    expect(getRootAttrs(attrs)).toEqual({ 'class': 'x', 'data-a': '1' });
+  });
+});

--- a/frontend/app/src/modules/core/common/helpers/route-uri.spec.ts
+++ b/frontend/app/src/modules/core/common/helpers/route-uri.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { fromUriEncoded, toUriEncoded } from './route-uri';
+
+describe('toUriEncoded', () => {
+  it('should encode a single key/value pair', () => {
+    expect(toUriEncoded({ foo: 'bar' })).toBe(encodeURIComponent('foo=bar'));
+  });
+
+  it('should join multiple params with an ampersand before encoding', () => {
+    expect(toUriEncoded({ a: '1', b: '2' })).toBe(encodeURIComponent('a=1&b=2'));
+  });
+
+  it('should stringify null entries as the literal "undefined"', () => {
+    expect(toUriEncoded({ missing: null })).toBe(encodeURIComponent('missing=undefined'));
+  });
+
+  it('should return an empty string for an empty query', () => {
+    expect(toUriEncoded({})).toBe('');
+  });
+});
+
+describe('fromUriEncoded', () => {
+  it('should decode a single key/value pair', () => {
+    expect(fromUriEncoded(encodeURIComponent('foo=bar'))).toEqual({ foo: 'bar' });
+  });
+
+  it('should decode multiple params', () => {
+    expect(fromUriEncoded(encodeURIComponent('a=1&b=2'))).toEqual({ a: '1', b: '2' });
+  });
+
+  it('should round-trip values produced by toUriEncoded', () => {
+    const params = { chain: 'ethereum', page: '3' };
+    expect(fromUriEncoded(toUriEncoded(params))).toEqual(params);
+  });
+
+  it('should return an empty object for an empty string', () => {
+    expect(fromUriEncoded('')).toEqual({});
+  });
+});

--- a/frontend/app/src/modules/core/common/use-report-issue.spec.ts
+++ b/frontend/app/src/modules/core/common/use-report-issue.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadComposable(): Promise<typeof import('./use-report-issue')['useReportIssue']> {
+  vi.resetModules();
+  return (await import('./use-report-issue')).useReportIssue;
+}
+
+describe('useReportIssue', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('should start hidden with empty defaults', async () => {
+    const useReportIssue = await loadComposable();
+    const { initialDescription, initialTitle, visible } = useReportIssue();
+    expect(get(visible)).toBe(false);
+    expect(get(initialTitle)).toBe('');
+    expect(get(initialDescription)).toBe('');
+  });
+
+  it('should populate title and description and become visible on show', async () => {
+    const useReportIssue = await loadComposable();
+    const { initialDescription, initialTitle, show, visible } = useReportIssue();
+    show({ title: 'Broken', description: 'It fails' });
+    expect(get(visible)).toBe(true);
+    expect(get(initialTitle)).toBe('Broken');
+    expect(get(initialDescription)).toBe('It fails');
+  });
+
+  it('should fall back to empty strings when show is called without a payload', async () => {
+    const useReportIssue = await loadComposable();
+    const { initialDescription, initialTitle, show, visible } = useReportIssue();
+    show();
+    expect(get(visible)).toBe(true);
+    expect(get(initialTitle)).toBe('');
+    expect(get(initialDescription)).toBe('');
+  });
+
+  it('should hide on close without clearing the stored payload', async () => {
+    const useReportIssue = await loadComposable();
+    const { close, initialTitle, show, visible } = useReportIssue();
+    show({ title: 'Broken' });
+    close();
+    expect(get(visible)).toBe(false);
+    expect(get(initialTitle)).toBe('Broken');
+  });
+
+  it('should share state across calls (shared composable)', async () => {
+    const useReportIssue = await loadComposable();
+    useReportIssue().show({ title: 'Shared' });
+    expect(get(useReportIssue().initialTitle)).toBe('Shared');
+  });
+});

--- a/frontend/app/src/modules/dashboard/progress/use-balance-query-progress.spec.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-balance-query-progress.spec.ts
@@ -1,0 +1,119 @@
+import type { BalanceQueryQueueItem } from '@/modules/dashboard/progress/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskType } from '@/modules/core/tasks/task-type';
+import { useBalanceQueryProgress } from './use-balance-query-progress';
+
+const completedItems = ref<number>(0);
+const totalItems = ref<number>(0);
+const runningItems = ref<number>(0);
+const progress = ref<number>(0);
+const queueItems = ref<BalanceQueryQueueItem[]>([]);
+const runningTasks = ref<Set<TaskType>>(new Set());
+
+vi.mock('@/modules/balances/use-balance-queue', () => ({
+  useBalanceQueue: (): object => ({ completedItems, progress, queueItems, runningItems, totalItems }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): object => ({ getChainName: (chain: string) => `Chain(${chain})` }),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: (): object => ({
+    useIsTaskRunning: (type: TaskType) => computed<boolean>(() => get(runningTasks).has(type)),
+  }),
+}));
+
+function item(overrides: Partial<BalanceQueryQueueItem>): BalanceQueryQueueItem {
+  return {
+    id: '1',
+    type: TaskType.QUERY_BLOCKCHAIN_BALANCES,
+    chain: 'ethereum',
+    status: 'pending',
+    addedAt: 0,
+    ...overrides,
+  };
+}
+
+describe('useBalanceQueryProgress', () => {
+  beforeEach(() => {
+    set(completedItems, 0);
+    set(totalItems, 0);
+    set(runningItems, 0);
+    set(progress, 0);
+    set(queueItems, []);
+    set(runningTasks, new Set());
+  });
+
+  describe('balanceProgress', () => {
+    it('should be undefined when there are no items', () => {
+      const { balanceProgress } = useBalanceQueryProgress();
+      expect(get(balanceProgress)).toBeUndefined();
+    });
+
+    it('should describe a running blockchain balance query', () => {
+      set(totalItems, 2);
+      set(completedItems, 1);
+      set(progress, 50);
+      set(queueItems, [item({ status: 'running', chain: 'optimism' })]);
+      const { balanceProgress } = useBalanceQueryProgress();
+      const result = get(balanceProgress);
+      expect(result?.currentStep).toBe(2);
+      expect(result?.totalSteps).toBe(2);
+      expect(result?.percentage).toBe(50);
+      expect(result?.currentOperationData).toMatchObject({
+        chain: 'optimism',
+        type: TaskType.QUERY_BLOCKCHAIN_BALANCES,
+      });
+    });
+
+    it('should describe a running token detection', () => {
+      set(totalItems, 1);
+      set(completedItems, 0);
+      set(queueItems, [item({ status: 'running', type: TaskType.FETCH_DETECTED_TOKENS, address: '0xabc' })]);
+      const { balanceProgress } = useBalanceQueryProgress();
+      const result = get(balanceProgress);
+      expect(result?.currentStep).toBe(1);
+      expect(result?.currentOperationData).toMatchObject({
+        address: '0xabc',
+        type: TaskType.FETCH_DETECTED_TOKENS,
+      });
+    });
+
+    it('should describe the first pending item when nothing is running', () => {
+      set(totalItems, 3);
+      set(completedItems, 1);
+      set(queueItems, [item({ status: 'pending', chain: 'base' })]);
+      const { balanceProgress } = useBalanceQueryProgress();
+      const result = get(balanceProgress);
+      expect(result?.currentStep).toBe(1);
+      expect(result?.currentOperationData).toMatchObject({ chain: 'base', status: 'pending' });
+    });
+
+    it('should be undefined when items exist but none are running or pending', () => {
+      set(totalItems, 1);
+      set(queueItems, [item({ status: 'completed' })]);
+      const { balanceProgress } = useBalanceQueryProgress();
+      expect(get(balanceProgress)).toBeUndefined();
+    });
+  });
+
+  describe('isBalanceQuerying', () => {
+    it('should be false when nothing is running', () => {
+      const { isBalanceQuerying } = useBalanceQueryProgress();
+      expect(get(isBalanceQuerying)).toBe(false);
+    });
+
+    it('should be true when a blockchain balance task runs', () => {
+      set(runningTasks, new Set([TaskType.QUERY_BLOCKCHAIN_BALANCES]));
+      const { isBalanceQuerying } = useBalanceQueryProgress();
+      expect(get(isBalanceQuerying)).toBe(true);
+    });
+
+    it('should be true when the queue has running items', () => {
+      set(runningItems, 1);
+      const { isBalanceQuerying } = useBalanceQueryProgress();
+      expect(get(isBalanceQuerying)).toBe(true);
+    });
+  });
+});

--- a/frontend/app/src/modules/dashboard/progress/use-history-query-indicator-settings.spec.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-history-query-indicator-settings.spec.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHistoryQueryIndicatorSettings } from './use-history-query-indicator-settings';
+
+const evmQueryIndicatorDismissalThreshold = ref<number>(0);
+const evmQueryIndicatorMinOutOfSyncPeriod = ref<number>(0);
+
+vi.mock('@/modules/settings/use-frontend-settings-store', () => ({
+  useFrontendSettingsStore: (): object => ({
+    evmQueryIndicatorDismissalThreshold,
+    evmQueryIndicatorMinOutOfSyncPeriod,
+  }),
+}));
+
+const HOUR_IN_MS = 60 * 60 * 1000;
+
+describe('useHistoryQueryIndicatorSettings', () => {
+  beforeEach(() => {
+    set(evmQueryIndicatorDismissalThreshold, 0);
+    set(evmQueryIndicatorMinOutOfSyncPeriod, 0);
+  });
+
+  it('should convert the dismissal threshold from hours to milliseconds', () => {
+    set(evmQueryIndicatorDismissalThreshold, 3);
+    const { dismissalThresholdMs } = useHistoryQueryIndicatorSettings();
+    expect(get(dismissalThresholdMs)).toBe(3 * HOUR_IN_MS);
+  });
+
+  it('should convert the min out-of-sync period from hours to milliseconds', () => {
+    set(evmQueryIndicatorMinOutOfSyncPeriod, 2);
+    const { minOutOfSyncPeriodMs } = useHistoryQueryIndicatorSettings();
+    expect(get(minOutOfSyncPeriodMs)).toBe(2 * HOUR_IN_MS);
+  });
+
+  it('should react to the underlying setting changing', () => {
+    const { dismissalThresholdMs } = useHistoryQueryIndicatorSettings();
+    expect(get(dismissalThresholdMs)).toBe(0);
+    set(evmQueryIndicatorDismissalThreshold, 1);
+    expect(get(dismissalThresholdMs)).toBe(HOUR_IN_MS);
+  });
+});

--- a/frontend/app/src/modules/dashboard/progress/use-transaction-status-check.spec.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-transaction-status-check.spec.ts
@@ -1,0 +1,134 @@
+import type { Ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Routes } from '@/router/routes';
+import { useTransactionStatusCheck } from './use-transaction-status-check';
+
+interface Summary {
+  hasEvmAccounts?: boolean;
+  hasExchangesAccounts?: boolean;
+  evmLastQueriedTs?: number;
+  exchangesLastQueriedTs?: number;
+}
+
+const transactionStatusSummary = ref<Summary | undefined>(undefined);
+const minOutOfSyncPeriodMs = ref<number>(60 * 60 * 1000);
+const rawProcessing = ref<boolean>(false);
+const push = vi.fn();
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>();
+  return { ...actual, useRouter: (): object => ({ push }) };
+});
+
+vi.mock('@/modules/history/use-history-store', () => ({
+  useHistoryStore: (): object => ({ transactionStatusSummary }),
+}));
+
+vi.mock('@/modules/dashboard/progress/use-history-query-indicator-settings', () => ({
+  useHistoryQueryIndicatorSettings: (): object => ({ minOutOfSyncPeriodMs }),
+}));
+
+vi.mock('@/modules/history/events/use-history-events-status', () => ({
+  useHistoryEventsStatus: (): object => ({ processing: rawProcessing }),
+}));
+
+vi.mock('@/modules/core/common/use-ref-debounce', () => ({
+  useRefWithDebounce: (value: Ref<boolean>): Ref<boolean> => value,
+}));
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+describe('useTransactionStatusCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(transactionStatusSummary, undefined);
+    set(minOutOfSyncPeriodMs, 60 * 60 * 1000);
+    set(rawProcessing, false);
+  });
+
+  describe('hasTxAccounts', () => {
+    it('should be false without a summary', () => {
+      const { hasTxAccounts } = useTransactionStatusCheck();
+      expect(get(hasTxAccounts)).toBe(false);
+    });
+
+    it('should be true when evm accounts exist', () => {
+      set(transactionStatusSummary, { hasEvmAccounts: true });
+      const { hasTxAccounts } = useTransactionStatusCheck();
+      expect(get(hasTxAccounts)).toBe(true);
+    });
+  });
+
+  describe('earliestQueriedTimestamp', () => {
+    it('should be 0 when there are no accounts', () => {
+      const { earliestQueriedTimestamp } = useTransactionStatusCheck();
+      expect(get(earliestQueriedTimestamp)).toBe(0);
+    });
+
+    it('should return the earliest timestamp in milliseconds', () => {
+      set(transactionStatusSummary, {
+        hasEvmAccounts: true,
+        hasExchangesAccounts: true,
+        evmLastQueriedTs: 2000,
+        exchangesLastQueriedTs: 1000,
+      });
+      const { earliestQueriedTimestamp } = useTransactionStatusCheck();
+      expect(get(earliestQueriedTimestamp)).toBe(1000 * 1000);
+    });
+
+    it('should be 0 when accounts exist but were never queried', () => {
+      set(transactionStatusSummary, { hasEvmAccounts: true, evmLastQueriedTs: 0 });
+      const { earliestQueriedTimestamp } = useTransactionStatusCheck();
+      expect(get(earliestQueriedTimestamp)).toBe(0);
+    });
+  });
+
+  describe('isNeverQueried', () => {
+    it('should be true when accounts exist but earliest timestamp is 0', () => {
+      set(transactionStatusSummary, { hasEvmAccounts: true, evmLastQueriedTs: 0 });
+      const { isNeverQueried } = useTransactionStatusCheck();
+      expect(get(isNeverQueried)).toBe(true);
+    });
+
+    it('should be false once queried', () => {
+      set(transactionStatusSummary, { hasEvmAccounts: true, evmLastQueriedTs: nowSeconds() });
+      const { isNeverQueried } = useTransactionStatusCheck();
+      expect(get(isNeverQueried)).toBe(false);
+    });
+  });
+
+  describe('isOutOfSync', () => {
+    it('should be false without accounts', () => {
+      const { isOutOfSync } = useTransactionStatusCheck();
+      expect(get(isOutOfSync)).toBe(false);
+    });
+
+    it('should be true when the last query is older than the threshold', () => {
+      set(transactionStatusSummary, { hasEvmAccounts: true, evmLastQueriedTs: 1000 });
+      const { isOutOfSync } = useTransactionStatusCheck();
+      expect(get(isOutOfSync)).toBe(true);
+    });
+
+    it('should be false when recently queried', () => {
+      set(transactionStatusSummary, { hasEvmAccounts: true, evmLastQueriedTs: nowSeconds() });
+      const { isOutOfSync } = useTransactionStatusCheck();
+      expect(get(isOutOfSync)).toBe(false);
+    });
+  });
+
+  describe('navigateToHistory', () => {
+    it('should push the history events route', async () => {
+      const { navigateToHistory } = useTransactionStatusCheck();
+      await navigateToHistory();
+      expect(push).toHaveBeenCalledWith(Routes.HISTORY_EVENTS);
+    });
+  });
+
+  it('should expose the debounced processing ref', () => {
+    set(rawProcessing, true);
+    const { processing } = useTransactionStatusCheck();
+    expect(get(processing)).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/dashboard/progress/use-unified-progress.spec.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-unified-progress.spec.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUnifiedProgress } from './use-unified-progress';
+
+interface BalanceProgress {
+  currentOperation: string;
+  percentage: number;
+  currentStep: number;
+  totalSteps: number;
+  currentOperationData: object;
+}
+
+interface HistoryProgress {
+  currentStep: number;
+  totalSteps: number;
+  percentage: number;
+}
+
+interface Summary {
+  undecodedTxCount: number;
+}
+
+const historyProgress = ref<HistoryProgress | undefined>(undefined);
+const balanceProgress = ref<BalanceProgress | undefined>(undefined);
+const isBalanceQuerying = ref<boolean>(false);
+const processing = ref<boolean>(false);
+const hasTxAccounts = ref<boolean>(false);
+const isNeverQueried = ref<boolean>(false);
+const isOutOfSync = ref<boolean>(false);
+const earliestQueriedTimestamp = ref<number>(0);
+const transactionStatusSummary = ref<Summary | undefined>(undefined);
+const dismissalThresholdMs = ref<number>(0);
+const minOutOfSyncPeriodMs = ref<number>(0);
+const navigateToHistory = vi.fn();
+
+vi.mock('@/modules/auth/use-logged-user-identifier', () => ({
+  useLoggedUserIdentifier: (): object => ref('user1'),
+}));
+
+vi.mock('@/modules/dashboard/progress/use-history-query-progress', () => ({
+  useHistoryQueryProgress: (): object => ({ progress: historyProgress }),
+}));
+
+vi.mock('@/modules/dashboard/progress/use-transaction-status-check', () => ({
+  useTransactionStatusCheck: (): object => ({
+    earliestQueriedTimestamp,
+    hasTxAccounts,
+    isNeverQueried,
+    isOutOfSync,
+    navigateToHistory,
+    processing,
+  }),
+}));
+
+vi.mock('@/modules/dashboard/progress/use-balance-query-progress', () => ({
+  useBalanceQueryProgress: (): object => ({ balanceProgress, isBalanceQuerying }),
+}));
+
+vi.mock('@/modules/history/events/use-history-events-status', () => ({
+  useHistoryEventsStatus: (): object => ({
+    refreshing: ref(false),
+    sectionLoading: ref(false),
+    shouldFetchEventsRegularly: ref(false),
+  }),
+}));
+
+vi.mock('@/modules/dashboard/progress/use-history-query-indicator-settings', () => ({
+  useHistoryQueryIndicatorSettings: (): object => ({ dismissalThresholdMs, minOutOfSyncPeriodMs }),
+}));
+
+vi.mock('@/modules/history/use-history-store', () => ({
+  useHistoryStore: (): object => ({ transactionStatusSummary }),
+}));
+
+describe('useUnifiedProgress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    set(historyProgress, undefined);
+    set(balanceProgress, undefined);
+    set(isBalanceQuerying, false);
+    set(processing, false);
+    set(hasTxAccounts, false);
+    set(isOutOfSync, false);
+    set(earliestQueriedTimestamp, 0);
+    set(transactionStatusSummary, undefined);
+  });
+
+  describe('processingMessage', () => {
+    it('should prioritise the balance operation message', () => {
+      set(balanceProgress, { currentOperation: 'Querying', percentage: 10, currentStep: 1, totalSteps: 2, currentOperationData: {} });
+      const { processingMessage } = useUnifiedProgress();
+      expect(get(processingMessage)).toBe('Querying');
+    });
+
+    it('should show history progress when processing and no balance query runs', () => {
+      set(processing, true);
+      set(historyProgress, { currentStep: 3, totalSteps: 10, percentage: 30 });
+      const { processingMessage } = useUnifiedProgress();
+      expect(get(processingMessage)).toContain('dashboard.history_query_indicator.processing_with_progress');
+    });
+
+    it('should show a generic processing message with no history steps', () => {
+      set(processing, true);
+      const { processingMessage } = useUnifiedProgress();
+      expect(get(processingMessage)).toBe('dashboard.history_query_indicator.processing');
+    });
+
+    it('should be empty when idle', () => {
+      const { processingMessage } = useUnifiedProgress();
+      expect(get(processingMessage)).toBe('');
+    });
+  });
+
+  describe('processingPercentage', () => {
+    it('should use the balance percentage when present', () => {
+      set(balanceProgress, { currentOperation: 'x', percentage: 42, currentStep: 1, totalSteps: 2, currentOperationData: {} });
+      const { processingPercentage } = useUnifiedProgress();
+      expect(get(processingPercentage)).toBe(42);
+    });
+
+    it('should fall back to history percentage without a balance query', () => {
+      set(historyProgress, { currentStep: 1, totalSteps: 2, percentage: 75 });
+      const { processingPercentage } = useUnifiedProgress();
+      expect(get(processingPercentage)).toBe(75);
+    });
+
+    it('should be 0 while a balance query runs without balance progress', () => {
+      set(isBalanceQuerying, true);
+      const { processingPercentage } = useUnifiedProgress();
+      expect(get(processingPercentage)).toBe(0);
+    });
+  });
+
+  describe('showIdleMessage', () => {
+    it('should be false without accounts', () => {
+      set(isOutOfSync, true);
+      const { showIdleMessage } = useUnifiedProgress();
+      expect(get(showIdleMessage)).toBe(false);
+    });
+
+    it('should mirror the out-of-sync check when accounts exist', () => {
+      set(hasTxAccounts, true);
+      set(isOutOfSync, true);
+      const { showIdleMessage } = useUnifiedProgress();
+      expect(get(showIdleMessage)).toBe(true);
+    });
+  });
+
+  describe('longQuery', () => {
+    it('should be true when queried long ago with no undecoded transactions', () => {
+      set(hasTxAccounts, true);
+      set(earliestQueriedTimestamp, 0);
+      set(transactionStatusSummary, { undecodedTxCount: 0 });
+      const { longQuery } = useUnifiedProgress();
+      expect(get(longQuery)).toBe(true);
+    });
+
+    it('should be false when there are undecoded transactions', () => {
+      set(hasTxAccounts, true);
+      set(earliestQueriedTimestamp, 0);
+      set(transactionStatusSummary, { undecodedTxCount: 5 });
+      const { longQuery } = useUnifiedProgress();
+      expect(get(longQuery)).toBe(false);
+    });
+  });
+
+  describe('hasUndecodedTransactions', () => {
+    it('should be true when the count is positive', () => {
+      set(transactionStatusSummary, { undecodedTxCount: 2 });
+      const { hasUndecodedTransactions } = useUnifiedProgress();
+      expect(get(hasUndecodedTransactions)).toBe(true);
+    });
+
+    it('should be false when the count is zero', () => {
+      set(transactionStatusSummary, { undecodedTxCount: 0 });
+      const { hasUndecodedTransactions } = useUnifiedProgress();
+      expect(get(hasUndecodedTransactions)).toBe(false);
+    });
+
+    it('should be false without a summary', () => {
+      const { hasUndecodedTransactions } = useUnifiedProgress();
+      expect(get(hasUndecodedTransactions)).toBe(false);
+    });
+  });
+
+  describe('resetQueryStatus', () => {
+    it('should restore the dismissal defaults', () => {
+      const { queryStatus, resetQueryStatus } = useUnifiedProgress();
+      set(queryStatus, { lastBalanceProgressDismissedTs: 5, lastDismissedTs: 5, lastUsedVersion: '1.0' });
+      resetQueryStatus();
+      expect(get(queryStatus)).toEqual({
+        lastBalanceProgressDismissedTs: 0,
+        lastDismissedTs: 0,
+        lastUsedVersion: null,
+      });
+    });
+  });
+});

--- a/frontend/app/src/modules/session/use-cache-clear.spec.ts
+++ b/frontend/app/src/modules/session/use-cache-clear.spec.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCacheClear } from './use-cache-clear';
+
+const show = vi.fn();
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): { show: typeof show } => ({ show }),
+}));
+
+type Source = 'a' | 'b';
+
+const clearable: { id: Source; text: string }[] = [
+  { id: 'a', text: 'Cache A' },
+  { id: 'b', text: 'Cache B' },
+];
+
+function message(source: string): { success: string; error: string } {
+  return {
+    success: `cleared ${source}`,
+    error: `failed ${source}`,
+  };
+}
+
+function confirmText(text: string): { title: string; message: string } {
+  return {
+    title: `Clear ${text}?`,
+    message: `Really clear ${text}?`,
+  };
+}
+
+describe('useCacheClear', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should open the confirmation dialog with resolved text', () => {
+    const clearHandle = vi.fn().mockResolvedValue(undefined);
+    const { showConfirmation } = useCacheClear<Source>(clearable, clearHandle, message, confirmText);
+    showConfirmation('a');
+    expect(show).toHaveBeenCalledWith(
+      { title: 'Clear Cache A?', message: 'Really clear Cache A?' },
+      expect.any(Function),
+    );
+  });
+
+  it('should set a success status after clearing', async () => {
+    const clearHandle = vi.fn().mockResolvedValue(undefined);
+    const { pending, showConfirmation, status } = useCacheClear<Source>(clearable, clearHandle, message, confirmText);
+    showConfirmation('a');
+    await show.mock.calls[0][1]();
+    expect(clearHandle).toHaveBeenCalledWith('a');
+    expect(get(status)).toEqual({ error: '', success: 'cleared Cache A' });
+    expect(get(pending)).toBe(false);
+  });
+
+  it('should clear the success status after five seconds', async () => {
+    const clearHandle = vi.fn().mockResolvedValue(undefined);
+    const { showConfirmation, status } = useCacheClear<Source>(clearable, clearHandle, message, confirmText);
+    showConfirmation('a');
+    await show.mock.calls[0][1]();
+    expect(get(status)).not.toBeNull();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(get(status)).toBeNull();
+  });
+
+  it('should set an error status when the handle rejects', async () => {
+    const clearHandle = vi.fn().mockRejectedValue(new Error('boom'));
+    const { pending, showConfirmation, status } = useCacheClear<Source>(clearable, clearHandle, message, confirmText);
+    showConfirmation('b');
+    await show.mock.calls[0][1]();
+    expect(get(status)).toEqual({ error: 'failed Cache B', success: '' });
+    expect(get(pending)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/session/use-purge.spec.ts
+++ b/frontend/app/src/modules/session/use-purge.spec.ts
@@ -1,0 +1,86 @@
+import type { TaskResult } from '@/modules/core/tasks/use-task-handler';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Section } from '@/modules/core/common/status';
+import { Purgeable } from './purge';
+import { useSessionPurge } from './use-purge';
+
+const refreshGeneralCacheTask = vi.fn();
+const resetStatus = vi.fn();
+const runTask = vi.fn();
+const notifyError = vi.fn();
+const markAllProtocolCacheCancelled = vi.fn();
+const resetProtocolCacheUpdatesStatus = vi.fn();
+
+vi.mock('@/modules/session/api/use-session-api', () => ({
+  useSessionApi: (): object => ({ refreshGeneralCacheTask }),
+}));
+
+vi.mock('@/modules/core/common/use-status-store', () => ({
+  useStatusStore: (): object => ({ resetStatus }),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-handler', () => ({
+  useTaskHandler: (): object => ({ runTask }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: (): object => ({ notifyError }),
+}));
+
+vi.mock('@/modules/history/use-protocol-cache-status-store', () => ({
+  useProtocolCacheStatusStore: (): object => ({ markAllProtocolCacheCancelled, resetProtocolCacheUpdatesStatus }),
+}));
+
+const success: TaskResult<boolean> = { success: true, result: true };
+
+describe('useSessionPurge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runTask.mockResolvedValue(success);
+  });
+
+  describe('purgeCache', () => {
+    it.each([Purgeable.CENTRALIZED_EXCHANGES, Purgeable.TRANSACTIONS])(
+      'should reset the history status for %s',
+      (purgeable) => {
+        useSessionPurge().purgeCache(purgeable, '');
+        expect(resetStatus).toHaveBeenCalledWith(Section.HISTORY);
+      },
+    );
+
+    it('should not reset any status for unrelated purgeables', () => {
+      useSessionPurge().purgeCache(Purgeable.DEFI_MODULES, '');
+      expect(resetStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('refreshGeneralCache', () => {
+    it('should reset the protocol cache and run the refresh task', async () => {
+      await useSessionPurge().refreshGeneralCache('opensea');
+      expect(resetProtocolCacheUpdatesStatus).toHaveBeenCalledOnce();
+      expect(runTask).toHaveBeenCalledOnce();
+      expect(notifyError).not.toHaveBeenCalled();
+    });
+
+    it('should mark the protocol cache cancelled when the task is cancelled', async () => {
+      runTask.mockResolvedValue({ success: false, message: '', cancelled: true, backendCancelled: false, skipped: false });
+      await useSessionPurge().refreshGeneralCache('opensea');
+      expect(markAllProtocolCacheCancelled).toHaveBeenCalledOnce();
+      expect(notifyError).not.toHaveBeenCalled();
+    });
+
+    it('should notify on an actionable failure', async () => {
+      runTask.mockResolvedValue({ success: false, message: 'boom', cancelled: false, backendCancelled: false, skipped: false });
+      await useSessionPurge().refreshGeneralCache('opensea');
+      expect(notifyError).toHaveBeenCalledOnce();
+      expect(markAllProtocolCacheCancelled).not.toHaveBeenCalled();
+    });
+
+    it('should stay silent when the task is skipped', async () => {
+      runTask.mockResolvedValue({ success: false, message: '', cancelled: false, backendCancelled: false, skipped: true });
+      await useSessionPurge().refreshGeneralCache('opensea');
+      expect(notifyError).not.toHaveBeenCalled();
+      expect(markAllProtocolCacheCancelled).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/session/use-session-state-cleaner.spec.ts
+++ b/frontend/app/src/modules/session/use-session-state-cleaner.spec.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type EffectScope, nextTick } from 'vue';
+import { useSessionStateCleaner } from './use-session-state-cleaner';
+
+const logged = ref<boolean>(false);
+const clearUploadStatus = vi.fn();
+const start = vi.fn();
+const stop = vi.fn();
+const resetInstance = vi.fn();
+const resetState = vi.fn();
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: (): object => ({ logged }),
+}));
+
+vi.mock('@/modules/session/use-session-sync', () => ({
+  useSync: (): object => ({ clearUploadStatus }),
+}));
+
+vi.mock('@/modules/shell/app/use-monitor-service', () => ({
+  useMonitorService: (): object => ({ start, stop }),
+}));
+
+vi.mock('@/modules/balances/services/balance-queue', () => ({
+  BalanceQueueService: { resetInstance: (): void => resetInstance() },
+}));
+
+vi.mock('@/modules/shell/app/store-plugins', () => ({
+  resetState: (): void => resetState(),
+}));
+
+describe('useSessionStateCleaner', () => {
+  let scope: EffectScope;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(logged, false);
+    scope = effectScope();
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  it('should start the monitor when the user logs in', async () => {
+    scope.run(() => useSessionStateCleaner());
+    set(logged, true);
+    await nextTick();
+    expect(start).toHaveBeenCalledOnce();
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  it('should stop the monitor and run cleanup when the user logs out', async () => {
+    set(logged, true);
+    scope.run(() => useSessionStateCleaner());
+    set(logged, false);
+    await nextTick();
+    expect(stop).toHaveBeenCalledOnce();
+    expect(clearUploadStatus).toHaveBeenCalledOnce();
+    expect(resetInstance).toHaveBeenCalledOnce();
+    expect(resetState).toHaveBeenCalledOnce();
+  });
+
+  it('should not clean up while the user stays logged in', async () => {
+    scope.run(() => useSessionStateCleaner());
+    set(logged, true);
+    await nextTick();
+    expect(clearUploadStatus).not.toHaveBeenCalled();
+    expect(resetState).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/session/use-update-checker.spec.ts
+++ b/frontend/app/src/modules/session/use-update-checker.spec.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const checkForUpdates = vi.fn();
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): { checkForUpdates: typeof checkForUpdates } => ({ checkForUpdates }),
+}));
+
+async function loadComposable(): Promise<typeof import('./use-update-checker')['useUpdateChecker']> {
+  vi.resetModules();
+  return (await import('./use-update-checker')).useUpdateChecker;
+}
+
+describe('useUpdateChecker', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('should default the update popup to false', async () => {
+    const useUpdateChecker = await loadComposable();
+    const { showUpdatePopup } = useUpdateChecker();
+    expect(get(showUpdatePopup)).toBe(false);
+  });
+
+  it('should flag the popup when an update is available', async () => {
+    checkForUpdates.mockResolvedValue(true);
+    const useUpdateChecker = await loadComposable();
+    const { checkForUpdate, showUpdatePopup } = useUpdateChecker();
+    await checkForUpdate();
+    expect(checkForUpdates).toHaveBeenCalledOnce();
+    expect(get(showUpdatePopup)).toBe(true);
+  });
+
+  it('should keep the popup hidden when no update is available', async () => {
+    checkForUpdates.mockResolvedValue(false);
+    const useUpdateChecker = await loadComposable();
+    const { checkForUpdate, showUpdatePopup } = useUpdateChecker();
+    await checkForUpdate();
+    expect(get(showUpdatePopup)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/settings/accounting/use-accounting-settings.spec.ts
+++ b/frontend/app/src/modules/settings/accounting/use-accounting-settings.spec.ts
@@ -1,0 +1,266 @@
+import type { TaskResult } from '@/modules/core/tasks/use-task-handler';
+import type {
+  AccountingRuleConflictRequestPayload,
+  AccountingRuleRequestPayload,
+} from '@/modules/settings/types/accounting';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccountingSettings } from './use-accounting-settings';
+
+const rulePayload: AccountingRuleRequestPayload = { limit: 10, offset: 0 };
+const conflictPayload: AccountingRuleConflictRequestPayload = { limit: 10, offset: 0 };
+
+const fetchAccountingRule = vi.fn();
+const fetchAccountingRules = vi.fn();
+const fetchAccountingRuleConflicts = vi.fn();
+const resolveAccountingRuleConflictsCaller = vi.fn();
+const exportAccountingRules = vi.fn();
+const importAccountingRulesData = vi.fn();
+const uploadAccountingRulesData = vi.fn();
+const resetAccountingRules = vi.fn();
+
+const notifyError = vi.fn();
+const showErrorMessage = vi.fn();
+const showSuccessMessage = vi.fn();
+
+const runTask = vi.fn();
+const downloadFileByTextContent = vi.fn();
+
+const openDirectory = vi.fn();
+const getPath = vi.fn();
+let appSession = false;
+
+vi.mock('@/modules/settings/api/use-accounting-api', () => ({
+  useAccountingApi: (): object => ({
+    exportAccountingRules,
+    fetchAccountingRule,
+    fetchAccountingRuleConflicts,
+    fetchAccountingRules,
+    importAccountingRulesData,
+    resetAccountingRules,
+    resolveAccountingRuleConflicts: resolveAccountingRuleConflictsCaller,
+    uploadAccountingRulesData,
+  }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  getErrorMessage: (error: unknown): string => error instanceof Error ? error.message : String(error),
+  useNotifications: (): object => ({ notifyError, showErrorMessage, showSuccessMessage }),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-handler', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/modules/core/tasks/use-task-handler')>();
+  return { ...actual, useTaskHandler: (): object => ({ runTask }) };
+});
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): object => ({ appSession, getPath, openDirectory }),
+}));
+
+vi.mock('@/modules/core/common/file/download', () => ({
+  downloadFileByTextContent: (...args: unknown[]): void => downloadFileByTextContent(...args),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+function success<R>(result: R): TaskResult<R> {
+  return { success: true, result };
+}
+
+const actionableFailure: TaskResult<never> = {
+  success: false,
+  message: 'boom',
+  cancelled: false,
+  backendCancelled: false,
+  skipped: false,
+};
+
+const cancelledFailure: TaskResult<never> = {
+  success: false,
+  message: '',
+  cancelled: true,
+  backendCancelled: false,
+  skipped: false,
+};
+
+const collectionResponse = {
+  entries: [{ identifier: 1 }],
+  entriesFound: 1,
+  entriesLimit: 10,
+  entriesTotal: 1,
+};
+
+describe('useAccountingSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appSession = false;
+  });
+
+  describe('getAccountingRule', () => {
+    it('should return the fetched rule', async () => {
+      fetchAccountingRule.mockResolvedValue({ identifier: 1 });
+      const result = await useAccountingSettings().getAccountingRule(rulePayload, 'uniswap');
+      expect(result).toEqual({ identifier: 1 });
+    });
+
+    it('should map a null result to undefined', async () => {
+      fetchAccountingRule.mockResolvedValue(null);
+      const result = await useAccountingSettings().getAccountingRule(rulePayload, null);
+      expect(result).toBeUndefined();
+    });
+
+    it('should notify and return undefined on error', async () => {
+      fetchAccountingRule.mockRejectedValue(new Error('nope'));
+      const result = await useAccountingSettings().getAccountingRule(rulePayload, null);
+      expect(result).toBeUndefined();
+      expect(notifyError).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('getAccountingRules', () => {
+    it('should map the collection response', async () => {
+      fetchAccountingRules.mockResolvedValue(collectionResponse);
+      const result = await useAccountingSettings().getAccountingRules(rulePayload);
+      expect(result).toMatchObject({ data: [{ identifier: 1 }], found: 1, limit: 10, total: 1 });
+    });
+
+    it('should notify and return an empty collection on error', async () => {
+      fetchAccountingRules.mockRejectedValue(new Error('nope'));
+      const result = await useAccountingSettings().getAccountingRules(rulePayload);
+      expect(result.data).toEqual([]);
+      expect(notifyError).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('getAccountingRulesConflicts', () => {
+    it('should map the collection response', async () => {
+      fetchAccountingRuleConflicts.mockResolvedValue(collectionResponse);
+      const result = await useAccountingSettings().getAccountingRulesConflicts(conflictPayload);
+      expect(result.total).toBe(1);
+    });
+
+    it('should notify and return an empty collection on error', async () => {
+      fetchAccountingRuleConflicts.mockRejectedValue(new Error('nope'));
+      const result = await useAccountingSettings().getAccountingRulesConflicts(conflictPayload);
+      expect(result.data).toEqual([]);
+      expect(notifyError).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('resolveAccountingRuleConflicts', () => {
+    it('should return success when the call resolves', async () => {
+      resolveAccountingRuleConflictsCaller.mockResolvedValue(undefined);
+      const result = await useAccountingSettings().resolveAccountingRuleConflicts({ conflicts: [] });
+      expect(result).toEqual({ success: true });
+    });
+
+    it('should return the error message when the call rejects', async () => {
+      resolveAccountingRuleConflictsCaller.mockRejectedValue(new Error('bad'));
+      const result = await useAccountingSettings().resolveAccountingRuleConflicts({ conflicts: [] });
+      expect(result).toEqual({ message: 'bad', success: false });
+    });
+  });
+
+  describe('exportJSON', () => {
+    it('should download the exported rules in a web session', async () => {
+      appSession = false;
+      runTask.mockResolvedValue(success({ rules: [] }));
+      await useAccountingSettings().exportJSON();
+      expect(downloadFileByTextContent).toHaveBeenCalledOnce();
+    });
+
+    it('should abort when no directory is selected in an app session', async () => {
+      appSession = true;
+      openDirectory.mockResolvedValue(undefined);
+      await useAccountingSettings().exportJSON();
+      expect(runTask).not.toHaveBeenCalled();
+      expect(downloadFileByTextContent).not.toHaveBeenCalled();
+    });
+
+    it('should show a success message in an app session', async () => {
+      appSession = true;
+      openDirectory.mockResolvedValue('/tmp');
+      runTask.mockResolvedValue(success(true));
+      await useAccountingSettings().exportJSON();
+      expect(showSuccessMessage).toHaveBeenCalledOnce();
+    });
+
+    it('should show an error message when the app-session export fails', async () => {
+      appSession = true;
+      openDirectory.mockResolvedValue('/tmp');
+      runTask.mockResolvedValue(success(false));
+      await useAccountingSettings().exportJSON();
+      expect(showErrorMessage).toHaveBeenCalledOnce();
+    });
+
+    it('should stop silently when the export task is not actionable', async () => {
+      appSession = false;
+      runTask.mockResolvedValue(cancelledFailure);
+      await useAccountingSettings().exportJSON();
+      expect(downloadFileByTextContent).not.toHaveBeenCalled();
+      expect(showErrorMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('importJSON', () => {
+    const file = new File(['{}'], 'rules.json');
+
+    it('should import via path when interop resolves one', async () => {
+      getPath.mockReturnValue('/tmp/rules.json');
+      runTask.mockImplementation(async (task: () => Promise<unknown>) => {
+        await task();
+        return success(true);
+      });
+      const result = await useAccountingSettings().importJSON(file);
+      expect(importAccountingRulesData).toHaveBeenCalledWith('/tmp/rules.json');
+      expect(result).toEqual({ message: '', success: true });
+    });
+
+    it('should upload the file when no path is available', async () => {
+      getPath.mockReturnValue(undefined);
+      runTask.mockImplementation(async (task: () => Promise<unknown>) => {
+        await task();
+        return success(true);
+      });
+      await useAccountingSettings().importJSON(file);
+      expect(uploadAccountingRulesData).toHaveBeenCalledWith(file);
+    });
+
+    it('should return the failure message on an actionable failure', async () => {
+      getPath.mockReturnValue(undefined);
+      runTask.mockResolvedValue(actionableFailure);
+      const result = await useAccountingSettings().importJSON(file);
+      expect(result).toEqual({ message: 'boom', success: false });
+    });
+
+    it('should return null on a non-actionable failure', async () => {
+      getPath.mockReturnValue(undefined);
+      runTask.mockResolvedValue(cancelledFailure);
+      const result = await useAccountingSettings().importJSON(file);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('resetToDefaults', () => {
+    it('should show a success message and return success', async () => {
+      runTask.mockResolvedValue(success(true));
+      const result = await useAccountingSettings().resetToDefaults();
+      expect(showSuccessMessage).toHaveBeenCalledOnce();
+      expect(result).toEqual({ message: '', success: true });
+    });
+
+    it('should show an error message on an actionable failure', async () => {
+      runTask.mockResolvedValue(actionableFailure);
+      const result = await useAccountingSettings().resetToDefaults();
+      expect(showErrorMessage).toHaveBeenCalledOnce();
+      expect(result).toEqual({ message: 'boom', success: false });
+    });
+
+    it('should return null on a non-actionable failure', async () => {
+      runTask.mockResolvedValue(cancelledFailure);
+      const result = await useAccountingSettings().resetToDefaults();
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/use-asset-statistic-state.spec.ts
+++ b/frontend/app/src/modules/settings/use-asset-statistic-state.spec.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAssetStatisticState } from './use-asset-statistic-state';
+
+const storeEnabled = ref<boolean>(false);
+const useAssetField = vi.fn((_asset?: unknown, _key?: unknown) => computed<string>(() => 'Bitcoin'));
+
+vi.mock('@/modules/settings/use-frontend-settings-store', () => ({
+  useFrontendSettingsStore: (): object => ({ useHistoricalAssetBalances: storeEnabled }),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: (): object => ({
+    useAssetField: (asset: unknown, key: unknown) => useAssetField(asset, key),
+  }),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+describe('useAssetStatisticState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    set(storeEnabled, false);
+  });
+
+  it('should expose the asset name from the retrieval helper', () => {
+    const { name } = useAssetStatisticState(() => 'BTC');
+    expect(get(name)).toBe('Bitcoin');
+  });
+
+  it('should report no preference for an untracked asset', () => {
+    const { getPreference, rememberStateForAsset } = useAssetStatisticState(() => 'BTC');
+    expect(getPreference('BTC')).toBeUndefined();
+    expect(get(rememberStateForAsset)).toBe(false);
+  });
+
+  it('should store the snapshot preference when remembering with historical disabled', () => {
+    const { getPreference, rememberStateForAsset } = useAssetStatisticState(() => 'BTC');
+    set(rememberStateForAsset, true);
+    expect(get(rememberStateForAsset)).toBe(true);
+    expect(getPreference('BTC')).toBe('snapshot');
+  });
+
+  it('should store the events preference when remembering with historical enabled', () => {
+    const { getPreference, rememberStateForAsset, useHistoricalAssetBalances } = useAssetStatisticState(() => 'BTC');
+    set(useHistoricalAssetBalances, true);
+    set(rememberStateForAsset, true);
+    expect(getPreference('BTC')).toBe('events');
+  });
+
+  it('should drop the preference when remembering is turned off', () => {
+    const { getPreference, rememberStateForAsset } = useAssetStatisticState(() => 'BTC');
+    set(rememberStateForAsset, true);
+    expect(getPreference('BTC')).toBe('snapshot');
+    set(rememberStateForAsset, false);
+    expect(getPreference('BTC')).toBeUndefined();
+  });
+
+  it('should skip the callback in suppressIfPerAsset when remembering per asset', async () => {
+    const { rememberStateForAsset, suppressIfPerAsset } = useAssetStatisticState(() => 'BTC');
+    set(rememberStateForAsset, true);
+    const func = vi.fn().mockResolvedValue(undefined);
+    await suppressIfPerAsset(func);
+    expect(func).not.toHaveBeenCalled();
+  });
+
+  it('should run the callback in suppressIfPerAsset when not remembering per asset', async () => {
+    const { suppressIfPerAsset } = useAssetStatisticState(() => 'BTC');
+    const func = vi.fn().mockResolvedValue(undefined);
+    await suppressIfPerAsset(func);
+    expect(func).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/settings/use-privacy.spec.ts
+++ b/frontend/app/src/modules/settings/use-privacy.spec.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrivacyMode } from '@/modules/session/types';
+import { usePrivacyMode } from './use-privacy';
+
+const privacyMode = ref<PrivacyMode>(PrivacyMode.NORMAL);
+const updateFrontendSetting = vi.fn();
+
+vi.mock('@/modules/settings/use-frontend-settings-store', () => ({
+  useFrontendSettingsStore: (): object => ({ privacyMode }),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): object => ({ updateFrontendSetting }),
+}));
+
+describe('usePrivacyMode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(privacyMode, PrivacyMode.NORMAL);
+  });
+
+  it.each([
+    [PrivacyMode.NORMAL, 'lu-eye'],
+    [PrivacyMode.SEMI_PRIVATE, 'lu-eye-off'],
+    [PrivacyMode.PRIVATE, 'lu-eye-closed'],
+  ])('should map privacy mode %s to icon %s', (mode, icon) => {
+    set(privacyMode, mode);
+    const { privacyModeIcon } = usePrivacyMode();
+    expect(get(privacyModeIcon)).toBe(icon);
+  });
+
+  it('should persist the requested mode on change', async () => {
+    const { changePrivacyMode } = usePrivacyMode();
+    await changePrivacyMode(PrivacyMode.PRIVATE);
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ privacyMode: PrivacyMode.PRIVATE });
+  });
+
+  it('should cycle to the next mode on toggle', async () => {
+    set(privacyMode, PrivacyMode.NORMAL);
+    const { togglePrivacyMode } = usePrivacyMode();
+    await togglePrivacyMode();
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ privacyMode: PrivacyMode.SEMI_PRIVATE });
+  });
+
+  it('should wrap around from the last mode back to normal', async () => {
+    set(privacyMode, PrivacyMode.PRIVATE);
+    const { togglePrivacyMode } = usePrivacyMode();
+    await togglePrivacyMode();
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ privacyMode: PrivacyMode.NORMAL });
+  });
+});

--- a/frontend/app/src/modules/settings/use-scramble-settings.spec.ts
+++ b/frontend/app/src/modules/settings/use-scramble-settings.spec.ts
@@ -1,0 +1,82 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, type VNode } from 'vue';
+import { useScrambleSetting } from './use-scramble-settings';
+
+type ScrambleApi = ReturnType<typeof useScrambleSetting>;
+
+const scrambleData = ref<boolean>(false);
+const scrambleMultiplier = ref<number | undefined>(undefined);
+const applyFrontendSettingLocal = vi.fn();
+const updateFrontendSetting = vi.fn();
+const generateRandomScrambleMultiplier = vi.fn(() => 5);
+
+vi.mock('@/modules/settings/use-frontend-settings-store', () => ({
+  useFrontendSettingsStore: (): object => ({ scrambleData, scrambleMultiplier }),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): object => ({ applyFrontendSettingLocal, updateFrontendSetting }),
+}));
+
+vi.mock('@/modules/session/session-utils', () => ({
+  generateRandomScrambleMultiplier: (): number => generateRandomScrambleMultiplier(),
+}));
+
+function mountComposable(): { api: ScrambleApi; unmount: () => void } {
+  let api!: ScrambleApi;
+  const wrapper = mount(defineComponent({
+    setup(): () => VNode {
+      api = useScrambleSetting();
+      return () => h('div');
+    },
+  }));
+  return { api, unmount: () => wrapper.unmount() };
+}
+
+describe('useScrambleSetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    set(scrambleData, false);
+    set(scrambleMultiplier, undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should initialize local state from the store', () => {
+    set(scrambleData, true);
+    set(scrambleMultiplier, 7);
+    const { api, unmount } = mountComposable();
+    expect(get(api.scrambleData)).toBe(true);
+    expect(get(api.scrambleMultiplier)).toBe('7');
+    unmount();
+  });
+
+  it('should fall back to a random multiplier when none is stored', () => {
+    const { api, unmount } = mountComposable();
+    expect(get(api.scrambleMultiplier)).toBe('5');
+    unmount();
+  });
+
+  it('should generate and store a random multiplier on demand', () => {
+    const { api, unmount } = mountComposable();
+    const value = api.randomMultiplier();
+    expect(value).toBe('5');
+    expect(get(api.scrambleMultiplier)).toBe('5');
+    unmount();
+  });
+
+  it('should apply the setting locally immediately and to the backend after debounce', async () => {
+    const { api, unmount } = mountComposable();
+    api.handleMultiplierUpdate('3');
+    expect(get(api.scrambleMultiplier)).toBe('3');
+    expect(applyFrontendSettingLocal).toHaveBeenCalledWith({ scrambleMultiplier: 3 });
+    expect(updateFrontendSetting).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ scrambleMultiplier: 3 });
+    unmount();
+  });
+});

--- a/frontend/app/src/modules/settings/use-theme-migration.spec.ts
+++ b/frontend/app/src/modules/settings/use-theme-migration.spec.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useThemeMigration } from './use-theme-migration';
+
+const darkTheme = ref<Record<string, string>>({});
+const lightTheme = ref<Record<string, string>>({});
+const defaultThemeVersion = ref<number>(0);
+const updateFrontendSetting = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/modules/settings/use-frontend-settings-store', () => ({
+  useFrontendSettingsStore: (): object => ({ darkTheme, defaultThemeVersion, lightTheme }),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): object => ({ updateFrontendSetting }),
+}));
+
+vi.mock('@/plugins/theme', () => ({
+  CURRENT_DEFAULT_THEME_VERSION: 2,
+  DARK_COLORS: {},
+  LIGHT_COLORS: {},
+  DEFAULT_THEME_HISTORIES: [{ version: 0, darkColors: {}, lightColors: {} }],
+}));
+
+describe('useThemeMigration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(darkTheme, {});
+    set(lightTheme, {});
+    set(defaultThemeVersion, 0);
+  });
+
+  it('should do nothing when the theme version is already current', () => {
+    set(defaultThemeVersion, 2);
+    useThemeMigration().checkDefaultThemeVersion();
+    expect(updateFrontendSetting).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing when there is no matching historic default', () => {
+    set(defaultThemeVersion, 1);
+    useThemeMigration().checkDefaultThemeVersion();
+    expect(updateFrontendSetting).not.toHaveBeenCalled();
+  });
+
+  it('should migrate to the current version when an outdated default is found', () => {
+    set(defaultThemeVersion, 0);
+    useThemeMigration().checkDefaultThemeVersion();
+    expect(updateFrontendSetting).toHaveBeenCalledOnce();
+    expect(updateFrontendSetting).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultThemeVersion: 2 }),
+    );
+  });
+});

--- a/frontend/app/src/modules/shell/app/schedulers/use-balance-refresh-scheduler.spec.ts
+++ b/frontend/app/src/modules/shell/app/schedulers/use-balance-refresh-scheduler.spec.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBalanceRefreshScheduler } from './use-balance-refresh-scheduler';
+
+interface SchedulerOptions {
+  callback: () => void;
+  intervalMs: number;
+}
+
+let capturedOptions: SchedulerOptions | undefined;
+const schedulerStart = vi.fn();
+const schedulerStop = vi.fn();
+
+const canRequestData = ref<boolean>(false);
+const refreshPeriod = ref<number>(0);
+const autoRefresh = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./use-interval-scheduler', () => ({
+  useIntervalScheduler: (options: SchedulerOptions): object => {
+    capturedOptions = options;
+    return { start: schedulerStart, stop: schedulerStop };
+  },
+}));
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: (): object => ({ canRequestData }),
+}));
+
+vi.mock('@/modules/settings/use-frontend-settings-store', () => ({
+  useFrontendSettingsStore: (): object => ({ refreshPeriod }),
+}));
+
+vi.mock('@/modules/balances/use-balance-fetching', () => ({
+  useBalanceFetching: (): object => ({ autoRefresh }),
+}));
+
+describe('useBalanceRefreshScheduler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOptions = undefined;
+    set(canRequestData, false);
+    set(refreshPeriod, 0);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should convert the refresh period from minutes to milliseconds', () => {
+    set(refreshPeriod, 5);
+    useBalanceRefreshScheduler();
+    expect(capturedOptions?.intervalMs).toBe(5 * 60 * 1000);
+  });
+
+  it('should floor the interval at 1ms when the period is zero', () => {
+    set(refreshPeriod, 0);
+    useBalanceRefreshScheduler();
+    expect(capturedOptions?.intervalMs).toBe(1);
+  });
+
+  it('should auto refresh when data can be requested', () => {
+    set(canRequestData, true);
+    useBalanceRefreshScheduler();
+    capturedOptions?.callback();
+    expect(autoRefresh).toHaveBeenCalledOnce();
+  });
+
+  it('should not auto refresh when data cannot be requested', () => {
+    set(canRequestData, false);
+    useBalanceRefreshScheduler();
+    capturedOptions?.callback();
+    expect(autoRefresh).not.toHaveBeenCalled();
+  });
+
+  it('should start the scheduler when the period is positive', () => {
+    set(refreshPeriod, 5);
+    useBalanceRefreshScheduler().start();
+    expect(schedulerStart).toHaveBeenCalledOnce();
+  });
+
+  it('should not start the scheduler when the period is zero', () => {
+    set(refreshPeriod, 0);
+    useBalanceRefreshScheduler().start();
+    expect(schedulerStart).not.toHaveBeenCalled();
+  });
+
+  it('should not start when auto fetch is disabled via env', () => {
+    vi.stubEnv('VITE_NO_AUTO_FETCH', 'true');
+    set(refreshPeriod, 5);
+    useBalanceRefreshScheduler().start();
+    expect(schedulerStart).not.toHaveBeenCalled();
+  });
+
+  it('should delegate stop to the interval scheduler', () => {
+    useBalanceRefreshScheduler().stop();
+    expect(schedulerStop).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/shell/app/schedulers/use-evm-status-scheduler.spec.ts
+++ b/frontend/app/src/modules/shell/app/schedulers/use-evm-status-scheduler.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEvmStatusScheduler } from './use-evm-status-scheduler';
+
+interface SchedulerOptions {
+  callback: () => void;
+  intervalMs: number;
+}
+
+let capturedOptions: SchedulerOptions | undefined;
+const schedulerStart = vi.fn();
+const schedulerStop = vi.fn();
+
+const canRequestData = ref<boolean>(false);
+const fetchTransactionStatusSummary = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./use-interval-scheduler', () => ({
+  useIntervalScheduler: (options: SchedulerOptions): object => {
+    capturedOptions = options;
+    return { start: schedulerStart, stop: schedulerStop };
+  },
+}));
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: (): object => ({ canRequestData }),
+}));
+
+vi.mock('@/modules/history/use-history-data-fetching', () => ({
+  useHistoryDataFetching: (): object => ({ fetchTransactionStatusSummary }),
+}));
+
+describe('useEvmStatusScheduler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOptions = undefined;
+    set(canRequestData, false);
+  });
+
+  it('should poll every ten minutes', () => {
+    useEvmStatusScheduler();
+    expect(capturedOptions?.intervalMs).toBe(10 * 60 * 1000);
+  });
+
+  it('should fetch the status summary when data can be requested', () => {
+    set(canRequestData, true);
+    useEvmStatusScheduler();
+    capturedOptions?.callback();
+    expect(fetchTransactionStatusSummary).toHaveBeenCalledOnce();
+  });
+
+  it('should not fetch when data cannot be requested', () => {
+    set(canRequestData, false);
+    useEvmStatusScheduler();
+    capturedOptions?.callback();
+    expect(fetchTransactionStatusSummary).not.toHaveBeenCalled();
+  });
+
+  it('should start immediately when data can already be requested', () => {
+    set(canRequestData, true);
+    useEvmStatusScheduler().start();
+    expect(schedulerStart).toHaveBeenCalledWith(true);
+  });
+
+  it('should delegate stop to the interval scheduler', () => {
+    useEvmStatusScheduler().stop();
+    expect(schedulerStop).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/shell/app/schedulers/use-password-check-scheduler.spec.ts
+++ b/frontend/app/src/modules/shell/app/schedulers/use-password-check-scheduler.spec.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePasswordCheckScheduler } from './use-password-check-scheduler';
+
+interface SchedulerOptions {
+  callback: () => void;
+  intervalMs: number;
+}
+
+let capturedOptions: SchedulerOptions | undefined;
+const schedulerStart = vi.fn();
+const schedulerStop = vi.fn();
+
+const logged = ref<boolean>(false);
+const username = ref<string>('');
+const checkIfPasswordConfirmationNeeded = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./use-interval-scheduler', () => ({
+  useIntervalScheduler: (options: SchedulerOptions): object => {
+    capturedOptions = options;
+    return { start: schedulerStart, stop: schedulerStop };
+  },
+}));
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: (): object => ({ logged, username }),
+}));
+
+vi.mock('@/modules/auth/use-password-confirmation', () => ({
+  usePasswordConfirmation: (): object => ({ checkIfPasswordConfirmationNeeded }),
+}));
+
+describe('usePasswordCheckScheduler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOptions = undefined;
+    set(logged, false);
+    set(username, '');
+  });
+
+  it('should poll hourly', () => {
+    usePasswordCheckScheduler();
+    expect(capturedOptions?.intervalMs).toBe(60 * 60 * 1000);
+  });
+
+  it('should check the password when logged in with a username', () => {
+    set(logged, true);
+    set(username, 'alice');
+    usePasswordCheckScheduler();
+    capturedOptions?.callback();
+    expect(checkIfPasswordConfirmationNeeded).toHaveBeenCalledWith('alice');
+  });
+
+  it('should do nothing when not logged in', () => {
+    set(logged, false);
+    set(username, 'alice');
+    usePasswordCheckScheduler();
+    capturedOptions?.callback();
+    expect(checkIfPasswordConfirmationNeeded).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing when there is no username', () => {
+    set(logged, true);
+    set(username, '');
+    usePasswordCheckScheduler();
+    capturedOptions?.callback();
+    expect(checkIfPasswordConfirmationNeeded).not.toHaveBeenCalled();
+  });
+
+  it('should delegate start and stop to the interval scheduler', () => {
+    const { start, stop } = usePasswordCheckScheduler();
+    start();
+    expect(schedulerStart).toHaveBeenCalledOnce();
+    stop();
+    expect(schedulerStop).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/shell/app/schedulers/use-periodic-polling-scheduler.spec.ts
+++ b/frontend/app/src/modules/shell/app/schedulers/use-periodic-polling-scheduler.spec.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePeriodicPollingScheduler } from './use-periodic-polling-scheduler';
+
+interface SchedulerOptions {
+  callback: () => void;
+  intervalMs: number;
+}
+
+let capturedOptions: SchedulerOptions | undefined;
+const schedulerStart = vi.fn();
+const schedulerStop = vi.fn();
+
+const canRequestData = ref<boolean>(false);
+const queryPeriod = ref<number>(5);
+const connected = ref<boolean>(false);
+const check = vi.fn().mockResolvedValue(undefined);
+const consume = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('./use-interval-scheduler', () => ({
+  useIntervalScheduler: (options: SchedulerOptions): object => {
+    capturedOptions = options;
+    return { start: schedulerStart, stop: schedulerStop };
+  },
+}));
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: (): object => ({ canRequestData }),
+}));
+
+vi.mock('@/modules/settings/use-frontend-settings-store', () => ({
+  useFrontendSettingsStore: (): object => ({ queryPeriod }),
+}));
+
+vi.mock('@/modules/session/use-periodic-data-fetcher', () => ({
+  usePeriodicDataFetcher: (): object => ({ check }),
+}));
+
+vi.mock('@/modules/core/messaging', () => ({
+  useMessageHandling: (): object => ({ consume }),
+}));
+
+vi.mock('../use-websocket-connection', () => ({
+  useWebsocketConnection: (): object => ({ connected }),
+}));
+
+describe('usePeriodicPollingScheduler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOptions = undefined;
+    set(canRequestData, false);
+    set(queryPeriod, 5);
+    set(connected, false);
+  });
+
+  it('should compute the interval from the query period in seconds', () => {
+    usePeriodicPollingScheduler();
+    expect(capturedOptions?.intervalMs).toBe(5000);
+  });
+
+  it('should fetch periodic data when data can be requested', () => {
+    set(canRequestData, true);
+    usePeriodicPollingScheduler();
+    capturedOptions?.callback();
+    expect(check).toHaveBeenCalledOnce();
+  });
+
+  it('should not fetch periodic data when data cannot be requested', () => {
+    set(canRequestData, false);
+    usePeriodicPollingScheduler();
+    capturedOptions?.callback();
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it('should consume messages when the websocket is disconnected', () => {
+    set(connected, false);
+    usePeriodicPollingScheduler();
+    capturedOptions?.callback();
+    expect(consume).toHaveBeenCalledOnce();
+  });
+
+  it('should not consume messages when the websocket is connected', () => {
+    set(connected, true);
+    usePeriodicPollingScheduler();
+    capturedOptions?.callback();
+    expect(consume).not.toHaveBeenCalled();
+  });
+
+  it('should delegate start and stop to the interval scheduler', () => {
+    const { start, stop } = usePeriodicPollingScheduler();
+    start(true);
+    expect(schedulerStart).toHaveBeenCalledWith(true);
+    stop();
+    expect(schedulerStop).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/shell/app/schedulers/use-task-polling-scheduler.spec.ts
+++ b/frontend/app/src/modules/shell/app/schedulers/use-task-polling-scheduler.spec.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTaskPollingScheduler } from './use-task-polling-scheduler';
+
+interface SchedulerOptions {
+  callback: () => void;
+  intervalMs: number;
+}
+
+let capturedOptions: SchedulerOptions | undefined;
+const schedulerStart = vi.fn();
+const schedulerStop = vi.fn();
+const monitor = vi.fn();
+
+vi.mock('./use-interval-scheduler', () => ({
+  useIntervalScheduler: (options: SchedulerOptions): object => {
+    capturedOptions = options;
+    return { start: schedulerStart, stop: schedulerStop };
+  },
+}));
+
+vi.mock('@/modules/core/tasks/use-task-monitor', () => ({
+  useTaskMonitor: (): object => ({ monitor }),
+}));
+
+describe('useTaskPollingScheduler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedOptions = undefined;
+  });
+
+  it('should poll every four seconds using the task monitor', () => {
+    useTaskPollingScheduler();
+    expect(capturedOptions?.intervalMs).toBe(4000);
+    expect(capturedOptions?.callback).toBe(monitor);
+  });
+
+  it('should delegate start and stop to the interval scheduler', () => {
+    const { start, stop } = useTaskPollingScheduler();
+    start(true);
+    expect(schedulerStart).toHaveBeenCalledWith(true);
+    stop();
+    expect(schedulerStop).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Continues the frontend unit-coverage effort for #11252, adding specs for zero-coverage composables and stores.

## Coverage added
- **core**: `async-utilities`, `collection-utils`, `attrs`/`route-uri` helpers, `use-report-issue`
- **session**: `use-purge`, `use-cache-clear`, `use-session-state-cleaner`, `use-update-checker`
- **settings**: `use-privacy`, `use-theme-migration`, `use-scramble-settings`, `use-asset-statistic-state`, `accounting/use-accounting-settings`
- **dashboard**: progress indicators (`use-balance-query-progress`, `use-unified-progress`, `use-transaction-status-check`, `use-history-query-indicator-settings`)
- **shell**: interval-scheduler wrappers (`periodic-polling`, `balance-refresh`, `evm-status`, `task-polling`, `password-check`)

## Bug fix
`waitForCondition` in `async-utilities` now rejects with a `TimeoutError` on timeout. Previously the internal `abortController.abort()` fired the `AbortSignal.any` handler synchronously and rejected with an `AbortedError` before the `TimeoutError` reject ran, so callers never observed a timeout.

## Testing
23 spec files, 160 tests. `pnpm run test:unit`, `pnpm run typecheck` and lint all pass.