### PR TITLE
Expectations mismatch

### DIFF
--- a/frontend/app/shared/external-links.ts
+++ b/frontend/app/shared/external-links.ts
@@ -21,6 +21,7 @@ export const heliusLink = 'https://dev.helius.xyz/dashboard/app';
 export const blockscoutLink = 'https://dev.blockscout.com/';
 
 export const externalLinks = {
+  integrations: `${BASE_URL}integrations`,
   premium: `${BASE_URL}products${UTM_PARAMS}`,
   premiumDevices: `${DOCS_BASE_URL}premium/devices`,
   sponsor: `${BASE_URL}sponsor/mint`,

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -438,15 +438,16 @@
           "failed_reason": {
             "existed": "Has been added before",
             "is_contract": "Is ETH contract address",
-            "no_activity": "No activity"
+            "no_activity": "No activity found on this chain yet"
           },
+          "no_activity_hint": "Chains where the address has no activity yet are skipped. This is normal for a fresh wallet — once the address has transactions, add it again, or add it now with a specific chain selected to track it anyway.",
           "non_eth": "All non ETH chains"
         },
         "no_new": {
           "description": "The selected addresses are already tracked by rotki"
         },
         "success": {
-          "description": "Address {address} is successfully added for all EVM chains | Address {address} is successfully added for these chains: \n {list}"
+          "description": "Address {address} is successfully added for all EVM chains. Token detection and balance queries are now running — open the History page to also fetch and decode its transactions. | Address {address} is successfully added for these chains: \n {list}\nToken detection and balance queries are now running — open the History page to also fetch and decode its transactions."
         },
         "task": {
           "description": "Adding {address}",
@@ -1829,6 +1830,7 @@
     "add_account": "Add Account",
     "add_validator_premium": "Adding ETH staking validators is a premium feature. Upgrade to rotki Premium to add validators.",
     "binance_warning": "Binance Smart Chain accounts can only be detected with a paid Etherscan key.",
+    "early_chain_warning": "rotki's {chain} integration is early: only a limited set of protocols is decoded on this chain for now. Transactions from other protocols will appear as plain transfers, with more protocols added over time.",
     "eth_staking_limit_error": "Adding this validator would put you over your {currentTier} plan's ETH staking limit of {limit} ETH. Upgrade your plan via {link} or contact us for a custom plan to raise your limit.",
     "eth_staking_no_access": "Your {currentTier} plan doesn't include ETH staking. Upgrade your plan via {link} or contact us for a custom plan to get access.",
     "evm_detection": {
@@ -2362,10 +2364,10 @@
       },
       "go_to_history_events": "Go to history events",
       "incomplete_decoding": "The last event query completed {time}. Due to incomplete event processing, protocol balances may not reflect the latest state. Navigate to history events to begin processing.",
-      "just_updated": "The application has recently been updated. Some balances may not display until transaction processing is fully complete. Navigate to history events to begin to begin processing.",
+      "just_updated": "The application has recently been updated. Some balances may not display until transaction processing is fully complete. Navigate to history events to begin processing.",
       "last_queried": "The last event query completed {time}. Protocol balances may be stale or missing if the transaction history has not been refreshed recently. Navigate to history events to begin refreshing them.",
-      "last_queried_long": "Some balances may not display until transaction processing is fully complete. Navigate to history events to begin to begin processing.",
-      "never_queried": "The transaction history has not been queried yet. Navigate to history events to begin querying them.",
+      "last_queried_long": "Some balances may not display until transaction processing is fully complete. Navigate to history events to begin processing.",
+      "never_queried": "Your transaction history has not been downloaded yet. rotki is local-first: it fetches and decodes your full on-chain history on your device, which can take a while for active multi-chain addresses. Navigate to history events to start.",
       "processing": "Historical event processing is underway. Updated protocol balances will be available once the operation concludes.",
       "processing_operation_event": "{status} for {name} ({location})",
       "processing_operation_transaction": "{status} for {address}",
@@ -2622,6 +2624,7 @@
       "percentage_of_total_net_value": "% of net Value",
       "percentage_total": "% of total"
     },
+    "no_assets": "No assets yet. Add a blockchain address, connect an exchange, or add a manual balance above — your balances will appear here once the first query completes.",
     "no_search_result": "Your search for \"{search}\" yielded no results.",
     "select_visible_columns": "Select visible columns"
   },
@@ -3136,7 +3139,11 @@
       "signing_key": "Signing Key"
     },
     "keys": "Keys",
-    "subtitle": "rotki can connect to supported exchanges and automatically pull your trades and balances from them. See the {0} for more information.",
+    "setup_success": {
+      "message": "Your {location} balances are being fetched now. Open the History page to also import and process its trades, deposits and withdrawals.",
+      "title": "Exchange connected"
+    },
+    "subtitle": "rotki can connect to supported exchanges and automatically pull your balances from them. Trades, deposits and withdrawals are imported when you open the History page. See the {0} for more information.",
     "sync": {
       "messages": {
         "description": "Cannot {action} syncing exchange {location} with name {name}: {message}",
@@ -4624,8 +4631,10 @@
     }
   },
   "module_settings": {
+    "coverage_note": "These modules only control balance queries for a few specific protocols — they are not the full list of what rotki supports. Transaction decoding automatically covers 100+ DeFi protocols regardless of these settings. See the full list of supported chains, exchanges and protocols on {link}.",
     "hint": "Only data for the selected modules will be queried. If no modules are selected, querying for all the supported modules will be disabled. Also, please remember that after activating a module, you need to logout and login again for the activation to take effect",
-    "subtitle": "Manage and view your module settings.",
+    "integrations_link_label": "rotki.com/integrations",
+    "subtitle": "Manage and view your balance-query module settings.",
     "title": "Module Settings"
   },
   "modules": {
@@ -4808,7 +4817,8 @@
       "title": "Address has been added to {chain}|Addresses have been added to {chain}"
     },
     "backend": {
-      "title": "Backend"
+      "title": "Backend",
+      "warning_title": "Some data was skipped during processing"
     },
     "beaconchain_rate_limited": {
       "message": "Beaconcha.in is rate limited{until}. The following query failed:\n{endpoints}\nCheck logs for more details.|Beaconcha.in is rate limited{until}. The following {count} queries failed:\n{endpoints}\n\nCheck logs for more details.",
@@ -5926,6 +5936,7 @@
     "decoding_label": "chains decoded",
     "decoding_progress": "{processed}/{total} txns",
     "events": "Events",
+    "explanation": "The first sync downloads and decodes your entire on-chain history locally. You can keep using rotki — results appear as they are ready. A personal (free) Etherscan API key speeds this up significantly.",
     "locations_label": "location | locations",
     "period": {
       "beginning": "Beginning"
@@ -6152,7 +6163,8 @@
     "empty_state": {
       "clear_filters": "Clear filters",
       "no_data_with_filters": "No events match the current filters",
-      "no_events": "No events found.\nAdd exchanges, track blockchain addresses, or manually add events to get started."
+      "no_events": "No events found.\nAdd exchanges, track blockchain addresses, or manually add events to get started.",
+      "syncing": "Your history is being queried and decoded.\nEvents will appear here as they are processed — this can take a while on the first sync."
     },
     "events": {
       "accounting_rule": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -440,14 +440,14 @@
             "is_contract": "Is ETH contract address",
             "no_activity": "No activity found on this chain yet"
           },
-          "no_activity_hint": "Chains where the address has no activity yet are skipped. This is normal for a fresh wallet — once the address has transactions, add it again, or add it now with a specific chain selected to track it anyway.",
+          "no_activity_hint": "Chains where the address has no activity yet are skipped. This is normal for a fresh wallet. Once the address has transactions, add it again, or add it now with a specific chain selected to track it anyway.",
           "non_eth": "All non ETH chains"
         },
         "no_new": {
           "description": "The selected addresses are already tracked by rotki"
         },
         "success": {
-          "description": "Address {address} is successfully added for all EVM chains. Token detection and balance queries are now running — open the History page to also fetch and decode its transactions. | Address {address} is successfully added for these chains: \n {list}\nToken detection and balance queries are now running — open the History page to also fetch and decode its transactions."
+          "description": "Address {address} is successfully added for all EVM chains. Token detection and balance queries are now running. Open the History page to also fetch and decode its transactions. | Address {address} is successfully added for these chains: \n {list}\nToken detection and balance queries are now running. Open the History page to also fetch and decode its transactions."
         },
         "task": {
           "description": "Adding {address}",
@@ -2629,7 +2629,7 @@
       "percentage_of_total_net_value": "% of net Value",
       "percentage_total": "% of total"
     },
-    "no_assets": "No assets yet. Add a blockchain address, connect an exchange, or add a manual balance above — your balances will appear here once the first query completes.",
+    "no_assets": "No assets yet. Add a blockchain address, connect an exchange, or add a manual balance above. Your balances will appear here once the first query completes.",
     "no_search_result": "Your search for \"{search}\" yielded no results.",
     "price_unknown": "No price could be found for this asset from any of your configured oracles, so it does not count towards your net worth. You can set a price manually in the price manager.",
     "select_visible_columns": "Select visible columns"
@@ -3145,10 +3145,7 @@
       "signing_key": "Signing Key"
     },
     "keys": "Keys",
-    "setup_success": {
-      "message": "Your {location} balances are being fetched now. Open the History page to also import and process its trades, deposits and withdrawals.",
-      "title": "Exchange connected"
-    },
+    "setup_hint": "Balances are being fetched. Trades, deposits and withdrawals import when you open the History page.",
     "subtitle": "rotki can connect to supported exchanges and automatically pull your balances from them. Trades, deposits and withdrawals are imported when you open the History page. See the {0} for more information.",
     "sync": {
       "messages": {
@@ -4637,7 +4634,7 @@
     }
   },
   "module_settings": {
-    "coverage_note": "These modules only control balance queries for a few specific protocols — they are not the full list of what rotki supports. Transaction decoding automatically covers 100+ DeFi protocols regardless of these settings. See the full list of supported chains, exchanges and protocols on {link}.",
+    "coverage_note": "These modules only control balance queries for a few specific protocols. They are not the full list of what rotki supports. Transaction decoding automatically covers 100+ DeFi protocols regardless of these settings. See the full list of supported chains, exchanges and protocols on {link}.",
     "hint": "Only data for the selected modules will be queried. If no modules are selected, querying for all the supported modules will be disabled. Also, please remember that after activating a module, you need to logout and login again for the activation to take effect",
     "integrations_link_label": "rotki.com/integrations",
     "subtitle": "Manage and view your balance-query module settings.",
@@ -5584,9 +5581,12 @@
         "title": "Missing Prices ({total})",
         "total_skipped_prices": "{total} prices are skipped"
       },
-      "overview_warning": "This report has {acquisitions} disposal(s) with missing acquisition history and {prices} missing price(s). The totals below may overstate your gains — use \"Show Issues\" to review and fix them.",
+      "overview_warning": "The totals below may overstate your gains. Use \"Show Issues\" to review and fix them.",
+      "overview_warning_acquisitions": "{count} disposal(s) with missing acquisition history",
+      "overview_warning_prices": "{count} missing price(s)",
+      "overview_warning_title": "This report has incomplete data:",
       "show_issues": "Show Issues",
-      "skipped_no_rule": "{count} history events were excluded from this report because they have no accounting rule. They are marked with a warning icon in the History view — assign a rule there to include them.",
+      "skipped_no_rule": "{count} history events were excluded from this report because they have no accounting rule. They are marked with a warning icon in the History view. Assign a rule there to include them.",
       "stale_details": "Missing price and missing acquisition details are only kept for the most recently generated report. Re-generate this report to inspect them."
     },
     "binance_markets_alert": "The following Binance exchange(s) do not have market pairs configured: \n{exchanges}.\n\n Please configure market pairs before generating a report.",
@@ -5945,7 +5945,8 @@
     "decoding_label": "chains decoded",
     "decoding_progress": "{processed}/{total} txns",
     "events": "Events",
-    "explanation": "The first sync downloads and decodes your entire on-chain history locally. You can keep using rotki — results appear as they are ready. A personal (free) Etherscan API key speeds this up significantly.",
+    "explanation": "The first sync downloads and decodes your entire on-chain history locally. You can keep using rotki; results appear as they are ready.",
+    "explanation_etherscan_hint": "A personal (free) Etherscan API key speeds this up significantly.",
     "locations_label": "location | locations",
     "period": {
       "beginning": "Beginning"
@@ -6173,7 +6174,7 @@
       "clear_filters": "Clear filters",
       "no_data_with_filters": "No events match the current filters",
       "no_events": "No events found.\nAdd exchanges, track blockchain addresses, or manually add events to get started.",
-      "syncing": "Your history is being queried and decoded.\nEvents will appear here as they are processed — this can take a while on the first sync."
+      "syncing": "Your history is being queried and decoded.\nEvents will appear here as they are processed. This can take a while on the first sync."
     },
     "events": {
       "accounting_rule": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2344,6 +2344,11 @@
       },
       "title": "blockchain"
     },
