### PR TITLE
fix(pinned): keep pinned tabs across a logout

### DIFF
--- a/frontend/app/src/modules/shell/pinned/use-pinned-persistence.spec.ts
+++ b/frontend/app/src/modules/shell/pinned/use-pinned-persistence.spec.ts
@@ -4,15 +4,24 @@ import { get, set } from '@vueuse/core';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { type EffectScope, effectScope, nextTick } from 'vue';
+import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
 import { PinnedNames } from '@/modules/session/types';
 import { usePinnedPersistence } from '@/modules/shell/pinned/use-pinned-persistence';
 
 const WIDTH_KEY = 'rotki.pinned.width';
-const TABS_KEY = 'rotki.pinned.tabs';
+const USER = 'alice';
+const TABS_KEY = `rotki.pinned.tabs.${USER}`;
 
-function readTabs(): { names: string[]; activeId: string | null } {
-  return JSON.parse(localStorage.getItem(TABS_KEY) ?? '{"activeId":null,"names":[]}');
+function readTabs(key: string = TABS_KEY): { names: string[]; activeId: string | null } {
+  return JSON.parse(localStorage.getItem(key) ?? '{"activeId":null,"names":[]}');
+}
+
+/** The app shell only mounts for an unlocked user, so every case starts from a signed-in session. */
+function signIn(name: string = USER): void {
+  const { logged, username } = storeToRefs(useSessionAuthStore());
+  set(username, name);
+  set(logged, true);
 }
 
 describe('usePinnedPersistence', () => {
@@ -22,6 +31,7 @@ describe('usePinnedPersistence', () => {
     setActivePinia(createPinia());
     localStorage.clear();
     scope = effectScope();
+    signIn();
   });
 
   afterEach(() => {
@@ -134,5 +144,81 @@ describe('usePinnedPersistence', () => {
     await nextTick();
 
     expect(localStorage.getItem(WIDTH_KEY)).toBe('640');
+  });
+
+  it('should keep the persisted tabs when logging out empties the rail', async () => {
+    const store = useAreaVisibilityStore();
+    const { logged } = storeToRefs(useSessionAuthStore());
+    scope.run(() => usePinnedPersistence());
+
+    store.pinPanel({ name: PinnedNames.DATA_ISSUES, props: {} });
+    await nextTick();
+    expect(readTabs().names).toEqual([PinnedNames.DATA_ISSUES]);
+
+    // Logout flips `logged` first, then resets every store, which empties the rail.
+    set(logged, false);
+    store.clearPinned();
+    await nextTick();
+
+    // The rail is empty, but what we restore on the next sign-in must survive.
+    expect(get(store.pinnedPanels)).toHaveLength(0);
+    expect(readTabs().names).toEqual([PinnedNames.DATA_ISSUES]);
+  });
+
+  it('should restore the tabs again on the next sign-in', async () => {
+    const first = useAreaVisibilityStore();
+    scope.run(() => usePinnedPersistence());
+    first.pinPanel({ name: PinnedNames.DATA_ISSUES, props: {} });
+    await nextTick();
+
+    // Log out: the stores reset and the app shell unmounts.
+    set(storeToRefs(useSessionAuthStore()).logged, false);
+    first.clearPinned();
+    await nextTick();
+    scope.stop();
+
+    // Sign back in: a fresh shell re-runs the composable against an untouched rail.
+    setActivePinia(createPinia());
+    signIn();
+    const second = useAreaVisibilityStore();
+    scope = effectScope();
+    scope.run(() => usePinnedPersistence());
+
+    expect(get(second.pinnedPanels).map(panel => panel.name)).toEqual([PinnedNames.DATA_ISSUES]);
+  });
+
+  it('should not hand one user the tabs of another', async () => {
+    const alice = useAreaVisibilityStore();
+    scope.run(() => usePinnedPersistence());
+    alice.pinPanel({ name: PinnedNames.DATA_ISSUES, props: {} });
+    await nextTick();
+    scope.stop();
+
+    // Bob signs in on the same device.
+    setActivePinia(createPinia());
+    signIn('bob');
+    const bob = useAreaVisibilityStore();
+    scope = effectScope();
+    scope.run(() => usePinnedPersistence());
+
+    expect(get(bob.pinnedPanels)).toHaveLength(0);
+    // Alice's tabs are untouched, waiting for her next sign-in.
+    expect(readTabs().names).toEqual([PinnedNames.DATA_ISSUES]);
+  });
+
+  it('should share the rail width across users, since it describes the screen', async () => {
+    const { pinnedWidth: aliceWidth } = storeToRefs(useAreaVisibilityStore());
+    scope.run(() => usePinnedPersistence());
+    set(aliceWidth, 700);
+    await nextTick();
+    scope.stop();
+
+    setActivePinia(createPinia());
+    signIn('bob');
+    const { pinnedWidth: bobWidth } = storeToRefs(useAreaVisibilityStore());
+    scope = effectScope();
+    scope.run(() => usePinnedPersistence());
+
+    expect(get(bobWidth)).toBe(700);
   });
 });

--- a/frontend/app/src/modules/shell/pinned/use-pinned-persistence.ts
+++ b/frontend/app/src/modules/shell/pinned/use-pinned-persistence.ts
@@ -1,4 +1,5 @@
 import type { Nullable } from '@rotki/common';
+import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
 import { type PinnedName, PinnedNames, toPinned } from '@/modules/session/types';
 import { PINNED_DEFAULT_WIDTH } from '@/modules/shell/layout/sidebar-resize-constants';
@@ -12,7 +13,17 @@ interface PersistedPinnedTabs {
 }
 
 const WIDTH_KEY = 'rotki.pinned.width';
-const TABS_KEY = 'rotki.pinned.tabs';
+const TABS_KEY_PREFIX = 'rotki.pinned.tabs';
+
+/**
+ * Tabs are stored per user. The rail records what someone was investigating rather than how they
+ * like their machine set up, so another user signing in on the same device starts with their own
+ * tabs. The width is the opposite - it describes the screen, like the ui language - so it stays
+ * device-global.
+ */
+function tabsKeyFor(username: string): string {
+  return `${TABS_KEY_PREFIX}.${username}`;
+}
 
 const restorableNames = new Set<string>(
   Object.values(PinnedNames).filter(name => PINNED_PANELS[name].restorable !== false),
@@ -22,14 +33,6 @@ function isRestorable(name: string): name is PinnedName {
   return restorableNames.has(name);
 }
 
-/**
- * Persists the pinned rail's width and its open tabs (names + active id, never the
- * transient props) to localStorage, and restores them on load. Device-local, like
- * the app's other layout prefs. Restore is non-intrusive: the tabs come back but the
- * rail stays collapsed until the user opens it (the indicator shows the count).
- * Panels flagged `restorable: false` in the registry (they need live context) are
- * skipped. Call once from the app shell.
- */
 /** Falls back to the default when the stored width is corrupt (e.g. `NaN`). */
 function validWidth(width: unknown): number {
   return typeof width === 'number' && Number.isFinite(width) ? width : PINNED_DEFAULT_WIDTH;
@@ -45,12 +48,22 @@ function resolveActiveId(names: PinnedName[], storedActive: Nullable<PinnedName>
   return storedActive && names.includes(storedActive) ? storedActive : names.at(-1) ?? null;
 }
 
+/**
+ * Persists the pinned rail's width and its open tabs (names + active id, never the transient
+ * props), and restores them on load. The width is device-local; the tabs are stored per user
+ * (see `tabsKeyFor`). Restore is non-intrusive: the tabs come back but the rail stays collapsed
+ * until the user opens it (the indicator shows the count). Panels flagged `restorable: false` in
+ * the registry (they need live context) are skipped. Call once from the app shell.
+ */
 export function usePinnedPersistence(): void {
   const store = useAreaVisibilityStore();
   const { activePinnedId, pinnedPanels, pinnedWidth } = storeToRefs(store);
+  const { logged, username } = storeToRefs(useSessionAuthStore());
 
   const persistedWidth = useLocalStorage<number>(WIDTH_KEY, PINNED_DEFAULT_WIDTH);
-  const persistedTabs = useLocalStorage<PersistedPinnedTabs>(TABS_KEY, { activeId: null, names: [] });
+  // The app shell only mounts once a user is unlocked, and `username` is set before `logged`
+  // flips, so the key is bound to the user this rail belongs to.
+  const persistedTabs = useLocalStorage<PersistedPinnedTabs>(tabsKeyFor(get(username)), { activeId: null, names: [] });
 
   // Restore once, and only into an untouched rail so nothing already pinned is clobbered.
   if (get(pinnedPanels).length === 0) {
@@ -72,6 +85,12 @@ export function usePinnedPersistence(): void {
   // never mutates it in place), so a shallow watch is enough and avoids deep-traversing
   // panel props such as the report card's report object.
   watch([pinnedPanels, activePinnedId], ([panels, active]) => {
+    // Logging out resets every pinia store, which empties the rail. Writing that emptied state
+    // through would destroy the very tabs we are meant to restore on the next sign-in, so only
+    // a logged-in user's own changes are saved.
+    if (!get(logged))
+      return;
+
     const names = panels.map(panel => panel.name).filter(isRestorable);
     set(persistedTabs, { activeId: resolveActiveId(names, active), names });
   });


### PR DESCRIPTION
Follow-up to #12601 / #12605.

## The bug

Logging out resets every pinia store (`useSessionStateCleaner` → `resetState()`), which empties the rail. The persistence watcher faithfully wrote that emptied state through, so **signing out destroyed the tabs the feature exists to restore**. Restarting the app while logged in worked; logging out and back in did not.

Reproduced in a test: pin two panels, and localStorage holds both; run the same `resetState()` the logout path runs, and localStorage becomes `{"activeId":null,"names":[]}`.

## The fix

Skip persisting while logged out. Logout flips `logged` to false *before* the cleaner resets the stores, so the guard catches the reset and leaves the saved tabs alone for the next sign-in.

## Tabs are now stored per user

The rail records what someone was *investigating*, not how they like their machine set up, so another user signing in on the same device should not inherit it. Tabs move to `rotki.pinned.tabs.<username>`, following the existing per-user storage idiom (`use-eth-staking-refresh.ts:40-44`).

The width deliberately stays device-global (`rotki.pinned.width`): it describes the screen, much like the ui language, and reveals nothing about its owner.

This is safe because `use-unlock-steps.ts:182-183` sets `username` before `logged` flips, and the app shell only mounts for an unlocked user. Login pages use a different layout (`auth`), so logging out unmounts the shell and the next sign-in re-runs the composable and restores.

## Base

`develop`, not `bugfixes`: pinned persistence is develop-only (merged today) and absent from `bugfixes`/`master`, so no release ever shipped this.

## Testing

- typecheck clean, lint clean, full unit suite green (587 files / 5571 tests)
- 4 new specs: tabs survive the logout reset, they restore on the next sign-in, one user does not inherit another's tabs, and the width stays shared across users
- **regression-verified**: removing the `logged` guard fails exactly 2 of the 13 specs in this file

## Note for review

The test proves the wipe when the watcher outlives the reset. In the running app the shell also unmounts on logout, so there is a race between the watcher firing and its scope being disposed — meaning the wipe may not reproduce on every logout. The guard makes the outcome deterministic either way. Behavioural check if you want certainty: pin a tab, log out, log back in, and see whether it returns.

Also fixed in passing: the composable's docstring was orphaned above `validWidth` and claimed the storage was device-local, which is now only half true.