### PR TITLE
Record CoinEx CET discount fees

### DIFF
--- a/rotkehlchen/exchanges/coinex.py
+++ b/rotkehlchen/exchanges/coinex.py
@@ -293,8 +293,8 @@ class Coinex(ExchangeInterface, SignatureGeneratorMixin):
     ) -> list[SwapEvent]:
         """Deserialize a CoinEx finished order into swap events.
 
-        CoinEx does not name the deduction currency in the response.
-        discount_fee is assumed to be CET.
+        CoinEx does not name the deduction currency in the response, so discount_fee
+        is assumed to be CET.
 
         May raise DeserializationError.
         """

--- a/rotkehlchen/exchanges/coinex.py
+++ b/rotkehlchen/exchanges/coinex.py
@@ -289,8 +289,12 @@ class Coinex(ExchangeInterface, SignatureGeneratorMixin):
             self,
             trade: dict[str, Any],
             market: CoinexMarket,
+            cet_fee_asset: 'AssetWithOracles | None',
     ) -> list[SwapEvent]:
         """Deserialize a CoinEx finished order into swap events.
+
+        CoinEx does not name the deduction currency in the response.
+        discount_fee is assumed to be CET.
 
         May raise DeserializationError.
         """
@@ -317,10 +321,17 @@ class Coinex(ExchangeInterface, SignatureGeneratorMixin):
             ), None, None),
         ]
         if (discount_fee := deserialize_fval_or_zero(trade.get('discount_fee'))) != ZERO:
