### PR TITLE
Make composable browser-global access SSR-safe

### DIFF
--- a/frontend/app/src/modules/history/api/events/use-skipped-history-events-api.ts
+++ b/frontend/app/src/modules/history/api/events/use-skipped-history-events-api.ts
@@ -39,7 +39,7 @@ export function useSkippedHistoryEventsApi(): UseSkippedHistoryEventsApiReturn {
         method: 'PATCH',
       });
 
-      const url = window.URL.createObjectURL(blob);
+      const url = URL.createObjectURL(blob);
       downloadFileByUrl(url, 'skipped_external_events.csv');
       return { success: true };
     }

--- a/frontend/app/src/modules/reports/use-reports-api.ts
+++ b/frontend/app/src/modules/reports/use-reports-api.ts
@@ -53,7 +53,7 @@ export function useReportsApi(): UseReportsApi {
         method: 'GET',
       });
 
-      const url = window.URL.createObjectURL(blob);
+      const url = URL.createObjectURL(blob);
       downloadFileByUrl(url, 'reports.zip');
       return { success: true };
     }

--- a/frontend/app/src/modules/settings/use-settings-page-highlight.ts
+++ b/frontend/app/src/modules/settings/use-settings-page-highlight.ts
@@ -1,3 +1,4 @@
+import { defaultDocument } from '@vueuse/core';
 import { type HighlightRequest, useSettingsHighlight } from '@/modules/settings/use-settings-highlight';
 
 // A brief background flash, rounded and with horizontal padding, so the highlighted row reads as a
