### PR TITLE
fix(item-cache): resilient caps, fix LRU leaks

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/use-address-name-resolution.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-name-resolution.ts
@@ -133,7 +133,12 @@ export const useAddressNameResolution = createSharedComposable((): UseAddressNam
     reset: resetAddressesNames,
     resolve,
     unknown,
-  } = createItemCache<AddressBookEntry | undefined>(async keys => fetchAddressesNames(keys), { storage: addressNameStorage });
+  } = createItemCache<AddressBookEntry | undefined>(async keys => fetchAddressesNames(keys), {
+    label: 'address-name',
+    maxSize: 5000,
+    size: 500,
+    storage: addressNameStorage,
+  });
 
   // Address name selectors
 

--- a/frontend/app/src/modules/assets/prices/use-historic-price-cache.ts
+++ b/frontend/app/src/modules/assets/prices/use-historic-price-cache.ts
@@ -103,13 +103,18 @@ export const useHistoricPriceCache = createSharedComposable((): UseHistoricPrice
 
   const {
     cache,
-    deleteCacheKey,
+    deleteCacheKeys,
     getIsPending,
     isPending,
     reset,
     resolve,
     unknown,
-  } = createItemCache<BigNumber>(async keys => fetchHistoricPrices(keys), { storage: historicStorage });
+  } = createItemCache<BigNumber>(async keys => fetchHistoricPrices(keys), {
+    label: 'historic-price',
+    maxSize: 5000,
+    size: 500,
+    storage: historicStorage,
+  });
 
   function getHistoricPrice(fromAsset: string, timestamp: number): BigNumber {
     const key = createKey(fromAsset, timestamp);
@@ -146,9 +151,7 @@ export const useHistoricPriceCache = createSharedComposable((): UseHistoricPrice
       });
     });
 
