### PR TITLE
test(frontend): add composable unit coverage

### DIFF
--- a/frontend/app/src/modules/core/common/use-form-error-scroll.spec.ts
+++ b/frontend/app/src/modules/core/common/use-form-error-scroll.spec.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFormErrorScroll } from '@/modules/core/common/use-form-error-scroll';
+
+describe('useFormErrorScroll', () => {
+  let scrollIntoView: ReturnType<typeof vi.fn<(arg?: boolean | ScrollIntoViewOptions) => void>>;
+
+  beforeEach(() => {
+    scrollIntoView = vi.fn<(arg?: boolean | ScrollIntoViewOptions) => void>();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('should do nothing when there is no error element', async () => {
+    document.body.innerHTML = '<div><input /></div>';
+    const { scrollToFirstError } = useFormErrorScroll();
+    await scrollToFirstError();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('should scroll the first error element into view', async () => {
+    document.body.innerHTML = '<div data-error>bad</div>';
+    const { scrollToFirstError } = useFormErrorScroll();
+    await scrollToFirstError();
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+  });
+
+  it('should expand a collapsed accordion before scrolling', async () => {
+    document.body.innerHTML = `
+      <div data-accordion data-state="closed">
+        <button data-accordion-trigger></button>
+        <div data-error>bad</div>
+      </div>
+    `;
+    const trigger = document.querySelector<HTMLElement>('[data-accordion-trigger]');
+    const click = vi.fn();
+    trigger?.addEventListener('click', click);
+
+    const { scrollToFirstError } = useFormErrorScroll();
+    await scrollToFirstError();
+
+    expect(click).toHaveBeenCalledOnce();
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('should not click the trigger when the accordion is already open', async () => {
+    document.body.innerHTML = `
+      <div data-accordion data-state="open">
+        <button data-accordion-trigger></button>
+        <div data-error>bad</div>
+      </div>
+    `;
+    const trigger = document.querySelector<HTMLElement>('[data-accordion-trigger]');
+    const click = vi.fn();
+    trigger?.addEventListener('click', click);
+
+    const { scrollToFirstError } = useFormErrorScroll();
+    await scrollToFirstError();
+
+    expect(click).not.toHaveBeenCalled();
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('should only search within the provided container', async () => {
+    document.body.innerHTML = `
+      <div id="outside" data-error>outside</div>
+      <div id="scope"><input /></div>
+    `;
+    const scope = document.querySelector<HTMLElement>('#scope');
+    const { scrollToFirstError } = useFormErrorScroll();
+    await scrollToFirstError(scope ?? undefined);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/core/common/validation/model.spec.ts
+++ b/frontend/app/src/modules/core/common/validation/model.spec.ts
@@ -1,5 +1,15 @@
+import type { WritableComputedRef } from 'vue';
+import { type BigNumber, bigNumberify } from '@rotki/common';
 import { describe, expect, it } from 'vitest';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
+import { nullDefined, refOptional, useBigNumberModel, useRefPropVModel } from '@/modules/core/common/validation/model';
+
+function writable<T>(initial: T): WritableComputedRef<T> {
+  const state = shallowRef<T>(initial);
+  return computed<T>({
+    get: () => get(state),
+    set: (value: T) => set(state, value),
+  });
+}
 
 describe('model-utils', () => {
   it('should properly map computed property to parent ref', () => {
@@ -14,5 +24,80 @@ describe('model-utils', () => {
     set(prop, 'newValue');
     expect(get(prop)).toBe('newValue');
     expect(get(objRef).value).toBe('newValue');
+  });
+});
+
+describe('useBigNumberModel', () => {
+  it('should render an empty string for a null value', () => {
+    const model = useBigNumberModel(writable<BigNumber | null | undefined>(null));
+    expect(get(model)).toBe('');
+  });
+
+  it('should render an empty string for a NaN value', () => {
+    const model = useBigNumberModel(writable<BigNumber | null | undefined>(bigNumberify(Number.NaN)));
+    expect(get(model)).toBe('');
+  });
+
+  it('should render the string form of a valid number', () => {
+    const model = useBigNumberModel(writable<BigNumber | null | undefined>(bigNumberify(42)));
+    expect(get(model)).toBe('42');
+  });
+
+  it('should parse a string back into a big number', () => {
+    const source = writable<BigNumber | null | undefined>(null);
+    const model = useBigNumberModel(source);
+    set(model, '123');
+    expect(get(source)?.toNumber()).toBe(123);
+  });
+
+  it('should store null when the string is empty', () => {
+    const source = writable<BigNumber | null | undefined>(bigNumberify(1));
+    const model = useBigNumberModel(source);
+    set(model, '');
+    expect(get(source)).toBeNull();
+  });
+});
+
+describe('nullDefined', () => {
+  it('should expose null as undefined', () => {
+    const model = nullDefined(writable<number | null>(null));
+    expect(get(model)).toBeUndefined();
+  });
+
+  it('should store undefined as null', () => {
+    const source = writable<number | null>(5);
+    const model = nullDefined(source);
+    set(model, undefined);
+    expect(get(source)).toBeNull();
+  });
+});
+
+describe('refOptional', () => {
+  it('should fall back to the default value when null', () => {
+    const model = refOptional(writable<number | null | undefined>(null), 10);
+    expect(get(model)).toBe(10);
+  });
+
+  it('should store undefined when set to a nullish value', () => {
+    const source = writable<number | null | undefined>(3);
+    const model = refOptional(source, 10);
+    set(model, undefined);
+    expect(get(source)).toBeUndefined();
+  });
+});
+
+describe('useRefPropVModel transform', () => {
+  it('should apply the transform when the value is truthy', () => {
+    const obj = ref<{ name: string }>({ name: 'alice' });
+    const model = useRefPropVModel(obj, 'name', { transform: value => value.toUpperCase() });
+    set(model, 'bob');
+    expect(get(obj).name).toBe('BOB');
+  });
+
+  it('should skip the transform for a falsy value', () => {
+    const obj = ref<{ name: string }>({ name: 'alice' });
+    const model = useRefPropVModel(obj, 'name', { transform: value => value.toUpperCase() });
+    set(model, '');
+    expect(get(obj).name).toBe('');
   });
 });

--- a/frontend/app/src/modules/core/messaging/use-update-message.spec.ts
+++ b/frontend/app/src/modules/core/messaging/use-update-message.spec.ts
@@ -1,0 +1,84 @@
+import { externalLinks } from '@shared/external-links';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type Ref } from 'vue';
+
+const mockAppVersion = ref<string>('1.0.0');
+
+vi.mock('@/modules/core/common/use-main-store', () => ({
+  useMainStore: (): { appVersion: Ref<string> } => ({ appVersion: mockAppVersion }),
+}));
+
+const LAST_VERSION_KEY = 'rotki.last_version';
+
+async function mountUpdateMessage(): Promise<{
+  wrapper: ReturnType<typeof mount>;
+  result: Awaited<ReturnType<typeof import('@/modules/core/messaging/use-update-message')['useUpdateMessage']>>;
+}> {
+  vi.resetModules();
+  const { useUpdateMessage } = await import('@/modules/core/messaging/use-update-message');
+  let result!: ReturnType<typeof useUpdateMessage>;
+  const component = defineComponent({
+    setup() {
+      result = useUpdateMessage();
+      return {};
+    },
+    template: '<div />',
+  });
+  const wrapper = mount(component);
+  return { result, wrapper };
+}
+
+describe('useUpdateMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    set(mockAppVersion, '1.0.0');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should show release notes on first launch of a new version', async () => {
+    const { result } = await mountUpdateMessage();
+    expect(get(result.showReleaseNotes)).toBe(true);
+    expect(localStorage.getItem(LAST_VERSION_KEY)).toBe('1.0.0');
+  });
+
+  it('should not show release notes when the last used version matches', async () => {
+    localStorage.setItem(LAST_VERSION_KEY, '1.0.0');
+    const { result } = await mountUpdateMessage();
+    expect(get(result.showReleaseNotes)).toBe(false);
+  });
+
+  it('should show release notes when the version changed since last use', async () => {
+    localStorage.setItem(LAST_VERSION_KEY, '0.9.0');
+    const { result } = await mountUpdateMessage();
+    expect(get(result.showReleaseNotes)).toBe(true);
+  });
+
+  it('should skip release notes for a dev version', async () => {
+    set(mockAppVersion, '1.0.0-dev');
+    const { result } = await mountUpdateMessage();
+    expect(get(result.showReleaseNotes)).toBe(false);
+    expect(localStorage.getItem(LAST_VERSION_KEY)).toBeNull();
+  });
+
+  it('should skip release notes when the version is empty', async () => {
+    set(mockAppVersion, '');
+    const { result } = await mountUpdateMessage();
+    expect(get(result.showReleaseNotes)).toBe(false);
+  });
+
+  it('should build the release link for the current version', async () => {
+    const { result } = await mountUpdateMessage();
+    expect(get(result.link)).toBe(externalLinks.releasesVersion.replace('$version', '1.0.0'));
+  });
+
+  it('should expose the current version', async () => {
+    set(mockAppVersion, '2.3.4');
+    const { result } = await mountUpdateMessage();
+    expect(get(result.version)).toBe('2.3.4');
+  });
+});

--- a/frontend/app/src/modules/core/table/filters/use-accounting-rule-filter.spec.ts
+++ b/frontend/app/src/modules/core/table/filters/use-accounting-rule-filter.spec.ts
@@ -1,0 +1,74 @@
+import type { Ref } from 'vue';
+import { assert, describe, expect, it, vi } from 'vitest';
+import { useAccountingRuleFilter } from '@/modules/core/table/filters/use-accounting-rule-filter';
+
+const mockEventTypes = ref<string[]>(['spend', 'receive']);
+const mockEventSubTypes = ref<string[]>(['fee', 'reward']);
+const mockCounterparties = ref<string[]>(['uniswap', 'aave']);
+
+vi.mock('vue-i18n', async importOriginal => ({
+  ...await importOriginal<typeof import('vue-i18n')>(),
+  useI18n: (): { t: (key: string) => string } => ({ t: (key: string): string => key }),
+}));
+
+vi.mock('@/modules/history/events/mapping/use-history-event-mappings', () => ({
+  useHistoryEventMappings: (): { historyEventSubTypes: Ref<string[]>; historyEventTypes: Ref<string[]> } => ({
+    historyEventSubTypes: mockEventSubTypes,
+    historyEventTypes: mockEventTypes,
+  }),
+}));
+
+vi.mock('@/modules/history/events/mapping/use-history-event-counterparty-mappings', () => ({
+  useHistoryEventCounterpartyMappings: (): { counterparties: Ref<string[]> } => ({
+    counterparties: mockCounterparties,
+  }),
+}));
+
+describe('useAccountingRuleFilter', () => {
+  it('should start with an empty filter', () => {
+    const { filters } = useAccountingRuleFilter();
+    expect(get(filters)).toEqual({});
+  });
+
+  it('should expose matchers for event type, subtype and counterparty', () => {
+    const { matchers } = useAccountingRuleFilter();
+    const keys = get(matchers).map(matcher => matcher.key);
+    expect(keys).toEqual(['event_type', 'event_subtype', 'counterparty']);
+  });
+
+  it('should source suggestions from the history event mappings', () => {
+    const { matchers } = useAccountingRuleFilter();
+
+    const typeMatcher = get(matchers).find(matcher => matcher.key === 'event_type');
+    const subtypeMatcher = get(matchers).find(matcher => matcher.key === 'event_subtype');
+    const counterpartyMatcher = get(matchers).find(matcher => matcher.key === 'counterparty');
+    assert(typeMatcher && 'string' in typeMatcher);
+    assert(subtypeMatcher && 'string' in subtypeMatcher);
+    assert(counterpartyMatcher && 'string' in counterpartyMatcher);
+
+    expect(typeMatcher.suggestions()).toEqual(['spend', 'receive']);
+    expect(subtypeMatcher.suggestions()).toEqual(['fee', 'reward']);
+    expect(counterpartyMatcher.suggestions()).toEqual(['uniswap', 'aave']);
+  });
+
+  it('should validate all values as non-empty strings', () => {
+    const { matchers } = useAccountingRuleFilter();
+    const typeMatcher = get(matchers).find(matcher => matcher.key === 'event_type');
+    assert(typeMatcher && 'string' in typeMatcher);
+    expect(typeMatcher.validate('spend')).toBe(true);
+    expect(typeMatcher.validate('')).toBe(false);
+  });
+
+  it('should coerce single route values into arrays', () => {
+    const { RouteFilterSchema } = useAccountingRuleFilter();
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({ counterparties: 'uniswap', eventTypes: 'spend' }))
+      .toEqual({ counterparties: ['uniswap'], eventTypes: ['spend'] });
+  });
+
+  it('should allow an empty route filter', () => {
+    const { RouteFilterSchema } = useAccountingRuleFilter();
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({})).toEqual({});
+  });
+});

--- a/frontend/app/src/modules/core/table/filters/use-address-book-filter.spec.ts
+++ b/frontend/app/src/modules/core/table/filters/use-address-book-filter.spec.ts
@@ -1,0 +1,44 @@
+import { assert, describe, expect, it, vi } from 'vitest';
+import { useAddressBookFilter } from '@/modules/core/table/filters/use-address-book-filter';
+
+vi.mock('vue-i18n', async importOriginal => ({
+  ...await importOriginal<typeof import('vue-i18n')>(),
+  useI18n: (): { t: (key: string) => string } => ({ t: (key: string): string => key }),
+}));
+
+describe('useAddressBookFilter', () => {
+  it('should start with an empty filter', () => {
+    const { filters } = useAddressBookFilter();
+    expect(get(filters)).toEqual({});
+  });
+
+  it('should expose matchers for name and address', () => {
+    const { matchers } = useAddressBookFilter();
+    const keys = get(matchers).map(matcher => matcher.key);
+    expect(keys).toEqual(['name', 'address']);
+  });
+
+  it('should keep the name value as a single string', () => {
+    const { RouteFilterSchema } = useAddressBookFilter();
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({ nameSubstring: 'alice' })).toEqual({ nameSubstring: 'alice' });
+  });
+
+  it('should coerce a single address into an array', () => {
+    const { RouteFilterSchema } = useAddressBookFilter();
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({ address: '0xabc' })).toEqual({ address: ['0xabc'] });
+  });
+
+  it('should keep multiple addresses as an array', () => {
+    const { RouteFilterSchema } = useAddressBookFilter();
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({ address: ['0xabc', '0xdef'] })).toEqual({ address: ['0xabc', '0xdef'] });
+  });
+
+  it('should allow an empty route filter', () => {
+    const { RouteFilterSchema } = useAddressBookFilter();
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({})).toEqual({});
+  });
+});

--- a/frontend/app/src/modules/core/table/filters/use-custom-assets-filter.spec.ts
+++ b/frontend/app/src/modules/core/table/filters/use-custom-assets-filter.spec.ts
@@ -1,0 +1,54 @@
+import { assert, describe, expect, it, vi } from 'vitest';
+import { useCustomAssetFilter } from '@/modules/core/table/filters/use-custom-assets-filter';
+
+vi.mock('vue-i18n', async importOriginal => ({
+  ...await importOriginal<typeof import('vue-i18n')>(),
+  useI18n: (): { t: (key: string) => string } => ({ t: (key: string): string => key }),
+}));
+
+describe('useCustomAssetFilter', () => {
+  it('should start with an empty filter', () => {
+    const { filters } = useCustomAssetFilter([]);
+    expect(get(filters)).toEqual({});
+  });
+
+  it('should expose matchers for name and type', () => {
+    const { matchers } = useCustomAssetFilter([]);
+    const keys = get(matchers).map(matcher => matcher.key);
+    expect(keys).toEqual(['name', 'type']);
+  });
+
+  it('should surface the provided type suggestions', () => {
+    const { matchers } = useCustomAssetFilter(['fiat', 'stock']);
+    const typeMatcher = get(matchers).find(matcher => matcher.key === 'type');
+    assert(typeMatcher && 'string' in typeMatcher);
+    expect(typeMatcher.suggestions()).toEqual(['fiat', 'stock']);
+  });
+
+  it('should validate the type against the provided suggestions', () => {
+    const { matchers } = useCustomAssetFilter(['fiat', 'stock']);
+    const typeMatcher = get(matchers).find(matcher => matcher.key === 'type');
+    assert(typeMatcher && 'string' in typeMatcher);
+    expect(typeMatcher.validate('fiat')).toBe(true);
+    expect(typeMatcher.validate('crypto')).toBe(false);
+  });
+
+  it('should react to changes in a reactive suggestions ref', () => {
+    const suggestions = ref<string[]>(['fiat']);
+    const { matchers } = useCustomAssetFilter(suggestions);
+    set(suggestions, ['stock']);
+    const typeMatcher = get(matchers).find(matcher => matcher.key === 'type');
+    assert(typeMatcher && 'string' in typeMatcher);
+    expect(typeMatcher.suggestions()).toEqual(['stock']);
+  });
+
+  it('should keep name and type route values as optional strings', () => {
+    const { RouteFilterSchema } = useCustomAssetFilter([]);
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({ custom_asset_type: 'fiat', name: 'gold' })).toEqual({
+      custom_asset_type: 'fiat',
+      name: 'gold',
+    });
+    expect(RouteFilterSchema.parse({})).toEqual({});
+  });
+});

--- a/frontend/app/src/modules/core/table/filters/use-eth-validator-filter.spec.ts
+++ b/frontend/app/src/modules/core/table/filters/use-eth-validator-filter.spec.ts
@@ -1,0 +1,69 @@
+import { assert, describe, expect, it } from 'vitest';
+import {
+  isValidStatus,
+  useEthValidatorAccountFilter,
+  validStatuses,
+} from '@/modules/core/table/filters/use-eth-validator-filter';
+
+const t = (key: string): string => key;
+
+describe('isValidStatus', () => {
+  it('should accept known statuses', () => {
+    for (const status of validStatuses) {
+      expect(isValidStatus(status)).toBe(true);
+    }
+  });
+
+  it('should reject unknown statuses', () => {
+    expect(isValidStatus('unknown')).toBe(false);
+    expect(isValidStatus('')).toBe(false);
+  });
+});
+
+describe('useEthValidatorAccountFilter', () => {
+  it('should start with an empty filter', () => {
+    const { filters } = useEthValidatorAccountFilter(t);
+    expect(get(filters)).toEqual({});
+  });
+
+  it('should expose matchers for index, public key and status', () => {
+    const { matchers } = useEthValidatorAccountFilter(t);
+    const keys = get(matchers).map(matcher => matcher.key);
+    expect(keys).toEqual(['validator_index', 'public_key', 'status']);
+  });
+
+  it('should suggest all statuses except all', () => {
+    const { matchers } = useEthValidatorAccountFilter(t);
+    const statusMatcher = get(matchers).find(matcher => matcher.key === 'status');
+    assert(statusMatcher && 'string' in statusMatcher);
+    expect(statusMatcher.suggestions()).toEqual(['exited', 'active', 'consolidated']);
+  });
+
+  it('should validate the status value against the known statuses', () => {
+    const { matchers } = useEthValidatorAccountFilter(t);
+    const statusMatcher = get(matchers).find(matcher => matcher.key === 'status');
+    assert(statusMatcher && 'string' in statusMatcher);
+    expect(statusMatcher.validate('active')).toBe(true);
+    expect(statusMatcher.validate('nope')).toBe(false);
+  });
+
+  it('should coerce single route values into arrays', () => {
+    const { RouteFilterSchema } = useEthValidatorAccountFilter(t);
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({ index: '5', publicKey: '0xabc', status: 'active' }))
+      .toEqual({ index: ['5'], publicKey: ['0xabc'], status: ['active'] });
+  });
+
+  it('should keep array route values as arrays', () => {
+    const { RouteFilterSchema } = useEthValidatorAccountFilter(t);
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({ status: ['active', 'exited'] }))
+      .toEqual({ status: ['active', 'exited'] });
+  });
+
+  it('should allow an empty route filter', () => {
+    const { RouteFilterSchema } = useEthValidatorAccountFilter(t);
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({})).toEqual({});
+  });
+});

--- a/frontend/app/src/modules/core/table/filters/use-manual-balances-filter.spec.ts
+++ b/frontend/app/src/modules/core/table/filters/use-manual-balances-filter.spec.ts
@@ -1,0 +1,79 @@
+import { assert, describe, expect, it, vi } from 'vitest';
+import {
+  ManualBalancesFilterSchema,
+  useManualBalanceFilter,
+} from '@/modules/core/table/filters/use-manual-balances-filter';
+
+vi.mock('vue-i18n', async importOriginal => ({
+  ...await importOriginal<typeof import('vue-i18n')>(),
+  useI18n: (): { t: (key: string) => string } => ({ t: (key: string): string => key }),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: (): { assetSearch: () => Promise<never[]>; getAssetInfo: () => undefined } => ({
+    assetSearch: async (): Promise<never[]> => [],
+    getAssetInfo: (): undefined => undefined,
+  }),
+}));
+
+vi.mock('@/modules/core/common/display/assets', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/core/common/display/assets')>(),
+  assetSuggestions: (): (() => Promise<never[]>) => async (): Promise<never[]> => [],
+}));
+
+describe('useManualBalanceFilter', () => {
+  it('should start with an empty filter', () => {
+    const { filters } = useManualBalanceFilter([]);
+    expect(get(filters)).toEqual({});
+  });
+
+  it('should expose matchers for location, label and asset', () => {
+    const { matchers } = useManualBalanceFilter([]);
+    const keys = get(matchers).map(matcher => matcher.key);
+    expect(keys).toEqual(['location', 'label', 'asset']);
+  });
+
+  it('should surface the provided location suggestions', () => {
+    const { matchers } = useManualBalanceFilter(['kraken', 'binance']);
+    const locationMatcher = get(matchers).find(matcher => matcher.key === 'location');
+    assert(locationMatcher && 'string' in locationMatcher);
+    expect(locationMatcher.suggestions()).toEqual(['kraken', 'binance']);
+  });
+
+  it('should validate the location against the provided list', () => {
+    const { matchers } = useManualBalanceFilter(['kraken']);
+    const locationMatcher = get(matchers).find(matcher => matcher.key === 'location');
+    assert(locationMatcher && 'string' in locationMatcher);
+    expect(locationMatcher.validate('kraken')).toBe(true);
+    expect(locationMatcher.validate('unknown')).toBe(false);
+  });
+
+  it('should validate the label as any non-empty string', () => {
+    const { matchers } = useManualBalanceFilter([]);
+    const labelMatcher = get(matchers).find(matcher => matcher.key === 'label');
+    assert(labelMatcher && 'string' in labelMatcher);
+    expect(labelMatcher.validate('savings')).toBe(true);
+    expect(labelMatcher.validate('')).toBe(false);
+  });
+
+  it('should parse optional route filter values', () => {
+    const { RouteFilterSchema } = useManualBalanceFilter([]);
+    assert(RouteFilterSchema);
+    expect(RouteFilterSchema.parse({ asset: 'ETH', label: 'x', location: 'kraken' })).toEqual({
+      asset: 'ETH',
+      label: 'x',
+      location: 'kraken',
+    });
+    expect(RouteFilterSchema.parse({})).toEqual({});
+  });
+});
+
+describe('manualBalancesFilterSchema', () => {
+  it('should split a comma-separated tags string into an array', () => {
+    expect(ManualBalancesFilterSchema.parse({ tags: 'a,b,c' })).toEqual({ tags: ['a', 'b', 'c'] });
+  });
+
+  it('should default missing tags to an empty array', () => {
+    expect(ManualBalancesFilterSchema.parse({})).toEqual({ tags: [] });
+  });
+});

