### PR TITLE
fix: keep filter chip order on matches echo

### DIFF
--- a/frontend/app/src/modules/core/table/composables/use-filter-selection.spec.ts
+++ b/frontend/app/src/modules/core/table/composables/use-filter-selection.spec.ts
@@ -408,4 +408,50 @@ describe('composables/use-filter-selection', () => {
       expect(get(selection)[0].value).toBe('value');
     });
   });
+
+  describe('echo guard (matches round-trip)', () => {
+    it('should not reorder chips when the parent echoes the emitted matches back', () => {
+      const setup = createTestSetup([createStringMatcher('type'), createStringMatcher('protocol')]);
+      const { updateMatches, restoreSelection, selection } = useFilterSelection(
+        setup.search,
+        setup.matcherForKey,
+        setup.matcherForKeyValue,
+        setup.emit,
+      );
+
+      // User adds chips interleaved: type, protocol, then type again.
+      updateMatches([
+        createSuggestion('type', 'a'),
+        createSuggestion('protocol', 'x'),
+        createSuggestion('type', 'b'),
+      ]);
+      expect(setup.emit).toHaveBeenLastCalledWith('update:matches', { protocol: ['x'], type: ['a', 'b'] });
+
+      // The parent round-trips a structurally-equal matches object straight back.
+      restoreSelection({ protocol: ['x'], type: ['a', 'b'] });
+
+      // Selection keeps the user's insertion order instead of being regrouped by key.
+      expect(get(selection).map(item => `${item.key}=${item.value}`)).toStrictEqual([
+        'type=a',
+        'protocol=x',
+        'type=b',
+      ]);
+    });
+
+    it('should rebuild selection when matches differ from the last emit', () => {
+      const setup = createTestSetup([createStringMatcher('type')]);
+      const { updateMatches, restoreSelection, selection } = useFilterSelection(
+        setup.search,
+        setup.matcherForKey,
+        setup.matcherForKeyValue,
+        setup.emit,
+      );
+
+      updateMatches([createSuggestion('type', 'a')]);
+      restoreSelection({ type: ['c'] });
+
+      expect(get(selection)).toHaveLength(1);
+      expect(get(selection)[0].value).toBe('c');
+    });
+  });
 });

--- a/frontend/app/src/modules/core/table/composables/use-filter-selection.ts
+++ b/frontend/app/src/modules/core/table/composables/use-filter-selection.ts
@@ -6,6 +6,7 @@ import type {
   Suggestion,
 } from '@/modules/core/table/filtering';
 import { assert } from '@rotki/common';
+import { isEqual } from 'es-toolkit';
 import { arrayify } from '@/modules/core/common/data/array';
 
 interface SuggestionText {
@@ -36,6 +37,11 @@ export function useFilterSelection(
 ): UseFilterSelectionReturn {
   const selection = ref<Suggestion[]>([]);
   const suggestionBeingEdited = ref<Suggestion>();
+  // The matches object we last emitted. The parent echoes it straight back through the `matches`
+  // prop after every edit; restoreSelection uses this to skip rebuilding `selection` for that
+  // echo, since re-deriving it regroups chips by key (reordering them) and drops any match it
+  // can't map, diverging the visible chips from a filter that never actually changed.
+  const lastEmitted = ref<MatchedKeywordWithBehaviour<any>>();
 
   // TODO: This is too specific for custom asset, move it!
   function getDisplayValue(suggestion: Suggestion): string {
@@ -138,6 +144,7 @@ export function useFilterSelection(
     }
 
     set(selection, validPairs);
+    set(lastEmitted, matched);
     emit('update:matches', matched);
   }
 
@@ -178,6 +185,11 @@ export function useFilterSelection(
   }
 
   function restoreSelection(matchesData: MatchedKeywordWithBehaviour<any>): void {
+    // Ignore the echo of our own last emit: the parent round-trips `matches` back after every
+    // edit, and rebuilding `selection` from it would reorder/drop chips for no real change.
+    if (isEqual(matchesData, get(lastEmitted)))
+      return;
+
     const oldSelection = get(selection);
     const newSelection: Suggestion[] = [];
     Object.entries(matchesData).forEach(([key, value]) => {


### PR DESCRIPTION
### Summary

The table filter chips could silently reorder (and in some cases a chip could disappear while its filter stayed active) after every edit, even though the active filter had not changed.

`TableFilter` round-trips its `matches` prop back into `useFilterSelection`: the composable emits `update:matches`, the parent updates the prop, and a watcher calls `restoreSelection` with it. `restoreSelection` rebuilds the chip list by grouping `Object.entries(matches)` per key, so the echo of the just-emitted matches regrouped the chips (e.g. adding `type=a`, `protocol=x`, `type=b` re-rendered as `type=a`, `type=b`, `protocol=x`) and dropped any matched key it could not map back to a chip.

### Fix

Track the last matches object the composable emitted, and skip `restoreSelection` when the incoming object structurally equals it (the self-echo). Only genuine external changes (mount, saved filters, URL) now rebuild the selection.

The guard lives entirely inside the composable at the single `restoreSelection` choke point, so no consumer change is needed.

### Testing

- New specs in `use-filter-selection.spec.ts`: chip order is preserved on an echoed matches object, and a genuinely different matches object still rebuilds the selection.
- `pnpm run test:unit` on the spec: 23/23 pass
- `pnpm run typecheck` clean
- `pnpm run lint-staged` clean