### PR TITLE
test(frontend): add staking unit coverage

### DIFF
--- a/frontend/app/src/modules/core/common/helpers/e2e.spec.ts
+++ b/frontend/app/src/modules/core/common/helpers/e2e.spec.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { attemptPolyfillResizeObserver } from '@/modules/core/common/helpers/e2e';
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  callback: ResizeObserverCallback;
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    FakeResizeObserver.instances.push(this);
+  }
+
+  trigger(entries: ResizeObserverEntry[]): void {
+    this.callback(entries, this);
+  }
+}
+
+describe('attemptPolyfillResizeObserver', () => {
+  beforeEach(() => {
+    FakeResizeObserver.instances = [];
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+      cb(0);
+      return 0;
+    });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('should do nothing when VITE_E2E is not set', () => {
+    vi.stubEnv('VITE_E2E', '');
+    attemptPolyfillResizeObserver();
+    expect(window.ResizeObserver).toBe(FakeResizeObserver);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('should install the polyfill and warn when VITE_E2E is set', () => {
+    vi.stubEnv('VITE_E2E', 'true');
+    attemptPolyfillResizeObserver();
+    expect(window.ResizeObserver).not.toBe(FakeResizeObserver);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('polyfill for ResizeObserver'));
+  });
+
+  it('should forward observe, unobserve and disconnect to the real observer', () => {
+    vi.stubEnv('VITE_E2E', 'true');
+    attemptPolyfillResizeObserver();
+
+    const observer = new window.ResizeObserver(vi.fn());
+    const element = document.createElement('div');
+    observer.observe(element);
+    observer.unobserve(element);
+    observer.disconnect();
+
+    const real = FakeResizeObserver.instances[0];
+    expect(real.observe).toHaveBeenCalledWith(element);
+    expect(real.unobserve).toHaveBeenCalledWith(element);
+    expect(real.disconnect).toHaveBeenCalled();
+  });
+
+  it('should batch resize callbacks through an animation frame', () => {
+    vi.stubEnv('VITE_E2E', 'true');
+    attemptPolyfillResizeObserver();
+
+    const userCallback = vi.fn();
+    const observer = new window.ResizeObserver(userCallback);
+    expect(observer).toBeDefined();
+    const real = FakeResizeObserver.instances[0];
+    const entries: ResizeObserverEntry[] = [];
+
+    real.trigger(entries);
+
+    expect(userCallback).toHaveBeenCalledTimes(1);
+    expect(userCallback).toHaveBeenCalledWith(entries, expect.anything());
+  });
+
+  it('should collapse repeated triggers of the same observer into one callback', () => {
+    vi.stubEnv('VITE_E2E', 'true');
+    let flush: FrameRequestCallback | undefined;
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback): number => {
+      flush = cb;
+      return 1;
+    });
+    attemptPolyfillResizeObserver();
+
+    const userCallback = vi.fn();
+    const observer = new window.ResizeObserver(userCallback);
+    expect(observer).toBeDefined();
+    const real = FakeResizeObserver.instances[0];
+    const first: ResizeObserverEntry[] = [];
+    const second: ResizeObserverEntry[] = [];
+
+    real.trigger(first);
+    real.trigger(second);
+    flush?.(0);
+
+    expect(userCallback).toHaveBeenCalledTimes(1);
+    expect(userCallback).toHaveBeenLastCalledWith(second, expect.anything());
+  });
+});

