### PR TITLE
fix: decode eigenlayer post-slashing withdrawals

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` EigenLayer withdrawals queued or completed after the protocol's slashing upgrade (ELIP-002, April 2025) are now decoded again, including withdrawals of natively restaked ETH sent by an eigenpod. Queued and completed withdrawals of the EIGEN strategy are now also shown as EIGEN instead of its wrapped bEIGEN underlying token.
 * :feature:`2922` The Docker version of rotki can now require authentication. When set up with the session key environment variable it issues a secure, HttpOnly session cookie on login and rejects unauthenticated API and websocket access, so a rotki instance reachable on your network is no longer open to anyone who can reach its port.
 * :feature:`3156` When rotki runs in a browser (Docker), only one session can be active at a time. Logging in from another browser or window takes over the session and signs the previous one out, and opening rotki in a second tab of the same browser now pauses the older tab with a prompt to continue in whichever tab you choose, so two frontends no longer compete over one backend.
 * :feature:`-` Kinetiq liquid staking on HyperEVM is now supported. Staking, withdrawals (queued and instant) are decoded, and the HYPE value of pending withdrawals is detected in your balances. Also Kinetiq earn vaults are supported.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,14 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import ast
+
+if not hasattr(ast, 'Str'):
+    # sphinxcontrib-httpexample 1.1 still builds ast.Str nodes, which were removed
+    # in python 3.12. It renders them via ast.unparse, for which Constant is a
+    # drop-in replacement. Remove once a fixed version of the extension is released.
+    ast.Str = ast.Constant  # type: ignore[attr-defined]
+
 
 # -- Project information -----------------------------------------------------
 

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/constants.py
@@ -27,6 +27,8 @@ OPERATOR_SHARES_INCREASED: Final = b'\x1e\xc0B\xc9e\xe2\xed\xd7\x10{Q\x18\x8e\xe
 OPERATOR_SHARES_DECREASED: Final = b'i\t`\x007\xb7]{G3\xae\xdd\x81TB\xb5\xec\x01\x8a\x82wQ\xc82\xaa\xffd\xeb\xa5\xd6\xd2\xdd'  # noqa: E501
 WITHDRAWAL_QUEUED: Final = b'\x90\t\xab\x15>\x80\x14\xfb\xfb\x02\xf2!\x7f\\\xdez\xa7\xf9\xadsJ\xe8\\\xa3\xee?L\xa2\xfd\xd4\x99\xf9'  # noqa: E501
 WITHDRAWAL_COMPLETED: Final = b'\xc9p\x98\xc2\xf6X\x80\x0bM\xf2\x90\x01R\x7fs$\xbc\xdf\xfc\xf6\xe8u\x1ai\x9a\xb9 \xa1\xec\xed[\x1d'  # noqa: E501
+SLASHING_WITHDRAWAL_QUEUED: Final = b'&\xb2\xaa\xe2e\x16\xe8q\x9e\xf5\x0e\xa2\xf6\x83\x1a.\xfb\xd4\xe3}\xcc\xdf\x0fi6\xb2{\xc0\x8ey>0'  # noqa: E501
+SLASHING_WITHDRAWAL_COMPLETED: Final = b"\x1f@@\x08\x89'N\xd0{$\x84^PT\xa8z\x0c\xab\x96\x9e\xb1'z\xaf\xe6\x1a\xe3R\xe7\xc3*\x00"  # noqa: E501
 POD_SHARES_UPDATED: Final = b'N+y\x1d\xed\xcc\xd9\xfb0\x14\x1b\x08\x8c\xab\xf5\xc1J\x89\x12\xb5/Y7\\\x95\xc0\x10p\x0b\x8ca\x93'  # noqa: E501
 CHECKPOINT_CREATED: Final = b'WW\x96\x13;\xbe\xd37\xe5\xb3\x9a\xa4\x9a0\xdc%V\xa9\x1e\x0cl*\xf4\xb7\xb8\x86\xaew\xeb\xef\x10v'  # noqa: E501
 CHECKPOINT_FINALIZED: Final = b'RT\x08\xc2\x01\xbc\x15v\xebD\x11odx\xf1\xc2\xa5Gu\xb1\x9a\x04;\xcf\xdcp\x83d\xf7O\x8eD'  # noqa: E501
@@ -39,6 +41,9 @@ EIGENLAYER_CPT_DETAILS: Final = CounterpartyDetails(
     image='eigenlayer.png',
 )
 EIGEN_TOKEN_ID: Final = 'eip155:1/erc20:0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83'
+BEIGEN_TOKEN_ID: Final = 'eip155:1/erc20:0x83E9115d334D248Ce39a6f36144aEaB5b3456e75'
+# withdrawal struct emitted by both WithdrawalQueued and SlashingWithdrawalQueued
+WITHDRAWAL_STRUCT: Final = '(address,address,address,uint256,uint32,address[],uint256[])'
 
 # not the full ABIs, just the functions we call for each contract
 STRATEGY_ABI: Final[ABI] = [{'inputs': [{'name': 'amountShares', 'type': 'uint256'}], 'name': 'sharesToUnderlyingView', 'outputs': [{'name': '', 'type': 'uint256'}], 'stateMutability': 'view', 'type': 'function'}, {'inputs': [], 'name': 'underlyingToken', 'outputs': [{'name': '', 'type': 'address'}], 'stateMutability': 'view', 'type': 'function'}]  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/decoder.py
@@ -1,10 +1,15 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from eth_abi import decode as decode_abi
+from eth_utils import to_checksum_address
+
+from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.utils import TokenEncounterInfo, token_normalized_value
 from rotkehlchen.chain.ethereum.airdrops import AIRDROP_IDENTIFIER_KEY
 from rotkehlchen.chain.ethereum.modules.eigenlayer.constants import (
     BEACON_ETH_STRATEGY,
+    BEIGEN_TOKEN_ID,
     CHECKPOINT_CREATED,
     CHECKPOINT_FINALIZED,
     CPT_EIGENLAYER,
@@ -28,18 +33,23 @@ from rotkehlchen.chain.ethereum.modules.eigenlayer.constants import (
     POD_SHARES_UPDATED,
     REWARDS_CLAIMED,
     REWARDS_COORDINATOR,
+    SLASHING_WITHDRAWAL_COMPLETED,
+    SLASHING_WITHDRAWAL_QUEUED,
     STRATEGY_ABI,
     STRATEGY_WITHDRAWAL_COMPLETE_TOPIC,
     VALIDATOR_BALANCE_UPDATED,
     WITHDRAWAL_COMPLETED,
     WITHDRAWAL_QUEUED,
+    WITHDRAWAL_STRUCT,
 )
 from rotkehlchen.chain.ethereum.modules.eigenlayer.utils import get_eigenpods_to_owners_mapping
 from rotkehlchen.chain.evm.contracts import EvmContract
 from rotkehlchen.chain.evm.decoding.clique.decoder import CliqueAirdropDecoderInterface
+from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.chain.evm.decoding.interfaces import ReloadableDecoderMixin
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,
+    ActionItem,
     DecoderContext,
     EvmDecodingOutput,
 )
@@ -66,6 +76,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.fval import FVal
+    from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
 
 logger = logging.getLogger(__name__)
@@ -356,19 +367,47 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface, ReloadableDecoderMixin):
                         extra_data=withdrawal_event.extra_data | {'completed': True},
                     )
 
