### PR TITLE
feat(settings): generic owning controls for settings

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5658,6 +5658,18 @@
     "security_settings": {
       "subtitle": "Manage your account security",
       "title": "Security"
+    },
+    "validation": {
+      "number": {
+        "between": "The value must be between {min} and {max}",
+        "max": "The value must be at most {max}",
+        "min": "The value must be at least {min}",
+        "non_empty": "The value cannot be empty"
+      },
+      "text": {
+        "max_length": "Use at most {max} character(s)",
+        "non_empty": "The value cannot be empty"
+      }
     }
   },
   "settings_suggestions": {

--- a/frontend/app/src/modules/settings/GeneralSettingsCategory.vue
+++ b/frontend/app/src/modules/settings/GeneralSettingsCategory.vue
@@ -27,9 +27,25 @@ const { t } = useI18n({ useScope: 'global' });
     <template #subtitle>
       {{ t('general_settings.subtitle') }}
     </template>
-    <UsageAnalyticsSetting :id="SettingsHighlightIds.USAGE_ANALYTICS" />
-    <AutoDetectTokensSetting :id="SettingsHighlightIds.AUTO_DETECT_TOKENS" />
+    <SettingsItem :id="SettingsHighlightIds.USAGE_ANALYTICS">
+      <template #title>
+        {{ t('general_settings.usage_analytics.title') }}
+      </template>
+      <UsageAnalyticsSetting />
+    </SettingsItem>
+    <SettingsItem :id="SettingsHighlightIds.AUTO_DETECT_TOKENS">
+      <template #title>
+        {{ t('general_settings.auto_detect_tokens.title') }}
+      </template>
+      <AutoDetectTokensSetting />
+    </SettingsItem>
     <SettingsItem :id="SettingsHighlightIds.AUTO_DETECT_TOKENS_ON_LOGIN">
+      <template #title>
+        {{ t('general_settings.auto_detect_tokens_on_login.title') }}
+      </template>
+      <template #subtitle>
+        {{ t('general_settings.auto_detect_tokens_on_login.subtitle') }}
+      </template>
       <AutoDetectTokensOnLoginSetting />
     </SettingsItem>
     <SettingsItem :id="SettingsHighlightIds.AUTO_DETECT_TOKENS_COOLDOWN">
@@ -46,8 +62,18 @@ const { t } = useI18n({ useScope: 'global' });
     </SettingsItem>
     <AskUserUponSizeDiscrepancySetting :id="SettingsHighlightIds.ASK_SIZE_DISCREPANCY" />
     <VersionUpdateFrequencySetting :id="SettingsHighlightIds.VERSION_UPDATE_CHECK" />
-    <BalanceSaveFrequencySetting :id="SettingsHighlightIds.BALANCE_SAVE_FREQUENCY" />
-    <BtcDerivationGapLimitSetting :id="SettingsHighlightIds.BTC_DERIVATION_GAP" />
+    <SettingsItem :id="SettingsHighlightIds.BALANCE_SAVE_FREQUENCY">
+      <template #title>
+        {{ t('general_settings.balance_frequency.title') }}
+      </template>
+      <BalanceSaveFrequencySetting />
+    </SettingsItem>
+    <SettingsItem :id="SettingsHighlightIds.BTC_DERIVATION_GAP">
+      <template #title>
+        {{ t('general_settings.labels.btc_derivation_gap') }}
+      </template>
+      <BtcDerivationGapLimitSetting />
+    </SettingsItem>
     <SettingsItem :id="SettingsHighlightIds.DATE_FORMAT">
       <template #title>
         {{ t('date_format_help.title') }}

--- a/frontend/app/src/modules/settings/HistoryEventSettingsCategory.vue
+++ b/frontend/app/src/modules/settings/HistoryEventSettingsCategory.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
 import AutoCreateProfitEventsSetting from '@/modules/settings/general/AutoCreateProfitEventsSetting.vue';
 import InternalTxConflictRepullSettings from '@/modules/settings/general/InternalTxConflictRepullSettings.vue';
 import { SettingsHighlightIds } from '@/modules/settings/setting-highlight-ids';
@@ -19,7 +20,12 @@ const { t } = useI18n({ useScope: 'global' });
     <template #subtitle>
       {{ t('general_settings.history_event.subtitle') }}
     </template>
-    <AutoCreateProfitEventsSetting :id="SettingsHighlightIds.AUTO_CREATE_PROFIT_EVENTS" />
+    <SettingsItem :id="SettingsHighlightIds.AUTO_CREATE_PROFIT_EVENTS">
+      <template #title>
+        {{ t('general_settings.history_event.auto_create_profit_events.title') }}
+      </template>
+      <AutoCreateProfitEventsSetting />
+    </SettingsItem>
     <InternalTxConflictRepullSettings :id="SettingsHighlightIds.INTERNAL_TX_CONFLICT_REPULL" />
     <HistoryEventsSkippedExternalEvents :id="SettingsHighlightIds.SKIPPED_EVENTS" />
   </SettingCategory>

--- a/frontend/app/src/modules/settings/InferZeroTimedBalancesSetting.vue
+++ b/frontend/app/src/modules/settings/InferZeroTimedBalancesSetting.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
 
 const emit = defineEmits<{
@@ -8,24 +7,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const updated = () => emit('updated');
-
-const inferZeroTimedBalances = ref<boolean>(false);
-const enabled = useSetting('inferZeroTimedBalances');
-
-function resetState() {
-  set(inferZeroTimedBalances, get(enabled));
-}
-
-function finished() {
-  resetState();
-  updated();
-}
-
-onMounted(() => {
-  resetState();
-});
 </script>
 
 <template>
@@ -33,21 +14,13 @@ onMounted(() => {
     <CardTitle>
       {{ t('statistics_graph_settings.infer_zero_timed_balances.title') }}
     </CardTitle>
-    <SettingsOption
-      #default="{ error, success, update }"
+    <SettingSwitch
       setting="inferZeroTimedBalances"
-      @finished="finished()"
-    >
-      <RuiSwitch
-        v-model="inferZeroTimedBalances"
-        :label="t('statistics_graph_settings.infer_zero_timed_balances.label')"
-        color="primary"
-        class="mt-4 [&_span]:!text-sm"
-        size="sm"
-        :success-messages="success"
-        :error-messages="error"
-        @update:model-value="update($event)"
-      />
-    </SettingsOption>
+      size="sm"
+      class="mt-4 [&_span]:!text-sm"
+      :debounce="1500"
+      :label="t('statistics_graph_settings.infer_zero_timed_balances.label')"
+      @updated="emit('updated')"
+    />
   </div>
 </template>

--- a/frontend/app/src/modules/settings/accounting/CostBasisFeesSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/CostBasisFeesSetting.vue
@@ -1,17 +1,9 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const includeFeesInCostBasis = ref(true);
-const enabled = useSetting('includeFeesInCostBasis');
-
-onMounted(() => {
-  set(includeFeesInCostBasis, get(enabled));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 
-function getSuccessMessage(enabled: boolean) {
+function getSuccessMessage(enabled: boolean): string {
   return enabled
     ? t('account_settings.messages.include_fees_in_cost_basis.enabled')
     : t('account_settings.messages.include_fees_in_cost_basis.disabled');
@@ -19,20 +11,12 @@ function getSuccessMessage(enabled: boolean) {
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, update }"
+  <SettingSwitch
     setting="includeFeesInCostBasis"
+    data-cy="include-fees-in-cost-basis-switch"
+    :debounce="1500"
+    :label="t('accounting_settings.trade.labels.include_fees_in_cost_basis')"
     :error-message="t('account_settings.messages.include_fees_in_cost_basis.error')"
     :success-message="getSuccessMessage"
-  >
-    <RuiSwitch
-      v-model="includeFeesInCostBasis"
-      data-cy="include-fees-in-cost-basis-switch"
-      :success-messages="success"
-      :error-messages="error"
-      :label="t('accounting_settings.trade.labels.include_fees_in_cost_basis')"
-      color="primary"
-      @update:model-value="update($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/accounting/EthStakingTaxableAfterWithdrawalSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/EthStakingTaxableAfterWithdrawalSetting.vue
@@ -1,17 +1,9 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const ethStakingTaxableAfterWithdrawalEnabled = ref(false);
-const enabled = useSetting('ethStakingTaxableAfterWithdrawalEnabled');
-
-onMounted(() => {
-  set(ethStakingTaxableAfterWithdrawalEnabled, get(enabled));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 
-function getSuccessMessage(enabled: boolean) {
+function getSuccessMessage(enabled: boolean): string {
   return enabled
     ? t('account_settings.messages.eth_staking_taxable_after_withdrawal.enabled')
     : t('account_settings.messages.eth_staking_taxable_after_withdrawal.disabled');
@@ -19,19 +11,11 @@ function getSuccessMessage(enabled: boolean) {
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, update }"
+  <SettingSwitch
     setting="ethStakingTaxableAfterWithdrawalEnabled"
+    :debounce="1500"
+    :label="t('accounting_settings.trade.labels.eth_staking_taxable_after_withdrawal_enabled')"
     :error-message="t('account_settings.messages.eth_staking_taxable_after_withdrawal.error')"
     :success-message="getSuccessMessage"
-  >
-    <RuiSwitch
-      v-model="ethStakingTaxableAfterWithdrawalEnabled"
-      :success-messages="success"
-      :error-messages="error"
-      :label="t('accounting_settings.trade.labels.eth_staking_taxable_after_withdrawal_enabled')"
-      color="primary"
-      @update:model-value="update($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/accounting/UseAssetCollectionsInCostBasisSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/UseAssetCollectionsInCostBasisSetting.vue
@@ -1,13 +1,5 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const useAssetCollectionsInCostBasis = ref<boolean>(true);
-const enabled = useSetting('useAssetCollectionsInCostBasis');
-
-onMounted(() => {
-  set(useAssetCollectionsInCostBasis, get(enabled));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -19,20 +11,12 @@ function getSuccessMessage(enabled: boolean): string {
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, update }"
+  <SettingSwitch
     setting="useAssetCollectionsInCostBasis"
+    data-cy="use-asset-collections-in-cost-basis-switch"
+    :debounce="1500"
+    :label="t('accounting_settings.trade.labels.use_asset_collections_in_cost_basis')"
     :error-message="t('account_settings.messages.use_asset_collections_in_cost_basis.error')"
     :success-message="getSuccessMessage"
-  >
-    <RuiSwitch
-      v-model="useAssetCollectionsInCostBasis"
-      data-cy="use-asset-collections-in-cost-basis-switch"
-      :success-messages="success"
-      :error-messages="error"
-      :label="t('accounting_settings.trade.labels.use_asset_collections_in_cost_basis')"
-      color="primary"
-      @update:model-value="update($event)"
-    />
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/controls/SettingNumber.spec.ts
+++ b/frontend/app/src/modules/settings/controls/SettingNumber.spec.ts
@@ -1,0 +1,85 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
+
+const { flushMock, useSettingModelMock } = vi.hoisted(() => ({ flushMock: vi.fn(), useSettingModelMock: vi.fn() }));
+vi.mock('@/modules/settings/use-setting-model', () => ({ useSettingModel: useSettingModelMock }));
+
+const RuiTextFieldStub = {
+  props: ['modelValue', 'successMessages', 'errorMessages', 'label'],
+  emits: ['update:model-value'],
+  template: `<div>
+    <span class="model">{{ modelValue }}</span>
+    <span class="success">{{ successMessages }}</span>
+    <span class="error">{{ errorMessages }}</span>
+  </div>`,
+};
+
+const ResetStub = {
+  emits: ['confirm'],
+  template: `<button class="reset" @click="$emit('confirm')" />`,
+};
+
+describe('settingNumber', () => {
+  let model: Ref<number>;
+  let error: Ref<string>;
+  let success: Ref<boolean>;
+
+  function createWrapper(props: Record<string, unknown> = {}): VueWrapper {
+    return mount(SettingNumber, {
+      props: { setting: 'balanceSaveFrequency', label: 'Frequency', ...props },
+      global: {
+        stubs: { RuiTextField: RuiTextFieldStub, SettingResetConfirmButton: ResetStub },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    flushMock.mockClear();
+    model = ref<number>(3);
+    error = ref<string>('');
+    success = ref<boolean>(false);
+    useSettingModelMock.mockReturnValue({ error, flush: flushMock, model, pending: ref(false), success });
+  });
+
+  it('should render the field with the current value', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.model').text()).toBe('3');
+  });
+
+  it('should persist a valid value as a number', async () => {
+    const wrapper = createWrapper({ min: 1, max: 20 });
+    await wrapper.findComponent(RuiTextFieldStub).vm.$emit('update:model-value', '15');
+    await nextTick();
+    expect(get(model)).toBe(15);
+  });
+
+  it('should not persist a value below the minimum', async () => {
+    const wrapper = createWrapper({ min: 1, max: 20 });
+    await wrapper.findComponent(RuiTextFieldStub).vm.$emit('update:model-value', '0');
+    await nextTick();
+    expect(get(model)).toBe(3);
+    expect(wrapper.find('.error').text()).not.toBe('');
+  });
+
+  it('should show a saved message after a successful write', async () => {
+    const wrapper = createWrapper();
+    set(success, true);
+    await nextTick();
+    expect(wrapper.find('.success').text()).not.toBe('');
+  });
+
+  it('should reset to the default and flush immediately', async () => {
+    const wrapper = createWrapper({ default: 10, min: 1, max: 20 });
+    await wrapper.find('.reset').trigger('click');
+    await nextTick();
+    expect(get(model)).toBe(10);
+    expect(flushMock).toHaveBeenCalledOnce();
+  });
+
+  it('should not render a reset button without a default', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.reset').exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/settings/controls/SettingNumber.vue
+++ b/frontend/app/src/modules/settings/controls/SettingNumber.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import type { WritableSettingKeyOf } from '@/modules/settings/settings-writer';
+import useVuelidate, { type ValidationArgs } from '@vuelidate/core';
+import { between, helpers, maxValue, minValue, required as requiredRule } from '@vuelidate/validators';
+import { useValidation } from '@/modules/core/common/use-validation';
+import { toMessages } from '@/modules/core/common/validation/validation';
+import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
+import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
+import { useSettingModel } from '@/modules/settings/use-setting-model';
+
+/**
+ * Generic owning component for a numeric setting. Bakes in the common `required` + `between`/`min`/`max`
+ * validation from props and persists through `useSettingModel` (debounced while typing, immediate on
+ * reset). Renders only the field + optional reset button; put it inside a `SettingsItem` for the header.
+ * For settings whose validation is not min/max/required (single-character, cross-field, custom formats),
+ * pass a full vuelidate `rules` object keyed under `value` to replace the baked rules.
+ */
+defineOptions({ inheritAttrs: false });
+
+const {
+  setting,
+  label = '',
+  min,
+  max,
+  default: defaultValue,
+  required = true,
+  rules,
+  transform = (value: string): number => Number.parseInt(value),
+  successMessage = '',
+  errorMessage = '',
+  debounce = 1500,
+  // eslint-disable-next-line vue/max-props -- a generic owning control needs the full setting/label/validation/message surface
+} = defineProps<{
+  setting: WritableSettingKeyOf<number>;
+  label?: string;
+  min?: number;
+  max?: number;
+  /** When provided, shows a reset-to-default button that writes this value immediately. */
+  default?: number;
+  required?: boolean;
+  /** Escape hatch: a vuelidate rules object keyed under `value`, replacing the baked min/max/required. */
+  rules?: ValidationArgs;
+  /** Maps the field string to the stored number. Defaults to `Number.parseInt`; override for floats. */
+  transform?: (value: string) => number;
+  /** Static text, or a callback given the persisted value. */
+  successMessage?: string | ((value: number) => string);
+  errorMessage?: string;
+  debounce?: number;
+}>();
+
+const emit = defineEmits<{
+  /** Fired after a successful persist, mirroring the old `SettingsOption` `@finished` hook. */
+  updated: [value: number];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const { error: writeError, flush, model, success: writeSuccess } = useSettingModel(setting, { debounce });
+const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
+
+const input = ref<string>(String(get(model)));
+
+const bakedRules = computed<ValidationArgs>(() => {
+  const valueRules: Record<string, ReturnType<typeof helpers.withMessage>> = {};
+  if (required)
+    valueRules.required = helpers.withMessage(t('settings.validation.number.non_empty'), requiredRule);
+
+  if (min !== undefined && max !== undefined)
+    valueRules.between = helpers.withMessage(t('settings.validation.number.between', { max, min }), between(min, max));
+  else if (min !== undefined)
+    valueRules.min = helpers.withMessage(t('settings.validation.number.min', { min }), minValue(min));
+  else if (max !== undefined)
+    valueRules.max = helpers.withMessage(t('settings.validation.number.max', { max }), maxValue(max));
+
+  return { value: valueRules };
+});
+
+const activeRules = computed<ValidationArgs>(() => rules ?? get(bakedRules));
+
+const states = computed(() => ({ value: get(input) }));
+
+const v$ = useVuelidate(activeRules, states, { $autoDirty: true });
+const { callIfValid } = useValidation(v$);
+
+const hasDefault = computed<boolean>(() => defaultValue !== undefined);
+
+// Reflect external changes into the field, but ignore the echo of our own writes (same string).
+watch(model, (value) => {
+  if (String(value) !== get(input))
+    set(input, String(value));
+});
+
+watch(writeSuccess, (saved) => {
+  if (saved) {
+    setSuccess(typeof successMessage === 'function' ? successMessage(get(model)) : successMessage, true);
+    emit('updated', get(model));
+  }
+});
+
+watch(writeError, (message) => {
+  if (message)
+    setError(errorMessage ? `${errorMessage}: ${message}` : message, true);
+});
+
+function persistValue(value: string): void {
+  set(model, transform(value));
+}
+
+function onInput(value: string): void {
+  clearAll();
+  callIfValid(value, persistValue);
+}
+
+async function reset(): Promise<void> {
+  if (defaultValue === undefined)
+    return;
+
+  set(input, String(defaultValue));
+  set(model, transform(String(defaultValue)));
+  await flush();
+}
+</script>
+
+<template>
+  <div class="flex items-start w-full">
+    <RuiTextField
+      v-bind="$attrs"
+      v-model="input"
+      type="number"
+      variant="outlined"
+      color="primary"
+      class="w-full"
+      :label="label"
+      :success-messages="success"
+      :error-messages="error || toMessages(v$.value)"
+      @update:model-value="onInput($event)"
+    />
+
+    <SettingResetConfirmButton
+      v-if="hasDefault"
+      @confirm="reset()"
+    />
+  </div>
+</template>

--- a/frontend/app/src/modules/settings/controls/SettingSwitch.spec.ts
+++ b/frontend/app/src/modules/settings/controls/SettingSwitch.spec.ts
@@ -72,4 +72,29 @@ describe('settingSwitch', () => {
     await nextTick();
     expect(wrapper.find('.error').text()).toBe('');
   });
+
+  it('should emit updated with the persisted value after a successful write', async () => {
+    set(model, true);
+    const wrapper = createWrapper();
+    set(success, true);
+    await nextTick();
+    expect(wrapper.emitted('updated')).toStrictEqual([[true]]);
+  });
+
+  it('should coerce a nullish draft to false for the switch', () => {
+    const nullableModel = ref<boolean | null | undefined>(null);
+    useSettingModelMock.mockReturnValue({ error, model: nullableModel, pending: ref(false), success });
+    const wrapper = createWrapper({ setting: 'includeFeesInCostBasis' });
+    expect(wrapper.find('.model').text()).toBe('false');
+  });
+
+  it('should treat a nullish draft as off in a callback success message', async () => {
+    const successMessage = (value: boolean): string => (value ? 'turned on' : 'turned off');
+    const nullableModel = ref<boolean | null | undefined>(null);
+    useSettingModelMock.mockReturnValue({ error, model: nullableModel, pending: ref(false), success });
+    const wrapper = createWrapper({ setting: 'includeFeesInCostBasis', successMessage });
+    set(success, true);
+    await nextTick();
+    expect(wrapper.find('.success').text()).toContain('turned off');
+  });
 });

--- a/frontend/app/src/modules/settings/controls/SettingSwitch.vue
+++ b/frontend/app/src/modules/settings/controls/SettingSwitch.vue
@@ -16,7 +16,7 @@ const {
   errorMessage = '',
   debounce = 0,
 } = defineProps<{
-  setting: WritableSettingKeyOf<boolean>;
+  setting: WritableSettingKeyOf<boolean | null | undefined>;
   label?: string;
   /** Static text, or a callback given the persisted value (e.g. distinct enabled/disabled copy). */
   successMessage?: string | ((value: boolean) => string);
@@ -24,16 +24,32 @@ const {
   debounce?: number;
 }>();
 
+const emit = defineEmits<{
+  /** Fired after a successful persist, mirroring the old `SettingsOption` `@finished` hook. */
+  updated: [value: boolean];
+}>();
+
 const { error: writeError, model, success: writeSuccess } = useSettingModel(setting, { debounce });
 const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
+
+// The switch needs a plain boolean; nullable-boolean settings read `null`/`undefined` before the user
+// has ever toggled them, which we treat as off. Writes always push a concrete boolean.
+const enabled = computed<boolean>({
+  get: () => get(model) ?? false,
+  set: (value) => {
+    set(model, value);
+  },
+});
 
 watch(model, () => {
   clearAll();
 });
 
 watch(writeSuccess, (saved) => {
-  if (saved)
-    setSuccess(typeof successMessage === 'function' ? successMessage(get(model)) : successMessage, true);
+  if (saved) {
+    setSuccess(typeof successMessage === 'function' ? successMessage(get(enabled)) : successMessage, true);
+    emit('updated', get(enabled));
+  }
 });
 
 watch(writeError, (message) => {
@@ -44,7 +60,7 @@ watch(writeError, (message) => {
 
 <template>
   <RuiSwitch
-    v-model="model"
+    v-model="enabled"
     color="primary"
     :label="label"
     :success-messages="success"

--- a/frontend/app/src/modules/settings/controls/SettingText.spec.ts
+++ b/frontend/app/src/modules/settings/controls/SettingText.spec.ts
@@ -1,0 +1,85 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { helpers } from '@vuelidate/validators';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import SettingText from '@/modules/settings/controls/SettingText.vue';
+
+const { flushMock, useSettingModelMock } = vi.hoisted(() => ({ flushMock: vi.fn(), useSettingModelMock: vi.fn() }));
+vi.mock('@/modules/settings/use-setting-model', () => ({ useSettingModel: useSettingModelMock }));
+
+const RuiTextFieldStub = {
+  props: ['modelValue', 'successMessages', 'errorMessages', 'label'],
+  emits: ['update:model-value'],
+  template: `<div>
+    <span class="model">{{ modelValue }}</span>
+    <span class="success">{{ successMessages }}</span>
+    <span class="error">{{ errorMessages }}</span>
+  </div>`,
+};
+
+const ResetStub = {
+  emits: ['confirm'],
+  template: `<button class="reset" @click="$emit('confirm')" />`,
+};
+
+describe('settingText', () => {
+  let model: Ref<string>;
+  let error: Ref<string>;
+  let success: Ref<boolean>;
+
+  function createWrapper(props: Record<string, unknown> = {}): VueWrapper {
+    return mount(SettingText, {
+      props: { setting: 'csvExportDelimiter', label: 'Delimiter', ...props },
+      global: {
+        stubs: { RuiTextField: RuiTextFieldStub, SettingResetConfirmButton: ResetStub },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    flushMock.mockClear();
+    model = ref<string>(',');
+    error = ref<string>('');
+    success = ref<boolean>(false);
+    useSettingModelMock.mockReturnValue({ error, flush: flushMock, model, pending: ref(false), success });
+  });
+
+  it('should render the field with the current value', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.model').text()).toBe(',');
+  });
+
+  it('should persist a valid value', async () => {
+    const wrapper = createWrapper({ maxLength: 1, required: true });
+    await wrapper.findComponent(RuiTextFieldStub).vm.$emit('update:model-value', ';');
+    await nextTick();
+    expect(get(model)).toBe(';');
+  });
+
+  it('should not persist a value that exceeds maxLength', async () => {
+    const wrapper = createWrapper({ maxLength: 1, required: true });
+    await wrapper.findComponent(RuiTextFieldStub).vm.$emit('update:model-value', ';;');
+    await nextTick();
+    expect(get(model)).toBe(',');
+    expect(wrapper.find('.error').text()).not.toBe('');
+  });
+
+  it('should gate on a custom rules escape hatch', async () => {
+    const rules = { value: { onlyDash: helpers.withMessage('dash only', (v: string) => v === '-') } };
+    const wrapper = createWrapper({ rules });
+    await wrapper.findComponent(RuiTextFieldStub).vm.$emit('update:model-value', 'x');
+    await nextTick();
+    expect(get(model)).toBe(',');
+    await wrapper.findComponent(RuiTextFieldStub).vm.$emit('update:model-value', '-');
+    await nextTick();
+    expect(get(model)).toBe('-');
+  });
+
+  it('should reset to the default and flush immediately', async () => {
+    const wrapper = createWrapper({ default: '.', maxLength: 1, required: true });
+    await wrapper.find('.reset').trigger('click');
+    await nextTick();
+    expect(get(model)).toBe('.');
+    expect(flushMock).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/settings/controls/SettingText.vue
+++ b/frontend/app/src/modules/settings/controls/SettingText.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import type { WritableSettingKeyOf } from '@/modules/settings/settings-writer';
+import useVuelidate, { type ValidationArgs } from '@vuelidate/core';
+import { helpers, maxLength as maxLengthRule, required as requiredRule } from '@vuelidate/validators';
+import { useValidation } from '@/modules/core/common/use-validation';
+import { toMessages } from '@/modules/core/common/validation/validation';
+import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
+import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
+import { useSettingModel } from '@/modules/settings/use-setting-model';
+
+/**
+ * Generic owning component for a string setting. Bakes in optional `required` + `maxLength` validation
+ * from props and persists through `useSettingModel` (debounced while typing, immediate on reset). Renders
+ * only the field + optional reset button; put it inside a `SettingsItem` for the header. For settings
+ * with bespoke validation (format directives, custom checks), pass a full vuelidate `rules` object keyed
+ * under `value` to replace the baked rules.
+ */
+defineOptions({ inheritAttrs: false });
+
+const {
+  setting,
+  label = '',
+  default: defaultValue,
+  required = false,
+  maxLength,
+  rules,
+  transform = (value: string): string => value,
+  successMessage = '',
+  errorMessage = '',
+  debounce = 1500,
+  // eslint-disable-next-line vue/max-props -- a generic owning control needs the full setting/label/validation/message surface
+} = defineProps<{
+  setting: WritableSettingKeyOf<string>;
+  label?: string;
+  /** When provided, shows a reset-to-default button that writes this value immediately. */
+  default?: string;
+  required?: boolean;
+  maxLength?: number;
+  /** Escape hatch: a vuelidate rules object keyed under `value`, replacing the baked required/maxLength. */
+  rules?: ValidationArgs;
+  /** Maps the field string to the stored value. Defaults to identity. */
+  transform?: (value: string) => string;
+  /** Static text, or a callback given the persisted value. */
+  successMessage?: string | ((value: string) => string);
+  errorMessage?: string;
+  debounce?: number;
+}>();
+
+const emit = defineEmits<{
+  /** Fired after a successful persist, mirroring the old `SettingsOption` `@finished` hook. */
+  updated: [value: string];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const { error: writeError, flush, model, success: writeSuccess } = useSettingModel(setting, { debounce });
+const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
+
+const input = ref<string>(get(model));
+
+const bakedRules = computed<ValidationArgs>(() => {
+  const valueRules: Record<string, ReturnType<typeof helpers.withMessage>> = {};
+  if (required)
+    valueRules.required = helpers.withMessage(t('settings.validation.text.non_empty'), requiredRule);
+
+  if (maxLength !== undefined)
+    valueRules.maxLength = helpers.withMessage(t('settings.validation.text.max_length', { max: maxLength }), maxLengthRule(maxLength));
+
+  return { value: valueRules };
+});
+
+const activeRules = computed<ValidationArgs>(() => rules ?? get(bakedRules));
+
+const states = computed(() => ({ value: get(input) }));
+
+const v$ = useVuelidate(activeRules, states, { $autoDirty: true });
+const { callIfValid } = useValidation(v$);
+
+const hasDefault = computed<boolean>(() => defaultValue !== undefined);
+
+// Reflect external changes into the field, but ignore the echo of our own writes (same string).
+watch(model, (value) => {
+  if (value !== get(input))
+    set(input, value);
+});
+
+watch(writeSuccess, (saved) => {
+  if (saved) {
+    setSuccess(typeof successMessage === 'function' ? successMessage(get(model)) : successMessage, true);
+    emit('updated', get(model));
+  }
+});
+
+watch(writeError, (message) => {
+  if (message)
+    setError(errorMessage ? `${errorMessage}: ${message}` : message, true);
+});
+
+function persistValue(value: string): void {
+  set(model, transform(value));
+}
+
+function onInput(value: string): void {
+  clearAll();
+  callIfValid(value, persistValue);
+}
+
+async function reset(): Promise<void> {
+  if (defaultValue === undefined)
+    return;
+
+  set(input, defaultValue);
+  set(model, transform(defaultValue));
+  await flush();
+}
+</script>
+
+<template>
+  <div class="flex items-start w-full">
+    <RuiTextField
+      v-bind="$attrs"
+      v-model="input"
+      type="text"
+      variant="outlined"
+      color="primary"
+      class="w-full"
+      :label="label"
+      :success-messages="success"
+      :error-messages="error || toMessages(v$.value)"
+      @update:model-value="onInput($event)"
+    />
+
+    <SettingResetConfirmButton
+      v-if="hasDefault"
+      @confirm="reset()"
+    />
+  </div>
+</template>

--- a/frontend/app/src/modules/settings/data-security/oracle/OraclePenaltyDurationSetting.vue
+++ b/frontend/app/src/modules/settings/data-security/oracle/OraclePenaltyDurationSetting.vue
@@ -1,72 +1,14 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, minValue, required } from '@vuelidate/validators';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { SettingsHighlightIds } from '@/modules/settings/setting-highlight-ids';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const oraclePenaltyDuration = ref<string>('0');
-
-const frequency = useSetting('oraclePenaltyDuration');
+import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 
 const { t } = useI18n({ useScope: 'global' });
-
-const min = 1;
-const rules = {
-  oraclePenaltyDuration: {
-    min: helpers.withMessage(
-      t('oracle_cache_management.penalty.validation.oracle_penalty_duration.invalid_period', { min }),
-      minValue(min),
-    ),
-    required: helpers.withMessage(
-      t('oracle_cache_management.penalty.validation.oracle_penalty_duration.non_empty'),
-      required,
-    ),
-  },
-};
-const v$ = useVuelidate(rules, { oraclePenaltyDuration }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
-
-function resetBalanceSaveFrequency() {
-  set(oraclePenaltyDuration, get(frequency).toString());
-}
-
-const transform = (value?: string) => (value ? Number.parseInt(value) : value);
-
-onMounted(() => {
-  resetBalanceSaveFrequency();
-});
 </script>
 
 <template>
-  <SettingsOption
-    :id="SettingsHighlightIds.ORACLE_PENALTY_DURATION"
+  <SettingNumber
     setting="oraclePenaltyDuration"
-    :transform="transform"
-    @finished="resetBalanceSaveFrequency()"
-  >
-    <template #title>
-      {{ t('oracle_cache_management.penalty.labels.oracle_penalty_duration') }}
-    </template>
-    <template #subtitle>
-      {{ t('oracle_cache_management.penalty.hints.oracle_penalty_duration') }}
-    </template>
-    <template #default="{ error, success, update }">
-      <RuiTextField
-        v-model="oraclePenaltyDuration"
-        variant="outlined"
-        color="primary"
-        :min="min"
-        class="mt-2"
-        data-testid="oracle-penalty-duration"
-        :label="t('oracle_cache_management.penalty.labels.oracle_penalty_duration')"
-        type="number"
-        :success-messages="success"
-        :error-messages="error || toMessages(v$.oraclePenaltyDuration)"
-        @update:model-value="callIfValid($event, update)"
-      />
-    </template>
-  </SettingsOption>
+    data-testid="oracle-penalty-duration"
+    :label="t('oracle_cache_management.penalty.labels.oracle_penalty_duration')"
+    :min="1"
+  />
 </template>

--- a/frontend/app/src/modules/settings/data-security/oracle/OraclePenaltySettings.vue
+++ b/frontend/app/src/modules/settings/data-security/oracle/OraclePenaltySettings.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
 import OraclePenaltyDurationSetting from '@/modules/settings/data-security/oracle/OraclePenaltyDurationSetting.vue';
 import OraclePenaltyThresholdCountSetting
   from '@/modules/settings/data-security/oracle/OraclePenaltyThresholdCountSetting.vue';
+import { SettingsHighlightIds } from '@/modules/settings/setting-highlight-ids';
 import SettingCategory from '@/modules/settings/SettingCategory.vue';
 
 const { t } = useI18n({ useScope: 'global' });
@@ -16,7 +18,23 @@ const { t } = useI18n({ useScope: 'global' });
       {{ t('oracle_cache_management.penalty.subtitle') }}
     </template>
 
-    <OraclePenaltyDurationSetting />
-    <OraclePenaltyThresholdCountSetting />
+    <SettingsItem :id="SettingsHighlightIds.ORACLE_PENALTY_DURATION">
+      <template #title>
+        {{ t('oracle_cache_management.penalty.labels.oracle_penalty_duration') }}
+      </template>
+      <template #subtitle>
+        {{ t('oracle_cache_management.penalty.hints.oracle_penalty_duration') }}
+      </template>
+      <OraclePenaltyDurationSetting />
+    </SettingsItem>
+    <SettingsItem :id="SettingsHighlightIds.ORACLE_PENALTY_THRESHOLD">
+      <template #title>
+        {{ t('oracle_cache_management.penalty.labels.oracle_penalty_threshold_count') }}
+      </template>
+      <template #subtitle>
+        {{ t('oracle_cache_management.penalty.hints.oracle_penalty_threshold_count') }}
+      </template>
+      <OraclePenaltyThresholdCountSetting />
+    </SettingsItem>
   </SettingCategory>
 </template>

--- a/frontend/app/src/modules/settings/data-security/oracle/OraclePenaltyThresholdCountSetting.vue
+++ b/frontend/app/src/modules/settings/data-security/oracle/OraclePenaltyThresholdCountSetting.vue
@@ -1,73 +1,13 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, minValue, required } from '@vuelidate/validators';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { SettingsHighlightIds } from '@/modules/settings/setting-highlight-ids';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const oraclePenaltyThresholdCount = ref<string>('0');
-
-const frequency = useSetting('oraclePenaltyThresholdCount');
+import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 
 const { t } = useI18n({ useScope: 'global' });
-
-const min = 1;
-const rules = {
-  oraclePenaltyThresholdCount: {
-    min: helpers.withMessage(
-      t('oracle_cache_management.penalty.validation.oracle_penalty_threshold_count.invalid_period', { min }),
-      minValue(min),
-    ),
-    required: helpers.withMessage(
-      t('oracle_cache_management.penalty.validation.oracle_penalty_threshold_count.non_empty'),
-      required,
-    ),
-  },
-};
-const v$ = useVuelidate(rules, { oraclePenaltyThresholdCount }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
-
-function resetBalanceSaveFrequency() {
-  set(oraclePenaltyThresholdCount, get(frequency).toString());
-}
-
-const transform = (value?: string) => (value ? Number.parseInt(value) : value);
-
-onMounted(() => {
-  resetBalanceSaveFrequency();
-});
 </script>
 
 <template>
-  <SettingsOption
-    :id="SettingsHighlightIds.ORACLE_PENALTY_THRESHOLD"
+  <SettingNumber
     setting="oraclePenaltyThresholdCount"
-    :transform="transform"
-    @finished="resetBalanceSaveFrequency()"
-  >
-    <template #title>
-      {{ t('oracle_cache_management.penalty.labels.oracle_penalty_threshold_count') }}
-    </template>
-    <template #subtitle>
-      {{ t('oracle_cache_management.penalty.hints.oracle_penalty_threshold_count') }}
-    </template>
-    <template
-      #default="{ error, success, update }"
-    >
-      <RuiTextField
-        v-model="oraclePenaltyThresholdCount"
-        variant="outlined"
-        color="primary"
-        :min="min"
-        class="mt-2"
-        :label="t('oracle_cache_management.penalty.labels.oracle_penalty_threshold_count')"
-        type="number"
-        :success-messages="success"
-        :error-messages="error || toMessages(v$.oraclePenaltyThresholdCount)"
-        @update:model-value="callIfValid($event, update)"
-      />
-    </template>
-  </SettingsOption>
+    :label="t('oracle_cache_management.penalty.labels.oracle_penalty_threshold_count')"
+    :min="1"
+  />
 </template>

--- a/frontend/app/src/modules/settings/frontend/InterfaceOnlyCategory.vue
+++ b/frontend/app/src/modules/settings/frontend/InterfaceOnlyCategory.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
 import Explorers from '@/modules/settings/explorers/Explorers.vue';
 import AnimationsEnabledSetting from '@/modules/settings/frontend/AnimationsEnabledSetting.vue';
 import PersistPrivacySettings from '@/modules/settings/frontend/PersistPrivacySettings.vue';
@@ -21,11 +22,26 @@ const { t } = useI18n({ useScope: 'global' });
     </template>
     <LanguageSetting />
     <AnimationsEnabledSetting :id="SettingsHighlightIds.ANIMATIONS" />
-    <PersistTableSortingSetting :id="SettingsHighlightIds.PERSIST_TABLE_SORTING" />
+    <SettingsItem :id="SettingsHighlightIds.PERSIST_TABLE_SORTING">
+      <template #title>
+        {{ t('frontend_settings.persist_table_sorting.title') }}
+      </template>
+      <PersistTableSortingSetting />
+    </SettingsItem>
     <ScrambleDataSetting :id="SettingsHighlightIds.SCRAMBLE" />
-    <PersistPrivacySettings :id="SettingsHighlightIds.PERSIST_PRIVACY" />
+    <SettingsItem :id="SettingsHighlightIds.PERSIST_PRIVACY">
+      <template #title>
+        {{ t('frontend_settings.persist_privacy.title') }}
+      </template>
+      <PersistPrivacySettings />
+    </SettingsItem>
     <RefreshSetting :id="SettingsHighlightIds.REFRESH_BALANCE" />
-    <QueryPeriodSetting :id="SettingsHighlightIds.PERIODIC_QUERY" />
+    <SettingsItem :id="SettingsHighlightIds.PERIODIC_QUERY">
+      <template #title>
+        {{ t('frontend_settings.periodic_query.title') }}
+      </template>
+      <QueryPeriodSetting />
+    </SettingsItem>
     <Explorers :id="SettingsHighlightIds.EXPLORERS" />
     <HistoryQueryIndicatorSettings />
   </SettingCategory>

--- a/frontend/app/src/modules/settings/frontend/PersistPrivacySettings.vue
+++ b/frontend/app/src/modules/settings/frontend/PersistPrivacySettings.vue
@@ -1,44 +1,15 @@
 <script setup lang="ts">
-import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const persistPrivacySettings = useSetting('persistPrivacySettings');
-
-const persistPrivacy = ref<boolean>(false);
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
-
-function setData() {
-  set(persistPrivacy, get(persistPrivacySettings));
-}
-
-onMounted(setData);
-
-watch(persistPrivacySettings, setData);
 </script>
 
 <template>
-  <SettingsItem>
-    <template #title>
-      {{ t('frontend_settings.persist_privacy.title') }}
-    </template>
-
-    <SettingsOption
-      #default="{ error, success, updateImmediate }"
-      setting="persistPrivacySettings"
-      :error-message="t('frontend_settings.persist_privacy.validation.error')"
-    >
-      <RuiSwitch
-        v-model="persistPrivacy"
-        color="primary"
-        class="my-2"
-        :label="t('frontend_settings.persist_privacy.label')"
-        :hint="t('frontend_settings.persist_privacy.hint')"
-        :success-messages="success"
-        :error-messages="error"
-        @update:model-value="updateImmediate($event)"
-      />
-    </SettingsOption>
-  </SettingsItem>
+  <SettingSwitch
+    setting="persistPrivacySettings"
+    class="my-2"
+    :label="t('frontend_settings.persist_privacy.label')"
+    :hint="t('frontend_settings.persist_privacy.hint')"
+    :error-message="t('frontend_settings.persist_privacy.validation.error')"
+  />
 </template>

--- a/frontend/app/src/modules/settings/frontend/PersistTableSortingSetting.vue
+++ b/frontend/app/src/modules/settings/frontend/PersistTableSortingSetting.vue
@@ -1,34 +1,13 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
-const persist = ref<boolean>(false);
 const { t } = useI18n({ useScope: 'global' });
-
-const enabled = useSetting('persistTableSorting');
-
-watchImmediate(enabled, (enabled) => {
-  set(persist, enabled);
-});
 </script>
 
 <template>
-  <SettingsOption
+  <SettingSwitch
     setting="persistTableSorting"
+    :label="t('frontend_settings.persist_table_sorting.subtitle')"
     :error-message="t('frontend_settings.persist_table_sorting.validation.error')"
-  >
-    <template #title>
-      {{ t('frontend_settings.persist_table_sorting.title') }}
-    </template>
-    <template #default="{ error, success, updateImmediate }">
-      <RuiSwitch
-        color="primary"
-        :model-value="persist"
-        :label="t('frontend_settings.persist_table_sorting.subtitle')"
-        :success-messages="success"
-        :error-messages="error"
-        @update:model-value="updateImmediate($event)"
-      />
-    </template>
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/AutoCreateProfitEventsSetting.vue
+++ b/frontend/app/src/modules/settings/general/AutoCreateProfitEventsSetting.vue
@@ -1,34 +1,13 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const autoCreateProfitEvents = ref<boolean>(false);
-const storedAutoCreateProfitEvents = useSetting('autoCreateProfitEvents');
-
-onMounted(() => {
-  set(autoCreateProfitEvents, get(storedAutoCreateProfitEvents));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
+  <SettingSwitch
     setting="autoCreateProfitEvents"
+    :label="t('general_settings.history_event.auto_create_profit_events.label')"
     :error-message="t('general_settings.history_event.auto_create_profit_events.validation.error')"
-  >
-    <template #title>
-      {{ t('general_settings.history_event.auto_create_profit_events.title') }}
-    </template>
-    <template #default="{ error, success, updateImmediate }">
-      <RuiSwitch
-        v-model="autoCreateProfitEvents"
-        color="primary"
-        :label="t('general_settings.history_event.auto_create_profit_events.label')"
-        :success-messages="success"
-        :error-messages="error"
-        @update:model-value="updateImmediate($event)"
-      />
-    </template>
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/AutoDetectTokensOnLoginSetting.vue
+++ b/frontend/app/src/modules/settings/general/AutoDetectTokensOnLoginSetting.vue
@@ -1,38 +1,14 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const value = ref<boolean>(false);
-const autoDetectTokensOnLogin = useSetting('autoDetectTokensOnLogin');
-
-onMounted(() => {
-  set(value, get(autoDetectTokensOnLogin));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
+  <SettingSwitch
     setting="autoDetectTokensOnLogin"
+    data-cy="auto-detect-tokens-on-login-toggle"
+    :label="t('general_settings.auto_detect_tokens_on_login.label')"
     :error-message="t('general_settings.auto_detect_tokens_on_login.validation.error')"
-  >
-    <template #title>
-      {{ t('general_settings.auto_detect_tokens_on_login.title') }}
-    </template>
-    <template #subtitle>
-      {{ t('general_settings.auto_detect_tokens_on_login.subtitle') }}
-    </template>
-    <template #default="{ error, success, updateImmediate }">
-      <RuiSwitch
-        v-model="value"
-        color="primary"
-        data-cy="auto-detect-tokens-on-login-toggle"
-        :label="t('general_settings.auto_detect_tokens_on_login.label')"
-        :success-messages="success"
-        :error-messages="error"
-        @update:model-value="updateImmediate($event)"
-      />
-    </template>
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/AutoDetectTokensSetting.vue
+++ b/frontend/app/src/modules/settings/general/AutoDetectTokensSetting.vue
@@ -1,36 +1,13 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const value = ref<boolean>(false);
-const autoDetectTokens = useSetting('autoDetectTokens');
-
-onMounted(() => {
-  set(value, get(autoDetectTokens));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
+  <SettingSwitch
     setting="autoDetectTokens"
+    :label="t('general_settings.auto_detect_tokens.label')"
     :error-message="t('general_settings.auto_detect_tokens.validation.error')"
-  >
-    <template #title>
-      {{ t('general_settings.auto_detect_tokens.title') }}
-    </template>
-    <template
-      #default="{ error, success, updateImmediate }"
-    >
-      <RuiSwitch
-        v-model="value"
-        color="primary"
-        :label="t('general_settings.auto_detect_tokens.label')"
-        :success-messages="success"
-        :error-messages="error"
-        @update:model-value="updateImmediate($event)"
-      />
-    </template>
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/BalanceSaveFrequencySetting.vue
+++ b/frontend/app/src/modules/settings/general/BalanceSaveFrequencySetting.vue
@@ -1,92 +1,24 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { between, helpers, required } from '@vuelidate/validators';
 import { Constraints } from '@/modules/core/common/constraints';
 import { Defaults } from '@/modules/core/common/defaults';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const DEFAULT_FREQUENCY = Defaults.BALANCE_SAVE_FREQUENCY;
-
-const balanceSaveFrequency = ref<string>(DEFAULT_FREQUENCY.toString());
-
-const frequency = useSetting('balanceSaveFrequency');
+import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 
-const maxBalanceSaveFrequency = Constraints.MAX_HOURS_DELAY;
-const rules = {
-  balanceSaveFrequency: {
-    between: helpers.withMessage(
-      t('general_settings.balance_frequency.validation.invalid_frequency', {
-        end: maxBalanceSaveFrequency,
-        start: 1,
-      }),
-      between(1, maxBalanceSaveFrequency),
-    ),
-    required: helpers.withMessage(t('general_settings.balance_frequency.validation.non_empty'), required),
-  },
-};
-const v$ = useVuelidate(rules, { balanceSaveFrequency }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
-
-function resetBalanceSaveFrequency() {
-  set(balanceSaveFrequency, get(frequency).toString());
+function successMessage(frequency: number): string {
+  return t('general_settings.balance_frequency.validation.success', { frequency });
 }
-
-function transform(value?: string) {
-  return value ? Number.parseInt(value) : value;
-}
-
-function successMessage(frequency: string) {
-  return t('general_settings.balance_frequency.validation.success', {
-    frequency,
-  });
-}
-
-function reset(update: (value: number) => void): void {
-  update(DEFAULT_FREQUENCY);
-  set(balanceSaveFrequency, DEFAULT_FREQUENCY.toString());
-}
-
-onMounted(() => {
-  resetBalanceSaveFrequency();
-});
 </script>
 
 <template>
-  <SettingsOption
+  <SettingNumber
     setting="balanceSaveFrequency"
-    :transform="transform"
+    data-cy="balance-save-frequency-input"
+    :label="t('general_settings.balance_frequency.label')"
+    :min="1"
+    :max="Constraints.MAX_HOURS_DELAY"
+    :default="Defaults.BALANCE_SAVE_FREQUENCY"
     :error-message="t('general_settings.balance_frequency.validation.error')"
     :success-message="successMessage"
-    @finished="resetBalanceSaveFrequency()"
-  >
-    <template #title>
-      {{ t('general_settings.balance_frequency.title') }}
-    </template>
-    <template #default="{ error, success, update, updateImmediate }">
-      <div class="flex items-start w-full">
-        <RuiTextField
-          v-model="balanceSaveFrequency"
-          variant="outlined"
-          color="primary"
-          min="1"
-          :max="maxBalanceSaveFrequency"
-          data-cy="balance-save-frequency-input"
-          class="w-full"
-          :label="t('general_settings.balance_frequency.label')"
-          type="number"
-          :success-messages="success"
-          :error-messages="error || toMessages(v$.balanceSaveFrequency)"
-          @update:model-value="callIfValid($event, update)"
-        />
-
-        <SettingResetConfirmButton @confirm="reset(updateImmediate)" />
-      </div>
-    </template>
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/BtcDerivationGapLimitSetting.vue
+++ b/frontend/app/src/modules/settings/general/BtcDerivationGapLimitSetting.vue
@@ -1,57 +1,20 @@
 <script setup lang="ts">
 import { Defaults } from '@/modules/core/common/defaults';
-import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
-import { useSetting } from '@/modules/settings/use-setting';
+import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 
-const DEFAULT = Defaults.BTC_DERIVATION_GAP_LIMIT;
-
-const btcDerivationGapLimit = ref<string>(DEFAULT.toString());
-const limit = useSetting('btcDerivationGapLimit');
 const { t } = useI18n({ useScope: 'global' });
 
-function successMessage(limit: string) {
-  return t('general_settings.validation.btc_derivation_gap.success', {
-    limit,
-  });
+function successMessage(limit: number): string {
+  return t('general_settings.validation.btc_derivation_gap.success', { limit });
 }
-
-function reset(update: (value: number) => void) {
-  update(DEFAULT);
-  set(btcDerivationGapLimit, DEFAULT.toString());
-}
-
-onMounted(() => {
-  set(btcDerivationGapLimit, get(limit).toString());
-});
 </script>
 
 <template>
-  <SettingsItem>
-    <template #title>
-      {{ t('general_settings.labels.btc_derivation_gap') }}
-    </template>
-    <SettingsOption
-      #default="{ error, success, update, updateImmediate }"
-      setting="btcDerivationGapLimit"
-      :error-message="t('general_settings.validation.btc_derivation_gap.error')"
-      :success-message="successMessage"
-    >
-      <div class="flex items-start w-full">
-        <RuiTextField
-          v-model.number="btcDerivationGapLimit"
-          variant="outlined"
-          color="primary"
-          class="w-full"
-          :label="t('general_settings.labels.btc_derivation_gap')"
-          type="number"
-          :success-messages="success"
-          :error-messages="error"
-          @update:model-value="update($event ? parseInt($event) : $event)"
-        />
-        <SettingResetConfirmButton @confirm="reset(updateImmediate)" />
-      </div>
-    </SettingsOption>
-  </SettingsItem>
+  <SettingNumber
+    setting="btcDerivationGapLimit"
+    :label="t('general_settings.labels.btc_derivation_gap')"
+    :default="Defaults.BTC_DERIVATION_GAP_LIMIT"
+    :error-message="t('general_settings.validation.btc_derivation_gap.error')"
+    :success-message="successMessage"
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/CsvExportDelimiterSetting.vue
+++ b/frontend/app/src/modules/settings/general/CsvExportDelimiterSetting.vue
@@ -1,74 +1,24 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, maxLength, required } from '@vuelidate/validators';
 import { Defaults } from '@/modules/core/common/defaults';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
-import { useSetting } from '@/modules/settings/use-setting';
+import SettingText from '@/modules/settings/controls/SettingText.vue';
 
-const DEFAULT_DELIMITER = Defaults.DEFAULT_CSV_EXPORT_DELIMITER;
-const csvExportDelimiter = ref<string>(DEFAULT_DELIMITER);
-const delimiter = useSetting('csvExportDelimiter');
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  csvExportDelimiter: {
-    required: helpers.withMessage(t('general_settings.validation.csv_delimiter.empty'), required),
-    singleCharacter: helpers.withMessage(
-      t('general_settings.validation.csv_delimiter.single_character'),
-      maxLength(1),
-    ),
-  },
-};
-
-const v$ = useVuelidate(rules, { csvExportDelimiter }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
-
-function callIfCsvExportDelimiterValid(value: string, method: (value: string) => void) {
-  const validator = get(v$);
-  callIfValid(value, method, () => validator.csvExportDelimiter.$error);
+function successMessage(delimiter: string): string {
+  return t('general_settings.validation.csv_delimiter.success', { delimiter });
 }
-
-function successMessage(delimiterValue: string) {
-  return t('general_settings.validation.csv_delimiter.success', {
-    delimiter: delimiterValue,
-  });
-}
-
-function reset(update: (value: string) => void) {
-  update(DEFAULT_DELIMITER);
-  set(csvExportDelimiter, DEFAULT_DELIMITER);
-}
-
-onMounted(() => {
-  set(csvExportDelimiter, get(delimiter));
-});
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, updateImmediate }"
+  <SettingText
     setting="csvExportDelimiter"
+    maxlength="1"
+    required
+    :debounce="0"
+    :max-length="1"
+    :default="Defaults.DEFAULT_CSV_EXPORT_DELIMITER"
+    :label="t('general_settings.labels.csv_delimiter')"
     :error-message="t('general_settings.validation.csv_delimiter.error')"
     :success-message="successMessage"
-  >
-    <div class="flex items-start w-full">
-      <RuiTextField
-        v-model="csvExportDelimiter"
-        variant="outlined"
-        color="primary"
-        maxlength="1"
-        class="w-full"
-        :label="t('general_settings.labels.csv_delimiter')"
-        type="text"
-        :success-messages="success"
-        :error-messages="error || toMessages(v$.csvExportDelimiter)"
-        @update:model-value="callIfCsvExportDelimiterValid($event, updateImmediate)"
-      />
-
-      <SettingResetConfirmButton @confirm="reset(updateImmediate)" />
-    </div>
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/QueryPeriodSetting.vue
+++ b/frontend/app/src/modules/settings/general/QueryPeriodSetting.vue
@@ -1,75 +1,20 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { between, helpers, required } from '@vuelidate/validators';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
+import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 import { useMonitorService } from '@/modules/shell/app/use-monitor-service';
-
-const queryPeriod = ref<string>('5');
-const minQueryPeriod = 5;
-const maxQueryPeriod = 3600;
 
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  queryPeriod: {
-    between: helpers.withMessage(
-      t('frontend_settings.periodic_query.validation.invalid_period', {
-        end: maxQueryPeriod,
-        start: minQueryPeriod,
-      }),
-      between(minQueryPeriod, maxQueryPeriod),
-    ),
-    required: helpers.withMessage(t('frontend_settings.periodic_query.validation.non_empty'), required),
-  },
-};
-
-const currentPeriod = useSetting('queryPeriod');
-
-function resetQueryPeriod() {
-  set(queryPeriod, get(currentPeriod).toString());
-}
-
-const v$ = useVuelidate(rules, { queryPeriod }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
-
 const { restart } = useMonitorService();
-
-const transform = (value: string) => (value ? Number.parseInt(value) : value);
-
-onMounted(() => {
-  resetQueryPeriod();
-});
 </script>
 
 <template>
-  <SettingsOption
-    class="mt-1"
+  <SettingNumber
     setting="queryPeriod"
-    :transform="transform"
+    :label="t('frontend_settings.periodic_query.label')"
+    :hint="t('frontend_settings.periodic_query.hint')"
+    :min="5"
+    :max="3600"
     :error-message="t('frontend_settings.periodic_query.validation.error')"
     @updated="restart()"
-    @finished="resetQueryPeriod()"
-  >
-    <template #title>
-      {{ t('frontend_settings.periodic_query.title') }}
-    </template>
-    <template #default="{ error, success, update }">
-      <RuiTextField
-        v-model="queryPeriod"
-        variant="outlined"
-        color="primary"
-        :label="t('frontend_settings.periodic_query.label')"
-        :hint="t('frontend_settings.periodic_query.hint')"
-        type="number"
-        :min="minQueryPeriod"
-        :max="maxQueryPeriod"
-        :success-messages="success"
-        :error-messages="error || toMessages(v$.queryPeriod)"
-        @update:model-value="callIfValid($event, update)"
-      />
-    </template>
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/UsageAnalyticsSetting.vue
+++ b/frontend/app/src/modules/settings/general/UsageAnalyticsSetting.vue
@@ -1,35 +1,14 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const anonymousUsageAnalytics = ref<boolean>(false);
-const submitUsageAnalytics = useSetting('submitUsageAnalytics');
-
-onMounted(() => {
-  set(anonymousUsageAnalytics, get(submitUsageAnalytics));
-});
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
+  <SettingSwitch
     setting="submitUsageAnalytics"
+    data-cy="anonymous-usage-statistics-input"
+    :label="t('general_settings.usage_analytics.label')"
     :error-message="t('general_settings.usage_analytics.validation.error')"
-  >
-    <template #title>
-      {{ t('general_settings.usage_analytics.title') }}
-    </template>
-    <template #default="{ error, success, updateImmediate }">
-      <RuiSwitch
-        v-model="anonymousUsageAnalytics"
-        data-cy="anonymous-usage-statistics-input"
-        color="primary"
-        :label="t('general_settings.usage_analytics.label')"
-        :success-messages="success"
-        :error-messages="error"
-        @update:model-value="updateImmediate($event)"
-      />
-    </template>
-  </SettingsOption>
+  />
 </template>

--- a/frontend/app/src/modules/settings/general/nft/NftsInNetValueSetting.vue
+++ b/frontend/app/src/modules/settings/general/nft/NftsInNetValueSetting.vue
@@ -1,32 +1,17 @@
 <script setup lang="ts">
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
+import SettingSwitch from '@/modules/settings/controls/SettingSwitch.vue';
 import { useStatisticsDataFetching } from '@/modules/statistics/use-statistics-data-fetching';
 
-const includeNfts = ref<boolean>(true);
 const { fetchNetValue } = useStatisticsDataFetching();
-const enabled = useSetting('nftsInNetValue');
-
-onMounted(() => {
-  set(includeNfts, get(enabled));
-});
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <SettingsOption
-    #default="{ error, success, update }"
+  <SettingSwitch
     setting="nftsInNetValue"
-    @finished="fetchNetValue()"
-  >
-    <RuiSwitch
-      v-model="includeNfts"
-      color="primary"
-      :label="t('general_settings.nft_setting.label.include_nfts')"
-      :success-messages="success"
-      :error-messages="error"
-      @update:model-value="update($event)"
-    />
-  </SettingsOption>
+    :debounce="1500"
+    :label="t('general_settings.nft_setting.label.include_nfts')"
+    @updated="fetchNetValue()"
+  />
 </template>

--- a/frontend/app/src/modules/settings/interface/HistoryQueryIndicatorDismissalThresholdSetting.vue
+++ b/frontend/app/src/modules/settings/interface/HistoryQueryIndicatorDismissalThresholdSetting.vue
@@ -1,76 +1,16 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { between, helpers, required } from '@vuelidate/validators';
 import { Constraints } from '@/modules/core/common/constraints';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
-import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const evmQueryIndicatorDismissalThreshold = ref<string>('');
-
-const minThreshold = 1;
-const maxThreshold = Constraints.MAX_HOURS_DELAY;
+import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 
 const { t } = useI18n({ useScope: 'global' });
-
-const rules = {
-  evmQueryIndicatorDismissalThreshold: {
-    between: helpers.withMessage(
-      t('frontend_settings.history_query_indicator.dismissal_threshold.validation.invalid_period', {
-        end: maxThreshold,
-        start: minThreshold,
-      }),
-      between(minThreshold, maxThreshold),
-    ),
-    required: helpers.withMessage(t('frontend_settings.history_query_indicator.dismissal_threshold.validation.non_empty'), required),
-  },
-};
-
-const v$ = useVuelidate(rules, { evmQueryIndicatorDismissalThreshold }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
-
-const currentThreshold = useSetting('evmQueryIndicatorDismissalThreshold');
-
-function resetValue() {
-  set(evmQueryIndicatorDismissalThreshold, get(currentThreshold).toString());
-}
-
-const transform = (value: string) => (value ? Number.parseInt(value) : value);
-
-onMounted(() => {
-  resetValue();
-});
 </script>
 
 <template>
-  <SettingsItem>
-    <template #title>
-      {{ t('frontend_settings.history_query_indicator.dismissal_threshold.title') }}
-    </template>
-    <template #subtitle>
-      {{ t('frontend_settings.history_query_indicator.dismissal_threshold.subtitle') }}
-    </template>
-    <SettingsOption
-      #default="{ error, success, update }"
-      setting="evmQueryIndicatorDismissalThreshold"
-      :transform="transform"
-      :error-message="t('frontend_settings.history_query_indicator.dismissal_threshold.validation.error')"
-      @finished="resetValue()"
-    >
-      <RuiTextField
-        v-model="evmQueryIndicatorDismissalThreshold"
-        variant="outlined"
-        color="primary"
-        type="number"
-        :min="minThreshold"
-        :max="maxThreshold"
-        :label="t('frontend_settings.history_query_indicator.dismissal_threshold.label')"
-        :success-messages="success"
-        :error-messages="error || toMessages(v$.evmQueryIndicatorDismissalThreshold)"
-        @update:model-value="callIfValid($event, update)"
-      />
-    </SettingsOption>
-  </SettingsItem>
+  <SettingNumber
+    setting="evmQueryIndicatorDismissalThreshold"
+    :label="t('frontend_settings.history_query_indicator.dismissal_threshold.label')"
+    :min="1"
+    :max="Constraints.MAX_HOURS_DELAY"
+    :error-message="t('frontend_settings.history_query_indicator.dismissal_threshold.validation.error')"
+  />
 </template>

--- a/frontend/app/src/modules/settings/interface/HistoryQueryIndicatorMinOutOfSyncPeriodSetting.vue
+++ b/frontend/app/src/modules/settings/interface/HistoryQueryIndicatorMinOutOfSyncPeriodSetting.vue
@@ -1,76 +1,16 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { between, helpers, required } from '@vuelidate/validators';
 import { Constraints } from '@/modules/core/common/constraints';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
-import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
-import SettingsOption from '@/modules/settings/controls/SettingsOption.vue';
-import { useSetting } from '@/modules/settings/use-setting';
-
-const evmQueryIndicatorMinOutOfSyncPeriod = ref<string>('');
-
-const minPeriod = 1;
-const maxPeriod = Constraints.MAX_HOURS_DELAY;
+import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 
 const { t } = useI18n({ useScope: 'global' });
-
-const rules = {
-  evmQueryIndicatorMinOutOfSyncPeriod: {
-    between: helpers.withMessage(
-      t('frontend_settings.history_query_indicator.min_out_of_sync_period.validation.invalid_period', {
-        end: maxPeriod,
-        start: minPeriod,
-      }),
-      between(minPeriod, maxPeriod),
-    ),
-    required: helpers.withMessage(t('frontend_settings.history_query_indicator.min_out_of_sync_period.validation.non_empty'), required),
-  },
-};
-
-const v$ = useVuelidate(rules, { evmQueryIndicatorMinOutOfSyncPeriod }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
-
-const currentPeriod = useSetting('evmQueryIndicatorMinOutOfSyncPeriod');
-
-function resetValue() {
-  set(evmQueryIndicatorMinOutOfSyncPeriod, get(currentPeriod).toString());
-}
-
-const transform = (value: string) => (value ? Number.parseInt(value) : value);
-
-onMounted(() => {
-  resetValue();
-});
 </script>
 
 <template>
-  <SettingsItem>
-    <template #title>
-      {{ t('frontend_settings.history_query_indicator.min_out_of_sync_period.title') }}
-    </template>
-    <template #subtitle>
-      {{ t('frontend_settings.history_query_indicator.min_out_of_sync_period.subtitle') }}
-    </template>
-    <SettingsOption
-      #default="{ error, success, update }"
-      setting="evmQueryIndicatorMinOutOfSyncPeriod"
-      :transform="transform"
-      :error-message="t('frontend_settings.history_query_indicator.min_out_of_sync_period.validation.error')"
-      @finished="resetValue()"
-    >
-      <RuiTextField
-        v-model="evmQueryIndicatorMinOutOfSyncPeriod"
-        variant="outlined"
-        color="primary"
-        type="number"
-        :min="minPeriod"
-        :max="maxPeriod"
-        :label="t('frontend_settings.history_query_indicator.min_out_of_sync_period.label')"
-        :success-messages="success"
-        :error-messages="error || toMessages(v$.evmQueryIndicatorMinOutOfSyncPeriod)"
-        @update:model-value="callIfValid($event, update)"
-      />
-    </SettingsOption>
-  </SettingsItem>
+  <SettingNumber
+    setting="evmQueryIndicatorMinOutOfSyncPeriod"
+    :label="t('frontend_settings.history_query_indicator.min_out_of_sync_period.label')"
+    :min="1"
+    :max="Constraints.MAX_HOURS_DELAY"
+    :error-message="t('frontend_settings.history_query_indicator.min_out_of_sync_period.validation.error')"
+  />
 </template>

--- a/frontend/app/src/modules/settings/interface/HistoryQueryIndicatorSettings.vue
+++ b/frontend/app/src/modules/settings/interface/HistoryQueryIndicatorSettings.vue
@@ -38,8 +38,24 @@ onUnmounted(() => {
     <template #title>
       {{ t('frontend_settings.history_query_indicator.title') }}
     </template>
-    <HistoryQueryIndicatorMinOutOfSyncPeriodSetting :id="SettingsHighlightIds.MIN_OUT_OF_SYNC_PERIOD" />
-    <HistoryQueryIndicatorDismissalThresholdSetting :id="SettingsHighlightIds.DISMISSAL_THRESHOLD" />
+    <SettingsItem :id="SettingsHighlightIds.MIN_OUT_OF_SYNC_PERIOD">
+      <template #title>
+        {{ t('frontend_settings.history_query_indicator.min_out_of_sync_period.title') }}
+      </template>
+      <template #subtitle>
+        {{ t('frontend_settings.history_query_indicator.min_out_of_sync_period.subtitle') }}
+      </template>
+      <HistoryQueryIndicatorMinOutOfSyncPeriodSetting />
+    </SettingsItem>
+    <SettingsItem :id="SettingsHighlightIds.DISMISSAL_THRESHOLD">
+      <template #title>
+        {{ t('frontend_settings.history_query_indicator.dismissal_threshold.title') }}
+      </template>
+      <template #subtitle>
+        {{ t('frontend_settings.history_query_indicator.dismissal_threshold.subtitle') }}
+      </template>
+      <HistoryQueryIndicatorDismissalThresholdSetting />
+    </SettingsItem>
     <div>
       <SettingsItem :id="SettingsHighlightIds.RESET_DISMISSAL_STATUS">
         <template #title>

--- a/frontend/app/src/modules/settings/use-setting-model.ts
+++ b/frontend/app/src/modules/settings/use-setting-model.ts
@@ -16,6 +16,12 @@ interface UseSettingModelReturn<K extends WritableSettingKey> {
   readonly pending: Readonly<Ref<boolean>>;
   readonly error: Readonly<Ref<string>>;
   readonly success: Readonly<Ref<boolean>>;
+  /**
+   * Persist the current draft now, bypassing the debounce (e.g. a reset-to-default button: set the
+   * draft, then flush). Intended for debounced models: the debounced write the draft change also
+   * scheduled re-checks the source at fire time and no-ops once this immediate write has landed.
+   */
+  readonly flush: () => Promise<void>;
 }
 
 /**
@@ -70,8 +76,13 @@ export function useSettingModel<K extends WritableSettingKey>(
     startPromise(schedule());
   });
 
+  const flush = async (): Promise<void> => {
+    await persist();
+  };
+
   return {
     error: readonly(error),
+    flush,
     model,
     pending: readonly(pending),
     success: readonly(success),


### PR DESCRIPTION
## Summary

Continues the settings-registry follow-up work (after #12556 / #12560) by adding generic **owning controls** that persist a setting themselves via `useSettingModel`, so simple settings no longer reimplement debounce, validation, and success/error messaging in every component.

### New / extended controls

- **`SettingSwitch`** — now accepts nullable booleans (coerces `null`/`undefined` drafts to off) and emits `updated` after a successful persist, mirroring the old `SettingsOption` `@finished` hook.
- **`SettingNumber`** — required + `between`/`min`/`max` validation baked from props, an optional vuelidate `rules` escape hatch for bespoke cases, reset-to-default, and string↔number `transform`. Adds `useSettingModel.flush()` for an immediate persist that bypasses the debounce (used by reset).
- **`SettingText`** — string analog of `SettingNumber` (required + `maxLength`, same `rules` escape hatch, reset-to-default, `transform`).

### Migrated settings

Simple single-control settings moved onto the new controls (each ~15 lines → ~5):

- **Nullable accounting toggles:** eth-staking-taxable-after-withdrawal, include-fees-in-cost-basis, use-asset-collections-in-cost-basis.
- **Post-save side-effect toggles:** nfts-in-net-value, infer-zero-timed-balances (via the new `updated` emit).
- **Title-owning toggles (title relocated into the category `SettingsItem`):** usage-analytics, auto-detect-tokens, auto-detect-tokens-on-login, auto-create-profit-events, persist-table-sorting, persist-privacy.
- **Numeric settings → `SettingNumber`:** balance-save-frequency, btc-derivation-gap-limit, query-period, both history-query-indicator periods, both oracle-penalty settings.
- **Text → `SettingText`:** csv-export-delimiter.

Net `+742 / -821` across 32 files.

## Testing

- `pnpm run typecheck` — clean
- `pnpm run test:unit` — 4673 passed (490 files), incl. new SettingNumber/SettingText/SettingSwitch specs
- `pnpm run lint` — 0 errors
- `GROUP=settings playwright test` — 37 passed, including the persist-after-relogin checks for cost-basis-fee (nullable switch), balance-save-frequency + oracle-penalty (SettingNumber), and anonymous-statistics (title-owning toggle).
