### PR TITLE
Cut complexity in production code (table, history, api, settings)

### DIFF
--- a/frontend/app/src/modules/core/api/rotki-api.spec.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.spec.ts
@@ -460,6 +460,27 @@ describe('modules/api/rotki-api', () => {
       expect(window.location.href).toBe('/#/');
     });
 
+    it('should not call the auth failure handler on 401 when skipAuthHandler is set', async () => {
+      server.use(
+        http.get(`${backendUrl}/api/1/test`, () =>
+          HttpResponse.json(
+            {
+              result: null,
+              message: 'Unauthorized',
+            },
+            { status: HTTPStatus.UNAUTHORIZED },
+          )),
+      );
+
+      const authFailureAction = vi.fn();
+      api.setOnAuthFailure(authFailureAction);
+
+      // Still throws, but the auth-failure handler is skipped
+      await expect(api.get('test', { skipAuthHandler: true })).rejects.toThrow();
+
+      expect(authFailureAction).not.toHaveBeenCalled();
+    });
+
     it('should throw ApiValidationError for 400 status with message', async () => {
       server.use(
         http.get(`${backendUrl}/api/1/test`, () =>
@@ -699,6 +720,20 @@ describe('modules/api/rotki-api', () => {
 
       expect(authFailureAction).toHaveBeenCalled();
       expect(window.location.href).toBe('/#/');
+    });
+
+    it('should throw a generic error for a non-json error response', async () => {
+      server.use(
+        http.get(`${backendUrl}/api/1/download`, () =>
+          new HttpResponse('boom', {
+            status: HTTPStatus.INTERNAL_SERVER_ERROR,
+            headers: {
+              'Content-Type': 'application/octet-stream',
+            },
+          })),
+      );
+
+      await expect(api.fetchBlob('download')).rejects.toThrow('Request failed with status 500');
     });
 
     it('should transform body in blob request', async () => {

--- a/frontend/app/src/modules/core/api/rotki-api.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.ts
@@ -12,7 +12,7 @@ import { createResponseParser, createStatusError, tryParseJson } from '@/modules
 import { queryTransformer } from '@/modules/core/api/transformers';
 import { ApiValidationError } from '@/modules/core/api/types/errors';
 import { HTTPStatus } from '@/modules/core/api/types/http';
-import { VALID_STATUS_CODES } from '@/modules/core/api/utils';
+import { VALID_STATUS_CODES, type ValidStatuses } from '@/modules/core/api/utils';
 import { withRetry } from '@/modules/core/api/with-retry';
 
 export class RotkiApi {
@@ -170,6 +170,61 @@ export class RotkiApi {
     });
   }
 
+  /**
+   * Rejects 401 (after running the auth-failure handler unless skipped) and any
+   * status outside the allowed set, mirroring the raw fetch error handling.
+   */
+  private checkResponseStatus<T>(
+    response: { status: number; _data?: ActionResult<T> },
+    flags: { validStatuses?: ValidStatuses; skipAuthHandler?: boolean },
+  ): void {
+    const status = response.status;
+
+    if (status === HTTPStatus.UNAUTHORIZED) {
+      if (!flags.skipAuthHandler)
+        this.handleAuthFailure();
+
+      throw createStatusError(status, response._data?.message, response._data);
+    }
+
+    const allowedStatuses: readonly number[] = flags.validStatuses ?? VALID_STATUS_CODES;
+    if (!allowedStatuses.includes(status))
+      throw createStatusError(status, response._data?.message, response._data);
+  }
+
+  /**
+   * Unwraps an ActionResult: returns its result, falls back to defaultValue, or
+   * throws (ApiValidationError on 400, plain Error otherwise) when it is an error.
+   */
+  private unwrapResult<T>(data: ActionResult<T> | undefined, status: number, defaultValue?: T): T {
+    if (!data)
+      throw createStatusError(status);
+
+    const { result, message } = data;
+    const isError = result === null || result === undefined || (!result && message);
+
+    if (!isError)
+      return result;
+
+    if (defaultValue !== undefined)
+      return defaultValue;
+
+    if (status === HTTPStatus.BAD_REQUEST)
+      throw new ApiValidationError(message);
+
+    throw new Error(message);
+  }
+
+  /**
+   * The single sanctioned generic-boundary escape. Some options
+   * (`skipResultUnwrap`, `treat409AsSuccess`) intentionally resolve to a value
+   * the wrapper cannot type as `T` — the caller opted into that shape — so this
+   * is the one place that asserts it, keeping the assertion contained.
+   */
+  private asResult<T>(value: unknown): T {
+    return value as T;
+  }
+
   private async fetchDirect<T>(url: string, options: Omit<RotkiFetchOptions<'json', T>, 'skipQueue' | 'priority' | 'tags' | 'dedupe' | 'maxQueueTime' | 'queueRetries'> = {}): Promise<T> {
     const {
       validStatuses,
@@ -200,43 +255,18 @@ export class RotkiApi {
         parseResponse: createResponseParser({ skipCamelCase, skipRootCamelCase }),
       });
 
+      this.checkResponseStatus<T>(response, { validStatuses, skipAuthHandler });
+
       const status = response.status;
-
-      if (status === HTTPStatus.UNAUTHORIZED) {
-        if (!skipAuthHandler)
-          this.handleAuthFailure();
-
-        const responseData = response._data;
-        throw createStatusError(status, responseData?.message, responseData);
-      }
-
-      const allowedStatuses = validStatuses ?? VALID_STATUS_CODES;
-      if (!allowedStatuses.includes(status)) {
-        const responseData = response._data;
-        throw createStatusError(status, responseData?.message, responseData);
-      }
-
       const data = response._data;
 
       if (treat409AsSuccess && status === HTTPStatus.CONFLICT)
-        return true as unknown as T;
+        return this.asResult<T>(true);
 
       if (skipResultUnwrap)
-        return data as unknown as T;
+        return this.asResult<T>(data);
 
-      const { result, message } = data as ActionResult<T>;
-      const isError = result === null || result === undefined || (!result && message);
-
-      if (!isError)
-        return result;
-
-      if (defaultValue !== undefined)
-        return defaultValue;
-
-      if (status === HTTPStatus.BAD_REQUEST)
-        throw new ApiValidationError(message);
-
-      throw new Error(message);
+      return this.unwrapResult<T>(data, status, defaultValue);
     };
 
     if (retry) {
@@ -309,7 +339,7 @@ export class RotkiApi {
     const body = transformRequestBody(fetchOptions.body, { skipSnakeCase });
     const query = transformRequestQuery(fetchOptions.query as Record<string, unknown> | undefined, { skipSnakeCase });
 
-    const response = await ofetch.raw(url, {
+    const response = await ofetch.raw<Blob, 'blob'>(url, {
       method: fetchOptions.method,
       baseURL: fetchOptions.baseURL ?? this._baseURL,
       timeout: fetchOptions.timeout ?? DEFAULT_TIMEOUT,
@@ -320,16 +350,31 @@ export class RotkiApi {
       query,
     });
 
+    const blob = response._data;
+    if (!blob)
+      throw createStatusError(response.status);
+
+    await this.assertBlobSuccess(response, blob, validStatuses);
+    return blob;
+  }
+
+  /**
+   * Validates a blob response: runs the auth-failure handler on 401, surfaces a
+   * JSON error payload as an Error (or TypeError when it cannot be parsed), and
+   * rejects any status outside the allowed set.
+   */
+  private async assertBlobSuccess(
+    response: { status: number; headers: Headers },
+    blob: Blob,
+    validStatuses?: ValidStatuses,
+  ): Promise<void> {
     const status = response.status;
 
     if (status === HTTPStatus.UNAUTHORIZED)
       this.handleAuthFailure();
 
-    const blob = response._data as Blob;
     const contentType = response.headers.get('content-type');
-    const isJsonError = contentType?.includes('application/json');
-
-    if (isJsonError) {
+    if (contentType?.includes('application/json')) {
       const text = await blob.text();
       const json = tryParseJson<ActionResult<unknown>>(text);
       if (json)
@@ -337,11 +382,9 @@ export class RotkiApi {
       throw new TypeError(`Request failed with status ${status}`);
     }
 
-    const allowedStatuses = validStatuses ?? VALID_STATUS_CODES;
+    const allowedStatuses: readonly number[] = validStatuses ?? VALID_STATUS_CODES;
     if (!allowedStatuses.includes(status))
       throw new Error(`Request failed with status ${status}`);
-
-    return blob;
   }
 }
 

--- a/frontend/app/src/modules/core/table/param-sources.spec.ts
+++ b/frontend/app/src/modules/core/table/param-sources.spec.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { FilterBehaviour, type MatchedKeywordWithBehaviour, type SearchMatcher, type StringSuggestionMatcher } from '@/modules/core/table/filtering';
+import { collectSources, mergeParams, type ParamSource, transformFilters } from '@/modules/core/table/param-sources';
+
+type Filters = MatchedKeywordWithBehaviour<string>;
+
+function stringMatcher(overrides: Partial<Omit<StringSuggestionMatcher<string, string>, 'string'>> = {}): SearchMatcher<string, string> {
+  const matcher: StringSuggestionMatcher<string, string> = {
+    behaviourRequired: true,
+    description: 'Type',
+    key: 'type',
+    string: true,
+    suggestions: () => [],
+    validate: () => true,
+    ...overrides,
+  };
+  return matcher;
+}
+
+describe('transformFilters', () => {
+  it('should return the filters unchanged when they are not an object', () => {
+    expect(transformFilters(undefined, [stringMatcher()])).toBeUndefined();
+  });
+
+  it('should return the filters unchanged when there are no matchers', () => {
+    const filters: Filters = { type: 'deposit' };
+    expect(transformFilters(filters, [])).toStrictEqual({ type: 'deposit' });
+  });
+
+  it('should ignore matchers that do not require a behaviour', () => {
+    const filters: Filters = { type: 'deposit' };
+    const result = transformFilters(filters, [stringMatcher({ behaviourRequired: false })]);
+    expect(result).toStrictEqual({ type: 'deposit' });
+  });
+
+  it('should ignore keys that are not present in the filters', () => {
+    const filters: Filters = { location: 'kraken' };
+    const result = transformFilters(filters, [stringMatcher({ key: 'type' })]);
+    expect(result).toStrictEqual({ location: 'kraken' });
+  });
+
+  it('should ignore falsy values', () => {
+    const filters: Filters = { type: '' };
+    const result = transformFilters(filters, [stringMatcher()]);
+    expect(result).toStrictEqual({ type: '' });
+  });
+
+  it('should wrap a plain string value with the INCLUDE behaviour', () => {
+    const filters: Filters = { type: 'deposit' };
+    const result = transformFilters(filters, [stringMatcher()]);
+    expect(result).toStrictEqual({ type: { behaviour: FilterBehaviour.INCLUDE, values: 'deposit' } });
+  });
+
+  it('should wrap a boolean value with the INCLUDE behaviour', () => {
+    const filters: Filters = { type: true };
+    const result = transformFilters(filters, [stringMatcher()]);
+    expect(result).toStrictEqual({ type: { behaviour: FilterBehaviour.INCLUDE, values: true } });
+  });
+
+  it('should use keyValue over key for the lookup', () => {
+    const filters: Filters = { eventTypes: 'deposit' };
+    const result = transformFilters(filters, [stringMatcher({ key: 'type', keyValue: 'eventTypes' })]);
+    expect(result).toStrictEqual({ eventTypes: { behaviour: FilterBehaviour.INCLUDE, values: 'deposit' } });
+  });
+
+  it('should resolve a leading ! on a string to EXCLUDE when exclusion is allowed', () => {
+    const filters: Filters = { type: '!deposit' };
+    const result = transformFilters(filters, [stringMatcher({ allowExclusion: true })]);
+    expect(result).toStrictEqual({ type: { behaviour: FilterBehaviour.EXCLUDE, values: 'deposit' } });
+  });
+
+  it('should keep the ! and use INCLUDE when exclusion is not allowed', () => {
+    const filters: Filters = { type: '!deposit' };
+    const result = transformFilters(filters, [stringMatcher({ allowExclusion: false })]);
+    expect(result).toStrictEqual({ type: { behaviour: FilterBehaviour.INCLUDE, values: '!deposit' } });
+  });
+
+  it('should resolve a leading ! on an array to EXCLUDE and strip every element', () => {
+    const filters: Filters = { type: ['!deposit', '!withdrawal'] };
+    const result = transformFilters(filters, [stringMatcher({ allowExclusion: true })]);
+    expect(result).toStrictEqual({ type: { behaviour: FilterBehaviour.EXCLUDE, values: ['deposit', 'withdrawal'] } });
+  });
+
+  it('should keep an array as INCLUDE when its first element has no !', () => {
+    const filters: Filters = { type: ['deposit', 'withdrawal'] };
+    const result = transformFilters(filters, [stringMatcher({ allowExclusion: true })]);
+    expect(result).toStrictEqual({ type: { behaviour: FilterBehaviour.INCLUDE, values: ['deposit', 'withdrawal'] } });
+  });
+
+  it('should normalize an already-wrapped value, defaulting the behaviour to INCLUDE', () => {
+    const filters: Filters = { type: { values: 'deposit' } };
+    const result = transformFilters(filters, [stringMatcher()]);
+    expect(result).toStrictEqual({ type: { behaviour: FilterBehaviour.INCLUDE, values: 'deposit' } });
+  });
+
+  it('should preserve an explicit behaviour on an already-wrapped value', () => {
+    const filters: Filters = { type: { behaviour: FilterBehaviour.EXCLUDE, values: 'deposit' } };
+    const result = transformFilters(filters, [stringMatcher()]);
+    expect(result).toStrictEqual({ type: { behaviour: FilterBehaviour.EXCLUDE, values: 'deposit' } });
+  });
+
+  it('should transform several matchers independently', () => {
+    const filters: Filters = { location: '!kraken', type: 'deposit' };
+    const result = transformFilters(filters, [
+      stringMatcher({ key: 'type' }),
+      stringMatcher({ allowExclusion: true, key: 'location' }),
+    ]);
+    expect(result).toStrictEqual({
+      location: { behaviour: FilterBehaviour.EXCLUDE, values: 'kraken' },
+      type: { behaviour: FilterBehaviour.INCLUDE, values: 'deposit' },
+    });
+  });
+});
+
+describe('collectSources', () => {
+  function source(overrides: Partial<ParamSource>): ParamSource {
+    return { to: 'both', values: {}, ...overrides };
+  }
+
+  it('should merge only the sources that contribute to the destination', () => {
+    const sources = [
+      source({ to: 'request', values: { a: 1 } }),
+      source({ to: 'url', values: { b: 2 } }),
+      source({ to: 'both', values: { c: 3 } }),
+    ];
+    expect(collectSources(sources, 'request')).toStrictEqual({ a: 1, c: 3 });
+    expect(collectSources(sources, 'url')).toStrictEqual({ b: '2', c: '3' });
+  });
+
+  it('should apply the predicate filter', () => {
+    const sources = [
+      source({ isDefault: true, values: { a: 1 } }),
+      source({ values: { b: 2 } }),
+    ];
+    expect(collectSources(sources, 'request', s => !!s.isDefault)).toStrictEqual({ a: 1 });
+  });
+
+  it('should drop null request values only when skipEmpty is set', () => {
+    expect(collectSources([source({ skipEmpty: true, values: { a: null, b: 2 } })], 'request')).toStrictEqual({ b: 2 });
+    expect(collectSources([source({ values: { a: null, b: 2 } })], 'request')).toStrictEqual({ a: null, b: 2 });
+  });
+});
+
+describe('mergeParams', () => {
+  function source(overrides: Partial<ParamSource>): ParamSource {
+    return { to: 'request', values: {}, ...overrides };
+  }
+
+  it('should let non-default sources win over the filter, and the filter win over defaults', () => {
+    const sources = [
+      source({ isDefault: true, values: { shared: 'default' } }),
+      source({ values: { shared: 'source' } }),
+    ];
+    const merged = mergeParams(sources, 'request', { shared: 'filter', only: 'filter' });
+    expect(merged).toStrictEqual({ only: 'filter', shared: 'source' });
+  });
+
+  it('should let the filter override a default source', () => {
+    const sources = [source({ isDefault: true, values: { shared: 'default' } })];
+    expect(mergeParams(sources, 'request', { shared: 'filter' })).toStrictEqual({ shared: 'filter' });
+  });
+});

--- a/frontend/app/src/modules/core/table/param-sources.ts
+++ b/frontend/app/src/modules/core/table/param-sources.ts
@@ -1,7 +1,9 @@
 import type { MaybeRefOrGetter } from 'vue';
 import type { LocationQuery } from '@/modules/core/table/route';
 import { nonEmptyProperties } from '@/modules/core/common/data/data';
-import { FilterBehaviour, type MatchedKeywordWithBehaviour, type SearchMatcher } from '@/modules/core/table/filtering';
+import { FilterBehaviour, type FilterObjectWithBehaviour, type MatchedKeywordWithBehaviour, type SearchMatcher, type StringSuggestionMatcher } from '@/modules/core/table/filtering';
+
+type FilterValue = string | string[] | boolean | FilterObjectWithBehaviour<string | string[] | boolean>;
 
 /** Where a param source contributes its values. */
 export type ParamDestination = 'request' | 'url' | 'both';
@@ -101,6 +103,51 @@ export function mergeParams(
 }
 
 /**
+ * Resolves a leading `!` into an EXCLUDE behaviour when the matcher allows
+ * exclusion, stripping the `!` from the string or every array element.
+ */
+function resolveExclusion(
+  matcher: StringSuggestionMatcher<string, string>,
+  data: string | string[] | boolean,
+): { exclude: boolean; values: string | string[] | boolean } {
+  if (!matcher.allowExclusion)
+    return { exclude: false, values: data };
+
+  if (typeof data === 'string' && data.startsWith('!'))
+    return { exclude: true, values: data.substring(1) };
+
+  if (Array.isArray(data) && data.length > 0 && data[0].startsWith('!'))
+    return { exclude: true, values: data.map(item => (item.startsWith('!') ? item.substring(1) : item)) };
+
+  return { exclude: false, values: data };
+}
+
+/**
+ * Builds the `{ behaviour, values }` pair for one matcher's value: an
+ * already-wrapped value keeps (or defaults) its behaviour, a plain value is
+ * wrapped and resolved for exclusion. Returns undefined when there is nothing
+ * to rewrite.
+ */
+function toBehaviourValue(
+  matcher: StringSuggestionMatcher<string, string>,
+  data: FilterValue,
+  keyPresent: boolean,
+): FilterObjectWithBehaviour<string | string[] | boolean> | undefined {
+  if (typeof data === 'object' && !Array.isArray(data)) {
+    if (data.values && keyPresent)
+      return { behaviour: data.behaviour ?? FilterBehaviour.INCLUDE, values: data.values };
+
+    return undefined;
+  }
+
+  const { exclude, values } = resolveExclusion(matcher, data);
+  return {
+    behaviour: exclude ? FilterBehaviour.EXCLUDE : FilterBehaviour.INCLUDE,
+    values,
+  };
+}
+
+/**
  * Rewrites plain filter values into `{ behaviour, values }` pairs for matchers that
  * require it, resolving a leading `!` into an EXCLUDE behaviour.
  */
@@ -126,34 +173,9 @@ export function transformFilters<TFilter extends MatchedKeywordWithBehaviour<str
     if (!data)
       return;
 
-    if (typeof data === 'object' && !Array.isArray(data)) {
-      if (data.values && usedKey in newFilters) {
-        newFilters[usedKey] = {
-          behaviour: data.behaviour ?? FilterBehaviour.INCLUDE,
-          values: data.values,
-        };
-      }
-      return;
-    }
-
-    let formattedData: string | string[] | boolean = data;
-    let exclude = false;
-
-    if (matcher.allowExclusion) {
-      if (typeof data === 'string' && data.startsWith('!')) {
-        exclude = true;
-        formattedData = data.substring(1);
-      }
-      else if (Array.isArray(data) && data.length > 0 && data[0].startsWith('!')) {
-        exclude = true;
-        formattedData = data.map(item => (item.startsWith('!') ? item.substring(1) : item));
-      }
-    }
-
-    newFilters[usedKey] = {
-      behaviour: exclude ? FilterBehaviour.EXCLUDE : FilterBehaviour.INCLUDE,
-      values: formattedData,
-    };
+    const value = toBehaviourValue(matcher, data, usedKey in newFilters);
+    if (value !== undefined)
+      newFilters[usedKey] = value;
   });
 
   return newFilters;

--- a/frontend/app/src/modules/history/events/use-history-event-navigation-consumer.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-navigation-consumer.spec.ts
@@ -454,7 +454,7 @@ describe('use-history-event-navigation-consumer', () => {
 
       // Simulate pagination system loading cycle
       set(loading, true);
-      await nextTick();
+      await flushPromises();
       set(loading, false);
       await flushPromises();
 
@@ -547,7 +547,7 @@ describe('use-history-event-navigation-consumer', () => {
         useHistoryEventNavigationConsumer(pagination, undefined, loading);
       });
 
-      await nextTick();
+      await flushPromises();
       // Position is computed within the asset-filtered view.
       expect(mockGetHistoryEventGroupPosition).toHaveBeenCalledWith('group-route', { asset: 'ETH' });
       // The push is deferred until the pagination refetch settles.
@@ -555,7 +555,7 @@ describe('use-history-event-navigation-consumer', () => {
 
       // Simulate the pagination system loading cycle.
       set(loading, true);
-      await nextTick();
+      await flushPromises();
       set(loading, false);
       await flushPromises();
 

--- a/frontend/app/src/modules/history/events/use-history-event-navigation-consumer.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-navigation-consumer.ts
@@ -121,6 +121,83 @@ export function useHistoryEventNavigationConsumer(
     return query;
   }
 
+  /**
+   * Resolve the target group's position within the (possibly asset-filtered)
+   * view, so the computed page matches the filter applied on arrival.
+   */
+  async function resolveGroupPosition(request: HistoryEventNavigationRequest): Promise<number> {
+    const basePayload = request.preserveFilters && requestPayload ? get(requestPayload) : undefined;
+    const filterPayload = request.assetFilter
+      ? { ...basePayload, asset: request.assetFilter }
+      : basePayload;
+    return getHistoryEventGroupPosition(request.targetGroupIdentifier, filterPayload);
+  }
+
+  /**
+   * Pop the next fallback request, carrying any remaining fallbacks forward.
+   * Returns undefined when none are left.
+   */
+  function selectNextRequest(request: HistoryEventNavigationRequest): HistoryEventNavigationRequest | undefined {
+    if (!request.fallbacks?.length)
+      return undefined;
+
+    const [next, ...remaining]: HistoryEventNavigationRequest[] = request.fallbacks;
+    return { ...next, fallbacks: remaining.length > 0 ? remaining : undefined };
+  }
+
+  /**
+   * Wait for the pagination system's loading cycle to complete. The loading may
+   * not have started yet (fetchDebounce), so wait for it to start first.
+   */
+  async function waitForFilterLoad(loading: Ref<boolean>): Promise<void> {
+    if (!get(loading)) {
+      await until(loading).toBe(true, {
+        timeout: HIGHLIGHT_LOADING_START_TIMEOUT,
+        throwOnTimeout: false,
+      });
+    }
+    if (get(loading)) {
+      await until(loading).toBe(false);
+    }
+  }
+
+  /**
+   * Push the highlight route for a resolved position. An asset-filter or
+   * preserveFilters navigation changes a real filter, so it waits for the
+   * pagination refetch to settle first (otherwise the push races the refetch
+   * and the "clear highlights on filter change" watcher wipes the highlight).
+   * Returns false when the request became stale while waiting.
+   */
+  async function pushHighlight(
+    request: HistoryEventNavigationRequest,
+    activeRequest: HistoryEventNavigationRequest,
+    highlightQuery: Record<string, string>,
+  ): Promise<boolean> {
+    if ((request.preserveFilters || request.assetFilter) && groupLoading) {
+      await waitForFilterLoad(groupLoading);
+
+      // Check if this request is still current after waiting
+      if (get(pendingNavigation) !== activeRequest)
+        return false;
+
+      // Route now has the correct filter/limit values from the pagination system
+      await router.push({
+        force: true,
+        name: historyEventsName,
+        query: { ...get(route).query, ...highlightQuery },
+      });
+      return true;
+    }
+
+    const limit = get(pagination).limit;
+    await router.push({
+      force: true,
+      name: historyEventsName,
+      query: { limit: limit.toString(), ...highlightQuery },
+    });
+    return true;
+  }
+
   // Watch for composable-based navigation requests
   watchImmediate(pendingNavigation, async (request) => {
     if (!request)
@@ -130,27 +207,17 @@ export function useHistoryEventNavigationConsumer(
 
     try {
       while (currentRequest) {
-        const basePayload =
-          currentRequest.preserveFilters && requestPayload ? get(requestPayload) : undefined;
-        // Compute the target's position within the asset-filtered view so the page number
-        // matches the filter that will be applied on arrival.
-        const filterPayload = currentRequest.assetFilter
-          ? { ...basePayload, asset: currentRequest.assetFilter }
-          : basePayload;
-        const position = await getHistoryEventGroupPosition(
-          currentRequest.targetGroupIdentifier,
-          filterPayload,
-        );
+        const position = await resolveGroupPosition(currentRequest);
 
         // Check if this request is still current after the await
         if (get(pendingNavigation) !== request)
           return;
 
         if (position < 0) {
-          // Target not in filtered results, try fallback
-          if (currentRequest.fallbacks?.length) {
-            const [next, ...remaining]: HistoryEventNavigationRequest[] = currentRequest.fallbacks;
-            currentRequest = { ...next, fallbacks: remaining.length > 0 ? remaining : undefined };
+          // Target not in filtered results, try the next fallback
+          const next = selectNextRequest(currentRequest);
+          if (next) {
+            currentRequest = next;
             continue;
           }
           // No fallbacks left, clear highlights
@@ -158,48 +225,10 @@ export function useHistoryEventNavigationConsumer(
           break;
         }
 
-        const limit = get(pagination).limit;
-        const page = Math.floor(position / limit) + 1;
-        const highlightQuery = buildHighlightQuery(currentRequest, page);
-
-        // An asset filter navigation changes a real filter, so it must wait for the
-        // pagination system's refetch to settle before pushing (the same coordination
-        // preserveFilters uses). Without this the highlight push races the filter refetch
-        // and the "clear highlights on filter change" watcher can wipe the highlight.
-        if ((currentRequest.preserveFilters || currentRequest.assetFilter) && groupLoading) {
-          /**
-           * Wait for the pagination system's loading cycle to complete.
-           * The loading may not have started yet (fetchDebounce), so wait for it to start first.
-           */
-          if (!get(groupLoading)) {
-            await until(groupLoading).toBe(true, {
-              timeout: HIGHLIGHT_LOADING_START_TIMEOUT,
-              throwOnTimeout: false,
-            });
-          }
-          // Now wait for loading to finish
-          if (get(groupLoading)) {
-            await until(groupLoading).toBe(false);
-          }
-
-          // Check if this request is still current after waiting
-          if (get(pendingNavigation) !== request)
-            return;
-
-          // Route now has the correct filter/limit values from the pagination system
-          await router.push({
-            force: true,
-            name: historyEventsName,
-            query: { ...get(route).query, ...highlightQuery },
-          });
-        }
-        else {
-          await router.push({
-            force: true,
-            name: historyEventsName,
-            query: { limit: limit.toString(), ...highlightQuery },
-          });
-        }
+        const page = Math.floor(position / get(pagination).limit) + 1;
+        const stillCurrent = await pushHighlight(currentRequest, request, buildHighlightQuery(currentRequest, page));
+        if (!stillCurrent)
+          return;
         break;
       }
     }

--- a/frontend/app/src/modules/history/events/use-virtual-scroll-highlight.spec.ts
+++ b/frontend/app/src/modules/history/events/use-virtual-scroll-highlight.spec.ts
@@ -78,6 +78,7 @@ interface SetupResult {
 function setupComposable(overrides: {
   rows?: VirtualRow[];
   identifiers?: string[];
+  groupId?: string;
   types?: Record<string, HighlightType>;
   loading?: boolean;
   pagination?: TablePaginationData;
@@ -88,7 +89,7 @@ function setupComposable(overrides: {
   const loading = ref<boolean>(overrides.loading ?? false);
   const pagination = ref<TablePaginationData>(overrides.pagination ?? { page: 1, total: 0, limit: 10 });
 
-  const highlightedGroupIdentifier = ref<string | undefined>(undefined);
+  const highlightedGroupIdentifier = ref<string | undefined>(overrides.groupId);
 
   const composable = useVirtualScrollHighlight({
     flattenedRows: computed<VirtualRow[]>(() => get(flattenedRows)),
@@ -329,6 +330,43 @@ describe('use-virtual-scroll-highlight', () => {
       const { loading } = setupComposable({
         rows,
         identifiers: ['1'],
+        loading: true,
+      });
+
+      set(loading, false);
+      await triggerDebouncedWatch();
+
+      expect(scrollToSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('group highlight via auto-scroll', () => {
+    it('should scroll to the group header when a group is highlighted without identifiers', async () => {
+      const rows: VirtualRow[] = [
+        createEventRow(createMockEvent({ identifier: 1 }), 0),
+        createGroupHeaderRow(createMockEvent({ groupIdentifier: 'target-group', identifier: 10 })),
+      ];
+
+      const { loading } = setupComposable({
+        rows,
+        groupId: 'target-group',
+        loading: true,
+      });
+
+      set(loading, false);
+      await triggerDebouncedWatch();
+
+      expect(scrollToSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should not scroll when the highlighted group is not present in the rows', async () => {
+      const rows: VirtualRow[] = [
+        createEventRow(createMockEvent({ identifier: 1 }), 0),
+      ];
+
+      const { loading } = setupComposable({
+        rows,
+        groupId: 'missing-group',
         loading: true,
       });
 

--- a/frontend/app/src/modules/history/events/use-virtual-scroll-highlight.ts
+++ b/frontend/app/src/modules/history/events/use-virtual-scroll-highlight.ts
@@ -8,6 +8,13 @@ import { useMediaQuery, useVirtualList, type UseVirtualListReturn } from '@vueus
 
 const OVERSCAN_COUNT = 15;
 
+interface HighlightScrollTarget {
+  /** Whether a highlight target was located; drives whether we mark as scrolled. */
+  found: boolean;
+  /** Row index to scroll to; `undefined` means "found, but no scroll needed". */
+  index?: number;
+}
+
 interface UseVirtualScrollHighlightOptions {
   /** The fully flattened row list (group headers, event rows, swap rows) that backs the virtual list; row indices used for scrolling refer to this array. */
   flattenedRows: ComputedRef<VirtualRow[]>;
@@ -217,59 +224,68 @@ export function useVirtualScrollHighlight(options: UseVirtualScrollHighlightOpti
     }
   });
 
-  watchDebounced([flattenedRows, (): string[] | undefined => toValue(highlightedIdentifiers), (): string | undefined => toValue(highlightedGroupIdentifier), loading], ([rows, identifiers, groupId, isLoading]) => {
-    if (isLoading || rows.length === 0 || get(hasScrolledToHighlight))
-      return;
+  /**
+   * Locate the group-header row for a whole-group highlight (used when no
+   * individual identifiers are given).
+   */
+  function resolveGroupScroll(rows: VirtualRow[], groupId: string | undefined): HighlightScrollTarget {
+    if (!groupId)
+      return { found: false };
 
-    const hasIdentifiers = identifiers && identifiers.length > 0;
-    if (!hasIdentifiers && !groupId)
-      return;
+    const groupIndex = rows.findIndex(row => row.type === 'group-header' && row.groupId === groupId);
+    if (groupIndex < 0)
+      return { found: false };
 
-    // For group-based highlights (no identifiers), find the group header row
-    if (!hasIdentifiers && groupId) {
-      const groupIndex = rows.findIndex(row => row.type === 'group-header' && row.groupId === groupId);
-      if (groupIndex < 0)
-        return;
+    return { found: true, index: groupIndex };
+  }
 
-      set(hasScrolledToHighlight, true);
-      set(pendingHighlightScroll, false);
-      startPromise(nextTick(() => {
-        scrollTo(groupIndex);
-      }));
-      return;
-    }
-
+  /**
+   * Locate the scroll target for individual identifier highlights, positioning
+   * to show as many as possible: a single target directly, two via
+   * calculateScrollPosition, and three or more only when the last is offscreen.
+   */
+  function resolveIdentifierScroll(rows: VirtualRow[], identifiers: string[] | undefined): HighlightScrollTarget {
     if (!identifiers || identifiers.length === 0)
-      return;
+      return { found: false };
 
     const indices = identifiers
       .map(id => ({ id, index: findRowIndexForIdentifier(rows, id) }))
       .filter(item => item.index >= 0);
 
     if (indices.length === 0)
-      return;
-
-    let scrollIndex: number | undefined;
+      return { found: false };
 
     if (indices.length === 1) {
       const targetIndex = indices[0].index;
-      scrollIndex = get(isCardLayout) && targetIndex > 0 ? targetIndex + 2 : targetIndex;
+      return { found: true, index: get(isCardLayout) && targetIndex > 0 ? targetIndex + 2 : targetIndex };
     }
-    else if (indices.length === 2) {
-      const primaryIndex = indices[0].index;
-      const secondaryIndex = indices[1].index;
-      scrollIndex = calculateScrollPosition(primaryIndex, secondaryIndex);
-    }
-    else {
-      const lastIndex = indices.at(-1)!.index;
-      if (!isRowVisible(lastIndex)) {
-        scrollIndex = lastIndex;
-      }
-    }
+
+    if (indices.length === 2)
+      return { found: true, index: calculateScrollPosition(indices[0].index, indices[1].index) };
+
+    const lastIndex = indices.at(-1)!.index;
+    return { found: true, index: isRowVisible(lastIndex) ? undefined : lastIndex };
+  }
+
+  watchDebounced([flattenedRows, (): string[] | undefined => toValue(highlightedIdentifiers), (): string | undefined => toValue(highlightedGroupIdentifier), loading], ([rows, identifiers, groupId, isLoading]) => {
+    if (isLoading || rows.length === 0 || get(hasScrolledToHighlight))
+      return;
+
+    const hasIdentifiers = !!identifiers && identifiers.length > 0;
+    if (!hasIdentifiers && !groupId)
+      return;
+
+    const target = hasIdentifiers
+      ? resolveIdentifierScroll(rows, identifiers)
+      : resolveGroupScroll(rows, groupId);
+
+    if (!target.found)
+      return;
 
     set(hasScrolledToHighlight, true);
     set(pendingHighlightScroll, false);
 
+    const scrollIndex = target.index;
     if (scrollIndex !== undefined) {
       startPromise(nextTick(() => {
         scrollTo(scrollIndex);

--- a/frontend/app/src/modules/settings/OnboardingSettings.vue
+++ b/frontend/app/src/modules/settings/OnboardingSettings.vue
@@ -9,6 +9,7 @@ import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useMainStore } from '@/modules/core/common/use-main-store';
 import { toMessages } from '@/modules/core/common/validation/validation';
 import { useSettingsApi } from '@/modules/settings/api/use-settings-api';
+import { resolveInitialBackendOptions } from '@/modules/settings/backend/backend-initial-options';
 import LogLevelInput from '@/modules/settings/backend/LogLevelInput.vue';
 import { useLogLevelUpdate } from '@/modules/settings/backend/use-log-level-update';
 import LanguageSetting from '@/modules/settings/general/language/LanguageSetting.vue';
@@ -71,21 +72,16 @@ const {
   saveOptions,
 } = useBackendManagement(loaded);
 
-const initialOptions = computed<Partial<BackendOptions>>(() => {
-  const config = get(configuration);
-  const opts = get(options);
-  const defaults = get(defaultBackendArguments);
-
-  return {
-    dataDirectory: opts.dataDirectory ?? get(dataDirectory),
-    logDirectory: opts.logDirectory ?? get(defaultLogDirectory),
-    logFromOtherModules: opts.logFromOtherModules ?? false,
-    loglevel: opts.loglevel ?? config?.loglevel?.value ?? get(defaultLogLevel),
-    maxLogfilesNum: opts.maxLogfilesNum ?? config?.maxLogfilesNum?.value ?? defaults.maxLogfilesNum,
-    maxSizeInMbAllLogs: opts.maxSizeInMbAllLogs ?? config?.maxSizeInMbAllLogs?.value ?? defaults.maxSizeInMbAllLogs,
-    sqliteInstructions: opts.sqliteInstructions ?? config?.sqliteInstructions?.value ?? defaults.sqliteInstructions,
-  };
-});
+const initialOptions = computed<Partial<BackendOptions>>(() => resolveInitialBackendOptions(
+  get(options),
+  get(configuration),
+  {
+    dataDirectory: get(dataDirectory),
+    logDirectory: get(defaultLogDirectory),
+    defaultLogLevel: get(defaultLogLevel),
+    defaults: get(defaultBackendArguments),
+  },
+));
 
 async function loaded() {
   // Wait for the backend configuration before snapshotting initial values,

--- a/frontend/app/src/modules/settings/backend/backend-initial-options.spec.ts
+++ b/frontend/app/src/modules/settings/backend/backend-initial-options.spec.ts
@@ -1,0 +1,87 @@
+import type { BackendOptions } from '@shared/ipc';
+import type { BackendConfiguration, DefaultBackendArguments } from '@/modules/shell/app/backend';
+import { LogLevel } from '@shared/log-level';
+import { describe, expect, it } from 'vitest';
+import { type BackendOptionFallbacks, resolveInitialBackendOptions } from './backend-initial-options';
+
+const defaults: DefaultBackendArguments = {
+  maxLogfilesNum: 3,
+  maxSizeInMbAllLogs: 300,
+  sqliteInstructions: 5000,
+};
+
+const fallbacks: BackendOptionFallbacks = {
+  dataDirectory: '/fallback/data',
+  logDirectory: '/fallback/logs',
+  defaultLogLevel: LogLevel.CRITICAL,
+  defaults,
+};
+
+function makeConfiguration(): BackendConfiguration {
+  return {
+    loglevel: { value: LogLevel.INFO, isDefault: true },
+    maxLogfilesNum: { value: 7, isDefault: false },
+    maxSizeInMbAllLogs: { value: 500, isDefault: false },
+    sqliteInstructions: { value: 9000, isDefault: false },
+  };
+}
+
+describe('resolveInitialBackendOptions', () => {
+  it('should fall back to defaults when neither options nor configuration are set', () => {
+    expect(resolveInitialBackendOptions({}, undefined, fallbacks)).toStrictEqual({
+      dataDirectory: '/fallback/data',
+      logDirectory: '/fallback/logs',
+      logFromOtherModules: false,
+      loglevel: LogLevel.CRITICAL,
+      maxLogfilesNum: 3,
+      maxSizeInMbAllLogs: 300,
+      sqliteInstructions: 5000,
+    });
+  });
+
+  it('should use configuration values over the fallbacks for config-backed fields', () => {
+    expect(resolveInitialBackendOptions({}, makeConfiguration(), fallbacks)).toStrictEqual({
+      dataDirectory: '/fallback/data',
+      logDirectory: '/fallback/logs',
+      logFromOtherModules: false,
+      loglevel: LogLevel.INFO,
+      maxLogfilesNum: 7,
+      maxSizeInMbAllLogs: 500,
+      sqliteInstructions: 9000,
+    });
+  });
+
+  it('should let persisted options win over both configuration and fallbacks', () => {
+    const options: Partial<BackendOptions> = {
+      dataDirectory: '/user/data',
+      logDirectory: '/user/logs',
+      logFromOtherModules: true,
+      loglevel: LogLevel.DEBUG,
+      maxLogfilesNum: 10,
+      maxSizeInMbAllLogs: 999,
+      sqliteInstructions: 12345,
+    };
+    expect(resolveInitialBackendOptions(options, makeConfiguration(), fallbacks)).toStrictEqual(options);
+  });
+
+  it('should resolve each field independently along the option → config → fallback chain', () => {
+    const options: Partial<BackendOptions> = {
+      dataDirectory: '/user/data',
+      maxLogfilesNum: 10,
+    };
+    expect(resolveInitialBackendOptions(options, makeConfiguration(), fallbacks)).toStrictEqual({
+      dataDirectory: '/user/data', // from options
+      logDirectory: '/fallback/logs', // from fallbacks (no option, no config field)
+      logFromOtherModules: false,
+      loglevel: LogLevel.INFO, // from configuration
+      maxLogfilesNum: 10, // from options
+      maxSizeInMbAllLogs: 500, // from configuration
+      sqliteInstructions: 9000, // from configuration
+    });
+  });
+
+  it('should keep an explicit false logFromOtherModules from options', () => {
+    const result = resolveInitialBackendOptions({ logFromOtherModules: false }, undefined, fallbacks);
+    expect(result.logFromOtherModules).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/settings/backend/backend-initial-options.ts
+++ b/frontend/app/src/modules/settings/backend/backend-initial-options.ts
@@ -1,0 +1,65 @@
+import type { BackendOptions } from '@shared/ipc';
+import type { BackendConfiguration, DefaultBackendArguments } from '@/modules/shell/app/backend';
+
+export interface BackendOptionFallbacks {
+  dataDirectory: string;
+  logDirectory: string;
+  defaultLogLevel: BackendOptions['loglevel'];
+  defaults: DefaultBackendArguments;
+}
+
+/**
+ * Flattens the backend configuration to its bare `.value`s (or `undefined`),
+ * so the precedence resolution below stays free of optional-chaining noise.
+ */
+function extractConfiguredValues(configuration?: BackendConfiguration): {
+  loglevel?: BackendOptions['loglevel'];
+  maxLogfilesNum?: number;
+  maxSizeInMbAllLogs?: number;
+  sqliteInstructions?: number;
+} {
+  return {
+    loglevel: configuration?.loglevel?.value,
+    maxLogfilesNum: configuration?.maxLogfilesNum?.value,
+    maxSizeInMbAllLogs: configuration?.maxSizeInMbAllLogs?.value,
+    sqliteInstructions: configuration?.sqliteInstructions?.value,
+  };
+}
+
+function resolveDirectoryOptions(options: Partial<BackendOptions>, fallbacks: BackendOptionFallbacks): Partial<BackendOptions> {
+  return {
+    dataDirectory: options.dataDirectory ?? fallbacks.dataDirectory,
+    logDirectory: options.logDirectory ?? fallbacks.logDirectory,
+    logFromOtherModules: options.logFromOtherModules ?? false,
+  };
+}
+
+function resolveConfigBackedOptions(
+  options: Partial<BackendOptions>,
+  configured: ReturnType<typeof extractConfiguredValues>,
+  fallbacks: BackendOptionFallbacks,
+): Partial<BackendOptions> {
+  return {
+    loglevel: options.loglevel ?? configured.loglevel ?? fallbacks.defaultLogLevel,
+    maxLogfilesNum: options.maxLogfilesNum ?? configured.maxLogfilesNum ?? fallbacks.defaults.maxLogfilesNum,
+    maxSizeInMbAllLogs: options.maxSizeInMbAllLogs ?? configured.maxSizeInMbAllLogs ?? fallbacks.defaults.maxSizeInMbAllLogs,
+    sqliteInstructions: options.sqliteInstructions ?? configured.sqliteInstructions ?? fallbacks.defaults.sqliteInstructions,
+  };
+}
+
+/**
+ * Resolves the initial backend options shown in the onboarding form.
+ * Precedence per field: persisted user option, then backend configuration,
+ * then the environment fallback/default.
+ */
+export function resolveInitialBackendOptions(
+  options: Partial<BackendOptions>,
+  configuration: BackendConfiguration | undefined,
+  fallbacks: BackendOptionFallbacks,
+): Partial<BackendOptions> {
+  const configured = extractConfiguredValues(configuration);
+  return {
+    ...resolveDirectoryOptions(options, fallbacks),
+    ...resolveConfigBackedOptions(options, configured, fallbacks),
+  };
+}


### PR DESCRIPTION
## Summary

Clears **5 production `complexity` warnings** by extracting focused helpers, preserving behaviour throughout. Each refactor is paired with unit tests (new specs where the file had none) that pin the current behaviour before the extraction, so they guard the change. Part of the ongoing lint-warning decomposition; follows #12667 (non-production batch).

## What changed

**`core/table/param-sources.ts`** — extract `resolveExclusion` and `toBehaviourValue` from the `transformFilters` matcher loop. Adds the previously-missing spec: `transformFilters` (wrap / exclude / array / already-wrapped / keyValue branches) plus `collectSources` and `mergeParams` precedence.

**`history/events/use-virtual-scroll-highlight.ts`** — collapse the group-based and identifier-based scroll resolution in the debounced watcher into `resolveGroupScroll` / `resolveIdentifierScroll` returning a shared `{ found, index? }` result; both paths mark scroll state once. Adds coverage for the group-highlight auto-scroll path (found and not-found).

**`core/api/rotki-api.ts`** — split raw fetch/blob response handling out of `fetchDirect` / `fetchBlob` into `checkResponseStatus`, `unwrapResult` and `assertBlobSuccess`. Also cuts type assertions from 10 to 5: `ofetch.raw` gets its `<Blob, 'blob'>` generics, `unwrapResult` takes an optional `ActionResult` and fails explicitly, and the two `skipResultUnwrap` / `treat409` generic-boundary escapes funnel through a single contained `asResult()` hatch. Adds coverage for the `skipAuthHandler`-on-401 and non-json blob-error paths.

**`history/events/use-history-event-navigation-consumer.ts`** — split the pending-navigation watcher into `resolveGroupPosition`, `selectNextRequest`, `waitForFilterLoad` and `pushHighlight`, keeping the staleness returns in the slim orchestrating loop. `resolveGroupPosition` stays a plain promise-returning function so the microtask timing the loading-cycle tests depend on is unchanged. All 20 existing tests pass.

**`settings/OnboardingSettings.vue`** — pull the `initialOptions` fallback chain into a pure `resolveInitialBackendOptions()` (option → config → default per field), decomposed so each helper stays under threshold. Adds a focused unit test for the precedence; component behaviour and its existing spec are unchanged.

## Testing

- `pnpm run typecheck`: clean.
- `pnpm run lint` on touched files: 0 errors. Remaining warnings are pre-existing (5 `Record<string, unknown>` assertions in `rotki-api.ts` unrelated to these hunks, 1 `composable-input-flexibility` blocked on the eslint-plugin update).
- 122 unit tests pass across the affected specs.