--- a/frontend/app/src/modules/staking/api/use-lido-csm-api.spec.ts
+++ b/frontend/app/src/modules/staking/api/use-lido-csm-api.spec.ts
@@ -1,0 +1,102 @@
+import type { LidoCsmNodeOperator } from '@/modules/staking/staking-types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  VALID_STATUS_CODES,
+  VALID_WITH_SESSION_AND_EXTERNAL_SERVICE,
+  VALID_WITH_SESSION_STATUS,
+} from '@/modules/core/api/utils';
+import { useLidoCsmApi } from '@/modules/staking/api/use-lido-csm-api';
+
+const { mockDelete, mockGet, mockPost, mockPut } = vi.hoisted(() => ({
+  mockDelete: vi.fn(),
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+  mockPut: vi.fn(),
+}));
+
+vi.mock('@/modules/core/api', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/core/api')>(),
+  api: {
+    delete: mockDelete,
+    get: mockGet,
+    post: mockPost,
+    put: mockPut,
+  },
+}));
+
+function operator(): LidoCsmNodeOperator {
+  return { address: '0xabc', metrics: null, nodeOperatorId: 1 };
+}
+
+function response(message?: string): { message?: string; result: LidoCsmNodeOperator[] } {
+  return { message, result: [operator()] };
+}
+
+describe('useLidoCsmApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(response('ok'));
+    mockPut.mockResolvedValue(response('added'));
+    mockDelete.mockResolvedValue(response('deleted'));
+    mockPost.mockResolvedValue(response('refreshed'));
+  });
+
+  it('should list node operators', async () => {
+    const { listNodeOperators } = useLidoCsmApi();
+    const result = await listNodeOperators();
+
+    expect(mockGet).toHaveBeenCalledWith('/lido-csm/node-operators', {
+      skipResultUnwrap: true,
+      validStatuses: VALID_WITH_SESSION_STATUS,
+    });
+    expect(result).toEqual({ entries: [operator()], message: 'ok' });
+  });
+
+  it('should add a node operator with a schema-validated payload', async () => {
+    const { addNodeOperator } = useLidoCsmApi();
+    const result = await addNodeOperator({ address: '0xabc', nodeOperatorId: 2 });
+
+    expect(mockPut).toHaveBeenCalledWith('/lido-csm/node-operators', { address: '0xabc', nodeOperatorId: 2 }, {
+      skipResultUnwrap: true,
+      validStatuses: VALID_WITH_SESSION_AND_EXTERNAL_SERVICE,
+    });
+    expect(result.message).toBe('added');
+  });
+
+  it('should strip unknown fields from the payload before sending', async () => {
+    const { addNodeOperator } = useLidoCsmApi();
+    const payload = { address: '0xabc', extra: 'nope', nodeOperatorId: 3 };
+    await addNodeOperator(payload);
+
+    expect(mockPut).toHaveBeenCalledWith('/lido-csm/node-operators', { address: '0xabc', nodeOperatorId: 3 }, expect.any(Object));
+  });
+
+  it('should delete a node operator using the payload as the request body', async () => {
+    const { deleteNodeOperator } = useLidoCsmApi();
+    await deleteNodeOperator({ address: '0xabc', nodeOperatorId: 4 });
+
+    expect(mockDelete).toHaveBeenCalledWith('/lido-csm/node-operators', {
+      body: { address: '0xabc', nodeOperatorId: 4 },
+      skipResultUnwrap: true,
+      validStatuses: VALID_STATUS_CODES,
+    });
+  });
+
+  it('should refresh metrics via the metrics path', async () => {
+    const { refreshMetrics } = useLidoCsmApi();
+    const result = await refreshMetrics();
+
+    expect(mockPost).toHaveBeenCalledWith('/lido-csm/metrics', undefined, {
+      skipResultUnwrap: true,
+      validStatuses: VALID_WITH_SESSION_AND_EXTERNAL_SERVICE,
+    });
+    expect(result.message).toBe('refreshed');
+  });
+
+  it('should default the message to an empty string when absent', async () => {
+    mockGet.mockResolvedValue(response(undefined));
+    const { listNodeOperators } = useLidoCsmApi();
+    const result = await listNodeOperators();
+    expect(result.message).toBe('');
+  });
+});

