### PR TITLE
test: centralize repeated unit-test mock helpers

### DIFF
--- a/frontend/app/src/modules/assets/prices/use-historic-price-cache.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-historic-price-cache.spec.ts
@@ -1,28 +1,17 @@
 import { bigNumberify } from '@rotki/common';
+import { mockUseNotifications } from '@test/utils/mocks/notifications';
+import { mockUseTaskHandler } from '@test/utils/mocks/task-runner';
 import flushPromises from 'flush-promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { effectScope } from 'vue';
 import { usePriceApi } from '@/modules/balances/api/use-price-api';
 
-const runTaskMock = vi.fn();
+const { runTaskMock } = vi.hoisted(() => ({ runTaskMock: vi.fn() }));
 
-vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  useTaskHandler: vi.fn().mockReturnValue({
-    runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => {
-      await taskFn();
-      return runTaskMock(taskFn, ...rest);
-    },
-    cancelTask: vi.fn(),
-    cancelTaskByTaskType: vi.fn(),
-  }),
-}));
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal =>
+  mockUseTaskHandler(await importOriginal<Record<string, unknown>>(), { runTask: runTaskMock }));
 
-vi.mock('@/modules/core/notifications/use-notifications', () => ({
-  useNotifications: vi.fn(() => ({
-    notifyError: vi.fn(),
-  })),
-}));
+vi.mock('@/modules/core/notifications/use-notifications', () => mockUseNotifications());
 
 /** Exceeds CACHE_EXPIRY (10 min) from item-cache.ts to ensure cache invalidation */
 const PAST_CACHE_EXPIRY_MS = 1000 * 60 * 11;

--- a/frontend/app/src/modules/assets/prices/use-price-task-manager.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-price-task-manager.spec.ts
@@ -1,5 +1,6 @@
 import { bigNumberify } from '@rotki/common';
 import { updateGeneralSettings } from '@test/utils/general-settings';
+import { mockUseTaskHandler } from '@test/utils/mocks/task-runner';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCurrencies } from '@/modules/assets/amount-display/currencies';
 import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
@@ -7,19 +8,10 @@ import { usePriceApi } from '@/modules/balances/api/use-price-api';
 import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
 import { PriceOracle } from '@/modules/settings/types/price-oracle';
 
-const runTaskMock = vi.fn();
+const { runTaskMock } = vi.hoisted(() => ({ runTaskMock: vi.fn() }));
 
-vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  useTaskHandler: vi.fn().mockReturnValue({
-    runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => {
-      await taskFn();
-      return runTaskMock(taskFn, ...rest);
-    },
-    cancelTask: vi.fn(),
-    cancelTaskByTaskType: vi.fn(),
-  }),
-}));
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal =>
+  mockUseTaskHandler(await importOriginal<Record<string, unknown>>(), { runTask: runTaskMock }));
 
 interface PriceResponse {
   assets: Record<string, [number, number]>;

--- a/frontend/app/src/modules/assets/use-asset-info-retrieval.spec.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-retrieval.spec.ts
@@ -1,4 +1,5 @@
 import type { ERC20Token } from '@/modules/accounts/blockchain-accounts';
+import { mockUseTaskHandler } from '@test/utils/mocks/task-runner';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAssetInfoApi } from '@/modules/assets/api/use-asset-info-api';
 import { CUSTOM_ASSET } from '@/modules/assets/types';
@@ -7,8 +8,10 @@ import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
 import { TaskType } from '@/modules/core/tasks/task-type';
 