--- a/frontend/app/src/modules/core/table/filters/use-saved-filters.spec.ts
+++ b/frontend/app/src/modules/core/table/filters/use-saved-filters.spec.ts
@@ -1,0 +1,99 @@
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type BaseSuggestion, SavedFilterLocation, type Suggestion } from '@/modules/core/table/filtering';
+import { useSavedFilter } from '@/modules/core/table/filters/use-saved-filters';
+
+type SavedFilters = Partial<Record<SavedFilterLocation, BaseSuggestion[][]>>;
+
+const mockSavedFilters = ref<SavedFilters>({});
+const mockUpdateFrontendSetting = vi.fn(async (_setting: { savedFilters: SavedFilters }) => ({ success: true }));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: vi.fn(() => mockSavedFilters),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): { updateFrontendSetting: typeof mockUpdateFrontendSetting } => ({
+    updateFrontendSetting: mockUpdateFrontendSetting,
+  }),
+}));
+
+vi.mock('vue-i18n', async importOriginal => ({
+  ...await importOriginal<typeof import('vue-i18n')>(),
+  useI18n: (): { t: (key: string, args?: Record<string, unknown>) => string } => ({
+    t: (key: string, args?: Record<string, unknown>): string => (args ? `${key}::${JSON.stringify(args)}` : key),
+  }),
+}));
+
+const LOCATION = SavedFilterLocation.HISTORY_EVENTS;
+
+function suggestion(overrides: Partial<Suggestion> = {}): Suggestion {
+  return { asset: false, index: 0, key: 'type', total: 1, value: 'deposit', ...overrides };
+}
+
+describe('useSavedFilter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(mockSavedFilters, {});
+    mockUpdateFrontendSetting.mockResolvedValue({ success: true });
+  });
+
+  it('should expose an empty list when no filters are saved for the location', () => {
+    const { savedFilters } = useSavedFilter(LOCATION, () => false);
+    expect(get(savedFilters)).toEqual([]);
+  });
+
+  it('should decorate saved base suggestions with asset, index and total', () => {
+    set(mockSavedFilters, { [LOCATION]: [[{ key: 'asset', value: 'ETH' }]] });
+    const isAsset = (key: string): boolean => key === 'asset';
+    const { savedFilters } = useSavedFilter(LOCATION, isAsset);
+    expect(get(savedFilters)).toEqual([[{ asset: true, index: 0, key: 'asset', total: 1, value: 'ETH' }]]);
+  });
+
+  it('should persist filters for the location via the frontend setting', async () => {
+    const { saveFilters } = useSavedFilter(LOCATION, () => false);
+    await saveFilters([[{ key: 'type', value: 'deposit' }]]);
+    expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({
+      savedFilters: { [LOCATION]: [[{ key: 'type', value: 'deposit' }]] },
+    });
+  });
+
+  it('should append a new filter when under the limit', async () => {
+    const { addFilter } = useSavedFilter(LOCATION, () => false);
+    const status = await addFilter([suggestion()]);
+    expect(status).toEqual({ success: true });
+    expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({
+      savedFilters: { [LOCATION]: [[{ exclude: undefined, key: 'type', value: 'deposit' }]] },
+    });
+  });
+
+  it('should use the asset identifier when saving an asset suggestion', async () => {
+    const { addFilter } = useSavedFilter(LOCATION, () => true);
+    await addFilter([suggestion({ asset: true, key: 'asset', value: { identifier: 'ETH' } })]);
+    expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({
+      savedFilters: { [LOCATION]: [[{ exclude: undefined, key: 'asset', value: 'ETH' }]] },
+    });
+  });
+
+  it('should reject adding a filter when the location limit is reached', async () => {
+    const existing = Array.from({ length: 10 }, () => [{ key: 'type', value: 'deposit' }]);
+    set(mockSavedFilters, { [LOCATION]: existing });
+    const { addFilter } = useSavedFilter(LOCATION, () => false);
+
+    const status = await addFilter([suggestion()]);
+
+    expect(status.success).toBe(false);
+    expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
+  });
+
+  it('should delete a saved filter by index', async () => {
+    set(mockSavedFilters, { [LOCATION]: [[{ key: 'a', value: '1' }], [{ key: 'b', value: '2' }]] });
+    const { deleteFilter } = useSavedFilter(LOCATION, () => false);
+
+    await deleteFilter(0);
+
+    const saved = mockUpdateFrontendSetting.mock.calls[0][0].savedFilters[LOCATION];
+    assert(saved);
+    expect(saved).toHaveLength(1);
+    expect(saved[0][0].key).toBe('b');
+  });
+});