+                withdrawal_strategy = withdrawal_event.extra_data.get('strategy')
+                matched_transfer = False
                 for event in context.decoded_events:  # and now match the transfer
                     if (
-                            event.event_type == HistoryEventType.RECEIVE and event.event_subtype == HistoryEventSubType.NONE and  # noqa: E501
-                            event.asset == withdrawal_event.asset and
-                            event.address == withdrawal_event.extra_data.get('strategy')  # strategy sends it  # noqa: E501
-                    ):  # not checking amount as it can differ due to rebasing in some assets
+                            event.event_type != HistoryEventType.RECEIVE or
+                            event.event_subtype != HistoryEventSubType.NONE or
+                            event.asset != withdrawal_event.asset
+                    ):
+                        continue
+
+                    if withdrawal_strategy == BEACON_ETH_STRATEGY:
+                        # natively restaked ETH is sent by the user's eigenpod. Since
+                        # these withdrawals are already tracked by validator index count
+                        # it as a transfer between accounts to avoid double counting
+                        event.event_type = HistoryEventType.TRANSFER
+                        event.counterparty = CPT_EIGENLAYER
+                        event.notes = f'Withdraw {event.amount} ETH from Eigenlayer'
+                        matched_transfer = True
+                        break
+
+                    if event.address == withdrawal_strategy:  # strategy sends it
+                        # not checking amount as it can differ due to rebasing in some assets
                         event.event_type = HistoryEventType.WITHDRAWAL
                         event.event_subtype = HistoryEventSubType.WITHDRAW_FROM_PROTOCOL
                         event.counterparty = CPT_EIGENLAYER
                         event.notes = f'Withdraw {event.amount} {event.asset.resolve_to_asset_with_symbol().symbol} from Eigenlayer'  # noqa: E501