-const runTaskMock = vi.fn();
-const cancelTaskByTaskTypeMock = vi.fn();
+const { runTaskMock, cancelTaskByTaskTypeMock } = vi.hoisted(() => ({
+  cancelTaskByTaskTypeMock: vi.fn(),
+  runTaskMock: vi.fn(),
+}));
 
 vi.mock('@/modules/assets/api/use-asset-info-api', () => ({
   useAssetInfoApi: vi.fn().mockReturnValue({
@@ -16,17 +19,11 @@ vi.mock('@/modules/assets/api/use-asset-info-api', () => ({
   }),
 }));
 
-vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  useTaskHandler: vi.fn().mockReturnValue({
-    runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => {
-      await taskFn();
-      return runTaskMock(taskFn, ...rest);
-    },
-    cancelTask: vi.fn(),
-    cancelTaskByTaskType: async (...args: unknown[]): Promise<unknown> => cancelTaskByTaskTypeMock(...args),
-  }),
-}));
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal =>
+  mockUseTaskHandler(await importOriginal<Record<string, unknown>>(), {
+    cancelTaskByTaskType: cancelTaskByTaskTypeMock,
+    runTask: runTaskMock,
+  }));
 
 vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
   useNotificationDispatcher: vi.fn().mockReturnValue({

--- a/frontend/app/src/modules/assets/use-asset-locations-data.spec.ts
+++ b/frontend/app/src/modules/assets/use-asset-locations-data.spec.ts
@@ -1,6 +1,7 @@
 import type { AddressData, AssetBreakdown, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
 import { bigNumberify } from '@rotki/common';
 import { createMock } from '@test/utils/create-mock';
+import { mockUseSupportedChains } from '@test/utils/mocks/supported-chains';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAssetLocationsData } from './use-asset-locations-data';
 
@@ -34,9 +35,8 @@ vi.mock('@/modules/accounts/address-book/use-address-name-resolution', () => ({
 vi.mock('@/modules/balances/use-aggregated-balances', () => ({
   useAggregatedBalances: (): object => ({ getAssetPriceInfo: spies.getAssetPriceInfo }),
 }));
-vi.mock('@/modules/core/common/use-supported-chains', () => ({
-  useSupportedChains: (): object => ({ getChainName: spies.getChainName, matchChain: spies.matchChain }),
-}));
+vi.mock('@/modules/core/common/use-supported-chains', () =>
+  mockUseSupportedChains({ getChainName: spies.getChainName, matchChain: spies.matchChain }));
 vi.mock('@/modules/balances/use-asset-balances-breakdown', () => ({
   useAssetBalancesBreakdown: (): object => ({ getAssetBreakdown: spies.getAssetBreakdown }),
 }));

--- a/frontend/app/src/modules/assets/use-asset-nft.spec.ts
+++ b/frontend/app/src/modules/assets/use-asset-nft.spec.ts
@@ -1,9 +1,10 @@
 import type { NftResponse } from '@/modules/assets/nfts';
+import { mockUseTaskHandler } from '@test/utils/mocks/task-runner';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAssetsApi } from '@/modules/assets/api/use-assets-api';
 import { useNfts } from '@/modules/assets/use-asset-nft';
 
-const runTaskMock = vi.fn();
+const { runTaskMock } = vi.hoisted(() => ({ runTaskMock: vi.fn() }));
 
 vi.mock('@/modules/assets/api/use-assets-api', () => ({
   useAssetsApi: vi.fn().mockReturnValue({
@@ -11,17 +12,8 @@ vi.mock('@/modules/assets/api/use-assets-api', () => ({
   }),
 }));
 
-vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  useTaskHandler: vi.fn().mockReturnValue({
-    runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => {
-      await taskFn();
-      return runTaskMock(taskFn, ...rest);
-    },
-    cancelTask: vi.fn(),
-    cancelTaskByTaskType: vi.fn(),
-  }),
-}));
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal =>
+  mockUseTaskHandler(await importOriginal<Record<string, unknown>>(), { runTask: runTaskMock }));
 
 describe('useNftStore', () => {
   setActivePinia(createPinia());

--- a/frontend/app/src/modules/assets/use-assets.spec.ts
+++ b/frontend/app/src/modules/assets/use-assets.spec.ts
@@ -1,12 +1,13 @@
 import type { useAssetIconApi } from '@/modules/assets/api/use-asset-icon-api';
 import type { AssetMergePayload, AssetUpdatePayload } from '@/modules/assets/types';
+import { mockUseTaskHandler } from '@test/utils/mocks/task-runner';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAssetsApi } from '@/modules/assets/api/use-assets-api';
 import { useAssets } from '@/modules/assets/use-assets';
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
 
-const runTaskMock = vi.fn();
+const { runTaskMock } = vi.hoisted(() => ({ runTaskMock: vi.fn() }));
 
 vi.mock('@/modules/assets/api/use-assets-api', () => ({
   useAssetsApi: vi.fn().mockReturnValue({
@@ -24,17 +25,8 @@ vi.mock('@/modules/assets/api/use-asset-icon-api', () => ({
   } satisfies Partial<ReturnType<typeof useAssetIconApi>>),
 }));
 
-vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  useTaskHandler: vi.fn().mockReturnValue({
-    runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => {
-      await taskFn();
-      return runTaskMock(taskFn, ...rest);
-    },
-    cancelTask: vi.fn(),
-    cancelTaskByTaskType: vi.fn(),
-  }),
-}));
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal =>
+  mockUseTaskHandler(await importOriginal<Record<string, unknown>>(), { runTask: runTaskMock }));
 
 vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
   useNotificationDispatcher: vi.fn().mockReturnValue({

--- a/frontend/app/src/modules/assets/use-ignored-asset-operations.spec.ts
+++ b/frontend/app/src/modules/assets/use-ignored-asset-operations.spec.ts
@@ -1,3 +1,4 @@
+import { mockUseNotifications } from '@test/utils/mocks/notifications';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useIgnoredAssetOperations } from '@/modules/assets/use-ignored-asset-operations';
 
@@ -25,15 +26,13 @@ vi.mock('@/modules/balances/manual/use-manual-balance-data', () => ({
   })),
 }));
 
-const mockNotifyError = vi.fn();
-const mockShowErrorMessage = vi.fn();
-
-vi.mock('@/modules/core/notifications/use-notifications', () => ({
-  useNotifications: vi.fn(() => ({
-    notifyError: mockNotifyError,
-    showErrorMessage: mockShowErrorMessage,
-  })),
+const { mockNotifyError, mockShowErrorMessage } = vi.hoisted(() => ({
+  mockNotifyError: vi.fn(),
+  mockShowErrorMessage: vi.fn(),
 }));
+
+vi.mock('@/modules/core/notifications/use-notifications', () =>
+  mockUseNotifications({ notifyError: mockNotifyError, showErrorMessage: mockShowErrorMessage }));
 
 describe('useIgnoredAssetOperations', () => {
   beforeEach(() => {

--- a/frontend/app/src/modules/assets/use-whitelisted-asset-operations.spec.ts
+++ b/frontend/app/src/modules/assets/use-whitelisted-asset-operations.spec.ts
@@ -1,3 +1,4 @@
+import { mockUseNotifications } from '@test/utils/mocks/notifications';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useWhitelistedAssetOperations } from '@/modules/assets/use-whitelisted-asset-operations';
 
@@ -21,13 +22,10 @@ vi.mock('@/modules/assets/use-ignored-asset-operations', () => ({
   })),
 }));
 
-const mockNotifyError = vi.fn();
+const { mockNotifyError } = vi.hoisted(() => ({ mockNotifyError: vi.fn() }));
 
-vi.mock('@/modules/core/notifications/use-notifications', () => ({
-  useNotifications: vi.fn(() => ({
-    notifyError: mockNotifyError,
-  })),
-}));
+vi.mock('@/modules/core/notifications/use-notifications', () =>
+  mockUseNotifications({ notifyError: mockNotifyError }));
 
 describe('useWhitelistedAssetOperations', () => {
   beforeEach(() => {

--- a/frontend/app/src/modules/balances/manual/use-manual-balance-data.spec.ts
+++ b/frontend/app/src/modules/balances/manual/use-manual-balance-data.spec.ts
@@ -1,6 +1,7 @@
 import type { AssetPrices } from '@/modules/assets/prices/price-types';
 import type { ManualBalanceWithValue } from '@/modules/balances/types/manual-balances';
 import { bigNumberify } from '@rotki/common';
+import { mockUseTaskHandler } from '@test/utils/mocks/task-runner';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Currency, CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
 import { useManualBalancesApi } from '@/modules/balances/api/use-manual-balances-api';
@@ -12,7 +13,7 @@ import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { TRADE_LOCATION_BANKS, TRADE_LOCATION_BLOCKCHAIN } from '@/modules/core/common/defaults';
 import { useSettingsRepo } from '@/modules/settings/settings-repo';
 
-const runTaskMock = vi.fn();
+const { runTaskMock } = vi.hoisted(() => ({ runTaskMock: vi.fn() }));
 
 vi.mock('@/modules/balances/api/use-manual-balances-api', () => ({
   useManualBalancesApi: vi.fn().mockReturnValue({
@@ -23,17 +24,8 @@ vi.mock('@/modules/balances/api/use-manual-balances-api', () => ({
   }),
 }));
 
-vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  useTaskHandler: vi.fn().mockReturnValue({
-    runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => {
-      await taskFn();
-      return runTaskMock(taskFn, ...rest);
-    },
-    cancelTask: vi.fn(),
-    cancelTaskByTaskType: vi.fn(),
-  }),
-}));
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal =>
+  mockUseTaskHandler(await importOriginal<Record<string, unknown>>(), { runTask: runTaskMock }));
 
 interface ManualBalance extends Omit<ManualBalanceWithValue, 'amount' | 'value'> {
   amount: string;

--- a/frontend/app/src/modules/core/messaging/handlers/no-available-indexers.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/no-available-indexers.spec.ts
@@ -1,5 +1,6 @@
 import { assert, type Notification, type NotificationAction, NotificationGroup } from '@rotki/common';
 import { mockT } from '@test/i18n';
+import { mockUseSupportedChains } from '@test/utils/mocks/supported-chains';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { createNoAvailableIndexersHandler } from '@/modules/core/messaging/handlers/no-available-indexers';
@@ -17,11 +18,8 @@ vi.mock('@/modules/settings/use-settings-operations', () => ({
   }),
 }));
 
-vi.mock('@/modules/core/common/use-supported-chains', () => ({
-  useSupportedChains: (): { getChainName: (chain: string) => string } => ({
-    getChainName: (chain: string): string => chain.toUpperCase(),
-  }),
-}));
+vi.mock('@/modules/core/common/use-supported-chains', () =>
+  mockUseSupportedChains({ getChainName: (chain: string): string => chain.toUpperCase() }));
 
 const router = { push: vi.fn() };
 

--- a/frontend/app/src/modules/history/balances/use-accounting-overlay.spec.ts
+++ b/frontend/app/src/modules/history/balances/use-accounting-overlay.spec.ts
@@ -1,17 +1,14 @@
 import type { Ref } from 'vue';
 import type { OverlayPair } from '@/modules/history/balances/use-accounting-overlay';
+import { mockUseTaskHandler } from '@test/utils/mocks/task-runner';
 import flushPromises from 'flush-promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TaskType } from '@/modules/core/tasks/task-type';
 
-const runTaskMock = vi.fn();
+const { runTaskMock } = vi.hoisted(() => ({ runTaskMock: vi.fn() }));
 
-vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
-  ...(await importOriginal<typeof import('@/modules/core/tasks/use-task-handler')>()),
-  useTaskHandler: vi.fn().mockReturnValue({
-    runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => runTaskMock(taskFn, ...rest),
-  }),
-}));
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal =>
+  mockUseTaskHandler(await importOriginal<Record<string, unknown>>(), { invoke: false, runTask: runTaskMock }));
 
 vi.mock('@/modules/balances/api/use-historical-balances-api', () => ({
   useHistoricalBalancesApi: vi.fn().mockReturnValue({

--- a/frontend/app/src/modules/history/balances/use-balance-divergence.spec.ts
+++ b/frontend/app/src/modules/history/balances/use-balance-divergence.spec.ts
@@ -1,22 +1,16 @@
 import { bigNumberify } from '@rotki/common';
+import { mockUseTaskHandler } from '@test/utils/mocks/task-runner';
 import { get } from '@vueuse/core';
 import flushPromises from 'flush-promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const runTaskMock = vi.fn();
+const { runTaskMock } = vi.hoisted(() => ({ runTaskMock: vi.fn() }));
 const mockFindDivergence = vi.fn();
 const mockRequestNavigation = vi.fn();
 const mockSetHighlightTarget = vi.fn();
 
-vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
-  ...(await importOriginal<typeof import('@/modules/core/tasks/use-task-handler')>()),
-  useTaskHandler: vi.fn().mockReturnValue({
-    runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => {
-      await taskFn();
-      return runTaskMock(...rest);
-    },
-  }),
-}));
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal =>
+  mockUseTaskHandler(await importOriginal<Record<string, unknown>>(), { runTask: runTaskMock }));
 
 vi.mock('@/modules/balances/api/use-historical-balances-api', () => ({
   useHistoricalBalancesApi: (): object => ({

--- a/frontend/app/src/modules/history/management/forms/use-evm-tx-lookup.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/use-evm-tx-lookup.spec.ts
@@ -1,4 +1,5 @@
 import type { Ref } from 'vue';
+import { mockUseTaskHandler } from '@test/utils/mocks/task-runner';
 import flushPromises from 'flush-promises';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -6,23 +7,16 @@ import { ApiValidationError } from '@/modules/core/api/types/errors';
 import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import { useEvmTxAutoFill } from '@/modules/history/management/forms/use-evm-tx-lookup';
 
-const runTaskMock = vi.fn();
-const cancelTaskByTaskTypeMock = vi.fn();
+const { runTaskMock, cancelTaskByTaskTypeMock } = vi.hoisted(() => ({
+  cancelTaskByTaskTypeMock: vi.fn(),
+  runTaskMock: vi.fn(),
+}));
 
-vi.mock('@/modules/core/tasks/use-task-handler', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useTaskHandler: (): Record<string, unknown> => ({
-      cancelTask: vi.fn(),
-      cancelTaskByTaskType: cancelTaskByTaskTypeMock,
-      runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => {
-        await taskFn();
-        return runTaskMock(taskFn, ...rest);
-      },
-    }),
-  };
-});
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal =>
+  mockUseTaskHandler(await importOriginal<Record<string, unknown>>(), {
+    cancelTaskByTaskType: cancelTaskByTaskTypeMock,
+    runTask: runTaskMock,
+  }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();

--- a/frontend/app/tests/unit/utils/mocks/notifications.ts
+++ b/frontend/app/tests/unit/utils/mocks/notifications.ts
@@ -1,0 +1,42 @@
+import { type Mock, vi } from 'vitest';
+
+export interface NotificationSpies {
+  notify?: Mock;
+  notifyError?: Mock;
+  notifyWarning?: Mock;
+  notifyInfo?: Mock;
+  removeMatching?: Mock;
+  showSuccessMessage?: Mock;
+  showErrorMessage?: Mock;
+}
+
+/**
+ * Builds the `useNotifications` mock used by ~48 specs. Pass only the spies the
+ * test asserts on; the rest default to harmless `vi.fn()` stubs so unrelated
+ * calls (e.g. an incidental `notifyInfo`) don't blow up.
+ *
+ * Declare the spies with `vi.hoisted` so they exist before the `vi.mock`
+ * factory reads them:
+ *
+ * ```ts
+ * const { notifyError } = vi.hoisted(() => ({ notifyError: vi.fn() }));
+ * vi.mock('@/modules/core/notifications/use-notifications', () =>
+ *   mockUseNotifications({ notifyError }),
+ * );
+ * ```
+ */
+export function mockUseNotifications(spies: NotificationSpies = {}): { useNotifications: Mock } {
+  const resolved = {
+    notify: spies.notify ?? vi.fn(),
+    notifyError: spies.notifyError ?? vi.fn(),
+    notifyWarning: spies.notifyWarning ?? vi.fn(),
+    notifyInfo: spies.notifyInfo ?? vi.fn(),
+    removeMatching: spies.removeMatching ?? vi.fn(),
+    showSuccessMessage: spies.showSuccessMessage ?? vi.fn(),
+    showErrorMessage: spies.showErrorMessage ?? vi.fn(),
+  };
+
+  return {
+    useNotifications: vi.fn(() => resolved),
+  };
+}

--- a/frontend/app/tests/unit/utils/mocks/supported-chains.ts
+++ b/frontend/app/tests/unit/utils/mocks/supported-chains.ts
@@ -1,0 +1,54 @@
+import type { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { Blockchain } from '@rotki/common';
+import { type Mock, vi } from 'vitest';
+
+type SupportedChainsReturn = ReturnType<typeof useSupportedChains>;
+
+/**
+ * Builds the `useSupportedChains` mock used by ~58 specs. Provides sensible
+ * defaults for the commonly-touched members (`getChainName` echoes its input,
+ * the predicates return `false`, the list getters resolve to empty arrays) so a
+ * spec only has to override what it actually asserts on, and won't break when an
+ * unrelated code path reaches for a member it never mocked.
+ *
+ * ```ts
+ * const { getChainName } = vi.hoisted(() => ({ getChainName: vi.fn((c: string) => c) }));
+ * vi.mock('@/modules/core/common/use-supported-chains', () =>
+ *   mockUseSupportedChains({ getChainName }),
+ * );
+ * ```
+ */
+export function mockUseSupportedChains(
+  overrides: Partial<SupportedChainsReturn> = {},
+): { useSupportedChains: Mock } {
+  const defaults: Partial<SupportedChainsReturn> = {
+    allTxChainsInfo: computed(() => []),
+    bitcoinChainsData: computed(() => []),
+    decodableTxChainsInfo: computed(() => []),
+    evmAndEvmLikeTxChainsInfo: computed(() => []),
+    evmChains: computed(() => []),
+    evmChainsData: computed(() => []),
+    evmLikeChainsData: computed(() => []),
+    getChain: (_location: string, defaultValue?: Blockchain): Blockchain => defaultValue ?? Blockchain.ETH,
+    getChainName: (location: string): string => location,
+    getEvmChainName: (): string | undefined => undefined,
+    getNativeAsset: (chain: string): string => chain,
+    isBtcChains: (): boolean => false,
+    isDecodableChains: (): boolean => false,
+    isEvm: (): boolean => false,
+    isEvmCompatible: (): boolean => false,
+    isEvmLikeChains: (): boolean => false,
+    isSolanaChains: (): boolean => false,
+    matchChain: (): Blockchain | undefined => undefined,
+    refreshSupportedChains: async (): Promise<void> => {},
+    solanaChainsData: computed(() => []),
+    supportedChains: ref([]),
+    supportsTransactions: (): boolean => false,
+    txChainsToLocation: computed(() => []),
+    txEvmChains: computed(() => []),
+  };
+
+  return {
+    useSupportedChains: vi.fn(() => ({ ...defaults, ...overrides })),
+  };
+}

--- a/frontend/app/tests/unit/utils/mocks/task-runner.ts
+++ b/frontend/app/tests/unit/utils/mocks/task-runner.ts
@@ -1,0 +1,54 @@
+import { type Mock, vi } from 'vitest';
+
+export interface TaskRunnerOptions {
+  /** The spy `runTask` delegates its return value to (create with `vi.fn()`). */
+  runTask?: Mock;
+  cancelTask?: Mock;
+  cancelTaskByTaskType?: Mock;
+  handleResult?: Mock;
+  /**
+   * When `true` (default) the stubbed `runTask` awaits the passed `taskFn`
+   * before resolving, matching production. Set `false` for specs that assert
+   * the callback must NOT auto-run.
+   */
+  invoke?: boolean;
+}
+
+/**
+ * Builds the `useTaskHandler` mock used by ~35 orchestration specs, replacing
+ * the verbatim `runTask: async taskFn => { await taskFn(); return runTaskMock() }`
+ * block copied byte-for-byte across the suite.
+ *
+ * Call it inside a `vi.mock` factory, spreading the original module so unrelated
+ * exports survive. Declare the spy with `vi.hoisted` so it exists before the
+ * factory reads it (a plain `const` hits a temporal-dead-zone error):
+ *
+ * ```ts
+ * const { runTaskMock } = vi.hoisted(() => ({ runTaskMock: vi.fn() }));
+ * vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal =>
+ *   mockUseTaskHandler(await importOriginal(), { runTask: runTaskMock }),
+ * );
+ * ```
+ */
+export function mockUseTaskHandler(
+  original: Record<string, unknown>,
+  options: TaskRunnerOptions = {},
+): Record<string, unknown> {
+  const runTask = options.runTask ?? vi.fn();
+  const invoke = options.invoke ?? true;
+
+  return {
+    ...original,
+    useTaskHandler: vi.fn().mockReturnValue({
+      runTask: async (taskFn: () => Promise<unknown>, ...rest: unknown[]): Promise<unknown> => {
+        if (invoke)
+          await taskFn();
+
+        return runTask(taskFn, ...rest);
+      },
+      cancelTask: options.cancelTask ?? vi.fn(),
+      cancelTaskByTaskType: options.cancelTaskByTaskType ?? vi.fn(),
+      handleResult: options.handleResult ?? vi.fn(),
+    }),
+  };
+}


### PR DESCRIPTION
## What

Extracts the mock boilerplate that unit specs re-hand-roll into three shared helpers under `frontend/app/tests/unit/utils/mocks/` (imported via `@test/utils/mocks/*`, no barrel), and adopts them across 13 proof specs.

| Helper | Replaces | Specs in suite |
|--------|----------|----------------|
| `mockUseTaskHandler(original, { runTask, invoke? })` | the verbatim `runTask: async taskFn => { await taskFn(); return runTaskMock() }` block copied byte-for-byte | ~35 mock `useTaskHandler` |
| `mockUseNotifications({ notifyError, ... })` | partial `useNotifications` stubs; unmocked methods default to harmless `vi.fn()` | ~48 |
| `mockUseSupportedChains(overrides)` | a full default stub (getChainName echoes, predicates `false`, list getters `computed([])`) so a spec only overrides what it asserts on | ~58 |

## Why

These three shapes are the highest-count, most stable mock boilerplate in the suite. Centralizing them removes duplication and, for supported-chains, stops specs breaking when an unrelated code path reaches a member the spec never stubbed.

## Notes

- **`vi.hoisted` is required for the spies.** The helpers read the passed spies eagerly when the `vi.mock` factory runs (at hoist time), so a spec must declare its spies with `vi.hoisted(() => ({ spy: vi.fn() }))` rather than a plain `const`. The old inline mocks got away with a plain const only because the spy was read lazily inside the `runTask` closure. Documented in each helper's JSDoc.
- A fourth planned helper (composable-ref) was dropped: only 2 specs fit its narrow shape, and the broader `await import('vue')` pattern can't be centralized (each factory builds different refs, and the dynamic import is required because vi.mock factories hoist above top-level imports).
- Migration is opportunistic: this PR proves the pattern on 13 specs; future specs (and touched ones) adopt the helpers going forward.

## Testing

- `pnpm run test:unit` on all 13 migrated specs: green (99 tests).
- `pnpm run typecheck`: 0 errors.
- `pnpm run lint-staged`: clean.
