### PR TITLE
Settings registry follow-ups: session writes, facades, SettingSwitch

### DIFF
--- a/frontend/app/src/modules/assets/amount-display/use-amount-display-settings.ts
+++ b/frontend/app/src/modules/assets/amount-display/use-amount-display-settings.ts
@@ -1,30 +1,33 @@
 import type { Ref } from 'vue';
-import type { Currency } from '@/modules/assets/amount-display/currencies';
-import type { RoundingMode } from '@/modules/settings/types/frontend-settings';
-import { useSetting } from '@/modules/settings/use-setting';
+import { type SettingValue, useSetting } from '@/modules/settings/use-setting';
 
+/**
+ * Read value types are derived from the settings registry via `SettingValue`, so this interface
+ * cannot drift from the registry's precise per-key types (e.g. `currencySymbol` stays the currency
+ * union rather than widening to `string`).
+ */
 export interface AmountDisplaySettings {
   // General settings
-  floatingPrecision: Readonly<Ref<number>>;
-  currency: Readonly<Ref<Currency>>;
-  currencySymbol: Readonly<Ref<string>>;
+  floatingPrecision: Readonly<Ref<SettingValue<'floatingPrecision'>>>;
+  currency: Readonly<Ref<SettingValue<'currency'>>>;
+  currencySymbol: Readonly<Ref<SettingValue<'currencySymbol'>>>;
 
   // Frontend settings - formatting
-  thousandSeparator: Readonly<Ref<string>>;
-  decimalSeparator: Readonly<Ref<string>>;
-  currencyLocation: Readonly<Ref<'before' | 'after'>>;
-  abbreviateNumber: Readonly<Ref<boolean>>;
-  minimumDigitToBeAbbreviated: Readonly<Ref<number>>;
-  subscriptDecimals: Readonly<Ref<boolean>>;
+  thousandSeparator: Readonly<Ref<SettingValue<'thousandSeparator'>>>;
+  decimalSeparator: Readonly<Ref<SettingValue<'decimalSeparator'>>>;
+  currencyLocation: Readonly<Ref<SettingValue<'currencyLocation'>>>;
+  abbreviateNumber: Readonly<Ref<SettingValue<'abbreviateNumber'>>>;
+  minimumDigitToBeAbbreviated: Readonly<Ref<SettingValue<'minimumDigitToBeAbbreviated'>>>;
+  subscriptDecimals: Readonly<Ref<SettingValue<'subscriptDecimals'>>>;
 
   // Frontend settings - rounding
-  amountRoundingMode: Readonly<Ref<RoundingMode>>;
-  valueRoundingMode: Readonly<Ref<RoundingMode>>;
+  amountRoundingMode: Readonly<Ref<SettingValue<'amountRoundingMode'>>>;
+  valueRoundingMode: Readonly<Ref<SettingValue<'valueRoundingMode'>>>;
 
   // Frontend settings - privacy
-  scrambleData: Readonly<Ref<boolean>>;
-  scrambleMultiplier: Readonly<Ref<number | undefined>>;
-  shouldShowAmount: Readonly<Ref<boolean>>;
+  scrambleData: Readonly<Ref<SettingValue<'scrambleData'>>>;
+  scrambleMultiplier: Readonly<Ref<SettingValue<'scrambleMultiplier'>>>;
+  shouldShowAmount: Readonly<Ref<SettingValue<'shouldShowAmount'>>>;
 }
 
 /**

--- a/frontend/app/src/modules/premium/setup-interface.ts
+++ b/frontend/app/src/modules/premium/setup-interface.ts
@@ -12,8 +12,8 @@ import dayjs from 'dayjs';
 import { convertToTimestamp } from '@/modules/core/common/data/date';
 import { logger } from '@/modules/core/common/logging/logging';
 import { assetsApi, balancesApi, statisticsApi, userSettings, utilsApi } from '@/modules/premium/premium-apis';
-import { useSetting } from '@/modules/settings/use-setting';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
+import { useThemeSettings } from '@/modules/shell/theme/use-theme-settings';
 import { useGraph } from '@/modules/statistics/use-graph';
 import { DARK_COLORS, LIGHT_COLORS } from '@/plugins/theme';
 
@@ -42,6 +42,7 @@ export function createPremiumApi(): PremiumApi {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const { t, te } = useI18n({ useScope: 'global' });
     const { updateFrontendSetting } = useSettingsOperations();
+    const { darkTheme, lightTheme } = useThemeSettings();
     return {
       defaultThemes(): Themes {
         return {
@@ -56,8 +57,8 @@ export function createPremiumApi(): PremiumApi {
       isDark: useRotkiTheme().isDark,
       themes(): Themes {
         return {
-          dark: get(useSetting('darkTheme')),
-          light: get(useSetting('lightTheme')),
+          dark: get(darkTheme),
+          light: get(lightTheme),
         };
       },
       async update(settings: FrontendSettingsPayload): Promise<void> {

--- a/frontend/app/src/modules/session/use-animations-enabled.ts
+++ b/frontend/app/src/modules/session/use-animations-enabled.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared, global instance of the `animationsEnabled` session setting's localStorage backing
+ * (`rotki.animations_enabled`).
+ *
+ * It is declared as the `animationsEnabled` registry entry's `mirror`, so writing the setting through
+ * the normal settings pipeline keeps localStorage in sync (no bespoke setter needed). The settings
+ * repo also reads it to seed the session default on boot, which is what makes the toggle persist
+ * across restarts.
+ */
+export const useAnimationsEnabled = createSharedComposable(() => useLocalStorage<boolean>('rotki.animations_enabled', true));

--- a/frontend/app/src/modules/settings/accounting/CalculatePastCostBasisSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/CalculatePastCostBasisSetting.vue
@@ -1,36 +1,21 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
-const calculatePastCostBasis = ref(false);
-const enabled = useSetting('calculatePastCostBasis');
 const { t } = useI18n({ useScope: 'global' });
 
-function switchSuccessMessage(enabled: boolean) {
+function switchSuccessMessage(enabled: boolean): string {
   return enabled
     ? t('account_settings.messages.cost_basis.enabled')
     : t('account_settings.messages.cost_basis.disabled');
 }
-
-onMounted(() => {
-  set(calculatePastCostBasis, get(enabled));
-});
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, update }"
+  <SettingSwitch
     setting="calculatePastCostBasis"