--- a/frontend/app/src/modules/staking/eth/use-eth-staking-access.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-staking-access.spec.ts
@@ -1,0 +1,55 @@
+import type { Ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PremiumFeature } from '@/modules/premium/use-feature-access';
+import { Module } from '@/modules/session/use-module-enabled';
+import { useEthStakingAccess } from '@/modules/staking/eth/use-eth-staking-access';
+
+const mockEnabled = ref<boolean>(true);
+const mockAllowed = ref<boolean>(true);
+const mockUseModuleEnabled = vi.fn((_module: Module) => ({ enabled: mockEnabled }));
+const mockUseFeatureAccess = vi.fn((_feature: PremiumFeature) => ({ allowed: mockAllowed }));
+
+vi.mock('@/modules/session/use-module-enabled', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/session/use-module-enabled')>(),
+  useModuleEnabled: (module: Module): { enabled: Ref<boolean> } => mockUseModuleEnabled(module),
+}));
+
+vi.mock('@/modules/premium/use-feature-access', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/premium/use-feature-access')>(),
+  useFeatureAccess: (feature: PremiumFeature): { allowed: Ref<boolean> } => mockUseFeatureAccess(feature),
+}));
+
+describe('useEthStakingAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(mockEnabled, true);
+    set(mockAllowed, true);
+  });
+
+  it('should expose the eth2 module', () => {
+    const { module } = useEthStakingAccess();
+    expect(module).toBe(Module.ETH2);
+  });
+
+  it('should check module enablement for eth2', () => {
+    useEthStakingAccess();
+    expect(mockUseModuleEnabled).toHaveBeenCalledWith(Module.ETH2);
+  });
+
+  it('should check feature access for the eth staking view', () => {
+    useEthStakingAccess();
+    expect(mockUseFeatureAccess).toHaveBeenCalledWith(PremiumFeature.ETH_STAKING_VIEW);
+  });
+
+  it('should reflect the module enabled state', () => {
+    set(mockEnabled, false);
+    const { enabled } = useEthStakingAccess();
+    expect(get(enabled)).toBe(false);
+  });
+
+  it('should reflect the feature allowed state', () => {
+    set(mockAllowed, false);
+    const { allowed } = useEthStakingAccess();
+    expect(get(allowed)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/staking/eth/use-eth-staking-performance.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-staking-performance.spec.ts
@@ -1,0 +1,62 @@
+import type { Ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEthStakingPerformance } from '@/modules/staking/eth/use-eth-staking-performance';
+
+interface MockPerformance { entriesTotal: number }
+
+const mockPagination = ref<Record<string, unknown>>({});
+const mockPerformance = ref<MockPerformance | undefined>({ entriesTotal: 5 });
+const mockPerformanceLoading = ref<boolean>(false);
+const mockRefreshPerformance = vi.fn(async (_userInitiated?: boolean) => {});
+
+vi.mock('@/modules/staking/eth2/use-eth2', () => ({
+  useEth2Staking: (): {
+    pagination: Ref<Record<string, unknown>>;
+    performance: Ref<MockPerformance | undefined>;
+    performanceLoading: Ref<boolean>;
+    refreshPerformance: typeof mockRefreshPerformance;
+  } => ({
+    pagination: mockPagination,
+    performance: mockPerformance,
+    performanceLoading: mockPerformanceLoading,
+    refreshPerformance: mockRefreshPerformance,
+  }),
+}));
+
+describe('useEthStakingPerformance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(mockPerformance, { entriesTotal: 5 });
+    set(mockPerformanceLoading, false);
+  });
+
+  it('should pass through the underlying performance, loading and pagination refs', () => {
+    const { performance, performanceLoading, performancePagination } = useEthStakingPerformance();
+    expect(performance).toBe(mockPerformance);
+    expect(performanceLoading).toBe(mockPerformanceLoading);
+    expect(performancePagination).toBe(mockPagination);
+  });
+
+  it('should return the entries total from getPerformance', () => {
+    const { getPerformance } = useEthStakingPerformance();
+    expect(getPerformance()).toEqual({ entriesTotal: 5 });
+  });
+
+  it('should default entries total to zero when there is no performance', () => {
+    set(mockPerformance, undefined);
+    const { getPerformance } = useEthStakingPerformance();
+    expect(getPerformance()).toEqual({ entriesTotal: 0 });
+  });
+
+  it('should forward the user-initiated flag to refreshPerformance', async () => {
+    const { refreshPerformance } = useEthStakingPerformance();
+    await refreshPerformance(true);
+    expect(mockRefreshPerformance).toHaveBeenCalledWith(true);
+  });
+
+  it('should default the user-initiated flag to false', async () => {
+    const { refreshPerformance } = useEthStakingPerformance();
+    await refreshPerformance();
+    expect(mockRefreshPerformance).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-data.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-data.spec.ts
@@ -1,0 +1,152 @@
+import type { EthereumValidator } from '@/modules/accounts/blockchain-accounts';
+import { bigNumberify } from '@rotki/common';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type EffectScope, effectScope, type Ref } from 'vue';
+import { TableId } from '@/modules/core/table/use-remember-table-sorting';
+import { useEthValidatorData } from '@/modules/staking/eth/use-eth-validator-data';
+
+function validator(index: number): EthereumValidator {
+  return {
+    amount: bigNumberify(32),
+    index,
+    publicKey: '0xabc',
+    status: 'active',
+    type: 'validator',
+    value: bigNumberify(64000),
+  };
+}
+
+const mockFetchData = vi.fn();
+const mockFetchValidators = vi.fn();
+const mockRememberSorting = vi.fn();
+const mockEthStakingValidators = ref<EthereumValidator[]>([]);
+const mockCurrencySymbol = ref<string>('USD');
+const mockFilters = ref({});
+const mockMatchers = ref([]);
+const mockPagination = ref({});
+const mockSort = ref({ column: 'index', direction: 'desc' });
+const mockRows = ref({ data: [], found: 0, limit: 10, total: 0 });
+
+vi.mock('vue-i18n', async importOriginal => ({
+  ...await importOriginal<typeof import('vue-i18n')>(),
+  useI18n: (): { t: (key: string, args?: { symbol?: string }) => string } => ({
+    t: (key: string, args?: { symbol?: string }): string => (args ? `${key}:${args.symbol}` : key),
+  }),
+}));
+
+vi.mock('@/modules/staking/use-blockchain-validators-store', () => ({
+  useBlockchainValidatorsStore: (): {
+    ethStakingValidators: Ref<EthereumValidator[]>;
+    fetchValidators: typeof mockFetchValidators;
+  } => ({
+    ethStakingValidators: mockEthStakingValidators,
+    fetchValidators: mockFetchValidators,
+  }),
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: vi.fn(() => mockCurrencySymbol),
+}));
+
+vi.mock('@/modules/core/table/use-remember-table-sorting', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/core/table/use-remember-table-sorting')>(),
+  useRememberTableSorting: (...args: unknown[]): void => mockRememberSorting(...args),
+}));
+
+vi.mock('@/modules/core/table/use-pagination-filter', () => ({
+  usePaginationFilters: (): Record<string, unknown> => ({
+    fetchData: mockFetchData,
+    filters: mockFilters,
+    matchers: mockMatchers,
+    pagination: mockPagination,
+    sort: mockSort,
+    state: mockRows,
+  }),
+}));
+
+describe('useEthValidatorData', () => {
+  let scope: EffectScope | undefined;
+
+  function create(): ReturnType<typeof useEthValidatorData> {
+    scope = effectScope();
+    const result = scope.run(() => useEthValidatorData());
+    assert(result);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(mockEthStakingValidators, []);
+    set(mockCurrencySymbol, 'USD');
+  });
+
+  afterEach(() => {
+    scope?.stop();
+    scope = undefined;
+  });
+
+  it('should expose seven columns in order', () => {
+    const { cols } = create();
+    expect(get(cols).map(col => col.key)).toEqual([
+      'index',
+      'publicKey',
+      'status',
+      'amount',
+      'value',
+      'ownershipPercentage',
+      'actions',
+    ]);
+  });
+
+  it('should label the value column with the current currency symbol', () => {
+    set(mockCurrencySymbol, 'EUR');
+    const { cols } = create();
+    const valueCol = get(cols).find(col => col.key === 'value');
+    expect(valueCol?.label).toBe('common.value_in_symbol:EUR');
+  });
+
+  it('should mark all columns except ownership and actions as sortable', () => {
+    const { cols } = create();
+    const sortable = Object.fromEntries(get(cols).map(col => [col.key, col.sortable ?? false]));
+    expect(sortable.ownershipPercentage).toBe(false);
+    expect(sortable.actions).toBe(false);
+    expect(sortable.index).toBe(true);
+  });
+
+  it('should pass through pagination state from the paginator', () => {
+    const data = create();
+    expect(data.fetchData).toBe(mockFetchData);
+    expect(data.filters).toBe(mockFilters);
+    expect(data.matchers).toBe(mockMatchers);
+    expect(data.pagination).toBe(mockPagination);
+    expect(data.sort).toBe(mockSort);
+    expect(data.rows).toBe(mockRows);
+  });
+
+  it('should expose the validators from the store', () => {
+    const validators = [validator(7)];
+    set(mockEthStakingValidators, validators);
+    const data = create();
+    expect(get(data.ethStakingValidators)).toStrictEqual(validators);
+  });
+
+  it('should start with no selection', () => {
+    const { selected } = create();
+    expect(get(selected)).toEqual([]);
+  });
+
+  it('should register table sorting for the validators table', () => {
+    create();
+    expect(mockRememberSorting).toHaveBeenCalledWith(TableId.ETH_STAKING_VALIDATORS, mockSort, expect.anything());
+  });
+
+  it('should fetch immediately and again whenever the validators change', async () => {
+    create();
+    expect(mockFetchData).toHaveBeenCalledTimes(1);
+
+    set(mockEthStakingValidators, [validator(1)]);
+    await nextTick();
+
+    expect(mockFetchData).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-operations.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-operations.spec.ts
@@ -1,0 +1,130 @@
+import type { Ref } from 'vue';
+import type { EthereumValidator } from '@/modules/accounts/blockchain-accounts';
+import { bigNumberify, Blockchain } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskType } from '@/modules/core/tasks/task-type';
+import { useEthValidatorOperations } from '@/modules/staking/eth/use-eth-validator-operations';
+
+const mockShowConfirmation = vi.fn();
+const mockFetchEthStakingValidators = vi.fn();
+const mockRefreshBlockchainBalances = vi.fn();
+const mockLoading = ref<boolean>(false);
+const mockAddRunning = ref<boolean>(false);
+const mockRemoveRunning = ref<boolean>(false);
+
+vi.mock('@/modules/accounts/blockchain/use-account-delete', () => ({
+  useAccountDelete: (): { showConfirmation: typeof mockShowConfirmation } => ({ showConfirmation: mockShowConfirmation }),
+}));
+
+vi.mock('@/modules/accounts/use-eth-staking', () => ({
+  useEthStaking: (): { fetchEthStakingValidators: typeof mockFetchEthStakingValidators } => ({
+    fetchEthStakingValidators: mockFetchEthStakingValidators,
+  }),
+}));
+
+vi.mock('@/modules/balances/use-blockchain-balances', () => ({
+  useBlockchainBalances: (): { refreshBlockchainBalances: typeof mockRefreshBlockchainBalances } => ({
+    refreshBlockchainBalances: mockRefreshBlockchainBalances,
+  }),
+}));
+
+vi.mock('@/modules/shell/sync-progress/use-section-status', () => ({
+  useSectionStatus: (): { isLoading: Ref<boolean> } => ({ isLoading: mockLoading }),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: (): { useIsTaskRunning: (type: TaskType) => Ref<boolean> } => {
+    const byType = new Map<TaskType, Ref<boolean>>([
+      [TaskType.ADD_ACCOUNT, mockAddRunning],
+      [TaskType.REMOVE_ACCOUNT, mockRemoveRunning],
+    ]);
+    return {
+      useIsTaskRunning: (type: TaskType): Ref<boolean> => byType.get(type) ?? ref<boolean>(false),
+    };
+  },
+}));
+
+function validator(overrides: Partial<EthereumValidator> = {}): EthereumValidator {
+  return {
+    amount: bigNumberify(32),
+    index: 1,
+    publicKey: '0xabc',
+    status: 'active',
+    type: 'validator',
+    value: bigNumberify(64000),
+    ...overrides,
+  };
+}
+
+describe('useEthValidatorOperations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(mockLoading, false);
+    set(mockAddRunning, false);
+    set(mockRemoveRunning, false);
+  });
+
+  describe('edit', () => {
+    it('should map a validator into an edit manage payload', () => {
+      const { edit } = useEthValidatorOperations();
+      expect(edit(validator({ index: 42, ownershipPercentage: '50', publicKey: '0xdef' }))).toEqual({
+        chain: Blockchain.ETH2,
+        data: { ownershipPercentage: '50', publicKey: '0xdef', validatorIndex: '42' },
+        mode: 'edit',
+        type: 'validator',
+      });
+    });
+
+    it('should default the ownership percentage to 100', () => {
+      const { edit } = useEthValidatorOperations();
+      expect(edit(validator()).data.ownershipPercentage).toBe('100');
+    });
+  });
+
+  describe('refresh', () => {
+    it('should refetch validators ignoring cache then refresh balances', async () => {
+      const { refresh } = useEthValidatorOperations();
+      await refresh();
+      expect(mockFetchEthStakingValidators).toHaveBeenCalledWith({ ignoreCache: true });
+      expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: Blockchain.ETH2 });
+    });
+  });
+
+  describe('confirmDelete', () => {
+    it('should ask for confirmation for a single validator', () => {
+      const item = validator();
+      const { confirmDelete } = useEthValidatorOperations();
+      confirmDelete(item);
+      expect(mockShowConfirmation).toHaveBeenCalledWith({ data: [item], type: 'validator' });
+    });
+  });
+
+  describe('deleteSelected', () => {
+    it('should confirm deletion only for the selected validator indexes', () => {
+      const rows = [validator({ index: 1 }), validator({ index: 2 }), validator({ index: 3 })];
+      const { deleteSelected } = useEthValidatorOperations();
+      deleteSelected(rows, [1, 3]);
+      expect(mockShowConfirmation).toHaveBeenCalledWith({
+        data: [rows[0], rows[2]],
+        type: 'validator',
+      });
+    });
+  });
+
+  describe('accountOperation', () => {
+    it('should be false when nothing is running', () => {
+      const { accountOperation } = useEthValidatorOperations();
+      expect(get(accountOperation)).toBe(false);
+    });
+
+    it.each([
+      ['add account', mockAddRunning],
+      ['remove account', mockRemoveRunning],
+      ['section loading', mockLoading],
+    ])('should be true while %s is active', (_label, flag) => {
+      set(flag, true);
+      const { accountOperation } = useEthValidatorOperations();
+      expect(get(accountOperation)).toBe(true);
+    });
+  });
+});

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-utils.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-utils.spec.ts
@@ -1,0 +1,85 @@
+import type { EthereumValidator } from '@/modules/accounts/blockchain-accounts';
+import type { Collection } from '@/modules/core/common/collection';
+import { bigNumberify, Zero } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { useEthValidatorUtils } from '@/modules/staking/eth/use-eth-validator-utils';
+
+function validator(overrides: Partial<EthereumValidator> = {}): EthereumValidator {
+  return {
+    amount: bigNumberify(32),
+    index: 1,
+    publicKey: '0xabc',
+    status: 'active',
+    type: 'validator',
+    value: bigNumberify(64000),
+    ...overrides,
+  };
+}
+
+function collection(overrides: Partial<Collection<EthereumValidator>> = {}): Collection<EthereumValidator> {
+  return {
+    data: [],
+    found: 0,
+    limit: 10,
+    total: 0,
+    ...overrides,
+  };
+}
+
+describe('useEthValidatorUtils', () => {
+  const { getColor, getOwnershipPercentage, useTotal, useTotalAmount } = useEthValidatorUtils();
+
+  describe('getColor', () => {
+    it.each([
+      ['active', 'success'],
+      ['consolidated', 'secondary'],
+      ['exited', 'error'],
+      ['exiting', 'warning'],
+      ['pending', 'info'],
+    ])('should map %s to %s', (status, color) => {
+      expect(getColor(status)).toBe(color);
+    });
+
+    it('should return undefined for an unknown status', () => {
+      expect(getColor('unknown')).toBeUndefined();
+    });
+  });
+
+  describe('getOwnershipPercentage', () => {
+    it('should return the ownership percentage when present', () => {
+      expect(getOwnershipPercentage(validator({ ownershipPercentage: '42' }))).toBe('42');
+    });
+
+    it('should default to 100 when the ownership percentage is missing', () => {
+      expect(getOwnershipPercentage(validator())).toBe('100');
+    });
+
+    it('should default to 100 when the ownership percentage is empty', () => {
+      expect(getOwnershipPercentage(validator({ ownershipPercentage: '' }))).toBe('100');
+    });
+  });
+
+  describe('useTotal', () => {
+    it('should expose the collection total value', () => {
+      const rows = ref(collection({ totalValue: bigNumberify(500) }));
+      expect(get(useTotal(rows)).toNumber()).toBe(500);
+    });
+
+    it('should fall back to zero when there is no total value', () => {
+      const rows = ref(collection());
+      expect(get(useTotal(rows))).toStrictEqual(Zero);
+    });
+  });
+
+  describe('useTotalAmount', () => {
+    it('should expose the collection total amount', () => {
+      const rows = ref(collection({ totalAmount: bigNumberify(64) }));
+      expect(get(useTotalAmount(rows)).toNumber()).toBe(64);
+    });
+
+    it('should fall back to zero when there is no total amount', () => {
+      const rows = ref(collection());
+      expect(get(useTotalAmount(rows))).toStrictEqual(Zero);
+    });
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/use-liquity-store.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/use-liquity-store.spec.ts
@@ -1,0 +1,62 @@
+import { bigNumberify, type CommonQueryStatusData } from '@rotki/common';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Section } from '@/modules/core/common/status';
+import { useLiquityStore } from '@/modules/staking/liquity/use-liquity-store';
+
+const mockResetStatus = vi.fn();
+
+vi.mock('@/modules/shell/sync-progress/use-status-updater', () => ({
+  useStatusUpdater: (): { resetStatus: typeof mockResetStatus } => ({ resetStatus: mockResetStatus }),
+}));
+
+describe('useLiquityStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('should start with default balances and empty state', () => {
+    const store = useLiquityStore();
+    expect(get(store.balances)).toEqual({ balances: {}, totalCollateralRatio: null });
+    expect(get(store.staking)).toEqual({});
+    expect(get(store.stakingPools)).toEqual({});
+    expect(get(store.statistics)).toBeNull();
+    expect(get(store.stakingQueryStatus)).toBeUndefined();
+  });
+
+  it('should set the staking query status', () => {
+    const store = useLiquityStore();
+    const status: CommonQueryStatusData = { processed: 1, total: 2 };
+    store.setStakingQueryStatus(status);
+    expect(get(store.stakingQueryStatus)).toEqual(status);
+  });
+
+  it('should clear the staking query status when set to null', () => {
+    const store = useLiquityStore();
+    store.setStakingQueryStatus({ processed: 1, total: 2 });
+    store.setStakingQueryStatus(null);
+    expect(get(store.stakingQueryStatus)).toBeNull();
+  });
+
+  it('should reset balances, staking and statistics to their defaults', () => {
+    const store = useLiquityStore();
+    store.balances = { balances: {}, totalCollateralRatio: bigNumberify(2) };
+    store.statistics = {};
+
+    store.reset();
+
+    expect(get(store.balances)).toEqual({ balances: {}, totalCollateralRatio: null });
+    expect(get(store.staking)).toEqual({});
+    expect(get(store.statistics)).toBeNull();
+  });
+
+  it('should reset the status of all three liquity sections', () => {
+    const store = useLiquityStore();
+    store.reset();
+
+    expect(mockResetStatus).toHaveBeenCalledWith({ section: Section.DEFI_LIQUITY_BALANCES });
+    expect(mockResetStatus).toHaveBeenCalledWith({ section: Section.DEFI_LIQUITY_STAKING });
+    expect(mockResetStatus).toHaveBeenCalledWith({ section: Section.DEFI_LIQUITY_STATISTICS });
+  });
+});

