### PR TITLE
fix: arm64 docker build broken by hardcoded libz path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,18 @@ RUN APP=$(find "/opt/rotki" -name "rotki-core-*-linux" | head -n 1) && \
     mv "${APP}" /opt/rotki/rotki-core/rotki && \
     find /opt/rotki -perm /6000 -type f -exec chmod a-s {} + || true
 
+# Stage libz into a rootfs tree at its real multiarch path, so the runtime can
+# pull it with a single arch-agnostic COPY. Hardcoding /usr/lib/x86_64-linux-gnu
+# breaks the arm64 build, where zlib lives under aarch64-linux-gnu; the exact
+# patch version in the SONAME symlink target also varies. Resolve the real
+# directory here (a shell exists) and copy the SONAME plus its target,
+# preserving the symlink with `cp -a`.
+RUN set -eux; \
+    libz=$(find /usr/lib /lib -name 'libz.so.1' 2>/dev/null | head -n 1); \
+    libdir=$(dirname "${libz}"); \
+    mkdir -p "/rootfs${libdir}"; \
+    cp -a "${libdir}"/libz.so.1* "/rootfs${libdir}/"
+
 # Runtime. nginx is gone, starling is the only externally-bound listener and
 # serves the SPA + proxies to the loopback backends. This drops the entire nginx
 # userland, python3 (entrypoint.py), and curl (the old healthcheck).
@@ -146,8 +158,7 @@ ARG ROTKI_VERSION
 ENV REVISION=$REVISION
 ENV ROTKI_VERSION=$ROTKI_VERSION
 
-COPY --from=layout-stage /usr/lib/x86_64-linux-gnu/libz.so.1.2.13 /usr/lib/x86_64-linux-gnu/libz.so.1.2.13
-COPY --from=layout-stage /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/libz.so.1
+COPY --from=layout-stage /rootfs/ /
 COPY --from=backend-build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=layout-stage /opt/rotki /opt/rotki
 


### PR DESCRIPTION
The runtime stage copied zlib from a hardcoded \
`/usr/lib/x86_64-linux-gnu` path:

```dockerfile
COPY --from=layout-stage /usr/lib/x86_64-linux-gnu/libz.so.1.2.13 ...
COPY --from=layout-stage /usr/lib/x86_64-linux-gnu/libz.so.1 ...
```

The `layout-stage` and `runtime` stages both build for `TARGETPLATFORM`, so on
`linux/arm64` zlib lives under `aarch64-linux-gnu` and the copy fails at build
time:

```
COPY --from=layout-stage /usr/lib/x86_64-linux-gnu/libz.so.1.2.13 ...
ERROR: failed to calculate checksum ...: "/usr/lib/x86_64-linux-gnu/libz.so.1.2.13": not found
```

The pinned patch version (`libz.so.1.2.13`) in the SONAME symlink target was a
second fragility that would break on any zlib bump.

## Fix

Stage libz into a `/rootfs` tree at its real multiarch path in the `layout-stage`
(which still has a shell), resolving the directory with a glob and preserving the
SONAME symlink with `cp -a`. The runtime then pulls it with a single
arch-agnostic copy:

```dockerfile
COPY --from=layout-stage /rootfs/ /
```

This lands libz at whatever multiarch path the target expects (`x86_64-linux-gnu`
on amd64, `aarch64-linux-gnu` on arm64); the distroless/cc loader searches the
multiarch dirs on both. No version is hardcoded.

## Testing

- arm64 image builds through the previously failing `layout-stage`/`runtime`
  libz steps (built locally under qemu).
- amd64 image unchanged in behavior (libz still lands at `x86_64-linux-gnu`).