### PR TITLE
perf: lazily create database read pool connections

### DIFF
--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -413,9 +413,10 @@ class DBHandler:
                 ('version', str(ROTKEHLCHEN_TRANSIENT_DB_VERSION)),
             )
 
-        # Only now that upgrades ran, WAL mode is on and the schema is checked, spin
-        # up the pool of read-only connections isolating read_ctx() readers from
-        # write commits. Only for the user DB -- the transient DB is not worth it.
+        # Only now that upgrades ran, WAL mode is on and the schema is checked,
+        # configure the lazy pool of read-only connections isolating read_ctx()
+        # readers from write commits. Only for the user DB -- the transient DB is
+        # not worth it.
         self.conn.enable_read_pool(reader_setup=self._setup_read_pool_connection)
 
     def _setup_read_pool_connection(self, reader: DBConnection) -> None:
@@ -597,12 +598,7 @@ class DBHandler:
         )
         if result is True:
             self.password = new_password
-        try:
-            self.conn.enable_read_pool(reader_setup=self._setup_read_pool_connection)
-        except sqlcipher.DatabaseError as e:  # pylint: disable=no-member
-            # can only happen if the DB ended up half-rekeyed (conn succeeded but
-            # conn_transient failed) leaving self.password wrong for the user DB
-            log.error('Could not re-key the user DB read pool after password change: %s', e)
+        self.conn.enable_read_pool(reader_setup=self._setup_read_pool_connection)
         return result
 
     def disconnect(self, conn_attribute: Literal['conn', 'conn_transient'] = 'conn') -> None:

--- a/rotkehlchen/db/drivers/sqlite.py
+++ b/rotkehlchen/db/drivers/sqlite.py
@@ -23,7 +23,7 @@ import random
 import threading
 import time
 from collections.abc import Callable, Generator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from enum import Enum, auto
 from pathlib import Path
 from types import TracebackType
@@ -347,11 +347,15 @@ class DBConnection:
         self._conn: UnderlyingConnection
         self._path = path
         self._read_only = read_only
-        # Pool of read-only connections lazily created by enable_read_pool(). While
-        # None, read_ctx() serves cursors of this (the write) connection. The lock
-        # guards the pool reference swap at close() against concurrent returns.
-        self._read_pool: queue.SimpleQueue[DBConnection] | None = None
+        # Pool of read-only connections configured by enable_read_pool() and created
+        # lazily as concurrent reads need them. LIFO reuse keeps sequential reads on
+        # the same warm SQLite page cache instead of rotating through every reader.
+        # While None, read_ctx() serves cursors of this (the write) connection.
+        self._read_pool: queue.LifoQueue[DBConnection] | None = None
         self._read_pool_lock = threading.Lock()
+        self._read_pool_size = 0
+        self._readers_num = 0
+        self._reader_setup: Callable[[DBConnection], None] | None = None
         # The reader this thread has currently borrowed, so that nested read_ctx
         # calls reuse it instead of borrowing a second one. Without this, N threads
         # nesting read contexts could each hold one reader while waiting for
@@ -478,50 +482,33 @@ class DBConnection:
             size: int = 4,
             reader_setup: 'Callable[[DBConnection], None] | None' = None,
     ) -> None:
-        """Create the pool of read-only connections that read_ctx() borrows from.
+        """Configure the pool of read-only connections that read_ctx() borrows from.
 
         Must only be called after the database is in WAL mode: with the default
         journal mode a writer's transaction blocks readers on other connections
         (and vice versa), while under WAL they proceed concurrently and each read
         statement sees a consistent committed snapshot.
 
