### PR TITLE
test(frontend): add wallet bridge transport coverage

### DIFF
--- a/frontend/app/src/modules/wallet/bridge/use-bridge-message-handlers.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-bridge-message-handlers.spec.ts
@@ -1,0 +1,230 @@
+import type { WalletBridgeRequest } from '@shared/wallet-bridge-types';
+import type { EIP1193Provider } from '@/types';
+import {
+  BRIDGE_ERROR_CODES,
+  BRIDGE_NOTIFICATION_TYPES,
+  ROTKI_RPC_RESPONSES,
+  WALLET_EVENT_TYPES,
+} from '@shared/proxy/constants';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useBridgeLogging } from '@/modules/wallet/bridge/use-bridge-logging';
+import { useWalletConnectionState } from '@/modules/wallet/bridge/use-wallet-connection-state';
+import { useUnifiedProviders } from '../providers/use-unified-providers';
+import { useBridgeMessageHandlers } from './use-bridge-message-handlers';
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('../providers/use-unified-providers', () => ({ useUnifiedProviders: vi.fn() }));
+vi.mock('@/modules/wallet/bridge/use-bridge-logging', () => ({ useBridgeLogging: vi.fn() }));
+vi.mock('@/modules/wallet/bridge/use-wallet-connection-state', () => ({ useWalletConnectionState: vi.fn() }));
+
+function makeRequest(method: string, params?: unknown, id: string | number = 1): WalletBridgeRequest {
+  return { id, jsonrpc: '2.0', method, params } as WalletBridgeRequest;
+}
+
+const activeProvider = ref<EIP1193Provider>();
+const selectedProviderMetadata = ref<{ name: string; uuid: string }>();
+const selectedProviderUuid = ref<string>();
+let providerChangedCb: ((newProvider: any, oldProvider: any) => void) | undefined;
+let addLog: ReturnType<typeof vi.fn>;
+let trackAccountsRequest: ReturnType<typeof vi.fn>;
+let detectProviders: ReturnType<typeof vi.fn>;
+let selectProvider: ReturnType<typeof vi.fn>;
+
+type MockProvider = EIP1193Provider & {
+  on: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+};
+
+function makeProvider(overrides: Partial<EIP1193Provider> = {}): MockProvider {
+  return {
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    request: vi.fn(async () => '0x1'),
+    ...overrides,
+  } as unknown as MockProvider;
+}
+
+describe('modules/wallet/bridge/use-bridge-message-handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(activeProvider, undefined);
+    set(selectedProviderMetadata, undefined);
+    set(selectedProviderUuid, undefined);
+    providerChangedCb = undefined;
+    addLog = vi.fn();
+    trackAccountsRequest = vi.fn(async (promise: Promise<unknown>) => promise);
+    detectProviders = vi.fn(async () => []);
+    selectProvider = vi.fn(async () => true);
+
+    vi.mocked(useUnifiedProviders).mockReturnValue({
+      activeProvider,
+      detectProviders,
+      onProviderChanged: vi.fn((cb: any) => { providerChangedCb = cb; }),
+      selectedProviderMetadata,
+      selectedProviderUuid,
+      selectProvider,
+    } as any);
+    vi.mocked(useBridgeLogging).mockReturnValue({ addLog } as any);
+    vi.mocked(useWalletConnectionState).mockReturnValue({ trackAccountsRequest } as any);
+  });
+
+  describe('rotki rpc methods', () => {
+    it('should answer a ping with pong', async () => {
+      const { handleRequest } = useBridgeMessageHandlers();
+      const response = await handleRequest(makeRequest('rotki_ping'));
+      expect(response).toEqual({ id: 1, jsonrpc: '2.0', result: ROTKI_RPC_RESPONSES.PONG });
+    });
+
+    it('should return the serialized available providers', async () => {
+      detectProviders.mockResolvedValue([
+        { info: { name: 'MetaMask', uuid: 'u1' }, isConnected: true, lastSeen: 5, provider: {}, source: 'eip6963' },
+      ]);
+      const { handleRequest } = useBridgeMessageHandlers();
+      const response = await handleRequest(makeRequest('rotki_getAvailableProviders'));
+
+      expect(response.result).toEqual([
+        { info: { name: 'MetaMask', uuid: 'u1' }, isConnected: true, lastSeen: 5, source: 'eip6963' },
+      ]);
+      expect(addLog).toHaveBeenCalledWith('The app asked for the available providers: 1', 'info');
+    });
+
+    it('should return the selected provider detail when one is set', async () => {
+      set(activeProvider, makeProvider());
+      set(selectedProviderMetadata, { name: 'MetaMask', uuid: 'u1' });
+      set(selectedProviderUuid, 'u1');
+      const { handleRequest } = useBridgeMessageHandlers();
+
+      const response = await handleRequest(makeRequest('rotki_getSelectedProvider'));
+      expect(response.result).toEqual({ info: { name: 'MetaMask', uuid: 'u1' }, provider: {} });
+    });
+
+    it('should return null when no provider is selected', async () => {
+      const { handleRequest } = useBridgeMessageHandlers();
+      const response = await handleRequest(makeRequest('rotki_getSelectedProvider'));
+      expect(response.result).toBeNull();
+    });
+
+    it('should reject a select-provider call without a uuid', async () => {
+      const { handleRequest } = useBridgeMessageHandlers();
+      const response = await handleRequest(makeRequest('rotki_selectProvider', []));
+      expect(response.error?.code).toBe(BRIDGE_ERROR_CODES.INVALID_PARAMS);
+      expect(selectProvider).not.toHaveBeenCalled();
+    });
+
+    it('should select the provider and focus the window', async () => {
+      const focusSpy = vi.spyOn(window, 'focus').mockImplementation(() => {});
+      const { handleRequest } = useBridgeMessageHandlers();
+
+      const response = await handleRequest(makeRequest('rotki_selectProvider', ['u1']));
+      expect(selectProvider).toHaveBeenCalledWith('u1');
+      expect(response.result).toBe(true);
+      expect(focusSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('standard rpc methods', () => {
+    it('should error when no provider is available', async () => {
+      const { handleRequest } = useBridgeMessageHandlers();
+      const response = await handleRequest(makeRequest('eth_chainId'));
+      expect(response.error?.code).toBe(BRIDGE_ERROR_CODES.NO_PROVIDER);
+      expect(response.error?.message).toBe('No browser wallet provider found');
+    });
+
+    it('should forward a standard request to the provider', async () => {
+      const provider = makeProvider({ request: vi.fn(async () => '0x89') as any });
+      set(activeProvider, provider);
+      const { handleRequest } = useBridgeMessageHandlers();
+
+      const response = await handleRequest(makeRequest('eth_chainId', ['a']));
+      expect(provider.request).toHaveBeenCalledWith({ method: 'eth_chainId', params: ['a'] });
+      expect(response.result).toBe('0x89');
+    });
+
+    it('should initialize the provider and track eth_requestAccounts', async () => {
+      const initialize = vi.fn(async () => {});
+      const provider = makeProvider({ initialize, request: vi.fn(async () => ['0xabc']) } as any);
+      set(activeProvider, provider);
+      const { handleRequest } = useBridgeMessageHandlers();
+
+      const response = await handleRequest(makeRequest('eth_requestAccounts'));
+      expect(initialize).toHaveBeenCalledTimes(1);
+      expect(trackAccountsRequest).toHaveBeenCalledTimes(1);
+      expect(response.result).toEqual(['0xabc']);
+    });
+
+    it('should retry the first eth_requestAccounts after a 4001 error', async () => {
+      vi.useFakeTimers();
+      const request = vi.fn()
+        .mockRejectedValueOnce(Object.assign(new Error('rejected'), { code: 4001 }))
+        .mockResolvedValueOnce(['0xabc']);
+      const provider = makeProvider({ request });
+      set(activeProvider, provider);
+      const { handleRequest } = useBridgeMessageHandlers();
+
+      const promise = handleRequest(makeRequest('eth_requestAccounts'));
+      await vi.advanceTimersByTimeAsync(600);
+      const response = await promise;
+
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(response.result).toEqual(['0xabc']);
+      vi.useRealTimers();
+    });
+
+    it('should map a provider error into an error response', async () => {
+      const request = vi.fn(async () => {
+        throw Object.assign(new Error('boom'), { code: -32000, data: { info: 'x' } });
+      });
+      set(activeProvider, makeProvider({ request } as any));
+      const { handleRequest } = useBridgeMessageHandlers();
+
+      const response = await handleRequest(makeRequest('eth_call'));
+      expect(response.error).toEqual({ code: -32000, data: { info: 'x' }, message: 'boom' });
+    });
+  });
+
+  describe('wallet event forwarding', () => {
+    it('should register listeners and forward provider events when the provider changes', () => {
+      const sendMessage = vi.fn();
+      const newProvider = makeProvider();
+      useBridgeMessageHandlers(sendMessage);
+
+      expect(providerChangedCb).toBeDefined();
+      providerChangedCb!(newProvider, undefined);
+
+      // one listener per wallet event type
+      expect(newProvider.on).toHaveBeenCalledTimes(4);
+
+      // fire the accountsChanged listener and check it is forwarded
+      const call = newProvider.on.mock.calls.find(([type]) => type === WALLET_EVENT_TYPES.ACCOUNTS_CHANGED);
+      const listener = call?.[1];
+      listener(['0xabc']);
+
+      expect(sendMessage).toHaveBeenCalledWith({
+        eventData: ['0xabc'],
+        eventName: WALLET_EVENT_TYPES.ACCOUNTS_CHANGED,
+        type: BRIDGE_NOTIFICATION_TYPES.WALLET_EVENT,
+      });
+    });
+
+    it('should clean up the previous provider listeners on change', () => {
+      const oldProvider = makeProvider();
+      const newProvider = makeProvider();
+      useBridgeMessageHandlers(vi.fn());
+
+      providerChangedCb!(oldProvider, undefined); // registers on oldProvider
+      providerChangedCb!(newProvider, oldProvider); // should clean old, register new
+
+      expect(oldProvider.removeListener).toHaveBeenCalledTimes(4);
+      expect(newProvider.on).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+});

--- a/frontend/app/src/modules/wallet/bridge/use-injected-wallet.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-injected-wallet.spec.ts
@@ -1,0 +1,216 @@
+import type { EIP1193Provider } from '@/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { useUnifiedProviders } from '../providers/use-unified-providers';
+import { useInjectedWallet } from './use-injected-wallet';
+import { useWalletProxy } from './use-wallet-proxy';
+
+vi.mock('@vueuse/core', async importOriginal => ({
+  ...(await importOriginal<typeof import('@vueuse/core')>()),
+  createSharedComposable: <T>(fn: T): T => fn,
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@/modules/core/common/logging/error-handling', () => ({
+  getErrorMessage: vi.fn((error: unknown) => String(error)),
+}));
+
+vi.mock('../viem-client', () => ({
+  createViemWalletClient: vi.fn(() => ({ __client: true })),
+  getAddress: vi.fn((address: string) => address),
+}));
+
+const getWalletNetwork = vi.fn();
+vi.mock('../chains-viem', () => ({ getWalletNetwork: (chainId: bigint): any => getWalletNetwork(chainId) }));
+
+vi.mock('../providers/use-unified-providers', () => ({ useUnifiedProviders: vi.fn() }));
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({ useInterop: vi.fn() }));
+vi.mock('./use-wallet-proxy', () => ({ useWalletProxy: vi.fn() }));
+
+const selectedProvider = ref<any>();
+let isPackaged: boolean;
+let disconnectProxy: ReturnType<typeof vi.fn>;
+let startConnectionHealthCheck: ReturnType<typeof vi.fn>;
+let stopConnectionHealthCheck: ReturnType<typeof vi.fn>;
+
+type MockProvider = EIP1193Provider & {
+  on: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+};
+
+function makeProvider(overrides: Partial<EIP1193Provider> = {}): MockProvider {
+  return {
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    request: vi.fn(async ({ method }: { method: string }) => {
+      if (method === 'eth_requestAccounts')
+        return ['0xabc'];
+      if (method === 'eth_chainId')
+        return '0x1';
+      return undefined;
+    }),
+    ...overrides,
+  } as unknown as MockProvider;
+}
+
+function selectProvider(provider: EIP1193Provider, name = 'MetaMask'): void {
+  set(selectedProvider, { info: { name, uuid: 'u1' }, provider, source: 'eip6963' });
+}
+
+describe('modules/wallet/bridge/use-injected-wallet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(selectedProvider, undefined);
+    isPackaged = false;
+    disconnectProxy = vi.fn(async () => {});
+    startConnectionHealthCheck = vi.fn();
+    stopConnectionHealthCheck = vi.fn();
+
+    vi.mocked(useUnifiedProviders).mockReturnValue({ selectedProvider } as any);
+    vi.mocked(useInterop).mockReturnValue({ isPackaged } as any);
+    vi.mocked(useWalletProxy).mockReturnValue({
+      disconnectProxy,
+      startConnectionHealthCheck,
+      stopConnectionHealthCheck,
+    } as any);
+  });
+
+  describe('connectToSelectedProvider', () => {
+    it('should throw when no provider is selected', async () => {
+      const wallet = useInjectedWallet();
+      await expect(wallet.connectToSelectedProvider()).rejects.toThrow('No provider selected');
+    });
+
+    it('should request accounts, set state and register listeners', async () => {
+      const provider = makeProvider();
+      selectProvider(provider);
+      const wallet = useInjectedWallet();
+
+      await wallet.connectToSelectedProvider();
+
+      expect(get(wallet.connected)).toBe(true);
+      expect(get(wallet.connectedAddress)).toBe('0xabc');
+      expect(get(wallet.connectedChainId)).toBe(1);
+      expect(provider.on).toHaveBeenCalledWith('accountsChanged', expect.any(Function));
+      expect(get(wallet.isConnecting)).toBe(false);
+    });
+
+    it('should start a health check only when packaged', async () => {
+      isPackaged = true;
+      vi.mocked(useInterop).mockReturnValue({ isPackaged: true } as any);
+      const provider = makeProvider();
+      selectProvider(provider);
+      const wallet = useInjectedWallet();
+
+      await wallet.connectToSelectedProvider();
+      expect(startConnectionHealthCheck).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('provider events', () => {
+    it('should update state from accountsChanged and chainChanged listeners', async () => {
+      const provider = makeProvider();
+      selectProvider(provider);
+      const wallet = useInjectedWallet();
+      await wallet.connectToSelectedProvider();
+
+      const calls = provider.on.mock.calls;
+      const accountsListener = calls.find(([e]) => e === 'accountsChanged')?.[1];
+      const chainListener = calls.find(([e]) => e === 'chainChanged')?.[1];
+
+      accountsListener?.([]);
+      expect(get(wallet.connected)).toBe(false);
+      expect(get(wallet.connectedAddress)).toBeUndefined();
+
+      chainListener?.('0xa');
+      expect(get(wallet.connectedChainId)).toBe(10);
+    });
+  });
+
+  describe('disconnect', () => {
+    it('should revoke permissions, remove listeners and reset state', async () => {
+      const provider = makeProvider();
+      selectProvider(provider);
+      const wallet = useInjectedWallet();
+      await wallet.connectToSelectedProvider();
+
+      await wallet.disconnect();
+
+      expect(stopConnectionHealthCheck).toHaveBeenCalled();
+      expect(provider.request).toHaveBeenCalledWith({ method: 'wallet_revokePermissions', params: [{ eth_accounts: {} }] });
+      expect(provider.removeListener).toHaveBeenCalled();
+      expect(get(wallet.connected)).toBe(false);
+      expect(get(wallet.connectedAddress)).toBeUndefined();
+    });
+
+    it('should disconnect the proxy when packaged', async () => {
+      vi.mocked(useInterop).mockReturnValue({ isPackaged: true } as any);
+      const provider = makeProvider();
+      selectProvider(provider);
+      const wallet = useInjectedWallet();
+      await wallet.connectToSelectedProvider();
+
+      await wallet.disconnect();
+      expect(disconnectProxy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getWalletClient', () => {
+    it('should throw before a provider is connected', () => {
+      const wallet = useInjectedWallet();
+      expect(() => wallet.getWalletClient()).toThrow('Injected provider not initialized');
+    });
+
+    it('should build a viem client once connected', async () => {
+      const provider = makeProvider();
+      selectProvider(provider);
+      const wallet = useInjectedWallet();
+      await wallet.connectToSelectedProvider();
+
+      expect(wallet.getWalletClient()).toEqual({ __client: true });
+    });
+  });
+
+  describe('switchNetwork', () => {
+    it('should request a chain switch and refresh the chain id', async () => {
+      const provider = makeProvider();
+      selectProvider(provider);
+      const wallet = useInjectedWallet();
+      await wallet.connectToSelectedProvider();
+      vi.mocked(provider.request).mockClear();
+
+      await wallet.switchNetwork(10n);
+      expect(provider.request).toHaveBeenCalledWith({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: '0xa' }],
+      });
+    });
+
+    it('should add the chain when the wallet does not know it (4902)', async () => {
+      const request = vi.fn()
+        .mockImplementationOnce(async () => ['0xabc']) // eth_requestAccounts
+        .mockImplementationOnce(async () => '0x1') // eth_chainId
+        .mockImplementationOnce(async () => { throw Object.assign(new Error('unknown chain'), { code: 4902 }); })
+        .mockImplementation(async () => undefined);
+      const provider = makeProvider({ request });
+      selectProvider(provider);
+      getWalletNetwork.mockReturnValue({
+        blockExplorers: { default: { url: 'https://explorer' } },
+        name: 'Optimism',
+        nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
+        rpcUrls: { default: { http: ['https://rpc.op'] } },
+      });
+      const wallet = useInjectedWallet();
+      await wallet.connectToSelectedProvider();
+
+      await wallet.switchNetwork(10n);
+
+      expect(request).toHaveBeenCalledWith(expect.objectContaining({ method: 'wallet_addEthereumChain' }));
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-proxy-client.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-proxy-client.spec.ts
@@ -1,0 +1,153 @@
+import type { WalletBridgeRequest, WalletBridgeResponse } from '@shared/wallet-bridge-types';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBridgeMessageHandlers } from '@/modules/wallet/bridge/use-bridge-message-handlers';
+import { useWalletProxyClient } from './use-wallet-proxy-client';
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@/modules/wallet/bridge/use-bridge-message-handlers', () => ({
+  useBridgeMessageHandlers: vi.fn(),
+}));
+
+let handleRequest: (message: WalletBridgeRequest) => Promise<WalletBridgeResponse>;
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+  static instances: FakeWebSocket[] = [];
+  readyState = 0;
+  onopen?: (event: unknown) => void;
+  onmessage?: (event: { data: string }) => void;
+  onclose?: (event: unknown) => void;
+  onerror?: (event: unknown) => void;
+  readonly sent: string[] = [];
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = 3;
+  }
+
+  // test helpers
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.({});
+  }
+
+  receive(message: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+}
+
+function lastSocket(): FakeWebSocket {
+  return FakeWebSocket.instances.at(-1)!;
+}
+
+describe('modules/wallet/bridge/use-wallet-proxy-client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    handleRequest = vi.fn<(message: WalletBridgeRequest) => Promise<WalletBridgeResponse>>(
+      async () => ({ id: 1, jsonrpc: '2.0', result: '0x1' }),
+    );
+    vi.mocked(useBridgeMessageHandlers).mockReturnValue({ handleRequest });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('should connect and flip isConnected on open', async () => {
+    const client = useWalletProxyClient();
+    await client.connect();
+    expect(get(client.isConnecting)).toBe(true);
+
+    lastSocket().open();
+    expect(get(client.isConnected)).toBe(true);
+    expect(get(client.isConnecting)).toBe(false);
+    expect(lastSocket().url).toContain('/wallet-bridge');
+  });
+
+  it('should dispatch a request and send back the handler response', async () => {
+    const client = useWalletProxyClient();
+    await client.connect();
+    lastSocket().open();
+
+    lastSocket().receive({ id: 1, jsonrpc: '2.0', method: 'eth_chainId' });
+    await flushPromises();
+
+    expect(handleRequest).toHaveBeenCalledWith(expect.objectContaining({ method: 'eth_chainId' }));
+    expect(lastSocket().sent).toContainEqual(JSON.stringify({ id: 1, jsonrpc: '2.0', result: '0x1' }));
+  });
+
+  it('should prevent reconnection and run the takeover callback on a reconnected notification', async () => {
+    const client = useWalletProxyClient();
+    const takeover = vi.fn();
+    client.onTakeOver(takeover);
+    await client.connect();
+    lastSocket().open();
+
+    lastSocket().receive({ type: 'reconnected' });
+    expect(takeover).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close the tab on a close_tab notification', async () => {
+    const closeSpy = vi.spyOn(window, 'close').mockImplementation(() => {});
+    const client = useWalletProxyClient();
+    await client.connect();
+    lastSocket().open();
+
+    lastSocket().receive({ type: 'close_tab' });
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not schedule a reconnect after an intentional disconnect', async () => {
+    vi.useFakeTimers();
+    const client = useWalletProxyClient();
+    await client.connect();
+    const socket = lastSocket();
+    socket.open();
+
+    client.disconnect();
+    expect(get(client.isConnected)).toBe(false);
+
+    // simulate the socket firing onclose after close()
+    socket.onclose?.({});
+    await vi.advanceTimersByTimeAsync(1000);
+    // no new socket created by a retry
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it('should schedule a reconnect after an unexpected close', async () => {
+    vi.useFakeTimers();
+    const client = useWalletProxyClient();
+    await client.connect();
+    const socket = lastSocket();
+    socket.open();
+
+    socket.onclose?.({}); // unexpected close (not intentional)
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(1);
+  });
+
+  it('should record the error message on socket error', async () => {
+    vi.useFakeTimers();
+    const client = useWalletProxyClient();
+    await client.connect();
+    const socket = lastSocket();
+
+    socket.onerror?.({});
+    expect(get(client.lastError)).toContain('WebSocket connection error');
+  });
+});

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.spec.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { waitForCondition } from '@/modules/core/common/async/async-utilities';
+import { useWalletBridge } from '@/modules/shell/app/use-wallet-bridge';
+import { useWalletProxy } from './use-wallet-proxy';
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@/modules/shell/app/use-wallet-bridge', () => ({ useWalletBridge: vi.fn() }));
+vi.mock('@/modules/core/common/async/async-utilities', () => ({ waitForCondition: vi.fn(async () => true) }));
+
+let bridge: Record<string, ReturnType<typeof vi.fn>>;
+
+function stubWalletBridge(value: unknown): void {
+  Object.defineProperty(window, 'walletBridge', { configurable: true, value });
+}
+
+describe('modules/wallet/bridge/use-wallet-proxy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bridge = {
+      isProxyClientConnected: vi.fn(async () => true),
+      isProxyClientReady: vi.fn(async () => true),
+      isProxyHttpListening: vi.fn(async () => true),
+      isProxyWebSocketListening: vi.fn(async () => true),
+      openProxyPageInDefaultBrowser: vi.fn(async () => {}),
+      proxyStopServers: vi.fn(async () => {}),
+    };
+    vi.mocked(useWalletBridge).mockReturnValue(bridge as any);
+    stubWalletBridge({ enable: vi.fn(async () => {}), isEnabled: vi.fn(() => true) });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'walletBridge');
+    vi.useRealTimers();
+  });
+
+  describe('setupProxy', () => {
+    it('should return early without opening the page when fully connected and ready', async () => {
+      const { setupProxy } = useWalletProxy();
+      await setupProxy();
+      expect(bridge.openProxyPageInDefaultBrowser).not.toHaveBeenCalled();
+    });
+
+    it('should open the bridge page when fully connected but the client is not ready', async () => {
+      bridge.isProxyClientReady.mockResolvedValue(false);
+      const { setupProxy } = useWalletProxy();
+      await setupProxy();
+      expect(bridge.openProxyPageInDefaultBrowser).toHaveBeenCalledTimes(1);
+    });
+
+    it('should start the servers when the bridge is not fully connected', async () => {
+      bridge.isProxyClientConnected.mockResolvedValue(false);
+      const { setupProxy } = useWalletProxy();
+      await setupProxy();
+
+      expect(bridge.openProxyPageInDefaultBrowser).toHaveBeenCalled();
+      expect(vi.mocked(waitForCondition)).toHaveBeenCalled();
+    });
+
+    it('should enable the wallet bridge when it is disabled', async () => {
+      const enable = vi.fn(async () => {});
+      stubWalletBridge({ enable, isEnabled: vi.fn(() => false) });
+      const { setupProxy } = useWalletProxy();
+      await setupProxy();
+      expect(enable).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject when the wallet bridge is missing from the window', async () => {
+      Reflect.deleteProperty(window, 'walletBridge');
+      const { setupProxy } = useWalletProxy();
+      await expect(setupProxy()).rejects.toThrow('Wallet bridge not available in window object');
+    });
+  });
+
+  describe('disconnectProxy', () => {
+    it('should stop the servers', async () => {
+      const { disconnectProxy } = useWalletProxy();
+      await disconnectProxy();
+      expect(bridge.proxyStopServers).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw when stopping the servers fails', async () => {
+      bridge.proxyStopServers.mockRejectedValue(new Error('nope'));
+      const { disconnectProxy } = useWalletProxy();
+      await expect(disconnectProxy()).rejects.toThrow('Failed to stop bridge servers: nope');
+    });
+  });
+
+  describe('health check', () => {
+    it('should call onDisconnect and stop when the client drops', async () => {
+      vi.useFakeTimers();
+      bridge.isProxyClientConnected.mockResolvedValue(false);
+      const onDisconnect = vi.fn();
+      const { startConnectionHealthCheck } = useWalletProxy();
+
+      startConnectionHealthCheck(() => true, onDisconnect);
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fire onDisconnect while the client stays connected', async () => {
+      vi.useFakeTimers();
+      bridge.isProxyClientConnected.mockResolvedValue(true);
+      const onDisconnect = vi.fn();
+      const { startConnectionHealthCheck, stopConnectionHealthCheck } = useWalletProxy();
+
+      startConnectionHealthCheck(() => true, onDisconnect);
+      await vi.advanceTimersByTimeAsync(5000);
+      stopConnectionHealthCheck();
+
+      expect(onDisconnect).not.toHaveBeenCalled();
+    });
+
+    it('should stop the interval so no further checks run', async () => {
+      vi.useFakeTimers();
+      const onDisconnect = vi.fn();
+      const { startConnectionHealthCheck, stopConnectionHealthCheck } = useWalletProxy();
+
+      startConnectionHealthCheck(() => true, onDisconnect);
+      stopConnectionHealthCheck();
+      bridge.isProxyClientConnected.mockClear();
+      await vi.advanceTimersByTimeAsync(15000);
+
+      expect(bridge.isProxyClientConnected).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Adds unit coverage for the wallet bridge transport layer: the JSON-RPC dispatcher, the browser-side WebSocket client, the injected-wallet backend, and the Electron proxy lifecycle.

### `use-bridge-message-handlers`
The JSON-RPC request dispatcher:
- Rotki custom methods: `rotki_ping` (pong), `rotki_getAvailableProviders` (serialized list), `rotki_getSelectedProvider` (detail vs null), `rotki_selectProvider` (missing-uuid rejection, select + window focus).
- Standard methods: no-provider error, request forwarding, `eth_requestAccounts` initialize + tracking, the 4001 retry-once path, and provider-error mapping.
- Wallet event forwarding: listener registration on provider change, event forwarding through `sendMessage`, and cleanup of the previous provider's listeners.

### `use-wallet-proxy-client`
The browser WebSocket client, driven by a fake `WebSocket`:
- Connect/open state transitions, request dispatch and response send-back.
- `reconnected` notification (prevent reconnect + takeover callback) and `close_tab` (window close).
- Reconnect scheduling: skipped after an intentional disconnect, scheduled after an unexpected close, and error message capture on socket error.

### `use-injected-wallet`
The EIP-1193 injected-provider backend:
- `connectToSelectedProvider` (no-selection throw, account request + state + listeners, packaged health check), provider event listeners (accounts/chain), `disconnect` (revoke permissions, reset, packaged proxy disconnect), `getWalletClient`, and `switchNetwork` including the 4902 add-chain path.

### `use-wallet-proxy`
The Electron bridge proxy lifecycle:
- `setupProxy`: early return when fully connected and ready, opening the page when not ready, starting servers when disconnected, enabling a disabled bridge, and rejecting when the bridge is missing.
- `disconnectProxy` (stop servers, error propagation) and the connection health check (fires `onDisconnect` on drop, stays quiet while connected, stops cleanly).

40 tests. `test:unit`, `typecheck`, and lint all green.

Refs #11252
