### PR TITLE
Cut complexity in non-production code and add electron tests

### DIFF
--- a/frontend/app/electron/main/address-import-server.spec.ts
+++ b/frontend/app/electron/main/address-import-server.spec.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+import type { LogService } from '@electron/main/log-service';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { AddressImportServer } from './address-import-server';
+
+describe('addressImportServer', () => {
+  let server: AddressImportServer | undefined;
+
+  afterEach(() => {
+    server?.stop();
+    server = undefined;
+  });
+
+  function startServer(cb: Mock = vi.fn(), maxContentLength?: number): string {
+    server = new AddressImportServer(createMock<LogService>(), maxContentLength);
+    const port = server.start(cb, 0);
+    return `http://127.0.0.1:${port}`;
+  }
+
+  it('should reject a request whose content length exceeds the limit', async () => {
+    const base = startServer(vi.fn(), 10);
+    const res = await fetch(`${base}/import`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ addresses: ['0xabc', '0xdef', '0x123'] }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toStrictEqual({ message: 'Only requests up to 0.0MB are allowed' });
+  });
+
+  it('should reject an import with a non-json content type', async () => {
+    const base = startServer();
+    const res = await fetch(`${base}/import`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: '{}',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toStrictEqual({ message: 'Invalid content type' });
+  });
+
+  it('should invoke the callback with the parsed addresses', async () => {
+    const cb = vi.fn();
+    const base = startServer(cb);
+    const res = await fetch(`${base}/import`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ addresses: ['0xabc', '0xdef'] }),
+    });
+    expect(res.status).toBe(200);
+    expect(cb).toHaveBeenCalledWith(['0xabc', '0xdef']);
+    expect(server?.isListening()).toBe(false);
+  });
+
+  it('should reject malformed json on import', async () => {
+    const base = startServer();
+    const res = await fetch(`${base}/import`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{ not valid json',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toStrictEqual({ message: 'Malformed JSON' });
+  });
+
+  it('should reject an import payload without an addresses array', async () => {
+    const cb = vi.fn();
+    const base = startServer(cb);
+    const res = await fetch(`${base}/import`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ notAddresses: true }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toStrictEqual({ message: 'Invalid request schema' });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('should return 404 for a non-whitelisted path', async () => {
+    const base = startServer();
+    const res = await fetch(`${base}/etc/passwd`);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toStrictEqual({ message: 'Resource not found' });
+  });
+});

--- a/frontend/app/electron/main/address-import-server.ts
+++ b/frontend/app/electron/main/address-import-server.ts
@@ -147,48 +147,70 @@ export class AddressImportServer {
     }
   }
 
+  /**
+   * Rejects the request when its declared content length exceeds the limit.
+   * Returns `true` when a response was already sent and handling should stop.
+   */
+  private exceedsContentLength(req: IncomingMessage, res: ServerResponse): boolean {
+    const contentLengthHeader = req.headers['content-length'];
+    if (!contentLengthHeader)
+      return false;
+
+    try {
+      const contentLength = Number.parseInt(contentLengthHeader);
+      if (contentLength > this.maxContentLength) {
+        const limitMB = (this.maxContentLength / 1024 / 1024).toFixed(1);
+        this.invalidRequest(res, `Only requests up to ${limitMB}MB are allowed`, HttpStatus.BAD_REQUEST);
+        return true;
+      }
+      return false;
+    }
+    catch {
+      this.invalidRequest(res, HttpErrorMessage.INVALID_CONTENT_LENGTH, HttpStatus.CONTENT_LENGTH_REQUIRED);
+      return true;
+    }
+  }
+
+  private resolveBasePath(): string {
+    const dirname = import.meta.dirname;
+    return checkIfDevelopment() ? path.join(dirname, '..', 'public') : dirname;
+  }
+
+  private async serveImportPage(res: ServerResponse, basePath: string): Promise<void> {
+    try {
+      const htmlContent = await fs.readFile(path.join(basePath, 'address-import/import.html'));
+      this.okResponse(res, htmlContent, AddressImportServer.headersHtml);
+    }
+    catch (error) {
+      this.logger.error('Failed to read import.html:', error);
+      this.invalidRequest(res, HttpErrorMessage.RESOURCE_NOT_FOUND, HttpStatus.NOT_FOUND);
+    }
+  }
+
+  private async route(req: IncomingMessage, res: ServerResponse, cb: AddressImportCallback, basePath: string): Promise<void> {
+    const url = req.url ?? '';
+
+    if (url === '/') {
+      await this.serveImportPage(res, basePath);
+    }
+    else if (url === '/import' && req.method === 'POST') {
+      this.handleAddresses(req, res, cb);
+      this.stop();
+    }
+    else if (await this.isAllowed(basePath, url)) {
+      await this.serveFile(res, basePath, url);
+    }
+    else {
+      this.invalidRequest(res, HttpErrorMessage.RESOURCE_NOT_FOUND, HttpStatus.NOT_FOUND);
+    }
+  }
+
   private async handleRequests(req: IncomingMessage, res: ServerResponse, cb: AddressImportCallback): Promise<void> {
     try {
-      const contentLengthHeader = req.headers['content-length'];
-      if (contentLengthHeader) {
-        try {
-          const contentLength = Number.parseInt(contentLengthHeader);
-          if (contentLength > this.maxContentLength) {
-            const limitMB = (this.maxContentLength / 1024 / 1024).toFixed(1);
-            this.invalidRequest(res, `Only requests up to ${limitMB}MB are allowed`, HttpStatus.BAD_REQUEST);
-            return;
-          }
-        }
-        catch {
-          this.invalidRequest(res, HttpErrorMessage.INVALID_CONTENT_LENGTH, HttpStatus.CONTENT_LENGTH_REQUIRED);
-          return;
-        }
-      }
+      if (this.exceedsContentLength(req, res))
+        return;
 
-      const dirname = import.meta.dirname;
-      const basePath = checkIfDevelopment() ? path.join(dirname, '..', 'public') : dirname;
-      const url = req.url ?? '';
-
-      if (url === '/') {
-        try {
-          const htmlContent = await fs.readFile(path.join(basePath, 'address-import/import.html'));
-          this.okResponse(res, htmlContent, AddressImportServer.headersHtml);
-        }
-        catch (error) {
-          this.logger.error('Failed to read import.html:', error);
-          this.invalidRequest(res, HttpErrorMessage.RESOURCE_NOT_FOUND, HttpStatus.NOT_FOUND);
-        }
-      }
-      else if (url === '/import' && req.method === 'POST') {
-        this.handleAddresses(req, res, cb);
-        this.stop();
-      }
-      else if (await this.isAllowed(basePath, url)) {
-        await this.serveFile(res, basePath, url);
-      }
-      else {
-        this.invalidRequest(res, HttpErrorMessage.RESOURCE_NOT_FOUND, HttpStatus.NOT_FOUND);
-      }
+      await this.route(req, res, cb, this.resolveBasePath());
     }
     catch (error) {
       this.logger.error('Error handling request:', error);

--- a/frontend/app/electron/main/config.spec.ts
+++ b/frontend/app/electron/main/config.spec.ts
@@ -1,0 +1,71 @@
+import { LogLevel } from '@shared/log-level';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadConfig } from './config';
+
+const { existsSync, readFileSync } = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  default: { existsSync, readFileSync },
+}));
+
+describe('loadConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return empty options when the config file does not exist', () => {
+    existsSync.mockReturnValue(false);
+    expect(loadConfig()).toStrictEqual({});
+    expect(readFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should map every recognized key to its option', () => {
+    existsSync.mockReturnValue(true);
+    readFileSync.mockReturnValue(JSON.stringify({
+      'loglevel': LogLevel.DEBUG,
+      'logfromothermodules': true,
+      'log-dir': '/var/log',
+      'data-dir': '/data',
+      'max_size_in_mb_all_logs': '30',
+      'max_logfiles_num': '5',
+      'sqlite_instructions': '1000',
+    }));
+
+    expect(loadConfig()).toStrictEqual({
+      loglevel: LogLevel.DEBUG,
+      logFromOtherModules: true,
+      logDirectory: '/var/log',
+      dataDirectory: '/data',
+      maxSizeInMbAllLogs: 30,
+      maxLogfilesNum: 5,
+      sqliteInstructions: 1000,
+    });
+  });
+
+  it('should ignore an unrecognized loglevel', () => {
+    existsSync.mockReturnValue(true);
+    readFileSync.mockReturnValue(JSON.stringify({ loglevel: 'not-a-level' }));
+    expect(loadConfig()).toStrictEqual({});
+  });
+
+  it('should coerce logfromothermodules to a strict boolean', () => {
+    existsSync.mockReturnValue(true);
+    readFileSync.mockReturnValue(JSON.stringify({ logfromothermodules: 'yes' }));
+    expect(loadConfig()).toStrictEqual({ logFromOtherModules: false });
+  });
+
+  it('should return empty options when the file is malformed JSON', () => {
+    existsSync.mockReturnValue(true);
+    readFileSync.mockReturnValue('{ not valid json');
+    expect(loadConfig()).toStrictEqual({});
+  });
+
+  it('should only include keys present in the file', () => {
+    existsSync.mockReturnValue(true);
+    readFileSync.mockReturnValue(JSON.stringify({ 'data-dir': '/only-data' }));
+    expect(loadConfig()).toStrictEqual({ dataDirectory: '/only-data' });
+  });
+});