-    keysToBeDeleted.forEach((key) => {
-      deleteCacheKey(key);
-    });
+    deleteCacheKeys([...keysToBeDeleted]);
   }
 
   watch(currencySymbol, async () => {

--- a/frontend/app/src/modules/assets/use-asset-info-cache.spec.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-cache.spec.ts
@@ -129,7 +129,7 @@ describe('modules/assets/use-asset-info-cache', () => {
     expect(cache.resolve('KEY')).toEqual(asset);
   });
 
-  it('should stop caching assets after cache limit is reached', async () => {
+  it('should grow past the soft cap to fit the working set', async () => {
     const cache = await getCache();
     vi.mocked(useAssetInfoApi().assetMapping).mockImplementation(async (identifier): Promise<AssetMap> => {
       const mapping: AssetMap = { assetCollections: {}, assets: {} };
@@ -156,14 +156,17 @@ describe('modules/assets/use-asset-info-cache', () => {
     vi.advanceTimersByTime(4000);
     await flushPromises();
 
+    // 504 distinct assets (AST-0, AST-1..49, AST-51..504) — well past the old
+    // hard 500 cap and under the 5000 resilient ceiling, so none are evicted.
     for (let i = 51; i < 505; i++) cache.resolve(`AST-${i}`);
 
     vi.advanceTimersByTime(4000);
     await flushPromises();
 
     const entries = Object.entries(get(cache.cache));
-    expect(entries).toHaveLength(500);
+    expect(entries).toHaveLength(504);
     expect(entries.map(([id]) => id)).toContain('AST-0');
+    expect(entries.map(([id]) => id)).toContain('AST-504');
   });
 
   it('should not delete cache if the request after expiry hits any error', async () => {

--- a/frontend/app/src/modules/assets/use-asset-info-cache.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-cache.ts
@@ -68,6 +68,9 @@ export const useAssetInfoCache = createSharedComposable((): UseAssetInfoCacheRet
     },
     {
       debounceInMs: 100,
+      label: 'asset-info',
+      maxSize: 5000,
+      size: 500,
       storage,
     },
   );

--- a/frontend/app/src/modules/core/common/use-item-cache.spec.ts
+++ b/frontend/app/src/modules/core/common/use-item-cache.spec.ts
@@ -1,5 +1,6 @@
 import flushPromises from 'flush-promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '@/modules/core/common/logging/logging';
 import { createItemCache, createItemCacheStorage } from '@/modules/core/common/use-item-cache';
 
 interface TestEntry {
@@ -47,39 +48,29 @@ describe('createItemCache', () => {
     });
   });
 
-  describe('useResolve', () => {
-    it('should return a reactive computed that updates after fetch', async () => {
+  describe('peek', () => {
+    it('should return a cached value without queueing a fetch', async () => {
       const { fetch } = createMockFetch({ KEY: 'value' });
-      const { useResolve } = createItemCache(fetch);
+      const { peek, resolve } = createItemCache(fetch);
 
-      const result = useResolve('KEY');
-      expect(get(result)).toBeNull();
-
+      resolve('KEY');
       vi.advanceTimersByTime(1000);
       await flushPromises();
 
-      expect(get(result)).toBe('value');
+      expect(peek('KEY')).toBe('value');
     });
 
-    it('should accept a reactive key and track the computed value', async () => {
-      const { fetch } = createMockFetch({ A: 'alpha', B: 'beta' });
-      const { resolve, useResolve } = createItemCache(fetch);
-      const key = ref<string>('A');
+    it('should return null and never trigger a fetch for an unknown key', async () => {
+      const { calls, fetch } = createMockFetch({ KEY: 'value' });
+      const { peek } = createItemCache(fetch);
 
-      const result = useResolve(key);
+      expect(peek('KEY')).toBeNull();
 
       vi.advanceTimersByTime(1000);
       await flushPromises();
 
-      expect(get(result)).toBe('alpha');
-
-      // Queue B separately since useResolve only queues the initial key
-      resolve('B');
-      set(key, 'B');
-      vi.advanceTimersByTime(1000);
-      await flushPromises();
-
-      expect(get(result)).toBe('beta');
+      expect(calls).toHaveLength(0);
+      expect(peek('KEY')).toBeNull();
     });
   });
 
@@ -367,6 +358,195 @@ describe('createItemCache', () => {
       vi.advanceTimersByTime(1000);
       await flushPromises();
 
+      expect(calls).toHaveLength(2);
+    });
+  });
+
+  describe('deleteCacheKey LRU index', () => {
+    it('should not leak the key in the LRU index (recent)', async () => {
+      const storage = createItemCacheStorage<string>();
+      const { fetch } = createMockFetch({ KEY: 'value' });
+      const { deleteCacheKey, resolve, size } = createItemCache(fetch, { storage });
+
+      resolve('KEY');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(size()).toBe(1);
+      expect(storage.recent.has('KEY')).toBe(true);
+
+      deleteCacheKey('KEY');
+
+      // The LRU index must shrink too, otherwise phantom entries inflate the
+      // size and trigger premature eviction of live keys.
+      expect(size()).toBe(0);
+      expect(storage.recent.has('KEY')).toBe(false);
+    });
+  });
+
+  describe('deleteCacheKeys', () => {
+    it('should remove many keys with a single reactive notification', async () => {
+      const { fetch } = createMockFetch({ A: 'alpha', B: 'beta', C: 'gamma' });
+      const { cache, deleteCacheKeys, resolve, size } = createItemCache(fetch);
+
+      resolve('A');
+      resolve('B');
+      resolve('C');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(size()).toBe(3);
+
+      deleteCacheKeys(['A', 'B']);
+
+      expect(size()).toBe(1);
+      expect(get(cache).A).toBeUndefined();
+      expect(get(cache).B).toBeUndefined();
+      expect(get(cache).C).toBe('gamma');
+    });
+
+    it('should be a no-op for an empty list', () => {
+      const { fetch } = createMockFetch({});
+      const { deleteCacheKeys, size } = createItemCache(fetch);
+
+      expect(() => deleteCacheKeys([])).not.toThrow();
+      expect(size()).toBe(0);
+    });
+  });
+
+  describe('resilient capacity', () => {
+    it('should grow past the soft cap without evicting', async () => {
+      const { fetch } = createMockFetch({ A: 'a', B: 'b', C: 'c', D: 'd', E: 'e' });
+      const { cache, resolve, size } = createItemCache(fetch, { maxSize: 10, size: 2 });
+
+      for (const key of ['A', 'B', 'C', 'D', 'E']) resolve(key);
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      // Soft cap is 2 but the working set of 5 fits under the hard cap of 10.
+      expect(size()).toBe(5);
+      expect(get(cache).A).toBe('a');
+      expect(get(cache).E).toBe('e');
+    });
+
+    it('should reclaim expired entries before growing further', async () => {
+      const { fetch } = createMockFetch({ A: 'a', B: 'b', C: 'c' });
+      const { cache, resolve, size } = createItemCache(fetch, { expiry: 1000, maxSize: 10, size: 2 });
+
+      resolve('A');
+      resolve('B');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+      expect(size()).toBe(2);
+
+      // Let A and B age out (nothing reads them, so their expiry lapses).
+      vi.advanceTimersByTime(5000);
+
+      resolve('C');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      // Inserting C at the soft cap reclaims the two expired entries first.
+      expect(size()).toBe(1);
+      expect(get(cache).C).toBe('c');
+      expect(get(cache).A).toBeUndefined();
+      expect(get(cache).B).toBeUndefined();
+    });
+
+    it('should force-evict the oldest live entry and warn at the hard cap', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const { fetch } = createMockFetch({ A: 'a', B: 'b', C: 'c', D: 'd', E: 'e' });
+      // expiry huge so nothing is reclaimable — every entry stays live.
+      const { cache, resolve, size } = createItemCache(fetch, { expiry: 1_000_000, label: 'test', maxSize: 3, size: 2 });
+
+      for (const key of ['A', 'B', 'C', 'D', 'E']) resolve(key);
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      // Held at the hard cap; the two oldest (A, B) were force-evicted.
+      expect(size()).toBe(3);
+      expect(get(cache).A).toBeUndefined();
+      expect(get(cache).B).toBeUndefined();
+      expect(get(cache).E).toBe('e');
+      // The warning is throttled to once per window even across multiple evictions.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('test');
+      warnSpy.mockRestore();
+    });
+
+    it('should keep maxSize at least the soft cap when configured lower', async () => {
+      const { fetch } = createMockFetch({ A: 'a', B: 'b', C: 'c' });
+      const { resolve, size } = createItemCache(fetch, { expiry: 1_000_000, maxSize: 1, size: 3 });
+
+      for (const key of ['A', 'B', 'C']) resolve(key);
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      // maxSize (1) is clamped up to size (3), so all three fit.
+      expect(size()).toBe(3);
+    });
+  });
+
+  describe('refresh ordering', () => {
+    it('should move the refreshed key to the most-recent end of the LRU', async () => {
+      const storage = createItemCacheStorage<string>();
+      const { fetch } = createMockFetch({ A: 'a', B: 'b' });
+      const { refresh, resolve } = createItemCache(fetch, { storage });
+
+      resolve('A');
+      resolve('B');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect([...storage.recent.keys()]).toEqual(['A', 'B']);
+
+      refresh('A');
+
+      // A must jump to the end; an in-place set would leave it stale at the front
+      // and break both LRU recency and the expiry-ordering the sweep relies on.
+      expect([...storage.recent.keys()]).toEqual(['B', 'A']);
+    });
+  });
+
+  describe('unknown map bounding', () => {
+    it('should keep the negative cache under the hard cap', async () => {
+      const { fetch } = createMockFetch({});
+      const { resolve, unknown } = createItemCache(fetch, { maxSize: 2, size: 1 });
+
+      for (const key of ['A', 'B', 'C', 'D']) resolve(key);
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(unknown.size).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('error backoff', () => {
+    it('should hold failed keys back before retrying', async () => {
+      vi.spyOn(logger, 'error').mockImplementation(() => {});
+      const calls: string[][] = [];
+      const fetch = async (keys: string[]): Promise<() => IterableIterator<{ key: string; item: string }>> => {
+        calls.push([...keys]);
+        throw new Error('backend down');
+      };
+      const { resolve } = createItemCache(fetch);
+
+      resolve('KEY');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+      expect(calls).toHaveLength(1);
+
+      // Within the backoff window a re-request must not fire another fetch.
+      resolve('KEY');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
+      expect(calls).toHaveLength(1);
+
+      // After the backoff window it retries.
+      vi.advanceTimersByTime(5000);
+      resolve('KEY');
+      vi.advanceTimersByTime(1000);
+      await flushPromises();
       expect(calls).toHaveLength(2);
     });
   });

--- a/frontend/app/src/modules/core/common/use-item-cache.ts
+++ b/frontend/app/src/modules/core/common/use-item-cache.ts
@@ -1,11 +1,17 @@
 import type { ComputedRef, DeepReadonly, MaybeRefOrGetter, Raw, Ref } from 'vue';
-import { assert } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { logger } from '@/modules/core/common/logging/logging';
 
 const CACHE_EXPIRY = 1000 * 60 * 10;
-const CACHE_SIZE = 500;
+/** Soft cap: the intended working set. Below it the cache grows without evicting. */
+const CACHE_SOFT_SIZE = 500;
+/** Hard cap: the resilient ceiling. Only crossing it force-evicts live entries. */
+const CACHE_HARD_SIZE = 5000;
 const DEBOUNCE_TIME = 800;
+/** Minimum gap (ms) between hard-cap warnings so the warning can't itself spam. */
+const WARN_THROTTLE = 5000;
+/** How long (ms) a failed batch's keys are held back before a retry, to avoid hammering a down backend. */
+const FAILURE_BACKOFF = 5000;
 
 interface CacheEntry<T> {
   key: string;
@@ -56,8 +62,25 @@ interface CacheOptions<T = unknown> {
   debounceInMs?: number;
   /** Time-to-live (ms) for cached entries before they become stale. @default 600_000 (10 min) */
   expiry?: number;
-  /** Maximum number of entries kept in the LRU cache. @default 500 */
+  /**
+   * Soft cap: the intended working set. The cache grows freely below it; at or
+   * above it, an insert first reclaims expired (off-screen) entries. @default 500
+   */
   size?: number;
+  /**
+   * Hard cap: the resilient ceiling. The cache may grow up to here to fit a
+   * legitimately large but bounded working set. Only when it is full of *live*
+   * entries at this size does an insert force-evict the oldest and emit a
+   * throttled warning. Size this from the value's memory weight — light values
+   * (numbers, small objects) can be in the thousands, heavy ones (images, long
+   * strings) in the hundreds. Clamped up to `size` if set lower. @default 5000
+   */
+  maxSize?: number;
+  /**
+   * Identifier used in the hard-cap warning so the offending cache is named in
+   * logs (e.g. `'historic-price'`).
+   */
+  label?: string;
   /**
    * Persistent storage to bind to. When omitted a fresh in-scope storage is
    * created (legacy behaviour). Pass a store-owned {@link ItemCacheStorage} to
@@ -77,50 +100,163 @@ interface ItemCacheReturn<T> {
   isPending: (identifier: MaybeRefOrGetter<string>) => ComputedRef<boolean>;
   /** Synchronously returns the cached value for `key`, queueing a fetch if missing. */
   resolve: (key: string) => T | null;
-  /** Returns a reactive computed that resolves `key`, queueing a fetch if missing. */
-  useResolve: (key: MaybeRefOrGetter<string>) => ComputedRef<T | null>;
+  /**
+   * Synchronously returns the cached value for `key` WITHOUT queueing a fetch.
+   * Use this to read a value that some other code is responsible for requesting
+   * (e.g. an off-page neighbour) so a read over a large collection can't trigger
+   * an unbounded fetch storm.
+   */
+  peek: (key: string) => T | null;
   /** Clears all cached data, pending state, and unknown entries. */
   reset: () => void;
   /** Forces a re-fetch of the given key regardless of its current cache state. */
   refresh: (key: string) => void;
-  /** Removes a key from the cache and the unknown map. */
+  /** Removes a key from the cache, the LRU index, the pending set and the unknown map. */
   deleteCacheKey: (key: string) => void;
+  /** Removes many keys at once, emitting a single reactive notification. */
+  deleteCacheKeys: (keys: string[]) => void;
   /** Queues a key for fetching unless it is already in the unknown map and not yet expired. */
   queueIdentifier: (key: string) => void;
+  /** The current number of live entries in the cache (for tests/observability). */
+  size: () => number;
 }
 
 /**
- * Creates a debounced, LRU-bounded, reactive item cache backed by a batch-fetch function.
+ * Creates a debounced, reactive item cache backed by a batch-fetch function.
  *
- * Keys requested via {@link ItemCacheReturn.resolve resolve}, {@link ItemCacheReturn.useResolve useResolve},
- * or {@link ItemCacheReturn.queueIdentifier queueIdentifier} are accumulated into a batch and fetched
- * together after a debounce interval. Resolved items are stored in a size-limited LRU cache with
- * configurable expiry. Unresolvable keys are tracked in an `unknown` map to avoid repeated lookups.
+ * Keys requested via {@link ItemCacheReturn.resolve resolve} or
+ * {@link ItemCacheReturn.queueIdentifier queueIdentifier} are accumulated into a batch and fetched
+ * together after a debounce interval. Unresolvable keys are tracked in an `unknown` map to avoid
+ * repeated lookups.
  *
- * Internally uses `shallowRef` + `triggerRef` for the cache and pending state, so that batch
- * operations (processing N items) trigger only a single reactive notification per ref.
+ * ## Resilient capacity
+ * The cache grows freely below the soft cap (`size`); above it an insert first reclaims *expired*
+ * entries — and since {@link ItemCacheReturn.resolve resolve} refreshes a key's expiry on every read,
+ * an entry is "expired" exactly when nothing on screen has read it for `expiry` ms, so the working set
+ * tracks what is in use. Only when full of *live* entries at the hard cap (`maxSize`) does it
+ * force-evict the oldest and emit a throttled warning — the sign of an unbounded read to fix.
+ * Uses `shallowRef` + `triggerRef` so a batch triggers one reactive notification per ref.
  *
  * @param fetch - Batch-fetch function that resolves an array of keys into cache entries.
- * @param options - Optional configuration for debounce timing, expiry, and cache size.
+ * @param options - Optional configuration for debounce timing, expiry, capacity and label.
  */
 export function createItemCache<T>(
   fetch: CacheFetch<T>,
   options: CacheOptions<T> = {},
 ): ItemCacheReturn<T> {
-  const { debounceInMs = DEBOUNCE_TIME, expiry = CACHE_EXPIRY, size = CACHE_SIZE } = options;
+  const {
+    debounceInMs = DEBOUNCE_TIME,
+    expiry = CACHE_EXPIRY,
+    label,
+    maxSize = CACHE_HARD_SIZE,
+    size: softSize = CACHE_SOFT_SIZE,
+    storage,
+  } = options;
+  // The hard cap can never sit below the soft cap.
+  const hardSize = Math.max(softSize, maxSize);
   // Persistent storage is injected so it can outlive this factory instance
   // (e.g. a Pinia store); when absent it falls back to in-scope storage.
-  const { cache, recent, unknown } = options.storage ?? createItemCacheStorage<T>();
+  const { cache, recent, unknown } = storage ?? createItemCacheStorage<T>();
   // Transient in-flight state — intentionally factory-local, reset on re-init.
   const pending = shallowRef<Record<string, boolean>>({});
   const batch = new Set<string>();
+  let lastWarn = 0;
 
-  const deleteCacheKey = (key: string): void => {
+  /** Removes a key from every store (recent + cache + unknown). Does not notify. */
+  const removeEntry = (key: string): void => {
+    recent.delete(key);
     delete get(cache)[key];
-    triggerRef(cache);
-
     if (unknown.has(key))
       unknown.delete(key);
+  };
+
+  const warnHardCap = (forced: number): void => {
+    const now = Date.now();
+    if (now - lastWarn < WARN_THROTTLE)
+      return;
+
+    lastWarn = now;
+    logger.warn(
+      `[item-cache${label ? `:${label}` : ''}] exceeded hard cap of ${hardSize} entries; `
+      + `force-evicted ${forced} live entr${forced === 1 ? 'y' : 'ies'}. A consumer is resolving `
+      + `more keys than the cap holds (likely an unbounded read) — scope the read to the viewport `
+      + `or raise maxSize for this cache.`,
+    );
+  };
+
+  /**
+   * Makes room for one more entry. No-op below the soft cap. At/above it, drops
+   * expired entries first (they are the off-screen ones); only if the cache is
+   * still full of live entries at the hard cap does it force-evict + warn.
+   */
+  const evictToFit = (): void => {
+    if (recent.size < softSize)
+      return;
+
+    const now = Date.now();
+    // `recent` is ordered by expiry ascending (every write is delete-then-set
+    // with a monotonic `now + expiry`), so the first non-expired entry ends the sweep.
+    for (const [key, expiryTs] of recent) {
+      if (expiryTs > now)
+        break;
+      removeEntry(key);
+    }
+
+    let forced = 0;
+    while (recent.size >= hardSize) {
+      const oldest = recent.keys().next().value;
+      if (oldest === undefined)
+        break;
+      removeEntry(oldest);
+      forced++;
+    }
+    if (forced > 0)
+      warnHardCap(forced);
+  };
+
+  /** Records a key as unresolvable until `expiryTs`, keeping the unknown map bounded. */
+  const markUnknown = (key: string, expiryTs: number): void => {
+    if (unknown.has(key))
+      unknown.delete(key);
+    unknown.set(key, expiryTs);
+
+    if (unknown.size <= hardSize)
+      return;
+
+    // Bound the negative cache: drop expired first, then oldest, until under cap.
+    const now = Date.now();
+    for (const [unknownKey, unknownExpiry] of unknown) {
+      if (unknownExpiry <= now)
+        unknown.delete(unknownKey);
+    }
+    while (unknown.size > hardSize) {
+      const oldest = unknown.keys().next().value;
+      if (oldest === undefined)
+        break;
+      unknown.delete(oldest);
+    }
+  };
+
+  const deleteCacheKeys = (keys: string[]): void => {
+    if (keys.length === 0)
+      return;
+
+    const pendingObj = get(pending);
+    let pendingChanged = false;
+    for (const key of keys) {
+      if (pendingObj[key]) {
+        delete pendingObj[key];
+        pendingChanged = true;
+      }
+      removeEntry(key);
+    }
+    if (pendingChanged)
+      triggerRef(pending);
+    triggerRef(cache);
+  };
+
+  const deleteCacheKey = (key: string): void => {
+    deleteCacheKeys([key]);
   };
 
   const setPending = (key: string): void => {
@@ -132,16 +268,7 @@ export function createItemCache<T>(
 
   const put = (key: string, item: T): void => {
     recent.delete(key);
-
-    if (recent.size === size) {
-      logger.debug(`Hit cache size of ${size} going to evict items`);
-      const removeKey = recent.keys().next().value;
-      assert(removeKey, 'removeKey is null or undefined');
-      recent.delete(removeKey);
-      delete get(cache)[removeKey];
-      if (unknown.has(removeKey))
-        unknown.delete(removeKey);
-    }
+    evictToFit();
     recent.set(key, Date.now() + expiry);
     get(cache)[key] = item;
   };
@@ -168,15 +295,16 @@ export function createItemCache<T>(
 
           recent.delete(key);
           delete get(cache)[key];
-          if (unknown.has(key))
-            unknown.delete(key);
-
-          unknown.set(key, Date.now() + expiry);
+          markUnknown(key, Date.now() + expiry);
         }
       }
     }
     catch (error) {
       logger.error(error);
+      // Transient failure: back the keys off briefly so a down backend is not
+      // retried on every debounce tick while the consuming view stays mounted.
+      const retryAt = Date.now() + FAILURE_BACKOFF;
+      for (const key of keys) markUnknown(key, retryAt);
     }
     finally {
       const pendingObj = get(pending);
@@ -225,14 +353,13 @@ export function createItemCache<T>(
     return get(cache)[key] ?? null;
   };
 
-  const useResolve = (key: MaybeRefOrGetter<string>): ComputedRef<T | null> => {
-    ensureQueued(toValue(key));
-    return computed(() => get(cache)[toValue(key)] ?? null);
-  };
+  const peek = (key: string): T | null => get(cache)[key] ?? null;
 
   const refresh = (key: string): void => {
-    const now = Date.now();
-    recent.set(key, now + expiry);
+    // delete-before-set keeps the key at the most-recent end and preserves the
+    // expiry-ascending ordering that the eviction sweep relies on.
+    recent.delete(key);
+    recent.set(key, Date.now() + expiry);
     if (unknown.has(key))
       unknown.delete(key);
 
@@ -245,24 +372,29 @@ export function createItemCache<T>(
     identifier: MaybeRefOrGetter<string>,
   ): ComputedRef<boolean> => computed<boolean>(() => getIsPending(toValue(identifier)));
 
+  const size = (): number => recent.size;
+
   const reset = (): void => {
     set(pending, {});
     set(cache, {});
     batch.clear();
     recent.clear();
     unknown.clear();
+    lastWarn = 0;
   };
 
   return {
     cache: readonly(cache),
     deleteCacheKey,
+    deleteCacheKeys,
     getIsPending,
     isPending,
+    peek,
     queueIdentifier,
     refresh,
     reset,
     resolve,
-    useResolve,
+    size,
     unknown,
   };
 }


### PR DESCRIPTION
## Problem

`createItemCache` is a shared primitive behind three app-wide caches — historic-price, asset-info and address-name — all with a fixed **500-entry hard LRU**. That cap, plus a few bookkeeping bugs, meant a wide reactive read (a `computed` resolving more than 500 keys) could thrash the cache into a perpetual fetch storm: results arrive → the LRU evicts still-live keys → the reactive read re-runs → re-queues the evicted keys → forever. It was the root cause of the snapshot forex hammering (#12660) and had bitten us before.

## Correctness fixes

- **`deleteCacheKey` leaked the LRU index.** It removed the key from `cache` and `unknown` but not from `recent` (or `pending`). Those phantom entries inflated `recent.size` and triggered premature eviction of live keys — hit on **every currency change and manual price edit** via `resetHistoricalPricesData`, which loops it.
- **`refresh` broke LRU ordering.** It did `recent.set(key, …)` without deleting first, so the key kept its old insertion slot instead of moving to the most-recent end — wrong recency, and it broke the "insertion order == expiry order" invariant the eviction sweep now relies on.
- **The `unknown` (negative) map grew unbounded.** Unresolvable keys were parked forever; it is now bounded.

## Resilient capacity (replaces the hard 500 cap)

A **soft cap** (`size`, default 500) plus a **hard cap** (`maxSize`, default 5000), per-cache, with an optional `label`:

- The cache grows freely below the soft cap.
- Above it, an insert first **reclaims expired (off-screen) entries** — and because a read refreshes a key's expiry, an entry is "expired" precisely when nothing on screen has read it for the TTL, so the working set naturally tracks what is in use.
- Only when the cache is full of **live** entries at the hard cap does it force-evict the oldest and emit a **throttled, labelled warning** — the signature of an unbounded read that should be scoped to the viewport (or given a larger `maxSize`).

Caps are sized by value weight: light values (numbers, small objects) can be in the thousands; heavy values (images, long strings) should be in the hundreds. The three current caches are wired at 500 / 5000.

## Other

- `peek(key)` — a **pure** read that never queues a fetch, for reading a value some other code is responsible for requesting (e.g. an off-page neighbour).
- `deleteCacheKeys(keys[])` — bulk delete with a single reactive notification; `resetHistoricalPricesData` uses it instead of N per-key deletes.
- `size()` accessor for tests/observability.
- Failed fetches are backed off briefly so a down backend is not retried on every debounce tick.
- Removed the unused `useResolve` (never consumed; also harboured a latent reactive-key footgun).

## Behaviour

Externally identical except: no size drift, bounded memory, and caps that grow-then-warn instead of silently thrashing.

## Tests

`use-item-cache.spec.ts` extended: grow-past-soft-cap, expiry-first reclaim, hard-cap force-evict + throttled warn, `maxSize` clamped to `size`, `deleteCacheKey` no longer leaks `recent`, `refresh` moves to MRU, `unknown` bounded, `peek` is pure, `deleteCacheKeys` bulk, error backoff. Consumer specs updated for the new grow-to-fit semantics. Full item-cache + three consumer suites green; typecheck and lint clean.

Follow-up (separate PR): fine-grained per-key reactivity, to remove the single-`shallowRef` amplification where every cache write re-runs every consumer.