--- a/frontend/app/src/modules/core/table/use-common-table-props.spec.ts
+++ b/frontend/app/src/modules/core/table/use-common-table-props.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { useCommonTableProps } from '@/modules/core/table/use-common-table-props';
+
+interface Row { id: number }
+
+describe('useCommonTableProps', () => {
+  it('should expose default table state refs', () => {
+    const {
+      confirmationMessage,
+      editableItem,
+      expanded,
+      itemsToDelete,
+      openDialog,
+      selected,
+    } = useCommonTableProps<Row>();
+
+    expect(get(selected)).toEqual([]);
+    expect(get(openDialog)).toBe(false);
+    expect(get(editableItem)).toBeUndefined();
+    expect(get(itemsToDelete)).toEqual([]);
+    expect(get(confirmationMessage)).toBe('');
+    expect(get(expanded)).toEqual([]);
+  });
+
+  it('should return independent state across instances', () => {
+    const first = useCommonTableProps<Row>();
+    const second = useCommonTableProps<Row>();
+
+    set(first.selected, [{ id: 1 }]);
+    set(first.openDialog, true);
+
+    expect(get(second.selected)).toEqual([]);
+    expect(get(second.openDialog)).toBe(false);
+  });
+
+  it('should allow updating the exposed refs', () => {
+    const { confirmationMessage, editableItem, expanded } = useCommonTableProps<Row>();
+
+    set(editableItem, { id: 7 });
+    set(expanded, [{ id: 7 }]);
+    set(confirmationMessage, 'delete?');
+
+    expect(get(editableItem)).toEqual({ id: 7 });
+    expect(get(expanded)).toEqual([{ id: 7 }]);
+    expect(get(confirmationMessage)).toBe('delete?');
+  });
+});

