### PR TITLE
Decompose the login and create-account forms

### DIFF
--- a/frontend/app/src/modules/auth/create-account/CreateAccountWizard.vue
+++ b/frontend/app/src/modules/auth/create-account/CreateAccountWizard.vue
@@ -1,16 +1,14 @@
 <script lang="ts" setup>
 import type { CreateAccountMode } from '@/modules/auth/create-account/types';
 import type { CreateAccountPayload, LoginCredentials, PremiumSetup } from '@/modules/auth/login';
-import { externalLinks } from '@shared/external-links';
-import CreateAccountSubmitAnalytics
-  from '@/modules/auth/create-account/analytics/CreateAccountSubmitAnalytics.vue';
+import CreateAccountSubmitStep
+  from '@/modules/auth/create-account/analytics/CreateAccountSubmitStep.vue';
 import CreateAccountCredentials
   from '@/modules/auth/create-account/credentials/CreateAccountCredentials.vue';
 import CreateAccountIntroduction
   from '@/modules/auth/create-account/introduction/CreateAccountIntroduction.vue';
 import CreateAccountPremium from '@/modules/auth/create-account/premium/CreateAccountPremium.vue';
 import { useSavedProfiles } from '@/modules/auth/use-saved-profiles';
-import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 import RotkiLogo from '@/modules/shell/components/RotkiLogo.vue';
 
 const step = defineModel<number>('step', { required: true });
@@ -29,6 +27,31 @@ const emit = defineEmits<{
   'confirm': [payload: CreateAccountPayload];
   'clear-error': [];
 }>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const premiumEnabled = ref<boolean>(false);
+const premiumSetupForm = ref<PremiumSetup>({
+  apiKey: '',
+  apiSecret: '',
+  syncDatabase: false,
+});
+
+const credentialsForm = ref<LoginCredentials>({
+  password: '',
+  username: '',
+});
+const passwordConfirm = ref<string>('');
+const userPrompted = ref<boolean>(false);
+const submitUsageAnalytics = ref<boolean>(true);
+
+const { hasProfiles, loadProfiles } = useSavedProfiles();
+
+const isRestoreMode = computed<boolean>(() => get(mode) === 'restore');
+
+const wizardTitle = computed<string>(() =>
+  get(isRestoreMode) ? t('create_account.title_restore') : t('create_account.title'),
+);
 
 const cancel = (): void => emit('cancel');
 const errorClear = (): void => emit('clear-error');
@@ -53,53 +76,6 @@ function nextStep(): void {
   set(step, get(step) + 1);
 }
 
