### PR TITLE
chore(dev): warm colibri and verify backend before dev start

### DIFF
--- a/frontend/scripts/dev/prerequisites.ts
+++ b/frontend/scripts/dev/prerequisites.ts
@@ -55,6 +55,35 @@ export function ensurePrerequisites(): void {
   }
 }
 
+/**
+ * When a python virtualenv is active, confirm the `rotkehlchen` package is
+ * actually installed AND answers. A common fresh-worktree footgun is activating a
+ * venv but forgetting to sync the backend deps: `python -m rotkehlchen` then fails
+ * at spawn time and the dev server just times out waiting for a backend that never
+ * came up. `python -m rotkehlchen version` imports the package and runs its entry
+ * point, so it catches both a missing install and an import that blows up — a
+ * stronger signal than merely resolving the module.
+ *
+ * The uv path is skipped: `uv run` resolves the project and its deps itself.
+ */
+export function verifyBackendReady(): void {
+  const venv = process.env.VIRTUAL_ENV;
+  if (!venv)
+    return;
+  try {
+    const version = execSync('python -m rotkehlchen version', { encoding: 'utf-8' }).trim();
+    logger.info(`detected rotkehlchen ${version} in the active virtualenv`);
+  }
+  catch {
+    logger.error(
+      `A python virtualenv is active (${venv}) but \`rotkehlchen\` did not answer.\n`
+      + 'It is likely not installed there — sync the backend deps (`uv sync`) or install it '
+      + 'editable (`pip install -e .`) and re-run.',
+    );
+    process.exit(1);
+  }
+}
+
 export function parsePort(raw: string | undefined, defaultValue: number): number {
   if (!raw)
     return defaultValue;

--- a/frontend/scripts/dev/services.ts
+++ b/frontend/scripts/dev/services.ts
@@ -123,14 +123,23 @@ interface ColibriSpawnOptions {
   dataDir?: string;
 }
 
+/**
+ * Warm the colibri debug build before anything tries to launch it. Both start
+ * paths run colibri via `cargo run --locked` (web mode here; electron mode from
+ * its own subprocess handler), which compiles on the fly on a cold cache. On a
+ * fresh worktree that cold compile happens at the worst moment — after the dev
+ * server is already up in web mode, or mid electron-startup — and on Windows the
+ * vendored-openssl compile blows past the readiness timeout entirely. Building
+ * synchronously first (same debug profile, same target dir) means the later
+ * `cargo run` is just a launch. Incremental rebuilds are near-instant, so this is
+ * cheap once the cache is warm.
+ */
+export async function warmColibri(): Promise<void> {
+  await buildColibriEagerly(path.join('..', 'colibri'));
+}
+
 async function buildColibriEagerly(cwd: string): Promise<void> {
-  // Windows-only: `rusqlite`'s `bundled-sqlcipher-vendored-openssl` feature
-  // compiles OpenSSL from source, which on a cold cache can take several
-  // minutes on Windows — well past the readiness timeout. Run `cargo build`
-  // synchronously first so the user sees the compile progress, and the
-  // subsequent `cargo run` only races the socket bind. Incremental rebuilds
-  // are near-instant, so this is cheap once the cache is warm.
-  logger.info('Pre-building colibri (cargo build --locked) — first build compiles vendored openssl and may take a while');
+  logger.info('Warming colibri (cargo build --locked) so the dev launch does not compile at startup; the first build may take a while');
   const buildEnv = buildColibriEnv();
   if (buildEnv === null) {
     logger.warn(
@@ -163,8 +172,6 @@ async function startColibriService(opts: ColibriSpawnOptions): Promise<number> {
   const chosenPort = opts.strictPort ? opts.colibriPort : await selectPort(opts.colibriPort);
 
   const colibriCwd = path.join('..', 'colibri');
-  if (isWindows)
-    await buildColibriEagerly(colibriCwd);
 
   logger.info(`Starting colibri on port ${formatPort(chosenPort)}`);
 

--- a/frontend/scripts/start-dev.ts
+++ b/frontend/scripts/start-dev.ts
@@ -19,9 +19,9 @@ import {
 } from './dev-instance';
 import { errorMessage, formatPort } from './dev-instance/format';
 import { getCurrentGitBranch } from './dev-instance/git';
-import { ensurePrerequisites, parsePort } from './dev/prerequisites';
+import { ensurePrerequisites, parsePort, verifyBackendReady } from './dev/prerequisites';
 import { registerShutdownHandlers, terminateSubprocesses } from './dev/process-pool';
-import { startDevelopmentEnvironment } from './dev/services';
+import { startDevelopmentEnvironment, warmColibri } from './dev/services';
 
 const ENV_FILE_RELATIVE = 'app/.env.development.local';
 const APP_ENV_RELATIVE = 'app/.env';
@@ -277,6 +277,13 @@ async function runDevAction(options: DevCliOptions): Promise<void> {
   }
 
   ensurePrerequisites();
+  verifyBackendReady();
+
+  // Warm the colibri build before either mode reaches its start point. In web
+  // mode startColibriService runs `cargo run`; in electron mode electron spawns
+  // colibri itself. On a fresh worktree both otherwise hit a cold compile at
+  // launch — pre-building here makes that later `cargo run` a plain launch.
+  await warmColibri();
 
   // Decide instance vs default from CLI/shell before loading env, then for a
   // default run strip the managed block first so it can't leak into process.env.


### PR DESCRIPTION
## Problem

On a fresh worktree the first `pnpm dev` / `pnpm dev:web` cold-compiles colibri at the worst moment:

- in `--web` mode, after the dev server is already up (a burst of readiness polling / a stalled first load), and
- in electron mode, mid electron-startup: electron's own subprocess handler spawns colibri via `cargo run --locked`, so the cold compile blocks the app coming up.

The existing eager `cargo build` only ran on **Windows** and only in **`--web`** mode, so electron mode had no warm-up on any platform. That's what broke on a fresh worktree.

## Changes

- **Warm colibri before either mode reaches its start point.** Promote the eager `cargo build --locked` to a cross-platform `warmColibri()` preflight in `start-dev.ts`, run right after the prerequisite checks. The later `cargo run` (web mode here, or electron's own) is then just a launch. Incremental rebuilds stay near-instant once the cache is warm.
- **Verify the backend answers when a virtualenv is active.** New `verifyBackendReady()` runs `python -m rotkehlchen version`, so a venv missing the `rotkehlchen` install fails fast with a clear message (pointing at `uv sync` / `pip install -e .`) instead of a 60s readiness timeout. The `uv` path is skipped since `uv run` resolves deps itself.
- Removed the now-redundant Windows-only eager-build call from `startColibriService`; the preflight covers all platforms and both modes.

## Notes

On a cold worktree the first `pnpm dev` now shows the colibri compile progress up front (stdio inherited); subsequent runs are incremental and near-instant.