### PR TITLE
Remove type-assertion casts from test files (part 1)

### DIFF
--- a/frontend/app/electron/main/html-mime-protection.spec.ts
+++ b/frontend/app/electron/main/html-mime-protection.spec.ts
@@ -1,5 +1,6 @@
 import type { LogService } from '@electron/main/log-service';
 import process from 'node:process';
+import { createMock } from '@test/utils/create-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { protectHtmlAssociation } from './html-mime-protection';
 
@@ -8,12 +9,7 @@ const { execFileSync } = vi.hoisted(() => ({ execFileSync: vi.fn() }));
 vi.mock('node:child_process', () => ({ default: { execFileSync }, execFileSync }));
 
 function createLogger(): LogService {
-  return {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  } as unknown as LogService;
+  return createMock<LogService>();
 }
 
 /**

--- a/frontend/app/electron/main/ipc-handlers/backend-handlers.spec.ts
+++ b/frontend/app/electron/main/ipc-handlers/backend-handlers.spec.ts
@@ -1,9 +1,10 @@
 import type { LogService } from '@electron/main/log-service';
+import { createMock } from '@test/utils/create-mock';
 import { describe, expect, it, vi } from 'vitest';
 import { BackendHandlers } from './backend-handlers';
 
 function makeLogger(): LogService {
-  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as LogService;
+  return createMock<LogService>();
 }
 
 describe('backendHandlers', () => {

--- a/frontend/app/electron/main/starling-handler.spec.ts
+++ b/frontend/app/electron/main/starling-handler.spec.ts
@@ -3,6 +3,8 @@ import type { LogService } from '@electron/main/log-service';
 import { EventEmitter } from 'node:events';
 import { PassThrough, Writable } from 'node:stream';
 import { BackendCode } from '@shared/ipc';
+import { LogLevel } from '@shared/log-level';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { StarlingHandler } from './starling-handler';
 
@@ -81,26 +83,21 @@ function emitReady(child: FakeChild): void {
 }
 
 function makeLogger(): LogService {
-  return {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-    write: vi.fn(),
-    getLogLevel: vi.fn(() => 0),
-    updateLogDirectory: vi.fn(),
+  return createMock<LogService>({
+    getLogLevel: vi.fn(() => LogLevel.INFO),
     get coreProcessLogPath(): string {
       return '/tmp/logs/rotkehlchen.log';
     },
-  } as unknown as LogService;
+  });
 }
 
 function makeConfig(): AppConfig {
   return {
     isDev: false,
+    isMac: false,
     ports: { corePort: 4242, colibriPort: 4343 },
     urls: { coreApiUrl: '', colibriApiUrl: '' },
-  } as unknown as AppConfig;
+  } satisfies AppConfig;
 }
 
 describe('starlingHandler', () => {

--- a/frontend/app/src/modules/assets/prices/components/oracle/OracleCacheContent.spec.ts
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OracleCacheContent.spec.ts
@@ -1,4 +1,5 @@
 import type { OracleCacheMeta } from '@/modules/assets/prices/price-types';
+import { componentVm } from '@test/utils/component-vm';
 import { mount } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -89,7 +90,7 @@ describe('oracleCacheContent', () => {
     const wrapper = createWrapper();
     await flushPromises();
 
-    const vm = wrapper.vm as unknown as CacheContentVm;
+    const vm = componentVm<CacheContentVm>(wrapper);
     vm.newFromAsset = 'ETH';
     vm.newToAsset = 'USD';
     await vm.populateCache();
@@ -108,7 +109,7 @@ describe('oracleCacheContent', () => {
     await flushPromises();
     mockGetPriceCache.mockClear();
 
-    const vm = wrapper.vm as unknown as CacheContentVm;
+    const vm = componentVm<CacheContentVm>(wrapper);
     vm.newFromAsset = 'ETH';
     vm.newToAsset = 'USD';
     await vm.populateCache();
@@ -131,7 +132,7 @@ describe('oracleCacheContent', () => {
     const wrapper = createWrapper();
     await flushPromises();
 
-    const vm = wrapper.vm as unknown as CacheContentVm;
+    const vm = componentVm<CacheContentVm>(wrapper);
     await vm.clearCache(entries[0]);
 
     expect(mockDeletePriceCache).toHaveBeenCalledWith('cryptocompare', 'ETH', 'USD');
@@ -143,7 +144,7 @@ describe('oracleCacheContent', () => {
     const wrapper = createWrapper();
     await flushPromises();
 
-    const vm = wrapper.vm as unknown as CacheContentVm;
+    const vm = componentVm<CacheContentVm>(wrapper);
     await vm.clearCache({
       fromAsset: 'ETH',
       fromTimestamp: '1700000000',
@@ -167,7 +168,7 @@ describe('oracleCacheContent', () => {
     const wrapper = createWrapper();
     await flushPromises();
 
-    const vm = wrapper.vm as unknown as CacheContentVm;
+    const vm = componentVm<CacheContentVm>(wrapper);
     expect(vm.rows).toHaveLength(3);
 
     vm.filterFromAsset = 'ETH';

--- a/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceEditDialog.spec.ts
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceEditDialog.spec.ts
@@ -1,5 +1,6 @@
 import type { OraclePriceEntry } from '@/modules/assets/prices/price-types';
 import { bigNumberify } from '@rotki/common';
+import { componentVm } from '@test/utils/component-vm';
 import { mount } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -62,10 +63,7 @@ describe('oraclePriceEditDialog', () => {
     });
     await flushPromises();
 
-    const vm = wrapper.vm as unknown as {
-      editedPrice: string;
-      save: () => Promise<void>;
-    };
+    const vm = componentVm<{ editedPrice: string; save: () => Promise<void> }>(wrapper);
     vm.editedPrice = '3000';
     await vm.save();
     await flushPromises();
@@ -92,10 +90,7 @@ describe('oraclePriceEditDialog', () => {
     });
     await flushPromises();
 
-    const vm = wrapper.vm as unknown as {
-      editedPrice: string;
-      save: () => Promise<void>;
-    };
+    const vm = componentVm<{ editedPrice: string; save: () => Promise<void> }>(wrapper);
     vm.editedPrice = '3000';
     await vm.save();
     await flushPromises();

--- a/frontend/app/src/modules/core/sigil/use-sigil.spec.ts
+++ b/frontend/app/src/modules/core/sigil/use-sigil.spec.ts
@@ -1,16 +1,16 @@
 import type { EffectScope } from 'vue';
-import type { SigilEventMap } from '@/modules/core/sigil/types';
+import type { SigilEventMap, SigilQueueEntry } from '@/modules/core/sigil/types';
 import { flushPromises } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { sigilBus } from '@/modules/core/sigil/event-bus';
 
-const mockEnqueue = vi.fn().mockResolvedValue(undefined);
+const mockEnqueue = vi.fn<(entry: Omit<SigilQueueEntry, 'id'>) => Promise<void>>().mockResolvedValue(undefined);
 const mockStartQueue = vi.fn();
 const mockStopQueue = vi.fn();
 
 vi.mock('@/modules/core/sigil/use-sigil-queue', () => ({
   WEBSITE_ID: 'test-website-id',
-  enqueue: (...args: unknown[]): unknown => mockEnqueue(...args),
+  enqueue: async (entry: Omit<SigilQueueEntry, 'id'>): Promise<void> => mockEnqueue(entry),
   startQueue: (): void => mockStartQueue(),
   stopQueue: (): void => mockStopQueue(),
 }));
@@ -208,7 +208,7 @@ describe('useSigil', () => {
       await flushPromises();
 
       const eventNames = mockEnqueue.mock.calls.map(
-        (call: unknown[]) => (call[0] as Record<string, unknown>).name,
+        call => call[0].name,
       );
       expect(eventNames).toContain('session_config');
       expect(eventNames).toContain('exchanges_summary');
@@ -223,7 +223,7 @@ describe('useSigil', () => {
       await nextTick();
 
       const eventNames = mockEnqueue.mock.calls.map(
-        (call: unknown[]) => (call[0] as Record<string, unknown>).name,
+        call => call[0].name,
       );
       expect(eventNames).toContain('balances_summary');
     });
@@ -238,7 +238,7 @@ describe('useSigil', () => {
       await flushPromises();
 
       const eventNames = mockEnqueue.mock.calls.map(
-        (call: unknown[]) => (call[0] as Record<string, unknown>).name,
+        call => call[0].name,
       );
       expect(eventNames).toContain('history_sync');
     });
@@ -254,7 +254,7 @@ describe('useSigil', () => {
       await flushPromises();
 
       const sessionCalls = mockEnqueue.mock.calls.filter(
-        (call: unknown[]) => (call[0] as Record<string, unknown>).name === 'session_config',
+        call => call[0].name === 'session_config',
       );
       expect(sessionCalls).toHaveLength(1);
     });
@@ -280,7 +280,7 @@ describe('useSigil', () => {
       await flushPromises();
 
       const sessionCalls = mockEnqueue.mock.calls.filter(
-        (call: unknown[]) => (call[0] as Record<string, unknown>).name === 'session_config',
+        call => call[0].name === 'session_config',
       );
       expect(sessionCalls).toHaveLength(1);
     });
@@ -331,7 +331,7 @@ describe('useSigil', () => {
       });
       await nextTick();
 
-      const call = mockEnqueue.mock.calls[0] as [Record<string, unknown>];
+      const call = mockEnqueue.mock.calls[0];
       expect(call[0].url).toBe('/accounts/:address');
     });
 
@@ -348,7 +348,7 @@ describe('useSigil', () => {
       });
       await nextTick();
 
-      const call = mockEnqueue.mock.calls[0] as [Record<string, unknown>];
+      const call = mockEnqueue.mock.calls[0];
       expect(call[0].url).toBe('/balances/binance/deposits');
     });
   });
@@ -363,11 +363,11 @@ describe('useSigil', () => {
       await flushPromises();
 
       const sessionCall = mockEnqueue.mock.calls.find(
-        (call: unknown[]) => (call[0] as Record<string, unknown>).name === 'session_config',
+        call => call[0].name === 'session_config',
       );
       expect(sessionCall).toBeDefined();
 
-      const entry = sessionCall![0] as Record<string, unknown>;
+      const entry = sessionCall![0];
       expect(entry.name).toBe('session_config');
       expect(entry.data).toMatchObject({ premium: false, appVersion: '1.0' });
       expect(entry.url).toBe('/dashboard');

--- a/frontend/app/src/modules/settings/backend/use-log-level-update.spec.ts
+++ b/frontend/app/src/modules/settings/backend/use-log-level-update.spec.ts
@@ -1,4 +1,5 @@
-import type { LogLevel } from '@shared/log-level';
+import { LogLevel } from '@shared/log-level';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useLogLevelUpdate } from '@/modules/settings/backend/use-log-level-update';
 
@@ -40,7 +41,7 @@ describe('useLogLevelUpdate', () => {
 
   it('should propagate the level to backend, colibri, consola and the Electron LogService', async () => {
     const { applyLogLevelChange } = useLogLevelUpdate();
-    await applyLogLevelChange('warning' as LogLevel);
+    await applyLogLevelChange(LogLevel.WARNING);
 
     expect(updateBackendConfigurationMock).toHaveBeenCalledWith('warning');
     expect(updateColibriConfigurationMock).toHaveBeenCalledWith('warning');
@@ -58,20 +59,20 @@ describe('useLogLevelUpdate', () => {
     });
 
     const { applyLogLevelChange } = useLogLevelUpdate();
-    await applyLogLevelChange('debug' as LogLevel);
+    await applyLogLevelChange(LogLevel.DEBUG);
 
     expect(order).toStrictEqual(['backend', 'colibri']);
   });
 
   it('should skip the Electron LogService IPC when not running in a packaged build', async () => {
     const { useInterop } = await import('@/modules/shell/app/use-electron-interop');
-    vi.mocked(useInterop).mockReturnValueOnce({
+    vi.mocked(useInterop).mockReturnValueOnce(createMock<ReturnType<typeof useInterop>>({
       isPackaged: false,
       setLogLevel: setLogLevelMock,
-    } as unknown as ReturnType<typeof useInterop>);
+    }));
 
     const { applyLogLevelChange } = useLogLevelUpdate();
-    await applyLogLevelChange('info' as LogLevel);
+    await applyLogLevelChange(LogLevel.INFO);
 
     expect(setLevelMock).toHaveBeenCalledWith('info');
     expect(setLogLevelMock).not.toHaveBeenCalled();

--- a/frontend/app/tests/unit/utils/component-vm.ts
+++ b/frontend/app/tests/unit/utils/component-vm.ts
@@ -1,0 +1,14 @@
+import type { VueWrapper } from '@vue/test-utils';
+
+/**
+ * Access a component's `<script setup>` internals (setup-scoped state and
+ * methods) from a test. Vue's public `vm` type never exposes those, so a cast
+ * is unavoidable — it is contained here instead of being repeated across specs.
+ *
+ * @example
+ * const vm = componentVm<{ save: () => void }>(wrapper);
+ */
+export function componentVm<T>(wrapper: VueWrapper): T {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- vm never exposes <script setup> internals in its public type; contained to this helper
+  return wrapper.vm as unknown as T;
+}