--- a/frontend/app/electron/main/config.ts
+++ b/frontend/app/electron/main/config.ts
@@ -13,6 +13,34 @@ const MAX_LOG_SIZE = 'max_size_in_mb_all_logs';
 const MAX_LOG_NUMBER = 'max_logfiles_num';
 const SQLITE_INSTRUCTIONS = 'sqlite_instructions';
 
+// `config` is an untrusted JSON blob; each field is validated/coerced the same
+// way the caller always has, so the values are read as `any` by design.
+function applyConfig(config: Record<string, any>, options: Writeable<Partial<BackendOptions>>): void {
+  if (LOGLEVEL in config) {
+    const configLogLevel = config[LOGLEVEL];
+    if (Object.values(LogLevel).includes(configLogLevel))
+      options.loglevel = configLogLevel;
+  }
+
+  if (LOG_FROM_OTHER_MODULES in config)
+    options.logFromOtherModules = config[LOG_FROM_OTHER_MODULES] === true;
+
+  if (LOGDIR in config)
+    options.logDirectory = config[LOGDIR];
+
+  if (DATA_DIR in config)
+    options.dataDirectory = config[DATA_DIR];
+
+  if (MAX_LOG_SIZE in config)
+    options.maxSizeInMbAllLogs = Number.parseInt(config[MAX_LOG_SIZE]);
+
+  if (MAX_LOG_NUMBER in config)
+    options.maxLogfilesNum = Number.parseInt(config[MAX_LOG_NUMBER]);
+
+  if (SQLITE_INSTRUCTIONS in config)
+    options.sqliteInstructions = Number.parseInt(config[SQLITE_INSTRUCTIONS]);
+}
+
 export function loadConfig(): Partial<BackendOptions> {
   const options: Writeable<Partial<BackendOptions>> = {};
   const filePath = CONFIG_FILE;
@@ -23,31 +51,7 @@ export function loadConfig(): Partial<BackendOptions> {
   try {
     const configFile = fs.readFileSync(filePath);
     const config = JSON.parse(configFile.toString());
-
-    if (LOGLEVEL in config) {
-      const configLogLevel = config[LOGLEVEL];
-      if (Object.values(LogLevel).includes(configLogLevel))
-        options.loglevel = configLogLevel;
-    }
-
-    if (LOG_FROM_OTHER_MODULES in config)
-      options.logFromOtherModules = config[LOG_FROM_OTHER_MODULES] === true;
-
-    if (LOGDIR in config)
-      options.logDirectory = config[LOGDIR];
-
-    if (DATA_DIR in config)
-      options.dataDirectory = config[DATA_DIR];
-
-    if (MAX_LOG_SIZE in config)
-      options.maxSizeInMbAllLogs = Number.parseInt(config[MAX_LOG_SIZE]);
-
-    if (MAX_LOG_NUMBER in config)
-      options.maxLogfilesNum = Number.parseInt(config[MAX_LOG_NUMBER]);
-
-    if (SQLITE_INSTRUCTIONS in config)
-      options.sqliteInstructions = Number.parseInt(config[SQLITE_INSTRUCTIONS]);
-
+    applyConfig(config, options);
     return options;
   }
   catch {

--- a/frontend/app/electron/main/create-protocol.spec.ts
+++ b/frontend/app/electron/main/create-protocol.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { getMimeType } from './create-protocol';
+
+describe('getMimeType', () => {
+  it.each([
+    ['app.js', 'application/javascript'],
+    ['index.html', 'text/html'],
+    ['styles.css', 'text/css'],
+    ['icon.svg', 'image/svg+xml'],
+    ['icon.svgz', 'image/svg+xml'],
+    ['logo.png', 'image/png'],
+    ['photo.jpg', 'image/jpeg'],
+    ['photo.jpeg', 'image/jpeg'],
+    ['data.json', 'application/json'],
+    ['module.wasm', 'application/wasm'],
+  ])('should map %s to %s', (fileName, expected) => {
+    expect(getMimeType(fileName)).toBe(expected);
+  });
+
+  it('should fall back to application/octet-stream for unknown extensions', () => {
+    expect(getMimeType('archive.zip')).toBe('application/octet-stream');
+  });
+
+  it('should fall back to application/octet-stream when there is no extension', () => {
+    expect(getMimeType('LICENSE')).toBe('application/octet-stream');
+  });
+
+  it('should match extensions case-insensitively', () => {
+    expect(getMimeType('APP.JS')).toBe('application/javascript');
+    expect(getMimeType('Photo.JPEG')).toBe('image/jpeg');
+  });
+
+  it('should resolve the extension from a full path', () => {
+    expect(getMimeType('/some/nested/dir/app.css')).toBe('text/css');
+  });
+});

--- a/frontend/app/electron/main/create-protocol.ts
+++ b/frontend/app/electron/main/create-protocol.ts
@@ -5,27 +5,22 @@ import { type Protocol, protocol } from 'electron';
 
 const currentDir = import.meta.dirname;
 
+const MIME_TYPES_BY_EXTENSION: Record<string, string> = {
+  '.js': 'application/javascript',
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.svg': 'image/svg+xml',
+  '.svgz': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.json': 'application/json',
+  '.wasm': 'application/wasm',
+};
+
 export function getMimeType(pathName: string): string {
   const extension = path.extname(pathName).toLowerCase();
-
-  if (extension === '.js')
-    return 'application/javascript';
-  else if (extension === '.html')
-    return 'text/html';
-  else if (extension === '.css')
-    return 'text/css';
-  else if (extension === '.svg' || extension === '.svgz')
-    return 'image/svg+xml';
-  else if (extension === '.png')
-    return 'image/png';
-  else if (extension === '.jpg' || extension === '.jpeg')
-    return 'image/jpeg';
-  else if (extension === '.json')
-    return 'application/json';
-  else if (extension === '.wasm')
-    return 'application/wasm';
-
-  return 'application/octet-stream';
+  return MIME_TYPES_BY_EXTENSION[extension] ?? 'application/octet-stream';
 }
 
 export function createProtocol(scheme: string, customProtocol?: Protocol) {

--- a/frontend/app/electron/main/oauth-utils.spec.ts
+++ b/frontend/app/electron/main/oauth-utils.spec.ts
@@ -1,0 +1,75 @@
+import { assert } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { parseToken } from './oauth-utils';
+
+const BASE = 'rotki://auth';
+
+describe('parseToken', () => {
+  it('should parse a success callback with all parameters', () => {
+    const result = parseToken(`${BASE}/success?access_token=abc&refresh_token=ref&service=google&expires_in=3600`);
+    assert(result.success);
+    expect(result).toStrictEqual({
+      success: true,
+      service: 'google',
+      accessToken: 'abc',
+      refreshToken: 'ref',
+      expiresIn: 3600,
+    });
+  });
+
+  it('should default service to google and leave optionals undefined on a minimal success', () => {
+    const result = parseToken(`${BASE}/success?access_token=abc`);
+    assert(result.success);
+    expect(result.service).toBe('google');
+    expect(result.refreshToken).toBeUndefined();
+    expect(result.expiresIn).toBeUndefined();
+  });
+
+  it('should treat a non-numeric expires_in as undefined', () => {
+    const result = parseToken(`${BASE}/success?access_token=abc&expires_in=not-a-number`);
+    assert(result.success);
+    expect(result.expiresIn).toBeUndefined();
+  });
+
+  it('should return a failure when the success callback has no access_token', () => {
+    const result = parseToken(`${BASE}/success?service=dropbox`);
+    assert(!result.success);
+    expect(result.service).toBe('dropbox');
+    expect(result.error.message).toBe('Failed to parse OAuth callback URL. missing access_token');
+  });
+
+  it('should default service to unknown when access_token and service are both missing', () => {
+    const result = parseToken(`${BASE}/success`);
+    assert(!result.success);
+    expect(result.service).toBe('unknown');
+  });
+
+  it('should parse a failure callback with an error message', () => {
+    const result = parseToken(`${BASE}/failure?error=access_denied&service=google`);
+    assert(!result.success);
+    expect(result.service).toBe('google');
+    expect(result.error.message).toBe('access_denied');
+  });
+
+  it('should fall back to invalid-path when a failure callback has no error', () => {
+    const url = `${BASE}/failure`;
+    const result = parseToken(url);
+    assert(!result.success);
+    expect(result.service).toBe('unknown');
+    expect(result.error.message).toBe(`Invalid path in OAuth callback URL: ${url}`);
+  });
+
+  it('should return invalid-path for an unrecognized pathname', () => {
+    const url = `${BASE}/whatever?access_token=abc`;
+    const result = parseToken(url);
+    assert(!result.success);
+    expect(result.error.message).toBe(`Invalid path in OAuth callback URL: ${url}`);
+  });
+
+  it('should return a parse failure for a malformed URL', () => {
+    const result = parseToken('::: not a url :::');
+    assert(!result.success);
+    expect(result.service).toBe('unknown');
+    expect(result.error.message).toMatch(/^Failed to parse OAuth callback URL:/);
+  });
+});

--- a/frontend/app/electron/main/oauth-utils.ts
+++ b/frontend/app/electron/main/oauth-utils.ts
@@ -1,44 +1,52 @@
 import type { OAuthResult } from '@shared/ipc';
 
+function parseSuccessCallback(callbackUrl: URL): OAuthResult {
+  const accessToken = callbackUrl.searchParams.get('access_token');
+  if (!accessToken) {
+    return {
+      success: false,
+      service: callbackUrl.searchParams.get('service') ?? 'unknown',
+      error: new Error('Failed to parse OAuth callback URL. missing access_token'),
+    };
+  }
+
+  const refreshToken = callbackUrl.searchParams.get('refresh_token') ?? undefined;
+  const service = callbackUrl.searchParams.get('service') ?? 'google';
+  const expiresInRaw = callbackUrl.searchParams.get('expires_in');
+  const expiresIn = expiresInRaw ? Number.parseInt(expiresInRaw, 10) : undefined;
+  return {
+    success: true,
+    service,
+    accessToken,
+    refreshToken,
+    expiresIn: Number.isNaN(expiresIn) ? undefined : expiresIn,
+  };
+}
+
+function parseFailureCallback(callbackUrl: URL): OAuthResult | undefined {
+  const errorMessage = callbackUrl.searchParams.get('error');
+  if (!errorMessage)
+    return undefined;
+
+  return {
+    success: false,
+    service: callbackUrl.searchParams.get('service') ?? 'unknown',
+    error: new Error(errorMessage),
+  };
+}
+
 export function parseToken(oAuthUrl: string): OAuthResult {
   // Parse the OAuth callback URL
   try {
     const callbackUrl = new URL(oAuthUrl);
 
-    if (callbackUrl.pathname === '/success') {
-      const accessToken = callbackUrl.searchParams.get('access_token');
-      if (accessToken) {
-        const refreshToken = callbackUrl.searchParams.get('refresh_token') ?? undefined;
-        const service = callbackUrl.searchParams.get('service') ?? 'google';
-        const expiresInRaw = callbackUrl.searchParams.get('expires_in');
-        const expiresIn = expiresInRaw ? Number.parseInt(expiresInRaw, 10) : undefined;
-        return {
-          success: true,
-          service,
-          accessToken,
-          refreshToken,
-          expiresIn: Number.isNaN(expiresIn) ? undefined : expiresIn,
-        };
-      }
-      else {
-        const service = callbackUrl.searchParams.get('service') ?? 'unknown';
-        return {
-          success: false,
-          service,
-          error: new Error('Failed to parse OAuth callback URL. missing access_token'),
-        };
-      }
-    }
-    else if (callbackUrl.pathname === '/failure') {
-      const errorMessage = callbackUrl.searchParams.get('error');
-      if (errorMessage) {
-        const service = callbackUrl.searchParams.get('service') ?? 'unknown';
-        return {
-          success: false,
-          service,
-          error: new Error(errorMessage),
-        };
-      }
+    if (callbackUrl.pathname === '/success')
+      return parseSuccessCallback(callbackUrl);
+
+    if (callbackUrl.pathname === '/failure') {
+      const failure = parseFailureCallback(callbackUrl);
+      if (failure)
+        return failure;
     }
   }
   catch (parseError: any) {

--- a/frontend/app/tests/e2e/rpc-mock/balance-scanner.ts
+++ b/frontend/app/tests/e2e/rpc-mock/balance-scanner.ts
@@ -57,17 +57,20 @@ export interface BalanceMaps {
  * Checks whether an eth_call targets a given contract address.
  */
 function isCallTo(params: unknown[] | undefined, address: string): boolean {
-  if (!params || !params[0])
+  const call = params?.[0];
+  if (typeof call !== 'object' || call === null || !('to' in call) || typeof call.to !== 'string')
     return false;
-  const call = params[0] as { to?: string };
-  return call.to?.toLowerCase() === address.toLowerCase();
+  return call.to.toLowerCase() === address.toLowerCase();
 }
 
 /**
  * Gets the calldata hex string from eth_call params.
  */
 function getCalldata(params: unknown[]): string {
-  return (params[0] as { data: string }).data;
+  const call = params[0];
+  if (typeof call === 'object' && call !== null && 'data' in call && typeof call.data === 'string')
+    return call.data;
+  return '0x';
 }
 
 /**
@@ -107,44 +110,73 @@ function hasBalanceScannerSubCalls(calldata: string): boolean {
  * parsing. At resolve time we always return success with the correct
  * balances — this is more deterministic than replaying transient errors.
  */
-export function buildBalanceMaps(cassette: Record<string, { method: string; params?: unknown[]; result?: unknown; error?: unknown }>): BalanceMaps {
-  const tokenBalances: TokenBalanceMap = new Map();
-  const etherBalances: EtherBalanceMap = new Map();
-  const subCallResults: SubCallResultMap = new Map();
-  let blockNumber = 0n;
+interface CassetteEntry {
+  method: string;
+  params?: unknown[];
+  result?: unknown;
+  error?: unknown;
+}
+
+interface ParseTargets {
+  tokenBalances: TokenBalanceMap;
+  etherBalances: EtherBalanceMap;
+  subCallResults: SubCallResultMap;
+}
+
+/**
+ * Parses a single cassette entry into the balance maps. Returns the aggregate
+ * block number when the entry is a multicall with balance-scanner sub-calls,
+ * otherwise `undefined`.
+ */
+function parseCassetteEntry(entry: CassetteEntry, targets: ParseTargets): bigint | undefined {
+  if (entry.method !== 'eth_call' || !entry.params || !isHex(entry.result))
+    return undefined;
+
+  const result = entry.result;
+  const calldata = getCalldata(entry.params);
+  const selector = getSelector(calldata);
+
+  if (isCallTo(entry.params, BALANCE_SCANNER)) {
+    if (selector === SEL_TOKENS_BALANCE)
+      parseTokensBalance(calldata, result, targets.tokenBalances);
+    else if (selector === SEL_ETHER_BALANCES)
+      parseEtherBalances(calldata, result, targets.etherBalances);
+    return undefined;
+  }
+
+  if (isCallTo(entry.params, MULTICALL) && selector === SEL_AGGREGATE) {
+    const aggBlockNumber = parseAggregate(calldata, result, targets.tokenBalances, targets.etherBalances, targets.subCallResults);
+    if (hasBalanceScannerSubCalls(calldata))
+      return aggBlockNumber;
+  }
+
+  return undefined;
+}
+
+function findBlockNumber(cassette: Record<string, CassetteEntry>): bigint {
+  for (const entry of Object.values(cassette)) {
+    if (entry.method === 'eth_blockNumber' && typeof entry.result === 'string')
+      return BigInt(entry.result);
+  }
+  return 0n;
+}
+
+export function buildBalanceMaps(cassette: Record<string, CassetteEntry>): BalanceMaps {
+  const targets: ParseTargets = {
+    tokenBalances: new Map(),
+    etherBalances: new Map(),
+    subCallResults: new Map(),
+  };
   let aggregateBlockNumber = 0n;
 
   for (const entry of Object.values(cassette)) {
-    if (entry.method !== 'eth_call' || !entry.params || !isHex(entry.result))
-      continue;
-
-    const result = entry.result;
-    const calldata = getCalldata(entry.params);
-    const selector = getSelector(calldata);
-
-    if (isCallTo(entry.params, BALANCE_SCANNER)) {
-      if (selector === SEL_TOKENS_BALANCE) {
-        parseTokensBalance(calldata, result, tokenBalances);
-      }
-      else if (selector === SEL_ETHER_BALANCES) {
-        parseEtherBalances(calldata, result, etherBalances);
-      }
-    }
-    else if (isCallTo(entry.params, MULTICALL) && selector === SEL_AGGREGATE) {
-      const aggBlockNumber = parseAggregate(calldata, result, tokenBalances, etherBalances, subCallResults);
-      if (hasBalanceScannerSubCalls(calldata)) {
-        aggregateBlockNumber = aggBlockNumber;
-      }
-    }
+    const aggBlockNumber = parseCassetteEntry(entry, targets);
+    if (aggBlockNumber !== undefined)
+      aggregateBlockNumber = aggBlockNumber;
   }
 
-  // Try to get block number from eth_blockNumber entry
-  for (const entry of Object.values(cassette)) {
-    if (entry.method === 'eth_blockNumber' && entry.result) {
-      blockNumber = BigInt(entry.result as string);
-      break;
-    }
-  }
+  const { tokenBalances, etherBalances, subCallResults } = targets;
+  const blockNumber = findBlockNumber(cassette);
 
   logger.info(`Built balance maps: ${countTokenEntries(tokenBalances)} token balances, ${etherBalances.size} ether balances, ${subCallResults.size} sub-call results`);
   return { tokenBalances, etherBalances, subCallResults, blockNumber, aggregateBlockNumber };

--- a/frontend/app/tests/e2e/rpc-mock/server.ts
+++ b/frontend/app/tests/e2e/rpc-mock/server.ts
@@ -10,7 +10,7 @@ import { type BalanceMaps, buildBalanceMaps, tryResolveBalanceCall } from './bal
 const logger = createConsola({ defaults: { tag: 'mock-rpc' } });
 
 const PORT = Number(process.env.MOCK_RPC_PORT) || 30304;
-const MODE = (process.env.MOCK_RPC_MODE || 'replay') as 'record' | 'replay';
+const MODE: 'record' | 'replay' = process.env.MOCK_RPC_MODE === 'record' ? 'record' : 'replay';
 const TARGET_URL = process.env.MOCK_RPC_TARGET || '';
 const CASSETTE_DIR = path.resolve(import.meta.dirname, '..', 'cassettes', 'rpc');
 
@@ -141,7 +141,7 @@ async function forwardRequest(rpcRequest: JsonRpcRequest): Promise<ForwardResult
 
     if (response.ok) {
       try {
-        const parsed = JSON.parse(text) as { result?: unknown; error?: unknown };
+        const parsed: { result?: unknown; error?: unknown } = JSON.parse(text);
         return { body: text, result: parsed.result, error: parsed.error };
       }
       catch {
@@ -191,43 +191,40 @@ function buildResponseBody(id: number | string, fields: Record<string, unknown>)
   return JSON.stringify({ jsonrpc: '2.0', id, ...fields });
 }
 
-async function handleSingleRequest(req: JsonRpcRequest): Promise<string> {
-  const hash = hashRequest(req.method, req.params);
-
-  if (MODE === 'replay') {
-    // Try semantic balance scanner resolution first (order-independent)
-    if (balanceMaps) {
-      const resolved = tryResolveBalanceCall(req.method, req.params, balanceMaps);
-      if (resolved !== null) {
-        logger.debug(`BALANCE HIT: ${req.method}`);
-        return buildResponseBody(req.id, { result: resolved });
-      }
+function handleReplayRequest(req: JsonRpcRequest, hash: string): string {
+  // Try semantic balance scanner resolution first (order-independent)
+  if (balanceMaps) {
+    const resolved = tryResolveBalanceCall(req.method, req.params, balanceMaps);
+    if (resolved !== null) {
+      logger.debug(`BALANCE HIT: ${req.method}`);
+      return buildResponseBody(req.id, { result: resolved });
     }
+  }
 
-    const entry = cassette[hash];
-    if (entry) {
-      logger.debug(`HIT: ${req.method} (hash: ${hash})`);
-      if (entry.body !== undefined) {
-        return patchResponseId(entry.body, req.id);
-      }
-      // Legacy cassette entries without the raw body — reconstruct from
-      // parsed result/error. May lose precision on huge integers.
-      return buildResponseBody(req.id, {
-        ...(entry.result !== undefined && { result: entry.result }),
-        ...(entry.error !== undefined && { error: entry.error }),
-      });
+  const entry = cassette[hash];
+  if (entry) {
+    logger.debug(`HIT: ${req.method} (hash: ${hash})`);
+    if (entry.body !== undefined) {
+      return patchResponseId(entry.body, req.id);
     }
-
-    logger.warn(`MISS: ${req.method} (hash: ${hash}) params: ${JSON.stringify(req.params).slice(0, 200)}`);
+    // Legacy cassette entries without the raw body — reconstruct from
+    // parsed result/error. May lose precision on huge integers.
     return buildResponseBody(req.id, {
-      error: {
-        code: -32603,
-        message: `No recorded response for ${req.method} (hash: ${hash})`,
-      },
+      ...(entry.result !== undefined && { result: entry.result }),
+      ...(entry.error !== undefined && { error: entry.error }),
     });
   }
 
-  // Record mode
+  logger.warn(`MISS: ${req.method} (hash: ${hash}) params: ${JSON.stringify(req.params).slice(0, 200)}`);
+  return buildResponseBody(req.id, {
+    error: {
+      code: -32603,
+      message: `No recorded response for ${req.method} (hash: ${hash})`,
+    },
+  });
+}
+
+async function handleRecordRequest(req: JsonRpcRequest, hash: string): Promise<string> {
   logger.info(`RECORD: ${req.method} (hash: ${hash})`);
   const { body, result, error, transient } = await forwardRequest(req);
 
@@ -250,6 +247,11 @@ async function handleSingleRequest(req: JsonRpcRequest): Promise<string> {
     ...(result !== undefined && { result }),
     ...(error !== undefined && { error }),
   });
+}
+
+async function handleSingleRequest(req: JsonRpcRequest): Promise<string> {
+  const hash = hashRequest(req.method, req.params);
+  return MODE === 'replay' ? handleReplayRequest(req, hash) : handleRecordRequest(req, hash);
 }
 
 async function readBody(req: IncomingMessage): Promise<string> {
@@ -280,24 +282,28 @@ const server = createServer((req: IncomingMessage, res: ServerResponse) => {
   });
 });
 
-async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+/**
+ * Handles the server's control endpoints (health/cassette/save/stats).
+ * Returns `true` when the request was one of them and a response was sent.
+ */
+async function handleControlEndpoint(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
   // Health check endpoint for Playwright
   if (req.url === '/health') {
     sendJson(res, 200, { status: 'ok', mode: MODE, cassette: cassetteName, entries: Object.keys(cassette).length });
-    return;
+    return true;
   }
 
   // Switch cassette: POST /cassette { name: "blockchain-balances" }
   if (req.url === '/cassette' && req.method === 'POST') {
-    const body = JSON.parse(await readBody(req)) as { name?: string };
+    const body: { name?: string } = JSON.parse(await readBody(req));
     const name = body.name;
     if (!name) {
       sendJson(res, 400, { error: 'Missing "name" in request body' });
-      return;
+      return true;
     }
     switchCassette(name);
     sendJson(res, 200, { cassette: cassetteName, entries: Object.keys(cassette).length });
-    return;
+    return true;
   }
 
   // Save current cassette: POST /save
@@ -307,7 +313,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       dirty = false;
     }
     sendJson(res, 200, { saved: true, cassette: cassetteName, entries: Object.keys(cassette).length });
-    return;
+    return true;
   }
 
   // Stats endpoint
@@ -319,10 +325,13 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       dirty,
       cassetteFile: getCassettePath(),
     });
-    return;
+    return true;
   }
 
-  // Handle JSON-RPC requests
+  return false;
+}
+
+async function handleJsonRpc(req: IncomingMessage, res: ServerResponse): Promise<void> {
   if (req.method !== 'POST') {
     logger.debug(`Non-POST request: ${req.method} ${req.url}`);
     sendJson(res, 405, { error: 'Method not allowed' });
@@ -333,7 +342,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
 
   try {
     const body = await readBody(req);
-    const parsed = JSON.parse(body);
+    const parsed: JsonRpcRequest | JsonRpcRequest[] = JSON.parse(body);
 
     // Handle batch requests
     if (Array.isArray(parsed)) {
@@ -343,7 +352,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       sendRaw(res, 200, `[${bodies.join(',')}]`);
     }
     else {
-      const body = await handleSingleRequest(parsed as JsonRpcRequest);
+      const body = await handleSingleRequest(parsed);
       sendRaw(res, 200, body);
     }
   }
@@ -355,6 +364,13 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
       error: { code: -32603, message: `Internal error: ${String(error)}` },
     });
   }
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (await handleControlEndpoint(req, res))
+    return;
+
+  await handleJsonRpc(req, res);
 }
 
 // Save cassette on shutdown

--- a/frontend/scripts/dev/services.ts
+++ b/frontend/scripts/dev/services.ts
@@ -41,15 +41,16 @@ export interface BackendSpawnOptions {
   profilingCmd?: string;
 }
 
-async function startPythonBackend(opts: BackendSpawnOptions): Promise<number> {
-  const chosenPort = opts.strictPort ? opts.webPort : await selectPort(opts.webPort);
-  logger.info(`Starting python backend on port ${formatPort(chosenPort)}`);
-  const pythonInterpreterArgs = process.env.ROTKI_GIL === 'false' ? ['-X', 'gil=0'] : [];
+function resolvePythonPrefix(opts: BackendSpawnOptions, pythonInterpreterArgs: string[]): string[] {
+  const profilingArgs = opts.profilingArgs?.split(' ') ?? [];
+  return opts.profilingCmd
+    ? [...profilingArgs, 'python', ...pythonInterpreterArgs]
+    : [...pythonInterpreterArgs, ...profilingArgs];
+}
 
-  const args = [
-    ...(opts.profilingCmd
-      ? [...(opts.profilingArgs?.split(' ') ?? []), 'python', ...pythonInterpreterArgs]
-      : [...pythonInterpreterArgs, ...(opts.profilingArgs?.split(' ') ?? [])]),
+function buildBackendArgs(opts: BackendSpawnOptions, chosenPort: number, pythonInterpreterArgs: string[]): string[] {
+  return [
+    ...resolvePythonPrefix(opts, pythonInterpreterArgs),
     '-m',
     'rotkehlchen',
     '--rest-api-port',
@@ -60,6 +61,14 @@ async function startPythonBackend(opts: BackendSpawnOptions): Promise<number> {
     `${path.join(opts.logDir, 'backend.log')}`,
     ...(opts.dataDir ? ['--data-dir', opts.dataDir] : []),
   ];
+}
+
+async function startPythonBackend(opts: BackendSpawnOptions): Promise<number> {
+  const chosenPort = opts.strictPort ? opts.webPort : await selectPort(opts.webPort);
+  logger.info(`Starting python backend on port ${formatPort(chosenPort)}`);
+  const pythonInterpreterArgs = process.env.ROTKI_GIL === 'false' ? ['-X', 'gil=0'] : [];
+
+  const args = buildBackendArgs(opts, chosenPort, pythonInterpreterArgs);
 
   // `uv run --locked` honours uv.lock and errors if it's out of date,
   // matching `cargo run --locked` semantics — no silent dep drift in dev.


### PR DESCRIPTION
## Summary

Clears the **8 non-production `complexity` warnings** (e2e mock infra, a dev script, and Electron main-process code) by extracting focused helpers, and backfills the previously-missing unit tests for the Electron files. Behaviour is preserved throughout; the tests pin the current behaviour so they guard the refactors.

## What changed

**e2e rpc-mock + dev script (4 warnings)** — structure-only, no unit specs (Playwright infra):
- `balance-scanner.ts`: split `buildBalanceMaps` into `parseCassetteEntry` + `findBlockNumber`.
- `rpc-mock server.ts`: split `handleSingleRequest` into replay/record helpers and `handleRequest` into control-endpoint + json-rpc helpers.
- `scripts/dev/services.ts`: extract `buildBackendArgs`/`resolvePythonPrefix` out of `startPythonBackend`.
- Bonus while in these files: removed all pre-existing type assertions (`typeof`/`in` guards, typed `JSON.parse` declarations, a ternary for the env mode). `getCalldata` now falls back to `'0x'` on malformed params instead of a lying cast.

**Electron main process (4 warnings) + 35 new unit tests** (these files had no coverage before):
- `oauth-utils.ts`: split `parseToken` into success/failure parsers — 9 tests.
- `create-protocol.ts`: replace the `getMimeType` if-chain with a lookup map — 14 tests.
- `config.ts`: extract per-key application out of `loadConfig` — 6 tests (fs mocked).
- `address-import-server.ts`: extract content-length / base-path / page-serving / routing helpers from `handleRequests` — 6 tests driving the real HTTP server on an ephemeral port (node env).

## Testing

- `pnpm run lint`: 0 errors / 0 warnings on all touched files (complexity threshold is 10).
- `pnpm run typecheck`: clean.
- 35 new Electron unit tests pass.
