### PR TITLE
refactor: declare explicit slots on components

### DIFF
--- a/frontend/app/src/modules/accounts/table/AccountBalancesTable.vue
+++ b/frontend/app/src/modules/accounts/table/AccountBalancesTable.vue
@@ -40,6 +40,10 @@ const emit = defineEmits<{
   refresh: [];
 }>();
 
+defineSlots<{
+  details: (props: { row: T }) => any;
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 
 // Use composables

--- a/frontend/app/src/modules/assets/amount-display/components/AmountDisplayBase.vue
+++ b/frontend/app/src/modules/assets/amount-display/components/AmountDisplayBase.vue
@@ -43,6 +43,10 @@ defineOptions({
 
 const { value, format, symbol = '' } = defineProps<Props>();
 
+defineSlots<{
+  tooltip: () => any;
+}>();
+
 // Extract format options
 const isInteger = computed<boolean>(() => format?.integer ?? false);
 

--- a/frontend/app/src/modules/balances/protocols/components/AssetDetailsLayout.vue
+++ b/frontend/app/src/modules/balances/protocols/components/AssetDetailsLayout.vue
@@ -6,6 +6,11 @@ const { row } = defineProps<{
   row: AssetBalanceWithPrice;
 }>();
 
+defineSlots<{
+  breakdown: () => any;
+  perprotocol: () => any;
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 
 const tab = ref(0);

--- a/frontend/app/src/modules/core/table/TableStatusFilter.vue
+++ b/frontend/app/src/modules/core/table/TableStatusFilter.vue
@@ -2,6 +2,10 @@
 defineOptions({
   inheritAttrs: false,
 });
+
+defineSlots<{
+  default: () => any;
+}>();
 </script>
 
 <template>

--- a/frontend/app/src/modules/dashboard/DashboardExpandableTable.vue
+++ b/frontend/app/src/modules/dashboard/DashboardExpandableTable.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
 
+defineSlots<{
+  title: () => any;
+  details: () => any;
+  shortDetails: () => any;
+  default: () => any;
+}>();
+
 const expanded = ref<boolean>(true);
 
 const panel = computed<number>(() => (get(expanded) ? 0 : -1));

--- a/frontend/app/src/modules/dashboard/summary/SummaryCardCreateButton.vue
+++ b/frontend/app/src/modules/dashboard/summary/SummaryCardCreateButton.vue
@@ -3,6 +3,10 @@ import type { RouteLocationRaw } from 'vue-router';
 
 const { to } = defineProps<{ to?: RouteLocationRaw }>();
 
+defineSlots<{
+  default: () => any;
+}>();
+
 const router = useRouter();
 
 function navigate() {

--- a/frontend/app/src/modules/history/BadgeDisplay.vue
+++ b/frontend/app/src/modules/history/BadgeDisplay.vue
@@ -6,6 +6,10 @@ const {
   color?: Color;
 }>();
 
+defineSlots<{
+  default: () => any;
+}>();
+
 const colorVariants: Record<Color, string> = {
   green: 'text-rui-green-700 bg-rui-green-100',
   grey: 'text-rui-grey-700 bg-rui-grey-100 dark:text-rui-grey-400 dark:bg-rui-grey-800',

--- a/frontend/app/src/modules/history/HistoryTableActions.vue
+++ b/frontend/app/src/modules/history/HistoryTableActions.vue
@@ -1,5 +1,10 @@
 <script lang="ts" setup>
 const { hideDivider = false } = defineProps<{ hideDivider?: boolean }>();
+
+defineSlots<{
+  default: () => any;
+  filter: () => any;
+}>();
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/events/CustomizedEventDuplicatesList.vue
+++ b/frontend/app/src/modules/history/events/CustomizedEventDuplicatesList.vue
@@ -23,6 +23,10 @@ const emit = defineEmits<{
   'show-in-history': [];
 }>();
 
+defineSlots<{
+  actions: (props: { row: DuplicateRow }) => any;
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 
 const columns = computed<DataTableColumn<DuplicateRow>[]>(() => [

--- a/frontend/app/src/modules/history/management/forms/common/EventDateLocation.vue
+++ b/frontend/app/src/modules/history/management/forms/common/EventDateLocation.vue
@@ -19,6 +19,10 @@ const emit = defineEmits<{
   blur: [source: 'location' | 'timestamp'];
 }>();
 
+defineSlots<{
+  default: () => any;
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 </script>
 

--- a/frontend/app/src/modules/integrations/gnosis-pay/components/GnosisPayAuthStep.vue
+++ b/frontend/app/src/modules/integrations/gnosis-pay/components/GnosisPayAuthStep.vue
@@ -13,6 +13,10 @@ const emit = defineEmits<{
   'click-step': [stepNumber: number];
 }>();
 
+defineSlots<{
+  default: () => any;
+}>();
+
 const shouldShowContent = computed<boolean>(() => isCurrent || isComplete);
 const isHeaderClickable = computed<boolean>(() => isComplete && isClickable);
 const stepBadgeClass = computed<string>(() => isComplete ? 'bg-rui-success' : 'bg-rui-primary');

--- a/frontend/app/src/modules/settings/SettingCategory.vue
+++ b/frontend/app/src/modules/settings/SettingCategory.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
 import SettingCategoryHeader from '@/modules/settings/SettingCategoryHeader.vue';
+
+defineSlots<{
+  title: () => any;
+  subtitle: () => any;
+  default: () => any;
+}>();
 </script>
 
 <template>

--- a/frontend/app/src/modules/settings/controls/SettingMultiSelect.vue
+++ b/frontend/app/src/modules/settings/controls/SettingMultiSelect.vue
@@ -38,6 +38,11 @@ const {
   debounce?: number;
 }>();
 
+defineSlots<{
+  selection: (props: { item: TOption }) => any;
+  item: (props: { item: TOption }) => any;
+}>();
+
 const { error: writeError, model, pending, success: writeSuccess } = useSettingModel(setting, { debounce });
 const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
 

--- a/frontend/app/src/modules/settings/controls/SettingSelect.vue
+++ b/frontend/app/src/modules/settings/controls/SettingSelect.vue
@@ -48,6 +48,12 @@ const emit = defineEmits<{
   updated: [value: string];
 }>();
 
+defineSlots<{
+  option: (props: { option: TOption }) => any;
+  item: (props: { item: TOption }) => any;
+  selection: (props: { item: TOption }) => any;
+}>();
+
 const { error: writeError, model, success: writeSuccess } = useSettingModel(setting, { debounce });
 const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
 

--- a/frontend/app/src/modules/settings/evm/IndexerOrderSetting.vue
+++ b/frontend/app/src/modules/settings/evm/IndexerOrderSetting.vue
@@ -22,6 +22,10 @@ defineProps<{
   id?: string;
 }>();
 
+defineSlots<{
+  footer: () => any;
+}>();
+
 interface ChainItem {
   id: string;
   name: string;

--- a/frontend/app/src/modules/settings/general/amount/RoundingSelector.vue
+++ b/frontend/app/src/modules/settings/general/amount/RoundingSelector.vue
@@ -14,6 +14,10 @@ defineProps<{
   hint: string;
 }>();
 
+defineSlots<{
+  default: () => any;
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 
 const selections: { value: RoundingMode; text: string; description: string }[] = [

--- a/frontend/app/src/modules/shell/app/AppHost.vue
+++ b/frontend/app/src/modules/shell/app/AppHost.vue
@@ -9,6 +9,10 @@ import { useSetting } from '@/modules/settings/use-setting';
 import { useBackendManagement } from '@/modules/shell/app/use-backend-management';
 import { useThemeChecker } from '@/modules/shell/theme/use-theme-checker';
 
+defineSlots<{
+  default: () => any;
+}>();
+
 useThemeChecker();
 useSigil();
 

--- a/frontend/app/src/modules/shell/components/FadeTransition.vue
+++ b/frontend/app/src/modules/shell/components/FadeTransition.vue
@@ -2,6 +2,10 @@
 defineOptions({
   inheritAttrs: false,
 });
+
+defineSlots<{
+  default: () => any;
+}>();
 </script>
 
 <template>

--- a/frontend/app/src/modules/shell/components/FullSizeContent.vue
+++ b/frontend/app/src/modules/shell/components/FullSizeContent.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+defineSlots<{
+  default: () => any;
+}>();
+
 const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
 const topOffset = ref<number>(0);
 

--- a/frontend/app/src/modules/shell/components/HintMenuIcon.vue
+++ b/frontend/app/src/modules/shell/components/HintMenuIcon.vue
@@ -2,6 +2,10 @@
 defineOptions({
   inheritAttrs: false,
 });
+
+defineSlots<{
+  default: () => any;
+}>();
 </script>
 
 <template>

--- a/frontend/app/src/modules/shell/components/MenuTooltipButton.vue
+++ b/frontend/app/src/modules/shell/components/MenuTooltipButton.vue
@@ -14,6 +14,10 @@ const { tooltip, retainFocusOnClick = false, className = '', href, variant = 'te
   size?: ButtonProps['size'];
   customColor?: boolean;
 }>();
+
+defineSlots<{
+  default: () => any;
+}>();
 </script>
 
 <template>

--- a/frontend/app/src/modules/shell/components/NavigatorLink.vue
+++ b/frontend/app/src/modules/shell/components/NavigatorLink.vue
@@ -11,6 +11,10 @@ const { enabled = true, tag = 'span', to } = defineProps<{
   to: RouteLocationRaw | undefined;
 }>();
 
+defineSlots<{
+  default: () => any;
+}>();
+
 const router = useRouter();
 
 async function navigate(): Promise<void> {

--- a/frontend/app/src/modules/shell/components/NoDataScreen.vue
+++ b/frontend/app/src/modules/shell/components/NoDataScreen.vue
@@ -11,6 +11,12 @@ const { full = false, icon, variant = 'default' } = defineProps<{
   variant?: 'default' | 'success';
 }>();
 
+defineSlots<{
+  logo: () => any;
+  title: () => any;
+  default: () => any;
+}>();
+
 const { isMdAndUp } = useBreakpoint();
 
 const circleClasses = computed<string>(() => {

--- a/frontend/app/src/modules/shell/components/PaginatedCards.vue
+++ b/frontend/app/src/modules/shell/components/PaginatedCards.vue
@@ -8,6 +8,10 @@ const { items, identifier } = defineProps<{
   identifier: GetKey;
 }>();
 
+defineSlots<{
+  item: (props: { item: any }) => any;
+}>();
+
 const { isXlAndDown, isXs } = useBreakpoint();
 const page = ref(1);
 const itemsPerPage = ref(8);

--- a/frontend/app/src/modules/shell/components/RowActions.vue
+++ b/frontend/app/src/modules/shell/components/RowActions.vue
@@ -15,6 +15,10 @@ const emit = defineEmits<{
   'delete-click': [];
 }>();
 
+defineSlots<{
+  default: () => any;
+}>();
+
 const editClick = (): void => emit('edit-click');
 const deleteClick = (): void => emit('delete-click');
 

--- a/frontend/app/src/modules/shell/components/RowAppend.vue
+++ b/frontend/app/src/modules/shell/components/RowAppend.vue
@@ -15,6 +15,12 @@ const {
   isMobile?: boolean;
 }>();
 
+defineSlots<{
+  'label': () => any;
+  'custom-columns': () => any;
+  'default': () => any;
+}>();
+
 const formattedClassName = computed(() => {
   const propClassName
     = typeof className === 'object'

--- a/frontend/app/src/modules/shell/components/dialogs/ConfirmDialog.vue
+++ b/frontend/app/src/modules/shell/components/dialogs/ConfirmDialog.vue
@@ -30,6 +30,10 @@ const emit = defineEmits<{
   cancel: [];
 }>();
 
+defineSlots<{
+  default: () => any;
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 
 const color = computed(() => themes[confirmType].color);

--- a/frontend/app/src/modules/shell/layout/LayoutWrapper.vue
+++ b/frontend/app/src/modules/shell/layout/LayoutWrapper.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+defineSlots<{
+  default: () => any;
+}>();
+
 const AuthLayout = defineAsyncComponent(() => import('@/layouts/auth.vue'));
 const DefaultLayout = defineAsyncComponent(() => import('@/layouts/default.vue'));
 const PlainLayout = defineAsyncComponent(() => import('@/layouts/plain.vue'));

--- a/frontend/app/src/modules/statistics/wrapped/components/WrappedCard.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/WrappedCard.vue
@@ -5,6 +5,13 @@ const { items } = defineProps<{
   items: T[];
 }>();
 
+defineSlots<{
+  'header-icon': () => any;
+  'header': () => any;
+  'label': (props: { item: T; index: number }) => any;
+  'value': (props: { item: T; index: number }) => any;
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 
 const INITIAL_LENGTH = 5;


### PR DESCRIPTION
## Summary

Clears all **48 `vue/require-explicit-slots` warnings** by adding `defineSlots` declarations to the 29 flagged components. Purely additive, no behaviour change.

## What changed

Each component now declares the slots its template already renders, following the existing house style (47 components already use `defineSlots`):

- Plain slots → `default: () => any`, `header: () => any`, etc.
- **Scoped slots are typed from their real bindings**, so slot content gets type-checking it didn't have before:
  - `WrappedCard` `label`/`value` → `(props: { item: T; index: number }) => any`
  - `AccountBalancesTable` `details` → `(props: { row: T }) => any`
  - `SettingSelect`/`SettingMultiSelect` `item`/`option`/`selection` → `(props: { item: TOption }) => any`
  - `CustomizedEventDuplicatesList` `actions` → `(props: { row: DuplicateRow }) => any`
- Generic components (`generic="T …"`) reference the type param directly in slot props.

## Testing

- `pnpm run typecheck` — clean
- `pnpm run lint` — 0 errors; `require-explicit-slots` count 0 (was 48); total frontend warnings 458 → 410
- Co-located component specs pass (`SettingSelect`, `SettingMultiSelect`)