### PR TITLE
build(deps): upgrade zod to v4.4.3

### DIFF
--- a/frontend/app/electron/main/settings-manager.ts
+++ b/frontend/app/electron/main/settings-manager.ts
@@ -1,7 +1,7 @@
 import type { App } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const AppSettingsSchema = z.object({
   displayTray: z.boolean().default(true),

--- a/frontend/app/scripts/check-external-links.ts
+++ b/frontend/app/scripts/check-external-links.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 import consola from 'consola';
-import z from 'zod/v4';
+import z from 'zod';
 import { externalLinks } from '../shared/external-links';
 
 const Release = z.object({

--- a/frontend/app/shared/ipc.ts
+++ b/frontend/app/shared/ipc.ts
@@ -1,6 +1,6 @@
 import type { DebugSettings } from '@rotki/common';
 import { LogLevel } from '@shared/log-level';
-import z from 'zod/v4';
+import z from 'zod';
 
 export const BackendCode = {
   TERMINATED: 0,

--- a/frontend/app/shared/wallet-bridge-types.ts
+++ b/frontend/app/shared/wallet-bridge-types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 /**
  * Unified Wallet Bridge Types with Runtime Validation

--- a/frontend/app/src/modules/accounts/address-book/eth-names.ts
+++ b/frontend/app/src/modules/accounts/address-book/eth-names.ts
@@ -1,6 +1,6 @@
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
 import { Blockchain } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 
 export const EthNamesSchema = z.record(z.string(), z.string().nullable());

--- a/frontend/app/src/modules/accounts/address-book/types/address-name-priorities.ts
+++ b/frontend/app/src/modules/accounts/address-book/types/address-name-priorities.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export enum AddressNamePriority {
   BLOCKCHAIN_ACCOUNT = 'blockchain_account',

--- a/frontend/app/src/modules/accounts/address-book/use-address-book-import.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-book-import.ts
@@ -1,5 +1,5 @@
 import { groupBy, omit } from 'es-toolkit';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { useAddressBookOperations } from '@/modules/accounts/address-book/use-address-book-operations';
 import { logger } from '@/modules/core/common/logging/logging';
 import { CSVMissingHeadersError, useCsvImportExport } from '@/modules/core/common/use-csv-import-export';

--- a/frontend/app/src/modules/accounts/blockchain-accounts.ts
+++ b/frontend/app/src/modules/accounts/blockchain-accounts.ts
@@ -2,7 +2,7 @@ import type { AssetBalance, Balance, BigNumber } from '@rotki/common';
 import type { BlockchainAssetBalances } from '@/modules/balances/types/blockchain-balances';
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
 import type { Module } from '@/modules/core/common/modules';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export interface AddressData {
   readonly type: 'address';

--- a/frontend/app/src/modules/accounts/import-export/account-csv-schema.ts
+++ b/frontend/app/src/modules/accounts/import-export/account-csv-schema.ts
@@ -2,7 +2,7 @@ import type { AccountPayload } from '@/modules/accounts/blockchain-accounts';
 import type { StakingValidatorManage } from '@/modules/accounts/blockchain/use-account-manage';
 import type { Eth2Validator } from '@/modules/balances/types/balances';
 import { Blockchain } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const CSVRow = z.object({
   address: z.string(),

--- a/frontend/app/src/modules/airdrops/airdrops.ts
+++ b/frontend/app/src/modules/airdrops/airdrops.ts
@@ -1,5 +1,5 @@
 import { NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const AIRDROP_POAP = 'poap';
 

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/schema.ts
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/schema.ts
@@ -1,5 +1,5 @@
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 
 export const CounterpartyMappingDeletePayload = z.object({

--- a/frontend/app/src/modules/assets/admin/missing-mappings/AssetMissingMappings.vue
+++ b/frontend/app/src/modules/assets/admin/missing-mappings/AssetMissingMappings.vue
@@ -2,7 +2,7 @@
 import type { DataTableColumn } from '@rotki/ui-library';
 import type { CexMapping } from '@/modules/assets/types';
 import type { MissingMapping } from '@/modules/user-data/schemas';
-import z from 'zod/v4';
+import z from 'zod';
 import ExchangeMappingFilter from '@/modules/assets/admin/cex-mapping/ExchangeMappingFilter.vue';
 import ManageCexMappingFormDialog from '@/modules/assets/admin/cex-mapping/ManageCexMappingFormDialog.vue';
 import { useMissingMappingsDB } from '@/modules/assets/admin/missing-mappings/use-missing-mappings-db';

--- a/frontend/app/src/modules/assets/amount-display/currency-location.ts
+++ b/frontend/app/src/modules/assets/amount-display/currency-location.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export enum CurrencyLocation {
   BEFORE = 'before',

--- a/frontend/app/src/modules/assets/detection/types.ts
+++ b/frontend/app/src/modules/assets/detection/types.ts
@@ -1,5 +1,5 @@
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export enum NewDetectedTokenKind {
   EVM = 'evm',

--- a/frontend/app/src/modules/assets/nfts.ts
+++ b/frontend/app/src/modules/assets/nfts.ts
@@ -1,5 +1,5 @@
 import { type AssetInfoWithId, NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 /**
  * It is like {@link AssetInfoWithId} but with two extra properties for

--- a/frontend/app/src/modules/assets/prices/price-types.ts
+++ b/frontend/app/src/modules/assets/prices/price-types.ts
@@ -1,7 +1,7 @@
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
 import { AssetEntry, type Balance, type BigNumber, NumericString } from '@rotki/common';
 import { forEach } from 'es-toolkit/compat';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 import { PriceOracle, PriceOracleEnum } from '@/modules/settings/types/price-oracle';
 

--- a/frontend/app/src/modules/assets/prices/use-oracle-prices-filter.ts
+++ b/frontend/app/src/modules/assets/prices/use-oracle-prices-filter.ts
@@ -1,6 +1,6 @@
 import type { MatchedKeyword, SearchMatcher } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { dateDeserializer, dateRangeValidator, dateSerializer, getDateInputISOFormat } from '@/modules/core/common/data/date';
 import { assetSuggestions } from '@/modules/core/common/display/assets';

--- a/frontend/app/src/modules/assets/types.ts
+++ b/frontend/app/src/modules/assets/types.ts
@@ -1,6 +1,6 @@
 import type { ConflictResolutionStrategy, PaginationRequestPayload } from '@/modules/core/common/common-types';
 import { AssetCollection, AssetInfoWithId, AssetInfoWithTransformer, SupportedAsset } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 
 export interface AssetDBVersion {

--- a/frontend/app/src/modules/auth/login.ts
+++ b/frontend/app/src/modules/auth/login.ts
@@ -1,6 +1,6 @@
 import type { Exchange } from '@/modules/balances/types/exchanges';
 import type { UserSettingsModel } from '@/modules/settings/types/user-settings';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export type SyncApproval = 'yes' | 'no' | 'unknown';
 

--- a/frontend/app/src/modules/balances/protocols/types.ts
+++ b/frontend/app/src/modules/balances/protocols/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const ProtocolMetadataSchema = z.object({
   identifier: z.string(),

--- a/frontend/app/src/modules/balances/types/balances.ts
+++ b/frontend/app/src/modules/balances/types/balances.ts
@@ -1,5 +1,5 @@
 import { Balance, type BigNumber } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export interface Eth2Validator {
   readonly validatorIndex?: string;

--- a/frontend/app/src/modules/balances/types/blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/types/blockchain-balances.ts
@@ -1,5 +1,5 @@
 import { Balance } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const ProtocolBalances = z.record(z.string(), Balance);
 

--- a/frontend/app/src/modules/balances/types/exchanges.ts
+++ b/frontend/app/src/modules/balances/types/exchanges.ts
@@ -1,7 +1,7 @@
 import type { AssetBalances } from '@/modules/balances/types/balances';
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
 import { AssetBalance, type BigNumber, NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { type Collection, CollectionCommonFields } from '@/modules/core/common/collection';
 
 export const KrakenAccountType = z.enum(['starter', 'intermediate', 'pro']);

--- a/frontend/app/src/modules/balances/types/manual-balances.ts
+++ b/frontend/app/src/modules/balances/types/manual-balances.ts
@@ -1,6 +1,6 @@
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
 import { NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { BalanceType } from '@/modules/balances/types/balances';
 
 const RawManualBalance = z.object({

--- a/frontend/app/src/modules/balances/types/nfbalances.ts
+++ b/frontend/app/src/modules/balances/types/nfbalances.ts
@@ -1,6 +1,6 @@
 import type { IgnoredAssetsHandlingType } from '@/modules/assets/types';
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { PriceInformation } from '@/modules/assets/prices/price-types';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 

--- a/frontend/app/src/modules/calendar/reminder.ts
+++ b/frontend/app/src/modules/calendar/reminder.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const CalenderReminderPayload = z.object({
   eventId: z.number(),

--- a/frontend/app/src/modules/calendar/types.ts
+++ b/frontend/app/src/modules/calendar/types.ts
@@ -1,5 +1,5 @@
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 
 export const CalendarEventPayload = z.object({

--- a/frontend/app/src/modules/core/api/types/accounts.ts
+++ b/frontend/app/src/modules/core/api/types/accounts.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const EvmAccountsResult = z.object({
   added: z.record(z.string(), z.array(z.string())).optional(),

--- a/frontend/app/src/modules/core/api/types/chains.ts
+++ b/frontend/app/src/modules/core/api/types/chains.ts
@@ -1,5 +1,5 @@
 import { toCapitalCase } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const ChainType = {
   BITCOIN: 'bitcoin',

--- a/frontend/app/src/modules/core/common/action.ts
+++ b/frontend/app/src/modules/core/common/action.ts
@@ -1,6 +1,6 @@
 import type { ContextColorsType, RuiIcons } from '@rotki/ui-library';
 import type { Section, Status } from '@/modules/core/common/status';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 interface ActionFailure<T = string> {
   readonly message: T;

--- a/frontend/app/src/modules/core/common/collection.ts
+++ b/frontend/app/src/modules/core/common/collection.ts
@@ -1,5 +1,5 @@
 import { type BigNumber, NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const CollectionCommonFields = z.object({
   entriesFound: z.number(),

--- a/frontend/app/src/modules/core/common/date-format.ts
+++ b/frontend/app/src/modules/core/common/date-format.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export enum DateFormat {
   DateMonthYearHourMinuteSecondTimezone = '%d/%m/%Y %H:%M:%S %Z',

--- a/frontend/app/src/modules/core/common/location.ts
+++ b/frontend/app/src/modules/core/common/location.ts
@@ -1,6 +1,6 @@
 import type { RuiIcons } from '@rotki/ui-library';
 import type { ActionDataEntry } from '@/modules/core/common/action';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export interface TradeLocationData {
   readonly identifier: string;

--- a/frontend/app/src/modules/core/common/modules.ts
+++ b/frontend/app/src/modules/core/common/modules.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { getPublicProtocolImagePath } from '@/modules/core/common/file/file';
 
 export enum Module {

--- a/frontend/app/src/modules/core/common/notes.ts
+++ b/frontend/app/src/modules/core/common/notes.ts
@@ -1,5 +1,5 @@
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 
 export const UserNote = z.object({

--- a/frontend/app/src/modules/core/messaging/dynamic-messages.ts
+++ b/frontend/app/src/modules/core/messaging/dynamic-messages.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const Action = z.object({
   text: z.string(),

--- a/frontend/app/src/modules/core/messaging/messages.ts
+++ b/frontend/app/src/modules/core/messaging/messages.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { NewDetectedToken } from '@/modules/assets/detection';
 import { CalendarEventWithReminder } from '@/modules/calendar/types';
 import { LegacyMessageData, SocketMessageType } from './types/base';

--- a/frontend/app/src/modules/core/messaging/types/base.ts
+++ b/frontend/app/src/modules/core/messaging/types/base.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const MESSAGE_WARNING = 'warning';
 const MESSAGE_ERROR = 'error';

--- a/frontend/app/src/modules/core/messaging/types/business-types.ts
+++ b/frontend/app/src/modules/core/messaging/types/business-types.ts
@@ -1,5 +1,5 @@
 import { Blockchain } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const AccountingRuleConflictData = z.object({
   numOfConflicts: z.number(),

--- a/frontend/app/src/modules/core/messaging/types/notification-types.ts
+++ b/frontend/app/src/modules/core/messaging/types/notification-types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const BalanceSnapshotError = z.object({
   error: z.string(),

--- a/frontend/app/src/modules/core/messaging/types/shared-types.ts
+++ b/frontend/app/src/modules/core/messaging/types/shared-types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const PremiumStatusUpdateData = z.object({
   expired: z.boolean(),

--- a/frontend/app/src/modules/core/messaging/types/status-types.ts
+++ b/frontend/app/src/modules/core/messaging/types/status-types.ts
@@ -1,5 +1,5 @@
 import { CommonQueryStatusData, NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { EvmChainLikeAddress } from '@/modules/history/events/event-payloads';
 import { SocketMessageProgressUpdateSubType } from './base';
 

--- a/frontend/app/src/modules/core/table/filtering.ts
+++ b/frontend/app/src/modules/core/table/filtering.ts
@@ -1,6 +1,6 @@
 import type { AssetsWithId } from '@/modules/assets/types';
 import { AssetInfoWithId } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export enum FilterBehaviour {
   INCLUDE = 'include',

--- a/frontend/app/src/modules/core/table/filters/use-accounting-rule-filter.ts
+++ b/frontend/app/src/modules/core/table/filters/use-accounting-rule-filter.ts
@@ -1,6 +1,6 @@
 import type { MatchedKeywordWithBehaviour, SearchMatcher } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { arrayify } from '@/modules/core/common/data/array';
 import { useHistoryEventCounterpartyMappings } from '@/modules/history/events/mapping/use-history-event-counterparty-mappings';
 import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';

--- a/frontend/app/src/modules/core/table/filters/use-address-book-filter.ts
+++ b/frontend/app/src/modules/core/table/filters/use-address-book-filter.ts
@@ -1,6 +1,6 @@
 import type { MatchedKeyword, SearchMatcher } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { arrayify } from '@/modules/core/common/data/array';
 
 enum AddressBookFilterKeys {

--- a/frontend/app/src/modules/core/table/filters/use-assets-filter.ts
+++ b/frontend/app/src/modules/core/table/filters/use-assets-filter.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue';
 import type { MatchedKeyword, SearchMatcher } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { SOLANA_CHAIN } from '@/modules/assets/types';
 import { arrayify } from '@/modules/core/common/data/array';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';

--- a/frontend/app/src/modules/core/table/filters/use-blockchain-account-filter.ts
+++ b/frontend/app/src/modules/core/table/filters/use-blockchain-account-filter.ts
@@ -1,7 +1,7 @@
 import type { MaybeRefOrGetter } from 'vue';
 import type { MatchedKeywordWithBehaviour, SearchMatcher } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { getAccountAddress, getAccountLabel, getChain, isXpubAccount } from '@/modules/accounts/account-utils';
 import { useAddressNameResolution } from '@/modules/accounts/address-book/use-address-name-resolution';
 import { useAccountCategoryHelper } from '@/modules/accounts/use-account-category-helper';

--- a/frontend/app/src/modules/core/table/filters/use-custom-assets-filter.ts
+++ b/frontend/app/src/modules/core/table/filters/use-custom-assets-filter.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef } from 'vue';
 import type { MatchedKeyword, SearchMatcher } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 enum CustomAssetFilterKeys {
   NAME = 'name',

--- a/frontend/app/src/modules/core/table/filters/use-eth-validator-filter.ts
+++ b/frontend/app/src/modules/core/table/filters/use-eth-validator-filter.ts
@@ -1,6 +1,6 @@
 import type { MatchedKeywordWithBehaviour, SearchMatcher } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { arrayify } from '@/modules/core/common/data/array';
 
 enum EthValidatorAccountFilterKeys {

--- a/frontend/app/src/modules/core/table/filters/use-events-filter.ts
+++ b/frontend/app/src/modules/core/table/filters/use-events-filter.ts
@@ -10,7 +10,7 @@ import {
   isValidTxHashOrSignature,
 } from '@rotki/common';
 import { isEqual } from 'es-toolkit';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { arrayify } from '@/modules/core/common/data/array';
 import { uniqueStrings } from '@/modules/core/common/data/data';

--- a/frontend/app/src/modules/core/table/filters/use-manual-balances-filter.ts
+++ b/frontend/app/src/modules/core/table/filters/use-manual-balances-filter.ts
@@ -1,7 +1,7 @@
 import type { MaybeRef } from 'vue';
 import type { MatchedKeyword, SearchMatcher } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import z from 'zod/v4';
+import z from 'zod';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { assetSuggestions } from '@/modules/core/common/display/assets';
 import { CommaSeparatedStringSchema } from '@/modules/core/table/route';

--- a/frontend/app/src/modules/core/table/pagination-filter-types.ts
+++ b/frontend/app/src/modules/core/table/pagination-filter-types.ts
@@ -1,6 +1,6 @@
 import type { DataTableSortColumn } from '@rotki/ui-library';
 import type { ComputedRef, Ref } from 'vue';
-import type { Schema } from 'zod/v4';
+import type { Schema } from 'zod';
 
 export type TableRowKey<T> = keyof T extends string ? keyof T : never;
 

--- a/frontend/app/src/modules/core/table/route.ts
+++ b/frontend/app/src/modules/core/table/route.ts
@@ -1,6 +1,6 @@
 import type { LocationQueryValue, LocationQueryValueRaw } from 'vue-router';
 import { type Account, Blockchain } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { arrayify } from '@/modules/core/common/data/array';
 
 export type LocationQuery = Record<string, LocationQueryValue | LocationQueryValue[]>;

--- a/frontend/app/src/modules/core/table/table-column.ts
+++ b/frontend/app/src/modules/core/table/table-column.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export enum TableColumn {
   PERCENTAGE_OF_TOTAL_NET_VALUE = 'percentage_of_total_net_value',

--- a/frontend/app/src/modules/core/table/use-pagination-filter.spec.ts
+++ b/frontend/app/src/modules/core/table/use-pagination-filter.spec.ts
@@ -5,7 +5,7 @@ import type { MatchedKeywordWithBehaviour, SearchMatcher } from '@/modules/core/
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
 import flushPromises from 'flush-promises';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { arrayify } from '@/modules/core/common/data/array';
 import { usePaginationFilters } from '@/modules/core/table/use-pagination-filter';
 import { TableId } from '@/modules/core/table/use-remember-table-sorting';

--- a/frontend/app/src/modules/core/tasks/types.ts
+++ b/frontend/app/src/modules/core/tasks/types.ts
@@ -1,5 +1,5 @@
 import type { TaskType } from '@/modules/core/tasks/task-type';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export interface Task<T extends TaskMeta> {
   readonly id: number;

--- a/frontend/app/src/modules/dashboard/liquidity-pools/types.ts
+++ b/frontend/app/src/modules/dashboard/liquidity-pools/types.ts
@@ -1,5 +1,5 @@
 import { Balance, type BigNumber, NumericString } from '@rotki/common';
-import z from 'zod/v4';
+import z from 'zod';
 
 const PoolAsset = z.object({
   asset: z.string(),

--- a/frontend/app/src/modules/dashboard/snapshots.ts
+++ b/frontend/app/src/modules/dashboard/snapshots.ts
@@ -1,5 +1,5 @@
 import { NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { BalanceType } from '@/modules/balances/types/balances';
 
 export const BalanceSnapshotSchema = z.object({

--- a/frontend/app/src/modules/history/api/events/use-history-events-api.ts
+++ b/frontend/app/src/modules/history/api/events/use-history-events-api.ts
@@ -2,7 +2,7 @@ import type { QueryExchangeEventsPayload } from '@/modules/balances/types/exchan
 import type { CollectionResponse } from '@/modules/core/common/collection';
 import type { HistoryEventExportPayload, HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import { omit } from 'es-toolkit';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { api } from '@/modules/core/api/rotki-api';
 import {
   VALID_TASK_STATUS,

--- a/frontend/app/src/modules/history/balances/types.ts
+++ b/frontend/app/src/modules/history/balances/types.ts
@@ -1,5 +1,5 @@
 import { NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const HistoricalBalanceSeriesEntry = z.object({
   location: z.string(),

--- a/frontend/app/src/modules/history/data-issues/schemas.ts
+++ b/frontend/app/src/modules/history/data-issues/schemas.ts
@@ -1,6 +1,6 @@
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
 import { NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
 
 /**

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-filter.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-filter.ts
@@ -1,6 +1,6 @@
 import type { MatchedKeyword, SearchMatcher } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { arrayify } from '@/modules/core/common/data/array';
 import { dateDeserializer, dateRangeValidator, dateSerializer, getDateInputISOFormat } from '@/modules/core/common/data/date';

--- a/frontend/app/src/modules/history/events/event-payloads.ts
+++ b/frontend/app/src/modules/history/events/event-payloads.ts
@@ -1,5 +1,5 @@
 import { type HistoryEventEntryType, NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const LiquityStakingEventExtraData = z.object({
   asset: z.string(),

--- a/frontend/app/src/modules/history/events/event-type.ts
+++ b/frontend/app/src/modules/history/events/event-type.ts
@@ -1,6 +1,6 @@
 import { HistoryEventEntryType } from '@rotki/common';
 import { contextColors, RuiIcons } from '@rotki/ui-library';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const HistoryEventTypeMapping = z.record(z.string(), z.record(z.string(), z.string()));
 

--- a/frontend/app/src/modules/history/events/schemas.ts
+++ b/frontend/app/src/modules/history/events/schemas.ts
@@ -1,5 +1,5 @@
 import { type BigNumber, HistoryEventEntryType, NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 import { EntryMeta } from '@/modules/history/meta';
 

--- a/frontend/app/src/modules/history/meta.ts
+++ b/frontend/app/src/modules/history/meta.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const EntryMeta = z.object({
   ignoredInAccounting: z.boolean().optional(),

--- a/frontend/app/src/modules/integrations/gnosis-pay/types.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export enum GnosisPayError {
   NO_REGISTERED_ACCOUNTS = 'NO_REGISTERED_ACCOUNTS',

--- a/frontend/app/src/modules/integrations/monerium/types.ts
+++ b/frontend/app/src/modules/integrations/monerium/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const MoneriumProfileSchema = z.object({
   id: z.string(),

--- a/frontend/app/src/modules/integrations/types.ts
+++ b/frontend/app/src/modules/integrations/types.ts
@@ -1,5 +1,5 @@
 import type { ToSnakeCase } from '@/modules/core/common/common-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const ApiKey = z.object({
   apiKey: z.string(),

--- a/frontend/app/src/modules/premium/devices/premium.ts
+++ b/frontend/app/src/modules/premium/devices/premium.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const PremiumDevice = z.object({
   deviceIdentifier: z.string(),

--- a/frontend/app/src/modules/premium/setup-premium.ts
+++ b/frontend/app/src/modules/premium/setup-premium.ts
@@ -15,7 +15,7 @@ import { CanvasRenderer } from 'echarts/renderers';
 import * as Vue from 'vue';
 import VChart from 'vue-echarts';
 import * as VueRouter from 'vue-router';
-import * as zod from 'zod/v4';
+import * as zod from 'zod';
 import { app } from '@/main';
 
 // Register only the needed echarts components for premium

--- a/frontend/app/src/modules/reports/report-types.ts
+++ b/frontend/app/src/modules/reports/report-types.ts
@@ -1,7 +1,7 @@
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
 import type { Quarter } from '@/modules/settings/types/frontend-settings';
 import { NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 import { BaseAccountingSettings } from '@/modules/settings/types/user-settings';
 

--- a/frontend/app/src/modules/session/backup.ts
+++ b/frontend/app/src/modules/session/backup.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const GlobalDbVersion = z.object({
   globaldbAssetsVersion: z.number(),

--- a/frontend/app/src/modules/session/types.ts
+++ b/frontend/app/src/modules/session/types.ts
@@ -1,6 +1,6 @@
 import type { TimeFramePeriod } from '@rotki/common';
 import type { Module } from '@/modules/core/common/modules';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const PeriodicClientQueryResultSchema = z.object({
   connectedNodes: z.record(z.string(), z.array(z.string())),

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleSetting.vue
@@ -4,7 +4,7 @@ import type {
   AccountingRuleEntry,
   AccountingRuleRequestPayload,
 } from '@/modules/settings/types/accounting';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
 import { type Filters, type Matcher, useAccountingRuleFilter } from '@/modules/core/table/filters/use-accounting-rule-filter';

--- a/frontend/app/src/modules/settings/types/accounting.ts
+++ b/frontend/app/src/modules/settings/types/accounting.ts
@@ -1,5 +1,5 @@
 import type { ConflictResolutionStrategy, PaginationRequestPayload } from '@/modules/core/common/common-types';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 
 export enum AccountingTreatment {

--- a/frontend/app/src/modules/settings/types/evm-indexer.ts
+++ b/frontend/app/src/modules/settings/types/evm-indexer.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export enum EvmIndexer {
   ETHERSCAN = 'etherscan',

--- a/frontend/app/src/modules/settings/types/frontend-settings.ts
+++ b/frontend/app/src/modules/settings/types/frontend-settings.ts
@@ -9,7 +9,7 @@ import {
   TimeFrameSetting,
 } from '@rotki/common';
 import { isEmpty } from 'es-toolkit/compat';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { CurrencyLocationEnum } from '@/modules/assets/amount-display/currency-location';
 import { camelCaseTransformer } from '@/modules/core/api/transformers';
 import { Constraints, MINIMUM_DIGIT_TO_BE_ABBREVIATED } from '@/modules/core/common/constraints';

--- a/frontend/app/src/modules/settings/types/google-calendar.ts
+++ b/frontend/app/src/modules/settings/types/google-calendar.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const GoogleCalendarStatusSchema = z.object({
   authenticated: z.boolean(),

--- a/frontend/app/src/modules/settings/types/price-oracle.ts
+++ b/frontend/app/src/modules/settings/types/price-oracle.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const PriceOracle = {
   ALCHEMY: 'alchemy',

--- a/frontend/app/src/modules/settings/types/rpc.ts
+++ b/frontend/app/src/modules/settings/types/rpc.ts
@@ -1,5 +1,5 @@
 import type { Blockchain } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const BlockchainRpcNode = z.object({
   active: z.boolean(),

--- a/frontend/app/src/modules/settings/types/user-settings.ts
+++ b/frontend/app/src/modules/settings/types/user-settings.ts
@@ -1,5 +1,5 @@
 import { NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { AddressNamePriorityEnum } from '@/modules/accounts/address-book/types/address-name-priorities';
 import { useCurrencies } from '@/modules/assets/amount-display/currencies';
 import { Exchange, KrakenAccountType } from '@/modules/balances/types/exchanges';

--- a/frontend/app/src/modules/shell/app/backend.ts
+++ b/frontend/app/src/modules/shell/app/backend.ts
@@ -1,5 +1,5 @@
 import { ActiveLogLevel } from '@shared/ipc';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 const BackendVersion = z.object({
   downloadUrl: z.string().nullish(),

--- a/frontend/app/src/modules/staking/staking-types.ts
+++ b/frontend/app/src/modules/staking/staking-types.ts
@@ -1,5 +1,5 @@
 import { AssetBalance, NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 enum KrakenStakingEventType {
   REWARD = 'reward',

--- a/frontend/app/src/modules/statistics/api/use-wrap-statistics-api.ts
+++ b/frontend/app/src/modules/statistics/api/use-wrap-statistics-api.ts
@@ -1,5 +1,5 @@
 import { NumericString } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { api } from '@/modules/core/api/rotki-api';
 
 const WrapStatisticsSchema = z.object({

--- a/frontend/app/src/modules/tags/tags.ts
+++ b/frontend/app/src/modules/tags/tags.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const Tag = z.object({
   backgroundColor: z.string(),

--- a/frontend/app/src/modules/wallet/types.ts
+++ b/frontend/app/src/modules/wallet/types.ts
@@ -1,5 +1,5 @@
 import type { BigNumber } from '@rotki/common';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export interface TradableAssetWithoutValue {
   asset: string;

--- a/frontend/common/package.json
+++ b/frontend/common/package.json
@@ -27,7 +27,7 @@
     "@vueuse/core": ">=12.0.0",
     "bignumber.js": "9.3.1",
     "vue": ">=3.5.0",
-    "zod": "3.23.8"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@vueuse/core": "catalog:",

--- a/frontend/common/src/balances/index.ts
+++ b/frontend/common/src/balances/index.ts
@@ -1,4 +1,4 @@
-import z from 'zod/v4';
+import z from 'zod';
 import { bigNumberify, NumericString } from '../numbers';
 
 export const Balance = z.object({

--- a/frontend/common/src/data/index.ts
+++ b/frontend/common/src/data/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export interface ActionResult<T> {
   readonly result: T;

--- a/frontend/common/src/liquity/index.ts
+++ b/frontend/common/src/liquity/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { AssetBalance } from '../balances';
 import { NumericString } from '../numbers';
 

--- a/frontend/common/src/numbers/index.ts
+++ b/frontend/common/src/numbers/index.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'bignumber.js';
 import { markRaw } from 'vue';
-import z from 'zod/v4';
+import z from 'zod';
 
 markRaw(BigNumber.prototype);
 

--- a/frontend/common/src/settings/graphs.ts
+++ b/frontend/common/src/settings/graphs.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { assert } from '../assertions';
 import { TimeUnit } from './frontend';
 

--- a/frontend/common/src/settings/themes.ts
+++ b/frontend/common/src/settings/themes.ts
@@ -1,4 +1,4 @@
-import z from 'zod/v4';
+import z from 'zod';
 
 export interface Themes {
   readonly light: ThemeColors;

--- a/frontend/common/src/staking/eth2/index.ts
+++ b/frontend/common/src/staking/eth2/index.ts
@@ -1,5 +1,5 @@
 import type { Account } from '../../account';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { Percentage } from '../../balances';
 import { type BigNumber, NumericString } from '../../numbers';
 

--- a/frontend/common/src/statistics/index.ts
+++ b/frontend/common/src/statistics/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { AssetBalance, AssetEntry, Balance } from '../balances';
 import { NumericString } from '../numbers';
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -295,8 +295,8 @@ catalogs:
       specifier: 3.3.5
       version: 3.3.5
     zod:
-      specifier: 3.25.76
-      version: 3.25.76
+      specifier: 4.4.3
+      version: 4.4.3
 
 overrides:
   chokidar: 5.0.0
@@ -357,7 +357,7 @@ importers:
         version: 6.0.3
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
   app:
     dependencies:
@@ -393,10 +393,10 @@ importers:
         version: 14.3.0(vue@3.5.38(typescript@6.0.3))
       '@walletconnect/core':
         specifier: 'catalog:'
-        version: 2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+        version: 2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3)
       '@walletconnect/universal-provider':
         specifier: 'catalog:'
-        version: 2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+        version: 2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3)
       bignumber.js:
         specifier: 'catalog:'
         version: 9.3.1(patch_hash=61396dd0164598dffc80190e90a8d2bd4ec88d03f7ec9956ab22182f63c0cb1d)
@@ -438,7 +438,7 @@ importers:
         version: 3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       plainfp:
         specifier: 'catalog:'
-        version: 0.1.1(zod@3.25.76)
+        version: 0.1.1(zod@4.4.3)
       ps-list:
         specifier: 'catalog:'
         version: 9.0.0
@@ -456,7 +456,7 @@ importers:
         version: 3.12.0(@typescript-eslint/types@8.61.0)
       viem:
         specifier: 'catalog:'
-        version: 2.53.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+        version: 2.53.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3)
       vue:
         specifier: 'catalog:'
         version: 3.5.38(typescript@6.0.3)
@@ -474,7 +474,7 @@ importers:
         version: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@electron/notarize':
         specifier: 'catalog:'
@@ -631,7 +631,7 @@ importers:
         version: 3.5.38(typescript@6.0.3)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
 
   dev-proxy:
     dependencies:
@@ -6544,8 +6544,8 @@ packages:
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zrender@6.1.0:
     resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
@@ -8451,7 +8451,7 @@ snapshots:
     dependencies:
       vue: 3.5.38(typescript@6.0.3)
 
-  '@walletconnect/core@2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
+  '@walletconnect/core@2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -8465,7 +8465,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.9
-      '@walletconnect/utils': 2.23.9(typescript@6.0.3)(zod@3.25.76)
+      '@walletconnect/utils': 2.23.9(typescript@6.0.3)(zod@4.4.3)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.44.0
       events: 3.3.0
@@ -8592,16 +8592,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
     dependencies:
-      '@walletconnect/core': 2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@walletconnect/core': 2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 3.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.9
-      '@walletconnect/utils': 2.23.9(typescript@6.0.3)(zod@3.25.76)
+      '@walletconnect/utils': 2.23.9(typescript@6.0.3)(zod@4.4.3)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -8661,7 +8661,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/universal-provider@2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
+  '@walletconnect/universal-provider@2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -8670,9 +8670,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 3.0.2
-      '@walletconnect/sign-client': 2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.23.9(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3)
       '@walletconnect/types': 2.23.9
-      '@walletconnect/utils': 2.23.9(typescript@6.0.3)(zod@3.25.76)
+      '@walletconnect/utils': 2.23.9(typescript@6.0.3)(zod@4.4.3)
       es-toolkit: 1.44.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -8701,7 +8701,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.23.9(typescript@6.0.3)(zod@3.25.76)':
+  '@walletconnect/utils@2.23.9(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@msgpack/msgpack': 3.1.3
       '@noble/ciphers': 1.3.0
@@ -8720,7 +8720,7 @@ snapshots:
       '@walletconnect/window-metadata': 1.0.1
       blakejs: 1.2.1
       detect-browser: 5.3.0
-      ox: 0.9.3(typescript@6.0.3)(zod@3.25.76)
+      ox: 0.9.3(typescript@6.0.3)(zod@4.4.3)
       uint8arrays: 3.1.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -8762,15 +8762,15 @@ snapshots:
 
   abbrev@4.0.0: {}
 
-  abitype@1.2.3(typescript@6.0.3)(zod@3.25.76):
+  abitype@1.2.3(typescript@6.0.3)(zod@4.4.3):
     optionalDependencies:
       typescript: 6.0.3
-      zod: 3.25.76
+      zod: 4.4.3
 
-  abitype@1.2.4(typescript@6.0.3)(zod@3.25.76):
+  abitype@1.2.4(typescript@6.0.3)(zod@4.4.3):
     optionalDependencies:
       typescript: 6.0.3
-      zod: 3.25.76
+      zod: 4.4.3
 
   accepts@2.0.0:
     dependencies:
@@ -11489,7 +11489,7 @@ snapshots:
 
   outvariant@1.4.3: {}
 
-  ox@0.14.29(typescript@6.0.3)(zod@3.25.76):
+  ox@0.14.29(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -11497,14 +11497,14 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.4(typescript@6.0.3)(zod@3.25.76)
+      abitype: 1.2.4(typescript@6.0.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.3(typescript@6.0.3)(zod@3.25.76):
+  ox@0.9.3(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -11512,7 +11512,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.4(typescript@6.0.3)(zod@3.25.76)
+      abitype: 1.2.4(typescript@6.0.3)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 6.0.3
@@ -11678,9 +11678,9 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  plainfp@0.1.1(zod@3.25.76):
+  plainfp@0.1.1(zod@4.4.3):
     optionalDependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
   playwright-core@1.61.0: {}
 
@@ -12734,15 +12734,15 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
 
-  viem@2.53.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76):
+  viem@2.53.1(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@4.4.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@6.0.3)(zod@4.4.3)
       isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
-      ox: 0.14.29(typescript@6.0.3)(zod@3.25.76)
+      ox: 0.14.29(typescript@6.0.3)(zod@4.4.3)
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 6.0.3
@@ -13146,7 +13146,7 @@ snapshots:
 
   zimmerframe@1.1.4: {}
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}
 
   zrender@6.1.0:
     dependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -132,7 +132,7 @@ catalog:
   vue-router: 5.1.0
   vue-tsc: 3.3.5
   ws: 8.21.0
-  zod: 3.25.76
+  zod: 4.4.3
 peerDependencyRules:
   allowedVersions:
     tailwind-variants>tailwind-merge: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
## Summary

Upgrades zod from the transitional `zod@3.25.76` to standalone **zod v4.4.3**.

The codebase already consumed the zod v4 API through the `zod/v4` compat subpath, so this is a package bump plus an import-path swap. No schema/validation semantics changed.

## Changes

- Bump catalog `zod` `3.25.76` -> `4.4.3` (`frontend/pnpm-workspace.yaml`)
- Fix stray peer pin `3.23.8` -> `^4.0.0` in `frontend/common/package.json`
- Swap all imports `from 'zod/v4'` -> `from 'zod'` (95 files)
- Lockfile now resolves a single `zod@4.4.3` (no dual install)

## Compatibility

- `abitype` and `plainfp` are the only libraries that peer-depend on zod; both accept `^3.22.0 || ^4.0.0` (peer marked optional). Nothing requires zod 3.
- TypeScript `6.0.3`, well above zod 4's minimum.

## Verification

- `typecheck` (vue-tsc): clean
- `test:unit`: 490 files / 4673 tests pass
- `lint`: 0 errors
- production web build (`build:app`): succeeds