--- a/frontend/app/src/modules/core/table/use-remember-table-filter.spec.ts
+++ b/frontend/app/src/modules/core/table/use-remember-table-filter.spec.ts
@@ -1,0 +1,91 @@
+import type { Ref } from 'vue';
+import type { LocationQuery } from '@/modules/core/table/route';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRememberTableFilter } from '@/modules/core/table/use-remember-table-filter';
+import { TableId } from '@/modules/core/table/use-remember-table-sorting';
+
+const mockUserId = ref<string>('user1');
+const mockReplace = vi.fn();
+
+vi.mock('@/modules/auth/use-logged-user-identifier', () => ({
+  useLoggedUserIdentifier: (): Ref<string> => mockUserId,
+}));
+
+vi.mock('vue-router', async importOriginal => ({
+  ...await importOriginal<typeof import('vue-router')>(),
+  useRouter: (): { replace: typeof mockReplace } => ({ replace: mockReplace }),
+}));
+
+const STORAGE_KEY = 'user1.rotki.table_filters';
+
+interface Options {
+  enabled?: boolean;
+  history?: false | 'router' | 'external';
+  query?: Ref<LocationQuery>;
+}
+
+function create(options: Options = {}): ReturnType<typeof useRememberTableFilter> {
+  return useRememberTableFilter({
+    enabled: ref(options.enabled ?? true),
+    history: options.history ?? 'router',
+    query: options.query ?? ref<LocationQuery>({}),
+    tableId: ref(TableId.HISTORY),
+  });
+}
+
+describe('useRememberTableFilter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    set(mockUserId, 'user1');
+  });
+
+  it('should not restore anything when disabled', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ [TableId.HISTORY]: { type: 'deposit' } }));
+    const { restorePersistedFilter } = create({ enabled: false });
+    await restorePersistedFilter();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('should replace the router query when history is router', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ [TableId.HISTORY]: { limit: '10', page: '2', type: 'deposit' } }));
+    const { restorePersistedFilter } = create({ history: 'router' });
+    await restorePersistedFilter();
+    expect(mockReplace).toHaveBeenCalledWith({ query: { type: 'deposit' } });
+  });
+
+  it('should update the external query ref when history is external', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ [TableId.HISTORY]: { page: '2', type: 'withdrawal' } }));
+    const query = ref<LocationQuery>({});
+    const { restorePersistedFilter } = create({ history: 'external', query });
+    await restorePersistedFilter();
+    expect(get(query)).toEqual({ type: 'withdrawal' });
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing when the saved filter is empty', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ [TableId.HISTORY]: {} }));
+    const query = ref<LocationQuery>({});
+    const { restorePersistedFilter } = create({ history: 'external', query });
+    await restorePersistedFilter();
+    expect(get(query)).toEqual({});
+  });
+
+  it('should persist a filter stripped of the limit param', async () => {
+    const { savePersistedFilter } = create();
+    savePersistedFilter({ limit: '25', page: '3', type: 'deposit' });
+    await nextTick();
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+    expect(stored[TableId.HISTORY]).toEqual({ page: '3', type: 'deposit' });
+  });
+
+  it('should merge persisted filters across table ids', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ OTHER: { foo: 'bar' } }));
+    const { savePersistedFilter } = create();
+    savePersistedFilter({ type: 'deposit' });
+    await nextTick();
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+    expect(stored.OTHER).toEqual({ foo: 'bar' });
+    expect(stored[TableId.HISTORY]).toEqual({ type: 'deposit' });
+  });
+});

