### PR TITLE
Rework balance divergence panel and polish account/asset pickers

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1754,6 +1754,7 @@
     "asset": "Asset",
     "block": "Block",
     "chain": "Chain",
+    "chain_missing_archive_node": "No archive node configured for {chain}. Configure one in {link} to run this check for this chain.",
     "checked": "Checked {probes} points.",
     "difference": "Difference",
     "event": "Tx",
@@ -1764,6 +1765,7 @@
     "no_divergence": "The latest tracked and on-chain balances match. No persistent divergence to locate. Checked {probes} points.",
     "no_options": "No EVM location labels are available.",
     "onchain": "On-chain",
+    "settings_link": "RPC node settings",
     "task": {
       "title": "Finding balance divergence for {asset}"
     },

--- a/frontend/app/src/modules/history/LocationLabelSelector.spec.ts
+++ b/frontend/app/src/modules/history/LocationLabelSelector.spec.ts
@@ -1,0 +1,48 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import LocationLabelSelector from '@/modules/history/LocationLabelSelector.vue';
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): object => ({
+    allTxChainsInfo: ref([{ id: 'eth' }]),
+    getEvmChainName: (chain: string): string | undefined => chain === 'eth' ? 'ethereum' : undefined,
+    matchChain: (location: string): string | undefined => location === 'eth' ? 'eth' : undefined,
+  }),
+}));
+
+vi.mock('@/modules/accounts/address-book/use-address-name-resolution', () => ({
+  useAddressNameResolution: (): object => ({ getAddressName: (): undefined => undefined }),
+}));
+
+const stubs = {
+  AccountDisplay: true,
+  LocationIcon: true,
+  RuiAutoComplete: {
+    props: ['menuClass', 'options'],
+    template: '<div data-testid="autocomplete" :data-menu-class="menuClass"><slot /></div>',
+  },
+  TagDisplay: true,
+};
+
+function createWrapper(): VueWrapper {
+  return mount(LocationLabelSelector, {
+    global: { stubs },
+    props: { modelValue: '', options: [] },
+  });
+}
+
+describe('locationLabelSelector', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should constrain the dropdown menu to the field width', () => {
+    // The full address is used as text-attr, so without this the menu auto-sizes to the address
+    // length and overflows the field (see AssetSelect, which does the same).
+    const wrapper = createWrapper();
+
+    expect(wrapper.find('[data-testid=autocomplete]').attributes('data-menu-class')).toBe('!min-w-full');
+  });
+});

--- a/frontend/app/src/modules/history/LocationLabelSelector.vue
+++ b/frontend/app/src/modules/history/LocationLabelSelector.vue
@@ -1,14 +1,9 @@
 <script setup lang="ts">
-import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
 import type { LocationLabel } from '@/modules/core/common/location';
-import { getTextToken } from '@rotki/common';
-import { hasAccountAddress } from '@/modules/accounts/account-helpers';
-import { getAccountAddress } from '@/modules/accounts/account-utils';
-import { useAddressNameResolution } from '@/modules/accounts/address-book/use-address-name-resolution';
-import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
-import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { useHistoryStore } from '@/modules/history/use-history-store';
-import AccountDisplay from '@/modules/shell/components/display/AccountDisplay.vue';
+import { truncateAddress } from '@/modules/core/common/display/truncate';
+import { useLocationLabels } from '@/modules/history/use-location-labels';
+import { useScramble } from '@/modules/settings/use-scramble';
+import EnsAvatar from '@/modules/shell/components/display/EnsAvatar.vue';
 import LocationIcon from '@/modules/shell/components/display/LocationIcon.vue';
 import TagDisplay from '@/modules/tags/TagDisplay.vue';
 