### PR DESCRIPTION
## Summary

First slice of removing `@typescript-eslint/consistent-type-assertions` warnings from the **test** files (the rule forbids every `as`, but allows `as const`/`satisfies`). Clears **20 spec-side casts** (95 → 75) using the priority order: type/guard → satisfies → shared mock util → suppress only when unavoidable (and then contained in one helper).

- **New `componentVm<T>(wrapper)` helper** (`tests/unit/utils/component-vm.ts`) — contains the single unavoidable cast for reaching a component's `<script setup>` internals; adopted in the oracle specs (7 casts).
- **Typed the sigil `mockEnqueue`** as `vi.fn<(entry: Omit<SigilQueueEntry, 'id'>) => Promise<void>>()` so `mock.calls` entries are typed — removes all 9 `as Record<string, unknown>` casts in one shot.
- **`createMock<LogService>()`** adopted in three electron specs; the starling `AppConfig` now built with `satisfies` (adding the missing `isMac`; `getLogLevel` returns a real `LogLevel` member instead of `0`).
- **`LogLevel` enum** instead of `'warning' as LogLevel`, plus `createMock<ReturnType<typeof useInterop>>` in the log-level spec.

No new suppressions except the one contained inside `componentVm`.

## Deliberately not in this PR
- The two wallet-bridge specs and `use-price-seed.spec.ts` — these turned out to be genuine type-modeling issues, not mechanical casts (loose `vi.fn` mocks that don't match the real composable signatures; a flat balances fixture vs the nested `AssetProtocolBalances` type). They deserve a focused follow-up rather than a blanket cast, so `createMock` doesn't just relocate the mismatch.
- src-side casts (135) — a later effort.

## Checks
- Lint: 20 assertion warnings cleared, 0 errors
- Typecheck: 0
- Unit tests: all touched specs pass (oracle, sigil, 3 electron, log-level)
