### PR TITLE
Reduce template-depth warnings via presentational extraction

### DIFF
--- a/frontend/app/src/modules/assets/detection/NewlyDetectedAssetRowActions.spec.ts
+++ b/frontend/app/src/modules/assets/detection/NewlyDetectedAssetRowActions.spec.ts
@@ -1,0 +1,21 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import NewlyDetectedAssetRowActions from '@/modules/assets/detection/NewlyDetectedAssetRowActions.vue';
+
+function mountRowActions(): VueWrapper<InstanceType<typeof NewlyDetectedAssetRowActions>> {
+  return mount(NewlyDetectedAssetRowActions);
+}
+
+describe('modules/assets/detection/NewlyDetectedAssetRowActions', () => {
+  it('should emit accept when the accept button is clicked', async () => {
+    const wrapper = mountRowActions();
+    await wrapper.find('[data-testid=accept-token]').trigger('click');
+    expect(wrapper.emitted('accept')).toHaveLength(1);
+  });
+
+  it('should emit mark-spam when the spam button is clicked', async () => {
+    const wrapper = mountRowActions();
+    await wrapper.find('[data-testid=mark-token-spam]').trigger('click');
+    expect(wrapper.emitted('mark-spam')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/assets/detection/NewlyDetectedAssetRowActions.vue
+++ b/frontend/app/src/modules/assets/detection/NewlyDetectedAssetRowActions.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+const emit = defineEmits<{
+  'accept': [];
+  'mark-spam': [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <RuiButtonGroup class="dark:!divide-rui-grey-800">
+    <RuiTooltip
+      :open-delay="300"
+      :close-delay="0"
+    >
+      <template #activator>
+        <RuiButton
+          color="success"
+          icon
+          variant="text"
+          class="m-auto !rounded-none"
+          data-testid="accept-token"
+          @click="emit('accept')"
+        >
+          <RuiIcon name="lu-check" />
+        </RuiButton>
+      </template>
+      {{ t('asset_table.newly_detected.accept') }}
+    </RuiTooltip>
+    <RuiTooltip
+      :open-delay="300"
+      :close-delay="0"
+    >
+      <template #activator>
+        <RuiButton
+          color="error"
+          icon
+          variant="text"
+          class="m-auto !rounded-none"
+          data-testid="mark-token-spam"
+          @click="emit('mark-spam')"
+        >
+          <RuiIcon name="lu-octagon-alert" />
+        </RuiButton>
+      </template>
+      {{ t('asset_table.newly_detected.mark_as_spam') }}
+    </RuiTooltip>
+  </RuiButtonGroup>
+</template>

--- a/frontend/app/src/modules/assets/detection/NewlyDetectedAssetTable.vue
+++ b/frontend/app/src/modules/assets/detection/NewlyDetectedAssetTable.vue
@@ -13,9 +13,10 @@ import { usePaginationFilters } from '@/modules/core/table/use-pagination-filter
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import HashLink from '@/modules/shell/components/HashLink.vue';
-import HintMenuIcon from '@/modules/shell/components/HintMenuIcon.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 import { getTokenChain } from './get-token-chain';
+import NewlyDetectedAssetRowActions from './NewlyDetectedAssetRowActions.vue';
+import NewlyDetectedAssetToolbar from './NewlyDetectedAssetToolbar.vue';
 import { type NewDetectedToken, NewDetectedTokenKind } from './types';
 import { useNewlyDetectedTokens } from './use-newly-detected-tokens';
 
@@ -206,90 +207,16 @@ onMounted(async () => {
   >
     <RuiCard>
       <template #custom-header>
-        <div class="flex flex-col gap-4 px-4 pt-4">
-          <div class="flex gap-4 justify-between grow">
-            <div class="flex gap-4 content-center">
-              <RuiTooltip
-                :popper="{ placement: 'bottom' }"
-                :open-delay="500"
-              >
-                <template #activator>
-                  <RuiCheckbox
-                    color="primary"
-                    hide-details
-                    size="sm"
-                    class="ml-2 mt-1 text-body-2"
-                    :disabled="state.found === 0"
-                    :model-value="allSelected"
-                    @update:model-value="toggleSelection()"
-                  >
-                    {{ t('asset_table.selected', { count: selected.length }) }}
-                  </RuiCheckbox>
-                </template>
-                {{ t('asset_table.newly_detected.select_deselect_all_tokens') }}
-              </RuiTooltip>
-
-              <div>
-                <RuiTooltip
-                  :popper="{ placement: 'bottom' }"
-                  :open-delay="500"
-                >
-                  <template #activator>
-                    <RuiButton
-                      :disabled="selected.length === 0"
-                      color="success"
-                      variant="text"
-                      class="w-12 h-12"
-                      @click="removeTokens()"
-                    >
-                      <RuiIcon name="lu-check" />
-                    </RuiButton>
-                  </template>
-
-                  {{ t('asset_table.newly_detected.accept_selected') }}
-                </RuiTooltip>
-
-                <RuiTooltip
-                  :popper="{ placement: 'bottom' }"
-                  :open-delay="500"
-                >
-                  <template #activator>
-                    <RuiButton
-                      :disabled="selected.length === 0"
-                      color="error"
-                      variant="text"
-                      class="w-12 h-12"
-                      @click="markAsSpam()"
-                    >
-                      <RuiIcon name="lu-octagon-alert" />
-                    </RuiButton>
-                  </template>
-
-                  {{ t('asset_table.newly_detected.mark_selected_as_spam') }}
-                </RuiTooltip>
-              </div>
-            </div>
-
-            <HintMenuIcon :popper="{ placement: 'left-start' }">
-              {{ t('asset_table.newly_detected.subtitle') }}
-            </HintMenuIcon>
-          </div>
-
-          <!-- Filters -->
-          <div class="flex gap-4 items-center">
-            <RuiMenuSelect
-              v-model="tokenKindFilter"
-              :options="tokenKindOptions"
-              :label="t('asset_table.newly_detected.token_type')"
-              key-attr="value"
-              text-attr="title"
-              variant="outlined"
-              dense
-              hide-details
-              class="max-w-[180px]"
-            />
-          </div>
-        </div>
+        <NewlyDetectedAssetToolbar
+          v-model="tokenKindFilter"
+          :all-selected="allSelected"
+          :selected-count="selected.length"
+          :found="state.found"
+          :token-kind-options="tokenKindOptions"
+          @toggle-selection="toggleSelection()"
+          @accept="removeTokens()"
+          @mark-spam="markAsSpam()"
+        />
       </template>
 
       <RuiDataTable
@@ -347,45 +274,11 @@ onMounted(async () => {
         </template>
 
         <template #item.actions="{ row }">
-          <RuiButtonGroup
+          <NewlyDetectedAssetRowActions
             :key="row.tokenIdentifier"
-            class="dark:!divide-rui-grey-800"
-          >
-            <RuiTooltip
-              :open-delay="300"
-              :close-delay="0"
-            >
-              <template #activator>
-                <RuiButton
-                  color="success"
-                  icon
-                  variant="text"
-                  class="m-auto !rounded-none"
-                  @click="removeTokens(row.tokenIdentifier)"
-                >
-                  <RuiIcon name="lu-check" />
-                </RuiButton>
-              </template>
-              {{ t('asset_table.newly_detected.accept') }}
-            </RuiTooltip>
-            <RuiTooltip
-              :open-delay="300"
-              :close-delay="0"
-            >
-              <template #activator>
-                <RuiButton
-                  color="error"
-                  icon
-                  variant="text"
-                  class="m-auto !rounded-none"
-                  @click="markAsSpam(row.tokenIdentifier)"
-                >
-                  <RuiIcon name="lu-octagon-alert" />
-                </RuiButton>
-              </template>
-              {{ t('asset_table.newly_detected.mark_as_spam') }}
-            </RuiTooltip>
-          </RuiButtonGroup>
+            @accept="removeTokens(row.tokenIdentifier)"
+            @mark-spam="markAsSpam(row.tokenIdentifier)"
+          />
         </template>
       </RuiDataTable>
     </RuiCard>

--- a/frontend/app/src/modules/assets/detection/NewlyDetectedAssetToolbar.spec.ts
+++ b/frontend/app/src/modules/assets/detection/NewlyDetectedAssetToolbar.spec.ts
@@ -1,0 +1,42 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import NewlyDetectedAssetToolbar from '@/modules/assets/detection/NewlyDetectedAssetToolbar.vue';
+import { NewDetectedTokenKind } from '@/modules/assets/detection/types';
+
+interface Props {
+  allSelected?: boolean;
+  selectedCount?: number;
+  found?: number;
+}
+
+function mountToolbar(props: Props = {}): VueWrapper<InstanceType<typeof NewlyDetectedAssetToolbar>> {
+  return mount(NewlyDetectedAssetToolbar, {
+    props: {
+      allSelected: false,
+      found: 3,
+      selectedCount: 1,
+      tokenKindOptions: [{ title: 'EVM', value: NewDetectedTokenKind.EVM }],
+      ...props,
+    },
+  });
+}
+
+describe('modules/assets/detection/NewlyDetectedAssetToolbar', () => {
+  it('should emit accept when the accept-selected button is clicked', async () => {
+    const wrapper = mountToolbar({ selectedCount: 2 });
+    await wrapper.find('[data-testid=accept-selected]').trigger('click');
+    expect(wrapper.emitted('accept')).toHaveLength(1);
+  });
+
+  it('should emit mark-spam when the mark-selected-spam button is clicked', async () => {
+    const wrapper = mountToolbar({ selectedCount: 2 });
+    await wrapper.find('[data-testid=mark-selected-spam]').trigger('click');
+    expect(wrapper.emitted('mark-spam')).toHaveLength(1);
+  });
+
+  it('should disable the action buttons when nothing is selected', () => {
+    const wrapper = mountToolbar({ selectedCount: 0 });
+    expect(wrapper.find('[data-testid=accept-selected]').attributes('disabled')).toBeDefined();
+    expect(wrapper.find('[data-testid=mark-selected-spam]').attributes('disabled')).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/assets/detection/NewlyDetectedAssetToolbar.vue
+++ b/frontend/app/src/modules/assets/detection/NewlyDetectedAssetToolbar.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import type { NewDetectedTokenKind } from './types';
+import HintMenuIcon from '@/modules/shell/components/HintMenuIcon.vue';
+
+interface TokenKindOption {
+  title: string;
+  value: NewDetectedTokenKind | undefined;
+}
+
+const tokenKindFilter = defineModel<NewDetectedTokenKind>();
+
+const {
+  allSelected,
+  selectedCount,
+  found,
+  tokenKindOptions,
+} = defineProps<{
+  allSelected: boolean;
+  selectedCount: number;
+  found: number;
+  tokenKindOptions: TokenKindOption[];
+}>();
+
+const emit = defineEmits<{
+  'toggle-selection': [];
+  'accept': [];
+  'mark-spam': [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="flex flex-col gap-4 px-4 pt-4">
+    <div class="flex gap-4 justify-between grow">
+      <div class="flex gap-4 content-center">
+        <RuiTooltip
+          :popper="{ placement: 'bottom' }"
+          :open-delay="500"
+        >
+          <template #activator>
+            <RuiCheckbox
+              color="primary"
+              hide-details
+              size="sm"
+              class="ml-2 mt-1 text-body-2"
+              :disabled="found === 0"
+              :model-value="allSelected"
+              @update:model-value="emit('toggle-selection')"
+            >
+              {{ t('asset_table.selected', { count: selectedCount }) }}
+            </RuiCheckbox>
+          </template>
+          {{ t('asset_table.newly_detected.select_deselect_all_tokens') }}
+        </RuiTooltip>
+
+        <div>
+          <RuiTooltip
+            :popper="{ placement: 'bottom' }"
+            :open-delay="500"
+          >
+            <template #activator>
+              <RuiButton
+                :disabled="selectedCount === 0"
+                color="success"
+                variant="text"
+                class="w-12 h-12"
+                data-testid="accept-selected"
+                @click="emit('accept')"
+              >
+                <RuiIcon name="lu-check" />
+              </RuiButton>
+            </template>
+
+            {{ t('asset_table.newly_detected.accept_selected') }}
+          </RuiTooltip>
+
+          <RuiTooltip
+            :popper="{ placement: 'bottom' }"
+            :open-delay="500"
+          >
+            <template #activator>
+              <RuiButton
+                :disabled="selectedCount === 0"
+                color="error"
+                variant="text"
+                class="w-12 h-12"
+                data-testid="mark-selected-spam"
+                @click="emit('mark-spam')"
+              >
+                <RuiIcon name="lu-octagon-alert" />
+              </RuiButton>
+            </template>
+
+            {{ t('asset_table.newly_detected.mark_selected_as_spam') }}
+          </RuiTooltip>
+        </div>
+      </div>
+
+      <HintMenuIcon :popper="{ placement: 'left-start' }">
+        {{ t('asset_table.newly_detected.subtitle') }}
+      </HintMenuIcon>
+    </div>
+
+    <!-- Filters -->
+    <div class="flex gap-4 items-center">
+      <RuiMenuSelect
+        v-model="tokenKindFilter"
+        :options="tokenKindOptions"
+        :label="t('asset_table.newly_detected.token_type')"
+        key-attr="value"
+        text-attr="title"
+        variant="outlined"
+        dense
+        hide-details
+        class="max-w-[180px]"
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/history/events/UnmatchedBridgesList.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedBridgesList.vue
@@ -6,6 +6,7 @@ import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogConten
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
+import UnmatchedRowActions, { type UnmatchedRowActionLabels } from '@/modules/history/events/UnmatchedRowActions.vue';
 import { type ColumnClassConfig, usePinnedAssetColumnClass, usePinnedColumnClass } from '@/modules/history/events/use-pinned-column-class';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
@@ -141,6 +142,21 @@ function getRowClass(row: UnmatchedBridgeRow): string {
   }
   return classes.join(' ');
 }
+
+function actionLabels(row: UnmatchedBridgeRow): UnmatchedRowActionLabels {
+  return {
+    findMatch: t('asset_movement_matching.dialog.find_match'),
+    ignore: t('asset_movement_matching.dialog.ignore'),
+    ignoreTooltip: t('bridge_matching.dialog.ignore_tooltip'),
+    markExternal: t('bridge_matching.dialog.mark_external'),
+    markExternalTooltip: row.direction === 'deposit'
+      ? t('bridge_matching.dialog.mark_external_tooltip')
+      : t('bridge_matching.dialog.mark_external_in_tooltip'),
+    restore: t('asset_movement_matching.dialog.restore'),
+    restoreTooltip: t('bridge_matching.dialog.restore_tooltip'),
+    showInEventsTooltip: t('asset_movement_matching.dialog.show_in_events'),
+  };
+}
 </script>
 
 <template>
@@ -272,101 +288,19 @@ function getRowClass(row: UnmatchedBridgeRow): string {
           </div>
         </template>
         <template #item.actions="{ row }">
-          <div class="flex items-center gap-2">
-            <RuiTooltip
-              :open-delay="400"
-              :popper="{ placement: 'top' }"
-            >
-              <template #activator>
-                <RuiButton
-                  size="sm"
-                  variant="outlined"
-                  icon
-                  color="primary"
-                  class="!px-2 h-[30px]"
-                  @click="emit('show-in-events', row.original)"
-                >
-                  <RuiIcon
-                    size="16"
-                    name="lu-external-link"
-                  />
-                </RuiButton>
-              </template>
-              {{ t('asset_movement_matching.dialog.show_in_events') }}
-            </RuiTooltip>
-            <template v-if="showRestore">
-              <RuiTooltip
-                :open-delay="400"
-                :popper="{ placement: 'top' }"
-              >
-                <template #activator>
-                  <RuiButton
-                    size="sm"
-                    color="primary"
-                    :loading="ignoreLoading"
-                    @click="emit('restore', row.original)"
-                  >
-                    {{ t('asset_movement_matching.dialog.restore') }}
-                  </RuiButton>
-                </template>
-                {{ t('bridge_matching.dialog.restore_tooltip') }}
-              </RuiTooltip>
-            </template>
-            <div
-              v-else
-              class="flex"
-              :class="isPinned ? 'flex-wrap gap-1' : 'gap-2'"
-            >
-              <RuiButton
-                size="sm"
-                color="primary"
-                :class="{ '!py-0.5': isPinned }"
-                :disabled="matchDisabled"
-                @click="emit('select', row.original)"
-              >
-                {{ t('asset_movement_matching.dialog.find_match') }}
-              </RuiButton>
-              <RuiTooltip
-                :open-delay="400"
-                :popper="{ placement: 'top' }"
-              >
-                <template #activator>
-                  <RuiButton
-                    size="sm"
-                    variant="outlined"
-                    :class="{ '!py-0.5': isPinned }"
-                    :loading="ignoreLoading"
-                    @click="emit('ignore', row.original)"
-                  >
-                    {{ t('asset_movement_matching.dialog.ignore') }}
-                  </RuiButton>
-                </template>
-                {{ t('bridge_matching.dialog.ignore_tooltip') }}
-              </RuiTooltip>
-              <RuiTooltip
-                :open-delay="400"
-                :popper="{ placement: 'top' }"
-              >
-                <template #activator>
-                  <RuiButton
-                    size="sm"
-                    variant="outlined"
-                    color="warning"
-                    :class="{ '!py-0.5': isPinned }"
-                    :loading="ignoreLoading"
-                    @click="emit('mark-external', row.original)"
-                  >
-                    {{ t('bridge_matching.dialog.mark_external') }}
-                  </RuiButton>
-                </template>
-                {{
-                  row.direction === 'deposit'
-                    ? t('bridge_matching.dialog.mark_external_tooltip')
-                    : t('bridge_matching.dialog.mark_external_in_tooltip')
-                }}
-              </RuiTooltip>
-            </div>
-          </div>
+          <UnmatchedRowActions
+            :labels="actionLabels(row)"
+            :is-pinned="isPinned"
+            :show-restore="showRestore"
+            :ignore-loading="ignoreLoading"
+            :match-disabled="matchDisabled"
+            show-mark-external
+            @show-in-events="emit('show-in-events', row.original)"
+            @restore="emit('restore', row.original)"
+            @select="emit('select', row.original)"
+            @ignore="emit('ignore', row.original)"
+            @mark-external="emit('mark-external', row.original)"
+          />
         </template>
       </RuiDataTable>
     </ScrollableDialogContent>

--- a/frontend/app/src/modules/history/events/UnmatchedBridgesList.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedBridgesList.vue
@@ -6,12 +6,12 @@ import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogConten
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
+import UnmatchedMatchDisabledAlert from '@/modules/history/events/UnmatchedMatchDisabledAlert.vue';
 import UnmatchedRowActions, { type UnmatchedRowActionLabels } from '@/modules/history/events/UnmatchedRowActions.vue';
 import { type ColumnClassConfig, usePinnedAssetColumnClass, usePinnedColumnClass } from '@/modules/history/events/use-pinned-column-class';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
-import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 
 interface UnmatchedBridgeRow {
   groupIdentifier: string;
@@ -203,49 +203,12 @@ function actionLabels(row: UnmatchedBridgeRow): UnmatchedRowActionLabels {
         >
           <tr>
             <td :colspan="columns.length + 1">
-              <RuiAlert
-                type="warning"
-                size="sm"
-                class="whitespace-break-spaces !py-0.5 !rounded-none"
-              >
-                <i18n-t
-                  v-if="premium"
-                  scope="global"
-                  keypath="bridge_matching.premium.premium_tooltip"
-                >
-                  <template #tier>
-                    <strong>{{ matchMinimumTier }}</strong>
-                  </template>
-                  <template #currentTier>
-                    <strong>{{ currentTier }}</strong>
-                  </template>
-                  <template #link>
-                    <ExternalLink
-                      premium
-                      color="primary"
-                    >
-                      {{ t('asset_movement_matching.premium.link') }}
-                    </ExternalLink>
-                  </template>
-                </i18n-t>
-                <i18n-t
-                  v-else
-                  scope="global"
-                  keypath="bridge_matching.premium.free_tooltip"
-                >
-                  <template #tier>
-                    <strong>{{ matchMinimumTier }}</strong>
-                  </template>
-                  <template #link>
-                    <ExternalLink
-                      premium
-                      color="primary"
-                    >
-                      {{ t('asset_movement_matching.premium.link') }}
-                    </ExternalLink>
-                  </template>
-                </i18n-t>
-              </RuiAlert>
+              <UnmatchedMatchDisabledAlert
+                variant="bridge"
+                :premium="premium"
+                :current-tier="currentTier"
+                :match-minimum-tier="matchMinimumTier"
+              />
             </td>
           </tr>
         </template>

--- a/frontend/app/src/modules/history/events/UnmatchedMatchDisabledAlert.spec.ts
+++ b/frontend/app/src/modules/history/events/UnmatchedMatchDisabledAlert.spec.ts
@@ -1,0 +1,38 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import UnmatchedMatchDisabledAlert from '@/modules/history/events/UnmatchedMatchDisabledAlert.vue';
+
+interface Props {
+  variant: 'bridge' | 'asset-movement';
+  premium?: boolean;
+  currentTier?: string | null;
+  matchMinimumTier?: string | null;
+}
+
+function mountAlert(props: Props): VueWrapper<InstanceType<typeof UnmatchedMatchDisabledAlert>> {
+  return mount(UnmatchedMatchDisabledAlert, {
+    props,
+  });
+}
+
+describe('modules/history/events/UnmatchedMatchDisabledAlert', () => {
+  it('should render the bridge premium message', () => {
+    const wrapper = mountAlert({ premium: true, variant: 'bridge' });
+    expect(wrapper.find('i18n-t-stub').attributes('keypath')).toBe('bridge_matching.premium.premium_tooltip');
+  });
+
+  it('should render the bridge free message', () => {
+    const wrapper = mountAlert({ premium: false, variant: 'bridge' });
+    expect(wrapper.find('i18n-t-stub').attributes('keypath')).toBe('bridge_matching.premium.free_tooltip');
+  });
+
+  it('should render the asset-movement premium message', () => {
+    const wrapper = mountAlert({ premium: true, variant: 'asset-movement' });
+    expect(wrapper.find('i18n-t-stub').attributes('keypath')).toBe('asset_movement_matching.premium.premium_tooltip');
+  });
+
+  it('should render the asset-movement free message', () => {
+    const wrapper = mountAlert({ premium: false, variant: 'asset-movement' });
+    expect(wrapper.find('i18n-t-stub').attributes('keypath')).toBe('asset_movement_matching.premium.free_tooltip');
+  });
+});

--- a/frontend/app/src/modules/history/events/UnmatchedMatchDisabledAlert.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMatchDisabledAlert.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
+
+const {
+  variant,
+  premium = false,
+  currentTier = null,
+  matchMinimumTier = null,
+} = defineProps<{
+  variant: 'bridge' | 'asset-movement';
+  premium?: boolean;
+  currentTier?: string | null;
+  matchMinimumTier?: string | null;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <RuiAlert
+    type="warning"
+    size="sm"
+    class="whitespace-break-spaces !py-0.5 !rounded-none"
+  >
+    <i18n-t
+      v-if="variant === 'bridge' && premium"
+      scope="global"
+      keypath="bridge_matching.premium.premium_tooltip"
+    >
+      <template #tier>
+        <strong>{{ matchMinimumTier }}</strong>
+      </template>
+      <template #currentTier>
+        <strong>{{ currentTier }}</strong>
+      </template>
+      <template #link>
+        <ExternalLink
+          premium
+          color="primary"
+        >
+          {{ t('asset_movement_matching.premium.link') }}
+        </ExternalLink>
+      </template>
+    </i18n-t>
+    <i18n-t
+      v-else-if="variant === 'bridge'"
+      scope="global"
+      keypath="bridge_matching.premium.free_tooltip"
+    >
+      <template #tier>
+        <strong>{{ matchMinimumTier }}</strong>
+      </template>
+      <template #link>
+        <ExternalLink
+          premium
+          color="primary"
+        >
+          {{ t('asset_movement_matching.premium.link') }}
+        </ExternalLink>
+      </template>
+    </i18n-t>
+    <i18n-t
+      v-else-if="premium"
+      scope="global"
+      keypath="asset_movement_matching.premium.premium_tooltip"
+    >
+      <template #tier>
+        <strong>{{ matchMinimumTier }}</strong>
+      </template>
+      <template #currentTier>
+        <strong>{{ currentTier }}</strong>
+      </template>
+      <template #link>
+        <ExternalLink
+          premium
+          color="primary"
+        >
+          {{ t('asset_movement_matching.premium.link') }}
+        </ExternalLink>
+      </template>
+    </i18n-t>
+    <i18n-t
+      v-else
+      scope="global"
+      keypath="asset_movement_matching.premium.free_tooltip"
+    >
+      <template #tier>
+        <strong>{{ matchMinimumTier }}</strong>
+      </template>
+      <template #link>
+        <ExternalLink
+          premium
+          color="primary"
+        >
+          {{ t('asset_movement_matching.premium.link') }}
+        </ExternalLink>
+      </template>
+    </i18n-t>
+  </RuiAlert>
+</template>

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsList.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsList.vue
@@ -6,13 +6,13 @@ import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogConten
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
+import UnmatchedMatchDisabledAlert from '@/modules/history/events/UnmatchedMatchDisabledAlert.vue';
 import UnmatchedRowActions, { type UnmatchedRowActionLabels } from '@/modules/history/events/UnmatchedRowActions.vue';
 import { type ColumnClassConfig, usePinnedAssetColumnClass, usePinnedColumnClass } from '@/modules/history/events/use-pinned-column-class';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import { getAssetMovementsType } from '@/modules/history/management/forms/utils';
 import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
-import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 
 interface UnmatchedMovementRow {
   groupIdentifier: string;
@@ -199,49 +199,12 @@ const actionLabels = computed<UnmatchedRowActionLabels>(() => ({
         >
           <tr>
             <td :colspan="columns.length + 1">
-              <RuiAlert
-                type="warning"
-                size="sm"
-                class="whitespace-break-spaces !py-0.5 !rounded-none"
-              >
-                <i18n-t
-                  v-if="premium"
-                  scope="global"
-                  keypath="asset_movement_matching.premium.premium_tooltip"
-                >
-                  <template #tier>
-                    <strong>{{ matchMinimumTier }}</strong>
-                  </template>
-                  <template #currentTier>
-                    <strong>{{ currentTier }}</strong>
-                  </template>
-                  <template #link>
-                    <ExternalLink
-                      premium
-                      color="primary"
-                    >
-                      {{ t('asset_movement_matching.premium.link') }}
-                    </ExternalLink>
-                  </template>
-                </i18n-t>
-                <i18n-t
-                  v-else
-                  scope="global"
-                  keypath="asset_movement_matching.premium.free_tooltip"
-                >
-                  <template #tier>
-                    <strong>{{ matchMinimumTier }}</strong>
-                  </template>
-                  <template #link>
-                    <ExternalLink
-                      premium
-                      color="primary"
-                    >
-                      {{ t('asset_movement_matching.premium.link') }}
-                    </ExternalLink>
-                  </template>
-                </i18n-t>
-              </RuiAlert>
+              <UnmatchedMatchDisabledAlert
+                variant="asset-movement"
+                :premium="premium"
+                :current-tier="currentTier"
+                :match-minimum-tier="matchMinimumTier"
+              />
             </td>
           </tr>
         </template>

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsList.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsList.vue
@@ -6,6 +6,7 @@ import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogConten
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
+import UnmatchedRowActions, { type UnmatchedRowActionLabels } from '@/modules/history/events/UnmatchedRowActions.vue';
 import { type ColumnClassConfig, usePinnedAssetColumnClass, usePinnedColumnClass } from '@/modules/history/events/use-pinned-column-class';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import { getAssetMovementsType } from '@/modules/history/management/forms/utils';
@@ -143,6 +144,15 @@ function getRowClass(row: UnmatchedMovementRow): string {
   }
   return classes.join(' ');
 }
+
+const actionLabels = computed<UnmatchedRowActionLabels>(() => ({
+  findMatch: t('asset_movement_matching.dialog.find_match'),
+  ignore: t('asset_movement_matching.dialog.ignore'),
+  ignoreTooltip: t('asset_movement_matching.dialog.ignore_tooltip'),
+  restore: t('asset_movement_matching.dialog.restore'),
+  restoreTooltip: t('asset_movement_matching.dialog.restore_tooltip'),
+  showInEventsTooltip: t('asset_movement_matching.dialog.show_in_events'),
+}));
 </script>
 
 <template>
@@ -292,79 +302,17 @@ function getRowClass(row: UnmatchedMovementRow): string {
           </div>
         </template>
         <template #item.actions="{ row }">
-          <div class="flex items-center gap-2">
-            <RuiTooltip
-              :open-delay="400"
-              :popper="{ placement: 'top' }"
-            >
-              <template #activator>
-                <RuiButton
-                  size="sm"
-                  variant="outlined"
-                  icon
-                  color="primary"
-                  class="!px-2 h-[30px]"
-                  @click="emit('show-in-events', row.original)"
-                >
-                  <RuiIcon
-                    size="16"
-                    name="lu-external-link"
-                  />
-                </RuiButton>
-              </template>
-              {{ t('asset_movement_matching.dialog.show_in_events') }}
-            </RuiTooltip>
-            <template v-if="showRestore">
-              <RuiTooltip
-                :open-delay="400"
-                :popper="{ placement: 'top' }"
-              >
-                <template #activator>
-                  <RuiButton
-                    size="sm"
-                    color="primary"
-                    :loading="ignoreLoading"
-                    @click="emit('restore', row.original)"
-                  >
-                    {{ t('asset_movement_matching.dialog.restore') }}
-                  </RuiButton>
-                </template>
-                {{ t('asset_movement_matching.dialog.restore_tooltip') }}
-              </RuiTooltip>
-            </template>
-            <div
-              v-else
-              class="flex"
-              :class="isPinned ? 'flex-wrap gap-1' : 'gap-2'"
-            >
-              <RuiButton
-                size="sm"
-                color="primary"
-                :class="{ '!py-0.5': isPinned }"
-                :disabled="matchDisabled"
-                @click="emit('select', row.original)"
-              >
-                {{ t('asset_movement_matching.dialog.find_match') }}
-              </RuiButton>
-              <RuiTooltip
-                :open-delay="400"
-                :popper="{ placement: 'top' }"
-              >
-                <template #activator>
-                  <RuiButton
-                    size="sm"
-                    variant="outlined"
-                    :class="{ '!py-0.5': isPinned }"
-                    :loading="ignoreLoading"
-                    @click="emit('ignore', row.original)"
-                  >
-                    {{ t('asset_movement_matching.dialog.ignore') }}
-                  </RuiButton>
-                </template>
-                {{ t('asset_movement_matching.dialog.ignore_tooltip') }}
-              </RuiTooltip>
-            </div>
-          </div>
+          <UnmatchedRowActions
+            :labels="actionLabels"
+            :is-pinned="isPinned"
+            :show-restore="showRestore"
+            :ignore-loading="ignoreLoading"
+            :match-disabled="matchDisabled"
+            @show-in-events="emit('show-in-events', row.original)"
+            @restore="emit('restore', row.original)"
+            @select="emit('select', row.original)"
+            @ignore="emit('ignore', row.original)"
+          />
         </template>
       </RuiDataTable>
     </ScrollableDialogContent>

--- a/frontend/app/src/modules/history/events/UnmatchedRowActions.spec.ts
+++ b/frontend/app/src/modules/history/events/UnmatchedRowActions.spec.ts
@@ -1,0 +1,84 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import UnmatchedRowActions, { type UnmatchedRowActionLabels } from '@/modules/history/events/UnmatchedRowActions.vue';
+
+const labels: UnmatchedRowActionLabels = {
+  findMatch: 'Find match',
+  ignore: 'Ignore',
+  ignoreTooltip: 'Ignore tooltip',
+  markExternal: 'Mark external',
+  markExternalTooltip: 'Mark external tooltip',
+  restore: 'Restore',
+  restoreTooltip: 'Restore tooltip',
+  showInEventsTooltip: 'Show in events',
+};
+
+interface Props {
+  isPinned?: boolean;
+  showRestore?: boolean;
+  ignoreLoading?: boolean;
+  matchDisabled?: boolean;
+  showMarkExternal?: boolean;
+}
+
+function mountActions(props: Props = {}): VueWrapper<InstanceType<typeof UnmatchedRowActions>> {
+  return mount(UnmatchedRowActions, {
+    props: { labels, ...props },
+  });
+}
+
+describe('modules/history/events/UnmatchedRowActions', () => {
+  it('should render find-match and ignore actions by default', () => {
+    const wrapper = mountActions();
+    expect(wrapper.text()).toContain('Find match');
+    expect(wrapper.text()).toContain('Ignore');
+    expect(wrapper.text()).not.toContain('Restore');
+    expect(wrapper.text()).not.toContain('Mark external');
+  });
+
+  it('should emit show-in-events when the first button is clicked', async () => {
+    const wrapper = mountActions();
+    await wrapper.findAll('button')[0].trigger('click');
+    expect(wrapper.emitted('show-in-events')).toHaveLength(1);
+  });
+
+  it('should emit select when find-match is clicked', async () => {
+    const wrapper = mountActions();
+    const findMatch = wrapper.findAll('button').find(button => button.text() === 'Find match');
+    await findMatch?.trigger('click');
+    expect(wrapper.emitted('select')).toHaveLength(1);
+  });
+
+  it('should emit ignore when ignore is clicked', async () => {
+    const wrapper = mountActions();
+    const ignore = wrapper.findAll('button').find(button => button.text() === 'Ignore');
+    await ignore?.trigger('click');
+    expect(wrapper.emitted('ignore')).toHaveLength(1);
+  });
+
+  it('should disable find-match when matchDisabled is set', () => {
+    const wrapper = mountActions({ matchDisabled: true });
+    const findMatch = wrapper.findAll('button').find(button => button.text() === 'Find match');
+    expect(findMatch?.attributes('disabled')).toBeDefined();
+  });
+
+  it('should show restore instead of match actions when showRestore is set', async () => {
+    const wrapper = mountActions({ showRestore: true });
+    expect(wrapper.text()).toContain('Restore');
+    expect(wrapper.text()).not.toContain('Find match');
+    const restore = wrapper.findAll('button').find(button => button.text() === 'Restore');
+    await restore?.trigger('click');
+    expect(wrapper.emitted('restore')).toHaveLength(1);
+  });
+
+  it('should render the mark-external action only when enabled', async () => {
+    const hidden = mountActions();
+    expect(hidden.findAll('button').some(button => button.text() === 'Mark external')).toBe(false);
+
+    const wrapper = mountActions({ showMarkExternal: true });
+    const markExternal = wrapper.findAll('button').find(button => button.text() === 'Mark external');
+    expect(markExternal).toBeDefined();
+    await markExternal?.trigger('click');
+    expect(wrapper.emitted('mark-external')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/history/events/UnmatchedRowActions.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedRowActions.vue
@@ -1,0 +1,133 @@
+<script lang="ts">
+export interface UnmatchedRowActionLabels {
+  showInEventsTooltip: string;
+  restore: string;
+  restoreTooltip: string;
+  findMatch: string;
+  ignore: string;
+  ignoreTooltip: string;
+  markExternal?: string;
+  markExternalTooltip?: string;
+}
+</script>
+
+<script setup lang="ts">
+const {
+  labels,
+  isPinned = false,
+  showRestore = false,
+  ignoreLoading = false,
+  matchDisabled = false,
+  showMarkExternal = false,
+} = defineProps<{
+  labels: UnmatchedRowActionLabels;
+  isPinned?: boolean;
+  showRestore?: boolean;
+  ignoreLoading?: boolean;
+  matchDisabled?: boolean;
+  showMarkExternal?: boolean;
+}>();
+
+const emit = defineEmits<{
+  'show-in-events': [];
+  'restore': [];
+  'select': [];
+  'ignore': [];
+  'mark-external': [];
+}>();
+</script>
+
+<template>
+  <div class="flex items-center gap-2">
+    <RuiTooltip
+      :open-delay="400"
+      :popper="{ placement: 'top' }"
+    >
+      <template #activator>
+        <RuiButton
+          size="sm"
+          variant="outlined"
+          icon
+          color="primary"
+          class="!px-2 h-[30px]"
+          @click="emit('show-in-events')"
+        >
+          <RuiIcon
+            size="16"
+            name="lu-external-link"
+          />
+        </RuiButton>
+      </template>
+      {{ labels.showInEventsTooltip }}
+    </RuiTooltip>
+    <template v-if="showRestore">
+      <RuiTooltip
+        :open-delay="400"
+        :popper="{ placement: 'top' }"
+      >
+        <template #activator>
+          <RuiButton
+            size="sm"
+            color="primary"
+            :loading="ignoreLoading"
+            @click="emit('restore')"
+          >
+            {{ labels.restore }}
+          </RuiButton>
+        </template>
+        {{ labels.restoreTooltip }}
+      </RuiTooltip>
+    </template>
+    <div
+      v-else
+      class="flex"
+      :class="isPinned ? 'flex-wrap gap-1' : 'gap-2'"
+    >
+      <RuiButton
+        size="sm"
+        color="primary"
+        :class="{ '!py-0.5': isPinned }"
+        :disabled="matchDisabled"
+        @click="emit('select')"
+      >
+        {{ labels.findMatch }}
+      </RuiButton>
+      <RuiTooltip
+        :open-delay="400"
+        :popper="{ placement: 'top' }"
+      >
+        <template #activator>
+          <RuiButton
+            size="sm"
+            variant="outlined"
+            :class="{ '!py-0.5': isPinned }"
+            :loading="ignoreLoading"
+            @click="emit('ignore')"
+          >
+            {{ labels.ignore }}
+          </RuiButton>
+        </template>
+        {{ labels.ignoreTooltip }}
+      </RuiTooltip>
+      <RuiTooltip
+        v-if="showMarkExternal"
+        :open-delay="400"
+        :popper="{ placement: 'top' }"
+      >
+        <template #activator>
+          <RuiButton
+            size="sm"
+            variant="outlined"
+            color="warning"
+            :class="{ '!py-0.5': isPinned }"
+            :loading="ignoreLoading"
+            @click="emit('mark-external')"
+          >
+            {{ labels.markExternal }}
+          </RuiButton>
+        </template>
+        {{ labels.markExternalTooltip }}
+      </RuiTooltip>
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
@@ -6,17 +6,18 @@ import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
-import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import { useSessionMetadataStore } from '@/modules/session/use-session-metadata-store';
 import { useEvmNodesApi } from '@/modules/settings/api/use-evm-nodes-api';
 import BlockchainRpcNodeFormDialog from '@/modules/settings/general/rpc/BlockchainRpcNodeFormDialog.vue';
+import { NODE_STATUS, type NodeStatus } from '@/modules/settings/general/rpc/rpc-node-status';
+import RpcNodeStatusCell from '@/modules/settings/general/rpc/RpcNodeStatusCell.vue';
+import RpcReconnectButton from '@/modules/settings/general/rpc/RpcReconnectButton.vue';
 import {
   type BlockchainRpcNode,
   type BlockchainRpcNodeList,
   type BlockchainRpcNodeManageState,
   getPlaceholderNode,
 } from '@/modules/settings/types/rpc';
-import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import RowActions from '@/modules/shell/components/RowActions.vue';
 import SimpleTable from '@/modules/shell/components/SimpleTable.vue';
 
@@ -113,15 +114,6 @@ function isNodeInDataset(dataset: Record<string, string[]>, item: BlockchainRpcN
   return nodes.includes(item.name);
 }
 
-const NODE_STATUS = {
-  CONNECTED: 'connected',
-  COOLING_DOWN: 'cooling_down',
-  FAILED: 'failed',
-  READY: 'ready',
-} as const;
-
-type NodeStatus = typeof NODE_STATUS[keyof typeof NODE_STATUS];
-
 function isNodeConnected(item: BlockchainRpcNode): boolean {
   return isEtherscan(item) || isNodeInDataset(get(connectedNodes), item);
 }
@@ -185,27 +177,12 @@ defineExpose({
         <th>
           <div class="flex items-center gap-2">
             <div class="w-6">
-              <RuiTooltip
+              <RpcReconnectButton
                 v-if="anyDisconnected"
-                :open-delay="400"
-              >
-                <template #activator>
-                  <RuiButton
-                    :disabled="reconnecting"
-                    icon
-                    color="primary"
-                    variant="text"
-                    size="sm"
-                    @click="reConnect()"
-                  >
-                    <RuiIcon
-                      name="lu-rotate-cw"
-                      size="16"
-                    />
-                  </RuiButton>
-                </template>
-                {{ t('evm_rpc_node_manager.reconnect.all') }}
-              </RuiTooltip>
+                :disabled="reconnecting"
+                :tooltip="t('evm_rpc_node_manager.reconnect.all')"
+                @reconnect="reConnect()"
+              />
             </div>
             {{ t('evm_rpc_node_manager.connectivity') }}
           </div>
@@ -283,96 +260,13 @@ defineExpose({
           </span>
         </td>
         <td>
-          <div class="flex items-center gap-2">
-            <div class="w-6">
-              <RuiTooltip
-                v-if="getNodeStatus(item) === NODE_STATUS.FAILED && item.active"
-                :open-delay="400"
-              >
-                <template #activator>
-                  <RuiButton
-                    :disabled="reconnecting"
-                    icon
-                    color="primary"
-                    variant="text"
-                    size="sm"
-                    @click="reConnect(item.identifier)"
-                  >
-                    <RuiIcon
-                      name="lu-rotate-cw"
-                      size="16"
-                    />
-                  </RuiButton>
-                </template>
-                {{ t('evm_rpc_node_manager.reconnect.single') }}
-              </RuiTooltip>
-            </div>
-            <BadgeDisplay
-              v-if="getNodeStatus(item) === NODE_STATUS.CONNECTED"
-              color="green"
-              class="items-center gap-2 !leading-6"
-            >
-              <RuiIcon
-                color="success"
-                size="16"
-                name="lu-wifi"
-              />
-              <span>
-                {{ t('evm_rpc_node_manager.connected.true') }}
-              </span>
-            </BadgeDisplay>
-            <RuiTooltip
-              v-else-if="getNodeStatus(item) === NODE_STATUS.COOLING_DOWN"
-              :open-delay="400"
-            >
-              <template #activator>
-                <BadgeDisplay
-                  color="orange"
-                  class="items-center gap-2 !leading-6"
-                >
-                  <RuiIcon
-                    size="16"
-                    name="lu-clock"
-                  />
-                  <span>
-                    {{ t('evm_rpc_node_manager.connected.cooling_down') }}
-                  </span>
-                </BadgeDisplay>
-              </template>
-              <span v-if="item.cooldownUntil">
-                {{ t('evm_rpc_node_manager.cooldown_until') }}
-                <DateDisplay :timestamp="item.cooldownUntil" />
-              </span>
-            </RuiTooltip>
-            <BadgeDisplay
-              v-else-if="getNodeStatus(item) === NODE_STATUS.FAILED"
-              color="red"
-              class="items-center gap-2 !leading-6"
-            >
-              <RuiIcon
-                color="error"
-                size="16"
-                name="lu-wifi-off"
-              />
-              <span>
-                {{ t('evm_rpc_node_manager.connected.failure') }}
-              </span>
-            </BadgeDisplay>
-            <BadgeDisplay
-              v-else
-              color="grey"
-              class="items-center gap-2 !leading-6"
-            >
-              <RuiIcon
-                color="info"
-                size="16"
-                name="lu-wifi"
-              />
-              <span>
-                {{ t('evm_rpc_node_manager.connected.false') }}
-              </span>
-            </BadgeDisplay>
-          </div>
+          <RpcNodeStatusCell
+            :status="getNodeStatus(item)"
+            :active="item.active"
+            :cooldown-until="item.cooldownUntil"
+            :reconnecting="reconnecting"
+            @reconnect="reConnect(item.identifier)"
+          />
         </td>
         <td>
           <div class="flex items-center gap-2 justify-end">

--- a/frontend/app/src/modules/settings/general/rpc/RpcNodeStatusCell.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/RpcNodeStatusCell.spec.ts
@@ -1,0 +1,43 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { NODE_STATUS, type NodeStatus } from '@/modules/settings/general/rpc/rpc-node-status';
+import RpcNodeStatusCell from '@/modules/settings/general/rpc/RpcNodeStatusCell.vue';
+
+interface Props {
+  status: NodeStatus;
+  active?: boolean;
+  cooldownUntil?: number | null;
+  reconnecting?: boolean;
+}
+
+function mountCell(props: Props): VueWrapper<InstanceType<typeof RpcNodeStatusCell>> {
+  return mount(RpcNodeStatusCell, {
+    props,
+  });
+}
+
+describe('modules/settings/general/rpc/RpcNodeStatusCell', () => {
+  it('should render the connected badge', () => {
+    const wrapper = mountCell({ status: NODE_STATUS.CONNECTED });
+    expect(wrapper.text()).toContain('evm_rpc_node_manager.connected.true');
+  });
+
+  it('should render the cooling-down badge', () => {
+    const wrapper = mountCell({ status: NODE_STATUS.COOLING_DOWN });
+    expect(wrapper.text()).toContain('evm_rpc_node_manager.connected.cooling_down');
+  });
+
+  it('should render the ready/disconnected badge for the default case', () => {
+    const wrapper = mountCell({ status: NODE_STATUS.READY });
+    expect(wrapper.text()).toContain('evm_rpc_node_manager.connected.false');
+  });
+
+  it('should show the reconnect button only for an active failed node and emit reconnect', async () => {
+    const inactive = mountCell({ active: false, status: NODE_STATUS.FAILED });
+    expect(inactive.find('button').exists()).toBe(false);
+
+    const wrapper = mountCell({ active: true, status: NODE_STATUS.FAILED });
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('reconnect')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/RpcNodeStatusCell.vue
+++ b/frontend/app/src/modules/settings/general/rpc/RpcNodeStatusCell.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
+import { NODE_STATUS, type NodeStatus } from '@/modules/settings/general/rpc/rpc-node-status';
+import RpcReconnectButton from '@/modules/settings/general/rpc/RpcReconnectButton.vue';
+import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
+
+const { status, active = false, cooldownUntil, reconnecting = false } = defineProps<{
+  status: NodeStatus;
+  active?: boolean;
+  cooldownUntil?: number | null;
+  reconnecting?: boolean;
+}>();
+
+const emit = defineEmits<{
+  reconnect: [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="flex items-center gap-2">
+    <div class="w-6">
+      <RpcReconnectButton
+        v-if="status === NODE_STATUS.FAILED && active"
+        :disabled="reconnecting"
+        :tooltip="t('evm_rpc_node_manager.reconnect.single')"
+        @reconnect="emit('reconnect')"
+      />
+    </div>
+    <BadgeDisplay
+      v-if="status === NODE_STATUS.CONNECTED"
+      color="green"
+      class="items-center gap-2 !leading-6"
+    >
+      <RuiIcon
+        color="success"
+        size="16"
+        name="lu-wifi"
+      />
+      <span>
+        {{ t('evm_rpc_node_manager.connected.true') }}
+      </span>
+    </BadgeDisplay>
+    <RuiTooltip
+      v-else-if="status === NODE_STATUS.COOLING_DOWN"
+      :open-delay="400"
+    >
+      <template #activator>
+        <BadgeDisplay
+          color="orange"
+          class="items-center gap-2 !leading-6"
+        >
+          <RuiIcon
+            size="16"
+            name="lu-clock"
+          />
+          <span>
+            {{ t('evm_rpc_node_manager.connected.cooling_down') }}
+          </span>
+        </BadgeDisplay>
+      </template>
+      <span v-if="cooldownUntil">
+        {{ t('evm_rpc_node_manager.cooldown_until') }}
+        <DateDisplay :timestamp="cooldownUntil" />
+      </span>
+    </RuiTooltip>
+    <BadgeDisplay
+      v-else-if="status === NODE_STATUS.FAILED"
+      color="red"
+      class="items-center gap-2 !leading-6"
+    >
+      <RuiIcon
+        color="error"
+        size="16"
+        name="lu-wifi-off"
+      />
+      <span>
+        {{ t('evm_rpc_node_manager.connected.failure') }}
+      </span>
+    </BadgeDisplay>
+    <BadgeDisplay
+      v-else
+      color="grey"
+      class="items-center gap-2 !leading-6"
+    >
+      <RuiIcon
+        color="info"
+        size="16"
+        name="lu-wifi"
+      />
+      <span>
+        {{ t('evm_rpc_node_manager.connected.false') }}
+      </span>
+    </BadgeDisplay>
+  </div>
+</template>

--- a/frontend/app/src/modules/settings/general/rpc/RpcReconnectButton.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/RpcReconnectButton.spec.ts
@@ -1,0 +1,27 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import RpcReconnectButton from '@/modules/settings/general/rpc/RpcReconnectButton.vue';
+
+interface Props {
+  tooltip?: string;
+  disabled?: boolean;
+}
+
+function mountButton(props: Props = {}): VueWrapper<InstanceType<typeof RpcReconnectButton>> {
+  return mount(RpcReconnectButton, {
+    props: { tooltip: 'Reconnect', ...props },
+  });
+}
+
+describe('modules/settings/general/rpc/RpcReconnectButton', () => {
+  it('should emit reconnect when clicked', async () => {
+    const wrapper = mountButton();
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('reconnect')).toHaveLength(1);
+  });
+
+  it('should be disabled when the disabled prop is set', () => {
+    const wrapper = mountButton({ disabled: true });
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/RpcReconnectButton.vue
+++ b/frontend/app/src/modules/settings/general/rpc/RpcReconnectButton.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+const { tooltip, disabled = false } = defineProps<{
+  tooltip: string;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+  reconnect: [];
+}>();
+</script>
+
+<template>
+  <RuiTooltip :open-delay="400">
+    <template #activator>
+      <RuiButton
+        :disabled="disabled"
+        icon
+        color="primary"
+        variant="text"
+        size="sm"
+        @click="emit('reconnect')"
+      >
+        <RuiIcon
+          name="lu-rotate-cw"
+          size="16"
+        />
+      </RuiButton>
+    </template>
+    {{ tooltip }}
+  </RuiTooltip>
+</template>

--- a/frontend/app/src/modules/settings/general/rpc/rpc-node-status.ts
+++ b/frontend/app/src/modules/settings/general/rpc/rpc-node-status.ts
@@ -1,0 +1,8 @@
+export const NODE_STATUS = {
+  CONNECTED: 'connected',
+  COOLING_DOWN: 'cooling_down',
+  FAILED: 'failed',
+  READY: 'ready',
+} as const;
+
+export type NodeStatus = typeof NODE_STATUS[keyof typeof NODE_STATUS];

--- a/frontend/app/src/modules/shell/components/About.vue
+++ b/frontend/app/src/modules/shell/components/About.vue
@@ -5,8 +5,8 @@ import { millisecondsToSeconds } from '@/modules/core/common/data/date';
 import { useMainStore } from '@/modules/core/common/use-main-store';
 import { usePremium } from '@/modules/premium/use-premium';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
+import AboutDataDirectory from '@/modules/shell/components/AboutDataDirectory.vue';
 import AppUpdateIndicator from '@/modules/shell/components/AppUpdateIndicator.vue';
-import CopyButton from '@/modules/shell/components/CopyButton.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 import RotkiLogo from '@/modules/shell/components/RotkiLogo.vue';
@@ -128,52 +128,11 @@ const { copy } = useClipboard({ source: versionText });
               {{ t('about.data_directory') }}
             </td>
             <td>
-              <div class="flex items-center justify-between">
-                <RuiTooltip
-                  :popper="{ placement: 'top' }"
-                  :open-delay="400"
-                >
-                  <template #activator>
-                    <div class="truncate text-rui-text-secondary max-w-[280px]">
-                      {{ dataDirectory }}
-                    </div>
-                  </template>
-                  <span class="max-w-[280px]">
-                    {{ dataDirectory }}
-                  </span>
-                </RuiTooltip>
-                <div
-                  v-if="isPackaged"
-                  class="ml-2"
-                >
-                  <RuiTooltip
-                    :popper="{ placement: 'top' }"
-                    :open-delay="400"
-                  >
-                    <template #activator>
-                      <RuiButton
-                        icon
-                        size="sm"
-                        variant="text"
-                        @click="openPath(dataDirectory)"
-                      >
-                        <RuiIcon
-                          size="18"
-                          name="lu-folder-open"
-                        />
-                      </RuiButton>
-                    </template>
-                    <span>{{ t('about.open_data_dir_tooltip') }}</span>
-                  </RuiTooltip>
-                </div>
-                <div v-else>
-                  <CopyButton
-                    size="sm"
-                    :value="dataDirectory"
-                    :tooltip="t('about.copy_data_directory_tooltip')"
-                  />
-                </div>
-              </div>
+              <AboutDataDirectory
+                :data-directory="dataDirectory"
+                :is-packaged="isPackaged"
+                @open-path="openPath(dataDirectory)"
+              />
             </td>
           </tr>
           <tr>

--- a/frontend/app/src/modules/shell/components/AboutDataDirectory.spec.ts
+++ b/frontend/app/src/modules/shell/components/AboutDataDirectory.spec.ts
@@ -1,0 +1,34 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import AboutDataDirectory from '@/modules/shell/components/AboutDataDirectory.vue';
+import CopyButton from '@/modules/shell/components/CopyButton.vue';
+
+interface Props {
+  dataDirectory?: string;
+  isPackaged?: boolean;
+}
+
+function mountDataDirectory(props: Props = {}): VueWrapper<InstanceType<typeof AboutDataDirectory>> {
+  return mount(AboutDataDirectory, {
+    props: { dataDirectory: '/home/user/.rotki', ...props },
+  });
+}
+
+describe('modules/shell/components/AboutDataDirectory', () => {
+  it('should render the data directory path', () => {
+    const wrapper = mountDataDirectory();
+    expect(wrapper.text()).toContain('/home/user/.rotki');
+  });
+
+  it('should show the copy button when not packaged', () => {
+    const wrapper = mountDataDirectory({ isPackaged: false });
+    expect(wrapper.findComponent(CopyButton).exists()).toBe(true);
+  });
+
+  it('should show the open-folder action when packaged and emit open-path', async () => {
+    const wrapper = mountDataDirectory({ isPackaged: true });
+    expect(wrapper.findComponent(CopyButton).exists()).toBe(false);
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('open-path')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/shell/components/AboutDataDirectory.vue
+++ b/frontend/app/src/modules/shell/components/AboutDataDirectory.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import CopyButton from '@/modules/shell/components/CopyButton.vue';
+
+const { dataDirectory, isPackaged = false } = defineProps<{
+  dataDirectory: string;
+  isPackaged?: boolean;
+}>();
+
+const emit = defineEmits<{
+  'open-path': [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="flex items-center justify-between">
+    <RuiTooltip
+      :popper="{ placement: 'top' }"
+      :open-delay="400"
+    >
+      <template #activator>
+        <div class="truncate text-rui-text-secondary max-w-[280px]">
+          {{ dataDirectory }}
+        </div>
+      </template>
+      <span class="max-w-[280px]">
+        {{ dataDirectory }}
+      </span>
+    </RuiTooltip>
+    <div
+      v-if="isPackaged"
+      class="ml-2"
+    >
+      <RuiTooltip
+        :popper="{ placement: 'top' }"
+        :open-delay="400"
+      >
+        <template #activator>
+          <RuiButton
+            icon
+            size="sm"
+            variant="text"
+            @click="emit('open-path')"
+          >
+            <RuiIcon
+              size="18"
+              name="lu-folder-open"
+            />
+          </RuiButton>
+        </template>
+        <span>{{ t('about.open_data_dir_tooltip') }}</span>
+      </RuiTooltip>
+    </div>
+    <div v-else>
+      <CopyButton
+        size="sm"
+        :value="dataDirectory"
+        :tooltip="t('about.copy_data_directory_tooltip')"
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
+++ b/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
@@ -5,6 +5,8 @@ import { useReportIssue } from '@/modules/core/common/use-report-issue';
 import { usePrivacyMode } from '@/modules/settings/use-privacy';
 import { useScrambleSetting } from '@/modules/settings/use-scramble-settings';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
+import ReportIssueDiscordTip from '@/modules/shell/components/ReportIssueDiscordTip.vue';
+import ReportIssueEmailButton from '@/modules/shell/components/ReportIssueEmailButton.vue';
 
 const { close, initialDescription: storeDescription, initialTitle: storeTitle, visible } = useReportIssue();
 
@@ -173,56 +175,13 @@ onMounted(() => {
               </template>
               {{ t('help_sidebar.report_issue.dialog.submit_options.google_form') }}
             </RuiButton>
-            <div class="flex">
-              <RuiButton
-                variant="outlined"
-                color="primary"
-                size="lg"
-                class="!rounded-r-none !border-r-0"
-                :disabled="!isFormValid"
-                @click="submitViaEmail()"
-              >
-                <template #prepend>
-                  <RuiIcon name="lu-mail" />
-                </template>
-                {{ t('help_sidebar.report_issue.dialog.submit_options.email') }}
-              </RuiButton>
-              <RuiMenu
-                :popper="{ placement: 'bottom-end' }"
-                close-on-content-click
-              >
-                <template #activator="{ attrs }">
-                  <RuiButton
-                    variant="outlined"
-                    color="primary"
-                    size="lg"
-                    class="!rounded-l-none !px-2 -ml-[1px]"
-                    v-bind="attrs"
-                  >
-                    <RuiIcon name="lu-chevron-down" />
-                  </RuiButton>
-                </template>
-                <RuiButton
-                  variant="list"
-                  @click="copyEmail()"
-                >
-                  <template #prepend>
-                    <RuiIcon name="lu-copy" />
-                  </template>
-                  {{ t('help_sidebar.report_issue.dialog.submit_options.copy_email', { email: SUPPORT_EMAIL }) }}
-                </RuiButton>
-                <RuiButton
-                  variant="list"
-                  :disabled="!isFormValid"
-                  @click="openGmail()"
-                >
-                  <template #prepend>
-                    <RuiIcon name="lu-mail" />
-                  </template>
-                  {{ t('help_sidebar.report_issue.dialog.submit_options.open_gmail') }}
-                </RuiButton>
-              </RuiMenu>
-            </div>
+            <ReportIssueEmailButton
+              :email="SUPPORT_EMAIL"
+              :is-form-valid="isFormValid"
+              @submit-email="submitViaEmail()"
+              @copy-email="copyEmail()"
+              @open-gmail="openGmail()"
+            />
           </div>
           <span class="text-xs text-rui-text-secondary flex items-center gap-1">
             <RuiIcon
@@ -244,36 +203,7 @@ onMounted(() => {
             {{ t('help_sidebar.report_issue.dialog.tips.title') }}
           </span>
 
-          <div :class="uiClasses.tipCard">
-            <RuiIcon
-              name="lu-discord"
-              :class="uiClasses.tipCardIcon"
-            />
-            <div class="flex flex-col gap-1">
-              <span class="text-sm">
-                {{ t('help_sidebar.report_issue.dialog.tips.discord.title') }}
-              </span>
-              <i18n-t
-                keypath="help_sidebar.report_issue.dialog.tips.discord.description"
-                tag="span"
-                class="text-xs text-rui-text-secondary"
-                scope="global"
-              >
-                <template #channel>
-                  <span class="font-mono">{{ t('help_sidebar.report_issue.dialog.tips.discord.channel') }}</span>
-                </template>
-              </i18n-t>
-              <RuiButton
-                variant="text"
-                color="primary"
-                size="sm"
-                class="self-start -ml-1.5 !py-0"
-                @click="openDiscord()"
-              >
-                {{ t('help_sidebar.report_issue.dialog.tips.discord.action') }}
-              </RuiButton>
-            </div>
-          </div>
+          <ReportIssueDiscordTip @open-discord="openDiscord()" />
 
           <div :class="uiClasses.tipCard">
             <RuiIcon

--- a/frontend/app/src/modules/shell/components/ReportIssueDiscordTip.spec.ts
+++ b/frontend/app/src/modules/shell/components/ReportIssueDiscordTip.spec.ts
@@ -1,0 +1,20 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import ReportIssueDiscordTip from '@/modules/shell/components/ReportIssueDiscordTip.vue';
+
+function mountDiscordTip(): VueWrapper<InstanceType<typeof ReportIssueDiscordTip>> {
+  return mount(ReportIssueDiscordTip);
+}
+
+describe('modules/shell/components/ReportIssueDiscordTip', () => {
+  it('should render the discord tip title', () => {
+    const wrapper = mountDiscordTip();
+    expect(wrapper.text()).toContain('help_sidebar.report_issue.dialog.tips.discord.title');
+  });
+
+  it('should emit open-discord when the action button is clicked', async () => {
+    const wrapper = mountDiscordTip();
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('open-discord')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/shell/components/ReportIssueDiscordTip.vue
+++ b/frontend/app/src/modules/shell/components/ReportIssueDiscordTip.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+const emit = defineEmits<{
+  'open-discord': [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="flex items-start gap-3 p-3 bg-rui-grey-100 dark:bg-rui-grey-800 rounded">
+    <RuiIcon
+      name="lu-discord"
+      class="text-rui-text-secondary shrink-0 mt-0.5"
+    />
+    <div class="flex flex-col gap-1">
+      <span class="text-sm">
+        {{ t('help_sidebar.report_issue.dialog.tips.discord.title') }}
+      </span>
+      <i18n-t
+        keypath="help_sidebar.report_issue.dialog.tips.discord.description"
+        tag="span"
+        class="text-xs text-rui-text-secondary"
+        scope="global"
+      >
+        <template #channel>
+          <span class="font-mono">{{ t('help_sidebar.report_issue.dialog.tips.discord.channel') }}</span>
+        </template>
+      </i18n-t>
+      <RuiButton
+        variant="text"
+        color="primary"
+        size="sm"
+        class="self-start -ml-1.5 !py-0"
+        @click="emit('open-discord')"
+      >
+        {{ t('help_sidebar.report_issue.dialog.tips.discord.action') }}
+      </RuiButton>
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/shell/components/ReportIssueEmailButton.spec.ts
+++ b/frontend/app/src/modules/shell/components/ReportIssueEmailButton.spec.ts
@@ -1,0 +1,27 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import ReportIssueEmailButton from '@/modules/shell/components/ReportIssueEmailButton.vue';
+
+interface Props {
+  email?: string;
+  isFormValid?: boolean;
+}
+
+function mountEmailButton(props: Props = {}): VueWrapper<InstanceType<typeof ReportIssueEmailButton>> {
+  return mount(ReportIssueEmailButton, {
+    props: { email: 'support@rotki.com', isFormValid: true, ...props },
+  });
+}
+
+describe('modules/shell/components/ReportIssueEmailButton', () => {
+  it('should emit submit-email when the email button is clicked', async () => {
+    const wrapper = mountEmailButton();
+    await wrapper.find('[data-testid=submit-email]').trigger('click');
+    expect(wrapper.emitted('submit-email')).toHaveLength(1);
+  });
+
+  it('should disable the email button when the form is invalid', () => {
+    const wrapper = mountEmailButton({ isFormValid: false });
+    expect(wrapper.find('[data-testid=submit-email]').attributes('disabled')).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/shell/components/ReportIssueEmailButton.vue
+++ b/frontend/app/src/modules/shell/components/ReportIssueEmailButton.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+const { email, isFormValid = false } = defineProps<{
+  email: string;
+  isFormValid?: boolean;
+}>();
+
+const emit = defineEmits<{
+  'submit-email': [];
+  'copy-email': [];
+  'open-gmail': [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="flex">
+    <RuiButton
+      variant="outlined"
+      color="primary"
+      size="lg"
+      class="!rounded-r-none !border-r-0"
+      :disabled="!isFormValid"
+      data-testid="submit-email"
+      @click="emit('submit-email')"
+    >
+      <template #prepend>
+        <RuiIcon name="lu-mail" />
+      </template>
+      {{ t('help_sidebar.report_issue.dialog.submit_options.email') }}
+    </RuiButton>
+    <RuiMenu
+      :popper="{ placement: 'bottom-end' }"
+      close-on-content-click
+    >
+      <template #activator="{ attrs }">
+        <RuiButton
+          variant="outlined"
+          color="primary"
+          size="lg"
+          class="!rounded-l-none !px-2 -ml-[1px]"
+          v-bind="attrs"
+        >
+          <RuiIcon name="lu-chevron-down" />
+        </RuiButton>
+      </template>
+      <RuiButton
+        variant="list"
+        @click="emit('copy-email')"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-copy" />
+        </template>
+        {{ t('help_sidebar.report_issue.dialog.submit_options.copy_email', { email }) }}
+      </RuiButton>
+      <RuiButton
+        variant="list"
+        :disabled="!isFormValid"
+        @click="emit('open-gmail')"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-mail" />
+        </template>
+        {{ t('help_sidebar.report_issue.dialog.submit_options.open_gmail') }}
+      </RuiButton>
+    </RuiMenu>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

Continues the frontend lint-warning cleanup by clearing **59 `vue/max-template-depth` warnings** (the rule warns above nesting depth 8). Same technique as the merged #12620: extract deeply-nested markup into small presentational subcomponents with co-located specs. No behavior changes.

Six files fully cleared, 6 commits (one per file/pair):

- **UnmatchedBridgesList + UnmatchedMovementsList** (27) — shared `UnmatchedRowActions` (the `#item.actions` cell) and `UnmatchedMatchDisabledAlert` (the premium/free `#body.prepend` alert, keyed by a `variant` prop to keep i18n keypaths static).
- **About** (9) — `AboutDataDirectory` (path tooltip + open/copy actions).
- **NewlyDetectedAssetTable** (9) — `NewlyDetectedAssetToolbar` (custom-header) and `NewlyDetectedAssetRowActions`; the toolbar also moves `HintMenuIcon` out to keep the parent under the 20-import cap.
- **ReportIssueDialog** (8) — `ReportIssueEmailButton` (email split-button/menu) and `ReportIssueDiscordTip`.
- **BlockchainRpcNodeManager** (6) — `RpcNodeStatusCell` and a shared `RpcReconnectButton` (reused by the header reconnect-all), plus a small `rpc-node-status` module. The `ethereum-node` `data-cy` stays on the row element (status `<td>` extracted, not the `<tr>`).

Each new presentational component is pure (props in, events out) and has a co-located `.spec.ts` — **29 new tests**.

### Deliberately deferred

`HistoryEventsVirtualTable.vue` (8 warnings) is left out. It sits at the 20/20 import cap, so a placeholder-row extraction trips `@rotki/max-dependencies` as an error. The correct fix is a proper modularization (a `useHistoryEventsTable` facade composable folding its 5 wired composables into one, plus a `HistoryEventsVirtualRow` row-switch component that would host the placeholder) — too large and reactivity-sensitive for a lint batch, so it will be its own PR.

## Checks

- Lint: 0 errors (602 warnings total, down from 661)
- Typecheck: 0
- Unit tests: 29 new, all green; full suite via CI