-const { t } = useI18n({ useScope: 'global' });
-
-const { hasProfiles, loadProfiles } = useSavedProfiles();
-
-onBeforeMount(loadProfiles);
-
-const parsedError = computed<{ hasLink: boolean; parts: string[] }>(() => {
-  const linkPlaceholder = '_DEVICE_LIMIT_LINK_';
-
-  if (!error || !error.includes(linkPlaceholder)) {
-    return {
-      hasLink: false,
-      parts: [error],
-    };
-  }
-
-  return {
-    hasLink: true,
-    parts: error.split(linkPlaceholder),
-  };
-});
-
-const premiumEnabled = ref<boolean>(false);
-const premiumSetupForm = ref<PremiumSetup>({
-  apiKey: '',
-  apiSecret: '',
-  syncDatabase: false,
-});
-
-const credentialsForm = ref<LoginCredentials>({
-  password: '',
-  username: '',
-});
-const passwordConfirm = ref<string>('');
-const userPrompted = ref<boolean>(false);
-const submitUsageAnalytics = ref<boolean>(true);
-
-const isRestoreMode = computed<boolean>(() => get(mode) === 'restore');
-
-const wizardTitle = computed<string>(() =>
-  get(isRestoreMode) ? t('create_account.title_restore') : t('create_account.title'),
-);
-
-const submitLabel = computed<string>(() =>
-  get(isRestoreMode) ? t('create_account.actions.restore_account') : t('create_account.actions.create_account'),
-);
-
 function selectMode(selected: CreateAccountMode): void {
   set(mode, selected);
   if (selected === 'restore') {
@@ -122,6 +98,8 @@ function confirm() {
 
   emit('confirm', payload);
 }
+
+onBeforeMount(loadProfiles);
 </script>
 
 <template>
@@ -171,55 +149,14 @@ function confirm() {
                 />
               </RuiTabItem>
               <RuiTabItem>
-                <div class="space-y-8">
-                  <CreateAccountSubmitAnalytics
-                    v-model:submit-usage-analytics="submitUsageAnalytics"
-                    :loading="loading"
-                  />
-                  <RuiAlert
-                    v-if="error"
-                    type="error"
-                  >
-                    <template v-if="parsedError.hasLink">
-                      {{ parsedError.parts[0] }}
-                      <i18n-t keypath="create_account.error.device_limit_link">
-                        <template #here>
-                          <ExternalLink
-                            :url="externalLinks.premiumDevices"
-                            custom
-                          >
-                            {{ t('common.here') }}
-                          </ExternalLink>
-                        </template>
-                      </i18n-t>
-                      {{ parsedError.parts[1] }}
-                    </template>
-                    <template v-else>
-                      {{ error }}
-                    </template>
-                  </RuiAlert>
-                  <div class="grid grid-cols-2 gap-4">
-                    <RuiButton
-                      size="lg"
-                      class="w-full"
-                      :disabled="loading"
-                      @click="prevStep()"
-                    >
-                      {{ t('common.actions.back') }}
-                    </RuiButton>
-                    <RuiButton
-                      data-cy="create-account__submit-analytics__button__continue"
-                      size="lg"
-                      class="w-full"
-                      :disabled="loading"
-                      :loading="loading"
-                      color="primary"
-                      @click="confirm()"
-                    >
-                      {{ submitLabel }}
-                    </RuiButton>
-                  </div>
-                </div>
+                <CreateAccountSubmitStep
+                  v-model:submit-usage-analytics="submitUsageAnalytics"
+                  :loading="loading"
+                  :mode="mode ?? 'create'"
+                  :error="error"
+                  @back="prevStep()"
+                  @confirm="confirm()"
+                />
               </RuiTabItem>
             </RuiTabItems>
           </div>

--- a/frontend/app/src/modules/auth/create-account/analytics/CreateAccountErrorAlert.spec.ts
+++ b/frontend/app/src/modules/auth/create-account/analytics/CreateAccountErrorAlert.spec.ts
@@ -1,0 +1,56 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
+import CreateAccountErrorAlert from './CreateAccountErrorAlert.vue';
+
+// The unit setup stubs I18nT with `true`, which renders none of its slots. Override it
+// with a stub that renders #here so the link branch is actually observable.
+const I18nTStub = {
+  name: 'I18nT',
+  template: '<span><slot name="here" /></span>',
+};
+
+function mountAlert(error: string): VueWrapper<InstanceType<typeof CreateAccountErrorAlert>> {
+  return mount(CreateAccountErrorAlert, {
+    global: { stubs: { I18nT: I18nTStub } },
+    props: { error },
+  });
+}
+
+describe('modules/auth/create-account/analytics/CreateAccountErrorAlert', () => {
+  it('should render a plain error without a link', () => {
+    const wrapper = mountAlert('Something went wrong');
+
+    expect(wrapper.text()).toContain('Something went wrong');
+    expect(wrapper.findComponent(ExternalLink).exists()).toBe(false);
+  });
+
+  it('should render both message parts and a link around the device-limit placeholder', () => {
+    const wrapper = mountAlert('You reached the limit._DEVICE_LIMIT_LINK_Please retry.');
+
+    expect(wrapper.findComponent(ExternalLink).exists()).toBe(true);
+    expect(wrapper.text()).toContain('You reached the limit.');
+    expect(wrapper.text()).toContain('Please retry.');
+    // the placeholder itself must never reach the user
+    expect(wrapper.text()).not.toContain('_DEVICE_LIMIT_LINK_');
+  });
+
+  it('should point the link at the premium devices doc', () => {
+    const wrapper = mountAlert('limit._DEVICE_LIMIT_LINK_retry.');
+
+    expect(wrapper.findComponent(ExternalLink).props('url')).toBeTruthy();
+  });
+
+  it('should not render a link when the placeholder is absent', () => {
+    const wrapper = mountAlert('DEVICE_LIMIT_LINK without underscores');
+
+    expect(wrapper.findComponent(ExternalLink).exists()).toBe(false);
+    expect(wrapper.text()).toContain('DEVICE_LIMIT_LINK without underscores');
+  });
+
+  it('should tolerate an empty error string', () => {
+    const wrapper = mountAlert('');
+
+    expect(wrapper.findComponent(ExternalLink).exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/auth/create-account/analytics/CreateAccountErrorAlert.vue
+++ b/frontend/app/src/modules/auth/create-account/analytics/CreateAccountErrorAlert.vue
@@ -1,0 +1,38 @@
+<script lang="ts" setup>
+import { externalLinks } from '@shared/external-links';
+import {
+  type ParsedDeviceLimitError,
+  parseDeviceLimitError,
+} from '@/modules/auth/create-account/analytics/parse-device-limit-error';
+import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
+
+const { error } = defineProps<{
+  error: string;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const parsedError = computed<ParsedDeviceLimitError>(() => parseDeviceLimitError(error));
+</script>
+
+<template>
+  <RuiAlert type="error">
+    <template v-if="parsedError.hasLink">
+      {{ parsedError.parts[0] }}
+      <i18n-t keypath="create_account.error.device_limit_link">
+        <template #here>
+          <ExternalLink
+            :url="externalLinks.premiumDevices"
+            custom
+          >
+            {{ t('common.here') }}
+          </ExternalLink>
+        </template>
+      </i18n-t>
+      {{ parsedError.parts[1] }}
+    </template>
+    <template v-else>
+      {{ error }}
+    </template>
+  </RuiAlert>
+</template>

--- a/frontend/app/src/modules/auth/create-account/analytics/CreateAccountSubmitStep.spec.ts
+++ b/frontend/app/src/modules/auth/create-account/analytics/CreateAccountSubmitStep.spec.ts
@@ -1,0 +1,82 @@
+import type { CreateAccountMode } from '@/modules/auth/create-account/types';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import CreateAccountErrorAlert from './CreateAccountErrorAlert.vue';
+import CreateAccountSubmitAnalytics from './CreateAccountSubmitAnalytics.vue';
+import CreateAccountSubmitStep from './CreateAccountSubmitStep.vue';
+
+interface StepProps {
+  loading?: boolean;
+  mode?: CreateAccountMode;
+  error?: string;
+  submitUsageAnalytics?: boolean;
+}
+
+function mountStep(props: StepProps = {}): VueWrapper<InstanceType<typeof CreateAccountSubmitStep>> {
+  return mount(CreateAccountSubmitStep, {
+    props: {
+      loading: false,
+      mode: 'create',
+      submitUsageAnalytics: true,
+      ...props,
+    },
+  });
+}
+
+describe('modules/auth/create-account/analytics/CreateAccountSubmitStep', () => {
+  it('should emit back when the back button is clicked', async () => {
+    const wrapper = mountStep();
+
+    await wrapper.findAll('button')[0].trigger('click');
+
+    expect(wrapper.emitted('back')).toHaveLength(1);
+    expect(wrapper.emitted('confirm')).toBeUndefined();
+  });
+
+  it('should emit confirm when the submit button is clicked', async () => {
+    const wrapper = mountStep();
+
+    await wrapper.find('[data-cy=create-account__submit-analytics__button__continue]').trigger('click');
+
+    expect(wrapper.emitted('confirm')).toHaveLength(1);
+    expect(wrapper.emitted('back')).toBeUndefined();
+  });
+
+  it('should keep the e2e submit selector on the submit button', () => {
+    const wrapper = mountStep();
+
+    expect(wrapper.find('[data-cy=create-account__submit-analytics__button__continue]').exists()).toBe(true);
+  });
+
+  it('should hide the error alert when there is no error', () => {
+    const wrapper = mountStep();
+
+    expect(wrapper.findComponent(CreateAccountErrorAlert).exists()).toBe(false);
+  });
+
+  it('should show the error alert and forward the message when an error is present', () => {
+    const wrapper = mountStep({ error: 'boom' });
+    const alert = wrapper.findComponent(CreateAccountErrorAlert);
+
+    expect(alert.exists()).toBe(true);
+    expect(alert.props('error')).toBe('boom');
+  });
+
+  it('should forward loading to the analytics step and disable both buttons', () => {
+    const wrapper = mountStep({ loading: true });
+
+    expect(wrapper.findComponent(CreateAccountSubmitAnalytics).props('loading')).toBe(true);
+    const buttons = wrapper.findAll('button');
+    expect(buttons[0].attributes('disabled')).toBeDefined();
+    expect(buttons[1].attributes('disabled')).toBeDefined();
+  });
+
+  it('should propagate the analytics model back to the parent', async () => {
+    const wrapper = mountStep({ submitUsageAnalytics: true });
+
+    wrapper.findComponent(CreateAccountSubmitAnalytics).vm.$emit('update:submitUsageAnalytics', false);
+    await nextTick();
+
+    expect(wrapper.emitted('update:submitUsageAnalytics')).toEqual([[false]]);
+  });
+});

--- a/frontend/app/src/modules/auth/create-account/analytics/CreateAccountSubmitStep.vue
+++ b/frontend/app/src/modules/auth/create-account/analytics/CreateAccountSubmitStep.vue
@@ -1,0 +1,63 @@
+<script lang="ts" setup>
+import type { CreateAccountMode } from '@/modules/auth/create-account/types';
+import CreateAccountErrorAlert from '@/modules/auth/create-account/analytics/CreateAccountErrorAlert.vue';
+import CreateAccountSubmitAnalytics
+  from '@/modules/auth/create-account/analytics/CreateAccountSubmitAnalytics.vue';
+
+const submitUsageAnalytics = defineModel<boolean>('submitUsageAnalytics', { required: true });
+
+const {
+  error = '',
+  loading,
+  mode,
+} = defineProps<{
+  loading: boolean;
+  mode: CreateAccountMode;
+  error?: string;
+}>();
+
+const emit = defineEmits<{
+  back: [];
+  confirm: [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const submitLabel = computed<string>(() =>
+  mode === 'restore' ? t('create_account.actions.restore_account') : t('create_account.actions.create_account'),
+);
+</script>
+
+<template>
+  <div class="space-y-8">
+    <CreateAccountSubmitAnalytics
+      v-model:submit-usage-analytics="submitUsageAnalytics"
+      :loading="loading"
+    />
+    <CreateAccountErrorAlert
+      v-if="error"
+      :error="error"
+    />
+    <div class="grid grid-cols-2 gap-4">
+      <RuiButton
+        size="lg"
+        class="w-full"
+        :disabled="loading"
+        @click="emit('back')"
+      >
+        {{ t('common.actions.back') }}
+      </RuiButton>
+      <RuiButton
+        data-cy="create-account__submit-analytics__button__continue"
+        size="lg"
+        class="w-full"
+        :disabled="loading"
+        :loading="loading"
+        color="primary"
+        @click="emit('confirm')"
+      >
+        {{ submitLabel }}
+      </RuiButton>
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/auth/create-account/analytics/parse-device-limit-error.spec.ts
+++ b/frontend/app/src/modules/auth/create-account/analytics/parse-device-limit-error.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { parseDeviceLimitError } from './parse-device-limit-error';
+
+describe('modules/auth/create-account/analytics/parseDeviceLimitError', () => {
+  it('should report no link for a plain message', () => {
+    expect(parseDeviceLimitError('Something went wrong')).toEqual({
+      hasLink: false,
+      parts: ['Something went wrong'],
+    });
+  });
+
+  it('should split the message around the placeholder', () => {
+    expect(parseDeviceLimitError('You reached the limit._DEVICE_LIMIT_LINK_Please retry.')).toEqual({
+      hasLink: true,
+      parts: ['You reached the limit.', 'Please retry.'],
+    });
+  });
+
+  it('should keep an empty leading part when the placeholder starts the message', () => {
+    expect(parseDeviceLimitError('_DEVICE_LIMIT_LINK_trailing')).toEqual({
+      hasLink: true,
+      parts: ['', 'trailing'],
+    });
+  });
+
+  it('should keep an empty trailing part when the placeholder ends the message', () => {
+    expect(parseDeviceLimitError('leading_DEVICE_LIMIT_LINK_')).toEqual({
+      hasLink: true,
+      parts: ['leading', ''],
+    });
+  });
+
+  it('should not match a near-miss placeholder', () => {
+    expect(parseDeviceLimitError('DEVICE_LIMIT_LINK without underscores')).toEqual({
+      hasLink: false,
+      parts: ['DEVICE_LIMIT_LINK without underscores'],
+    });
+  });
+
+  it('should treat an empty message as linkless', () => {
+    expect(parseDeviceLimitError('')).toEqual({
+      hasLink: false,
+      parts: [''],
+    });
+  });
+});

--- a/frontend/app/src/modules/auth/create-account/analytics/parse-device-limit-error.ts
+++ b/frontend/app/src/modules/auth/create-account/analytics/parse-device-limit-error.ts
@@ -1,0 +1,30 @@
+export interface ParsedDeviceLimitError {
+  hasLink: boolean;
+  parts: string[];
+}
+
+/**
+ * The backend marks the spot where a "learn more about premium devices" link should go
+ * with this placeholder, so the frontend can render a real anchor mid-sentence.
+ */
+const DEVICE_LIMIT_PLACEHOLDER = '_DEVICE_LIMIT_LINK_';
+
+/**
+ * Splits a create-account error message around the device-limit link placeholder.
+ *
+ * @param error the raw error message from the backend
+ * @returns whether a link should be rendered, and the message parts to render around it
+ */
+export function parseDeviceLimitError(error: string): ParsedDeviceLimitError {
+  if (!error || !error.includes(DEVICE_LIMIT_PLACEHOLDER)) {
+    return {
+      hasLink: false,
+      parts: [error],
+    };
+  }
+
+  return {
+    hasLink: true,
+    parts: error.split(DEVICE_LIMIT_PLACEHOLDER),
+  };
+}

--- a/frontend/app/src/modules/auth/login/LoginBackendToggle.spec.ts
+++ b/frontend/app/src/modules/auth/login/LoginBackendToggle.spec.ts
@@ -1,0 +1,39 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import LoginBackendToggle from './LoginBackendToggle.vue';
+
+interface ToggleProps {
+  open?: boolean;
+  loading?: boolean;
+  color?: 'primary' | 'success';
+}
+
+function mountToggle(props: ToggleProps = {}): VueWrapper<InstanceType<typeof LoginBackendToggle>> {
+  return mount(LoginBackendToggle, {
+    props: { loading: false, open: false, ...props },
+  });
+}
+
+describe('modules/auth/login/LoginBackendToggle', () => {
+  it('should emit toggle when clicked', async () => {
+    const wrapper = mountToggle();
+
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('toggle')).toHaveLength(1);
+  });
+
+  it('should not emit toggle while loading', async () => {
+    const wrapper = mountToggle({ loading: true });
+
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('toggle')).toBeUndefined();
+  });
+
+  it('should disable the button while loading', () => {
+    const wrapper = mountToggle({ loading: true });
+
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/auth/login/LoginBackendToggle.vue
+++ b/frontend/app/src/modules/auth/login/LoginBackendToggle.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { ServerColor } from '@/modules/auth/login/use-custom-backend';
+
+const { color, loading, open } = defineProps<{
+  open: boolean;
+  loading: boolean;
+  color?: ServerColor;
+}>();
+
+const emit = defineEmits<{
+  toggle: [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <RuiTooltip
+    :open-delay="400"
+    :close-delay="0"
+    :text="t('login.custom_backend.tooltip')"
+  >
+    <template #activator>
+      <RuiButton
+        :disabled="loading"
+        variant="text"
+        type="button"
+        icon
+        @click="emit('toggle')"
+      >
+        <RuiIcon
+          name="lu-server"
+          :color="color"
+        />
+        <template #append>
+          <RuiIcon
+            size="16"
+            class="-ml-2"
+            :name="open ? 'lu-chevron-up' : 'lu-chevron-down'"
+          />
+        </template>
+      </RuiButton>
+    </template>
+  </RuiTooltip>
+</template>

--- a/frontend/app/src/modules/auth/login/LoginCustomBackendFields.spec.ts
+++ b/frontend/app/src/modules/auth/login/LoginCustomBackendFields.spec.ts
@@ -1,0 +1,77 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import LoginCustomBackendFields from './LoginCustomBackendFields.vue';
+
+interface FieldProps {
+  open?: boolean;
+  loading?: boolean;
+  saved?: boolean;
+  errorMessages?: string[];
+  url?: string;
+  sessionOnly?: boolean;
+}
+
+function mountFields(props: FieldProps = {}): VueWrapper<InstanceType<typeof LoginCustomBackendFields>> {
+  return mount(LoginCustomBackendFields, {
+    props: {
+      loading: false,
+      open: true,
+      saved: false,
+      sessionOnly: false,
+      url: '',
+      ...props,
+    },
+  });
+}
+
+describe('modules/auth/login/LoginCustomBackendFields', () => {
+  it('should render nothing while collapsed', () => {
+    const wrapper = mountFields({ open: false });
+
+    expect(wrapper.find('input').exists()).toBe(false);
+  });
+
+  it('should render the url field while expanded', () => {
+    const wrapper = mountFields();
+
+    expect(wrapper.find('input').exists()).toBe(true);
+  });
+
+  it('should emit save when the save button is clicked', async () => {
+    const wrapper = mountFields({ saved: false, url: 'http://localhost:9001' });
+
+    await wrapper.findAll('button')[0].trigger('click');
+
+    expect(wrapper.emitted('save')).toHaveLength(1);
+    expect(wrapper.emitted('clear')).toBeUndefined();
+  });
+
+  it('should emit clear instead of save once an override is persisted', async () => {
+    const wrapper = mountFields({ saved: true, url: 'http://localhost:9001' });
+
+    await wrapper.findAll('button')[0].trigger('click');
+
+    expect(wrapper.emitted('clear')).toHaveLength(1);
+    expect(wrapper.emitted('save')).toBeUndefined();
+  });
+
+  it('should propagate url edits to the parent', async () => {
+    const wrapper = mountFields();
+
+    await wrapper.find('input').setValue('http://localhost:9001');
+
+    expect(wrapper.emitted('update:url')?.at(-1)).toEqual(['http://localhost:9001']);
+  });
+
+  it('should surface validation errors', () => {
+    const wrapper = mountFields({ errorMessages: ['not a valid url'] });
+
+    expect(wrapper.text()).toContain('not a valid url');
+  });
+
+  it('should disable the url field once the override is persisted', () => {
+    const wrapper = mountFields({ saved: true });
+
+    expect(wrapper.find('input').attributes('disabled')).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/auth/login/LoginCustomBackendFields.vue
+++ b/frontend/app/src/modules/auth/login/LoginCustomBackendFields.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import type { ServerColor } from '@/modules/auth/login/use-custom-backend';
+
+const url = defineModel<string>('url', { required: true });
+const sessionOnly = defineModel<boolean>('sessionOnly', { required: true });
+
+const {
+  color,
+  errorMessages = [],
+  loading,
+  open,
+  saved,
+} = defineProps<{
+  open: boolean;
+  loading: boolean;
+  saved: boolean;
+  color?: ServerColor;
+  errorMessages?: string[];
+}>();
+
+const emit = defineEmits<{
+  save: [];
+  clear: [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <RuiAccordion :open="open">
+    <div
+      v-if="open"
+      class="flex flex-col justify-stretch space-y-4 pt-4"
+    >
+      <RuiTextField
+        v-model="url"
+        color="primary"
+        variant="outlined"
+        :error-messages="errorMessages"
+        :disabled="saved"
+        :label="t('login.custom_backend.label')"
+        :placeholder="t('login.custom_backend.placeholder')"
+        :hint="t('login.custom_backend.hint')"
+        class="[&>div]:bg-transparent"
+        dense
+      >
+        <template #prepend>
+          <RuiIcon
+            name="lu-server"
+            :color="color"
+          />
+        </template>
+        <template #append>
+          <RuiButton
+            v-if="!saved"
+            :disabled="loading"
+            variant="text"
+            class="-mr-1 !p-2"
+            type="button"
+            icon
+            @click="emit('save')"
+          >
+            <RuiIcon
+              name="lu-save"
+              color="primary"
+              size="20"
+            />
+          </RuiButton>
+          <RuiButton
+            v-else
+            variant="text"
+            class="-mr-1 !p-2"
+            type="button"
+            icon
+            @click="emit('clear')"
+          >
+            <RuiIcon
+              name="lu-trash-2"
+              color="primary"
+              size="20"
+            />
+          </RuiButton>
+        </template>
+      </RuiTextField>
+
+      <RuiCheckbox
+        v-model="sessionOnly"
+        class="-ml-2"
+        color="primary"
+        hide-details
+        :disabled="saved"
+      >
+        {{ t('login.custom_backend.session_only') }}
+      </RuiCheckbox>
+    </div>
+  </RuiAccordion>
+</template>

--- a/frontend/app/src/modules/auth/login/LoginForm.vue
+++ b/frontend/app/src/modules/auth/login/LoginForm.vue
@@ -4,22 +4,24 @@ import { isValidUrl } from '@rotki/common';
 import { externalLinks } from '@shared/external-links';
 import useVuelidate from '@vuelidate/core';
 import { helpers, required, requiredIf } from '@vuelidate/validators';
-import { deleteBackendUrl, getBackendUrl, saveBackendUrl } from '@/modules/auth/account-management';
+import { focusInput } from '@/modules/auth/login/focus-input';
 import IncompleteUpgradeAlert from '@/modules/auth/login/IncompleteUpgradeAlert.vue';
+import LoginBackendToggle from '@/modules/auth/login/LoginBackendToggle.vue';
+import LoginCustomBackendFields from '@/modules/auth/login/LoginCustomBackendFields.vue';
+import LoginRememberOptions from '@/modules/auth/login/LoginRememberOptions.vue';
+import LoginUsernameField from '@/modules/auth/login/LoginUsernameField.vue';
+import LoginWelcomeMessageDialog from '@/modules/auth/login/LoginWelcomeMessageDialog.vue';
 import PremiumSyncConflictAlert from '@/modules/auth/login/PremiumSyncConflictAlert.vue';
-import WelcomeMessageDisplay from '@/modules/auth/login/WelcomeMessageDisplay.vue';
+import { useCustomBackend } from '@/modules/auth/login/use-custom-backend';
+import { useLoginRememberOptions } from '@/modules/auth/login/use-login-remember-options';
 import { useLogout } from '@/modules/auth/use-logout';
-import { useRememberSettings } from '@/modules/auth/use-remember-settings';
 import { useSavedProfiles } from '@/modules/auth/use-saved-profiles';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
-import { compareTextByKeyword } from '@/modules/core/common/display/assets';
 import { toMessages } from '@/modules/core/common/validation/validation';
-import { useDynamicMessages } from '@/modules/core/messaging/use-dynamic-messages';
-import { useInterop } from '@/modules/shell/app/use-electron-interop';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 
 const {
-  errors = [] as string[],
+  errors = [],
   isDocker,
   loading,
 } = defineProps<{
@@ -37,8 +39,6 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const isTest = import.meta.env.VITE_TEST;
-
 const { loadProfiles, resolveStoredUsername, savedUsernames } = useSavedProfiles();
 const authStore = useSessionAuthStore();
 const { conflictExist } = storeToRefs(authStore);
@@ -53,19 +53,29 @@ const { logoutRemoteSession } = useLogout();
 const username = ref<string>('');
 const usernameSearch = ref<string>('');
 const password = ref<string>('');
-const rememberUsername = ref<boolean>(false);
-const rememberPassword = ref<boolean>(false);
-const customBackendDisplay = ref<boolean>(false);
-const customBackendUrl = ref<string>('');
-const customBackendSessionOnly = ref<boolean>(false);
-const customBackendSaved = ref<boolean>(false);
-const dynamicMessageDialog = ref<boolean>(false);
 
-const usernameRef = useTemplateRef('usernameRef');
+const usernameFieldRef = useTemplateRef<InstanceType<typeof LoginUsernameField>>('usernameFieldRef');
 const passwordRef = useTemplateRef('passwordRef');
 
-const { savedRememberPassword, savedRememberUsername, savedUsername } = useRememberSettings();
-const { activeWelcomeMessages, welcomeMessage } = useDynamicMessages();
+const {
+  clearBackend,
+  display: customBackendDisplay,
+  loadBackendSettings,
+  modelSessionOnly: customBackendSessionOnly,
+  modelUrl: customBackendUrl,
+  saveBackend,
+  saved: customBackendSaved,
+  serverColor,
+  toggleDisplay: toggleCustomBackend,
+} = useCustomBackend({ onChange: backendChanged });
+
+const {
+  loadRememberSettings,
+  modelRememberPassword: rememberPassword,
+  modelRememberUsername: rememberUsername,
+  rememberCredentials,
+  storedUsername,
+} = useLoginRememberOptions({ isDocker: () => !!isDocker });
 
 const rules = {
   customBackendUrl: {
@@ -99,11 +109,9 @@ const v$ = useVuelidate(
   },
 );
 
-const { clearPassword, isPackaged, storePassword } = useInterop();
-
 watch([username, password], ([username, password], [oldUsername, oldPassword]) => {
   // touched should not be emitted when restoring from local storage
-  if (!oldUsername && username === get(savedUsername))
+  if (!oldUsername && username === get(storedUsername))
     return;
 
   if (username !== oldUsername || password !== oldPassword)
@@ -114,16 +122,6 @@ const isLoggedInError = useArraySome(() => errors, error => error.includes('is a
 
 const usernameError = useArrayFind(() => errors, error => error.startsWith('User '));
 const passwordError = useArrayFind(() => errors, error => error.startsWith('Wrong password '));
-
-const orderedUsernamesList = computed(() => {
-  const search = get(usernameSearch) || '';
-  const usernames = get(savedUsernames);
-
-  if (!search)
-    return usernames;
-
-  return usernames.sort((a, b) => compareTextByKeyword(a, b, search));
-});
 
 const hasServerError = computed(() => !!get(usernameError) || !!get(passwordError));
 
@@ -151,50 +149,13 @@ async function logout() {
     touched();
 }
 
-const serverColor = computed(() => {
-  if (get(customBackendSessionOnly))
-    return 'primary';
-  else if (get(customBackendSaved))
-    return 'success';
-
-  return undefined;
-});
-
-function focusElement(element: any) {
-  if (!element)
-    return;
-
-  const input = element.$el.querySelector('input:not([type=hidden])') as HTMLInputElement;
-  input.focus();
-}
-
 function updateFocus() {
   nextTick(() => {
-    focusElement(get(username) ? get(passwordRef) : get(usernameRef));
+    if (get(username))
+      focusInput(get(passwordRef));
+    else
+      get(usernameFieldRef)?.focus();
   });
-}
-
-function saveCustomBackend() {
-  saveBackendUrl({
-    sessionOnly: get(customBackendSessionOnly),
-    url: get(customBackendUrl),
-  });
-  backendChanged(get(customBackendUrl));
-  set(customBackendSaved, true);
-  set(customBackendDisplay, false);
-}
-
-function clearCustomBackend() {
-  set(customBackendUrl, '');
-  set(customBackendSessionOnly, false);
-  deleteBackendUrl();
-  backendChanged(null);
-  set(customBackendSaved, false);
-  set(customBackendDisplay, false);
-}
-
-function checkRememberUsername() {
-  set(rememberUsername, !!get(savedRememberUsername) || !!get(savedRememberPassword) || !isDocker);
 }
 
 // Pre-fills the form and remember toggles for a manual login. The saved-password
@@ -202,15 +163,11 @@ function checkRememberUsername() {
 // `useAutoLogin` on backend connect (see use-auto-login.ts / startAuto), so this
 // component can never race that flow.
 function loadSettings(): void {
-  set(rememberPassword, !!get(savedRememberPassword));
-  checkRememberUsername();
+  loadRememberSettings();
   if (!get(username))
     set(username, resolveStoredUsername());
 
-  const { sessionOnly, url } = getBackendUrl();
-  set(customBackendUrl, url);
-  set(customBackendSessionOnly, sessionOnly);
-  set(customBackendSaved, !!url);
+  loadBackendSettings();
 }
 
 onBeforeMount(async () => {
@@ -226,35 +183,6 @@ onMounted(() => {
   updateFocus();
 });
 
-watch(rememberUsername, (remember: boolean, previous: boolean) => {
-  if (remember === previous)
-    return;
-
-  if (!remember) {
-    set(savedRememberUsername, null);
-    set(savedUsername, null);
-  }
-  else {
-    set(savedRememberUsername, 'true');
-  }
-});
-
-watch(rememberPassword, async (remember: boolean, previous: boolean) => {
-  if (remember === previous)
-    return;
-
-  if (!remember) {
-    set(savedRememberPassword, null);
-    if (isPackaged)
-      await clearPassword();
-  }
-  else {
-    set(savedRememberPassword, 'true');
-  }
-
-  checkRememberUsername();
-});
-
 async function login(actions?: { syncApproval?: SyncApproval; resumeFromBackup?: boolean }) {
   const credentials: LoginCredentials = {
     password: get(password),
@@ -262,11 +190,7 @@ async function login(actions?: { syncApproval?: SyncApproval; resumeFromBackup?:
     ...actions,
   };
   emit('login', credentials);
-  if (get(rememberUsername))
-    set(savedUsername, get(username));
-
-  if (get(rememberPassword) && isPackaged)
-    await storePassword(get(username), get(password));
+  await rememberCredentials(get(username), get(password));
 }
 
 function abortLogin() {
@@ -314,92 +238,16 @@ function abortLogin() {
             novalidate
             @submit.stop.prevent="login()"
           >
-            <RuiTextField
-              v-if="isDocker || isTest"
-              ref="usernameRef"
+            <LoginUsernameField
+              ref="usernameFieldRef"
               v-model="username"
-              variant="outlined"
-              color="primary"
-              autocomplete="username"
-              :label="t('login.label_username')"
-              :error-messages="usernameErrors"
+              v-model:search="usernameSearch"
               :disabled="loading || conflictExist || customBackendDisplay"
-              class="mb-2"
-              data-cy="username-input"
-              dense
+              :loading="loading"
+              :is-docker="isDocker"
+              :error-messages="usernameErrors"
+              @new-account="newAccount()"
             />
-            <RuiAutoComplete
-              v-else
-              ref="usernameRef"
-              v-model="username"
-              v-model:search-input="usernameSearch"
-              :label="t('login.label_username')"
-              :options="orderedUsernamesList"
-              :disabled="loading || conflictExist || customBackendDisplay"
-              :error-messages="usernameErrors"
-              data-cy="username-input"
-              class="mb-2 [&_[data-id=activator]]:bg-transparent"
-              auto-select-first
-              :hide-no-data="savedUsernames.length > 0"
-              clearable
-              variant="outlined"
-              :item-height="38"
-              dense
-            >
-              <template #item="{ item }">
-                <div class="py-1">
-                  {{ item }}
-                </div>
-              </template>
-              <template #no-data>
-                <div class="flex flex-col items-center py-3">
-                  <div>{{ t('login.no_profiles_found') }}</div>
-                  <div class="flex items-center gap-1">
-                    <i18n-t
-                      scope="global"
-                      keypath="login.no_profiles_found_action"
-                    >
-                      <template #refresh_profiles>
-                        <RuiButton
-                          color="primary"
-                          variant="text"
-                          class="text-[1em] py-0 px-1"
-                          :disabled="loading"
-                          type="button"
-                          @click="loadProfiles()"
-                        >
-                          <template #prepend>
-                            <RuiIcon
-                              name="lu-refresh-ccw"
-                              size="14"
-                            />
-                          </template>
-                          {{ t('login.button_refresh_profiles') }}
-                        </RuiButton>
-                      </template>
-                      <template #create_account>
-                        <RuiButton
-                          color="primary"
-                          variant="text"
-                          class="text-[1em] py-0 px-1"
-                          :disabled="loading"
-                          type="button"
-                          @click="newAccount()"
-                        >
-                          <template #prepend>
-                            <RuiIcon
-                              name="lu-plus"
-                              size="14"
-                            />
-                          </template>
-                          {{ t('login.button_create_account') }}
-                        </RuiButton>
-                      </template>
-                    </i18n-t>
-                  </div>
-                </div>
-              </template>
-            </RuiAutoComplete>
 
             <RuiRevealableTextField
               ref="passwordRef"
@@ -416,144 +264,31 @@ function abortLogin() {
             />
 
             <div class="flex items-center justify-between">
-              <div>
-                <RuiCheckbox
-                  v-if="isDocker"
-                  v-model="rememberUsername"
-                  :disabled="customBackendDisplay || rememberPassword || loading"
-                  color="primary"
-                  hide-details
-                  class="-ml-2"
-                >
-                  {{ t('login.remember_username') }}
-                </RuiCheckbox>
-                <div
-                  v-if="isPackaged"
-                  class="flex items-center justify-between"
-                >
-                  <div>
-                    <RuiCheckbox
-                      v-model="rememberPassword"
-                      :disabled="customBackendDisplay || loading"
-                      color="primary"
-                      hide-details
-                      class="-ml-2"
-                    >
-                      {{ t('login.remember_password') }}
-                    </RuiCheckbox>
-                  </div>
-                  <RuiTooltip
-                    :open-delay="400"
-                    :close-delay="0"
-                    class="ml-2"
-                    tooltip-class="max-w-[16rem]"
-                    :text="t('login.remember_password_tooltip')"
-                  >
-                    <template #activator>
-                      <RuiIcon
-                        name="lu-circle-question-mark"
-                        color="primary"
-                      />
-                    </template>
-                  </RuiTooltip>
-                </div>
-              </div>
-              <RuiTooltip
-                :open-delay="400"
-                :close-delay="0"
-                :text="t('login.custom_backend.tooltip')"
-              >
-                <template #activator>
-                  <RuiButton
-                    :disabled="loading"
-                    variant="text"
-                    type="button"
-                    icon
-                    @click="customBackendDisplay = !customBackendDisplay"
-                  >
-                    <RuiIcon
-                      name="lu-server"
-                      :color="serverColor"
-                    />
-                    <template #append>
-                      <RuiIcon
-                        size="16"
-                        class="-ml-2"
-                        :name="customBackendDisplay ? 'lu-chevron-up' : 'lu-chevron-down'"
-                      />
-                    </template>
-                  </RuiButton>
-                </template>
-              </RuiTooltip>
+              <LoginRememberOptions
+                v-model:remember-username="rememberUsername"
+                v-model:remember-password="rememberPassword"
+                :disabled="customBackendDisplay || loading"
+                :is-docker="isDocker"
+              />
+              <LoginBackendToggle
+                :open="customBackendDisplay"
+                :loading="loading"
+                :color="serverColor"
+                @toggle="toggleCustomBackend()"
+              />
             </div>
 
-            <RuiAccordion :open="customBackendDisplay">
-              <div
-                v-if="customBackendDisplay"
-                class="flex flex-col justify-stretch space-y-4 pt-4"
-              >
-                <RuiTextField
-                  v-model="customBackendUrl"
-                  color="primary"
-                  variant="outlined"
-                  :error-messages="toMessages(v$.customBackendUrl)"
-                  :disabled="customBackendSaved"
-                  :label="t('login.custom_backend.label')"
-                  :placeholder="t('login.custom_backend.placeholder')"
-                  :hint="t('login.custom_backend.hint')"
-                  class="[&>div]:bg-transparent"
-                  dense
-                >
-                  <template #prepend>
-                    <RuiIcon
-                      name="lu-server"
-                      :color="serverColor"
-                    />
-                  </template>
-                  <template #append>
-                    <RuiButton
-                      v-if="!customBackendSaved"
-                      :disabled="loading"
-                      variant="text"
-                      class="-mr-1 !p-2"
-                      type="button"
-                      icon
-                      @click="saveCustomBackend()"
-                    >
-                      <RuiIcon
-                        name="lu-save"
-                        color="primary"
-                        size="20"
-                      />
-                    </RuiButton>
-                    <RuiButton
-                      v-else
-                      variant="text"
-                      class="-mr-1 !p-2"
-                      type="button"
-                      icon
-                      @click="clearCustomBackend()"
-                    >
-                      <RuiIcon
-                        name="lu-trash-2"
-                        color="primary"
-                        size="20"
-                      />
-                    </RuiButton>
-                  </template>
-                </RuiTextField>
-
-                <RuiCheckbox
-                  v-model="customBackendSessionOnly"
-                  class="-ml-2"
-                  color="primary"
-                  hide-details
-                  :disabled="customBackendSaved"
-                >
-                  {{ t('login.custom_backend.session_only') }}
-                </RuiCheckbox>
-              </div>
-            </RuiAccordion>
+            <LoginCustomBackendFields
+              v-model:url="customBackendUrl"
+              v-model:session-only="customBackendSessionOnly"
+              :open="customBackendDisplay"
+              :loading="loading"
+              :saved="customBackendSaved"
+              :color="serverColor"
+              :error-messages="toMessages(v$.customBackendUrl)"
+              @save="saveBackend()"
+              @clear="clearBackend()"
+            />
 
             <PremiumSyncConflictAlert @proceed="login({ syncApproval: $event })" />
 
@@ -574,44 +309,7 @@ function abortLogin() {
                 {{ t('common.actions.continue') }}
               </RuiButton>
 
-              <RuiDialog
-                v-if="welcomeMessage && welcomeMessage.action"
-                v-model="dynamicMessageDialog"
-                max-width="400"
-              >
-                <template #activator="{ attrs }">
-                  <RuiButton
-                    color="primary"
-                    class="lg:hidden w-full"
-                    size="lg"
-                    :disabled="loading"
-                    variant="outlined"
-                    type="button"
-                    data-cy="show-dynamic-messages"
-                    v-bind="attrs"
-                  >
-                    {{ welcomeMessage.action.text }}
-                  </RuiButton>
-                </template>
-
-                <RuiCard>
-                  <WelcomeMessageDisplay
-                    class="!bg-transparent !p-0"
-                    :messages="activeWelcomeMessages"
-                  />
-
-                  <template #footer>
-                    <div class="w-full" />
-                    <RuiButton
-                      color="primary"
-                      variant="text"
-                      @click="dynamicMessageDialog = false"
-                    >
-                      {{ t('common.actions.close') }}
-                    </RuiButton>
-                  </template>
-                </RuiCard>
-              </RuiDialog>
+              <LoginWelcomeMessageDialog :loading="loading" />
 
               <div class="flex flex-wrap gap-1 sm:gap-0 items-center justify-center text-rui-text-secondary">
                 <span>{{ t('login.button_no_account') }}</span>

--- a/frontend/app/src/modules/auth/login/LoginNoProfilesMessage.spec.ts
+++ b/frontend/app/src/modules/auth/login/LoginNoProfilesMessage.spec.ts
@@ -1,0 +1,45 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import LoginNoProfilesMessage from './LoginNoProfilesMessage.vue';
+
+// The unit setup stubs I18nT with `true`, which renders none of its slots. Override it so
+// the refresh / create-account buttons inside the message are reachable.
+const I18nTStub = {
+  name: 'I18nT',
+  template: '<span><slot name="refresh_profiles" /><slot name="create_account" /></span>',
+};
+
+function mountMessage(loading = false): VueWrapper<InstanceType<typeof LoginNoProfilesMessage>> {
+  return mount(LoginNoProfilesMessage, {
+    global: { stubs: { I18nT: I18nTStub } },
+    props: { loading },
+  });
+}
+
+describe('modules/auth/login/LoginNoProfilesMessage', () => {
+  it('should emit refresh-profiles from the first action', async () => {
+    const wrapper = mountMessage();
+
+    await wrapper.findAll('button')[0].trigger('click');
+
+    expect(wrapper.emitted('refresh-profiles')).toHaveLength(1);
+    expect(wrapper.emitted('new-account')).toBeUndefined();
+  });
+
+  it('should emit new-account from the second action', async () => {
+    const wrapper = mountMessage();
+
+    await wrapper.findAll('button')[1].trigger('click');
+
+    expect(wrapper.emitted('new-account')).toHaveLength(1);
+    expect(wrapper.emitted('refresh-profiles')).toBeUndefined();
+  });
+
+  it('should disable both actions while loading', () => {
+    const wrapper = mountMessage(true);
+
+    const buttons = wrapper.findAll('button');
+    expect(buttons).toHaveLength(2);
+    buttons.forEach(button => expect(button.attributes('disabled')).toBeDefined());
+  });
+});

--- a/frontend/app/src/modules/auth/login/LoginNoProfilesMessage.vue
+++ b/frontend/app/src/modules/auth/login/LoginNoProfilesMessage.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+const { loading } = defineProps<{
+  loading: boolean;
+}>();
+
+const emit = defineEmits<{
+  'refresh-profiles': [];
+  'new-account': [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="flex flex-col items-center py-3">
+    <div>{{ t('login.no_profiles_found') }}</div>
+    <div class="flex items-center gap-1">
+      <i18n-t
+        scope="global"
+        keypath="login.no_profiles_found_action"
+      >
+        <template #refresh_profiles>
+          <RuiButton
+            color="primary"
+            variant="text"
+            class="text-[1em] py-0 px-1"
+            :disabled="loading"
+            type="button"
+            @click="emit('refresh-profiles')"
+          >
+            <template #prepend>
+              <RuiIcon
+                name="lu-refresh-ccw"
+                size="14"
+              />
+            </template>
+            {{ t('login.button_refresh_profiles') }}
+          </RuiButton>
+        </template>
+        <template #create_account>
+          <RuiButton
+            color="primary"
+            variant="text"
+            class="text-[1em] py-0 px-1"
+            :disabled="loading"
+            type="button"
+            @click="emit('new-account')"
+          >
+            <template #prepend>
+              <RuiIcon
+                name="lu-plus"
+                size="14"
+              />
+            </template>
+            {{ t('login.button_create_account') }}
+          </RuiButton>
+        </template>
+      </i18n-t>
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/auth/login/LoginRememberOptions.vue
+++ b/frontend/app/src/modules/auth/login/LoginRememberOptions.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { useInterop } from '@/modules/shell/app/use-electron-interop';
+
+const rememberUsername = defineModel<boolean>('rememberUsername', { required: true });
+const rememberPassword = defineModel<boolean>('rememberPassword', { required: true });
+
+const { disabled, isDocker } = defineProps<{
+  disabled: boolean;
+  isDocker?: boolean;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const { isPackaged } = useInterop();
+</script>
+
+<template>
+  <div>
+    <RuiCheckbox
+      v-if="isDocker"
+      v-model="rememberUsername"
+      :disabled="disabled || rememberPassword"
+      color="primary"
+      hide-details
+      class="-ml-2"
+    >
+      {{ t('login.remember_username') }}
+    </RuiCheckbox>
+    <div
+      v-if="isPackaged"
+      class="flex items-center justify-between"
+    >
+      <div>
+        <RuiCheckbox
+          v-model="rememberPassword"
+          :disabled="disabled"
+          color="primary"
+          hide-details
+          class="-ml-2"
+        >
+          {{ t('login.remember_password') }}
+        </RuiCheckbox>
+      </div>
+      <RuiTooltip
+        :open-delay="400"
+        :close-delay="0"
+        class="ml-2"
+        tooltip-class="max-w-[16rem]"
+        :text="t('login.remember_password_tooltip')"
+      >
+        <template #activator>
+          <RuiIcon
+            name="lu-circle-question-mark"
+            color="primary"
+          />
+        </template>
+      </RuiTooltip>
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/auth/login/LoginUsernameField.vue
+++ b/frontend/app/src/modules/auth/login/LoginUsernameField.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { focusInput } from '@/modules/auth/login/focus-input';
+import LoginNoProfilesMessage from '@/modules/auth/login/LoginNoProfilesMessage.vue';
+import { sortUsernamesByKeyword } from '@/modules/auth/login/sort-usernames';
+import { useSavedProfiles } from '@/modules/auth/use-saved-profiles';
+
+const username = defineModel<string>({ required: true });
+const search = defineModel<string>('search', { required: true });
+
+const {
+  disabled,
+  errorMessages = [],
+  isDocker,
+  loading,
+} = defineProps<{
+  disabled: boolean;
+  loading: boolean;
+  isDocker?: boolean;
+  errorMessages?: string[];
+}>();
+
+const emit = defineEmits<{
+  'new-account': [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const isTest = import.meta.env.VITE_TEST;
+
+const inputRef = useTemplateRef('inputRef');
+
+const { loadProfiles, savedUsernames } = useSavedProfiles();
+
+// A plain text field is used on docker (where profiles are not enumerable) and under test,
+// where the autocomplete's overlay makes the input awkward to drive.
+const usePlainField = computed<boolean>(() => !!isDocker || !!isTest);
+
+const orderedUsernames = computed<string[]>(() => sortUsernamesByKeyword(get(savedUsernames), get(search)));
+
+function focus(): void {
+  focusInput(get(inputRef));
+}
+
+defineExpose({ focus });
+</script>
+
+<template>
+  <RuiTextField
+    v-if="usePlainField"
+    ref="inputRef"
+    v-model="username"
+    variant="outlined"
+    color="primary"
+    autocomplete="username"
+    :label="t('login.label_username')"
+    :error-messages="errorMessages"
+    :disabled="disabled"
+    class="mb-2"
+    data-cy="username-input"
+    dense
+  />
+  <RuiAutoComplete
+    v-else
+    ref="inputRef"
+    v-model="username"
+    v-model:search-input="search"
+    :label="t('login.label_username')"
+    :options="orderedUsernames"
+    :disabled="disabled"
+    :error-messages="errorMessages"
+    data-cy="username-input"
+    class="mb-2 [&_[data-id=activator]]:bg-transparent"
+    auto-select-first
+    :hide-no-data="savedUsernames.length > 0"
+    clearable
+    variant="outlined"
+    :item-height="38"
+    dense
+  >
+    <template #item="{ item }">
+      <div class="py-1">
+        {{ item }}
+      </div>
+    </template>
+    <template #no-data>
+      <LoginNoProfilesMessage
+        :loading="loading"
+        @refresh-profiles="loadProfiles()"
+        @new-account="emit('new-account')"
+      />
+    </template>
+  </RuiAutoComplete>
+</template>

--- a/frontend/app/src/modules/auth/login/LoginWelcomeMessageDialog.vue
+++ b/frontend/app/src/modules/auth/login/LoginWelcomeMessageDialog.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import WelcomeMessageDisplay from '@/modules/auth/login/WelcomeMessageDisplay.vue';
+import { useDynamicMessages } from '@/modules/core/messaging/use-dynamic-messages';
+
+const { loading } = defineProps<{
+  loading: boolean;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const dialog = ref<boolean>(false);
+
+const { activeWelcomeMessages, welcomeMessage } = useDynamicMessages();
+</script>
+
+<template>
+  <RuiDialog
+    v-if="welcomeMessage && welcomeMessage.action"
+    v-model="dialog"
+    max-width="400"
+  >
+    <template #activator="{ attrs }">
+      <RuiButton
+        color="primary"
+        class="lg:hidden w-full"
+        size="lg"
+        :disabled="loading"
+        variant="outlined"
+        type="button"
+        data-cy="show-dynamic-messages"
+        v-bind="attrs"
+      >
+        {{ welcomeMessage.action.text }}
+      </RuiButton>
+    </template>
+
+    <RuiCard>
+      <WelcomeMessageDisplay
+        class="!bg-transparent !p-0"
+        :messages="activeWelcomeMessages"
+      />
+
+      <template #footer>
+        <div class="w-full" />
+        <RuiButton
+          color="primary"
+          variant="text"
+          @click="dialog = false"
+        >
+          {{ t('common.actions.close') }}
+        </RuiButton>
+      </template>
+    </RuiCard>
+  </RuiDialog>
+</template>

--- a/frontend/app/src/modules/auth/login/focus-input.spec.ts
+++ b/frontend/app/src/modules/auth/login/focus-input.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { focusInput } from './focus-input';
+
+function componentWith(html: string): { $el: Element } {
+  const root = document.createElement('div');
+  root.innerHTML = html;
+  document.body.append(root);
+  return { $el: root };
+}
+
+describe('modules/auth/login/focusInput', () => {
+  it('should focus the first visible input', () => {
+    const component = componentWith('<input id="first"><input id="second">');
+
+    focusInput(component);
+
+    expect(document.activeElement?.id).toBe('first');
+  });
+
+  it('should skip hidden inputs', () => {
+    const component = componentWith('<input type="hidden" id="hidden"><input id="visible">');
+
+    focusInput(component);
+
+    expect(document.activeElement?.id).toBe('visible');
+  });
+
+  it('should do nothing when the component renders no input', () => {
+    const component = componentWith('<span>no input here</span>');
+
+    expect(() => focusInput(component)).not.toThrow();
+  });
+
+  it('should tolerate null and undefined', () => {
+    expect(() => focusInput(null)).not.toThrow();
+    expect(() => focusInput(undefined)).not.toThrow();
+  });
+
+  it('should tolerate a component without a root element', () => {
+    expect(() => focusInput({})).not.toThrow();
+    expect(() => focusInput({ $el: undefined })).not.toThrow();
+  });
+});

--- a/frontend/app/src/modules/auth/login/focus-input.ts
+++ b/frontend/app/src/modules/auth/login/focus-input.ts
@@ -1,0 +1,26 @@
+/**
+ * Focuses the first non-hidden input rendered inside a field component.
+ *
+ * Field components wrap their native input, so the caller cannot reach it directly. The
+ * parameter is `unknown` rather than `ComponentPublicInstance` because a concrete
+ * component instance is not assignable to that generic type (its `$emit` is narrower),
+ * and narrowing here keeps every field component usable without a cast.
+ *
+ * Every step is guarded: a component that renders no input is a no-op.
+ *
+ * @param component the field component instance whose input should receive focus
+ */
+export function focusInput(component: unknown): void {
+  if (typeof component !== 'object' || component === null || !('$el' in component))
+    return;
+
+  const root = component.$el;
+
+  if (!(root instanceof Element))
+    return;
+
+  const input = root.querySelector('input:not([type=hidden])');
+
+  if (input instanceof HTMLInputElement)
+    input.focus();
+}

--- a/frontend/app/src/modules/auth/login/sort-usernames.spec.ts
+++ b/frontend/app/src/modules/auth/login/sort-usernames.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { sortUsernamesByKeyword } from './sort-usernames';
+
+describe('modules/auth/login/sortUsernamesByKeyword', () => {
+  it('should preserve the original order when the search is empty', () => {
+    const usernames = ['charlie', 'alice', 'bob'];
+
+    expect(sortUsernamesByKeyword(usernames, '')).toEqual(['charlie', 'alice', 'bob']);
+  });
+
+  it('should rank a matching username ahead of a non-matching one', () => {
+    const result = sortUsernamesByKeyword(['zebra', 'alice'], 'ali');
+
+    expect(result[0]).toBe('alice');
+  });
+
+  it('should not mutate the input array', () => {
+    const usernames = ['zebra', 'alice'];
+
+    sortUsernamesByKeyword(usernames, 'ali');
+
+    expect(usernames).toEqual(['zebra', 'alice']);
+  });
+
+  it('should handle an empty username list', () => {
+    expect(sortUsernamesByKeyword([], 'anything')).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/auth/login/sort-usernames.ts
+++ b/frontend/app/src/modules/auth/login/sort-usernames.ts
@@ -1,0 +1,18 @@
+import { compareTextByKeyword } from '@/modules/core/common/display/assets';
+
+/**
+ * Orders saved usernames by how well they match what the user has typed.
+ *
+ * Returns a new array rather than sorting in place, so the caller's list (which is backed
+ * by shared state) is never mutated as a side effect of rendering.
+ *
+ * @param usernames the saved profile usernames
+ * @param search the current search input; an empty search preserves the original order
+ * @returns the usernames ordered by relevance to the search
+ */
+export function sortUsernamesByKeyword(usernames: string[], search: string): string[] {
+  if (!search)
+    return usernames;
+
+  return [...usernames].sort((a, b) => compareTextByKeyword(a, b, search));
+}

--- a/frontend/app/src/modules/auth/login/use-custom-backend.spec.ts
+++ b/frontend/app/src/modules/auth/login/use-custom-backend.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { useCustomBackend } from './use-custom-backend';
 
 const { deleteBackendUrl, getBackendUrl, saveBackendUrl } = vi.hoisted(() => ({
@@ -14,12 +14,12 @@ vi.mock('@/modules/auth/account-management', () => ({
 }));
 
 describe('modules/auth/login/useCustomBackend', () => {
-  let onChange: ReturnType<typeof vi.fn>;
+  let onChange: Mock<(url: string | null) => void>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     getBackendUrl.mockReturnValue({ sessionOnly: false, url: '' });
-    onChange = vi.fn();
+    onChange = vi.fn<(url: string | null) => void>();
   });
 
   it('should start collapsed with no override', () => {

--- a/frontend/app/src/modules/auth/login/use-custom-backend.spec.ts
+++ b/frontend/app/src/modules/auth/login/use-custom-backend.spec.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCustomBackend } from './use-custom-backend';
+
+const { deleteBackendUrl, getBackendUrl, saveBackendUrl } = vi.hoisted(() => ({
+  deleteBackendUrl: vi.fn(),
+  getBackendUrl: vi.fn(() => ({ sessionOnly: false, url: '' })),
+  saveBackendUrl: vi.fn(),
+}));
+
+vi.mock('@/modules/auth/account-management', () => ({
+  deleteBackendUrl,
+  getBackendUrl,
+  saveBackendUrl,
+}));
+
+describe('modules/auth/login/useCustomBackend', () => {
+  let onChange: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBackendUrl.mockReturnValue({ sessionOnly: false, url: '' });
+    onChange = vi.fn();
+  });
+
+  it('should start collapsed with no override', () => {
+    const { display, modelSessionOnly, modelUrl, saved } = useCustomBackend({ onChange });
+
+    expect(get(display)).toBe(false);
+    expect(get(saved)).toBe(false);
+    expect(get(modelUrl)).toBe('');
+    expect(get(modelSessionOnly)).toBe(false);
+  });
+
+  it('should hydrate the form from a persisted override', () => {
+    getBackendUrl.mockReturnValue({ sessionOnly: true, url: 'http://localhost:9001' });
+    const { loadBackendSettings, modelSessionOnly, modelUrl, saved } = useCustomBackend({ onChange });
+
+    loadBackendSettings();
+
+    expect(get(modelUrl)).toBe('http://localhost:9001');
+    expect(get(modelSessionOnly)).toBe(true);
+    expect(get(saved)).toBe(true);
+  });
+
+  it('should not mark as saved when no url is persisted', () => {
+    const { loadBackendSettings, saved } = useCustomBackend({ onChange });
+
+    loadBackendSettings();
+
+    expect(get(saved)).toBe(false);
+  });
+
+  it('should persist the url, notify the caller and collapse on save', () => {
+    const { display, modelSessionOnly, modelUrl, saveBackend, saved, toggleDisplay } = useCustomBackend({ onChange });
+
+    toggleDisplay();
+    set(modelUrl, 'http://localhost:9001');
+    set(modelSessionOnly, true);
+    saveBackend();
+
+    expect(saveBackendUrl).toHaveBeenCalledWith({ sessionOnly: true, url: 'http://localhost:9001' });
+    expect(onChange).toHaveBeenCalledWith('http://localhost:9001');
+    expect(get(saved)).toBe(true);
+    expect(get(display)).toBe(false);
+  });
+
+  it('should delete the override, notify with null and collapse on clear', () => {
+    getBackendUrl.mockReturnValue({ sessionOnly: true, url: 'http://localhost:9001' });
+    const { clearBackend, display, loadBackendSettings, modelSessionOnly, modelUrl, saved } = useCustomBackend({ onChange });
+
+    loadBackendSettings();
+    clearBackend();
+
+    expect(deleteBackendUrl).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(get(modelUrl)).toBe('');
+    expect(get(modelSessionOnly)).toBe(false);
+    expect(get(saved)).toBe(false);
+    expect(get(display)).toBe(false);
+  });
+
+  it('should expand and collapse the panel on toggle', () => {
+    const { display, toggleDisplay } = useCustomBackend({ onChange });
+
+    toggleDisplay();
+    expect(get(display)).toBe(true);
+
+    toggleDisplay();
+    expect(get(display)).toBe(false);
+  });
+
+  it('should tint the server icon primary while the override is session-only', () => {
+    const { modelSessionOnly, serverColor } = useCustomBackend({ onChange });
+
+    set(modelSessionOnly, true);
+
+    expect(get(serverColor)).toBe('primary');
+  });
+
+  it('should tint the server icon success once the override is persisted', () => {
+    getBackendUrl.mockReturnValue({ sessionOnly: false, url: 'http://localhost:9001' });
+    const { loadBackendSettings, serverColor } = useCustomBackend({ onChange });
+
+    loadBackendSettings();
+
+    expect(get(serverColor)).toBe('success');
+  });
+
+  it('should prefer the session-only tint over the persisted one', () => {
+    getBackendUrl.mockReturnValue({ sessionOnly: true, url: 'http://localhost:9001' });
+    const { loadBackendSettings, serverColor } = useCustomBackend({ onChange });
+
+    loadBackendSettings();
+
+    expect(get(serverColor)).toBe('primary');
+  });
+
+  it('should leave the server icon untinted with no override', () => {
+    const { serverColor } = useCustomBackend({ onChange });
+
+    expect(get(serverColor)).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/auth/login/use-custom-backend.ts
+++ b/frontend/app/src/modules/auth/login/use-custom-backend.ts
@@ -1,0 +1,98 @@
+import type { ComputedRef, Ref } from 'vue';
+import { deleteBackendUrl, getBackendUrl, saveBackendUrl } from '@/modules/auth/account-management';
+
+export type ServerColor = 'primary' | 'success' | undefined;
+
+interface UseCustomBackendOptions {
+  /** Notified whenever the configured backend changes; `null` means the override was cleared. */
+  onChange: (url: string | null) => void;
+}
+
+interface UseCustomBackendReturn {
+  /** Bound to the backend URL field. */
+  modelUrl: Ref<string>;
+  /** Bound to the "session only" checkbox. */
+  modelSessionOnly: Ref<boolean>;
+  /** Whether the backend settings panel is expanded. */
+  display: Readonly<Ref<boolean>>;
+  /** Whether a backend override is currently persisted. */
+  saved: Readonly<Ref<boolean>>;
+  /** Tints the server icon to signal a session-only or persisted override. */
+  serverColor: ComputedRef<ServerColor>;
+  /** Restores the persisted backend override into the form. */
+  loadBackendSettings: () => void;
+  /** Persists the entered backend URL and collapses the panel. */
+  saveBackend: () => void;
+  /** Removes the persisted backend override and collapses the panel. */
+  clearBackend: () => void;
+  /** Expands or collapses the backend settings panel. */
+  toggleDisplay: () => void;
+}
+
+/**
+ * Owns the login form's custom-backend override: the URL being edited, whether it is
+ * session-only, and whether the settings panel is expanded.
+ *
+ * Saving and clearing both write through to the persisted backend URL and notify the
+ * caller, so the two stay in step without the component coordinating them.
+ */
+export function useCustomBackend(options: UseCustomBackendOptions): UseCustomBackendReturn {
+  const { onChange } = options;
+
+  // `model` prefix marks these as intentionally writable: both are bound with v-model.
+  const modelUrl = shallowRef<string>('');
+  const modelSessionOnly = shallowRef<boolean>(false);
+  const display = shallowRef<boolean>(false);
+  const saved = shallowRef<boolean>(false);
+
+  const serverColor = computed<ServerColor>(() => {
+    if (get(modelSessionOnly))
+      return 'primary';
+    else if (get(saved))
+      return 'success';
+
+    return undefined;
+  });
+
+  function loadBackendSettings(): void {
+    const { sessionOnly, url } = getBackendUrl();
+    set(modelUrl, url);
+    set(modelSessionOnly, sessionOnly);
+    set(saved, !!url);
+  }
+
+  function saveBackend(): void {
+    saveBackendUrl({
+      sessionOnly: get(modelSessionOnly),
+      url: get(modelUrl),
+    });
+    onChange(get(modelUrl));
+    set(saved, true);
+    set(display, false);
+  }
+
+  function clearBackend(): void {
+    set(modelUrl, '');
+    set(modelSessionOnly, false);
+    deleteBackendUrl();
+    onChange(null);
+    set(saved, false);
+    set(display, false);
+  }
+
+  function toggleDisplay(): void {
+    set(display, !get(display));
+  }
+
+  return {
+    clearBackend,
+    display: readonly(display),
+    loadBackendSettings,
+    modelSessionOnly,
+    modelUrl,
+    saveBackend,
+    saved: readonly(saved),
+    serverColor,
+    toggleDisplay,
+  };
+}

--- a/frontend/app/src/modules/auth/login/use-login-remember-options.spec.ts
+++ b/frontend/app/src/modules/auth/login/use-login-remember-options.spec.ts
@@ -10,7 +10,7 @@ const { clearPassword, interop, storePassword } = vi.hoisted(() => ({
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
   useInterop: (): Record<string, unknown> => ({
     clearPassword,
-    get isPackaged() {
+    get isPackaged(): boolean {
       return interop.isPackaged;
     },
     storePassword,

--- a/frontend/app/src/modules/auth/login/use-login-remember-options.spec.ts
+++ b/frontend/app/src/modules/auth/login/use-login-remember-options.spec.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLoginRememberOptions } from './use-login-remember-options';
+
+const { clearPassword, interop, storePassword } = vi.hoisted(() => ({
+  clearPassword: vi.fn(),
+  interop: { isPackaged: false },
+  storePassword: vi.fn(),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): Record<string, unknown> => ({
+    clearPassword,
+    get isPackaged() {
+      return interop.isPackaged;
+    },
+    storePassword,
+  }),
+}));
+
+describe('modules/auth/login/useLoginRememberOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    interop.isPackaged = false;
+  });
+
+  it('should default remember-username to true when not running on docker', () => {
+    const { loadRememberSettings, modelRememberUsername } = useLoginRememberOptions({ isDocker: false });
+
+    loadRememberSettings();
+
+    expect(get(modelRememberUsername)).toBe(true);
+  });
+
+  it('should default remember-username to false on docker with nothing persisted', () => {
+    const { loadRememberSettings, modelRememberUsername } = useLoginRememberOptions({ isDocker: true });
+
+    loadRememberSettings();
+
+    expect(get(modelRememberUsername)).toBe(false);
+  });
+
+  it('should restore remember-username on docker when it was persisted', () => {
+    localStorage.setItem('rotki.remember_username', 'true');
+    const { loadRememberSettings, modelRememberUsername } = useLoginRememberOptions({ isDocker: true });
+
+    loadRememberSettings();
+
+    expect(get(modelRememberUsername)).toBe(true);
+  });
+
+  it('should restore remember-password from persisted settings', () => {
+    localStorage.setItem('rotki.remember_password', 'true');
+    const { loadRememberSettings, modelRememberPassword } = useLoginRememberOptions({ isDocker: false });
+
+    loadRememberSettings();
+
+    expect(get(modelRememberPassword)).toBe(true);
+  });
+
+  it('should persist the flag when remember-username is enabled', async () => {
+    const { modelRememberUsername } = useLoginRememberOptions({ isDocker: true });
+
+    set(modelRememberUsername, true);
+    await nextTick();
+
+    expect(localStorage.getItem('rotki.remember_username')).toBe('true');
+  });
+
+  it('should drop the stored username when remember-username is disabled', async () => {
+    localStorage.setItem('rotki.remember_username', 'true');
+    localStorage.setItem('rotki.username', 'alice');
+    const { modelRememberUsername } = useLoginRememberOptions({ isDocker: true });
+
+    set(modelRememberUsername, true);
+    await nextTick();
+    set(modelRememberUsername, false);
+    await nextTick();
+
+    expect(localStorage.getItem('rotki.remember_username')).toBeNull();
+  });
+
+  it('should clear the stored password when remember-password is disabled on a packaged build', async () => {
+    interop.isPackaged = true;
+    const { modelRememberPassword } = useLoginRememberOptions({ isDocker: false });
+
+    set(modelRememberPassword, true);
+    await nextTick();
+    set(modelRememberPassword, false);
+    await nextTick();
+
+    expect(clearPassword).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not touch the stored password on a non-packaged build', async () => {
+    const { modelRememberPassword } = useLoginRememberOptions({ isDocker: false });
+
+    set(modelRememberPassword, true);
+    await nextTick();
+    set(modelRememberPassword, false);
+    await nextTick();
+
+    expect(clearPassword).not.toHaveBeenCalled();
+  });
+
+  it('should store the username on login when remember-username is on', async () => {
+    const { modelRememberUsername, rememberCredentials } = useLoginRememberOptions({ isDocker: true });
+
+    set(modelRememberUsername, true);
+    await nextTick();
+    await rememberCredentials('alice', 'secret');
+
+    expect(localStorage.getItem('rotki.username')).toBe('alice');
+  });
+
+  it('should not store the username on login when remember-username is off', async () => {
+    const { modelRememberUsername, rememberCredentials } = useLoginRememberOptions({ isDocker: true });
+
+    set(modelRememberUsername, false);
+    await nextTick();
+    await rememberCredentials('alice', 'secret');
+
+    // useLocalStorage writes its '' default on init, so the key exists but stays empty
+    expect(localStorage.getItem('rotki.username')).toBe('');
+  });
+
+  it('should store the password on login only on a packaged build', async () => {
+    interop.isPackaged = true;
+    const { modelRememberPassword, rememberCredentials } = useLoginRememberOptions({ isDocker: false });
+
+    set(modelRememberPassword, true);
+    await nextTick();
+    await rememberCredentials('alice', 'secret');
+
+    expect(storePassword).toHaveBeenCalledWith('alice', 'secret');
+  });
+
+  it('should not store the password when remember-password is off', async () => {
+    interop.isPackaged = true;
+    const { modelRememberPassword, rememberCredentials } = useLoginRememberOptions({ isDocker: false });
+
+    set(modelRememberPassword, false);
+    await nextTick();
+    await rememberCredentials('alice', 'secret');
+
+    expect(storePassword).not.toHaveBeenCalled();
+  });
+
+  it('should expose the persisted username so the form can suppress the initial touched emit', () => {
+    localStorage.setItem('rotki.username', 'alice');
+    const { storedUsername } = useLoginRememberOptions({ isDocker: false });
+
+    expect(get(storedUsername)).toBe('alice');
+  });
+});

--- a/frontend/app/src/modules/auth/login/use-login-remember-options.ts
+++ b/frontend/app/src/modules/auth/login/use-login-remember-options.ts
@@ -30,30 +30,32 @@ interface UseLoginRememberOptionsReturn {
 export function useLoginRememberOptions(options: UseLoginRememberOptionsOptions): UseLoginRememberOptionsReturn {
   const { isDocker } = options;
 
-  const rememberUsername = ref<boolean>(false);
-  const rememberPassword = ref<boolean>(false);
+  // `model` prefix marks these as intentionally writable: they are bound with v-model in
+  // the template, so wrapping them in readonly() would break the binding.
+  const modelRememberUsername = shallowRef<boolean>(false);
+  const modelRememberPassword = shallowRef<boolean>(false);
 
   const { savedRememberPassword, savedRememberUsername, savedUsername } = useRememberSettings();
   const { clearPassword, isPackaged, storePassword } = useInterop();
 
   function checkRememberUsername(): void {
-    set(rememberUsername, !!get(savedRememberUsername) || !!get(savedRememberPassword) || !toValue(isDocker));
+    set(modelRememberUsername, !!get(savedRememberUsername) || !!get(savedRememberPassword) || !toValue(isDocker));
   }
 
   function loadRememberSettings(): void {
-    set(rememberPassword, !!get(savedRememberPassword));
+    set(modelRememberPassword, !!get(savedRememberPassword));
     checkRememberUsername();
   }
 
   async function rememberCredentials(username: string, password: string): Promise<void> {
-    if (get(rememberUsername))
+    if (get(modelRememberUsername))
       set(savedUsername, username);
 
-    if (get(rememberPassword) && isPackaged)
+    if (get(modelRememberPassword) && isPackaged)
       await storePassword(username, password);
   }
 
-  watch(rememberUsername, (remember: boolean, previous: boolean) => {
+  watch(modelRememberUsername, (remember: boolean, previous: boolean) => {
     if (remember === previous)
       return;
 
@@ -66,7 +68,7 @@ export function useLoginRememberOptions(options: UseLoginRememberOptionsOptions)
     }
   });
 
-  watch(rememberPassword, async (remember: boolean, previous: boolean) => {
+  watch(modelRememberPassword, async (remember: boolean, previous: boolean) => {
     if (remember === previous)
       return;
 
@@ -84,8 +86,8 @@ export function useLoginRememberOptions(options: UseLoginRememberOptionsOptions)
 
   return {
     loadRememberSettings,
-    modelRememberPassword: rememberPassword,
-    modelRememberUsername: rememberUsername,
+    modelRememberPassword,
+    modelRememberUsername,
     rememberCredentials,
     storedUsername: readonly(savedUsername),
   };

--- a/frontend/app/src/modules/auth/login/use-login-remember-options.ts
+++ b/frontend/app/src/modules/auth/login/use-login-remember-options.ts
@@ -1,0 +1,92 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import { useRememberSettings } from '@/modules/auth/use-remember-settings';
+import { useInterop } from '@/modules/shell/app/use-electron-interop';
+
+interface UseLoginRememberOptionsOptions {
+  /** Whether the app talks to a docker backend, which flips the remember-username default. */
+  isDocker: MaybeRefOrGetter<boolean>;
+}
+
+interface UseLoginRememberOptionsReturn {
+  /** Bound to the remember-username checkbox. */
+  modelRememberUsername: Ref<boolean>;
+  /** Bound to the remember-password checkbox, which only shows on packaged builds. */
+  modelRememberPassword: Ref<boolean>;
+  /** The username persisted by a previous session, used to suppress the initial touched emit. */
+  storedUsername: Readonly<Ref<string>>;
+  /** Restores both remember toggles from persisted settings. */
+  loadRememberSettings: () => void;
+  /** Persists username and password according to the current remember toggles. */
+  rememberCredentials: (username: string, password: string) => Promise<void>;
+}
+
+/**
+ * Owns the login form's "remember username/password" toggles and their persistence.
+ *
+ * The toggles are two-way bound in the template, so they are returned as writable
+ * `model`-prefixed refs. Persistence is a side effect of flipping a toggle, which is why
+ * the watchers live here rather than in the component.
+ */
+export function useLoginRememberOptions(options: UseLoginRememberOptionsOptions): UseLoginRememberOptionsReturn {
+  const { isDocker } = options;
+
+  const rememberUsername = ref<boolean>(false);
+  const rememberPassword = ref<boolean>(false);
+
+  const { savedRememberPassword, savedRememberUsername, savedUsername } = useRememberSettings();
+  const { clearPassword, isPackaged, storePassword } = useInterop();
+
+  function checkRememberUsername(): void {
+    set(rememberUsername, !!get(savedRememberUsername) || !!get(savedRememberPassword) || !toValue(isDocker));
+  }
+
+  function loadRememberSettings(): void {
+    set(rememberPassword, !!get(savedRememberPassword));
+    checkRememberUsername();
+  }
+
+  async function rememberCredentials(username: string, password: string): Promise<void> {
+    if (get(rememberUsername))
+      set(savedUsername, username);
+
+    if (get(rememberPassword) && isPackaged)
+      await storePassword(username, password);
+  }
+
+  watch(rememberUsername, (remember: boolean, previous: boolean) => {
+    if (remember === previous)
+      return;
+
+    if (!remember) {
+      set(savedRememberUsername, null);
+      set(savedUsername, null);
+    }
+    else {
+      set(savedRememberUsername, 'true');
+    }
+  });
+
+  watch(rememberPassword, async (remember: boolean, previous: boolean) => {
+    if (remember === previous)
+      return;
+
+    if (!remember) {
+      set(savedRememberPassword, null);
+      if (isPackaged)
+        await clearPassword();
+    }
+    else {
+      set(savedRememberPassword, 'true');
+    }
+
+    checkRememberUsername();
+  });
+
+  return {
+    loadRememberSettings,
+    modelRememberPassword: rememberPassword,
+    modelRememberUsername: rememberUsername,
+    rememberCredentials,
+    storedUsername: readonly(savedUsername),
+  };
+}


### PR DESCRIPTION
Splits the two largest template-depth offenders in the auth module into subcomponents and composables. Behaviour is unchanged; this is a structural cleanup that clears 46 lint warnings.

## Why

`LoginForm.vue` was 677 lines and already nested eight levels deep before any field, so every element inside the `<form>` breached `vue/max-template-depth` by construction. `CreateAccountWizard.vue` had three tabs delegating to child components and a fourth holding its whole step inline, nesting up to 13 levels.

## What changed

**create-account** (12 warnings → 0)
- `CreateAccountSubmitStep` and `CreateAccountErrorAlert` extracted, so all four wizard tabs now follow the same `RuiTabItem > <StepComponent />` shape
- device-limit placeholder parsing pulled into a pure `parseDeviceLimitError`
- setup script reordered to declare state before the methods reading it, clearing two `no-use-before-define` warnings

**login** (34 warnings → 0)
- template split into `LoginUsernameField`, `LoginNoProfilesMessage`, `LoginRememberOptions`, `LoginBackendToggle`, `LoginCustomBackendFields` and `LoginWelcomeMessageDialog`
- logic moved into `useCustomBackend` and `useLoginRememberOptions`
- `sortUsernamesByKeyword` and `focusInput` extracted as pure helpers

## Worth a look in review

- `sortUsernamesByKeyword` no longer sorts in place. The previous `usernames.sort(...)` mutated the shared saved-profiles array as a side effect of rendering.
- `focusInput` replaces an `as HTMLInputElement` assertion with `instanceof` guards. It takes `unknown` because a concrete component instance is not assignable to `ComponentPublicInstance` (its `$emit` is narrower), and `RuiRevealableTextField` does not expose a `focus()` method the way `RuiTextField` and `RuiAutoComplete` do.
- The remember toggles are returned as `model`-prefixed refs rather than suppressing `composable-return-readonly`, since they are bound with `v-model`.
- The custom-backend vuelidate rule deliberately stays in `LoginForm`'s `v$`, keeping one validation object for the whole form.

## Testing

- 63 new unit tests; 221 pass across `modules/auth/`
- `pnpm run typecheck` clean, `pnpm run lint` reports 0 errors and 0 warnings in `modules/auth/`
- full e2e suite passes; the `data-cy` selectors driven by the shared `rotki-app.ts` page object were verified to survive the moves