### PR TITLE
test(frontend): add accounts module unit coverage

### DIFF
--- a/frontend/app/src/modules/accounts/account-common.spec.ts
+++ b/frontend/app/src/modules/accounts/account-common.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { includes, isFilterEnabled, sortBy } from './account-common';
+
+describe('sortBy', () => {
+  it('should sort numbers ascending', () => {
+    expect(sortBy(1, 2, true)).toBeLessThan(0);
+    expect(sortBy(2, 1, true)).toBeGreaterThan(0);
+    expect(sortBy(2, 2, true)).toBe(0);
+  });
+
+  it('should sort numbers descending', () => {
+    expect(sortBy(1, 2, false)).toBeGreaterThan(0);
+    expect(sortBy(2, 1, false)).toBeLessThan(0);
+  });
+
+  it('should treat numeric strings as numbers', () => {
+    expect(sortBy('10', '9', true)).toBeGreaterThan(0);
+    expect(sortBy('10', '9', false)).toBeLessThan(0);
+  });
+
+  it('should sort strings using locale comparison', () => {
+    expect(sortBy('apple', 'banana', true)).toBeLessThan(0);
+    expect(sortBy('banana', 'apple', true)).toBeGreaterThan(0);
+  });
+
+  it('should reverse string comparison when descending', () => {
+    expect(sortBy('apple', 'banana', false)).toBeGreaterThan(0);
+  });
+
+  it('should compare case-insensitively for accent sensitivity', () => {
+    expect(sortBy('Apple', 'apple', true)).toBe(0);
+  });
+});
+
+describe('isFilterEnabled', () => {
+  it('should return false for undefined', () => {
+    expect(isFilterEnabled(undefined)).toBe(false);
+  });
+
+  it('should return false for an empty string', () => {
+    expect(isFilterEnabled('')).toBe(false);
+  });
+
+  it('should return true for a non-empty string', () => {
+    expect(isFilterEnabled('active')).toBe(true);
+  });
+
+  it('should return false for an empty array', () => {
+    expect(isFilterEnabled([])).toBe(false);
+  });
+
+  it('should return true for a non-empty array', () => {
+    expect(isFilterEnabled(['active'])).toBe(true);
+  });
+});
+
+describe('includes', () => {
+  it('should match case-insensitively', () => {
+    expect(includes('Ethereum', 'ether')).toBe(true);
+    expect(includes('ethereum', 'ETHER')).toBe(true);
+  });
+
+  it('should return false when the search term is absent', () => {
+    expect(includes('Ethereum', 'bitcoin')).toBe(false);
+  });
+
+  it('should return true for an empty search term', () => {
+    expect(includes('Ethereum', '')).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/accounts/account-helpers.spec.ts
+++ b/frontend/app/src/modules/accounts/account-helpers.spec.ts
@@ -1,0 +1,313 @@
+import type {
+  Balances,
+  BitcoinAccounts,
+  BlockchainAccount,
+  BlockchainAccountGroupWithBalance,
+  BlockchainAccountRequestPayload,
+  BlockchainAccountWithBalance,
+} from './blockchain-accounts';
+import type { BlockchainAssetBalances, BlockchainTotals, BtcBalances } from '@/modules/balances/types/blockchain-balances';
+import { type Balance, bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateTotals,
+  convertBtcAccounts,
+  convertBtcBalances,
+  getAccountBalance,
+  hasAccountAddress,
+  hasTokens,
+  isAccountWithBalanceValidator,
+  sortAndFilterAccounts,
+} from './account-helpers';
+
+function bal(amount: number, value: number): Balance {
+  return { amount: bigNumberify(amount), value: bigNumberify(value) };
+}
+
+function account(overrides: Partial<BlockchainAccountWithBalance> = {}): BlockchainAccountWithBalance {
+  return {
+    amount: bigNumberify(1),
+    chain: 'eth',
+    data: { address: '0xabc', type: 'address' },
+    nativeAsset: 'ETH',
+    type: 'account',
+    value: bigNumberify(1000),
+    ...overrides,
+  };
+}
+
+function payload(overrides: Partial<BlockchainAccountRequestPayload> = {}): BlockchainAccountRequestPayload {
+  return {
+    limit: 10,
+    offset: 0,
+    ...overrides,
+  };
+}
+
+const noLabel = (): undefined => undefined;
+
+describe('hasAccountAddress', () => {
+  it('should return true for an address account', () => {
+    const data: BlockchainAccount = { chain: 'eth', data: { address: '0xabc', type: 'address' }, nativeAsset: 'ETH' };
+    expect(hasAccountAddress(data)).toBe(true);
+  });
+
+  it('should return false for a validator account', () => {
+    const data: BlockchainAccount = {
+      chain: 'eth2',
+      data: { index: 1, publicKey: '0xpub', status: 'active', type: 'validator' },
+      nativeAsset: 'ETH',
+    };
+    expect(hasAccountAddress(data)).toBe(false);
+  });
+});
+
+describe('isAccountWithBalanceValidator', () => {
+  it('should return true when the account data has a public key', () => {
+    const validator = account({ data: { index: 1, publicKey: '0xpub', status: 'active', type: 'validator' } });
+    expect(isAccountWithBalanceValidator(validator)).toBe(true);
+  });
+
+  it('should return false for an address account', () => {
+    expect(isAccountWithBalanceValidator(account())).toBe(false);
+  });
+});
+
+describe('sortAndFilterAccounts', () => {
+  const accounts = (): BlockchainAccountWithBalance[] => [
+    account({ chain: 'eth', data: { address: '0xaaa', type: 'address' }, label: 'Alpha', tags: ['hot'], value: bigNumberify(300) }),
+    account({ chain: 'optimism', data: { address: '0xbbb', type: 'address' }, label: 'Beta', tags: ['cold'], value: bigNumberify(100) }),
+    account({ chain: 'eth', data: { address: '0xccc', type: 'address' }, label: 'Gamma', tags: ['hot', 'cold'], value: bigNumberify(200) }),
+  ];
+
+  it('should return all accounts when no filter is applied', () => {
+    const result = sortAndFilterAccounts(accounts(), payload(), { getLabel: noLabel });
+    expect(result.data).toHaveLength(3);
+    expect(result.found).toBe(3);
+    expect(result.total).toBe(3);
+    expect(result.totalValue?.toNumber()).toBe(600);
+  });
+
+  it('should filter by address partially', () => {
+    const result = sortAndFilterAccounts(accounts(), payload({ address: '0xbbb' }), { getLabel: noLabel });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].data).toMatchObject({ address: '0xbbb' });
+  });
+
+  it('should filter by label falling back to the account label', () => {
+    const result = sortAndFilterAccounts(accounts(), payload({ label: 'gamma' }), { getLabel: noLabel });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].label).toBe('Gamma');
+  });
+
+  it('should prefer the resolver label over the account label when filtering', () => {
+    const result = sortAndFilterAccounts(
+      accounts(),
+      payload({ label: 'resolved' }),
+      { getLabel: acc => (getAddress(acc) === '0xaaa' ? 'Resolved Name' : undefined) },
+    );
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].label).toBe('Alpha');
+  });
+
+  it('should filter by chain', () => {
+    const result = sortAndFilterAccounts(accounts(), payload({ chain: ['eth'] }), { getLabel: noLabel });
+    expect(result.data.map(a => getAddress(a))).toEqual(['0xaaa', '0xccc']);
+  });
+
+  it('should filter by tags requiring every tag to match', () => {
+    const result = sortAndFilterAccounts(accounts(), payload({ tags: ['hot', 'cold'] }), { getLabel: noLabel });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].label).toBe('Gamma');
+  });
+
+  it('should filter by category', () => {
+    const withCategory = accounts().map((acc, i) => ({ ...acc, category: i === 1 ? 'manual' : 'evm' }));
+    const result = sortAndFilterAccounts(withCategory, payload({ category: 'manual' }), { getLabel: noLabel });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].label).toBe('Beta');
+  });
+
+  it('should sort ascending by value', () => {
+    const result = sortAndFilterAccounts(accounts(), payload({ ascending: [true], orderByAttributes: ['value'] }), { getLabel: noLabel });
+    expect(result.data.map(a => a.value.toNumber())).toEqual([100, 200, 300]);
+  });
+
+  it('should sort descending by value', () => {
+    const result = sortAndFilterAccounts(accounts(), payload({ ascending: [false], orderByAttributes: ['value'] }), { getLabel: noLabel });
+    expect(result.data.map(a => a.value.toNumber())).toEqual([300, 200, 100]);
+  });
+
+  it('should sort by label using the resolver', () => {
+    const result = sortAndFilterAccounts(accounts(), payload({ ascending: [false], orderByAttributes: ['label'] }), { getLabel: noLabel });
+    expect(result.data.map(a => a.label)).toEqual(['Gamma', 'Beta', 'Alpha']);
+  });
+
+  it('should paginate using offset and limit', () => {
+    const result = sortAndFilterAccounts(accounts(), payload({
+      ascending: [true],
+      limit: 1,
+      offset: 1,
+      orderByAttributes: ['value'],
+    }), { getLabel: noLabel });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].value.toNumber()).toBe(200);
+    expect(result.found).toBe(3);
+  });
+});
+
+describe('convertBtcAccounts', () => {
+  const accounts: BitcoinAccounts = {
+    standalone: [{ address: 'bc1standalone', label: 'Standalone', tags: null }],
+    xpubs: [{
+      addresses: [{ address: 'bc1child', label: null, tags: null }],
+      derivationPath: 'm/0',
+      label: 'My Xpub',
+      tags: ['savings'],
+      xpub: 'xpub123',
+    }],
+  };
+
+  it('should upper-case the native asset from the resolver', () => {
+    const result = convertBtcAccounts(() => 'btc', 'btc', accounts);
+    expect(result.every(acc => acc.nativeAsset === 'BTC')).toBe(true);
+  });
+
+  it('should build a group header for each xpub', () => {
+    const result = convertBtcAccounts(() => 'btc', 'btc', accounts);
+    const group = result.find(acc => acc.groupHeader);
+    expect(group?.data).toMatchObject({ derivationPath: 'm/0', type: 'xpub', xpub: 'xpub123' });
+    expect(group?.groupId).toBe('xpub123#m/0#btc');
+  });
+
+  it('should include the xpub child addresses and standalone accounts', () => {
+    const result = convertBtcAccounts(() => 'btc', 'btc', accounts);
+    const addresses = result.filter(acc => acc.data.type === 'address').map(acc => hasAccountAddress(acc) ? acc.data.address : '');
+    expect(addresses).toContain('bc1child');
+    expect(addresses).toContain('bc1standalone');
+  });
+
+  it('should omit the derivation path from the group id when absent', () => {
+    const noPath: BitcoinAccounts = {
+      standalone: [],
+      xpubs: [{ addresses: null, derivationPath: null, label: null, tags: null, xpub: 'xpubNoPath' }],
+    };
+    const result = convertBtcAccounts(() => 'btc', 'btc', noPath);
+    expect(result[0].groupId).toBe('xpubNoPath#btc');
+  });
+});
+
+describe('convertBtcBalances', () => {
+  const totals: BlockchainTotals = { assets: {}, liabilities: {} };
+
+  it('should convert standalone balances into per-account entries', () => {
+    const perAccount: BtcBalances = { standalone: { bc1standalone: bal(1, 50000) } };
+    const result = convertBtcBalances('btc', totals, perAccount);
+    expect(result.totals).toBe(totals);
+    expect(result.perAccount.btc).toEqual({
+      bc1standalone: { assets: { BTC: { address: bal(1, 50000) } }, liabilities: {} },
+    });
+  });
+
+  it('should flatten xpub addresses into per-account entries', () => {
+    const perAccount: BtcBalances = {
+      xpubs: [{ addresses: { bc1child: bal(2, 100000) }, derivationPath: 'm/0', xpub: 'xpub123' }],
+    };
+    const result = convertBtcBalances('btc', totals, perAccount);
+    expect(result.perAccount.btc).toEqual({
+      bc1child: { assets: { BTC: { address: bal(2, 100000) } }, liabilities: {} },
+    });
+  });
+});
+
+describe('aggregateTotals', () => {
+  const balances: Balances = {
+    eth: { '0xabc': { assets: { ETH: { evm: bal(1, 1000) } }, liabilities: {} } },
+    optimism: { '0xdef': { assets: { ETH: { evm: bal(2, 2000) } }, liabilities: {} } },
+  };
+
+  it('should aggregate the same asset across chains', () => {
+    const result = aggregateTotals(balances);
+    expect(result.ETH.amount.toNumber()).toBe(3);
+    expect(result.ETH.value.toNumber()).toBe(3000);
+  });
+
+  it('should restrict aggregation to the requested chains', () => {
+    const result = aggregateTotals(balances, 'assets', { chains: ['eth'] });
+    expect(result.ETH.amount.toNumber()).toBe(1);
+  });
+
+  it('should skip identifiers rejected by the predicate', () => {
+    const result = aggregateTotals(balances, 'assets', { skipIdentifier: id => id === 'ETH' });
+    expect(result.ETH).toBeUndefined();
+  });
+
+  it('should resolve identifiers through the resolver', () => {
+    const result = aggregateTotals(balances, 'assets', { resolveIdentifier: () => 'WETH' });
+    expect(result.WETH.amount.toNumber()).toBe(3);
+    expect(result.ETH).toBeUndefined();
+  });
+});
+
+describe('hasTokens', () => {
+  it('should return false when there are no balances', () => {
+    expect(hasTokens('ETH')).toBe(false);
+    expect(hasTokens('ETH', {})).toBe(false);
+  });
+
+  it('should return false when only the native asset is present', () => {
+    expect(hasTokens('ETH', { ETH: { evm: bal(1, 1000) } })).toBe(false);
+  });
+
+  it('should return true when a non-native token is present', () => {
+    expect(hasTokens('ETH', { DAI: { evm: bal(100, 100) }, ETH: { evm: bal(1, 1000) } })).toBe(true);
+  });
+});
+
+describe('getAccountBalance', () => {
+  const acc: BlockchainAccount = { chain: 'eth', data: { address: '0xabc', type: 'address' }, nativeAsset: 'ETH' };
+  const notIgnored = (): boolean => false;
+
+  it('should sum the native amount and the total value', () => {
+    const chainBalances: BlockchainAssetBalances = {
+      '0xabc': {
+        assets: { DAI: { evm: bal(100, 100) }, ETH: { evm: bal(2, 4000) } },
+        liabilities: {},
+      },
+    };
+    const result = getAccountBalance(acc, chainBalances, notIgnored);
+    expect(result.balance.amount.toNumber()).toBe(2);
+    expect(result.balance.value.toNumber()).toBe(4100);
+    expect(result.expansion).toBe('assets');
+  });
+
+  it('should not mark an account expandable when only the native asset is held', () => {
+    const chainBalances: BlockchainAssetBalances = {
+      '0xabc': { assets: { ETH: { evm: bal(2, 4000) } }, liabilities: {} },
+    };
+    const result = getAccountBalance(acc, chainBalances, notIgnored);
+    expect(result.expansion).toBeUndefined();
+  });
+
+  it('should return zero balances when the account has no entry', () => {
+    const result = getAccountBalance(acc, {}, notIgnored);
+    expect(result.balance.amount.toNumber()).toBe(0);
+    expect(result.balance.value.toNumber()).toBe(0);
+    expect(result.expansion).toBeUndefined();
+  });
+
+  it('should exclude ignored assets from the value sum', () => {
+    const chainBalances: BlockchainAssetBalances = {
+      '0xabc': {
+        assets: { DAI: { evm: bal(100, 100) }, ETH: { evm: bal(2, 4000) } },
+        liabilities: {},
+      },
+    };
+    const result = getAccountBalance(acc, chainBalances, asset => asset === 'DAI');
+    expect(result.balance.value.toNumber()).toBe(4000);
+  });
+});
+
+function getAddress(acc: BlockchainAccountGroupWithBalance | BlockchainAccountWithBalance): string {
+  return 'address' in acc.data ? acc.data.address : '';
+}