--- a/frontend/app/src/modules/core/table/use-remember-table-sorting.spec.ts
+++ b/frontend/app/src/modules/core/table/use-remember-table-sorting.spec.ts
@@ -1,0 +1,103 @@
+import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type Ref } from 'vue';
+import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
+
+interface Row { id: string }
+
+const mockPersist = ref<boolean>(true);
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: vi.fn(() => mockPersist),
+}));
+
+const STORAGE_KEY = 'rotki.table_sorting';
+
+function headers(): Ref<DataTableColumn<Row>[]> {
+  return ref<DataTableColumn<Row>[]>([
+    { key: 'id', label: 'ID', sortable: true },
+    { key: 'name', label: 'Name', sortable: false },
+  ]);
+}
+
+function mountSorting(sort: Ref<DataTableSortData<Row>>): ReturnType<typeof mount> {
+  const component = defineComponent({
+    setup() {
+      useRememberTableSorting<Row>(TableId.HISTORY, sort, headers());
+      return {};
+    },
+    template: '<div />',
+  });
+  return mount(component);
+}
+
+describe('useRememberTableSorting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    set(mockPersist, true);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should restore a saved sort for the table on mount', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ [TableId.HISTORY]: { column: 'id', direction: 'desc' } }));
+    const sort = ref<DataTableSortData<Row>>({ column: 'id', direction: 'asc' });
+    mountSorting(sort);
+    expect(get(sort)).toStrictEqual({ column: 'id', direction: 'desc' });
+  });
+
+  it('should drop saved sorts referencing non-sortable columns', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ [TableId.HISTORY]: { column: 'name', direction: 'desc' } }));
+    const sort = ref<DataTableSortData<Row>>({ column: 'id', direction: 'asc' });
+    mountSorting(sort);
+    expect(get(sort)).toStrictEqual({ column: 'id', direction: 'asc' });
+  });
+
+  it('should restore only the sortable entries from a saved array sort', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      [TableId.HISTORY]: [
+        { column: 'name', direction: 'asc' },
+        { column: 'id', direction: 'desc' },
+      ],
+    }));
+    const sort = ref<DataTableSortData<Row>>([]);
+    mountSorting(sort);
+    expect(get(sort)).toStrictEqual([{ column: 'id', direction: 'desc' }]);
+  });
+
+  it('should not restore anything when persistence is disabled', () => {
+    set(mockPersist, false);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ [TableId.HISTORY]: { column: 'id', direction: 'desc' } }));
+    const sort = ref<DataTableSortData<Row>>({ column: 'id', direction: 'asc' });
+    mountSorting(sort);
+    expect(get(sort)).toStrictEqual({ column: 'id', direction: 'asc' });
+  });
+
+  it('should persist sort changes when persistence is enabled', async () => {
+    const sort = ref<DataTableSortData<Row>>({ column: 'id', direction: 'asc' });
+    mountSorting(sort);
+
+    set(sort, { column: 'id', direction: 'desc' });
+    await nextTick();
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+    expect(stored[TableId.HISTORY]).toStrictEqual({ column: 'id', direction: 'desc' });
+  });
+
+  it('should remove the stored sort when persistence is disabled and the sort changes', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ [TableId.HISTORY]: { column: 'id', direction: 'desc' } }));
+    set(mockPersist, false);
+    const sort = ref<DataTableSortData<Row>>({ column: 'id', direction: 'asc' });
+    mountSorting(sort);
+
+    set(sort, { column: 'id', direction: 'asc' });
+    await nextTick();
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
+    expect(stored[TableId.HISTORY]).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/dashboard/use-dashboard-asset-data.spec.ts
+++ b/frontend/app/src/modules/dashboard/use-dashboard-asset-data.spec.ts
@@ -1,0 +1,100 @@
+import type { DataTableSortData } from '@rotki/ui-library';
+import { type AssetBalanceWithPrice, bigNumberify } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDashboardAssetData } from '@/modules/dashboard/use-dashboard-asset-data';
+
+const mockTotalNetWorth = ref(bigNumberify(1000));
+const mockMissingCustomAssets = ref<string[]>([]);
+const mockAssetInfo = vi.fn((identifier: string | undefined) => ({ name: identifier, symbol: identifier }));
+
+vi.mock('@/modules/dashboard/use-dashboard-stores', () => ({
+  useDashboardStores: (): { totalNetWorth: typeof mockTotalNetWorth } => ({ totalNetWorth: mockTotalNetWorth }),
+}));
+
+vi.mock('@/modules/assets/use-asset-select-info', () => ({
+  useAssetSelectInfo: (): { getAssetInfo: typeof mockAssetInfo } => ({ getAssetInfo: mockAssetInfo }),
+}));
+
+vi.mock('@/modules/balances/manual/use-manual-balance-data', () => ({
+  useManualBalanceData: (): { missingCustomAssets: typeof mockMissingCustomAssets } => ({ missingCustomAssets: mockMissingCustomAssets }),
+}));
+
+function balance(asset: string, value: number): AssetBalanceWithPrice {
+  return {
+    amount: bigNumberify(value),
+    asset,
+    price: bigNumberify(1),
+    value: bigNumberify(value),
+  };
+}
+
+const noSort: DataTableSortData<AssetBalanceWithPrice> = [];
+
+describe('useDashboardAssetData', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    set(mockTotalNetWorth, bigNumberify(1000));
+    set(mockMissingCustomAssets, []);
+    mockAssetInfo.mockImplementation((identifier: string | undefined) => ({ name: identifier, symbol: identifier }));
+  });
+
+  it('should sum the value of all balances', () => {
+    const balances = [balance('BTC', 300), balance('ETH', 200)];
+    const { total } = useDashboardAssetData(balances, noSort);
+    expect(get(total).toNumber()).toBe(500);
+  });
+
+  it('should compute percentage of total net value against net worth', () => {
+    const balances = [balance('BTC', 250)];
+    const { percentageOfTotalNetValue } = useDashboardAssetData(balances, noSort);
+    expect(percentageOfTotalNetValue(balance('BTC', 250))).toBe('25.00');
+  });
+
+  it('should fall back to total when net worth is negative', () => {
+    set(mockTotalNetWorth, bigNumberify(-1));
+    const balances = [balance('BTC', 400)];
+    const { percentageOfTotalNetValue } = useDashboardAssetData(balances, noSort);
+    expect(percentageOfTotalNetValue(balance('BTC', 100))).toBe('25.00');
+  });
+
+  it('should compute percentage of the current group', () => {
+    const balances = [balance('BTC', 100), balance('ETH', 300)];
+    const { percentageOfCurrentGroup } = useDashboardAssetData(balances, noSort);
+    expect(percentageOfCurrentGroup(balance('BTC', 100))).toBe('25.00');
+  });
+
+  it('should flag an asset as missing when in the missing custom assets list', () => {
+    set(mockMissingCustomAssets, ['CUSTOM']);
+    const { isAssetMissing } = useDashboardAssetData([], noSort);
+    expect(isAssetMissing(balance('CUSTOM', 1))).toBe(true);
+    expect(isAssetMissing(balance('BTC', 1))).toBe(false);
+  });
+
+  it('should return all balances sorted when there is no search', () => {
+    const balances = [balance('BTC', 100), balance('ETH', 200)];
+    const { sorted } = useDashboardAssetData(balances, noSort);
+    expect(get(sorted)).toHaveLength(2);
+  });
+
+  it('should filter balances by the debounced search keyword', async () => {
+    vi.useFakeTimers();
+    const balances = [balance('BTC', 100), balance('ETH', 200)];
+    const { search, sorted } = useDashboardAssetData(balances, noSort);
+
+    set(search, 'BTC');
+    await vi.advanceTimersByTimeAsync(200);
+
+    const result = get(sorted);
+    expect(result).toHaveLength(1);
+    expect(result[0].asset).toBe('BTC');
+  });
+
+  it('should react to changes in the balances input', () => {
+    const balances = ref<AssetBalanceWithPrice[]>([balance('BTC', 100)]);
+    const { total } = useDashboardAssetData(balances, noSort);
+    expect(get(total).toNumber()).toBe(100);
+
+    set(balances, [balance('BTC', 100), balance('ETH', 400)]);
+    expect(get(total).toNumber()).toBe(500);
+  });
+});

