### PR TITLE
fix: search assets on ethereum for zksync lite

### DIFF
--- a/colibri/src/api/assets.rs
+++ b/colibri/src/api/assets.rs
@@ -224,7 +224,15 @@ pub async fn search_assets_levenshtein(
         )
     };
 
-    let filter_chain = payload.evm_chain.as_deref().and_then(ChainID::from_name);
+    let filter_chain = payload.evm_chain.as_deref().and_then(|name| {
+        // Evmlike chains (zksync lite) have no tokens of their own since they
+        // use the L1 tokens, so search as if on ethereum
+        if name == "zksync_lite" {
+            Some(ChainID::Ethereum)
+        } else {
+            ChainID::from_name(name)
+        }
+    });
     let asset_type_db = payload
         .asset_type
         .as_deref()
@@ -704,6 +712,39 @@ mod tests {
         assert!(result
             .iter()
             .any(|entry| entry.get("identifier").and_then(|v| v.as_str()) == Some("ETH2")));
+    }
+
+    #[tokio::test]
+    async fn test_search_assets_evmlike_chain_searches_ethereum() {
+        // Evmlike chains (zksync lite) have no tokens of their own since they use
+        // the L1 tokens, so filtering by them should search as if on ethereum
+        let state = create_test_state().await;
+        normalize_eth_assets(&state).await;
+
+        let (status, body) = call_search(
+            state,
+            AssetsLevenshteinSearch {
+                value: Some("eth".to_string()),
+                evm_chain: Some("zksync_lite".to_string()),
+                asset_type: Some("evm token".to_string()),
+                address: None,
+                limit: 50,
+                search_nfts: false,
+            },
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let result = body.get("result").and_then(|v| v.as_array()).unwrap();
+        // native ETH is included despite the evm token type filter
+        assert!(result
+            .iter()
+            .any(|entry| entry.get("identifier").and_then(|v| v.as_str()) == Some("ETH")));
+        // all token results are ethereum ones
+        assert!(result.iter().all(|entry| entry
+            .get("evm_chain")
+            .and_then(|v| v.as_str())
+            .is_none_or(|chain| chain == "ethereum")));
     }
 
     #[tokio::test]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Searching for zksync lite assets should now show you ethereum mainnet assets and you should be able to easily select relevant assets when adding/editing events.
 * :bug:`-` Omnibridge events containing fee payments will now be properly decoded.
 * :feature:`-` The rotki Docker image is now smaller, shuts down cleanly and immediately on ``docker stop`` instead of risking a forced kill in the middle of a database write, and can be run fully locked down as a read-only, unprivileged container. Internally a single supervisor now starts rotki and colibri, serves the frontend and proxies to them, replacing the previous nginx and Python entrypoint. Your existing setup keeps working unchanged: the published port, the ``/data``, ``/logs`` and ``/config`` volumes and every environment variable behave exactly as before.
 * :bug:`-` The Docker image now ships without a shell, package manager or coreutils (it is built on a distroless base), so there is far less inside it for an attacker to use and the image is smaller. The only thing that changes for you is that ``docker exec <container> sh`` no longer works; inspect a running container with ``docker exec <container> /opt/rotki/starling ctl status`` (also ``health`` and ``restart``) instead.

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -144,6 +144,7 @@ from rotkehlchen.types import (
     EVM_CHAIN_IDS_WITH_TRANSACTIONS,
     EVM_CHAINS_WITH_TRANSACTIONS,
     EVM_EVMLIKE_LOCATIONS,
+    EVMLIKE_CHAIN_NAMES,
     NON_EVM_CHAINS,
     SUPPORTED_SUBSTRATE_CHAINS_TYPE,
     AddressbookEntry,
@@ -2852,6 +2853,18 @@ class AssetsSearchLevenshteinSchema(Schema):
     def __init__(self, db: DBHandler) -> None:
         super().__init__()
         self.db = db
+
+    @pre_load
+    def maybe_replace_evmlike_chain(
+            self,
+            data: dict[str, Any],
+            **_kwargs: Any,
+    ) -> dict[str, Any]:
+        """Evmlike chains (zksync lite) have no tokens of their own since they
+        use the L1 tokens, so search as if on ethereum"""
+        if isinstance(data, dict) and data.get('evm_chain') in EVMLIKE_CHAIN_NAMES:
+            data['evm_chain'] = ChainID.ETHEREUM.to_name()
+        return data
 
     @validates_schema
     def validate_schema(

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -1096,6 +1096,18 @@ def test_search_assets_with_levenshtein(rotkehlchen_api_server: APIServer) -> No
     result = assert_proper_sync_response_with_result(response)
     assert 'ETH' in {x['identifier'] for x in result}
 
+    # check that filtering by an evmlike chain (zksync lite) searches as if on ethereum
+    # since evmlike chains have no tokens of their own
+    response = requests.post(
+        api_url_for(rotkehlchen_api_server, 'assetssearchlevenshteinresource'),
+        json={'value': 'ETH', 'limit': 50, 'evm_chain': 'zksync_lite', 'asset_type': 'evm token'},
+    )
+    result = assert_proper_sync_response_with_result(response)
+    identifiers = {x['identifier'] for x in result}
+    assert 'ETH' in identifiers  # native ETH is included despite the evm token type filter
+    assert 'eip155:1/erc20:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' in identifiers  # WETH
+    assert all(entry.get('evm_chain', 'ethereum') == 'ethereum' for entry in result)
+
 
 def test_search_nfts_with_levenshtein(rotkehlchen_api_server: APIServer) -> None:
     with rotkehlchen_api_server.rest_api.rotkehlchen.data.db.user_write() as cursor:

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -330,6 +330,9 @@ class EvmlikeChain(StrEnum):
     ZKSYNC_LITE = auto()
 
 
+EVMLIKE_CHAIN_NAMES: Final = frozenset(chain.value for chain in EvmlikeChain)
+
+
 class EvmTransactionAuthorization(NamedTuple):
     """EIP-7702 authorization to delegate EOA execution to a contract.
 


### PR DESCRIPTION
Searching for an asset with evm_chain zksync_lite gave bad results since zksync lite is not an evm chain with its own tokens. Colibri, which serves the search for the frontend, silently dropped the unknown chain name from the filter and returned assets from all chains, while the python endpoint rejected the request entirely.

Since evmlike chains (zksync lite) have no tokens of their own and use the L1 tokens, treat filtering by them as filtering by ethereum in both backends:

- colibri: map zksync_lite to the ethereum chain id when resolving the search chain filter
- python: replace evmlike chain names with ethereum in a pre_load hook of the levenshtein search schema, driven by a new EVMLIKE_CHAIN_NAMES constant

With the chain resolving to ethereum the existing native token inclusion also kicks in, so searching ETH with the evm token type filter now returns native ETH as well.