-        reader_setup runs once per created reader before it enters the pool, for
-        connection-level preparation reads need -- keying sqlcipher readers
-        (PRAGMA key) most importantly. If it raises, already-created readers are
-        closed and the error propagates with the pool left disabled.
+        Readers are created lazily up to size as concurrent reads require them.
+        reader_setup runs once per created reader, for connection-level preparation
+        reads need -- keying sqlcipher readers (PRAGMA key) most importantly.
+        Persistent database errors disable the pool; transient errors release the
+        reader reservation so a later read can retry.
 
         No-op for in-memory databases (used by tests): they cannot use WAL and
         there is no file for a second connection to open, so read_ctx() keeps
         serving cursors of this connection there.
         """
         assert self._read_only is False, 'cannot enable a read pool on a pool reader'
+        assert size > 0, 'read pool size must be positive'
         if str(self._path) == ':memory:':
             return
         with self._read_pool_lock:
             if self._read_pool is not None:
                 return  # already enabled -- happens when connect-time actions rerun
-        readers: list[DBConnection] = []
-        try:
-            for _ in range(size):
-                readers.append(reader := DBConnection(
-                    path=self._path,
-                    connection_type=self.connection_type,
-                    sql_vm_instructions_cb=self.sql_vm_instructions_cb,
-                    read_only=True,
-                ))
-                if reader_setup is not None:
-                    reader_setup(reader)
-        except BaseException:
-            for reader in readers:
-                reader.close()
-            raise
-
-        read_pool: queue.SimpleQueue[DBConnection] = queue.SimpleQueue()
-        for reader in readers:
-            read_pool.put(reader)
-        with self._read_pool_lock:
-            assert self._read_pool is None, 'read pool is already enabled'
-            self._read_pool = read_pool
+            self._read_pool = queue.LifoQueue()
+            self._read_pool_size = size
+            self._reader_setup = reader_setup
 
     def disable_read_pool(self) -> None:
         """Close the pooled readers and make read_ctx() serve cursors of this
@@ -534,31 +521,113 @@ class DBConnection:
         """
         with self._read_pool_lock:
             read_pool, self._read_pool = self._read_pool, None
+            self._read_pool_size = 0
+            self._readers_num = 0
+            self._reader_setup = None
         if read_pool is not None:
-            while True:
-                try:
-                    read_pool.get_nowait().close()
-                except queue.Empty:
-                    break
+            self._close_idle_readers(read_pool)
 
-    def _borrow_reader(self, read_pool: 'queue.SimpleQueue[DBConnection]') -> 'DBConnection':
-        """Blocking borrow of a pooled reader that stays responsive to task
-        cancellation, mirroring _acquire_transaction_lock.
+    @staticmethod
+    def _close_idle_readers(read_pool: 'queue.LifoQueue[DBConnection]') -> None:
+        """Detach and close all readers that are currently idle in the pool."""
+        with read_pool.mutex:
+            readers = list(read_pool.queue)
+            read_pool.queue.clear()
+        for reader in readers:
+            reader.close()
+
+    def _create_reader(
+            self,
+            reader_setup: 'Callable[[DBConnection], None] | None',
+    ) -> 'DBConnection':
+        """Create and prepare one read-only connection for the pool."""
+        reader = DBConnection(
+            path=self._path,
+            connection_type=self.connection_type,
+            sql_vm_instructions_cb=self.sql_vm_instructions_cb,
+            read_only=True,
+        )
+        try:
+            if reader_setup is not None:
+                reader_setup(reader)
+        except BaseException:
+            reader.close()
+            raise
+        return reader
+
+    def _borrow_reader(
+            self,
+            read_pool: 'queue.LifoQueue[DBConnection]',
+    ) -> 'DBConnection | None':
+        """Borrow an idle reader, lazily creating one while below the pool limit.
+
+        If all readers are borrowed, wait while staying responsive to task
+        cancellation, mirroring _acquire_transaction_lock. Returns None if the
+        pool is disabled concurrently, so read_ctx can fall back to the write
+        connection.
 
         May raise TaskCancelledError.
         """
         while True:
+            with suppress(queue.Empty):
+                reader = read_pool.get_nowait()
+                with self._read_pool_lock:
+                    if self._read_pool is read_pool:
+                        return reader
+                reader.close()
+                return None
+
+            with self._read_pool_lock:
+                if self._read_pool is not read_pool:
+                    return None
+                with suppress(queue.Empty):  # may have been returned before we got the lock
+                    return read_pool.get_nowait()
+                if self._readers_num < self._read_pool_size:
+                    self._readers_num += 1  # reserve capacity before creating outside the lock
+                    reader_setup = self._reader_setup
+                    break
+
             try:
                 return read_pool.get(timeout=CONTEXT_SWITCH_WAIT)
             except queue.Empty:
                 checkpoint()  # cancelled tasks should not keep waiting for a reader
 
-    def _return_reader(self, reader: 'DBConnection') -> None:
+        try:
+            reader = self._create_reader(reader_setup)
+        except BaseException as e:
+            persistent_error = isinstance(  # pylint: disable=no-member
+                e,
+                (sqlcipher.DatabaseError, rsqlite.Error),
+            )
+            with self._read_pool_lock:
+                if self._read_pool is read_pool:
+                    if persistent_error:
+                        self._read_pool = None
+                        self._read_pool_size = 0
+                        self._readers_num = 0
+                        self._reader_setup = None
+                    else:
+                        self._readers_num -= 1
+            if persistent_error:
+                self._close_idle_readers(read_pool)
+            raise
+
         with self._read_pool_lock:
