### PR TITLE
Single active tab in the browser (#3156)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`2922` The Docker version of rotki can now require authentication. When set up with the session key environment variable it issues a secure, HttpOnly session cookie on login and rejects unauthenticated API and websocket access, so a rotki instance reachable on your network is no longer open to anyone who can reach its port.
+* :feature:`3156` When rotki runs in a browser (Docker), only one session can be active at a time. Logging in from another browser or window takes over the session and signs the previous one out, and opening rotki in a second tab of the same browser now pauses the older tab with a prompt to continue in whichever tab you choose, so two frontends no longer compete over one backend.
 * :feature:`-` Kinetiq liquid staking on HyperEVM is now supported. Staking, withdrawals (queued and instant) are decoded, and the HYPE value of pending withdrawals is detected in your balances. Also Kinetiq earn vaults are supported.
 * :feature:`12559` History events can now be filtered by an amount range. Two new filters, minimum and maximum amount, are available in the history events view and can be combined with the asset filter to e.g. find all EURe payments between 25 and 30 EURe.
 * :feature:`-` Add support for CoinEx exchange.

--- a/docs/dev_changelog.rst
+++ b/docs/dev_changelog.rst
@@ -7,6 +7,16 @@ This changelog documents API changes, schema modifications, and other developer-
 Unreleased
 ==========
 
+Session Cookie Authentication (Docker)
+--------------------------------------
+
+When rotki is set up with the ``ROTKI_SESSION_KEY`` environment variable (the Docker/web deployment), the API enforces a single active session backed by an ``HttpOnly`` cookie. Requests without a valid session cookie are rejected with ``401`` and the websocket handshake is refused. Logging in a user establishes the session and revokes any previous one, so only one frontend is served at a time.
+
+* **New Endpoint**: ``POST /api/(version)/users/(name)/authenticate``
+
+  - Accepts the account ``password`` and issues the session cookie before the asynchronous unlock, so the gated task poll and websocket handshake are authorized.
+  - Has no effect when ``ROTKI_SESSION_KEY`` is unset (desktop/Electron deployment), where the API stays session-less as before.
+
 Spam Token Endpoint Renamed
 ----------------------------
 

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5687,6 +5687,11 @@
     "historical_price_oracles_v1_43": "Prioritize DefiLlama for historical prices (less rate limiting)",
     "keep_current": "Keep current"
   },