+    :debounce="1500"
+    :label="t('accounting_settings.trade.labels.calculate_past_cost_basis')"
     :error-message="t('account_settings.messages.cost_basis.error')"
     :success-message="switchSuccessMessage"
-  >
-    <RuiSwitch
-      v-model="calculatePastCostBasis"
-      :success-messages="success"
-      :error-messages="error"
-      :label="t('accounting_settings.trade.labels.calculate_past_cost_basis')"
-      color="primary"
-      @update:model-value="update($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/accounting/CryptoToCryptoTradeSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/CryptoToCryptoTradeSetting.vue
@@ -1,31 +1,15 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const crypto2CryptoTrades = ref(false);
-const includeCrypto2crypto = useSetting('includeCrypto2crypto');
-
-onMounted(() => {
-  set(crypto2CryptoTrades, get(includeCrypto2crypto));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, update }"
+  <SettingSwitch
     setting="includeCrypto2crypto"
+    data-cy="crypto2crypto-switch"
+    :debounce="1500"
+    :label="t('accounting_settings.trade.labels.include_crypto2crypto')"
     :error-message="t('account_settings.messages.crypto_to_crypto')"
-  >
-    <RuiSwitch
-      v-model="crypto2CryptoTrades"
-      data-cy="crypto2crypto-switch"
-      :label="t('accounting_settings.trade.labels.include_crypto2crypto')"
-      color="primary"
-      :success-messages="success"
-      :error-messages="error"
-      @update:model-value="update($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/accounting/GasCostSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/GasCostSetting.vue
@@ -1,31 +1,15 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const gasCosts = ref(false);
-const includeGasCosts = useSetting('includeGasCosts');
-
-onMounted(() => {
-  set(gasCosts, get(includeGasCosts));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, update }"
+  <SettingSwitch
     setting="includeGasCosts"
+    data-cy="include-gas-costs-switch"
+    :debounce="1500"
+    :label="t('accounting_settings.trade.labels.include_gas_costs')"
     :error-message="t('account_settings.messages.gas_costs')"
-  >
-    <RuiSwitch
-      v-model="gasCosts"
-      data-cy="include-gas-costs-switch"
-      :label="t('accounting_settings.trade.labels.include_gas_costs')"
-      :success-messages="success"
-      :error-messages="error"
-      color="primary"
-      @update:model-value="update($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/accounting/PnlCsvSummarySetting.vue
+++ b/frontend/app/src/modules/settings/accounting/PnlCsvSummarySetting.vue
@@ -1,31 +1,15 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const haveCSVSummary = ref(false);
-const pnlCsvHaveSummary = useSetting('pnlCsvHaveSummary');
-
-onMounted(() => {
-  set(haveCSVSummary, get(pnlCsvHaveSummary));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, update }"
+  <SettingSwitch
     setting="pnlCsvHaveSummary"
+    class="csv_export_settings__haveCSVSummary"
+    :debounce="1500"
+    :label="t('account_settings.csv_export_settings.labels.have_csv_summary')"
     :error-message="t('account_settings.messages.have_csv_summary')"
-  >
-    <RuiSwitch
-      v-model="haveCSVSummary"
-      class="csv_export_settings__haveCSVSummary"
-      :label="t('account_settings.csv_export_settings.labels.have_csv_summary')"
-      color="primary"
-      :success-messages="success"
-      :error-messages="error"
-      @update:model-value="update($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/accounting/PnlCsvWithFormulasSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/PnlCsvWithFormulasSetting.vue
@@ -1,31 +1,15 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const exportCSVFormulas = ref(false);
-const pnlCsvWithFormulas = useSetting('pnlCsvWithFormulas');
-
-onMounted(() => {
-  set(exportCSVFormulas, get(pnlCsvWithFormulas));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, update }"
+  <SettingSwitch
     setting="pnlCsvWithFormulas"
+    class="csv_export_settings__exportCSVFormulas"
+    :debounce="1500"
+    :label="t('account_settings.csv_export_settings.labels.export_csv_formulas')"
     :error-message="t('account_settings.messages.export_csv_formulas')"
-  >
-    <RuiSwitch
-      v-model="exportCSVFormulas"
-      class="csv_export_settings__exportCSVFormulas"
-      :label="t('account_settings.csv_export_settings.labels.export_csv_formulas')"
-      color="primary"
-      :success-messages="success"
-      :error-messages="error"
-      @update:model-value="update($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/controls/SettingSwitch.spec.ts
+++ b/frontend/app/src/modules/settings/controls/SettingSwitch.spec.ts
@@ -1,0 +1,75 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
+
+const { useSettingModelMock } = vi.hoisted(() => ({ useSettingModelMock: vi.fn() }));
+vi.mock('@/modules/settings/use-setting-model', () => ({ useSettingModel: useSettingModelMock }));
+
+const RuiSwitchStub = {
+  props: ['modelValue', 'successMessages', 'errorMessages', 'label'],
+  template: `<div>
+    <span class="model">{{ modelValue }}</span>
+    <span class="success">{{ successMessages }}</span>
+    <span class="error">{{ errorMessages }}</span>
+  </div>`,
+};
+
+describe('settingSwitch', () => {
+  let model: Ref<boolean>;
+  let error: Ref<string>;
+  let success: Ref<boolean>;
+
+  function createWrapper(props: Record<string, unknown> = {}): VueWrapper {
+    return mount(SettingSwitch, {
+      props: { setting: 'treatEth2AsEth', label: 'Treat', ...props },
+      global: { stubs: { RuiSwitch: RuiSwitchStub } },
+    });
+  }
+
+  beforeEach(() => {
+    model = ref<boolean>(false);
+    error = ref<string>('');
+    success = ref<boolean>(false);
+    useSettingModelMock.mockReturnValue({ error, model, pending: ref(false), success });
+  });
+
+  it('should bind the switch to the setting draft', () => {
+    set(model, true);
+    const wrapper = createWrapper();
+    expect(wrapper.find('.model').text()).toBe('true');
+  });
+
+  it('should show a saved message after a successful write', async () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.success').text()).toBe('');
+    set(success, true);
+    await nextTick();
+    expect(wrapper.find('.success').text()).not.toBe('');
+  });
+
+  it('should derive the success message from the persisted value when given a callback', async () => {
+    const successMessage = (value: boolean): string => (value ? 'turned on' : 'turned off');
+    set(model, true);
+    const wrapper = createWrapper({ successMessage });
+    set(success, true);
+    await nextTick();
+    expect(wrapper.find('.success').text()).toContain('turned on');
+  });
+
+  it('should surface the write error message', async () => {
+    const wrapper = createWrapper();
+    set(error, 'boom');
+    await nextTick();
+    expect(wrapper.find('.error').text()).toContain('boom');
+  });
+
+  it('should clear messages when the draft changes again', async () => {
+    const wrapper = createWrapper();
+    set(error, 'boom');
+    await nextTick();
+    set(model, true);
+    await nextTick();
+    expect(wrapper.find('.error').text()).toBe('');
+  });
+});

--- a/frontend/app/src/modules/settings/controls/SettingSwitch.vue
+++ b/frontend/app/src/modules/settings/controls/SettingSwitch.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type { WritableSettingKeyOf } from '@/modules/settings/settings-writer';
+import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
+import { useSettingModel } from '@/modules/settings/use-setting-model';
+
+/**
+ * Generic owning component for a boolean setting. Given a registry key it manages its own local draft
+ * and persistence through `useSettingModel` (the writer pipeline), and surfaces the same "Settings
+ * saved" / error messages the hand-written toggles did. Place it inside a `SettingsItem` for the
+ * title/subtitle; this renders only the switch.
+ */
+const {
+  setting,
+  label = '',
+  successMessage = '',
+  errorMessage = '',
+  debounce = 0,
+} = defineProps<{
+  setting: WritableSettingKeyOf<boolean>;
+  label?: string;
+  /** Static text, or a callback given the persisted value (e.g. distinct enabled/disabled copy). */
+  successMessage?: string | ((value: boolean) => string);
+  errorMessage?: string;
+  debounce?: number;
+}>();
+
+const { error: writeError, model, success: writeSuccess } = useSettingModel(setting, { debounce });
+const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
+
+watch(model, () => {
+  clearAll();
+});
+
+watch(writeSuccess, (saved) => {
+  if (saved)
+    setSuccess(typeof successMessage === 'function' ? successMessage(get(model)) : successMessage, true);
+});
+
+watch(writeError, (message) => {
+  if (message)
+    setError(errorMessage ? `${errorMessage}: ${message}` : message, true);
+});
+</script>
+
+<template>
+  <RuiSwitch
+    v-model="model"
+    color="primary"
+    :label="label"
+    :success-messages="success"
+    :error-messages="error"
+  />
+</template>

--- a/frontend/app/src/modules/settings/frontend/EnableEnsNamesSetting.vue
+++ b/frontend/app/src/modules/settings/frontend/EnableEnsNamesSetting.vue
@@ -1,31 +1,15 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const enableAliasNames = ref<boolean>(true);
-const enabled = useSetting('enableAliasNames');
-
-onMounted(() => {
-  set(enableAliasNames, get(enabled));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, update }"
+  <SettingSwitch
     setting="enableAliasNames"
+    class="mt-4"
+    :debounce="1500"
+    :label="t('frontend_settings.alias_names.label')"
     :error-message="t('frontend_settings.alias_names.validation.error')"
-  >
-    <RuiSwitch
-      v-model="enableAliasNames"
-      class="mt-4"
-      :label="t('frontend_settings.alias_names.label')"
-      :messages="success"
-      :error-messages="error"
-      color="primary"
-      @update:model-value="update($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/frontend/ShowGraphRangeSelectorSetting.vue
+++ b/frontend/app/src/modules/settings/frontend/ShowGraphRangeSelectorSetting.vue
@@ -1,29 +1,12 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const showGraphRangeSelector = ref<boolean>(true);
-const enabled = useSetting('showGraphRangeSelector');
-
-onMounted(() => {
-  set(showGraphRangeSelector, get(enabled));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, updateImmediate }"
+  <SettingSwitch
     setting="showGraphRangeSelector"
-  >
-    <RuiSwitch
-      v-model="showGraphRangeSelector"
-      :label="t('frontend_settings.graph_basis.range_selector.label')"
-      :success-messages="success"
-      :error-messages="error"
-      color="primary"
-      @update:model-value="updateImmediate($event)"
-    />
-  </SettingsOption>
+    :label="t('frontend_settings.graph_basis.range_selector.label')"
+  />
 </template>

--- a/frontend/app/src/modules/settings/frontend/ZeroBasedGraphSetting.vue
+++ b/frontend/app/src/modules/settings/frontend/ZeroBasedGraphSetting.vue
@@ -1,32 +1,15 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const zeroBased = ref<boolean>(false);
-const enabled = useSetting('graphZeroBased');
-
-onMounted(() => {
-  set(zeroBased, get(enabled));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
   <div class="pb-2">
-    <SettingsOption
-      #default="{ error, success, updateImmediate }"
+    <SettingSwitch
       setting="graphZeroBased"
-    >
-      <RuiSwitch
-        v-model="zeroBased"
-        :label="t('frontend_settings.graph_basis.zero_based.label')"
-        :hint="t('frontend_settings.graph_basis.zero_based.hint')"
-        :success-messages="success"
-        :error-messages="error"
-        color="primary"
-        @update:model-value="updateImmediate($event)"
-      />
-    </SettingsOption>
+      :label="t('frontend_settings.graph_basis.zero_based.label')"
+      :hint="t('frontend_settings.graph_basis.zero_based.hint')"
+    />
   </div>
 </template>

--- a/frontend/app/src/modules/settings/general/DisplayDateInLocaltimeSetting.vue
+++ b/frontend/app/src/modules/settings/general/DisplayDateInLocaltimeSetting.vue
@@ -1,30 +1,13 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const displayDateInLocaltime = ref<boolean>(true);
-const enabled = useSetting('displayDateInLocaltime');
-
-onMounted(() => {
-  set(displayDateInLocaltime, get(enabled));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, updateImmediate }"
+  <SettingSwitch
     setting="displayDateInLocaltime"
+    :label="t('general_settings.display_date_in_localtime.label')"
     :error-message="t('general_settings.display_date_in_localtime.validation.error')"
-  >
-    <RuiSwitch
-      v-model="displayDateInLocaltime"
-      color="primary"
-      :label="t('general_settings.display_date_in_localtime.label')"
-      :success-messages="success"
-      :error-messages="error"
-      @update:model-value="updateImmediate($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/TreatEthAsEth2Setting.vue
+++ b/frontend/app/src/modules/settings/general/TreatEthAsEth2Setting.vue
@@ -1,30 +1,13 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const treatEth2asEth = ref<boolean>(false);
-const enabled = useSetting('treatEth2AsEth');
-
-onMounted(() => {
-  set(treatEth2asEth, get(enabled));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, updateImmediate }"
+  <SettingSwitch
     setting="treatEth2AsEth"
+    :label="t('general_settings.labels.treat_eth2_as_eth')"
     :error-message="t('general_settings.validation.treat_eth2_as_eth.error')"
-  >
-    <RuiSwitch
-      v-model="treatEth2asEth"
-      color="primary"
-      :label="t('general_settings.labels.treat_eth2_as_eth')"
-      :success-messages="success"
-      :error-messages="error"
-      @update:model-value="updateImmediate($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue
@@ -21,10 +21,8 @@ const form = useTemplateRef<InstanceType<typeof SimpleRpcNodeManagerForm>>('form
 const stateUpdated = ref(false);
 const inputUrl = ref<string>('');
 
-const settingValue = useSetting(setting);
+const value = useSetting(setting);
 const { updateSetting } = useSettings();
-
-const value = computed(() => get(settingValue));
 
 function addNewRpcNode() {
   set(errorMessages, {});

--- a/frontend/app/src/modules/settings/settings-registry.ts
+++ b/frontend/app/src/modules/settings/settings-registry.ts
@@ -4,6 +4,7 @@ import type { AccountingSettings, GeneralSettings } from '@/modules/settings/typ
 import { BigNumber } from '@rotki/common';
 import { getBnFormat } from '@/modules/assets/amount-display/amount-formatter';
 import { PrivacyMode, type SessionSettings } from '@/modules/session/types';
+import { useAnimationsEnabled } from '@/modules/session/use-animations-enabled';
 import { useItemsPerPage } from '@/modules/session/use-items-per-page';
 
 /** Post-persist effect: reconfigure BigNumber's global format when the separators change. */
@@ -221,7 +222,7 @@ export const settingsRegistry = {
   visibleTimeframes: frontend('visibleTimeframes'),
   whitelistedDomainsForNftImages: frontend('whitelistedDomainsForNftImages'),
   // session
-  animationsEnabled: session('animationsEnabled'),
+  animationsEnabled: session('animationsEnabled', { mirror: useAnimationsEnabled }),
   timeframe: session('timeframe'),
   // accounting
   calculatePastCostBasis: accounting('calculatePastCostBasis'),

--- a/frontend/app/src/modules/settings/settings-repo.spec.ts
+++ b/frontend/app/src/modules/settings/settings-repo.spec.ts
@@ -5,6 +5,7 @@ import { CurrencyLocation } from '@/modules/assets/amount-display/currency-locat
 import { DateFormat } from '@/modules/core/common/date-format';
 import { TableColumn } from '@/modules/core/table/table-column';
 import { PrivacyMode } from '@/modules/session/types';
+import { useAnimationsEnabled } from '@/modules/session/use-animations-enabled';
 import { useItemsPerPage } from '@/modules/session/use-items-per-page';
 import { useSettingsRepo } from '@/modules/settings/settings-repo';
 import {
@@ -253,5 +254,15 @@ describe('useSettingsRepo registry effects and mirrors', () => {
     store.updateFrontend({ language: SupportedLanguage.GR });
 
     expect(get(itemsPerPage)).toBe(99);
+  });
+
+  it('should sync the animationsEnabled mirror (localStorage) when it changes via the session channel', () => {
+    const animationsEnabled = useAnimationsEnabled();
+    set(animationsEnabled, true);
+    const store = useSettingsRepo(pinia);
+
+    store.updateSession({ animationsEnabled: false });
+
+    expect(get(animationsEnabled)).toBe(false);
   });
 });

--- a/frontend/app/src/modules/settings/settings-repo.ts
+++ b/frontend/app/src/modules/settings/settings-repo.ts
@@ -4,8 +4,9 @@ import type { SessionSettings } from '@/modules/session/types';
 import type { AccountingSettings, GeneralSettings } from '@/modules/settings/types/user-settings';
 import { TimeFramePeriod } from '@rotki/common';
 import { useCurrencies } from '@/modules/assets/amount-display/currencies';
+import { useAnimationsEnabled } from '@/modules/session/use-animations-enabled';
 import { defaultAccountingSettings, defaultGeneralSettings } from '@/modules/settings/factories';
-import { getRegistryEntry, registryEntries } from '@/modules/settings/settings-registry';
+import { Channel, registryEntries, type RegistryEntry, type SettingChannel } from '@/modules/settings/settings-registry';
 import { type FrontendSettings, getDefaultFrontendSettings } from '@/modules/settings/types/frontend-settings';
 
 /** Resolves each registry entry that declares a `mirror` factory to its external shared ref, once. */
@@ -18,12 +19,26 @@ function resolveMirrors(): Map<string, Ref<unknown>> {
   return mirrors;
 }
 
-const useSharedLocalStorage = createSharedComposable(useLocalStorage);
-const isAnimationEnabledSetting = useSharedLocalStorage('rotki.animations_enabled', true);
+/**
+ * Reverse index from a channel's wire field name to its `[logicalKey, entry]`. The repo's update
+ * methods receive wire-keyed payloads, but effects and mirrors are declared on (and mirrors keyed by)
+ * the logical registry key. This lets the effect runner resolve the right entry even when a key's
+ * `wireKey` differs from its logical key, instead of assuming the two are identical.
+ */
+function buildWireIndex(): Map<string, readonly [string, RegistryEntry]> {
+  const index = new Map<string, readonly [string, RegistryEntry]>();
+  for (const [logicalKey, entry] of registryEntries()) {
+    // Projected keys are read-only derivations with no wire field, so they never appear in a payload.
+    if (entry.project)
+      continue;
+    index.set(`${entry.channel}:${entry.wireKey ?? logicalKey}`, [logicalKey, entry]);
+  }
+  return index;
+}
 
 function defaultSessionSettings(): SessionSettings {
   return {
-    animationsEnabled: get<boolean>(isAnimationEnabledSetting),
+    animationsEnabled: get<boolean>(useAnimationsEnabled()),
     timeframe: TimeFramePeriod.ALL,
   };
 }
@@ -45,6 +60,28 @@ export const useSettingsRepo = defineStore('settings', () => {
   const session = ref<SessionSettings>(defaultSessionSettings());
 
   const mirrors = resolveMirrors();
+  const wireIndex = buildWireIndex();
+
+  // Runs the registry-declared effects and mirror syncs for the keys of a channel that just changed.
+  // `changedWireKeys` are the wire field names of the merged object; each is resolved to its logical
+  // registry entry via `wireIndex`. Effects (e.g. reconfiguring BigNumber's format) get the whole
+  // merged object; mirrors (e.g. the `itemsPerPage` global ref, or animations' localStorage) are
+  // pushed the new value, guarded to avoid a write echo.
+  const applySideEffects = (channel: SettingChannel, changedWireKeys: string[], merged: object): void => {
+    for (const wireKey of changedWireKeys) {
+      const found = wireIndex.get(`${channel}:${wireKey}`);
+      if (!found)
+        continue;
+      const [logicalKey, entry] = found;
+      entry.effects?.forEach(effect => effect(merged));
+      const mirror = mirrors.get(logicalKey);
+      if (!mirror)
+        continue;
+      const value: unknown = Reflect.get(merged, wireKey);
+      if (get(mirror) !== value)
+        set(mirror, value);
+    }
+  };
 
   const updateGeneral = (settings: GeneralSettings): void => {
     set(general, { ...get(general), ...settings });
@@ -54,36 +91,17 @@ export const useSettingsRepo = defineStore('settings', () => {
     set(accounting, { ...get(accounting), ...settings });
   };
 
-  // Runs the registry-declared effects and mirror syncs for the frontend keys that just changed.
-  // Effects (e.g. reconfiguring BigNumber's format) get the whole merged object; mirrors (e.g. the
-  // standalone `itemsPerPage` global ref) are pushed the new value, guarded to avoid a write echo.
-  const applyFrontendSideEffects = (changedKeys: string[], merged: FrontendSettings): void => {
-    for (const key of changedKeys) {
-      const entry = getRegistryEntry(key);
-      if (!entry)
-        continue;
-      entry.effects?.forEach(effect => effect(merged));
-      const mirror = mirrors.get(key);
-      const value: unknown = Reflect.get(merged, key);
-      if (mirror && get(mirror) !== value)
-        set(mirror, value);
-    }
-  };
-
   const updateFrontend = (settings: Partial<FrontendSettings>): void => {
     const merged = { ...get(frontend), ...settings };
     set(frontend, merged);
-    applyFrontendSideEffects(Object.keys(settings), merged);
+    applySideEffects(Channel.frontend, Object.keys(settings), merged);
   };
 
   const updateSession = (settings: Partial<SessionSettings>): ActionStatus => {
-    set(session, { ...get(session), ...settings });
+    const merged = { ...get(session), ...settings };
+    set(session, merged);
+    applySideEffects(Channel.session, Object.keys(settings), merged);
     return { success: true };
-  };
-
-  const setAnimationsEnabled = (enabled: boolean): void => {
-    set(isAnimationEnabledSetting, enabled);
-    updateSession({ animationsEnabled: enabled });
   };
 
   return {
@@ -91,7 +109,6 @@ export const useSettingsRepo = defineStore('settings', () => {
     frontend,
     general,
     session,
-    setAnimationsEnabled,
     updateAccounting,
     updateFrontend,
     updateGeneral,

--- a/frontend/app/src/modules/settings/settings-writer.spec.ts
+++ b/frontend/app/src/modules/settings/settings-writer.spec.ts
@@ -9,7 +9,6 @@ import { CostBasisMethod } from '@/modules/settings/types/user-settings';
 const mockUpdate = vi.fn(async (): Promise<{ success: boolean; message?: string }> => ({ success: true }));
 const mockUpdateFrontendSetting = vi.fn(async (): Promise<{ success: boolean; message?: string }> => ({ success: true }));
 const mockUpdateSession = vi.fn((): { success: boolean } => ({ success: true }));
-const mockSetAnimationsEnabled = vi.fn();
 
 vi.mock('@/modules/settings/use-settings-operations', () => ({
   useSettingsOperations: vi.fn((): Record<string, unknown> => ({
@@ -20,7 +19,6 @@ vi.mock('@/modules/settings/use-settings-operations', () => ({
 
 vi.mock('@/modules/settings/settings-repo', () => ({
   useSettingsRepo: vi.fn((): Record<string, unknown> => ({
-    setAnimationsEnabled: mockSetAnimationsEnabled,
     updateSession: mockUpdateSession,
   })),
 }));
@@ -69,11 +67,10 @@ describe('useSettingsWriter', () => {
       expect(mockUpdateSession).toHaveBeenCalledWith({ timeframe: TimeFramePeriod.ALL });
     });
 
-    it('should route animationsEnabled through its dedicated setter', async () => {
+    it('should route animationsEnabled through the session store update', async () => {
       const { write } = useSettingsWriter();
       await write('animationsEnabled', false);
-      expect(mockSetAnimationsEnabled).toHaveBeenCalledWith(false);
-      expect(mockUpdateSession).not.toHaveBeenCalled();
+      expect(mockUpdateSession).toHaveBeenCalledWith({ animationsEnabled: false });
     });
 
     it('should surface a write failure', async () => {
@@ -100,12 +97,11 @@ describe('useSettingsWriter', () => {
       expect(mockUpdateSession).toHaveBeenCalledWith({ timeframe: TimeFramePeriod.WEEK });
     });
 
-    it('should route animationsEnabled separately within a batch', async () => {
+    it('should route animationsEnabled through the session channel within a batch', async () => {
       const { writeMany } = useSettingsWriter();
       await writeMany({ animationsEnabled: true, itemsPerPage: 10 });
-      expect(mockSetAnimationsEnabled).toHaveBeenCalledWith(true);
+      expect(mockUpdateSession).toHaveBeenCalledWith({ animationsEnabled: true });
       expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({ itemsPerPage: 10 });
-      expect(mockUpdateSession).not.toHaveBeenCalled();
     });
 
     it('should return the first failure', async () => {

--- a/frontend/app/src/modules/settings/settings-writer.ts
+++ b/frontend/app/src/modules/settings/settings-writer.ts
@@ -15,6 +15,15 @@ type ProjectedKey = {
  */
 export type WritableSettingKey = Exclude<SettingKey, ProjectedKey>;
 
+/**
+ * A writable setting whose read value is assignable to `V`. Constrains generic owning components to
+ * the keys they can bind (e.g. `SettingSwitch` to `WritableSettingKeyOf<boolean>`), so passing a
+ * wrong-typed setting fails to compile.
+ */
+export type WritableSettingKeyOf<V> = {
+  [K in WritableSettingKey]: SettingValue<K> extends V ? K : never;
+}[WritableSettingKey];
+
 type SettingsPatch = Partial<{ [K in WritableSettingKey]: SettingValue<K> }>;
 
 /**

--- a/frontend/app/src/modules/settings/settings-writer.ts
+++ b/frontend/app/src/modules/settings/settings-writer.ts
@@ -32,15 +32,13 @@ interface ChannelPartition {
   readonly general: Record<string, unknown>;
   readonly frontend: Record<string, unknown>;
   readonly session: Record<string, unknown>;
-  readonly animationsEnabled?: boolean;
 }
 
-/** Splits a patch into one merged wire payload per channel, pulling animationsEnabled out for its setter. */
+/** Splits a patch into one merged wire payload per channel. */
 function partitionByChannel(patch: SettingsPatch): ChannelPartition {
   const general: Record<string, unknown> = {};
   const frontend: Record<string, unknown> = {};
   const session: Record<string, unknown> = {};
-  let animationsEnabled: boolean | undefined;
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Object.keys widens to string[]; the patch owns exactly WritableSettingKey entries
   for (const key of Object.keys(patch) as WritableSettingKey[]) {
@@ -52,14 +50,11 @@ function partitionByChannel(patch: SettingsPatch): ChannelPartition {
       Object.assign(general, toWirePayload(key, value));
     else if (channel === Channel.frontend)
       Object.assign(frontend, toWirePayload(key, value));
-    else if (key === 'animationsEnabled')
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- animationsEnabled's value type is boolean
-      animationsEnabled = value as boolean;
     else
       Object.assign(session, toWirePayload(key, value));
   }
 
-  return { animationsEnabled, frontend, general, session };
+  return { frontend, general, session };
 }
 
 interface UseSettingsWriterReturn {
@@ -76,7 +71,7 @@ interface UseSettingsWriterReturn {
  */
 export function useSettingsWriter(): UseSettingsWriterReturn {
   const { update, updateFrontendSetting } = useSettingsOperations();
-  const { setAnimationsEnabled, updateSession } = useSettingsRepo();
+  const { updateSession } = useSettingsRepo();
 
   async function write<K extends WritableSettingKey>(key: K, value: SettingValue<K>): Promise<ActionStatus> {
     const channel = settingsRegistry[key].channel;
@@ -87,17 +82,12 @@ export function useSettingsWriter(): UseSettingsWriterReturn {
       case Channel.frontend:
         return updateFrontendSetting(toWirePayload(key, value));
       case Channel.session:
-        if (key === 'animationsEnabled') {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- animationsEnabled's value type is boolean; TS cannot prove it for a generic K
-          setAnimationsEnabled(value as boolean);
-          return { success: true };
-        }
         return updateSession(toWirePayload(key, value));
     }
   }
 
   async function writeMany(patch: SettingsPatch): Promise<ActionStatus> {
-    const { animationsEnabled, frontend, general, session } = partitionByChannel(patch);
+    const { frontend, general, session } = partitionByChannel(patch);
 
     const results: ActionStatus[] = [];
     if (Object.keys(general).length > 0)
@@ -106,8 +96,6 @@ export function useSettingsWriter(): UseSettingsWriterReturn {
       results.push(await updateFrontendSetting(frontend));
     if (Object.keys(session).length > 0)
       results.push(updateSession(session));
-    if (animationsEnabled !== undefined)
-      setAnimationsEnabled(animationsEnabled);
 
     return results.find(result => !result.success) ?? { success: true };
   }

--- a/frontend/app/src/modules/settings/use-setting-model.spec.ts
+++ b/frontend/app/src/modules/settings/use-setting-model.spec.ts
@@ -98,4 +98,22 @@ describe('useSettingModel', () => {
       vi.useRealTimers();
     }
   });
+
+  it('should not persist a transient edit reverted to the source within the debounce window', async () => {
+    vi.useFakeTimers();
+    try {
+      const { model } = createModel({ debounce: 500 });
+      set(model, 50);
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(300);
+      // revert to the persisted value before the pending debounced write fires
+      set(model, 25);
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(mockWrite).not.toHaveBeenCalled();
+    }
+    finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/frontend/app/src/modules/settings/use-setting-model.ts
+++ b/frontend/app/src/modules/settings/use-setting-model.ts
@@ -45,7 +45,12 @@ export function useSettingModel<K extends WritableSettingKey>(
       set(model, value);
   });
 
-  const persist = async (value: SettingValue<K>): Promise<void> => {
+  const persist = async (): Promise<void> => {
+    // Read the live draft at fire time. A debounced fire can be stale: if the draft was changed again
+    // during the window (in particular reverted back to the persisted value), there is nothing to write.
+    const value = get(model);
+    if (isEqual(value, get(source)))
+      return;
     set(pending, true);
     set(error, '');
     set(success, false);
@@ -62,7 +67,7 @@ export function useSettingModel<K extends WritableSettingKey>(
   watch(model, (value) => {
     if (isEqual(value, get(source)))
       return;
-    startPromise(schedule(value));
+    startPromise(schedule());
   });
 
   return {

--- a/frontend/app/src/modules/settings/use-settings.spec.ts
+++ b/frontend/app/src/modules/settings/use-settings.spec.ts
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '@/modules/core/common/logging/logging';
 import { SettingLocation, useSettings } from '@/modules/settings/use-settings';
 
 const mockWrite = vi.fn(async (): Promise<{ success: boolean; message?: string }> => ({ success: true }));
@@ -25,9 +26,12 @@ vi.mock('@/modules/settings/settings-repo', () => ({
 const message = { error: 'failed', success: 'saved' };
 
 describe('useSettings', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
   });
 
   it('should route a registered general key through the writer', async () => {
@@ -44,11 +48,25 @@ describe('useSettings', () => {
     expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
   });
 
-  it('should keep session keys on the session path, not the writer', async () => {
+  it('should route a registered session key through the writer', async () => {
     const { updateSetting } = useSettings();
     await updateSetting('animationsEnabled', false, SettingLocation.SESSION, message);
-    expect(mockUpdateSession).toHaveBeenCalledWith({ animationsEnabled: false });
-    expect(mockWrite).not.toHaveBeenCalled();
+    expect(mockWrite).toHaveBeenCalledWith('animationsEnabled', false);
+    expect(mockUpdateSession).not.toHaveBeenCalled();
+  });
+
+  it('should warn when the supplied location disagrees with the registered channel', async () => {
+    const { updateSetting } = useSettings();
+    // animationsEnabled is a session key; passing GENERAL should still route by registry but warn.
+    await updateSetting('animationsEnabled', false, SettingLocation.GENERAL, message);
+    expect(mockWrite).toHaveBeenCalledWith('animationsEnabled', false);
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it('should not warn when the supplied location matches the registered channel', async () => {
+    const { updateSetting } = useSettings();
+    await updateSetting('submitUsageAnalytics', true, SettingLocation.GENERAL, message);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('should keep unregistered (wire-named) keys on the location path', async () => {

--- a/frontend/app/src/modules/settings/use-settings.ts
+++ b/frontend/app/src/modules/settings/use-settings.ts
@@ -34,6 +34,18 @@ function channelFor(key: string): SettingChannel | undefined {
   return getRegistryEntry(key)?.channel;
 }
 
+/**
+ * The `SettingLocation` a registered channel is expected to be written through. Routing for registered
+ * keys now derives from the registry, so this is only used to warn on a caller/registry mismatch.
+ */
+function expectedLocation(channel: SettingChannel): SettingLocation {
+  if (channel === Channel.frontend)
+    return SettingLocation.FRONTEND;
+  if (channel === Channel.session)
+    return SettingLocation.SESSION;
+  return SettingLocation.GENERAL; // general + accounting
+}
+
 async function getActionStatus(method: () => Promise<ActionStatus>, messages?: BaseMessage): Promise<UpdateResult> {
   let message: UpdateResult = {
     error: messages?.error ?? '',
@@ -77,13 +89,17 @@ export function useSettings(): UseSettingsReturn {
     settingLocation: SettingLocation,
     message: BaseMessage,
   ): Promise<UpdateResult> => {
-    // Route registered general/accounting/frontend keys through the single write facade. Session keys
-    // keep the location path (animationsEnabled has a bespoke setter that must not fire here), as do
-    // unregistered keys (dynamic, wire-named, premium flags).
+    // Route every registered key through the single write facade; the owning channel (and its per-key
+    // effects/mirrors, including animationsEnabled's localStorage) is derived from the registry. Only
+    // unregistered keys (dynamic, wire-named, premium flags) fall through to the location path.
     const channel = channelFor(settingKey);
-    if (channel !== undefined && channel !== Channel.session) {
+    if (channel !== undefined) {
+      // Routing derives from the registry, so the caller's location is advisory; warn on a mismatch so
+      // a future miswiring surfaces instead of being silently ignored.
+      if (expectedLocation(channel) !== settingLocation)
+        logger.warn(`updateSetting('${settingKey}'): supplied location ${SettingLocation[settingLocation]} does not match its registered channel '${channel}'; routing by registry.`);
       // The generic write<K> can't correlate a widened key with its value, so call it through a
-      // non-generic view. channelFor resolving a non-session channel proves the key is writable.
+      // non-generic view. channelFor resolving a channel proves the key is writable.
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- contained cast to a non-generic writer signature at this boundary
       const writeAny = write as (key: WritableSettingKey, value: unknown) => Promise<ActionStatus>;
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- settingKey is a WritableSettingKey here

--- a/frontend/app/src/modules/settings/use-theme-migration.ts
+++ b/frontend/app/src/modules/settings/use-theme-migration.ts
@@ -1,15 +1,13 @@
 import { ThemeColors } from '@rotki/common';
 import { startPromise } from '@shared/utils';
-import { useSetting } from '@/modules/settings/use-setting';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
+import { useThemeSettings } from '@/modules/shell/theme/use-theme-settings';
 import { CURRENT_DEFAULT_THEME_VERSION, DARK_COLORS, DEFAULT_THEME_HISTORIES, LIGHT_COLORS } from '@/plugins/theme';
 
 interface UseThemeMigrationReturn { checkDefaultThemeVersion: () => void }
 
 export function useThemeMigration(): UseThemeMigrationReturn {
-  const darkTheme = useSetting('darkTheme');
-  const defaultThemeVersion = useSetting('defaultThemeVersion');
-  const lightTheme = useSetting('lightTheme');
+  const { darkTheme, defaultThemeVersion, lightTheme } = useThemeSettings();
   const { updateFrontendSetting } = useSettingsOperations();
 
   function checkDefaultThemeVersion(): void {

--- a/frontend/app/src/modules/shell/theme/use-dark-mode.ts
+++ b/frontend/app/src/modules/shell/theme/use-dark-mode.ts
@@ -2,15 +2,14 @@ import { hexToRgbPoints, type ThemeColors } from '@rotki/common';
 import { ThemeMode, useRotkiTheme } from '@rotki/ui-library';
 import { getColors } from 'theme-colors';
 import { usePremium } from '@/modules/premium/use-premium';
-import { useSetting } from '@/modules/settings/use-setting';
+import { useThemeSettings } from '@/modules/shell/theme/use-theme-settings';
 import { DARK_COLORS, LIGHT_COLORS } from '@/plugins/theme';
 
 interface ColorScheme { DEFAULT: string; lighter: string; darker: string }
 
 export const useDarkMode = createSharedComposable(() => {
   const { config, isDark, setThemeConfig, switchThemeScheme } = useRotkiTheme();
-  const darkTheme = useSetting('darkTheme');
-  const lightTheme = useSetting('lightTheme');
+  const { darkTheme, lightTheme } = useThemeSettings();
   const premium = usePremium();
 
   const updateDarkMode = (enabled: boolean): void => {

--- a/frontend/app/src/modules/shell/theme/use-theme-settings.ts
+++ b/frontend/app/src/modules/shell/theme/use-theme-settings.ts
@@ -1,0 +1,22 @@
+import type { Ref } from 'vue';
+import { type SettingValue, useSetting } from '@/modules/settings/use-setting';
+
+export interface ThemeSettings {
+  lightTheme: Readonly<Ref<SettingValue<'lightTheme'>>>;
+  darkTheme: Readonly<Ref<SettingValue<'darkTheme'>>>;
+  defaultThemeVersion: Readonly<Ref<SettingValue<'defaultThemeVersion'>>>;
+}
+
+/**
+ * Domain facade bundling the theme customization settings consumed together by the theme
+ * renderer, the default-theme migration, and the premium interface setup. Each entry reads
+ * through `useSetting`, so this composable knows nothing about which store owns each key.
+ * Theme *mode* (`selectedTheme`) is a separate single-key read and is intentionally not bundled here.
+ */
+export function useThemeSettings(): ThemeSettings {
+  return {
+    darkTheme: useSetting('darkTheme'),
+    defaultThemeVersion: useSetting('defaultThemeVersion'),
+    lightTheme: useSetting('lightTheme'),
+  };
+}

--- a/frontend/app/src/modules/statistics/use-statistics-store.ts
+++ b/frontend/app/src/modules/statistics/use-statistics-store.ts
@@ -3,6 +3,7 @@ import type { NetValueChartData } from '@/modules/dashboard/graph/types';
 import { type AssetBalanceWithPriceAndChains, type BigNumber, type NetValue, One, type TimeFramePeriod, timeframes, TimeUnit, Zero } from '@rotki/common';
 import dayjs from 'dayjs';
 import { CURRENCY_USD, type SupportedCurrency } from '@/modules/assets/amount-display/currencies';
+import { useAmountDisplaySettings } from '@/modules/assets/amount-display/use-amount-display-settings';
 import { useNumberScrambler } from '@/modules/assets/amount-display/use-number-scrambler';
 import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
 import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
@@ -30,14 +31,16 @@ export const useStatisticsStore = defineStore('statistics', () => {
   const netValue = ref<NetValue>(defaultNetValue());
 
   const nftsInNetValue = useSetting('nftsInNetValue');
-  const scrambleData = useSetting('scrambleData');
-  const scrambleMultiplier = useSetting('scrambleMultiplier');
-  const shouldShowAmount = useSetting('shouldShowAmount');
-  const valueRoundingMode = useSetting('valueRoundingMode');
-  const currencySymbol = useSetting('currencySymbol');
-  const floatingPrecision = useSetting('floatingPrecision');
-  const { nonFungibleTotalValue } = storeToRefs(useBalancesStore());
   const timeframe = useSetting('timeframe');
+  const {
+    currencySymbol,
+    floatingPrecision,
+    scrambleData,
+    scrambleMultiplier,
+    shouldShowAmount,
+    valueRoundingMode,
+  } = useAmountDisplaySettings();
+  const { nonFungibleTotalValue } = storeToRefs(useBalancesStore());
   const { getExchangeRate } = usePriceUtils();
 
   const { getBalances, getLiabilities } = useAggregatedBalances();


### PR DESCRIPTION
Follow-up work after the settings registry landed (#12556). Frontend-only. Five focused commits.

## Write pipeline
- **Route session writes through the registry effect/mirror runner.** `animationsEnabled` now declares a localStorage `mirror` and the repo's side-effect runner is generalized to run for the session channel, so the "Enable animations" toggle persists across restarts (it previously reverted on restart). Removes the bespoke `setAnimationsEnabled` setter and its three writer special-cases; all registered keys route through the writer.
- **Resolve effects/mirrors by wire→logical key**, so a key whose `wireKey` differs from its logical key still fires its side effects (latent trap, safe today).
- **Warn on a caller-supplied location that disagrees with the registered channel**, since routing for registered keys now derives entirely from the registry.

## Bug fixes / cleanup
- **`useSettingModel`: cancel stale debounced writes.** The persist step now reads the live draft at fire time, so an edit reverted to the persisted value within the debounce window no longer writes a transient value.
- **`SimpleRpcNodeManager`:** drop a redundant `computed` re-wrap of a `useSetting` ref.

## Read facades
- **`useThemeSettings`** bundles the theme-customization settings (`lightTheme`, `darkTheme`, `defaultThemeVersion`) read together by the theme renderer, the default-theme migration, and the premium setup; migrated all three off raw `useSetting`.
- **Statistics store** reuses `useAmountDisplaySettings` for its six formatting/privacy reads. The facade's value types are now derived from `SettingValue` so the interface cannot drift from the registry (e.g. `currencySymbol` stays the currency union rather than widening to `string`).

## Owning components (start of Step C)
- **`SettingSwitch`** — a generic owning component for boolean settings built on `useSettingModel`. It manages the local draft, persistence, and the saved/error messages, so a toggle collapses from ~15 lines of `ref` + `onMounted` + `SettingsOption` + `RuiSwitch` boilerplate to a single element. The `setting` prop is compile-time constrained to boolean keys. **10 simple toggles migrated.** Toggles that own their title, emit post-save side effects, or back a nullish boolean are intentionally left for a follow-up.

## Testing
typecheck, lint (0 warnings on touched files), and the settings + session unit suites all green. New specs cover the session mirror, the debounced-revert fix, the location-mismatch warning, and `SettingSwitch`.