@@ -53,7 +54,7 @@ export function useSettingsPageHighlight({ scrollToElement, isElementInViewport 
   }
 
   async function scrollAndHighlight(targetId: string): Promise<void> {
-    const element = document.getElementById(targetId);
+    const element = defaultDocument?.getElementById(targetId);
     if (!element)
       return;
 

--- a/frontend/app/src/modules/settings/use-settings-scroll-spy.ts
+++ b/frontend/app/src/modules/settings/use-settings-scroll-spy.ts
@@ -1,4 +1,5 @@
 import type { MaybeRef, Ref, ShallowRef } from 'vue';
+import { defaultDocument } from '@vueuse/core';
 
 interface Nav {
   id: string;
@@ -58,7 +59,7 @@ export function useSettingsScrollSpy({ navigation, scroller }: UseSettingsScroll
     }
 
     for (const nav of navItems) {
-      const element = document.getElementById(nav.id);
+      const element = defaultDocument?.getElementById(nav.id);
       if (element && isElementInViewport(element)) {
         set(currentId, nav.id);
         return;
@@ -73,7 +74,7 @@ export function useSettingsScrollSpy({ navigation, scroller }: UseSettingsScroll
         resolve();
         return;
       }
-      const element = typeof el === 'string' ? document.getElementById(el) : el;
+      const element = typeof el === 'string' ? defaultDocument?.getElementById(el) : el;
       const parent = get(scroller);
       if (element && parent) {
         const parentRect = parent.getBoundingClientRect();

--- a/frontend/app/src/modules/shell/layout/use-core-scroll.ts
+++ b/frontend/app/src/modules/shell/layout/use-core-scroll.ts
@@ -1,4 +1,5 @@
 import type { ComputedRef } from 'vue';
+import { defaultDocument } from '@vueuse/core';
 
 interface UseScrollReturn {
   scrollToTop: () => void;
@@ -6,12 +7,12 @@ interface UseScrollReturn {
 }
 
 export function useCoreScroll(): UseScrollReturn {
-  const { y: scrollY } = useScroll(document.body);
+  const { y: scrollY } = useScroll(defaultDocument?.body);
 
   const shouldShowScrollToTopButton = computed<boolean>(() => get(scrollY) > 200);
 
   function scrollToTop(): void {
-    document.body.scrollTo(0, 0);
+    defaultDocument?.body.scrollTo(0, 0);
   }
 
   return {

--- a/frontend/app/src/modules/shell/layout/use-sidebar-resize.spec.ts
+++ b/frontend/app/src/modules/shell/layout/use-sidebar-resize.spec.ts
@@ -1,24 +1,29 @@
 import { createTestingPinia } from '@pinia/testing';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
 import { PINNED_DEFAULT_WIDTH } from '@/modules/shell/layout/sidebar-resize-constants';
 import { useSidebarResize } from '@/modules/shell/layout/use-sidebar-resize';
 
 interface MockTarget {
-  setPointerCapture: ReturnType<typeof vi.fn>;
-  releasePointerCapture: ReturnType<typeof vi.fn>;
+  setPointerCapture: Mock<(pointerId: number) => void>;
+  releasePointerCapture: Mock<(pointerId: number) => void>;
 }
 
 function createPointerEvent(overrides: { clientX?: number } = {}): { event: PointerEvent; mockTarget: MockTarget } {
   const mockTarget: MockTarget = {
-    setPointerCapture: vi.fn(),
-    releasePointerCapture: vi.fn(),
+    setPointerCapture: vi.fn<(pointerId: number) => void>(),
+    releasePointerCapture: vi.fn<(pointerId: number) => void>(),
   };
+  // Use a real element so the source's `instanceof HTMLElement` guard passes,
+  // while keeping the spies for assertions.
+  const target = document.createElement('div');
+  target.setPointerCapture = mockTarget.setPointerCapture;
+  target.releasePointerCapture = mockTarget.releasePointerCapture;
   const event = new PointerEvent('pointermove', {
     clientX: overrides.clientX ?? 0,
   });
-  // Override target and pointerId via spies since PointerEvent constructor doesn't support them
-  Object.defineProperty(event, 'target', { value: mockTarget });
+  // Override target and pointerId since the PointerEvent constructor doesn't support them
+  Object.defineProperty(event, 'target', { value: target });
   Object.defineProperty(event, 'pointerId', { value: 1 });
   vi.spyOn(event, 'preventDefault');
   return { event, mockTarget };

--- a/frontend/app/src/modules/shell/layout/use-sidebar-resize.ts
+++ b/frontend/app/src/modules/shell/layout/use-sidebar-resize.ts
@@ -29,7 +29,8 @@ export function useSidebarResize(): {
   function onPointerDown(event: PointerEvent): void {
     event.preventDefault();
     set(dragging, true);
-    (event.target as HTMLElement).setPointerCapture(event.pointerId);
+    if (event.target instanceof HTMLElement)
+      event.target.setPointerCapture(event.pointerId);
     const body = defaultDocument?.body;
     if (body) {
       body.style.cursor = 'col-resize';
@@ -61,7 +62,8 @@ export function useSidebarResize(): {
     }
 
     set(dragging, false);
-    (event.target as HTMLElement).releasePointerCapture(event.pointerId);
+    if (event.target instanceof HTMLElement)
+      event.target.releasePointerCapture(event.pointerId);
     const body = defaultDocument?.body;
     if (body) {
       body.style.cursor = '';

--- a/frontend/app/src/modules/shell/layout/use-sidebar-resize.ts
+++ b/frontend/app/src/modules/shell/layout/use-sidebar-resize.ts
@@ -1,4 +1,5 @@
 import type { ComputedRef, Ref } from 'vue';
+import { defaultDocument } from '@vueuse/core';
 import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
 import { PINNED_DEFAULT_WIDTH, PINNED_MAX_VIEWPORT_RATIO, PINNED_MAX_WIDTH } from '@/modules/shell/layout/sidebar-resize-constants';
 
@@ -11,6 +12,7 @@ export function useSidebarResize(): {
 } {
   const { pinnedDragging: dragging, pinnedWidth } = storeToRefs(useAreaVisibilityStore());
   const { isLgAndDown } = useBreakpoint();
+  const { width: windowWidth } = useWindowSize();
   let rafId = 0;
 
   const widthPx = computed<string>(() => {
@@ -20,7 +22,7 @@ export function useSidebarResize(): {
   });
 
   function clampWidth(width: number): number {
-    const max = Math.min(PINNED_MAX_WIDTH, window.innerWidth * PINNED_MAX_VIEWPORT_RATIO);
+    const max = Math.min(PINNED_MAX_WIDTH, get(windowWidth) * PINNED_MAX_VIEWPORT_RATIO);
     return Math.max(PINNED_DEFAULT_WIDTH, Math.min(width, max));
   }
 
@@ -28,8 +30,11 @@ export function useSidebarResize(): {
     event.preventDefault();
     set(dragging, true);
     (event.target as HTMLElement).setPointerCapture(event.pointerId);
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
+    const body = defaultDocument?.body;
+    if (body) {
+      body.style.cursor = 'col-resize';
+      body.style.userSelect = 'none';
+    }
   }
 
   function onPointerMove(event: PointerEvent): void {
@@ -40,7 +45,7 @@ export function useSidebarResize(): {
       cancelAnimationFrame(rafId);
 
     rafId = requestAnimationFrame(() => {
-      const newWidth = clampWidth(window.innerWidth - event.clientX);
+      const newWidth = clampWidth(get(windowWidth) - event.clientX);
       set(pinnedWidth, newWidth);
       rafId = 0;
     });
@@ -57,8 +62,11 @@ export function useSidebarResize(): {
 
     set(dragging, false);
     (event.target as HTMLElement).releasePointerCapture(event.pointerId);
-    document.body.style.cursor = '';
-    document.body.style.userSelect = '';
+    const body = defaultDocument?.body;
+    if (body) {
+      body.style.cursor = '';
+      body.style.userSelect = '';
+    }
   }
 
   return {

--- a/frontend/app/src/modules/wallet/bridge/use-bridge-message-handlers.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-bridge-message-handlers.ts
@@ -1,7 +1,7 @@
 import type { WalletBridgeRequest, WalletBridgeResponse } from '@shared/wallet-bridge-types';
 import type { EIP1193Provider, EIP1193ProviderEvents } from '@/types';
 import { BRIDGE_ERROR_CODES, BRIDGE_NOTIFICATION_TYPES, ROTKI_RPC_METHODS, ROTKI_RPC_RESPONSES, WALLET_EVENT_TYPES } from '@shared/proxy/constants';
-import { get, promiseTimeout } from '@vueuse/core';
+import { defaultWindow, get, promiseTimeout } from '@vueuse/core';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useBridgeLogging } from '@/modules/wallet/bridge/use-bridge-logging';
 import { useWalletConnectionState } from '@/modules/wallet/bridge/use-wallet-connection-state';
@@ -103,7 +103,7 @@ export function useBridgeMessageHandlers(sendMessage?: (message: any) => void): 
     }
 
     const success = await selectProvider(uuid);
-    window.focus();
+    defaultWindow?.focus();
     return createSuccessResponse(message.id, success);
   }
 

--- a/frontend/app/src/modules/wallet/bridge/use-proxy-provider.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-proxy-provider.ts
@@ -1,4 +1,5 @@
 import type { EIP1193EventName, EIP1193Provider, EIP1193ProviderEvents, RpcRequest } from '@/types';
+import { defaultWindow } from '@vueuse/core';
 import { logger } from '@/modules/core/common/logging/logging';
 
 /**
@@ -7,7 +8,7 @@ import { logger } from '@/modules/core/common/logging/logging';
  */
 export function useProxyProvider(): EIP1193Provider | undefined {
   // Only set up if walletBridge is available
-  const walletBridge = window.walletBridge;
+  const walletBridge = defaultWindow?.walletBridge;
   if (!walletBridge) {
     return undefined;
   }

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-proxy-client.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-proxy-client.ts
@@ -7,7 +7,7 @@ import {
   type WalletBridgeRequest,
   type WalletBridgeResponse,
 } from '@shared/wallet-bridge-types';
-import { get, isDefined, set } from '@vueuse/core';
+import { defaultWindow, get, isDefined, set } from '@vueuse/core';
 import { ref, type Ref } from 'vue';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useBridgeMessageHandlers } from '@/modules/wallet/bridge/use-bridge-message-handlers';
@@ -49,7 +49,7 @@ export function useWalletProxyClient(): WalletProxyClientComposable {
     if (notification.type === BRIDGE_NOTIFICATION_TYPES.CLOSE_TAB) {
       logger.info('Received close_tab notification, attempting to close browser tab');
       try {
-        window.close();
+        defaultWindow?.close();
       }
       catch (error) {
         logger.error('Failed to close tab:', error);
@@ -113,7 +113,7 @@ export function useWalletProxyClient(): WalletProxyClientComposable {
 
   const getWebSocketUrl = (): string => {
     // Get the current window location to determine the HTTP port
-    const currentPort = window.location.port;
+    const currentPort = defaultWindow?.location.port;
     if (currentPort) {
       // WebSocket server runs on HTTP port + 1
       const wsPort = Number.parseInt(currentPort) + 1;


### PR DESCRIPTION
## Summary

Clears all **17 `@rotki/composable-ssr-safety` warnings** by routing browser-global access in composables through VueUse's SSR-safe primitives instead of raw `window`/`document`.

- `window.innerWidth` → `useWindowSize()` (`use-sidebar-resize`)
- `window.URL.createObjectURL` → `URL.createObjectURL` (the `URL` global stands alone; the `window.` prefix was redundant) — `use-reports-api`, `use-skipped-history-events-api`
- remaining `window.*` / `document.*` → `defaultWindow?.` / `defaultDocument?.` (`= isClient ? window/document : undefined`) — sidebar-resize, core-scroll, settings scroll-spy / page-highlight, wallet bridge composables

In the browser these resolve to the same globals, so **no behavior change**; the two setup-time accesses (`useCoreScroll`, `useProxyProvider`) become genuinely SSR-safe rather than throwing on a server.

Also, on a file this touched (`use-sidebar-resize`), replaced two `event.target as HTMLElement` casts with an `instanceof` guard (clears 2 `consistent-type-assertions` warnings); the spec now uses a real element as the pointer target.

## Checks

- Lint: the 17 SSR-safety + 2 assertion warnings on these files are gone; 0 errors
- Typecheck: 0
- Unit tests: the 8 existing composable specs (94 tests) still pass
