### PR TITLE
feat(settings): link search anchors to the settings registry

### DIFF
--- a/frontend/app/src/modules/settings/settings-registry.ts
+++ b/frontend/app/src/modules/settings/settings-registry.ts
@@ -6,6 +6,7 @@ import { getBnFormat } from '@/modules/assets/amount-display/amount-formatter';
 import { PrivacyMode, type SessionSettings } from '@/modules/session/types';
 import { useAnimationsEnabled } from '@/modules/session/use-animations-enabled';
 import { useItemsPerPage } from '@/modules/session/use-items-per-page';
+import { type SettingsHighlightId, SettingsHighlightIds } from '@/modules/settings/setting-highlight-ids';
 
 /** Post-persist effect: reconfigure BigNumber's global format when the separators change. */
 function applyBigNumberFormat(settings: FrontendSettings): void {
@@ -43,6 +44,8 @@ export interface RegistryEntry {
   readonly userFacing?: boolean;
   readonly effects?: ReadonlyArray<(settings: any) => void>;
   readonly mirror?: () => Ref<any>;
+  /** The settings-search anchor (`SettingsHighlightId`) this key scrolls to; many keys may share one. */
+  readonly anchor?: SettingsHighlightId;
 }
 
 /** A setting backed by a real field on its channel object, identified by the typed wire key `W`. */
@@ -53,6 +56,7 @@ interface FieldDef<C extends SettingChannel, W extends string> {
   readonly userFacing?: boolean;
   readonly effects?: ReadonlyArray<(settings: any) => void>;
   readonly mirror?: () => Ref<any>;
+  readonly anchor?: SettingsHighlightId;
 }
 
 /** A read-only setting whose value is derived from the whole channel object (e.g. `currencySymbol`). */
@@ -60,6 +64,7 @@ interface ProjectedDef<C extends SettingChannel, V> {
   readonly channel: C;
   readonly project: (settings: any) => V;
   readonly userFacing?: boolean;
+  readonly anchor?: SettingsHighlightId;
 }
 
 interface FieldOptions<T, W extends keyof T> {
@@ -71,10 +76,13 @@ interface FieldOptions<T, W extends keyof T> {
   readonly effects?: ReadonlyArray<(settings: T) => void>;
   /** External shared ref kept in sync with this key's value after each write. */
   readonly mirror?: () => Ref<T[W]>;
+  /** Settings-search anchor this key scrolls to (a `SettingsHighlightId`); composites share one. */
+  readonly anchor?: SettingsHighlightId;
 }
 
 interface ProjectedOptions {
   readonly userFacing?: boolean;
+  readonly anchor?: SettingsHighlightId;
 }
 
 /**
@@ -125,116 +133,116 @@ export const settingsRegistry = {
   // general
   activeModules: general('activeModules'),
   addressNamePriority: general('addressNamePriority'),
-  askUserUponSizeDiscrepancy: general('askUserUponSizeDiscrepancy'),
+  askUserUponSizeDiscrepancy: general('askUserUponSizeDiscrepancy', { anchor: SettingsHighlightIds.ASK_SIZE_DISCREPANCY }),
   assetMovementAmountTolerance: general('assetMovementAmountTolerance'),
   assetMovementTimeRange: general('assetMovementTimeRange'),
   autoCreateCalendarReminders: general('autoCreateCalendarReminders'),
-  autoCreateProfitEvents: general('autoCreateProfitEvents'),
+  autoCreateProfitEvents: general('autoCreateProfitEvents', { anchor: SettingsHighlightIds.AUTO_CREATE_PROFIT_EVENTS }),
   autoDeleteCalendarEntries: general('autoDeleteCalendarEntries'),
-  autoDetectTokens: general('autoDetectTokens'),
-  balanceSaveFrequency: general('balanceSaveFrequency'),
+  autoDetectTokens: general('autoDetectTokens', { anchor: SettingsHighlightIds.AUTO_DETECT_TOKENS }),
+  balanceSaveFrequency: general('balanceSaveFrequency', { anchor: SettingsHighlightIds.BALANCE_SAVE_FREQUENCY }),
   beaconRpcEndpoint: general('beaconRpcEndpoint'),
-  btcDerivationGapLimit: general('btcDerivationGapLimit'),
+  btcDerivationGapLimit: general('btcDerivationGapLimit', { anchor: SettingsHighlightIds.BTC_DERIVATION_GAP }),
   btcMempoolApi: general('btcMempoolApi'),
-  connectTimeout: general('connectTimeout'),
-  csvExportDelimiter: general('csvExportDelimiter'),
-  currency: general('mainCurrency', { encode: value => value.tickerSymbol }),
+  connectTimeout: general('connectTimeout', { anchor: SettingsHighlightIds.CONNECT_TIMEOUT }),
+  csvExportDelimiter: general('csvExportDelimiter', { anchor: SettingsHighlightIds.CSV_EXPORT }),
+  currency: general('mainCurrency', { anchor: SettingsHighlightIds.AMOUNT_FORMAT, encode: value => value.tickerSymbol }),
   currencySymbol: general.projected(settings => settings.mainCurrency.tickerSymbol),
   currentPriceOracles: general('currentPriceOracles'),
-  dateDisplayFormat: general('dateDisplayFormat'),
+  dateDisplayFormat: general('dateDisplayFormat', { anchor: SettingsHighlightIds.DATE_FORMAT }),
   defaultEvmIndexerOrder: general('defaultEvmIndexerOrder'),
-  disabledChainQueries: general('disabledChainQueries'),
-  displayDateInLocaltime: general('displayDateInLocaltime'),
+  disabledChainQueries: general('disabledChainQueries', { anchor: SettingsHighlightIds.DISABLED_CHAIN_QUERIES }),
+  displayDateInLocaltime: general('displayDateInLocaltime', { anchor: SettingsHighlightIds.DISPLAY_DATE_IN_LOCALTIME }),
   dotRpcEndpoint: general('dotRpcEndpoint'),
   evmIndexersOrder: general('evmIndexersOrder'),
-  evmchainsToSkipDetection: general('evmchainsToSkipDetection'),
-  floatingPrecision: general('uiFloatingPrecision'),
+  evmchainsToSkipDetection: general('evmchainsToSkipDetection', { anchor: SettingsHighlightIds.CHAINS_TO_SKIP_DETECTION }),
+  floatingPrecision: general('uiFloatingPrecision', { anchor: SettingsHighlightIds.AMOUNT_FORMAT }),
   historicalPriceOracles: general('historicalPriceOracles'),
   inferZeroTimedBalances: general('inferZeroTimedBalances'),
-  internalTxConflictRepullFrequency: general('internalTxConflictRepullFrequency'),
-  internalTxsToRepull: general('internalTxsToRepull'),
+  internalTxConflictRepullFrequency: general('internalTxConflictRepullFrequency', { anchor: SettingsHighlightIds.INTERNAL_TX_CONFLICT_REPULL }),
+  internalTxsToRepull: general('internalTxsToRepull', { anchor: SettingsHighlightIds.INTERNAL_TX_CONFLICT_REPULL }),
   ksmRpcEndpoint: general('ksmRpcEndpoint'),
   nonSyncingExchanges: general('nonSyncingExchanges'),
-  oraclePenaltyDuration: general('oraclePenaltyDuration'),
-  oraclePenaltyThresholdCount: general('oraclePenaltyThresholdCount'),
-  queryRetryLimit: general('queryRetryLimit'),
-  readTimeout: general('readTimeout'),
+  oraclePenaltyDuration: general('oraclePenaltyDuration', { anchor: SettingsHighlightIds.ORACLE_PENALTY_DURATION }),
+  oraclePenaltyThresholdCount: general('oraclePenaltyThresholdCount', { anchor: SettingsHighlightIds.ORACLE_PENALTY_THRESHOLD }),
+  queryRetryLimit: general('queryRetryLimit', { anchor: SettingsHighlightIds.QUERY_RETRY_LIMIT }),
+  readTimeout: general('readTimeout', { anchor: SettingsHighlightIds.READ_TIMEOUT }),
   ssfGraphMultiplier: general('ssfGraphMultiplier'),
-  submitUsageAnalytics: general('submitUsageAnalytics'),
-  suppressMissingKeyMsgServices: general('suppressMissingKeyMsgServices'),
-  treatEth2AsEth: general('treatEth2AsEth'),
+  submitUsageAnalytics: general('submitUsageAnalytics', { anchor: SettingsHighlightIds.USAGE_ANALYTICS }),
+  suppressMissingKeyMsgServices: general('suppressMissingKeyMsgServices', { anchor: SettingsHighlightIds.SUPPRESS_MISSING_KEY }),
+  treatEth2AsEth: general('treatEth2AsEth', { anchor: SettingsHighlightIds.TREAT_ETH2_AS_ETH }),
   // frontend
-  abbreviateNumber: frontend('abbreviateNumber'),
-  amountRoundingMode: frontend('amountRoundingMode'),
-  autoDetectTokensCooldownHours: frontend('autoDetectTokensCooldownHours'),
-  autoDetectTokensOnLogin: frontend('autoDetectTokensOnLogin'),
+  abbreviateNumber: frontend('abbreviateNumber', { anchor: SettingsHighlightIds.ABBREVIATION }),
+  amountRoundingMode: frontend('amountRoundingMode', { anchor: SettingsHighlightIds.ROUNDING }),
+  autoDetectTokensCooldownHours: frontend('autoDetectTokensCooldownHours', { anchor: SettingsHighlightIds.AUTO_DETECT_TOKENS_COOLDOWN }),
+  autoDetectTokensOnLogin: frontend('autoDetectTokensOnLogin', { anchor: SettingsHighlightIds.AUTO_DETECT_TOKENS_ON_LOGIN }),
   balanceValueThreshold: frontend('balanceValueThreshold'),
   blockchainRefreshButtonBehaviour: frontend('blockchainRefreshButtonBehaviour'),
-  currencyLocation: frontend('currencyLocation'),
+  currencyLocation: frontend('currencyLocation', { anchor: SettingsHighlightIds.CURRENCY_LOCATION }),
   darkTheme: frontend('darkTheme'),
   dashboardTablesVisibleColumns: frontend('dashboardTablesVisibleColumns', { userFacing: false }),
   dateInputFormat: frontend('dateInputFormat'),
-  decimalSeparator: frontend('decimalSeparator', { effects: [applyBigNumberFormat] }),
+  decimalSeparator: frontend('decimalSeparator', { anchor: SettingsHighlightIds.AMOUNT_FORMAT, effects: [applyBigNumberFormat] }),
   defaultThemeVersion: frontend('defaultThemeVersion'),
   enableAliasNames: frontend('enableAliasNames'),
-  enablePasswordConfirmation: frontend('enablePasswordConfirmation'),
-  evmQueryIndicatorDismissalThreshold: frontend('evmQueryIndicatorDismissalThreshold'),
-  evmQueryIndicatorMinOutOfSyncPeriod: frontend('evmQueryIndicatorMinOutOfSyncPeriod'),
-  explorers: frontend('explorers'),
+  enablePasswordConfirmation: frontend('enablePasswordConfirmation', { anchor: SettingsHighlightIds.PASSWORD_CONFIRMATION }),
+  evmQueryIndicatorDismissalThreshold: frontend('evmQueryIndicatorDismissalThreshold', { anchor: SettingsHighlightIds.DISMISSAL_THRESHOLD }),
+  evmQueryIndicatorMinOutOfSyncPeriod: frontend('evmQueryIndicatorMinOutOfSyncPeriod', { anchor: SettingsHighlightIds.MIN_OUT_OF_SYNC_PERIOD }),
+  explorers: frontend('explorers', { anchor: SettingsHighlightIds.EXPLORERS }),
   gnosisPaySafeMigrationLastNotified: frontend('gnosisPaySafeMigrationLastNotified', { userFacing: false }),
   gnosisPaySafeMigrationNeverNotify: frontend('gnosisPaySafeMigrationNeverNotify'),
-  graphZeroBased: frontend('graphZeroBased'),
+  graphZeroBased: frontend('graphZeroBased', { anchor: SettingsHighlightIds.GRAPH_BASIS }),
   ignoreSnapshotError: frontend('ignoreSnapshotError'),
   itemsPerPage: frontend('itemsPerPage', { mirror: useItemsPerPage }),
-  language: frontend('language'),
+  language: frontend('language', { anchor: SettingsHighlightIds.LANGUAGE }),
   lastAppliedSettingsVersion: frontend('lastAppliedSettingsVersion', { userFacing: false }),
   lastAutoDetectAt: frontend('lastAutoDetectAt', { userFacing: false }),
   lastKnownTimeframe: frontend('lastKnownTimeframe', { userFacing: false }),
   lastPasswordConfirmed: frontend('lastPasswordConfirmed', { userFacing: false }),
   lightTheme: frontend('lightTheme'),
-  minimumDigitToBeAbbreviated: frontend('minimumDigitToBeAbbreviated'),
-  newlyDetectedTokensMaxCount: frontend('newlyDetectedTokensMaxCount'),
-  newlyDetectedTokensTtlDays: frontend('newlyDetectedTokensTtlDays'),
-  nftsInNetValue: frontend('nftsInNetValue'),
-  notifyNewNfts: frontend('notifyNewNfts'),
-  passwordConfirmationInterval: frontend('passwordConfirmationInterval'),
-  persistPrivacySettings: frontend('persistPrivacySettings'),
-  persistTableSorting: frontend('persistTableSorting'),
+  minimumDigitToBeAbbreviated: frontend('minimumDigitToBeAbbreviated', { anchor: SettingsHighlightIds.ABBREVIATION }),
+  newlyDetectedTokensMaxCount: frontend('newlyDetectedTokensMaxCount', { anchor: SettingsHighlightIds.NEWLY_DETECTED_TOKENS_MAX_COUNT }),
+  newlyDetectedTokensTtlDays: frontend('newlyDetectedTokensTtlDays', { anchor: SettingsHighlightIds.NEWLY_DETECTED_TOKENS_TTL }),
+  nftsInNetValue: frontend('nftsInNetValue', { anchor: SettingsHighlightIds.NFT_IN_NET_VALUE }),
+  notifyNewNfts: frontend('notifyNewNfts', { anchor: SettingsHighlightIds.NFT_IMAGE_RENDERING }),
+  passwordConfirmationInterval: frontend('passwordConfirmationInterval', { anchor: SettingsHighlightIds.PASSWORD_CONFIRMATION }),
+  persistPrivacySettings: frontend('persistPrivacySettings', { anchor: SettingsHighlightIds.PERSIST_PRIVACY }),
+  persistTableSorting: frontend('persistTableSorting', { anchor: SettingsHighlightIds.PERSIST_TABLE_SORTING }),
   privacyMode: frontend('privacyMode'),
   profitLossReportPeriod: frontend('profitLossReportPeriod'),
-  queryPeriod: frontend('queryPeriod'),
-  refreshPeriod: frontend('refreshPeriod'),
-  renderAllNftImages: frontend('renderAllNftImages'),
+  queryPeriod: frontend('queryPeriod', { anchor: SettingsHighlightIds.PERIODIC_QUERY }),
+  refreshPeriod: frontend('refreshPeriod', { anchor: SettingsHighlightIds.REFRESH_BALANCE }),
+  renderAllNftImages: frontend('renderAllNftImages', { anchor: SettingsHighlightIds.NFT_IMAGE_RENDERING }),
   savedFilters: frontend('savedFilters', { userFacing: false }),
-  scrambleData: frontend('scrambleData'),
-  scrambleMultiplier: frontend('scrambleMultiplier'),
+  scrambleData: frontend('scrambleData', { anchor: SettingsHighlightIds.SCRAMBLE }),
+  scrambleMultiplier: frontend('scrambleMultiplier', { anchor: SettingsHighlightIds.SCRAMBLE }),
   selectedTheme: frontend('selectedTheme'),
   shouldShowAmount: frontend.projected(settings => settings.privacyMode < PrivacyMode.SEMI_PRIVATE),
   shouldShowPercentage: frontend.projected(settings => settings.privacyMode < PrivacyMode.PRIVATE),
   showGraphRangeSelector: frontend('showGraphRangeSelector'),
-  subscriptDecimals: frontend('subscriptDecimals'),
-  suppressNoIndexerChains: frontend('suppressNoIndexerChains'),
-  thousandSeparator: frontend('thousandSeparator', { effects: [applyBigNumberFormat] }),
-  timeframeSetting: frontend('timeframeSetting'),
+  subscriptDecimals: frontend('subscriptDecimals', { anchor: SettingsHighlightIds.SUBSCRIPT }),
+  suppressNoIndexerChains: frontend('suppressNoIndexerChains', { anchor: SettingsHighlightIds.SUPPRESSED_NO_INDEXER_CHAINS }),
+  thousandSeparator: frontend('thousandSeparator', { anchor: SettingsHighlightIds.AMOUNT_FORMAT, effects: [applyBigNumberFormat] }),
+  timeframeSetting: frontend('timeframeSetting', { anchor: SettingsHighlightIds.TIMEFRAME }),
   useHistoricalAssetBalances: frontend('useHistoricalAssetBalances'),
-  valueRoundingMode: frontend('valueRoundingMode'),
-  versionUpdateCheckFrequency: frontend('versionUpdateCheckFrequency'),
-  visibleTimeframes: frontend('visibleTimeframes'),
-  whitelistedDomainsForNftImages: frontend('whitelistedDomainsForNftImages'),
+  valueRoundingMode: frontend('valueRoundingMode', { anchor: SettingsHighlightIds.ROUNDING }),
+  versionUpdateCheckFrequency: frontend('versionUpdateCheckFrequency', { anchor: SettingsHighlightIds.VERSION_UPDATE_CHECK }),
+  visibleTimeframes: frontend('visibleTimeframes', { anchor: SettingsHighlightIds.TIMEFRAME }),
+  whitelistedDomainsForNftImages: frontend('whitelistedDomainsForNftImages', { anchor: SettingsHighlightIds.NFT_IMAGE_RENDERING }),
   // session
-  animationsEnabled: session('animationsEnabled', { mirror: useAnimationsEnabled }),
+  animationsEnabled: session('animationsEnabled', { anchor: SettingsHighlightIds.ANIMATIONS, mirror: useAnimationsEnabled }),
   timeframe: session('timeframe'),
   // accounting
-  calculatePastCostBasis: accounting('calculatePastCostBasis'),
-  costBasisMethod: accounting('costBasisMethod'),
-  ethStakingTaxableAfterWithdrawalEnabled: accounting('ethStakingTaxableAfterWithdrawalEnabled'),
-  includeCrypto2crypto: accounting('includeCrypto2crypto'),
-  includeFeesInCostBasis: accounting('includeFeesInCostBasis'),
-  includeGasCosts: accounting('includeGasCosts'),
-  pnlCsvHaveSummary: accounting('pnlCsvHaveSummary'),
-  pnlCsvWithFormulas: accounting('pnlCsvWithFormulas'),
-  taxfreeAfterPeriod: accounting('taxfreeAfterPeriod'),
-  useAssetCollectionsInCostBasis: accounting('useAssetCollectionsInCostBasis'),
+  calculatePastCostBasis: accounting('calculatePastCostBasis', { anchor: SettingsHighlightIds.ACCOUNTING_TRADE }),
+  costBasisMethod: accounting('costBasisMethod', { anchor: SettingsHighlightIds.ACCOUNTING_TRADE }),
+  ethStakingTaxableAfterWithdrawalEnabled: accounting('ethStakingTaxableAfterWithdrawalEnabled', { anchor: SettingsHighlightIds.ACCOUNTING_TRADE }),
+  includeCrypto2crypto: accounting('includeCrypto2crypto', { anchor: SettingsHighlightIds.ACCOUNTING_TRADE }),
+  includeFeesInCostBasis: accounting('includeFeesInCostBasis', { anchor: SettingsHighlightIds.ACCOUNTING_TRADE }),
+  includeGasCosts: accounting('includeGasCosts', { anchor: SettingsHighlightIds.ACCOUNTING_TRADE }),
+  pnlCsvHaveSummary: accounting('pnlCsvHaveSummary', { anchor: SettingsHighlightIds.CSV_EXPORT }),
+  pnlCsvWithFormulas: accounting('pnlCsvWithFormulas', { anchor: SettingsHighlightIds.CSV_EXPORT }),
+  taxfreeAfterPeriod: accounting('taxfreeAfterPeriod', { anchor: SettingsHighlightIds.ACCOUNTING_TRADE }),
+  useAssetCollectionsInCostBasis: accounting('useAssetCollectionsInCostBasis', { anchor: SettingsHighlightIds.ACCOUNTING_TRADE }),
 } satisfies Record<string, RegistryEntry>;
 
 /**
@@ -253,4 +261,26 @@ export function getRegistryEntry(key: string): RegistryEntry | undefined {
 /** All registry entries as typed `[logicalKey, entry]` pairs (a bare `Object.entries` widens to a union). */
 export function registryEntries(): ReadonlyArray<readonly [string, RegistryEntry]> {
   return [...registryByKey];
+}
+
+/**
+ * Reverse index: the logical keys that share a given settings-search anchor. Built once from the
+ * registry so it cannot drift; composite anchors return several keys, keyless anchors return `[]`.
+ */
+const keysByAnchor: ReadonlyMap<SettingsHighlightId, readonly string[]> = ((): ReadonlyMap<SettingsHighlightId, readonly string[]> => {
+  const map = new Map<SettingsHighlightId, string[]>();
+  for (const [key, entry] of registryByKey) {
+    const { anchor } = entry;
+    if (!anchor)
+      continue;
+    const keys = map.get(anchor) ?? [];
+    keys.push(key);
+    map.set(anchor, keys);
+  }
+  return map;
+})();
+
+/** The registry keys anchored to `anchor` (empty for keyless anchors such as action targets). */
+export function registryKeysForAnchor(anchor: SettingsHighlightId): readonly string[] {
+  return keysByAnchor.get(anchor) ?? [];
 }

--- a/frontend/app/src/modules/settings/use-settings-search.spec.ts
+++ b/frontend/app/src/modules/settings/use-settings-search.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsHighlightIds, type SettingsSearchEntry } from '@/modules/settings/setting-highlight-ids';
+import { getRegistryEntry, registryEntries, registryKeysForAnchor } from '@/modules/settings/settings-registry';
 
 vi.mock('@/router/routes', () => ({
   useAppRoutes: vi.fn((): { appRoutes: ReturnType<typeof import('vue')['ref']> } => ({
@@ -59,6 +60,72 @@ describe('useSettingsSearch', () => {
         .filter((id): id is NonNullable<typeof id> => id !== undefined)
         .filter(id => !definedIds.has(id));
       expect(unknown, 'search entries referencing an undefined highlight id').toEqual([]);
+    });
+  });
+
+  describe('registry <-> anchor coverage', () => {
+    // Anchors that intentionally back no registry setting: action targets, info displays, backend
+    // settings and subsystems that are not part of the settings registry. Keeping this list explicit
+    // makes "this anchor has no setting" a reviewed decision rather than silent drift.
+    const keylessAnchors: string[] = [
+      SettingsHighlightIds.ACCOUNTING_RULE,
+      SettingsHighlightIds.ASSET_UPDATE,
+      SettingsHighlightIds.CHANGE_PASSWORD,
+      SettingsHighlightIds.GLOBALDB_INFO,
+      SettingsHighlightIds.LOG_LEVEL,
+      SettingsHighlightIds.MODULES,
+      SettingsHighlightIds.PURGE_DATA,
+      SettingsHighlightIds.PURGE_IMAGES_CACHE,
+      SettingsHighlightIds.REFRESH_CACHE,
+      SettingsHighlightIds.RESET_DISMISSAL_STATUS,
+      SettingsHighlightIds.RESTORE_ASSETS_DB,
+      SettingsHighlightIds.RPC_NODES,
+      SettingsHighlightIds.SKIPPED_EVENTS,
+      SettingsHighlightIds.USERDB_INFO,
+    ].sort();
+
+    it('should only anchor registry entries to defined highlight ids', () => {
+      const definedIds = new Set<string>(Object.values(SettingsHighlightIds));
+      const invalid = registryEntries()
+        .map(([key, entry]) => ({ anchor: entry.anchor, key }))
+        .filter(({ anchor }) => anchor !== undefined && !definedIds.has(anchor));
+      expect(invalid, 'registry entries anchored to an undefined highlight id').toEqual([]);
+    });
+
+    it('should surface every registry anchor in the search entries', () => {
+      const surfaced = new Set(
+        allEntries.map(entry => entry.highlightId).filter((id): id is NonNullable<typeof id> => id !== undefined),
+      );
+      const unsurfaced = registryEntries()
+        .map(([key, entry]) => ({ anchor: entry.anchor, key }))
+        .filter(({ anchor }) => anchor !== undefined && !surfaced.has(anchor));
+      expect(unsurfaced, 'registry keys anchored to a highlight id the search does not surface').toEqual([]);
+    });
+
+    it('should resolve every anchored highlight id back to existing registry keys', () => {
+      const anchoredIds = Object.values(SettingsHighlightIds).filter(id => registryKeysForAnchor(id).length > 0);
+      for (const id of anchoredIds) {
+        const keys = registryKeysForAnchor(id);
+        expect(keys.length, `anchor ${id} should map to at least one registry key`).toBeGreaterThan(0);
+        for (const key of keys)
+          expect(getRegistryEntry(key), `key ${key} for anchor ${id} should resolve to a registry entry`).toBeDefined();
+      }
+    });
+
+    it('should keep the keyless-anchor allowlist in sync with the registry', () => {
+      const keyless = Object.values(SettingsHighlightIds)
+        .filter(id => registryKeysForAnchor(id).length === 0)
+        .sort();
+      expect(keyless).toEqual(keylessAnchors);
+    });
+
+    it('should find settings by their derived enum-value keywords', () => {
+      const anchorOf = (keyword: string): (string | undefined)[] =>
+        filterEntries(allEntries, keyword).map(entry => entry.highlightId);
+      expect(anchorOf('fifo')).toContain(SettingsHighlightIds.ACCOUNTING_TRADE);
+      expect(anchorOf('hifo')).toContain(SettingsHighlightIds.ACCOUNTING_TRADE);
+      expect(anchorOf('6m')).toContain(SettingsHighlightIds.TIMEFRAME);
+      expect(anchorOf('before')).toContain(SettingsHighlightIds.CURRENCY_LOCATION);
     });
   });
 

--- a/frontend/app/src/modules/settings/use-settings-search.ts
+++ b/frontend/app/src/modules/settings/use-settings-search.ts
@@ -1,9 +1,22 @@
 import type { RuiIcons } from '@rotki/ui-library';
 import type { Ref } from 'vue';
 import type { RouteLocationRaw } from 'vue-router';
-import { getTextToken } from '@rotki/common';
+import { getTextToken, TimeFramePeriod } from '@rotki/common';
+import { CurrencyLocation } from '@/modules/assets/amount-display/currency-location';
 import { type SettingsCategoryId, SettingsCategoryIds, type SettingsHighlightId, SettingsHighlightIds, type SettingsSearchEntry } from '@/modules/settings/setting-highlight-ids';
+import { CostBasisMethod } from '@/modules/settings/types/user-settings';
 import { useAppRoutes } from '@/router/routes';
+
+/**
+ * Extra search keywords derived from a setting's option domain, so a value like `fifo` or `6m` finds
+ * its setting even though the value is never rendered as UI text. Only anchors whose option set is a
+ * cleanly-importable enum qualify (see the fold plan); everything else keeps its hand-written keywords.
+ */
+const anchorKeywordDomains: Partial<Record<SettingsHighlightId, readonly string[]>> = {
+  [SettingsHighlightIds.ACCOUNTING_TRADE]: Object.values(CostBasisMethod),
+  [SettingsHighlightIds.CURRENCY_LOCATION]: Object.values(CurrencyLocation),
+  [SettingsHighlightIds.TIMEFRAME]: Object.values(TimeFramePeriod),
+};
 
 interface TabInfo {
   icon: RuiIcons;
@@ -252,14 +265,17 @@ export function useSettingsSearch(): UseSettingsSearchReturn {
 
     return tabs.flatMap(({ tab, categories }: TabGroup) =>
       categories.flatMap(({ categoryId, children }: CategoryDef) =>
-        children.map(({ texts, keywords, highlightId }: EntryDef) => ({
-          categoryId,
-          highlightId,
-          icon: tab.icon,
-          keywords,
-          route: tab.route,
-          texts: [tab.text, ...texts],
-        })),
+        children.map(({ texts, keywords, highlightId }: EntryDef) => {
+          const derived = highlightId ? anchorKeywordDomains[highlightId] : undefined;
+          return {
+            categoryId,
+            highlightId,
+            icon: tab.icon,
+            keywords: derived ? [...new Set([...(keywords ?? []), ...derived])] : keywords,
+            route: tab.route,
+            texts: [tab.text, ...texts],
+          };
+        }),
       ),
     );
   });


### PR DESCRIPTION
## Summary

Folds the hand-written settings search into the settings registry (the last remaining registry-refactor piece). Every setting now names the search highlight target it scrolls to, and enum-backed settings contribute derived search keywords, so a user can search by a value (e.g. `fifo`, `6m`, `before`) and land on the setting.

This is the **Core** scope: it establishes the registry↔search linkage, coverage-integrity tests, and derived keywords, while keeping the search manifest anchor-centric and i18n resolved via `t()`. Search UX and navigation are unchanged.

## What changed

- **Registry** (`settings-registry.ts`): added an optional `anchor?: SettingsHighlightId` to `RegistryEntry`/`FieldDef`/`ProjectedDef` and the channel-builder options (the `...options` spread propagates it, no builder-body change). Populated it on the 46 setting-backed keys, including composite anchors where several settings share one target (`AMOUNT_FORMAT`, `ROUNDING`, `ABBREVIATION`, `NFT_IMAGE_RENDERING`, `INTERNAL_TX_CONFLICT_REPULL`, `SCRAMBLE`, `PASSWORD_CONFIRMATION`, `TIMEFRAME`, `CSV_EXPORT`, `ACCOUNTING_TRADE`). Added `registryKeysForAnchor(anchor)`, a reverse index built from the registry so it cannot drift.
- **Search** (`use-settings-search.ts`): derive extra keywords from three cleanly-importable enums (`CostBasisMethod`, `CurrencyLocation`, `TimeFramePeriod`) and merge them (deduped) into each entry's keywords. All `t()` strings stay in place, so existing query results are unchanged and only new enum-value queries begin matching.
- **Tests** (`use-settings-search.spec.ts`): a new `registry <-> anchor coverage` block — anchor validity, every registry anchor is surfaced by search, the reverse index resolves to real keys, an explicit keyless-anchor allowlist (action/info/backend anchors), and derived-keyword smoke tests.

Anchors relate to settings **many-to-one**: composites converge several keys onto one anchor, and action anchors (change password, purge data, RPC nodes, modules, …) intentionally back no setting. The `anchor`-on-entry field models exactly this.

## Follow-up (not in this PR)

The manifest stays anchor-centric and i18n stays in the composable, so a later "full" pass is purely additive: live current-value in search results (single-key anchors), a typed `LocaleKey`, an eslint guard over registry keys, and single-sourcing each component's `SettingsItem :id` from the registry.

## Testing

- `pnpm run typecheck` — clean.
- `pnpm run test:unit` — settings-search spec 19/19 (14 existing + 5 new), full settings module 408/408.
- `pnpm run lint` — 0 errors on the touched files.
- Settings e2e (`GROUP=settings`, chromium) — 37/37, incl. search navigation and persist-after-relogin.
- Manual smoke test of the search box.