--- a/frontend/app/src/modules/accounts/account-utils.spec.ts
+++ b/frontend/app/src/modules/accounts/account-utils.spec.ts
@@ -1,0 +1,121 @@
+import type { AddressData, ValidatorData, XpubData } from './blockchain-accounts';
+import { describe, expect, it } from 'vitest';
+import {
+  getAccountAddress,
+  getAccountId,
+  getAccountLabel,
+  getChain,
+  getGroupId,
+  getXpubId,
+  isValidatorAccount,
+  isXpubAccount,
+} from './account-utils';
+
+const addressData: AddressData = { address: '0xabc', type: 'address' };
+const xpubData: XpubData = { type: 'xpub', xpub: 'xpub123' };
+const xpubWithPath: XpubData = { derivationPath: 'm/0', type: 'xpub', xpub: 'xpub123' };
+const validatorData: ValidatorData = { index: 42, publicKey: '0xpub', status: 'active', type: 'validator' };
+
+describe('getXpubId', () => {
+  it('should return the xpub when no derivation path is set', () => {
+    expect(getXpubId(xpubData)).toBe('xpub123');
+  });
+
+  it('should append the derivation path when present', () => {
+    expect(getXpubId(xpubWithPath)).toBe('xpub123#m/0');
+  });
+});
+
+describe('getGroupId', () => {
+  it('should return the address for an address account', () => {
+    expect(getGroupId({ chains: ['eth'], data: addressData })).toBe('0xabc');
+  });
+
+  it('should return the public key for a validator account', () => {
+    expect(getGroupId({ chains: ['eth2'], data: validatorData })).toBe('0xpub');
+  });
+
+  it('should combine the xpub id with the chain for an xpub account', () => {
+    expect(getGroupId({ chains: ['btc'], data: xpubWithPath })).toBe('xpub123#m/0#btc');
+  });
+});
+
+describe('getAccountId', () => {
+  it('should combine the data id with the chain', () => {
+    expect(getAccountId({ chain: 'eth', data: addressData })).toBe('0xabc#eth');
+  });
+
+  it('should use the public key for a validator', () => {
+    expect(getAccountId({ chain: 'eth2', data: validatorData })).toBe('0xpub#eth2');
+  });
+
+  it('should use the xpub id for an xpub account', () => {
+    expect(getAccountId({ chain: 'btc', data: xpubWithPath })).toBe('xpub123#m/0#btc');
+  });
+});
+
+describe('getAccountAddress', () => {
+  it('should return the address for an address account', () => {
+    expect(getAccountAddress({ data: addressData })).toBe('0xabc');
+  });
+
+  it('should return the public key for a validator account', () => {
+    expect(getAccountAddress({ data: validatorData })).toBe('0xpub');
+  });
+
+  it('should return the raw xpub for an xpub account', () => {
+    expect(getAccountAddress({ data: xpubWithPath })).toBe('xpub123');
+  });
+});
+
+describe('getAccountLabel', () => {
+  it('should prefer an explicit label', () => {
+    expect(getAccountLabel({ data: addressData, label: 'My Account' })).toBe('My Account');
+  });
+
+  it('should fall back to the address for an address account', () => {
+    expect(getAccountLabel({ data: addressData })).toBe('0xabc');
+  });
+
+  it('should fall back to the index for a validator account', () => {
+    expect(getAccountLabel({ data: validatorData })).toBe('42');
+  });
+
+  it('should fall back to the xpub for an xpub account', () => {
+    expect(getAccountLabel({ data: xpubData })).toBe('xpub123');
+  });
+});
+
+describe('isValidatorAccount', () => {
+  it('should return true for validator data', () => {
+    expect(isValidatorAccount({ data: validatorData })).toBe(true);
+  });
+
+  it('should return false for other data types', () => {
+    expect(isValidatorAccount({ data: addressData })).toBe(false);
+  });
+});
+
+describe('isXpubAccount', () => {
+  it('should return true for xpub data', () => {
+    expect(isXpubAccount({ data: xpubData })).toBe(true);
+  });
+
+  it('should return false for other data types', () => {
+    expect(isXpubAccount({ data: addressData })).toBe(false);
+  });
+});
+
+describe('getChain', () => {
+  it('should return the chain for a single-chain account', () => {
+    expect(getChain({ chain: 'eth' })).toBe('eth');
+  });
+
+  it('should return the first chain for a multi-chain account', () => {
+    expect(getChain({ chains: ['btc', 'bch'] })).toBe('btc');
+  });
+
+  it('should return undefined when chains is empty', () => {
+    expect(getChain({ chains: [] })).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/accounts/account-validator.spec.ts
+++ b/frontend/app/src/modules/accounts/account-validator.spec.ts
@@ -1,0 +1,108 @@
+import type { EthereumValidator, EthereumValidatorRequestPayload } from './blockchain-accounts';
+import { bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { sortAndFilterValidators } from './account-validator';
+
+function validator(overrides: Partial<EthereumValidator> = {}): EthereumValidator {
+  return {
+    amount: bigNumberify(32),
+    index: 1,
+    publicKey: '0xabc',
+    status: 'active',
+    type: 'validator',
+    value: bigNumberify(64000),
+    ...overrides,
+  };
+}
+
+function payload(overrides: Partial<EthereumValidatorRequestPayload> = {}): EthereumValidatorRequestPayload {
+  return {
+    limit: 10,
+    offset: 0,
+    ...overrides,
+  };
+}
+
+describe('sortAndFilterValidators', () => {
+  // sortAndFilterValidators sorts the input array in place, so build a fresh set per test.
+  const validators = (): EthereumValidator[] => [
+    validator({ amount: bigNumberify(10), index: 1, publicKey: '0xaaa', status: 'active', value: bigNumberify(100) }),
+    validator({ amount: bigNumberify(20), index: 2, publicKey: '0xbbb', status: 'exited', value: bigNumberify(200) }),
+    validator({ amount: bigNumberify(30), index: 3, publicKey: '0xccc', status: 'active', value: bigNumberify(300) }),
+  ];
+
+  it('should return all validators when no filter is applied', () => {
+    const result = sortAndFilterValidators(validators(), payload());
+    expect(result.data).toHaveLength(3);
+    expect(result.found).toBe(3);
+    expect(result.total).toBe(3);
+  });
+
+  it('should compute the total value and amount over the filtered set', () => {
+    const result = sortAndFilterValidators(validators(), payload());
+    expect(result.totalValue?.toNumber()).toBe(600);
+    expect(result.totalAmount?.toNumber()).toBe(60);
+  });
+
+  it('should filter by index', () => {
+    const result = sortAndFilterValidators(validators(), payload({ index: ['2'] }));
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].index).toBe(2);
+    expect(result.found).toBe(1);
+    expect(result.total).toBe(3);
+  });
+
+  it('should filter by public key with partial match', () => {
+    const result = sortAndFilterValidators(validators(), payload({ publicKey: ['ccc'] }));
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].publicKey).toBe('0xccc');
+  });
+
+  it('should filter by status', () => {
+    const result = sortAndFilterValidators(validators(), payload({ status: ['active'] }));
+    expect(result.data).toHaveLength(2);
+    expect(result.data.map(v => v.index)).toEqual([1, 3]);
+  });
+
+  it('should require all provided filters to match', () => {
+    const result = sortAndFilterValidators(validators(), payload({ index: ['1'], status: ['exited'] }));
+    expect(result.data).toHaveLength(0);
+    expect(result.found).toBe(0);
+  });
+
+  it('should only total the filtered validators', () => {
+    const result = sortAndFilterValidators(validators(), payload({ status: ['active'] }));
+    expect(result.totalValue?.toNumber()).toBe(400);
+    expect(result.totalAmount?.toNumber()).toBe(40);
+  });
+
+  it('should sort ascending by an attribute', () => {
+    const result = sortAndFilterValidators(validators(), payload({ ascending: [true], orderByAttributes: ['value'] }));
+    expect(result.data.map(v => v.value.toNumber())).toEqual([100, 200, 300]);
+  });
+
+  it('should sort descending by an attribute', () => {
+    const result = sortAndFilterValidators(validators(), payload({ ascending: [false], orderByAttributes: ['value'] }));
+    expect(result.data.map(v => v.value.toNumber())).toEqual([300, 200, 100]);
+  });
+
+  it('should paginate using offset and limit', () => {
+    const result = sortAndFilterValidators(validators(), payload({
+      ascending: [true],
+      limit: 1,
+      offset: 1,
+      orderByAttributes: ['index'],
+    }));
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].index).toBe(2);
+    expect(result.found).toBe(3);
+  });
+
+  it('should return an empty collection when there are no validators', () => {
+    const result = sortAndFilterValidators([], payload());
+    expect(result.data).toHaveLength(0);
+    expect(result.total).toBe(0);
+    expect(result.totalValue?.toNumber()).toBe(0);
+    expect(result.totalAmount?.toNumber()).toBe(0);
+  });
+});