+                        matched_transfer = True
                         break
 
-                else:  # could not find the transfer, withdrawn as shares and not tokens
+                if not matched_transfer:
+                    # The post-slashing contracts emit WithdrawalCompleted before the token
+                    # transfer, so look ahead in the logs for the strategy's transfer and
+                    # transform it via an action item once it gets decoded
+                    matched_transfer = self._maybe_transform_upcoming_withdrawal_transfer(
+                        context=context,
+                        withdrawal_event=withdrawal_event,
+                        strategy=withdrawal_strategy,
+                    )
+
+                if not matched_transfer:
+                    # could not find the transfer, withdrawn as shares and not tokens
                     # https://github.com/Layr-Labs/eigenlayer-contracts/blob/dc3abf5d2a2689a98993c69e962d5d8b299e3fec/docs/core/DelegationManager.md#completequeuedwithdrawal
                     # https://github.com/Layr-Labs/eigenlayer-contracts/tree/dc3abf5d2a2689a98993c69e962d5d8b299e3fec/docs#completing-a-withdrawal-as-tokens
                     new_event.notes += ' as shares'  # type: ignore  # notes is not none
@@ -393,17 +432,68 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface, ReloadableDecoderMixin):
 
         return EvmDecodingOutput(events=[new_event])
 
+    def _maybe_transform_upcoming_withdrawal_transfer(
+            self,
+            context: DecoderContext,
+            withdrawal_event: EvmEvent,
+            strategy: str | None,
+    ) -> bool:
+        """Find a not yet decoded transfer of the withdrawn token sent by the strategy
+        in an upcoming log and register an action item to transform it once decoded.
+        Returns whether such a transfer was found."""
+        if strategy is None or strategy == BEACON_ETH_STRATEGY:
+            return False  # ETH internal transfers are always decoded before the logs
+
+        token = withdrawal_event.asset.resolve_to_evm_token()
+        for tx_log in context.all_logs:
+            if (
+                    tx_log.log_index > context.tx_log.log_index and
+                    tx_log.address == token.evm_address and
+                    tx_log.topics[0] == ERC20_OR_ERC721_TRANSFER and
+                    bytes_to_address(tx_log.topics[1]) == strategy
+            ):
+                amount = token_normalized_value(
+                    token_amount=int.from_bytes(tx_log.data[0:32]),
+                    token=token,
+                )
+                context.action_items.append(ActionItem(
+                    action='transform',
+                    from_event_type=HistoryEventType.RECEIVE,
+                    from_event_subtype=HistoryEventSubType.NONE,
+                    asset=token,
+                    amount=amount,
+                    to_event_type=HistoryEventType.WITHDRAWAL,
+                    to_event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
+                    to_notes=f'Withdraw {amount} {token.symbol} from Eigenlayer',
+                    to_counterparty=CPT_EIGENLAYER,
+                ))
+                return True
+
+        return False
+
     def _decode_withdrawal_queued(self, context: DecoderContext) -> EvmDecodingOutput:
         """Creates and adds a queued withdrawal for each withdrawal in the event"""