--- a/frontend/app/src/modules/shell/theme/use-dark-mode.spec.ts
+++ b/frontend/app/src/modules/shell/theme/use-dark-mode.spec.ts
@@ -1,0 +1,104 @@
+import type { ThemeColors } from '@rotki/common';
+import { ThemeMode } from '@rotki/ui-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDarkMode } from '@/modules/shell/theme/use-dark-mode';
+import { DARK_COLORS, LIGHT_COLORS } from '@/plugins/theme';
+
+const PREMIUM_DARK: ThemeColors = { accent: '#111111', graph: '#191919', primary: '#222222' };
+const PREMIUM_LIGHT: ThemeColors = { accent: '#333333', graph: '#3a3a3a', primary: '#444444' };
+
+const mockConfig = ref<Record<string, unknown> | undefined>({ dark: {}, light: {} });
+const mockIsDark = ref<boolean>(false);
+const mockSetThemeConfig = vi.fn();
+const mockSwitchThemeScheme = vi.fn();
+const mockDarkTheme = ref<ThemeColors>(PREMIUM_DARK);
+const mockLightTheme = ref<ThemeColors>(PREMIUM_LIGHT);
+const mockPremium = ref<boolean>(false);
+
+vi.mock('@rotki/ui-library', async importOriginal => ({
+  ...await importOriginal<typeof import('@rotki/ui-library')>(),
+  useRotkiTheme: (): Record<string, unknown> => ({
+    config: mockConfig,
+    isDark: mockIsDark,
+    setThemeConfig: mockSetThemeConfig,
+    switchThemeScheme: mockSwitchThemeScheme,
+  }),
+}));
+
+vi.mock('@/modules/shell/theme/use-theme-settings', () => ({
+  useThemeSettings: (): { darkTheme: typeof mockDarkTheme; lightTheme: typeof mockLightTheme } => ({
+    darkTheme: mockDarkTheme,
+    lightTheme: mockLightTheme,
+  }),
+}));
+
+vi.mock('@/modules/premium/use-premium', () => ({
+  usePremium: (): typeof mockPremium => mockPremium,
+}));
+
+describe('useDarkMode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(mockConfig, { dark: {}, light: {} });
+    set(mockIsDark, false);
+    set(mockDarkTheme, PREMIUM_DARK);
+    set(mockLightTheme, PREMIUM_LIGHT);
+    set(mockPremium, false);
+    useDarkMode(); // instantiate the shared composable
+  });
+
+  it('should switch to dark mode when enabled', () => {
+    useDarkMode().updateDarkMode(true);
+    expect(mockSwitchThemeScheme).toHaveBeenCalledWith(ThemeMode.dark);
+  });
+
+  it('should switch to light mode when disabled', () => {
+    useDarkMode().updateDarkMode(false);
+    expect(mockSwitchThemeScheme).toHaveBeenCalledWith(ThemeMode.light);
+  });
+
+  it('should use the default colors when not premium', () => {
+    const { usedTheme } = useDarkMode();
+    set(mockIsDark, false);
+    expect(get(usedTheme)).toStrictEqual(LIGHT_COLORS);
+    set(mockIsDark, true);
+    expect(get(usedTheme)).toStrictEqual(DARK_COLORS);
+  });
+
+  it('should use the configured premium themes when premium', () => {
+    set(mockPremium, true);
+    const { usedTheme } = useDarkMode();
+    set(mockIsDark, false);
+    expect(get(usedTheme)).toStrictEqual(PREMIUM_LIGHT);
+    set(mockIsDark, true);
+    expect(get(usedTheme)).toStrictEqual(PREMIUM_DARK);
+  });
+
+  it('should recompute theme colors when the premium dark theme changes', async () => {
+    set(mockPremium, true);
+    useDarkMode();
+    await nextTick();
+    mockSetThemeConfig.mockClear();
+
+    set(mockDarkTheme, { accent: '#555555', graph: '#5a5a5a', primary: '#666666' });
+    await nextTick();
+
+    expect(mockSetThemeConfig).toHaveBeenCalled();
+    const config = mockSetThemeConfig.mock.calls.at(-1)?.[0];
+    expect(config?.dark?.primary).toBeDefined();
+    expect(config?.dark?.secondary).toBeDefined();
+  });
+
+  it('should not push theme config when the base config is missing', async () => {
+    set(mockPremium, true);
+    useDarkMode();
+    await nextTick();
+    set(mockConfig, undefined);
+    mockSetThemeConfig.mockClear();
+
+    set(mockDarkTheme, { accent: '#777777', graph: '#7a7a7a', primary: '#888888' });
+    await nextTick();
+
+    expect(mockSetThemeConfig).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/shell/theme/use-theme-checker.spec.ts
+++ b/frontend/app/src/modules/shell/theme/use-theme-checker.spec.ts
@@ -1,0 +1,131 @@
+import { Theme } from '@rotki/common';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type Ref } from 'vue';
+
+const mockSelectedTheme = ref<Theme>(Theme.AUTO);
+const mockLogged = ref<boolean>(false);
+const mockUpdateDarkMode = vi.fn();
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: vi.fn(() => mockSelectedTheme),
+}));
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: vi.fn(() => ({ logged: mockLogged })),
+}));
+
+vi.mock('@/modules/shell/theme/use-dark-mode', () => ({
+  useDarkMode: vi.fn(() => ({ updateDarkMode: mockUpdateDarkMode })),
+}));
+
+interface MockMediaQueryList {
+  matches: boolean;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+}
+
+let mediaQueryList: MockMediaQueryList;
+
+function createMediaQueryList(matches: boolean): MockMediaQueryList {
+  return {
+    addEventListener: vi.fn(),
+    matches,
+    removeEventListener: vi.fn(),
+  };
+}
+
+async function mountChecker(): Promise<ReturnType<typeof mount>> {
+  vi.resetModules();
+  const { useThemeChecker } = await import('@/modules/shell/theme/use-theme-checker');
+  const component = defineComponent({
+    setup() {
+      useThemeChecker();
+      return {};
+    },
+    template: '<div />',
+  });
+  return mount(component);
+}
+
+describe('useThemeChecker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mediaQueryList = createMediaQueryList(false);
+    vi.stubGlobal('matchMedia', vi.fn(() => mediaQueryList));
+    set(mockSelectedTheme, Theme.AUTO);
+    set(mockLogged, false);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('should enable dark mode on mount when logged in with the dark theme selected', async () => {
+    set(mockLogged, true);
+    set(mockSelectedTheme, Theme.DARK);
+    await mountChecker();
+    expect(mockUpdateDarkMode).toHaveBeenLastCalledWith(true);
+  });
+
+  it('should disable dark mode on mount when logged in with the light theme selected', async () => {
+    set(mockLogged, true);
+    set(mockSelectedTheme, Theme.LIGHT);
+    await mountChecker();
+    expect(mockUpdateDarkMode).toHaveBeenLastCalledWith(false);
+  });
+
+  it('should use the stored theme when not logged in', async () => {
+    const stored: Ref<Theme> = useLocalStorage<Theme>('rotki.selected_theme', Theme.AUTO);
+    set(stored, Theme.DARK);
+    await mountChecker();
+    expect(mockUpdateDarkMode).toHaveBeenLastCalledWith(true);
+  });
+
+  it('should follow the preferred color scheme when the theme is auto', async () => {
+    set(mockLogged, true);
+    set(mockSelectedTheme, Theme.AUTO);
+    mediaQueryList = createMediaQueryList(true);
+    vi.stubGlobal('matchMedia', vi.fn(() => mediaQueryList));
+    await mountChecker();
+    expect(mockUpdateDarkMode).toHaveBeenLastCalledWith(true);
+  });
+
+  it('should register a media query change listener on mount', async () => {
+    await mountChecker();
+    expect(mediaQueryList.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+
+  it('should re-evaluate the theme when the media query changes', async () => {
+    set(mockLogged, true);
+    set(mockSelectedTheme, Theme.AUTO);
+    await mountChecker();
+    mockUpdateDarkMode.mockClear();
+
+    const handler = mediaQueryList.addEventListener.mock.calls[0][1];
+    handler({ matches: true });
+    await nextTick();
+
+    expect(mockUpdateDarkMode).toHaveBeenLastCalledWith(true);
+  });
+
+  it('should persist the selected theme to local storage when logged in', async () => {
+    set(mockLogged, true);
+    set(mockSelectedTheme, Theme.LIGHT);
+    await mountChecker();
+
+    set(mockSelectedTheme, Theme.DARK);
+    await nextTick();
+
+    const stored = useLocalStorage<Theme>('rotki.selected_theme', Theme.AUTO);
+    expect(get(stored)).toBe(Theme.DARK);
+  });
+
+  it('should remove the media query listener on unmount', async () => {
+    const wrapper = await mountChecker();
+    wrapper.unmount();
+    expect(mediaQueryList.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+});

--- a/frontend/app/src/modules/statistics/wrapped/use-wrapped-date-range.spec.ts
+++ b/frontend/app/src/modules/statistics/wrapped/use-wrapped-date-range.spec.ts
@@ -1,0 +1,79 @@
+import dayjs from 'dayjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWrappedDateRange } from '@/modules/statistics/wrapped/use-wrapped-date-range';
+
+describe('useWrappedDateRange', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should compute the unix range for a given year', () => {
+    const { getYearRange } = useWrappedDateRange();
+    const range = getYearRange(2023);
+    expect(range.start).toBe(dayjs().year(2023).startOf('year').unix());
+    expect(range.end).toBe(dayjs().year(2023).endOf('year').unix());
+    expect(range.start).toBeLessThan(range.end);
+  });
+
+  it('should set the start and end refs when applying a year range', () => {
+    const { end, setYearRange, start } = useWrappedDateRange();
+    setYearRange(2022);
+    expect(get(start)).toBe(dayjs().year(2022).startOf('year').unix());
+    expect(get(end)).toBe(dayjs().year(2022).endOf('year').unix());
+  });
+
+  it('should expose start as undefined through startModel when zero', () => {
+    const { startModel } = useWrappedDateRange();
+    expect(get(startModel)).toBeUndefined();
+  });
+
+  it('should map startModel writes back onto the start ref', () => {
+    const { start, startModel } = useWrappedDateRange();
+    set(startModel, 1000);
+    expect(get(start)).toBe(1000);
+    expect(get(startModel)).toBe(1000);
+  });
+
+  it('should reset start to zero when startModel is set to undefined', () => {
+    const { start, startModel } = useWrappedDateRange();
+    set(startModel, 1000);
+    set(startModel, undefined);
+    expect(get(start)).toBe(0);
+    expect(get(startModel)).toBeUndefined();
+  });
+
+  it('should not flag a valid range as invalid', () => {
+    const { end, invalidRange, start } = useWrappedDateRange();
+    set(start, 100);
+    set(end, 200);
+    expect(get(invalidRange)).toBe(false);
+  });
+
+  it('should flag a range where start is after end as invalid', () => {
+    const { end, invalidRange, start } = useWrappedDateRange();
+    set(start, 300);
+    set(end, 200);
+    expect(get(invalidRange)).toBe(true);
+  });
+
+  it('should not flag the range as invalid when either bound is unset', () => {
+    const { end, invalidRange, start } = useWrappedDateRange();
+    set(start, 300);
+    set(end, 0);
+    expect(get(invalidRange)).toBe(false);
+  });
+
+  it('should initialize the end date to now when it is unset', () => {
+    const { end, initializeEndDate } = useWrappedDateRange();
+    const before = dayjs().unix();
+    initializeEndDate();
+    expect(get(end)).toBeGreaterThanOrEqual(before);
+  });
+
+  it('should not override an already set end date on initialization', () => {
+    const { end, initializeEndDate } = useWrappedDateRange();
+    set(end, 12345);
+    initializeEndDate();
+    expect(get(end)).toBe(12345);
+  });
+});

--- a/frontend/app/src/modules/statistics/wrapped/use-wrapped-formatters.spec.ts
+++ b/frontend/app/src/modules/statistics/wrapped/use-wrapped-formatters.spec.ts
@@ -1,0 +1,44 @@
+import dayjs from 'dayjs';
+import { describe, expect, it } from 'vitest';
+import { useWrappedFormatters } from '@/modules/statistics/wrapped/use-wrapped-formatters';
+
+describe('useWrappedFormatters', () => {
+  const { calculateFontSize, formatDate, hasSectionData } = useWrappedFormatters();
+
+  describe('hasSectionData', () => {
+    it('should return false for undefined data', () => {
+      expect(hasSectionData(undefined)).toBe(false);
+    });
+
+    it('should return false for an empty array', () => {
+      expect(hasSectionData([])).toBe(false);
+    });
+
+    it('should return true for a non-empty array', () => {
+      expect(hasSectionData([1])).toBe(true);
+    });
+
+    it('should return false for an empty object', () => {
+      expect(hasSectionData({})).toBe(false);
+    });
+
+    it('should return true for a non-empty object', () => {
+      expect(hasSectionData({ a: 1 })).toBe(true);
+    });
+  });
+
+  describe('formatDate', () => {
+    it('should format a unix timestamp as a full date', () => {
+      const timestamp = dayjs('2023-06-15T12:00:00Z').unix();
+      expect(formatDate(timestamp)).toBe(dayjs(timestamp * 1000).format('dddd, MMMM D, YYYY'));
+    });
+  });
+
+  describe('calculateFontSize', () => {
+    it('should shrink the font size as the symbol grows', () => {
+      expect(calculateFontSize('A')).toBe('1.4em');
+      expect(calculateFontSize('AB')).toBe('1em');
+      expect(calculateFontSize('ABC')).toBe('0.5999999999999999em');
+    });
+  });
+});

--- a/frontend/app/src/modules/statistics/wrapped/use-wrapped-gnosis-pay.spec.ts
+++ b/frontend/app/src/modules/statistics/wrapped/use-wrapped-gnosis-pay.spec.ts
@@ -1,0 +1,96 @@
+import type { WrapStatisticsResult } from '@/modules/statistics/api/use-wrap-statistics-api';
+import { bigNumberify } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWrappedGnosisPay } from '@/modules/statistics/wrapped/use-wrapped-gnosis-pay';
+
+const mockAllowed = ref<boolean>(true);
+const mockGetApiKey = vi.fn<(name: string) => string>(() => 'key');
+const mockFindCurrency = vi.fn();
+
+vi.mock('@/modules/premium/use-feature-access', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/premium/use-feature-access')>(),
+  useFeatureAccess: (): { allowed: typeof mockAllowed } => ({ allowed: mockAllowed }),
+}));
+
+vi.mock('@/modules/settings/api-keys/external/use-external-api-keys', () => ({
+  useExternalApiKeys: (): { getApiKey: typeof mockGetApiKey } => ({ getApiKey: mockGetApiKey }),
+}));
+
+vi.mock('@/modules/assets/amount-display/currencies', () => ({
+  useCurrencies: (): { findCurrency: typeof mockFindCurrency } => ({ findCurrency: mockFindCurrency }),
+}));
+
+function summary(symbols: string[]): WrapStatisticsResult {
+  return {
+    ethOnGas: bigNumberify(0),
+    ethOnGasPerAddress: {},
+    gnosisMaxPaymentsByCurrency: symbols.map(symbol => ({ amount: bigNumberify(10), symbol })),
+    score: 0,
+    topDaysByNumberOfTransactions: [],
+    tradesByExchange: {},
+    transactionsPerChain: {},
+    transactionsPerProtocol: [],
+  };
+}
+
+describe('useWrappedGnosisPay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(mockAllowed, true);
+    mockGetApiKey.mockReturnValue('key');
+    mockFindCurrency.mockReset();
+  });
+
+  it('should expose the gnosis pay api key', () => {
+    mockGetApiKey.mockReturnValue('my-key');
+    const { gnosisPayKey } = useWrappedGnosisPay(null);
+    expect(get(gnosisPayKey)).toBe('my-key');
+    expect(mockGetApiKey).toHaveBeenCalledWith('gnosis_pay');
+  });
+
+  it('should show gnosis data only when allowed and a key exists', () => {
+    const { showGnosisData } = useWrappedGnosisPay(null);
+    expect(get(showGnosisData)).toBe(true);
+  });
+
+  it('should hide gnosis data when not allowed', () => {
+    set(mockAllowed, false);
+    const { showGnosisData } = useWrappedGnosisPay(null);
+    expect(get(showGnosisData)).toBe(false);
+  });
+
+  it('should hide gnosis data when no key is set', () => {
+    mockGetApiKey.mockReturnValue('');
+    const { showGnosisData } = useWrappedGnosisPay(null);
+    expect(get(showGnosisData)).toBe(false);
+  });
+
+  it('should return an empty result when the summary is missing', () => {
+    const { gnosisPayResult } = useWrappedGnosisPay(undefined);
+    expect(get(gnosisPayResult)).toEqual([]);
+  });
+
+  it('should map payments using the resolved currency metadata', () => {
+    mockFindCurrency.mockReturnValue({ name: 'US Dollar', unicodeSymbol: '$' });
+    const { gnosisPayResult } = useWrappedGnosisPay(summary(['USD']));
+    expect(get(gnosisPayResult)).toEqual([
+      { amount: bigNumberify(10), code: 'USD', name: 'US Dollar', symbol: '$' },
+    ]);
+  });
+
+  it('should fall back to the raw symbol when the currency lookup throws', () => {
+    mockFindCurrency.mockImplementation(() => {
+      throw new Error('unknown');
+    });
+    const { gnosisPayResult } = useWrappedGnosisPay(summary(['XYZ']));
+    expect(get(gnosisPayResult)).toEqual([
+      { amount: bigNumberify(10), code: 'XYZ', name: 'XYZ', symbol: 'XYZ' },
+    ]);
+  });
+
+  it('should skip payments when the currency lookup returns nothing', () => {
+    mockFindCurrency.mockReturnValue(undefined);
+    const { gnosisPayResult } = useWrappedGnosisPay(summary(['ZZZ']));
+    expect(get(gnosisPayResult)).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/statistics/wrapped/use-wrapped-history-events.spec.ts
+++ b/frontend/app/src/modules/statistics/wrapped/use-wrapped-history-events.spec.ts
@@ -1,0 +1,116 @@
+import type { Ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskType } from '@/modules/core/tasks/task-type';
+import { useWrappedHistoryEvents } from '@/modules/statistics/wrapped/use-wrapped-history-events';
+
+const mockGetEarliestEventTimestamp = vi.fn<() => Promise<number | undefined>>();
+const mockIsFirstLoad = vi.fn<() => boolean>(() => false);
+const mockSectionLoading = ref<boolean>(false);
+
+const mockEventTaskLoading = ref<boolean>(false);
+const mockProtocolCacheLoading = ref<boolean>(false);
+const mockOnlineEventsLoading = ref<boolean>(false);
+
+vi.mock('@/modules/history/events/use-history-events', () => ({
+  useHistoryEvents: (): { getEarliestEventTimestamp: typeof mockGetEarliestEventTimestamp } => ({
+    getEarliestEventTimestamp: mockGetEarliestEventTimestamp,
+  }),
+}));
+
+vi.mock('@/modules/shell/sync-progress/use-status-updater', () => ({
+  useStatusUpdater: (): { isFirstLoad: typeof mockIsFirstLoad; loading: Ref<boolean> } => ({
+    isFirstLoad: mockIsFirstLoad,
+    loading: mockSectionLoading,
+  }),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: (): { useIsTaskRunning: (type: TaskType) => Ref<boolean> } => {
+    const taskLoadingByType = new Map<TaskType, Ref<boolean>>([
+      [TaskType.TRANSACTIONS_DECODING, mockEventTaskLoading],
+      [TaskType.REFRESH_GENERAL_CACHE, mockProtocolCacheLoading],
+      [TaskType.QUERY_ONLINE_EVENTS, mockOnlineEventsLoading],
+    ]);
+    return {
+      useIsTaskRunning: (type: TaskType): Ref<boolean> => taskLoadingByType.get(type) ?? ref<boolean>(false),
+    };
+  },
+}));
+
+describe('useWrappedHistoryEvents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    mockIsFirstLoad.mockReturnValue(false);
+    mockGetEarliestEventTimestamp.mockResolvedValue(undefined);
+    set(mockSectionLoading, false);
+    set(mockEventTaskLoading, false);
+    set(mockProtocolCacheLoading, false);
+    set(mockOnlineEventsLoading, false);
+  });
+
+  it('should not be refreshing when nothing is loading', () => {
+    const { refreshing } = useWrappedHistoryEvents(ref(0));
+    expect(get(refreshing)).toBe(false);
+  });
+
+  it('should be refreshing when the section is loading', () => {
+    set(mockSectionLoading, true);
+    const { refreshing } = useWrappedHistoryEvents(ref(0));
+    expect(get(refreshing)).toBe(true);
+  });
+
+  it('should be refreshing when any related task is running', () => {
+    set(mockOnlineEventsLoading, true);
+    const { refreshing } = useWrappedHistoryEvents(ref(0));
+    expect(get(refreshing)).toBe(true);
+  });
+
+  it('should expose the first load state', () => {
+    mockIsFirstLoad.mockReturnValue(true);
+    const { isFirstLoad } = useWrappedHistoryEvents(ref(0));
+    expect(isFirstLoad()).toBe(true);
+  });
+
+  it('should be ready when not the first load and not refreshing', () => {
+    mockIsFirstLoad.mockReturnValue(false);
+    const { historyEventsReady } = useWrappedHistoryEvents(ref(0));
+    expect(get(historyEventsReady)).toBe(true);
+  });
+
+  it('should not be ready during the first load', () => {
+    mockIsFirstLoad.mockReturnValue(true);
+    const { historyEventsReady } = useWrappedHistoryEvents(ref(0));
+    expect(get(historyEventsReady)).toBe(false);
+  });
+
+  it('should set the start from the earliest event when it exists', async () => {
+    mockGetEarliestEventTimestamp.mockResolvedValue(1_600_000_000);
+    const start = ref<number>(0);
+    const { initializeStartFromEarliestEvent } = useWrappedHistoryEvents(start);
+    await initializeStartFromEarliestEvent();
+    expect(get(start)).toBe(1_600_000_000);
+  });
+
+  it('should leave the start unchanged when there is no earliest event', async () => {
+    mockGetEarliestEventTimestamp.mockResolvedValue(undefined);
+    const start = ref<number>(0);
+    const { initializeStartFromEarliestEvent } = useWrappedHistoryEvents(start);
+    await initializeStartFromEarliestEvent();
+    expect(get(start)).toBe(0);
+  });
+
+  it('should initialize the start when the debounced ready state turns true', async () => {
+    vi.useFakeTimers();
+    mockIsFirstLoad.mockReturnValue(false);
+    mockGetEarliestEventTimestamp.mockResolvedValue(1_700_000_000);
+    const start = ref<number>(0);
+    useWrappedHistoryEvents(start);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.runAllTimersAsync();
+
+    expect(mockGetEarliestEventTimestamp).toHaveBeenCalled();
+    expect(get(start)).toBe(1_700_000_000);
+  });
+});

