### PR TITLE
fix: kraken tokenized asset swap reconstruction

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`12564` Kraken tokenized asset (xStocks) trades are now imported with the correct fiat receive side, instead of a zero-amount receive, by ignoring Kraken's internal USD settlement legs that cancel each other out.
 * :bug:`-` fix order of aave v3 token interest earnings for a specific subset of events.
 * :feature:`12499` Additional crypto.com CSV import transaction kinds such as van purchases, fiat wallet limit orders, and extra earn interest payments will now be properly imported.
 * :bug:`12507` The documented ``LOGFROMOTHERMODULES`` Docker environment variable is now honored again (it was misspelled internally) and accepts truthy string values such as ``true``, ``1``, ``yes`` and ``on``.

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -139,6 +139,31 @@ def kraken_ledger_entry_type_to_ours(value: str) -> tuple[HistoryEventType, Hist
     return event_type, event_subtype
 
 
+def _remove_canceling_ledger_legs(event_set: list[tuple[int, HistoryEvent]]) -> None:
+    """Remove spend/receive leg pairs of the same asset and amount that cancel out.
+
+    Kraken reports trades of tokenized assets (aclass: tokenized_asset) as 4 ledger
+    entries sharing the same refid: the tokenized asset spend, the fiat receive and two
+    internal USD settlement legs (a spend and a receive of the same asset and amount)
+    that cancel each other out. Removing the settlement legs leaves the actual trade
+    pair. https://github.com/rotki/rotki/issues/12564
+    """
+    for spend_entry in [x for x in event_set if x[1].event_type == HistoryEventType.SPEND]:
+        for receive_entry in event_set:
+            if (
+                    receive_entry[1].event_type == HistoryEventType.RECEIVE and
+                    receive_entry[1].asset == spend_entry[1].asset and
+                    receive_entry[1].amount == spend_entry[1].amount
+            ):
+                log.debug(
+                    f'Removing kraken internal settlement legs that cancel each other '
+                    f'out: {spend_entry[1]} and {receive_entry[1]}',
+                )
+                event_set.remove(spend_entry)
+                event_set.remove(receive_entry)
+                break
+
+
 def _check_and_get_response(
         response: Response,
         method: Literal['Balance', 'TradesHistory', 'Ledgers', 'Assets', 'AssetPairs', 'accounts'],
@@ -1117,6 +1142,8 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 continue
 
         for event_set in receive_spend_events.values():
+            if len(event_set) > 2:  # tokenized asset trades come with extra settlement legs
+                _remove_canceling_ledger_legs(event_set)
             if len(event_set) == 2:
                 for _, history_event in event_set:
                     history_event.event_subtype = HistoryEventSubType.RECEIVE if history_event.event_type == HistoryEventType.RECEIVE else HistoryEventSubType.SPEND  # noqa: E501

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -146,7 +146,8 @@ def _remove_canceling_ledger_legs(event_set: list[tuple[int, HistoryEvent]]) -> 
     entries sharing the same refid: the tokenized asset spend, the fiat receive and two
     internal USD settlement legs (a spend and a receive of the same asset and amount)
     that cancel each other out. Removing the settlement legs leaves the actual trade
-    pair. https://github.com/rotki/rotki/issues/12564
+    pair. Only called for groups containing a tokenized_asset leg so that normal
+    kraken history is not affected. https://github.com/rotki/rotki/issues/12564
     """
     for spend_entry in [x for x in event_set if x[1].event_type == HistoryEventType.SPEND]:
         for receive_entry in event_set:
@@ -1144,7 +1145,10 @@ class Kraken(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 continue
 
         for event_set in receive_spend_events.values():
-            if len(event_set) > 2:  # tokenized asset trades come with extra settlement legs
+            if (  # tokenized asset trades come with extra settlement legs
+                    len(event_set) > 2 and
+                    any(x.get('aclass') == 'tokenized_asset' for x in events)
+            ):
                 _remove_canceling_ledger_legs(event_set)
             if len(event_set) == 2:
                 for _, history_event in event_set:

--- a/rotkehlchen/exchanges/kraken.py
+++ b/rotkehlchen/exchanges/kraken.py
@@ -156,8 +156,10 @@ def _remove_canceling_ledger_legs(event_set: list[tuple[int, HistoryEvent]]) -> 
                     receive_entry[1].amount == spend_entry[1].amount
             ):
                 log.debug(
-                    f'Removing kraken internal settlement legs that cancel each other '
-                    f'out: {spend_entry[1]} and {receive_entry[1]}',
+                    'Removing kraken internal settlement legs that cancel each other '
+                    'out: %s and %s',
+                    spend_entry[1],
+                    receive_entry[1],
                 )
                 event_set.remove(spend_entry)
                 event_set.remove(receive_entry)

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -776,6 +776,51 @@ def test_kraken_tokenized_asset_trade(kraken):
     assert len(kraken.msg_aggregator.consume_errors()) == 0
     assert len(kraken.msg_aggregator.consume_warnings()) == 0
 
+    # A group with more than 2 spend/receive legs containing a canceling pair but
+    # no tokenized_asset leg is left untouched by the settlement leg removal
+    events, skipped, found_unknown = kraken.history_event_from_kraken(
+        events=[{
+            'refid': 'NORMAL1',
+            'time': 1736246100.5,
+            'type': 'spend',
+            'subtype': '',
+            'aclass': 'currency',
+            'asset': 'XETH',
+            'amount': '-1',
+            'fee': '0',
+        }, {
+            'refid': 'NORMAL1',
+            'time': 1736246100.5,
+            'type': 'receive',
+            'subtype': '',
+            'aclass': 'currency',
+            'asset': 'ZEUR',
+            'amount': '100',
+            'fee': '0',
+        }, {
+            'refid': 'NORMAL1',
+            'time': 1736246100.5,
+            'type': 'spend',
+            'subtype': '',
+            'aclass': 'currency',
+            'asset': 'ZUSD',
+            'amount': '-50',
+            'fee': '0',
+        }, {
+            'refid': 'NORMAL1',
+            'time': 1736246100.5,
+            'type': 'receive',
+            'subtype': '',
+            'aclass': 'currency',
+            'asset': 'ZUSD',
+            'amount': '50',
+            'fee': '0',
+        }],
+        save_skipped_events=False,
+    )
+    assert skipped is False and found_unknown is False
+    assert len(events) == 4  # all legs kept
+
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_kraken_trade_with_adjustment(kraken):

--- a/rotkehlchen/tests/exchanges/test_kraken.py
+++ b/rotkehlchen/tests/exchanges/test_kraken.py
@@ -684,6 +684,100 @@ def test_kraken_trade_with_same_spend_receive_amount(kraken):
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
+def test_kraken_tokenized_asset_trade(kraken):
+    """Test that tokenized asset trades with internal settlement legs are processed.
+
+    Kraken reports trades of tokenized assets (aclass: tokenized_asset) as 4 ledger
+    entries sharing the same refid: the tokenized asset spend, the fiat receive and
+    two internal USD settlement legs of equal amounts that cancel each other out.
+    Regression test for https://github.com/rotki/rotki/issues/12564. XXBT stands in
+    for the tokenized asset symbol since xStocks are not in the assets db.
+    """
+    test_trades = """{
+        "ledger": {
+            "L1": {
+                "refid": "TOKTRADE1",
+                "time": 1736246000.1234,
+                "type": "spend",
+                "subtype": "",
+                "aclass": "tokenized_asset",
+                "asset": "XXBT",
+                "amount": "-3.71",
+                "fee": "0.000000",
+                "balance": "0.000000"
+            },
+            "L2": {
+                "refid": "TOKTRADE1",
+                "time": 1736246000.1234,
+                "type": "receive",
+                "subtype": "",
+                "aclass": "currency",
+                "asset": "ZEUR",
+                "amount": "285.5964",
+                "fee": "0.0000",
+                "balance": "285.5964"
+            },
+            "L3": {
+                "refid": "TOKTRADE1",
+                "time": 1736246000.1234,
+                "type": "spend",
+                "subtype": "",
+                "aclass": "currency",
+                "asset": "ZUSD",
+                "amount": "-332.9550",
+                "fee": "0.0000",
+                "balance": "0.0000"
+            },
+            "L4": {
+                "refid": "TOKTRADE1",
+                "time": 1736246000.1234,
+                "type": "receive",
+                "subtype": "",
+                "aclass": "currency",
+                "asset": "ZUSD",
+                "amount": "332.9550",
+                "fee": "0.0000",
+                "balance": "332.9550"
+            }
+        },
+        "count": 4
+    }"""
+
+    with _patch_ledger(kraken, test_trades):
+        kraken.query_history_events()
+
+    with kraken.db.conn.read_ctx() as cursor:
+        assert DBHistoryEvents(kraken.db).get_history_events_internal(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(location=Location.KRAKEN),
+        ) == [SwapEvent(
+            identifier=1,
+            timestamp=(timestamp := TimestampMS(1736246000123)),
+            location=Location.KRAKEN,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_BTC,
+            amount=FVal('3.71'),
+            group_identifier=(group_identifier := create_group_identifier_from_unique_id(
+                location=Location.KRAKEN,
+                unique_id='TOKTRADE11736246000123',
+            )),
+            location_label=kraken.name,
+        ), SwapEvent(
+            identifier=2,
+            timestamp=timestamp,
+            location=Location.KRAKEN,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            asset=A_EUR,
+            amount=FVal('285.5964'),
+            group_identifier=group_identifier,
+            location_label=kraken.name,
+        )]
+
+    assert len(kraken.msg_aggregator.consume_errors()) == 0
+    assert len(kraken.msg_aggregator.consume_warnings()) == 0
+
+
+@pytest.mark.parametrize('use_clean_caching_directory', [True])
 def test_kraken_trade_with_adjustment(kraken):
     """Test that trades based on adjustment events are processed"""
 


### PR DESCRIPTION
Kraken reports tokenized asset (xStocks) trades as 4 ledger entries sharing the same refid: the asset spend, the fiat receive and two internal USD settlement legs that cancel each other out. The extra legs broke the spend/receive pairing and produced a swap with a zero-amount USD receive side. Remove such canceling legs so the actual trade pair is matched, add a regression test with mocked ledger data and a changelog entry.

Fixes #12564