--- a/frontend/app/src/modules/accounts/use-account-addition-notifications.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-notifications.spec.ts
@@ -1,0 +1,97 @@
+import type { AccountPayload } from '@/modules/accounts/blockchain-accounts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccountAdditionNotifications } from './use-account-addition-notifications';
+import '@test/i18n';
+
+const h = vi.hoisted(() => ({
+  notifyError: vi.fn(),
+  notifyInfo: vi.fn(),
+  notifyWarning: vi.fn(),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn(() => ({
+    notifyError: h.notifyError,
+    notifyInfo: h.notifyInfo,
+    notifyWarning: h.notifyWarning,
+  })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({ getChainName: (chain: string): string => chain })),
+}));
+
+const account: AccountPayload = { address: '0xabc', tags: null };
+
+describe('useAccountAdditionNotifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('notifyUser', () => {
+    it('should notify with a chain list when not all chains were used', () => {
+      const { notifyUser } = useAccountAdditionNotifications();
+      notifyUser({ account, chains: ['eth', 'optimism'], isAll: false });
+      expect(h.notifyInfo).toHaveBeenCalledOnce();
+      const [, message] = h.notifyInfo.mock.calls[0];
+      expect(message).toContain('- eth');
+      expect(message).toContain('- optimism');
+    });
+
+    it('should notify without a chain list when all chains were used', () => {
+      const { notifyUser } = useAccountAdditionNotifications();
+      notifyUser({ account, chains: ['eth'], isAll: true });
+      expect(h.notifyInfo).toHaveBeenCalledOnce();
+      const [, message] = h.notifyInfo.mock.calls[0];
+      expect(message).not.toContain('- eth');
+    });
+  });
+
+  describe('notifyFailedToAddAddress', () => {
+    it('should notify an error using EVM as the default blockchain', () => {
+      const { notifyFailedToAddAddress } = useAccountAdditionNotifications();
+      notifyFailedToAddAddress([account], 1);
+      expect(h.notifyError).toHaveBeenCalledOnce();
+    });
+
+    it('should resolve the chain name for a specific blockchain', () => {
+      const { notifyFailedToAddAddress } = useAccountAdditionNotifications();
+      notifyFailedToAddAddress([account], 1, 'eth');
+      expect(h.notifyError).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('createFailureNotification', () => {
+    it('should not notify when there are no failures', () => {
+      const { createFailureNotification } = useAccountAdditionNotifications();
+      createFailureNotification({}, account);
+      expect(h.notifyWarning).not.toHaveBeenCalled();
+    });
+
+    it('should warn when there was no activity', () => {
+      const { createFailureNotification } = useAccountAdditionNotifications();
+      createFailureNotification({ noActivity: { '0xabc': ['eth'] } }, account);
+      expect(h.notifyWarning).toHaveBeenCalledOnce();
+      const [, message] = h.notifyWarning.mock.calls[0];
+      expect(message).toContain('- eth');
+    });
+
+    it('should warn for eth contracts and existing accounts', () => {
+      const { createFailureNotification } = useAccountAdditionNotifications();
+      createFailureNotification({ ethContracts: ['0xabc'], existed: { '0xabc': ['optimism'] } }, account);
+      expect(h.notifyWarning).toHaveBeenCalledOnce();
+    });
+
+    it('should skip a single binance_sc failure', () => {
+      const { createFailureNotification } = useAccountAdditionNotifications();
+      createFailureNotification({ failed: { '0xabc': ['binance_sc'] } }, account);
+      expect(h.notifyWarning).not.toHaveBeenCalled();
+    });
+
+    it('should warn for a non-binance failed chain', () => {
+      const { createFailureNotification } = useAccountAdditionNotifications();
+      createFailureNotification({ failed: { '0xabc': ['eth', 'binance_sc'] } }, account);
+      expect(h.notifyWarning).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
@@ -1,0 +1,261 @@
+import { Blockchain } from '@rotki/common';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type XpubAccountPayload, XpubKeyType } from '@/modules/accounts/blockchain-accounts';
+import { Module } from '@/modules/core/common/modules';
+import '@test/i18n';
+
+const h = vi.hoisted(() => ({
+  addAccount: vi.fn(),
+  addEvmAccount: vi.fn(),
+  createFailureNotification: vi.fn(),
+  detectTokens: vi.fn(),
+  enableModule: vi.fn(),
+  fetchTags: vi.fn(),
+  getAddresses: vi.fn((): string[] => []),
+  notifyFailedToAddAddress: vi.fn(),
+  notifyUser: vi.fn(),
+  supportsTransactions: vi.fn((): boolean => true),
+  trackAddedAddresses: vi.fn(),
+}));
+
+vi.mock('@/modules/accounts/use-blockchain-accounts', () => ({
+  useBlockchainAccounts: vi.fn(() => ({ addAccount: h.addAccount, addEvmAccount: h.addEvmAccount })),
+}));
+
+vi.mock('@/modules/balances/blockchain/use-token-detection-orchestrator', () => ({
+  useTokenDetectionOrchestrator: vi.fn(() => ({ detectTokens: h.detectTokens })),
+}));
+
+vi.mock('@/modules/accounts/use-blockchain-accounts-store', () => ({
+  useBlockchainAccountsStore: vi.fn(() => ({ trackAddedAddresses: h.trackAddedAddresses })),
+}));
+
+vi.mock('@/modules/tags/use-tag-operations', () => ({
+  useTagOperations: vi.fn(() => ({ fetchTags: h.fetchTags })),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: vi.fn(() => ({ enableModule: h.enableModule })),
+}));
+
+vi.mock('@/modules/balances/blockchain/use-account-addresses', () => ({
+  useAccountAddresses: vi.fn(() => ({ getAddresses: h.getAddresses })),
+}));
+
+vi.mock('@/modules/accounts/use-account-addition-notifications', () => ({
+  useAccountAdditionNotifications: vi.fn(() => ({
+    createFailureNotification: h.createFailureNotification,
+    notifyFailedToAddAddress: h.notifyFailedToAddAddress,
+    notifyUser: h.notifyUser,
+  })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const { ref } = await import('vue');
+  return {
+    useSupportedChains: vi.fn(() => ({
+      evmChains: ref(['eth', 'optimism']),
+      supportsTransactions: h.supportsTransactions,
+    })),
+  };
+});
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+async function importModule(): Promise<typeof import('./use-account-addition-service')> {
+  return import('./use-account-addition-service');
+}
+
+describe('useAccountAdditionService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.getAddresses.mockReturnValue([]);
+    h.supportsTransactions.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getNewAccountPayload', () => {
+    it('should filter out already known addresses case-insensitively', async () => {
+      h.getAddresses.mockReturnValue(['0xabc']);
+      const { useAccountAdditionService } = await importModule();
+      const result = useAccountAdditionService().getNewAccountPayload('eth', [
+        { address: '0xABC', tags: null },
+        { address: '0xdef', tags: null },
+      ]);
+      expect(result).toEqual([{ address: '0xdef', tags: null }]);
+    });
+  });
+
+  describe('addSingleAccount', () => {
+    it('should return the address on success', async () => {
+      h.addAccount.mockResolvedValue('0xabc');
+      const { useAccountAdditionService } = await importModule();
+      const result = await useAccountAdditionService().addSingleAccount({ address: '0xabc', tags: null }, 'eth');
+      expect(h.addAccount).toHaveBeenCalledWith('eth', [{ address: '0xabc', tags: null }]);
+      expect(result).toStrictEqual({ address: '0xabc', type: 'success' });
+    });
+
+    it('should pass an xpub payload through directly', async () => {
+      h.addAccount.mockResolvedValue('xpub123');
+      const xpubPayload: XpubAccountPayload = {
+        tags: null,
+        xpub: { derivationPath: '', xpub: 'xpub123', xpubType: XpubKeyType.XPUB },
+      };
+      const { useAccountAdditionService } = await importModule();
+      const result = await useAccountAdditionService().addSingleAccount(xpubPayload, 'btc');
+      expect(h.addAccount).toHaveBeenCalledWith('btc', xpubPayload);
+      expect(result).toStrictEqual({ address: 'xpub123', type: 'success' });
+    });
+
+    it('should return an error result when the addition throws', async () => {
+      h.addAccount.mockRejectedValue(new Error('nope'));
+      const { useAccountAdditionService } = await importModule();
+      const result = await useAccountAdditionService().addSingleAccount({ address: '0xabc', tags: null }, 'eth');
+      expect(result.type).toBe('error');
+    });
+  });
+
+  describe('addSingleEvmAddress', () => {
+    it('should expand added chains and notify the user', async () => {
+      h.addEvmAccount.mockResolvedValue({ added: { '0xabc': ['eth', 'optimism'] } });
+      const { useAccountAdditionService } = await importModule();
+      const result = await useAccountAdditionService().addSingleEvmAddress({ address: '0xabc', tags: null });
+      assert(result.type === 'success');
+      expect(result.accounts).toEqual([
+        { address: '0xabc', chain: 'eth' },
+        { address: '0xabc', chain: 'optimism' },
+      ]);
+      expect(h.notifyUser).toHaveBeenCalledOnce();
+      expect(h.createFailureNotification).toHaveBeenCalledOnce();
+    });
+
+    it('should expand to all evm chains when the result is "all"', async () => {
+      h.addEvmAccount.mockResolvedValue({ added: { '0xabc': ['all'] } });
+      const { useAccountAdditionService } = await importModule();
+      const result = await useAccountAdditionService().addSingleEvmAddress({ address: '0xabc', tags: null });
+      assert(result.type === 'success');
+      expect(result.accounts.map(a => a.chain)).toEqual(['eth', 'optimism']);
+    });
+
+    it('should skip chains that are not valid blockchains', async () => {
+      h.addEvmAccount.mockResolvedValue({ added: { '0xabc': ['eth', 'not-a-chain'] } });
+      const { useAccountAdditionService } = await importModule();
+      const result = await useAccountAdditionService().addSingleEvmAddress({ address: '0xabc', tags: null });
+      assert(result.type === 'success');
+      expect(result.accounts.map(a => a.chain)).toEqual(['eth']);
+    });
+
+    it('should return an error result when the addition throws', async () => {
+      h.addEvmAccount.mockRejectedValue(new Error('boom'));
+      const { useAccountAdditionService } = await importModule();
+      const result = await useAccountAdditionService().addSingleEvmAddress({ address: '0xabc', tags: null });
+      expect(result.type).toBe('error');
+    });
+  });
+
+  describe('addMultipleAccounts', () => {
+    it('should collect added accounts and invoke the completion callback', async () => {
+      h.addAccount.mockResolvedValue('0xabc');
+      const onComplete = vi.fn<() => Promise<void>>(async () => {});
+      const { useAccountAdditionService } = await importModule();
+      await useAccountAdditionService().addMultipleAccounts(
+        [{ address: '0xabc', tags: null }],
+        'eth',
+        undefined,
+        onComplete,
+      );
+      expect(onComplete).toHaveBeenCalledWith({ addedAccounts: [{ address: '0xabc', chain: 'eth' }], chain: 'eth', modulesToEnable: undefined });
+      expect(h.notifyFailedToAddAddress).not.toHaveBeenCalled();
+    });
+
+    it('should notify about failed additions', async () => {
+      h.addAccount.mockRejectedValue(new Error('nope'));
+      const onComplete = vi.fn<() => Promise<void>>(async () => {});
+      const { useAccountAdditionService } = await importModule();
+      await useAccountAdditionService().addMultipleAccounts(
+        [{ address: '0xabc', tags: null }],
+        'eth',
+        undefined,
+        onComplete,
+      );
+      expect(h.notifyFailedToAddAddress).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('addMultipleEvmAccounts', () => {
+    it('should collect added accounts and invoke the completion callback', async () => {
+      h.addEvmAccount.mockResolvedValue({ added: { '0xabc': ['eth'] } });
+      const onComplete = vi.fn<() => Promise<void>>(async () => {});
+      const { useAccountAdditionService } = await importModule();
+      await useAccountAdditionService().addMultipleEvmAccounts(
+        { modules: undefined, payload: [{ address: '0xabc', tags: null }] },
+        onComplete,
+      );
+      expect(onComplete).toHaveBeenCalledWith({ addedAccounts: [{ address: '0xabc', chain: 'eth' }], modulesToEnable: undefined });
+      expect(h.notifyFailedToAddAddress).not.toHaveBeenCalled();
+    });
+
+    it('should notify about failed evm additions', async () => {
+      h.addEvmAccount.mockRejectedValue(new Error('boom'));
+      const onComplete = vi.fn<() => Promise<void>>(async () => {});
+      const { useAccountAdditionService } = await importModule();
+      await useAccountAdditionService().addMultipleEvmAccounts(
+        { modules: undefined, payload: [{ address: '0xabc', tags: null }] },
+        onComplete,
+      );
+      expect(h.notifyFailedToAddAddress).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('completeAccountAddition', () => {
+    const added = [{ address: '0xabc', chain: Blockchain.ETH }];
+
+    it('should fetch account metadata for transaction-supporting chains', async () => {
+      const onRefreshAccounts = vi.fn<() => Promise<void>>(async () => {});
+      const onFetchAccounts = vi.fn<() => Promise<void>>(async () => {});
+      const { useAccountAdditionService } = await importModule();
+      await useAccountAdditionService().completeAccountAddition(
+        { addedAccounts: added, chain: 'eth' },
+        onRefreshAccounts,
+        onFetchAccounts,
+      );
+      expect(h.fetchTags).toHaveBeenCalledOnce();
+      expect(h.trackAddedAddresses).toHaveBeenCalledWith(['0xabc']);
+      expect(onFetchAccounts).toHaveBeenCalledWith('eth', true);
+      expect(onRefreshAccounts).not.toHaveBeenCalled();
+      expect(h.detectTokens).toHaveBeenCalledWith('eth', ['0xabc']);
+    });
+
+    it('should refresh accounts when the chain does not support transactions', async () => {
+      h.supportsTransactions.mockReturnValue(false);
+      const onRefreshAccounts = vi.fn<() => Promise<void>>(async () => {});
+      const onFetchAccounts = vi.fn<() => Promise<void>>(async () => {});
+      const { useAccountAdditionService } = await importModule();
+      await useAccountAdditionService().completeAccountAddition(
+        { addedAccounts: added, chain: 'btc', isXpub: true },
+        onRefreshAccounts,
+        onFetchAccounts,
+      );
+      expect(onRefreshAccounts).toHaveBeenCalledWith({ addresses: ['0xabc'], blockchain: 'btc', isXpub: true });
+      expect(onFetchAccounts).not.toHaveBeenCalled();
+      expect(h.detectTokens).not.toHaveBeenCalled();
+    });
+
+    it('should enable the requested modules for eth accounts', async () => {
+      const onRefreshAccounts = vi.fn<() => Promise<void>>(async () => {});
+      const onFetchAccounts = vi.fn<() => Promise<void>>(async () => {});
+      const { useAccountAdditionService } = await importModule();
+      await useAccountAdditionService().completeAccountAddition(
+        { addedAccounts: added, chain: 'eth', modulesToEnable: [Module.ETH2] },
+        onRefreshAccounts,
+        onFetchAccounts,
+      );
+      expect(h.enableModule).toHaveBeenCalledWith({ addresses: ['0xabc'], enable: [Module.ETH2] });
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/use-account-asset-selection.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-asset-selection.spec.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccountAssetSelection } from './use-account-asset-selection';
+import '@test/i18n';
+
+const h = vi.hoisted(() => ({
+  ignoreAsset: vi.fn(),
+  markAssetsAsSpam: vi.fn(),
+  showErrorMessage: vi.fn(),
+  unignoreAsset: vi.fn(),
+}));
+
+vi.mock('@/modules/assets/use-ignored-asset-operations', () => ({
+  useIgnoredAssetOperations: vi.fn(() => ({ ignoreAsset: h.ignoreAsset, unignoreAsset: h.unignoreAsset })),
+}));
+
+vi.mock('@/modules/assets/use-spam-asset', () => ({
+  useSpamAsset: vi.fn(() => ({ markAssetsAsSpam: h.markAssetsAsSpam })),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn(() => ({ showErrorMessage: h.showErrorMessage })),
+}));
+
+describe('useAccountAssetSelection', () => {
+  const onRefresh = vi.fn<() => Promise<void>>(async () => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('toggleSelectionMode', () => {
+    it('should enable selection mode and expose the selected assets', () => {
+      const { selectedAssets, selectionMode, toggleSelectionMode } = useAccountAssetSelection(onRefresh);
+      expect(get(selectionMode)).toBe(false);
+      expect(get(selectedAssets)).toBeUndefined();
+
+      toggleSelectionMode();
+      expect(get(selectionMode)).toBe(true);
+      set(selectedAssets, ['ETH']);
+      expect(get(selectedAssets)).toEqual(['ETH']);
+    });
+
+    it('should clear the selection when disabling selection mode', () => {
+      const { selectedAssets, selectionMode, toggleSelectionMode } = useAccountAssetSelection(onRefresh);
+      toggleSelectionMode();
+      set(selectedAssets, ['ETH']);
+      toggleSelectionMode();
+      expect(get(selectionMode)).toBe(false);
+      expect(get(selectedAssets)).toBeUndefined();
+    });
+  });
+
+  describe('handleIgnoreSelected', () => {
+    it('should show an error and not ignore when nothing is selected', async () => {
+      const { handleIgnoreSelected } = useAccountAssetSelection(onRefresh);
+      await handleIgnoreSelected(true);
+      expect(h.showErrorMessage).toHaveBeenCalledOnce();
+      expect(h.ignoreAsset).not.toHaveBeenCalled();
+    });
+
+    it('should ignore the selected assets and refresh on success', async () => {
+      h.ignoreAsset.mockResolvedValue({ success: true });
+      const { handleIgnoreSelected, selectedAssets, selectionMode, toggleSelectionMode } = useAccountAssetSelection(onRefresh);
+      toggleSelectionMode();
+      set(selectedAssets, ['ETH', 'DAI']);
+
+      await handleIgnoreSelected(true);
+      expect(h.ignoreAsset).toHaveBeenCalledWith(['ETH', 'DAI']);
+      expect(onRefresh).toHaveBeenCalledOnce();
+      expect(get(selectionMode)).toBe(false);
+    });
+
+    it('should unignore the selected assets when ignored is false', async () => {
+      h.unignoreAsset.mockResolvedValue({ success: true });
+      const { handleIgnoreSelected, selectedAssets, toggleSelectionMode } = useAccountAssetSelection(onRefresh);
+      toggleSelectionMode();
+      set(selectedAssets, ['ETH']);
+
+      await handleIgnoreSelected(false);
+      expect(h.unignoreAsset).toHaveBeenCalledWith(['ETH']);
+      expect(onRefresh).toHaveBeenCalledOnce();
+    });
+
+    it('should keep the selection when the operation fails', async () => {
+      h.ignoreAsset.mockResolvedValue({ success: false });
+      const { handleIgnoreSelected, selectedAssets, selectionMode, toggleSelectionMode } = useAccountAssetSelection(onRefresh);
+      toggleSelectionMode();
+      set(selectedAssets, ['ETH']);
+
+      await handleIgnoreSelected(true);
+      expect(onRefresh).not.toHaveBeenCalled();
+      expect(get(selectionMode)).toBe(true);
+      expect(get(selectedAssets)).toEqual(['ETH']);
+    });
+  });
+
+  describe('handleMarkSelectedAsSpam', () => {
+    it('should show an error when nothing is selected', async () => {
+      const { handleMarkSelectedAsSpam } = useAccountAssetSelection(onRefresh);
+      await handleMarkSelectedAsSpam();
+      expect(h.showErrorMessage).toHaveBeenCalledOnce();
+      expect(h.markAssetsAsSpam).not.toHaveBeenCalled();
+    });
+
+    it('should mark the selected assets as spam and refresh on success', async () => {
+      h.markAssetsAsSpam.mockResolvedValue({ success: true });
+      const { handleMarkSelectedAsSpam, selectedAssets, selectionMode, toggleSelectionMode } = useAccountAssetSelection(onRefresh);
+      toggleSelectionMode();
+      set(selectedAssets, ['SCAM']);
+
+      await handleMarkSelectedAsSpam();
+      expect(h.markAssetsAsSpam).toHaveBeenCalledWith(['SCAM']);
+      expect(onRefresh).toHaveBeenCalledOnce();
+      expect(get(selectionMode)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/use-blockchain-accounts.spec.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-accounts.spec.ts
@@ -1,0 +1,304 @@
+import type { TaskResult } from '@/modules/core/tasks/use-task-handler';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type AccountPayload, type XpubAccountPayload, XpubKeyType } from '@/modules/accounts/blockchain-accounts';
+import '@test/i18n';
+
+const mocks = vi.hoisted(() => ({
+  addBlockchainAccount: vi.fn(),
+  addEvmAccount: vi.fn(),
+  editAgnosticBlockchainAccount: vi.fn(),
+  editBlockchainAccount: vi.fn(),
+  editBtcAccount: vi.fn(),
+  fetchEthStakingValidators: vi.fn(),
+  getNativeAsset: vi.fn((chain: string): string => chain.toUpperCase()),
+  notifyError: vi.fn(),
+  queryAccounts: vi.fn(),
+  queryBtcAccounts: vi.fn(),
+  removeAgnosticBlockchainAccount: vi.fn(),
+  removeBlockchainAccount: vi.fn(),
+  resetAddressNamesData: vi.fn(),
+  runTask: vi.fn(),
+  updateAccounts: vi.fn(),
+  deleteXpub: vi.fn(),
+}));
+
+vi.mock('@/modules/accounts/api/use-blockchain-accounts-api', () => ({
+  useBlockchainAccountsApi: vi.fn(() => ({
+    addBlockchainAccount: mocks.addBlockchainAccount,
+    addEvmAccount: mocks.addEvmAccount,
+    deleteXpub: mocks.deleteXpub,
+    editAgnosticBlockchainAccount: mocks.editAgnosticBlockchainAccount,
+    editBlockchainAccount: mocks.editBlockchainAccount,
+    editBtcAccount: mocks.editBtcAccount,
+    queryAccounts: mocks.queryAccounts,
+    queryBtcAccounts: mocks.queryBtcAccounts,
+    removeAgnosticBlockchainAccount: mocks.removeAgnosticBlockchainAccount,
+    removeBlockchainAccount: mocks.removeBlockchainAccount,
+  })),
+}));
+
+vi.mock('@/modules/accounts/use-eth-staking', () => ({
+  useEthStaking: vi.fn(() => ({ fetchEthStakingValidators: mocks.fetchEthStakingValidators })),
+}));
+
+vi.mock('@/modules/accounts/use-blockchain-accounts-store', () => ({
+  useBlockchainAccountsStore: vi.fn(() => ({ updateAccounts: mocks.updateAccounts })),
+}));
+
+vi.mock('@/modules/accounts/address-book/use-address-name-resolution', () => ({
+  useAddressNameResolution: vi.fn(() => ({ resetAddressNamesData: mocks.resetAddressNamesData })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({
+    getChainName: (chain: string): string => chain,
+    getNativeAsset: mocks.getNativeAsset,
+  })),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  getErrorMessage: (e: unknown): string => (e instanceof Error ? e.message : String(e)),
+  useNotifications: vi.fn(() => ({ notifyError: mocks.notifyError })),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-handler', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/modules/core/tasks/use-task-handler')>();
+  return {
+    ...actual,
+    useTaskHandler: vi.fn(() => ({ runTask: mocks.runTask })),
+  };
+});
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+function success<R>(result: R): TaskResult<R> {
+  return { result, success: true };
+}
+
+function actionable(message: string): TaskResult<never> {
+  return { backendCancelled: false, cancelled: false, error: new Error(message), message, skipped: false, success: false };
+}
+
+function cancelled(): TaskResult<never> {
+  return { backendCancelled: false, cancelled: true, message: 'cancelled', skipped: false, success: false };
+}
+
+// runTask is mocked and does not invoke its callback; opt into invoking it when the API call must run.
+function whenTask<R>(outcome: TaskResult<R>, invoke = true): void {
+  mocks.runTask.mockImplementation(async (task: () => Promise<unknown>): Promise<TaskResult<R>> => {
+    if (invoke)
+      await task();
+    return outcome;
+  });
+}
+
+async function importModule(): Promise<typeof import('./use-blockchain-accounts')> {
+  return import('./use-blockchain-accounts');
+}
+
+describe('useBlockchainAccounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('addAccount', () => {
+    const payload: AccountPayload[] = [{ address: '0xabc', tags: null }];
+
+    it('should return the first result address on success', async () => {
+      whenTask(success(['0xdef']));
+      const { useBlockchainAccounts } = await importModule();
+      const result = await useBlockchainAccounts().addAccount('eth', payload);
+      expect(mocks.addBlockchainAccount).toHaveBeenCalledWith('eth', payload);
+      expect(result).toBe('0xdef');
+    });
+
+    it('should return the joined addresses when the result is true', async () => {
+      whenTask(success<string[] | true>(true));
+      const { useBlockchainAccounts } = await importModule();
+      const result = await useBlockchainAccounts().addAccount('eth', [
+        { address: '0xabc', tags: null },
+        { address: '0xdef', tags: null },
+      ]);
+      expect(result).toBe('0xabc,\n0xdef');
+    });
+
+    it('should return an empty string when the result array is empty', async () => {
+      whenTask(success<string[]>([]));
+      const { useBlockchainAccounts } = await importModule();
+      expect(await useBlockchainAccounts().addAccount('eth', payload)).toBe('');
+    });
+
+    it('should use the xpub as the address for an xpub payload', async () => {
+      whenTask(success(['0xdef']));
+      const xpubPayload: XpubAccountPayload = {
+        tags: null,
+        xpub: { derivationPath: '', xpub: 'xpub123', xpubType: XpubKeyType.XPUB },
+      };
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().addAccount('btc', xpubPayload);
+      expect(mocks.addBlockchainAccount).toHaveBeenCalledWith('btc', xpubPayload);
+    });
+
+    it('should throw on an actionable failure', async () => {
+      whenTask(actionable('boom'), false);
+      const { useBlockchainAccounts } = await importModule();
+      await expect(useBlockchainAccounts().addAccount('eth', payload)).rejects.toThrow('boom');
+    });
+
+    it('should return an empty string on a cancelled task', async () => {
+      whenTask(cancelled(), false);
+      const { useBlockchainAccounts } = await importModule();
+      expect(await useBlockchainAccounts().addAccount('eth', payload)).toBe('');
+    });
+  });
+
+  describe('addEvmAccount', () => {
+    const payload: AccountPayload = { address: '0xabc', tags: null };
+
+    it('should return the result on success', async () => {
+      whenTask(success({ added: { eth: ['0xabc'] } }));
+      const { useBlockchainAccounts } = await importModule();
+      const result = await useBlockchainAccounts().addEvmAccount(payload);
+      expect(mocks.addEvmAccount).toHaveBeenCalledWith(payload);
+      expect(result).toStrictEqual({ added: { eth: ['0xabc'] } });
+    });
+
+    it('should throw on an actionable failure', async () => {
+      whenTask(actionable('nope'), false);
+      const { useBlockchainAccounts } = await importModule();
+      await expect(useBlockchainAccounts().addEvmAccount(payload)).rejects.toThrow('nope');
+    });
+
+    it('should return an empty object on a cancelled task', async () => {
+      whenTask(cancelled(), false);
+      const { useBlockchainAccounts } = await importModule();
+      expect(await useBlockchainAccounts().addEvmAccount(payload)).toStrictEqual({});
+    });
+  });
+
+  describe('editAccount', () => {
+    it('should edit a btc account and reset address names for a non-xpub payload', async () => {
+      mocks.editBtcAccount.mockResolvedValue({ standalone: [], xpubs: [] });
+      const { useBlockchainAccounts } = await importModule();
+      const result = await useBlockchainAccounts().editAccount({ address: 'bc1', tags: null }, 'btc');
+      expect(mocks.editBtcAccount).toHaveBeenCalled();
+      expect(result).toStrictEqual([]);
+      expect(mocks.resetAddressNamesData).toHaveBeenCalledOnce();
+    });
+
+    it('should not reset address names for an xpub payload', async () => {
+      mocks.editBtcAccount.mockResolvedValue({ standalone: [], xpubs: [] });
+      const xpubPayload: XpubAccountPayload = {
+        tags: null,
+        xpub: { derivationPath: '', xpub: 'xpub123', xpubType: XpubKeyType.XPUB },
+      };
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().editAccount(xpubPayload, 'btc');
+      expect(mocks.resetAddressNamesData).not.toHaveBeenCalled();
+    });
+
+    it('should edit an evm account and map the result into accounts', async () => {
+      mocks.editBlockchainAccount.mockResolvedValue([{ address: '0xabc', label: null, tags: null }]);
+      const { useBlockchainAccounts } = await importModule();
+      const result = await useBlockchainAccounts().editAccount({ address: '0xabc', tags: null }, 'eth');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ chain: 'eth', data: { address: '0xabc', type: 'address' }, nativeAsset: 'ETH' });
+      expect(mocks.resetAddressNamesData).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('editAgnosticAccount', () => {
+    it('should edit the account and reset address names', async () => {
+      mocks.editAgnosticBlockchainAccount.mockResolvedValue(true);
+      const { useBlockchainAccounts } = await importModule();
+      const result = await useBlockchainAccounts().editAgnosticAccount('evm', { address: '0xabc', tags: null });
+      expect(result).toBe(true);
+      expect(mocks.resetAddressNamesData).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('removeAccount', () => {
+    it('should not notify on success', async () => {
+      whenTask(success({ perAccount: {}, totals: { assets: {}, liabilities: {} } }), false);
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().removeAccount({ accounts: ['0xabc'], chain: 'eth' });
+      expect(mocks.notifyError).not.toHaveBeenCalled();
+    });
+
+    it('should notify on an actionable failure', async () => {
+      whenTask(actionable('remove failed'), false);
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().removeAccount({ accounts: ['0xabc'], chain: 'eth' });
+      expect(mocks.notifyError).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('removeAgnosticAccount', () => {
+    it('should notify on an actionable failure', async () => {
+      whenTask(actionable('agnostic failed'), false);
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().removeAgnosticAccount('evm', '0xabc');
+      expect(mocks.notifyError).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('deleteXpub', () => {
+    it('should notify on an actionable failure', async () => {
+      whenTask(actionable('xpub failed'), false);
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().deleteXpub({ chain: 'btc', xpub: 'xpub123' });
+      expect(mocks.notifyError).toHaveBeenCalledOnce();
+    });
+
+    it('should not notify on success', async () => {
+      whenTask(success(true), false);
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().deleteXpub({ chain: 'btc', xpub: 'xpub123' });
+      expect(mocks.notifyError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetch', () => {
+    it('should fetch btc accounts for a btc chain', async () => {
+      mocks.queryBtcAccounts.mockResolvedValue({ standalone: [], xpubs: [] });
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().fetch('btc');
+      expect(mocks.queryBtcAccounts).toHaveBeenCalledWith('btc');
+      expect(mocks.updateAccounts).toHaveBeenCalledWith('btc', []);
+    });
+
+    it('should fetch eth staking validators for eth2', async () => {
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().fetch('eth2');
+      expect(mocks.fetchEthStakingValidators).toHaveBeenCalledOnce();
+    });
+
+    it('should fetch blockchain accounts for a regular chain', async () => {
+      mocks.queryAccounts.mockResolvedValue([{ address: '0xabc', label: null, tags: null }]);
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().fetch('eth');
+      expect(mocks.queryAccounts).toHaveBeenCalledWith('eth');
+      expect(mocks.updateAccounts).toHaveBeenCalledOnce();
+    });
+
+    it('should notify when fetching blockchain accounts fails', async () => {
+      mocks.queryAccounts.mockRejectedValue(new Error('query failed'));
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().fetch('eth');
+      expect(mocks.notifyError).toHaveBeenCalledOnce();
+    });
+
+    it('should notify when fetching btc accounts fails', async () => {
+      mocks.queryBtcAccounts.mockRejectedValue(new Error('btc failed'));
+      const { useBlockchainAccounts } = await importModule();
+      await useBlockchainAccounts().fetch('bch');
+      expect(mocks.notifyError).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/use-eth-staking.spec.ts
+++ b/frontend/app/src/modules/accounts/use-eth-staking.spec.ts
@@ -1,0 +1,268 @@
+import type { BlockchainAccount, ValidatorData } from '@/modules/accounts/blockchain-accounts';
+import type { TaskResult } from '@/modules/core/tasks/use-task-handler';
+import { Blockchain } from '@rotki/common';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+import { Module } from '@/modules/core/common/modules';
+import '@test/i18n';
+
+const h = vi.hoisted(() => ({
+  addEth2Validator: vi.fn(),
+  deleteEth2Validators: vi.fn(),
+  editEth2Validator: vi.fn(),
+  fetchEthStakingValidators: vi.fn(),
+  resetStatus: vi.fn(),
+  runTask: vi.fn(),
+  showErrorMessage: vi.fn(),
+  // plain holder: the SUT only reads these, so the mocks expose them via computed()
+  state: { activeModules: [] as string[], premium: false },
+}));
+
+vi.mock('@/modules/accounts/api/use-blockchain-accounts-api', () => ({
+  useBlockchainAccountsApi: vi.fn(() => ({
+    addEth2Validator: h.addEth2Validator,
+    deleteEth2Validators: h.deleteEth2Validators,
+    editEth2Validator: h.editEth2Validator,
+  })),
+}));
+
+vi.mock('@/modules/staking/eth/use-eth-validator-fetching', () => ({
+  useEthValidatorFetching: vi.fn(() => ({ fetchEthStakingValidators: h.fetchEthStakingValidators })),
+}));
+
+vi.mock('@/modules/premium/use-premium', async () => {
+  const { computed } = await import('vue');
+  return { usePremium: vi.fn(() => computed(() => h.state.premium)) };
+});
+
+vi.mock('@/modules/settings/use-setting', async () => {
+  const { computed } = await import('vue');
+  return { useSetting: vi.fn(() => computed(() => h.state.activeModules)) };
+});
+
+vi.mock('@/modules/shell/sync-progress/use-status-updater', () => ({
+  useStatusUpdater: vi.fn(() => ({ resetStatus: h.resetStatus })),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  getErrorMessage: (e: unknown): string => (e instanceof Error ? e.message : String(e)),
+  useNotifications: vi.fn(() => ({ showErrorMessage: h.showErrorMessage })),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-handler', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/modules/core/tasks/use-task-handler')>();
+  return { ...actual, useTaskHandler: vi.fn(() => ({ runTask: h.runTask })) };
+});
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+function success<R>(result: R): TaskResult<R> {
+  return { result, success: true };
+}
+
+function actionable(message: string, error: unknown = new Error(message)): TaskResult<never> {
+  return { backendCancelled: false, cancelled: false, error, message, skipped: false, success: false };
+}
+
+function cancelled(): TaskResult<never> {
+  return { backendCancelled: false, cancelled: true, message: 'cancelled', skipped: false, success: false };
+}
+
+function whenTask<R>(outcome: TaskResult<R>, invoke = true): void {
+  h.runTask.mockImplementation(async (task: () => Promise<unknown>): Promise<TaskResult<R>> => {
+    if (invoke)
+      await task();
+    return outcome;
+  });
+}
+
+function validatorAccount(publicKey: string, index: number): BlockchainAccount<ValidatorData> {
+  return { chain: 'eth2', data: { index, publicKey, status: 'active', type: 'validator' }, nativeAsset: 'ETH2' };
+}
+
+async function importModule(): Promise<typeof import('./use-eth-staking')> {
+  return import('./use-eth-staking');
+}
+
+describe('useEthStaking', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    h.state.activeModules = [Module.ETH2];
+    h.state.premium = false;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('addEth2Validator', () => {
+    const payload = { publicKey: '0xpub', validatorIndex: '1' };
+
+    it('should return failure without running a task when eth2 is disabled', async () => {
+      h.state.activeModules = [];
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().addEth2Validator(payload);
+      expect(result).toStrictEqual({ message: '', success: false });
+      expect(h.runTask).not.toHaveBeenCalled();
+    });
+
+    it('should reset statuses and return success when the validator is added', async () => {
+      whenTask(success(true));
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().addEth2Validator(payload);
+      expect(h.addEth2Validator).toHaveBeenCalledWith(payload);
+      expect(result).toStrictEqual({ message: '', success: true });
+      expect(h.resetStatus).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not reset statuses when the result is falsy', async () => {
+      whenTask(success(false));
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().addEth2Validator(payload);
+      expect(result).toStrictEqual({ message: '', success: false });
+      expect(h.resetStatus).not.toHaveBeenCalled();
+    });
+
+    it('should surface validation errors from an actionable failure', async () => {
+      whenTask(actionable('bad', new ApiValidationError('{"publicKey":["Invalid key"]}')), false);
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().addEth2Validator(payload);
+      assert(!result.success);
+      expect(result.message).not.toBe('');
+    });
+
+    it('should return the failure message for a plain actionable failure', async () => {
+      whenTask(actionable('some error'), false);
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().addEth2Validator(payload);
+      expect(result).toStrictEqual({ message: 'some error', success: false });
+    });
+
+    it('should return a generic failure on a cancelled task', async () => {
+      whenTask(cancelled(), false);
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().addEth2Validator(payload);
+      expect(result).toStrictEqual({ message: '', success: false });
+    });
+  });
+
+  describe('editEth2Validator', () => {
+    const payload = { publicKey: '0xpub', validatorIndex: '1' };
+
+    it('should return failure without calling the api when eth2 is disabled', async () => {
+      h.state.activeModules = [];
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().editEth2Validator(payload);
+      expect(result).toStrictEqual({ message: '', success: false });
+      expect(h.editEth2Validator).not.toHaveBeenCalled();
+    });
+
+    it('should return success when the edit succeeds', async () => {
+      h.editEth2Validator.mockResolvedValue(true);
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().editEth2Validator(payload);
+      expect(h.editEth2Validator).toHaveBeenCalledWith(payload);
+      expect(result).toStrictEqual({ message: '', success: true });
+    });
+
+    it('should map a validation error into the message', async () => {
+      h.editEth2Validator.mockRejectedValue(new ApiValidationError('{"publicKey":["Invalid key"]}'));
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().editEth2Validator(payload);
+      assert(!result.success);
+      expect(result.message).not.toBe('');
+    });
+
+    it('should return the error message on a generic failure', async () => {
+      h.editEth2Validator.mockRejectedValue(new Error('boom'));
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().editEth2Validator(payload);
+      expect(result).toStrictEqual({ message: 'boom', success: false });
+    });
+  });
+
+  describe('deleteEth2Validators', () => {
+    beforeEach(() => {
+      const accountsStore = useBlockchainAccountsStore();
+      accountsStore.updateAccounts(Blockchain.ETH2, [
+        validatorAccount('0xaaa', 1),
+        validatorAccount('0xbbb', 2),
+      ]);
+    });
+
+    it('should refetch validators on success for a non-premium user', async () => {
+      h.deleteEth2Validators.mockResolvedValue(true);
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().deleteEth2Validators(['0xaaa']);
+      expect(result).toBe(true);
+      expect(h.deleteEth2Validators).toHaveBeenCalledWith([
+        expect.objectContaining({ publicKey: '0xaaa' }),
+      ]);
+      expect(h.fetchEthStakingValidators).toHaveBeenCalledOnce();
+    });
+
+    it('should locally prune the accounts on success for a premium user', async () => {
+      h.state.premium = true;
+      h.deleteEth2Validators.mockResolvedValue(true);
+      const { useEthStaking } = await importModule();
+      await useEthStaking().deleteEth2Validators(['0xaaa']);
+      const accountsStore = useBlockchainAccountsStore();
+      const remaining = accountsStore.getAccounts(Blockchain.ETH2).map(a => 'publicKey' in a.data ? a.data.publicKey : '');
+      expect(remaining).toEqual(['0xbbb']);
+      expect(h.fetchEthStakingValidators).not.toHaveBeenCalled();
+    });
+
+    it('should not mutate state when the api reports no removal', async () => {
+      h.deleteEth2Validators.mockResolvedValue(false);
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().deleteEth2Validators(['0xaaa']);
+      expect(result).toBe(false);
+      expect(h.fetchEthStakingValidators).not.toHaveBeenCalled();
+    });
+
+    it('should show an error message when deletion fails', async () => {
+      h.deleteEth2Validators.mockRejectedValue(new Error('delete failed'));
+      const { useEthStaking } = await importModule();
+      const result = await useEthStaking().deleteEth2Validators(['0xaaa']);
+      expect(result).toBe(false);
+      expect(h.showErrorMessage).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('validatorsLimitInfo', () => {
+    it('should report zeros when no limits are known', async () => {
+      const { useEthStaking } = await importModule();
+      expect(get(useEthStaking().validatorsLimitInfo)).toStrictEqual({ limit: 0, showWarning: false, total: 0 });
+    });
+
+    it('should warn when the limit is reached', async () => {
+      const { useBlockchainValidatorsStore } = await import('@/modules/staking/use-blockchain-validators-store');
+      const { stakingValidatorsLimits } = storeToRefs(useBlockchainValidatorsStore());
+      set(stakingValidatorsLimits, { limit: 5, total: 5 });
+      const { useEthStaking } = await importModule();
+      expect(get(useEthStaking().validatorsLimitInfo)).toStrictEqual({ limit: 5, showWarning: true, total: 5 });
+    });
+
+    it('should not warn when below the limit', async () => {
+      const { useBlockchainValidatorsStore } = await import('@/modules/staking/use-blockchain-validators-store');
+      const { stakingValidatorsLimits } = storeToRefs(useBlockchainValidatorsStore());
+      set(stakingValidatorsLimits, { limit: 10, total: 3 });
+      const { useEthStaking } = await importModule();
+      expect(get(useEthStaking().validatorsLimitInfo)).toStrictEqual({ limit: 10, showWarning: false, total: 3 });
+    });
+  });
+
+  describe('passthrough exports', () => {
+    it('should expose the store ownership updater and validator fetcher', async () => {
+      const { useEthStaking } = await importModule();
+      const staking = useEthStaking();
+      expect(staking.fetchEthStakingValidators).toBe(h.fetchEthStakingValidators);
+      expect(typeof staking.updateEthStakingOwnership).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
Part of #11252 (frontend unit & integration test coverage).

Adds unit coverage for the `modules/accounts` cluster, from the pure helpers up to the orchestration composables.

## Covered
- **account-common / account-utils / account-validator** — sort/filter primitives, id/label/type-guard builders, and validator sort/filter/pagination.
- **account-helpers** — account type guards, `sortAndFilterAccounts` (filter/sort/paginate), BTC account and balance conversion, cross-chain total aggregation, token detection, per-account balance derivation.
- **useBlockchainAccounts** — add/edit/remove account flows, xpub deletion, and the `fetch` dispatch (btc, eth2 staking, regular chains) including task-failure notification and error paths.
- **useEthStaking** — eth2 validator add/edit/delete (module gate, validation-error mapping, premium vs non-premium prune paths) and the validators limit info computed.
- **useAccountAdditionService** — single/multiple account and EVM addition, chain expansion, and completion-callback branches.
- **useAccountAdditionNotifications** — the info/warning/error notification builders.
- **useAccountAssetSelection** — selection-mode toggling plus ignore/unignore/spam handlers.

## Test plan
- 152 new tests across 9 spec files.
- Full unit suite green: 563 files / 5433 tests.
- `pnpm run typecheck` clean; `pnpm run lint-staged` clean.