### PR TITLE
Extract repeated template blocks in assets, history and liquity

### DIFF
--- a/frontend/app/src/modules/assets/AssetActionButton.spec.ts
+++ b/frontend/app/src/modules/assets/AssetActionButton.spec.ts
@@ -1,0 +1,43 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import AssetActionButton from './AssetActionButton.vue';
+
+interface ActionProps {
+  icon?: string;
+  color?: 'primary' | 'warning' | 'error';
+  tooltip?: string;
+  dataCy?: string;
+}
+
+function mountButton(props: ActionProps = {}): VueWrapper<InstanceType<typeof AssetActionButton>> {
+  return mount(AssetActionButton, {
+    props: {
+      color: 'primary',
+      icon: 'lu-dollar-sign',
+      tooltip: 'Update price',
+      ...props,
+    },
+  });
+}
+
+describe('modules/assets/AssetActionButton', () => {
+  it('should emit click when the button is pressed', async () => {
+    const wrapper = mountButton();
+
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('click')).toHaveLength(1);
+  });
+
+  it('should apply the data-cy hook to the button itself, not the tooltip root', () => {
+    const wrapper = mountButton({ dataCy: 'asset-update-price' });
+
+    expect(wrapper.find('button').attributes('data-cy')).toBe('asset-update-price');
+  });
+
+  it('should omit the data-cy attribute when no hook is given', () => {
+    const wrapper = mountButton();
+
+    expect(wrapper.find('button').attributes('data-cy')).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/assets/AssetActionButton.vue
+++ b/frontend/app/src/modules/assets/AssetActionButton.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import type { RuiIcons } from '@rotki/ui-library';
+
+const { color, dataCy, icon, tooltip } = defineProps<{
+  icon: RuiIcons;
+  color: 'primary' | 'warning' | 'error';
+  tooltip: string;
+  dataCy?: string;
+}>();
+
+const emit = defineEmits<{
+  click: [];
+}>();
+</script>
+
+<template>
+  <RuiTooltip
+    :open-delay="200"
+    :popper="{ placement: 'top' }"
+  >
+    <template #activator>
+      <RuiButton
+        variant="text"
+        :color="color"
+        class="!py-0.5"
+        size="sm"
+        :data-cy="dataCy"
+        @click="emit('click')"
+      >
+        <template #append>
+          <RuiIcon
+            :name="icon"
+            size="18"
+          />
+        </template>
+      </RuiButton>
+    </template>
+    {{ tooltip }}
+  </RuiTooltip>
+</template>

--- a/frontend/app/src/modules/assets/AssetDetailsMenuContent.vue
+++ b/frontend/app/src/modules/assets/AssetDetailsMenuContent.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { NftAsset } from '@/modules/assets/nfts';
+import AssetActionButton from '@/modules/assets/AssetActionButton.vue';
 import { isSpammableAssetType } from '@/modules/assets/types';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { useAssetPageNavigation } from '@/modules/assets/use-asset-page-navigation';
@@ -168,81 +169,33 @@ defineExpose({
               vertical
               class="h-6"
             />
-            <RuiTooltip
-              :open-delay="200"
-              :popper="{ placement: 'top' }"
-            >
-              <template #activator>
-                <RuiButton
-                  variant="text"
-                  color="primary"
-                  class="!py-0.5"
-                  size="sm"
-                  data-cy="asset-update-price"
-                  @click="openPriceUpdate()"
-                >
-                  <template #append>
-                    <RuiIcon
-                      name="lu-dollar-sign"
-                      size="18"
-                    />
-                  </template>
-                </RuiButton>
-              </template>
-              {{ t('assets.action.update_price') }}
-            </RuiTooltip>
+            <AssetActionButton
+              icon="lu-dollar-sign"
+              color="primary"
+              data-cy="asset-update-price"
+              :tooltip="t('assets.action.update_price')"
+              @click="openPriceUpdate()"
+            />
           </template>
           <template v-if="!hideActions && (isIgnoredAsset || asset.isSpam)">
             <RuiDivider
               vertical
               class="h-6"
             />
-            <RuiTooltip
+            <AssetActionButton
               v-if="asset.isSpam"
-              :open-delay="200"
-              :popper="{ placement: 'top' }"
-            >
-              <template #activator>
-                <RuiButton
-                  variant="text"
-                  color="warning"
-                  class="!py-0.5"
-                  size="sm"
-                  @click="actionClick('unmark_spam')"
-                >
-                  <template #append>
-                    <RuiIcon
-                      name="lu-shield-off"
-                      size="18"
-                    />
-                  </template>
-                </RuiButton>
-              </template>
-              {{ t('assets.action.unmark_as_spam') }}
-            </RuiTooltip>
-            <RuiTooltip
+              icon="lu-shield-off"
+              color="warning"
+              :tooltip="t('assets.action.unmark_as_spam')"
+              @click="actionClick('unmark_spam')"
+            />
+            <AssetActionButton
               v-else
-              :open-delay="200"
-              :popper="{ placement: 'top' }"
-            >
-              <template #activator>
-                <RuiButton
-                  variant="text"
-                  color="warning"
-                  class="!py-0.5"
-                  size="sm"
-                  @click="actionClick('unignore')"
-                >
-                  <template #append>
-                    <RuiIcon
-                      name="lu-eye"
-                      size="18"
-                    />
-                  </template>
-                </RuiButton>
-              </template>
-              {{ t('assets.action.unignore') }}
-            </RuiTooltip>
+              icon="lu-eye"
+              color="warning"
+              :tooltip="t('assets.action.unignore')"
+              @click="actionClick('unignore')"
+            />
           </template>
           <template v-else-if="!hideActions">
             <RuiDivider
@@ -250,51 +203,19 @@ defineExpose({
               class="h-6"
             />
             <div class="w-full flex items-center gap-1">
-              <RuiTooltip
-                :open-delay="200"
-                :popper="{ placement: 'top' }"
-              >
-                <template #activator>
-                  <RuiButton
-                    variant="text"
-                    color="error"
-                    class="!py-0.5"
-                    size="sm"
-                    @click="actionClick('ignore')"
-                  >
-                    <template #append>
-                      <RuiIcon
-                        name="lu-eye-off"
-                        size="18"
-                      />
-                    </template>
-                  </RuiButton>
-                </template>
-                {{ t('assets.action.ignore') }}
-              </RuiTooltip>
-              <RuiTooltip
+              <AssetActionButton
+                icon="lu-eye-off"
+                color="error"
+                :tooltip="t('assets.action.ignore')"
+                @click="actionClick('ignore')"
+              />
+              <AssetActionButton
                 v-if="isSpammableAssetType(asset.assetType)"
-                :open-delay="200"
-                :popper="{ placement: 'top' }"
-              >
-                <template #activator>
-                  <RuiButton
-                    variant="text"
-                    color="error"
-                    class="!py-0.5"
-                    size="sm"
-                    @click="actionClick('mark_as_spam')"
-                  >
-                    <template #append>
-                      <RuiIcon
-                        name="lu-ban"
-                        size="18"
-                      />
-                    </template>
-                  </RuiButton>
-                </template>
-                {{ t('assets.action.mark_as_spam') }}
-              </RuiTooltip>
+                icon="lu-ban"
+                color="error"
+                :tooltip="t('assets.action.mark_as_spam')"
+                @click="actionClick('mark_as_spam')"
+              />
             </div>
           </template>
         </div>

--- a/frontend/app/src/modules/history/events/CustomizedEventDuplicatesDialog.vue
+++ b/frontend/app/src/modules/history/events/CustomizedEventDuplicatesDialog.vue
@@ -6,6 +6,7 @@ import { logger } from '@/modules/core/common/logging/logging';
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
 import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
 import CustomizedEventDuplicatesList from '@/modules/history/events/CustomizedEventDuplicatesList.vue';
+import DuplicateRowActions from '@/modules/history/events/DuplicateRowActions.vue';
 import { type DuplicateRow, useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
 
@@ -242,44 +243,13 @@ onBeforeMount(async () => {
             @show-in-history="showInHistoryEvents(autoFixGroupIds, DuplicateHandlingStatus.AUTO_FIX)"
           >
             <template #actions="{ row }">
-              <div class="flex items-center gap-2">
-                <RuiButton
-                  size="sm"
-                  color="primary"
-                  :loading="fixLoading"
-                  @click="confirmFixSingle(row.groupIdentifier)"
-                >
-                  <template #prepend>
-                    <RuiIcon
-                      size="16"
-                      name="lu-wand-sparkles"
-                    />
-                  </template>
-                  {{ t('customized_event_duplicates.actions.fix') }}
-                </RuiButton>
-                <RuiTooltip
-                  :open-delay="400"
-                  :popper="{ placement: 'top' }"
-                >
-                  <template #activator>
-                    <RuiButton
-                      size="sm"
-                      variant="outlined"
-                      :loading="ignoreLoading"
-                      @click="confirmIgnoreSingle(row.groupIdentifier)"
-                    >
-                      <template #prepend>
-                        <RuiIcon
-                          size="16"
-                          name="lu-eye-off"
-                        />
-                      </template>
-                      {{ t('customized_event_duplicates.actions.mark_non_duplicated') }}
-                    </RuiButton>
-                  </template>
-                  {{ t('customized_event_duplicates.actions.mark_non_duplicated_tooltip') }}
-                </RuiTooltip>
-              </div>
+              <DuplicateRowActions
+                mode="auto-fix"
+                :fix-loading="fixLoading"
+                :ignore-loading="ignoreLoading"
+                @fix="confirmFixSingle(row.groupIdentifier)"
+                @ignore="confirmIgnoreSingle(row.groupIdentifier)"
+              />
             </template>
           </CustomizedEventDuplicatesList>
         </RuiTabItem>
@@ -293,30 +263,11 @@ onBeforeMount(async () => {
             @show-in-history="showInHistoryEvents(manualReviewGroupIds, DuplicateHandlingStatus.MANUAL_REVIEW)"
           >
             <template #actions="{ row }">
-              <div class="flex items-center gap-2">
-                <RuiTooltip
-                  :open-delay="400"
-                  :popper="{ placement: 'top' }"
-                >
-                  <template #activator>
-                    <RuiButton
-                      size="sm"
-                      variant="outlined"
-                      :loading="ignoreLoading"
-                      @click="confirmIgnoreSingle(row.groupIdentifier)"
-                    >
-                      <template #prepend>
-                        <RuiIcon
-                          size="16"
-                          name="lu-eye-off"
-                        />
-                      </template>
-                      {{ t('customized_event_duplicates.actions.mark_non_duplicated') }}
-                    </RuiButton>
-                  </template>
-                  {{ t('customized_event_duplicates.actions.mark_non_duplicated_tooltip') }}
-                </RuiTooltip>
-              </div>
+              <DuplicateRowActions
+                mode="manual-review"
+                :ignore-loading="ignoreLoading"
+                @ignore="confirmIgnoreSingle(row.groupIdentifier)"
+              />
             </template>
           </CustomizedEventDuplicatesList>
         </RuiTabItem>
@@ -330,30 +281,11 @@ onBeforeMount(async () => {
             @show-in-history="showInHistoryEvents(ignoredGroupIds, DuplicateHandlingStatus.IGNORED)"
           >
             <template #actions="{ row }">
-              <div class="flex items-center gap-2">
-                <RuiTooltip
-                  :open-delay="400"
-                  :popper="{ placement: 'top' }"
-                >
-                  <template #activator>
-                    <RuiButton
-                      size="sm"
-                      color="primary"
-                      :loading="ignoreLoading"
-                      @click="confirmRestoreSingle(row.groupIdentifier)"
-                    >
-                      <template #prepend>
-                        <RuiIcon
-                          size="16"
-                          name="lu-rotate-ccw"
-                        />
-                      </template>
-                      {{ t('customized_event_duplicates.actions.restore') }}
-                    </RuiButton>
-                  </template>
-                  {{ t('customized_event_duplicates.actions.restore_tooltip') }}
-                </RuiTooltip>
-              </div>
+              <DuplicateRowActions
+                mode="ignored"
+                :ignore-loading="ignoreLoading"
+                @restore="confirmRestoreSingle(row.groupIdentifier)"
+              />
             </template>
           </CustomizedEventDuplicatesList>
         </RuiTabItem>

--- a/frontend/app/src/modules/history/events/DuplicateRowActions.spec.ts
+++ b/frontend/app/src/modules/history/events/DuplicateRowActions.spec.ts
@@ -1,0 +1,58 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import DuplicateRowActions from './DuplicateRowActions.vue';
+
+type Mode = 'auto-fix' | 'manual-review' | 'ignored';
+
+function mountActions(mode: Mode, loading: { fix?: boolean; ignore?: boolean } = {}): VueWrapper<InstanceType<typeof DuplicateRowActions>> {
+  return mount(DuplicateRowActions, {
+    props: { fixLoading: loading.fix ?? false, ignoreLoading: loading.ignore ?? false, mode },
+  });
+}
+
+describe('modules/history/events/DuplicateRowActions', () => {
+  it('should offer both fix and ignore in auto-fix mode', async () => {
+    const wrapper = mountActions('auto-fix');
+    const buttons = wrapper.findAll('button');
+
+    expect(buttons).toHaveLength(2);
+
+    await buttons[0].trigger('click');
+    await buttons[1].trigger('click');
+
+    expect(wrapper.emitted('fix')).toHaveLength(1);
+    expect(wrapper.emitted('ignore')).toHaveLength(1);
+    expect(wrapper.emitted('restore')).toBeUndefined();
+  });
+
+  it('should offer only ignore in manual-review mode', async () => {
+    const wrapper = mountActions('manual-review');
+    const buttons = wrapper.findAll('button');
+
+    expect(buttons).toHaveLength(1);
+
+    await buttons[0].trigger('click');
+
+    expect(wrapper.emitted('ignore')).toHaveLength(1);
+    expect(wrapper.emitted('fix')).toBeUndefined();
+    expect(wrapper.emitted('restore')).toBeUndefined();
+  });
+
+  it('should offer only restore in ignored mode', async () => {
+    const wrapper = mountActions('ignored');
+    const buttons = wrapper.findAll('button');
+
+    expect(buttons).toHaveLength(1);
+
+    await buttons[0].trigger('click');
+
+    expect(wrapper.emitted('restore')).toHaveLength(1);
+    expect(wrapper.emitted('ignore')).toBeUndefined();
+    expect(wrapper.emitted('fix')).toBeUndefined();
+  });
+
+  it('should never render the fix action outside auto-fix mode', () => {
+    expect(mountActions('manual-review').text()).not.toContain('fix');
+    expect(mountActions('ignored').text()).not.toContain('fix');
+  });
+});

--- a/frontend/app/src/modules/history/events/DuplicateRowActions.vue
+++ b/frontend/app/src/modules/history/events/DuplicateRowActions.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+const { fixLoading, ignoreLoading, mode } = defineProps<{
+  mode: 'auto-fix' | 'manual-review' | 'ignored';
+  fixLoading?: boolean;
+  ignoreLoading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  fix: [];
+  ignore: [];
+  restore: [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="flex items-center gap-2">
+    <RuiButton
+      v-if="mode === 'auto-fix'"
+      size="sm"
+      color="primary"
+      :loading="fixLoading"
+      @click="emit('fix')"
+    >
+      <template #prepend>
+        <RuiIcon
+          size="16"
+          name="lu-wand-sparkles"
+        />
+      </template>
+      {{ t('customized_event_duplicates.actions.fix') }}
+    </RuiButton>
+    <RuiTooltip
+      v-if="mode === 'ignored'"
+      :open-delay="400"
+      :popper="{ placement: 'top' }"
+    >
+      <template #activator>
+        <RuiButton
+          size="sm"
+          color="primary"
+          :loading="ignoreLoading"
+          @click="emit('restore')"
+        >
+          <template #prepend>
+            <RuiIcon
+              size="16"
+              name="lu-rotate-ccw"
+            />
+          </template>
+          {{ t('customized_event_duplicates.actions.restore') }}
+        </RuiButton>
+      </template>
+      {{ t('customized_event_duplicates.actions.restore_tooltip') }}
+    </RuiTooltip>
+    <RuiTooltip
+      v-else
+      :open-delay="400"
+      :popper="{ placement: 'top' }"
+    >
+      <template #activator>
+        <RuiButton
+          size="sm"
+          variant="outlined"
+          :loading="ignoreLoading"
+          @click="emit('ignore')"
+        >
+          <template #prepend>
+            <RuiIcon
+              size="16"
+              name="lu-eye-off"
+            />
+          </template>
+          {{ t('customized_event_duplicates.actions.mark_non_duplicated') }}
+        </RuiButton>
+      </template>
+      {{ t('customized_event_duplicates.actions.mark_non_duplicated_tooltip') }}
+    </RuiTooltip>
+  </div>
+</template>

--- a/frontend/app/src/modules/staking/liquity/LiquityAssetBalanceList.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/LiquityAssetBalanceList.spec.ts
@@ -1,0 +1,37 @@
+import { type AssetBalance, bigNumberify } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import BalanceDisplay from '@/modules/shell/components/display/BalanceDisplay.vue';
+import LiquityAssetBalanceList from './LiquityAssetBalanceList.vue';
+
+function balance(asset: string): AssetBalance {
+  return { amount: bigNumberify(1), asset, value: bigNumberify(2) };
+}
+
+function mountList(balances: AssetBalance[]): VueWrapper<InstanceType<typeof LiquityAssetBalanceList>> {
+  return mount(LiquityAssetBalanceList, {
+    props: { balances, emptyLabel: 'No gains', loading: false },
+    shallow: true,
+  });
+}
+
+describe('modules/staking/liquity/LiquityAssetBalanceList', () => {
+  it('should render one balance per entry', () => {
+    const wrapper = mountList([balance('ETH'), balance('LUSD')]);
+
+    expect(wrapper.findAllComponents(BalanceDisplay)).toHaveLength(2);
+  });
+
+  it('should show the empty label when there are no balances', () => {
+    const wrapper = mountList([]);
+
+    expect(wrapper.findAllComponents(BalanceDisplay)).toHaveLength(0);
+    expect(wrapper.text()).toContain('No gains');
+  });
+
+  it('should not show the empty label when balances exist', () => {
+    const wrapper = mountList([balance('ETH')]);
+
+    expect(wrapper.text()).not.toContain('No gains');
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/LiquityAssetBalanceList.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityAssetBalanceList.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import type { AssetBalance } from '@rotki/common';
+import BalanceDisplay from '@/modules/shell/components/display/BalanceDisplay.vue';
+
+const { balances, emptyLabel, loading } = defineProps<{
+  balances: AssetBalance[];
+  emptyLabel: string;
+  loading?: boolean;
+}>();
+</script>
+
+<template>
+  <div v-if="balances.length > 0">
+    <div
+      v-for="assetBalance in balances"
+      :key="assetBalance.asset"
+    >
+      <BalanceDisplay
+        :asset="assetBalance.asset"
+        :value="assetBalance"
+        :loading="loading"
+      />
+    </div>
+  </div>
+  <div
+    v-else
+    class="text-rui-text-secondary pb-2"
+  >
+    {{ emptyLabel }}
+  </div>
+</template>

--- a/frontend/app/src/modules/staking/liquity/LiquityPnlRow.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityPnlRow.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import type { BigNumber } from '@rotki/common';
+import { FiatDisplay } from '@/modules/assets/amount-display/components';
+import LiquityStatisticRow from '@/modules/staking/liquity/LiquityStatisticRow.vue';
+
+const { loading, value } = defineProps<{
+  value: BigNumber;
+  loading?: boolean;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <LiquityStatisticRow>
+    <template #label>
+      <div class="flex items-center justify-end gap-2">
+        <RuiTooltip
+          :popper="{ placement: 'top' }"
+          :open-delay="400"
+          tooltip-class="max-w-[10rem]"
+        >
+          <template #activator>
+            <RuiIcon name="lu-info" />
+          </template>
+          <span>
+            {{ t('liquity_statistic.estimated_pnl_warning') }}
+          </span>
+        </RuiTooltip>
+        {{ t('liquity_statistic.estimated_pnl') }}
+      </div>
+    </template>
+    <FiatDisplay
+      :value="value"
+      :loading="loading"
+      pnl
+    />
+  </LiquityStatisticRow>
+</template>

--- a/frontend/app/src/modules/staking/liquity/LiquityStatisticRow.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/LiquityStatisticRow.spec.ts
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import LiquityStatisticRow from './LiquityStatisticRow.vue';
+
+describe('modules/staking/liquity/LiquityStatisticRow', () => {
+  it('should render the plain text label and the default slot', () => {
+    const wrapper = mount(LiquityStatisticRow, {
+      props: { label: 'Total deposited' },
+      slots: { default: '<span class="value">42</span>' },
+    });
+
+    expect(wrapper.text()).toContain('Total deposited');
+    expect(wrapper.find('.value').text()).toBe('42');
+  });
+
+  it('should let the label slot replace the text label', () => {
+    const wrapper = mount(LiquityStatisticRow, {
+      props: { label: 'ignored' },
+      slots: { label: '<span class="custom">Estimated PnL</span>' },
+    });
+
+    expect(wrapper.find('.custom').exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('ignored');
+  });
+
+  it('should render without a label', () => {
+    const wrapper = mount(LiquityStatisticRow, {
+      slots: { default: '<span>value</span>' },
+    });
+
+    expect(wrapper.text()).toContain('value');
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/LiquityStatisticRow.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityStatisticRow.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+const { label = '' } = defineProps<{
+  label?: string;
+}>();
+
+defineSlots<{
+  /** The value shown under the label. */
+  default: () => any;
+  /** Replaces the plain text label when it needs more than text, e.g. a tooltip. */
+  label: () => any;
+}>();
+</script>
+
+<template>
+  <div>
+    <RuiDivider />
+    <div class="text-right py-4">
+      <div class="font-medium pb-2">
+        <slot name="label">
+          {{ label }}
+        </slot>
+      </div>
+      <slot />
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/staking/liquity/LiquityStatistics.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityStatistics.vue
@@ -6,6 +6,9 @@ import { bigNumberSum } from '@/modules/core/common/data/calculation';
 import { Section } from '@/modules/core/common/status';
 import BalanceDisplay from '@/modules/shell/components/display/BalanceDisplay.vue';
 import { useSectionStatus } from '@/modules/shell/sync-progress/use-section-status';
+import LiquityAssetBalanceList from '@/modules/staking/liquity/LiquityAssetBalanceList.vue';
+import LiquityPnlRow from '@/modules/staking/liquity/LiquityPnlRow.vue';
+import LiquityStatisticRow from '@/modules/staking/liquity/LiquityStatisticRow.vue';
 
 const { pool = null, statistic = null } = defineProps<{
   statistic?: LiquityStatisticDetails | null;
@@ -211,113 +214,49 @@ const totalPnl = computed<BigNumber | null>(() => {
         >
           <div class="grid md:grid-cols-2 md:gap-12">
             <div>
-              <div>
-                <RuiDivider />
-                <div class="text-right py-4">
-                  <div class="font-medium pb-2">
-                    {{ t('liquity_statistic.total_deposited_stability_pool') }}
-                  </div>
-                  <BalanceDisplay
-                    :asset="LUSD_ID"
-                    :value="totalDepositedStabilityPoolBalance"
-                    :loading="loading"
-                  />
-                </div>
-              </div>
-              <div>
-                <RuiDivider />
-                <div class="text-right py-4">
-                  <div class="font-medium pb-2">
-                    {{ t('liquity_statistic.total_withdrawn_stability_pool') }}
-                  </div>
-                  <BalanceDisplay
-                    :asset="LUSD_ID"
-                    :value="totalWithdrawnStabilityPoolBalance"
-                    :loading="loading"
-                  />
-                </div>
-              </div>
-              <div>
-                <RuiDivider />
-                <div class="text-right py-4">
-                  <div class="font-medium pb-2">
-                    {{ t('liquity_statistic.stability_pool_gains') }}
-                  </div>
-
-                  <div v-if="statisticWithAdjustedPrice.stabilityPoolGains.length > 0">
-                    <div
-                      v-for="assetBalance in statisticWithAdjustedPrice.stabilityPoolGains"
-                      :key="assetBalance.asset"
-                    >
-                      <BalanceDisplay
-                        :asset="assetBalance.asset"
-                        :value="assetBalance"
-                        :loading="loading"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    v-else
-                    class="text-rui-text-secondary pb-2"
-                  >
-                    {{ t('liquity_statistic.no_stability_pool_gains') }}
-                  </div>
-                </div>
-              </div>
-              <div v-if="totalPnl">
-                <RuiDivider />
-                <div class="text-right py-4">
-                  <div class="flex items-center justify-end gap-2 font-medium pb-2">
-                    <RuiTooltip
-                      :popper="{ placement: 'top' }"
-                      :open-delay="400"
-                      tooltip-class="max-w-[10rem]"
-                    >
-                      <template #activator>
-                        <RuiIcon name="lu-info" />
-                      </template>
-                      <span>
-                        {{ t('liquity_statistic.estimated_pnl_warning') }}
-                      </span>
-                    </RuiTooltip>
-                    {{ t('liquity_statistic.estimated_pnl') }}
-                  </div>
-                  <FiatDisplay
-                    :value="totalPnl"
-                    :loading="loading"
-                    pnl
-                  />
-                </div>
-              </div>
+              <LiquityStatisticRow
+                :label="t('liquity_statistic.total_deposited_stability_pool')"
+              >
+                <BalanceDisplay
+                  :asset="LUSD_ID"
+                  :value="totalDepositedStabilityPoolBalance"
+                  :loading="loading"
+                />
+              </LiquityStatisticRow>
+              <LiquityStatisticRow
+                :label="t('liquity_statistic.total_withdrawn_stability_pool')"
+              >
+                <BalanceDisplay
+                  :asset="LUSD_ID"
+                  :value="totalWithdrawnStabilityPoolBalance"
+                  :loading="loading"
+                />
+              </LiquityStatisticRow>
+              <LiquityStatisticRow
+                :label="t('liquity_statistic.stability_pool_gains')"
+              >
+                <LiquityAssetBalanceList
+                  :balances="statisticWithAdjustedPrice.stabilityPoolGains"
+                  :loading="loading"
+                  :empty-label="t('liquity_statistic.no_stability_pool_gains')"
+                />
+              </LiquityStatisticRow>
+              <LiquityPnlRow
+                v-if="totalPnl"
+                :value="totalPnl"
+                :loading="loading"
+              />
             </div>
             <div>
-              <div>
-                <RuiDivider />
-                <div class="text-right py-4">
-                  <div class="font-medium pb-2">
-                    {{ t('liquity_statistic.staking_gains') }}
-                  </div>
-
-                  <div v-if="statisticWithAdjustedPrice.stakingGains.length > 0">
-                    <div
-                      v-for="assetBalance in statisticWithAdjustedPrice.stakingGains"
-                      :key="assetBalance.asset"
-                    >
-                      <BalanceDisplay
-                        :asset="assetBalance.asset"
-                        :value="assetBalance"
-                        :loading="loading"
-                      />
-                    </div>
-                  </div>
-                  <div
-                    v-else
-                    class="text-rui-text-secondary pb-2"
-                  >
-                    {{ t('liquity_statistic.no_staking_gains') }}
-                  </div>
-                </div>
-              </div>
+              <LiquityStatisticRow
+                :label="t('liquity_statistic.staking_gains')"
+              >
+                <LiquityAssetBalanceList
+                  :balances="statisticWithAdjustedPrice.stakingGains"
+                  :loading="loading"
+                  :empty-label="t('liquity_statistic.no_staking_gains')"
+                />
+              </LiquityStatisticRow>
             </div>
           </div>
           <template #header="{ open }">


### PR DESCRIPTION
Follow-up to #12619, applying the same treatment to the next three `vue/max-template-depth` offenders. Behaviour is unchanged; this clears 46 lint warnings.

Each commit is one component and stands on its own.

## What changed

**`AssetDetailsMenuContent.vue`** (12 warnings → 0)
The asset actions row repeated the same tooltip-wrapped icon button six times, each ten levels deep. Replaced with a single `AssetActionButton`, removing ~110 template lines.

**`CustomizedEventDuplicatesDialog.vue`** (14 → 0)
Three near-identical `#actions` slot bodies were passed into `CustomizedEventDuplicatesList`, nesting twelve levels. Replaced with one variant-driven `DuplicateRowActions` (`auto-fix` / `manual-review` / `ignored`). All loading flags and handlers stay in the dialog.

**`LiquityStatistics.vue`** (20 → 0)
The statistics accordion was already eight levels deep before any content, so every label and balance inside breached the limit. Extracted `LiquityStatisticRow`, `LiquityAssetBalanceList` and `LiquityPnlRow`, all presentational with no computation moved.

## Worth a look in review

`AssetActionButton` takes `data-cy` as an explicit prop rather than relying on attribute fallthrough. The hook sat on the button, but the extracted component's root is the tooltip, so fallthrough would have silently relocated it. There is a test asserting it lands on the button.

## Not included

`HistoryEventsVirtualTable.vue` (8 warnings) was attempted and reverted. The extraction works, but that file already sits at exactly 20 imports and one more trips `@rotki/max-dependencies` as an error. It needs a facade composable for its five interdependent composables, or an extraction of the row-type switch, before the placeholder row can come out. That is worth doing together with its 13-props warning, since both come from the same cause.

## Testing

- 10 new unit tests; 1235 pass across `modules/history/events/`, `modules/assets/` and `modules/staking/`
- `pnpm run typecheck` clean; no new lint errors or warnings in the touched files

Rebased onto `develop` after #12619 merged.