### PR TITLE
dev logging improvements

### DIFF
--- a/frontend/app/electron/main/log-service.ts
+++ b/frontend/app/electron/main/log-service.ts
@@ -1,6 +1,7 @@
 import type { App } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import * as util from 'node:util';
 import { isLogLevelActive } from '@electron/main/log-level-severity';
 import { LogManager } from '@electron/main/log-manager';
@@ -11,6 +12,38 @@ const ELECTRON_LOG_FILENAME = 'rotki_electron.log';
 const CORE_LOG_FILENAME = 'rotkehlchen.log';
 const COLIBRI_LOG_FILENAME = 'colibri.log';
 const LOG_DIR = 'logs';
+
+// ANSI colors for the level badge on the console. The file stays plain so it
+// remains greppable; honor NO_COLOR for redirected/piped output.
+const ANSI_RESET = '\u001B[0m';
+const LEVEL_COLORS: Record<LogLevel, string> = {
+  [LogLevel.CRITICAL]: '\u001B[1;31m', // bold red
+  [LogLevel.ERROR]: '\u001B[31m', // red
+  [LogLevel.WARNING]: '\u001B[33m', // yellow
+  [LogLevel.INFO]: '\u001B[32m', // green
+  [LogLevel.DEBUG]: '\u001B[36m', // cyan
+  [LogLevel.TRACE]: '\u001B[90m', // gray
+};
+// Colors for the source marker ([main]/[vue]/[starling]) on the console.
+const SOURCE_COLORS: Record<string, string> = {
+  '[main]': '\u001B[35m', // magenta
+  '[vue]': '\u001B[34m', // blue
+  '[starling]': '\u001B[95m', // bright magenta
+};
+const USE_COLOR = !process.env.NO_COLOR;
+
+/**
+ * Colorize a known leading source marker (": [main] ...", ": [vue] ...", etc.)
+ * for the console. Unknown/absent markers are returned untouched.
+ */
+function colorizeSource(rest: string): string {
+  for (const [tag, color] of Object.entries(SOURCE_COLORS)) {
+    const prefix = `: ${tag}`;
+    if (rest.startsWith(prefix))
+      return `: ${color}${tag}${ANSI_RESET}${rest.slice(prefix.length)}`;
+  }
+  return rest;
+}
 
 export class LogService {
   readonly defaultLogDirectory: string;
@@ -145,7 +178,7 @@ export class LogService {
   /**
    * Core logging method
    */
-  private writeLog(level: LogLevel, logFilePath: string = this.electronLogPath, ...args: any[]): void {
+  private writeLog(level: LogLevel, source: 'main' | 'forwarded', ...args: any[]): void {
     if (!this.shouldLog(level) || args.length === 0) {
       return;
     }
@@ -157,11 +190,23 @@ export class LogService {
       const timestamp = new Date(Date.now()).toISOString();
       const levelString = this.getLogLevelString(level);
       const message = this.formatMessage(...args);
-      const logMessage = `${timestamp} [${levelString}]: ${message}`;
+      // Tag logs that originate in the electron main process. Forwarded logs
+      // (renderer, starling) already carry their own source marker ([vue], [starling]).
+      const sourceTag = source === 'main' ? '[main] ' : '';
+      const rest = `: ${sourceTag}${message}`;
 
-      fs.appendFileSync(logFilePath, `${logMessage}\n`, { encoding: 'utf8' });
+      // The file keeps the full ISO timestamp and plain markers for later reading;
+      // stdout skips the timestamp (the terminal already shows time) and colors the
+      // level badge and source marker for readability.
+      fs.appendFileSync(this.electronLogPath, `${timestamp} [${levelString}]${rest}\n`, { encoding: 'utf8' });
 
-      this.outputToConsole(level, logMessage);
+      if (USE_COLOR) {
+        const badge = `${LEVEL_COLORS[level]}[${levelString}]${ANSI_RESET}`;
+        this.outputToConsole(level, `${badge}${colorizeSource(rest)}`);
+      }
+      else {
+        this.outputToConsole(level, `[${levelString}]${rest}`);
+      }
     }
     catch {
       // Not much we can do if an error happens here.
@@ -172,32 +217,32 @@ export class LogService {
    * Log debug message with printf-style formatting
    */
   debug(message?: any, ...optionalParams: any[]): void {
-    this.writeLog(LogLevel.DEBUG, this.electronLogPath, message, ...optionalParams);
+    this.writeLog(LogLevel.DEBUG, 'main', message, ...optionalParams);
   }
 
   /**
    * Log info message with printf-style formatting
    */
   info(message?: any, ...optionalParams: any[]): void {
-    this.writeLog(LogLevel.INFO, this.electronLogPath, message, ...optionalParams);
+    this.writeLog(LogLevel.INFO, 'main', message, ...optionalParams);
   }
 
   /**
    * Log warning message with printf-style formatting
    */
   warn(message?: any, ...optionalParams: any[]): void {
-    this.writeLog(LogLevel.WARNING, this.electronLogPath, message, ...optionalParams);
+    this.writeLog(LogLevel.WARNING, 'main', message, ...optionalParams);
   }
 
   /**
    * Log error message with printf-style formatting
    */
   error(message?: any, ...optionalParams: any[]): void {
-    this.writeLog(LogLevel.ERROR, this.electronLogPath, message, ...optionalParams);
+    this.writeLog(LogLevel.ERROR, 'main', message, ...optionalParams);
   }
 
   write(level: LogLevel, message?: any, ...optionalParams: any[]): void {
-    this.writeLog(level, this.electronLogPath, message, ...optionalParams);
+    this.writeLog(level, 'forwarded', message, ...optionalParams);
   }
 
   updateLogDirectory(logDirectory: string = this.getLogDirectory()): void {

--- a/frontend/app/electron/main/starling-handler.ts
+++ b/frontend/app/electron/main/starling-handler.ts
@@ -8,6 +8,7 @@ import readline from 'node:readline';
 import { selectPort } from '@electron/main/port-utils';
 import { resolveLogLevel } from '@electron/main/resolve-log-level';
 import { buildStarlingInvocation, SHUTDOWN_GRACE_SECS, type StarlingInvocation } from '@electron/main/starling-args';
+import { forwardStarlingLine } from '@electron/main/starling-log';
 import { BackendCode, type BackendOptions } from '@shared/ipc';
 import { wait } from '@shared/utils';
 
@@ -216,7 +217,7 @@ export class StarlingHandler {
     // stderr carries starling's own logs and the inherited backend stderr, so
     // supervisor diagnostics land in the Electron log (gotcha 2).
     const errReader = readline.createInterface({ input: child.stderr });
-    errReader.on('line', line => this.logger.write(this.logger.getLogLevel(), `[starling] ${line}`));
+    errReader.on('line', line => forwardStarlingLine(this.logger, line));
 
     child.on('error', (error) => {
       this.logger.error('Failed to spawn starling', error);

--- a/frontend/app/electron/main/starling-log.ts
+++ b/frontend/app/electron/main/starling-log.ts
@@ -1,0 +1,28 @@
+import type { LogService } from '@electron/main/log-service';
+import { LogLevel } from '@shared/log-level';
+
+/**
+ * starling emits tracing-formatted stderr: `<ISO timestamp>  <LEVEL> <target>: <msg>`,
+ * often with ANSI coloring around the timestamp and level. We strip the ANSI, parse
+ * the real level (so the log badge matches) and drop the duplicate timestamp. Lines
+ * that do not match (e.g. the inherited backend stderr) are forwarded as-is.
+ */
+// Matches ANSI SGR sequences (ESC [ ... m) without embedding a control char in source.
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+const STARLING_LOG_LINE = /^\d{4}-\d{2}-\d{2}[T ][\d:.]+Z?\s+(TRACE|DEBUG|INFO|WARN|ERROR)\s+(.*)$/;
+const STARLING_LEVELS: Record<string, LogLevel> = {
+  TRACE: LogLevel.TRACE,
+  DEBUG: LogLevel.DEBUG,
+  INFO: LogLevel.INFO,
+  WARN: LogLevel.WARNING,
+  ERROR: LogLevel.ERROR,
+};
+
+/** Forward one starling stderr line to the electron log under the `[starling]` marker. */
+export function forwardStarlingLine(logger: LogService, line: string): void {
+  const clean = line.replace(ANSI_PATTERN, '');
+  const match = STARLING_LOG_LINE.exec(clean);
+  const level = match ? STARLING_LEVELS[match[1]] ?? logger.getLogLevel() : logger.getLogLevel();
+  const text = match ? match[2] : clean;
+  logger.write(level, `[starling] ${text}`);
+}

--- a/frontend/app/scripts/serve.ts
+++ b/frontend/app/scripts/serve.ts
@@ -52,9 +52,7 @@ async function setupMainPackageWatcher({ config: { server } }: ViteDevServer, mo
   const urlPath = '/';
   process.env.VITE_DEV_SERVER_URL = `${protocol}//${host}:${port}${urlPath}`;
 
-  const logger = createLogger(LOG_LEVEL, {
-    prefix: '[main]',
-  });
+  const logger = createLogger(LOG_LEVEL);
 
   let spawnProcess: ChildProcessWithoutNullStreams | null = null;
 
@@ -79,7 +77,11 @@ async function setupMainPackageWatcher({ config: { server } }: ViteDevServer, mo
       spawnProcess = spawn(String(electron), args);
       childProcesses.push(spawnProcess);
 
-      spawnProcess.stdout.on('data', d => d.toString().trim() && logger.warn(d.toString(), { timestamp: true }));
+      spawnProcess.stdout.on('data', (d) => {
+        const data = d.toString().trim();
+        if (data)
+          logger.warn(data);
+      });
       spawnProcess.stderr.on('data', (d) => {
         const data = d.toString().trim();
         if (!data)
@@ -89,7 +91,7 @@ async function setupMainPackageWatcher({ config: { server } }: ViteDevServer, mo
         if (mayIgnore)
           return;
 
-        logger.error(data, { timestamp: true });
+        logger.error(data);
       });
 
       // Stops the watch script when the application has been quit

--- a/frontend/scripts/dev-instance/fs-walk.ts
+++ b/frontend/scripts/dev-instance/fs-walk.ts
@@ -1,10 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import consola from 'consola';
-
+import { createDevLogger } from '../dev/logger';
 import { errorMessage } from './format';
 
-const logger = consola.withTag('dev-instance:fs-walk');
+const logger = createDevLogger('dev-instance:fs-walk');
 
 /**
  * Files we never carry over from a live rotki data dir: SQLite WAL/SHM

--- a/frontend/scripts/dev-instance/git.ts
+++ b/frontend/scripts/dev-instance/git.ts
@@ -1,9 +1,8 @@
 import { execSync } from 'node:child_process';
-import consola from 'consola';
-
+import { createDevLogger } from '../dev/logger';
 import { errorMessage } from './format';
 
-const logger = consola.withTag('dev-instance:git');
+const logger = createDevLogger('dev-instance:git');
 
 export function getCurrentGitBranch(): string | undefined {
   try {

--- a/frontend/scripts/dev-instance/instance.ts
+++ b/frontend/scripts/dev-instance/instance.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import process from 'node:process';
-import consola from 'consola';
+import { createDevLogger } from '../dev/logger';
 import { loadEnvFile, MANAGED_ENV_KEYS, writeManagedEnv } from './env-file';
 import { formatHostPort, formatPort, humanBytes } from './format';
 import { estimateSeedSize, freeDiskBytes, seedInstance } from './fs-walk';
@@ -10,7 +10,7 @@ import { probePortsLive } from './port-probe';
 import { allocatePortSlot, type PortSet, portsForSlot } from './port-registry';
 import { type InstanceMeta, readMetadata, SIDECAR_VERSION, writeMetadata } from './sidecar';
 
-const logger = consola.withTag('dev-instance:instance');
+const logger = createDevLogger('dev-instance:instance');
 
 const SEED_BUFFER_RATIO = 1.1;
 

--- a/frontend/scripts/dev-instance/lifecycle.ts
+++ b/frontend/scripts/dev-instance/lifecycle.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { confirm, isCancel } from '@clack/prompts';
-import consola from 'consola';
+import { createDevLogger } from '../dev/logger';
 import { clearManagedEnvBlock, readManagedInstanceName } from './env-file';
 import { formatHostPort, formatTable, humanBytes } from './format';
 import { dirSizeBytes } from './fs-walk';
@@ -12,7 +12,7 @@ import { probePortsLive } from './port-probe';
 import { readPortIndex, releasePortSlot, writePortIndex } from './port-registry';
 import { type InstanceMeta, readMetadata } from './sidecar';
 
-const logger = consola.withTag('dev-instance:lifecycle');
+const logger = createDevLogger('dev-instance:lifecycle');
 
 export interface InstanceSummary {
   name: string;

--- a/frontend/scripts/dev-instance/port-registry.ts
+++ b/frontend/scripts/dev-instance/port-registry.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import consola from 'consola';
 import { z } from 'zod/v4';
+import { createDevLogger } from '../dev/logger';
 import { errorCode, errorMessage } from './format';
 import { ensureInstanceParent, resolveInstanceParent, sanitizeName } from './paths';
 
@@ -68,7 +68,7 @@ const PortIndexSchema = z.object({
 
 export type PortIndex = z.infer<typeof PortIndexSchema>;
 
-const logger = consola.withTag('dev-instance:port-registry');
+const logger = createDevLogger('dev-instance:port-registry');
 
 export function portsForSlot(slot: number): PortSet {
   if (slot === 0) {

--- a/frontend/scripts/dev-instance/sidecar.ts
+++ b/frontend/scripts/dev-instance/sidecar.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import consola from 'consola';
 import { z } from 'zod/v4';
+import { createDevLogger } from '../dev/logger';
 import { errorMessage } from './format';
 import { atomicWriteJson } from './port-registry';
 
@@ -9,7 +9,7 @@ const SIDECAR_FILENAME = '.rotki-instance.json';
 
 export const SIDECAR_VERSION = 1;
 
-const logger = consola.withTag('dev-instance:sidecar');
+const logger = createDevLogger('dev-instance:sidecar');
 
 const InstanceMetaSchema = z.object({
   version: z.number(),

--- a/frontend/scripts/dev/logger.ts
+++ b/frontend/scripts/dev/logger.ts
@@ -1,0 +1,114 @@
+import process from 'node:process';
+
+/**
+ * Shared logger for the `pnpm dev` / `pnpm dev:web` run path (start-dev + its dev/
+ * and dev-instance/ helpers) and for forwarding child-process output. Every line is
+ * formatted as `<label> <time> <message>` so the orchestrator's own logs and the
+ * forwarded child logs read the same. The timestamp uses the local 12-hour clock,
+ * e.g. "2:21:05 PM".
+ *
+ * Child labels carry a reserved color (app/backend/colibri/proxy) and are passed to
+ * formatDevLine directly. The orchestrator's own tags go through createDevLogger,
+ * which paints them a single shared color so they are visually distinct from the
+ * reserved child labels.
+ */
+
+// ESC-based regexes built without embedding a control char in source.
+const ESC = String.fromCharCode(27);
+const ANSI_GLOBAL = new RegExp(`${ESC}\\[[0-9;]*m`, 'g');
+const ANSI_AT_START = new RegExp(`^${ESC}\\[[0-9;]*m`);
+
+// Shared color for orchestrator tags: blue (not white, and not one of the reserved
+// child-label colors red/green/yellow/magenta).
+const TAG_COLOR = '\u001B[34m';
+const RESET = '\u001B[0m';
+
+function timestamp(): string {
+  return new Date().toLocaleTimeString('en-US');
+}
+
+function render(args: unknown[]): string {
+  return args
+    .map((arg) => {
+      if (typeof arg === 'string')
+        return arg;
+      if (arg instanceof Error)
+        return arg.stack ?? arg.message;
+      return JSON.stringify(arg);
+    })
+    .join(' ');
+}
+
+/** Visible width of a string, ignoring ANSI SGR sequences. */
+function visibleWidth(text: string): number {
+  return text.replace(ANSI_GLOBAL, '').length;
+}
+
+/** Index in `text` just past the first `width` visible chars, never splitting an ANSI sequence. */
+function cutAtVisible(text: string, width: number): number {
+  let visible = 0;
+  let i = 0;
+  while (i < text.length && visible < width) {
+    const match = ANSI_AT_START.exec(text.slice(i));
+    if (match) {
+      i += match[0].length;
+      continue;
+    }
+    i += 1;
+    visible += 1;
+  }
+  return i;
+}
+
+/**
+ * Hard-wrap `message` to the terminal width, indenting continuation lines by
+ * `indent` visible columns so wrapped text lines up under the message (i.e. past
+ * the `<tag> <time> ` prefix). ANSI-aware so color codes do not count toward width.
+ */
+function wrapMessage(message: string, indent: number, columns: number): string {
+  const width = columns - indent;
+  if (width <= 0)
+    return message;
+  const pad = ' '.repeat(indent);
+  const out: string[] = [];
+  for (const rawLine of message.split('\n')) {
+    let line = rawLine;
+    let first = true;
+    while (visibleWidth(line) > width) {
+      const cut = cutAtVisible(line, width);
+      out.push((first ? '' : pad) + line.slice(0, cut));
+      line = line.slice(cut);
+      first = false;
+    }
+    out.push((first ? '' : pad) + line);
+  }
+  return out.join('\n');
+}
+
+export function formatDevLine(label: string, message: string): string {
+  const prefix = `${label} ${timestamp()} `;
+  const columns = process.stdout.columns ?? 0;
+  const indent = visibleWidth(prefix);
+  // Only wrap for a real terminal wide enough to leave room for the message.
+  const body = columns > indent + 8 ? wrapMessage(message, indent, columns) : message;
+  return `${prefix}${body}`;
+}
+
+export interface DevLogger {
+  log: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  success: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+export function createDevLogger(label: string): DevLogger {
+  const tag = `${TAG_COLOR}${label.replace(ANSI_GLOBAL, '')}${RESET}`;
+  const toOut = (...args: unknown[]): void => {
+    process.stdout.write(`${formatDevLine(tag, render(args))}\n`);
+  };
+  const toErr = (...args: unknown[]): void => {
+    process.stderr.write(`${formatDevLine(tag, render(args))}\n`);
+  };
+  return { log: toOut, info: toOut, success: toOut, warn: toErr, error: toErr };
+}

--- a/frontend/scripts/dev/prerequisites.ts
+++ b/frontend/scripts/dev/prerequisites.ts
@@ -1,10 +1,10 @@
 import { execSync } from 'node:child_process';
 import net from 'node:net';
 import process from 'node:process';
-import consola from 'consola';
 import { MAX_PORT } from '../dev-instance';
+import { createDevLogger } from './logger';
 
-const logger = consola.withTag('dev:prerequisites');
+const logger = createDevLogger('dev:prerequisites');
 
 let useUvForPython = false;
 

--- a/frontend/scripts/dev/process-pool.ts
+++ b/frontend/scripts/dev/process-pool.ts
@@ -1,8 +1,8 @@
 import type { Buffer } from 'node:buffer';
 import { type ChildProcess, spawn, spawnSync } from 'node:child_process';
 import process from 'node:process';
-import consola from 'consola';
 import { errorCode, errorMessage } from '../dev-instance/format';
+import { createDevLogger, formatDevLine } from './logger';
 
 const isWindows = process.platform === 'win32';
 
@@ -20,7 +20,7 @@ interface TrackedProcess {
 
 const SHUTDOWN_GRACE_MS = 5_000;
 
-const logger = consola.withTag('dev:process-pool');
+const logger = createDevLogger('dev:process-pool');
 const tracked: TrackedProcess[] = [];
 
 export interface SpawnOpts {
@@ -59,15 +59,19 @@ function shellQuoteArg(arg: string): string {
 }
 
 export function startProcess(cmd: string, tag: string, name: string, args: string[] = [], opts: SpawnOpts = {}): ChildProcess {
-  const childLogger = consola.withTag(tag);
-  const listeners: OutputListener = {
-    out: (buffer: Buffer): void => {
-      childLogger.log(buffer.toString().replace(/\n$/, ''));
-    },
-    err: (buffer: Buffer): void => {
-      childLogger.log(buffer.toString().replace(/\n$/, ''));
-    },
+  // Format each child line as `<label> <time> <line>` on the LEFT and write it
+  // straight through. consola's tagged reporter right-aligned the tag+timestamp
+  // to the terminal width, which misfired on multi-line chunks and on any line
+  // wider than the terminal (the badge wrapped in front of the next line). A plain
+  // left format is stable regardless of line length. Split per line so a chunk
+  // carrying several lines is formatted line-by-line.
+  const emit = (buffer: Buffer): void => {
+    for (const line of buffer.toString().split(/\r?\n/)) {
+      if (line.length > 0)
+        process.stdout.write(`${formatDevLine(tag, line)}\n`);
+    }
   };
+  const listeners: OutputListener = { out: emit, err: emit };
 
   const env: NodeJS.ProcessEnv = {
     FORCE_COLOR: '1',

--- a/frontend/scripts/dev/services.ts
+++ b/frontend/scripts/dev/services.ts
@@ -3,14 +3,14 @@ import fs from 'node:fs';
 import { platform } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
-import consola from 'consola';
 import { buildCargoEnv, STRAWBERRY_MISSING_WARNING } from '../../app/shared/cargo-env';
 import { DEFAULT_PORTS, type InstanceRuntime } from '../dev-instance';
 import { formatPort } from '../dev-instance/format';
+import { createDevLogger } from './logger';
 import { getDebuggerPort, isUsingUvForPython, selectPort } from './prerequisites';
 import { startProcess } from './process-pool';
 
-const logger = consola.withTag('dev:services');
+const logger = createDevLogger('dev:services');
 
 const colors = {
   red: (msg: string) => `\u001B[31m${msg}\u001B[0m`,
@@ -20,7 +20,7 @@ const colors = {
 } as const;
 
 const PROXY = 'proxy';
-const ROTKI = 'rotki';
+const APP = 'app';
 const BACKEND = 'backend';
 const COLIBRI = 'colibri';
 
@@ -313,7 +313,7 @@ export function startDevServer(opts: DevServerOptions): void {
     : baseServeCmd;
 
   const env = { ...opts.backendEnv, ...opts.extraEnv };
-  const child = startProcess(`${serveCmd}${debuggerArgs}`, colors.magenta(ROTKI), ROTKI, [], {
+  const child = startProcess(`${serveCmd}${debuggerArgs}`, colors.magenta(APP), APP, [], {
     env: Object.keys(env).length > 0 ? env : undefined,
     // Electron mode only: this chain ends in an electron window, the one child
     // that can act on a polite close and quit cleanly (which is what lets starling

--- a/frontend/scripts/start-dev.ts
+++ b/frontend/scripts/start-dev.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import process from 'node:process';
 import { cac } from 'cac';
-import consola from 'consola';
 import { config } from 'dotenv';
 import {
   cleanAll,
@@ -19,6 +18,7 @@ import {
 } from './dev-instance';
 import { errorMessage, formatPort } from './dev-instance/format';
 import { getCurrentGitBranch } from './dev-instance/git';
+import { createDevLogger } from './dev/logger';
 import { ensurePrerequisites, parsePort, verifyBackendReady } from './dev/prerequisites';
 import { registerShutdownHandlers, terminateSubprocesses } from './dev/process-pool';
 import { startDevelopmentEnvironment, warmDevServices } from './dev/services';
@@ -26,7 +26,7 @@ import { startDevelopmentEnvironment, warmDevServices } from './dev/services';
 const ENV_FILE_RELATIVE = 'app/.env.development.local';
 const APP_ENV_RELATIVE = 'app/.env';
 
-const logger = consola.withTag('[36mdev[0m');
+const logger = createDevLogger('dev');
 
 interface DevCliOptions {
   web?: boolean;


### PR DESCRIPTION
## What

Cleans up and unifies the electron dev-server log output (the stream you see during `pnpm dev` / `pnpm dev:web`). No runtime/app behavior changes; this only affects developer-facing logs.

### `log-service` (electron main)
- Emit an accurate `[main]` source tag **at the source**, only for main-origin logs, in the same slot as the forwarded `[vue]` / `[starling]` markers (previously the dev script stamped `[main]` on every forwarded line, including renderer lines).
- Console drops the timestamp (kept in the `rotki_electron.log` file, which retains the full ISO timestamp for later reading).
- Colorize the level badge and the source marker on the console only; the file stays plain. Honors `NO_COLOR`.

### `serve`
- Drop vite's redundant locale timestamp and the blanket `[main]` prefix.
- Trim forwarded stdout chunks so there is no blank line between entries.

### `starling-log` (new)
- Parse starling's own tracing level so the log-level badge matches (no more `[DEBUG]` on an `INFO` line) and strip its duplicate leading timestamp, handling ANSI-colored tracing output. Non-matching lines (inherited backend stderr) pass through unchanged.

### dev run-path logger (new `scripts/dev/logger.ts`)
- Replace consola with a shared `createDevLogger` **only** in the `pnpm dev` / `pnpm dev:web` run path (`start-dev` + its `dev/` and `dev-instance/` helpers). Standalone scripts (build, get-protocols, etc.) keep consola.
- Every line is formatted `<tag> <time> <message>`; orchestrator tags share one non-reserved color (blue), child labels keep their reserved colors.
- Fixes the child-label badge misfire: consola right-aligned the tag+timestamp, which landed before the level on multi-line chunks and on lines wider than the terminal. Now a stable left format with hanging-indent wrapping so wrapped lines align under the message.
- Rename the app child label from `rotki` to `app`.

## Test plan
- `pnpm run lint` / `pnpm run typecheck` green.
- Verified in a real `pnpm dev` session: tags, colors, spacing, hanging-indent wrapping, and the starling level/timestamp all render as intended.