### PR TITLE
Dashboard and history UI polish

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2351,9 +2351,9 @@
       "title": "blockchain"
     },
     "completeness": {
-      "data_issues": "{count} data issues need attention",
-      "missing_prices": "{count} assets without a price",
-      "undecoded": "{count} undecoded transactions"
+      "data_issues": "{count} data issue needs attention | {count} data issues need attention",
+      "missing_prices": "{count} asset without a price | {count} assets without a price",
+      "undecoded": "{count} undecoded transaction | {count} undecoded transactions"
     },
     "exchange_balances": {
       "add": "Add an exchange",
@@ -2665,6 +2665,13 @@
       "unknown": "rotki flagged a data issue. Open the details below to see what was recorded.",
       "unmatched_bridge_deposit": "A {asset} bridge deposit has no matched counterpart event on the destination chain. Match it manually or resolve it as an external payment.",
       "unmatched_bridge_withdrawal": "A {asset} bridge withdrawal has no matched counterpart deposit on the source chain. Match it manually to link the two legs."
+    },
+    "description_short": {
+      "current_balance_mismatch": "{asset} balance is off by {delta} from the on-chain amount.",
+      "negative_balance": "{asset} balance went negative to {amount}, likely from a missing earlier transaction.",
+      "unknown": "rotki flagged a data issue. Open the details for more.",
+      "unmatched_bridge_deposit": "Unmatched {asset} bridge deposit. Match it manually.",
+      "unmatched_bridge_withdrawal": "Unmatched {asset} bridge withdrawal. Match it manually."
     },
     "detail": {
       "detected": "Detected",

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
@@ -61,7 +61,7 @@ describe('dashboardCompletenessIndicator', () => {
     expect(wrapper.find('[data-testid=dashboard-completeness]').exists()).toBe(false);
   });
 
-  it('should show a chip when assets are missing prices', async () => {
+  it('should show a button when assets are missing prices', async () => {
     useBalancePricesStore().prices = {
       ETH: { isManualPrice: false, oracle: 'blockchain', priceMissing: true, usdPrice: null, value: '0' },
     } as never;
@@ -69,20 +69,20 @@ describe('dashboardCompletenessIndicator', () => {
     expect(wrapper.find('[data-testid=dashboard-completeness]').text()).toContain('missing_prices');
   });
 
-  it('should show a chip for leftover undecoded transactions', async () => {
+  it('should show a button for leftover undecoded transactions', async () => {
     useDecodingStatusStore().setUndecodedTransactionsStatus({ chain: 'eth', processed: 2, total: 10 });
     const wrapper = await createWrapper();
     expect(wrapper.find('[data-testid=dashboard-completeness]').text()).toContain('undecoded');
   });
 
-  it('should hide the undecoded chip while history is processing', async () => {
+  it('should hide the undecoded button while history is processing', async () => {
     state.processing = true;
     useDecodingStatusStore().setUndecodedTransactionsStatus({ chain: 'eth', processed: 2, total: 10 });
     const wrapper = await createWrapper();
     expect(wrapper.find('[data-testid=dashboard-completeness]').exists()).toBe(false);
   });
 
-  it('should show a chip when data issues need attention', async () => {
+  it('should show a button when data issues need attention', async () => {
     state.actionableCount = 3;
     const wrapper = await createWrapper();
     expect(wrapper.find('[data-testid=dashboard-completeness]').text()).toContain('data_issues');

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
@@ -35,14 +35,13 @@ onMounted(() => {
   >
     <RouterLink
       v-if="missingPricesCount > 0"
-      class="inline-flex no-underline"
+      class="no-underline"
       :to="{ name: '/price-manager/latest/' }"
     >
-      <RuiChip
+      <RuiButton
         size="sm"
-        color="grey"
+        color="secondary"
         variant="outlined"
-        class="cursor-pointer hover:brightness-95"
       >
         <template #prepend>
           <RuiIcon
@@ -50,19 +49,18 @@ onMounted(() => {
             size="14"
           />
         </template>
-        {{ t('dashboard.completeness.missing_prices', { count: missingPricesCount }) }}
-      </RuiChip>
+        {{ t('dashboard.completeness.missing_prices', { count: missingPricesCount }, missingPricesCount) }}
+      </RuiButton>
     </RouterLink>
     <RouterLink
       v-if="undecodedCount > 0"
-      class="inline-flex no-underline"
+      class="no-underline"
       :to="{ name: '/history/events/' }"
     >
-      <RuiChip
+      <RuiButton
         size="sm"
         color="warning"
         variant="outlined"
-        class="cursor-pointer hover:brightness-95"
       >
         <template #prepend>
           <RuiIcon
@@ -70,19 +68,18 @@ onMounted(() => {
             size="14"
           />
         </template>
-        {{ t('dashboard.completeness.undecoded', { count: undecodedCount }) }}
-      </RuiChip>
+        {{ t('dashboard.completeness.undecoded', { count: undecodedCount }, undecodedCount) }}
+      </RuiButton>
     </RouterLink>
     <RouterLink
       v-if="actionableCount > 0"
-      class="inline-flex no-underline"
+      class="no-underline"
       :to="{ name: '/history/data-issues/' }"
     >
-      <RuiChip
+      <RuiButton
         size="sm"
         color="warning"
         variant="outlined"
-        class="cursor-pointer hover:brightness-95"
       >
         <template #prepend>
           <RuiIcon
@@ -90,8 +87,8 @@ onMounted(() => {
             size="14"
           />
         </template>
-        {{ t('dashboard.completeness.data_issues', { count: actionableCount }) }}
-      </RuiChip>
+        {{ t('dashboard.completeness.data_issues', { count: actionableCount }, actionableCount) }}
+      </RuiButton>
     </RouterLink>
   </div>
 </template>

--- a/frontend/app/src/modules/dashboard/OverallBalances.vue
+++ b/frontend/app/src/modules/dashboard/OverallBalances.vue
@@ -142,13 +142,11 @@ onMounted(() => {
           class="pr-4"
           :value="percentage"
         />
-        <span>
-          (
+        <span class="whitespace-nowrap before:content-['('] after:content-[')']">
           <FiatDisplay
             v-if="!isLoading"
             :value="balanceDelta"
           />
-          )
         </span>
       </div>
     </div>

--- a/frontend/app/src/modules/history/balances/AccountingOverlayToggle.vue
+++ b/frontend/app/src/modules/history/balances/AccountingOverlayToggle.vue
@@ -19,7 +19,9 @@ const options = computed<{ value: OverlayMode; label: string; icon: RuiIcons }[]
         v-model="modelValue"
         variant="outlined"
         color="primary"
+        active-color="primary"
         size="sm"
+        required
         data-testid="accounting-overlay-mode"
       >
         <RuiButton

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueDescription.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueDescription.vue
@@ -5,10 +5,15 @@ import type { IssueDescription } from '@/modules/history/data-issues/types';
 import { ValueDisplay } from '@/modules/assets/amount-display/components';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 
-const { description, tag = 'span' } = defineProps<{
+const { description, tag = 'span', short = false } = defineProps<{
   description: IssueDescription;
   tag?: string;
+  short?: boolean;
 }>();
+
+// The inbox card uses a condensed one-liner; the detail drawer keeps the full
+// sentence. Both share the same interpolation slots below.
+const keypath = computed<string>(() => short ? description.shortMessageKey : description.messageKey);
 
 const { useAssetField } = useAssetInfoRetrieval();
 
@@ -37,7 +42,7 @@ function exact(amount: BigNumber): FormatOptions {
 
 <template>
   <i18n-t
-    :keypath="description.messageKey"
+    :keypath="keypath"
     :tag="tag"
     scope="global"
   >

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuePanelCard.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuePanelCard.vue
@@ -50,18 +50,18 @@ useMutationObserver(descriptionRef, checkTruncation, { characterData: true, chil
 
 <template>
   <RuiCard
-    class="cursor-pointer transition-colors"
+    class="cursor-pointer transition-colors h-full"
     :class="active
       ? '!border-rui-primary ring-1 ring-rui-primary bg-rui-primary/5'
       : 'hover:bg-rui-grey-50 dark:hover:bg-rui-grey-900'"
     no-padding
-    content-class="overflow-hidden"
+    content-class="overflow-hidden h-full"
     data-testid="data-issues-panel-item"
     :data-active="active"
     @click="emit('open')"
   >
-    <div class="flex items-stretch">
-      <div class="flex flex-col gap-2 p-3 grow min-w-0">
+    <div class="flex items-stretch h-full">
+      <div class="flex flex-col gap-2 p-3 pb-4 grow min-w-0">
         <div class="flex items-center gap-2">
           <DataIssueKindChip :kind="issue.kind" />
           <DataIssueStateChip :state="issue.state" />
@@ -72,18 +72,22 @@ useMutationObserver(descriptionRef, checkTruncation, { characterData: true, chil
         </div>
 
         <RuiTooltip
+          class="w-full grow"
           :disabled="!descriptionTruncated"
           :open-delay="400"
         >
           <template #activator>
-            <div
-              ref="descriptionRef"
-              class="text-body-2 text-rui-text-secondary line-clamp-3 leading-relaxed h-[3lh]"
-            >
-              <DataIssueDescription
-                :description="description"
-                tag="span"
-              />
+            <div class="w-full h-full flex flex-col justify-center">
+              <div
+                ref="descriptionRef"
+                class="text-body-2 text-rui-text-secondary line-clamp-3 leading-relaxed min-w-0"
+              >
+                <DataIssueDescription
+                  :description="description"
+                  tag="span"
+                  short
+                />
+              </div>
             </div>
           </template>
           <div class="max-w-xs">

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesPanelContent.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesPanelContent.vue
@@ -254,8 +254,8 @@ watchDebounced(panelFilters, () => {
 
 // Virtualise the loaded cards so only the visible window mounts (each card resolves an
 // asset icon/avatar and runs observers), and append the next page as the user nears the
-// end. Cards are a fixed height (the description reserves 3 lines), so the row height is
-// exact: 159px card + 8px gap.
+// end. Each card fills its row exactly (the card is `h-full` and distributes its rows
+// with flex), so the row height is fixed: 159px card + 8px gap.
 const ITEM_HEIGHT = 167;
 const { containerProps, list: visibleRows, wrapperProps } = useVirtualList(rows, {
   itemHeight: ITEM_HEIGHT,

--- a/frontend/app/src/modules/history/data-issues/transforms.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.spec.ts
@@ -50,6 +50,7 @@ describe('data-issues transforms', () => {
       const result = describeIssue(issue);
 
       expect(result.messageKey).toBe('data_issues.description.negative_balance');
+      expect(result.shortMessageKey).toBe('data_issues.description_short.negative_balance');
       expect(result.eventIdentifier).toBe(42);
       expect(result.asset).toBe('ETH');
       // amount keeps its sign; the i18n string no longer prepends a literal "-".
@@ -72,6 +73,7 @@ describe('data-issues transforms', () => {
       const result = describeIssue(issue);
 
       expect(result.messageKey).toBe('data_issues.description.current_balance_mismatch');
+      expect(result.shortMessageKey).toBe('data_issues.description_short.current_balance_mismatch');
       expect(result.eventIdentifier).toBe(7);
       expect(result.amounts.delta?.toString()).toBe('5');
     });
@@ -106,6 +108,7 @@ describe('data-issues transforms', () => {
       const result = describeIssue(issue);
 
       expect(result.messageKey).toBe('data_issues.description.unmatched_bridge_deposit');
+      expect(result.shortMessageKey).toBe('data_issues.description_short.unmatched_bridge_deposit');
       expect(result.eventIdentifier).toBe(12);
       expect(result.asset).toBe('ETH');
     });
@@ -120,7 +123,9 @@ describe('data-issues transforms', () => {
         },
       });
 
-      expect(describeIssue(issue).messageKey).toBe('data_issues.description.unmatched_bridge_withdrawal');
+      const withdrawal = describeIssue(issue);
+      expect(withdrawal.messageKey).toBe('data_issues.description.unmatched_bridge_withdrawal');
+      expect(withdrawal.shortMessageKey).toBe('data_issues.description_short.unmatched_bridge_withdrawal');
     });
 
     it('should fall back to an unknown description when the payload does not match the kind', () => {
@@ -129,6 +134,7 @@ describe('data-issues transforms', () => {
       const result = describeIssue(issue);
 
       expect(result.messageKey).toBe('data_issues.description.unknown');
+      expect(result.shortMessageKey).toBe('data_issues.description_short.unknown');
       expect(result.eventIdentifier).toBeUndefined();
       expect(result.amounts).toEqual({});
     });

--- a/frontend/app/src/modules/history/data-issues/transforms.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.ts
@@ -48,6 +48,7 @@ function describeNegativeBalance(issue: DataIssue): IssueDescription | undefined
     asset: issue.asset ?? undefined,
     eventIdentifier: payload.eventIdentifier,
     messageKey: msg.$t('data_issues.description.negative_balance'),
+    shortMessageKey: msg.$t('data_issues.description_short.negative_balance'),
   };
 }
 
@@ -68,6 +69,7 @@ function describeBalanceMismatch(issue: DataIssue): IssueDescription | undefined
       (option): number | undefined => getOr(option, undefined),
     ),
     messageKey: msg.$t('data_issues.description.current_balance_mismatch'),
+    shortMessageKey: msg.$t('data_issues.description_short.current_balance_mismatch'),
   };
 }
 
@@ -83,6 +85,9 @@ function describeUnmatchedBridge(issue: DataIssue): IssueDescription | undefined
     messageKey: payload.direction === 'deposit'
       ? msg.$t('data_issues.description.unmatched_bridge_deposit')
       : msg.$t('data_issues.description.unmatched_bridge_withdrawal'),
+    shortMessageKey: payload.direction === 'deposit'
+      ? msg.$t('data_issues.description_short.unmatched_bridge_deposit')
+      : msg.$t('data_issues.description_short.unmatched_bridge_withdrawal'),
   };
 }
 
@@ -94,7 +99,11 @@ const KIND_DESCRIBERS: Partial<Record<IssueKind, (issue: DataIssue) => IssueDesc
 
 export function describeIssue(issue: DataIssue): IssueDescription {
   const described = KIND_DESCRIBERS[issue.kind]?.(issue);
-  return described ?? { amounts: {}, messageKey: msg.$t('data_issues.description.unknown') };
+  return described ?? {
+    amounts: {},
+    messageKey: msg.$t('data_issues.description.unknown'),
+    shortMessageKey: msg.$t('data_issues.description_short.unknown'),
+  };
 }
 
 /**

--- a/frontend/app/src/modules/history/data-issues/types.ts
+++ b/frontend/app/src/modules/history/data-issues/types.ts
@@ -31,8 +31,10 @@ export interface RemediationTimelineItem {
  * instead of embedding the raw asset identifier in the text.
  */
 export interface IssueDescription {
-  /** i18n keypath for the "what's wrong" sentence. */
+  /** i18n keypath for the full "what's wrong" sentence (detail drawer). */
   readonly messageKey: string;
+  /** i18n keypath for a condensed one-line variant used in the inbox card. */
+  readonly shortMessageKey: string;
   /** Numeric interpolation values, keyed by placeholder name, rendered with the
    * user's decimals setting (and a full-value tooltip) via `ValueDisplay`. */
   readonly amounts: Record<string, BigNumber>;

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -372,8 +372,8 @@ watchDebounced(route, async () => {
               class="flex items-center justify-end gap-2 px-2 pt-2 mb-1"
             >
               <AccountingOverlayToggle v-model="overlayMode" />
-              <DataIssuesToggle />
               <BalanceDivergenceToggle />
+              <DataIssuesToggle />
             </div>
 
             <HistoryEventsFiltersChips

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -1,5 +1,4 @@
 import type { ComponentResolver } from 'unplugin-vue-components';
-import type { Plugin } from 'vite';
 import { builtinModules } from 'node:module';
 import { join, relative, resolve } from 'node:path';
 import process from 'node:process';
@@ -8,6 +7,7 @@ import { ruiIconsPlugin } from '@rotki/ui-library/vite-plugin';
 import vue from '@vitejs/plugin-vue';
 import AutoImport from 'unplugin-auto-import/vite';
 import Components from 'unplugin-vue-components/vite';
+import { createLogger, type Logger, type LogOptions, type Plugin } from 'vite';
 import checker from 'vite-plugin-checker';
 import vueDevTools from 'vite-plugin-vue-devtools';
 import { defineConfig } from 'vitest/config';
@@ -18,6 +18,27 @@ import { backendIconsCachePlugin } from './scripts/extract-backend-icons';
 
 const PACKAGE_ROOT = __dirname;
 const PROJECT_ROOT = resolve(PACKAGE_ROOT, '../..');
+
+/**
+ * Under `pnpm dev` the process forwarder already prefixes every line with its own
+ * `<label> <time>`, so Vite's own `timestamp: true` logs (HMR/client messages)
+ * would print a second clock. When forwarded, wrap the default logger to force
+ * `timestamp: false`; standalone `vite` runs keep their timestamps.
+ */
+function createConfigLogger(): Logger | undefined {
+  if (process.env.ROTKI_DEV_FORWARDED !== '1')
+    return undefined;
+
+  const base = createLogger();
+  const noTimestamp = (options?: LogOptions): LogOptions => ({ ...options, timestamp: false });
+  return {
+    ...base,
+    error: (msg, options): void => base.error(msg, noTimestamp(options)),
+    info: (msg, options): void => base.info(msg, noTimestamp(options)),
+    warn: (msg, options): void => base.warn(msg, noTimestamp(options)),
+    warnOnce: (msg, options): void => base.warnOnce(msg, noTimestamp(options)),
+  };
+}
 
 const envPath = process.env.VITE_PUBLIC_PATH;
 const publicPath = envPath || '/';
@@ -103,6 +124,7 @@ export default defineConfig({
     dedupe: ['vue'],
   },
   base: publicPath,
+  customLogger: createConfigLogger(),
   define: {
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
   },

--- a/frontend/scripts/dev/process-pool.ts
+++ b/frontend/scripts/dev/process-pool.ts
@@ -75,6 +75,9 @@ export function startProcess(cmd: string, tag: string, name: string, args: strin
 
   const env: NodeJS.ProcessEnv = {
     FORCE_COLOR: '1',
+    // The forwarder prepends its own `<label> <time>` to every child line, so tell
+    // child tools (Vite) to drop their own timestamp and avoid a doubled clock.
+    ROTKI_DEV_FORWARDED: '1',
     ...process.env,
     NODE_ENV: 'development',
     ...(opts.env ?? {}),


### PR DESCRIPTION
Dashboard and history UI polish, plus a dev-server logging fix.

### Data issues inbox cards
- Added a condensed one-line variant of each issue description for the inbox card; the detail drawer keeps the full sentence.
- Cards now fill their fixed virtual-list slot and distribute with flex: text is vertically centred, the meta/icon row is pinned to the bottom with comfortable bottom padding.

### Dashboard completeness indicators
- Pluralize the missing-price / undecoded-transaction / data-issue counts (`1 undecoded transaction` vs `2 undecoded transactions`).
- Render each shortcut as a small outlined button with an inline icon instead of a chip, whose `#prepend` slot rendered the icon inside a grey avatar circle.

### Overall balances
- Keep the parenthesised balance delta on one line so the `()` no longer orphan onto their own line at narrow widths.

### History events overlay toolbar
- Reorder the toggles (data issues after balance divergence).
- Fix the accounting overlay mode toggle: add `color`/`active-color` and `required` so the whole group is primary-tinted and the selected mode highlights and can't be deselected into an invalid state.

### Dev logging
- Fix the doubled timestamp in `pnpm dev` output: the forwarder already prefixes each line with its own time, so Vite's own log timestamp is dropped when running under the forwarder (`ROTKI_DEV_FORWARDED`).

Gates: typecheck clean, lint clean, affected unit specs green.