@@ -24,91 +19,18 @@ const modelValue = defineModel<string[] | string>({
 
 const { options } = defineProps<{
   options?: LocationLabel[];
-  noTruncate?: boolean;
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const { locationLabels: storeLocationLabels } = storeToRefs(useHistoryStore());
+const { scrambleAddress } = useScramble();
 
-const locationLabelOptions = computed<LocationLabel[]>(() => options ?? get(storeLocationLabels));
-const { allTxChainsInfo, matchChain } = useSupportedChains();
-const txChainIds = useArrayMap(allTxChainsInfo, x => x.id);
-
-const { accounts: accountsPerChain } = storeToRefs(useBlockchainAccountsStore());
-const { getAddressName } = useAddressNameResolution();
-
-const accounts = computed<BlockchainAccount<AddressData>[]>(() =>
-  Object.values(get(accountsPerChain))
-    .flatMap(x => x)
-    .filter(hasAccountAddress),
-);
-
-function getBlockchainLocation(location: string): string | undefined {
-  const chain = matchChain(location);
-  if (!chain)
-    return undefined;
-
-  if (!get(txChainIds).includes(chain))
-    return undefined;
-
-  return chain;
-}
-
-function getTags(item: LocationLabel): string[] {
-  const registeredAccounts = getRegisteredAccounts(item);
-  if (registeredAccounts.length === 0)
-    return [];
-
-  return registeredAccounts[0].tags || [];
-}
-
-function getRegisteredAccounts(item: LocationLabel): BlockchainAccount<AddressData>[] {
-  const chain = getBlockchainLocation(item.location);
-
-  if (!chain)
-    return [];
-
-  return get(accounts).filter(acc => getAccountAddress(acc) === item.locationLabel && acc.chain === chain);
-}
-
-function getTrackedAccountLabel(item: LocationLabel): string | undefined {
-  const label = getRegisteredAccounts(item)[0]?.label;
-  return label && label !== item.locationLabel ? label : undefined;
-}
-
-function filter(item: LocationLabel, queryText: string): boolean {
-  const locationLabel = getTextToken(item.locationLabel);
-  const query = getTextToken(queryText);
-
-  const locationLabelMatches = locationLabel.includes(query);
-
-  if (locationLabelMatches) {
-    return true;
-  }
-
-  const chain = getBlockchainLocation(item.location);
-
-  if (!chain) {
-    return false;
-  }
-
-  const text = getTextToken(getAddressName(item.locationLabel, chain) ?? '');
-  const trackedAccountLabel = getTextToken(getTrackedAccountLabel(item) ?? '');
-
-  const labelMatches = text.includes(query) || trackedAccountLabel.includes(query);
-
-  if (labelMatches) {
-    return true;
-  }
-
-  const tags = getTags(item);
-  return tags
-    ? tags
-        .map(tag => getTextToken(tag))
-        .join(' ')
-        .includes(query)
-    : false;
-}
+const {
+  filter,
+  getAccountName,
+  getBlockchainLocation,
+  getTags,
+  locationLabelOptions,
+} = useLocationLabels(() => options);
 
 const [DefineLocationItem, ReuseLocationItem] = createReusableTemplate<{ item: LocationLabel; dense: boolean }>();
 </script>
@@ -117,21 +39,50 @@ const [DefineLocationItem, ReuseLocationItem] = createReusableTemplate<{ item: L
   <DefineLocationItem #default="{ item, dense }">
     <div
       v-if="getBlockchainLocation(item.location)"
-      :class="{ 'py-1': !dense }"
-      class="flex items-center gap-2 min-w-0"
+      class="flex items-center gap-2.5 min-w-0"
     >
-      <AccountDisplay
-        :size="dense ? '16px' : '24px'"
-        :account="{ address: item.locationLabel, chain: getBlockchainLocation(item.location)! }"
-        hide-chain-icon
-        :no-truncate="noTruncate"
+      <EnsAvatar
+        :address="scrambleAddress(item.locationLabel)"
+        avatar
+        class="shrink-0"
+        :size="dense ? '22px' : '28px'"
       />
-      <span
-        v-if="getTrackedAccountLabel(item)"
-        class="text-rui-text-secondary truncate"
+      <!-- field: keep the name and address on one compact line -->
+      <div
+        v-if="dense"
+        class="flex items-baseline gap-1.5 min-w-0"
       >
-        {{ getTrackedAccountLabel(item) }}
-      </span>
+        <span
+          v-if="getAccountName(item)"
+          class="truncate text-sm"
+        >
+          {{ getAccountName(item) }}
+        </span>
+        <span
+          class="truncate font-mono text-xs"
+          :class="getAccountName(item) ? 'text-rui-text-secondary' : 'text-rui-text'"
+        >
+          {{ truncateAddress(scrambleAddress(item.locationLabel), 4) }}
+        </span>
+      </div>
+      <!-- dropdown: name over the muted address -->
+      <div
+        v-else
+        class="flex flex-col min-w-0 leading-tight"
+      >
+        <span
+          v-if="getAccountName(item)"
+          class="truncate text-sm font-medium"
+        >
+          {{ getAccountName(item) }}
+        </span>
+        <span
+          class="truncate font-mono text-xs"
+          :class="getAccountName(item) ? 'text-rui-text-secondary' : 'text-rui-text'"
+        >
+          {{ truncateAddress(scrambleAddress(item.locationLabel), 10) }}
+        </span>
+      </div>
     </div>
     <div
       v-else
@@ -151,13 +102,14 @@ const [DefineLocationItem, ReuseLocationItem] = createReusableTemplate<{ item: L
   <RuiAutoComplete
     v-model="modelValue"
     :options="locationLabelOptions"
-    :item-height="40"
+    :item-height="56"
     clearable
     key-attr="locationLabel"
     text-attr="locationLabel"
     :filter="filter"
     :label="t('transactions.filter.account')"
     variant="outlined"
+    menu-class="!min-w-full"
     v-bind="$attrs"
   >
     <template #selection="{ item }">

--- a/frontend/app/src/modules/history/balances/BalanceDivergenceView.spec.ts
+++ b/frontend/app/src/modules/history/balances/BalanceDivergenceView.spec.ts
@@ -11,6 +11,14 @@ const mockFetchLocationLabels = vi.fn();
 const mockRequestNavigation = vi.fn();
 const mockSetHighlightTarget = vi.fn();
 
+const { archiveState } = vi.hoisted(() => ({ archiveState: { hasArchive: true } }));
+
+vi.mock('@/modules/settings/api/use-evm-nodes-api', () => ({
+  useEvmNodesApi: (): object => ({
+    fetchEvmNodes: async (): Promise<{ isArchive: boolean }[]> => [{ isArchive: archiveState.hasArchive }],
+  }),
+}));
+
 vi.mock('@/modules/core/common/use-supported-chains', () => ({
   useSupportedChains: (): object => ({
     getEvmChainName: (chain: string): string | undefined => chain === 'eth' ? 'ethereum' : undefined,
@@ -25,11 +33,15 @@ vi.mock('@/modules/balances/api/use-historical-balances-api', () => ({
   }),
 }));
 
+const { taskControl } = vi.hoisted(() => ({ taskControl: { failure: null as null | Record<string, unknown> } }));
+
 vi.mock('@/modules/core/tasks/use-task-handler', () => ({
+  isActionableFailure: (outcome: { success: boolean; cancelled: boolean; skipped: boolean }): boolean =>
+    !outcome.success && !outcome.cancelled && !outcome.skipped,
   useTaskHandler: (): object => ({
     runTask: async (task: () => Promise<unknown>): Promise<object> => {
       await task();
-      return makeDivergenceResult();
+      return taskControl.failure ?? makeDivergenceResult();
     },
   }),
 }));
@@ -86,6 +98,12 @@ const stubs = {
     template: '<button :disabled="disabled"><slot name="prepend" /><slot /></button>',
   }),
   RuiIcon: { template: '<i class="icon" />' },
+  RuiTooltip: { template: '<div><slot name="activator" /><slot /></div>' },
+  I18nT: { template: '<span><slot name="chain" /><slot name="link" /></span>' },
+  InternalLink: { template: '<a><slot /></a>' },
+  HashLink: { props: ['text'], template: '<span class="hash">{{ text }}</span>' },
+  RuiAlert: { template: '<div class="alert"><slot /></div>' },
+  HistoryEventNote: { props: ['notes'], template: '<div class="notes">{{ notes }}</div>' },
 };
 
 function makeDivergenceResult(): object {
@@ -145,6 +163,8 @@ function mountView(): VueWrapper {
 
 describe('balanceDivergenceView.vue', () => {
   beforeEach(() => {
+    archiveState.hasArchive = true;
+    taskControl.failure = null;
     mockFetchLocationLabels.mockResolvedValue(undefined);
     mockFindDivergence.mockReset();
     mockRequestNavigation.mockReset();
@@ -155,6 +175,7 @@ describe('balanceDivergenceView.vue', () => {
     const wrapper = mountView();
 
     await nextTick();
+    await flushPromises();
     await wrapper.find('[data-testid=asset-select-input]').setValue('ETH');
     await wrapper.find('[data-testid=find-divergence]').trigger('click');
     await flushPromises();
@@ -180,10 +201,41 @@ describe('balanceDivergenceView.vue', () => {
     });
   });
 
+  it('should block the search and link to rpc settings when the selected chain has no archive node', async () => {
+    archiveState.hasArchive = false;
+    const wrapper = mountView();
+
+    await nextTick();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid=balance-divergence-missing-archive]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid=find-divergence]').attributes('disabled')).toBeDefined();
+  });
+
+  it('should render an actionable failure as an alert with the parsed message', async () => {
+    taskControl.failure = {
+      cancelled: false,
+      message: 'No historical wallet balance data found for eip155:1/erc20:0xA at 0xA on ethereum',
+      skipped: false,
+      success: false,
+    };
+    const wrapper = mountView();
+
+    await nextTick();
+    await flushPromises();
+    await wrapper.find('[data-testid=asset-select-input]').setValue('ETH');
+    await wrapper.find('[data-testid=find-divergence]').trigger('click');
+    await flushPromises();
+
+    const alert = wrapper.find('[data-testid=divergence-error]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.text()).toContain('No historical wallet balance data');
+  });
+
   it('should emit close when the panel header is closed', async () => {
     const wrapper = mountView();
 
-    await wrapper.find('button').trigger('click');
+    await wrapper.find('[data-testid=balance-divergence-close]').trigger('click');
 
     expect(wrapper.emitted('close')).toHaveLength(1);
   });

--- a/frontend/app/src/modules/history/balances/BalanceDivergenceView.vue
+++ b/frontend/app/src/modules/history/balances/BalanceDivergenceView.vue
@@ -1,234 +1,64 @@
 <script setup lang="ts">
-import type { LocationLabel } from '@/modules/core/common/location';
-import type { TaskMeta } from '@/modules/core/tasks/types';
-import { startPromise } from '@shared/utils';
-import { hasAccountAddress } from '@/modules/accounts/account-helpers';
-import { getAccountAddress } from '@/modules/accounts/account-utils';
 import ChainSelect from '@/modules/accounts/blockchain/ChainSelect.vue';
-import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
-import { AssetAmountDisplay } from '@/modules/assets/amount-display/components';
-import { useHistoricalBalancesApi } from '@/modules/balances/api/use-historical-balances-api';
-import { truncateAddress } from '@/modules/core/common/display/truncate';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { TaskType } from '@/modules/core/tasks/task-type';
-import { useTaskHandler } from '@/modules/core/tasks/use-task-handler';
-import { type HistoricalBalanceDivergenceEvent, HistoricalBalanceDivergenceResponse } from '@/modules/history/balances/types';
-import { HighlightTargetTypes, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
+import DivergenceBoundaryCard from '@/modules/history/balances/DivergenceBoundaryCard.vue';
+import { useArchiveNodes } from '@/modules/history/balances/use-archive-nodes';
+import { useBalanceDivergence } from '@/modules/history/balances/use-balance-divergence';
+import { useDivergenceSelection } from '@/modules/history/balances/use-divergence-selection';
+import HistoryEventNote from '@/modules/history/events/HistoryEventNote.vue';
 import LocationLabelSelector from '@/modules/history/LocationLabelSelector.vue';
-import { useHistoryDataFetching } from '@/modules/history/use-history-data-fetching';
-import { useHistoryStore } from '@/modules/history/use-history-store';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
-
-interface DivergenceBoundaryEvent {
-  key: 'last_matching' | 'first_diverged';
-  color: 'success' | 'warning';
-  event: HistoricalBalanceDivergenceEvent;
-}
+import InternalLink from '@/modules/shell/components/InternalLink.vue';
 
 const emit = defineEmits<{
   close: [];
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const { getEvmChainName, isEvm, matchChain } = useSupportedChains();
-const { findHistoricalBalanceDivergence } = useHistoricalBalancesApi();
-const { runTask } = useTaskHandler();
-const { requestNavigation, setHighlightTarget } = useHistoryEventNavigation();
-const { fetchLocationLabels } = useHistoryDataFetching();
-const { locationLabels } = storeToRefs(useHistoryStore());
-const { accounts: accountsPerChain } = storeToRefs(useBlockchainAccountsStore());
 
-const selectedAsset = ref<string>();
-const selectedChain = ref<string>();
-const selectedLocationLabel = ref<string>('');
-const loading = ref<boolean>(false);
-const divergenceResult = ref<HistoricalBalanceDivergenceResponse>();
-const divergenceError = ref<string>();
+const {
+  chainOptions,
+  locationLabelOptions,
+  modelSelectedAsset,
+  modelSelectedChain,
+  modelSelectedLocationLabel,
+  selectedEvmChain,
+} = useDivergenceSelection();
 
-const availableLocationLabels = computed<LocationLabel[]>(() => {
-  const labels = new Map<string, LocationLabel>();
+const { boundaries, clear, error, find, loading, navigate, summary } = useBalanceDivergence();
 
-  const addLabel = (item: LocationLabel): void => {
-    const chain = matchChain(item.location);
-    if (!chain || !isEvm(chain) || !getEvmChainName(chain))
-      return;
+const { hasArchiveNode, loading: archiveLoading } = useArchiveNodes(chainOptions);
+const selectedChainHasArchive = hasArchiveNode(modelSelectedChain);
 
-    labels.set(`${chain}:${item.locationLabel.toLowerCase()}`, {
-      location: chain,
-      locationLabel: item.locationLabel,
-    });
-  };
-
-  get(locationLabels).forEach(addLabel);
-  Object.values(get(accountsPerChain))
-    .flatMap(accounts => accounts)
-    .filter(hasAccountAddress)
-    .forEach(account => addLabel({
-      location: account.chain,
-      locationLabel: getAccountAddress(account),
-    }));
-
-  return [...labels.values()];
-});
-
-const chainOptions = computed<string[]>(() => {
-  const options = new Set<string>();
-  for (const item of get(availableLocationLabels)) {
-    const chain = matchChain(item.location);
-    if (chain)
-      options.add(chain);
-  }
-  return [...options].sort((a, b) => a.localeCompare(b));
-});
-
-const locationLabelOptions = computed<LocationLabel[]>(() => {
-  const chain = get(selectedChain);
-  if (!chain)
-    return [];
-
-  return get(availableLocationLabels)
-    .filter((item) => {
-      const matchedChain = matchChain(item.location);
-      return matchedChain === chain;
-    })
-    .sort((a, b) => a.locationLabel.localeCompare(b.locationLabel));
-});
-
-const selectedEvmChain = computed<string | undefined>(() => {
-  const chain = get(selectedChain);
-  return chain ? getEvmChainName(chain) : undefined;
-});
-
-const canFindDivergence = computed<boolean>(() =>
-  !!get(selectedAsset) && !!get(selectedLocationLabel) && !!get(selectedEvmChain),
+const missingArchiveNode = computed<boolean>(() =>
+  !!get(modelSelectedChain) && !get(archiveLoading) && !get(selectedChainHasArchive),
 );
 
-const divergenceEvents = computed<DivergenceBoundaryEvent[]>(() => {
-  const result = get(divergenceResult);
-  if (!result)
-    return [];
-
-  const events: DivergenceBoundaryEvent[] = [];
-  if (result.lastMatching) {
-    events.push({
-      color: 'success',
-      event: result.lastMatching,
-      key: 'last_matching',
-    });
-  }
-  if (result.firstDiverged) {
-    events.push({
-      color: 'warning',
-      event: result.firstDiverged,
-      key: 'first_diverged',
-    });
-  }
-  return events;
-});
-
-const divergenceSummary = computed<string | undefined>(() => {
-  const result = get(divergenceResult);
-  if (!result)
-    return undefined;
-
-  if (result.status === 'no_divergence')
-    return t('balance_divergence.no_divergence', { probes: result.probes.length });
-
-  return t('balance_divergence.checked', { probes: result.probes.length });
-});
-
-function displayGroupIdentifier(groupIdentifier: string | null): string {
-  return groupIdentifier ? truncateAddress(groupIdentifier, 8) : t('balance_divergence.missing_group');
-}
-
-function divergenceBoundaryLabel(key: DivergenceBoundaryEvent['key']): string {
-  return key === 'last_matching'
-    ? t('balance_divergence.last_matching')
-    : t('balance_divergence.first_diverged');
-}
-
-function clearResult(): void {
-  set(divergenceResult, undefined);
-  set(divergenceError, undefined);
-}
-
-function navigateToDivergenceEvent(boundaryEvent: HistoricalBalanceDivergenceEvent): void {
-  const asset = get(selectedAsset);
-  if (!boundaryEvent.groupIdentifier || !asset)
-    return;
-
-  setHighlightTarget(HighlightTargetTypes.ACCOUNTING_EVENT, {
-    groupIdentifier: boundaryEvent.groupIdentifier,
-    identifier: boundaryEvent.eventIdentifier,
-  });
-  requestNavigation({
-    assetFilter: asset,
-    highlightedAccountingEvent: boundaryEvent.eventIdentifier,
-    targetGroupIdentifier: boundaryEvent.groupIdentifier,
-  });
-}
+const canFindDivergence = computed<boolean>(() =>
+  !!get(modelSelectedAsset) && !!get(modelSelectedLocationLabel) && !!get(selectedEvmChain)
+  && get(selectedChainHasArchive),
+);
 
 async function findDivergence(): Promise<void> {
-  const asset = get(selectedAsset);
+  const asset = get(modelSelectedAsset);
   const evmChain = get(selectedEvmChain);
-  const locationLabel = get(selectedLocationLabel);
+  const locationLabel = get(modelSelectedLocationLabel);
   if (!asset || !evmChain || !locationLabel)
     return;
 
-  set(loading, true);
-  clearResult();
-  try {
-    const outcome = await runTask<HistoricalBalanceDivergenceResponse, TaskMeta>(
-      async () => findHistoricalBalanceDivergence({ address: locationLabel, asset, evmChain }),
-      {
-        type: TaskType.QUERY_HISTORICAL_BALANCE_DIVERGENCE,
-        meta: { title: t('balance_divergence.task.title', { asset }) },
-        unique: false,
-        guard: false,
-      },
-    );
-    if (outcome.success) {
-      set(divergenceResult, HistoricalBalanceDivergenceResponse.parse(outcome.result));
-    }
-    else if (!outcome.cancelled && !outcome.skipped) {
-      set(divergenceError, outcome.message);
-    }
-  }
-  catch (error: unknown) {
-    set(divergenceError, getErrorMessage(error));
-  }
-  finally {
-    set(loading, false);
-  }
+  await find({ address: locationLabel, asset, evmChain });
 }
 
-watch(chainOptions, (options) => {
-  const current = get(selectedChain);
-  if (!current || !options.includes(current))
-    set(selectedChain, options[0]);
-}, { immediate: true });
-
-watch(locationLabelOptions, (options) => {
-  const current = get(selectedLocationLabel);
-  if (!current || !options.some(option => option.locationLabel === current))
-    set(selectedLocationLabel, options[0]?.locationLabel ?? '');
-}, { immediate: true });
-
-watch([selectedAsset, selectedChain, selectedLocationLabel], clearResult);
-
-onMounted(() => {
-  startPromise(fetchLocationLabels());
-});
+watch([modelSelectedAsset, modelSelectedChain, modelSelectedLocationLabel], clear);
 </script>
 
 <template>
   <div class="h-full flex flex-col overflow-hidden">
-    <div class="flex items-center bg-rui-primary text-white p-2 shrink-0">
+    <div class="flex items-center h-10 pl-2 pr-2 border-b border-default shrink-0">
       <RuiButton
         variant="text"
-        size="sm"
         icon
+        size="sm"
+        data-testid="balance-divergence-close"
         @click="emit('close')"
       >
         <RuiIcon
@@ -236,7 +66,7 @@ onMounted(() => {
           size="20"
         />
       </RuiButton>
-      <h6 class="flex items-center text-body-1 pl-2">
+      <h6 class="font-medium pl-1">
         {{ t('balance_divergence.title') }}
       </h6>
       <div class="grow" />
@@ -253,7 +83,7 @@ onMounted(() => {
     <div class="flex-1 overflow-y-auto p-4 md:p-6 flex flex-col gap-6">
       <div class="grid grid-cols-1 gap-4">
         <ChainSelect
-          v-model="selectedChain"
+          v-model="modelSelectedChain"
           :items="chainOptions"
           evm-only
           :label="t('balance_divergence.chain')"
@@ -261,7 +91,7 @@ onMounted(() => {
         />
 
         <LocationLabelSelector
-          v-model="selectedLocationLabel"
+          v-model="modelSelectedLocationLabel"
           :options="locationLabelOptions"
           :label="t('balance_divergence.location_label')"
           :disabled="locationLabelOptions.length === 0"
@@ -269,14 +99,35 @@ onMounted(() => {
         />
 
         <AssetSelect
-          v-model="selectedAsset"
+          v-model="modelSelectedAsset"
           outlined
           show-ignored
           clearable
           :label="t('balance_divergence.asset')"
-          :chain="selectedChain"
+          :chain="modelSelectedChain"
           data-testid="balance-divergence-asset"
         />
+      </div>
+
+      <div
+        v-if="missingArchiveNode"
+        class="text-sm text-rui-text-secondary"
+        data-testid="balance-divergence-missing-archive"
+      >
+        <i18n-t
+          keypath="balance_divergence.chain_missing_archive_node"
+          tag="span"
+          scope="global"
+        >
+          <template #chain>
+            {{ modelSelectedChain }}
+          </template>
+          <template #link>
+            <InternalLink :to="{ name: '/settings/rpc/' }">
+              {{ t('balance_divergence.settings_link') }}
+            </InternalLink>
+          </template>
+        </i18n-t>
       </div>
 
       <div
@@ -305,85 +156,38 @@ onMounted(() => {
       </div>
 
       <div
-        v-if="divergenceSummary"
+        v-if="summary"
         class="text-sm text-rui-text-secondary"
       >
-        {{ divergenceSummary }}
+        {{ summary }}
       </div>
 
       <div
-        v-if="divergenceEvents.length > 0"
-        class="grid lg:grid-cols-2 gap-4"
+        v-if="boundaries.length > 0"
+        class="flex flex-col gap-3"
         data-testid="divergence-boundaries"
       >
-        <div
-          v-for="boundary in divergenceEvents"
+        <DivergenceBoundaryCard
+          v-for="boundary in boundaries"
           :key="boundary.key"
-          class="flex flex-col gap-3 rounded border border-rui-grey-300 p-4 text-sm"
-          :data-testid="`divergence-${boundary.key}`"
-        >
-          <div class="flex items-center justify-between gap-3">
-            <span
-              class="font-medium"
-              :class="boundary.color === 'success' ? 'text-rui-success' : 'text-rui-warning'"
-            >
-              {{ divergenceBoundaryLabel(boundary.key) }}
-            </span>
-            <RuiButton
-              variant="text"
-              color="primary"
-              size="sm"
-              :disabled="!boundary.event.groupIdentifier"
-              :data-testid="`view-divergence-${boundary.key}`"
-              @click="navigateToDivergenceEvent(boundary.event)"
-            >
-              <template #prepend>
-                <RuiIcon
-                  name="lu-arrow-right"
-                  size="14"
-                />
-              </template>
-              {{ t('balance_divergence.view_event') }}
-            </RuiButton>
-          </div>
-          <div class="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-2 text-rui-text-secondary">
-            <span>{{ t('balance_divergence.event') }}</span>
-            <span class="truncate font-mono text-rui-text">
-              {{ displayGroupIdentifier(boundary.event.groupIdentifier) }}
-            </span>
-            <span>{{ t('balance_divergence.block') }}</span>
-            <span class="text-rui-text">{{ boundary.event.blockNumber }}</span>
-            <span>{{ t('balance_divergence.tracked') }}</span>
-            <AssetAmountDisplay
-              :amount="boundary.event.trackedBalance"
-              :asset="selectedAsset"
-              no-collection-parent
-              class="text-rui-text"
-            />
-            <span>{{ t('balance_divergence.onchain') }}</span>
-            <AssetAmountDisplay
-              :amount="boundary.event.onchainBalance"
-              :asset="selectedAsset"
-              no-collection-parent
-              class="text-rui-text"
-            />
-            <span>{{ t('balance_divergence.difference') }}</span>
-            <AssetAmountDisplay
-              :amount="boundary.event.difference"
-              :asset="selectedAsset"
-              no-collection-parent
-              class="text-rui-text"
-            />
-          </div>
-        </div>
+          :boundary="boundary"
+          :asset="modelSelectedAsset"
+          :location="modelSelectedChain"
+          @view="navigate(boundary.event, modelSelectedAsset ?? '')"
+        />
       </div>
 
-      <div
-        v-else-if="divergenceError"
-        class="text-sm text-rui-error"
+      <RuiAlert
+        v-else-if="error"
+        type="error"
+        data-testid="divergence-error"
       >
-        {{ divergenceError }}
-      </div>
+        <HistoryEventNote
+          :notes="error"
+          :chain="modelSelectedChain"
+          :asset="modelSelectedAsset"
+        />
+      </RuiAlert>
     </div>
   </div>
 </template>

--- a/frontend/app/src/modules/history/balances/DivergenceBoundaryCard.spec.ts
+++ b/frontend/app/src/modules/history/balances/DivergenceBoundaryCard.spec.ts
@@ -1,0 +1,67 @@
+import type { DivergenceBoundaryEvent } from '@/modules/history/balances/use-balance-divergence';
+import { bigNumberify } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { defineComponent } from 'vue';
+import DivergenceBoundaryCard from '@/modules/history/balances/DivergenceBoundaryCard.vue';
+
+const stubs = {
+  AssetAmountDisplay: { props: ['amount', 'asset'], template: '<span class="amount">{{ amount?.toString() }}</span>' },
+  HashLink: { props: ['text'], template: '<span class="hash">{{ text }}</span>' },
+  RuiButton: defineComponent({
+    emits: ['click'],
+    props: { disabled: Boolean },
+    template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot name="prepend" /><slot /></button>',
+  }),
+  RuiIcon: { template: '<i class="icon" />' },
+};
+
+function boundary(overrides: Partial<DivergenceBoundaryEvent['event']> = {}): DivergenceBoundaryEvent {
+  return {
+    color: 'success',
+    event: {
+      blockNumber: 11,
+      difference: bigNumberify('0'),
+      eventIdentifier: 101,
+      groupIdentifier: `1${'a'.repeat(64)}`,
+      onchainBalance: bigNumberify('5'),
+      timestamp: 100,
+      trackedBalance: bigNumberify('5'),
+      ...overrides,
+    },
+    key: 'last_matching',
+  };
+}
+
+function createWrapper(boundaryEvent: DivergenceBoundaryEvent): VueWrapper {
+  return mount(DivergenceBoundaryCard, {
+    global: { stubs },
+    props: { asset: 'ETH', boundary: boundaryEvent },
+  });
+}
+
+describe('divergenceBoundaryCard', () => {
+  it('should render the truncated group identifier and balances', () => {
+    const wrapper = createWrapper(boundary());
+
+    const card = wrapper.find('[data-testid="divergence-last_matching"]');
+    expect(card.exists()).toBe(true);
+    expect(card.find('.hash').text()).toBe(`1${'a'.repeat(64)}`);
+    expect(card.text()).toContain('11');
+  });
+
+  it('should emit view when the view button is clicked', async () => {
+    const wrapper = createWrapper(boundary());
+
+    await wrapper.find('[data-testid="view-divergence-last_matching"]').trigger('click');
+
+    expect(wrapper.emitted('view')).toHaveLength(1);
+  });
+
+  it('should disable the view button when the boundary has no group identifier', () => {
+    const wrapper = createWrapper(boundary({ groupIdentifier: null }));
+
+    const button = wrapper.find('[data-testid="view-divergence-last_matching"]');
+    expect(button.attributes('disabled')).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/history/balances/DivergenceBoundaryCard.vue
+++ b/frontend/app/src/modules/history/balances/DivergenceBoundaryCard.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import type { DivergenceBoundaryEvent } from '@/modules/history/balances/use-balance-divergence';
+import { AssetAmountDisplay } from '@/modules/assets/amount-display/components';
+import HashLink from '@/modules/shell/components/HashLink.vue';
+
+const { boundary } = defineProps<{
+  boundary: DivergenceBoundaryEvent;
+  asset?: string;
+  location?: string;
+}>();
+
+const emit = defineEmits<{
+  view: [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const isMatching = computed<boolean>(() => boundary.color === 'success');
+
+const label = computed<string>(() => isMatching.value
+  ? t('balance_divergence.last_matching')
+  : t('balance_divergence.first_diverged'));
+</script>
+
+<template>
+  <div
+    class="flex flex-col gap-3 rounded border border-default border-l-[3px] p-4 text-sm"
+    :class="isMatching ? 'border-l-rui-success' : 'border-l-rui-warning'"
+    :data-testid="`divergence-${boundary.key}`"
+  >
+    <div class="flex items-center justify-between gap-3">
+      <span
+        class="inline-flex items-center gap-2 font-medium"
+        :class="isMatching ? 'text-rui-success' : 'text-rui-warning'"
+      >
+        <RuiIcon
+          :name="isMatching ? 'lu-check' : 'lu-triangle-alert'"
+          size="16"
+        />
+        {{ label }}
+      </span>
+      <RuiButton
+        variant="outlined"
+        color="primary"
+        size="sm"
+        :disabled="!boundary.event.groupIdentifier"
+        :data-testid="`view-divergence-${boundary.key}`"
+        @click="emit('view')"
+      >
+        <template #prepend>
+          <RuiIcon
+            name="lu-arrow-right"
+            size="14"
+          />
+        </template>
+        {{ t('balance_divergence.view_event') }}
+      </RuiButton>
+    </div>
+
+    <div class="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-3 gap-y-2 text-rui-text-secondary">
+      <span>{{ t('balance_divergence.event') }}</span>
+      <HashLink
+        v-if="boundary.event.groupIdentifier"
+        class="justify-self-end"
+        :text="boundary.event.groupIdentifier"
+        type="transaction"
+        :location="location"
+        :truncate-length="8"
+      />
+      <span
+        v-else
+        class="justify-self-end text-rui-text"
+      >
+        {{ t('balance_divergence.missing_group') }}
+      </span>
+
+      <span>{{ t('balance_divergence.block') }}</span>
+      <span class="justify-self-end text-rui-text">{{ boundary.event.blockNumber }}</span>
+
+      <span>{{ t('balance_divergence.tracked') }}</span>
+      <AssetAmountDisplay
+        class="justify-self-end text-rui-text"
+        :amount="boundary.event.trackedBalance"
+        :asset="asset"
+        no-collection-parent
+      />
+
+      <span>{{ t('balance_divergence.onchain') }}</span>
+      <AssetAmountDisplay
+        class="justify-self-end text-rui-text"
+        :amount="boundary.event.onchainBalance"
+        :asset="asset"
+        no-collection-parent
+      />
+
+      <span>{{ t('balance_divergence.difference') }}</span>
+      <AssetAmountDisplay
+        class="justify-self-end text-rui-text"
+        :amount="boundary.event.difference"
+        :asset="asset"
+        no-collection-parent
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/history/balances/use-archive-nodes.spec.ts
+++ b/frontend/app/src/modules/history/balances/use-archive-nodes.spec.ts
@@ -1,0 +1,54 @@
+import { flushPromises } from '@vue/test-utils';
+import { get, set } from '@vueuse/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useArchiveNodes } from '@/modules/history/balances/use-archive-nodes';
+
+const nodesByChain: Record<string, { isArchive: boolean }[]> = {};
+
+vi.mock('@/modules/settings/api/use-evm-nodes-api', () => ({
+  useEvmNodesApi: (chain: string): object => ({
+    fetchEvmNodes: async (): Promise<{ isArchive: boolean }[]> => {
+      if (chain === 'fail')
+        throw new Error('network');
+      return nodesByChain[chain] ?? [];
+    },
+  }),
+}));
+
+describe('useArchiveNodes', () => {
+  beforeEach(() => {
+    nodesByChain.eth = [{ isArchive: false }, { isArchive: true }];
+    nodesByChain.optimism = [{ isArchive: false }];
+  });
+
+  it('should flag only chains that have a connected archive node', async () => {
+    const { hasArchiveNode, loading } = useArchiveNodes(ref(['eth', 'optimism']));
+    await flushPromises();
+
+    expect(get(loading)).toBe(false);
+    expect(get(hasArchiveNode('eth'))).toBe(true);
+    expect(get(hasArchiveNode('optimism'))).toBe(false);
+    expect(get(hasArchiveNode(undefined))).toBe(false);
+  });
+
+  it('should treat a failed node lookup as no archive node', async () => {
+    const { hasArchiveNode } = useArchiveNodes(ref(['fail']));
+    await flushPromises();
+
+    expect(get(hasArchiveNode('fail'))).toBe(false);
+  });
+
+  it('should re-resolve when the chain list changes', async () => {
+    const chains = ref<string[]>([]);
+    const { hasArchiveNode } = useArchiveNodes(chains);
+    await flushPromises();
+
+    expect(get(hasArchiveNode('eth'))).toBe(false);
+
+    set(chains, ['eth']);
+    await flushPromises();
+
+    expect(get(hasArchiveNode('eth'))).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/history/balances/use-archive-nodes.ts
+++ b/frontend/app/src/modules/history/balances/use-archive-nodes.ts
@@ -1,0 +1,61 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { useEvmNodesApi } from '@/modules/settings/api/use-evm-nodes-api';
+
+interface ArchiveProbe {
+  chain: string;
+  hasArchive: boolean;
+}
+
+interface UseArchiveNodesReturn {
+  loading: Readonly<Ref<boolean>>;
+  hasArchiveNode: (chain: MaybeRefOrGetter<string | undefined>) => ComputedRef<boolean>;
+}
+
+/**
+ * Resolves which of the given EVM chains have an archive RPC node connected. The balance divergence
+ * check queries on-chain balances at historical blocks, which the backend only serves when an
+ * archive node is available (otherwise it returns 409). The panel uses this to guide the user
+ * before running a query that would fail.
+ */
+export function useArchiveNodes(chains: MaybeRefOrGetter<string[]>): UseArchiveNodesReturn {
+  const chainsWithArchiveNode = ref<string[]>([]);
+  const loading = shallowRef<boolean>(false);
+
+  async function refresh(list: string[]): Promise<void> {
+    if (list.length === 0) {
+      set(chainsWithArchiveNode, []);
+      return;
+    }
+
+    set(loading, true);
+    try {
+      const results = await Promise.allSettled(
+        list.map(async (chain): Promise<ArchiveProbe> => ({
+          chain,
+          hasArchive: (await useEvmNodesApi(chain).fetchEvmNodes()).some(node => node.isArchive),
+        })),
+      );
+      set(chainsWithArchiveNode, results
+        .filter((result): result is PromiseFulfilledResult<ArchiveProbe> =>
+          result.status === 'fulfilled' && result.value.hasArchive)
+        .map(result => result.value.chain));
+    }
+    finally {
+      set(loading, false);
+    }
+  }
+
+  function hasArchiveNode(chain: MaybeRefOrGetter<string | undefined>): ComputedRef<boolean> {
+    return computed<boolean>(() => {
+      const value = toValue(chain);
+      return !!value && get(chainsWithArchiveNode).includes(value);
+    });
+  }
+
+  watchImmediate(() => toValue(chains), refresh);
+
+  return {
+    hasArchiveNode,
+    loading: readonly(loading),
+  };
+}

--- a/frontend/app/src/modules/history/balances/use-balance-divergence.spec.ts
+++ b/frontend/app/src/modules/history/balances/use-balance-divergence.spec.ts
@@ -1,0 +1,168 @@
+import { bigNumberify } from '@rotki/common';
+import { get } from '@vueuse/core';
+import flushPromises from 'flush-promises';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runTaskMock = vi.fn();
+const mockFindDivergence = vi.fn();
+const mockRequestNavigation = vi.fn();
+const mockSetHighlightTarget = vi.fn();
+
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/modules/core/tasks/use-task-handler')>()),
+  useTaskHandler: vi.fn().mockReturnValue({
+    runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => {
+      await taskFn();
+      return runTaskMock(...rest);
+    },
+  }),
+}));
+
+vi.mock('@/modules/balances/api/use-historical-balances-api', () => ({
+  useHistoricalBalancesApi: (): object => ({
+    findHistoricalBalanceDivergence: mockFindDivergence,
+  }),
+}));
+
+vi.mock('@/modules/history/events/use-history-event-navigation', () => ({
+  HighlightTargetTypes: {
+    ACCOUNTING_EVENT: 'accountingEvent',
+  },
+  useHistoryEventNavigation: (): object => ({
+    requestNavigation: mockRequestNavigation,
+    setHighlightTarget: mockSetHighlightTarget,
+  }),
+}));
+
+function boundaryEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    blockNumber: 11,
+    difference: '0',
+    eventIdentifier: 101,
+    groupIdentifier: `1${'a'.repeat(64)}`,
+    onchainBalance: '5',
+    timestamp: 100,
+    trackedBalance: '5',
+    ...overrides,
+  };
+}
+
+function divergedResult(): Record<string, unknown> {
+  return {
+    address: '0xA',
+    asset: 'ETH',
+    firstDiverged: boundaryEvent({ blockNumber: 12, difference: '0.1', eventIdentifier: 102, groupIdentifier: `1${'b'.repeat(64)}`, onchainBalance: '4.9' }),
+    lastMatching: boundaryEvent(),
+    location: 'ethereum',
+    probes: [],
+    status: 'diverged',
+    tolerance: '0',
+    totalEvents: 2,
+  };
+}
+
+describe('useBalanceDivergence', () => {
+  let useBalanceDivergence: typeof import('./use-balance-divergence').useBalanceDivergence;
+
+  beforeEach(async () => {
+    runTaskMock.mockReset();
+    mockFindDivergence.mockReset();
+    mockFindDivergence.mockResolvedValue({ taskId: 1 });
+    mockRequestNavigation.mockReset();
+    mockSetHighlightTarget.mockReset();
+    ({ useBalanceDivergence } = await import('./use-balance-divergence'));
+  });
+
+  it('should run the divergence task and expose the derived boundaries and summary', async () => {
+    runTaskMock.mockReturnValue({ result: divergedResult(), success: true });
+    const divergence = useBalanceDivergence();
+
+    await divergence.find({ address: '0xA', asset: 'ETH', evmChain: 'ethereum' });
+    await flushPromises();
+
+    expect(mockFindDivergence).toHaveBeenCalledWith({ address: '0xA', asset: 'ETH', evmChain: 'ethereum' });
+    expect(get(divergence.loading)).toBe(false);
+    expect(get(divergence.boundaries).map(boundary => boundary.key)).toStrictEqual(['last_matching', 'first_diverged']);
+    expect(get(divergence.summary)).toContain('balance_divergence.checked');
+    expect(get(divergence.error)).toBeUndefined();
+  });
+
+  it('should surface the failure message on an actionable failure', async () => {
+    runTaskMock.mockReturnValue({ backendCancelled: false, cancelled: false, message: 'boom', skipped: false, success: false });
+    const divergence = useBalanceDivergence();
+
+    await divergence.find({ address: '0xA', asset: 'ETH', evmChain: 'ethereum' });
+    await flushPromises();
+
+    expect(get(divergence.error)).toBe('boom');
+    expect(get(divergence.boundaries)).toStrictEqual([]);
+  });
+
+  it('should not set an error when the task is cancelled', async () => {
+    runTaskMock.mockReturnValue({ backendCancelled: false, cancelled: true, message: 'cancelled', skipped: false, success: false });
+    const divergence = useBalanceDivergence();
+
+    await divergence.find({ address: '0xA', asset: 'ETH', evmChain: 'ethereum' });
+    await flushPromises();
+
+    expect(get(divergence.error)).toBeUndefined();
+  });
+
+  it('should navigate to a boundary event by highlighting it and requesting navigation', () => {
+    const divergence = useBalanceDivergence();
+
+    divergence.navigate({
+      blockNumber: 11,
+      difference: bigNumberify('0'),
+      eventIdentifier: 101,
+      groupIdentifier: 'group-1',
+      onchainBalance: bigNumberify('5'),
+      timestamp: 100,
+      trackedBalance: bigNumberify('5'),
+    }, 'ETH');
+
+    expect(mockSetHighlightTarget).toHaveBeenCalledWith('accountingEvent', {
+      groupIdentifier: 'group-1',
+      identifier: 101,
+    });
+    expect(mockRequestNavigation).toHaveBeenCalledWith({
+      assetFilter: 'ETH',
+      highlightedAccountingEvent: 101,
+      targetGroupIdentifier: 'group-1',
+    });
+  });
+
+  it('should not navigate without a group identifier or asset', () => {
+    const divergence = useBalanceDivergence();
+    const event = {
+      blockNumber: 11,
+      difference: bigNumberify('0'),
+      eventIdentifier: 101,
+      groupIdentifier: null,
+      onchainBalance: bigNumberify('5'),
+      timestamp: 100,
+      trackedBalance: bigNumberify('5'),
+    };
+
+    divergence.navigate(event, 'ETH');
+    divergence.navigate({ ...event, groupIdentifier: 'group-1' }, '');
+
+    expect(mockSetHighlightTarget).not.toHaveBeenCalled();
+    expect(mockRequestNavigation).not.toHaveBeenCalled();
+  });
+
+  it('should clear a previous result and error', async () => {
+    runTaskMock.mockReturnValue({ result: divergedResult(), success: true });
+    const divergence = useBalanceDivergence();
+
+    await divergence.find({ address: '0xA', asset: 'ETH', evmChain: 'ethereum' });
+    await flushPromises();
+    expect(get(divergence.boundaries)).toHaveLength(2);
+
+    divergence.clear();
+
+    expect(get(divergence.boundaries)).toStrictEqual([]);
+    expect(get(divergence.summary)).toBeUndefined();
+    expect(get(divergence.error)).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/history/balances/use-balance-divergence.ts
+++ b/frontend/app/src/modules/history/balances/use-balance-divergence.ts
@@ -1,0 +1,159 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { TaskMeta } from '@/modules/core/tasks/types';
+import { err, none, ok, type OptionType as Option, type ResultType as Result, some } from 'plainfp';
+import { fromNullable, isSome, map as mapOption } from 'plainfp/option';
+import { useHistoricalBalancesApi } from '@/modules/balances/api/use-historical-balances-api';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { TaskType } from '@/modules/core/tasks/task-type';
+import { isActionableFailure, useTaskHandler } from '@/modules/core/tasks/use-task-handler';
+import {
+  type HistoricalBalanceDivergenceEvent,
+  type HistoricalBalanceDivergencePayload,
+  HistoricalBalanceDivergenceResponse,
+} from '@/modules/history/balances/types';
+import { HighlightTargetTypes, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
+
+export interface DivergenceBoundaryEvent {
+  key: 'last_matching' | 'first_diverged';
+  color: 'success' | 'warning';
+  event: HistoricalBalanceDivergenceEvent;
+}
+
+interface DivergenceError {
+  message: string;
+}
+
+interface UseBalanceDivergenceReturn {
+  loading: Readonly<Ref<boolean>>;
+  error: Readonly<Ref<string | undefined>>;
+  boundaries: ComputedRef<DivergenceBoundaryEvent[]>;
+  summary: ComputedRef<string | undefined>;
+  find: (payload: HistoricalBalanceDivergencePayload) => Promise<void>;
+  navigate: (event: HistoricalBalanceDivergenceEvent, asset: string) => void;
+  clear: () => void;
+}
+
+/**
+ * Runs the balance divergence query as a task and exposes its state plus the derived boundary
+ * events used to render (and navigate to) the last matching and first diverged history events.
+ */
+export function useBalanceDivergence(): UseBalanceDivergenceReturn {
+  const { t } = useI18n({ useScope: 'global' });
+  const { findHistoricalBalanceDivergence } = useHistoricalBalancesApi();
+  const { runTask } = useTaskHandler();
+  const { requestNavigation, setHighlightTarget } = useHistoryEventNavigation();
+
+  const loading = shallowRef<boolean>(false);
+  const result = ref<HistoricalBalanceDivergenceResponse>();
+  const error = ref<string>();
+
+  const boundaries = computed<DivergenceBoundaryEvent[]>(() => {
+    const current = get(result);
+    if (!current)
+      return [];
+
+    const candidates = [
+      mapOption(fromNullable(current.lastMatching), (event): DivergenceBoundaryEvent => ({
+        color: 'success',
+        event,
+        key: 'last_matching',
+      })),
+      mapOption(fromNullable(current.firstDiverged), (event): DivergenceBoundaryEvent => ({
+        color: 'warning',
+        event,
+        key: 'first_diverged',
+      })),
+    ];
+    return candidates.filter(isSome).map(candidate => candidate.value);
+  });
+
+  const summary = computed<string | undefined>(() => {
+    const current = get(result);
+    if (!current)
+      return undefined;
+
+    if (current.status === 'no_divergence')
+      return t('balance_divergence.no_divergence', { probes: current.probes.length });
+
+    return t('balance_divergence.checked', { probes: current.probes.length });
+  });
+
+  function clear(): void {
+    set(result, undefined);
+    set(error, undefined);
+  }
+
+  function navigate(event: HistoricalBalanceDivergenceEvent, asset: string): void {
+    if (!event.groupIdentifier || !asset)
+      return;
+
+    setHighlightTarget(HighlightTargetTypes.ACCOUNTING_EVENT, {
+      groupIdentifier: event.groupIdentifier,
+      identifier: event.eventIdentifier,
+    });
+    requestNavigation({
+      assetFilter: asset,
+      highlightedAccountingEvent: event.eventIdentifier,
+      targetGroupIdentifier: event.groupIdentifier,
+    });
+  }
+
+  /**
+   * Folds the divergence task into a Result: `ok(some)` on a parsed response, `ok(none)` when the
+   * task was cancelled or skipped (leave the panel untouched), and `err` for actionable failures
+   * or a thrown/unparseable response.
+   */
+  async function run(
+    payload: HistoricalBalanceDivergencePayload,
+  ): Promise<Result<Option<HistoricalBalanceDivergenceResponse>, DivergenceError>> {
+    try {
+      const outcome = await runTask<HistoricalBalanceDivergenceResponse, TaskMeta>(
+        async () => findHistoricalBalanceDivergence(payload),
+        {
+          guard: false,
+          meta: { title: t('balance_divergence.task.title', { asset: payload.asset }) },
+          type: TaskType.QUERY_HISTORICAL_BALANCE_DIVERGENCE,
+          unique: false,
+        },
+      );
+
+      if (outcome.success)
+        return ok(some(HistoricalBalanceDivergenceResponse.parse(outcome.result)));
+
+      if (isActionableFailure(outcome))
+        return err({ message: outcome.message });
+
+      return ok(none);
+    }
+    catch (error_: unknown) {
+      return err({ message: getErrorMessage(error_) });
+    }
+  }
+
+  async function find(payload: HistoricalBalanceDivergencePayload): Promise<void> {
+    set(loading, true);
+    clear();
+
+    const outcome = await run(payload);
+    set(loading, false);
+
+    if (!outcome.ok) {
+      set(error, outcome.error.message);
+      return;
+    }
+
+    const found = outcome.value;
+    if (found.some)
+      set(result, found.value);
+  }
+
+  return {
+    boundaries,
+    clear,
+    error: readonly(error),
+    find,
+    loading: readonly(loading),
+    navigate,
+    summary,
+  };
+}

--- a/frontend/app/src/modules/history/balances/use-divergence-selection.spec.ts
+++ b/frontend/app/src/modules/history/balances/use-divergence-selection.spec.ts
@@ -1,0 +1,87 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { get, set } from '@vueuse/core';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, nextTick } from 'vue';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { useDivergenceSelection } from '@/modules/history/balances/use-divergence-selection';
+import { useHistoryStore } from '@/modules/history/use-history-store';
+
+const mockFetchLocationLabels = vi.fn();
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): object => ({
+    getEvmChainName: (chain: string): string | undefined => chain === 'eth' ? 'ethereum' : undefined,
+    isEvm: (chain: string): boolean => chain === 'eth',
+    matchChain: (location: string): string | undefined => ['eth', 'ethereum'].includes(location) ? 'eth' : undefined,
+  }),
+}));
+
+vi.mock('@/modules/history/use-history-data-fetching', () => ({
+  useHistoryDataFetching: (): object => ({
+    fetchLocationLabels: mockFetchLocationLabels,
+  }),
+}));
+
+function mountSelection(): { wrapper: VueWrapper; result: ReturnType<typeof useDivergenceSelection> } {
+  let result!: ReturnType<typeof useDivergenceSelection>;
+  const wrapper = mount(defineComponent({
+    render: () => null,
+    setup() {
+      result = useDivergenceSelection();
+      return {};
+    },
+  }));
+  return { result, wrapper };
+}
+
+describe('useDivergenceSelection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockFetchLocationLabels.mockReset();
+    mockFetchLocationLabels.mockResolvedValue(undefined);
+    useHistoryStore().setLocationLabels([]);
+    useBlockchainAccountsStore().updateAccounts('eth', [{
+      chain: 'eth',
+      data: {
+        address: '0xA',
+        type: 'address',
+      },
+      nativeAsset: 'ETH',
+    }]);
+  });
+
+  it('should build chain and location-label options from tracked evm accounts', async () => {
+    const { result } = mountSelection();
+    await nextTick();
+
+    expect(get(result.chainOptions)).toStrictEqual(['eth']);
+    expect(get(result.locationLabelOptions)).toStrictEqual([{ location: 'eth', locationLabel: '0xA' }]);
+  });
+
+  it('should default the selected chain, label and evm chain to the first valid option', async () => {
+    const { result } = mountSelection();
+    await nextTick();
+
+    expect(get(result.modelSelectedChain)).toBe('eth');
+    expect(get(result.modelSelectedLocationLabel)).toBe('0xA');
+    expect(get(result.selectedEvmChain)).toBe('ethereum');
+  });
+
+  it('should fetch the location labels on mount', () => {
+    mountSelection();
+
+    expect(mockFetchLocationLabels).toHaveBeenCalledOnce();
+  });
+
+  it('should clear the selected asset when the chain changes', async () => {
+    const { result } = mountSelection();
+    await nextTick();
+
+    set(result.modelSelectedAsset, 'eip155:42161/erc20:0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1');
+    set(result.modelSelectedChain, 'arbitrum_one');
+    await nextTick();
+
+    expect(get(result.modelSelectedAsset)).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/history/balances/use-divergence-selection.ts
+++ b/frontend/app/src/modules/history/balances/use-divergence-selection.ts
@@ -1,0 +1,117 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { LocationLabel } from '@/modules/core/common/location';
+import { startPromise } from '@shared/utils';
+import { hasAccountAddress } from '@/modules/accounts/account-helpers';
+import { getAccountAddress } from '@/modules/accounts/account-utils';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useHistoryDataFetching } from '@/modules/history/use-history-data-fetching';
+import { useHistoryStore } from '@/modules/history/use-history-store';
+
+interface UseDivergenceSelectionReturn {
+  modelSelectedAsset: Ref<string | undefined>;
+  modelSelectedChain: Ref<string | undefined>;
+  modelSelectedLocationLabel: Ref<string>;
+  chainOptions: ComputedRef<string[]>;
+  locationLabelOptions: ComputedRef<LocationLabel[]>;
+  selectedEvmChain: ComputedRef<string | undefined>;
+}
+
+/**
+ * Owns the chain/location-label/asset selection for the balance divergence panel: it builds the
+ * list of tracked EVM location labels, keeps the selects defaulted to valid options, and fetches
+ * the label list on mount. The `model*` refs are writable so the selects can bind them via v-model.
+ */
+export function useDivergenceSelection(): UseDivergenceSelectionReturn {
+  const { getEvmChainName, isEvm, matchChain } = useSupportedChains();
+  const { fetchLocationLabels } = useHistoryDataFetching();
+  const { locationLabels } = storeToRefs(useHistoryStore());
+  const { accounts: accountsPerChain } = storeToRefs(useBlockchainAccountsStore());
+
+  const modelSelectedAsset = shallowRef<string>();
+  const modelSelectedChain = shallowRef<string>();
+  const modelSelectedLocationLabel = shallowRef<string>('');
+
+  const availableLocationLabels = computed<LocationLabel[]>(() => {
+    const labels = new Map<string, LocationLabel>();
+
+    const addLabel = (item: LocationLabel): void => {
+      const chain = matchChain(item.location);
+      if (!chain || !isEvm(chain) || !getEvmChainName(chain))
+        return;
+
+      labels.set(`${chain}:${item.locationLabel.toLowerCase()}`, {
+        location: chain,
+        locationLabel: item.locationLabel,
+      });
+    };
+
+    get(locationLabels).forEach(addLabel);
+    Object.values(get(accountsPerChain))
+      .flatMap(accounts => accounts)
+      .filter(hasAccountAddress)
+      .forEach(account => addLabel({
+        location: account.chain,
+        locationLabel: getAccountAddress(account),
+      }));
+
+    return [...labels.values()];
+  });
+
+  const chainOptions = computed<string[]>(() => {
+    const options = new Set<string>();
+    for (const item of get(availableLocationLabels)) {
+      const chain = matchChain(item.location);
+      if (chain)
+        options.add(chain);
+    }
+    return [...options].sort((a, b) => a.localeCompare(b));
+  });
+
+  const locationLabelOptions = computed<LocationLabel[]>(() => {
+    const chain = get(modelSelectedChain);
+    if (!chain)
+      return [];
+
+    return get(availableLocationLabels)
+      .filter(item => matchChain(item.location) === chain)
+      .sort((a, b) => a.locationLabel.localeCompare(b.locationLabel));
+  });
+
+  const selectedEvmChain = computed<string | undefined>(() => {
+    const chain = get(modelSelectedChain);
+    return chain ? getEvmChainName(chain) : undefined;
+  });
+
+  watch(chainOptions, (options) => {
+    const current = get(modelSelectedChain);
+    if (!current || !options.includes(current))
+      set(modelSelectedChain, options[0]);
+  }, { immediate: true });
+
+  watch(locationLabelOptions, (options) => {
+    const current = get(modelSelectedLocationLabel);
+    if (!current || !options.some(option => option.locationLabel === current))
+      set(modelSelectedLocationLabel, options[0]?.locationLabel ?? '');
+  }, { immediate: true });
+
+  // The asset dropdown is scoped to the selected chain, so a token picked for one chain (e.g. an
+  // Arbitrum asset) is invalid after switching chains. Clear it to avoid submitting a mismatch the
+  // backend rejects ("<asset> is not on <chain>").
+  watch(modelSelectedChain, () => {
+    set(modelSelectedAsset, undefined);
+  });
+
+  onMounted(() => {
+    startPromise(fetchLocationLabels());
+  });
+
+  return {
+    chainOptions,
+    locationLabelOptions,
+    modelSelectedAsset,
+    modelSelectedChain,
+    modelSelectedLocationLabel,
+    selectedEvmChain,
+  };
+}

--- a/frontend/app/src/modules/history/use-location-labels.spec.ts
+++ b/frontend/app/src/modules/history/use-location-labels.spec.ts
@@ -1,0 +1,96 @@
+import type { LocationLabel } from '@/modules/core/common/location';
+import { get } from '@vueuse/core';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { useHistoryStore } from '@/modules/history/use-history-store';
+import { useLocationLabels } from '@/modules/history/use-location-labels';
+
+const mockGetAddressName = vi.fn();
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): object => ({
+    allTxChainsInfo: ref([{ id: 'eth' }]),
+    matchChain: (location: string): string | undefined => ['eth', 'ethereum'].includes(location) ? 'eth' : undefined,
+  }),
+}));
+
+vi.mock('@/modules/accounts/address-book/use-address-name-resolution', () => ({
+  useAddressNameResolution: (): object => ({ getAddressName: mockGetAddressName }),
+}));
+
+function trackAccount(overrides: Record<string, unknown> = {}): void {
+  useBlockchainAccountsStore().updateAccounts('eth', [{
+    chain: 'eth',
+    data: { address: '0xA', type: 'address' },
+    label: 'Main wallet',
+    nativeAsset: 'ETH',
+    tags: ['defi'],
+    ...overrides,
+  }]);
+}
+
+const item: LocationLabel = { location: 'eth', locationLabel: '0xA' };
+
+describe('useLocationLabels', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockGetAddressName.mockReset();
+    mockGetAddressName.mockReturnValue(undefined);
+  });
+
+  it('should use the provided options and fall back to the store labels', () => {
+    const provided: LocationLabel[] = [{ location: 'eth', locationLabel: '0xA' }];
+    const { locationLabelOptions } = useLocationLabels(ref(provided));
+    expect(get(locationLabelOptions)).toStrictEqual(provided);
+
+    useHistoryStore().setLocationLabels([{ location: 'eth', locationLabel: '0xB' }]);
+    const { locationLabelOptions: fromStore } = useLocationLabels(ref(undefined));
+    expect(get(fromStore)).toStrictEqual([{ location: 'eth', locationLabel: '0xB' }]);
+  });
+
+  it('should resolve only tx-chain locations', () => {
+    const { getBlockchainLocation } = useLocationLabels(ref(undefined));
+    expect(getBlockchainLocation('eth')).toBe('eth');
+    expect(getBlockchainLocation('unknown')).toBeUndefined();
+  });
+
+  it('should expose the tags and tracked label of a registered account', () => {
+    trackAccount();
+    const { getTags, getTrackedAccountLabel } = useLocationLabels(ref(undefined));
+
+    expect(getTags(item)).toStrictEqual(['defi']);
+    expect(getTrackedAccountLabel(item)).toBe('Main wallet');
+  });
+
+  it('should not report a tracked label that just repeats the address', () => {
+    trackAccount({ label: '0xA' });
+    const { getTrackedAccountLabel } = useLocationLabels(ref(undefined));
+
+    expect(getTrackedAccountLabel(item)).toBeUndefined();
+  });
+
+  it('should prefer the tracked label, then the address-book name, for the display name', () => {
+    trackAccount();
+    const { getAccountName } = useLocationLabels(ref(undefined));
+    expect(getAccountName(item)).toBe('Main wallet');
+
+    setActivePinia(createPinia());
+    mockGetAddressName.mockReturnValue('vitalik.eth');
+    const { getAccountName: fromAddressBook } = useLocationLabels(ref(undefined));
+    expect(fromAddressBook(item)).toBe('vitalik.eth');
+  });
+
+  it('should match by address, resolved name, tracked label and tags', () => {
+    trackAccount();
+    mockGetAddressName.mockReturnValue('vitalik.eth');
+    const { filter } = useLocationLabels(ref(undefined));
+
+    expect(filter(item, '0xa')).toBe(true);
+    expect(filter(item, 'vitalik')).toBe(true);
+    expect(filter(item, 'main')).toBe(true);
+    expect(filter(item, 'defi')).toBe(true);
+    expect(filter(item, 'nope')).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/history/use-location-labels.ts
+++ b/frontend/app/src/modules/history/use-location-labels.ts
@@ -1,0 +1,121 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import type { LocationLabel } from '@/modules/core/common/location';
+import { getTextToken } from '@rotki/common';
+import { hasAccountAddress } from '@/modules/accounts/account-helpers';
+import { getAccountAddress } from '@/modules/accounts/account-utils';
+import { useAddressNameResolution } from '@/modules/accounts/address-book/use-address-name-resolution';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useHistoryStore } from '@/modules/history/use-history-store';
+
+interface UseLocationLabelsReturn {
+  locationLabelOptions: ComputedRef<LocationLabel[]>;
+  getBlockchainLocation: (location: string) => string | undefined;
+  getTags: (item: LocationLabel) => string[];
+  getTrackedAccountLabel: (item: LocationLabel) => string | undefined;
+  getAccountName: (item: LocationLabel) => string | undefined;
+  filter: (item: LocationLabel, queryText: string) => boolean;
+}
+
+/**
+ * Resolves the option list, tracked-account metadata (tags, custom label) and the search filter for
+ * an EVM location-label picker. Kept UI-free so the matching logic can be tested on its own.
+ *
+ * @param options optional explicit option list; falls back to the tracked history location labels.
+ */
+export function useLocationLabels(options: MaybeRefOrGetter<LocationLabel[] | undefined>): UseLocationLabelsReturn {
+  const { locationLabels: storeLocationLabels } = storeToRefs(useHistoryStore());
+  const { allTxChainsInfo, matchChain } = useSupportedChains();
+  const txChainIds = useArrayMap(allTxChainsInfo, x => x.id);
+  const { accounts: accountsPerChain } = storeToRefs(useBlockchainAccountsStore());
+  const { getAddressName } = useAddressNameResolution();
+
+  const locationLabelOptions = computed<LocationLabel[]>(() => toValue(options) ?? get(storeLocationLabels));
+
+  const accounts = computed<BlockchainAccount<AddressData>[]>(() =>
+    Object.values(get(accountsPerChain))
+      .flatMap(x => x)
+      .filter(hasAccountAddress),
+  );
+
+  function getBlockchainLocation(location: string): string | undefined {
+    const chain = matchChain(location);
+    if (!chain)
+      return undefined;
+
+    if (!get(txChainIds).includes(chain))
+      return undefined;
+
+    return chain;
+  }
+
+  function getRegisteredAccounts(item: LocationLabel): BlockchainAccount<AddressData>[] {
+    const chain = getBlockchainLocation(item.location);
+
+    if (!chain)
+      return [];
+
+    return get(accounts).filter(acc => getAccountAddress(acc) === item.locationLabel && acc.chain === chain);
+  }
+
+  function getTags(item: LocationLabel): string[] {
+    const registeredAccounts = getRegisteredAccounts(item);
+    if (registeredAccounts.length === 0)
+      return [];
+
+    return registeredAccounts[0].tags || [];
+  }
+
+  function getTrackedAccountLabel(item: LocationLabel): string | undefined {
+    const label = getRegisteredAccounts(item)[0]?.label;
+    return label && label !== item.locationLabel ? label : undefined;
+  }
+
+  /** The human name to show for an item: the tracked account's custom label, else its address-book/ENS name. */
+  function getAccountName(item: LocationLabel): string | undefined {
+    const trackedLabel = getTrackedAccountLabel(item);
+    if (trackedLabel)
+      return trackedLabel;
+
+    const chain = getBlockchainLocation(item.location);
+    if (!chain)
+      return undefined;
+
+    return getAddressName(item.locationLabel, chain) ?? undefined;
+  }
+
+  function filter(item: LocationLabel, queryText: string): boolean {
+    const locationLabel = getTextToken(item.locationLabel);
+    const query = getTextToken(queryText);
+
+    if (locationLabel.includes(query))
+      return true;
+
+    const chain = getBlockchainLocation(item.location);
+
+    if (!chain)
+      return false;
+
+    const text = getTextToken(getAddressName(item.locationLabel, chain) ?? '');
+    const trackedAccountLabel = getTextToken(getTrackedAccountLabel(item) ?? '');
+
+    if (text.includes(query) || trackedAccountLabel.includes(query))
+      return true;
+
+    const tags = getTags(item);
+    return tags
+      .map(tag => getTextToken(tag))
+      .join(' ')
+      .includes(query);
+  }
+
+  return {
+    filter,
+    getAccountName,
+    getBlockchainLocation,
+    getTags,
+    getTrackedAccountLabel,
+    locationLabelOptions,
+  };
+}

--- a/frontend/app/src/modules/shell/components/inputs/AssetSelect.vue
+++ b/frontend/app/src/modules/shell/components/inputs/AssetSelect.vue
@@ -1,19 +1,9 @@
 <script setup lang="ts">
 import type { NftAsset } from '@/modules/assets/nfts';
-import {
-  assert,
-  type AssetInfoWithId,
-  getValidSelectorFromEvmAddress,
-  transformCase,
-} from '@rotki/common';
-import { useAssetInfoApi } from '@/modules/assets/api/use-asset-info-api';
+import { type AssetInfoWithId, getValidSelectorFromEvmAddress } from '@rotki/common';
 import AssetDetailsBase from '@/modules/assets/AssetDetailsBase.vue';
-import { useAssetsStore } from '@/modules/assets/use-assets-store';
 import NftDetails from '@/modules/balances/nft/NftDetails.vue';
-import { uniqueObjects } from '@/modules/core/common/data/data';
-import { getAssetSearchTypeParams, getSanitizedChain, parseAssetSearchKeyword } from '@/modules/core/common/display/assets';
-import { isAbortError } from '@/modules/core/common/helpers/is-of-enum';
-import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useAssetSearch } from '@/modules/shell/components/inputs/use-asset-search';
 
 defineOptions({
   inheritAttrs: false,
@@ -61,19 +51,19 @@ const emit = defineEmits<{
 defineSlots<{
   prepend: () => any;
 }>();
-const { isAssetIgnored } = useAssetsStore();
-const { getEvmChainName, matchChain } = useSupportedChains();
 
-const search = ref<string>('');
-const assets = ref<(AssetInfoWithId | NftAsset)[]>([]);
-const error = ref('');
-const loading = ref(false);
-let pending: AbortController | null = null;
-
-const { assetMapping, assetSearch } = useAssetInfoApi();
 const { t } = useI18n({ useScope: 'global' });
 
-const errors = computed(() => {
+const { error, getVisibleAsset, loading, modelSearch, visibleAssets } = useAssetSearch({
+  chain: () => chain,
+  excludes: () => excludes,
+  includeNfts: () => includeNfts,
+  items: () => items,
+  modelValue,
+  showIgnored: () => showIgnored,
+});
+
+const errors = computed<string[]>(() => {
   const messages = [...errorMessages];
   const errorMessage = get(error);
   if (errorMessage)
@@ -82,115 +72,10 @@ const errors = computed(() => {
   return messages;
 });
 
-const visibleAssets = computed<AssetInfoWithId[]>(() => {
-  const knownAssets = get(assets);
-  const currentValue = get(modelValue);
-
-  const filtered = knownAssets.filter(({ identifier }: AssetInfoWithId) => {
-    const isCurrentValue = identifier === currentValue;
-    const unIgnored = showIgnored || isCurrentValue || !isAssetIgnored(identifier);
-
-    const included = items && items.length > 0 ? items.includes(identifier) : true;
-
-    const excluded
-      = excludes && excludes.length > 0
-        ? excludes.some(excludedId => identifier.toLowerCase() === excludedId?.toLowerCase())
-        : false;
-
-    return !!identifier && unIgnored && included && !excluded;
-  });
-
-  return uniqueObjects<AssetInfoWithId>(filtered, item => item.identifier);
-});
-
-async function searchAssets(keyword: string, signal: AbortSignal): Promise<void> {
-  set(loading, true);
-  try {
-    const { address, value } = parseAssetSearchKeyword(keyword);
-    const usedChain = getSanitizedChain(chain, matchChain, getEvmChainName);
-
-    const fetchedAssets = await assetSearch({
-      address,
-      ...getAssetSearchTypeParams(usedChain),
-      limit: 50,
-      searchNfts: includeNfts,
-      signal,
-      value,
-    });
-    if (get(modelValue))
-      await retainSelectedValueInOptions(fetchedAssets);
-    else
-      set(assets, fetchedAssets);
-
-    pending = null;
-    set(loading, false);
-  }
-  catch (error_: any) {
-    if (!isAbortError(error_)) {
-      set(loading, false);
-      set(error, error_.message);
-    }
-  }
-}
-
-function getVisibleAsset(identifier: string) {
-  return get(visibleAssets)?.find(asset => asset.identifier === identifier);
-}
-
-function onUpdateModelValue(value: string) {
+function onUpdateModelValue(value: string): void {
   set(modelValue, value);
   emit('update:asset', getVisibleAsset(value));
 }
-
-async function retainSelectedValueInOptions(newAssets: (AssetInfoWithId | NftAsset)[]) {
-  try {
-    const val = get(modelValue);
-    assert(val);
-    const mapping = await assetMapping([val]);
-    set(assets, [
-      ...newAssets,
-      {
-        identifier: val,
-        ...mapping.assets[transformCase(val, true)],
-      },
-    ]);
-  }
-  catch (error_: any) {
-    set(loading, false);
-    set(error, error_.message);
-  }
-}
-
-async function checkValue() {
-  if (!get(modelValue))
-    return;
-
-  await retainSelectedValueInOptions(get(assets));
-}
-
-watch(modelValue, async () => {
-  await checkValue();
-});
-
-watch(search, (search) => {
-  if (search)
-    set(loading, true);
-  else if (!pending)
-    set(loading, false);
-});
-
-watchDebounced(search, async (search) => {
-  if (!search)
-    return set(loading, false);
-
-  if (pending) {
-    pending.abort();
-    pending = null;
-  }
-  set(error, '');
-  pending = new AbortController();
-  await searchAssets(search, pending.signal);
-}, { debounce: 800 });
 
 watch(visibleAssets, (_, oldVisibleAssets) => {
   const identifier = get(modelValue);
@@ -206,30 +91,12 @@ watch(visibleAssets, (_, oldVisibleAssets) => {
   if (!getVisibleAsset(identifier))
     onUpdateModelValue('');
 });
-
-watch(() => [chain], async () => {
-  if (!get(modelValue)) {
-    return;
-  }
-  await retainSelectedValueInOptions([]);
-});
-
-onMounted(async () => {
-  await checkValue();
-});
-
-onUnmounted(() => {
-  if (!isDefined(pending)) {
-    return;
-  }
-  get(pending).abort();
-});
 </script>
 
 <template>
   <RuiAutoComplete
     v-model="modelValue"
-    v-model:search-input="search"
+    v-model:search-input="modelSearch"
     :disabled="disabled"
     :options="visibleAssets"
     class="asset-select w-full [&_.group]:py-1.5"
@@ -244,7 +111,7 @@ onUnmounted(() => {
     key-attr="identifier"
     text-attr="identifier"
     :hide-details="hideDetails"
-    :hide-no-data="loading || !search || !!error"
+    :hide-no-data="loading || !modelSearch || !!error"
     auto-select-first
     :loading="loading"
     :variant="outlined ? 'outlined' : 'default'"

--- a/frontend/app/src/modules/shell/components/inputs/use-asset-search.spec.ts
+++ b/frontend/app/src/modules/shell/components/inputs/use-asset-search.spec.ts
@@ -1,0 +1,128 @@
+import type { AssetInfoWithId } from '@rotki/common';
+import { flushPromises, mount } from '@vue/test-utils';
+import { get, set } from '@vueuse/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, ref, type Ref } from 'vue';
+import { useAssetSearch } from '@/modules/shell/components/inputs/use-asset-search';
+
+const EVM_CHAIN_BY_ID: Record<string, string> = { arbitrum_one: 'arbitrum', eth: 'ethereum' };
+
+const mockAssetSearch = vi.fn();
+const mockAssetMapping = vi.fn();
+const mockIsAssetIgnored = vi.fn();
+
+vi.mock('@/modules/assets/api/use-asset-info-api', () => ({
+  useAssetInfoApi: (): object => ({
+    assetMapping: mockAssetMapping,
+    assetSearch: mockAssetSearch,
+  }),
+}));
+
+vi.mock('@/modules/assets/use-assets-store', () => ({
+  useAssetsStore: (): object => ({
+    isAssetIgnored: mockIsAssetIgnored,
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): object => ({
+    getEvmChainName: (chain: string): string | undefined => EVM_CHAIN_BY_ID[chain],
+    matchChain: (chain: string): string | undefined => EVM_CHAIN_BY_ID[chain] ? chain : undefined,
+  }),
+}));
+
+function makeAsset(identifier: string): AssetInfoWithId {
+  return { assetType: 'evm token', identifier, name: 'USD Coin', symbol: 'USDC' };
+}
+
+interface Harness {
+  api: ReturnType<typeof useAssetSearch>;
+  chain: Ref<string | undefined>;
+  modelValue: Ref<string | undefined>;
+}
+
+function setup(opts: { modelValue?: string; chain?: string; showIgnored?: boolean; excludes?: string[] } = {}): Harness {
+  const modelValue = ref<string | undefined>(opts.modelValue);
+  const chain = ref<string | undefined>(opts.chain);
+  let api!: ReturnType<typeof useAssetSearch>;
+  mount(defineComponent({
+    setup() {
+      api = useAssetSearch({
+        chain,
+        excludes: () => opts.excludes ?? [],
+        includeNfts: () => false,
+        items: () => [],
+        modelValue,
+        showIgnored: () => opts.showIgnored ?? false,
+      });
+      return (): null => null;
+    },
+  }));
+  return { api, chain, modelValue };
+}
+
+async function runSearch(api: ReturnType<typeof useAssetSearch>, term: string): Promise<void> {
+  set(api.modelSearch, term);
+  await vi.advanceTimersByTimeAsync(800);
+  await flushPromises();
+}
+
+describe('useAssetSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockAssetSearch.mockReset();
+    mockAssetMapping.mockReset();
+    mockAssetMapping.mockResolvedValue({ assets: {} });
+    mockIsAssetIgnored.mockReset();
+    mockIsAssetIgnored.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should populate the options from a chain-scoped search', async () => {
+    mockAssetSearch.mockResolvedValue([makeAsset('eip155:1/erc20:0xA')]);
+    const { api } = setup({ chain: 'eth' });
+
+    await runSearch(api, 'usdc');
+
+    expect(mockAssetSearch).toHaveBeenCalledWith(expect.objectContaining({ evmChain: 'ethereum' }));
+    expect(get(api.visibleAssets)).toHaveLength(1);
+  });
+
+  it('should hide ignored assets unless they are the selected value', async () => {
+    mockAssetSearch.mockResolvedValue([makeAsset('A'), makeAsset('B')]);
+    mockIsAssetIgnored.mockImplementation((id: string) => id === 'B');
+
+    const hidden = setup({});
+    await runSearch(hidden.api, 'x');
+    expect(get(hidden.api.visibleAssets).map(a => a.identifier)).toStrictEqual(['A']);
+
+    const selected = setup({ modelValue: 'B' });
+    await runSearch(selected.api, 'x');
+    expect(get(selected.api.visibleAssets).map(a => a.identifier)).toContain('B');
+  });
+
+  it('should drop cached options when the chain changes and nothing is selected', async () => {
+    mockAssetSearch.mockResolvedValue([makeAsset('eip155:1/erc20:0xA')]);
+    const { api, chain } = setup({ chain: 'eth' });
+    await runSearch(api, 'usdc');
+    expect(get(api.visibleAssets)).toHaveLength(1);
+
+    set(chain, 'arbitrum_one');
+    await flushPromises();
+
+    expect(get(api.visibleAssets)).toHaveLength(0);
+  });
+
+  it('should retain the selected asset in the options when the chain changes', async () => {
+    const { chain } = setup({ modelValue: 'eip155:1/erc20:0xA' });
+    mockAssetMapping.mockClear();
+
+    set(chain, 'arbitrum_one');
+    await flushPromises();
+
+    expect(mockAssetMapping).toHaveBeenCalledWith(['eip155:1/erc20:0xA']);
+  });
+});

--- a/frontend/app/src/modules/shell/components/inputs/use-asset-search.ts
+++ b/frontend/app/src/modules/shell/components/inputs/use-asset-search.ts
@@ -1,0 +1,185 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { NftAsset } from '@/modules/assets/nfts';
+import { assert, type AssetInfoWithId, transformCase } from '@rotki/common';
+import { useAssetInfoApi } from '@/modules/assets/api/use-asset-info-api';
+import { useAssetsStore } from '@/modules/assets/use-assets-store';
+import { uniqueObjects } from '@/modules/core/common/data/data';
+import { getAssetSearchTypeParams, getSanitizedChain, parseAssetSearchKeyword } from '@/modules/core/common/display/assets';
+import { isAbortError } from '@/modules/core/common/helpers/is-of-enum';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+
+type Asset = AssetInfoWithId | NftAsset;
+
+interface UseAssetSearchOptions {
+  /** The selected asset identifier; kept in the options and used to gate ignored-asset filtering. */
+  modelValue: Ref<string | undefined>;
+  /** Scopes the remote search to a chain and resets the cached options when it changes. */
+  chain?: MaybeRefOrGetter<string | undefined>;
+  /** When true, ignored assets stay in the options. */
+  showIgnored?: MaybeRefOrGetter<boolean>;
+  /** Restricts the options to this allow-list of identifiers. */
+  items?: MaybeRefOrGetter<string[]>;
+  /** Removes these identifiers from the options. */
+  excludes?: MaybeRefOrGetter<string[]>;
+  /** Includes NFTs in the search results. */
+  includeNfts?: MaybeRefOrGetter<boolean>;
+}
+
+interface UseAssetSearchReturn {
+  modelSearch: Ref<string>;
+  loading: Readonly<Ref<boolean>>;
+  error: Readonly<Ref<string>>;
+  visibleAssets: ComputedRef<AssetInfoWithId[]>;
+  getVisibleAsset: (identifier: string) => AssetInfoWithId | undefined;
+}
+
+/**
+ * Owns the asset search for the asset picker: the debounced, chain-scoped remote search, the
+ * cached option list and its ignored/items/excludes filtering, and keeping the selected value in
+ * the options. Kept UI-free so the search/filter behaviour can be tested without mounting the
+ * autocomplete.
+ */
+export function useAssetSearch(options: UseAssetSearchOptions): UseAssetSearchReturn {
+  const { chain, excludes, includeNfts, items, modelValue, showIgnored } = options;
+
+  const { isAssetIgnored } = useAssetsStore();
+  const { getEvmChainName, matchChain } = useSupportedChains();
+  const { assetMapping, assetSearch } = useAssetInfoApi();
+
+  const modelSearch = shallowRef<string>('');
+  const assets = ref<Asset[]>([]);
+  const error = shallowRef<string>('');
+  const loading = shallowRef<boolean>(false);
+  let pending: AbortController | null = null;
+
+  const visibleAssets = computed<AssetInfoWithId[]>(() => {
+    const knownAssets = get(assets);
+    const currentValue = get(modelValue);
+    const ignoredVisible = toValue(showIgnored) ?? false;
+    const includeList = toValue(items) ?? [];
+    const excludeList = toValue(excludes) ?? [];
+
+    const filtered = knownAssets.filter(({ identifier }: AssetInfoWithId) => {
+      const isCurrentValue = identifier === currentValue;
+      const unIgnored = ignoredVisible || isCurrentValue || !isAssetIgnored(identifier);
+      const included = includeList.length > 0 ? includeList.includes(identifier) : true;
+      const excluded = excludeList.length > 0
+        ? excludeList.some(excludedId => identifier.toLowerCase() === excludedId?.toLowerCase())
+        : false;
+
+      return !!identifier && unIgnored && included && !excluded;
+    });
+
+    return uniqueObjects<AssetInfoWithId>(filtered, item => item.identifier);
+  });
+
+  function getVisibleAsset(identifier: string): AssetInfoWithId | undefined {
+    return get(visibleAssets)?.find(asset => asset.identifier === identifier);
+  }
+
+  async function retainSelectedValueInOptions(newAssets: Asset[]): Promise<void> {
+    try {
+      const val = get(modelValue);
+      assert(val);
+      const mapping = await assetMapping([val]);
+      set(assets, [
+        ...newAssets,
+        {
+          identifier: val,
+          ...mapping.assets[transformCase(val, true)],
+        },
+      ]);
+    }
+    catch (error_: any) {
+      set(loading, false);
+      set(error, error_.message);
+    }
+  }
+
+  async function searchAssets(keyword: string, signal: AbortSignal): Promise<void> {
+    set(loading, true);
+    try {
+      const { address, value } = parseAssetSearchKeyword(keyword);
+      const usedChain = getSanitizedChain(toValue(chain), matchChain, getEvmChainName);
+
+      const fetchedAssets = await assetSearch({
+        address,
+        ...getAssetSearchTypeParams(usedChain),
+        limit: 50,
+        searchNfts: toValue(includeNfts) ?? false,
+        signal,
+        value,
+      });
+      if (get(modelValue))
+        await retainSelectedValueInOptions(fetchedAssets);
+      else
+        set(assets, fetchedAssets);
+
+      pending = null;
+      set(loading, false);
+    }
+    catch (error_: any) {
+      if (!isAbortError(error_)) {
+        set(loading, false);
+        set(error, error_.message);
+      }
+    }
+  }
+
+  async function checkValue(): Promise<void> {
+    if (!get(modelValue))
+      return;
+
+    await retainSelectedValueInOptions(get(assets));
+  }
+
+  watch(modelValue, async () => {
+    await checkValue();
+  });
+
+  watch(modelSearch, (value) => {
+    if (value)
+      set(loading, true);
+    else if (!pending)
+      set(loading, false);
+  });
+
+  watchDebounced(modelSearch, async (value) => {
+    if (!value)
+      return set(loading, false);
+
+    if (pending) {
+      pending.abort();
+      pending = null;
+    }
+    set(error, '');
+    pending = new AbortController();
+    await searchAssets(value, pending.signal);
+  }, { debounce: 800 });
+
+  watch(() => toValue(chain), async () => {
+    if (!get(modelValue)) {
+      // Drop options cached for the previous chain so a stale, off-chain asset can't be picked;
+      // the next search repopulates for the new chain.
+      set(assets, []);
+      return;
+    }
+    await retainSelectedValueInOptions([]);
+  });
+
+  onMounted(async () => {
+    await checkValue();
+  });
+
+  onUnmounted(() => {
+    pending?.abort();
+  });
+
+  return {
+    error: readonly(error),
+    getVisibleAsset,
+    loading: readonly(loading),
+    modelSearch,
+    visibleAssets,
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up frontend rework of the balance divergence tool (base #12586, already merged), plus the shared account/asset picker improvements it surfaced.

### Balance divergence panel
- Decompose the ~389-line view into focused composables (`use-divergence-selection`, `use-balance-divergence`) and a `DivergenceBoundaryCard` component.
- Fold the task outcome into a `Result` and derive the boundary cards via `Option.fromNullable`, matching the `data-issues`/`unlock-flow` idiom.
- Add an **archive-node pre-check**: disable the search and link to RPC settings when the selected chain has no archive node (the backend hard-requires one), instead of letting it fail with a 409.
- Style the boundary cards to match the design (accent border, status icon, `HashLink` transaction, right-aligned amounts).
- Render failures in a `RuiAlert`, running the message through the history-event note parser so asset ids and addresses render cleanly.
- Reset the selected asset when the chain changes, so a token from a previous chain no longer submits a mismatch the backend rejects (`<asset> is not on <chain>`).

### Location label picker (`LocationLabelSelector`)
- Constrain the dropdown to the field width — `RuiAutoComplete` otherwise sizes the menu to the full-address `text-attr` and overflows the narrow field.
- Fix the menu height (`item-height` 40 → 56, which was clipping to ~1.5 rows).
- Extract a UI-free `useLocationLabels` composable (options, tx-chain resolution, tags/label lookup, account-name resolution, search filter) with unit tests.
- Redesign the rows: account name over a muted, scramble-aware address with an avatar (dropdown two-line, field one-line).

### Asset picker (`AssetSelect`)
- Extract a UI-free `useAssetSearch` composable (debounced chain-scoped search, cached options, ignored/items/excludes filtering, keep-selected-in-options) with unit tests.
- Fix a stale-cache bug: when the chain changed with no asset selected, the previous chain's cached options lingered, so an off-chain asset could still be picked.

## Testing
- Frontend unit suite: **561 files / 5310 tests passing**; `typecheck` and `lint` clean.
- Verified the location and asset pickers in the running app (menu sizing, row layout, search, selection, chain switch).
- Note: the end-to-end bisect flow against a live archive node has not been exercised; the divergence composables are covered by unit tests.