-        contract = self.node_inquirer.contracts.contract(EIGENLAYER_DELEGATION)
-        _, log_data = contract.decode_event(tx_log=context.tx_log, event_name='WithdrawalQueued', argument_names=('withdrawalRoot', 'withdrawal'))  # noqa: E501
-        if not self.base.any_tracked([staker := log_data[1][0], withdrawer := log_data[1][2]]):
+        if context.tx_log.topics[0] == SLASHING_WITHDRAWAL_QUEUED:
+            # The post-slashing event is not in the delegation manager ABI we ship,
+            # so decode it directly. The third argument (sharesToWithdraw) contains
+            # the actually withdrawable shares after any slashing is applied
+            withdrawal_root, withdrawal, shares_entries = decode_abi(
+                types=['bytes32', WITHDRAWAL_STRUCT, 'uint256[]'],
+                data=context.tx_log.data,
+            )
+            staker, withdrawer = to_checksum_address(withdrawal[0]), to_checksum_address(withdrawal[2])  # noqa: E501
+            strategies = [to_checksum_address(x) for x in withdrawal[5]]
+        else:  # the pre-slashing upgrade (April 2025) WithdrawalQueued event
+            contract = self.node_inquirer.contracts.contract(EIGENLAYER_DELEGATION)
+            _, log_data = contract.decode_event(tx_log=context.tx_log, event_name='WithdrawalQueued', argument_names=('withdrawalRoot', 'withdrawal'))  # noqa: E501
+            withdrawal_root = log_data[0]
+            staker, withdrawer = log_data[1][0], log_data[1][2]
+            strategies, shares_entries = log_data[1][5], log_data[1][6]
+
+        if not self.base.any_tracked([staker, withdrawer]):
             return DEFAULT_EVM_DECODING_OUTPUT
 
         location_label = withdrawer if self.base.is_tracked(withdrawer) else staker
-
-        strategies = log_data[1][5]
-        shares_entries = log_data[1][6]
         if len(strategies) != len(shares_entries):  # should not happen according to contracts
             log.error(f'When decoding eigenlayer WithdrawalQueued len(strategies) != len(shares) for {context.transaction.tx_hash!s}')  # noqa: E501
             return DEFAULT_EVM_DECODING_OUTPUT
@@ -428,7 +518,7 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface, ReloadableDecoderMixin):
                 extra_data={
                     'amount': str(underlying_amount),
                     'withdrawer': withdrawer,
-                    'withdrawal_root': '0x' + log_data[0].hex(),
+                    'withdrawal_root': '0x' + withdrawal_root.hex(),
                     'strategy': strategies[idx],
                 },
             )
@@ -469,12 +559,17 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface, ReloadableDecoderMixin):
 
             ])
 
-        output = self.node_inquirer.multicall(calls=calls)
+        output = self.node_inquirer.multicall(calls=calls) if len(calls) != 0 else []
         for raw_address, raw_amount in pairwise(output):
