### PR TITLE
test(frontend): cover remaining accounts composables

### DIFF
--- a/frontend/app/src/modules/accounts/create-account-with-balance.spec.ts
+++ b/frontend/app/src/modules/accounts/create-account-with-balance.spec.ts
@@ -1,0 +1,49 @@
+import type { BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import type { BlockchainAssetBalances } from '@/modules/balances/types/blockchain-balances';
+import { bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { createAccountWithBalance } from './create-account-with-balance';
+
+function account(tags?: string[]): BlockchainAccount {
+  return { chain: 'eth', data: { address: '0xabc', type: 'address' }, nativeAsset: 'ETH', tags };
+}
+
+const chainBalances: BlockchainAssetBalances = {
+  '0xabc': {
+    assets: {
+      DAI: { evm: { amount: bigNumberify(100), value: bigNumberify(100) } },
+      ETH: { evm: { amount: bigNumberify(2), value: bigNumberify(4000) } },
+    },
+    liabilities: {},
+  },
+};
+
+const notIgnored = (): boolean => false;
+
+describe('createAccountWithBalance', () => {
+  it('should merge the derived balance and group id into the account', () => {
+    const result = createAccountWithBalance(account(), chainBalances, notIgnored);
+    expect(result.type).toBe('account');
+    expect(result.groupId).toBe('0xabc');
+    expect(result.amount.toNumber()).toBe(2);
+    expect(result.value.toNumber()).toBe(4100);
+    expect(result.expansion).toBe('assets');
+  });
+
+  it('should deduplicate the account tags', () => {
+    const result = createAccountWithBalance(account(['Public', 'public', 'Cold']), chainBalances, notIgnored);
+    expect(result.tags).toEqual(['Public', 'Cold']);
+  });
+
+  it('should leave tags undefined when the account has none', () => {
+    const result = createAccountWithBalance(account(), chainBalances, notIgnored);
+    expect(result.tags).toBeUndefined();
+  });
+
+  it('should return zero balances when the account has no chain entry', () => {
+    const result = createAccountWithBalance(account(), {}, notIgnored);
+    expect(result.amount.toNumber()).toBe(0);
+    expect(result.value.toNumber()).toBe(0);
+    expect(result.expansion).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/accounts/use-account-balances-refresh.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-balances-refresh.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccountBalancesRefresh } from './use-account-balances-refresh';
+
+const h = vi.hoisted(() => ({
+  fetchAccounts: vi.fn(),
+  handleBlockchainRefresh: vi.fn(),
+  refreshBlockchainBalances: vi.fn(),
+}));
+
+vi.mock('@/modules/balances/use-balance-refresh', () => ({
+  useBalanceRefresh: vi.fn(() => ({
+    handleBlockchainRefresh: h.handleBlockchainRefresh,
+    refreshBlockchainBalances: h.refreshBlockchainBalances,
+  })),
+}));
+
+vi.mock('@/modules/accounts/use-blockchain-account-management', () => ({
+  useBlockchainAccountManagement: vi.fn(() => ({ fetchAccounts: h.fetchAccounts })),
+}));
+
+describe('useAccountBalancesRefresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch accounts then run the evm refresh for evm chains', async () => {
+    const fetchData = vi.fn<() => Promise<void>>(async () => {});
+    const { refreshClick } = useAccountBalancesRefresh({ chainIds: ['eth', 'optimism'], fetchData, isEvm: true });
+
+    await refreshClick();
+
+    expect(h.fetchAccounts).toHaveBeenCalledWith(['eth', 'optimism'], true);
+    expect(h.handleBlockchainRefresh).toHaveBeenCalledWith(['eth', 'optimism']);
+    expect(h.refreshBlockchainBalances).not.toHaveBeenCalled();
+    expect(fetchData).toHaveBeenCalledOnce();
+  });
+
+  it('should run the plain balance refresh for non-evm chains', async () => {
+    const fetchData = vi.fn<() => Promise<void>>(async () => {});
+    const { refreshClick } = useAccountBalancesRefresh({ chainIds: ['btc'], fetchData, isEvm: false });
+
+    await refreshClick();
+
+    expect(h.refreshBlockchainBalances).toHaveBeenCalledWith(['btc']);
+    expect(h.handleBlockchainRefresh).not.toHaveBeenCalled();
+    expect(fetchData).toHaveBeenCalledOnce();
+  });
+
+  it('should resolve reactive chain and evm inputs', async () => {
+    const chainIds = ref<string[]>(['eth']);
+    const isEvm = ref<boolean>(true);
+    const fetchData = vi.fn<() => Promise<void>>(async () => {});
+    const { refreshClick } = useAccountBalancesRefresh({ chainIds, fetchData, isEvm });
+
+    set(isEvm, false);
+    set(chainIds, ['btc']);
+    await refreshClick();
+
+    expect(h.fetchAccounts).toHaveBeenCalledWith(['btc'], true);
+    expect(h.refreshBlockchainBalances).toHaveBeenCalledWith(['btc']);
+  });
+});

--- a/frontend/app/src/modules/accounts/use-account-category-helper.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-category-helper.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccountCategoryHelper } from './use-account-category-helper';
+
+const h = vi.hoisted(() => ({
+  supportedChains: [
+    { id: 'eth', type: 'evm' },
+    { id: 'optimism', type: 'evm' },
+    { id: 'zksync_lite', type: 'evmlike' },
+    { id: 'btc', type: 'bitcoin' },
+  ],
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const vue = await import('vue');
+  return { useSupportedChains: vi.fn(() => ({ supportedChains: vue.ref(h.supportedChains) })) };
+});
+
+describe('useAccountCategoryHelper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should flag the evm category and include evm plus evmlike chains', () => {
+    const { chainIds, isEvm } = useAccountCategoryHelper('evm');
+    expect(get(isEvm)).toBe(true);
+    expect(get(chainIds)).toEqual(['eth', 'optimism', 'zksync_lite']);
+  });
+
+  it('should return only the matching chains for a non-evm category', () => {
+    const { chainIds, isEvm } = useAccountCategoryHelper('bitcoin');
+    expect(get(isEvm)).toBe(false);
+    expect(get(chainIds)).toEqual(['btc']);
+  });
+
+  it('should react to a changing category getter', () => {
+    const category = ref<string>('bitcoin');
+    const { chainIds, isEvm } = useAccountCategoryHelper(category);
+    expect(get(isEvm)).toBe(false);
+    expect(get(chainIds)).toEqual(['btc']);
+
+    set(category, 'evm');
+    expect(get(isEvm)).toBe(true);
+    expect(get(chainIds)).toEqual(['eth', 'optimism', 'zksync_lite']);
+  });
+});

--- a/frontend/app/src/modules/accounts/use-account-loading.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-loading.spec.ts
@@ -1,0 +1,82 @@
+import type { Ref } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
+import { TaskType } from '@/modules/core/tasks/task-type';
+
+const h = vi.hoisted(() => ({ useIsTaskRunning: vi.fn() }));
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@vueuse/core')>();
+  return { ...actual, createSharedComposable: <T>(fn: T): T => fn };
+});
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: vi.fn(() => ({ useIsTaskRunning: h.useIsTaskRunning })),
+}));
+
+let addRunning: Ref<boolean>;
+let removeRunning: Ref<boolean>;
+
+describe('useAccountLoading', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    addRunning = ref<boolean>(false);
+    removeRunning = ref<boolean>(false);
+    h.useIsTaskRunning.mockImplementation((type: TaskType): Ref<boolean> => {
+      if (type === TaskType.ADD_ACCOUNT)
+        return addRunning;
+      if (type === TaskType.REMOVE_ACCOUNT)
+        return removeRunning;
+      return ref<boolean>(false);
+    });
+  });
+
+  async function importModule(): Promise<typeof import('./use-account-loading')> {
+    return import('./use-account-loading');
+  }
+
+  it('should not be loading when nothing is running', async () => {
+    const { useAccountLoading } = await importModule();
+    const { loading } = useAccountLoading();
+    expect(get(loading)).toBe(false);
+  });
+
+  it('should be loading while an add-account task runs', async () => {
+    const { useAccountLoading } = await importModule();
+    const { isAccountOperationRunning, loading } = useAccountLoading();
+    set(addRunning, true);
+    expect(get(loading)).toBe(true);
+    expect(get(isAccountOperationRunning())).toBe(true);
+  });
+
+  it('should be loading while a remove-account task runs', async () => {
+    const { useAccountLoading } = await importModule();
+    const { loading } = useAccountLoading();
+    set(removeRunning, true);
+    expect(get(loading)).toBe(true);
+  });
+
+  it('should be loading while the pending flag is set', async () => {
+    const { useAccountLoading } = await importModule();
+    const { loading, pending } = useAccountLoading();
+    set(pending, true);
+    expect(get(loading)).toBe(true);
+  });
+
+  it('should be loading while balances are refreshing', async () => {
+    const { useAccountLoading } = await importModule();
+    const { loading } = useAccountLoading();
+    useBalanceRefreshState().start('eth');
+    expect(get(loading)).toBe(true);
+  });
+
+  it('should pass the blockchain filter to the task lookup', async () => {
+    const { useAccountLoading } = await importModule();
+    const { isAccountOperationRunning } = useAccountLoading();
+    isAccountOperationRunning('eth');
+    expect(h.useIsTaskRunning).toHaveBeenCalledWith(TaskType.ADD_ACCOUNT, { blockchain: 'eth' });
+    expect(h.useIsTaskRunning).toHaveBeenCalledWith(TaskType.REMOVE_ACCOUNT, { blockchain: 'eth' });
+  });
+});