+  "single_tab": {
+    "action": "Use rotki in this tab",
+    "message": "rotki was opened in another browser tab. Only one tab can be active at a time, so this tab has been paused to avoid interfering with your session.",
+    "title": "rotki is active in another tab"
+  },
   "snapshot_action_button": {
     "force_save": "Force save",
     "ignore_errors_label": "Ignore Errors",

--- a/frontend/app/src/modules/session/single-tab/SingleTabOverlay.vue
+++ b/frontend/app/src/modules/session/single-tab/SingleTabOverlay.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { useSingleTab } from '@/modules/session/single-tab/use-single-tab';
+
+const { t } = useI18n({ useScope: 'global' });
+
+const { isActiveTab, reclaim } = useSingleTab();
+const { logged } = storeToRefs(useSessionAuthStore());
+
+const visible = computed<boolean>(() => get(logged) && !get(isActiveTab));
+</script>
+
+<template>
+  <Transition
+    enter-from-class="opacity-0"
+    enter-to-class="opacity-1"
+    enter-active-class="transition duration-300"
+    leave-from-class="opacity-1"
+    leave-to-class="opacity-0"
+    leave-active-class="transition duration-100"
+  >
+    <div
+      v-if="visible"
+      class="fixed top-0 left-0 w-full h-full bg-white dark:bg-rui-grey-900 z-[9999] flex items-center justify-center p-4"
+    >
+      <div class="flex flex-col gap-6 justify-center items-center max-w-md text-center">
+        <RuiIcon
+          name="lu-app-window"
+          size="48"
+          class="text-rui-text-secondary"
+        />
+        <div class="flex flex-col gap-2">
+          <h4 class="text-h6 text-rui-text">
+            {{ t('single_tab.title') }}
+          </h4>
+          <p class="mb-0 text-rui-text-secondary">
+            {{ t('single_tab.message') }}
+          </p>
+        </div>
+        <RuiButton
+          color="primary"
+          @click="reclaim()"
+        >
+          {{ t('single_tab.action') }}
+        </RuiButton>
+      </div>
+    </div>
+  </Transition>
+</template>

--- a/frontend/app/src/modules/session/single-tab/use-single-tab-guard.spec.ts
+++ b/frontend/app/src/modules/session/single-tab/use-single-tab-guard.spec.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type EffectScope, nextTick } from 'vue';
+import { useSingleTabGuard } from './use-single-tab-guard';
+
+const logged = ref<boolean>(false);
+const isActiveTab = ref<boolean>(true);
+const supported = ref<boolean>(true);
+const claim = vi.fn(() => set(isActiveTab, true));
+const release = vi.fn(() => set(isActiveTab, true));
+const start = vi.fn();
+const stop = vi.fn();
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: (): object => ({ logged }),
+}));
+
+vi.mock('@/modules/shell/app/use-monitor-service', () => ({
+  useMonitorService: (): object => ({ start, stop }),
+}));
+
+vi.mock('@/modules/session/single-tab/use-single-tab', () => ({
+  useSingleTab: (): object => ({
+    claim,
+    isActiveTab,
+    release,
+    get supported(): boolean {
+      return get(supported);
+    },
+  }),
+}));
+
+describe('useSingleTabGuard', () => {
+  let scope: EffectScope;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(logged, false);
+    set(isActiveTab, true);
+    set(supported, true);
+    scope = effectScope();
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  it('should claim ownership when the user logs in', async () => {
+    scope.run(() => useSingleTabGuard());
+    set(logged, true);
+    await nextTick();
+    expect(claim).toHaveBeenCalledOnce();
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it('should release ownership when the user logs out', async () => {
+    set(logged, true);
+    scope.run(() => useSingleTabGuard());
+    set(logged, false);
+    await nextTick();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('should stop the monitor when another tab takes over', async () => {
+    set(logged, true);
+    scope.run(() => useSingleTabGuard());
+    set(isActiveTab, false);
+    await nextTick();
+    expect(stop).toHaveBeenCalledOnce();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('should not restart the monitor in place when ownership returns (reclaim reloads)', async () => {
+    set(logged, true);
+    scope.run(() => useSingleTabGuard());
+    set(isActiveTab, false);
+    await nextTick();
+    set(isActiveTab, true);
+    await nextTick();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('should not touch the monitor on ownership changes while logged out', async () => {
+    scope.run(() => useSingleTabGuard());
+    set(isActiveTab, false);
+    await nextTick();
+    set(isActiveTab, true);
+    await nextTick();
+    expect(stop).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing when coordination is unsupported', async () => {
+    set(supported, false);
+    scope.run(() => useSingleTabGuard());
+    set(logged, true);
+    await nextTick();
+    set(isActiveTab, false);
+    await nextTick();
+    expect(claim).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/session/single-tab/use-single-tab-guard.ts
+++ b/frontend/app/src/modules/session/single-tab/use-single-tab-guard.ts
@@ -1,0 +1,38 @@
+import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { useSingleTab } from '@/modules/session/single-tab/use-single-tab';
+import { useMonitorService } from '@/modules/shell/app/use-monitor-service';
+
+/**
+ * Wires same-browser tab coordination ([[useSingleTab]]) into the session lifecycle.
+ * Mounted once in `AppHost.vue`, alongside `useSessionStateCleaner`.
+ *
+ * - On login this tab claims ownership, superseding any older tab of the same browser.
+ * - On logout it releases the claim so a backgrounded tab does not keep the lock.
+ * - When a newer tab takes over, the monitor is stopped here (websocket + all pollers)
+ *   without a backend logout. Reclaiming is a full page reload (see `SingleTabOverlay`),
+ *   which reboots the tab clean, so there is no in-place restart to do here.
+ */
+export function useSingleTabGuard(): void {
+  const { claim, isActiveTab, release, supported } = useSingleTab();
+  if (!supported)
+    return;
+
+  const { logged } = storeToRefs(useSessionAuthStore());
+  const { stop } = useMonitorService();
+
+  watch(logged, (isLogged, wasLogged) => {
+    if (isLogged)
+      claim();
+    else if (wasLogged)
+      release();
+  }, { immediate: true });
+
+  watch(isActiveTab, (isActive) => {
+    // A newer tab took over: pause this one (stop the websocket + all pollers) without a
+    // backend logout. Only meaningful while logged in — a claim heard on the login screen
+    // is a no-op. `immediate` covers a takeover that lands during the login->app remount,
+    // when this watcher would otherwise miss the already-false value.
+    if (!isActive && get(logged))
+      stop();
+  }, { immediate: true });
+}

--- a/frontend/app/src/modules/session/single-tab/use-single-tab.spec.ts
+++ b/frontend/app/src/modules/session/single-tab/use-single-tab.spec.ts
@@ -1,0 +1,256 @@
+import type { UseSingleTabReturn } from './use-single-tab';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const isPackaged = ref<boolean>(false);
+const reload = vi.fn();
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): object => ({
+    get isPackaged(): boolean {
+      return get(isPackaged);
+    },
+  }),
+}));
+
+interface TabMessage {
+  type: 'claim' | 'release';
+  tabId: string;
+}
+
+class FakeBroadcastChannel {
+  static instances: FakeBroadcastChannel[] = [];
+  readonly name: string;
+  onmessage: ((event: MessageEvent<TabMessage>) => void) | null = null;
+  readonly posted: TabMessage[] = [];
+  closed = false;
+
+  constructor(name: string) {
+    this.name = name;
+    FakeBroadcastChannel.instances.push(this);
+  }
+
+  postMessage(data: TabMessage): void {
+    this.posted.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+const originalAddEventListener = window.addEventListener.bind(window);
+let pagehideHandlers: EventListener[] = [];
+
+async function loadSingleTab(): Promise<UseSingleTabReturn> {
+  vi.resetModules();
+  const module = await import('./use-single-tab');
+  return module.useSingleTab();
+}
+
+function receive(channel: FakeBroadcastChannel, data: TabMessage): void {
+  channel.onmessage?.({ data } as MessageEvent<TabMessage>);
+}
+
+function postedOfType(channel: FakeBroadcastChannel, type: TabMessage['type']): TabMessage[] {
+  return channel.posted.filter(message => message.type === type);
+}
+
+describe('useSingleTab', () => {
+  beforeEach(() => {
+    set(isPackaged, false);
+    reload.mockClear();
+    FakeBroadcastChannel.instances = [];
+    pagehideHandlers = [];
+    vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel);
+    vi.stubGlobal('location', { reload });
+    // Capture the pagehide listeners each load registers so they can be torn down per test —
+    // the createGlobalState singleton never disposes, so they would otherwise accumulate.
+    vi.spyOn(window, 'addEventListener').mockImplementation(((type: string, handler: EventListener, options?: unknown): void => {
+      if (type === 'pagehide')
+        pagehideHandlers.push(handler);
+      originalAddEventListener(type, handler, options as AddEventListenerOptions);
+    }) as typeof window.addEventListener);
+  });
+
+  afterEach(() => {
+    for (const handler of pagehideHandlers)
+      window.removeEventListener('pagehide', handler);
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('should be supported in the web/docker build with BroadcastChannel available', async () => {
+    const { supported } = await loadSingleTab();
+    expect(supported).toBe(true);
+  });
+
+  it('should broadcast a claim and keep this tab active', async () => {
+    const { claim, isActiveTab } = await loadSingleTab();
+    claim();
+
+    expect(FakeBroadcastChannel.instances).toHaveLength(1);
+    const [channel] = FakeBroadcastChannel.instances;
+    expect(channel.name).toBe('rotki.session.single-tab');
+    expect(postedOfType(channel, 'claim')).toHaveLength(1);
+    expect(get(isActiveTab)).toBe(true);
+  });
+
+  it('should deactivate this tab when another tab claims the session', async () => {
+    const { claim, isActiveTab } = await loadSingleTab();
+    claim();
+    const [channel] = FakeBroadcastChannel.instances;
+
+    receive(channel, { tabId: 'another-tab', type: 'claim' });
+
+    expect(get(isActiveTab)).toBe(false);
+  });
+
+  it('should ignore its own claim echoed back on the channel', async () => {
+    const { claim, isActiveTab } = await loadSingleTab();
+    claim();
+    const [channel] = FakeBroadcastChannel.instances;
+    const ownTabId = channel.posted[0].tabId;
+
+    receive(channel, { tabId: ownTabId, type: 'claim' });
+
+    expect(get(isActiveTab)).toBe(true);
+  });
+
+  it('should reactivate and post a fresh claim when it claims again after takeover', async () => {
+    const { claim, isActiveTab } = await loadSingleTab();
+    claim();
+    const [channel] = FakeBroadcastChannel.instances;
+    receive(channel, { tabId: 'another-tab', type: 'claim' });
+    expect(get(isActiveTab)).toBe(false);
+
+    claim();
+
+    expect(get(isActiveTab)).toBe(true);
+    expect(postedOfType(channel, 'claim')).toHaveLength(2);
+  });
+
+  it('should claim and reload on reclaim', async () => {
+    const { reclaim } = await loadSingleTab();
+    reclaim();
+
+    const [channel] = FakeBroadcastChannel.instances;
+    expect(postedOfType(channel, 'claim')).toHaveLength(1);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('should take over after a release once it has been superseded', async () => {
+    const { claim, isActiveTab } = await loadSingleTab();
+    claim();
+    const [channel] = FakeBroadcastChannel.instances;
+    receive(channel, { tabId: 'another-tab', type: 'claim' });
+    expect(get(isActiveTab)).toBe(false);
+
+    vi.useFakeTimers();
+    receive(channel, { tabId: 'another-tab', type: 'release' });
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('should ignore a release while it is still the active tab', async () => {
+    const { claim } = await loadSingleTab();
+    claim();
+    const [channel] = FakeBroadcastChannel.instances;
+
+    vi.useFakeTimers();
+    receive(channel, { tabId: 'another-tab', type: 'release' });
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('should cancel a queued takeover when another tab claims first', async () => {
+    const { claim, isActiveTab } = await loadSingleTab();
+    claim();
+    const [channel] = FakeBroadcastChannel.instances;
+    receive(channel, { tabId: 'tab-a', type: 'claim' });
+
+    vi.useFakeTimers();
+    receive(channel, { tabId: 'tab-a', type: 'release' });
+    receive(channel, { tabId: 'tab-b', type: 'claim' });
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(get(isActiveTab)).toBe(false);
+  });
+
+  it('should broadcast a release on logout when it is the active tab', async () => {
+    const { claim, release } = await loadSingleTab();
+    claim();
+    const [channel] = FakeBroadcastChannel.instances;
+
+    release();
+
+    expect(postedOfType(channel, 'release')).toHaveLength(1);
+    expect(channel.closed).toBe(true);
+  });
+
+  it('should not broadcast a release on logout when already superseded', async () => {
+    const { claim, release } = await loadSingleTab();
+    claim();
+    const [channel] = FakeBroadcastChannel.instances;
+    receive(channel, { tabId: 'another-tab', type: 'claim' });
+
+    release();
+
+    expect(postedOfType(channel, 'release')).toHaveLength(0);
+  });
+
+  it('should hand off on pagehide when it is the active tab', async () => {
+    const { claim } = await loadSingleTab();
+    claim();
+    const [channel] = FakeBroadcastChannel.instances;
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(postedOfType(channel, 'release')).toHaveLength(1);
+  });
+
+  it('should not hand off on pagehide when superseded', async () => {
+    const { claim } = await loadSingleTab();
+    claim();
+    const [channel] = FakeBroadcastChannel.instances;
+    receive(channel, { tabId: 'another-tab', type: 'claim' });
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(postedOfType(channel, 'release')).toHaveLength(0);
+  });
+
+  it('should not hand off on pagehide during its own reclaim reload', async () => {
+    const { reclaim } = await loadSingleTab();
+    reclaim();
+    const [channel] = FakeBroadcastChannel.instances;
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(postedOfType(channel, 'release')).toHaveLength(0);
+  });
+
+  it('should be inert in the electron build', async () => {
+    set(isPackaged, true);
+    const { claim, isActiveTab, supported } = await loadSingleTab();
+
+    claim();
+
+    expect(supported).toBe(false);
+    expect(FakeBroadcastChannel.instances).toHaveLength(0);
+    expect(get(isActiveTab)).toBe(true);
+  });
+
+  it('should be unsupported when BroadcastChannel is unavailable', async () => {
+    vi.stubGlobal('BroadcastChannel', undefined);
+    const { claim, supported } = await loadSingleTab();
+
+    claim();
+
+    expect(supported).toBe(false);
+    expect(FakeBroadcastChannel.instances).toHaveLength(0);
+  });
+});

--- a/frontend/app/src/modules/session/single-tab/use-single-tab.ts
+++ b/frontend/app/src/modules/session/single-tab/use-single-tab.ts
@@ -1,0 +1,156 @@
+import type { Ref } from 'vue';
+import { useInterop } from '@/modules/shell/app/use-electron-interop';
+
+const CHANNEL_NAME = 'rotki.session.single-tab';
+// Upper bound for the random delay before a paused tab takes over a vacated session. Staggers
+// concurrent paused tabs so the first to fire claims and cancels the rest (see scheduleReclaim).
+const RECLAIM_MAX_JITTER_MS = 400;
+
+interface TabMessage {
+  type: 'claim' | 'release';
+  tabId: string;
+}
+
+export interface UseSingleTabReturn {
+  /** Whether this tab currently owns the session. `false` means another tab took over. */
+  isActiveTab: Readonly<Ref<boolean>>;
+  /** True when cross-tab coordination is available (web/docker + BroadcastChannel present). */
+  supported: boolean;
+  /** Announce this tab as the sole active session, superseding every other tab. */
+  claim: () => void;
+  /** Become active and reboot this tab clean (claim + full reload). */
+  reclaim: () => void;
+  /** Stop coordinating (logout): hand off to any paused tab, then drop the channel. */
+  release: () => void;
+}
+
+// A collision-safe id that does not depend on crypto.randomUUID, which is undefined outside
+// a secure context — a Docker instance reached over plain http on a LAN IP is not one.
+function createTabId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Same-browser single-active-tab coordination for the Docker/web deployment (issue #3156).
+ *
+ * The backend cannot tell two tabs of the same browser apart — they share one session
+ * cookie — so ownership is negotiated purely on the frontend over a `BroadcastChannel`.
+ * The newest tab to `claim()` becomes the active one; every other tab hears the claim and
+ * flips `isActiveTab` to `false`, which the guard uses to stop its polling and websocket.
+ * When the active tab goes away (close/reload/logout) it broadcasts a `release`, so a paused
+ * tab takes over instead of being stranded behind the overlay.
+ * Electron is inert here (a single window, session lifecycle already tied to the backend).
+ */
+function createSingleTab(): UseSingleTabReturn {
+  const { isPackaged } = useInterop();
+  const supported = !isPackaged && typeof BroadcastChannel !== 'undefined';
+  const active = ref<boolean>(true);
+  const tabId = supported ? createTabId() : '';
+
+  let channel: BroadcastChannel | undefined;
+  let reclaimTimer: ReturnType<typeof setTimeout> | undefined;
+  // Set right before an intentional reload (reclaim) so our own `pagehide` does not broadcast
+  // a release — that would tell the tab we just paused to take over and bounce ownership back.
+  let reloading = false;
+
+  function cancelScheduledReclaim(): void {
+    if (reclaimTimer !== undefined) {
+      clearTimeout(reclaimTimer);
+      reclaimTimer = undefined;
+    }
+  }
+
+  function scheduleReclaim(): void {
+    if (reclaimTimer !== undefined)
+      return;
+    reclaimTimer = setTimeout(() => {
+      reclaimTimer = undefined;
+      reclaim();
+    }, Math.floor(Math.random() * RECLAIM_MAX_JITTER_MS));
+  }
+
+  function ensureChannel(): BroadcastChannel | undefined {
+    if (!supported)
+      return undefined;
+    if (!channel) {
+      channel = new BroadcastChannel(CHANNEL_NAME);
+      channel.onmessage = (event: MessageEvent<TabMessage>): void => {
+        const data = event.data;
+        // Our own messages are never echoed back, but guard on tabId defensively.
+        if (!data || data.tabId === tabId)
+          return;
+        if (data.type === 'claim') {
+          // Another tab became active: yield, and drop any takeover we had queued.
+          cancelScheduledReclaim();
+          set(active, false);
+        }
+        else if (data.type === 'release' && !get(active)) {
+          // The active tab is leaving. Queue a takeover after a short random delay so that,
+          // with several paused tabs, the first to fire claims (which reaches the others and
+          // cancels their timers) instead of all reloading at once.
+          scheduleReclaim();
+        }
+      };
+    }
+    return channel;
+  }
+
+  function claim(): void {
+    if (!supported)
+      return;
+    cancelScheduledReclaim();
+    set(active, true);
+    ensureChannel()?.postMessage({ tabId, type: 'claim' } satisfies TabMessage);
+  }
+
+  function reclaim(): void {
+    if (!supported)
+      return;
+    // Claim first (so the other tab pauses), then a full reload re-resumes the session and
+    // re-fetches through the normal unlock flow — the reclaimed tab never carries stale state
+    // or tasks stranded by the takeover (the backend serves a single frontend at a time).
+    reloading = true;
+    claim();
+    window.location.reload();
+  }
+
+  function broadcastRelease(): void {
+    // Only the active tab hands off; a paused tab closing must not wake the others.
+    if (!supported || !get(active))
+      return;
+    ensureChannel()?.postMessage({ tabId, type: 'release' } satisfies TabMessage);
+  }
+
+  function release(): void {
+    // Logout: hand off first (a paused tab reloads and lands on login too, since the shared
+    // session is now gone), then drop the channel and reset for a future login on this tab.
+    broadcastRelease();
+    cancelScheduledReclaim();
+    set(active, true);
+    channel?.close();
+    channel = undefined;
+  }
+
+  if (supported) {
+    // Closing or reloading the active tab hands the session to a surviving tab, so a lone tab
+    // is not stranded behind the "active in another tab" overlay. Skipped for our own reclaim
+    // reload, which already re-establishes ownership after booting.
+    window.addEventListener('pagehide', () => {
+      if (!reloading)
+        broadcastRelease();
+    });
+  }
+
+  return {
+    claim,
+    isActiveTab: readonly(active),
+    reclaim,
+    release,
+    supported,
+  };
+}
+
+// A global singleton (like the monitor/websocket services): the channel and tab id must
+// outlive layout remounts — the login-to-app layout switch would otherwise tear the shared
+// state down and drop the channel between subscribers.
+export const useSingleTab = createGlobalState(createSingleTab);

--- a/frontend/app/src/modules/shell/app/AppHost.vue
+++ b/frontend/app/src/modules/shell/app/AppHost.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { checkIfDevelopment, startPromise } from '@shared/utils';
 import { useSigil } from '@/modules/core/sigil/use-sigil';
+import SingleTabOverlay from '@/modules/session/single-tab/SingleTabOverlay.vue';
+import { useSingleTabGuard } from '@/modules/session/single-tab/use-single-tab-guard';
 import { useLocale } from '@/modules/session/use-locale';
 import { useSessionStateCleaner } from '@/modules/session/use-session-state-cleaner';
 import { useSetting } from '@/modules/settings/use-setting';
@@ -16,6 +18,7 @@ const animationsEnabled = useSetting('animationsEnabled');
 const { setupBackend } = useBackendManagement();
 const route = useRoute();
 useSessionStateCleaner();
+useSingleTabGuard();
 
 const isDevelopment = checkIfDevelopment();
 const isPlayground = computed(() => isDevelopment && get(route).path === '/playground');
@@ -40,6 +43,7 @@ watch(adaptiveLanguage, async (language) => {
     :class="{ 'animations-disabled': !animationsEnabled }"
   >
     <slot />
+    <SingleTabOverlay />
   </div>
   <DevApp v-else />
 </template>


### PR DESCRIPTION
## Summary

Completes the same-browser half of #3156, following the Docker session-cookie auth work (#2922, PR #12545, which handled the cross-browser half). Only one tab of a browser may drive the backend at a time.

The backend cannot tell two tabs of the same browser apart — they share one session cookie — so ownership is negotiated purely on the frontend over a `BroadcastChannel`. The newest tab to claim becomes the active one; every other tab hears the claim, stops its websocket + all pollers, and shows a full-screen overlay to continue in whichever tab the user chooses. Web/Docker only (gated on `!isPackaged`); inert in Electron (single window).

## Behaviour

- **Takeover:** opening/logging into a second tab supersedes the older one, which pauses behind the overlay.
- **Reclaim:** the overlay's "Use rotki in this tab" button claims ownership then does a full page reload, so the reclaimed tab reboots clean — it never carries stale in-memory state or tasks stranded by the takeover (the backend serves a single frontend at a time, so a paused tab's in-flight tasks are abandoned rather than handed over).
- **Hand-off:** when the active tab closes, reloads, or logs out it broadcasts a `release`, so a surviving paused tab takes over (jittered so exactly one wins) instead of being stranded behind the overlay.

## Files

New `frontend/app/src/modules/session/single-tab/`:
- `use-single-tab.ts` — `createGlobalState` singleton owning the channel, claim/reclaim/release + the release-on-`pagehide` hand-off.
- `use-single-tab-guard.ts` — wires it into the session lifecycle (claim on login, release on logout, stop the monitor on takeover); mounted in `AppHost.vue` next to `useSessionStateCleaner`.
- `SingleTabOverlay.vue` — the overlay.

Also adds the missing changelog entries for the session cookie auth (#2922) and this feature (#3156), user-facing and developer.

## Testing

- 22 unit tests (`use-single-tab` + guard), lint and typecheck clean.
- Verified live in the browser (`pnpm dev:web`, two tabs): takeover, reclaim-reload, and active-tab-close auto-recovery.

Closes #3156