--- a/frontend/app/src/modules/staking/use-kraken-staking-store.spec.ts
+++ b/frontend/app/src/modules/staking/use-kraken-staking-store.spec.ts
@@ -1,0 +1,77 @@
+import type { KrakenStakingEvents } from '@/modules/staking/staking-types';
+import { bigNumberify, Zero } from '@rotki/common';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useKrakenStakingStore } from '@/modules/staking/use-kraken-staking-store';
+
+const mockResolve = vi.fn((asset: string) => asset);
+
+vi.mock('@/modules/assets/use-resolve-asset-identifier', () => ({
+  useResolveAssetIdentifier: (): typeof mockResolve => mockResolve,
+}));
+
+function events(received: KrakenStakingEvents['received']): KrakenStakingEvents {
+  return {
+    assets: [],
+    entriesFound: received.length,
+    entriesLimit: 0,
+    entriesTotal: received.length,
+    received,
+    totalValue: Zero,
+  };
+}
+
+describe('useKrakenStakingStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    mockResolve.mockImplementation((asset: string) => asset);
+  });
+
+  it('should start with default pagination and empty events', () => {
+    const store = useKrakenStakingStore();
+    expect(get(store.pagination)).toEqual({
+      ascending: [false],
+      limit: 10,
+      offset: 0,
+      orderByAttributes: ['timestamp'],
+    });
+    expect(get(store.events).received).toEqual([]);
+    expect(get(store.events).assets).toEqual([]);
+  });
+
+  it('should resolve asset identifiers and list them under assets', () => {
+    const store = useKrakenStakingStore();
+    store.rawEvents = events([
+      { amount: bigNumberify(1), asset: 'ETH', value: bigNumberify(100) },
+    ]);
+    expect(get(store.events).assets).toEqual(['ETH']);
+  });
+
+  it('should aggregate received entries that resolve to the same asset', () => {
+    mockResolve.mockImplementation(() => 'ETH');
+    const store = useKrakenStakingStore();
+    store.rawEvents = events([
+      { amount: bigNumberify(1), asset: 'ETH', value: bigNumberify(100) },
+      { amount: bigNumberify(2), asset: 'ETH2', value: bigNumberify(200) },
+    ]);
+
+    const result = get(store.events);
+    expect(result.assets).toEqual(['ETH']);
+    expect(result.received).toHaveLength(1);
+    expect(result.received[0].amount.toNumber()).toBe(3);
+    expect(result.received[0].value.toNumber()).toBe(300);
+  });
+
+  it('should keep entries that resolve to different assets separate', () => {
+    const store = useKrakenStakingStore();
+    store.rawEvents = events([
+      { amount: bigNumberify(1), asset: 'ETH', value: bigNumberify(100) },
+      { amount: bigNumberify(2), asset: 'BTC', value: bigNumberify(200) },
+    ]);
+
+    const result = get(store.events);
+    expect(result.assets).toEqual(['ETH', 'BTC']);
+    expect(result.received).toHaveLength(2);
+  });
+});

--- a/frontend/app/vitest.config.ts
+++ b/frontend/app/vitest.config.ts
@@ -54,6 +54,7 @@ export default mergeConfig(
           'src/DevApp.vue',
           'src/i18n.ts',
           'src/main.ts',
+          'src/modules/shell/app/store-debug-plugin.ts',
           'src/pages/playground/**',
         ],
       },


### PR DESCRIPTION
Part of the frontend unit-coverage push for #11252.

Adds unit coverage for the staking module (9 spec files / 60 tests):

- ETH validator data, operations, and utils
- ETH staking access + performance composables
- Kraken staking store
- Liquity staking store
- Lido CSM API
- e2e ResizeObserver helper

Also excludes `store-debug-plugin` from vitest coverage.

Refs #11252

## Gates
- Suite green (all staking specs pass)
- Typecheck clean
- Lint: 0 errors