### PR TITLE
test: expand frontend unit coverage

### DIFF
--- a/frontend/app/src/modules/core/common/display/assets.spec.ts
+++ b/frontend/app/src/modules/core/common/display/assets.spec.ts
@@ -1,0 +1,162 @@
+import { type AssetInfoWithId, bigNumberify } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EVM_TOKEN, SOLANA_CHAIN, SOLANA_TOKEN } from '@/modules/assets/types';
+import {
+  assetFilterByKeyword,
+  assetSuggestions,
+  compareTextByKeyword,
+  getAssetSearchTypeParams,
+  getSanitizedChain,
+  getSortItems,
+  parseAssetSearchKeyword,
+} from './assets';
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): { getEvmChainName: (chain: string) => string | undefined; matchChain: (chain: string) => string | undefined } => ({
+    getEvmChainName: (chain: string): string | undefined => (chain === 'eth' ? 'ethereum' : undefined),
+    matchChain: (chain: string): string | undefined => (chain === 'ethereum' ? 'eth' : undefined),
+  }),
+}));
+
+const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+
+function info(symbol: string): AssetInfoWithId {
+  return createMock<AssetInfoWithId>({ identifier: symbol, symbol });
+}
+
+describe('parseAssetSearchKeyword', () => {
+  it('should treat a plain keyword as a value', () => {
+    expect(parseAssetSearchKeyword('bitcoin')).toEqual({ value: 'bitcoin' });
+  });
+
+  it('should extract the address from an evm identifier', () => {
+    expect(parseAssetSearchKeyword(`eip155:1/erc20:${DAI}`)).toEqual({ address: DAI, value: '' });
+  });
+
+  it('should treat a raw eth address as an address', () => {
+    expect(parseAssetSearchKeyword(DAI)).toEqual({ address: DAI, value: '' });
+  });
+});
+
+describe('getSanitizedChain', () => {
+  const matchChain = (chain: string): string | undefined => (chain === 'ethereum' ? 'eth' : undefined);
+  const getEvmChainName = (chain: string): string | undefined => (chain === 'eth' ? 'ethereum' : undefined);
+
+  it('should return undefined without a chain', () => {
+    expect(getSanitizedChain(undefined, matchChain, getEvmChainName)).toBeUndefined();
+  });
+
+  it('should return undefined when the chain does not match', () => {
+    expect(getSanitizedChain('unknown', matchChain, getEvmChainName)).toBeUndefined();
+  });
+
+  it('should return the evm chain name when resolvable', () => {
+    expect(getSanitizedChain('ethereum', matchChain, getEvmChainName)).toBe('ethereum');
+  });
+
+  it('should fall back to the matched chain when no evm name exists', () => {
+    const noEvmName = (): string | undefined => undefined;
+    expect(getSanitizedChain('ethereum', matchChain, noEvmName)).toBe('eth');
+  });
+});
+
+describe('getAssetSearchTypeParams', () => {
+  it('should map the solana chain to the solana token type', () => {
+    expect(getAssetSearchTypeParams(SOLANA_CHAIN)).toEqual({ assetType: SOLANA_TOKEN, evmChain: undefined });
+  });
+
+  it('should map any other chain to the evm token type', () => {
+    expect(getAssetSearchTypeParams('eth')).toEqual({ assetType: EVM_TOKEN, evmChain: 'eth' });
+  });
+
+  it('should leave both undefined without a chain', () => {
+    expect(getAssetSearchTypeParams(undefined)).toEqual({ assetType: undefined, evmChain: undefined });
+  });
+});
+
+describe('compareTextByKeyword', () => {
+  it('should rank an exact match on the first string highest', () => {
+    expect(compareTextByKeyword('hop', 'other', 'hop')).toBe(-1);
+  });
+
+  it('should rank an exact match on the second string highest', () => {
+    expect(compareTextByKeyword('other', 'hop', 'hop')).toBe(1);
+  });
+
+  it('should prefer the string that starts with the keyword', () => {
+    expect(compareTextByKeyword('hop-protocol', 'hoo', 'hop')).toBeLessThan(0);
+  });
+});
+
+describe('getSortItems', () => {
+  const sort = getSortItems<{ asset: string; amount: ReturnType<typeof bigNumberify>; value: ReturnType<typeof bigNumberify> }>(
+    id => (id === 'a' ? info('AAA') : info('ZZZ')),
+  );
+
+  function item(asset: string, value: number): { asset: string; amount: ReturnType<typeof bigNumberify>; value: ReturnType<typeof bigNumberify> } {
+    return { amount: bigNumberify(value), asset, value: bigNumberify(value) };
+  }
+
+  it('should sort by asset symbol ascending', () => {
+    const result = sort([item('b', 1), item('a', 2)], ['asset'], [false]);
+    expect(result.map(r => r.asset)).toEqual(['a', 'b']);
+  });
+
+  it('should sort by asset symbol descending', () => {
+    const result = sort([item('a', 1), item('b', 2)], ['asset'], [true]);
+    expect(result.map(r => r.asset)).toEqual(['b', 'a']);
+  });
+
+  it('should sort numeric columns ascending and descending', () => {
+    const asc = sort([item('a', 5), item('b', 1)], ['value'], [false]);
+    expect(asc.map(r => r.value.toNumber())).toEqual([1, 5]);
+    const desc = sort([item('a', 1), item('b', 5)], ['value'], [true]);
+    expect(desc.map(r => r.value.toNumber())).toEqual([5, 1]);
+  });
+});
+
+describe('assetFilterByKeyword', () => {
+  const getInfo = (id: string | undefined): { name?: string | null; symbol?: string | null } | null =>
+    (id === 'dai' ? { name: 'Dai Stablecoin', symbol: 'DAI' } : null);
+
+  it('should keep everything when the search is empty', () => {
+    expect(assetFilterByKeyword({ amount: bigNumberify(1), asset: 'dai', value: bigNumberify(1) }, '', getInfo)).toBe(true);
+  });
+
+  it('should keep everything when the item is null', () => {
+    expect(assetFilterByKeyword(null, 'dai', getInfo)).toBe(true);
+  });
+
+  it('should match on symbol or name', () => {
+    expect(assetFilterByKeyword({ amount: bigNumberify(1), asset: 'dai', value: bigNumberify(1) }, 'dai', getInfo)).toBe(true);
+    expect(assetFilterByKeyword({ amount: bigNumberify(1), asset: 'dai', value: bigNumberify(1) }, 'stablecoin', getInfo)).toBe(true);
+  });
+
+  it('should reject a non-matching keyword', () => {
+    expect(assetFilterByKeyword({ amount: bigNumberify(1), asset: 'dai', value: bigNumberify(1) }, 'bitcoin', getInfo)).toBe(false);
+  });
+});
+
+describe('assetSuggestions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('should search with the parsed keyword and chain params', async () => {
+    const assetSearch = vi.fn().mockResolvedValue([{ identifier: 'DAI', symbol: 'DAI' }]);
+    const suggest = assetSuggestions(assetSearch, 'ethereum');
+
+    const promise = suggest(DAI);
+    await vi.advanceTimersByTimeAsync(200);
+    const result = await promise;
+
+    expect(result).toEqual([{ identifier: 'DAI', symbol: 'DAI' }]);
+    expect(assetSearch).toHaveBeenCalledTimes(1);
+    const params = assetSearch.mock.calls[0][0];
+    expect(params.address).toBe(DAI);
+    expect(params.assetType).toBe(EVM_TOKEN);
+    expect(params.evmChain).toBe('ethereum');
+    expect(params.limit).toBe(10);
+  });
+});

--- a/frontend/app/src/modules/core/messaging/handlers/calendar-reminder.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/calendar-reminder.spec.ts
@@ -1,0 +1,134 @@
+import type { Router } from 'vue-router';
+import type { CalendarEventWithReminder } from '@/modules/calendar/types';
+import { NotificationCategory, Severity } from '@rotki/common';
+import { mockT } from '@test/i18n';
+import { createMock } from '@test/utils/create-mock';
+import dayjs from 'dayjs';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCalendarReminderHandler } from '@/modules/core/messaging/handlers/calendar-reminder';
+
+dayjs.extend(isSameOrAfter);
+dayjs.extend(relativeTime);
+
+const mockGetChainName = vi.fn((chain: string): string => chain.toUpperCase());
+const mockGetAddressName = vi.fn();
+const mockRemoveMatching = vi.fn();
+const mockEditCalendarReminder = vi.fn();
+const mockPush = vi.fn();
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({
+    getChainName: mockGetChainName,
+  })),
+}));
+
+vi.mock('@/modules/accounts/address-book/use-address-name-resolution', () => ({
+  useAddressNameResolution: vi.fn(() => ({
+    getAddressName: mockGetAddressName,
+  })),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications-store', () => ({
+  useNotificationsStore: vi.fn(() => ({
+    removeMatching: mockRemoveMatching,
+  })),
+}));
+
+vi.mock('@/modules/calendar/use-calendar-reminder-api', () => ({
+  useCalendarReminderApi: vi.fn(() => ({
+    editCalendarReminder: mockEditCalendarReminder,
+  })),
+}));
+
+const PAST = 1_000_000; // seconds — far in the past
+const FUTURE = 9_999_999_999; // seconds — year 2286
+
+function event(overrides: Partial<CalendarEventWithReminder> = {}): CalendarEventWithReminder {
+  return createMock<CalendarEventWithReminder>({
+    address: '',
+    blockchain: '',
+    counterparty: '',
+    description: '',
+    identifier: 7,
+    name: 'Vesting unlock',
+    reminder: { identifier: 3, secsBefore: 3600 },
+    timestamp: PAST,
+    ...overrides,
+  });
+}
+
+const router = createMock<Router>({ push: mockPush });
+
+describe('createCalendarReminderHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetChainName.mockImplementation((chain: string): string => chain.toUpperCase());
+    mockGetAddressName.mockReturnValue(undefined);
+    mockEditCalendarReminder.mockResolvedValue(undefined);
+  });
+
+  it('should remove any existing reminder for the same event', async () => {
+    const handler = createCalendarReminderHandler(mockT, router);
+    await handler.handle(event());
+
+    expect(mockRemoveMatching).toHaveBeenCalledOnce();
+  });
+
+  it('should use the plain name once the event time has passed', async () => {
+    const handler = createCalendarReminderHandler(mockT, router);
+    const notification = await handler.handle(event({ name: 'Vesting unlock', timestamp: PAST }));
+
+    expect(notification.title).toBe('Vesting unlock');
+    expect(notification.category).toBe(NotificationCategory.CALENDAR_REMINDER);
+    expect(notification.severity).toBe(Severity.REMINDER);
+  });
+
+  it('should prepend a relative time when the event is still upcoming', async () => {
+    const handler = createCalendarReminderHandler(mockT, router);
+    const notification = await handler.handle(event({ name: 'Vesting unlock', timestamp: FUTURE }));
+
+    expect(notification.title).not.toBe('Vesting unlock');
+    expect(notification.title).toContain('Vesting unlock');
+  });
+
+  it('should include the resolved account and chain in the message', async () => {
+    mockGetAddressName.mockReturnValue('alice.eth');
+    const handler = createCalendarReminderHandler(mockT, router);
+    const notification = await handler.handle(event({ address: '0xabc', blockchain: 'eth' }));
+
+    expect(notification.message).toContain('alice.eth');
+    expect(notification.message).toContain('ETH');
+  });
+
+  it('should fall back to the raw address when no name resolves', async () => {
+    mockGetAddressName.mockReturnValue(undefined);
+    const handler = createCalendarReminderHandler(mockT, router);
+    const notification = await handler.handle(event({ address: '0xabc', blockchain: 'eth' }));
+
+    expect(notification.message).toContain('0xabc');
+  });
+
+  it('should include counterparty and description in the message', async () => {
+    const handler = createCalendarReminderHandler(mockT, router);
+    const notification = await handler.handle(event({ counterparty: 'uniswap', description: 'unlock tokens' }));
+
+    expect(notification.message).toContain('uniswap');
+    expect(notification.message).toContain('unlock tokens');
+  });
+
+  it('should acknowledge the reminder and open the calendar from the action', async () => {
+    const handler = createCalendarReminderHandler(mockT, router);
+    const notification = await handler.handle(event({ identifier: 7, timestamp: PAST }));
+
+    assert(!Array.isArray(notification.action) && notification.action);
+    await notification.action.action();
+
+    expect(mockEditCalendarReminder).toHaveBeenCalledWith(expect.objectContaining({
+      acknowledged: true,
+      eventId: 7,
+    }));
+    expect(mockPush).toHaveBeenCalledWith({ path: '/calendar', query: { timestamp: PAST.toString() } });
+  });
+});

--- a/frontend/app/src/modules/core/messaging/handlers/csv-import-result.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/csv-import-result.spec.ts
@@ -1,0 +1,76 @@
+import type { CsvImportResult } from '../types/status-types';
+import { NotificationCategory, Priority, Severity } from '@rotki/common';
+import { mockT } from '@test/i18n';
+import { describe, expect, it } from 'vitest';
+import { createCsvImportResultHandler } from '@/modules/core/messaging/handlers/csv-import-result';
+
+function result(overrides: Partial<CsvImportResult> = {}): CsvImportResult {
+  return {
+    messages: [],
+    processed: 10,
+    sourceName: 'binance',
+    total: 10,
+    ...overrides,
+  };
+}
+
+describe('createCsvImportResultHandler', () => {
+  it('should produce an info notification for a fully processed import', async () => {
+    const handler = createCsvImportResultHandler(mockT);
+    const notification = await handler.handle(result({ processed: 10, total: 10 }));
+
+    expect(notification.severity).toBe(Severity.INFO);
+    expect(notification.category).toBe(NotificationCategory.DEFAULT);
+    expect(notification.priority).toBe(Priority.HIGH);
+    expect(notification.display).toBe(true);
+  });
+
+  it('should warn when only part of the rows were processed', async () => {
+    const handler = createCsvImportResultHandler(mockT);
+    const notification = await handler.handle(result({ processed: 4, total: 10 }));
+
+    expect(notification.severity).toBe(Severity.WARNING);
+  });
+
+  it('should error when nothing was processed', async () => {
+    const handler = createCsvImportResultHandler(mockT);
+    const notification = await handler.handle(result({ processed: 0, total: 10 }));
+
+    expect(notification.severity).toBe(Severity.ERROR);
+  });
+
+  it('should append error messages to the body', async () => {
+    const handler = createCsvImportResultHandler(mockT);
+    const notification = await handler.handle(result({
+      messages: [{ isError: true, msg: 'bad row' }],
+      processed: 9,
+      total: 10,
+    }));
+
+    expect(notification.message).toContain('1. bad row');
+  });
+
+  it('should render the affected rows when present', async () => {
+    const handler = createCsvImportResultHandler(mockT);
+    const notification = await handler.handle(result({
+      messages: [{ isError: true, msg: 'bad row', rows: [1, 2, 3] }],
+      processed: 9,
+      total: 10,
+    }));
+
+    expect(notification.message).toContain('1-3');
+  });
+
+  it('should ignore negative row indices', async () => {
+    const handler = createCsvImportResultHandler(mockT);
+    const notification = await handler.handle(result({
+      messages: [{ isError: true, msg: 'bad row', rows: [-1] }],
+      processed: 9,
+      total: 10,
+    }));
+
+    // Only the "rows:" line is skipped; the message line itself is kept.
+    expect(notification.message).not.toContain('csv_import_result.rows');
+    expect(notification.message).toContain('1. bad row');
+  });
+});

