### PR TITLE
fix(pinned): keep rail below the notifications drawer

### DIFF
--- a/frontend/app/src/modules/shell/components/navigation/PinnedSidebar.vue
+++ b/frontend/app/src/modules/shell/components/navigation/PinnedSidebar.vue
@@ -82,7 +82,7 @@ function collapse(): void {
     :temporary="isLgAndDown"
     :width="widthPx"
     position="right"
-    class="border-l border-rui-grey-300 dark:border-rui-grey-800 z-[6]"
+    class="border-l border-rui-grey-300 dark:border-rui-grey-800 !z-[6]"
     :class="{ '!transition-none': dragging }"
   >
     <div class="relative h-full">


### PR DESCRIPTION
## Problem

When the pinned rail is visible, opening the notifications drawer does nothing visible: the drawer is rendered but hidden behind the pinned rail.

## Root cause

Both panels are `RuiNavigationDrawer` with `position="right"`, teleported to `<body>`, and mounted together in `AppSidebars.vue`. The pinned rail sets `z-[6]` on its class to sit *below* the temporary sidebars, but `RuiNavigationDrawer` builds its aside class as `[variant, ...fallthrough]` (the `overlay=false` variant contributes `z-[7]`) with no `twMerge`. So the rail element carries **both** `z-[7]` and `z-[6]`, and `z-[7]` wins the cascade, leaving the rail at effective z-7, tied with the notification drawer.

At an equal z-index, paint order follows DOM order. `NotificationSidebar` is declared before `PinnedSidebar`, so it is teleported into `<body>` first and the later-mounted rail paints over it. Notes and Help are declared *after* the rail, so they were unaffected, which is why only notifications broke.

## Fix

`z-[6]` → `!z-[6]` so the important modifier actually demotes the rail below the temporary sidebars. Verified against the compiled CSS: the rail now resolves to z-index 6 and the notification drawer (z-7) renders above it regardless of DOM order.