### PR TITLE
fix: use normal AppImage compression

### DIFF
--- a/frontend/app/.electron-builder.config.ts
+++ b/frontend/app/.electron-builder.config.ts
@@ -55,7 +55,7 @@ async function afterSign(context: AfterPackContext): Promise<void> {
  */
 export default {
   appId: 'com.rotki.app',
-  compression: 'maximum',
+  compression: 'normal',
   directories: {
     output: 'build',
     buildResources: 'buildResources',


### PR DESCRIPTION
## Problem

`compression: 'maximum'` (added in bf4c4602be) builds the AppImage squashfs with xz/LZMA. AppImage decompresses file blocks **on demand** at runtime, so every cold launch pays a heavy per-block decompress cost while paging in the Electron/Chromium binary and `app.asar`. In practice this adds roughly **40 seconds** to startup versus the previous behavior.

This only affects `develop`-based builds — `bf4c4602be` was never in `bugfixes`/`master`, so no stable release shipped it.

## Fix

Switch to `compression: 'normal'`, which restores launch speed.

## Measurements

Linux x64, full package (Electron + `app.asar` + PyInstaller backend + colibri), reusing one build and only re-running `electron:package`:

| compression | AppImage size | cold start |
|---|---|---|
| `maximum` | 203 MB | slow (~+40s) |
| `normal` | 256 MB | fast |
| `store` | 256 MB | fast (identical to `normal`) |

## Tradeoff

`normal` is ~53 MB (~26%) larger to download, but that is a one-time cost, whereas the `maximum` decompress penalty is paid on **every** launch. `store` gives no size benefit over `normal` for AppImage, and electron-builder exposes no level between `normal` and `maximum`, so `normal` is the fast option.