### PR TITLE
Test location DB schema coverage

### DIFF
--- a/rotkehlchen/tests/unit/test_location.py
+++ b/rotkehlchen/tests/unit/test_location.py
@@ -1,4 +1,5 @@
 from rotkehlchen.constants.location_details import LOCATION_DETAILS
+from rotkehlchen.db.schema import DB_CREATE_LOCATION
 from rotkehlchen.exchanges.constants import (
     ALL_SUPPORTED_EXCHANGES,
     EXCHANGES_WITH_PASSPHRASE,
@@ -26,3 +27,12 @@ def test_location_details_coverage():
                     assert 'is_exchange_without_api_secret' in exchange_details
                 continue
             assert 'is_exchange' in location_detail
+
+
+def test_all_locations_exist_in_db_schema():
+    """Test that fresh user DBs contain all Location enum values."""
+    for location in Location:
+        assert (
+            f"INSERT OR IGNORE INTO location(location, seq) VALUES "
+            f"('{location.serialize_for_db()}', {location.value});"
+        ) in DB_CREATE_LOCATION


### PR DESCRIPTION
## Summary

Adds a unit test ensuring every `Location` enum value exists in the fresh user DB location schema.

## Motivation

When adding a new location it is easy to update the enum and location metadata but forget the fresh DB schema insert. That can lead to runtime failures when creating credentials or writing location-linked data for fresh users.

This test catches that class of issue generically.

## Testing

- `python -m pytest rotkehlchen/tests/unit/test_location.py`

## My test setup

I ran the tests from a local virtual environment created inside the repository checkout.
The test command was executed with a repo-local `HOME` and `UV_CACHE_DIR` so no user-level rotki data or global uv cache was used.

Actual command:

```sh
HOME="$PWD/.cache/test-home" UV_CACHE_DIR=.cache/uv .venv/bin/python -m pytest rotkehlchen/tests/unit/test_location.py
```