### PR TITLE
fix: refresh balance overlay on sync complete

### DIFF
--- a/frontend/app/src/modules/history/balances/AccountingOverlayCell.spec.ts
+++ b/frontend/app/src/modules/history/balances/AccountingOverlayCell.spec.ts
@@ -47,7 +47,6 @@ function mountCell(opts: {
     bucketsAt: () => [],
     ensurePair: () => {},
     refresh: async () => {},
-    refreshProcessing: () => {},
     seriesUpTo: () => [],
     state: computed(() => 'ready'),
     statusFor: () => opts.status ?? 'ready',

--- a/frontend/app/src/modules/history/balances/use-accounting-overlay.spec.ts
+++ b/frontend/app/src/modules/history/balances/use-accounting-overlay.spec.ts
@@ -219,49 +219,6 @@ describe('useAccountingOverlay', () => {
     expect(runTaskMock).toHaveBeenCalledTimes(1);
   });
 
-  describe('refreshProcessing', () => {
-    it('should refetch only the pairs stuck on processing', async () => {
-      // 0xA resolves immediately; 0xB is still processing.
-      runTaskMock.mockImplementation(async (taskFn: () => Promise<unknown>) => {
-        const meta = await taskFn();
-        return meta;
-      });
-      runTaskMock.mockResolvedValueOnce(success([entry({ times: [100], values: ['5'] })])); // 0xA
-      runTaskMock.mockResolvedValueOnce(success([], true)); // 0xB processing
-      const { overlay } = create([
-        { asset: 'ETH', locationLabel: '0xA' },
-        { asset: 'ETH', locationLabel: '0xB' },
-      ]);
-      await overlay.refresh();
-      await flushPromises();
-      expect(overlay.statusFor('0xA', 'ETH')).toBe('ready');
-      expect(overlay.statusFor('0xB', 'ETH')).toBe('processing');
-      expect(runTaskMock).toHaveBeenCalledTimes(2);
-
-      // Sync completed: 0xB now has metrics. Only it should be refetched.
-      runTaskMock.mockResolvedValue(success([entry({ times: [100], values: ['8'] })]));
-      overlay.refreshProcessing();
-      await flushPromises();
-
-      expect(runTaskMock).toHaveBeenCalledTimes(3); // only 0xB refetched, not the ready 0xA
-      expect(overlay.statusFor('0xB', 'ETH')).toBe('ready');
-      expect(overlay.balanceAfter('0xB', 'ETH', 150_000)?.toString()).toBe('8');
-    });
-
-    it('should do nothing when the overlay is disabled', async () => {
-      runTaskMock.mockResolvedValue(success([], true));
-      const { overlay, enabledRef } = create([{ asset: 'ETH', locationLabel: '0xA' }]);
-      await overlay.refresh();
-      await flushPromises();
-      expect(runTaskMock).toHaveBeenCalledTimes(1);
-
-      set(enabledRef, false);
-      overlay.refreshProcessing();
-      await flushPromises();
-      expect(runTaskMock).toHaveBeenCalledTimes(1); // guarded: no refetch while disabled
-    });
-  });
-
   describe('seriesUpTo', () => {
     it('should return the full balance trajectory up to the event, plus the event point', async () => {
       runTaskMock.mockResolvedValue(success([entry({ times: [100, 200, 300], values: ['1', '3', '2'] })]));

--- a/frontend/app/src/modules/history/balances/use-accounting-overlay.ts
+++ b/frontend/app/src/modules/history/balances/use-accounting-overlay.ts
@@ -84,8 +84,6 @@ export interface UseAccountingOverlayReturn {
    */
   ensurePair: (pair: OverlayPair) => void;
   refresh: () => Promise<void>;
-  /** Refetch only the pairs currently in the PROCESSING state (e.g. once sync completes). */
-  refreshProcessing: () => void;
 }
 
 /** Backend returns this message (404) when the scope has no computed metrics yet. */
@@ -255,15 +253,6 @@ export function useAccountingOverlay(params: AccountingOverlayParams): UseAccoun
     fetchMissing();
   }
 
-  /**
-   * Refetch only the pairs currently stuck on PROCESSING — used when historical-balance sync
-   * reaches 100%. Their event_metrics now exist, so a re-query flips them to ready/empty while
-   * leaving already-resolved pairs untouched (no blanket cache reset).
-   */
-  function refreshProcessing(): void {
-    fetchPairsWhere(entry => entry?.status === PairOverlayStatus.PROCESSING);
-  }
-
   function statusFor(locationLabel: string, asset: string): PairOverlayStatus {
     return get(cache).get(pairKey(locationLabel, asset))?.status ?? PairOverlayStatus.LOADING;
   }
@@ -332,6 +321,5 @@ export function useAccountingOverlay(params: AccountingOverlayParams): UseAccoun
     seriesUpTo,
     ensurePair,
     refresh,
-    refreshProcessing,
   };
 }

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -5,7 +5,6 @@ import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/event
 import AccountingOverlayToggle from '@/modules/history/balances/AccountingOverlayToggle.vue';
 import { OverlayMode, type OverlayPair, useAccountingOverlay } from '@/modules/history/balances/use-accounting-overlay';
 import { provideAccountingOverlay } from '@/modules/history/balances/use-accounting-overlay-context';
-import { useHistoricalBalancesStore } from '@/modules/history/balances/use-historical-balances-store';
 import { DataIssuesPanel, DataIssuesToggle } from '@/modules/history/data-issues/components/inbox';
 import { HISTORY_EVENT_ACTIONS, type HistoryEventAction } from '@/modules/history/events/action-types';
 import HistoryEventsVirtualTable from '@/modules/history/events/components/HistoryEventsVirtualTable.vue';
@@ -33,6 +32,7 @@ import {
 } from '@/modules/history/events/prices/use-event-price-update-trigger';
 import RefreshButton from '@/modules/shell/components/RefreshButton.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
+import { useSyncCompleted } from '@/modules/shell/sync-progress/use-sync-completed';
 
 type Period = { fromTimestamp?: string; toTimestamp?: string } | { fromTimestamp?: number; toTimestamp?: number };
 
@@ -173,13 +173,13 @@ const accountingOverlay = useAccountingOverlay({
 
 provideAccountingOverlay({ enabled: overlayEnabled, overlay: accountingOverlay });
 
-// When historical-balance sync finishes (isProcessing flips true -> false, i.e. it hit 100%),
-// any rows that were waiting on metrics now have them — refetch just those PROCESSING pairs so
-// their spinners resolve without re-querying everything. Guarded so a hidden overlay stays idle.
-const { isProcessing } = storeToRefs(useHistoricalBalancesStore());
-watch(isProcessing, (processing, wasProcessing) => {
-  if (get(overlayEnabled) && wasProcessing && !processing)
-    accountingOverlay.refreshProcessing();
+// When the history sync (tx query + exchange events + decoding) completes, new events have
+// landed and their historical balances may have shifted, so the whole overlay is refreshed to
+// re-resolve every visible row against the updated series. Guarded so a hidden overlay stays idle.
+const { syncCompleted } = useSyncCompleted();
+watch(syncCompleted, async () => {
+  if (get(overlayEnabled))
+    await accountingOverlay.refresh();
 });
 
 const actions = useHistoryEventsActions({


### PR DESCRIPTION
### Summary

The accounting (balance) overlay on the history events page was refreshed off the historical-balances `isProcessing` flag. That signal did not fire reliably, and even when it did it only refetched pairs still stuck in the `PROCESSING` state, so an enabled overlay could keep showing stale balances after a sync surfaced new events.

This wires the refresh to the new `useSyncCompleted` composable instead: when the history sync (transaction query + exchange events + decoding) reaches `SyncPhase.COMPLETE` **and** the overlay is enabled, the overlay does a full `refresh()` so every visible row re-resolves against the updated series.

### Changes

- `HistoryEventsView.vue`: watch `syncCompleted` (edge-triggered on the transition into `COMPLETE`, not `immediate`) and call `accountingOverlay.refresh()` when the overlay is enabled. Removes the old `isProcessing` watch and its store import.
- `use-accounting-overlay.ts`: remove the now-unused `refreshProcessing()` method.
- Specs updated accordingly.

### Notes

- The watcher fires once per sync-completion transition; it does not re-fire while the phase stays complete, nor on mount.
- Kept the file at the 20-import `@rotki/max-dependencies` limit by using an async `watch` callback (existing pattern in the file) rather than importing `startPromise`.

### Testing

- `pnpm run typecheck` clean
- `pnpm run test:unit` on the affected overlay specs: 23/23 pass
- `pnpm run lint-staged` clean