-            if (read_pool := self._read_pool) is not None:
-                read_pool.put(reader)
+            if self._read_pool is read_pool:
+                return reader
+        reader.close()  # the pool was disabled while this reader was being prepared
+        return None
+
+    def _return_reader(
+            self,
+            reader: 'DBConnection',
+            source_pool: 'queue.LifoQueue[DBConnection]',
+    ) -> None:
+        with self._read_pool_lock:
+            if self._read_pool is source_pool:
+                source_pool.put(reader)
                 return
-        reader.close()  # the pool was closed while this reader was borrowed
+        reader.close()  # its source pool was closed while this reader was borrowed
 
     @contextmanager
     def read_ctx(self) -> Generator['DBCursor', None, None]:
@@ -582,14 +651,23 @@ class DBConnection:
                 yield cursor
             return
 
-        reader = self._borrow_reader(read_pool)
+        if (reader := self._borrow_reader(read_pool)) is None:
+            # The pool was disabled after read_ctx observed it. Fall back to the
+            # write connection just as a read starting after disable_read_pool does.
+            cursor = self.cursor()
+            try:
+                yield cursor
+            finally:
+                cursor.close()
+            return
+
         self._borrowed_reader.reader = reader
         try:
             with reader.read_ctx() as cursor:
                 yield cursor
         finally:
             self._borrowed_reader.reader = None
-            self._return_reader(reader)
+            self._return_reader(reader, read_pool)
 
     def _acquire_transaction_lock(self) -> None:
         """Blocking acquire of the transaction slot that stays responsive to task

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -3508,6 +3508,8 @@ def test_unfinished_upgrades(user_data_dir):
             backup_connection.close()
 
             if backup_version == 33:
+                if write_version != backup_version:
+                    db.logout()  # close the connection restored for the previous backup
                 db = _init_db_with_target_version(  # Now the backup should be used
                     target_version=34,
                     user_data_dir=user_data_dir,

--- a/rotkehlchen/tests/db/test_read_pool.py
+++ b/rotkehlchen/tests/db/test_read_pool.py
@@ -1,15 +1,17 @@
 """Tests for the pool of read-only connections that isolates read_ctx() readers
 from write commits on the same DB (WAL mode). See DBConnection.enable_read_pool.
 """
+import threading
 import time
 from pathlib import Path
 from typing import Final
+from unittest.mock import Mock
 
 import pytest
 import rsqlite
 from sqlcipher3 import dbapi2 as sqlcipher
 
-from rotkehlchen.concurrency import Task, spawn, wait
+from rotkehlchen.concurrency import Task, TaskCancelledError, spawn, wait
 from rotkehlchen.db.drivers.sqlite import DBConnection, DBConnectionType
 from rotkehlchen.db.utils import unlock_database
 
@@ -44,6 +46,47 @@ def test_write_through_read_cursor_raises(conn: DBConnection):
             cursor.execute('INSERT INTO t(a) VALUES (2)')
 
 
+def test_read_pool_grows_lazily_and_reuses_last_reader(conn: DBConnection):
+    """Enabling the pool opens nothing until needed, grows only with concurrent
+    demand and keeps sequential reads on the most recently used warm connection."""
+    assert conn._readers_num == 0
+    assert (read_pool := conn._read_pool) is not None
+
+    with conn.read_ctx():
+        first_reader = conn._borrowed_reader.reader
+    assert conn._readers_num == 1
+
+    borrowed_first = conn._borrow_reader(read_pool)
+    borrowed_second = conn._borrow_reader(read_pool)
+    assert borrowed_first is first_reader
+    assert borrowed_first is not None
+    assert borrowed_second is not None
+    assert conn._readers_num == POOL_SIZE
+    conn._return_reader(borrowed_first, read_pool)
+    conn._return_reader(borrowed_second, read_pool)
+
+    with conn.read_ctx():
+        assert conn._borrowed_reader.reader is borrowed_second
+
+
+def test_transient_reader_setup_failure_keeps_pool_enabled(conn: DBConnection):
+    """Cancellation during lazy setup releases the reserved slot and lets a later read retry."""
+    conn.disable_read_pool()
+    reader_setup = Mock(side_effect=(TaskCancelledError('cancelled'), None))
+    conn.enable_read_pool(size=1, reader_setup=reader_setup)
+    read_pool = conn._read_pool
+
+    with pytest.raises(TaskCancelledError), conn.read_ctx():
+        pass
+    assert conn._read_pool is read_pool
+    assert conn._readers_num == 0
+
+    with conn.read_ctx() as cursor:
+        assert cursor.execute('SELECT COUNT(*) FROM t').fetchone() == (1,)
+    assert conn._readers_num == 1
+    assert reader_setup.call_count == 2
+
+
 def test_own_uncommitted_data_stays_visible(conn: DBConnection):
     """The thread holding the write transaction or savepoint stack must keep
     reading its own uncommitted data, so its read_ctx uses the write connection"""
@@ -65,15 +108,18 @@ def test_readers_are_isolated_from_write_commits(conn: DBConnection):
         write_cursor.executemany('INSERT INTO t(a) VALUES (?)', [(i,) for i in range(2, 11)])
 
     read_results: list[int] = []
+    reader_started = threading.Event()
 
     def slow_reader() -> None:
         with conn.read_ctx() as cursor:
             cursor.execute('SELECT a FROM t')
+            reader_started.set()
             for _ in cursor:  # keep the statement active across the writer's commits
                 read_results.append(1)
                 time.sleep(0.01)
 
     def writer() -> None:
+        assert reader_started.wait(timeout=5)
         for i in range(5):
             with conn.write_ctx() as write_cursor:
                 write_cursor.execute('INSERT INTO t(a) VALUES (?)', (100 + i,))
@@ -164,6 +210,21 @@ def test_close_with_borrowed_reader(conn: DBConnection):
         reader.cursor()
 
 
+def test_borrowed_reader_is_not_returned_to_replacement_pool(conn: DBConnection):
+    """A reader from a disabled pool must be closed rather than returned into a
+    replacement pool, where it may have stale connection setup such as an old key."""
+    with conn.read_ctx():
+        old_reader = conn._borrowed_reader.reader
+        conn.disable_read_pool()
+        conn.enable_read_pool(size=POOL_SIZE)
+
+    assert conn._readers_num == 0
+    with pytest.raises(rsqlite.ProgrammingError):
+        old_reader.cursor()
+    with conn.read_ctx():
+        assert conn._borrowed_reader.reader is not old_reader
+
+
 @pytest.fixture(name='user_conn')
 def fixture_user_conn(tmp_path: Path):
     """A keyed sqlcipher user-type connection with the read pool enabled,
