### PR TITLE
test(frontend): add wallet provider unit coverage

### DIFF
--- a/frontend/app/src/modules/wallet/bridge/bridge-config.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/bridge-config.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { CLIENT_CONFIG, PROXY_CONFIG } from '@/modules/wallet/bridge/bridge-config';
+
+describe('bridge-config', () => {
+  it('should expose the proxy configuration constants', () => {
+    expect(PROXY_CONFIG).toStrictEqual({
+      BRIDGE_PAGE_DELAY: 250,
+      CONNECTION_TIMEOUT: 30000,
+      HEALTH_CHECK_INTERVAL: 5000,
+      RETRY_INTERVAL: 500,
+      SERVER_TIMEOUT: 30000,
+    });
+  });
+
+  it('should expose the websocket client configuration constants', () => {
+    expect(CLIENT_CONFIG).toStrictEqual({
+      DEFAULT_BASE_PORT: 40011,
+      MAX_RETRIES: 5,
+      RETRY_DELAY: 500,
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/bridge/resource-management.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/resource-management.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createResourceManager } from '@/modules/wallet/bridge/resource-management';
+
+describe('createResourceManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should start with an idle resource state', () => {
+    const { resources } = createResourceManager();
+    expect(resources.isSetupInProgress).toBe(false);
+    expect(resources.setupAbortController).toBeNull();
+    expect(resources.setupTimeout).toBeNull();
+  });
+
+  it('should abort an ongoing controller and reset flags on cleanup', () => {
+    const { cleanupResources, resources } = createResourceManager();
+    const controller = new AbortController();
+    resources.setupAbortController = controller;
+    resources.isSetupInProgress = true;
+
+    cleanupResources();
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(resources.setupAbortController).toBeNull();
+    expect(resources.isSetupInProgress).toBe(false);
+  });
+
+  it('should not re-abort a controller that is already aborted', () => {
+    const { cleanupResources, resources } = createResourceManager();
+    const controller = new AbortController();
+    controller.abort();
+    const abortSpy = vi.spyOn(controller, 'abort');
+    resources.setupAbortController = controller;
+
+    cleanupResources();
+
+    expect(abortSpy).not.toHaveBeenCalled();
+    expect(resources.setupAbortController).toBeNull();
+  });
+
+  it('should clear a pending timeout on cleanup', () => {
+    vi.useFakeTimers();
+    try {
+      const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+      const { cleanupResources, resources } = createResourceManager();
+      const timeout = setTimeout(() => {}, 1000);
+      resources.setupTimeout = timeout;
+
+      cleanupResources();
+
+      expect(clearSpy).toHaveBeenCalledWith(timeout);
+      expect(resources.setupTimeout).toBeNull();
+    }
+    finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should be a no-op when there is nothing to clean up', () => {
+    const { cleanupResources, resources } = createResourceManager();
+    expect(() => cleanupResources()).not.toThrow();
+    expect(resources.setupAbortController).toBeNull();
+    expect(resources.setupTimeout).toBeNull();
+    expect(resources.isSetupInProgress).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-connection.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-connection.spec.ts
@@ -1,0 +1,245 @@
+import type { EIP1193Provider, EIP1193ProviderEvents } from '@/types';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { useWalletConnection } from '@/modules/wallet/bridge/use-wallet-connection';
+
+// A lowercase address and its checksummed form (real viem getAddress runs unmocked).
+const LOWER_ADDRESS = '0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c';
+const CHECKSUM_ADDRESS = '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c';
+
+type Listeners = Map<string, (...args: any[]) => void>;
+
+type RequestMock = Mock<(args: { method: string; params?: unknown }) => Promise<any>>;
+
+interface ProviderHarness {
+  provider: EIP1193Provider;
+  listeners: Listeners;
+  request: RequestMock;
+}
+
+function createProvider(overrides: Partial<EIP1193Provider> = {}): ProviderHarness {
+  const listeners: Listeners = new Map();
+  const request: RequestMock = vi.fn();
+  const provider: EIP1193Provider = {
+    on: vi.fn((event: keyof EIP1193ProviderEvents, cb: (...args: any[]) => void) => {
+      listeners.set(event, cb);
+    }),
+    removeListener: vi.fn((event: keyof EIP1193ProviderEvents) => {
+      listeners.delete(event);
+    }),
+    request,
+    ...overrides,
+  };
+  return { listeners, provider, request };
+}
+
+describe('useWalletConnection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should default all connection refs to undefined/false', () => {
+    const { connectedAddress, connectedChainId, connectionError, isConnecting } = useWalletConnection();
+    expect(get(connectedAddress)).toBeUndefined();
+    expect(get(connectedChainId)).toBeUndefined();
+    expect(get(connectionError)).toBeUndefined();
+    expect(get(isConnecting)).toBe(false);
+  });
+
+  it('should set a connection error message and return it for Error inputs', () => {
+    const { connectionError, handleConnectionError } = useWalletConnection();
+    const message = handleConnectionError(new Error('boom'), 'connect wallet');
+    expect(message).toBe('boom');
+    expect(get(connectionError)).toBe('boom');
+  });
+
+  it('should fall back to a context message for non-object errors', () => {
+    const { connectionError, handleConnectionError } = useWalletConnection();
+    const message = handleConnectionError('nope', 'connect wallet');
+    expect(message).toBe('Failed to connect wallet');
+    expect(get(connectionError)).toBe('Failed to connect wallet');
+  });
+
+  it('should reset the connection error', () => {
+    const { connectionError, handleConnectionError, resetError } = useWalletConnection();
+    handleConnectionError(new Error('boom'), 'x');
+    expect(get(connectionError)).toBe('boom');
+    resetError();
+    expect(get(connectionError)).toBeUndefined();
+  });
+
+  it('should connect and store the checksummed address and chain id', async () => {
+    const { provider, request } = createProvider();
+    request.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === 'eth_requestAccounts')
+        return [LOWER_ADDRESS];
+      if (method === 'eth_chainId')
+        return '0xa';
+      return undefined;
+    });
+
+    const { connectToProvider, connectedAddress, connectedChainId, isConnecting } = useWalletConnection();
+    await connectToProvider(provider);
+
+    expect(get(connectedAddress)).toBe(CHECKSUM_ADDRESS);
+    expect(get(connectedChainId)).toBe(10);
+    expect(get(isConnecting)).toBe(false);
+  });
+
+  it('should throw and clear state when no accounts are returned', async () => {
+    const { provider, request } = createProvider();
+    request.mockResolvedValue([]);
+
+    const { connectToProvider, connectedAddress, connectionError, isConnecting } = useWalletConnection();
+    await expect(connectToProvider(provider)).rejects.toThrow('No accounts returned from wallet.');
+
+    expect(get(connectedAddress)).toBeUndefined();
+    // handleConnectionError set the error, then clearConnectionState reset it.
+    expect(get(connectionError)).toBeUndefined();
+    expect(get(isConnecting)).toBe(false);
+  });
+
+  it('should rethrow and reset isConnecting when the request fails', async () => {
+    const { provider, request } = createProvider();
+    request.mockRejectedValue(new Error('rpc down'));
+
+    const { connectToProvider, connectedAddress, isConnecting } = useWalletConnection();
+    await expect(connectToProvider(provider)).rejects.toThrow('rpc down');
+    expect(get(connectedAddress)).toBeUndefined();
+    expect(get(isConnecting)).toBe(false);
+  });
+
+  it('should register listeners and query the current provider state on setup', async () => {
+    const { provider, listeners, request } = createProvider();
+    request.mockImplementation(async ({ method }: { method: string }) => {
+      if (method === 'eth_accounts')
+        return [LOWER_ADDRESS];
+      if (method === 'eth_chainId')
+        return '0x1';
+      return undefined;
+    });
+
+    const { setupProvider, connectedAddress, connectedChainId } = useWalletConnection();
+    await setupProvider(provider);
+
+    expect(listeners.has('accountsChanged')).toBe(true);
+    expect(listeners.has('chainChanged')).toBe(true);
+    expect(get(connectedAddress)).toBe(CHECKSUM_ADDRESS);
+    expect(get(connectedChainId)).toBe(1);
+  });
+
+  it('should swallow errors thrown while querying provider state on setup', async () => {
+    const { provider, request } = createProvider();
+    request.mockRejectedValue(new Error('not connected'));
+
+    const { setupProvider, connectedAddress } = useWalletConnection();
+    await expect(setupProvider(provider)).resolves.toBeUndefined();
+    expect(get(connectedAddress)).toBeUndefined();
+  });
+
+  it('should skip listener registration when the provider has no on()', async () => {
+    const { provider } = createProvider({ on: undefined });
+    const { setupProvider, connectedAddress } = useWalletConnection();
+    await expect(setupProvider(provider)).resolves.toBeUndefined();
+    expect(get(connectedAddress)).toBeUndefined();
+  });
+
+  it('should update the address via the accountsChanged listener', async () => {
+    const { provider, listeners, request } = createProvider();
+    request.mockResolvedValue(undefined);
+
+    const { setupProvider, connectedAddress } = useWalletConnection();
+    await setupProvider(provider);
+
+    listeners.get('accountsChanged')?.([LOWER_ADDRESS]);
+    expect(get(connectedAddress)).toBe(CHECKSUM_ADDRESS);
+
+    listeners.get('accountsChanged')?.([]);
+    expect(get(connectedAddress)).toBeUndefined();
+  });
+
+  it('should update the chain id via the chainChanged listener', async () => {
+    const { provider, listeners, request } = createProvider();
+    request.mockResolvedValue(undefined);
+
+    const { setupProvider, connectedChainId } = useWalletConnection();
+    await setupProvider(provider);
+
+    listeners.get('chainChanged')?.('0x89');
+    expect(get(connectedChainId)).toBe(137);
+  });
+
+  it('should remove listeners on cleanupProviderListeners', async () => {
+    const { provider, request } = createProvider();
+    request.mockResolvedValue(undefined);
+
+    const { setupProvider, cleanupProviderListeners } = useWalletConnection();
+    await setupProvider(provider);
+    cleanupProviderListeners();
+
+    expect(provider.removeListener).toHaveBeenCalledWith('accountsChanged', expect.any(Function));
+    expect(provider.removeListener).toHaveBeenCalledWith('chainChanged', expect.any(Function));
+  });
+
+  it('should clean up the previous provider when setting up a new one', async () => {
+    const first = createProvider();
+    const second = createProvider();
+    first.request.mockResolvedValue(undefined);
+    second.request.mockResolvedValue(undefined);
+
+    const { setupProvider } = useWalletConnection();
+    await setupProvider(first.provider);
+    await setupProvider(second.provider);
+
+    expect(first.provider.removeListener).toHaveBeenCalled();
+  });
+
+  it('should disconnect, revoke permissions and clear state', async () => {
+    const disconnect = vi.fn().mockResolvedValue(undefined);
+    const { provider, request } = createProvider({ disconnect });
+    request.mockResolvedValue(undefined);
+
+    const { disconnectFromProvider, connectedAddress } = useWalletConnection();
+    await disconnectFromProvider(provider);
+
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledWith({
+      method: 'wallet_revokePermissions',
+      params: [{ eth_accounts: {} }],
+    });
+    expect(get(connectedAddress)).toBeUndefined();
+  });
+
+  it('should still clear state when the provider lacks disconnect()', async () => {
+    const { provider, request } = createProvider({ disconnect: undefined });
+    request.mockResolvedValue(undefined);
+
+    const { disconnectFromProvider } = useWalletConnection();
+    await expect(disconnectFromProvider(provider)).resolves.toBeUndefined();
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({ method: 'wallet_revokePermissions' }));
+  });
+
+  it('should swallow a failing disconnect() and continue', async () => {
+    const disconnect = vi.fn().mockRejectedValue(new Error('unsupported'));
+    const { provider, request } = createProvider({ disconnect });
+    request.mockResolvedValue(undefined);
+
+    const { disconnectFromProvider } = useWalletConnection();
+    await expect(disconnectFromProvider(provider)).resolves.toBeUndefined();
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({ method: 'wallet_revokePermissions' }));
+  });
+
+  it('should clear provider and connection state via clearProvider', async () => {
+    const { provider, request } = createProvider();
+    request.mockImplementation(async ({ method }: { method: string }) =>
+      method === 'eth_accounts' ? [LOWER_ADDRESS] : '0x1');
+
+    const { setupProvider, clearProvider, connectedAddress, connectedChainId } = useWalletConnection();
+    await setupProvider(provider);
+    expect(get(connectedAddress)).toBe(CHECKSUM_ADDRESS);
+
+    clearProvider();
+    expect(get(connectedAddress)).toBeUndefined();
+    expect(get(connectedChainId)).toBeUndefined();
+    expect(provider.removeListener).toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/wallet/providers/provider-detection.spec.ts
+++ b/frontend/app/src/modules/wallet/providers/provider-detection.spec.ts
@@ -1,0 +1,133 @@
+import type { EIP1193Provider, EIP6963ProviderDetail } from '@/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getAddressesFromWallet,
+  getAllBrowserWalletProviders,
+  getAllWalletProviders,
+} from '@/modules/wallet/providers/provider-detection';
+
+const proxyProvider = { request: vi.fn() };
+
+vi.mock('@/modules/wallet/bridge/use-proxy-provider', () => ({
+  useProxyProvider: vi.fn(() => proxyProvider),
+}));
+
+function makeDetail(uuid: string, name: string = uuid): EIP6963ProviderDetail {
+  return {
+    info: { icon: 'icon', name, rdns: `rdns.${uuid}`, uuid },
+    provider: { request: vi.fn() },
+  };
+}
+
+function announce(detail: EIP6963ProviderDetail): void {
+  window.dispatchEvent(new CustomEvent('eip6963:announceProvider', { detail }));
+}
+
+function stubWindow(prop: 'ethereum' | 'walletBridge', value: unknown): void {
+  Object.defineProperty(window, prop, { configurable: true, value });
+}
+
+describe('provider-detection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Reflect.deleteProperty(window, 'ethereum');
+    Reflect.deleteProperty(window, 'walletBridge');
+  });
+
+  describe('getAllWalletProviders (browser)', () => {
+    it('should return announced EIP-6963 providers', async () => {
+      const promise = getAllWalletProviders({ timeout: 500 });
+      announce(makeDetail('u1', 'Wallet One'));
+      announce(makeDetail('u2', 'Wallet Two'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      const result = await promise;
+      expect(result).toHaveLength(2);
+      expect(result.map(p => p.info.uuid)).toEqual(['u1', 'u2']);
+      expect(result[0].source).toBe('eip6963');
+    });
+
+    it('should de-duplicate providers announced twice by uuid', async () => {
+      const promise = getAllWalletProviders({ timeout: 500 });
+      announce(makeDetail('dup'));
+      announce(makeDetail('dup'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      const result = await promise;
+      expect(result).toHaveLength(1);
+    });
+
+    it('should fall back to a legacy provider when none announce', async () => {
+      stubWindow('ethereum', { isRotkiBridge: false, request: vi.fn() });
+      const promise = getAllWalletProviders({ timeout: 200 });
+      await vi.advanceTimersByTimeAsync(200); // outer eip6963 detection resolves empty
+      await vi.advanceTimersByTimeAsync(100); // nested detection inside legacy check
+
+      const result = await promise;
+      expect(result).toHaveLength(1);
+      expect(result[0].source).toBe('legacy');
+    });
+
+    it('should not add a legacy provider when includeLegacy is false', async () => {
+      stubWindow('ethereum', { isRotkiBridge: false, request: vi.fn() });
+      const promise = getAllWalletProviders({ includeLegacy: false, timeout: 200 });
+      await vi.advanceTimersByTimeAsync(200);
+
+      const result = await promise;
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getAllWalletProviders (electron)', () => {
+    it('should map bridge providers through the proxy provider', async () => {
+      stubWindow('walletBridge', {
+        getAvailableProviders: vi.fn().mockResolvedValue([makeDetail('bridge-1')]),
+      });
+
+      const result = await getAllWalletProviders();
+      expect(result).toHaveLength(1);
+      expect(result[0].source).toBe('bridge');
+      expect(result[0].provider).toBe(proxyProvider);
+    });
+
+    it('should return empty when the bridge lookup throws', async () => {
+      stubWindow('walletBridge', {
+        getAvailableProviders: vi.fn().mockRejectedValue(new Error('bridge down')),
+      });
+
+      const result = await getAllWalletProviders();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getAddressesFromWallet', () => {
+    it('should return the accounts from the provider', async () => {
+      const request = vi.fn().mockResolvedValue(['0xabc']);
+      const provider: EIP1193Provider = { request };
+
+      await expect(getAddressesFromWallet(provider)).resolves.toEqual(['0xabc']);
+      expect(request).toHaveBeenCalledWith({ method: 'eth_requestAccounts' });
+    });
+
+    it('should wrap a provider failure in a connection error', async () => {
+      const provider: EIP1193Provider = { request: vi.fn().mockRejectedValue(new Error('nope')) };
+      await expect(getAddressesFromWallet(provider)).rejects.toThrow('Failed to connect to wallet');
+    });
+  });
+
+  describe('getAllBrowserWalletProviders', () => {
+    it('should delegate to getAllWalletProviders with legacy support', async () => {
+      const promise = getAllBrowserWalletProviders();
+      announce(makeDetail('u1'));
+      await vi.advanceTimersByTimeAsync(2000);
+
+      const result = await promise;
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/providers/use-unified-providers.spec.ts
+++ b/frontend/app/src/modules/wallet/providers/use-unified-providers.spec.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type EnhancedProviderDetail, getAllWalletProviders } from '@/modules/wallet/providers/provider-detection';
+import { useUnifiedProviders } from '@/modules/wallet/providers/use-unified-providers';
+
+vi.mock('@/modules/wallet/providers/provider-detection', () => ({
+  getAllWalletProviders: vi.fn(),
+}));
+
+vi.mock('@shared/utils', async (importOriginal): Promise<any> => ({
+  ...(await importOriginal<any>()),
+  wait: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@vueuse/core', async (importOriginal): Promise<any> => ({
+  ...(await importOriginal<any>()),
+  createSharedComposable: <T>(fn: T): T => fn,
+}));
+
+const detectMock = vi.mocked(getAllWalletProviders);
+
+function makeProvider(
+  uuid: string,
+  source: EnhancedProviderDetail['source'] = 'eip6963',
+  name: string = uuid,
+): EnhancedProviderDetail {
+  return {
+    info: { icon: 'icon', name, rdns: `rdns.${uuid}`, uuid },
+    provider: { request: vi.fn() },
+    source,
+  };
+}
+
+function stubWalletBridge(value: Record<string, unknown>): void {
+  Object.defineProperty(window, 'walletBridge', { configurable: true, value });
+}
+
+describe('useUnifiedProviders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    detectMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'walletBridge');
+  });
+
+  it('should default to empty state', () => {
+    const { availableProviders, hasSelectedProvider, isDetecting, selectedProviderUuid } = useUnifiedProviders();
+    expect(get(availableProviders)).toEqual([]);
+    expect(get(hasSelectedProvider)).toBe(false);
+    expect(get(isDetecting)).toBe(false);
+    expect(get(selectedProviderUuid)).toBeUndefined();
+  });
+
+  it('should store detected providers without auto-selecting when multiple exist', async () => {
+    detectMock.mockResolvedValue([makeProvider('a'), makeProvider('b')]);
+    const { availableProviders, detectProviders, hasSelectedProvider } = useUnifiedProviders();
+
+    const result = await detectProviders();
+
+    expect(result).toHaveLength(2);
+    expect(get(availableProviders)).toHaveLength(2);
+    expect(get(hasSelectedProvider)).toBe(false);
+  });
+
+  it('should auto-select the sole detected provider', async () => {
+    detectMock.mockResolvedValue([makeProvider('solo', 'eip6963', 'Solo Wallet')]);
+    const { activeProvider, detectProviders, hasSelectedProvider, selectedProviderMetadata, selectedProviderUuid } = useUnifiedProviders();
+
+    await detectProviders();
+
+    expect(get(hasSelectedProvider)).toBe(true);
+    expect(get(selectedProviderUuid)).toBe('solo');
+    expect(get(selectedProviderMetadata)?.name).toBe('Solo Wallet');
+    expect(get(activeProvider)).toBeDefined();
+  });
+
+  it('should retry detection until providers appear', async () => {
+    detectMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([makeProvider('a')]);
+    const { detectProviders } = useUnifiedProviders();
+
+    await detectProviders({ maxRetries: 3 });
+
+    expect(detectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should stop retrying after maxRetries and return empty', async () => {
+    detectMock.mockResolvedValue([]);
+    const { availableProviders, detectProviders } = useUnifiedProviders();
+
+    const result = await detectProviders({ maxRetries: 1 });
+
+    expect(result).toEqual([]);
+    expect(detectMock).toHaveBeenCalledTimes(2);
+    expect(get(availableProviders)).toEqual([]);
+  });
+
+  it('should swallow a failing detection and record the error state', async () => {
+    detectMock.mockRejectedValue(new Error('detect failed'));
+    const { availableProviders, detectProviders, isDetecting } = useUnifiedProviders();
+
+    const result = await detectProviders({ maxRetries: 1 });
+
+    expect(result).toEqual([]);
+    expect(get(availableProviders)).toEqual([]);
+    expect(get(isDetecting)).toBe(false);
+    expect(detectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return false when selecting an unknown provider', async () => {
+    detectMock.mockResolvedValue([makeProvider('a'), makeProvider('b')]);
+    const { detectProviders, selectProvider } = useUnifiedProviders();
+    await detectProviders();
+
+    await expect(selectProvider('missing')).resolves.toBe(false);
+  });
+
+  it('should select a provider, persist the choice and notify listeners', async () => {
+    detectMock.mockResolvedValue([makeProvider('a'), makeProvider('b')]);
+    const { detectProviders, onProviderChanged, selectProvider, selectedProviderUuid } = useUnifiedProviders();
+    await detectProviders();
+
+    const listener = vi.fn();
+    onProviderChanged(listener);
+
+    const ok = await selectProvider('b');
+
+    expect(ok).toBe(true);
+    expect(get(selectedProviderUuid)).toBe('b');
+    expect(listener).toHaveBeenCalledOnce();
+    const stored = JSON.parse(localStorage.getItem('rotki-provider-preferences') ?? '{}');
+    expect(stored.lastSelectedUuid).toBe('b');
+  });
+
+  it('should stop notifying after the listener cleanup runs', async () => {
+    detectMock.mockResolvedValue([makeProvider('a'), makeProvider('b')]);
+    const { detectProviders, onProviderChanged, selectProvider } = useUnifiedProviders();
+    await detectProviders();
+
+    const listener = vi.fn();
+    const off = onProviderChanged(listener);
+    off();
+
+    await selectProvider('a');
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should clear the selection and notify listeners with undefined', async () => {
+    detectMock.mockResolvedValue([makeProvider('solo')]);
+    const { clearProvider, detectProviders, hasSelectedProvider, onProviderChanged } = useUnifiedProviders();
+    await detectProviders();
+    expect(get(hasSelectedProvider)).toBe(true);
+
+    const listener = vi.fn();
+    onProviderChanged(listener);
+    clearProvider();
+
+    expect(get(hasSelectedProvider)).toBe(false);
+    expect(listener).toHaveBeenCalledWith(undefined, expect.anything());
+  });
+
+  it('should clear the selection when selecting the empty uuid', async () => {
+    detectMock.mockResolvedValue([makeProvider('solo')]);
+    const { detectProviders, hasSelectedProvider, selectProvider } = useUnifiedProviders();
+    await detectProviders();
+
+    await expect(selectProvider('')).resolves.toBe(true);
+    expect(get(hasSelectedProvider)).toBe(false);
+  });
+
+  it('should restore the previously selected provider on detection', async () => {
+    localStorage.setItem('rotki-provider-preferences', JSON.stringify({ autoSelectSingle: true, lastSelectedUuid: 'b' }));
+    detectMock.mockResolvedValue([makeProvider('a'), makeProvider('b')]);
+    const { detectProviders, selectedProviderUuid } = useUnifiedProviders();
+
+    await detectProviders();
+
+    expect(get(selectedProviderUuid)).toBe('b');
+  });
+
+  it('should prompt for selection when multiple bridge providers exist in electron mode', async () => {
+    stubWalletBridge({});
+    detectMock.mockResolvedValue([makeProvider('a', 'bridge'), makeProvider('b', 'bridge')]);
+    const { detectProviders, hasSelectedProvider, showProviderSelection } = useUnifiedProviders();
+
+    await detectProviders();
+
+    expect(get(showProviderSelection)).toBe(true);
+    expect(get(hasSelectedProvider)).toBe(false);
+  });
+
+  it('should notify the bridge when a bridge provider is selected', async () => {
+    const selectProviderOnBridge = vi.fn().mockResolvedValue(undefined);
+    stubWalletBridge({ selectProvider: selectProviderOnBridge });
+    detectMock.mockResolvedValue([makeProvider('a', 'bridge'), makeProvider('b', 'bridge')]);
+    const { detectProviders, selectProvider } = useUnifiedProviders();
+    await detectProviders();
+
+    const ok = await selectProvider('a');
+
+    expect(ok).toBe(true);
+    expect(selectProviderOnBridge).toHaveBeenCalledWith('a');
+  });
+
+  it('should return false when the bridge rejects the selection', async () => {
+    const selectProviderOnBridge = vi.fn().mockRejectedValue(new Error('bridge down'));
+    stubWalletBridge({ selectProvider: selectProviderOnBridge });
+    detectMock.mockResolvedValue([makeProvider('a', 'bridge'), makeProvider('b', 'bridge')]);
+    const { detectProviders, selectProvider } = useUnifiedProviders();
+    await detectProviders();
+
+    await expect(selectProvider('a')).resolves.toBe(false);
+  });
+
+  it('should report selection state via the bridge in electron mode', async () => {
+    const getSelectedProvider = vi.fn().mockResolvedValue({ info: {} });
+    stubWalletBridge({ getSelectedProvider });
+    const { checkIfSelectedProvider } = useUnifiedProviders();
+
+    await expect(checkIfSelectedProvider()).resolves.toBe(true);
+
+    getSelectedProvider.mockResolvedValue(null);
+    await expect(checkIfSelectedProvider()).resolves.toBe(false);
+  });
+
+  it('should return false when the bridge selection check throws', async () => {
+    const getSelectedProvider = vi.fn().mockRejectedValue(new Error('boom'));
+    stubWalletBridge({ getSelectedProvider });
+    const { checkIfSelectedProvider } = useUnifiedProviders();
+
+    await expect(checkIfSelectedProvider()).resolves.toBe(false);
+  });
+
+  it('should fall back to local selection state in browser mode', async () => {
+    detectMock.mockResolvedValue([makeProvider('solo')]);
+    const { checkIfSelectedProvider, detectProviders } = useUnifiedProviders();
+    await detectProviders();
+
+    await expect(checkIfSelectedProvider()).resolves.toBe(true);
+  });
+
+  it('should reset all state on cleanup', async () => {
+    detectMock.mockResolvedValue([makeProvider('solo')]);
+    const { availableProviders, cleanup, detectProviders, hasSelectedProvider } = useUnifiedProviders();
+    await detectProviders();
+    expect(get(hasSelectedProvider)).toBe(true);
+
+    cleanup();
+
+    expect(get(availableProviders)).toEqual([]);
+    expect(get(hasSelectedProvider)).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of the frontend unit-coverage push for #11252, covering the provider-detection and connection layer of the wallet module.

Adds 5 spec files / 53 tests:

- `use-wallet-connection` - connect/disconnect flow, provider event listeners, chain/account state
- `use-unified-providers` - detection with retry, auto-selection, bridge/browser modes, listener notifications
- `provider-detection` - EIP-6963 announcement handling, legacy fallback, electron bridge providers
- `resource-management` - abort/timeout cleanup helper
- `bridge-config` - config constant guards

The rest of the wallet cluster (bridge transport, store, walletconnect) will follow in separate PRs.

Refs #11252

## Gates
- Full unit suite green (541 files / 5155 tests)
- Typecheck clean
- Lint: 0 errors