### PR TITLE
fix: decode omnibridge deposits of fee-charged tokens

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Omnibridge events containing fee payments will now be properly decoded.
 * :feature:`-` The GnosisDAO one-time pro-rata treasury redemption (GIP-151) is now decoded: GNO/osGNO deposits into the redemption contract and the subsequent claim of your share of the treasury are properly shown.
 * :bug:`-` EigenLayer withdrawals queued or completed after the protocol's slashing upgrade (ELIP-002, April 2025) are now decoded again, including withdrawals of natively restaked ETH sent by an eigenpod. Queued and completed withdrawals of the EIGEN strategy are now also shown as EIGEN instead of its wrapped bEIGEN underlying token.
 * :feature:`2922` The Docker version of rotki can now require authentication. When set up with the session key environment variable it issues a secure, HttpOnly session cookie on login and rejects unauthenticated API and websocket access, so a rotki instance reachable on your network is no longer open to anyone who can reach its port.

--- a/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/omnibridge/decoder.py
@@ -3,6 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.assets.utils import asset_normalized_value, get_or_create_evm_token
+from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
 from rotkehlchen.chain.ethereum.decoding.constants import GNOSIS_CPT_DETAILS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
@@ -13,8 +14,9 @@ from rotkehlchen.chain.evm.decoding.structures import (
 )
 from rotkehlchen.chain.evm.decoding.utils import bridge_match_transfer, bridge_prepare_data
 from rotkehlchen.constants.assets import A_ETH, A_WETH
+from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.history.events.structures.evm_event import BRIDGE_EXTRA_DATA_KEY
-from rotkehlchen.history.events.structures.types import HistoryEventType
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.utils.misc import bytes_to_address
 
@@ -30,6 +32,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 TOKENS_BRIDGING_INITIATED: Final = b'Y\xa9\xa8\x02{\x9c\x87\xb9a\xe2T\x89\x98!\xc9\xa2v\xb5\xef\xc3]\x1ft\t\xeaO)\x14p\xf1b\x9a'  # noqa: E501
 TOKENS_BRIDGED: Final = b'\x9a\xfdG\x90~%\x02\x8c\xda\xca\x89\xd1\x93Q\x8c0+\xbb\x12\x86\x17\xd5\xa9\x92\xc5\xab\xd4X\x15Re\x93'  # noqa: E501
+FEE_DISTRIBUTED: Final = b'\xd5`\xa5"\xf7|\xfbI$\xd6\xfeQ\xbe\x16\x15\xe5@\xa4\x8a\x891\xc4\x8f\xe04\x9c\x7fG\xeb\xab\xe7G'  # noqa: E501
 
 
 class OmnibridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
@@ -73,6 +76,23 @@ class OmnibridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
             amount=int.from_bytes(context.tx_log.data[0:32]),
             asset=bridged_asset,
         )
+        fee_amount = ZERO
+        if context.tx_log.topics[0] == TOKENS_BRIDGING_INITIATED:
+            # For fee-charged tokens the mediator takes a fee before bridging, so the
+            # TokensBridgingInitiated amount is lower than what the user transferred in
+            for tx_log in context.all_logs:
+                if (
+                    tx_log.address == context.tx_log.address and
+                    tx_log.topics[0] == FEE_DISTRIBUTED and
+                    tx_log.topics[1] == context.tx_log.topics[1] and  # same token
+                    tx_log.topics[2] == context.tx_log.topics[3]  # same AMB message id
+                ):
+                    fee_amount = asset_normalized_value(
+                        amount=int.from_bytes(tx_log.data[0:32]),
+                        asset=bridged_asset,
+                    )
+                    break
+
         expected_event_type, new_event_type, from_chain, to_chain, expected_location_label = bridge_prepare_data(  # noqa: E501
             tx_log=context.tx_log,
             deposit_topics=(TOKENS_BRIDGING_INITIATED,),
@@ -100,8 +120,9 @@ class OmnibridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
                 event.location_label == expected_location_label and
                 event.address in (expected_address, ZERO_ADDRESS) and
                 event.asset == expected_asset and
-                event.amount == amount
+                event.amount == amount + fee_amount
             ):