@@ -224,13 +285,15 @@ def test_user_db_failed_reader_setup_cleans_up(user_conn: DBConnection):
     """A reader_setup failure (e.g. wrong key) closes created readers, propagates
     and leaves the pool disabled so read_ctx falls back to the write connection"""
     user_conn.disable_read_pool()
-    with pytest.raises(sqlcipher.DatabaseError):  # pylint: disable=no-member
-        user_conn.enable_read_pool(reader_setup=lambda reader: unlock_database(
-            db_connection=reader,
-            password='wrong password',
-            sqlcipher_version=4,
-            apply_optimizations=False,
-        ))
+    user_conn.enable_read_pool(reader_setup=lambda reader: unlock_database(
+        db_connection=reader,
+        password='wrong password',
+        sqlcipher_version=4,
+        apply_optimizations=False,
+    ))
+    with pytest.raises(sqlcipher.DatabaseError), user_conn.read_ctx():  # pylint: disable=no-member
+        pass
+    assert user_conn._read_pool is None
     with user_conn.read_ctx() as cursor:  # falls back to the write connection
         assert cursor.execute('SELECT COUNT(*) FROM t').fetchone() == (1,)
 


### PR DESCRIPTION
Creating every read-only connection when enabling the pool made each user database initialization perform four additional SQLCipher key derivations. Since backend tests create file-backed user databases repeatedly, this significantly increased CI runtime and also added unnecessary login overhead.

Configure the pool without opening connections and create readers only when concurrent demand requires them, up to the configured limit. Reuse idle readers in LIFO order to preserve SQLite page-cache locality.

Also track the source pool when returning readers so connections from a disabled pool cannot leak into a replacement pool after operations such as password changes.

Add coverage for lazy growth, reader reuse, setup failures, concurrent read/write isolation, and pool replacement.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