--- a/frontend/app/src/modules/accounts/use-account-migration.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-migration.spec.ts
@@ -1,0 +1,103 @@
+import type { MigratedAddresses } from '@/modules/core/messaging/types';
+import { flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import '@test/i18n';
+
+const h = vi.hoisted(() => ({
+  detectTokens: vi.fn(),
+  fetchAccounts: vi.fn(),
+  isEvm: vi.fn((chain: string): boolean => chain === 'eth' || chain === 'optimism'),
+  notify: vi.fn(),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const vue = await import('vue');
+  return {
+    useSupportedChains: vi.fn(() => ({
+      evmAndEvmLikeTxChainsInfo: vue.ref([{ id: 'eth' }, { id: 'optimism' }, { id: 'zksync_lite' }]),
+      getChainName: (chain: string): string => chain,
+      isEvm: h.isEvm,
+    })),
+  };
+});
+
+vi.mock('@/modules/accounts/use-blockchain-account-management', () => ({
+  useBlockchainAccountManagement: vi.fn(() => ({ fetchAccounts: h.fetchAccounts })),
+}));
+
+vi.mock('@/modules/balances/blockchain/use-token-detection-orchestrator', () => ({
+  useTokenDetectionOrchestrator: vi.fn(() => ({ detectTokens: h.detectTokens })),
+}));
+
+vi.mock('@/modules/auth/use-logged-user-identifier', async () => {
+  const vue = await import('vue');
+  return { useLoggedUserIdentifier: vi.fn(() => vue.ref(null)) };
+});
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn(() => ({ notify: h.notify })),
+}));
+
+async function importModule(): Promise<typeof import('./use-account-migration')> {
+  return import('./use-account-migration');
+}
+
+describe('useAccountMigration', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    h.fetchAccounts.mockResolvedValue(undefined);
+    h.detectTokens.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should migrate an evm address once data can be requested', async () => {
+    const { canRequestData } = storeToRefs(useSessionAuthStore());
+    set(canRequestData, true);
+    const migrated: MigratedAddresses = [{ address: '0xabc', chain: 'eth' }];
+
+    const { useAccountMigration } = await importModule();
+    useAccountMigration().setUpgradedAddresses(migrated);
+
+    expect(h.fetchAccounts).toHaveBeenCalledWith('eth');
+    expect(h.detectTokens).toHaveBeenCalledWith('eth', ['0xabc']);
+    expect(h.notify).toHaveBeenCalledOnce();
+    await flushPromises();
+  });
+
+  it('should defer migration until data can be requested', async () => {
+    const { canRequestData } = storeToRefs(useSessionAuthStore());
+    set(canRequestData, false);
+    const { useAccountMigration } = await importModule();
+    useAccountMigration().setUpgradedAddresses([{ address: '0xabc', chain: 'eth' }]);
+    expect(h.fetchAccounts).not.toHaveBeenCalled();
+
+    set(canRequestData, true);
+    await nextTick();
+    expect(h.fetchAccounts).toHaveBeenCalledWith('eth');
+  });
+
+  it('should ignore addresses on chains without token detection', async () => {
+    const { canRequestData } = storeToRefs(useSessionAuthStore());
+    set(canRequestData, true);
+    const { useAccountMigration } = await importModule();
+    useAccountMigration().setUpgradedAddresses([{ address: 'bc1abc', chain: 'btc' }]);
+    expect(h.fetchAccounts).not.toHaveBeenCalled();
+    expect(h.notify).not.toHaveBeenCalled();
+  });
+
+  it('should fetch accounts but skip token detection for evmlike chains', async () => {
+    const { canRequestData } = storeToRefs(useSessionAuthStore());
+    set(canRequestData, true);
+    const { useAccountMigration } = await importModule();
+    useAccountMigration().setUpgradedAddresses([{ address: '0xdef', chain: 'zksync_lite' }]);
+    expect(h.fetchAccounts).toHaveBeenCalledWith('zksync_lite');
+    expect(h.detectTokens).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/accounts/use-account-operations.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.spec.ts
@@ -1,0 +1,173 @@
+import type { TaskResult } from '@/modules/core/tasks/use-task-handler';
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@test/i18n';
+
+const h = vi.hoisted(() => ({
+  detectEvmAccounts: vi.fn(),
+  fetch: vi.fn(),
+  fetchBlockchainBalances: vi.fn(),
+  fetchEnsNames: vi.fn(),
+  getAddresses: vi.fn((_chain: string): string[] => []),
+  isEvm: vi.fn((chain: string): boolean => chain === 'eth' || chain === 'optimism'),
+  notifyError: vi.fn(),
+  refreshBlockchainBalances: vi.fn(),
+  resetStatus: vi.fn(),
+  runTask: vi.fn(),
+  supportsTransactions: vi.fn((): boolean => true),
+}));
+
+vi.mock('@/modules/accounts/use-blockchain-accounts', () => ({
+  useBlockchainAccounts: vi.fn(() => ({ fetch: h.fetch })),
+}));
+
+vi.mock('@/modules/balances/use-blockchain-balances', () => ({
+  useBlockchainBalances: vi.fn(() => ({
+    fetchBlockchainBalances: h.fetchBlockchainBalances,
+    refreshBlockchainBalances: h.refreshBlockchainBalances,
+  })),
+}));
+
+vi.mock('@/modules/accounts/address-book/use-ens-operations', () => ({
+  useEnsOperations: vi.fn(() => ({ fetchEnsNames: h.fetchEnsNames })),
+}));
+
+vi.mock('@/modules/accounts/api/use-blockchain-accounts-api', () => ({
+  useBlockchainAccountsApi: vi.fn(() => ({ detectEvmAccounts: h.detectEvmAccounts })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const vue = await import('vue');
+  return {
+    useSupportedChains: vi.fn(() => ({
+      isEvm: h.isEvm,
+      supportedChains: vue.ref([{ id: 'eth' }, { id: 'btc' }]),
+      supportsTransactions: h.supportsTransactions,
+    })),
+  };
+});
+
+vi.mock('@/modules/balances/blockchain/use-account-addresses', () => ({
+  useAccountAddresses: vi.fn(() => ({ getAddresses: h.getAddresses })),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn(() => ({ notifyError: h.notifyError })),
+}));
+
+vi.mock('@/modules/shell/sync-progress/use-status-updater', () => ({
+  useStatusUpdater: vi.fn(() => ({ resetStatus: h.resetStatus })),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-handler', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/modules/core/tasks/use-task-handler')>();
+  return { ...actual, useTaskHandler: vi.fn(() => ({ runTask: h.runTask })) };
+});
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+function actionable(message: string): TaskResult<never> {
+  return { backendCancelled: false, cancelled: false, error: new Error(message), message, skipped: false, success: false };
+}
+
+async function importModule(): Promise<typeof import('./use-account-operations')> {
+  return import('./use-account-operations');
+}
+
+describe('useAccountOperations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.getAddresses.mockReturnValue([]);
+    h.supportsTransactions.mockReturnValue(true);
+    h.fetch.mockResolvedValue(undefined);
+    h.fetchBlockchainBalances.mockResolvedValue(undefined);
+    h.refreshBlockchainBalances.mockResolvedValue(undefined);
+    h.fetchEnsNames.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('resetStatuses', () => {
+    it('should reset the nft section status', async () => {
+      const { useAccountOperations } = await importModule();
+      useAccountOperations().resetStatuses();
+      expect(h.resetStatus).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('fetchAccounts', () => {
+    it('should fetch the given chain and resolve ens names for evm chains', async () => {
+      h.getAddresses.mockReturnValue(['0xabc']);
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().fetchAccounts('eth', true);
+      expect(h.fetch).toHaveBeenCalledWith('eth');
+      await flushPromises();
+      expect(h.fetchEnsNames).toHaveBeenCalledWith([{ address: '0xabc', blockchain: 'eth' }], true);
+    });
+
+    it('should not resolve ens names for non-evm chains', async () => {
+      h.getAddresses.mockReturnValue(['bc1abc']);
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().fetchAccounts('btc');
+      expect(h.fetch).toHaveBeenCalledWith('btc');
+      expect(h.fetchEnsNames).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to every supported chain when no chain is given', async () => {
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().fetchAccounts();
+      expect(h.fetch).toHaveBeenCalledWith('eth');
+      expect(h.fetch).toHaveBeenCalledWith('btc');
+    });
+  });
+
+  describe('refreshAccounts', () => {
+    it('should fetch balances for a regular chain', async () => {
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().refreshAccounts({ blockchain: 'eth' });
+      expect(h.fetchBlockchainBalances).toHaveBeenCalledWith({ addresses: undefined, blockchain: 'eth', isXpub: false });
+      expect(h.refreshBlockchainBalances).not.toHaveBeenCalled();
+    });
+
+    it('should refresh balances for the eth2 chain', async () => {
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().refreshAccounts({ blockchain: 'eth2' });
+      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith({ addresses: undefined, blockchain: 'eth2', isXpub: false }, false);
+    });
+
+    it('should pass unique addresses for a chain without transaction support', async () => {
+      h.supportsTransactions.mockReturnValue(false);
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().refreshAccounts({ addresses: ['0xa', '0xa', '0xb'], blockchain: 'gnosis', isXpub: true });
+      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith({ addresses: ['0xa', '0xb'], blockchain: 'gnosis', isXpub: true }, false);
+    });
+
+    it('should schedule an eth2 refresh when eth has validators', async () => {
+      h.getAddresses.mockImplementation((chain: string): string[] => (chain === 'eth2' ? ['0xval'] : []));
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().refreshAccounts({ blockchain: 'eth' });
+      await flushPromises();
+      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith({ addresses: undefined, blockchain: 'eth2', isXpub: false }, false);
+    });
+  });
+
+  describe('detectEvmAccounts', () => {
+    it('should notify on an actionable failure', async () => {
+      h.runTask.mockResolvedValue(actionable('detect failed'));
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().detectEvmAccounts();
+      expect(h.notifyError).toHaveBeenCalledOnce();
+    });
+
+    it('should not notify on success', async () => {
+      h.runTask.mockResolvedValue({ result: undefined, success: true });
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().detectEvmAccounts();
+      expect(h.notifyError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/use-blockchain-account-loading.spec.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-account-loading.spec.ts
@@ -1,0 +1,105 @@
+import type { Ref } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTokenDetectionStore } from '@/modules/balances/blockchain/use-token-detection-store';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
+import { TaskType } from '@/modules/core/tasks/task-type';
+
+const h = vi.hoisted(() => ({
+  getIsLoading: vi.fn((): boolean => false),
+  isTaskRunning: vi.fn((): boolean => false),
+  useIsTaskRunning: vi.fn(),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: vi.fn(() => ({ isTaskRunning: h.isTaskRunning, useIsTaskRunning: h.useIsTaskRunning })),
+}));
+
+vi.mock('@/modules/core/common/use-status-store', () => ({
+  useStatusStore: vi.fn(() => ({ getIsLoading: h.getIsLoading })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const vue = await import('vue');
+  return {
+    useSupportedChains: vi.fn(() => ({
+      supportedChains: vue.ref([
+        { id: 'eth', type: 'evm' },
+        { id: 'optimism', type: 'evm' },
+      ]),
+    })),
+  };
+});
+
+describe('useBlockchainAccountLoading', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    h.isTaskRunning.mockReturnValue(false);
+    h.getIsLoading.mockReturnValue(false);
+    h.useIsTaskRunning.mockImplementation((): Ref<boolean> => ref<boolean>(false));
+  });
+
+  async function importModule(): Promise<typeof import('./use-blockchain-account-loading')> {
+    return import('./use-blockchain-account-loading');
+  }
+
+  it('should report every flag as idle when nothing is happening', async () => {
+    const { useBlockchainAccountLoading } = await importModule();
+    const loading = useBlockchainAccountLoading();
+    expect(get(loading.isSectionLoading)).toBe(false);
+    expect(get(loading.operationRunning)).toBe(false);
+    expect(get(loading.isDetectingTokens)).toBe(false);
+    expect(get(loading.refreshDisabled)).toBe(false);
+    expect(get(loading.deleteDisabled)).toBe(false);
+    expect(get(loading.isLoadingActive)).toBe(false);
+  });
+
+  it('should be section loading when the blockchain section loads', async () => {
+    h.getIsLoading.mockReturnValue(true);
+    const { useBlockchainAccountLoading } = await importModule();
+    const loading = useBlockchainAccountLoading();
+    expect(get(loading.isSectionLoading)).toBe(true);
+    expect(get(loading.refreshDisabled)).toBe(true);
+    expect(get(loading.isLoadingActive)).toBe(true);
+  });
+
+  it('should be section loading when a chain is refreshing', async () => {
+    const { useBlockchainAccountLoading } = await importModule();
+    const loading = useBlockchainAccountLoading();
+    useBalanceRefreshState().start('eth');
+    expect(get(loading.isSectionLoading)).toBe(true);
+  });
+
+  it('should flag a running add/remove operation', async () => {
+    h.useIsTaskRunning.mockImplementation((type: TaskType): Ref<boolean> =>
+      ref<boolean>(type === TaskType.ADD_ACCOUNT));
+    const { useBlockchainAccountLoading } = await importModule();
+    const loading = useBlockchainAccountLoading();
+    expect(get(loading.operationRunning)).toBe(true);
+    expect(get(loading.deleteDisabled)).toBe(true);
+    expect(get(loading.isLoadingActive)).toBe(true);
+  });
+
+  it('should disable delete while balances are fetching', async () => {
+    h.isTaskRunning.mockReturnValue(true);
+    const { useBlockchainAccountLoading } = await importModule();
+    const loading = useBlockchainAccountLoading();
+    expect(get(loading.deleteDisabled)).toBe(true);
+  });
+
+  it('should detect tokens for an evm category when mass detection runs', async () => {
+    const { useBlockchainAccountLoading } = await importModule();
+    const loading = useBlockchainAccountLoading('evm');
+    useTokenDetectionStore().setMassDetecting('eth');
+    expect(get(loading.isDetectingTokens)).toBe(true);
+    expect(get(loading.refreshDisabled)).toBe(true);
+  });
+
+  it('should not detect tokens for a non-evm category', async () => {
+    const { useBlockchainAccountLoading } = await importModule();
+    const loading = useBlockchainAccountLoading('bitcoin');
+    useTokenDetectionStore().setMassDetecting('eth');
+    expect(get(loading.isDetectingTokens)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/accounts/use-blockchain-account-management.spec.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-account-management.spec.ts
@@ -1,0 +1,162 @@
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type AddAccountsPayload, type XpubAccountPayload, XpubKeyType } from '@/modules/accounts/blockchain-accounts';
+import '@test/i18n';
+
+const h = vi.hoisted(() => ({
+  addMultipleAccounts: vi.fn(),
+  addMultipleEvmAccounts: vi.fn(),
+  addSingleAccount: vi.fn(),
+  addSingleEvmAddress: vi.fn(),
+  completeAccountAddition: vi.fn(),
+  detectEvmAccounts: vi.fn(),
+  fetchAccounts: vi.fn(),
+  getNewAccountPayload: vi.fn(),
+  isTaskRunning: vi.fn((): boolean => false),
+  notifyInfo: vi.fn(),
+  refreshAccounts: vi.fn(),
+}));
+
+vi.mock('@/modules/accounts/use-account-addition-service', () => ({
+  useAccountAdditionService: vi.fn(() => ({
+    addMultipleAccounts: h.addMultipleAccounts,
+    addMultipleEvmAccounts: h.addMultipleEvmAccounts,
+    addSingleAccount: h.addSingleAccount,
+    addSingleEvmAddress: h.addSingleEvmAddress,
+    completeAccountAddition: h.completeAccountAddition,
+    getNewAccountPayload: h.getNewAccountPayload,
+  })),
+}));
+
+vi.mock('@/modules/accounts/use-account-operations', () => ({
+  useAccountOperations: vi.fn(() => ({
+    detectEvmAccounts: h.detectEvmAccounts,
+    fetchAccounts: h.fetchAccounts,
+    refreshAccounts: h.refreshAccounts,
+  })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({ getChainName: (chain: string): string => chain })),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-store', () => ({
+  useTaskStore: vi.fn(() => ({ isTaskRunning: h.isTaskRunning })),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn(() => ({ notifyInfo: h.notifyInfo })),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+async function importModule(): Promise<typeof import('./use-blockchain-account-management')> {
+  return import('./use-blockchain-account-management');
+}
+
+describe('useBlockchainAccountManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.isTaskRunning.mockReturnValue(false);
+    h.completeAccountAddition.mockResolvedValue(undefined);
+    h.addMultipleEvmAccounts.mockResolvedValue(undefined);
+    h.addMultipleAccounts.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('addEvmAccounts', () => {
+    it('should add a single evm address and complete the addition', async () => {
+      h.addSingleEvmAddress.mockResolvedValue({ accounts: [{ address: '0xabc', chain: 'eth' }], type: 'success' });
+      const { useBlockchainAccountManagement } = await importModule();
+      await useBlockchainAccountManagement().addEvmAccounts({ modules: undefined, payload: [{ address: '0xabc', tags: null }] });
+      expect(h.addSingleEvmAddress).toHaveBeenCalledWith({ address: '0xabc', tags: null });
+      await flushPromises();
+      expect(h.completeAccountAddition).toHaveBeenCalledWith(
+        { addedAccounts: [{ address: '0xabc', chain: 'eth' }], modulesToEnable: undefined },
+        h.refreshAccounts,
+        h.fetchAccounts,
+      );
+    });
+
+    it('should throw when a single evm addition fails', async () => {
+      h.addSingleEvmAddress.mockResolvedValue({ account: { address: '0xabc', tags: null }, error: new Error('boom'), type: 'error' });
+      const { useBlockchainAccountManagement } = await importModule();
+      await expect(
+        useBlockchainAccountManagement().addEvmAccounts({ modules: undefined, payload: [{ address: '0xabc', tags: null }] }),
+      ).rejects.toThrow('boom');
+    });
+
+    it('should await multiple evm additions when wait is set', async () => {
+      const payload: AddAccountsPayload = { modules: undefined, payload: [
+        { address: '0xabc', tags: null },
+        { address: '0xdef', tags: null },
+      ] };
+      const { useBlockchainAccountManagement } = await importModule();
+      await useBlockchainAccountManagement().addEvmAccounts(payload, { wait: true });
+      expect(h.addMultipleEvmAccounts).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('addAccounts', () => {
+    it('should skip when an add-account task is already running', async () => {
+      h.isTaskRunning.mockReturnValue(true);
+      const { useBlockchainAccountManagement } = await importModule();
+      await useBlockchainAccountManagement().addAccounts('eth', { modules: undefined, payload: [{ address: '0xabc', tags: null }] });
+      expect(h.addSingleAccount).not.toHaveBeenCalled();
+    });
+
+    it('should notify when there are no new addresses to add', async () => {
+      h.getNewAccountPayload.mockReturnValue([]);
+      const { useBlockchainAccountManagement } = await importModule();
+      await useBlockchainAccountManagement().addAccounts('eth', { modules: undefined, payload: [{ address: '0xabc', tags: null }] });
+      expect(h.notifyInfo).toHaveBeenCalledOnce();
+      expect(h.addSingleAccount).not.toHaveBeenCalled();
+    });
+
+    it('should add a single new account and complete the addition', async () => {
+      h.getNewAccountPayload.mockReturnValue([{ address: '0xabc', tags: null }]);
+      h.addSingleAccount.mockResolvedValue({ address: '0xabc', type: 'success' });
+      const { useBlockchainAccountManagement } = await importModule();
+      await useBlockchainAccountManagement().addAccounts('eth', { modules: undefined, payload: [{ address: '0xabc', tags: null }] });
+      expect(h.addSingleAccount).toHaveBeenCalledWith({ address: '0xabc', tags: null }, 'eth');
+      await flushPromises();
+      expect(h.completeAccountAddition).toHaveBeenCalledOnce();
+    });
+
+    it('should add an xpub account directly', async () => {
+      const xpubPayload: XpubAccountPayload = {
+        tags: null,
+        xpub: { derivationPath: '', xpub: 'xpub123', xpubType: XpubKeyType.XPUB },
+      };
+      h.addSingleAccount.mockResolvedValue({ address: 'xpub123', type: 'success' });
+      const { useBlockchainAccountManagement } = await importModule();
+      await useBlockchainAccountManagement().addAccounts('btc', xpubPayload);
+      expect(h.addSingleAccount).toHaveBeenCalledWith(xpubPayload, 'btc');
+      expect(h.getNewAccountPayload).not.toHaveBeenCalled();
+    });
+
+    it('should throw when a single account addition fails', async () => {
+      h.getNewAccountPayload.mockReturnValue([{ address: '0xabc', tags: null }]);
+      h.addSingleAccount.mockResolvedValue({ account: { address: '0xabc', tags: null }, error: new Error('nope'), type: 'error' });
+      const { useBlockchainAccountManagement } = await importModule();
+      await expect(
+        useBlockchainAccountManagement().addAccounts('eth', { modules: undefined, payload: [{ address: '0xabc', tags: null }] }),
+      ).rejects.toThrow('nope');
+    });
+  });
+
+  describe('passthrough exports', () => {
+    it('should re-expose the account operation helpers', async () => {
+      const { useBlockchainAccountManagement } = await importModule();
+      const management = useBlockchainAccountManagement();
+      expect(management.detectEvmAccounts).toBe(h.detectEvmAccounts);
+      expect(management.fetchAccounts).toBe(h.fetchAccounts);
+      expect(management.refreshAccounts).toBe(h.refreshAccounts);
+    });
+  });
+});


### PR DESCRIPTION
Part of #11252 (frontend unit & integration test coverage).

Follow-up to #12590. Covers the remaining orchestration and helper composables in the `modules/accounts` cluster.

## Covered
- **createAccountWithBalance** — balance merge, tag dedup, and the empty-chain fallback.
- **useAccountCategoryHelper** — evm / evmlike chain filtering and reactive category input.
- **useAccountLoading** — task + refresh-driven loading state.
- **useAccountBalancesRefresh** — evm vs plain balance-refresh dispatch.
- **useBlockchainAccountLoading** — section / detection / operation loading flags.
- **useAccountOperations** — `fetchAccounts` (evm ENS resolution, all-chains fallback), `refreshAccounts` (regular / eth2 / non-transaction chains and eth2 validator scheduling), `detectEvmAccounts`, and status reset.
- **useBlockchainAccountManagement** — single/multiple EVM and account addition dispatch, the task-running guard, the no-new-address notification, and xpub handling.
- **useAccountMigration** — deferred vs immediate migration and per-chain token-detection filtering.

## Test plan
- 46 new tests across 8 spec files.
- Full unit suite green: 571 files / 5479 tests.
- `pnpm run typecheck` clean; `pnpm run lint-staged` clean.