+    "completeness": {
+      "data_issues": "{count} data issues need attention",
+      "missing_prices": "{count} assets without a price",
+      "undecoded": "{count} undecoded transactions"
+    },
     "exchange_balances": {
       "add": "Add an exchange",
       "refresh": "Refresh {exchange} balances",
@@ -2626,6 +2631,7 @@
     },
     "no_assets": "No assets yet. Add a blockchain address, connect an exchange, or add a manual balance above — your balances will appear here once the first query completes.",
     "no_search_result": "Your search for \"{search}\" yielded no results.",
+    "price_unknown": "No price could be found for this asset from any of your configured oracles, so it does not count towards your net worth. You can set a price manually in the price manager.",
     "select_visible_columns": "Select visible columns"
   },
   "data_issues": {
@@ -5578,7 +5584,10 @@
         "title": "Missing Prices ({total})",
         "total_skipped_prices": "{total} prices are skipped"
       },
-      "show_issues": "Show Issues"
+      "overview_warning": "This report has {acquisitions} disposal(s) with missing acquisition history and {prices} missing price(s). The totals below may overstate your gains — use \"Show Issues\" to review and fix them.",
+      "show_issues": "Show Issues",
+      "skipped_no_rule": "{count} history events were excluded from this report because they have no accounting rule. They are marked with a warning icon in the History view — assign a rule there to include them.",
+      "stale_details": "Missing price and missing acquisition details are only kept for the most recently generated report. Re-generate this report to inspect them."
     },
     "binance_markets_alert": "The following Binance exchange(s) do not have market pairs configured: \n{exchanges}.\n\n Please configure market pairs before generating a report.",
     "error": {
@@ -6475,6 +6484,10 @@
       "redecode_all": "Redecode All Transactions",
       "title": "Transaction decoding status",
       "transactions_processed": "{processed} / {total} transactions processed",
+      "undecoded_banner": {
+        "action": "View status",
+        "message": "{count} transactions have not been decoded into events yet. They are missing from your history and reports until they are processed."
+      },
       "undecoded_transactions": "Undecoded transactions"
     },
     "filter": {

--- a/frontend/app/src/modules/accounts/management/AccountForm.vue
+++ b/frontend/app/src/modules/accounts/management/AccountForm.vue
@@ -44,7 +44,7 @@ const form = useTemplateRef<
 
 const chain = useRefPropVModel(modelValue, 'chain');
 
-const { isEvm, isSolanaChains, txEvmChains } = useSupportedChains();
+const { getChainName, isEvm, isSolanaChains, txEvmChains } = useSupportedChains();
 const { t } = useI18n({ useScope: 'global' });
 const { getApiKey } = useExternalApiKeys();
 
@@ -114,6 +114,17 @@ const showSolanaInitialAlert = computed<boolean>(() => {
   return currentModelValue.mode === 'add' && !!selectedChain && isSolanaChains(selectedChain);
 });
 
+const EARLY_INTEGRATION_CHAINS: string[] = ['avax', 'hyperliquid', 'monad'];
+
+const earlyIntegrationChain = computed<string | undefined>(() => {
+  const selectedChain = get(chain);
+  const currentModelValue = get(modelValue);
+
+  if (currentModelValue.mode === 'add' && selectedChain && EARLY_INTEGRATION_CHAINS.includes(selectedChain))
+    return selectedChain;
+  return undefined;
+});
+
 const showBinanceEtherscanWarning = computed<boolean>(() => {
   const selectedChain = get(chain);
   const currentModelValue = get(modelValue);
@@ -123,11 +134,12 @@ const showBinanceEtherscanWarning = computed<boolean>(() => {
 
 const warningExpanded = ref<boolean>(false);
 
-type WarningType = 'solana' | 'apiKey' | 'binance';
+type WarningType = 'solana' | 'apiKey' | 'binance' | 'earlyChain';
 
 interface WarningItem {
   type: WarningType;
   service?: 'etherscan' | 'helius' | 'beaconchain' | 'consensusRpc' | 'blockscout';
+  chain?: string;
 }
 
 function isBeaconchainService(service: WarningItem['service']): boolean {
@@ -148,6 +160,9 @@ const warnings = computed<WarningItem[]>(() => {
     result.push({ service, type: 'apiKey' });
   if (get(showSolanaInitialAlert))
     result.push({ type: 'solana' });
+  const earlyChain = get(earlyIntegrationChain);
+  if (earlyChain)
+    result.push({ chain: earlyChain, type: 'earlyChain' });
   if (get(showBinanceEtherscanWarning))
     result.push({ type: 'binance' });
   return result;
@@ -322,6 +337,9 @@ defineExpose({
           </template>
           <template v-else-if="warning.type === 'solana'">
             {{ t('blockchain_balances.solana_warning') }}
+          </template>
+          <template v-else-if="warning.type === 'earlyChain' && warning.chain">
+            {{ t('blockchain_balances.early_chain_warning', { chain: getChainName(warning.chain) }) }}
           </template>
           <template v-else-if="warning.type === 'binance'">
             {{ t('blockchain_balances.binance_warning') }}

--- a/frontend/app/src/modules/accounts/management/AccountForm.vue
+++ b/frontend/app/src/modules/accounts/management/AccountForm.vue
@@ -44,7 +44,7 @@ const form = useTemplateRef<
 
 const chain = useRefPropVModel(modelValue, 'chain');
 
-const { getChainName, isEvm, isSolanaChains, txEvmChains } = useSupportedChains();
+const { getChainName, isEarlyIntegrationChain, isEvm, isSolanaChains, txEvmChains } = useSupportedChains();
 const { t } = useI18n({ useScope: 'global' });
 const { getApiKey } = useExternalApiKeys();
 
@@ -114,13 +114,11 @@ const showSolanaInitialAlert = computed<boolean>(() => {
   return currentModelValue.mode === 'add' && !!selectedChain && isSolanaChains(selectedChain);
 });
 
-const EARLY_INTEGRATION_CHAINS: string[] = ['avax', 'hyperliquid', 'monad'];
-
 const earlyIntegrationChain = computed<string | undefined>(() => {
   const selectedChain = get(chain);
   const currentModelValue = get(modelValue);
 
-  if (currentModelValue.mode === 'add' && selectedChain && EARLY_INTEGRATION_CHAINS.includes(selectedChain))
+  if (currentModelValue.mode === 'add' && selectedChain && isEarlyIntegrationChain(selectedChain))
     return selectedChain;
   return undefined;
 });

--- a/frontend/app/src/modules/accounts/use-account-addition-notifications.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-notifications.spec.ts
@@ -74,12 +74,14 @@ describe('useAccountAdditionNotifications', () => {
       expect(h.notifyWarning).toHaveBeenCalledOnce();
       const [, message] = h.notifyWarning.mock.calls[0];
       expect(message).toContain('- eth');
+      expect(message).toContain('no_activity_hint');
     });
 
     it('should warn for eth contracts and existing accounts', () => {
       const { createFailureNotification } = useAccountAdditionNotifications();
       createFailureNotification({ ethContracts: ['0xabc'], existed: { '0xabc': ['optimism'] } }, account);
       expect(h.notifyWarning).toHaveBeenCalledOnce();
+      expect(h.notifyWarning.mock.calls[0][1]).not.toContain('no_activity_hint');
     });
 
     it('should skip a single binance_sc failure', () => {

--- a/frontend/app/src/modules/accounts/use-account-addition-notifications.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-notifications.ts
@@ -62,6 +62,8 @@ export function useAccountAdditionNotifications(): UseAccountAdditionNotificatio
     };
 
     addFailureMessage(noActivity, t('actions.balances.blockchain_accounts_add.error.failed_reason.no_activity'));
+    if (noActivity)
+      listOfFailureText.push(t('actions.balances.blockchain_accounts_add.error.no_activity_hint'));
     addFailureMessage(existed, t('actions.balances.blockchain_accounts_add.error.failed_reason.existed'));
     addFailureMessage(ethContracts ? { ethContracts: [t('actions.balances.blockchain_accounts_add.error.non_eth')] } : undefined, t('actions.balances.blockchain_accounts_add.error.failed_reason.is_contract'));
 

--- a/frontend/app/src/modules/assets/prices/price-types.ts
+++ b/frontend/app/src/modules/assets/prices/price-types.ts
@@ -12,6 +12,7 @@ const AssetPriceInput = z.tuple([NumericString, z.number()]);
 export const AssetPrice = z.object({
   isManualPrice: z.boolean(),
   oracle: z.string(),
+  priceMissing: z.boolean().optional(),
   usdPrice: NumericString.nullish(),
   value: NumericString,
 });
@@ -37,6 +38,9 @@ export const AssetPriceResponse = z.object({
     mappedAssets[asset] = {
       isManualPrice: oracle === response.oracles[PriceOracle.MANUALCURRENT],
       oracle: oracleKey,
+      // the backend reports assets no oracle could price as a zero price with
+      // the blockchain oracle, so mark them to render as unknown instead of $0
+      priceMissing: value.isZero() && oracleKey === PriceOracle.BLOCKCHAIN,
       value,
     };
   });

--- a/frontend/app/src/modules/core/common/use-supported-chains.spec.ts
+++ b/frontend/app/src/modules/core/common/use-supported-chains.spec.ts
@@ -1,0 +1,27 @@
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+
+describe('useSupportedChains', () => {
+  beforeEach(() => {
+    setActivePinia(createCustomPinia());
+  });
+
+  describe('isEarlyIntegrationChain', () => {
+    it('should return true for chains with limited protocol coverage', () => {
+      const { isEarlyIntegrationChain } = useSupportedChains();
+      expect(isEarlyIntegrationChain('avax')).toBe(true);
+      expect(isEarlyIntegrationChain('hyperliquid')).toBe(true);
+      expect(isEarlyIntegrationChain('monad')).toBe(true);
+    });
+
+    it('should return false for fully supported or unknown chains', () => {
+      const { isEarlyIntegrationChain } = useSupportedChains();
+      expect(isEarlyIntegrationChain('eth')).toBe(false);
+      expect(isEarlyIntegrationChain('ethereum')).toBe(false);
+      expect(isEarlyIntegrationChain('solana')).toBe(false);
+      expect(isEarlyIntegrationChain('')).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/core/common/use-supported-chains.ts
+++ b/frontend/app/src/modules/core/common/use-supported-chains.ts
@@ -13,6 +13,12 @@ import { getPublicProtocolImagePath } from '@/modules/core/common/file/file';
 import { useSupportedChainsApi } from '@/modules/core/common/use-supported-chains-api';
 import { useSupportedChainsStore } from '@/modules/core/common/use-supported-chains-store';
 
+/**
+ * Chains whose protocol decoding coverage is still limited. The backend does
+ * not expose a maturity flag, so the set is maintained here until it does.
+ */
+const EARLY_INTEGRATION_CHAINS: ReadonlySet<string> = new Set(['avax', 'hyperliquid', 'monad']);
+
 function isEvmChain(info: ChainInfo): info is EvmChainInfo {
   return info.type === ChainType.EVM;
 }
@@ -48,6 +54,7 @@ interface UseSupportedChainsReturn {
   getNativeAsset: (chain: string) => string;
   isBtcChains: (chain: string) => boolean;
   isDecodableChains: (chain: string) => boolean;
+  isEarlyIntegrationChain: (chain: string) => boolean;
   isEvm: (chain: string) => boolean;
   isEvmCompatible: (chain: string) => boolean;
   isEvmLikeChains: (chain: string) => boolean;
@@ -148,6 +155,8 @@ export const useSupportedChains = createSharedComposable((): UseSupportedChainsR
   const isBtcChains = (chain: string): boolean => get(btcChainSet).has(chain);
 
   const isSolanaChains = (chain: string): boolean => get(solanaChainSet).has(chain);
+
+  const isEarlyIntegrationChain = (chain: string): boolean => EARLY_INTEGRATION_CHAINS.has(chain);
 
   const isDecodableChains = (chain: string): boolean => get(decodableChainSet).has(chain);
 
@@ -299,6 +308,7 @@ export const useSupportedChains = createSharedComposable((): UseSupportedChainsR
     getNativeAsset,
     isBtcChains,
     isDecodableChains,
+    isEarlyIntegrationChain,
     isEvm,
     isEvmCompatible,
     isEvmLikeChains,

--- a/frontend/app/src/modules/core/messaging/handlers/legacy.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/legacy.ts
@@ -10,6 +10,8 @@ export function createLegacyHandler(t: ReturnType<typeof useI18n>['t']): Notific
     message: value,
     priority: Priority.BULK,
     severity: verbosity === MESSAGE_WARNING ? Severity.WARNING : Severity.ERROR,
-    title: t('notification_messages.backend.title'),
+    title: verbosity === MESSAGE_WARNING
+      ? t('notification_messages.backend.warning_title')
+      : t('notification_messages.backend.title'),
   }));
 }

--- a/frontend/app/src/modules/core/table/use-row-highlight.spec.ts
+++ b/frontend/app/src/modules/core/table/use-row-highlight.spec.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRowHighlight } from '@/modules/core/table/use-row-highlight';
+
+interface Row {
+  location: string;
+  name: string;
+}
+
+const keyOf = (row: Row): string => `${row.location}#${row.name}`;
+
+describe('useRowHighlight', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not highlight any row initially', () => {
+    const { isHighlighted, rowClass } = useRowHighlight<Row>(keyOf);
+    const row = { location: 'kraken', name: 'main' };
+    expect(isHighlighted(row)).toBe(false);
+    expect(rowClass(row)).toBe('transition-colors duration-1000');
+  });
+
+  it('should highlight the matching row after highlight is called', () => {
+    const { highlight, isHighlighted, rowClass } = useRowHighlight<Row>(keyOf);
+    const target = { location: 'kraken', name: 'main' };
+    const other = { location: 'binance', name: 'main' };
+
+    highlight(target);
+
+    expect(isHighlighted(target)).toBe(true);
+    expect(isHighlighted(other)).toBe(false);
+    expect(rowClass(target)).toContain('bg-rui-primary/[0.08]');
+    expect(rowClass(other)).toBe('transition-colors duration-1000');
+  });
+
+  it('should clear the highlight once the duration elapses', () => {
+    const { highlight, isHighlighted } = useRowHighlight<Row>(keyOf, { duration: 1000 });
+    const target = { location: 'kraken', name: 'main' };
+
+    highlight(target);
+    expect(isHighlighted(target)).toBe(true);
+
+    vi.advanceTimersByTime(999);
+    expect(isHighlighted(target)).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(isHighlighted(target)).toBe(false);
+  });
+
+  it('should restart the timer when a new row is highlighted', () => {
+    const { highlight, isHighlighted } = useRowHighlight<Row>(keyOf, { duration: 1000 });
+    const first = { location: 'kraken', name: 'main' };
+    const second = { location: 'binance', name: 'main' };
+
+    highlight(first);
+    vi.advanceTimersByTime(800);
+    highlight(second);
+
+    // the first row's original timer must not clear the second highlight
+    vi.advanceTimersByTime(800);
+    expect(isHighlighted(second)).toBe(true);
+
+    vi.advanceTimersByTime(200);
+    expect(isHighlighted(second)).toBe(false);
+  });
+
+  it('should honour custom classes', () => {
+    const { highlight, rowClass } = useRowHighlight<Row>(keyOf, {
+      baseClass: 'base',
+      highlightClass: 'flash',
+    });
+    const row = { location: 'kraken', name: 'main' };
+
+    expect(rowClass(row)).toBe('base');
+    highlight(row);
+    expect(rowClass(row)).toBe('base flash');
+  });
+});

--- a/frontend/app/src/modules/core/table/use-row-highlight.ts
+++ b/frontend/app/src/modules/core/table/use-row-highlight.ts
@@ -1,0 +1,52 @@
+interface UseRowHighlightOptions {
+  /** How long the highlight stays before it fades, in milliseconds. */
+  duration?: number;
+  /** Class applied to every row so the highlight fades smoothly on/off. */
+  baseClass?: string;
+  /** Class applied only to the currently highlighted row. */
+  highlightClass?: string;
+}
+
+interface UseRowHighlightReturn<T> {
+  highlight: (item: T) => void;
+  isHighlighted: (item: T) => boolean;
+  rowClass: (item: T) => string;
+}
+
+/**
+ * Transiently highlights a single table row (e.g. one that was just added) so
+ * the eye lands on it, then fades it out. Rows are identified by `keyOf`, so it
+ * works with any row shape and any table that accepts a per-row class function.
+ */
+export function useRowHighlight<T>(
+  keyOf: (item: T) => string,
+  options: UseRowHighlightOptions = {},
+): UseRowHighlightReturn<T> {
+  const {
+    baseClass = 'transition-colors duration-1000',
+    duration = 2500,
+    highlightClass = 'bg-rui-primary/[0.08]',
+  } = options;
+
+  const highlighted = ref<string>();
+
+  const { start, stop } = useTimeoutFn(() => {
+    set(highlighted, undefined);
+  }, duration, { immediate: false });
+
+  function highlight(item: T): void {
+    stop();
+    set(highlighted, keyOf(item));
+    start();
+  }
+
+  function isHighlighted(item: T): boolean {
+    return isDefined(highlighted) && get(highlighted) === keyOf(item);
+  }
+
+  function rowClass(item: T): string {
+    return isHighlighted(item) ? `${baseClass} ${highlightClass}` : baseClass;
+  }
+
+  return { highlight, isHighlighted, rowClass };
+}

--- a/frontend/app/src/modules/dashboard/Dashboard.vue
+++ b/frontend/app/src/modules/dashboard/Dashboard.vue
@@ -4,6 +4,7 @@ import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balance
 import { useBalanceStatus } from '@/modules/balances/use-balance-status';
 import { useDynamicMessages } from '@/modules/core/messaging/use-dynamic-messages';
 import DashboardAssetTable from '@/modules/dashboard/DashboardAssetTable.vue';
+import DashboardCompletenessIndicator from '@/modules/dashboard/DashboardCompletenessIndicator.vue';
 import DynamicMessageDisplay from '@/modules/dashboard/DynamicMessageDisplay.vue';
 import NftBalanceTable from '@/modules/dashboard/NftBalanceTable.vue';
 import OverallBalances from '@/modules/dashboard/OverallBalances.vue';
@@ -85,6 +86,7 @@ watch(width, (newWidth) => {
       <div class="flex flex-wrap gap-6">
         <div class="w-full">
           <OverallBalances />
+          <DashboardCompletenessIndicator />
         </div>
         <Summary />
       </div>

--- a/frontend/app/src/modules/dashboard/Dashboard.vue
+++ b/frontend/app/src/modules/dashboard/Dashboard.vue
@@ -86,12 +86,12 @@ watch(width, (newWidth) => {
       <div class="flex flex-wrap gap-6">
         <div class="w-full">
           <OverallBalances />
-          <DashboardCompletenessIndicator />
         </div>
         <Summary />
       </div>
-      <div class="flex justify-end my-4">
-        <PriceRefresh />
+      <div class="flex flex-wrap items-center gap-4 my-4">
+        <DashboardCompletenessIndicator />
+        <PriceRefresh class="ml-auto" />
       </div>
       <DashboardAssetTable
         :title="t('common.assets')"

--- a/frontend/app/src/modules/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/modules/dashboard/DashboardAssetTable.vue
@@ -44,6 +44,10 @@ const {
 
 const { expanded, isRowExpandable, redirectToManualBalance } = useDashboardAssetOperations(() => tableType);
 
+const emptyDescription = computed<string>(() => tableType === DashboardTableType.ASSETS
+  ? t('dashboard_asset_table.no_assets')
+  : t('data_table.no_data'));
+
 // Watch search to reset pagination
 watch(search, () => setPage(1));
 </script>
@@ -84,7 +88,7 @@ watch(search, () => setPage(1));
       :cols="tableHeaders"
       :rows="sorted"
       :loading="loading"
-      :empty="{ description: t('data_table.no_data') }"
+      :empty="{ description: emptyDescription }"
       :expanded="expanded"
       :pagination="{
         page: pagination.page,

--- a/frontend/app/src/modules/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/modules/dashboard/DashboardAssetTable.vue
@@ -133,7 +133,11 @@ watch(search, () => setPage(1));
           tooltip-class="max-w-[16rem]"
         >
           <template #activator>
-            <span class="cursor-help underline decoration-dotted">-</span>
+            <RuiIcon
+              name="lu-banknote-x"
+              size="16"
+              class="text-rui-text-disabled cursor-help"
+            />
           </template>
           {{ t('dashboard_asset_table.price_unknown') }}
         </RuiTooltip>

--- a/frontend/app/src/modules/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/modules/dashboard/DashboardAssetTable.vue
@@ -3,6 +3,7 @@ import type { AssetBalanceWithPrice } from '@rotki/common';
 import { AssetValueDisplay, FiatDisplay, ValueDisplay } from '@/modules/assets/amount-display/components';
 import BalanceTopProtocols from '@/modules/balances/protocols/BalanceTopProtocols.vue';
 import AssetRowDetails from '@/modules/balances/protocols/components/AssetRowDetails.vue';
+import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
 import DashboardAssetWarnings from '@/modules/dashboard/DashboardAssetWarnings.vue';
 import DashboardExpandableTable from '@/modules/dashboard/DashboardExpandableTable.vue';
 import { useDashboardAssetData } from '@/modules/dashboard/use-dashboard-asset-data';
@@ -25,6 +26,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 // Stores
 const { totalNetWorth } = useDashboardStores();
+const { prices } = storeToRefs(useBalancePricesStore());
 
 // Use composables - sort needs to be defined first for the computed dependency
 const { pagination, setPage, setTablePagination, sort, tableHeaders } = useDashboardTableConfig(
@@ -47,6 +49,10 @@ const { expanded, isRowExpandable, redirectToManualBalance } = useDashboardAsset
 const emptyDescription = computed<string>(() => tableType === DashboardTableType.ASSETS
   ? t('dashboard_asset_table.no_assets')
   : t('data_table.no_data'));
+
+function isPriceMissing(asset: string): boolean {
+  return get(prices)[asset]?.priceMissing === true;
+}
 
 // Watch search to reset pagination
 watch(search, () => setPage(1));
@@ -121,6 +127,16 @@ watch(search, () => setPage(1));
         <template v-if="isAssetMissing(row)">
           -
         </template>
+        <RuiTooltip
+          v-else-if="isPriceMissing(row.asset)"
+          :open-delay="400"
+          tooltip-class="max-w-[16rem]"
+        >
+          <template #activator>
+            <span class="cursor-help underline decoration-dotted">-</span>
+          </template>
+          {{ t('dashboard_asset_table.price_unknown') }}
+        </RuiTooltip>
         <FiatDisplay
           v-else
           :price-asset="row.asset"

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
@@ -1,0 +1,89 @@
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, ref } from 'vue';
+import DashboardCompletenessIndicator from '@/modules/dashboard/DashboardCompletenessIndicator.vue';
+import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
+import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
+import '@test/i18n';
+
+interface MockState {
+  actionableCount: number;
+  processing: boolean;
+}
+
+const state = vi.hoisted((): MockState => ({
+  actionableCount: 0,
+  processing: false,
+}));
+
+vi.mock('@/modules/history/data-issues/use-data-issues-summary', () => ({
+  useDataIssuesSummary: (): Record<string, unknown> => ({
+    actionableCount: ref(state.actionableCount),
+    refreshSummary: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/modules/history/events/tx/use-history-transaction-decoding', () => ({
+  useHistoryTransactionDecoding: (): Record<string, unknown> => ({
+    fetchUndecodedTransactionsBreakdown: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/modules/history/events/use-history-events-status', () => ({
+  useHistoryEventsStatus: (): Record<string, unknown> => ({
+    processing: computed(() => state.processing),
+  }),
+}));
+
+async function createWrapper(): Promise<VueWrapper<InstanceType<typeof DashboardCompletenessIndicator>>> {
+  const wrapper = mount(DashboardCompletenessIndicator, {
+    global: {
+      stubs: {
+        RouterLink: { template: '<div><slot /></div>' },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('dashboardCompletenessIndicator', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    state.actionableCount = 0;
+    state.processing = false;
+  });
+
+  it('should render nothing when there are no completeness issues', async () => {
+    const wrapper = await createWrapper();
+    expect(wrapper.find('[data-cy=dashboard-completeness]').exists()).toBe(false);
+  });
+
+  it('should show a chip when assets are missing prices', async () => {
+    useBalancePricesStore().prices = {
+      ETH: { isManualPrice: false, oracle: 'blockchain', priceMissing: true, usdPrice: null, value: '0' },
+    } as never;
+    const wrapper = await createWrapper();
+    expect(wrapper.find('[data-cy=dashboard-completeness]').text()).toContain('missing_prices');
+  });
+
+  it('should show a chip for leftover undecoded transactions', async () => {
+    useDecodingStatusStore().setUndecodedTransactionsStatus({ chain: 'eth', processed: 2, total: 10 });
+    const wrapper = await createWrapper();
+    expect(wrapper.find('[data-cy=dashboard-completeness]').text()).toContain('undecoded');
+  });
+
+  it('should hide the undecoded chip while history is processing', async () => {
+    state.processing = true;
+    useDecodingStatusStore().setUndecodedTransactionsStatus({ chain: 'eth', processed: 2, total: 10 });
+    const wrapper = await createWrapper();
+    expect(wrapper.find('[data-cy=dashboard-completeness]').exists()).toBe(false);
+  });
+
+  it('should show a chip when data issues need attention', async () => {
+    state.actionableCount = 3;
+    const wrapper = await createWrapper();
+    expect(wrapper.find('[data-cy=dashboard-completeness]').text()).toContain('data_issues');
+  });
+});

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
@@ -1,5 +1,6 @@
+import { createCustomPinia } from '@test/utils/create-pinia';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
-import { createPinia, setActivePinia } from 'pinia';
+import { setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { computed, ref } from 'vue';
 import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
@@ -50,14 +51,14 @@ async function createWrapper(): Promise<VueWrapper<InstanceType<typeof Dashboard
 
 describe('dashboardCompletenessIndicator', () => {
   beforeEach(() => {
-    setActivePinia(createPinia());
+    setActivePinia(createCustomPinia());
     state.actionableCount = 0;
     state.processing = false;
   });
 
   it('should render nothing when there are no completeness issues', async () => {
     const wrapper = await createWrapper();
-    expect(wrapper.find('[data-cy=dashboard-completeness]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid=dashboard-completeness]').exists()).toBe(false);
   });
 
   it('should show a chip when assets are missing prices', async () => {
@@ -65,25 +66,25 @@ describe('dashboardCompletenessIndicator', () => {
       ETH: { isManualPrice: false, oracle: 'blockchain', priceMissing: true, usdPrice: null, value: '0' },
     } as never;
     const wrapper = await createWrapper();
-    expect(wrapper.find('[data-cy=dashboard-completeness]').text()).toContain('missing_prices');
+    expect(wrapper.find('[data-testid=dashboard-completeness]').text()).toContain('missing_prices');
   });
 
   it('should show a chip for leftover undecoded transactions', async () => {
     useDecodingStatusStore().setUndecodedTransactionsStatus({ chain: 'eth', processed: 2, total: 10 });
     const wrapper = await createWrapper();
-    expect(wrapper.find('[data-cy=dashboard-completeness]').text()).toContain('undecoded');
+    expect(wrapper.find('[data-testid=dashboard-completeness]').text()).toContain('undecoded');
   });
 
   it('should hide the undecoded chip while history is processing', async () => {
     state.processing = true;
     useDecodingStatusStore().setUndecodedTransactionsStatus({ chain: 'eth', processed: 2, total: 10 });
     const wrapper = await createWrapper();
-    expect(wrapper.find('[data-cy=dashboard-completeness]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid=dashboard-completeness]').exists()).toBe(false);
   });
 
   it('should show a chip when data issues need attention', async () => {
     state.actionableCount = 3;
     const wrapper = await createWrapper();
-    expect(wrapper.find('[data-cy=dashboard-completeness]').text()).toContain('data_issues');
+    expect(wrapper.find('[data-testid=dashboard-completeness]').text()).toContain('data_issues');
   });
 });

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
@@ -2,8 +2,8 @@ import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { computed, ref } from 'vue';
-import DashboardCompletenessIndicator from '@/modules/dashboard/DashboardCompletenessIndicator.vue';
 import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
+import DashboardCompletenessIndicator from '@/modules/dashboard/DashboardCompletenessIndicator.vue';
 import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import '@test/i18n';
 

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { startPromise } from '@shared/utils';
+import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
+import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
+import { useHistoryTransactionDecoding } from '@/modules/history/events/tx/use-history-transaction-decoding';
+import { useHistoryEventsStatus } from '@/modules/history/events/use-history-events-status';
+import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
+
+const { t } = useI18n({ useScope: 'global' });
+
+const { prices } = storeToRefs(useBalancePricesStore());
+const { decodingStatus } = storeToRefs(useDecodingStatusStore());
+const { actionableCount, refreshSummary } = useDataIssuesSummary();
+const { fetchUndecodedTransactionsBreakdown } = useHistoryTransactionDecoding();
+const { processing } = useHistoryEventsStatus();
+
+const missingPricesCount = computed<number>(() =>
+  Object.values(get(prices)).filter(price => price.priceMissing).length,
+);
+
+const undecodedCount = computed<number>(() => {
+  if (get(processing))
+    return 0;
+  return get(decodingStatus).reduce((sum, { processed, total }) => sum + Math.max(0, total - processed), 0);
+});
+
+const hasIssues = computed<boolean>(() =>
+  get(missingPricesCount) > 0 || get(undecodedCount) > 0 || get(actionableCount) > 0,
+);
+
+onMounted(() => {
+  startPromise(Promise.all([fetchUndecodedTransactionsBreakdown(), refreshSummary()]));
+});
+</script>
+
+<template>
+  <div
+    v-if="hasIssues"
+    class="flex flex-wrap gap-2 mt-2"
+    data-cy="dashboard-completeness"
+  >
+    <RouterLink
+      v-if="missingPricesCount > 0"
+      :to="{ name: '/price-manager/latest/' }"
+    >
+      <RuiChip
+        size="sm"
+        color="warning"
+        clickable
+      >
+        <template #prepend>
+          <RuiIcon
+            name="lu-circle-help"
+            size="14"
+          />
+        </template>
+        {{ t('dashboard.completeness.missing_prices', { count: missingPricesCount }) }}
+      </RuiChip>
+    </RouterLink>
+    <RouterLink
+      v-if="undecodedCount > 0"
+      :to="{ name: '/history/events/' }"
+    >
+      <RuiChip
+        size="sm"
+        color="warning"
+        clickable
+      >
+        <template #prepend>
+          <RuiIcon
+            name="lu-triangle-alert"
+            size="14"
+          />
+        </template>
+        {{ t('dashboard.completeness.undecoded', { count: undecodedCount }) }}
+      </RuiChip>
+    </RouterLink>
+    <RouterLink
+      v-if="actionableCount > 0"
+      :to="{ name: '/history/data-issues/' }"
+    >
+      <RuiChip
+        size="sm"
+        color="warning"
+        clickable
+      >
+        <template #prepend>
+          <RuiIcon
+            name="lu-inbox"
+            size="14"
+          />
+        </template>
+        {{ t('dashboard.completeness.data_issues', { count: actionableCount }) }}
+      </RuiChip>
+    </RouterLink>
+  </div>
+</template>

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
@@ -1,28 +1,22 @@
 <script setup lang="ts">
 import { startPromise } from '@shared/utils';
+import { useAssetsStore } from '@/modules/assets/use-assets-store';
 import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
 import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
-import { useHistoryTransactionDecoding } from '@/modules/history/events/tx/use-history-transaction-decoding';
-import { useHistoryEventsStatus } from '@/modules/history/events/use-history-events-status';
-import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
+import { useUndecodedTransactionsCount } from '@/modules/history/events/tx/use-undecoded-transactions-count';
 
 const { t } = useI18n({ useScope: 'global' });
 
 const { prices } = storeToRefs(useBalancePricesStore());
-const { decodingStatus } = storeToRefs(useDecodingStatusStore());
+const { isAssetIgnored } = useAssetsStore();
 const { actionableCount, refreshSummary } = useDataIssuesSummary();
-const { fetchUndecodedTransactionsBreakdown } = useHistoryTransactionDecoding();
-const { processing } = useHistoryEventsStatus();
+const { fetchUndecodedTransactionsBreakdown, undecodedCount } = useUndecodedTransactionsCount();
 
+// Ignored assets (spam/dust) are hidden from the balances table, so they must
+// not inflate the count either — only count assets the user actually sees.
 const missingPricesCount = computed<number>(() =>
-  Object.values(get(prices)).filter(price => price.priceMissing).length,
+  Object.entries(get(prices)).filter(([asset, price]) => price.priceMissing && !isAssetIgnored(asset)).length,
 );
-
-const undecodedCount = computed<number>(() => {
-  if (get(processing))
-    return 0;
-  return get(decodingStatus).reduce((sum, { processed, total }) => sum + Math.max(0, total - processed), 0);
-});
 
 const hasIssues = computed<boolean>(() =>
   get(missingPricesCount) > 0 || get(undecodedCount) > 0 || get(actionableCount) > 0,
@@ -36,21 +30,23 @@ onMounted(() => {
 <template>
   <div
     v-if="hasIssues"
-    class="flex flex-wrap gap-2 mt-2"
-    data-cy="dashboard-completeness"
+    class="flex flex-wrap items-center gap-2"
+    data-testid="dashboard-completeness"
   >
     <RouterLink
       v-if="missingPricesCount > 0"
+      class="inline-flex no-underline"
       :to="{ name: '/price-manager/latest/' }"
     >
       <RuiChip
         size="sm"
-        color="warning"
-        clickable
+        color="grey"
+        variant="outlined"
+        class="cursor-pointer hover:brightness-95"
       >
         <template #prepend>
           <RuiIcon
-            name="lu-circle-help"
+            name="lu-banknote-x"
             size="14"
           />
         </template>
@@ -59,12 +55,14 @@ onMounted(() => {
     </RouterLink>
     <RouterLink
       v-if="undecodedCount > 0"
+      class="inline-flex no-underline"
       :to="{ name: '/history/events/' }"
     >
       <RuiChip
         size="sm"
         color="warning"
-        clickable
+        variant="outlined"
+        class="cursor-pointer hover:brightness-95"
       >
         <template #prepend>
           <RuiIcon
@@ -77,12 +75,14 @@ onMounted(() => {
     </RouterLink>
     <RouterLink
       v-if="actionableCount > 0"
+      class="inline-flex no-underline"
       :to="{ name: '/history/data-issues/' }"
     >
       <RuiChip
         size="sm"
         color="warning"
-        clickable
+        variant="outlined"
+        class="cursor-pointer hover:brightness-95"
       >
         <template #prepend>
           <RuiIcon

--- a/frontend/app/src/modules/history/events/HistoryEventsAlerts.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsAlerts.vue
@@ -2,11 +2,11 @@
 import { Section } from '@/modules/core/common/status';
 import { useRefWithDebounce } from '@/modules/core/common/use-ref-debounce';
 import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import { useUndecodedTransactionsCount } from '@/modules/history/events/tx/use-undecoded-transactions-count';
 import { useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
 import { useUnmatchedAssetMovements } from '@/modules/history/events/use-unmatched-asset-movements';
 import { useUnmatchedBridgeTransactions } from '@/modules/history/events/use-unmatched-bridge-transactions';
 import { useInternalTxConflicts } from '@/modules/history/internal-tx-conflicts/use-internal-tx-conflicts';
-import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import { useStatusUpdater } from '@/modules/shell/sync-progress/use-status-updater';
 
 const show = defineModel<boolean>('show', { required: true });
@@ -54,13 +54,7 @@ const {
 } = useCustomizedEventDuplicates();
 
 const { fetchCounts, issueCount: internalConflictsCount } = useInternalTxConflicts();
-const { decodingStatus } = storeToRefs(useDecodingStatusStore());
-
-const undecodedCount = computed<number>(() => {
-  if (processing)
-    return 0;
-  return get(decodingStatus).reduce((sum, { processed, total }) => sum + Math.max(0, total - processed), 0);
-});
+const { fetchUndecodedTransactionsBreakdown, undecodedCount } = useUndecodedTransactionsCount(() => processing);
 
 const showUnmatchedMovements = computed<boolean>(() => !get(autoMatchLoading) && get(unmatchedCount) > 0);
 const showUnmatchedBridges = computed<boolean>(() => !get(bridgeAutoMatchLoading) && get(unmatchedBridgesCount) > 0);
@@ -117,6 +111,7 @@ watchImmediate(loading, async (isLoading) => {
       refreshUnmatchedBridgeTransactions(),
       fetchCustomizedEventDuplicates(),
       fetchCounts(),
+      fetchUndecodedTransactionsBreakdown(),
     ]);
   }
 });

--- a/frontend/app/src/modules/history/events/HistoryEventsAlerts.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsAlerts.vue
@@ -6,6 +6,7 @@ import { useCustomizedEventDuplicates } from '@/modules/history/events/use-custo
 import { useUnmatchedAssetMovements } from '@/modules/history/events/use-unmatched-asset-movements';
 import { useUnmatchedBridgeTransactions } from '@/modules/history/events/use-unmatched-bridge-transactions';
 import { useInternalTxConflicts } from '@/modules/history/internal-tx-conflicts/use-internal-tx-conflicts';
+import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import { useStatusUpdater } from '@/modules/shell/sync-progress/use-status-updater';
 
 const show = defineModel<boolean>('show', { required: true });
@@ -19,6 +20,7 @@ const emit = defineEmits<{
   'open:match-asset-movements': [];
   'open:match-bridge-transactions': [];
   'open:internal-tx-conflicts': [];
+  'open:decoding-status': [];
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
@@ -52,13 +54,22 @@ const {
 } = useCustomizedEventDuplicates();
 
 const { fetchCounts, issueCount: internalConflictsCount } = useInternalTxConflicts();
+const { decodingStatus } = storeToRefs(useDecodingStatusStore());
+
+const undecodedCount = computed<number>(() => {
+  if (processing)
+    return 0;
+  return get(decodingStatus).reduce((sum, { processed, total }) => sum + Math.max(0, total - processed), 0);
+});
+
 const showUnmatchedMovements = computed<boolean>(() => !get(autoMatchLoading) && get(unmatchedCount) > 0);
 const showUnmatchedBridges = computed<boolean>(() => !get(bridgeAutoMatchLoading) && get(unmatchedBridgesCount) > 0);
 const showAutoFixDuplicates = computed<boolean>(() => get(autoFixCount) > 0);
 const showManualReviewDuplicates = computed<boolean>(() => get(manualReviewCount) > 0);
 const showInternalConflicts = computed<boolean>(() => get(internalConflictsCount) > 0);
+const showUndecoded = computed<boolean>(() => get(undecodedCount) > 0);
 
-const hasAlerts = logicOr(showUnmatchedMovements, showUnmatchedBridges, showAutoFixDuplicates, showManualReviewDuplicates, showInternalConflicts);
+const hasAlerts = logicOr(showUnmatchedMovements, showUnmatchedBridges, showAutoFixDuplicates, showManualReviewDuplicates, showInternalConflicts, showUndecoded);
 const refreshing = logicOr(unmatchedLoading, unmatchedBridgesLoading, duplicatesLoading);
 
 const showAlerts = logicAnd(() => mainPage, hasAlerts, show);
@@ -80,6 +91,11 @@ function openMatchBridgeTransactions(): void {
 function openInternalTxConflicts(): void {
   closeAlerts();
   emit('open:internal-tx-conflicts');
+}
+
+function openDecodingStatus(): void {
+  closeAlerts();
+  emit('open:decoding-status');
 }
 
 async function viewDuplicates(groupIds: string[], status: DuplicateHandlingStatus): Promise<void> {
@@ -203,6 +219,20 @@ watchImmediate(loading, async (isLoading) => {
               @click="openInternalTxConflicts()"
             >
               {{ t('internal_tx_conflicts.banner.action') }}
+            </RuiButton>
+          </div>
+        </li>
+        <li v-if="showUndecoded">
+          <div class="flex items-center">
+            <span>{{ t('transactions.events_decoding.undecoded_banner.message', { count: undecodedCount }) }}</span>
+            <RuiButton
+              variant="text"
+              color="warning"
+              size="sm"
+              class="ml-2 underline"
+              @click="openDecodingStatus()"
+            >
+              {{ t('transactions.events_decoding.undecoded_banner.action') }}
             </RuiButton>
           </div>
         </li>

--- a/frontend/app/src/modules/history/events/HistoryEventsIssueCheckButton.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsIssueCheckButton.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import { startPromise } from '@shared/utils';
 import { DIALOG_TYPES, type DialogShowOptions } from '@/modules/history/events/dialog-types';
-import { useHistoryTransactionDecoding } from '@/modules/history/events/tx/use-history-transaction-decoding';
+import { useUndecodedTransactionsCount } from '@/modules/history/events/tx/use-undecoded-transactions-count';
 import { useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
-import { useHistoryEventsStatus } from '@/modules/history/events/use-history-events-status';
 import { useUnmatchedAssetMovements } from '@/modules/history/events/use-unmatched-asset-movements';
 import { useUnmatchedBridgeTransactions } from '@/modules/history/events/use-unmatched-bridge-transactions';
 import { useInternalTxConflicts } from '@/modules/history/internal-tx-conflicts/use-internal-tx-conflicts';
-import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 
 const showAlerts = defineModel<boolean>('showAlerts', { default: false });
 
@@ -21,15 +19,7 @@ const { autoMatchLoading, unmatchedCount } = useUnmatchedAssetMovements();
 const { autoMatchLoading: bridgeAutoMatchLoading, unmatchedCount: unmatchedBridgesCount } = useUnmatchedBridgeTransactions();
 const { actionableCount: duplicatesCount } = useCustomizedEventDuplicates();
 const { issueCount: internalConflictsCount } = useInternalTxConflicts();
-const { processing } = useHistoryEventsStatus();
-const { decodingStatus } = storeToRefs(useDecodingStatusStore());
-const { fetchUndecodedTransactionsBreakdown } = useHistoryTransactionDecoding();
-
-const undecodedCount = computed<number>(() => {
-  if (get(processing))
-    return 0;
-  return get(decodingStatus).reduce((sum, { processed, total }) => sum + Math.max(0, total - processed), 0);
-});
+const { fetchUndecodedTransactionsBreakdown, undecodedCount } = useUndecodedTransactionsCount();
 
 const totalIssuesCount = computed<number>(() => get(unmatchedCount) + get(unmatchedBridgesCount) + get(duplicatesCount) + get(internalConflictsCount) + get(undecodedCount));
 const hasIssues = computed<boolean>(() => !get(autoMatchLoading) && !get(bridgeAutoMatchLoading) && get(totalIssuesCount) > 0);

--- a/frontend/app/src/modules/history/events/HistoryEventsIssueCheckButton.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsIssueCheckButton.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import { startPromise } from '@shared/utils';
 import { DIALOG_TYPES, type DialogShowOptions } from '@/modules/history/events/dialog-types';
+import { useHistoryTransactionDecoding } from '@/modules/history/events/tx/use-history-transaction-decoding';
 import { useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
+import { useHistoryEventsStatus } from '@/modules/history/events/use-history-events-status';
 import { useUnmatchedAssetMovements } from '@/modules/history/events/use-unmatched-asset-movements';
 import { useUnmatchedBridgeTransactions } from '@/modules/history/events/use-unmatched-bridge-transactions';
 import { useInternalTxConflicts } from '@/modules/history/internal-tx-conflicts/use-internal-tx-conflicts';
+import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 
 const showAlerts = defineModel<boolean>('showAlerts', { default: false });
 
@@ -17,8 +21,17 @@ const { autoMatchLoading, unmatchedCount } = useUnmatchedAssetMovements();
 const { autoMatchLoading: bridgeAutoMatchLoading, unmatchedCount: unmatchedBridgesCount } = useUnmatchedBridgeTransactions();
 const { actionableCount: duplicatesCount } = useCustomizedEventDuplicates();
 const { issueCount: internalConflictsCount } = useInternalTxConflicts();
+const { processing } = useHistoryEventsStatus();
+const { decodingStatus } = storeToRefs(useDecodingStatusStore());
+const { fetchUndecodedTransactionsBreakdown } = useHistoryTransactionDecoding();
 
-const totalIssuesCount = computed<number>(() => get(unmatchedCount) + get(unmatchedBridgesCount) + get(duplicatesCount) + get(internalConflictsCount));
+const undecodedCount = computed<number>(() => {
+  if (get(processing))
+    return 0;
+  return get(decodingStatus).reduce((sum, { processed, total }) => sum + Math.max(0, total - processed), 0);
+});
+
+const totalIssuesCount = computed<number>(() => get(unmatchedCount) + get(unmatchedBridgesCount) + get(duplicatesCount) + get(internalConflictsCount) + get(undecodedCount));
 const hasIssues = computed<boolean>(() => !get(autoMatchLoading) && !get(bridgeAutoMatchLoading) && get(totalIssuesCount) > 0);
 
 const singleIssueDialog = computed<DialogShowOptions | undefined>(() => {
@@ -31,6 +44,8 @@ const singleIssueDialog = computed<DialogShowOptions | undefined>(() => {
     issueTypes.push({ type: DIALOG_TYPES.CUSTOMIZED_EVENT_DUPLICATES });
   if (get(internalConflictsCount) > 0)
     issueTypes.push({ type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS });
+  if (get(undecodedCount) > 0)
+    issueTypes.push({ type: DIALOG_TYPES.DECODING_STATUS });
   return issueTypes.length === 1 ? issueTypes[0] : undefined;
 });
 
@@ -47,6 +62,10 @@ function toggleAlerts(): void {
 watch(hasIssues, (value) => {
   if (!value)
     set(showAlerts, false);
+});
+
+onMounted(() => {
+  startPromise(fetchUndecodedTransactionsBreakdown());
 });
 </script>
 

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -387,6 +387,7 @@ watchDebounced(route, async () => {
               v-model:pagination="pagination"
               :table-height-offset="tableHeightOffset"
               :group-loading="groupLoading"
+              :processing="processing || refreshing"
               :groups="groups"
               :page-params="toggles.matchExactEvents ? pageParams : undefined"
               :exclude-ignored="!toggles.showIgnoredAssets"

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -331,6 +331,7 @@ watchDebounced(route, async () => {
           @open:match-asset-movements="dialogContainer?.show({ type: DIALOG_TYPES.MATCH_ASSET_MOVEMENTS })"
           @open:match-bridge-transactions="dialogContainer?.show({ type: DIALOG_TYPES.MATCH_BRIDGE_TRANSACTIONS })"
           @open:internal-tx-conflicts="dialogContainer?.show({ type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS })"
+          @open:decoding-status="dialogContainer?.show({ type: DIALOG_TYPES.DECODING_STATUS })"
         />
 
         <div class="flex gap-4 items-start">

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -29,6 +29,7 @@ const {
   excludeIgnored,
   groupLoading,
   hasActiveFilters,
+  processing,
   tableHeightOffset,
   identifiers,
   highlightedGroupIdentifier,
@@ -43,6 +44,7 @@ const {
   excludeIgnored: boolean;
   groupLoading: boolean;
   hasActiveFilters?: boolean;
+  processing?: boolean;
   tableHeightOffset?: number;
   identifiers?: string[];
   highlightedGroupIdentifier?: string;
@@ -262,6 +264,15 @@ function isShowingIgnoredAssets(groupId: string): boolean {
         >
           {{ t('transactions.empty_state.clear_filters') }}
         </RuiButton>
+      </template>
+      <template v-else-if="processing">
+        <RuiProgress
+          circular
+          variant="indeterminate"
+          color="primary"
+          size="24"
+        />
+        {{ t('transactions.empty_state.syncing') }}
       </template>
       <template v-else>
         {{ t('transactions.empty_state.no_events') }}

--- a/frontend/app/src/modules/history/events/tx/use-undecoded-transactions-count.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-undecoded-transactions-count.spec.ts
@@ -1,0 +1,71 @@
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed } from 'vue';
+import { useUndecodedTransactionsCount } from '@/modules/history/events/tx/use-undecoded-transactions-count';
+import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
+
+const state = vi.hoisted((): { processing: boolean } => ({ processing: false }));
+
+vi.mock('@/modules/history/events/tx/use-history-transaction-decoding', () => ({
+  useHistoryTransactionDecoding: (): Record<string, unknown> => ({
+    fetchUndecodedTransactionsBreakdown: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/modules/history/events/use-history-events-status', () => ({
+  useHistoryEventsStatus: (): Record<string, unknown> => ({
+    processing: computed(() => state.processing),
+  }),
+}));
+
+describe('useUndecodedTransactionsCount', () => {
+  beforeEach(() => {
+    setActivePinia(createCustomPinia());
+    state.processing = false;
+  });
+
+  it('should sum the leftover undecoded transactions across chains', () => {
+    const store = useDecodingStatusStore();
+    store.setUndecodedTransactionsStatus({ chain: 'eth', processed: 2, total: 10 });
+    store.setUndecodedTransactionsStatus({ chain: 'optimism', processed: 5, total: 8 });
+
+    const { undecodedCount } = useUndecodedTransactionsCount();
+    expect(get(undecodedCount)).toBe(11); // (10-2) + (8-5)
+  });
+
+  it('should clamp negative differences to zero', () => {
+    const store = useDecodingStatusStore();
+    store.setUndecodedTransactionsStatus({ chain: 'eth', processed: 12, total: 10 });
+
+    const { undecodedCount } = useUndecodedTransactionsCount();
+    expect(get(undecodedCount)).toBe(0);
+  });
+
+  it('should suppress the count while history is processing (default status)', () => {
+    state.processing = true;
+    const store = useDecodingStatusStore();
+    store.setUndecodedTransactionsStatus({ chain: 'eth', processed: 2, total: 10 });
+
+    const { undecodedCount } = useUndecodedTransactionsCount();
+    expect(get(undecodedCount)).toBe(0);
+  });
+
+  it('should honour a processing override over the shared status', () => {
+    state.processing = false; // shared status says idle
+    const store = useDecodingStatusStore();
+    store.setUndecodedTransactionsStatus({ chain: 'eth', processed: 2, total: 10 });
+
+    const { undecodedCount } = useUndecodedTransactionsCount(() => true);
+    expect(get(undecodedCount)).toBe(0);
+  });
+
+  it('should count when the override says not processing even if status is processing', () => {
+    state.processing = true; // shared status says busy
+    const store = useDecodingStatusStore();
+    store.setUndecodedTransactionsStatus({ chain: 'eth', processed: 2, total: 10 });
+
+    const { undecodedCount } = useUndecodedTransactionsCount(() => false);
+    expect(get(undecodedCount)).toBe(8);
+  });
+});

--- a/frontend/app/src/modules/history/events/tx/use-undecoded-transactions-count.ts
+++ b/frontend/app/src/modules/history/events/tx/use-undecoded-transactions-count.ts
@@ -1,0 +1,35 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import { useHistoryTransactionDecoding } from '@/modules/history/events/tx/use-history-transaction-decoding';
+import { useHistoryEventsStatus } from '@/modules/history/events/use-history-events-status';
+import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
+
+interface UseUndecodedTransactionsCountReturn {
+  undecodedCount: ComputedRef<number>;
+  fetchUndecodedTransactionsBreakdown: () => Promise<void>;
+}
+
+/**
+ * Counts transactions that have been fetched but not yet decoded into events.
+ * While history is processing the count is suppressed, since the decoding is
+ * still in flight. `processing` defaults to the shared history status but can be
+ * overridden by callers that already receive it (e.g. as a prop).
+ */
+export function useUndecodedTransactionsCount(
+  processing?: MaybeRefOrGetter<boolean>,
+): UseUndecodedTransactionsCountReturn {
+  const { decodingStatus } = storeToRefs(useDecodingStatusStore());
+  const { processing: statusProcessing } = useHistoryEventsStatus();
+  const { fetchUndecodedTransactionsBreakdown } = useHistoryTransactionDecoding();
+
+  const isProcessing = computed<boolean>(() =>
+    processing === undefined ? get(statusProcessing) : toValue(processing),
+  );
+
+  const undecodedCount = computed<number>(() => {
+    if (get(isProcessing))
+      return 0;
+    return get(decodingStatus).reduce((sum, { processed, total }) => sum + Math.max(0, total - processed), 0);
+  });
+
+  return { fetchUndecodedTransactionsBreakdown, undecodedCount };
+}

--- a/frontend/app/src/modules/reports/report-types.ts
+++ b/frontend/app/src/modules/reports/report-types.ts
@@ -149,6 +149,7 @@ export interface EditableMissingPrice extends MissingPrice {
 }
 
 export const ReportActionableItem = z.object({
+  eventsSkippedNoRule: z.number().default(0),
   missingAcquisitions: z.array(MissingAcquisition),
   missingPrices: z.array(MissingPrice),
 });

--- a/frontend/app/src/modules/reports/use-reports-store.ts
+++ b/frontend/app/src/modules/reports/use-reports-store.ts
@@ -48,6 +48,7 @@ export const useReportsStore = defineStore('reports', () => {
   const reportError = ref(emptyError());
   const lastGeneratedReport = ref<number | null>(null);
   const actionableItems = ref<ReportActionableItem>({
+    eventsSkippedNoRule: 0,
     missingAcquisitions: [],
     missingPrices: [],
   });

--- a/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.vue
@@ -6,11 +6,14 @@ import { useExchanges } from '@/modules/balances/exchanges/use-exchanges';
 import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
-import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import ExchangeKeysForm from '@/modules/settings/api-keys/exchange/ExchangeKeysForm.vue';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 
 const modelValue = defineModel<ExchangeFormData | undefined>({ required: true });
+
+const emit = defineEmits<{
+  added: [exchange: { location: string; name: string }];
+}>();
 
 const submitting = ref<boolean>(false);
 const stateUpdated = ref<boolean>(false);
@@ -19,7 +22,6 @@ const form = useTemplateRef<ComponentExposed<typeof ExchangeKeysForm>>('form');
 
 const { setupExchange } = useExchanges();
 const { setMessage } = useMessageStore();
-const { notifyInfo } = useNotifications();
 const { t } = useI18n({ useScope: 'global' });
 
 const title = computed<string>(() => {
@@ -72,12 +74,8 @@ async function save(): Promise<void> {
 
   set(submitting, false);
   if (success) {
-    if (exchange.mode !== 'edit') {
-      notifyInfo(
-        t('exchange_settings.setup_success.title'),
-        t('exchange_settings.setup_success.message', { location: exchange.location }),
-      );
-    }
+    if (exchange.mode !== 'edit')
+      emit('added', { location: exchange.location, name: exchange.name });
     set(modelValue, undefined);
   }
 }

--- a/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.vue
@@ -6,6 +6,7 @@ import { useExchanges } from '@/modules/balances/exchanges/use-exchanges';
 import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import ExchangeKeysForm from '@/modules/settings/api-keys/exchange/ExchangeKeysForm.vue';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 
@@ -18,6 +19,7 @@ const form = useTemplateRef<ComponentExposed<typeof ExchangeKeysForm>>('form');
 
 const { setupExchange } = useExchanges();
 const { setMessage } = useMessageStore();
+const { notifyInfo } = useNotifications();
 const { t } = useI18n({ useScope: 'global' });
 
 const title = computed<string>(() => {
@@ -70,6 +72,12 @@ async function save(): Promise<void> {
 
   set(submitting, false);
   if (success) {
+    if (exchange.mode !== 'edit') {
+      notifyInfo(
+        t('exchange_settings.setup_success.title'),
+        t('exchange_settings.setup_success.message', { location: exchange.location }),
+      );
+    }
     set(modelValue, undefined);
   }
 }

--- a/frontend/app/src/modules/shell/sync-progress/components/SyncProgressDetails.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/SyncProgressDetails.vue
@@ -57,10 +57,10 @@ const protocolCacheCountColor = computed<string>(() =>
 
 <template>
   <div class="px-3 pb-4 space-y-5">
-    <div
-      v-if="hasChains"
-      class="pt-4"
-    >
+    <div class="pt-4 text-xs text-rui-text-secondary leading-snug">
+      {{ t('sync_progress.explanation') }}
+    </div>
+    <div v-if="hasChains">
       <div class="flex items-center gap-2 mb-2">
         <span class="text-xs font-medium text-rui-text-secondary">
           {{ t('sync_progress.transactions') }}
@@ -81,10 +81,7 @@ const protocolCacheCountColor = computed<string>(() =>
       <ChainProgressList :chains="chains" />
     </div>
 
-    <div
-      v-if="hasLocations"
-      :class="{ 'pt-4': !hasChains }"
-    >
+    <div v-if="hasLocations">
       <div class="flex items-center gap-2 mb-2">
         <span class="text-xs font-medium text-rui-text-secondary">
           {{ t('sync_progress.events') }}
@@ -105,10 +102,7 @@ const protocolCacheCountColor = computed<string>(() =>
       <LocationProgressList :locations="locations" />
     </div>
 
-    <div
-      v-if="hasDecoding"
-      :class="{ 'pt-4': !hasChains && !hasLocations }"
-    >
+    <div v-if="hasDecoding">
       <div class="flex items-center gap-2 mb-2">
         <span class="text-xs font-medium text-rui-text-secondary">
           {{ t('sync_progress.decoding') }}
@@ -129,10 +123,7 @@ const protocolCacheCountColor = computed<string>(() =>
       <DecodingProgressList :decoding="decoding" />
     </div>
 
-    <div
-      v-if="hasProtocolCache"
-      :class="{ 'pt-4': !hasChains && !hasLocations && !hasDecoding }"
-    >
+    <div v-if="hasProtocolCache">
       <div class="flex items-center gap-2 mb-2">
         <span class="text-xs font-medium text-rui-text-secondary">
           {{ t('sync_progress.protocol_cache') }}
@@ -153,10 +144,7 @@ const protocolCacheCountColor = computed<string>(() =>
       <ProtocolCacheProgressList :protocol-cache="protocolCache" />
     </div>
 
-    <div
-      v-if="hasWarnings"
-      :class="{ 'pt-4': !hasChains && !hasLocations && !hasDecoding && !hasProtocolCache }"
-    >
+    <div v-if="hasWarnings">
       <div class="flex items-center gap-2 mb-2">
         <RuiIcon
           name="lu-circle-alert"

--- a/frontend/app/src/modules/shell/sync-progress/components/SyncProgressDetails.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/SyncProgressDetails.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useExternalApiKeys } from '@/modules/settings/api-keys/external/use-external-api-keys';
 import { useSyncProgress } from '../use-sync-progress';
 import ChainProgressList from './ChainProgressList.vue';
 import DecodingProgressList from './DecodingProgressList.vue';
@@ -6,6 +7,14 @@ import LocationProgressList from './LocationProgressList.vue';
 import ProtocolCacheProgressList from './ProtocolCacheProgressList.vue';
 
 const { t } = useI18n({ useScope: 'global' });
+
+const { loading: apiKeysLoading, useApiKey } = useExternalApiKeys();
+const etherscanKey = useApiKey('etherscan');
+
+// The free-Etherscan-key tip is only useful to users who have not set one up.
+// Wait for the keys to load first, otherwise it briefly flashes for users who
+// already have a key (getApiKey returns '' until the keys are fetched).
+const showEtherscanHint = computed<boolean>(() => !get(apiKeysLoading) && !get(etherscanKey));
 
 const {
   chains,
@@ -59,6 +68,7 @@ const protocolCacheCountColor = computed<string>(() =>
   <div class="px-3 pb-4 space-y-5">
     <div class="pt-4 text-xs text-rui-text-secondary leading-snug">
       {{ t('sync_progress.explanation') }}
+      <span v-if="showEtherscanHint">{{ t('sync_progress.explanation_etherscan_hint') }}</span>
     </div>
     <div v-if="hasChains">
       <div class="flex items-center gap-2 mb-2">

--- a/frontend/app/src/pages/api-keys/exchanges/index.spec.ts
+++ b/frontend/app/src/pages/api-keys/exchanges/index.spec.ts
@@ -1,0 +1,118 @@
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, type Ref, ref } from 'vue';
+import ExchangeKeysFormDialog from '@/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.vue';
+import Exchanges from '@/pages/api-keys/exchanges/index.vue';
+import '@test/i18n';
+
+vi.mock('vue-router', () => ({
+  useRouter: (): Record<string, unknown> => ({ push: vi.fn(), replace: vi.fn() }),
+  useRoute: (): Ref<{ query: Record<string, unknown> }> => ref({ query: {} }),
+}));
+
+vi.mock('@/modules/balances/exchanges/use-exchanges', () => ({
+  useExchanges: (): Record<string, unknown> => ({ removeExchange: vi.fn() }),
+}));
+
+vi.mock('@/modules/core/common/use-locations', () => ({
+  useLocations: (): Record<string, unknown> => ({ getExchangeName: (location: string): string => location }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
+  useNotificationDispatcher: (): Record<string, unknown> => ({ notify: vi.fn() }),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): Record<string, unknown> => ({ update: vi.fn() }),
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (): Ref<unknown[]> => ref([]),
+}));
+
+const HINT = '[data-testid=exchange-setup-hint]';
+
+describe('exchanges page', () => {
+  let wrapper: VueWrapper<InstanceType<typeof Exchanges>>;
+  let pinia: Pinia;
+
+  function createWrapper(): VueWrapper<InstanceType<typeof Exchanges>> {
+    return mount(Exchanges, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          RouterLink: true,
+          Teleport: { template: '<span><slot /></span>' },
+          Transition: { template: '<span><slot /></span>' },
+          TablePageLayout: { template: '<div><slot name="buttons" /><slot /></div>' },
+          HintMenuIcon: true,
+          ExternalLink: true,
+          LocationDisplay: true,
+          RowActions: true,
+          RuiDataTable: true,
+          ExchangeKeysFormDialog: true,
+        },
+      },
+    });
+  }
+
+  async function addExchange(): Promise<void> {
+    await wrapper
+      .findComponent(ExchangeKeysFormDialog)
+      .vm
+      .$emit('added', { location: 'kraken', name: 'main' });
+    await nextTick();
+  }
+
+  beforeEach(() => {
+    document.body.dataset.app = 'true';
+    pinia = createCustomPinia();
+    setActivePinia(pinia);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    wrapper?.unmount();
+  });
+
+  it('should not show the setup hint before an exchange is added', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+    expect(wrapper.find(HINT).exists()).toBe(false);
+  });
+
+  it('should show the setup hint when an exchange is added', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+    await addExchange();
+    const hint = wrapper.find(HINT);
+    expect(hint.exists()).toBe(true);
+    expect(hint.text()).toContain('exchange_settings.setup_hint');
+  });
+
+  it('should hide the setup hint when dismissed', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+    await addExchange();
+    expect(wrapper.find(HINT).exists()).toBe(true);
+
+    await wrapper.find(`${HINT} button`).trigger('click');
+    await nextTick();
+    expect(wrapper.find(HINT).exists()).toBe(false);
+  });
+
+  it('should auto-hide the setup hint after the timeout', async () => {
+    wrapper = createWrapper();
+    await flushPromises();
+    await addExchange();
+    expect(wrapper.find(HINT).exists()).toBe(true);
+
+    vi.advanceTimersByTime(9000);
+    await nextTick();
+    expect(wrapper.find(HINT).exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/pages/api-keys/exchanges/index.vue
+++ b/frontend/app/src/pages/api-keys/exchanges/index.vue
@@ -10,6 +10,7 @@ import { useLocationStore } from '@/modules/core/common/use-location-store';
 import { useLocations } from '@/modules/core/common/use-locations';
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
+import { useRowHighlight } from '@/modules/core/table/use-row-highlight';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import ExchangeKeysFormDialog from '@/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.vue';
 import { useSetting } from '@/modules/settings/use-setting';
@@ -135,6 +136,27 @@ async function toggleSync(exchange: Exchange) {
   resetNonSyncingExchanges();
 }
 
+const { highlight: highlightExchange, rowClass } = useRowHighlight<{ location: string; name: string }>(
+  ({ location, name }) => `${location}#${name}`,
+);
+
+const showSetupHint = ref<boolean>(false);
+const { start: startHintTimeout, stop: stopHintTimeout } = useTimeoutFn(() => {
+  set(showSetupHint, false);
+}, 9000, { immediate: false });
+
+function onExchangeAdded(exchange: { location: string; name: string }): void {
+  highlightExchange(exchange);
+  set(showSetupHint, true);
+  stopHintTimeout();
+  startHintTimeout();
+}
+
+function dismissSetupHint(): void {
+  stopHintTimeout();
+  set(showSetupHint, false);
+}
+
 function addExchange() {
   set(exchange, createNewExchange());
 }
@@ -210,19 +232,52 @@ watch(route, async (route) => {
     </template>
 
     <RuiCard>
-      <div class="flex flex-row-reverse mb-2">
-        <HintMenuIcon>
-          <i18n-t
-            scope="global"
-            keypath="exchange_settings.subtitle"
-            tag="div"
+      <div class="flex items-center gap-2 mb-2 min-h-8">
+        <Transition
+          enter-active-class="transition-opacity duration-300"
+          enter-from-class="opacity-0"
+          leave-active-class="transition-opacity duration-300"
+          leave-to-class="opacity-0"
+        >
+          <div
+            v-if="showSetupHint"
+            class="flex items-center gap-2 flex-1 min-w-0 text-sm text-rui-text-secondary"
+            data-testid="exchange-setup-hint"
           >
-            <ExternalLink
-              :text="t('exchange_settings.usage_guide')"
-              :url="externalLinks.usageGuideSection.addingAnExchange"
+            <RuiIcon
+              name="lu-info"
+              size="16"
+              class="text-rui-info shrink-0"
             />
-          </i18n-t>
-        </HintMenuIcon>
+            <span class="min-w-0">{{ t('exchange_settings.setup_hint') }}</span>
+            <RuiButton
+              variant="text"
+              icon
+              size="sm"
+              class="shrink-0"
+              @click="dismissSetupHint()"
+            >
+              <RuiIcon
+                name="lu-x"
+                size="14"
+              />
+            </RuiButton>
+          </div>
+        </Transition>
+        <div class="ml-auto">
+          <HintMenuIcon>
+            <i18n-t
+              scope="global"
+              keypath="exchange_settings.subtitle"
+              tag="div"
+            >
+              <ExternalLink
+                :text="t('exchange_settings.usage_guide')"
+                :url="externalLinks.usageGuideSection.addingAnExchange"
+              />
+            </i18n-t>
+          </HintMenuIcon>
+        </div>
       </div>
 
       <RuiDataTable
@@ -232,6 +287,7 @@ watch(route, async (route) => {
         data-cy="exchange-table"
         :rows="rows"
         :cols="cols"
+        :item-class="rowClass"
       >
         <template #item.location="{ row }">
           <LocationDisplay :identifier="row.location" />
@@ -256,6 +312,9 @@ watch(route, async (route) => {
       </RuiDataTable>
     </RuiCard>
 
-    <ExchangeKeysFormDialog v-model="exchange" />
+    <ExchangeKeysFormDialog
+      v-model="exchange"
+      @added="onExchangeAdded($event)"
+    />
   </TablePageLayout>
 </template>

--- a/frontend/app/src/pages/reports/[id].vue
+++ b/frontend/app/src/pages/reports/[id].vue
@@ -32,7 +32,7 @@ const refreshing = ref(false);
 const initialOpenReportActionable = ref<boolean>(false);
 
 const reportsStore = useReportsStore();
-const { reports } = storeToRefs(reportsStore);
+const { actionableItems, reports } = storeToRefs(reportsStore);
 const { isLatestReport } = reportsStore;
 const { fetchReports, getActionableItems } = useReportOperations();
 
@@ -44,6 +44,12 @@ const latest = isLatestReport(reportId);
 
 const selectedReport = computed<Report>(() => get(reports).entries.find(item => item.identifier === reportId)!);
 const settings = computed(() => get(selectedReport).settings);
+
+const missingAcquisitionsCount = computed<number>(() => get(actionableItems)?.missingAcquisitions.length ?? 0);
+const missingPricesCount = computed<number>(() => get(actionableItems)?.missingPrices.length ?? 0);
+const eventsSkippedCount = computed<number>(() => get(actionableItems)?.eventsSkippedNoRule ?? 0);
+const hasActionableIssues = computed<boolean>(() => get(latest) && (get(missingAcquisitionsCount) > 0 || get(missingPricesCount) > 0));
+const showCompletenessWarning = computed<boolean>(() => get(hasActionableIssues) || (get(latest) && get(eventsSkippedCount) > 0));
 
 const reportEvents = ref(defaultReportEvents());
 
@@ -111,6 +117,26 @@ async function regenerateReport() {
           {{ t('profit_loss_report.actionable.actions.regenerate_report') }}
         </RuiButton>
       </div>
+      <RuiAlert
+        v-if="showCompletenessWarning"
+        type="warning"
+      >
+        <div v-if="hasActionableIssues">
+          {{ t('profit_loss_report.actionable.overview_warning', {
+            acquisitions: missingAcquisitionsCount,
+            prices: missingPricesCount,
+          }) }}
+        </div>
+        <div v-if="eventsSkippedCount > 0">
+          {{ t('profit_loss_report.actionable.skipped_no_rule', { count: eventsSkippedCount }) }}
+        </div>
+      </RuiAlert>
+      <RuiAlert
+        v-else-if="!latest"
+        type="info"
+      >
+        {{ t('profit_loss_report.actionable.stale_details') }}
+      </RuiAlert>
       <ProfitLossOverview
         :report="selectedReport"
         :symbol="settings.profitCurrency"

--- a/frontend/app/src/pages/reports/[id].vue
+++ b/frontend/app/src/pages/reports/[id].vue
@@ -51,6 +51,15 @@ const eventsSkippedCount = computed<number>(() => get(actionableItems)?.eventsSk
 const hasActionableIssues = computed<boolean>(() => get(latest) && (get(missingAcquisitionsCount) > 0 || get(missingPricesCount) > 0));
 const showCompletenessWarning = computed<boolean>(() => get(hasActionableIssues) || (get(latest) && get(eventsSkippedCount) > 0));
 
+// Detailed issues are only kept for the latest report. For older reports we can
+// still tell whether they had incomplete processing, and only then is it worth
+// explaining why the details are unavailable.
+const reportHadIssues = computed<boolean>(() => {
+  const report = get(reports).entries.find(item => item.identifier === reportId);
+  return !!report && report.processedActions < report.totalActions;
+});
+const showStaleDetails = computed<boolean>(() => !get(latest) && get(reportHadIssues));
+
 const reportEvents = ref(defaultReportEvents());
 
 onMounted(async () => {
@@ -122,17 +131,25 @@ async function regenerateReport() {
         type="warning"
       >
         <div v-if="hasActionableIssues">
-          {{ t('profit_loss_report.actionable.overview_warning', {
-            acquisitions: missingAcquisitionsCount,
-            prices: missingPricesCount,
-          }) }}
+          <div class="font-medium">
+            {{ t('profit_loss_report.actionable.overview_warning_title') }}
+          </div>
+          <ul class="list-disc pl-4 my-1">
+            <li v-if="missingAcquisitionsCount > 0">
+              {{ t('profit_loss_report.actionable.overview_warning_acquisitions', { count: missingAcquisitionsCount }) }}
+            </li>
+            <li v-if="missingPricesCount > 0">
+              {{ t('profit_loss_report.actionable.overview_warning_prices', { count: missingPricesCount }) }}
+            </li>
+          </ul>
+          {{ t('profit_loss_report.actionable.overview_warning') }}
         </div>
         <div v-if="eventsSkippedCount > 0">
           {{ t('profit_loss_report.actionable.skipped_no_rule', { count: eventsSkippedCount }) }}
         </div>
       </RuiAlert>
       <RuiAlert
-        v-else-if="!latest"
+        v-else-if="showStaleDetails"
         type="info"
       >
         {{ t('profit_loss_report.actionable.stale_details') }}

--- a/frontend/app/src/pages/settings/modules/index.vue
+++ b/frontend/app/src/pages/settings/modules/index.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import { externalLinks } from '@shared/external-links';
 import { msg } from '@/message-key';
 import { NoteLocation } from '@/modules/core/common/notes';
 import SettingsPage from '@/modules/settings/controls/SettingsPage.vue';
 import ModuleSelector from '@/modules/settings/modules/ModuleSelector.vue';
 import SettingCategory from '@/modules/settings/SettingCategory.vue';
 import { anchorId } from '@/modules/settings/settings-actions';
+import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 
 definePage({
   meta: {
@@ -31,6 +33,18 @@ const { t } = useI18n({ useScope: 'global' });
       <div class="flex flex-col gap-4 pt-4">
         <RuiAlert type="info">
           {{ t('module_settings.hint') }}
+          <i18n-t
+            keypath="module_settings.coverage_note"
+            tag="div"
+            class="mt-2"
+          >
+            <template #link>
+              <ExternalLink
+                :url="externalLinks.integrations"
+                :text="t('module_settings.integrations_link_label')"
+              />
+            </template>
+          </i18n-t>
         </RuiAlert>
         <ModuleSelector />
       </div>

--- a/rotkehlchen/accounting/history_base_entries.py
+++ b/rotkehlchen/accounting/history_base_entries.py
@@ -84,6 +84,7 @@ class EventsAccountant:
                     f'Multi trade events are not supported in accounting yet, so the '
                     f'multi trade with identifier {group_id} is not included in the report.',
                 )
+            self.pot.events_skipped_no_rule += 1
             log.debug(
                 f'During transaction accounting found history base entry {event} '
                 f'with no mapped event settings. Skipping...',

--- a/rotkehlchen/accounting/pot.py
+++ b/rotkehlchen/accounting/pot.py
@@ -79,6 +79,9 @@ class AccountingPot(CustomizableDateMixin):
         )
         self.pnls = PnlTotals()
         self.processed_events: list[ProcessedAccountingEvent] = []
+        # events excluded from the report because no accounting rule matched them.
+        # Surfaced to the user so the report doesn't silently omit data.
+        self.events_skipped_no_rule = 0
         self.events_accountant = EventsAccountant(
             evm_accounting_aggregators=evm_accounting_aggregators,
             pot=self,
@@ -200,6 +203,7 @@ class AccountingPot(CustomizableDateMixin):
         self.cost_basis.reset(settings)
         self.events_accountant.reset()
         self.processed_events = []
+        self.events_skipped_no_rule = 0
         self._pending_report_rows = []
 
     def add_in_event(

--- a/rotkehlchen/api/services/history.py
+++ b/rotkehlchen/api/services/history.py
@@ -219,6 +219,7 @@ class HistoryService:
             'report_id': pot.report_id,
             'missing_acquisitions': processed_missing_acquisitions,
             'missing_prices': processed_missing_prices,
+            'events_skipped_no_rule': pot.events_skipped_no_rule,
         }
         return {'result': result, 'message': '', 'status_code': HTTPStatus.OK}
 

--- a/rotkehlchen/api/services/transactions.py
+++ b/rotkehlchen/api/services/transactions.py
@@ -14,6 +14,7 @@ from rotkehlchen.chain.evm.types import NodeName, string_to_evm_address
 from rotkehlchen.chain.gnosis.modules.gnosis_pay.constants import CPT_GNOSIS_PAY
 from rotkehlchen.chain.mixins.rpc_nodes import NodeStatus
 from rotkehlchen.chain.zksync_lite.constants import ZKL_IDENTIFIER
+from rotkehlchen.concurrency import exception_of, spawn, wait
 from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.db.eth2 import DBEth2
 from rotkehlchen.db.evmtx import DBEvmTx
@@ -509,27 +510,45 @@ class TransactionsService:
                 else:
                     del blockchain_addresses[chain]
 
+        def _query_one_chain(
+                blockchain: CHAINS_WITH_TRANSACTIONS_TYPE,
+                addresses: ListOfBlockchainAddresses,
+        ) -> None:
+            self.rotkehlchen.chains_aggregator.get_chain_manager(
+                blockchain=blockchain,
+            ).query_transactions(
+                addresses=addresses,
+                from_timestamp=from_timestamp,
+                to_timestamp=to_timestamp,
+            )
+
+        # Query all chains concurrently instead of serially, so the first visible
+        # sync phase takes max-of-chains instead of sum-of-chains. Independent
+        # backends (per-chain RPC nodes) parallelize freely, while shared upstreams
+        # (etherscan-v2's unified key) are gated by the per-client TokenBucket. The
+        # per-(address, chain) TRANSACTION_STATUS websocket messages already render
+        # concurrent chains correctly in the frontend progress panel.
+        tasks = {
+            blockchain: spawn(_query_one_chain, blockchain, addresses)
+            for blockchain, addresses in blockchain_addresses.items()
+        }
+        wait(list(tasks.values()))
+
         result, message, status_code = True, '', HTTPStatus.OK
-        for blockchain, addresses in blockchain_addresses.items():
-            try:
-                self.rotkehlchen.chains_aggregator.get_chain_manager(
-                    blockchain=blockchain,
-                ).query_transactions(
-                    addresses=addresses,
-                    from_timestamp=from_timestamp,
-                    to_timestamp=to_timestamp,
-                )
-            except AttributeError:
+        for blockchain, task in tasks.items():
+            if (chain_exception := exception_of(task)) is None:
+                continue
+            if isinstance(chain_exception, AttributeError):
                 result = False
                 message = f'Transaction querying for {blockchain} is not implemented.'
                 status_code = HTTPStatus.BAD_REQUEST
-                break
-            except RemoteError as e:
-                result, message, status_code = False, str(e), HTTPStatus.BAD_GATEWAY
-                break
-            except sqlcipher.OperationalError as e:  # pylint: disable=no-member
-                result, message, status_code = False, str(e), HTTPStatus.BAD_REQUEST
-                break
+            elif isinstance(chain_exception, RemoteError):
+                result, message, status_code = False, str(chain_exception), HTTPStatus.BAD_GATEWAY
+            elif isinstance(chain_exception, sqlcipher.OperationalError):  # pylint: disable=no-member
+                result, message, status_code = False, str(chain_exception), HTTPStatus.BAD_REQUEST
+            else:
+                raise chain_exception
+            break
 
         return {'result': result, 'message': message, 'status_code': status_code}
 

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -67,7 +67,7 @@ from rotkehlchen.chain.optimism.modules.velodrome.balances import VelodromeBalan
 from rotkehlchen.chain.optimism.modules.walletconnect.balances import WalletconnectBalances
 from rotkehlchen.chain.substrate.manager import wait_until_a_node_is_available
 from rotkehlchen.chain.substrate.utils import SUBSTRATE_NODE_CONNECTION_TIMEOUT
-from rotkehlchen.concurrency import exception_of, spawn, wait
+from rotkehlchen.concurrency import exception_of, result_of, spawn, wait
 from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ONE, ZERO
 from rotkehlchen.constants.assets import A_BCH, A_BTC, A_DAI, A_ETH, A_ETH2
 from rotkehlchen.constants.timing import HOUR_IN_SECONDS
@@ -1304,6 +1304,55 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             if EvmIndexer.ETHERSCAN not in chain_manager.node_inquirer.available_indexers:
                 chain_manager.node_inquirer.available_indexers[EvmIndexer.ETHERSCAN] = chain_manager.node_inquirer.etherscan  # noqa: E501
 
+    def _check_single_chain_activity(
+            self,
+            address: ChecksumEvmAddress,
+            chain: SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
+    ) -> bool | None:
+        """Checks whether address is active in the given chain.
+        Returns True if active, False if not and None if we couldn't query the chain.
+        """
+        chain_manager = self.get_chain_manager(chain)
+        try:
+            if chain == SupportedBlockchain.AVALANCHE:
+                avax_manager = cast('AvalancheManager', chain_manager)
+                try:
+                    # just check balance and nonce in avalanche
+                    return (
+                        avax_manager.w3.eth.get_transaction_count(address) != 0 or
+                        avax_manager.get_avax_balance(address) != ZERO
+                    )
+                except (requests.exceptions.RequestException, Web3Exception) as e:
+                    log.error('Failed to check %s activity in avalanche due to %s', address, e)
+                    return None
+
+            if chain == SupportedBlockchain.ZKSYNC_LITE:
+                options = {'from': 'latest', 'limit': 1, 'direction': 'older'}
+                try:
+                    response = self.zksync_lite._query_api(
+                        url=f'accounts/{address}/transactions',
+                        options=options,
+                    )
+                except RemoteError:
+                    return None
+
+                return bool(response.get('list', None))  # falsy -> None or no transactions
+
+            evm_manager = cast('EvmManager', chain_manager)
+            chain_activity = evm_manager.node_inquirer.has_activity(
+                chain_id=chain.to_chain_id(),
+                account=address,
+            )
+            only_token_spam = (
+                chain_activity == HasChainActivity.TOKENS and
+                evm_manager.transactions.address_has_been_spammed(address=address)
+            )
+        except RemoteError as e:
+            log.error('%s when checking if %s is active at %s', e, address, chain)
+            return None
+        else:
+            return not (only_token_spam or chain_activity == HasChainActivity.NONE)
+
     def check_single_address_activity(
             self,
             address: ChecksumEvmAddress,
@@ -1311,61 +1360,25 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
     ) -> tuple[list[SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE], list[SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE]]:
         """Checks whether address is active in the given chains.
         Returns a list of active chains and a list of chains where we couldn't query info
+
+        The per-chain checks run concurrently: independent backends (per-chain RPC
+        nodes) parallelize freely, while calls into shared upstreams (etherscan-v2's
+        unified key) are gated by the per-client TokenBucket. This turns the wait
+        from sum-of-chains into max-of-chains, which matters a lot when adding an
+        account since the user is blocked on the result.
         """
         active_chains = []
         failed_to_query_chains: list[SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE] = []
-        for chain in chains:
-            chain_manager = self.get_chain_manager(chain)
-            try:
-                if chain == SupportedBlockchain.AVALANCHE:
-                    avax_manager = cast('AvalancheManager', chain_manager)
-                    try:
-                        # just check balance and nonce in avalanche
-                        has_activity = (
-                            avax_manager.w3.eth.get_transaction_count(address) != 0 or
-                            avax_manager.get_avax_balance(address) != ZERO
-                        )
-                    except (requests.exceptions.RequestException, Web3Exception) as e:
-                        log.error(f'Failed to check {address} activity in avalanche due to {e!s}')
-                        failed_to_query_chains.append(chain)
-                        has_activity = False
-
-                    if has_activity is False:
-                        continue
-
-                elif chain == SupportedBlockchain.ZKSYNC_LITE:
-                    options = {'from': 'latest', 'limit': 1, 'direction': 'older'}
-                    try:
-                        response = self.zksync_lite._query_api(
-                            url=f'accounts/{address}/transactions',
-                            options=options,
-                        )
-                    except RemoteError:
-                        failed_to_query_chains.append(chain)
-                        continue
-                    else:
-                        result = response.get('list', None)
-                        if not result:  # falsy -> None or no transactions:
-                            continue  # do not add the address for the chain
-
-                else:
-                    evm_manager = cast('EvmManager', chain_manager)
-                    chain_activity = evm_manager.node_inquirer.has_activity(
-                        chain_id=chain.to_chain_id(),
-                        account=address,
-                    )
-                    only_token_spam = (
-                        chain_activity == HasChainActivity.TOKENS and
-                        evm_manager.transactions.address_has_been_spammed(address=address)
-                    )
-                    if only_token_spam or chain_activity == HasChainActivity.NONE:
-                        continue  # do not add the address for the chain
-            except RemoteError as e:
-                log.error(f'{e!s} when checking if {address} is active at {chain}')
+        tasks = {
+            chain: spawn(self._check_single_chain_activity, address, chain)
+            for chain in chains
+        }
+        wait(list(tasks.values()))
+        for chain, task in tasks.items():
+            if (is_active := result_of(task)) is True:
+                active_chains.append(chain)
+            elif is_active is None:
                 failed_to_query_chains.append(chain)
-                continue
-
-            active_chains.append(chain)
 
         return active_chains, failed_to_query_chains
 
@@ -1479,11 +1492,15 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
                 else:
                     chains_to_check.append(chain)
 
-            chains_with_valid_addresses = []
-            for chain in chains_to_check:
-                chains_with_valid_addresses.append(chain)
-                if chain in EVM_CHAINS_WITH_TRANSACTIONS and self.get_chain_manager(chain).node_inquirer.is_contract(address=account):  # noqa: E501
-                    evm_contract_addresses.add(account)
+            chains_with_valid_addresses = list(chains_to_check)
+            contract_tasks = [
+                spawn(self.get_chain_manager(chain).node_inquirer.is_contract, address=account)
+                for chain in chains_to_check
+                if chain in EVM_CHAINS_WITH_TRANSACTIONS
+            ]
+            wait(contract_tasks)
+            if any(result_of(task) for task in contract_tasks):
+                evm_contract_addresses.add(account)
 
             new_accounts, new_failed_accounts, had_activity = self.check_chains_and_add_accounts(
                 account=account,

--- a/rotkehlchen/chain/evm/transactions.py
+++ b/rotkehlchen/chain/evm/transactions.py
@@ -558,29 +558,37 @@ class EvmTransactions(ABC):  # noqa: B024
             if queried_from_ts is None:
                 continue
 
-            for _, timestamp in internal_txs_with_timestamps:
-                queried_to_ts = Timestamp(max(queried_from_ts, timestamp))
-                log.debug(f'Internal {self.evm_inquirer.chain_name} transactions for {address} -> update range {queried_from_ts} - {queried_to_ts}')  # noqa: E501
-                if update_ranges:  # update last queried time for address
-                    assert location_string is not None, 'should always be given for timestamps'
-                    with self.database.conn.write_ctx() as write_cursor:
-                        self.dbranges.update_used_query_range(
-                            write_cursor=write_cursor,
-                            location_string=location_string,
-                            queried_ranges=[(queried_from_ts, queried_to_ts)],
-                        )
+            # Update the used query range and notify the frontend once per fetched
+            # batch instead of once per internal transaction. A DeFi-heavy address
+            # can have thousands of internal txs per chain, and a committed write
+            # transaction plus a websocket message for each one is orders of
+            # magnitude slower. The cumulative effect is identical: the per-row
+            # updates only ever extended the range to the running max timestamp.
+            queried_to_ts = Timestamp(max(
+                queried_from_ts,
+                *(timestamp for _, timestamp in internal_txs_with_timestamps),
+            ))
+            log.debug('Internal %s transactions for %s -> update range %s - %s', self.evm_inquirer.chain_name, address, queried_from_ts, queried_to_ts)  # noqa: E501
+            if update_ranges:  # update last queried time for address
+                assert location_string is not None, 'should always be given for timestamps'
+                with self.database.conn.write_ctx() as write_cursor:
+                    self.dbranges.update_used_query_range(
+                        write_cursor=write_cursor,
+                        location_string=location_string,
+                        queried_ranges=[(queried_from_ts, queried_to_ts)],
+                    )
 
-                self.msg_aggregator.add_message(
-                    message_type=WSMessageType.TRANSACTION_STATUS,
-                    data={
-                        'address': address,
-                        'chain': self.evm_inquirer.blockchain.value,
-                        'subtype': str(TransactionStatusSubType.EVM),
-                        'period': [period.from_value, timestamp],
-                        'status': str(TransactionStatusStep.QUERYING_INTERNAL_TRANSACTIONS),
-                    },
-                )
-                queried_from_ts = queried_to_ts
+            self.msg_aggregator.add_message(
+                message_type=WSMessageType.TRANSACTION_STATUS,
+                data={
+                    'address': address,
+                    'chain': self.evm_inquirer.blockchain.value,
+                    'subtype': str(TransactionStatusSubType.EVM),
+                    'period': [period.from_value, queried_to_ts],
+                    'status': str(TransactionStatusStep.QUERYING_INTERNAL_TRANSACTIONS),
+                },
+            )
+            queried_from_ts = queried_to_ts
 
         return queried_hashes
 

--- a/rotkehlchen/tests/api/test_history.py
+++ b/rotkehlchen/tests/api/test_history.py
@@ -173,6 +173,7 @@ def test_query_history(rotkehlchen_api_server_with_exchanges: APIServer, start_t
     result = assert_proper_sync_response_with_result(response=response, status_code=HTTPStatus.OK)
     assert len(result['missing_acquisitions']) == (10 if fees_in_cost_basis is False else 9)
     assert len(result['missing_prices']) == 0
+    assert result['events_skipped_no_rule'] == 1
     assert result['report_id'] == 1
 
 


### PR DESCRIPTION
  Reduces expectations-mismatch churn for new users in their first session, based on recent cancellation feedback. Three areas:

  Clearer first-session expectations (copy only)
  - Adding a fresh wallet no longer reads as a failure: the "No activity" skip explains itself and how to still track the address
  - Post-add toast and exchange setup copy now say what actually happens next (balances now, trades/history when the History page is opened) instead of overpromising "automatic" imports
  - Dashboard idle banner and sync panel explain the local-first first sync, including the personal Etherscan key tip
  - History no longer shows "No events found — add exchanges…" while the first sync is still running
  - Early-integration warning (previously Solana-only) extended to Avalanche, Hyperliquid and Monad
  - Module Settings clarifies it's only balance-query modules and links the full integrations list
  - Misc: garbled "to begin to begin processing" string fixed; backend skipped-data warnings get a scannable notification title

  Data completeness surfaced where users look (addresses "incorrect results" churn)
  - New dashboard chip row under net worth: N assets without a price · N undecoded transactions · N data issues, each linking to the relevant page
  - Assets no oracle could price show – with a tooltip instead of a fake $0.00
  - Leftover undecoded transactions now count into the History "Actions needed" badge/panel
  - Events skipped for missing accounting rules are counted and exposed via the actionable-items endpoint
  - PnL report shows a warning banner when totals are affected by missing acquisitions/prices/skipped events, and non-latest reports explain why issue details are unavailable instead of hiding them

  First-sync performance
  - Add-account activity/contract checks run per-chain concurrently → blocking modal drops from sum-of-chains (~30–60 s) to roughly the slowest chain
  - refresh_transactions queries chains concurrently (~3–5× on the first visible sync phase)
  - Internal-tx bookkeeping batched per page instead of per row (eliminates thousands of DB commits + WS messages for DeFi-heavy addresses)