### PR TITLE
fix: Add OKX Earn balances

### DIFF
--- a/rotkehlchen/exchanges/okx.py
+++ b/rotkehlchen/exchanges/okx.py
@@ -66,6 +66,8 @@ class OkxEndpoint(Enum):
     CURRENCIES = '/api/v5/asset/currencies'
     TRADING_BALANCE = '/api/v5/account/balance'
     FUNDING_BALANCE = '/api/v5/asset/balances'
+    SAVINGS_BALANCE = '/api/v5/finance/savings/balance'
+    ONCHAIN_EARN_ORDERS = '/api/v5/finance/staking-defi/orders-active'
     TRADES = '/api/v5/trade/orders-history-archive'
     DEPOSITS = '/api/v5/asset/deposit-history'
     WITHDRAWALS = '/api/v5/asset/withdrawal-history'
@@ -256,12 +258,82 @@ class Okx(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             return False, 'Error validating API credentials'
         return True, ''
 
+    def _query_earn_data(self, endpoint: OkxEndpoint, product_name: str) -> list[dict]:
+        """Query an Earn endpoint without failing the whole balance query."""
+        try:
+            response = self._api_query(endpoint=endpoint)
+        except RemoteError as e:
+            log.warning(
+                f'Could not query {self.name} {product_name} balances due to {e!s}. '
+                f'Skipping {product_name} balances.',
+            )
+            return []
+
+        if response.get('code') != '0':
+            log.warning(
+                f'Could not query {self.name} {product_name} balances due to OKX API error '
+                f'{response.get("code", "unknown")}: {response.get("msg", "unknown error")}. '
+                f'Skipping {product_name} balances.',
+            )
+            return []
+
+        data = response.get('data')
+        if not isinstance(data, list):
+            log.warning(
+                f'Could not query {self.name} {product_name} balances because the response '
+                f'does not contain list `data`. Skipping {product_name} balances.',
+            )
+            return []
+
+        result: list[dict] = []
+        for entry in data:
+            if not isinstance(entry, dict):
+                log.warning(
+                    f'Could not process {self.name} {product_name} balance because an entry '
+                    'is not an object. Skipping entry.',
+                )
+                continue
+            result.append(entry)
+
+        return result
+
+    def _query_onchain_earn_balances(self) -> list[tuple[dict, tuple[str, ...]]]:
+        """Query active On-chain Earn orders without failing the whole balance query."""
+        balances: list[tuple[dict, tuple[str, ...]]] = []
+        for order in self._query_earn_data(OkxEndpoint.ONCHAIN_EARN_ORDERS, 'On-chain Earn'):
+            for entries_key, amount_key in (
+                    ('investData', 'amt'),
+                    ('earningData', 'earnings'),
+            ):
+                entries = order.get(entries_key, [])
+                if not isinstance(entries, list):
+                    log.warning(
+                        f'Could not process {self.name} On-chain Earn balance because '
+                        f'`{entries_key}` is not a list. Skipping order component.',
+                    )
+                    continue
+
+                for entry in entries:
+                    if not isinstance(entry, dict):
+                        log.warning(
+                            f'Could not process {self.name} On-chain Earn balance because an '
+                            f'`{entries_key}` entry is not an object. Skipping entry.',
+                        )
+                        continue
+                    if entries_key == 'earningData' and entry.get('earningType') != '0':
+                        continue
+                    balances.append((entry, (amount_key,)))
+
+        return balances
+
     def query_balances(self, **kwargs: Any) -> ExchangeQueryBalances:
         """
         https://www.okx.com/docs-v5/en/#trading-account-rest-api-get-balance
         https://www.okx.com/docs-v5/en/#funding-account-rest-api-get-balance
+        https://www.okx.com/docs-v5/en/#financial-product-simple-earn-flexible-get-saving-balance
+        https://www.okx.com/docs-v5/en/#financial-product-on-chain-earn-get-active-orders
         """
-        currencies_data: list[dict] = []
+        currencies_data: list[tuple[dict, tuple[str, ...]]] = []
         try:
             data = self._api_query_list(endpoint=OkxEndpoint.TRADING_BALANCE)
         except RemoteError as e:
@@ -275,15 +347,29 @@ class Okx(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
             return None, msg
 
         try:
-            currencies_data.extend(data[0]['details'])
+            currencies_data.extend(
+                (entry, ('availBal', 'frozenBal'))
+                for entry in data[0]['details']
+            )
         except KeyError as e:
             msg = f'Missing key: {e!s}'
             log.error(f'{self.name} API request failed due to {msg}')
             return None, msg
 
-        currencies_data.extend(self._api_query_list(endpoint=OkxEndpoint.FUNDING_BALANCE))
+        currencies_data.extend(
+            (entry, ('availBal', 'frozenBal'))
+            for entry in self._api_query_list(endpoint=OkxEndpoint.FUNDING_BALANCE)
+        )
+        # `amt` is the complete Simple Earn balance. `loanAmt`, `pendingAmt`, and
+        # `earnings` are components/information about that amount, so adding them
+        # would double count the holding.
+        currencies_data.extend(
+            (entry, ('amt',))
+            for entry in self._query_earn_data(OkxEndpoint.SAVINGS_BALANCE, 'Simple Earn')
+        )
+        currencies_data.extend(self._query_onchain_earn_balances())
         amounts: defaultdict[AssetWithOracles, FVal] = defaultdict(FVal)
-        for currency_data in currencies_data:
+        for currency_data, amount_keys in currencies_data:
             try:
                 asset = asset_from_okx(okx_name=currency_data['ccy'])
             except UnknownAsset as e:
@@ -294,12 +380,18 @@ class Okx(ExchangeInterface, ExchangeWithExtras, SignatureGeneratorMixin):
                 continue
 
             try:
-                amount = deserialize_fval(currency_data['availBal']) + deserialize_fval(currency_data['frozenBal'])  # noqa: E501
-            except DeserializationError as e:
+                amount = sum(
+                    (deserialize_fval(currency_data[key]) for key in amount_keys),
+                    start=ZERO,
+                )
+            except (DeserializationError, KeyError) as e:
                 self.msg_aggregator.add_error(
                     f'Error processing {self.name} {asset.name} balance result due to inability '
                     f'to deserialize asset amount due to {e!s}. Skipping balance result.',
                 )
+                continue
+
+            if amount == ZERO:
                 continue
 
             amounts[asset] += amount

--- a/rotkehlchen/tests/exchanges/test_okx.py
+++ b/rotkehlchen/tests/exchanges/test_okx.py
@@ -1,4 +1,6 @@
+import logging
 import warnings as test_warnings
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -7,6 +9,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.converters import asset_from_okx
 from rotkehlchen.constants.assets import A_ETH, A_USDC, A_USDT
 from rotkehlchen.errors.asset import UnknownAsset
+from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.exchanges.okx import Okx, OkxEndpoint
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
@@ -53,6 +56,10 @@ def test_okx_query_balances(mock_okx: Okx):
     def mock_okx_balances(method, url, **_kwargs):     # pylint: disable=unused-argument
         if '/api/v5/asset/balances' in url:
             return MockResponse(200, '{"code":"0","data":[{"availBal":"25","bal":"25","ccy":"USDT","frozenBal":"0"},{"availBal":"30","bal":"30","ccy":"USDC","frozenBal":"0"}],"msg":""}')  # noqa: E501
+        if '/api/v5/finance/savings/balance' in url:
+            return MockResponse(200, '{"code":"0","data":[],"msg":""}')
+        if '/api/v5/finance/staking-defi/orders-active' in url:
+            return MockResponse(200, '{"code":"0","data":[],"msg":""}')
 
         return MockResponse(
             200,
@@ -175,6 +182,97 @@ def test_okx_query_balances(mock_okx: Okx):
     errors = mock_okx.msg_aggregator.consume_errors()
     assert len(warnings) == 0
     assert len(errors) == 0
+
+
+def test_okx_query_balances_includes_earn_balances(mock_okx: Okx) -> None:
+    responses: dict[OkxEndpoint, dict] = {
+        OkxEndpoint.TRADING_BALANCE: {'data': [{'details': [
+            {'ccy': 'USDT', 'availBal': '2', 'frozenBal': '3'},
+        ]}]},
+        OkxEndpoint.FUNDING_BALANCE: {'data': [
+            {'ccy': 'USDT', 'availBal': '5', 'frozenBal': '7'},
+            {'ccy': 'ADA', 'availBal': '100', 'frozenBal': '0'},
+        ]},
+        OkxEndpoint.SAVINGS_BALANCE: {'code': '0', 'data': [
+            {'ccy': 'USDT', 'amt': '11.0010737453457821'},
+            {'ccy': 'ETH', 'amt': '0.5'},
+            {'ccy': 'USDC', 'amt': '0'},
+            {'ccy': 'INVALID', 'amt': '5'},
+        ]},
+        OkxEndpoint.ONCHAIN_EARN_ORDERS: {'code': '0', 'data': [
+            {
+                'investData': [{'ccy': 'ADA', 'amt': '400'}],
+                'earningData': [
+                    {'ccy': 'ADA', 'earnings': '1.604', 'earningType': '0'},
+                    {'ccy': 'ADA', 'earnings': '100', 'earningType': '1'},
+                ],
+            },
+            {
+                'investData': [{'ccy': 'ETH', 'amt': '0.25'}],
+                'earningData': [{'ccy': 'USDT', 'earnings': '2', 'earningType': '0'}],
+            },
+            {'investData': []},
+        ]},
+    }
+
+    with (
+            patch.object(mock_okx, '_api_query', side_effect=lambda endpoint, **_kwargs: responses[endpoint]),  # noqa: E501
+            patch.object(mock_okx, 'send_unknown_asset_message') as unknown_asset,
+    ):
+        balances, msg = mock_okx.query_balances()
+
+    assert msg == ''
+    assert balances is not None
+    assert balances[Asset('ADA').resolve_to_asset_with_oracles()].amount == FVal('501.604')
+    assert balances[A_ETH.resolve_to_asset_with_oracles()].amount == FVal('0.75')
+    assert balances[A_USDT.resolve_to_asset_with_oracles()].amount == FVal('30.0010737453457821')
+    assert A_USDC.resolve_to_asset_with_oracles() not in balances
+    unknown_asset.assert_called_once_with(asset_identifier='INVALID', details='balance query')
+    assert mock_okx.msg_aggregator.consume_warnings() == []
+    assert mock_okx.msg_aggregator.consume_errors() == []
+
+
+@pytest.mark.parametrize(
+    ('failing_endpoint', 'response', 'warning_text'),
+    [
+        (OkxEndpoint.SAVINGS_BALANCE, {'code': '50101', 'msg': 'Permission denied'}, '50101'),
+        (OkxEndpoint.ONCHAIN_EARN_ORDERS, RemoteError('connection reset'), 'connection reset'),
+        (OkxEndpoint.SAVINGS_BALANCE, {'code': '0', 'data': {}}, 'does not contain list'),
+    ],
+)
+def test_okx_query_balances_degrades_when_earn_query_fails(
+        mock_okx: Okx,
+        caplog: pytest.LogCaptureFixture,
+        failing_endpoint: OkxEndpoint,
+        response: dict[str, Any] | RemoteError,
+        warning_text: str,
+) -> None:
+    responses: dict[OkxEndpoint, dict[str, Any]] = {
+        OkxEndpoint.TRADING_BALANCE: {'data': [{'details': [
+            {'ccy': 'USDT', 'availBal': '1', 'frozenBal': '0'},
+        ]}]},
+        OkxEndpoint.FUNDING_BALANCE: {'data': []},
+        OkxEndpoint.SAVINGS_BALANCE: {'code': '0', 'data': []},
+        OkxEndpoint.ONCHAIN_EARN_ORDERS: {'code': '0', 'data': []},
+    }
+
+    def mock_api_query(endpoint: OkxEndpoint, **_kwargs: object) -> dict[str, Any]:
+        if endpoint == failing_endpoint:
+            if isinstance(response, RemoteError):
+                raise response
+            return response
+        return responses[endpoint]
+
+    with (
+            caplog.at_level(logging.WARNING),
+            patch.object(mock_okx, '_api_query', side_effect=mock_api_query),
+    ):
+        balances, msg = mock_okx.query_balances()
+
+    assert msg == ''
+    assert balances is not None
+    assert balances[A_USDT.resolve_to_asset_with_oracles()].amount == FVal(1)
+    assert warning_text in caplog.text
 
 
 def test_okx_query_trades(mock_okx: Okx) -> None:


### PR DESCRIPTION
Closes #12629

## Summary
- Include Simple Earn Flexible balances using the complete `amt` field.
- Include active On-chain Earn principal and accrued earnings.
- Keep Earn calls best-effort so unavailable regional or API endpoints do not hide Trading or Funding balances.

## Testing
- `python -m pytest rotkehlchen/tests/exchanges/test_okx.py -q` (11 passed)
- `ruff check --isolated rotkehlchen/exchanges/okx.py rotkehlchen/tests/exchanges/test_okx.py`