### PR TITLE
test(frontend): add wallet store and walletconnect coverage

### DIFF
--- a/frontend/app/src/modules/wallet/use-wallet-connect.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-connect.spec.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('./viem-client', () => ({
+  createViemWalletClient: vi.fn(() => ({ __client: true })),
+  getAddress: vi.fn((address: string) => address),
+}));
+
+const network1 = { id: 1, rpcUrls: { default: { http: ['https://rpc.one'] } } };
+const network8453 = { id: 8453, rpcUrls: { default: { http: ['https://rpc.base'] } } };
+
+vi.mock('./chains-viem', () => ({
+  SUPPORTED_WALLET_NETWORKS: [network1, network8453],
+  getWalletNetwork: vi.fn((chainId: bigint) => (chainId === 1n ? network1 : undefined)),
+}));
+
+// Set fresh per test; UniversalProvider.init reads it at call time.
+let mockProviderInstance: ReturnType<typeof createProvider>;
+
+vi.mock('@walletconnect/universal-provider', () => ({
+  UniversalProvider: { init: vi.fn(async () => mockProviderInstance) },
+}));
+
+interface WcSession {
+  topic: string;
+  namespaces: Record<string, { accounts: string[]; chains?: string[] }>;
+}
+
+function makeSession(accounts: string[], chains?: string[]): WcSession {
+  return { namespaces: { eip155: { accounts, chains } }, topic: 'topic-1' };
+}
+
+function createProvider(overrides: Record<string, unknown> = {}): Record<string, any> {
+  const handlers: Record<string, ((...args: any[]) => void)[]> = {};
+  return {
+    abortPairingAttempt: vi.fn(),
+    client: { ping: vi.fn(async () => {}) },
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+    emit: (event: string, ...args: unknown[]): void => {
+      (handlers[event] ?? []).forEach(handler => handler(...args));
+    },
+    isWalletConnect: true,
+    on: vi.fn((event: string, cb: (...args: any[]) => void) => {
+      (handlers[event] ??= []).push(cb);
+    }),
+    removeListener: vi.fn((event: string, cb: (...args: any[]) => void) => {
+      handlers[event] = (handlers[event] ?? []).filter(handler => handler !== cb);
+    }),
+    request: vi.fn(async () => {}),
+    session: undefined,
+    setDefaultChain: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function loadComposable(): Promise<ReturnType<typeof import('./use-wallet-connect').useWalletConnect>> {
+  const { useWalletConnect } = await import('./use-wallet-connect');
+  return useWalletConnect();
+}
+
+describe('modules/wallet/use-wallet-connect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockProviderInstance = createProvider();
+  });
+
+  describe('connect', () => {
+    it('should initialize the provider and request the eip155 namespace', async () => {
+      const wc = await loadComposable();
+      await wc.connect();
+
+      expect(mockProviderInstance.connect).toHaveBeenCalledTimes(1);
+      const arg = mockProviderInstance.connect.mock.calls[0][0];
+      expect(arg.optionalNamespaces.eip155.chains).toEqual(['eip155:1', 'eip155:8453']);
+      expect(arg.optionalNamespaces.eip155.rpcMap).toEqual({
+        'eip155:1': 'https://rpc.one',
+        'eip155:8453': 'https://rpc.base',
+      });
+    });
+
+    it('should sync an already-restored session and skip a new pairing', async () => {
+      mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
+      const wc = await loadComposable();
+      await wc.connect();
+
+      expect(mockProviderInstance.connect).not.toHaveBeenCalled();
+      expect(get(wc.connected)).toBe(true);
+      expect(get(wc.connectedAddress)).toBe('0xabc');
+      expect(get(wc.connectedChainId)).toBe(1);
+    });
+
+    it('should populate connection state from the session after pairing', async () => {
+      mockProviderInstance.connect = vi.fn(async () => {
+        mockProviderInstance.session = makeSession(['eip155:8453:0xdef'], ['eip155:8453', 'eip155:1']);
+      });
+      const wc = await loadComposable();
+      await wc.connect();
+
+      expect(get(wc.connected)).toBe(true);
+      expect(get(wc.connectedAddress)).toBe('0xdef');
+      expect(get(wc.connectedChainId)).toBe(8453);
+      expect(get(wc.supportedChainIds)).toEqual(['eip155:8453', 'eip155:1']);
+      expect(get(wc.preparing)).toBe(false);
+    });
+
+    it('should open the QR modal when the provider emits a display uri', async () => {
+      mockProviderInstance.connect = vi.fn(async () => {
+        mockProviderInstance.emit('display_uri', 'wc:pair-uri');
+      });
+      const wc = await loadComposable();
+      await wc.connect();
+
+      expect(get(wc.connectUri)).toBeUndefined(); // closed in finally
+      expect(get(wc.showConnectModal)).toBe(false);
+    });
+
+    it('should rethrow a pairing error that was not aborted by the user', async () => {
+      mockProviderInstance.connect = vi.fn(async () => {
+        throw new Error('pairing blew up');
+      });
+      const wc = await loadComposable();
+
+      await expect(wc.connect()).rejects.toThrow('pairing blew up');
+      expect(get(wc.preparing)).toBe(false);
+    });
+
+    it('should swallow the error when the user cancelled the pairing', async () => {
+      const wc = await loadComposable();
+      // Cancel mid-pairing, i.e. after connect() has reset connectAborted.
+      mockProviderInstance.connect = vi.fn(async () => {
+        wc.cancelConnect();
+        throw new Error('pairing aborted');
+      });
+
+      await expect(wc.connect()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('cancelConnect', () => {
+    it('should abort the pairing attempt and close the modal', async () => {
+      const wc = await loadComposable();
+      mockProviderInstance.connect = vi.fn(async () => {
+        mockProviderInstance.emit('display_uri', 'wc:pair-uri');
+        wc.cancelConnect();
+        throw new Error('aborted');
+      });
+
+      await wc.connect();
+
+      expect(mockProviderInstance.abortPairingAttempt).toHaveBeenCalledTimes(1);
+      expect(get(wc.showConnectModal)).toBe(false);
+      expect(get(wc.connectUri)).toBeUndefined();
+    });
+  });
+
+  describe('disconnect', () => {
+    it('should call provider.disconnect and reset state when a session exists', async () => {
+      mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
+      const wc = await loadComposable();
+      await wc.connect();
+      expect(get(wc.connected)).toBe(true);
+
+      await wc.disconnect();
+
+      expect(mockProviderInstance.disconnect).toHaveBeenCalledTimes(1);
+      expect(get(wc.connected)).toBe(false);
+      expect(get(wc.connectedAddress)).toBeUndefined();
+      expect(get(wc.connectedChainId)).toBeUndefined();
+    });
+
+    it('should reset state without calling provider.disconnect when there is no session', async () => {
+      const wc = await loadComposable();
+      await wc.disconnect();
+      expect(mockProviderInstance.disconnect).not.toHaveBeenCalled();
+      expect(get(wc.connected)).toBe(false);
+    });
+  });
+
+  describe('getWalletClient', () => {
+    it('should throw when no provider has been initialized', async () => {
+      const wc = await loadComposable();
+      expect(() => wc.getWalletClient()).toThrow('WalletConnect provider not available');
+    });
+
+    it('should build a viem client once the provider exists', async () => {
+      const wc = await loadComposable();
+      await wc.connect();
+      expect(wc.getWalletClient()).toEqual({ __client: true });
+    });
+  });
+
+  describe('switchNetwork', () => {
+    it('should request the chain switch and update the default chain', async () => {
+      const wc = await loadComposable();
+      await wc.connect();
+      await wc.switchNetwork(1n);
+
+      expect(mockProviderInstance.request).toHaveBeenCalledWith({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: '0x1' }],
+      });
+      expect(mockProviderInstance.setDefaultChain).toHaveBeenCalledWith('eip155:1', 'https://rpc.one');
+    });
+
+    it('should be a no-op when no provider is initialized', async () => {
+      const wc = await loadComposable();
+      await wc.switchNetwork(1n);
+      expect(mockProviderInstance.request).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkWalletConnection', () => {
+    it('should return early when there is no active WalletConnect session', async () => {
+      const wc = await loadComposable();
+      await wc.connect();
+      await wc.checkWalletConnection();
+      expect(mockProviderInstance.client.ping).not.toHaveBeenCalled();
+    });
+
+    it('should ping the session and resolve when the wallet responds', async () => {
+      mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
+      const wc = await loadComposable();
+      await wc.connect();
+
+      await wc.checkWalletConnection();
+
+      expect(mockProviderInstance.client.ping).toHaveBeenCalledWith({ topic: 'topic-1' });
+      expect(get(wc.preparing)).toBe(false);
+    });
+
+    it('should throw an inactive-wallet error when the ping rejects', async () => {
+      mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
+      mockProviderInstance.client.ping = vi.fn(async () => {
+        throw new Error('ping failed');
+      });
+      const wc = await loadComposable();
+      await wc.connect();
+
+      await expect(wc.checkWalletConnection()).rejects.toThrow(/wallet is inactive/);
+      expect(get(wc.preparing)).toBe(false);
+    });
+  });
+
+  describe('provider events', () => {
+    it('should update the address on accountsChanged and reset on empty', async () => {
+      mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
+      const wc = await loadComposable();
+      await wc.connect();
+
+      mockProviderInstance.emit('accountsChanged', ['eip155:1:0xdeadbeef']);
+      expect(get(wc.connectedAddress)).toBe('0xdeadbeef');
+      expect(get(wc.connected)).toBe(true);
+
+      mockProviderInstance.emit('accountsChanged', []);
+      expect(get(wc.connected)).toBe(false);
+      expect(get(wc.connectedAddress)).toBeUndefined();
+    });
+
+    it('should parse a hex chainChanged value', async () => {
+      const wc = await loadComposable();
+      await wc.connect();
+
+      mockProviderInstance.emit('chainChanged', '0xa');
+      expect(get(wc.connectedChainId)).toBe(10);
+    });
+
+    it('should reset state on disconnect and session_delete events', async () => {
+      mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
+      const wc = await loadComposable();
+      await wc.connect();
+      expect(get(wc.connected)).toBe(true);
+
+      mockProviderInstance.emit('disconnect');
+      expect(get(wc.connected)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
@@ -1,0 +1,310 @@
+import type { TransactionParams } from './types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { WALLET_MODES } from './constants';
+
+const txParams: TransactionParams = { amount: '1', chain: 'ethereum', native: true, to: '0xto' };
+
+// Stable mock fns + a per-test state bag. Because the store re-imports its
+// dependencies through `vi.resetModules()` and lazy dynamic imports, the mock
+// factories below return functions that read `mocks.state` at call time, so
+// each fresh import still sees the fakes wired up in beforeEach.
+const mocks = vi.hoisted((): {
+  handleTransactionError: ReturnType<typeof vi.fn>;
+  prepareTransactionPayload: ReturnType<typeof vi.fn>;
+  state: Record<string, any>;
+  validateTransactionRequirements: ReturnType<typeof vi.fn>;
+} => ({
+  handleTransactionError: vi.fn(),
+  prepareTransactionPayload: vi.fn(),
+  state: {},
+  validateTransactionRequirements: vi.fn(),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/modules/wallet/viem-client', () => ({
+  getAddress: vi.fn((address: string) => address),
+  isHex: vi.fn(() => true),
+}));
+
+vi.mock('./transaction-helpers', () => ({
+  handleTransactionError: mocks.handleTransactionError,
+  prepareTransactionPayload: mocks.prepareTransactionPayload,
+  validateTransactionRequirements: mocks.validateTransactionRequirements,
+}));
+
+type Fake = Record<string, any>;
+
+vi.mock('./bridge/use-wallet-proxy', () => ({ useWalletProxy: (): Fake => mocks.state.walletProxy }));
+vi.mock('./providers/use-unified-providers', () => ({ useUnifiedProviders: (): Fake => mocks.state.unifiedProviders }));
+vi.mock('./use-transaction-manager', () => ({ useTransactionManager: (): Fake => mocks.state.transactionManager }));
+vi.mock('./send/use-trade-api', () => ({ useTradeApi: (): Fake => mocks.state.tradeApi }));
+vi.mock('./use-wallet-connect', () => ({ useWalletConnect: (): Fake => mocks.state.walletConnect }));
+vi.mock('./bridge/use-injected-wallet', () => ({ useInjectedWallet: (): Fake => mocks.state.injectedWallet }));
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({ useInterop: (): Fake => ({ isPackaged: mocks.state.isPackaged }) }));
+vi.mock('@/modules/wallet/use-wallet-helper', () => ({ useWalletHelper: (): Fake => mocks.state.walletHelper }));
+vi.mock('@/modules/core/common/use-supported-chains', () => ({ useSupportedChains: (): Fake => mocks.state.supportedChains }));
+
+function makeInjectedWallet(): Record<string, any> {
+  return {
+    connected: ref(false),
+    connectedAddress: ref<string>(),
+    connectedChainId: ref<number>(),
+    connectToSelectedProvider: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => {}),
+    getWalletClient: vi.fn(() => ({
+      getBalance: vi.fn(async () => 5n),
+      getGasPrice: vi.fn(async () => 2n),
+      sendTransaction: vi.fn(async () => '0xhash'),
+    })),
+    isConnecting: ref(false),
+    switchNetwork: vi.fn(async () => {}),
+  };
+}
+
+function makeWalletConnect(): Record<string, any> {
+  return {
+    checkWalletConnection: vi.fn(async () => {}),
+    connect: vi.fn(async () => {}),
+    connected: ref(false),
+    connectedAddress: ref<string>(),
+    connectedChainId: ref<number>(),
+    disconnect: vi.fn(async () => {}),
+    getWalletClient: vi.fn(() => ({ sendTransaction: vi.fn(async () => '0xwc') })),
+    supportedChainIds: ref<string[]>([]),
+    switchNetwork: vi.fn(async () => {}),
+  };
+}
+
+async function getStore(): Promise<ReturnType<typeof import('./use-wallet-store').useWalletStore>> {
+  const { useWalletStore } = await import('./use-wallet-store');
+  return useWalletStore();
+}
+
+describe('modules/wallet/use-wallet-store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    setActivePinia(createPinia());
+
+    mocks.state = {
+      injectedWallet: makeInjectedWallet(),
+      isPackaged: ref<boolean>(false),
+      supportedChains: { getEvmChainName: vi.fn(() => 'ethereum') },
+      tradeApi: { prepareERC20Transfer: vi.fn(), prepareNativeTransfer: vi.fn() },
+      transactionManager: {
+        handleTransactionSuccess: vi.fn(async () => {}),
+        recentTransactions: ref([]),
+        updateTransactionStatus: vi.fn(),
+      },
+      unifiedProviders: {
+        availableProviders: ref<{ info: { uuid: string } }[]>([]),
+        checkIfSelectedProvider: vi.fn(async () => true),
+        clearProvider: vi.fn(),
+        detectProviders: vi.fn(async () => {}),
+        selectProvider: vi.fn(async () => {}),
+        showProviderSelection: ref<boolean>(false),
+      },
+      walletConnect: makeWalletConnect(),
+      walletHelper: {
+        getChainFromChainId: vi.fn((chainId: number) => `chain-${chainId}`),
+        getChainIdFromNamespace: vi.fn((ns: string) => Number(ns.split(':').pop())),
+      },
+      walletProxy: { setupProxy: vi.fn(async () => {}) },
+    };
+  });
+
+  const injected = (): Record<string, any> => mocks.state.injectedWallet;
+  const providers = (): Record<string, any> => mocks.state.unifiedProviders;
+  const walletConnect = (): Record<string, any> => mocks.state.walletConnect;
+
+  it('should start in local-bridge mode and disconnected', async () => {
+    const store = await getStore();
+    expect(get(store.walletMode)).toBe(WALLET_MODES.LOCAL_BRIDGE);
+    expect(get(store.connected)).toBe(false);
+    expect(get(store.isWalletConnect)).toBe(false);
+  });
+
+  it('should reflect walletconnect mode in isWalletConnect', async () => {
+    const store = await getStore();
+    store.walletMode = WALLET_MODES.WALLET_CONNECT;
+    await nextTick();
+    expect(get(store.isWalletConnect)).toBe(true);
+  });
+
+  describe('connect (local bridge)', () => {
+    it('should connect to the already-selected provider', async () => {
+      providers().checkIfSelectedProvider.mockResolvedValue(true);
+      const store = await getStore();
+      await store.connect();
+
+      expect(injected().connectToSelectedProvider).toHaveBeenCalledTimes(1);
+      expect(providers().detectProviders).not.toHaveBeenCalled();
+    });
+
+    it('should auto-select the sole detected provider', async () => {
+      providers().checkIfSelectedProvider.mockResolvedValue(false);
+      set(providers().availableProviders, [{ info: { uuid: 'only-one' } }]);
+      const store = await getStore();
+      await store.connect();
+
+      expect(providers().detectProviders).toHaveBeenCalledTimes(1);
+      expect(providers().selectProvider).toHaveBeenCalledWith('only-one');
+      expect(injected().connectToSelectedProvider).toHaveBeenCalledTimes(1);
+    });
+
+    it('should show the provider selection dialog when several are detected', async () => {
+      providers().checkIfSelectedProvider.mockResolvedValue(false);
+      set(providers().availableProviders, [{ info: { uuid: 'a' } }, { info: { uuid: 'b' } }]);
+      const store = await getStore();
+      await store.connect();
+
+      expect(get(providers().showProviderSelection)).toBe(true);
+      expect(providers().selectProvider).not.toHaveBeenCalled();
+    });
+
+    it('should throw when no providers are detected', async () => {
+      providers().checkIfSelectedProvider.mockResolvedValue(false);
+      set(providers().availableProviders, []);
+      const store = await getStore();
+
+      await expect(store.connect()).rejects.toThrow('No wallet providers detected');
+    });
+
+    it('should set up the proxy when running packaged', async () => {
+      set(mocks.state.isPackaged, true);
+      const store = await getStore();
+      await store.connect();
+      expect(mocks.state.walletProxy.setupProxy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not set up the proxy when not packaged', async () => {
+      const store = await getStore();
+      await store.connect();
+      expect(mocks.state.walletProxy.setupProxy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('connect (walletconnect)', () => {
+    it('should delegate connection to the walletconnect backend', async () => {
+      const store = await getStore();
+      store.walletMode = WALLET_MODES.WALLET_CONNECT;
+      await nextTick();
+
+      await store.connect();
+      expect(walletConnect().connect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('disconnect', () => {
+    it('should disconnect the injected wallet and clear the provider in local bridge', async () => {
+      const store = await getStore();
+      await store.connect(); // initialise injected instance
+
+      await store.disconnect();
+
+      expect(injected().disconnect).toHaveBeenCalledTimes(1);
+      expect(providers().clearProvider).toHaveBeenCalled();
+      expect(get(store.connected)).toBe(false);
+      expect(get(store.isDisconnecting)).toBe(false);
+    });
+  });
+
+  describe('switchNetwork', () => {
+    it('should delegate to the injected wallet in local bridge', async () => {
+      const store = await getStore();
+      await store.switchNetwork(10n);
+      expect(injected().switchNetwork).toHaveBeenCalledWith(10n);
+    });
+
+    it('should delegate to walletconnect in walletconnect mode', async () => {
+      const store = await getStore();
+      store.walletMode = WALLET_MODES.WALLET_CONNECT;
+      await nextTick();
+      await store.switchNetwork(56n);
+      expect(walletConnect().switchNetwork).toHaveBeenCalledWith(56n);
+    });
+  });
+
+  describe('supportedChainsForConnectedAccount', () => {
+    it('should list all supported chains in local bridge mode', async () => {
+      const store = await getStore();
+      expect(get(store.supportedChainsForConnectedAccount)).toEqual([
+        'chain-1',
+        'chain-8453',
+        'chain-42161',
+        'chain-10',
+        'chain-56',
+        'chain-100',
+        'chain-137',
+        'chain-534352',
+      ]);
+    });
+  });
+
+  describe('getGasFeeForChain', () => {
+    it('should return zero when no address is connected', async () => {
+      const store = await getStore();
+      await store.connect();
+      const result = await store.getGasFeeForChain();
+      expect(result).toEqual({ gasFee: '0', maxAmount: '0' });
+    });
+  });
+
+  describe('sendTransaction', () => {
+    it('should prepare, execute and record a successful transaction', async () => {
+      mocks.validateTransactionRequirements.mockReturnValue({
+        chainId: 1,
+        evmChain: 'ethereum',
+        fromAddress: '0xfrom',
+      });
+      mocks.prepareTransactionPayload.mockResolvedValue({
+        data: '0xdata',
+        from: '0xfrom',
+        nonce: 1,
+        to: '0xto',
+        value: 0n,
+      });
+
+      const store = await getStore();
+      await store.connect();
+      store.connectedAddress = '0xfrom';
+      store.connectedChainId = 1;
+
+      const hash = await store.sendTransaction(txParams);
+
+      expect(hash).toBe('0xhash');
+      expect(mocks.state.transactionManager.handleTransactionSuccess).toHaveBeenCalledTimes(1);
+      expect(get(store.preparing)).toBe(false);
+      expect(get(store.waitingForWalletConfirmation)).toBe(false);
+    });
+
+    it('should route a failure through handleTransactionError and rethrow', async () => {
+      mocks.validateTransactionRequirements.mockImplementation(() => {
+        throw new Error('bad requirements');
+      });
+
+      const store = await getStore();
+      await store.connect();
+
+      await expect(store.sendTransaction(txParams)).rejects.toThrow('bad requirements');
+      expect(mocks.handleTransactionError).toHaveBeenCalledTimes(1);
+    });
+
+    it('should check the walletconnect connection before sending', async () => {
+      mocks.validateTransactionRequirements.mockImplementation(() => {
+        throw new Error('stop here');
+      });
+
+      const store = await getStore();
+      store.walletMode = WALLET_MODES.WALLET_CONNECT;
+      await nextTick();
+
+      await expect(store.sendTransaction(txParams)).rejects.toThrow('stop here');
+      expect(walletConnect().checkWalletConnection).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Adds unit coverage for the two remaining orchestration-layer pieces of the wallet stack.

### `use-wallet-connect`
Covers the WalletConnect backend (module-level `UniversalProvider` singleton), driven via `vi.resetModules()` + a fake event-emitting provider:
- `connect` — fresh pairing (requests the `eip155` namespace with chains + rpcMap), an already-restored session (syncs and skips a new pairing), and user-aborted pairing (swallowed vs rethrown).
- `cancelConnect` — aborts the pairing attempt and closes the QR modal.
- `disconnect`, `getWalletClient` (throws with no provider), `switchNetwork`, and `checkWalletConnection` (ping success, timeout/failure, no-session early return).
- Provider events: `accountsChanged`, `chainChanged`, `disconnect`/`session_delete`.

### `use-wallet-store`
Covers the Pinia store that orchestrates both wallet backends:
- Initial state and `isWalletConnect` mode toggle.
- `connect` in local-bridge mode: already-selected provider, sole detected provider (auto-select), several detected (selection dialog), none detected (throws), and packaged proxy setup. Plus delegation to the WalletConnect backend.
- `disconnect`, `switchNetwork` (both modes), `supportedChainsForConnectedAccount`, and `getGasFeeForChain` (zero when no address).
- `sendTransaction`: successful prepare/execute/record, failure routed through `handleTransactionError` and rethrown, and the WalletConnect connection precheck.

36 tests. `test:unit`, `typecheck`, and lint all green.

Refs #11252