+                event.amount = amount  # deduct any bridge fee (split into its own event below)
                 bridge_match_transfer(
                     event=event,
                     from_address=from_address,
@@ -120,6 +141,24 @@ class OmnibridgeCommonDecoder(EvmDecoderInterface, abc.ABC):
                     # the fabricated one and keep only what this side's log actually states
                     event.extra_data[BRIDGE_EXTRA_DATA_KEY].pop(
                         'to_address' if context.tx_log.topics[0] == TOKENS_BRIDGING_INITIATED else 'from_address',  # noqa: E501
+                    )
+                if fee_amount > ZERO:
+                    fee_event = self.base.make_event_next_index(
+                        tx_ref=event.tx_ref,
+                        timestamp=context.transaction.timestamp,
+                        event_type=HistoryEventType.SPEND,
+                        event_subtype=HistoryEventSubType.FEE,
+                        asset=event.asset,
+                        amount=fee_amount,
+                        location_label=event.location_label,
+                        notes=f'Spend {fee_amount} {bridged_asset.symbol} as a {GNOSIS_CPT_DETAILS.label} bridge fee',  # noqa: E501
+                        counterparty=GNOSIS_CPT_DETAILS.identifier,
+                        address=event.address,
+                    )
+                    context.decoded_events.append(fee_event)
+                    maybe_reshuffle_events(
+                        ordered_events=[event, fee_event],
+                        events_list=context.decoded_events,
                     )
                 break
         else:

--- a/rotkehlchen/tests/unit/decoders/test_omnibridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_omnibridge.py
@@ -145,6 +145,66 @@ def test_omnibridge_gnosis_token_deposit(gnosis_inquirer, gnosis_accounts):
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('gnosis_accounts', [['0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12']])
+def test_omnibridge_gnosis_token_deposit_with_fee(gnosis_inquirer, gnosis_accounts):
+    """Test bridging a token for which the mediator takes a home to foreign fee.
+
+    The TokensBridgingInitiated amount is the post-fee amount, so the fee has to be
+    taken into account to match the user's transfer and gets split into its own event.
+    """
+    tx_hash = deserialize_evm_tx_hash('0xfc28641f28964a7d0c19684ca0023d852a077dd7bfbdac9941b041c803ef1cad')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=gnosis_inquirer, tx_hash=tx_hash)
+    timestamp, gas_amount, bridge_amount, fee_amount = TimestampMS(1640508790000), '0.000259037001813259', '10336.632820713184931506', '10.34697980051369863'  # noqa: E501
+    assert events == [
+        EvmEvent(
+            sequence_index=0,
+            timestamp=timestamp,
+            location=Location.GNOSIS,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_XDAI,
+            amount=FVal(gas_amount),
+            location_label=(user_address := gnosis_accounts[0]),
+            notes=f'Burn {gas_amount} XDAI for gas',
+            tx_ref=tx_hash,
+            counterparty=CPT_GAS,
+        ), EvmEvent(
+            sequence_index=1,
+            timestamp=timestamp,
+            location=Location.GNOSIS,
+            event_type=HistoryEventType.DEPOSIT,
+            event_subtype=HistoryEventSubType.BRIDGE,
+            asset=(a_giv := Asset('eip155:100/erc20:0x4f4F9b8D5B4d0Dc10506e5551B0513B61fD59e75')),
+            amount=FVal(bridge_amount),
+            location_label=user_address,
+            notes=f'Bridge {bridge_amount} GIV from Gnosis to Ethereum via Gnosis Chain bridge',
+            tx_ref=tx_hash,
+            counterparty=CPT_GNOSIS_CHAIN,
+            address=GNOSIS_BRIDGE_ADDRESS,
+            extra_data={'bridge': {
+                'from_chain': 100,
+                'to_chain': 1,
+                'from_address': user_address,
+                'transfer_id': '0x00050000a7823d6f1e31569f51861e345b30c6bebf70ebe700000000000087e4',  # noqa: E501
+            }},
+        ), EvmEvent(
+            sequence_index=2,
+            timestamp=timestamp,
+            location=Location.GNOSIS,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=a_giv,
+            amount=FVal(fee_amount),
+            location_label=user_address,
+            notes=f'Spend {fee_amount} GIV as a Gnosis Chain bridge fee',
+            tx_ref=tx_hash,
+            counterparty=CPT_GNOSIS_CHAIN,
+            address=GNOSIS_BRIDGE_ADDRESS,
+        ),
+    ]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('ethereum_accounts', [['0x9164dDF23c029E30b2eB0EbacbB4dEa3C0E1ac43']])
 def test_omnibridge_ethereum_token_withdrawal(ethereum_inquirer, ethereum_accounts):
     tx_hash = deserialize_evm_tx_hash('0xa56d72db76b6c7cfd3db1d2d51902b6f611f5124157ae50a6fd2f5dac7bbfa54')  # noqa: E501


### PR DESCRIPTION
The Omnibridge home mediator takes a HOME_TO_FOREIGN fee for some tokens (e.g. GIV), so the TokensBridgingInitiated log carries the post-fee amount while the user's transfer holds the full amount and the transfer matching failed, leaving the gnosis leg as a plain transfer that could not be paired with its mainnet counterpart.

Detect the FeeDistributed log for the same token and AMB message id, match the transfer including the fee, keep the net amount on the bridge event and split the fee into its own event. Add a test with such a GIV bridging transaction from gnosis to ethereum.