### PR TITLE
Fix scramble toggle blue box and add dev-only event type hint

### DIFF
--- a/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.vue
+++ b/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { HistoryEventEntryType } from '@rotki/common';
 import { externalLinks } from '@shared/external-links';
+import { checkIfDevelopment } from '@shared/utils';
 import { type HighlightSegment, splitHighlight } from '@/modules/history/events/action-picker/highlight-match';
 import HistoryEventActionDirectionBadge from '@/modules/history/events/action-picker/HistoryEventActionDirectionBadge.vue';
 import { useEventActionDescriptions } from '@/modules/history/events/action-picker/use-event-action-descriptions';
@@ -30,6 +31,10 @@ const RECENT_GROUP_ID = '__recent__';
 const RECENT_KEY_PREFIX = 'recent:';
 
 const { t } = useI18n({ useScope: 'global' });
+
+// Shown only in dev builds so developers can see the raw event type/subtype
+// combinations behind each user-facing action label.
+const isDevelopment = checkIfDevelopment();
 
 const search = ref<string>('');
 
@@ -301,6 +306,13 @@ function onUpdate(verbKey: string | undefined): void {
             class="text-xs text-rui-text-secondary whitespace-normal line-clamp-2"
           >
             {{ subtitleFor(item) }}
+          </div>
+          <div
+            v-if="isDevelopment"
+            class="text-xs text-rui-text-disabled font-mono whitespace-normal break-all"
+            data-testid="event-action-picker-row-dev-hint"
+          >
+            {{ rowEventTypes(item) }}
           </div>
         </div>
         <HistoryEventActionDirectionBadge

--- a/frontend/app/src/modules/settings/PrivacyModeDropdown.vue
+++ b/frontend/app/src/modules/settings/PrivacyModeDropdown.vue
@@ -166,7 +166,6 @@ async function updateScramble(value: boolean): Promise<void> {
       <div class="border-t border-default p-4 flex flex-col gap-4">
         <RuiSwitch
           v-model="scrambleData"
-          class="bg-rui-secondary border border-rui-secondary text-white px-2 rounded-l pt-[1px] -mt-[1px]"
           color="secondary"
           size="sm"
           data-cy="privacy-mode-scramble__toggle"


### PR DESCRIPTION
## Changes

### Fix stray blue box on the scramble toggle
The scramble switch in the privacy menu carried `bg-rui-secondary border border-rui-secondary text-white ... rounded-l` styling left over from the old layout where the toggle and the multiplier input sat side by side as one joined pill (the toggle was the rounded-left blue half). The controls are now stacked vertically, so that styling rendered as a stray solid blue box floating above the input. Removed the wrapper classes so the switch renders like the others.

### Dev-only event type/subtype hint in the history action picker
In dev builds only (`checkIfDevelopment()`), each action row in `HistoryEventActionPicker` now shows its underlying `eventType:eventSubtype` combinations as a small muted line under the description. This helps developers map a user-facing action label back to its raw type/subtype pair. It is not rendered in production builds.

## Testing
- `pnpm run typecheck` — clean
- `pnpm run lint-staged` — clean