### PR TITLE
Silence error noise on quit and cancelled requests

### DIFF
--- a/frontend/app/electron/ipc-commands.ts
+++ b/frontend/app/electron/ipc-commands.ts
@@ -42,6 +42,8 @@ export const IpcCommands = {
   SYNC_GET_STARTUP_ERROR: 'SYNC_GET_STARTUP_ERROR',
   RENDERER_READY: 'RENDERER_READY',
   STARTUP_ERROR: 'STARTUP_ERROR',
+  // Shutdown notice, main -> renderer, one-way
+  APP_CLOSING: 'APP_CLOSING',
 } as const;
 
 export type IpcCommands = typeof IpcCommands[keyof typeof IpcCommands];

--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -238,13 +238,17 @@ export class Application {
 
     this.cleanup();
     this.menu.cleanup();
-    this.window.cleanup();
     this.tray.cleanup();
     this.ipc.cleanup();
     try {
       await this.processHandler.stop();
     }
     finally {
+      // Destroy the window only now: it kept the shutdown screen visible while
+      // the backend was torn down, and releasing it here makes sure it cannot
+      // keep the process alive.
+      this.window.destroy();
+
       // `will-quit` preventDefault()s, so this is the only thing that ends the
       // process - every platform must reach it.
       //

--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -230,6 +230,12 @@ export class Application {
   }
 
   private async quit() {
+    // Tell the renderer before anything is torn down: it swaps in the shutdown
+    // screen, which unmounts the notification popup, so requests unwinding
+    // against the dying backend cannot surface errors over a closing window.
+    // Must run before window.cleanup() drops the webContents.
+    this.window.notifyClosing();
+
     this.cleanup();
     this.menu.cleanup();
     this.window.cleanup();

--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -239,7 +239,6 @@ export class Application {
     this.cleanup();
     this.menu.cleanup();
     this.tray.cleanup();
-    this.ipc.cleanup();
     try {
       await this.processHandler.stop();
     }
@@ -248,6 +247,12 @@ export class Application {
       // the backend was torn down, and releasing it here makes sure it cannot
       // keep the process alive.
       this.window.destroy();
+
+      // Drop the IPC handlers only once the renderer is gone. It stays alive
+      // for the whole teardown above and keeps invoking (provider detection,
+      // for one), which would fail with "No handler registered" if the handlers
+      // were released any earlier.
+      await this.ipc.cleanup();
 
       // `will-quit` preventDefault()s, so this is the only thing that ends the
       // process - every platform must reach it.

--- a/frontend/app/electron/main/ipc-setup.ts
+++ b/frontend/app/electron/main/ipc-setup.ts
@@ -42,6 +42,8 @@ export class IpcManager {
   private readonly oauthHandlers: OAuthHandlers;
 
   private callbacks: Callbacks | null = null;
+  private readonly registeredListeners: string[] = [];
+  private readonly registeredHandlers: string[] = [];
 
   private get requireCallbacks(): Callbacks {
     const callbacks = this.callbacks;
@@ -79,6 +81,25 @@ export class IpcManager {
     });
   }
 
+  /**
+   * Registers an `ipcMain` listener and records its channel so `cleanup()` can
+   * remove it again. Registering through here rather than touching `ipcMain`
+   * directly is what keeps teardown complete as handlers get added over time.
+   */
+  private on(channel: string, listener: Parameters<typeof ipcMain.on>[1]): void {
+    this.registeredListeners.push(channel);
+    ipcMain.on(channel, listener);
+  }
+
+  /**
+   * Registers an `ipcMain` invoke handler, recorded for `cleanup()` the same way
+   * as {@link on}. Handlers need `removeHandler`, not `removeAllListeners`.
+   */
+  private handle(channel: string, listener: Parameters<typeof ipcMain.handle>[1]): void {
+    this.registeredHandlers.push(channel);
+    ipcMain.handle(channel, listener);
+  }
+
   initialize(callbacks: Callbacks) {
     this.callbacks = callbacks;
     this.logger.info('Registering IPC handlers');
@@ -105,68 +126,68 @@ export class IpcManager {
     });
 
     // System handlers
-    ipcMain.on(IpcCommands.SYNC_GET_DEBUG, (event) => {
+    this.on(IpcCommands.SYNC_GET_DEBUG, (event) => {
       event.returnValue = this.systemHandlers.getDebugSettings();
     });
-    ipcMain.on(IpcCommands.SYNC_API_URL, (event) => {
+    this.on(IpcCommands.SYNC_API_URL, (event) => {
       event.returnValue = this.systemHandlers.getApiUrls();
     });
-    ipcMain.on(IpcCommands.PREMIUM_LOGIN, (_event, showPremium) => {
+    this.on(IpcCommands.PREMIUM_LOGIN, (_event, showPremium) => {
       callbacks.updatePremiumMenu(showPremium);
     });
-    ipcMain.handle(IpcCommands.INVOKE_CLOSE_APP, callbacks.quit);
-    ipcMain.handle(IpcCommands.INVOKE_OPEN_URL, async (_, url: string) => this.systemHandlers.openUrl(url));
-    ipcMain.handle(IpcCommands.INVOKE_OPEN_DIRECTORY, async (_, title: string, defaultPath?: string) => this.systemHandlers.openDirectory(title, defaultPath));
-    ipcMain.handle(IpcCommands.INVOKE_OPEN_PATH, (_, path: string) => this.systemHandlers.openPath(path));
-    ipcMain.handle(IpcCommands.INVOKE_CONFIG, async (_, defaultConfig: boolean) => this.systemHandlers.getConfig(defaultConfig));
-    ipcMain.handle(IpcCommands.INVOKE_VERSION, () => this.systemHandlers.getVersion());
-    ipcMain.handle(IpcCommands.INVOKE_IS_MAC, () => this.systemHandlers.getIsMac());
-    ipcMain.handle(IpcCommands.INVOKE_THEME, (_, selectedTheme: number) => this.systemHandlers.setSelectedTheme(selectedTheme));
-    ipcMain.on(IpcCommands.LOG_TO_FILE, (_, level: LogLevel, message: string) => {
+    this.handle(IpcCommands.INVOKE_CLOSE_APP, callbacks.quit);
+    this.handle(IpcCommands.INVOKE_OPEN_URL, async (_, url: string) => this.systemHandlers.openUrl(url));
+    this.handle(IpcCommands.INVOKE_OPEN_DIRECTORY, async (_, title: string, defaultPath?: string) => this.systemHandlers.openDirectory(title, defaultPath));
+    this.handle(IpcCommands.INVOKE_OPEN_PATH, (_, path: string) => this.systemHandlers.openPath(path));
+    this.handle(IpcCommands.INVOKE_CONFIG, async (_, defaultConfig: boolean) => this.systemHandlers.getConfig(defaultConfig));
+    this.handle(IpcCommands.INVOKE_VERSION, () => this.systemHandlers.getVersion());
+    this.handle(IpcCommands.INVOKE_IS_MAC, () => this.systemHandlers.getIsMac());
+    this.handle(IpcCommands.INVOKE_THEME, (_, selectedTheme: number) => this.systemHandlers.setSelectedTheme(selectedTheme));
+    this.on(IpcCommands.LOG_TO_FILE, (_, level: LogLevel, message: string) => {
       this.systemHandlers.logToFile(level, message);
     });
-    ipcMain.on(IpcCommands.SET_LOG_LEVEL, (_, level: LogLevel) => {
+    this.on(IpcCommands.SET_LOG_LEVEL, (_, level: LogLevel) => {
       this.systemHandlers.setLogLevel(level);
     });
-    ipcMain.on(IpcCommands.TRAY_UPDATE, (_event, trayUpdate: TrayUpdate) => {
+    this.on(IpcCommands.TRAY_UPDATE, (_event, trayUpdate: TrayUpdate) => {
       this.systemHandlers.updateTray(trayUpdate);
     });
 
     // Backend handlers
-    ipcMain.handle(IpcCommands.INVOKE_SUBPROCESS_START, async (_event, options) => this.backendHandlers.restartBackend(options));
+    this.handle(IpcCommands.INVOKE_SUBPROCESS_START, async (_event, options) => this.backendHandlers.restartBackend(options));
 
     // Update handlers
-    ipcMain.handle(IpcCommands.INVOKE_UPDATE_CHECK, this.updateHandlers.checkForUpdates);
-    ipcMain.handle(IpcCommands.INVOKE_DOWNLOAD_UPDATE, this.updateHandlers.downloadUpdate);
-    ipcMain.handle(IpcCommands.INVOKE_INSTALL_UPDATE, this.updateHandlers.installUpdate);
+    this.handle(IpcCommands.INVOKE_UPDATE_CHECK, this.updateHandlers.checkForUpdates);
+    this.handle(IpcCommands.INVOKE_DOWNLOAD_UPDATE, this.updateHandlers.downloadUpdate);
+    this.handle(IpcCommands.INVOKE_INSTALL_UPDATE, this.updateHandlers.installUpdate);
 
     // Security handlers
-    ipcMain.handle(IpcCommands.INVOKE_STORE_PASSWORD, async (_, credentials: Credentials) => this.securityHandlers.storePassword(credentials));
-    ipcMain.handle(IpcCommands.INVOKE_GET_PASSWORD, async (_, username: string) => this.securityHandlers.getPassword(username));
-    ipcMain.handle(IpcCommands.INVOKE_CLEAR_PASSWORD, async () => this.securityHandlers.clearPassword());
+    this.handle(IpcCommands.INVOKE_STORE_PASSWORD, async (_, credentials: Credentials) => this.securityHandlers.storePassword(credentials));
+    this.handle(IpcCommands.INVOKE_GET_PASSWORD, async (_, username: string) => this.securityHandlers.getPassword(username));
+    this.handle(IpcCommands.INVOKE_CLEAR_PASSWORD, async () => this.securityHandlers.clearPassword());
 
     // Wallet import handlers
-    ipcMain.handle(IpcCommands.INVOKE_WALLET_IMPORT, this.walletImportHandlers.importFromWallet);
+    this.handle(IpcCommands.INVOKE_WALLET_IMPORT, this.walletImportHandlers.importFromWallet);
 
     // Wallet bridge IPC handlers
-    ipcMain.handle(IpcCommands.OPEN_WALLET_CONNECT_BRIDGE, this.walletBridgeIpcHandlers.openWalletConnectBridge);
-    ipcMain.handle(IpcCommands.WALLET_BRIDGE_HTTP_LISTENING, this.walletBridgeIpcHandlers.handleWalletBridgeHttpListening);
-    ipcMain.handle(IpcCommands.WALLET_BRIDGE_WS_LISTENING, this.walletBridgeIpcHandlers.handleWalletBridgeWsListening);
-    ipcMain.handle(IpcCommands.WALLET_BRIDGE_CLIENT_READY, this.walletBridgeIpcHandlers.handleWalletBridgeClientReady);
-    ipcMain.on(IpcCommands.USER_LOGOUT, () => {
+    this.handle(IpcCommands.OPEN_WALLET_CONNECT_BRIDGE, this.walletBridgeIpcHandlers.openWalletConnectBridge);
+    this.handle(IpcCommands.WALLET_BRIDGE_HTTP_LISTENING, this.walletBridgeIpcHandlers.handleWalletBridgeHttpListening);
+    this.handle(IpcCommands.WALLET_BRIDGE_WS_LISTENING, this.walletBridgeIpcHandlers.handleWalletBridgeWsListening);
+    this.handle(IpcCommands.WALLET_BRIDGE_CLIENT_READY, this.walletBridgeIpcHandlers.handleWalletBridgeClientReady);
+    this.on(IpcCommands.USER_LOGOUT, () => {
       this.walletBridgeIpcHandlers.handleUserLogout();
       startPromise(this.oauthHandlers.clearOAuthCookies());
     });
 
     // Wallet Bridge handlers (from existing handler class)
-    ipcMain.handle(IpcCommands.WALLET_BRIDGE_REQUEST, this.walletBridgeHandlers.handleWalletBridgeRequest);
-    ipcMain.handle(IpcCommands.WALLET_BRIDGE_IS_CLIENT_CONNECTED, this.walletBridgeHandlers.handleWalletBridgeConnectionStatus);
-    ipcMain.handle(IpcCommands.WALLET_BRIDGE_STOP_SERVERS, this.walletBridgeIpcHandlers.handleStopServers);
+    this.handle(IpcCommands.WALLET_BRIDGE_REQUEST, this.walletBridgeHandlers.handleWalletBridgeRequest);
+    this.handle(IpcCommands.WALLET_BRIDGE_IS_CLIENT_CONNECTED, this.walletBridgeHandlers.handleWalletBridgeConnectionStatus);
+    this.handle(IpcCommands.WALLET_BRIDGE_STOP_SERVERS, this.walletBridgeIpcHandlers.handleStopServers);
 
     // EIP-6963 Provider Detection handlers
-    ipcMain.handle(IpcCommands.WALLET_BRIDGE_GET_PROVIDERS, this.walletBridgeIpcHandlers.getAvailableProviders);
-    ipcMain.handle(IpcCommands.WALLET_BRIDGE_SELECT_PROVIDER, this.walletBridgeIpcHandlers.selectProvider);
-    ipcMain.handle(IpcCommands.WALLET_BRIDGE_GET_SELECTED_PROVIDER, this.walletBridgeIpcHandlers.getSelectedProvider);
+    this.handle(IpcCommands.WALLET_BRIDGE_GET_PROVIDERS, this.walletBridgeIpcHandlers.getAvailableProviders);
+    this.handle(IpcCommands.WALLET_BRIDGE_SELECT_PROVIDER, this.walletBridgeIpcHandlers.selectProvider);
+    this.handle(IpcCommands.WALLET_BRIDGE_GET_SELECTED_PROVIDER, this.walletBridgeIpcHandlers.getSelectedProvider);
   }
 
   /**
@@ -177,11 +198,23 @@ export class IpcManager {
     startPromise(this.oauthHandlers.clearOAuthCookies('startup'));
   }
 
-  cleanup(): void {
+  async cleanup(): Promise<void> {
     this.logger.info('Cleaning up IPC manager resources...');
 
-    // Stop WebSocket server
-    this.walletBridgeWebSocketServer.stop();
+    // Drop every registered handler. They close over this manager and its
+    // handler classes, and a live handler can keep the process from exiting.
+    for (const channel of this.registeredListeners)
+      ipcMain.removeAllListeners(channel);
+
+    for (const channel of this.registeredHandlers)
+      ipcMain.removeHandler(channel);
+
+    this.registeredListeners.length = 0;
+    this.registeredHandlers.length = 0;
+    this.callbacks = null;
+
+    // Stop WebSocket server, waiting for it to release its handle
+    await this.walletBridgeWebSocketServer.stop();
 
     // Cleanup wallet import handlers (they manage their own servers)
     this.walletImportHandlers.cleanup();

--- a/frontend/app/electron/main/wallet-bridge-ws-types.ts
+++ b/frontend/app/electron/main/wallet-bridge-ws-types.ts
@@ -13,6 +13,9 @@ export const IDLE_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 
 export const REQUEST_TIMEOUT_MS = 60 * 1000; // 60 seconds
 
+// How long quit waits for the wallet bridge server to release its handle
+export const SERVER_CLOSE_TIMEOUT_MS = 2000; // 2 seconds
+
 export const WEBSOCKET_PATH = '/wallet-bridge';
 
 export const IPC_CONNECTION_STATUS_CHANNEL = 'WALLET_BRIDGE_CONNECTION_STATUS';

--- a/frontend/app/electron/main/window-manager.ts
+++ b/frontend/app/electron/main/window-manager.ts
@@ -228,6 +228,18 @@ export class WindowManager {
     this.window = null;
   }
 
+  /**
+   * Like {@link cleanup}, but also destroys the BrowserWindow. Called at the end
+   * of quit so the window can stay visible (shutdown screen) through teardown,
+   * yet not keep the process alive afterwards (esp. Windows, no final app.exit).
+   */
+  destroy(): void {
+    const window = this.window;
+    this.cleanup();
+    if (window && !window.isDestroyed())
+      window.destroy();
+  }
+
   private setupEventListeners(window: BrowserWindow) {
     window.on('close', e => this.handleClose(e));
     window.on('closed', () => this.handleClosed());
@@ -306,21 +318,11 @@ export class WindowManager {
   }
 
   /**
-   * Tells the renderer we are quitting so it can swap in the shutdown screen
-   * and stop talking to the backend. One-way: we do not wait for a reply, since
-   * nothing in the teardown depends on the renderer having finished.
+   * Tells the renderer we are quitting so it can swap in the shutdown screen and
+   * stop talking to the backend. One-way: nothing in teardown waits on it.
    */
   notifyClosing(): void {
-    const webContents = this.window?.webContents;
-    if (!webContents || webContents.isDestroyed())
-      return;
-
-    try {
-      webContents.send(IpcCommands.APP_CLOSING);
-    }
-    catch (error) {
-      this.logger.error('Failed to notify renderer of shutdown:', error);
-    }
+    this.sendIpcMessage(IpcCommands.APP_CLOSING);
   }
 
   sendIpcMessage(channel: string, ...args: any[]): void {

--- a/frontend/app/electron/main/window-manager.ts
+++ b/frontend/app/electron/main/window-manager.ts
@@ -305,6 +305,24 @@ export class WindowManager {
     }
   }
 
+  /**
+   * Tells the renderer we are quitting so it can swap in the shutdown screen
+   * and stop talking to the backend. One-way: we do not wait for a reply, since
+   * nothing in the teardown depends on the renderer having finished.
+   */
+  notifyClosing(): void {
+    const webContents = this.window?.webContents;
+    if (!webContents || webContents.isDestroyed())
+      return;
+
+    try {
+      webContents.send(IpcCommands.APP_CLOSING);
+    }
+    catch (error) {
+      this.logger.error('Failed to notify renderer of shutdown:', error);
+    }
+  }
+
   sendIpcMessage(channel: string, ...args: any[]): void {
     try {
       if (this.window?.webContents) {

--- a/frontend/app/electron/main/ws.ts
+++ b/frontend/app/electron/main/ws.ts
@@ -10,6 +10,7 @@ import {
   IDLE_TIMEOUT_MS,
   type PendingRequest,
   REQUEST_TIMEOUT_MS,
+  SERVER_CLOSE_TIMEOUT_MS,
   type WalletBridgeIpcCallbacks,
   WEBSOCKET_PATH,
 } from './wallet-bridge-ws-types';
@@ -218,8 +219,8 @@ export class WalletBridgeWebSocketServer {
     return !!this.wsServer;
   }
 
-  /** Disconnect all connections and stop the server */
-  public disconnect(): void {
+  /** Tear down connection state, leaving the server itself alone */
+  private teardown(): void {
     // Clear idle timer
     this.clearIdleTimer();
 
@@ -232,11 +233,6 @@ export class WalletBridgeWebSocketServer {
     // Clear all connection mappings
     this.connectionManager.clearAll();
 
-    if (this.wsServer) {
-      this.wsServer.close();
-      this.wsServer = undefined;
-    }
-
     // Reject all pending requests
     this.pendingRequests.forEach(({ reject }) => {
       reject(new Error('Wallet bridge disconnected'));
@@ -244,9 +240,48 @@ export class WalletBridgeWebSocketServer {
     this.pendingRequests.clear();
   }
 
-  /** Stop the server (alias for disconnect) */
-  public stop(): void {
-    this.disconnect();
+  /** Disconnect all connections and stop the server */
+  public disconnect(): void {
+    this.teardown();
+
+    if (this.wsServer) {
+      this.wsServer.close();
+      this.wsServer = undefined;
+    }
+  }
+
+  /**
+   * Stop the server and wait for it to release its handle.
+   *
+   * Used on quit, where `disconnect()` is not enough: `close()` only stops new
+   * connections and resolves once the existing ones end, so a socket whose peer
+   * never answers keeps the handle, and with it the process, alive.
+   */
+  public async stop(): Promise<void> {
+    const server = this.wsServer;
+
+    // Terminate rather than close: a graceful close waits on a peer that may
+    // never reply while we are quitting.
+    for (const client of server?.clients ?? [])
+      client.terminate();
+
+    this.teardown();
+    this.wsServer = undefined;
+
+    if (!server)
+      return;
+
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.logger.warn('Timed out waiting for the wallet bridge server to close');
+        resolve();
+      }, SERVER_CLOSE_TIMEOUT_MS);
+
+      server.close(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
   }
 
   public setOnBridgeDisconnected(callback: () => void): void {

--- a/frontend/app/electron/preload/index.ts
+++ b/frontend/app/electron/preload/index.ts
@@ -45,6 +45,10 @@ contextBridge.exposeInMainWorld('interop', {
       });
     }
 
+    ipcRenderer.on(IpcCommands.APP_CLOSING, () => {
+      listeners.onAppClosing?.();
+    });
+
     // Signal to main process that renderer is ready for async messages
     ipcRenderer.send(IpcCommands.RENDERER_READY);
   },

--- a/frontend/app/shared/ipc.ts
+++ b/frontend/app/shared/ipc.ts
@@ -103,6 +103,12 @@ export interface Listeners {
   onAbout: () => void;
   onRestart: () => void;
   onOAuthCallback?: (oAuthResult: OAuthResult) => void;
+  /**
+   * Invoked when the main process is about to quit, before the backend
+   * subprocesses are terminated. Gives the renderer a chance to swap in the
+   * shutdown screen and stop talking to a backend that is going down.
+   */
+  onAppClosing?: () => void;
 }
 
 export interface Interop {

--- a/frontend/app/src/App.spec.ts
+++ b/frontend/app/src/App.spec.ts
@@ -1,0 +1,45 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * The quitting flag lives in a `createGlobalState` singleton with no reset, so
+ * each test needs a fresh module graph to start from "not quitting".
+ */
+async function loadApp(): Promise<{
+  App: typeof import('@/App.vue').default;
+  AppQuitting: typeof import('@/modules/shell/app/AppQuitting.vue').default;
+  LayoutWrapper: typeof import('@/modules/shell/layout/LayoutWrapper.vue').default;
+  useAppQuitting: typeof import('@/modules/shell/app/use-app-quitting').useAppQuitting;
+}> {
+  vi.resetModules();
+  return {
+    App: (await import('@/App.vue')).default,
+    AppQuitting: (await import('@/modules/shell/app/AppQuitting.vue')).default,
+    LayoutWrapper: (await import('@/modules/shell/layout/LayoutWrapper.vue')).default,
+    useAppQuitting: (await import('@/modules/shell/app/use-app-quitting')).useAppQuitting,
+  };
+}
+
+describe('app', () => {
+  it('should render the layout while not quitting', async () => {
+    const { App, AppQuitting, LayoutWrapper } = await loadApp();
+
+    const wrapper = mount(App, { shallow: true });
+
+    expect(wrapper.findComponent(LayoutWrapper).exists()).toBe(true);
+    expect(wrapper.findComponent(AppQuitting).exists()).toBe(false);
+  });
+
+  it('should swap the layout for the shutdown screen when quitting', async () => {
+    const { App, AppQuitting, LayoutWrapper, useAppQuitting } = await loadApp();
+    const wrapper = mount(App, { shallow: true });
+
+    useAppQuitting().startQuitting();
+    await nextTick();
+
+    // The whole tree goes, not just the page: the notification popup lives
+    // inside the layout, and it is what would surface the shutdown errors.
+    expect(wrapper.findComponent(AppQuitting).exists()).toBe(true);
+    expect(wrapper.findComponent(LayoutWrapper).exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/App.vue
+++ b/frontend/app/src/App.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
+import AppQuitting from '@/modules/shell/app/AppQuitting.vue';
+import { useAppQuitting } from '@/modules/shell/app/use-app-quitting';
 import LayoutWrapper from '@/modules/shell/layout/LayoutWrapper.vue';
+
+const { quitting } = useAppQuitting();
 </script>
 
 <template>
-  <LayoutWrapper>
+  <AppQuitting v-if="quitting" />
+  <LayoutWrapper v-else>
     <RouterView />
   </LayoutWrapper>
 </template>

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1179,7 +1179,10 @@
   "app": {
     "copyright": "© Rotki Solutions GmbH 2018-{year}",
     "moto": "the opensource portfolio manager that protects your privacy",
-    "name": "rotki"
+    "name": "rotki",
+    "quitting": {
+      "message": "Shutting down..."
+    }
   },
   "asset_balances": {
     "loading": "Please wait while rotki queries the balances..."

--- a/frontend/app/src/modules/accounts/use-blockchain-accounts.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-accounts.ts
@@ -15,6 +15,7 @@ import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-
 import { createAccount } from '@/modules/accounts/create-account';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useEthStaking } from '@/modules/accounts/use-eth-staking';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { type BtcChains, isBtcChain } from '@/modules/core/common/chains';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -218,6 +219,9 @@ export function useBlockchainAccounts(): UseBlockchainAccountsReturn {
       return accounts.map(account => account.address);
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return null;
+
       logger.error(error);
       notifyError(
         t('actions.get_accounts.error.title'),
@@ -237,6 +241,9 @@ export function useBlockchainAccounts(): UseBlockchainAccountsReturn {
       return true;
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return false;
+
       logger.error(error);
       notifyError(
         t('actions.get_accounts.error.title'),

--- a/frontend/app/src/modules/accounts/use-eth-staking.ts
+++ b/frontend/app/src/modules/accounts/use-eth-staking.ts
@@ -5,6 +5,7 @@ import type { TaskMeta } from '@/modules/core/tasks/types';
 import { type BigNumber, Blockchain, type EthValidatorFilter } from '@rotki/common';
 import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-accounts-api';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
 import { logger } from '@/modules/core/common/logging/logging';
 import { Section } from '@/modules/core/common/status';
@@ -131,6 +132,9 @@ export function useEthStaking(): UseEthStakingReturn {
       return success;
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return false;
+
       logger.error(error);
       showErrorMessage(t('actions.delete_eth2_validator.error.title'), t('actions.delete_eth2_validator.error.description', {
         message: getErrorMessage(error),

--- a/frontend/app/src/modules/assets/prices/use-oracle-prices.ts
+++ b/frontend/app/src/modules/assets/prices/use-oracle-prices.ts
@@ -3,6 +3,7 @@ import type { OraclePriceEntry, OraclePricesQuery } from '@/modules/assets/price
 import type { Collection } from '@/modules/core/common/collection';
 import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
 import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { defaultCollectionState } from '@/modules/core/common/data/collection-utils';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -26,6 +27,9 @@ export function useOraclePrices(): UseOraclePricesReturn {
       return await fetchOraclePrices(get(payload));
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return defaultCollectionState<OraclePriceEntry>();
+
       notifyError(
         t('oracle_prices.fetch.failure.title'),
         t('oracle_prices.fetch.failure.message', { message: getErrorMessage(error) }),
@@ -46,6 +50,9 @@ export function useOraclePrices(): UseOraclePricesReturn {
       return true;
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return false;
+
       notifyError(
         t('oracle_prices.delete.failure.title'),
         t('oracle_prices.delete.failure.message', { message: getErrorMessage(error) }),

--- a/frontend/app/src/modules/assets/prices/use-price-task-manager.ts
+++ b/frontend/app/src/modules/assets/prices/use-price-task-manager.ts
@@ -6,6 +6,7 @@ import { type BigNumber, One } from '@rotki/common';
 import { AssetPriceResponse, type HistoricPricePayload, HistoricPrices, type OracleCachePayload } from '@/modules/assets/prices/price-types';
 import { usePriceApi } from '@/modules/balances/api/use-price-api';
 import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { chunkArray } from '@/modules/core/common/data/data';
 import { convertFromTimestamp } from '@/modules/core/common/data/date';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -74,6 +75,9 @@ export function usePriceTaskManager(): UsePriceTaskManagerReturn {
       }
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return;
+
       const title = t('actions.session.fetch_prices.error.title');
       const message = t('actions.session.fetch_prices.error.message', {
         error: getErrorMessage(error),

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-api.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-api.ts
@@ -2,6 +2,7 @@ import type { EvmTokensRecord } from '@/modules/balances/types/balances';
 import type { TaskMeta } from '@/modules/core/tasks/types';
 import { useBlockchainBalancesApi } from '@/modules/balances/api/use-blockchain-balances-api';
 import { useTokenDetectionStore } from '@/modules/balances/blockchain/use-token-detection-store';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { getErrorMessage, useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -58,6 +59,9 @@ export function useTokenDetectionApi(): UseTokenDetectionApiReturn {
         setState(chain, result);
       }
       catch (error: unknown) {
+        if (isRequestCancellation(error))
+          return;
+
         logger.error(error);
         notifyError(
           t('actions.balances.detect_tokens.task.title'),

--- a/frontend/app/src/modules/balances/exchanges/use-exchanges.ts
+++ b/frontend/app/src/modules/balances/exchanges/use-exchanges.ts
@@ -8,6 +8,7 @@ import { useConnectedExchangesStore } from '@/modules/balances/exchanges/use-con
 import { AssetBalances } from '@/modules/balances/types/balances';
 import { type EditExchange, Exchange, type ExchangeFormData } from '@/modules/balances/types/exchanges';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { Section, Status } from '@/modules/core/common/status';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -149,6 +150,9 @@ export function useExchanges(): UseExchangesReturn {
       return success;
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return false;
+
       showErrorMessage(
         t('actions.balances.exchange_removal.title'),
         t('actions.balances.exchange_removal.description', {

--- a/frontend/app/src/modules/balances/manual/use-manual-balances.ts
+++ b/frontend/app/src/modules/balances/manual/use-manual-balances.ts
@@ -10,6 +10,7 @@ import {
   type RawManualBalance,
 } from '@/modules/balances/types/manual-balances';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -155,6 +156,9 @@ export function useManualBalances(): UseManualBalancesReturn {
       updateBalances(balances);
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return;
+
       showErrorMessage(t('actions.balances.manual_delete.error.title'), getErrorMessage(error));
     }
   };

--- a/frontend/app/src/modules/balances/non-fungible/use-nft-price-management.ts
+++ b/frontend/app/src/modules/balances/non-fungible/use-nft-price-management.ts
@@ -2,6 +2,7 @@ import type { Ref } from 'vue';
 import type { ManualPriceFormPayload } from '@/modules/assets/prices/price-types';
 import type { NonFungibleBalance } from '@/modules/balances/types/nfbalances';
 import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 
@@ -29,7 +30,10 @@ export function useNftPriceManagement(
       await deleteLatestPrice(toDeletePrice.id);
       await fetchData();
     }
-    catch {
+    catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return;
+
       notifyError(
         t('assets.custom_price.delete.error.title'),
         t('assets.custom_price.delete.error.message', {

--- a/frontend/app/src/modules/core/api/request-queue/is-request-cancellation.ts
+++ b/frontend/app/src/modules/core/api/request-queue/is-request-cancellation.ts
@@ -1,0 +1,15 @@
+import { isAbortError } from '@/modules/core/common/helpers/is-of-enum';
+import { RequestCancelledError } from './errors';
+
+/**
+ * Check if an error means the request was cancelled rather than failed.
+ *
+ * Covers both cancellation paths: queued requests rejected by
+ * `cancel`/`cancelByTag`/`cancelAllQueued`, and in-flight requests aborted
+ * through their `AbortController`. Cancellation is expected during logout,
+ * user switch, session sync, quit and table/history navigation, so callers
+ * should bail out quietly instead of notifying the user.
+ */
+export function isRequestCancellation(error: unknown): boolean {
+  return error instanceof RequestCancelledError || isAbortError(error);
+}

--- a/frontend/app/src/modules/core/api/rotki-api.spec.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.spec.ts
@@ -2,6 +2,7 @@ import { server } from '@test/setup-files/server';
 import { http, HttpResponse } from 'msw';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defaultApiUrls } from '@/modules/core/api/api-urls';
+import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
 import { RotkiApi } from '@/modules/core/api/rotki-api';
 import { ApiValidationError } from '@/modules/core/api/types/errors';
 import { HTTPStatus } from '@/modules/core/api/types/http';
@@ -888,6 +889,48 @@ describe('modules/api/rotki-api', () => {
       );
 
       await expect(api.get('test')).rejects.toThrow();
+    });
+  });
+
+  describe('stopRequests', () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`${backendUrl}/api/1/test`, () => HttpResponse.json({ result: { ok: true }, message: '' })),
+        http.head(`${backendUrl}/api/1/test`, () => new HttpResponse(null, { status: HTTPStatus.OK })),
+      );
+    });
+
+    it('should reject a queued fetch once stopped', async () => {
+      api.stopRequests();
+
+      await expect(api.get('test')).rejects.toThrow(RequestCancelledError);
+    });
+
+    it('should reject a skipQueue fetch once stopped', async () => {
+      api.stopRequests();
+
+      await expect(api.fetch('test', { skipQueue: true })).rejects.toThrow(RequestCancelledError);
+    });
+
+    it('should reject headStatus once stopped', async () => {
+      api.stopRequests();
+
+      await expect(api.headStatus('test')).rejects.toThrow(RequestCancelledError);
+    });
+
+    it('should reject fetchBlob once stopped', async () => {
+      api.stopRequests();
+
+      await expect(api.fetchBlob('test')).rejects.toThrow(RequestCancelledError);
+    });
+
+    it('should accept requests again after setup, so a backend restart recovers', async () => {
+      api.stopRequests();
+      await expect(api.get('test')).rejects.toThrow(RequestCancelledError);
+
+      api.setup(defaultApiUrls.coreApiUrl);
+
+      await expect(api.get('test')).resolves.toEqual({ ok: true });
     });
   });
 });

--- a/frontend/app/src/modules/core/api/rotki-api.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.ts
@@ -4,6 +4,7 @@ import type { RotkiFetchOptions } from '@/modules/core/api/types';
 import { ofetch } from 'ofetch';
 import { defaultApiUrls } from '@/modules/core/api/api-urls';
 import { DEFAULT_TIMEOUT } from '@/modules/core/api/constants';
+import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
 import { RequestQueue } from '@/modules/core/api/request-queue/queue';
 import { RequestPriority } from '@/modules/core/api/request-queue/request-priority';
 import { transformRequestBody, transformRequestQuery } from '@/modules/core/api/request-transformers';
@@ -22,6 +23,7 @@ export class RotkiApi {
   private isSessionActive?: () => boolean;
   private _requestQueue: RequestQueue;
   private _colibriRequestQueue: RequestQueue;
+  private _stopped: boolean = false;
 
   constructor() {
     this._serverUrl = defaultApiUrls.coreApiUrl;
@@ -65,6 +67,18 @@ export class RotkiApi {
     this._colibriRequestQueue.cancelAll();
   }
 
+  /**
+   * Puts the api into a quitting state: rejects any new request, cancels
+   * everything queued, and aborts in-flight direct requests. Used on app
+   * shutdown so nothing keeps hitting a backend that is going down. Reset by
+   * {@link setup} if the backend is later restarted.
+   */
+  stopRequests(): void {
+    this._stopped = true;
+    this.cancelAllQueued();
+    this.cancel();
+  }
+
   getQueueMetrics(): QueueState {
     return this._requestQueue.getMetrics();
   }
@@ -97,6 +111,8 @@ export class RotkiApi {
     this._serverUrl = serverUrl;
     this._baseURL = `${serverUrl}/api/1/`;
     this.abortController = new AbortController();
+    // A fresh backend (e.g. after a restart) can accept requests again.
+    this._stopped = false;
   }
 
   setOnAuthFailure(action: () => void, isSessionActive?: () => boolean): void {
@@ -124,6 +140,9 @@ export class RotkiApi {
   }
 
   async fetch<T>(url: string, options: RotkiFetchOptions<'json', T> = {}): Promise<T> {
+    if (this._stopped)
+      throw new RequestCancelledError('Application is quitting');
+
     const {
       skipQueue,
       priority,
@@ -252,6 +271,9 @@ export class RotkiApi {
     url: string,
     options: Omit<RotkiFetchOptions, 'method' | 'retry'> = {},
   ): Promise<number> {
+    if (this._stopped)
+      throw new RequestCancelledError('Application is quitting');
+
     const { validStatuses, skipSnakeCase, query: rawQuery, baseURL, timeout } = options;
     const query = transformRequestQuery(rawQuery as Record<string, unknown> | undefined, { skipSnakeCase });
 
@@ -280,6 +302,9 @@ export class RotkiApi {
     url: string,
     options: Omit<RotkiFetchOptions, 'skipCamelCase' | 'skipRootCamelCase' | 'skipResultUnwrap'> = {},
   ): Promise<Blob> {
+    if (this._stopped)
+      throw new RequestCancelledError('Application is quitting');
+
     const { validStatuses, skipSnakeCase, ...fetchOptions } = options;
     const body = transformRequestBody(fetchOptions.body, { skipSnakeCase });
     const query = transformRequestQuery(fetchOptions.query as Record<string, unknown> | undefined, { skipSnakeCase });

--- a/frontend/app/src/modules/core/tasks/use-task-handler.spec.ts
+++ b/frontend/app/src/modules/core/tasks/use-task-handler.spec.ts
@@ -23,6 +23,9 @@ function makeTask(id: number, type: TaskType, meta: TaskMeta = getMeta()): Task<
 describe('useTaskHandler', () => {
   let handler: ReturnType<typeof import('@/modules/core/tasks/use-task-handler').useTaskHandler>;
   let store: ReturnType<typeof import('@/modules/core/tasks/use-task-store').useTaskStore>;
+  // built from the same (post-reset) module graph as the handler, otherwise the
+  // class identity differs and the handler's `instanceof` check misses
+  let cancellationError: (message: string) => Error;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -31,6 +34,8 @@ describe('useTaskHandler', () => {
 
     const { useTaskStore } = await import('@/modules/core/tasks/use-task-store');
     const { useTaskHandler } = await import('@/modules/core/tasks/use-task-handler');
+    const { RequestCancelledError } = await import('@/modules/core/api/request-queue/errors');
+    cancellationError = (message: string): Error => new RequestCancelledError(message);
     store = useTaskStore();
     handler = useTaskHandler();
   });
@@ -55,6 +60,41 @@ describe('useTaskHandler', () => {
         message: undefined,
       });
       expect(taskFn).toHaveBeenCalledOnce();
+    });
+
+    it('should return a cancelled outcome when the task start is cancelled', async () => {
+      const taskFn = vi.fn().mockRejectedValue(cancellationError('All requests cancelled'));
+
+      const outcome = await handler.runTask<string, TaskMeta>(taskFn, {
+        type: TaskType.TX,
+        meta: getMeta(),
+      });
+
+      assert(!outcome.success);
+      expect(outcome.cancelled).toBe(true);
+      expect(outcome.skipped).toBe(false);
+      expect(store.hasRunningTasks).toBe(false);
+    });
+
+    it('should return a cancelled outcome when the task start is aborted', async () => {
+      const taskFn = vi.fn().mockRejectedValue(new DOMException('aborted', 'AbortError'));
+
+      const outcome = await handler.runTask<string, TaskMeta>(taskFn, {
+        type: TaskType.TX,
+        meta: getMeta(),
+      });
+
+      assert(!outcome.success);
+      expect(outcome.cancelled).toBe(true);
+    });
+
+    it('should rethrow non-cancellation errors from the task start', async () => {
+      const taskFn = vi.fn().mockRejectedValue(new Error('backend exploded'));
+
+      await expect(handler.runTask<string, TaskMeta>(taskFn, {
+        type: TaskType.TX,
+        meta: getMeta(),
+      })).rejects.toThrow('backend exploded');
     });
 
     it('should return TaskSuccess with message when present', async () => {

--- a/frontend/app/src/modules/core/tasks/use-task-handler.ts
+++ b/frontend/app/src/modules/core/tasks/use-task-handler.ts
@@ -1,5 +1,6 @@
 import type { ActionResult } from '@rotki/common';
 import { checkIfDevelopment } from '@shared/utils';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { arrayify } from '@/modules/core/common/data/array';
 import { logger } from '@/modules/core/common/logging/logging';
 import { TaskType } from '@/modules/core/tasks/task-type';
@@ -121,7 +122,15 @@ function useTaskHandlerInternal(): {
     if (guard && store.isTaskRunning(type, meta))
       return makeSkipped('Task already running');
 
-    const { taskId } = await task();
+    let taskId: number;
+    try {
+      ({ taskId } = await task());
+    }
+    catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return makeCancelled('Request cancelled');
+      throw error;
+    }
 
     store.addTask(taskId, type, meta);
 

--- a/frontend/app/src/modules/history/use-history-data-fetching.ts
+++ b/frontend/app/src/modules/history/use-history-data-fetching.ts
@@ -1,3 +1,4 @@
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -23,6 +24,9 @@ export function useHistoryDataFetching(): UseHistoryDataFetchingReturn {
       store.setAssociatedLocations(await fetchAssociatedLocationsApi());
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return;
+
       logger.error(error);
       notifyError(
         t('actions.history.fetch_associated_locations.error.title'),
@@ -36,6 +40,9 @@ export function useHistoryDataFetching(): UseHistoryDataFetchingReturn {
       store.setLocationLabels(await fetchLocationLabelsApi());
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return;
+
       logger.error(error);
       notifyError(
         t('actions.history.fetch_location_labels.error.title'),
@@ -50,6 +57,9 @@ export function useHistoryDataFetching(): UseHistoryDataFetchingReturn {
       store.setTransactionStatusSummary(result);
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return;
+
       logger.error(error);
     }
   }

--- a/frontend/app/src/modules/session/use-periodic-data-fetcher.ts
+++ b/frontend/app/src/modules/session/use-periodic-data-fetcher.ts
@@ -1,4 +1,5 @@
 import { backoff } from '@shared/utils';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { getErrorMessage, useNotifications } from '@/modules/core/notifications/use-notifications';
 import { useSessionApi } from '@/modules/session/api/use-session-api';
 import { useSessionMetadataStore } from '@/modules/session/use-session-metadata-store';
@@ -49,6 +50,9 @@ export function usePeriodicDataFetcher(): UsePeriodicDataFetcherReturn {
       set(failedToConnect, failed ?? {});
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return;
+
       notifyError(
         t('actions.session.periodic_query.error.title'),
         t('actions.session.periodic_query.error.message', {

--- a/frontend/app/src/modules/shell/app/AppQuitting.vue
+++ b/frontend/app/src/modules/shell/app/AppQuitting.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div
+    class="fixed inset-0 flex flex-col gap-4 justify-center items-center bg-rui-grey-50 dark:bg-rui-grey-900"
+    data-testid="app-quitting"
+  >
+    <RuiProgress
+      color="primary"
+      variant="indeterminate"
+      circular
+      size="48"
+    />
+    <p class="mb-0 text-rui-text-secondary text-center">
+      {{ t('app.quitting.message') }}
+    </p>
+  </div>
+</template>

--- a/frontend/app/src/modules/shell/app/use-app-quitting.ts
+++ b/frontend/app/src/modules/shell/app/use-app-quitting.ts
@@ -1,0 +1,34 @@
+import type { Ref } from 'vue';
+
+interface UseAppQuittingInternalReturn {
+  quitting: Readonly<Ref<boolean>>;
+  startQuitting: () => void;
+}
+
+/**
+ * Tracks whether the app is shutting down.
+ *
+ * Setting this swaps the whole UI for the shutdown screen, which unmounts the
+ * notification popup along with the rest of the tree. That is what keeps the
+ * teardown quiet: the backend goes away while requests are still in flight, and
+ * their failures would otherwise surface as error notifications over a window
+ * that is about to disappear.
+ *
+ * It is a plain flag rather than a route so the swap is synchronous and cannot
+ * be delayed or vetoed by a navigation guard — any gap between the quit signal
+ * and the UI going away is a gap where those errors show up.
+ */
+function useAppQuittingInternal(): UseAppQuittingInternalReturn {
+  const quitting = shallowRef<boolean>(false);
+
+  function startQuitting(): void {
+    set(quitting, true);
+  }
+
+  return {
+    quitting: readonly(quitting),
+    startQuitting,
+  };
+}
+
+export const useAppQuitting = createGlobalState(useAppQuittingInternal);

--- a/frontend/app/src/modules/shell/app/use-backend-messages.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-messages.ts
@@ -2,9 +2,11 @@ import type { Ref } from 'vue';
 import { BackendCode, type OAuthResult } from '@shared/ipc';
 import { checkIfDevelopment, startPromise } from '@shared/utils';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { api } from '@/modules/core/api';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
 import { useMainStore } from '@/modules/core/common/use-main-store';
+import { useAppQuitting } from '@/modules/shell/app/use-app-quitting';
 import { useBackendConnection } from '@/modules/shell/app/use-backend-connection';
 import { useBackendManagement } from '@/modules/shell/app/use-backend-management';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
@@ -37,6 +39,19 @@ function useBackendMessagesInternal(): UseBackendMessagesInternalReturn {
   const { setConnectionEnabled: setWsConnectionEnabled } = useWebsocketConnection();
   const { stopConnectionAttempts } = useBackendConnection();
   const { connectionEnabled } = storeToRefs(useMainStore());
+  const { startQuitting } = useAppQuitting();
+
+  /**
+   * Halts all outbound activity against the backend: stops the connection ping
+   * loop and disables future attempts, stops all monitoring (periodic tasks,
+   * websocket, etc.), and disables websocket reconnection. Used whenever the
+   * backend is unavailable or about to become unavailable.
+   */
+  function haltBackendActivity(): void {
+    stopConnectionAttempts();
+    stopMonitoring();
+    setWsConnectionEnabled(false);
+  }
 
   /**
    * Handle a startup error by logging it and updating the appropriate state.
@@ -44,12 +59,7 @@ function useBackendMessagesInternal(): UseBackendMessagesInternalReturn {
    */
   function handleStartupError(message: string, code: BackendCode): void {
     logger.error(message, code);
-    // Stop connection ping loop and disable future connection attempts
-    stopConnectionAttempts();
-    // Stop all monitoring (periodic tasks, websocket, etc.) - backend is not available
-    stopMonitoring();
-    // Also explicitly disable websocket reconnection
-    setWsConnectionEnabled(false);
+    haltBackendActivity();
 
     if (code === BackendCode.TERMINATED) {
       set(startupErrorMessage, message);
@@ -97,6 +107,14 @@ function useBackendMessagesInternal(): UseBackendMessagesInternalReturn {
         handlers.forEach((handler) => {
           handler(oAuthResult);
         });
+      },
+      onAppClosing: () => {
+        // The app is quitting. Swap the UI for the shutdown screen first: that
+        // unmounts the notification popup, so requests still unwinding against
+        // the dying backend cannot surface errors over a closing window.
+        startQuitting();
+        haltBackendActivity();
+        api.stopRequests();
       },
       onRestart: () => {
         set(startupErrorMessage, '');

--- a/frontend/app/src/modules/staking/kraken/use-kraken-staking-operations.ts
+++ b/frontend/app/src/modules/staking/kraken/use-kraken-staking-operations.ts
@@ -4,6 +4,7 @@ import type {
   KrakenStakingPagination,
 } from '@/modules/staking/staking-types';
 import { omit } from 'es-toolkit';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { logger } from '@/modules/core/common/logging/logging';
 import { Section, Status } from '@/modules/core/common/status';
 import { getErrorMessage, useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -81,8 +82,12 @@ export function useKrakenStakingOperations(): UseKrakenStakingOperationsReturn {
       setStatus(isTaskRunning(TaskType.STAKING_KRAKEN) ? Status.REFRESHING : Status.LOADED);
     }
     catch (error: unknown) {
-      logger.error(error);
       setStatus(Status.LOADED);
+
+      if (isRequestCancellation(error))
+        return;
+
+      logger.error(error);
       notifyError(
         t('actions.kraken_staking.error.title'),
         t('actions.kraken_staking.error.message', {

--- a/frontend/app/src/modules/statistics/use-statistics-data-fetching.ts
+++ b/frontend/app/src/modules/statistics/use-statistics-data-fetching.ts
@@ -1,3 +1,4 @@
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { getErrorMessage, useNotifications } from '@/modules/core/notifications/use-notifications';
 import { useSetting } from '@/modules/settings/use-setting';
 import { useStatisticsApi } from '@/modules/statistics/api/use-statistics-api';
@@ -19,6 +20,9 @@ export function useStatisticsDataFetching(): UseStatisticsDataFetchingReturn {
       set(netValue, await api.queryNetValueData(get(nftsInNetValue)));
     }
     catch (error: unknown) {
+      if (isRequestCancellation(error))
+        return;
+
       notifyError(t('actions.statistics.net_value.error.title'), t('actions.statistics.net_value.error.message', {
         message: getErrorMessage(error),
       }), { display: false });


### PR DESCRIPTION
Stops the error-notification noise users see when in-flight requests are torn
down, in two related situations: quitting the app, and any flow that
mass-cancels requests. Also finishes off the remaining #12000 findings.

## Quit

The renderer kept rendering failures from requests unwinding against a backend
that was already going away.

- Main now sends a one-way `APP_CLOSING` IPC before anything is torn down. The
  renderer sets a quitting flag and `App.vue` swaps the whole tree for
  `AppQuitting.vue`, which unmounts the notification popup so nothing is left to
  render the failures. A flag swap is used rather than a route so it is
  synchronous and cannot be vetoed by a navigation guard.
- The renderer also halts backend activity and gates the api client, so no new
  requests start during teardown.
- The window is destroyed at the end of `quit()`. It stays alive through
  teardown so the shutdown screen remains visible, and releasing it there makes
  sure it cannot keep the process alive.

## Cancelled requests

Requests are mass-cancelled on logout, user switch, session sync, quit and
ordinary table/history navigation. Catch blocks formatted those rejections into
error toasts, for example "Failed to query accounts for MONAD: All requests
cancelled".

- New `isRequestCancellation()` classifier covering both cancellation paths:
  queued requests rejected with `RequestCancelledError`, and in-flight requests
  aborted through their `AbortController`.
- `runTask` awaited the task start outside any try/catch, so a task cancelled
  before it received an id escaped as an unhandled rejection. It now returns a
  cancelled outcome, which the existing `isActionableFailure()` checks handle at
  around 30 call sites for free.
- The 16 catch blocks that notified directly now bail out early on
  cancellation, each matching its existing return contract. Background pollers
  were the worst offenders since they get cancelled out from under the user with
  no action to attribute the failure to.

## Quit resource release

- `IpcManager.cleanup()` left all ~33 `ipcMain` registrations in place. They are
  now registered through wrappers that record the channel, so cleanup drops
  every one of them and handlers added later are torn down without anyone
  maintaining a second list.
- The wallet bridge WebSocket server was closed without being awaited. `stop()`
  now terminates the sockets, awaits the close, and gives up after a timeout so
  quit can never hang on it.

## #12000

All six findings are now covered. Findings 1, 5 and 6 were handled by the
Starling supervisor already on develop, which removed the win32 `app.exit()`
guard so every platform reaches `app.exit()`. Finding 3 (window destroy) and
findings 2 and 4 (IPC handlers, awaited WebSocket close) are in this PR.

Note that the main-process changes are not covered by the unit suite, so the
quit path is worth a manual check on Windows in particular, since that is where
the original report came from.

Gates green: 5594 unit tests, typecheck clean, no lint errors.