-            fees.append((AssetAmount(
-                asset=asset_from_coinex('CET'),
-                amount=discount_fee,
-            ), None, None))
+            if cet_fee_asset is None:
+                log.warning(
+                    'Skipping CoinEx discount fee for order %s because CET could not be '
+                    'resolved',
+                    trade['order_id'],
+                )
+            else:
+                fees.append((AssetAmount(
+                    asset=cet_fee_asset,
+                    amount=discount_fee,
+                ), None, None))
 
         return create_swap_events_multi_fee(
             timestamp=deserialize_coinex_timestamp(trade['created_at']),
@@ -453,6 +464,10 @@ class Coinex(ExchangeInterface, SignatureGeneratorMixin):
         markets = self._get_markets()
         start_ts_ms, end_ts_ms = ts_sec_to_ms(start_ts), ts_sec_to_ms(end_ts)
         missing_markets: set[str] = set()
+        try:
+            cet_fee_asset = asset_from_coinex('CET')
+        except UnknownAsset:
+            cet_fee_asset = None
 
         def deserialize_trade(entry: dict[str, Any]) -> list[SwapEvent]:
             """Deserialize a finished order, filtering by time client-side
@@ -465,7 +480,11 @@ class Coinex(ExchangeInterface, SignatureGeneratorMixin):
                 missing_markets.add(entry['market'])
                 return []
 
-            return self._deserialize_trade(trade=entry, market=market)
+            return self._deserialize_trade(
+                trade=entry,
+                market=market,
+                cet_fee_asset=cet_fee_asset,
+            )
 
         events = self._api_query_paginated(
             endpoint='/spot/finished-order',

--- a/rotkehlchen/exchanges/coinex.py
+++ b/rotkehlchen/exchanges/coinex.py
@@ -292,10 +292,6 @@ class Coinex(ExchangeInterface, SignatureGeneratorMixin):
     ) -> list[SwapEvent]:
         """Deserialize a CoinEx finished order into swap events.
 
-        A discount_fee (fee paid in the CET deduction currency) is not turned
-        into a fee event since the response does not name the deduction
-        currency and CET can't be resolved unambiguously by symbol.
-
         May raise DeserializationError.
         """
         if (filled_amount := deserialize_fval(trade['filled_amount'])) == ZERO:
@@ -310,21 +306,28 @@ class Coinex(ExchangeInterface, SignatureGeneratorMixin):
             amount=filled_amount,
             rate=deserialize_price(deserialize_fval(trade['filled_value']) / filled_amount),
         )
+        fees = [
+            (AssetAmount(
+                asset=market.base_asset,
+                amount=deserialize_fval_or_zero(trade['base_fee']),
+            ), None, None),
+            (AssetAmount(
+                asset=market.quote_asset,
+                amount=deserialize_fval_or_zero(trade['quote_fee']),
+            ), None, None),
+        ]
+        if (discount_fee := deserialize_fval_or_zero(trade.get('discount_fee'))) != ZERO:
+            fees.append((AssetAmount(
+                asset=asset_from_coinex('CET'),
+                amount=discount_fee,
+            ), None, None))
+
         return create_swap_events_multi_fee(
             timestamp=deserialize_coinex_timestamp(trade['created_at']),
             location=self.location,
             spend=spend,
             receive=receive,
-            fees=[
-                (AssetAmount(
-                    asset=market.base_asset,
-                    amount=deserialize_fval_or_zero(trade['base_fee']),
-                ), None, None),
-                (AssetAmount(
-                    asset=market.quote_asset,
-                    amount=deserialize_fval_or_zero(trade['quote_fee']),
-                ), None, None),
-            ],
+            fees=fees,
             location_label=self.name,
             group_identifier=create_group_identifier_from_unique_id(
                 location=self.location,

--- a/rotkehlchen/tests/exchanges/test_coinex.py
+++ b/rotkehlchen/tests/exchanges/test_coinex.py
@@ -1,10 +1,12 @@
 import hmac
 from hashlib import sha256
+from typing import TYPE_CHECKING
 from unittest.mock import call, patch
 
 import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.assets import A_BTC, A_USDT
 from rotkehlchen.exchanges.coinex import API_MAX_LIMIT, Coinex, CoinexMarket
 from rotkehlchen.fval import FVal
@@ -12,7 +14,10 @@ from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.swap import SwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType
 from rotkehlchen.history.events.utils import create_group_identifier_from_unique_id
-from rotkehlchen.types import Location, Timestamp, TimestampMS
+from rotkehlchen.types import Location, LocationAssetMappingUpdateEntry, Timestamp, TimestampMS
+
+if TYPE_CHECKING:
+    from rotkehlchen.globaldb.handler import GlobalDBHandler
 
 
 def test_name(coinex_exchange: Coinex) -> None:
@@ -185,7 +190,15 @@ def test_query_asset_movements(coinex_exchange: Coinex) -> None:
     ]
 
 
-def test_query_trades(coinex_exchange: Coinex) -> None:
+def test_query_trades(coinex_exchange: Coinex, globaldb: 'GlobalDBHandler') -> None:
+    cet_asset = Asset('eip155:1/erc20:0x081F67aFA0cCF8c7B17540767BBe95DF2bA8D97F').resolve_to_asset_with_oracles()  # noqa: E501
+    globaldb.add_location_asset_mappings([
+        LocationAssetMappingUpdateEntry(
+            location=Location.COINEX,
+            location_symbol='CET',
+            asset=cet_asset,
+        ),
+    ])
     market = CoinexMarket(
         market='BTCUSDT',
         base_asset_symbol='BTC',
@@ -205,6 +218,7 @@ def test_query_trades(coinex_exchange: Coinex) -> None:
                 'filled_value': '0.0998348650',
                 'base_fee': '0',
                 'quote_fee': '0.0001',
+                'discount_fee': '0.0002',
             }, {  # trade outside the queried range that has to be filtered out
                 'created_at': 1689152425000,
                 'market': 'BTCUSDT',
@@ -269,6 +283,15 @@ def test_query_trades(coinex_exchange: Coinex) -> None:
             event_subtype=HistoryEventSubType.FEE,
             asset=A_USDT,
             amount=FVal('0.0001'),
+            location_label='coinex',
+            group_identifier=group_identifier,
+        ), SwapEvent(
+            timestamp=TimestampMS(1689152421692),
+            location=Location.COINEX,
+            event_subtype=HistoryEventSubType.FEE,
+            sequence_index=3,
+            asset=cet_asset,
+            amount=FVal('0.0002'),
             location_label='coinex',
             group_identifier=group_identifier,
         ),

--- a/rotkehlchen/tests/exchanges/test_coinex.py
+++ b/rotkehlchen/tests/exchanges/test_coinex.py
@@ -1,4 +1,5 @@
 import hmac
+import logging
 from hashlib import sha256
 from typing import TYPE_CHECKING
 from unittest.mock import call, patch
@@ -8,6 +9,7 @@ import pytest
 from rotkehlchen.accounting.structures.balance import Balance
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.constants.assets import A_BTC, A_USDT
+from rotkehlchen.errors.asset import UnknownAsset
 from rotkehlchen.exchanges.coinex import API_MAX_LIMIT, Coinex, CoinexMarket
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -292,6 +294,88 @@ def test_query_trades(coinex_exchange: Coinex, globaldb: 'GlobalDBHandler') -> N
             sequence_index=3,
             asset=cet_asset,
             amount=FVal('0.0002'),
+            location_label='coinex',
+            group_identifier=group_identifier,
+        ),
+    ]
+
+
+def test_query_trades_skips_discount_fee_without_cet_mapping(
+        coinex_exchange: Coinex,
+        caplog: pytest.LogCaptureFixture,
+) -> None:
+    market = CoinexMarket(
+        market='BTCUSDT',
+        base_asset_symbol='BTC',
+        quote_asset_symbol='USDT',
+        base_asset=A_BTC.resolve_to_asset_with_oracles(),
+        quote_asset=A_USDT.resolve_to_asset_with_oracles(),
+    )
+    with (
+        caplog.at_level(logging.WARNING),
+        patch.object(coinex_exchange, '_query_markets', return_value=[market]),
+        patch(
+            'rotkehlchen.exchanges.coinex.asset_from_coinex',
+            side_effect=UnknownAsset('CET'),
+        ) as mock_asset_from_coinex,
+        patch.object(coinex_exchange, '_api_query', return_value={'code': 0, 'data': [{
+            'created_at': 1689152421692,
+            'market': 'BTCUSDT',
+            'side': 'buy',
+            'order_id': 8678890,
+            'filled_amount': '0.00000325',
+            'filled_value': '0.0998348650',
+            'base_fee': '0.00000001',
+            'quote_fee': '0.0001',
+            'discount_fee': '0.0002',
+        }], 'pagination': {'total': 1, 'has_next': False}, 'message': 'OK'}),
+    ):
+        trades = coinex_exchange._query_trades(
+            start_ts=Timestamp(1689152421),
+            end_ts=Timestamp(1689152422),
+        )
+
+    assert mock_asset_from_coinex.call_args_list == [call('CET')]
+    assert (
+        'Skipping CoinEx discount fee for order 8678890 because CET could not be resolved' in
+        caplog.text
+    )
+    group_identifier = create_group_identifier_from_unique_id(
+        location=Location.COINEX,
+        unique_id='trade-8678890',
+    )
+    assert trades == [
+        SwapEvent(
+            timestamp=TimestampMS(1689152421692),
+            location=Location.COINEX,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_USDT,
+            amount=FVal('0.0998348650'),
+            location_label='coinex',
+            group_identifier=group_identifier,
+        ), SwapEvent(
+            timestamp=TimestampMS(1689152421692),
+            location=Location.COINEX,
+            event_subtype=HistoryEventSubType.RECEIVE,
+            asset=A_BTC,
+            amount=FVal('0.00000325'),
+            location_label='coinex',
+            group_identifier=group_identifier,
+        ), SwapEvent(
+            timestamp=TimestampMS(1689152421692),
+            location=Location.COINEX,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_BTC,
+            amount=FVal('0.00000001'),
+            location_label='coinex',
+            group_identifier=group_identifier,
+        ), SwapEvent(
+            timestamp=TimestampMS(1689152421692),
+            location=Location.COINEX,
+            event_subtype=HistoryEventSubType.FEE,
+            sequence_index=3,
+            asset=A_USDT,
+            amount=FVal('0.0001'),
             location_label='coinex',
             group_identifier=group_identifier,
         ),


### PR DESCRIPTION
## What
Adds support for CoinEx `discount_fee` by recording it as a separate CET fee event on finished spot orders.

This is a follow-up to #12558. The required CoinEx CET asset mapping was added in rotki/data#284, so `asset_from_coinex("CET")` can now resolve through the normal location asset mapping path.

## Note

CoinEx returns `discount_fee` as a fee charged in the account deduction currency, but the finished order payload does not include a separate `discount_fee_currency` field. I am treating `discount_fee` as CET so the implementation resolves CET through the normal `asset_from_coinex('CET')` path.

## Testing
My test setup:
- ran the CoinEx exchange unit tests locally with Python 3.11
- the test inserts the CoinEx/CET location asset mapping into the test global DB, matching the merged rotki/data update
- verified through testing that a trade with `discount_fee` emits a second fee event in CET
- COULD NOT live test it since not have such transaction in my coinex account yet

Commands run:
```
python -m pytest rotkehlchen/tests/exchanges/test_coinex.py
ruff check rotkehlchen/exchanges/coinex.py rotkehlchen/tests/exchanges/test_coinex.py
```