--- a/frontend/app/src/modules/statistics/wrapped/use-wrapped-statistics.spec.ts
+++ b/frontend/app/src/modules/statistics/wrapped/use-wrapped-statistics.spec.ts
@@ -1,0 +1,97 @@
+import type { WrapStatisticsResult } from '@/modules/statistics/api/use-wrap-statistics-api';
+import { bigNumberify } from '@rotki/common';
+import { flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWrappedStatistics } from '@/modules/statistics/wrapped/use-wrapped-statistics';
+
+const mockFetchWrapStatistics = vi.fn();
+const mockLoggerError = vi.hoisted(() => vi.fn());
+
+vi.mock('@/modules/statistics/api/use-wrap-statistics-api', () => ({
+  useWrapStatisticsApi: (): { fetchWrapStatistics: typeof mockFetchWrapStatistics } => ({
+    fetchWrapStatistics: mockFetchWrapStatistics,
+  }),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { error: mockLoggerError },
+}));
+
+function statistics(): WrapStatisticsResult {
+  return {
+    ethOnGas: bigNumberify(1),
+    ethOnGasPerAddress: {},
+    gnosisMaxPaymentsByCurrency: [],
+    score: 5,
+    topDaysByNumberOfTransactions: [],
+    tradesByExchange: {},
+    transactionsPerChain: {},
+    transactionsPerProtocol: [],
+  };
+}
+
+describe('useWrappedStatistics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch statistics with the current range and store the summary', async () => {
+    const result = statistics();
+    mockFetchWrapStatistics.mockResolvedValue(result);
+    const { fetchData, loading, summary } = useWrappedStatistics(ref(100), ref(200), ref(false));
+
+    await fetchData();
+
+    expect(mockFetchWrapStatistics).toHaveBeenCalledWith({ end: 200, start: 100 });
+    expect(get(summary)).toStrictEqual(result);
+    expect(get(loading)).toBe(false);
+  });
+
+  it('should set the summary to null and log when the request fails', async () => {
+    const error = new Error('boom');
+    mockFetchWrapStatistics.mockRejectedValue(error);
+    const { fetchData, summary } = useWrappedStatistics(ref(0), ref(0), ref(false));
+
+    await fetchData();
+
+    expect(get(summary)).toBeNull();
+    expect(mockLoggerError).toHaveBeenCalledWith(error);
+  });
+
+  it('should skip fetching when a request is already in progress', async () => {
+    let resolveFetch: (value: WrapStatisticsResult) => void = () => {};
+    mockFetchWrapStatistics.mockReturnValue(new Promise<WrapStatisticsResult>((resolve) => {
+      resolveFetch = resolve;
+    }));
+    const { fetchData } = useWrappedStatistics(ref(0), ref(0), ref(false));
+
+    const first = fetchData();
+    await fetchData();
+    expect(mockFetchWrapStatistics).toHaveBeenCalledTimes(1);
+
+    resolveFetch(statistics());
+    await first;
+  });
+
+  it('should refetch when refreshing transitions from true to false', async () => {
+    mockFetchWrapStatistics.mockResolvedValue(statistics());
+    const refreshing = ref<boolean>(true);
+    useWrappedStatistics(ref(0), ref(0), refreshing);
+
+    set(refreshing, false);
+    await flushPromises();
+
+    expect(mockFetchWrapStatistics).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not refetch when refreshing transitions from false to true', async () => {
+    mockFetchWrapStatistics.mockResolvedValue(statistics());
+    const refreshing = ref<boolean>(false);
+    useWrappedStatistics(ref(0), ref(0), refreshing);
+
+    set(refreshing, true);
+    await flushPromises();
+
+    expect(mockFetchWrapStatistics).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "lint:all": "run-p lint \"lint:style {@}\" --",
     "lint:style": "pnpm run --filter rotki lint:style",
     "lint:fix": "eslint . --fix",
+    "lint:file": "eslint --fix",
     "check": "pnpm run lint && pnpm run build && pnpm run test:unit",
     "check:all": "pnpm run lint && pnpm run build && pnpm run --filter @rotki/common test:unit --w app && pnpm run --filter rotki test:e2e",
     "clean:modules": "rimraf node_modules app/node_modules common/node_modules dev-proxy/node_modules app/dist app/electron-build app/.e2e common/lib && pnpm store prune",


### PR DESCRIPTION
## Summary

Adds unit specs for previously uncovered composables, continuing the frontend unit-coverage effort for #11252.

Coverage added, by area:

- **shell/theme:** `use-dark-mode`, `use-theme-checker`
- **statistics/wrapped:** `use-wrapped-formatters`, `use-wrapped-date-range`, `use-wrapped-gnosis-pay`, `use-wrapped-history-events`, `use-wrapped-statistics` (whole cluster)
- **core/table + filters:** `use-remember-table-sorting`, `use-remember-table-filter`, `use-common-table-props`, `use-saved-filters`, `use-eth-validator-filter`, `use-address-book-filter`, `use-custom-assets-filter`, `use-manual-balances-filter`, `use-accounting-rule-filter` (whole cluster)
- **core/common:** `validation/model` (extended), `use-form-error-scroll`
- **core/messaging:** `use-update-message`
- **dashboard:** `use-dashboard-asset-data`

Also adds a `lint:file` npm script (`eslint --fix <path>`) for linting a single file without scanning the whole tree.

## Test plan

- 20 spec files, ~141 new tests
- Full unit suite green: 527 files / 5037 tests
- `pnpm run typecheck` clean
- `pnpm run lint` reports 0 errors (the new spec files are warning-free; remaining warnings are the repo's pre-existing baseline)

Refs #11252