--- a/frontend/app/src/modules/core/messaging/handlers/missing-api-key.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/missing-api-key.spec.ts
@@ -1,0 +1,165 @@
+import type { Router } from 'vue-router';
+import { assert, type Notification, type NotificationAction, NotificationCategory, Severity } from '@rotki/common';
+import { mockT } from '@test/i18n';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { createMissingApiKeyHandler } from '@/modules/core/messaging/handlers/missing-api-key';
+
+const { mockOpenUrl, mockUpdate } = vi.hoisted(() => ({ mockOpenUrl: vi.fn(), mockUpdate: vi.fn() }));
+const mockSuppressList = ref<string[]>([]);
+const mockPush = vi.fn();
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: vi.fn(() => ({
+    openUrl: mockOpenUrl,
+  })),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: vi.fn(() => ({
+    update: mockUpdate,
+  })),
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: vi.fn(() => mockSuppressList),
+}));
+
+const router = createMock<Router>({ push: mockPush });
+
+function actionsOf(notification: Notification | null | void): (NotificationAction | undefined)[] {
+  assert(notification);
+  return Array.isArray(notification.action) ? notification.action : [notification.action];
+}
+
+function findAction(notification: Notification | null | void, labelPart: string): NotificationAction {
+  const action = actionsOf(notification).find(a => a?.label.includes(labelPart));
+  assert(action);
+  return action;
+}
+
+describe('createMissingApiKeyHandler', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    set(mockSuppressList, []);
+    mockUpdate.mockResolvedValue(undefined);
+  });
+
+  it('should build a warning notification for etherscan', async () => {
+    const handler = createMissingApiKeyHandler(mockT, router);
+    const result = await handler.handle({ service: 'etherscan' });
+
+    assert(result);
+    expect(result.category).toBe(NotificationCategory.ETHERSCAN);
+    expect(result.severity).toBe(Severity.WARNING);
+    expect(result.display).toBe(true);
+  });
+
+  it('should route to the external service settings from the primary action', async () => {
+    const handler = createMissingApiKeyHandler(mockT, router);
+    const result = await handler.handle({ service: 'etherscan' });
+
+    const action = findAction(result, 'missing_api_key.action');
+    await action.action();
+
+    expect(mockPush).toHaveBeenCalledWith({
+      path: '/api-keys/external',
+      query: { service: 'etherscan' },
+    });
+  });
+
+  it('should offer to change the indexer order for transaction indexers', async () => {
+    const handler = createMissingApiKeyHandler(mockT, router);
+    const result = await handler.handle({ service: 'etherscan' });
+
+    const action = findAction(result, 'change_indexer_order');
+    await action.action();
+
+    expect(mockPush).toHaveBeenCalledWith({ hash: '#indexer', path: '/settings/evm' });
+  });
+
+  it('should offer to open the registration url for blockscout', async () => {
+    const handler = createMissingApiKeyHandler(mockT, router);
+    const result = await handler.handle({ service: 'blockscout' });
+
+    const action = findAction(result, 'get_key');
+    await action.action();
+
+    expect(mockOpenUrl).toHaveBeenCalledOnce();
+  });
+
+  it('should not offer a get-key action for etherscan', async () => {
+    const handler = createMissingApiKeyHandler(mockT, router);
+    const result = await handler.handle({ service: 'etherscan' });
+
+    expect(actionsOf(result).some(a => a?.label.includes('get_key'))).toBe(false);
+  });
+
+  it('should present beaconchain as a non-displayed info notification', async () => {
+    const handler = createMissingApiKeyHandler(mockT, router);
+    const result = await handler.handle({ service: 'beaconchain' });
+
+    assert(result);
+    expect(result.category).toBe(NotificationCategory.BEACONCHAIN);
+    expect(result.severity).toBe(Severity.INFO);
+    expect(result.display).toBe(false);
+  });
+
+  it('should include the docs url for thegraph', async () => {
+    const handler = createMissingApiKeyHandler(mockT, router);
+    const result = await handler.handle({ service: 'thegraph' });
+
+    assert(result);
+    expect(result.category).toBe(NotificationCategory.THEGRAPH);
+    expect(result.i18nParam?.props?.docsUrl).toBeTruthy();
+  });
+
+  it('should fall back to the etherscan config for an unknown service', async () => {
+    const handler = createMissingApiKeyHandler(mockT, router);
+    const result = await handler.handle({ service: 'unknown-service' });
+
+    assert(result);
+    expect(result.category).toBe(NotificationCategory.ETHERSCAN);
+  });
+
+  describe('suppress action', () => {
+    it('should add the service to the suppress list after confirmation', async () => {
+      const handler = createMissingApiKeyHandler(mockT, router);
+      const confirmStore = useConfirmStore();
+      const result = await handler.handle({ service: 'etherscan' });
+
+      const suppress = findAction(result, 'do_not_show_again');
+      await suppress.action();
+      expect(confirmStore.visible).toBe(true);
+
+      await confirmStore.confirm();
+
+      expect(mockUpdate).toHaveBeenCalledWith({ suppressMissingKeyMsgServices: ['etherscan'] });
+    });
+
+    it('should not update when the service is already suppressed', async () => {
+      set(mockSuppressList, ['etherscan']);
+      const handler = createMissingApiKeyHandler(mockT, router);
+      const confirmStore = useConfirmStore();
+      const result = await handler.handle({ service: 'etherscan' });
+
+      await findAction(result, 'do_not_show_again').action();
+      await confirmStore.confirm();
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should not update when the confirmation is dismissed', async () => {
+      const handler = createMissingApiKeyHandler(mockT, router);
+      const confirmStore = useConfirmStore();
+      const result = await handler.handle({ service: 'etherscan' });
+
+      await findAction(result, 'do_not_show_again').action();
+      await confirmStore.dismiss();
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/core/messaging/handlers/progress-updates.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/progress-updates.spec.ts
@@ -1,0 +1,131 @@
+import type { ProgressUpdateResultData } from '../types/status-types';
+import { mockT } from '@test/i18n';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createProgressUpdateHandler } from '@/modules/core/messaging/handlers/progress-updates';
+import { SocketMessageProgressUpdateSubType } from '@/modules/core/messaging/types/base';
+
+const mockSetUndecodedTransactionsStatus = vi.fn();
+const mockSetProtocolCacheStatus = vi.fn();
+const mockSetReceivingProtocolCacheStatus = vi.fn();
+const mockSetHistoricalDailyPriceStatus = vi.fn();
+const mockSetHistoricalPriceStatus = vi.fn();
+const mockSetStatsPriceQueryStatus = vi.fn();
+const mockSetStakingQueryStatus = vi.fn();
+const mockSetProcessingProgress = vi.fn();
+
+vi.mock('@/modules/history/use-decoding-status-store', () => ({
+  useDecodingStatusStore: vi.fn(() => ({
+    setUndecodedTransactionsStatus: mockSetUndecodedTransactionsStatus,
+  })),
+}));
+
+vi.mock('@/modules/history/use-protocol-cache-status-store', () => ({
+  useProtocolCacheStatusStore: vi.fn(() => ({
+    setProtocolCacheStatus: mockSetProtocolCacheStatus,
+    setReceivingProtocolCacheStatus: mockSetReceivingProtocolCacheStatus,
+  })),
+}));
+
+vi.mock('@/modules/assets/prices/use-historic-cache-price-store', () => ({
+  useHistoricCachePriceStore: vi.fn(() => ({
+    setHistoricalDailyPriceStatus: mockSetHistoricalDailyPriceStatus,
+    setHistoricalPriceStatus: mockSetHistoricalPriceStatus,
+    setStatsPriceQueryStatus: mockSetStatsPriceQueryStatus,
+  })),
+}));
+
+vi.mock('@/modules/staking/liquity/use-liquity-store', () => ({
+  useLiquityStore: vi.fn(() => ({
+    setStakingQueryStatus: mockSetStakingQueryStatus,
+  })),
+}));
+
+vi.mock('@/modules/history/balances/use-historical-balances-store', () => ({
+  useHistoricalBalancesStore: vi.fn(() => ({
+    setProcessingProgress: mockSetProcessingProgress,
+  })),
+}));
+
+function data(subtype: SocketMessageProgressUpdateSubType): ProgressUpdateResultData {
+  return createMock<ProgressUpdateResultData>({ subtype });
+}
+
+describe('createProgressUpdateHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should route undecoded transaction updates and stop the receiving flag', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    const result = await handler.handle(data(SocketMessageProgressUpdateSubType.UNDECODED_TRANSACTIONS));
+
+    expect(mockSetReceivingProtocolCacheStatus).toHaveBeenCalledWith(false);
+    expect(mockSetUndecodedTransactionsStatus).toHaveBeenCalledOnce();
+    expect(result).toBeNull();
+  });
+
+  it('should route protocol cache updates', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(data(SocketMessageProgressUpdateSubType.PROTOCOL_CACHE_UPDATES));
+
+    expect(mockSetProtocolCacheStatus).toHaveBeenCalledOnce();
+  });
+
+  it('should route historical price query updates', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(data(SocketMessageProgressUpdateSubType.HISTORICAL_PRICE_QUERY_STATUS));
+
+    expect(mockSetHistoricalDailyPriceStatus).toHaveBeenCalledOnce();
+  });
+
+  it('should route liquity staking query updates', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(data(SocketMessageProgressUpdateSubType.LIQUITY_STAKING_QUERY));
+
+    expect(mockSetStakingQueryStatus).toHaveBeenCalledOnce();
+  });
+
+  it('should route stats price query updates', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(data(SocketMessageProgressUpdateSubType.STATS_PRICE_QUERY));
+
+    expect(mockSetStatsPriceQueryStatus).toHaveBeenCalledOnce();
+  });
+
+  it('should route multiple prices query updates', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(data(SocketMessageProgressUpdateSubType.MULTIPLE_PRICES_QUERY_STATUS));
+
+    expect(mockSetHistoricalPriceStatus).toHaveBeenCalledOnce();
+  });
+
+  it('should route historical balance processing updates', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(data(SocketMessageProgressUpdateSubType.HISTORICAL_BALANCE_PROCESSING));
+
+    expect(mockSetProcessingProgress).toHaveBeenCalledOnce();
+  });
+
+  it('should delegate csv import results to the csv handler', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    const result = await handler.handle(createMock<ProgressUpdateResultData>({
+      messages: [],
+      processed: 1,
+      sourceName: 'binance',
+      subtype: SocketMessageProgressUpdateSubType.CSV_IMPORT_RESULT,
+      total: 1,
+    }));
+
+    expect(result).not.toBeNull();
+  });
+
+  it('should not touch any store for an unknown subtype', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    const result = await handler.handle(createMock<ProgressUpdateResultData>({}));
+
+    expect(result).toBeNull();
+    expect(mockSetProtocolCacheStatus).not.toHaveBeenCalled();
+    expect(mockSetProcessingProgress).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/core/messaging/index.spec.ts
+++ b/frontend/app/src/modules/core/messaging/index.spec.ts
@@ -1,11 +1,42 @@
 import type { EvmChainInfo } from '@/modules/core/api/types/chains';
 import { assert, type Blockchain } from '@rotki/common';
 import { mount } from '@vue/test-utils';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { useMessageHandling } from '@/modules/core/messaging';
 import { SocketMessageType } from '@/modules/core/messaging/types';
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+
+const { mockConsumeMessages } = vi.hoisted((): { mockConsumeMessages: ReturnType<typeof vi.fn> } => ({
+  mockConsumeMessages: vi.fn(),
+}));
+
+vi.mock('@/modules/session/api/use-session-api', () => ({
+  useSessionApi: vi.fn().mockReturnValue({
+    consumeMessages: mockConsumeMessages,
+  }),
+}));
+
+vi.mock('@shared/utils', async (importOriginal): Promise<typeof import('@shared/utils')> => {
+  const actual = await importOriginal<typeof import('@shared/utils')>();
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the stub skips the retry delays; the generic backoff signature cannot be reproduced inline
+    backoff: (async (_retries: number, call: () => Promise<unknown>) => call()) as typeof actual.backoff,
+  };
+});
+
+function setup(): ReturnType<typeof useMessageHandling> {
+  let messageHandling: ReturnType<typeof useMessageHandling> | undefined;
+  mount({
+    template: '<div/>',
+    setup() {
+      messageHandling = useMessageHandling();
+    },
+  });
+  assert(messageHandling);
+  return messageHandling;
+}
 
 vi.mock('@/modules/core/notifications/use-notifications-store', async () => {
   const { shallowRef } = await import('vue');
@@ -84,6 +115,10 @@ describe('useMessageHandling', () => {
     setActivePinia(pinia);
   });
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should notify the user and run token detection', async () => {
     let messageHandling: ReturnType<typeof useMessageHandling> | undefined;
 
@@ -115,5 +150,79 @@ describe('useMessageHandling', () => {
     expect(mockDetectTokens).toHaveBeenCalledTimes(1);
     expect(mockDetectTokens).toHaveBeenCalledWith('optimism', ['0xdead']);
     expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ignore a message with an invalid format', async () => {
+    const { handleMessage } = setup();
+    const { notify } = useNotificationDispatcher();
+
+    await handleMessage(JSON.stringify({ foo: 'bar' }));
+
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('should consume polling messages via the legacy fallback', async () => {
+    mockConsumeMessages.mockResolvedValue({
+      errors: ['plain error', 'plain error'],
+      warnings: ['a warning'],
+    });
+
+    const { consume } = setup();
+    const { notify } = useNotificationDispatcher();
+
+    await consume();
+
+    // duplicate error is de-duplicated, so one error + one warning notification
+    expect(notify).toHaveBeenCalledTimes(2);
+    const severities = vi.mocked(notify).mock.calls.map(([n]) => n.message);
+    expect(severities).toContain('plain error');
+    expect(severities).toContain('a warning');
+  });
+
+  it('should route a valid typed polling message to its handler', async () => {
+    mockConsumeMessages.mockResolvedValue({
+      errors: [JSON.stringify({
+        type: SocketMessageType.EVM_ACCOUNTS_DETECTION,
+        data: [{ address: '0xdead', chain: 'optimism' }],
+      })],
+      warnings: [],
+    });
+
+    const { canRequestData } = storeToRefs(useSessionAuthStore());
+    set(canRequestData, true);
+
+    const { consume } = setup();
+    const { notify } = useNotificationDispatcher();
+
+    await consume();
+
+    expect(mockDetectTokens).toHaveBeenCalledWith('optimism', ['0xdead']);
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fall back to the legacy handler for schema-invalid json', async () => {
+    mockConsumeMessages.mockResolvedValue({
+      errors: [JSON.stringify({ unexpected: true })],
+      warnings: [],
+    });
+
+    const { consume } = setup();
+    const { notify } = useNotificationDispatcher();
+
+    await consume();
+
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('should notify when message consumption fails', async () => {
+    mockConsumeMessages.mockRejectedValue(new Error('network down'));
+
+    const { consume } = setup();
+    const { notify } = useNotificationDispatcher();
+
+    await consume();
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(notify).mock.calls[0][0].message).toContain('network down');
   });
 });

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-chart-config.spec.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-chart-config.spec.ts
@@ -1,0 +1,134 @@
+import type { DataZoomComponentOption } from 'echarts/components';
+import type { NetValueChartData } from '@/modules/dashboard/graph/types';
+import { bigNumberify } from '@rotki/common';
+import { get } from '@vueuse/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNetValueChartConfig } from '@/modules/dashboard/graph/use-net-value-chart-config';
+
+const state = vi.hoisted((): { graphZeroBased: boolean; showGraphRangeSelector: boolean; baseColor: string } => ({
+  baseColor: '#123456',
+  graphZeroBased: false,
+  showGraphRangeSelector: false,
+}));
+
+vi.mock('@/modules/settings/use-setting', async (): Promise<{ useSetting: (key: string) => unknown }> => {
+  const { computed } = await import('vue');
+  return {
+    useSetting: (key: string): unknown =>
+      computed(() => (key === 'graphZeroBased' ? state.graphZeroBased : state.showGraphRangeSelector)),
+  };
+});
+
+vi.mock('@/modules/statistics/use-graph', async (): Promise<{ useGraph: () => unknown }> => {
+  const { computed } = await import('vue');
+  return {
+    useGraph: (): unknown => ({
+      baseColor: computed(() => state.baseColor),
+      gradient: computed(() => ({ color: state.baseColor })),
+    }),
+  };
+});
+
+function chartData(overrides?: Partial<NetValueChartData>): NetValueChartData {
+  return { data: [bigNumberify(10), bigNumberify(20)], snapshotCount: 2, times: [1, 2], ...overrides };
+}
+
+function seriesData(option: ReturnType<typeof useNetValueChartConfig>): unknown {
+  const series = get(option.chartOption).series;
+  const first = Array.isArray(series) ? series[0] : series;
+  return first && 'data' in first ? first.data : undefined;
+}
+
+function dataZoom(option: ReturnType<typeof useNetValueChartConfig>): DataZoomComponentOption[] {
+  const zoom = get(option.chartOption).dataZoom;
+  if (Array.isArray(zoom))
+    return zoom;
+  return zoom ? [zoom] : [];
+}
+
+describe('useNetValueChartConfig', () => {
+  beforeEach(() => {
+    state.graphZeroBased = false;
+    state.showGraphRangeSelector = false;
+    state.baseColor = '#123456';
+  });
+
+  it('should map times and values into millisecond data points', () => {
+    const option = useNetValueChartConfig(() => chartData());
+    expect(seriesData(option)).toEqual([[1000, 10], [2000, 20]]);
+  });
+
+  it('should return an empty series when there is no data', () => {
+    const option = useNetValueChartConfig(() => chartData({ data: [], times: [] }));
+    expect(seriesData(option)).toEqual([]);
+  });
+
+  it('should include only the inside zoom when the range selector is hidden', () => {
+    const option = useNetValueChartConfig(() => chartData());
+    const zooms = dataZoom(option);
+    expect(zooms).toHaveLength(1);
+    expect(zooms[0].type).toBe('inside');
+    expect(get(option.chartOption).grid).toMatchObject({ bottom: 16 });
+  });
+
+  it('should prepend the slider zoom when the range selector is shown', () => {
+    state.showGraphRangeSelector = true;
+    const option = useNetValueChartConfig(() => chartData());
+    const zooms = dataZoom(option);
+    expect(zooms).toHaveLength(2);
+    expect(zooms[0].type).toBe('slider');
+    expect(zooms[1].type).toBe('inside');
+    expect(get(option.chartOption).grid).toMatchObject({ bottom: 56 });
+  });
+
+  it('should persist the active zoom bounds from the range in seconds', () => {
+    const option = useNetValueChartConfig(() => chartData(), () => ({ end: 20, start: 10 }));
+    const zooms = dataZoom(option);
+    expect(zooms[0].startValue).toBe(10000);
+    expect(zooms[0].endValue).toBe(20000);
+  });
+
+  it('should omit zoom bounds when there is no active range', () => {
+    const option = useNetValueChartConfig(() => chartData());
+    const zooms = dataZoom(option);
+    expect(zooms[0].startValue).toBeUndefined();
+    expect(zooms[0].endValue).toBeUndefined();
+  });
+
+  it('should style the series with the graph colors', () => {
+    state.baseColor = '#abcdef';
+    const option = useNetValueChartConfig(() => chartData());
+    const series = get(option.chartOption).series;
+    const first = Array.isArray(series) ? series[0] : series;
+    expect(first).toMatchObject({
+      areaStyle: { color: '#abcdef' },
+      itemStyle: { color: '#abcdef' },
+      lineStyle: { color: '#abcdef' },
+    });
+  });
+
+  describe('y axis min/max', () => {
+    function yAxisMin(zeroBased: boolean): (value: { min: number; max: number }) => unknown {
+      state.graphZeroBased = zeroBased;
+      const option = useNetValueChartConfig(() => chartData());
+      const yAxis = get(option.chartOption).yAxis;
+      const axis = Array.isArray(yAxis) ? yAxis[0] : yAxis;
+      const min = axis?.min;
+      if (typeof min !== 'function')
+        throw new TypeError('expected a function min');
+      return min;
+    }
+
+    it('should clamp to zero when graphZeroBased is enabled', () => {
+      expect(yAxisMin(true)({ max: 100, min: 40 })).toBe(0);
+    });
+
+    it('should return zero when the minimum is already zero', () => {
+      expect(yAxisMin(false)({ max: 100, min: 0 })).toBe(0);
+    });
+
+    it('should pad below the minimum when not zero based', () => {
+      expect(yAxisMin(false)({ max: 100, min: 40 })).toBe(40 - (100 - 40) * 0.1);
+    });
+  });
+});

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.spec.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.spec.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from 'vitest';
-import { readZoomFields, resolveZoomRange } from '@/modules/dashboard/graph/use-net-value-event-handlers';
+import type VChart from 'vue-echarts';
+import type { NetValueZoomRange } from '@/modules/dashboard/graph/net-value-stats';
+import type { NetValueChartData } from '@/modules/dashboard/graph/types';
+import { type BigNumber, bigNumberify } from '@rotki/common';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, ref, type Ref, type ShallowRef, shallowRef, type VNode } from 'vue';
+import {
+  readZoomFields,
+  resolveZoomRange,
+  useNetValueEventHandlers,
+} from '@/modules/dashboard/graph/use-net-value-event-handlers';
 
 describe('readZoomFields', () => {
   it('should read top-level fields when batch is absent (slider drag shape)', () => {
@@ -69,5 +79,335 @@ describe('resolveZoomRange', () => {
   it('should return undefined when fields are missing or times empty', () => {
     expect(resolveZoomRange(undefined, times)).toBeUndefined();
     expect(resolveZoomRange({ end: 75, start: 25 }, [])).toBeUndefined();
+  });
+});
+
+type EventHandler = (arg: any) => void;
+
+interface FakeChart {
+  chart: {
+    on: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+    getZr: ReturnType<typeof vi.fn>;
+    dispatchAction: ReturnType<typeof vi.fn>;
+  };
+  handlers: Map<string, EventHandler>;
+  zr: { on: ReturnType<typeof vi.fn>; off: ReturnType<typeof vi.fn> };
+  zrHandlers: Map<string, EventHandler>;
+}
+
+function createFakeChart(): FakeChart {
+  const handlers = new Map<string, EventHandler>();
+  const zrHandlers = new Map<string, EventHandler>();
+  const zr = {
+    off: vi.fn((event: string) => { zrHandlers.delete(event); }),
+    on: vi.fn((event: string, handler: EventHandler) => { zrHandlers.set(event, handler); }),
+  };
+  const chart = {
+    dispatchAction: vi.fn(),
+    getZr: vi.fn(() => zr),
+    off: vi.fn((event: string) => {
+      handlers.delete(event);
+      return chart;
+    }),
+    on: vi.fn((event: string, handler: EventHandler) => { handlers.set(event, handler); }),
+  };
+  return { chart, handlers, zr, zrHandlers };
+}
+
+// The fake chart intentionally implements only the members the composable
+// touches (it reads `.chart` and its echarts methods), so a single contained
+// assertion bridges it to the vue-echarts instance type.
+function chartInstanceRef(chart: FakeChart['chart'] | null): ShallowRef<InstanceType<typeof VChart> | null> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the fake only mocks the members the SUT uses; contained here
+  const instance = chart === null ? null : ({ chart } as unknown as InstanceType<typeof VChart>);
+  return shallowRef(instance);
+}
+
+describe('useNetValueEventHandlers', () => {
+  let fake: FakeChart;
+  let container: HTMLElement;
+  let containerHandlers: Map<string, EventHandler>;
+  let removeSpy: ReturnType<typeof vi.spyOn>;
+  let onHover: (timestamp: number, value: BigNumber) => void;
+  let onZoomChange: (range: NetValueZoomRange | undefined) => void;
+  let chartData: Ref<NetValueChartData>;
+
+  function setupHarness(withZoom = true): {
+    setupChartEventHandlers: () => void;
+    setupZoomToolHandler: () => void;
+    tooltipData: ReturnType<typeof useNetValueEventHandlers>['tooltipData'];
+    unmount: () => void;
+  } {
+    let api: ReturnType<typeof useNetValueEventHandlers>;
+    const wrapper = mount(defineComponent({
+      setup(): () => VNode {
+        api = useNetValueEventHandlers({
+          chartContainer: ref(container),
+          chartData,
+          chartInstance: chartInstanceRef(fake.chart),
+          onHover,
+          onZoomChange: withZoom ? onZoomChange : undefined,
+        });
+        return () => h('div');
+      },
+    }));
+    return { ...api!, unmount: () => wrapper.unmount() };
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fake = createFakeChart();
+    container = document.createElement('div');
+    container.getBoundingClientRect = (): DOMRect => new DOMRect(0, 0, 500, 300);
+    containerHandlers = new Map();
+    vi.spyOn(container, 'addEventListener').mockImplementation((event: string, handler: EventListenerOrEventListenerObject): void => {
+      if (typeof handler === 'function')
+        containerHandlers.set(event, handler);
+    });
+    removeSpy = vi.spyOn(container, 'removeEventListener').mockImplementation((event: string): void => {
+      containerHandlers.delete(event);
+    });
+    onHover = vi.fn();
+    onZoomChange = vi.fn();
+    chartData = ref<NetValueChartData>({
+      data: [bigNumberify(10), bigNumberify(20), bigNumberify(30)],
+      snapshotCount: 2,
+      times: [1000, 2000, 3000],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('should not register handlers when the chart instance is missing', () => {
+    const harness = mount(defineComponent({
+      setup(): () => VNode {
+        useNetValueEventHandlers({
+          chartContainer: ref(container),
+          chartData,
+          chartInstance: chartInstanceRef(null),
+          onHover,
+        }).setupChartEventHandlers();
+        return () => h('div');
+      },
+    }));
+    expect(fake.chart.on).not.toHaveBeenCalled();
+    expect(containerHandlers.size).toBe(0);
+    harness.unmount();
+  });
+
+  it('should register chart, zrender and container handlers on setup', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+
+    expect(fake.chart.on).toHaveBeenCalledWith('updateAxisPointer', expect.any(Function));
+    expect(fake.chart.on).toHaveBeenCalledWith('datazoom', expect.any(Function));
+    expect([...fake.zrHandlers.keys()]).toEqual(expect.arrayContaining(['dblclick', 'mousemove', 'globalout']));
+    expect([...containerHandlers.keys()]).toEqual(expect.arrayContaining(['click', 'mousedown', 'mousemove', 'mouseup']));
+    unmount();
+  });
+
+  it('should not register the datazoom handler when no onZoomChange is provided', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness(false);
+    setupChartEventHandlers();
+    expect(fake.handlers.has('datazoom')).toBe(false);
+    unmount();
+  });
+
+  it('should populate tooltip data on axis pointer over a snapshot point', () => {
+    const { setupChartEventHandlers, tooltipData, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.zrHandlers.get('mousemove')?.({ offsetX: 40, offsetY: 50 });
+
+    fake.handlers.get('updateAxisPointer')?.({ axesInfo: [{ value: 2000 }], dataIndex: 1 });
+
+    expect(get(tooltipData)).toMatchObject({
+      currentBalance: false,
+      timestamp: 2000,
+      visible: true,
+      x: 60,
+      y: 70,
+    });
+    unmount();
+  });
+
+  it('should flag currentBalance for the last data point', () => {
+    const { setupChartEventHandlers, tooltipData, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.handlers.get('updateAxisPointer')?.({ axesInfo: [{ value: 3000 }], dataIndex: 2 });
+    expect(get(tooltipData).currentBalance).toBe(true);
+    unmount();
+  });
+
+  it('should flip the tooltip position near the container edges', () => {
+    const { setupChartEventHandlers, tooltipData, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.zrHandlers.get('mousemove')?.({ offsetX: 480, offsetY: 290 });
+    fake.handlers.get('updateAxisPointer')?.({ axesInfo: [{ value: 2000 }], dataIndex: 1 });
+
+    // 480 + 20 + 150 > 500 -> flip left: 480 - 20 - 150 = 310; 290 + 20 + 60 > 300 -> flip up: 290 - 20 - 60 = 210
+    expect(get(tooltipData)).toMatchObject({ x: 310, y: 210 });
+    unmount();
+  });
+
+  it('should hide the tooltip when axis info or data point is missing', () => {
+    const { setupChartEventHandlers, tooltipData, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.handlers.get('updateAxisPointer')?.({ axesInfo: [{ value: 2000 }], dataIndex: 1 });
+    expect(get(tooltipData).visible).toBe(true);
+
+    fake.handlers.get('updateAxisPointer')?.({ axesInfo: undefined, dataIndex: 1 });
+    expect(get(tooltipData).visible).toBe(false);
+
+    fake.handlers.get('updateAxisPointer')?.({ axesInfo: [{ value: 2000 }], dataIndex: 99 });
+    expect(get(tooltipData).visible).toBe(false);
+    unmount();
+  });
+
+  it('should reset the tooltip when the pointer leaves the chart', () => {
+    const { setupChartEventHandlers, tooltipData, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.handlers.get('updateAxisPointer')?.({ axesInfo: [{ value: 2000 }], dataIndex: 1 });
+    expect(get(tooltipData).visible).toBe(true);
+
+    fake.zrHandlers.get('globalout')?.(undefined);
+    expect(get(tooltipData).visible).toBe(false);
+    unmount();
+  });
+
+  it('should reset the zoom on double click and clear a pending single-click timer', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+
+    // first click arms the single-click timer
+    containerHandlers.get('click')?.({});
+    fake.zrHandlers.get('dblclick')?.(undefined);
+
+    expect(fake.chart.dispatchAction).toHaveBeenCalledWith({ end: 100, start: 0, type: 'dataZoom' });
+    // timer was cleared, so advancing does not fire onHover
+    vi.advanceTimersByTime(500);
+    expect(onHover).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should emit a hover on a single click after a snapshot pointer move', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+    // snapshot point records lastHover
+    fake.handlers.get('updateAxisPointer')?.({ axesInfo: [{ value: 2000 }], dataIndex: 1 });
+
+    containerHandlers.get('mousedown')?.({ offsetX: 0, offsetY: 0 });
+    containerHandlers.get('click')?.({});
+    vi.advanceTimersByTime(200);
+
+    expect(onHover).toHaveBeenCalledWith(2, bigNumberify(20));
+    unmount();
+  });
+
+  it('should ignore a click that follows a drag', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.handlers.get('updateAxisPointer')?.({ axesInfo: [{ value: 2000 }], dataIndex: 1 });
+
+    containerHandlers.get('mousedown')?.({ offsetX: 0, offsetY: 0 });
+    containerHandlers.get('mousemove')?.({ buttons: 1, offsetX: 40, offsetY: 0 });
+    containerHandlers.get('click')?.({});
+    vi.advanceTimersByTime(200);
+
+    expect(onHover).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should treat a second quick click as a double click and cancel the hover', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.handlers.get('updateAxisPointer')?.({ axesInfo: [{ value: 2000 }], dataIndex: 1 });
+
+    containerHandlers.get('click')?.({});
+    containerHandlers.get('click')?.({});
+    vi.advanceTimersByTime(300);
+
+    expect(onHover).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should activate the zoom select tool after the chart finishes rendering', () => {
+    const { setupZoomToolHandler, unmount } = setupHarness();
+    setupZoomToolHandler();
+
+    expect(fake.chart.on).toHaveBeenCalledWith('finished', expect.any(Function));
+    vi.advanceTimersByTime(300);
+    expect(fake.chart.dispatchAction).toHaveBeenCalledWith({
+      dataZoomSelectActive: true,
+      key: 'dataZoomSelect',
+      type: 'takeGlobalCursor',
+    });
+    expect(fake.chart.off).toHaveBeenCalledWith('finished', expect.any(Function));
+    unmount();
+  });
+
+  it('should emit the resolved range on a partial datazoom selection', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.handlers.get('datazoom')?.({ endValue: 2000000, startValue: 1500000 });
+    expect(onZoomChange).toHaveBeenCalledWith({ end: 2000, start: 1500 });
+    unmount();
+  });
+
+  it('should collapse a full-range datazoom selection to undefined', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.handlers.get('datazoom')?.({ end: 100, start: 0 });
+    expect(onZoomChange).toHaveBeenCalledWith(undefined);
+    unmount();
+  });
+
+  it('should emit undefined when the times series is empty', () => {
+    set(chartData, { data: [], snapshotCount: 0, times: [] });
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.handlers.get('datazoom')?.({ endValue: 2000000, startValue: 1500000 });
+    expect(onZoomChange).toHaveBeenCalledWith(undefined);
+    unmount();
+  });
+
+  it('should emit undefined when the zoom event carries no usable fields', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.handlers.get('datazoom')?.({});
+    expect(onZoomChange).toHaveBeenCalledWith(undefined);
+    unmount();
+  });
+
+  it('should tear down every handler when the setup runs again', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+    fake.chart.off.mockClear();
+    fake.zr.off.mockClear();
+
+    setupChartEventHandlers();
+
+    expect(fake.chart.off).toHaveBeenCalledWith('updateAxisPointer');
+    expect(fake.chart.off).toHaveBeenCalledWith('datazoom');
+    expect(fake.zr.off).toHaveBeenCalledWith('dblclick');
+    unmount();
+  });
+
+  it('should clean up handlers and pending timers on unmount', () => {
+    const { setupChartEventHandlers, unmount } = setupHarness();
+    setupChartEventHandlers();
+    // arm a single-click timer so unmount clears it
+    containerHandlers.get('click')?.({});
+
+    unmount();
+
+    expect(fake.chart.off).toHaveBeenCalledWith('updateAxisPointer');
+    expect(fake.zr.off).toHaveBeenCalledWith('globalout');
+    expect(removeSpy).toHaveBeenCalledWith('click', expect.any(Function));
+    vi.advanceTimersByTime(500);
+    expect(onHover).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/modules/dashboard/snapshots/use-snapshot-store.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/use-snapshot-store.spec.ts
@@ -1,0 +1,141 @@
+import type { Snapshot } from '@/modules/dashboard/snapshots';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSnapshotStore } from '@/modules/dashboard/snapshots/use-snapshot-store';
+
+const mockDeleteSnapshot = vi.fn();
+const mockGetSnapshotData = vi.fn();
+const mockUpdateSnapshotData = vi.fn();
+
+vi.mock('@/modules/settings/api/use-snapshot-api', () => ({
+  useSnapshotApi: vi.fn(() => ({
+    deleteSnapshot: mockDeleteSnapshot,
+    getSnapshotData: mockGetSnapshotData,
+    updateSnapshotData: mockUpdateSnapshotData,
+  })),
+}));
+
+function snapshot(): Snapshot {
+  return createMock<Snapshot>({ balancesSnapshot: [], locationDataSnapshot: [] });
+}
+
+describe('useSnapshotStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  describe('fetchSnapshot', () => {
+    it('should fetch and cache a snapshot on the first request', async () => {
+      const data = snapshot();
+      mockGetSnapshotData.mockResolvedValue(data);
+      const store = useSnapshotStore();
+
+      const result = await store.fetchSnapshot(1000);
+
+      expect(result).toBe(data);
+      expect(mockGetSnapshotData).toHaveBeenCalledOnce();
+    });
+
+    it('should return the cached snapshot without a second fetch', async () => {
+      mockGetSnapshotData.mockResolvedValue(snapshot());
+      const store = useSnapshotStore();
+
+      await store.fetchSnapshot(1000);
+      await store.fetchSnapshot(1000);
+
+      expect(mockGetSnapshotData).toHaveBeenCalledOnce();
+    });
+
+    it('should bypass the cache when refresh is requested', async () => {
+      mockGetSnapshotData.mockResolvedValue(snapshot());
+      const store = useSnapshotStore();
+
+      await store.fetchSnapshot(1000);
+      await store.fetchSnapshot(1000, true);
+
+      expect(mockGetSnapshotData).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('persist', () => {
+    it('should cache the snapshot after a successful update', async () => {
+      mockUpdateSnapshotData.mockResolvedValue(true);
+      const store = useSnapshotStore();
+      const data = snapshot();
+
+      const success = await store.persist(1000, data);
+      const fetched = await store.fetchSnapshot(1000);
+
+      expect(success).toBe(true);
+      expect(fetched).toBe(data);
+      expect(mockGetSnapshotData).not.toHaveBeenCalled();
+    });
+
+    it('should not cache the snapshot when the update fails', async () => {
+      mockUpdateSnapshotData.mockResolvedValue(false);
+      mockGetSnapshotData.mockResolvedValue(snapshot());
+      const store = useSnapshotStore();
+
+      const success = await store.persist(1000, snapshot());
+      await store.fetchSnapshot(1000);
+
+      expect(success).toBe(false);
+      expect(mockGetSnapshotData).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('remove', () => {
+    it('should evict the snapshot from the cache after a successful delete', async () => {
+      mockGetSnapshotData.mockResolvedValue(snapshot());
+      mockDeleteSnapshot.mockResolvedValue(true);
+      const store = useSnapshotStore();
+
+      await store.fetchSnapshot(1000);
+      const success = await store.remove(1000);
+      await store.fetchSnapshot(1000);
+
+      expect(success).toBe(true);
+      expect(mockGetSnapshotData).toHaveBeenCalledTimes(2);
+    });
+
+    it('should keep the cache when the delete fails', async () => {
+      mockGetSnapshotData.mockResolvedValue(snapshot());
+      mockDeleteSnapshot.mockResolvedValue(false);
+      const store = useSnapshotStore();
+
+      await store.fetchSnapshot(1000);
+      const success = await store.remove(1000);
+      await store.fetchSnapshot(1000);
+
+      expect(success).toBe(false);
+      expect(mockGetSnapshotData).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('invalidate', () => {
+    it('should drop a single timestamp from the cache', async () => {
+      mockGetSnapshotData.mockResolvedValue(snapshot());
+      const store = useSnapshotStore();
+
+      await store.fetchSnapshot(1000);
+      store.invalidate(1000);
+      await store.fetchSnapshot(1000);
+
+      expect(mockGetSnapshotData).toHaveBeenCalledTimes(2);
+    });
+
+    it('should clear the entire cache when no timestamp is given', async () => {
+      mockGetSnapshotData.mockResolvedValue(snapshot());
+      const store = useSnapshotStore();
+
+      await store.fetchSnapshot(1000);
+      await store.fetchSnapshot(2000);
+      store.invalidate();
+      await store.fetchSnapshot(1000);
+      await store.fetchSnapshot(2000);
+
+      expect(mockGetSnapshotData).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/frontend/app/src/modules/dashboard/use-dashboard-table-config.spec.ts
+++ b/frontend/app/src/modules/dashboard/use-dashboard-table-config.spec.ts
@@ -1,0 +1,125 @@
+import type { DashboardTableType } from '@/modules/settings/types/frontend-settings';
+import { type BigNumber, bigNumberify } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TableColumn } from '@/modules/core/table/table-column';
+import { useDashboardTableConfig } from '@/modules/dashboard/use-dashboard-table-config';
+
+const TABLE_TYPE = 'ASSETS' as DashboardTableType;
+
+const mockCurrencySymbol = ref<string>('USD');
+const mockVisibleColumns = ref<Record<string, TableColumn[]>>({ [TABLE_TYPE]: [] });
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: vi.fn((key: string) => (key === 'currencySymbol' ? mockCurrencySymbol : mockVisibleColumns)),
+}));
+
+vi.mock('@/modules/core/table/use-remember-table-sorting', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/core/table/use-remember-table-sorting')>(),
+  useRememberTableSorting: vi.fn(),
+}));
+
+vi.mock('vue-i18n', async importOriginal => ({
+  ...await importOriginal<typeof import('vue-i18n')>(),
+  useI18n: (): { t: (key: string) => string } => ({ t: (key: string): string => key }),
+}));
+
+function create(netWorth: BigNumber = bigNumberify(100)): ReturnType<typeof useDashboardTableConfig> {
+  return useDashboardTableConfig(TABLE_TYPE, 'My Table', netWorth);
+}
+
+describe('useDashboardTableConfig', () => {
+  beforeEach(() => {
+    set(mockCurrencySymbol, 'USD');
+    set(mockVisibleColumns, { [TABLE_TYPE]: [] });
+  });
+
+  describe('pagination', () => {
+    it('should default to page 1 with 10 items', () => {
+      const { pagination } = create();
+
+      expect(get(pagination)).toEqual({ itemsPerPage: 10, page: 1 });
+    });
+
+    it('should update the page via setPage', () => {
+      const { pagination, setPage } = create();
+
+      setPage(3);
+
+      expect(get(pagination).page).toBe(3);
+      expect(get(pagination).itemsPerPage).toBe(10);
+    });
+
+    it('should update page and limit from a table pagination event', () => {
+      const { pagination, setTablePagination } = create();
+
+      setTablePagination({ limit: 25, page: 2, total: 100 });
+
+      expect(get(pagination)).toEqual({ itemsPerPage: 25, page: 2 });
+    });
+
+    it('should ignore an undefined pagination event', () => {
+      const { pagination, setTablePagination } = create();
+
+      setTablePagination(undefined);
+
+      expect(get(pagination)).toEqual({ itemsPerPage: 10, page: 1 });
+    });
+  });
+
+  describe('sort', () => {
+    it('should default to sorting by value descending', () => {
+      const { sort } = create();
+
+      expect(get(sort)).toEqual({ column: 'value', direction: 'desc' });
+    });
+  });
+
+  describe('tableHeaders', () => {
+    it('should expose the base columns without the percentage columns', () => {
+      const { tableHeaders } = create();
+      const keys = get(tableHeaders).map(header => header.key);
+
+      expect(keys).toEqual(['asset', 'protocol', 'price', 'amount', 'value']);
+    });
+
+    it('should add the net-value percentage column when enabled', () => {
+      set(mockVisibleColumns, { [TABLE_TYPE]: [TableColumn.PERCENTAGE_OF_TOTAL_NET_VALUE] });
+      const { tableHeaders } = create();
+      const keys = get(tableHeaders).map(header => header.key);
+
+      expect(keys).toContain('percentageOfTotalNetValue');
+    });
+
+    it('should add the current-group percentage column when enabled', () => {
+      set(mockVisibleColumns, { [TABLE_TYPE]: [TableColumn.PERCENTAGE_OF_TOTAL_CURRENT_GROUP] });
+      const { tableHeaders } = create();
+      const keys = get(tableHeaders).map(header => header.key);
+
+      expect(keys).toContain('percentageOfTotalCurrentGroup');
+    });
+
+    it('should label the net-value column differently when net worth is positive', () => {
+      set(mockVisibleColumns, { [TABLE_TYPE]: [TableColumn.PERCENTAGE_OF_TOTAL_NET_VALUE] });
+      const { tableHeaders } = create(bigNumberify(500));
+      const header = get(tableHeaders).find(h => h.key === 'percentageOfTotalNetValue');
+
+      expect(header?.label).toBe('dashboard_asset_table.headers.percentage_of_total_net_value');
+    });
+
+    it('should label the net-value column as total when net worth is zero', () => {
+      set(mockVisibleColumns, { [TABLE_TYPE]: [TableColumn.PERCENTAGE_OF_TOTAL_NET_VALUE] });
+      const { tableHeaders } = create(bigNumberify(0));
+      const header = get(tableHeaders).find(h => h.key === 'percentageOfTotalNetValue');
+
+      expect(header?.label).toBe('dashboard_asset_table.headers.percentage_total');
+    });
+
+    it('should reflect the currency symbol in the price column label', () => {
+      set(mockCurrencySymbol, 'EUR');
+      const { tableHeaders } = create();
+      const priceHeader = get(tableHeaders).find(h => h.key === 'price');
+
+      expect(priceHeader?.label).toBe('common.price_in_symbol');
+    });
+  });
+});

--- a/frontend/app/src/modules/session/use-session-settings.spec.ts
+++ b/frontend/app/src/modules/session/use-session-settings.spec.ts
@@ -1,0 +1,166 @@
+import type { Exchange } from '@/modules/balances/types/exchanges';
+import type { FrontendSettings } from '@/modules/settings/types/frontend-settings';
+import type { UserSettingsModel } from '@/modules/settings/types/user-settings';
+import { TimeFramePeriod, TimeFramePersist } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrivacyMode } from '@/modules/session/types';
+import { useSessionSettings } from '@/modules/session/use-session-settings';
+
+const mockPremium = ref<boolean>(false);
+const mockPremiumSync = ref<boolean>(false);
+const mockFetchCapabilities = vi.fn();
+const mockUpdateAccounting = vi.fn();
+const mockUpdateFrontend = vi.fn();
+const mockUpdateGeneral = vi.fn();
+const mockUpdateSession = vi.fn();
+const mockUpdateFrontendSetting = vi.fn();
+const mockSetConnectedExchanges = vi.fn();
+const mockCheckDefaultThemeVersion = vi.fn();
+const mockCheckForSuggestions = vi.fn();
+
+vi.mock('@/modules/premium/use-premium-store', () => ({
+  usePremiumStore: vi.fn(() => ({
+    premium: mockPremium,
+    premiumSync: mockPremiumSync,
+  })),
+}));
+
+vi.mock('@/modules/premium/use-premium-watchers', () => ({
+  usePremiumWatchers: vi.fn(() => ({
+    fetchCapabilities: mockFetchCapabilities,
+  })),
+}));
+
+vi.mock('@/modules/settings/settings-repo', () => ({
+  useSettingsRepo: vi.fn(() => ({
+    updateAccounting: mockUpdateAccounting,
+    updateFrontend: mockUpdateFrontend,
+    updateGeneral: mockUpdateGeneral,
+    updateSession: mockUpdateSession,
+  })),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: vi.fn(() => ({
+    updateFrontendSetting: mockUpdateFrontendSetting,
+  })),
+}));
+
+vi.mock('@/modules/balances/exchanges/use-connected-exchanges-store', () => ({
+  useConnectedExchangesStore: vi.fn(() => ({
+    setConnectedExchanges: mockSetConnectedExchanges,
+  })),
+}));
+
+vi.mock('@/modules/settings/use-theme-migration', () => ({
+  useThemeMigration: vi.fn(() => ({
+    checkDefaultThemeVersion: mockCheckDefaultThemeVersion,
+  })),
+}));
+
+vi.mock('@/modules/settings/suggestions/use-settings-suggestions', () => ({
+  useSettingsSuggestions: vi.fn(() => ({
+    checkForSuggestions: mockCheckForSuggestions,
+  })),
+}));
+
+function frontend(overrides: Partial<FrontendSettings> = {}): FrontendSettings {
+  return createMock<FrontendSettings>({
+    lastKnownTimeframe: TimeFramePeriod.MONTH,
+    persistPrivacySettings: true,
+    timeframeSetting: TimeFramePeriod.WEEK,
+    ...overrides,
+  });
+}
+
+interface BuildOverrides {
+  frontendSettings?: FrontendSettings;
+  havePremium?: boolean;
+  premiumShouldSync?: boolean;
+}
+
+function buildModel(overrides: BuildOverrides = {}): UserSettingsModel {
+  const frontendSettings = 'frontendSettings' in overrides ? overrides.frontendSettings : frontend();
+  const havePremium = overrides.havePremium ?? false;
+  const premiumShouldSync = overrides.premiumShouldSync ?? false;
+  return createMock<UserSettingsModel>({
+    accounting: createMock(),
+    general: createMock(),
+    other: { frontendSettings, havePremium, premiumShouldSync },
+  });
+}
+
+describe('useSessionSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(mockPremium, false);
+    set(mockPremiumSync, false);
+    mockUpdateFrontendSetting.mockResolvedValue(undefined);
+    mockFetchCapabilities.mockResolvedValue(undefined);
+  });
+
+  it('should apply frontend settings and dependent effects', async () => {
+    const { initialize } = useSessionSettings();
+    const exchanges: Exchange[] = [];
+    await initialize(buildModel(), exchanges);
+
+    expect(mockUpdateFrontend).toHaveBeenCalledOnce();
+    expect(mockSetConnectedExchanges).toHaveBeenCalledWith(exchanges);
+    expect(mockCheckDefaultThemeVersion).toHaveBeenCalledOnce();
+    expect(mockCheckForSuggestions).toHaveBeenCalledOnce();
+  });
+
+  it('should use the explicit timeframe when it is not REMEMBER', async () => {
+    const { initialize } = useSessionSettings();
+    await initialize(buildModel({ frontendSettings: frontend({ timeframeSetting: TimeFramePeriod.WEEK }) }), []);
+
+    expect(mockUpdateSession).toHaveBeenCalledWith({ timeframe: TimeFramePeriod.WEEK });
+  });
+
+  it('should fall back to the last known timeframe when set to REMEMBER', async () => {
+    const { initialize } = useSessionSettings();
+    await initialize(buildModel({
+      frontendSettings: frontend({ lastKnownTimeframe: TimeFramePeriod.MONTH, timeframeSetting: TimeFramePersist.REMEMBER }),
+    }), []);
+
+    expect(mockUpdateSession).toHaveBeenCalledWith({ timeframe: TimeFramePeriod.MONTH });
+  });
+
+  it('should reset privacy settings when they should not persist', async () => {
+    const { initialize } = useSessionSettings();
+    await initialize(buildModel({ frontendSettings: frontend({ persistPrivacySettings: false }) }), []);
+
+    expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({
+      privacyMode: PrivacyMode.NORMAL,
+      scrambleData: false,
+    });
+  });
+
+  it('should keep privacy settings when they should persist', async () => {
+    const { initialize } = useSessionSettings();
+    await initialize(buildModel({ frontendSettings: frontend({ persistPrivacySettings: true }) }), []);
+
+    expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
+  });
+
+  it('should skip the frontend block when there are no frontend settings', async () => {
+    const { initialize } = useSessionSettings();
+    await initialize(buildModel({ frontendSettings: undefined }), []);
+
+    expect(mockUpdateFrontend).not.toHaveBeenCalled();
+    expect(mockCheckForSuggestions).not.toHaveBeenCalled();
+    expect(mockSetConnectedExchanges).not.toHaveBeenCalled();
+  });
+
+  it('should always apply premium, general and accounting settings', async () => {
+    const { initialize } = useSessionSettings();
+    await initialize(buildModel({ havePremium: true, premiumShouldSync: true }), []);
+
+    expect(get(mockPremium)).toBe(true);
+    expect(get(mockPremiumSync)).toBe(true);
+    expect(mockUpdateGeneral).toHaveBeenCalledOnce();
+    expect(mockUpdateAccounting).toHaveBeenCalledOnce();
+    expect(mockFetchCapabilities).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/session/use-session-sync.spec.ts
+++ b/frontend/app/src/modules/session/use-session-sync.spec.ts
@@ -1,0 +1,170 @@
+import type { TaskResult } from '@/modules/core/tasks/use-task-handler';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SYNC_DOWNLOAD, SYNC_UPLOAD } from '@/modules/session/sync';
+import { useSync } from '@/modules/session/use-session-sync';
+
+const mockRunTask = vi.fn();
+const mockIsTaskRunning = vi.fn((): boolean => false);
+const mockNotifyError = vi.fn();
+const mockNotifyInfo = vi.fn();
+const mockForceSync = vi.fn();
+const { mockCancelAllQueued, mockCancel } = vi.hoisted(() => ({ mockCancel: vi.fn(), mockCancelAllQueued: vi.fn() }));
+
+vi.mock('@/modules/core/tasks/use-task-handler', () => ({
+  isActionableFailure: vi.fn((outcome: TaskResult<unknown>): boolean =>
+    !outcome.success && !('cancelled' in outcome && outcome.cancelled) && !('skipped' in outcome && outcome.skipped),
+  ),
+  useTaskHandler: vi.fn(() => ({
+    runTask: mockRunTask,
+  })),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: vi.fn(() => ({
+    isTaskRunning: mockIsTaskRunning,
+  })),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn(() => ({
+    notifyError: mockNotifyError,
+    notifyInfo: mockNotifyInfo,
+  })),
+}));
+
+vi.mock('@/modules/session/api/use-sync-api', () => ({
+  useSyncApi: vi.fn(() => ({
+    forceSync: mockForceSync,
+  })),
+}));
+
+vi.mock('@/modules/core/api/rotki-api', () => ({
+  api: {
+    cancel: mockCancel,
+    cancelAllQueued: mockCancelAllQueued,
+  },
+}));
+
+describe('useSync', () => {
+  let sync: ReturnType<typeof useSync>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTaskRunning.mockReturnValue(false);
+    sync = useSync();
+    set(sync.syncAction, SYNC_DOWNLOAD);
+    set(sync.displaySyncConfirmation, false);
+    set(sync.confirmChecked, false);
+    set(sync.uploadStatus, null);
+    set(sync.uploadProgress, undefined);
+  });
+
+  describe('confirmation dialog', () => {
+    it('should show the confirmation dialog for the given action', () => {
+      sync.showSyncConfirmation(SYNC_UPLOAD);
+
+      expect(get(sync.syncAction)).toBe(SYNC_UPLOAD);
+      expect(get(sync.displaySyncConfirmation)).toBe(true);
+    });
+
+    it('should reset the dialog state on cancel', () => {
+      set(sync.displaySyncConfirmation, true);
+      set(sync.confirmChecked, true);
+
+      sync.cancelSync();
+
+      expect(get(sync.displaySyncConfirmation)).toBe(false);
+      expect(get(sync.confirmChecked)).toBe(false);
+    });
+  });
+
+  describe('clearUploadStatus', () => {
+    it('should clear the stored upload status and progress', () => {
+      set(sync.uploadStatus, { actionable: false, message: null, uploaded: true });
+      set(sync.uploadProgress, { currentChunk: 1, totalChunks: 2, type: 'uploading' });
+
+      sync.clearUploadStatus();
+
+      expect(get(sync.uploadStatus)).toBeNull();
+      expect(get(sync.uploadProgress)).toBeUndefined();
+    });
+  });
+
+  describe('forceSync', () => {
+    it('should do nothing when a force sync task is already running', async () => {
+      mockIsTaskRunning.mockReturnValue(true);
+      const logout = vi.fn(async (): Promise<void> => {});
+
+      await sync.forceSync(logout);
+
+      expect(mockRunTask).not.toHaveBeenCalled();
+      expect(logout).not.toHaveBeenCalled();
+    });
+
+    it('should cancel in-flight requests before syncing', async () => {
+      mockRunTask.mockResolvedValue({ result: false, success: true });
+      await sync.forceSync(vi.fn(async (): Promise<void> => {}));
+
+      expect(mockCancelAllQueued).toHaveBeenCalledOnce();
+      expect(mockCancel).toHaveBeenCalledOnce();
+    });
+
+    it('should close the confirmation dialog before an upload sync', async () => {
+      set(sync.syncAction, SYNC_UPLOAD);
+      set(sync.displaySyncConfirmation, true);
+      mockRunTask.mockResolvedValue({ result: true, success: true });
+
+      await sync.forceSync(vi.fn(async (): Promise<void> => {}));
+
+      expect(get(sync.displaySyncConfirmation)).toBe(false);
+    });
+
+    it('should notify and log out on a successful download sync', async () => {
+      set(sync.syncAction, SYNC_DOWNLOAD);
+      mockRunTask.mockResolvedValue({ result: true, success: true });
+      const logout = vi.fn(async (): Promise<void> => {});
+
+      await sync.forceSync(logout);
+
+      expect(mockNotifyInfo).toHaveBeenCalledOnce();
+      expect(logout).toHaveBeenCalledOnce();
+    });
+
+    it('should not log out on a successful upload sync', async () => {
+      set(sync.syncAction, SYNC_UPLOAD);
+      mockRunTask.mockResolvedValue({ result: true, success: true });
+      const logout = vi.fn(async (): Promise<void> => {});
+
+      await sync.forceSync(logout);
+
+      expect(mockNotifyInfo).toHaveBeenCalledOnce();
+      expect(logout).not.toHaveBeenCalled();
+    });
+
+    it('should notify a failure when the task succeeds but returns false', async () => {
+      mockRunTask.mockResolvedValue({ message: 'nope', result: false, success: true });
+
+      await sync.forceSync(vi.fn(async (): Promise<void> => {}));
+
+      expect(mockNotifyError).toHaveBeenCalledOnce();
+      expect(mockNotifyInfo).not.toHaveBeenCalled();
+    });
+
+    it('should notify a failure on an actionable task failure', async () => {
+      mockRunTask.mockResolvedValue({ cancelled: false, message: 'boom', skipped: false, success: false });
+
+      await sync.forceSync(vi.fn(async (): Promise<void> => {}));
+
+      expect(mockNotifyError).toHaveBeenCalledOnce();
+    });
+
+    it('should stay silent on a cancelled task', async () => {
+      mockRunTask.mockResolvedValue({ cancelled: true, message: 'cancelled', skipped: false, success: false });
+
+      await sync.forceSync(vi.fn(async (): Promise<void> => {}));
+
+      expect(mockNotifyError).not.toHaveBeenCalled();
+      expect(mockNotifyInfo).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/suggestions/use-settings-suggestions.spec.ts
+++ b/frontend/app/src/modules/settings/suggestions/use-settings-suggestions.spec.ts
@@ -1,5 +1,5 @@
 import type { GeneralSettings } from '@/modules/settings/types/user-settings';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Currency } from '@/modules/assets/amount-display/currencies';
 import { defaultGeneralSettings } from '@/modules/settings/factories';
 import {
@@ -7,8 +7,36 @@ import {
   getDefaultFrontendSettings,
 } from '@/modules/settings/types/frontend-settings';
 import { PriceOracle } from '@/modules/settings/types/price-oracle';
-import { getSuggestionKey, type VersionSuggestions } from './settings-suggestions';
-import { collectPendingSuggestions } from './use-settings-suggestions';
+import { getSuggestionKey, type PendingSuggestion, type VersionSuggestions } from './settings-suggestions';
+import { collectPendingSuggestions, useSettingsSuggestions } from './use-settings-suggestions';
+
+const { mockRegistry } = vi.hoisted(() => ({ mockRegistry: { value: [] as VersionSuggestions[] } }));
+const mockUpdate = vi.fn();
+const mockUpdateFrontendSetting = vi.fn();
+const mockAppVersion = ref<string>('1.43.0');
+const mockStore = { pendingSuggestions: [] as PendingSuggestion[], showSuggestionsDialog: false };
+
+vi.mock('./settings-suggestions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./settings-suggestions')>();
+  return { ...actual, createSettingsSuggestions: vi.fn(() => mockRegistry.value) };
+});
+
+vi.mock('./use-suggestions-store', () => ({
+  useSuggestionsStore: vi.fn(() => mockStore),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: vi.fn(() => ({
+    update: mockUpdate,
+    updateFrontendSetting: mockUpdateFrontendSetting,
+  })),
+}));
+
+vi.mock('@/modules/core/common/use-main-store', () => ({
+  useMainStore: vi.fn(() => ({
+    appVersion: mockAppVersion,
+  })),
+}));
 
 function createFrontendSettings(overrides: Partial<FrontendSettings> = {}): FrontendSettings {
   return getDefaultFrontendSettings(overrides);
@@ -275,5 +303,102 @@ describe('collectPendingSuggestions', () => {
       oracleRegistry,
     );
     expect(resultDifferent).toHaveLength(1);
+  });
+});
+
+describe('useSettingsSuggestions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegistry.value = [];
+    set(mockAppVersion, '1.43.0');
+    mockStore.pendingSuggestions = [];
+    mockStore.showSuggestionsDialog = false;
+    mockUpdateFrontendSetting.mockResolvedValue(undefined);
+    mockUpdate.mockResolvedValue(undefined);
+  });
+
+  describe('checkForSuggestions', () => {
+    it('should do nothing on a development version', () => {
+      set(mockAppVersion, '1.43.0-dev');
+      const { checkForSuggestions } = useSettingsSuggestions();
+      checkForSuggestions(createFrontendSettings(), createGeneralSettings());
+
+      expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
+      expect(mockStore.showSuggestionsDialog).toBe(false);
+    });
+
+    it('should do nothing when the app version is empty', () => {
+      set(mockAppVersion, '');
+      const { checkForSuggestions } = useSettingsSuggestions();
+      checkForSuggestions(createFrontendSettings(), createGeneralSettings());
+
+      expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
+    });
+
+    it('should open the dialog when there are pending suggestions', () => {
+      mockRegistry.value = [
+        { suggestions: [{ description: 'd', key: 'submitUsageAnalytics', settingType: 'general', suggestedValue: true }], version: '1.43.0' },
+      ];
+      const { checkForSuggestions } = useSettingsSuggestions();
+      checkForSuggestions(createFrontendSettings(), createGeneralSettings({ submitUsageAnalytics: false }));
+
+      expect(mockStore.showSuggestionsDialog).toBe(true);
+      expect(mockStore.pendingSuggestions).toHaveLength(1);
+      expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
+    });
+
+    it('should mark the version applied when there are no suggestions', () => {
+      const { checkForSuggestions } = useSettingsSuggestions();
+      checkForSuggestions(createFrontendSettings(), createGeneralSettings());
+
+      expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({ lastAppliedSettingsVersion: '1.43.0' });
+      expect(mockStore.showSuggestionsDialog).toBe(false);
+    });
+  });
+
+  describe('applySelected', () => {
+    it('should split frontend and general payloads and reset the store', async () => {
+      mockStore.showSuggestionsDialog = true;
+      const selected: PendingSuggestion[] = [
+        { currentValue: false, description: 'd', fromVersion: '1.43.0', key: 'defiSetupDone', settingType: 'frontend', suggestedValue: true },
+        { currentValue: 2, description: 'd', fromVersion: '1.43.0', key: 'uiFloatingPrecision', settingType: 'general', suggestedValue: 6 },
+      ];
+
+      const { applySelected } = useSettingsSuggestions();
+      await applySelected(selected);
+
+      expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({ defiSetupDone: true, lastAppliedSettingsVersion: '1.43.0' });
+      expect(mockUpdate).toHaveBeenCalledWith({ uiFloatingPrecision: 6 });
+      expect(mockStore.pendingSuggestions).toEqual([]);
+      expect(mockStore.showSuggestionsDialog).toBe(false);
+    });
+
+    it('should not call the general update when only frontend settings are selected', async () => {
+      const selected: PendingSuggestion[] = [
+        { currentValue: false, description: 'd', fromVersion: '1.43.0', key: 'defiSetupDone', settingType: 'frontend', suggestedValue: true },
+      ];
+
+      const { applySelected } = useSettingsSuggestions();
+      await applySelected(selected);
+
+      expect(mockUpdateFrontendSetting).toHaveBeenCalledOnce();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dismissAll', () => {
+    it('should persist the current version and reset the store', async () => {
+      mockStore.pendingSuggestions = [
+        { currentValue: false, description: 'd', fromVersion: '1.43.0', key: 'defiSetupDone', settingType: 'frontend', suggestedValue: true },
+      ];
+      mockStore.showSuggestionsDialog = true;
+
+      const { dismissAll } = useSettingsSuggestions();
+      await dismissAll();
+
+      expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({ lastAppliedSettingsVersion: '1.43.0' });
+      expect(mockStore.pendingSuggestions).toEqual([]);
+      expect(mockStore.showSuggestionsDialog).toBe(false);
+    });
   });
 });

--- a/frontend/app/src/modules/settings/use-settings-page-highlight.spec.ts
+++ b/frontend/app/src/modules/settings/use-settings-page-highlight.spec.ts
@@ -1,0 +1,176 @@
+import type { HighlightRequest } from '@/modules/settings/use-settings-highlight';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, type VNode } from 'vue';
+import { SettingsCategoryIds, SettingsHighlightIds } from '@/modules/settings/setting-highlight-ids';
+import { useSettingsPageHighlight } from '@/modules/settings/use-settings-page-highlight';
+
+const mockClearHighlight = vi.fn();
+const mockHighlightTarget = ref<HighlightRequest>();
+
+vi.mock('@/modules/settings/use-settings-highlight', () => ({
+  useSettingsHighlight: vi.fn(() => ({
+    clearHighlight: mockClearHighlight,
+    highlightTarget: mockHighlightTarget,
+  })),
+}));
+
+const FOO = SettingsHighlightIds.ABBREVIATION;
+const BAR = SettingsHighlightIds.AMOUNT_FORMAT;
+const CATEGORY = SettingsCategoryIds.AMOUNT;
+const MISSING = SettingsHighlightIds.CSV_EXPORT;
+
+function addTarget(id: string): { element: HTMLElement; animation: Animation } {
+  const element = document.createElement('div');
+  element.id = id;
+  document.body.appendChild(element);
+  // createMock supplies an `Animation`-typed stub; the SUT only reads `cancel`
+  // and assigns `onfinish`, which lands on the underlying mock and reads back.
+  const animation = createMock<Animation>({ cancel: vi.fn() });
+  element.animate = vi.fn(() => animation);
+  return { animation, element };
+}
+
+interface HarnessOptions {
+  isElementInViewport?: (el: Element) => boolean;
+}
+
+const wrappers: VueWrapper[] = [];
+
+function mountHighlight(options: HarnessOptions = {}): {
+  scrollToElement: ReturnType<typeof vi.fn>;
+  isElementInViewport: ReturnType<typeof vi.fn>;
+} {
+  const scrollToElement = vi.fn(async (): Promise<void> => {});
+  const isElementInViewport = vi.fn(options.isElementInViewport ?? ((): boolean => true));
+  wrappers.push(mount(defineComponent({
+    setup(): () => VNode {
+      useSettingsPageHighlight({ isElementInViewport, scrollToElement });
+      return () => h('div');
+    },
+  })));
+  return { isElementInViewport, scrollToElement };
+}
+
+describe('useSettingsPageHighlight', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(mockHighlightTarget, undefined);
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    wrappers.splice(0).forEach(wrapper => wrapper.unmount());
+    document.body.innerHTML = '';
+  });
+
+  describe('same-page highlighting', () => {
+    it('should scroll and highlight when the target enters the DOM', async () => {
+      const { animation, element } = addTarget(FOO);
+      const { scrollToElement } = mountHighlight({ isElementInViewport: () => false });
+
+      set(mockHighlightTarget, { categoryId: CATEGORY, highlightId: FOO });
+      await flushPromises();
+
+      expect(scrollToElement).toHaveBeenCalledWith(element);
+      expect(element.classList.contains('outline')).toBe(true);
+      expect(element.animate).toHaveBeenCalledOnce();
+      expect(animation.onfinish).toBeTypeOf('function');
+    });
+
+    it('should not scroll when the element is already in viewport', async () => {
+      addTarget(FOO);
+      const { scrollToElement } = mountHighlight({ isElementInViewport: () => true });
+
+      set(mockHighlightTarget, { categoryId: CATEGORY, highlightId: FOO });
+      await flushPromises();
+
+      expect(scrollToElement).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when no element matches the target id', async () => {
+      const { scrollToElement } = mountHighlight();
+
+      set(mockHighlightTarget, { categoryId: CATEGORY, highlightId: MISSING });
+      await flushPromises();
+
+      expect(scrollToElement).not.toHaveBeenCalled();
+      expect(mockClearHighlight).not.toHaveBeenCalled();
+    });
+
+    it('should ignore a cleared target', async () => {
+      addTarget(FOO);
+      const { scrollToElement } = mountHighlight();
+
+      set(mockHighlightTarget, undefined);
+      await flushPromises();
+
+      expect(scrollToElement).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the category id when no highlight id is given', async () => {
+      const { element } = addTarget(CATEGORY);
+      mountHighlight({ isElementInViewport: () => true });
+
+      set(mockHighlightTarget, { categoryId: CATEGORY });
+      await flushPromises();
+
+      expect(element.classList.contains('outline')).toBe(true);
+    });
+  });
+
+  describe('animation lifecycle', () => {
+    it('should clean up classes and clear the highlight when the animation finishes', async () => {
+      const { animation, element } = addTarget(FOO);
+      mountHighlight({ isElementInViewport: () => true });
+
+      set(mockHighlightTarget, { categoryId: CATEGORY, highlightId: FOO });
+      await flushPromises();
+      mockClearHighlight.mockClear();
+
+      animation.onfinish?.(createMock<AnimationPlaybackEvent>());
+
+      expect(element.classList.contains('outline')).toBe(false);
+      expect(mockClearHighlight).toHaveBeenCalledOnce();
+    });
+
+    it('should cancel the previous animation before starting a new one', async () => {
+      const first = addTarget(FOO);
+      const second = addTarget(BAR);
+      mountHighlight({ isElementInViewport: () => true });
+
+      set(mockHighlightTarget, { categoryId: CATEGORY, highlightId: FOO });
+      await flushPromises();
+
+      set(mockHighlightTarget, { categoryId: CATEGORY, highlightId: BAR });
+      await flushPromises();
+
+      expect(first.animation.cancel).toHaveBeenCalledOnce();
+      expect(first.element.classList.contains('outline')).toBe(false);
+      expect(second.element.classList.contains('outline')).toBe(true);
+    });
+  });
+
+  describe('cross-page highlighting', () => {
+    it('should highlight a pending target present at mount time', async () => {
+      const { element } = addTarget(FOO);
+      set(mockHighlightTarget, { categoryId: CATEGORY, highlightId: FOO });
+
+      const { scrollToElement } = mountHighlight({ isElementInViewport: () => false });
+      await flushPromises();
+
+      expect(scrollToElement).toHaveBeenCalledWith(element);
+      expect(element.classList.contains('outline')).toBe(true);
+    });
+
+    it('should do nothing at mount when there is no pending target', async () => {
+      addTarget(FOO);
+      const { scrollToElement } = mountHighlight();
+      await flushPromises();
+
+      expect(scrollToElement).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/use-settings-scroll-spy.spec.ts
+++ b/frontend/app/src/modules/settings/use-settings-scroll-spy.spec.ts
@@ -1,0 +1,130 @@
+import { assert } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { mount } from '@vue/test-utils';
+import { get } from '@vueuse/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, type ShallowRef, shallowRef, type VNode } from 'vue';
+import { useSettingsScrollSpy } from '@/modules/settings/use-settings-scroll-spy';
+
+interface ScrollerProps {
+  scrollTop?: number;
+  clientHeight?: number;
+  scrollHeight?: number;
+  rect?: DOMRect;
+}
+
+const navigation = [
+  { id: 'a', label: 'A' },
+  { id: 'b', label: 'B' },
+  { id: 'c', label: 'C' },
+];
+
+function makeEl(x: number, y: number, w: number, h: number): Element {
+  return createMock<Element>({ getBoundingClientRect: () => new DOMRect(x, y, w, h) });
+}
+
+function makeScroller(props: ScrollerProps = {}): HTMLDivElement {
+  const { clientHeight = 100, rect = new DOMRect(0, 0, 100, 100), scrollHeight = 100, scrollTop = 0 } = props;
+  const div = document.createElement('div');
+  div.getBoundingClientRect = (): DOMRect => rect;
+  div.scrollTo = vi.fn();
+  div.scrollTop = scrollTop;
+  Object.defineProperty(div, 'clientHeight', { configurable: true, value: clientHeight });
+  Object.defineProperty(div, 'scrollHeight', { configurable: true, value: scrollHeight });
+  return div;
+}
+
+function scrollerRef(div: HTMLDivElement | null): ShallowRef<HTMLDivElement | null> {
+  return shallowRef<HTMLDivElement | null>(div);
+}
+
+function setup(
+  scroller: ShallowRef<HTMLDivElement | null>,
+): ReturnType<typeof useSettingsScrollSpy> {
+  let api: ReturnType<typeof useSettingsScrollSpy> | undefined;
+  mount(defineComponent({
+    setup(): () => VNode {
+      api = useSettingsScrollSpy({ navigation, scroller });
+      return () => h('div');
+    },
+  }));
+  assert(api);
+  return api;
+}
+
+describe('useSettingsScrollSpy', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('isElementInViewport', () => {
+    it('should return false without a scroller', () => {
+      const { isElementInViewport } = setup(scrollerRef(null));
+      expect(isElementInViewport(makeEl(10, 10, 10, 10))).toBe(false);
+    });
+
+    it('should return true for an overlapping element', () => {
+      const { isElementInViewport } = setup(scrollerRef(makeScroller()));
+      expect(isElementInViewport(makeEl(10, 10, 10, 10))).toBe(true);
+    });
+
+    it('should return false for an element outside the scroller', () => {
+      const { isElementInViewport } = setup(scrollerRef(makeScroller()));
+      expect(isElementInViewport(makeEl(200, 200, 10, 10))).toBe(false);
+    });
+  });
+
+  describe('checkVisibility on mount', () => {
+    it('should select the first nav item when scrolled to the top', () => {
+      const { currentId } = setup(scrollerRef(makeScroller({ scrollTop: 0 })));
+      expect(get(currentId)).toBe('a');
+    });
+
+    it('should select the last nav item when scrolled to the bottom', () => {
+      const scroller = makeScroller({ clientHeight: 500, scrollHeight: 1500, scrollTop: 1000 });
+      const { currentId } = setup(scrollerRef(scroller));
+      expect(get(currentId)).toBe('c');
+    });
+
+    it('should fall back to the first nav item when no element is in view', () => {
+      const scroller = makeScroller({ clientHeight: 100, scrollHeight: 1000, scrollTop: 300 });
+      const { currentId } = setup(scrollerRef(scroller));
+      expect(get(currentId)).toBe('a');
+    });
+  });
+
+  describe('scrollToElement', () => {
+    it('should resolve immediately without a target', async () => {
+      const { scrollToElement } = setup(scrollerRef(makeScroller()));
+      await expect(scrollToElement()).resolves.toBeUndefined();
+    });
+
+    it('should resolve immediately when already at the target', async () => {
+      const scrollTo = vi.fn();
+      const scroller = makeScroller({ rect: new DOMRect(0, 0, 100, 100), scrollTop: 0 });
+      scroller.scrollTo = scrollTo;
+      const { scrollToElement } = setup(scrollerRef(scroller));
+      await expect(scrollToElement(makeEl(0, 20, 10, 10))).resolves.toBeUndefined();
+      expect(scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('should scroll and resolve on scrollend', async () => {
+      const scrollTo = vi.fn();
+      const scroller = makeScroller({ rect: new DOMRect(0, 0, 100, 100), scrollTop: 100 });
+      scroller.scrollTo = scrollTo;
+      const { scrollToElement } = setup(scrollerRef(scroller));
+
+      const promise = scrollToElement(makeEl(0, 500, 10, 10));
+
+      expect(scrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 580 });
+      scroller.dispatchEvent(new Event('scrollend'));
+
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('should resolve when the element cannot be found', async () => {
+      const { scrollToElement } = setup(scrollerRef(makeScroller()));
+      await expect(scrollToElement('missing-id')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/app/use-electron-interop.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-electron-interop.spec.ts
@@ -1,0 +1,278 @@
+import type { Interop, SystemVersion } from '@shared/ipc';
+import { externalLinks } from '@shared/external-links';
+import { LogLevel } from '@shared/log-level';
+import { createMock, type DeepPartial } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type UseInterop = ReturnType<(typeof import('./use-electron-interop'))['useInterop']>;
+
+const systemVersion: SystemVersion = { arch: 'x64', electron: '30.0.0', os: 'linux', osVersion: '6.0' };
+
+function makeInterop(overrides?: DeepPartial<Interop>): Interop {
+  return createMock<Interop>({
+    checkForUpdates: vi.fn().mockResolvedValue(true),
+    clearPassword: vi.fn().mockResolvedValue(undefined),
+    closeApp: vi.fn().mockResolvedValue(undefined),
+    config: vi.fn().mockResolvedValue({ dataDirectory: '/data' }),
+    downloadUpdate: vi.fn().mockResolvedValue(true),
+    getPassword: vi.fn().mockResolvedValue('secret'),
+    getStartupError: vi.fn().mockReturnValue(null),
+    installUpdate: vi.fn().mockResolvedValue(true),
+    isMac: vi.fn().mockResolvedValue(true),
+    logToFile: vi.fn(),
+    metamaskImport: vi.fn().mockResolvedValue({ addresses: ['0xabc'] }),
+    notifyUserLogout: vi.fn(),
+    openDirectory: vi.fn().mockResolvedValue('/selected'),
+    openPath: vi.fn().mockResolvedValue(undefined),
+    openUrl: vi.fn().mockResolvedValue(undefined),
+    premiumUserLoggedIn: vi.fn(),
+    restartBackend: vi.fn().mockResolvedValue(true),
+    setListeners: vi.fn(),
+    setLogLevel: vi.fn(),
+    setSelectedTheme: vi.fn().mockResolvedValue(true),
+    storePassword: vi.fn().mockResolvedValue(true),
+    updateTray: vi.fn(),
+    version: vi.fn().mockResolvedValue(systemVersion),
+    ...overrides,
+  });
+}
+
+async function loadInterop(interop?: Interop): Promise<UseInterop> {
+  vi.resetModules();
+  if (interop)
+    window.interop = interop;
+  else
+    Reflect.deleteProperty(window, 'interop');
+
+  const { useInterop } = await import('./use-electron-interop');
+  return useInterop();
+}
+
+describe('useInterop', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'interop');
+  });
+
+  describe('environment flags', () => {
+    it('should report isPackaged/appSession true inside electron without a backend url', async () => {
+      const interop = await loadInterop(makeInterop());
+      expect(interop.isPackaged).toBe(true);
+      expect(interop.appSession).toBe(true);
+    });
+
+    it('should report appSession false when a backend url is configured', async () => {
+      localStorage.setItem('rotki.backend_url', 'http://localhost:4242');
+      const interop = await loadInterop(makeInterop());
+      expect(interop.isPackaged).toBe(true);
+      expect(interop.appSession).toBe(false);
+    });
+
+    it('should report isPackaged/appSession false outside electron', async () => {
+      const interop = await loadInterop();
+      expect(interop.isPackaged).toBe(false);
+      expect(interop.appSession).toBe(false);
+    });
+  });
+
+  describe('update flow', () => {
+    it('should delegate checkForUpdates/downloadUpdate/installUpdate to interop', async () => {
+      const mock = makeInterop();
+      const interop = await loadInterop(mock);
+      const progress = vi.fn();
+
+      expect(await interop.checkForUpdates()).toBe(true);
+      expect(await interop.downloadUpdate(progress)).toBe(true);
+      expect(await interop.installUpdate()).toBe(true);
+      expect(mock.downloadUpdate).toHaveBeenCalledWith(progress);
+    });
+
+    it('should fall back to false when interop is unavailable', async () => {
+      const interop = await loadInterop();
+      expect(await interop.checkForUpdates()).toBe(false);
+      expect(await interop.downloadUpdate(vi.fn())).toBe(false);
+      expect(await interop.installUpdate()).toBe(false);
+    });
+  });
+
+  describe('passwords', () => {
+    it('should store and read passwords through interop', async () => {
+      const mock = makeInterop();
+      const interop = await loadInterop(mock);
+
+      expect(await interop.storePassword('user', 'pass')).toBe(true);
+      expect(mock.storePassword).toHaveBeenCalledWith({ password: 'pass', username: 'user' });
+      expect(await interop.getPassword('user')).toBe('secret');
+      await interop.clearPassword();
+      expect(mock.clearPassword).toHaveBeenCalled();
+    });
+
+    it('should return undefined from getPassword outside electron', async () => {
+      const interop = await loadInterop();
+      expect(await interop.getPassword('user')).toBeUndefined();
+    });
+
+    it('should throw from storePassword outside electron', async () => {
+      const interop = await loadInterop();
+      await expect(interop.storePassword('user', 'pass')).rejects.toThrow();
+    });
+  });
+
+  describe('navigation and urls', () => {
+    it('should open urls via interop inside electron', async () => {
+      const mock = makeInterop();
+      const interop = await loadInterop(mock);
+      await interop.openUrl('https://rotki.com');
+      expect(mock.openUrl).toHaveBeenCalledWith('https://rotki.com');
+    });
+
+    it('should open urls in a new tab outside electron', async () => {
+      const open = vi.spyOn(window, 'open').mockReturnValue(null);
+      const interop = await loadInterop();
+      await interop.openUrl('https://rotki.com');
+      expect(open).toHaveBeenCalledWith('https://rotki.com', '_blank');
+      open.mockRestore();
+    });
+
+    it('should navigate and navigateToPremium through interop.openUrl', async () => {
+      const mock = makeInterop();
+      const interop = await loadInterop(mock);
+      await interop.navigate('https://example.com');
+      await interop.navigateToPremium();
+      expect(mock.openUrl).toHaveBeenNthCalledWith(1, 'https://example.com');
+      expect(mock.openUrl).toHaveBeenNthCalledWith(2, externalLinks.premium);
+    });
+
+    it('should forward openDirectory/openPath results', async () => {
+      const mock = makeInterop();
+      const interop = await loadInterop(mock);
+      expect(await interop.openDirectory('pick')).toBe('/selected');
+      await interop.openPath('/some/path');
+      expect(mock.openPath).toHaveBeenCalledWith('/some/path');
+    });
+  });
+
+  describe('metamask import', () => {
+    it('should return the imported addresses', async () => {
+      const interop = await loadInterop(makeInterop());
+      expect(await interop.metamaskImport()).toEqual(['0xabc']);
+    });
+
+    it('should throw the reported import error', async () => {
+      const interop = await loadInterop(makeInterop({
+        metamaskImport: vi.fn().mockResolvedValue({ error: 'no metamask' }),
+      }));
+      await expect(interop.metamaskImport()).rejects.toThrow('no metamask');
+    });
+
+    it('should throw when interop is unavailable', async () => {
+      const interop = await loadInterop();
+      await expect(interop.metamaskImport()).rejects.toThrow('environment does not support interop');
+    });
+  });
+
+  describe('config and backend', () => {
+    it('should return config and restart the backend through interop', async () => {
+      const mock = makeInterop();
+      const interop = await loadInterop(mock);
+      expect(await interop.config(true)).toEqual({ dataDirectory: '/data' });
+      expect(mock.config).toHaveBeenCalledWith(true);
+      expect(await interop.restartBackend({ dataDirectory: '/x' })).toBe(true);
+      expect(mock.restartBackend).toHaveBeenCalledWith({ dataDirectory: '/x' }, false);
+    });
+
+    it('should throw from config outside electron', async () => {
+      const interop = await loadInterop();
+      await expect(interop.config(true)).rejects.toThrow();
+    });
+  });
+
+  describe('version and platform', () => {
+    it('should return the system version inside electron', async () => {
+      const interop = await loadInterop(makeInterop());
+      expect(await interop.version()).toEqual(systemVersion);
+      expect(await interop.isMac()).toBe(true);
+    });
+
+    it('should return a web version outside electron', async () => {
+      const interop = await loadInterop();
+      const version = await interop.version();
+      expect(version).toHaveProperty('platform');
+      expect(version).toHaveProperty('userAgent');
+    });
+  });
+
+  describe('file path resolution', () => {
+    it('should return the electron path attached to a file', async () => {
+      const interop = await loadInterop(makeInterop());
+      const file = Object.assign(new File([], 'a.txt'), { path: '/tmp/a.txt' });
+      expect(interop.getPath(file)).toBe('/tmp/a.txt');
+    });
+
+    it('should return undefined for a plain browser file', async () => {
+      const interop = await loadInterop(makeInterop());
+      expect(interop.getPath(new File([], 'a.txt'))).toBeUndefined();
+    });
+
+    it('should return undefined when not in an app session', async () => {
+      localStorage.setItem('rotki.backend_url', 'http://localhost:4242');
+      const interop = await loadInterop(makeInterop());
+      const file = Object.assign(new File([], 'a.txt'), { path: '/tmp/a.txt' });
+      expect(interop.getPath(file)).toBeUndefined();
+    });
+  });
+
+  describe('tray, logging and listeners', () => {
+    it('should reset and update the tray', async () => {
+      const mock = makeInterop();
+      const interop = await loadInterop(mock);
+      interop.resetTray();
+      interop.updateTray({ up: true });
+      expect(mock.updateTray).toHaveBeenNthCalledWith(1, {});
+      expect(mock.updateTray).toHaveBeenNthCalledWith(2, { up: true });
+    });
+
+    it('should forward logging and listener registration', async () => {
+      const mock = makeInterop();
+      const interop = await loadInterop(mock);
+      interop.logToFile(LogLevel.INFO, 'hello');
+      interop.setLogLevel(LogLevel.DEBUG);
+      const listeners = { onAbout: vi.fn(), onError: vi.fn(), onProcessDetected: vi.fn(), onRestart: vi.fn() };
+      interop.setupListeners(listeners);
+      expect(mock.logToFile).toHaveBeenCalledWith(LogLevel.INFO, 'hello');
+      expect(mock.setLogLevel).toHaveBeenCalledWith(LogLevel.DEBUG);
+      expect(mock.setListeners).toHaveBeenCalledWith(listeners);
+    });
+
+    it('should forward premium status, logout, theme and closeApp', async () => {
+      const mock = makeInterop();
+      const interop = await loadInterop(mock);
+      interop.premiumUserLoggedIn(true);
+      interop.notifyUserLogout();
+      await interop.setSelectedTheme(1);
+      await interop.closeApp();
+      expect(mock.premiumUserLoggedIn).toHaveBeenCalledWith(true);
+      expect(mock.notifyUserLogout).toHaveBeenCalled();
+      expect(mock.setSelectedTheme).toHaveBeenCalledWith(1);
+      expect(mock.closeApp).toHaveBeenCalled();
+    });
+  });
+
+  describe('startup error', () => {
+    it('should return the startup error reported by interop', async () => {
+      const interop = await loadInterop(makeInterop({
+        getStartupError: vi.fn().mockReturnValue({ code: 0, message: 'boom' }),
+      }));
+      expect(interop.getStartupError()).toEqual({ code: 0, message: 'boom' });
+    });
+
+    it('should return null when interop is unavailable', async () => {
+      const interop = await loadInterop();
+      expect(interop.getStartupError()).toBeNull();
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/layout/use-marquee-animation.spec.ts
+++ b/frontend/app/src/modules/shell/layout/use-marquee-animation.spec.ts
@@ -1,0 +1,97 @@
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMarqueeAnimation } from '@/modules/shell/layout/use-marquee-animation';
+
+function makeMarquee(scrollWidth: number, clientWidth: number, withChild = true): {
+  wrapper: HTMLElement;
+  inner: HTMLElement | undefined;
+  animation: Animation;
+} {
+  const wrapper = document.createElement('div');
+  Object.defineProperty(wrapper, 'clientWidth', { configurable: true, value: clientWidth });
+
+  const animation = createMock<Animation>({ cancel: vi.fn() });
+  let inner: HTMLElement | undefined;
+  if (withChild) {
+    inner = document.createElement('div');
+    Object.defineProperty(inner, 'scrollWidth', { configurable: true, value: scrollWidth });
+    inner.animate = vi.fn(() => animation);
+    wrapper.appendChild(inner);
+  }
+
+  return { animation, inner, wrapper };
+}
+
+describe('useMarqueeAnimation', () => {
+  let marquee: ReturnType<typeof useMarqueeAnimation>;
+
+  // Dispatch a real event so `currentTarget` is populated by the DOM (it is a
+  // read-only accessor that can only be set during actual event dispatch).
+  function fireEnter(wrapper: HTMLElement): void {
+    wrapper.addEventListener('mouseenter', marquee.onMarqueeEnter, { once: true });
+    wrapper.dispatchEvent(new MouseEvent('mouseenter'));
+  }
+
+  function fireLeave(wrapper: HTMLElement): void {
+    wrapper.addEventListener('mouseleave', marquee.onMarqueeLeave, { once: true });
+    wrapper.dispatchEvent(new MouseEvent('mouseleave'));
+  }
+
+  beforeEach(() => {
+    marquee = useMarqueeAnimation();
+  });
+
+  describe('onMarqueeEnter', () => {
+    it('should animate the inner element when it overflows', () => {
+      const { inner, wrapper } = makeMarquee(300, 200);
+      fireEnter(wrapper);
+
+      expect(inner?.animate).toHaveBeenCalledOnce();
+    });
+
+    it('should run the animation forever with the computed duration', () => {
+      const { inner, wrapper } = makeMarquee(300, 200);
+      fireEnter(wrapper);
+
+      // distance 100 → scrollDuration max(1000, 1500)=1500, +2*500 pause = 2500
+      const animateMock = vi.mocked(inner!.animate);
+      expect(animateMock.mock.calls[0][1]).toMatchObject({ duration: 2500, iterations: Infinity });
+    });
+
+    it('should not animate when the inner element does not overflow', () => {
+      const { inner, wrapper } = makeMarquee(150, 200);
+      fireEnter(wrapper);
+
+      expect(inner?.animate).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when there is no inner element', () => {
+      const { wrapper } = makeMarquee(0, 200, false);
+
+      expect(() => fireEnter(wrapper)).not.toThrow();
+    });
+  });
+
+  describe('onMarqueeLeave', () => {
+    it('should cancel a running animation', () => {
+      const { animation, wrapper } = makeMarquee(300, 200);
+      fireEnter(wrapper);
+      fireLeave(wrapper);
+
+      expect(animation.cancel).toHaveBeenCalledOnce();
+    });
+
+    it('should do nothing when there is no animation for the element', () => {
+      const { animation, wrapper } = makeMarquee(300, 200);
+      fireLeave(wrapper);
+
+      expect(animation.cancel).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when there is no inner element', () => {
+      const { wrapper } = makeMarquee(0, 200, false);
+
+      expect(() => fireLeave(wrapper)).not.toThrow();
+    });
+  });
+});

--- a/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.spec.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEthStakingRefresh } from '@/modules/staking/eth/use-eth-staking-refresh';
+
+const mockFetchEthStakingValidators = vi.fn();
+const mockFetchBlockchainBalances = vi.fn();
+const mockRefreshBlockchainBalances = vi.fn();
+const mockIsFirstLoad = vi.fn((): boolean => false);
+const { mockLoggerLog } = vi.hoisted(() => ({ mockLoggerLog: vi.fn() }));
+
+const mockUsername = ref<string>('test-user');
+const mockStakingValidatorsLimits = ref<{ limit: number; total: number }>();
+const mockPerformanceRefreshing = ref<boolean>(false);
+const mockEth2Loading = ref<boolean>(false);
+const mockBlockProductionLoading = ref<boolean>(false);
+
+vi.mock('@/modules/accounts/use-eth-staking', () => ({
+  useEthStaking: vi.fn(() => ({
+    fetchEthStakingValidators: mockFetchEthStakingValidators,
+  })),
+}));
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: vi.fn(() => ({
+    username: mockUsername,
+  })),
+}));
+
+vi.mock('@/modules/balances/use-blockchain-balances', () => ({
+  useBlockchainBalances: vi.fn(() => ({
+    fetchBlockchainBalances: mockFetchBlockchainBalances,
+    refreshBlockchainBalances: mockRefreshBlockchainBalances,
+  })),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: {
+    log: mockLoggerLog,
+  },
+}));
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: vi.fn(() => ({
+    useIsTaskRunning: vi.fn(() => mockBlockProductionLoading),
+  })),
+}));
+
+vi.mock('@/modules/shell/sync-progress/use-section-status', () => ({
+  useSectionStatus: vi.fn((_section: unknown, subsection?: unknown) => ({
+    isLoading: subsection === undefined ? mockPerformanceRefreshing : mockEth2Loading,
+  })),
+}));
+
+vi.mock('@/modules/shell/sync-progress/use-status-updater', () => ({
+  useStatusUpdater: vi.fn(() => ({
+    isFirstLoad: mockIsFirstLoad,
+  })),
+}));
+
+vi.mock('@/modules/staking/use-blockchain-validators-store', () => ({
+  useBlockchainValidatorsStore: vi.fn(() => ({
+    stakingValidatorsLimits: mockStakingValidatorsLimits,
+  })),
+}));
+
+interface RefreshCallbacks {
+  getPerformance: () => { entriesTotal: number };
+  refreshPerformance: (userInitiated: boolean) => Promise<void>;
+  setTotal: () => void;
+}
+
+function createCallbacks(overrides: {
+  entriesTotal?: number;
+  refreshPerformance?: RefreshCallbacks['refreshPerformance'];
+  setTotal?: RefreshCallbacks['setTotal'];
+} = {}): RefreshCallbacks {
+  return {
+    getPerformance: vi.fn((): { entriesTotal: number } => ({ entriesTotal: overrides.entriesTotal ?? 0 })),
+    refreshPerformance: overrides.refreshPerformance ?? vi.fn(async (): Promise<void> => {}),
+    setTotal: overrides.setTotal ?? vi.fn(),
+  };
+}
+
+describe('useEthStakingRefresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsFirstLoad.mockReturnValue(false);
+    set(mockUsername, 'test-user');
+    set(mockStakingValidatorsLimits, undefined);
+    set(mockPerformanceRefreshing, false);
+    set(mockEth2Loading, false);
+    set(mockBlockProductionLoading, false);
+    mockFetchEthStakingValidators.mockResolvedValue(undefined);
+    mockFetchBlockchainBalances.mockResolvedValue(undefined);
+    mockRefreshBlockchainBalances.mockResolvedValue(undefined);
+  });
+
+  describe('refresh', () => {
+    it('should force a balance refresh when user initiated', async () => {
+      const { refresh } = useEthStakingRefresh(createCallbacks());
+      await refresh(true);
+
+      expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' });
+      expect(mockFetchBlockchainBalances).not.toHaveBeenCalled();
+      expect(mockFetchEthStakingValidators).toHaveBeenCalledWith({ ignoreCache: true });
+    });
+
+    it('should force a balance refresh on first load even when not user initiated', async () => {
+      mockIsFirstLoad.mockReturnValue(true);
+
+      const { refresh } = useEthStakingRefresh(createCallbacks());
+      await refresh(false);
+
+      expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' });
+      expect(mockFetchBlockchainBalances).not.toHaveBeenCalled();
+      expect(mockFetchEthStakingValidators).toHaveBeenCalledWith({ ignoreCache: true });
+    });
+
+    it('should use cached balances when not user initiated and not first load', async () => {
+      const { refresh } = useEthStakingRefresh(createCallbacks());
+      await refresh(false);
+
+      expect(mockFetchBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' });
+      expect(mockRefreshBlockchainBalances).not.toHaveBeenCalled();
+      expect(mockFetchEthStakingValidators).toHaveBeenCalledWith({ ignoreCache: false });
+    });
+
+    it('should default userInitiated to false', async () => {
+      const { refresh } = useEthStakingRefresh(createCallbacks());
+      await refresh();
+
+      expect(mockFetchBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' });
+      expect(mockRefreshBlockchainBalances).not.toHaveBeenCalled();
+    });
+
+    it('should set the total after refreshing validators', async () => {
+      const setTotal = vi.fn();
+      const { refresh } = useEthStakingRefresh(createCallbacks({ setTotal }));
+      await refresh(false);
+
+      expect(setTotal).toHaveBeenCalledOnce();
+    });
+
+    it('should refresh performance once when validators do not exceed entries', async () => {
+      const refreshPerformance = vi.fn(async (): Promise<void> => {});
+      set(mockStakingValidatorsLimits, { limit: 10, total: 5 });
+
+      const { refresh } = useEthStakingRefresh(createCallbacks({ entriesTotal: 5, refreshPerformance }));
+      await refresh(false);
+
+      expect(refreshPerformance).toHaveBeenCalledTimes(1);
+      expect(refreshPerformance).toHaveBeenCalledWith(false);
+      expect(mockLoggerLog).not.toHaveBeenCalled();
+    });
+
+    it('should force a second performance refresh when validators exceed entries', async () => {
+      const refreshPerformance = vi.fn(async (): Promise<void> => {});
+      set(mockStakingValidatorsLimits, { limit: 10, total: 8 });
+
+      const { refresh } = useEthStakingRefresh(createCallbacks({ entriesTotal: 3, refreshPerformance }));
+      await refresh(true);
+
+      expect(refreshPerformance).toHaveBeenCalledTimes(2);
+      expect(refreshPerformance).toHaveBeenNthCalledWith(1, true);
+      expect(refreshPerformance).toHaveBeenNthCalledWith(2, true);
+      expect(mockLoggerLog).toHaveBeenCalledOnce();
+    });
+
+    it('should treat missing validator limits as zero total', async () => {
+      const refreshPerformance = vi.fn(async (): Promise<void> => {});
+      set(mockStakingValidatorsLimits, undefined);
+
+      const { refresh } = useEthStakingRefresh(createCallbacks({ entriesTotal: 0, refreshPerformance }));
+      await refresh(false);
+
+      expect(refreshPerformance).toHaveBeenCalledTimes(1);
+      expect(mockLoggerLog).not.toHaveBeenCalled();
+    });
+
+    it('should update lastRefresh timestamp after a successful refresh', async () => {
+      const { lastRefresh, refresh } = useEthStakingRefresh(createCallbacks());
+      set(lastRefresh, 0);
+      await refresh(false);
+
+      expect(get(lastRefresh)).toBeGreaterThan(0);
+    });
+  });
+
+  describe('loading states', () => {
+    it('should expose block production loading state', () => {
+      const { blockProductionLoading } = useEthStakingRefresh(createCallbacks());
+      set(mockBlockProductionLoading, true);
+
+      expect(get(blockProductionLoading)).toBe(true);
+    });
+
+    it('should expose performance refreshing state', () => {
+      const { performanceRefreshing } = useEthStakingRefresh(createCallbacks());
+      set(mockPerformanceRefreshing, true);
+
+      expect(get(performanceRefreshing)).toBe(true);
+    });
+
+    it('should be refreshing when performance is refreshing', () => {
+      const { refreshing } = useEthStakingRefresh(createCallbacks());
+      set(mockPerformanceRefreshing, true);
+
+      expect(get(refreshing)).toBe(true);
+    });
+
+    it('should be refreshing when eth2 balances are loading', () => {
+      const { refreshing } = useEthStakingRefresh(createCallbacks());
+      set(mockEth2Loading, true);
+
+      expect(get(refreshing)).toBe(true);
+    });
+
+    it('should be refreshing when block production is loading', () => {
+      const { refreshing } = useEthStakingRefresh(createCallbacks());
+      set(mockBlockProductionLoading, true);
+
+      expect(get(refreshing)).toBe(true);
+    });
+
+    it('should not be refreshing when nothing is loading', () => {
+      const { refreshing } = useEthStakingRefresh(createCallbacks());
+
+      expect(get(refreshing)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-management.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-management.spec.ts
@@ -1,0 +1,163 @@
+import type { EffectScope } from 'vue';
+import type { EthereumValidator } from '@/modules/accounts/blockchain-accounts';
+import { bigNumberify, Zero } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEthValidatorManagement } from '@/modules/staking/eth/use-eth-validator-management';
+
+const mockGetEth2Validators = vi.fn();
+const mockRunTask = vi.fn();
+const mockEthStakingValidators = ref<EthereumValidator[]>([]);
+
+vi.mock('@/modules/accounts/api/use-blockchain-accounts-api', () => ({
+  useBlockchainAccountsApi: vi.fn(() => ({
+    getEth2Validators: mockGetEth2Validators,
+  })),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-handler', () => ({
+  useTaskHandler: vi.fn(() => ({
+    runTask: mockRunTask,
+  })),
+}));
+
+vi.mock('@/modules/staking/use-blockchain-validators-store', () => ({
+  useBlockchainValidatorsStore: vi.fn(() => ({
+    ethStakingValidators: mockEthStakingValidators,
+  })),
+}));
+
+function validator(publicKey: string, amount: number): EthereumValidator {
+  return createMock<EthereumValidator>({ amount: bigNumberify(amount), publicKey });
+}
+
+describe('useEthValidatorManagement', () => {
+  let scope: EffectScope;
+
+  function create(): ReturnType<typeof useEthValidatorManagement> {
+    return scope.run(() => useEthValidatorManagement())!;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scope = effectScope();
+    set(mockEthStakingValidators, []);
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  describe('setTotal', () => {
+    it('should sum all staking validators when no filter is given', () => {
+      set(mockEthStakingValidators, [validator('0xaaa', 2), validator('0xbbb', 3)]);
+
+      const { setTotal, total } = create();
+      setTotal();
+
+      expect(get(total).toNumber()).toBe(5);
+    });
+
+    it('should only sum validators matching the provided public keys', () => {
+      set(mockEthStakingValidators, [validator('0xaaa', 2), validator('0xbbb', 3)]);
+
+      const { setTotal, total } = create();
+      setTotal([{ index: 1, publicKey: '0xbbb', status: 'active' }]);
+
+      expect(get(total).toNumber()).toBe(3);
+    });
+
+    it('should be zero when no validators match', () => {
+      set(mockEthStakingValidators, [validator('0xaaa', 2)]);
+
+      const { setTotal, total } = create();
+      setTotal([{ index: 9, publicKey: '0xzzz', status: 'active' }]);
+
+      expect(get(total)).toStrictEqual(Zero);
+    });
+  });
+
+  describe('fetchValidatorsWithFilter', () => {
+    it('should skip the task and total all validators when the filter is empty', async () => {
+      set(mockEthStakingValidators, [validator('0xaaa', 2), validator('0xbbb', 3)]);
+
+      const { fetchValidatorsWithFilter, total } = create();
+      await fetchValidatorsWithFilter();
+
+      expect(mockRunTask).not.toHaveBeenCalled();
+      expect(get(total).toNumber()).toBe(5);
+    });
+
+    it('should query by validator indices when validators are selected', async () => {
+      mockRunTask.mockImplementation(async (fn: () => Promise<unknown>) => {
+        await fn();
+        return { result: { entries: [], entriesFound: 0, entriesLimit: 100 }, success: true };
+      });
+
+      const { selection } = create();
+      set(selection, { validators: [{ index: 42, publicKey: '0xaaa', status: 'active' }] });
+      await flushPromises();
+
+      expect(mockRunTask).toHaveBeenCalledOnce();
+      expect(mockGetEth2Validators).toHaveBeenCalledWith({ validatorIndices: [42] });
+    });
+
+    it('should query by addresses when accounts are selected', async () => {
+      mockRunTask.mockImplementation(async (fn: () => Promise<unknown>) => {
+        await fn();
+        return { result: { entries: [], entriesFound: 0, entriesLimit: 100 }, success: true };
+      });
+
+      const { selection } = create();
+      set(selection, { accounts: [{ address: '0xdead', chain: 'eth2' }] });
+      await flushPromises();
+
+      expect(mockGetEth2Validators).toHaveBeenCalledWith({ addresses: ['0xdead'] });
+    });
+
+    it('should merge the status filter with the account selection', async () => {
+      mockRunTask.mockImplementation(async (fn: () => Promise<unknown>) => {
+        await fn();
+        return { result: { entries: [], entriesFound: 0, entriesLimit: 100 }, success: true };
+      });
+
+      const { filter, selection } = create();
+      set(selection, { validators: [{ index: 7, publicKey: '0xaaa', status: 'active' }] });
+      set(filter, { fromTimestamp: 100, status: 'active', toTimestamp: 200 });
+      await flushPromises();
+
+      expect(mockGetEth2Validators).toHaveBeenLastCalledWith({ status: 'active', validatorIndices: [7] });
+    });
+
+    it('should update the total from the parsed result on success', async () => {
+      set(mockEthStakingValidators, [validator('0xaaa', 4), validator('0xbbb', 6)]);
+      mockRunTask.mockResolvedValue({
+        result: { entries: [{ index: 1, publicKey: '0xbbb', status: 'active' }], entriesFound: 1, entriesLimit: 100 },
+        success: true,
+      });
+
+      const { selection, total } = create();
+      set(selection, { validators: [{ index: 1, publicKey: '0xbbb', status: 'active' }] });
+      await flushPromises();
+
+      expect(get(total).toNumber()).toBe(6);
+    });
+
+    it('should leave the total unchanged when the task fails', async () => {
+      set(mockEthStakingValidators, [validator('0xaaa', 4)]);
+      mockRunTask.mockResolvedValue({
+        cancelled: false,
+        message: 'boom',
+        skipped: false,
+        success: false,
+      });
+
+      const { selection, total } = create();
+      set(selection, { validators: [{ index: 1, publicKey: '0xaaa', status: 'active' }] });
+      await flushPromises();
+
+      expect(get(total)).toStrictEqual(Zero);
+    });
+  });
+});


### PR DESCRIPTION
Part of the ongoing unit-coverage effort for #11252.

Adds unit specs for previously uncovered composables, stores, and message handlers across the staking, settings, session, shell, dashboard, and core messaging/display modules. No product code changed: this is spec-only.

### Covered
- **staking** — `use-eth-staking-refresh`, `use-eth-validator-management`
- **settings** — `use-settings-page-highlight`, `use-settings-scroll-spy`, `use-settings-suggestions` (composable body)
- **session** — `use-session-sync`, `use-session-settings`
- **shell** — `use-electron-interop`, `layout/use-marquee-animation`
- **dashboard** — `graph/use-net-value-event-handlers`, `graph/use-net-value-chart-config`, `use-dashboard-table-config`, `snapshots/use-snapshot-store`
- **core** — `common/display/assets`, `messaging/index`, and the `missing-api-key`, `calendar-reminder`, `progress-updates`, `csv-import-result` message handlers

### Checks
- `pnpm run test:unit` — 506 files / 4883 tests pass
- `pnpm run typecheck` — clean
- `pnpm run lint` — clean

Rebased on latest `develop`.
