### PR TITLE
fix: stop snapshot list hammering the forex endpoint

### DIFF
--- a/frontend/app/src/modules/dashboard/ExportSnapshotDialog.vue
+++ b/frontend/app/src/modules/dashboard/ExportSnapshotDialog.vue
@@ -1,19 +1,20 @@
 <script setup lang="ts">
 import type { BigNumber, Message } from '@rotki/common';
 import dayjs from 'dayjs';
-import { FiatDisplay } from '@/modules/assets/amount-display/components';
 import { downloadFileByBlob } from '@/modules/core/common/file/download';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
+import SnapshotFiatDisplay from '@/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue';
 import { useSnapshotApi } from '@/modules/settings/api/use-snapshot-api';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 
 const display = defineModel<boolean>({ default: false, required: true });
 
-const { balance, loading = false, timestamp = 0 } = defineProps<{
+const { balance, timestamp = 0 } = defineProps<{
+  /** The snapshot's net worth, denominated in USD (converted for display here). */
   balance: BigNumber;
-  loading?: boolean;
+  /** The snapshot timestamp in seconds, used for the historic USD->fiat rate. */
   timestamp?: number;
 }>();
 
@@ -105,13 +106,10 @@ async function exportSnapshot() {
         <div class="text-rui-text-secondary">
           {{ t('common.balance') }}
         </div>
-        <RuiSkeletonLoader
-          v-if="loading"
-          class="w-24 h-5"
-        />
-        <FiatDisplay
-          v-else-if="balance"
+        <SnapshotFiatDisplay
+          v-if="balance"
           :value="balance"
+          :timestamp="timestamp"
           class="font-bold"
         />
       </div>

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotDeltaDisplay.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotDeltaDisplay.spec.ts
@@ -1,0 +1,127 @@
+import { bigNumberify, NoPrice } from '@rotki/common';
+import { updateGeneralSettings } from '@test/utils/general-settings';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FiatDisplay } from '@/modules/assets/amount-display/components';
+import { useCurrencies } from '@/modules/assets/amount-display/currencies';
+import SnapshotDeltaDisplay from '@/modules/dashboard/snapshots/components/SnapshotDeltaDisplay.vue';
+
+const getHistoricPrice = vi.fn();
+const getIsPending = vi.fn();
+
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: vi.fn(() => ({
+    createKey: (fromAsset: string, timestamp: number): string => `${fromAsset}#${timestamp}`,
+    getHistoricPrice,
+    getIsPending,
+  })),
+}));
+
+describe('modules/dashboard/snapshots/components/SnapshotDeltaDisplay', () => {
+  const day1 = 1_600_000_000;
+  const day2 = 1_600_086_400;
+
+  let wrapper: VueWrapper<InstanceType<typeof SnapshotDeltaDisplay>>;
+  let pinia: ReturnType<typeof createPinia>;
+
+  function createWrapper(props: InstanceType<typeof SnapshotDeltaDisplay>['$props']): VueWrapper<InstanceType<typeof SnapshotDeltaDisplay>> {
+    // Mount with the *active* pinia so the component's `useSetting('currencySymbol')`
+    // reads the currency that `setCurrency` (via updateGeneralSettings) wrote to.
+    return mount(SnapshotDeltaDisplay, {
+      global: {
+        plugins: [pinia],
+        provide: libraryDefaults,
+      },
+      props,
+    });
+  }
+
+  function setCurrency(symbol: string): void {
+    const { findCurrency } = useCurrencies();
+    updateGeneralSettings({ mainCurrency: findCurrency(symbol) });
+  }
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+    getHistoricPrice.mockReturnValue(NoPrice);
+    getIsPending.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should render a dash for the oldest snapshot (no predecessor)', () => {
+    setCurrency('USD');
+    wrapper = createWrapper({ timestamp: day1, value: bigNumberify(100) });
+
+    expect(wrapper.text()).toContain('—');
+    expect(wrapper.findComponent(FiatDisplay).exists()).toBe(false);
+  });
+
+  it('should compute the delta directly when the display currency is USD', () => {
+    setCurrency('USD');
+    wrapper = createWrapper({
+      previousTimestamp: day1,
+      previousUsdValue: bigNumberify(90),
+      timestamp: day2,
+      value: bigNumberify(100),
+    });
+
+    // USD needs no historic conversion.
+    expect(getHistoricPrice).not.toHaveBeenCalled();
+    expect(wrapper.findComponent(FiatDisplay).props('value')?.toNumber()).toBe(10);
+  });
+
+  it('should convert each side at its own historic rate for a non-USD currency', () => {
+    setCurrency('EUR');
+    getHistoricPrice.mockImplementation((_asset: string, ts: number) =>
+      ts === day1 ? bigNumberify(0.8) : bigNumberify(0.9));
+
+    wrapper = createWrapper({
+      previousTimestamp: day1,
+      previousUsdValue: bigNumberify(100),
+      timestamp: day2,
+      value: bigNumberify(200),
+    });
+
+    // (200 * 0.9) - (100 * 0.8) = 180 - 80 = 100
+    expect(wrapper.findComponent(FiatDisplay).props('value')?.toNumber()).toBe(100);
+  });
+
+  it('should render a skeleton while either historic rate is loading', () => {
+    setCurrency('EUR');
+    getIsPending.mockImplementation((key: string) => key === `USD#${day2}`);
+
+    wrapper = createWrapper({
+      previousTimestamp: day1,
+      previousUsdValue: bigNumberify(100),
+      timestamp: day2,
+      value: bigNumberify(200),
+    });
+
+    expect(wrapper.find('.animate-pulse').exists()).toBe(true);
+    expect(wrapper.findComponent(FiatDisplay).exists()).toBe(false);
+  });
+
+  it('should render a dash when a historic rate is permanently missing', () => {
+    setCurrency('EUR');
+    // day1 resolves, day2 is missing (not pending, no positive rate).
+    getHistoricPrice.mockImplementation((_asset: string, ts: number) =>
+      ts === day1 ? bigNumberify(0.8) : NoPrice);
+
+    wrapper = createWrapper({
+      previousTimestamp: day1,
+      previousUsdValue: bigNumberify(100),
+      timestamp: day2,
+      value: bigNumberify(200),
+    });
+
+    expect(wrapper.text()).toContain('—');
+    expect(wrapper.findComponent(FiatDisplay).exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotDeltaDisplay.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotDeltaDisplay.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { type BigNumber, Zero } from '@rotki/common';
+import { FiatDisplay } from '@/modules/assets/amount-display/components';
+import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
+import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
+import { useSetting } from '@/modules/settings/use-setting';
+
+/**
+ * Displays the change in net worth versus the chronologically previous snapshot,
+ * in the user's display currency, at each side's own *historic* rate (#12277).
+ *
+ * The conversion is done here (not in `useSnapshotList`) so it only runs for the
+ * rows the table actually renders — the visible page. Eagerly converting the
+ * whole series was what hammered the forex endpoint. Each mounted cell resolves
+ * at most two historic rates (its own + its predecessor's) through the shared,
+ * debounced, LRU-backed cache, so the working set stays ~page-size.
+ */
+const { previousTimestamp, previousUsdValue, timestamp, value } = defineProps<{
+  /** This snapshot's net worth, denominated in USD. */
+  value: BigNumber;
+  /** This snapshot's timestamp, in seconds (historic FX lookup). */
+  timestamp: number;
+  /** The previous snapshot's net worth (USD); absent for the oldest snapshot. */
+  previousUsdValue?: BigNumber;
+  /** The previous snapshot's timestamp (seconds); absent for the oldest. */
+  previousTimestamp?: number;
+}>();
+
+const { createKey, getHistoricPrice, getIsPending } = useHistoricPriceCache();
+const currencySymbol = useSetting('currencySymbol');
+
+const isUsd = computed<boolean>(() => get(currencySymbol) === CURRENCY_USD);
+
+interface Converted {
+  fiatValue: BigNumber;
+  pending: boolean;
+  ready: boolean;
+}
+
+/** Converts a USD net worth to display currency at its historic rate (lazy). */
+function convert(ts: number, usdValue: BigNumber): Converted {
+  if (get(isUsd))
+    return { fiatValue: usdValue, pending: false, ready: true };
+
+  const rate = getHistoricPrice(CURRENCY_USD, ts);
+  const pending = getIsPending(createKey(CURRENCY_USD, ts));
+  const ready = rate.isPositive();
+  return { fiatValue: ready ? usdValue.multipliedBy(rate) : Zero, pending, ready };
+}
+
+const current = computed<Converted>(() => convert(timestamp, value));
+
+const previous = computed<Converted | undefined>(() => {
+  if (previousTimestamp === undefined || previousUsdValue === undefined)
+    return undefined;
+  return convert(previousTimestamp, previousUsdValue);
+});
+
+/** True while either side's historic rate is still loading. */
+const pending = computed<boolean>(() => get(current).pending || (get(previous)?.pending ?? false));
+
+/**
+ * The Δ, or `undefined` when it cannot be shown: the oldest snapshot has no
+ * predecessor, and a not-yet-ready (loading or permanently missing) rate on
+ * either side must not produce a bogus zero-based delta.
+ */
+const delta = computed<BigNumber | undefined>(() => {
+  const prev = get(previous);
+  const cur = get(current);
+  if (!prev || !cur.ready || !prev.ready)
+    return undefined;
+  return cur.fiatValue.minus(prev.fiatValue);
+});
+
+/** Placeholder for "no change to show" (avoids a raw i18n text node). */
+const placeholder = '—';
+</script>
+
+<template>
+  <RuiSkeletonLoader
+    v-if="pending"
+    class="w-20 ml-auto"
+  />
+  <FiatDisplay
+    v-else-if="delta"
+    :value="delta"
+    pnl
+  />
+  <span v-else>{{ placeholder }}</span>
+</template>

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotListTable.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotListTable.spec.ts
@@ -8,10 +8,8 @@ import SnapshotListTable from '@/modules/dashboard/snapshots/components/Snapshot
 
 function createRow(overrides: Partial<SnapshotListRow> = {}): SnapshotListRow {
   return {
-    delta: bigNumberify(10),
-    fiatPending: false,
-    fiatValue: bigNumberify(100),
-    ready: true,
+    previousTimestamp: 1_599_913_600,
+    previousUsdValue: bigNumberify(90),
     timestamp: 1_600_000_000,
     usdValue: bigNumberify(100),
     ...overrides,
@@ -57,14 +55,10 @@ describe('modules/dashboard/snapshots/components/SnapshotListTable', () => {
     expect(wrapper.emitted('delete')).toEqual([[1_600_000_000]]);
   });
 
-  it('should render a skeleton while the historic rate is pending', () => {
-    wrapper = createWrapper([createRow({ fiatPending: true, ready: false })]);
-
-    expect(wrapper.find('.animate-pulse').exists()).toBe(true);
-  });
-
-  it('should render a dash when there is no delta', () => {
-    wrapper = createWrapper([createRow({ delta: undefined })]);
+  it('should render a dash in the delta column for the oldest snapshot', () => {
+    // No predecessor => no delta to show (currency defaults to USD in the test
+    // harness, so no historic lookup is involved).
+    wrapper = createWrapper([createRow({ previousTimestamp: undefined, previousUsdValue: undefined })]);
 
     expect(wrapper.text()).toContain('—');
   });

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotListTable.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotListTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { DataTableColumn, DataTableSortData, TablePaginationData } from '@rotki/ui-library';
 import type { SnapshotListRow } from '@/modules/dashboard/snapshots/composables/use-snapshot-list';
-import { FiatDisplay } from '@/modules/assets/amount-display/components';
+import SnapshotDeltaDisplay from '@/modules/dashboard/snapshots/components/SnapshotDeltaDisplay.vue';
 import SnapshotFiatDisplay from '@/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue';
 import { useSetting } from '@/modules/settings/use-setting';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
@@ -28,9 +28,6 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-/** Placeholder for an unavailable value / no change (avoids a raw text node). */
-const placeholder = '—';
-
 const currencySymbol = useSetting('currencySymbol');
 
 const cols = computed<DataTableColumn<SnapshotListRow>[]>(() => [
@@ -41,7 +38,10 @@ const cols = computed<DataTableColumn<SnapshotListRow>[]>(() => [
   },
   {
     align: 'end',
-    key: 'fiatValue',
+    // Sorting is by the stored USD value: the display fiat value is resolved
+    // lazily per visible cell, so it is not available to sort the full set. USD
+    // order is a faithful approximation (historic FX varies only mildly day-to-day).
+    key: 'usdValue',
     label: t('common.value_in_symbol', { symbol: get(currencySymbol) }),
     sortable: true,
   },
@@ -78,26 +78,20 @@ const cols = computed<DataTableColumn<SnapshotListRow>[]>(() => [
       </span>
     </template>
 
-    <template #item.fiatValue="{ row }">
-      <RuiSkeletonLoader
-        v-if="row.fiatPending"
-        class="w-20 ml-auto"
-      />
-      <span v-else-if="!row.ready">{{ placeholder }}</span>
+    <template #item.usdValue="{ row }">
       <SnapshotFiatDisplay
-        v-else
         :value="row.usdValue"
         :timestamp="row.timestamp"
       />
     </template>
 
     <template #item.delta="{ row }">
-      <FiatDisplay
-        v-if="row.delta"
-        :value="row.delta"
-        pnl
+      <SnapshotDeltaDisplay
+        :value="row.usdValue"
+        :timestamp="row.timestamp"
+        :previous-value="row.previousUsdValue"
+        :previous-timestamp="row.previousTimestamp"
       />
-      <span v-else>{{ placeholder }}</span>
     </template>
 
     <template #item.actions="{ row }">

--- a/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-list.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-list.spec.ts
@@ -1,4 +1,4 @@
-import { bigNumberify, type NetValue, NoPrice } from '@rotki/common';
+import { bigNumberify, type NetValue } from '@rotki/common';
 import { updateGeneralSettings } from '@test/utils/general-settings';
 import { withSetup } from '@test/utils/with-setup';
 import flushPromises from 'flush-promises';
@@ -12,6 +12,10 @@ const getIsPending = vi.fn();
 const fetchNetValue = vi.fn();
 const netValue = ref<NetValue>({ data: [], times: [] });
 
+// The historic-price cache is mocked purely as a regression guard: the list
+// derivation must stay pure (USD-only) so it never hammers the forex endpoint.
+// If eager conversion is ever reintroduced, these spies would be called and the
+// "does not touch the historic-price cache" assertions would fail.
 vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
   useHistoricPriceCache: vi.fn(() => ({
     createKey: (fromAsset: string, timestamp: number): string => `${fromAsset}#${timestamp}`,
@@ -37,8 +41,6 @@ describe('modules/dashboard/snapshots/composables/use-snapshot-list', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
-    getHistoricPrice.mockReturnValue(NoPrice);
-    getIsPending.mockReturnValue(false);
     set(netValue, { data: [], times: [] });
   });
 
@@ -47,7 +49,7 @@ describe('modules/dashboard/snapshots/composables/use-snapshot-list', () => {
     updateGeneralSettings({ mainCurrency: findCurrency(symbol) });
   }
 
-  it('should pass USD values through unchanged when the display currency is USD', () => {
+  it('should expose the stored USD value for each snapshot', () => {
     setCurrency('USD');
     set(netValue, { data: [bigNumberify(100), bigNumberify(150)], times: [day1, day2] });
 
@@ -55,41 +57,42 @@ describe('modules/dashboard/snapshots/composables/use-snapshot-list', () => {
     const result = get(rows);
 
     expect(result).toHaveLength(2);
-    expect(result[0].fiatValue.toNumber()).toBe(100);
-    expect(result[0].delta).toBeUndefined();
-    expect(result[1].fiatValue.toNumber()).toBe(150);
-    expect(result[1].delta?.toNumber()).toBe(50);
+    expect(result[0].timestamp).toBe(day1);
+    expect(result[0].usdValue.toNumber()).toBe(100);
+    expect(result[1].timestamp).toBe(day2);
+    expect(result[1].usdValue.toNumber()).toBe(150);
+  });
+
+  it('should attach the chronological predecessor for the delta', () => {
+    setCurrency('EUR');
+    set(netValue, { data: [bigNumberify(100), bigNumberify(200), bigNumberify(250)], times: [day1, day2, day3] });
+
+    const { rows } = withSetup(() => useSnapshotList()).result;
+    const result = get(rows);
+
+    // The oldest snapshot has no predecessor.
+    expect(result[0].previousTimestamp).toBeUndefined();
+    expect(result[0].previousUsdValue).toBeUndefined();
+    // Every later row points at the immediately preceding snapshot.
+    expect(result[1].previousTimestamp).toBe(day1);
+    expect(result[1].previousUsdValue?.toNumber()).toBe(100);
+    expect(result[2].previousTimestamp).toBe(day2);
+    expect(result[2].previousUsdValue?.toNumber()).toBe(200);
+  });
+
+  it('should never touch the historic-price cache, even for a large series', () => {
+    setCurrency('EUR');
+    const size = 3000;
+    const data = Array.from({ length: size }, (_, i) => bigNumberify(i + 1));
+    const times = Array.from({ length: size }, (_, i) => day1 + i * 86_400);
+    set(netValue, { data, times });
+
+    const { rows } = withSetup(() => useSnapshotList()).result;
+
+    // The derivation is pure: reading every row triggers no forex lookups.
+    expect(get(rows)).toHaveLength(size);
     expect(getHistoricPrice).not.toHaveBeenCalled();
-  });
-
-  it('should convert each row at its own historic rate for a non-USD currency', () => {
-    setCurrency('EUR');
-    getHistoricPrice.mockImplementation((_asset: string, ts: number) =>
-      ts === day1 ? bigNumberify(0.8) : bigNumberify(0.9));
-    set(netValue, { data: [bigNumberify(100), bigNumberify(200)], times: [day1, day2] });
-
-    const { rows } = withSetup(() => useSnapshotList()).result;
-    const result = get(rows);
-
-    expect(result[0].fiatValue.toNumber()).toBe(80); // 100 * 0.8
-    expect(result[1].fiatValue.toNumber()).toBe(180); // 200 * 0.9
-    expect(result[1].delta?.toNumber()).toBe(100); // 180 - 80
-  });
-
-  it('should mark a row pending and skip its delta while the rate is loading', () => {
-    setCurrency('EUR');
-    getHistoricPrice.mockImplementation((_asset: string, ts: number) =>
-      ts === day2 ? NoPrice : bigNumberify(0.8));
-    getIsPending.mockImplementation((key: string) => key === `USD#${day2}`);
-    set(netValue, { data: [bigNumberify(100), bigNumberify(200)], times: [day1, day2] });
-
-    const { rows } = withSetup(() => useSnapshotList()).result;
-    const result = get(rows);
-
-    expect(result[1].fiatPending).toBe(true);
-    expect(result[1].ready).toBe(false);
-    expect(result[1].fiatValue.toNumber()).toBe(0);
-    expect(result[1].delta).toBeUndefined();
+    expect(getIsPending).not.toHaveBeenCalled();
   });
 
   it('should filter by inclusive timestamp range', () => {
@@ -102,6 +105,20 @@ describe('modules/dashboard/snapshots/composables/use-snapshot-list', () => {
     const result = get(rows);
     expect(result).toHaveLength(1);
     expect(result[0].timestamp).toBe(day2);
+  });
+
+  it('should keep the full-series predecessor on a row excluded by the filter', () => {
+    setCurrency('EUR');
+    set(netValue, { data: [bigNumberify(100), bigNumberify(200), bigNumberify(300)], times: [day1, day2, day3] });
+
+    const { filters, rows } = withSetup(() => useSnapshotList()).result;
+    // Exclude day1, so day2 becomes the first visible row but keeps its day1 predecessor.
+    set(filters, { fromTimestamp: day2 });
+
+    const result = get(rows);
+    expect(result[0].timestamp).toBe(day2);
+    expect(result[0].previousTimestamp).toBe(day1);
+    expect(result[0].previousUsdValue?.toNumber()).toBe(100);
   });
 
   it('should report whether any snapshot exists regardless of the range filter', () => {

--- a/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-list.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-list.ts
@@ -1,38 +1,31 @@
 import type { ComputedRef, Ref } from 'vue';
 import { type BigNumber, Zero } from '@rotki/common';
 import { startPromise } from '@shared/utils';
-import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
-import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
-import { useSetting } from '@/modules/settings/use-setting';
 import { useStatisticsDataFetching } from '@/modules/statistics/use-statistics-data-fetching';
 import { useStatisticsStore } from '@/modules/statistics/use-statistics-store';
 
-/** A single row in the snapshot list, derived from the net-value series. */
+/**
+ * A single row in the snapshot list, derived from the net-value series.
+ *
+ * Rows are intentionally USD-only: the historic USD->fiat conversion (#12277)
+ * happens lazily in the display layer (`SnapshotFiatDisplay` /
+ * `SnapshotDeltaDisplay`), which is rendered only for the visible page. Eagerly
+ * converting the whole series here used to hammer the historic-rate endpoint —
+ * thousands of timestamps thrashing the shared 500-entry LRU on every mount.
+ * Keeping this derivation pure collapses the working set to one page.
+ */
 export interface SnapshotListRow {
   /** Snapshot timestamp in SECONDS (net-value series / historic-cache unit). */
   timestamp: number;
   /** The stored net worth at this snapshot, denominated in USD. */
   usdValue: BigNumber;
   /**
-   * The net worth converted to the user's display currency at the *historic*
-   * rate of this snapshot's timestamp (#12277). Equals `usdValue` when the
-   * display currency is USD, or `Zero` while the rate is not yet `ready`.
+   * The timestamp (seconds) of the chronologically previous snapshot, used by
+   * the display layer to compute the per-row Δ. `undefined` for the oldest.
    */
-  fiatValue: BigNumber;
-  /**
-   * The change in `fiatValue` versus the chronologically previous snapshot.
-   * `undefined` for the oldest snapshot, or whenever either side's historic
-   * rate is not yet resolved (so a placeholder zero never produces a bogus Δ).
-   */
-  delta?: BigNumber;
-  /** Whether the historic USD->fiat rate for this row is still loading. */
-  fiatPending: boolean;
-  /**
-   * Whether `fiatValue` is usable. `false` while pending, or when the historic
-   * rate is permanently missing (lets the table distinguish a skeleton from a
-   * "no price" dash).
-   */
-  ready: boolean;
+  previousTimestamp?: number;
+  /** The USD net worth of the chronologically previous snapshot (for the Δ). */
+  previousUsdValue?: BigNumber;
 }
 
 export interface SnapshotListFilters {
@@ -66,43 +59,26 @@ interface UseSnapshotListReturn {
 export function useSnapshotList(filters: Ref<SnapshotListFilters> = ref({})): UseSnapshotListReturn {
   const { netValue } = storeToRefs(useStatisticsStore());
   const { fetchNetValue } = useStatisticsDataFetching();
-  const currencySymbol = useSetting('currencySymbol');
-  const { createKey, getHistoricPrice, getIsPending } = useHistoricPriceCache();
 
   const loading = shallowRef<boolean>(false);
 
-  const isUsd = computed<boolean>(() => get(currencySymbol) === CURRENCY_USD);
-
-  /** Converts a single USD net worth to display currency at its historic rate. */
-  function convert(timestamp: number, usdValue: BigNumber): Pick<SnapshotListRow, 'fiatPending' | 'fiatValue' | 'ready'> {
-    if (get(isUsd))
-      return { fiatPending: false, fiatValue: usdValue, ready: true };
-
-    const rate = getHistoricPrice(CURRENCY_USD, timestamp);
-    const fiatPending = getIsPending(createKey(CURRENCY_USD, timestamp));
-    const ready = rate.isPositive();
-    return { fiatPending, fiatValue: ready ? usdValue.multipliedBy(rate) : Zero, ready };
-  }
-
+  // Pure USD-only derivation: no historic-rate lookups here. Each row carries
+  // its chronological predecessor (from the full series, before any range
+  // filter) so the display layer can compute the Δ for just the visible rows.
   const baseRows = computed<SnapshotListRow[]>(() => {
     const { data, times } = get(netValue);
     const rows: SnapshotListRow[] = [];
 
-    let prevFiat: BigNumber | undefined;
-    let prevReady = false;
+    let previousTimestamp: number | undefined;
+    let previousUsdValue: BigNumber | undefined;
 
     for (const [index, timestamp] of times.entries()) {
       const usdValue = data[index] ?? Zero;
-      const { fiatPending, fiatValue, ready } = convert(timestamp, usdValue);
 
-      const delta = index > 0 && ready && prevReady && prevFiat !== undefined
-        ? fiatValue.minus(prevFiat)
-        : undefined;
+      rows.push({ previousTimestamp, previousUsdValue, timestamp, usdValue });
 
-      rows.push({ delta, fiatPending, fiatValue, ready, timestamp, usdValue });
-
-      prevFiat = fiatValue;
-      prevReady = ready;
+      previousTimestamp = timestamp;
+      previousUsdValue = usdValue;
     }
 
     return rows;

--- a/frontend/app/src/pages/statistics/snapshots/index.vue
+++ b/frontend/app/src/pages/statistics/snapshots/index.vue
@@ -101,13 +101,12 @@ function open(timestamp: number): void {
   startPromise(router.push(`/statistics/snapshots/${timestamp}`));
 }
 
-// Resolve the export dialog's balance reactively from the selected row, so a
-// still-loading historic rate keeps showing a skeleton (and updates in place once
-// it resolves) instead of freezing a placeholder Zero at open time.
+// The export dialog shows the selected snapshot's stored USD net worth; the dialog
+// converts it at the snapshot's historic rate itself (#12277), lazily, so opening
+// it never triggers a whole-series conversion.
 const selectedRow = computed<SnapshotListRow | undefined>(() =>
   get(rows).find(item => item.timestamp === get(selectedTimestamp)));
-const selectedBalance = computed<BigNumber>(() => get(selectedRow)?.fiatValue ?? Zero);
-const selectedBalanceLoading = computed<boolean>(() => get(selectedRow)?.fiatPending ?? false);
+const selectedBalance = computed<BigNumber>(() => get(selectedRow)?.usdValue ?? Zero);
 
 function openExport(timestamp: number): void {
   set(selectedTimestamp, timestamp);
@@ -232,7 +231,6 @@ function confirmTakeSnapshot(): void {
       v-model="exportDialog"
       :timestamp="selectedTimestamp"
       :balance="selectedBalance"
-      :loading="selectedBalanceLoading"
     />
   </TablePageLayout>
 </template>


### PR DESCRIPTION
## Problem

Opening the snapshot manager on an account with many snapshots fires a storm of historic USD→fiat rate lookups (thousands of pairs), which rate-limits the forex source.

The cause is on the frontend. `useSnapshotList`'s `baseRows` eagerly converted the **entire** net-value series from USD to the display currency, calling the historic-price cache once per snapshot. With thousands of snapshots the working set far exceeds the shared 500-entry LRU, so entries are evicted, recomputed and re-queued in a loop for as long as the page stays mounted. `baseRows` is a `computed` that reads the cache, and each eviction-driven cache mutation re-runs it, finds the evicted keys missing, and re-queues them.

## Fix

Make the list derivation pure and USD-only, and move the historic conversion into the display layer, which only renders the visible page.

- `baseRows` now carries just `timestamp`, `usdValue` and each row's chronological predecessor (`previousTimestamp`/`previousUsdValue`). No historic-rate lookups happen here.
- The value cell keeps the existing lazy `SnapshotFiatDisplay`.
- New `SnapshotDeltaDisplay` converts both sides of the per-row Δ lazily, so only visible rows resolve rates.
- The value column now sorts by `usdValue` (a faithful approximation of fiat order; historic FX varies only mildly day to day).
- The export dialog converts just the one selected snapshot, via `SnapshotFiatDisplay`.

The working set collapses to one page (≤ ~100 rows), so both the LRU eviction storm and the endpoint hammering are gone.

Backend improvements (day-coalescing, scrape backoff, a range forex provider) are deferred as separate work; this PR is frontend-only.

## Tests

- `use-snapshot-list.spec.ts`: asserts the derivation is pure (3000 rows → zero historic-price calls) and that the chronological predecessor is wired correctly, including on rows excluded by the range filter.
- New `SnapshotDeltaDisplay.spec.ts`: USD passthrough, non-USD two-sided historic conversion, pending skeleton, permanently-missing rate → dash, oldest snapshot → dash.
- Full `modules/dashboard/snapshots/` suite green (227 tests); typecheck and lint clean.
