### PR TITLE
fix: decode direct portal ETH deposits on OP L2s

### DIFF
--- a/rotkehlchen/chain/arbitrum_one/decoding/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/decoding/decoder.py
@@ -59,7 +59,8 @@ class ArbitrumOneTransactionDecoder(EVMTransactionDecoder):
             self,
             transaction: ArbitrumOneTransaction,  # type: ignore[override]
     ) -> list[tuple[int, Callable]]:
-        return self.transaction_type_mappings.get(transaction.tx_type, [])
+        # return a copy since the caller extends and sorts the returned list
+        return list(self.transaction_type_mappings.get(transaction.tx_type, []))
 
     def _chain_specific_decoder_initialization(
             self,

--- a/rotkehlchen/chain/evm/decoding/superchain_bridge/l2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/superchain_bridge/l2/decoder.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any, Final
 
 from rotkehlchen.assets.asset import Asset, EvmToken
 from rotkehlchen.assets.utils import asset_normalized_value
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,
     DecoderContext,
@@ -13,29 +13,36 @@ from rotkehlchen.chain.evm.decoding.structures import (
 )
 from rotkehlchen.chain.evm.decoding.superchain_bridge.utils import get_messenger_transfer_id
 from rotkehlchen.chain.evm.decoding.utils import bridge_match_transfer, bridge_prepare_data
+from rotkehlchen.chain.evm.l2_with_l1_fees.decoding.interfaces import L2WithL1FeesDecoderInterface
 from rotkehlchen.constants.resolver import evm_address_to_identifier
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, TokenKind
-from rotkehlchen.utils.misc import bytes_to_address
+from rotkehlchen.utils.misc import bytes_to_address, from_wei
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from rotkehlchen.chain.decoding.types import CounterpartyDetails
     from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
+    from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2WithL1FeesTransaction
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
+    from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
+    from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.user_messages import MessagesAggregator
 
 
 DEPOSIT_FINALIZED: Final = b'\xb0DE#&\x87\x17\xa0&\x98\xbeG\xd0\x80:\xa7F\x8c\x00\xac\xbe\xd2\xf8\xbd\x93\xa0E\x9c\xdea\xdd\x89'  # noqa: E501
 WITHDRAWAL_INITIATED: Final = b"s\xd1p\x91\n\xba\x9emP\xb1\x02\xdbR+\x1d\xbc\xd7\x96!oQ(\xb4E\xaa!5'(\x86I~"  # noqa: E501
+DEPOSIT_TX_TYPE: Final = 126  # 0x7e. The system transaction relaying an L1 deposit on OP stack chains  # noqa: E501
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 
-class SuperchainL2SideBridgeCommonDecoder(EvmDecoderInterface, ABC):
+class SuperchainL2SideBridgeCommonDecoder(L2WithL1FeesDecoderInterface, ABC):
     def __init__(
             self,
             evm_inquirer: EvmNodeInquirer,
@@ -140,7 +147,68 @@ class SuperchainL2SideBridgeCommonDecoder(EvmDecoderInterface, ABC):
 
         return DEFAULT_EVM_DECODING_OUTPUT
 
+    def _decode_deposit_transaction(
+            self,
+            transaction: L2WithL1FeesTransaction,
+            decoded_events: list[EvmEvent],
+            all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+    ) -> list[EvmEvent]:
+        """Decode ETH bridged from L1 by depositing directly to the OptimismPortal.
+
+        The portal mints the deposited ETH on the L2 via a system deposit transaction
+        that emits no logs, so the bridging can only be recognized by the transaction
+        type. The mint has already been decoded as a plain ETH transfer (a transaction
+        to self when bridging to the depositing address), so find that event and turn
+        it into a bridge event. Deposit transactions pay no L2 fees and their input
+        data is just the deposit's extra data, so also remove the zero gas and message
+        events decoded from them.
+        """
+        if transaction.value == 0:
+            return decoded_events  # not an ETH mint. Deposits relayed via the messenger contracts are decoded by their logs  # noqa: E501
+
+        amount = from_wei(FVal(transaction.value))
+        for event in decoded_events:
+            if (
+                    event.event_type in (HistoryEventType.TRANSACTION_TO_SELF, HistoryEventType.RECEIVE) and  # noqa: E501
+                    event.event_subtype == HistoryEventSubType.NONE and
+                    event.location_label == transaction.to_address and
+                    event.asset == (native_token := self.node_inquirer.native_token) and
+                    event.amount == amount
+            ):
+                bridge_match_transfer(
+                    event=event,
+                    from_address=transaction.from_address,
+                    to_address=transaction.to_address,  # type: ignore[arg-type]  # matching location_label above guarantees to_address is not None
+                    from_chain=ChainID.ETHEREUM,
+                    to_chain=self.node_inquirer.chain_id,
+                    amount=amount,
+                    asset=native_token,
+                    expected_event_type=HistoryEventType.RECEIVE,
+                    new_event_type=HistoryEventType.WITHDRAWAL,
+                    counterparty=self.counterparty,
+                )
+                break
+        else:
+            return decoded_events  # no tracked ETH transfer was decoded for this deposit transaction  # noqa: E501
+
+        return [
+            event for event in decoded_events
+            if not (
+                (event.event_subtype == HistoryEventSubType.FEE and event.counterparty == CPT_GAS) or  # noqa: E501
+                event.event_subtype == HistoryEventSubType.MESSAGE
+            )
+        ]
+
     # -- DecoderInterface methods
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return dict.fromkeys(self.bride_addresses, (self._decode_receive_or_deposit,))
+
+    # -- L2WithL1FeesDecoderInterface methods
+
+    def decoding_by_tx_type(self) -> dict[int, list[tuple[int, Callable]]]:
+        return {
+            DEPOSIT_TX_TYPE: [
+                (0, self._decode_deposit_transaction),  # these transactions contain no logs so we can only run a decoder as a post decoding rule  # noqa: E501
+            ],
+        }

--- a/rotkehlchen/chain/evm/l2_with_l1_fees/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/l2_with_l1_fees/decoding/decoder.py
@@ -1,17 +1,22 @@
 import logging
 from abc import ABC
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from rotkehlchen.chain.evm.decoding.decoder import EventDecoderFunction, EVMTransactionDecoder
+from rotkehlchen.chain.evm.l2_with_l1_fees.decoding.interfaces import L2WithL1FeesDecoderInterface
 from rotkehlchen.db.l2withl1feestx import DBL2WithL1FeesTx
 from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.utils.misc import from_wei
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rotkehlchen.assets.asset import AssetWithOracles
     from rotkehlchen.chain.decoding.types import CounterpartyDetails
     from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
+    from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
     from rotkehlchen.chain.evm.l2_with_l1_fees.transactions import L2WithL1FeesTransactions
     from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2WithL1FeesTransaction
     from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
@@ -41,6 +46,7 @@ class L2WithL1FeesTransactionDecoder(EVMTransactionDecoder, ABC):
             dbevmtx_class: type[DBL2WithL1FeesTx] = DBL2WithL1FeesTx,
             monerium: Monerium | None = None,
     ):
+        self.transaction_type_mappings: dict[int, list[tuple[int, Callable]]] = defaultdict(list)
         super().__init__(
             database=database,
             evm_inquirer=node_inquirer,
@@ -56,3 +62,22 @@ class L2WithL1FeesTransactionDecoder(EVMTransactionDecoder, ABC):
 
     def _calculate_fees(self, tx: L2WithL1FeesTransaction) -> FVal:  # type: ignore[override]
         return from_wei(FVal(tx.gas_used * tx.gas_price + tx.l1_fee))
+
+    def _chain_specific_post_decoding_rules(
+            self,
+            transaction: L2WithL1FeesTransaction,  # type: ignore[override]
+    ) -> list[tuple[int, Callable]]:
+        # return a copy since the caller extends and sorts the returned list
+        return list(self.transaction_type_mappings.get(transaction.tx_type, []))
+
+    def _chain_specific_decoder_initialization(
+            self,
+            decoder: EvmDecoderInterface,
+    ) -> None:
+        """Initialize the transaction type mappings"""
+        if not isinstance(decoder, L2WithL1FeesDecoderInterface):
+            return  # not all decoders have tx type specific rules. Some common decoders exist for all chains  # noqa: E501
+
+        txtype_mapping = decoder.decoding_by_tx_type()
+        for txtype, rules in txtype_mapping.items():
+            self.transaction_type_mappings[txtype].extend(rules)

--- a/rotkehlchen/chain/evm/l2_with_l1_fees/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/l2_with_l1_fees/decoding/interfaces.py
@@ -1,0 +1,18 @@
+from abc import ABC
+from typing import TYPE_CHECKING
+
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class L2WithL1FeesDecoderInterface(EvmDecoderInterface, ABC):
+
+    def decoding_by_tx_type(self) -> dict[int, list[tuple[int, Callable]]]:
+        """Subclasses may implement this decoder rule to state that a rule should
+        be run only for specific transaction types.
+
+        It adds the given rules for the transaction type mapping
+        """
+        return {}

--- a/rotkehlchen/chain/evm/l2_with_l1_fees/transactions.py
+++ b/rotkehlchen/chain/evm/l2_with_l1_fees/transactions.py
@@ -85,6 +85,7 @@ class L2WithL1FeesTransactions(EvmTransactions, ABC):
             input_data=transaction.input_data,
             nonce=transaction.nonce,
             l1_fee=transaction.l1_fee,
+            tx_type=transaction.tx_type,
             db_id=tx_id,
             authorization_list=transaction.authorization_list,
         ), tx_receipt

--- a/rotkehlchen/chain/evm/l2_with_l1_fees/types.py
+++ b/rotkehlchen/chain/evm/l2_with_l1_fees/types.py
@@ -24,6 +24,7 @@ L2_CHAINIDS_WITH_L1_FEES: set[L2ChainIdsWithL1FeesType] = set(typing.get_args(L2
 class L2WithL1FeesTransaction(EvmTransaction):  # noqa: PLW1641  # hash implemented by superclass
     """Represent a transaction with an L1 fee. """
     l1_fee: int
+    tx_type: int
 
     def __init__(
             self,
@@ -40,10 +41,12 @@ class L2WithL1FeesTransaction(EvmTransaction):  # noqa: PLW1641  # hash implemen
             input_data: bytes,
             nonce: int,
             l1_fee: int,
+            tx_type: int = 0,
             db_id: int = -1,
             authorization_list: list[EvmTransactionAuthorization] | None = None,
     ):
         self.l1_fee = l1_fee
+        self.tx_type = tx_type
         super().__init__(
             tx_hash=tx_hash,
             chain_id=chain_id,

--- a/rotkehlchen/db/l2withl1feestx.py
+++ b/rotkehlchen/db/l2withl1feestx.py
@@ -24,7 +24,8 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 class DBL2WithL1FeesTx(DBEvmTx):
-    AUTHORIZATION_DATA_START_INDEX: ClassVar[int] = 14
+    # receipt type is included at index 14, shifting auth fields to start at 15
+    AUTHORIZATION_DATA_START_INDEX: ClassVar[int] = 15
 
     def add_transactions(
             self,
@@ -56,9 +57,10 @@ class DBL2WithL1FeesTx(DBEvmTx):
             'SELECT evm_transactions.tx_hash, evm_transactions.chain_id, evm_transactions.timestamp, '  # noqa: E501
             'evm_transactions.block_number, evm_transactions.from_address, evm_transactions.to_address, '  # noqa: E501
             'evm_transactions.value, evm_transactions.gas, evm_transactions.gas_price, evm_transactions.gas_used, '  # noqa: E501
-            'evm_transactions.input_data, evm_transactions.nonce, evm_transactions.identifier, OP.l1_fee, auth.nonce AS auth_nonce, auth.delegated_address '  # noqa: E501
+            'evm_transactions.input_data, evm_transactions.nonce, evm_transactions.identifier, OP.l1_fee, r.type, auth.nonce AS auth_nonce, auth.delegated_address '  # noqa: E501
             'FROM evm_transactions '
             'LEFT JOIN optimism_transactions AS OP ON evm_transactions.identifier=OP.tx_id '
+            'LEFT JOIN evmtx_receipts AS r ON evm_transactions.identifier = r.tx_id '
             'LEFT JOIN evm_transactions_authorizations AS auth ON evm_transactions.identifier = auth.tx_id'  # noqa: E501
         )
 
@@ -80,6 +82,7 @@ class DBL2WithL1FeesTx(DBEvmTx):
             nonce=result[11],
             db_id=result[12],
             l1_fee=0 if result[13] is None else int(result[13]),  # this check is only needed when _build_evm_transaction is called from a code path that does not call assert_tx_data_is_pulled().  # noqa: E501
+            tx_type=0 if result[14] is None else result[14],  # the receipt may not have been pulled yet  # noqa: E501
             authorization_list=None if len(authorization_list_result) == 0 else [
                 EvmTransactionAuthorization(nonce=entry[0], delegated_address=entry[1])
                 for entry in authorization_list_result

--- a/rotkehlchen/serialization/deserialize.py
+++ b/rotkehlchen/serialization/deserialize.py
@@ -787,6 +787,7 @@ def deserialize_evm_transaction(
                 input_data=input_data,
                 nonce=nonce,
                 l1_fee=l1_fee,
+                tx_type=deserialize_int_from_hex_or_int(data.get('type', '0x0'), location='l2 transaction deserialization'),  # noqa: E501
                 authorization_list=authorization_list,
             ), raw_receipt_data
     except KeyError as e:

--- a/rotkehlchen/tests/unit/decoders/test_superchain_bridge.py
+++ b/rotkehlchen/tests/unit/decoders/test_superchain_bridge.py
@@ -676,6 +676,66 @@ def test_receive_eth_ethereum_to_base_bridge(base_inquirer, base_accounts):
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('base_accounts', [['0x7593BDffF57f71ab718184a2E9c9a3dAaa535557']])
+def test_receive_eth_on_base_via_portal_deposit(base_inquirer, base_accounts):
+    """Test decoding the L2 side of bridging ETH deposited directly to the OptimismPortal.
+
+    The ETH is minted on Base via a system deposit transaction (type 126) that emits
+    no logs, so the bridging is only recognized by the transaction type.
+    """
+    tx_hash = deserialize_evm_tx_hash('0x5b97c69211cda5d0ac192302f478a7046da72004438beae14164550e2722d380')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=2,
+        timestamp=TimestampMS(1706432239000),
+        location=Location.BASE,
+        event_type=HistoryEventType.WITHDRAWAL,
+        event_subtype=HistoryEventSubType.BRIDGE,
+        asset=A_ETH,
+        amount=FVal(amount := '38'),
+        location_label=(user_address := base_accounts[0]),
+        notes=f'Bridge {amount} ETH from Ethereum to Base via Base bridge',
+        counterparty=CPT_BASE,
+        address=user_address,
+        extra_data={'bridge': {
+            'from_chain': 1,
+            'to_chain': 8453,
+            'from_address': user_address,
+            'to_address': user_address,
+        }},
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('base_accounts', [['0x22732C901C0C46128b418AE30b7b53FB95D18B38']])
+def test_receive_eth_on_base_via_portal_deposit_to_other_address(base_inquirer, base_accounts):
+    """Test decoding a type 126 deposit transaction minting ETH to a different recipient"""
+    tx_hash = deserialize_evm_tx_hash('0x79f10d432937928fe696434c79374a87b11eb17a75157d617877fef63a14fbf3')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=base_inquirer, tx_hash=tx_hash)
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=TimestampMS(1784064055000),
+        location=Location.BASE,
+        event_type=HistoryEventType.WITHDRAWAL,
+        event_subtype=HistoryEventSubType.BRIDGE,
+        asset=A_ETH,
+        amount=FVal(amount := '8.950285956308752'),
+        location_label=(user_address := base_accounts[0]),
+        notes=f'Bridge {amount} ETH from Ethereum address {(from_address := string_to_evm_address("0x4B34F943181408eac424116Af7b7790C94cba8B6"))} to Base via Base bridge',  # noqa: E501
+        counterparty=CPT_BASE,
+        address=from_address,
+        extra_data={'bridge': {
+            'from_chain': 1,
+            'to_chain': 8453,
+            'from_address': from_address,
+            'to_address': user_address,
+        }},
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('db_settings', LEGACY_TESTS_INDEXER_ORDER)
 @pytest.mark.parametrize('base_accounts', [['0x1218d6396dC67eC0FFBEBDF049C865B83636EddA']])
 def test_receive_erc20_ethereum_to_base_bridge(base_inquirer, base_accounts):


### PR DESCRIPTION
Bridging ETH by depositing directly to the OptimismPortal mints the ETH on Base/Optimism via a system deposit transaction (type 126) that emits no logs, so the L2 side was decoded as a plain transaction to self instead of a bridge event.

Mirror the arbitrum approach to recognize such transactions by type:

- carry tx_type on L2WithL1FeesTransaction, read from the stored receipt type via a JOIN in DBL2WithL1FeesTx and from the RPC data when deserializing
- add L2WithL1FeesDecoderInterface.decoding_by_tx_type() and dispatch it as chain specific post decoding rules in the L2 decoder
- register a type 126 rule in SuperchainL2SideBridgeCommonDecoder that turns the decoded ETH transfer into a bridge event and removes the zero gas and input data message artifacts of the system transaction
- return a copy of the tx type rules in the arbitrum decoder too since the caller extends and sorts the returned list in place, polluting the stored mapping across transactions