-            underlying_tokens.append(underlying_token := self.base.get_or_create_evm_token(
+            underlying_token = self.base.get_or_create_evm_token(
                 address=bytes_to_address(raw_address),
                 encounter=encounter,
-            ))
+            )
+            if underlying_token.identifier == BEIGEN_TOKEN_ID:
+                # the EIGEN strategy's underlying token is bEIGEN but deposits and
+                # withdrawals are unwrapped 1:1 to EIGEN, so show EIGEN to the user
+                underlying_token = Asset(EIGEN_TOKEN_ID).resolve_to_evm_token()
+            underlying_tokens.append(underlying_token)
             underlying_amounts.append(token_normalized_value(
                 token_amount=int.from_bytes(raw_amount),
                 token=underlying_token,
@@ -492,10 +587,10 @@ class EigenlayerDecoder(CliqueAirdropDecoderInterface, ReloadableDecoderMixin):
             verb, preposition = 'Delegate', 'to'
         elif context.tx_log.topics[0] == OPERATOR_SHARES_DECREASED:
             verb, preposition = 'Undelegate', 'from'
-        elif context.tx_log.topics[0] == WITHDRAWAL_QUEUED:
-            return self. _decode_withdrawal_queued(context)
-        elif context.tx_log.topics[0] == WITHDRAWAL_COMPLETED:
-            return self. _decode_withdrawal_completed(context)
+        elif context.tx_log.topics[0] in (WITHDRAWAL_QUEUED, SLASHING_WITHDRAWAL_QUEUED):
+            return self._decode_withdrawal_queued(context)
+        elif context.tx_log.topics[0] in (WITHDRAWAL_COMPLETED, SLASHING_WITHDRAWAL_COMPLETED):
+            return self._decode_withdrawal_completed(context)
         else:
             return DEFAULT_EVM_DECODING_OUTPUT
 

--- a/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
+++ b/rotkehlchen/tests/unit/decoders/test_eigenlayer.py
@@ -522,6 +522,247 @@ def test_lst_complete_delayed_withdrawals(database, ethereum_inquirer, ethereum_
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0x1DEd04611E3B48F620D42bC97f798cb085403f73']])
+def test_complete_withdrawal_post_slashing_token(database, ethereum_inquirer, ethereum_accounts):
+    """Test queueing and completing an EIGEN withdrawal emitting the SlashingWithdrawalQueued
+    and SlashingWithdrawalCompleted events introduced by the slashing upgrade (ELIP-002).
+    Also checks that the EIGEN strategy's bEIGEN underlying token is shown as EIGEN,
+    which is what is actually deposited and withdrawn by the user."""
+    queue_tx_hash = deserialize_evm_tx_hash('0x75d5947cf192631dd003fcf6fb5112f4f2eaca4d23f79397b72a3cf4d73a481e')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
+        tx_hash=queue_tx_hash,
+    )
+    user_address, timestamp, gas_amount, amount, eigen, eigen_strategy = ethereum_accounts[0], TimestampMS(1753875839000), '0.00093321233696448', '60', Asset(EIGEN_TOKEN_ID), string_to_evm_address('0xaCB55C530Acdb2849e6d4f36992Cd8c9D50ED8F7')  # noqa: E501
+    assert events == [EvmEvent(
+        tx_ref=queue_tx_hash,
+        sequence_index=0,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount),
+        location_label=user_address,
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=queue_tx_hash,
+        sequence_index=625,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=eigen,
+        amount=ZERO,
+        location_label=user_address,
+        notes=f'Undelegate {amount} restaked EIGEN from 0x5ACCC90436492F24E6aF278569691e2c942A676d',  # noqa: E501
+        counterparty=CPT_EIGENLAYER,
+        address=EIGENLAYER_DELEGATION,
+        extra_data={'amount': amount},
+    ), EvmEvent(
+        tx_ref=queue_tx_hash,
+        sequence_index=626,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.REMOVE_ASSET,
+        asset=eigen,
+        amount=ZERO,
+        location_label=user_address,
+        notes=f'Queue withdrawal of {amount} EIGEN from Eigenlayer',
+        counterparty=CPT_EIGENLAYER,
+        address=EIGENLAYER_DELEGATION,
+        extra_data={
+            'amount': amount,
+            'withdrawer': user_address,
+            'withdrawal_root': '0x8e4008a087a4095d217cc2e7996f42e31cbfff67aeead1332d41706de408ec4e',  # noqa: E501
+            'strategy': eigen_strategy,
+        },
+    )]
+
+    tx_hash = deserialize_evm_tx_hash('0x9340fb42391c734caccb46048238ba2579c51e6f8096d2abb6216b509a1c1db6')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
+    timestamp, gas_amount = TimestampMS(1784026463000), '0.000206362625778015'
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount),
+        location_label=user_address,
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=446,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=eigen,
+        amount=ZERO,
+        location_label=user_address,
+        notes='Complete eigenlayer withdrawal of EIGEN',
+        counterparty=CPT_EIGENLAYER,
+        address=EIGENLAYER_DELEGATION,
+        extra_data={'matched': True},
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=453,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.WITHDRAWAL,
+        event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
+        asset=eigen,
+        amount=FVal(amount),
+        location_label=user_address,
+        notes=f'Withdraw {amount} EIGEN from Eigenlayer',
+        counterparty=CPT_EIGENLAYER,
+        address=eigen_strategy,
+    )]
+
+    with database.conn.read_ctx() as cursor:  # check the queueing event is marked as completed
+        events = DBHistoryEvents(database).get_history_events_internal(
+            cursor=cursor,
+            filter_query=EvmEventFilterQuery.make(
+                tx_hashes=[queue_tx_hash],
+                event_subtypes=[HistoryEventSubType.REMOVE_ASSET],
+            ),
+        )
+    assert events[0].extra_data == {
+        'amount': amount,
+        'completed': True,
+        'withdrawer': user_address,
+        'withdrawal_root': '0x8e4008a087a4095d217cc2e7996f42e31cbfff67aeead1332d41706de408ec4e',
+        'strategy': eigen_strategy,
+    }
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0x79f4B334c0e290250Dd5b65799310805FD807F0F']])
+def test_complete_withdrawal_post_slashing_eth(database, ethereum_inquirer, ethereum_accounts):
+    """Test queueing and completing a natively restaked ETH withdrawal emitting the
+    events introduced by the slashing upgrade (ELIP-002). The ETH is sent to the
+    withdrawer by their eigenpod when the withdrawal is completed."""
+    queue_tx_hash = deserialize_evm_tx_hash('0xbc678ee75a2ee4fbbb24a29b614f6b601b9a08765f0b142f2c20b5aec27153a1')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=ethereum_inquirer,
+        tx_hash=queue_tx_hash,
+    )
+    user_address, timestamp, gas_amount, amount = ethereum_accounts[0], TimestampMS(1782421343000), '0.000073031120801748', '6.24'  # noqa: E501
+    assert events == [EvmEvent(
+        tx_ref=queue_tx_hash,
+        sequence_index=0,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount),
+        location_label=user_address,
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=queue_tx_hash,
+        sequence_index=640,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_ETH,
+        amount=ZERO,
+        location_label=user_address,
+        notes=f'Undelegate {amount} restaked ETH from 0xa026265a0F01A6E1A19b04655519429df0a57c4e',
+        counterparty=CPT_EIGENLAYER,
+        address=EIGENLAYER_DELEGATION,
+        extra_data={'amount': amount},
+    ), EvmEvent(
+        tx_ref=queue_tx_hash,
+        sequence_index=642,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.REMOVE_ASSET,
+        asset=A_ETH,
+        amount=ZERO,
+        location_label=user_address,
+        notes=f'Queue withdrawal of {amount} ETH from Eigenlayer',
+        counterparty=CPT_EIGENLAYER,
+        address=EIGENLAYER_DELEGATION,
+        extra_data={
+            'amount': amount,
+            'withdrawer': user_address,
+            'withdrawal_root': '0x359d4e37f59466007a6e5246531c6a46b53775266572072df45ec1a18848d9b6',  # noqa: E501
+            'strategy': '0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0',
+        },
+    )]
+
+    tx_hash = deserialize_evm_tx_hash('0xcc0f01a59a1ce8854106f0a901ed0b272467e868b862fe1d104b97ddd5f630ae')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
+    timestamp, gas_amount, eigenpod_address = TimestampMS(1784217623000), '0.000300333566183211', string_to_evm_address('0x951C0537b78A92E505a96e19d808ddd3ba76Eb44')  # noqa: E501
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount),
+        location_label=user_address,
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=1,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.TRANSFER,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_ETH,
+        amount=FVal(amount),
+        location_label=user_address,
+        notes=f'Withdraw {amount} ETH from Eigenlayer',
+        counterparty=CPT_EIGENLAYER,
+        address=eigenpod_address,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=188,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_ETH,
+        amount=ZERO,
+        location_label=user_address,
+        notes='Complete eigenlayer withdrawal of ETH',
+        counterparty=CPT_EIGENLAYER,
+        address=EIGENLAYER_DELEGATION,
+        extra_data={'matched': True},
+    )]
+
+    with database.conn.read_ctx() as cursor:  # check the queueing event is marked as completed
+        events = DBHistoryEvents(database).get_history_events_internal(
+            cursor=cursor,
+            filter_query=EvmEventFilterQuery.make(
+                tx_hashes=[queue_tx_hash],
+                event_subtypes=[HistoryEventSubType.REMOVE_ASSET],
+            ),
+        )
+    assert events[0].extra_data == {
+        'amount': amount,
+        'completed': True,
+        'withdrawer': user_address,
+        'withdrawal_root': '0x359d4e37f59466007a6e5246531c6a46b53775266572072df45ec1a18848d9b6',
+        'strategy': '0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0',
+    }
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0xCd2bCdE423F36E1B81a25168D5373f908546c9BE', '0xf17606D3FFbd5B07454542146a74712Eb797Ac0a']])  # noqa: E501
 def test_claim_delayed_withdrawals(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xc5d38c05567f5a4d51e686225dfc461ddf177eefa7c531822656b2ed9560ab12')  # noqa: E501


### PR DESCRIPTION
Support the SlashingWithdrawalQueued/SlashingWithdrawalCompleted events introduced by the eigenlayer slashing upgrade (ELIP-002). Also show the EIGEN strategy's bEIGEN underlying as EIGEN, match completion transfers emitted after the completed event via an action item and match natively restaked ETH sent by the user's eigenpod as a transfer to avoid double counting with validator withdrawals.