### PR TITLE
Align composable return type names with convention

### DIFF
--- a/frontend/app/src/modules/accounts/use-account-category-helper.ts
+++ b/frontend/app/src/modules/accounts/use-account-category-helper.ts
@@ -1,12 +1,12 @@
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 
-interface UseBlockchainAccountLoadingReturn {
+interface UseAccountCategoryHelperReturn {
   isEvm: ComputedRef<boolean>;
   chainIds: ComputedRef<string[]>;
 }
 
-export function useAccountCategoryHelper(category: MaybeRefOrGetter<string>): UseBlockchainAccountLoadingReturn {
+export function useAccountCategoryHelper(category: MaybeRefOrGetter<string>): UseAccountCategoryHelperReturn {
   const { supportedChains } = useSupportedChains();
 
   const isEvm = computed<boolean>(() => toValue(category) === 'evm');

--- a/frontend/app/src/modules/assets/admin/missing-mappings/use-missing-mappings-db.ts
+++ b/frontend/app/src/modules/assets/admin/missing-mappings/use-missing-mappings-db.ts
@@ -18,14 +18,14 @@ export type AddMissingMapping = Omit<MissingMapping, 'id'>;
 
 type DeleteMissingMapping = Pick<MissingMapping, 'location' | 'identifier'>;
 
-interface UseMappingDBReturn {
+interface UseMissingMappingsDBReturn {
   put: (mapping: AddMissingMapping) => Promise<number>;
   remove: (mapping: DeleteMissingMapping) => Promise<void>;
   count: () => Promise<number>;
   getData: (payload: MaybeRef<PaginationRequestPayload<MissingMapping>>) => Promise<Collection<MissingMapping>>;
 }
 
-export function useMissingMappingsDB(): UseMappingDBReturn {
+export function useMissingMappingsDB(): UseMissingMappingsDBReturn {
   // This should not be destructured to avoid accessing it during the composable creation
   const { db } = useDatabase();
 

--- a/frontend/app/src/modules/assets/api/use-asset-prices-api.ts
+++ b/frontend/app/src/modules/assets/api/use-asset-prices-api.ts
@@ -18,7 +18,7 @@ import { api } from '@/modules/core/api/rotki-api';
 import { VALID_WITHOUT_SESSION_STATUS } from '@/modules/core/api/utils';
 import { mapCollectionResponse } from '@/modules/core/common/data/collection-utils';
 
-interface UseAssetPriceApiReturn {
+interface UseAssetPricesApiReturn {
   fetchHistoricalPrices: (payload?: Partial<ManualPricePayload>) => Promise<HistoricalPrice[]>;
   addHistoricalPrice: (price: HistoricalPriceFormPayload) => Promise<boolean>;
   editHistoricalPrice: (price: HistoricalPriceFormPayload) => Promise<boolean>;
@@ -30,7 +30,7 @@ interface UseAssetPriceApiReturn {
   fetchNftsPrices: () => Promise<NftPriceArray>;
 }
 
-export function useAssetPricesApi(): UseAssetPriceApiReturn {
+export function useAssetPricesApi(): UseAssetPricesApiReturn {
   const fetchHistoricalPrices = async (payload?: Partial<ManualPricePayload>): Promise<HistoricalPrice[]> => {
     const response = await api.get<HistoricalPrice[]>('/assets/prices/historical', {
       filterEmptyProperties: { removeEmptyString: true },

--- a/frontend/app/src/modules/assets/api/use-assets-api.ts
+++ b/frontend/app/src/modules/assets/api/use-assets-api.ts
@@ -7,7 +7,7 @@ import { getFilename } from '@/modules/core/common/file/file';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { type PendingTask, PendingTaskSchema } from '@/modules/core/tasks/types';
 
-interface UseAssetApiReturn {
+interface UseAssetsApiReturn {
   checkForAssetUpdate: () => Promise<PendingTask>;
   performUpdate: (version: number, conflicts?: ConflictResolution) => Promise<PendingTask>;
   mergeAssets: (sourceIdentifier: string, targetAsset: string) => Promise<true>;
@@ -18,7 +18,7 @@ interface UseAssetApiReturn {
   fetchNfts: (ignoreCache: boolean) => Promise<PendingTask>;
 }
 
-export function useAssetsApi(): UseAssetApiReturn {
+export function useAssetsApi(): UseAssetsApiReturn {
   const checkForAssetUpdate = async (): Promise<PendingTask> => {
     const response = await api.get<PendingTask>('/assets/updates', {
       query: { asyncQuery: true },

--- a/frontend/app/src/modules/balances/blockchain/use-blockchain-total-summary.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-blockchain-total-summary.ts
@@ -5,9 +5,9 @@ import { isEmpty } from 'es-toolkit/compat';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { sortDesc } from '@/modules/core/common/data/bignumbers';
 
-interface UseBlockchainTotalsSummaryReturn { blockchainTotals: ComputedRef<BlockchainTotal[]> }
+interface UseBlockchainTotalSummaryReturn { blockchainTotals: ComputedRef<BlockchainTotal[]> }
 
-export function useBlockchainTotalSummary(): UseBlockchainTotalsSummaryReturn {
+export function useBlockchainTotalSummary(): UseBlockchainTotalSummaryReturn {
   const { balances } = storeToRefs(useBalancesStore());
 
   const blockchainTotals = computed<BlockchainTotal[]>(() => {

--- a/frontend/app/src/modules/core/common/use-csv-import-export.ts
+++ b/frontend/app/src/modules/core/common/use-csv-import-export.ts
@@ -24,12 +24,12 @@ interface CSVRow { [key: string]: string }
 
 interface CSVImportRow { [key: string]: any }
 
-interface UseCSVImportExportReturn {
+interface UseCsvImportExportReturn {
   generateCSV: (data: Array<CSVImportRow>, params?: CSVExportParams) => string;
   parseCSV: (text: string, params?: CSVImportParams) => Array<CSVRow>;
 }
 
-export function useCsvImportExport(params: CSVImportExportParams = {}): UseCSVImportExportReturn {
+export function useCsvImportExport(params: CSVImportExportParams = {}): UseCsvImportExportReturn {
   const { columnDelimiter = ',', rowDelimiter = '\n' } = params;
 
   function parseCSV(text: string, params: CSVImportParams = {}): Array<CSVRow> {

--- a/frontend/app/src/modules/history/events/tx/use-repulling-transaction-form.ts
+++ b/frontend/app/src/modules/history/events/tx/use-repulling-transaction-form.ts
@@ -41,14 +41,14 @@ export function getTimeRangeInDays(data: RepullingTransactionPayload): number {
   return Math.ceil((data.toTimestamp - data.fromTimestamp) / SECONDS_PER_DAY);
 }
 
-interface UseRepullingTransactionFormReturn {
+interface UseRepullingTransactionFormFnReturn {
   chainOptions: ComputedRef<string[]>;
   createDefaultFormData: () => RepullingTransactionPayload;
   getUsableChains: (chain: string | undefined) => string[];
   shouldShowConfirmation: (data: RepullingTransactionPayload) => boolean;
 }
 
-function useRepullingTransactionFormFn(): UseRepullingTransactionFormReturn {
+function useRepullingTransactionFormFn(): UseRepullingTransactionFormFnReturn {
   const { accounts: accountsPerChain } = storeToRefs(useBlockchainAccountsStore());
   const { decodableTxChainsInfo, getChain } = useSupportedChains();
   const decodableTxChains = useArrayMap(decodableTxChainsInfo, x => x.id);

--- a/frontend/app/src/modules/history/events/use-history-event-note.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-note.ts
@@ -44,11 +44,11 @@ interface FormatNoteParams {
   extraData?: MaybeRefOrGetter<Record<string, any> | undefined>;
 }
 
-interface UseHistoryEventsNoteReturn {
+interface UseHistoryEventNoteReturn {
   formatNotes: (params: FormatNoteParams) => ComputedRef<NoteFormat[]>;
 }
 
-export function useHistoryEventNote(): UseHistoryEventsNoteReturn {
+export function useHistoryEventNote(): UseHistoryEventNoteReturn {
   const { getAssetField } = useAssetInfoRetrieval();
   const { scrambleData, scrambleIdentifier } = useScramble();
 

--- a/frontend/app/src/modules/settings/accounting/use-accounting-settings.ts
+++ b/frontend/app/src/modules/settings/accounting/use-accounting-settings.ts
@@ -18,7 +18,7 @@ import { isActionableFailure, useTaskHandler } from '@/modules/core/tasks/use-ta
 import { useAccountingApi } from '@/modules/settings/api/use-accounting-api';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
 
-interface UseAccountingSettingReturn {
+interface UseAccountingSettingsReturn {
   getAccountingRule: (payload: MaybeRef<AccountingRuleRequestPayload>, counterparty: string | null) => Promise<AccountingRuleEntry | undefined>;
   getAccountingRules: (payload: MaybeRef<AccountingRuleRequestPayload>) => Promise<Collection<AccountingRuleEntry>>;
   getAccountingRulesConflicts: (payload: MaybeRef<AccountingRuleConflictRequestPayload>) => Promise<Collection<AccountingRuleConflict>>;
@@ -28,7 +28,7 @@ interface UseAccountingSettingReturn {
   resetToDefaults: () => Promise<ActionStatus | null>;
 }
 
-export function useAccountingSettings(): UseAccountingSettingReturn {
+export function useAccountingSettings(): UseAccountingSettingsReturn {
   const {
     exportAccountingRules,
     fetchAccountingRule,

--- a/frontend/app/src/modules/settings/api/use-settings-api.ts
+++ b/frontend/app/src/modules/settings/api/use-settings-api.ts
@@ -4,7 +4,7 @@ import { VALID_WITH_SESSION_STATUS } from '@/modules/core/api/utils';
 import { type SettingsUpdate, UserSettingsModel } from '@/modules/settings/types/user-settings';
 import { BackendConfiguration, ColibriConfiguration } from '@/modules/shell/app/backend';
 
-interface UseSettingApiReturn {
+interface UseSettingsApiReturn {
   setSettings: (settings: SettingsUpdate) => Promise<UserSettingsModel>;
   getSettings: () => Promise<UserSettingsModel>;
   getRawSettings: () => Promise<SettingsUpdate>;
@@ -14,7 +14,7 @@ interface UseSettingApiReturn {
   updateColibriConfiguration: (loglevel: string) => Promise<ColibriConfiguration>;
 }
 
-export function useSettingsApi(): UseSettingApiReturn {
+export function useSettingsApi(): UseSettingsApiReturn {
   const setSettings = async (settings: SettingsUpdate): Promise<UserSettingsModel> => {
     const response = await api.put<UserSettingsModel>(
       '/settings',

--- a/frontend/app/src/modules/settings/use-asset-statistic-state.ts
+++ b/frontend/app/src/modules/settings/use-asset-statistic-state.ts
@@ -16,7 +16,7 @@ enum Preference {
   EVENTS,
 }
 
-interface UseAssetStatisticsStateReturn {
+interface UseAssetStatisticStateReturn {
   getPreference: (asset: string) => Source | undefined;
   name: ComputedRef<string>;
   rememberStateForAsset: WritableComputedRef<boolean>;
@@ -24,7 +24,7 @@ interface UseAssetStatisticsStateReturn {
   modelUseHistoricalAssetBalances: Ref<boolean, boolean>;
 }
 
-export function useAssetStatisticState(asset: MaybeRefOrGetter<string | undefined>): UseAssetStatisticsStateReturn {
+export function useAssetStatisticState(asset: MaybeRefOrGetter<string | undefined>): UseAssetStatisticStateReturn {
   const modelUseHistoricalAssetBalances = shallowRef<boolean>(false);
 
   const enabled = useSetting('useHistoricalAssetBalances');

--- a/frontend/app/src/modules/shell/layout/use-core-scroll.ts
+++ b/frontend/app/src/modules/shell/layout/use-core-scroll.ts
@@ -1,12 +1,12 @@
 import type { ComputedRef } from 'vue';
 import { defaultDocument } from '@vueuse/core';
 
-interface UseScrollReturn {
+interface UseCoreScrollReturn {
   scrollToTop: () => void;
   shouldShowScrollToTopButton: ComputedRef<boolean>;
 }
 
-export function useCoreScroll(): UseScrollReturn {
+export function useCoreScroll(): UseCoreScrollReturn {
   const { y: scrollY } = useScroll(defaultDocument?.body);
 
   const shouldShowScrollToTopButton = computed<boolean>(() => get(scrollY) > 200);

--- a/frontend/app/src/modules/staking/eth2/use-eth2.ts
+++ b/frontend/app/src/modules/staking/eth2/use-eth2.ts
@@ -13,7 +13,7 @@ import { usePremium } from '@/modules/premium/use-premium';
 import { useStatusUpdater } from '@/modules/shell/sync-progress/use-status-updater';
 import { useEth2Api } from '@/modules/staking/api/use-eth2-api';
 
-interface UseEthStakingReturn {
+interface UseEth2StakingReturn {
   performance: ComputedRef<EthStakingPerformance>;
   pagination: Ref<EthStakingPayload>;
   performanceLoading: Ref<boolean>;
@@ -21,7 +21,7 @@ interface UseEthStakingReturn {
   refreshPerformance: (userInitiated: boolean) => Promise<void>;
 }
 
-export function useEth2Staking(): UseEthStakingReturn {
+export function useEth2Staking(): UseEth2StakingReturn {
   const defaultPagination = (): EthStakingPayload => ({
     limit: 10,
     offset: 0,

--- a/frontend/app/src/modules/wallet/use-tradable-asset.ts
+++ b/frontend/app/src/modules/wallet/use-tradable-asset.ts
@@ -8,12 +8,14 @@ import { sortDesc } from '@/modules/core/common/data/bignumbers';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useWalletStore } from './use-wallet-store';
 
-interface UseInjectedTradableAssetReturn {
+interface UseTradableAssetReturn {
   allOwnedAssets: ComputedRef<TradableAsset[]>;
   getAssetDetail: (asset: MaybeRefOrGetter<string>, chain: MaybeRefOrGetter<string>) => ComputedRef<TradableAsset | undefined>;
 }
 
-export function useTradableAsset(address: MaybeRefOrGetter<string | undefined>): UseInjectedTradableAssetReturn {
+type UseInjectedTradableAssetReturn = UseTradableAssetReturn;
+
+export function useTradableAsset(address: MaybeRefOrGetter<string | undefined>): UseTradableAssetReturn {
   const { balances } = storeToRefs(useBalancesStore());
   const { supportedChainsForConnectedAccount } = storeToRefs(useWalletStore());
   const { getAssetPrice } = usePriceUtils();
@@ -121,7 +123,7 @@ export function useTradableAsset(address: MaybeRefOrGetter<string | undefined>):
   };
 }
 
-export const TradableAssetKey: InjectionKey<UseInjectedTradableAssetReturn> = Symbol('tradable-asset');
+export const TradableAssetKey: InjectionKey<UseTradableAssetReturn> = Symbol('tradable-asset');
 
 export function useInjectedTradableAsset(): UseInjectedTradableAssetReturn {
   const injected = inject(TradableAssetKey);


### PR DESCRIPTION
## Summary

Clears **14 of the 15 `@rotki/composable-naming-convention` warnings** by renaming composable return types to the `useX` -> `UseXReturn` convention. Pure type renames, no runtime change.

Notable cases:
- `useCoreScroll` returned `UseScrollReturn`, `useEth2Staking` returned `UseEthStakingReturn`, `useAccountCategoryHelper` returned `UseBlockchainAccountLoadingReturn` — each had borrowed a name that reads like a different composable; now named after their own function.
- `use-tradable-asset` has two composables sharing one shape; added a `UseInjectedTradableAssetReturn = UseTradableAssetReturn` alias so `useInjectedTradableAsset` is named correctly too.

`use-pagination-filter.ts` (the 15th) is intentionally left untouched to avoid conflicting with the in-flight server-table decomposition.

## Checks

- Lint: 14 naming warnings cleared, 0 errors
- Typecheck: 0
- Unit tests: the 13 affected composable specs (161 tests) pass
