### PR TITLE
Only flag genuinely missing prices, and resolve them from the dashboard

### DIFF
--- a/colibri/src/api/prices.rs
+++ b/colibri/src/api/prices.rs
@@ -1,3 +1,4 @@
+use crate::api::schemas::assets::AssetsIdentifier;
 use crate::api::schemas::prices::OraclePricesQuery;
 use crate::api::{utils::ApiResponse, AppState};
 use crate::globaldb::{OraclePricesQueryFilters, OraclePricesQueryResult};
@@ -8,6 +9,7 @@ use axum::{
     Json,
 };
 use reqwest::StatusCode;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 fn normalize_source_type_for_db(source_type: Option<String>) -> Result<Option<String>, String> {
@@ -62,6 +64,35 @@ pub async fn get_oracle_prices(
                 Json(ApiResponse::<OraclePricesQueryResult> {
                     result: None,
                     message: "Failed to query oracle prices".to_string(),
+                }),
+            )
+        }
+    }
+}
+
+pub async fn oracle_price_existence(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<AssetsIdentifier>,
+) -> impl IntoResponse {
+    match state
+        .globaldb
+        .assets_have_oracle_price(&payload.identifiers)
+        .await
+    {
+        Ok(existence) => (
+            StatusCode::OK,
+            Json(ApiResponse::<HashMap<String, bool>> {
+                result: Some(existence),
+                message: "".to_string(),
+            }),
+        ),
+        Err(error) => {
+            log::error!("Failed to query oracle price existence due to {}", error);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse::<HashMap<String, bool>> {
+                    result: None,
+                    message: "Failed to query oracle price existence".to_string(),
                 }),
             )
         }
@@ -233,6 +264,55 @@ mod tests {
                 .get("source_type")
                 .and_then(|value| value.as_str()),
             Some("defillama")
+        );
+    }
+
+    async fn call_oracle_price_existence(
+        state: Arc<AppState>,
+        payload: AssetsIdentifier,
+    ) -> (StatusCode, JsonValue) {
+        let response = oracle_price_existence(State(state), Json(payload))
+            .await
+            .into_response();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (status, serde_json::from_slice(&bytes).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_oracle_price_existence_reports_oracle_rows_only() {
+        let state = create_test_state().await;
+        {
+            let conn = state.globaldb.conn.lock().await;
+            // ETH has a coingecko (oracle) row -> true.
+            conn.execute(
+                "INSERT OR REPLACE INTO price_history(from_asset, to_asset, source_type, timestamp, price) VALUES(?, ?, ?, ?, ?)",
+                rusqlite::params!["ETH", "USD", "B", 4102445800_i64, "1111.1"],
+            )
+            .unwrap();
+            // BTC has only a manual (A) row -> false (user-entered, not the oracle).
+            conn.execute(
+                "INSERT OR REPLACE INTO price_history(from_asset, to_asset, source_type, timestamp, price) VALUES(?, ?, ?, ?, ?)",
+                rusqlite::params!["BTC", "USD", "A", 4102445800_i64, "1.0"],
+            )
+            .unwrap();
+        }
+
+        let (status, body) = call_oracle_price_existence(
+            state,
+            AssetsIdentifier {
+                identifiers: vec!["ETH".to_string(), "BTC".to_string(), "UNKNOWN".to_string()],
+            },
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let result = body.get("result").unwrap();
+        assert_eq!(result.get("ETH").and_then(|value| value.as_bool()), Some(true));
+        assert_eq!(result.get("BTC").and_then(|value| value.as_bool()), Some(false));
+        assert_eq!(
+            result.get("UNKNOWN").and_then(|value| value.as_bool()),
+            Some(false)
         );
     }
 

--- a/colibri/src/globaldb/handler.rs
+++ b/colibri/src/globaldb/handler.rs
@@ -1,10 +1,14 @@
 use crate::blockchain::{RpcNode, SupportedBlockchain};
-use crate::types::PriceOracle;
+use crate::types::{PriceOracle, SerializableDBEnum};
 use rusqlite::{types::Type, types::Value, Connection, Result};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
+/// SQLite bind-parameter ceiling we stay under when chunking `IN (...)` lists.
+const SQLITE_SAFE_VARIABLE_LIMIT: usize = 900;
 
 #[derive(Clone)]
 pub struct GlobalDB {
@@ -262,6 +266,57 @@ impl GlobalDB {
             entries_total,
             entries_limit: -1,
         })
+    }
+
+    /// For each identifier, reports whether an oracle ever recorded a price for it.
+    ///
+    /// Oracle rows in `price_history` are only written after a successful non-zero
+    /// oracle response, so any such row means the oracle genuinely priced the asset at
+    /// some point. Manual (`A`) and manual-current (`E`) rows are user-entered and do
+    /// not count as the oracle having worked. An asset with no oracle row is
+    /// "unsupported" rather than "missing", which lets the caller drop it from a
+    /// missing-price count.
+    pub async fn assets_have_oracle_price(
+        &self,
+        identifiers: &[String],
+    ) -> Result<HashMap<String, bool>> {
+        let mut result: HashMap<String, bool> =
+            identifiers.iter().map(|id| (id.clone(), false)).collect();
+        if identifiers.is_empty() {
+            return Ok(result);
+        }
+
+        let excluded = [
+            PriceOracle::Manual.serialize_for_db(),
+            PriceOracle::ManualCurrent.serialize_for_db(),
+        ];
+
+        let conn = self.conn.lock().await;
+        let chunk_size = SQLITE_SAFE_VARIABLE_LIMIT
+            .saturating_sub(excluded.len())
+            .max(1);
+        for chunk in identifiers.chunks(chunk_size) {
+            let placeholders: String = std::iter::repeat_n("?", chunk.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let query = format!(
+                "SELECT DISTINCT from_asset FROM price_history
+                WHERE from_asset IN ({placeholders})
+                AND source_type NOT IN (?, ?)"
+            );
+            let mut params: Vec<Value> =
+                chunk.iter().map(|id| Value::Text(id.clone())).collect();
+            params.extend(excluded.iter().map(|code| Value::Text(code.clone())));
+
+            let mut stmt = conn.prepare(&query)?;
+            let mut rows = stmt.query(rusqlite::params_from_iter(params.iter()))?;
+            while let Some(row) = rows.next()? {
+                let identifier: String = row.get(0)?;
+                result.insert(identifier, true);
+            }
+        }
+
+        Ok(result)
     }
 }
 

--- a/colibri/src/main.rs
+++ b/colibri/src/main.rs
@@ -110,6 +110,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "/prices/oracle",
             routing::get(api::prices::get_oracle_prices),
         )
+        .route(
+            "/prices/oracle/existence",
+            routing::post(api::prices::oracle_price_existence),
+        )
         .route("/user", routing::post(api::database::unlock_user))
         .route("/user/logout", routing::post(api::database::logout_user))
         .route(

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2385,6 +2385,13 @@
     "completeness": {
       "data_issues": "{count} data issue needs attention | {count} data issues need attention",
       "missing_prices": "{count} asset without a price | {count} assets without a price",
+      "missing_prices_dialog": {
+        "add_price": "Add price",
+        "description": "These assets had an oracle price before but currently report none. Add a manual price to restore their value.",
+        "empty": "All prices resolved",
+        "open_manager": "Open price manager",
+        "title": "Missing prices"
+      },
       "undecoded": "{count} undecoded transaction | {count} undecoded transactions"
     },
     "exchange_balances": {

--- a/frontend/app/src/modules/assets/api/use-asset-prices-api.ts
+++ b/frontend/app/src/modules/assets/api/use-asset-prices-api.ts
@@ -1,5 +1,6 @@
 import type { Collection } from '@/modules/core/common/collection';
 import {
+  AssetOraclePriceExistence,
   type HistoricalPrice,
   type HistoricalPriceDeletePayload,
   type HistoricalPriceFormPayload,
@@ -24,6 +25,7 @@ interface UseAssetPricesApiReturn {
   editHistoricalPrice: (price: HistoricalPriceFormPayload) => Promise<boolean>;
   deleteHistoricalPrice: (payload: HistoricalPriceDeletePayload) => Promise<boolean>;
   fetchOraclePrices: (query?: OraclePricesQuery) => Promise<Collection<OraclePriceEntry>>;
+  assetsHadOraclePrice: (identifiers: string[]) => Promise<AssetOraclePriceExistence>;
   fetchLatestPrices: (payload?: Partial<ManualPricePayload>) => Promise<ManualPrice[]>;
   addLatestPrice: (payload: ManualPriceFormPayload) => Promise<boolean>;
   deleteLatestPrice: (asset: string) => Promise<boolean>;
@@ -73,6 +75,19 @@ export function useAssetPricesApi(): UseAssetPricesApiReturn {
     return mapCollectionResponse(OraclePricesCollectionResponse.parse(response));
   };
 
+  const assetsHadOraclePrice = async (identifiers: string[]): Promise<AssetOraclePriceExistence> => {
+    const response = await api.post<AssetOraclePriceExistence>(
+      '/prices/oracle/existence',
+      { identifiers },
+      {
+        baseURL: defaultApiUrls.colibriApiUrl,
+        retry: true,
+      },
+    );
+
+    return AssetOraclePriceExistence.parse(response);
+  };
+
   const fetchLatestPrices = async (payload?: Partial<ManualPricePayload>): Promise<ManualPrice[]> => {
     const response = await api.post<ManualPrice[]>(
       '/assets/prices/latest/all',
@@ -105,6 +120,7 @@ export function useAssetPricesApi(): UseAssetPricesApiReturn {
   return {
     addHistoricalPrice,
     addLatestPrice,
+    assetsHadOraclePrice,
     deleteHistoricalPrice,
     deleteLatestPrice,
     editHistoricalPrice,

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceFormDialog.spec.ts
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceFormDialog.spec.ts
@@ -1,0 +1,47 @@
+import type { ManualPriceFormPayload } from '@/modules/assets/prices/price-types';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+import LatestPriceFormDialog from '@/modules/assets/prices/latest/LatestPriceFormDialog.vue';
+import '@test/i18n';
+
+vi.mock('@/modules/assets/prices/use-latest-price-manager', () => ({
+  useLatestPrices: (): Record<string, unknown> => ({ save: vi.fn() }),
+}));
+
+const item: ManualPriceFormPayload = { fromAsset: 'ETH', price: '5', toAsset: 'USD' };
+
+function createWrapper(props: Record<string, unknown>): VueWrapper {
+  return mount(LatestPriceFormDialog, {
+    global: {
+      stubs: {
+        BigDialog: { props: ['title', 'display'], template: '<div v-if="display" data-testid="dlg" :data-title="title"><slot /></div>' },
+        LatestPriceForm: { name: 'LatestPriceForm', props: ['modelValue'], template: '<div />' },
+      },
+    },
+    props: { open: true, ...props },
+  });
+}
+
+describe('latestPriceFormDialog', () => {
+  it('should show the edit title when an editable item is provided', async () => {
+    const wrapper = createWrapper({ editableItem: item });
+    await nextTick();
+    expect(wrapper.find('[data-testid=dlg]').attributes('data-title')).toContain('edit_title');
+  });
+
+  it('should show the add title when there is no editable item', async () => {
+    const wrapper = createWrapper({ editableItem: null });
+    await nextTick();
+    expect(wrapper.find('[data-testid=dlg]').attributes('data-title')).toContain('add_title');
+  });
+
+  it('should keep the add title but seed the form when prefilled', async () => {
+    const prefill: ManualPriceFormPayload = { fromAsset: 'ETH', price: '', toAsset: 'USD' };
+    const wrapper = createWrapper({ prefill });
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=dlg]').attributes('data-title')).toContain('add_title');
+    expect(wrapper.findComponent({ name: 'LatestPriceForm' }).props('modelValue')).toMatchObject(prefill);
+  });
+});

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceFormDialog.vue
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceFormDialog.vue
@@ -11,10 +11,12 @@ const {
   disableFromAsset = false,
   editableItem = null,
   editMode,
+  prefill = null,
 } = defineProps<{
   editableItem?: ManualPriceFormPayload | null;
   editMode?: boolean;
   disableFromAsset?: boolean;
+  prefill?: ManualPriceFormPayload | null;
 }>();
 
 const emit = defineEmits<{
@@ -65,13 +67,16 @@ const dialogTitle = computed<string>(() =>
     : t('price_management.dialog.add_title'),
 );
 
-watchImmediate([open, () => editableItem], ([open, editableItemVal]) => {
+watchImmediate([open, () => editableItem, () => prefill], ([open, editableItemVal, prefillVal]) => {
   if (!open) {
     set(modelValue, undefined);
   }
   else {
     if (editableItemVal) {
       set(modelValue, editableItemVal);
+    }
+    else if (prefillVal) {
+      set(modelValue, { ...prefillVal });
     }
     else {
       set(modelValue, emptyPrice());

--- a/frontend/app/src/modules/assets/prices/price-types.ts
+++ b/frontend/app/src/modules/assets/prices/price-types.ts
@@ -193,3 +193,10 @@ export interface OraclePricesQuery extends PaginationRequestPayload<OraclePriceE
   readonly toAsset?: string;
   readonly toTimestamp?: number;
 }
+
+// Maps each requested asset identifier to whether an oracle ever recorded a price for
+// it. `true` means the oracle worked in the past, so a current zero price is a genuine
+// missing price rather than an asset the oracles never supported.
+export const AssetOraclePriceExistence = z.record(z.string(), z.boolean());
+
+export type AssetOraclePriceExistence = z.infer<typeof AssetOraclePriceExistence>;

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { computed, ref } from 'vue';
 import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
 import DashboardCompletenessIndicator from '@/modules/dashboard/DashboardCompletenessIndicator.vue';
+import DashboardMissingPricesDialog from '@/modules/dashboard/DashboardMissingPricesDialog.vue';
 import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import '@test/i18n';
 
@@ -51,6 +52,7 @@ async function createWrapper(): Promise<VueWrapper<InstanceType<typeof Dashboard
   const wrapper = mount(DashboardCompletenessIndicator, {
     global: {
       stubs: {
+        DashboardMissingPricesDialog: true,
         RouterLink: { template: '<div><slot /></div>' },
       },
     },
@@ -78,6 +80,20 @@ describe('dashboardCompletenessIndicator', () => {
     };
     const wrapper = await createWrapper();
     expect(wrapper.find('[data-testid=dashboard-completeness]').text()).toContain('missing_prices');
+  });
+
+  it('should open the missing-prices dialog with the affected assets', async () => {
+    useBalancePricesStore().prices = {
+      ETH: { isManualPrice: false, oracle: 'blockchain', priceMissing: true, usdPrice: null, value: bigNumberify(0) },
+    };
+    const wrapper = await createWrapper();
+
+    const dialog = wrapper.findComponent(DashboardMissingPricesDialog);
+    expect(dialog.props('open')).toBe(false);
+    expect(dialog.props('identifiers')).toEqual(['ETH']);
+
+    await wrapper.find('[data-testid=missing-prices-trigger]').trigger('click');
+    expect(dialog.props('open')).toBe(true);
   });
 
   it('should not count a missing price for an asset the oracles never supported', async () => {

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
@@ -12,11 +12,20 @@ import '@test/i18n';
 interface MockState {
   actionableCount: number;
   processing: boolean;
+  assetsWithoutOracleHistory: Set<string>;
 }
 
 const state = vi.hoisted((): MockState => ({
   actionableCount: 0,
+  assetsWithoutOracleHistory: new Set<string>(),
   processing: false,
+}));
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: (): Record<string, unknown> => ({
+    assetsHadOraclePrice: vi.fn(async (identifiers: string[]): Promise<Record<string, boolean>> =>
+      Object.fromEntries(identifiers.map(id => [id, !state.assetsWithoutOracleHistory.has(id)]))),
+  }),
 }));
 
 vi.mock('@/modules/history/data-issues/use-data-issues-summary', () => ({
@@ -55,6 +64,7 @@ describe('dashboardCompletenessIndicator', () => {
     setActivePinia(createCustomPinia());
     state.actionableCount = 0;
     state.processing = false;
+    state.assetsWithoutOracleHistory = new Set<string>();
   });
 
   it('should render nothing when there are no completeness issues', async () => {
@@ -68,6 +78,15 @@ describe('dashboardCompletenessIndicator', () => {
     };
     const wrapper = await createWrapper();
     expect(wrapper.find('[data-testid=dashboard-completeness]').text()).toContain('missing_prices');
+  });
+
+  it('should not count a missing price for an asset the oracles never supported', async () => {
+    state.assetsWithoutOracleHistory = new Set(['FOO']);
+    useBalancePricesStore().prices = {
+      FOO: { isManualPrice: false, oracle: 'blockchain', priceMissing: true, usdPrice: null, value: bigNumberify(0) },
+    };
+    const wrapper = await createWrapper();
+    expect(wrapper.find('[data-testid=dashboard-completeness]').exists()).toBe(false);
   });
 
   it('should show a button for leftover undecoded transactions', async () => {

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
@@ -1,22 +1,14 @@
 <script setup lang="ts">
 import { startPromise } from '@shared/utils';
-import { useAssetsStore } from '@/modules/assets/use-assets-store';
-import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
 import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
 import { useUndecodedTransactionsCount } from '@/modules/history/events/tx/use-undecoded-transactions-count';
+import { useMissingPrices } from './use-missing-prices';
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { prices } = storeToRefs(useBalancePricesStore());
-const { isAssetIgnored } = useAssetsStore();
+const { missingPricesCount } = useMissingPrices();
 const { actionableCount, refreshSummary } = useDataIssuesSummary();
 const { fetchUndecodedTransactionsBreakdown, undecodedCount } = useUndecodedTransactionsCount();
-
-// Ignored assets (spam/dust) are hidden from the balances table, so they must
-// not inflate the count either — only count assets the user actually sees.
-const missingPricesCount = computed<number>(() =>
-  Object.entries(get(prices)).filter(([asset, price]) => price.priceMissing && !isAssetIgnored(asset)).length,
-);
 
 const hasIssues = computed<boolean>(() =>
   get(missingPricesCount) > 0 || get(undecodedCount) > 0 || get(actionableCount) > 0,

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
@@ -2,11 +2,14 @@
 import { startPromise } from '@shared/utils';
 import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
 import { useUndecodedTransactionsCount } from '@/modules/history/events/tx/use-undecoded-transactions-count';
+import DashboardMissingPricesDialog from './DashboardMissingPricesDialog.vue';
 import { useMissingPrices } from './use-missing-prices';
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { missingPricesCount } = useMissingPrices();
+const missingPricesDialog = ref<boolean>(false);
+
+const { missingPriceIdentifiers, missingPricesCount } = useMissingPrices();
 const { actionableCount, refreshSummary } = useDataIssuesSummary();
 const { fetchUndecodedTransactionsBreakdown, undecodedCount } = useUndecodedTransactionsCount();
 
@@ -25,25 +28,22 @@ onMounted(() => {
     class="flex flex-wrap items-center gap-2"
     data-testid="dashboard-completeness"
   >
-    <RouterLink
+    <RuiButton
       v-if="missingPricesCount > 0"
-      class="no-underline"
-      :to="{ name: '/price-manager/latest/' }"
+      size="sm"
+      color="secondary"
+      variant="outlined"
+      data-testid="missing-prices-trigger"
+      @click="missingPricesDialog = true"
     >
-      <RuiButton
-        size="sm"
-        color="secondary"
-        variant="outlined"
-      >
-        <template #prepend>
-          <RuiIcon
-            name="lu-banknote-x"
-            size="14"
-          />
-        </template>
-        {{ t('dashboard.completeness.missing_prices', { count: missingPricesCount }, missingPricesCount) }}
-      </RuiButton>
-    </RouterLink>
+      <template #prepend>
+        <RuiIcon
+          name="lu-banknote-x"
+          size="14"
+        />
+      </template>
+      {{ t('dashboard.completeness.missing_prices', { count: missingPricesCount }, missingPricesCount) }}
+    </RuiButton>
     <RouterLink
       v-if="undecodedCount > 0"
       class="no-underline"
@@ -83,4 +83,9 @@ onMounted(() => {
       </RuiButton>
     </RouterLink>
   </div>
+
+  <DashboardMissingPricesDialog
+    v-model:open="missingPricesDialog"
+    :identifiers="missingPriceIdentifiers"
+  />
 </template>

--- a/frontend/app/src/modules/dashboard/DashboardMissingPricesDialog.spec.ts
+++ b/frontend/app/src/modules/dashboard/DashboardMissingPricesDialog.spec.ts
@@ -1,0 +1,71 @@
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DashboardMissingPricesDialog from '@/modules/dashboard/DashboardMissingPricesDialog.vue';
+import '@test/i18n';
+
+const refreshPrice = vi.fn<(asset: string) => Promise<void>>().mockResolvedValue(undefined);
+
+vi.mock('@/modules/assets/prices/use-price-refresh', () => ({
+  usePriceRefresh: (): Record<string, unknown> => ({ refreshPrice }),
+}));
+
+function createWrapper(identifiers: string[]): VueWrapper<InstanceType<typeof DashboardMissingPricesDialog>> {
+  return mount(DashboardMissingPricesDialog, {
+    global: {
+      stubs: {
+        AssetDetails: { props: ['asset'], template: '<div class="asset">{{ asset }}</div>' },
+        LatestPriceFormDialog: {
+          emits: ['refresh', 'update:open'],
+          name: 'LatestPriceFormDialog',
+          props: {
+            disableFromAsset: { type: Boolean },
+            open: { type: Boolean },
+            prefill: { default: null, type: Object },
+          },
+          template: '<div class="form-dialog" />',
+        },
+        RouterLink: { template: '<div><slot /></div>' },
+        RuiCard: { template: '<div><slot name="header" /><slot /><slot name="footer" /></div>' },
+        RuiDialog: { props: ['modelValue'], template: '<div v-if="modelValue"><slot /></div>' },
+      },
+    },
+    props: { identifiers, open: true },
+  });
+}
+
+describe('dashboardMissingPricesDialog', () => {
+  beforeEach(() => {
+    setActivePinia(createCustomPinia());
+    refreshPrice.mockClear();
+  });
+
+  it('should list a row per missing-price asset', () => {
+    const wrapper = createWrapper(['ETH', 'BTC']);
+    expect(wrapper.findAll('.asset')).toHaveLength(2);
+    expect(wrapper.findAll('[data-testid=missing-price-add]')).toHaveLength(2);
+    expect(wrapper.find('[data-testid=missing-prices-empty]').exists()).toBe(false);
+  });
+
+  it('should show the resolved state when nothing is left', () => {
+    const wrapper = createWrapper([]);
+    expect(wrapper.find('[data-testid=missing-prices-list]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid=missing-prices-empty]').exists()).toBe(true);
+  });
+
+  it('should open a pre-filled add form for the picked asset and re-price it once saved', async () => {
+    const wrapper = createWrapper(['ETH', 'BTC']);
+
+    await wrapper.findAll('[data-testid=missing-price-add]')[0].trigger('click');
+
+    const form = wrapper.findComponent({ name: 'LatestPriceFormDialog' });
+    expect(form.exists()).toBe(true);
+    expect(form.props('disableFromAsset')).toBe(true);
+    expect(form.props('prefill')).toMatchObject({ fromAsset: 'ETH', price: '' });
+
+    form.vm.$emit('refresh');
+    await flushPromises();
+    expect(refreshPrice).toHaveBeenCalledWith('ETH');
+  });
+});

--- a/frontend/app/src/modules/dashboard/DashboardMissingPricesDialog.vue
+++ b/frontend/app/src/modules/dashboard/DashboardMissingPricesDialog.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import type { ManualPriceFormPayload } from '@/modules/assets/prices/price-types';
+import { startPromise } from '@shared/utils';
+import AssetDetails from '@/modules/assets/AssetDetails.vue';
+import LatestPriceFormDialog from '@/modules/assets/prices/latest/LatestPriceFormDialog.vue';
+import { usePriceRefresh } from '@/modules/assets/prices/use-price-refresh';
+import { useSetting } from '@/modules/settings/use-setting';
+
+const open = defineModel<boolean>('open', { required: true });
+
+const { identifiers } = defineProps<{
+  identifiers: string[];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const activeAsset = ref<string>();
+
+const currencySymbol = useSetting('currencySymbol');
+
+const { refreshPrice } = usePriceRefresh();
+
+const formOpen = computed<boolean>({
+  get: () => isDefined(activeAsset),
+  set: (value) => {
+    if (!value)
+      set(activeAsset, undefined);
+  },
+});
+
+const prefill = computed<ManualPriceFormPayload | undefined>(() => {
+  const asset = get(activeAsset);
+  if (!asset)
+    return undefined;
+
+  return {
+    fromAsset: asset,
+    price: '',
+    toAsset: get(currencySymbol),
+  };
+});
+
+function addPrice(asset: string): void {
+  set(activeAsset, asset);
+}
+
+async function onAdded(asset: string): Promise<void> {
+  // Close the form and re-price just the asset we resolved; once it reports a
+  // price it drops off the list on its own.
+  set(activeAsset, undefined);
+  await refreshPrice(asset);
+}
+</script>
+
+<template>
+  <RuiDialog
+    v-model="open"
+    max-width="600"
+  >
+    <RuiCard>
+      <template #header>
+        {{ t('dashboard.completeness.missing_prices_dialog.title') }}
+      </template>
+
+      <div class="text-body-2 text-rui-text-secondary mb-4">
+        {{ t('dashboard.completeness.missing_prices_dialog.description') }}
+      </div>
+
+      <div
+        v-if="identifiers.length > 0"
+        class="border border-rui-grey-300 dark:border-rui-grey-800 rounded overflow-hidden divide-y divide-rui-grey-200 dark:divide-rui-grey-800 max-h-[22.5rem] overflow-y-auto"
+        data-testid="missing-prices-list"
+      >
+        <div
+          v-for="asset in identifiers"
+          :key="asset"
+          class="flex items-center justify-between gap-4 px-4 py-2"
+        >
+          <AssetDetails
+            :asset="asset"
+            dense
+            hide-menu
+            class="min-w-0 max-w-[17.5rem]"
+          />
+          <RuiButton
+            size="sm"
+            color="primary"
+            variant="outlined"
+            class="shrink-0"
+            data-testid="missing-price-add"
+            @click="addPrice(asset)"
+          >
+            <template #prepend>
+              <RuiIcon
+                name="lu-plus"
+                size="16"
+              />
+            </template>
+            {{ t('dashboard.completeness.missing_prices_dialog.add_price') }}
+          </RuiButton>
+        </div>
+      </div>
+
+      <div
+        v-else
+        class="flex flex-col items-center gap-2 py-8 text-rui-text-secondary"
+        data-testid="missing-prices-empty"
+      >
+        <RuiIcon
+          name="lu-circle-check"
+          size="32"
+          class="text-rui-success"
+        />
+        {{ t('dashboard.completeness.missing_prices_dialog.empty') }}
+      </div>
+
+      <template #footer>
+        <RouterLink
+          class="no-underline"
+          :to="{ name: '/price-manager/latest/' }"
+        >
+          <RuiButton
+            variant="text"
+            color="primary"
+            @click="open = false"
+          >
+            <template #prepend>
+              <RuiIcon
+                name="lu-external-link"
+                size="16"
+              />
+            </template>
+            {{ t('dashboard.completeness.missing_prices_dialog.open_manager') }}
+          </RuiButton>
+        </RouterLink>
+        <div class="grow" />
+        <RuiButton
+          color="primary"
+          @click="open = false"
+        >
+          {{ t('common.actions.close') }}
+        </RuiButton>
+      </template>
+    </RuiCard>
+
+    <LatestPriceFormDialog
+      v-if="activeAsset"
+      :key="activeAsset"
+      v-model:open="formOpen"
+      :prefill="prefill"
+      disable-from-asset
+      @refresh="startPromise(onAdded(activeAsset))"
+    />
+  </RuiDialog>
+</template>

--- a/frontend/app/src/modules/dashboard/use-missing-prices.spec.ts
+++ b/frontend/app/src/modules/dashboard/use-missing-prices.spec.ts
@@ -37,6 +37,16 @@ describe('useMissingPrices', () => {
     expect(get(missingPricesCount)).toBe(1);
   });
 
+  it('should expose the identifiers of the genuinely missing prices', async () => {
+    assetsHadOraclePrice.mockResolvedValue({ ETH: true, FOO: false });
+    useBalancePricesStore().prices = { ETH: missing(), FOO: missing() };
+
+    const { missingPriceIdentifiers } = useMissingPrices();
+    await flushPromises();
+
+    expect(get(missingPriceIdentifiers)).toEqual(['ETH']);
+  });
+
   it('should exclude ignored assets from the count', async () => {
     useAssetsStore().addIgnoredAsset('ETH');
     useBalancePricesStore().prices = { ETH: missing() };

--- a/frontend/app/src/modules/dashboard/use-missing-prices.spec.ts
+++ b/frontend/app/src/modules/dashboard/use-missing-prices.spec.ts
@@ -1,0 +1,69 @@
+import type { AssetPrices } from '@/modules/assets/prices/price-types';
+import { bigNumberify } from '@rotki/common';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAssetsStore } from '@/modules/assets/use-assets-store';
+import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
+import { useMissingPrices } from '@/modules/dashboard/use-missing-prices';
+
+const assetsHadOraclePrice = vi.fn<(identifiers: string[]) => Promise<Record<string, boolean>>>();
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: (): Record<string, unknown> => ({ assetsHadOraclePrice }),
+}));
+
+function missing(): AssetPrices[string] {
+  return { isManualPrice: false, oracle: 'blockchain', priceMissing: true, usdPrice: null, value: bigNumberify(0) };
+}
+
+describe('useMissingPrices', () => {
+  beforeEach(() => {
+    setActivePinia(createCustomPinia());
+    assetsHadOraclePrice.mockReset();
+    // Default: every queried asset had an oracle price in the past.
+    assetsHadOraclePrice.mockImplementation(async identifiers =>
+      Object.fromEntries(identifiers.map(id => [id, true])));
+  });
+
+  it('should count only assets that had an oracle price before', async () => {
+    assetsHadOraclePrice.mockResolvedValue({ ETH: true, FOO: false });
+    useBalancePricesStore().prices = { ETH: missing(), FOO: missing() };
+
+    const { missingPricesCount } = useMissingPrices();
+    await flushPromises();
+
+    expect(get(missingPricesCount)).toBe(1);
+  });
+
+  it('should exclude ignored assets from the count', async () => {
+    useAssetsStore().addIgnoredAsset('ETH');
+    useBalancePricesStore().prices = { ETH: missing() };
+
+    const { missingPricesCount } = useMissingPrices();
+    await flushPromises();
+
+    expect(get(missingPricesCount)).toBe(0);
+    expect(assetsHadOraclePrice).not.toHaveBeenCalled();
+  });
+
+  it('should cache results and only query newly seen assets', async () => {
+    const store = useBalancePricesStore();
+    store.prices = { ETH: missing() };
+
+    const { missingPricesCount } = useMissingPrices();
+    await flushPromises();
+
+    expect(assetsHadOraclePrice).toHaveBeenCalledTimes(1);
+    expect(assetsHadOraclePrice).toHaveBeenLastCalledWith(['ETH']);
+
+    store.prices = { BTC: missing(), ETH: missing() };
+    await flushPromises();
+
+    // ETH is cached, so only BTC is queried the second time.
+    expect(assetsHadOraclePrice).toHaveBeenCalledTimes(2);
+    expect(assetsHadOraclePrice).toHaveBeenLastCalledWith(['BTC']);
+    expect(get(missingPricesCount)).toBe(2);
+  });
+});

--- a/frontend/app/src/modules/dashboard/use-missing-prices.ts
+++ b/frontend/app/src/modules/dashboard/use-missing-prices.ts
@@ -5,6 +5,7 @@ import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-sto
 import { logger } from '@/modules/core/common/logging/logging';
 
 interface UseMissingPricesReturn {
+  missingPriceIdentifiers: ComputedRef<string[]>;
   missingPricesCount: ComputedRef<number>;
 }
 
@@ -33,10 +34,14 @@ export function useMissingPrices(): UseMissingPricesReturn {
       .map(([asset]) => asset),
   );
 
-  const missingPricesCount = computed<number>(() => {
+  // The assets that are genuinely missing a price: visible, zero-priced, and priced by an
+  // oracle at least once before. These are the ones worth surfacing and fixing.
+  const missingPriceIdentifiers = computed<string[]>(() => {
     const history = get(oraclePriceHistory);
-    return get(missingPriceAssets).filter(asset => history[asset]).length;
+    return get(missingPriceAssets).filter(asset => history[asset]);
   });
+
+  const missingPricesCount = computed<number>(() => get(missingPriceIdentifiers).length);
 
   watchImmediate(missingPriceAssets, async (assets) => {
     const unknown = assets.filter(asset => !requested.has(asset));
@@ -56,6 +61,7 @@ export function useMissingPrices(): UseMissingPricesReturn {
   });
 
   return {
+    missingPriceIdentifiers,
     missingPricesCount,
   };
 }

--- a/frontend/app/src/modules/dashboard/use-missing-prices.ts
+++ b/frontend/app/src/modules/dashboard/use-missing-prices.ts
@@ -1,0 +1,61 @@
+import type { ComputedRef } from 'vue';
+import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import { useAssetsStore } from '@/modules/assets/use-assets-store';
+import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
+import { logger } from '@/modules/core/common/logging/logging';
+
+interface UseMissingPricesReturn {
+  missingPricesCount: ComputedRef<number>;
+}
+
+/**
+ * Counts assets whose price is currently missing, but only those an oracle priced in
+ * the past. An asset the oracles never supported is "unsupported", not "missing", so a
+ * standing zero for it should not be flagged. Assets that once had an oracle price and
+ * now report zero are genuine failures (the oracle broke) and are what we count.
+ */
+export function useMissingPrices(): UseMissingPricesReturn {
+  const { prices } = storeToRefs(useBalancePricesStore());
+  const { isAssetIgnored } = useAssetsStore();
+  const { assetsHadOraclePrice } = useAssetPricesApi();
+
+  // Cache of asset id -> whether an oracle ever recorded a price. Oracle support rarely
+  // changes, so results are kept across price ticks; only unseen assets are queried.
+  const oraclePriceHistory = ref<Record<string, boolean>>({});
+  // Assets already queried (resolved or in-flight), so overlapping ticks don't re-fetch.
+  const requested = new Set<string>();
+
+  // Zero-priced assets the user can actually see. Ignored assets (spam/dust) are hidden
+  // from the balances table, so they must not inflate the count either.
+  const missingPriceAssets = computed<string[]>(() =>
+    Object.entries(get(prices))
+      .filter(([asset, price]) => price.priceMissing && !isAssetIgnored(asset))
+      .map(([asset]) => asset),
+  );
+
+  const missingPricesCount = computed<number>(() => {
+    const history = get(oraclePriceHistory);
+    return get(missingPriceAssets).filter(asset => history[asset]).length;
+  });
+
+  watchImmediate(missingPriceAssets, async (assets) => {
+    const unknown = assets.filter(asset => !requested.has(asset));
+    if (unknown.length === 0)
+      return;
+
+    unknown.forEach(asset => requested.add(asset));
+    try {
+      const existence = await assetsHadOraclePrice(unknown);
+      set(oraclePriceHistory, { ...get(oraclePriceHistory), ...existence });
+    }
+    catch (error) {
+      // Allow a later retry (e.g. colibri still starting) by forgetting these ids.
+      unknown.forEach(asset => requested.delete(asset));
+      logger.error(error);
+    }
+  });
+
+  return {
+    missingPricesCount,
+  };
+}

--- a/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.spec.ts
@@ -129,6 +129,7 @@ describe('forms/AssetMovementEventForm.vue', () => {
     vi.mocked(useAssetPricesApi).mockReturnValue({
       addHistoricalPrice: addHistoricalPriceMock,
       addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
+      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
       deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
       deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
       editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),

--- a/frontend/app/src/modules/history/management/forms/EthBlockEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EthBlockEventForm.spec.ts
@@ -83,6 +83,7 @@ describe('forms/EthBlockEventForm.vue', () => {
     vi.mocked(useAssetPricesApi).mockReturnValue({
       addHistoricalPrice: addHistoricalPriceMock,
       addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
+      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
       deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
       deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
       editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),

--- a/frontend/app/src/modules/history/management/forms/EthDepositEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EthDepositEventForm.spec.ts
@@ -87,6 +87,7 @@ describe('form/EthDepositEventForm.vue', () => {
     vi.mocked(useAssetPricesApi).mockReturnValue({
       addHistoricalPrice: addHistoricalPriceMock,
       addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
+      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
       deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
       deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
       editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),

--- a/frontend/app/src/modules/history/management/forms/EthWithdrawalEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EthWithdrawalEventForm.spec.ts
@@ -97,6 +97,7 @@ describe('forms/EthWithdrawalEventForm.vue', () => {
     vi.mocked(useAssetPricesApi).mockReturnValue({
       addHistoricalPrice: addHistoricalPriceMock,
       addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
+      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
       deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
       deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
       editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),

--- a/frontend/app/src/modules/history/management/forms/EvmEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EvmEventForm.spec.ts
@@ -102,6 +102,7 @@ describe('forms/EvmEventForm.vue', () => {
     vi.mocked(useAssetPricesApi).mockReturnValue({
       addHistoricalPrice: addHistoricalPriceMock,
       addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
+      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
       deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
       deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
       editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),

--- a/frontend/app/src/modules/history/management/forms/OnlineHistoryEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/OnlineHistoryEventForm.spec.ts
@@ -101,6 +101,7 @@ describe('forms/OnlineHistoryEventForm.vue', () => {
     vi.mocked(useAssetPricesApi).mockReturnValue({
       addHistoricalPrice: addHistoricalPriceMock,
       addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
+      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
       deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
       deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
       editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),

--- a/frontend/app/src/modules/history/management/forms/SolanaEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/SolanaEventForm.spec.ts
@@ -103,6 +103,7 @@ describe('forms/SolanaEventForm.vue', () => {
     vi.mocked(useAssetPricesApi).mockReturnValue({
       addHistoricalPrice: addHistoricalPriceMock,
       addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
+      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
       deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
       deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
       editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),


### PR DESCRIPTION
## Summary

Two related changes to the dashboard missing-prices indicator.

### 1. Count only genuinely missing prices

An asset with a standing zero price is only a genuine missing price if an oracle priced it in the past. Assets the oracles never supported are unsupported, not missing, and should not inflate the dashboard indicator.

- Adds a Colibri `POST /prices/oracle/existence` endpoint that, for a list of asset identifiers, reports whether `price_history` holds any oracle-sourced row (manual and manual-current sources excluded). Oracle rows are only written after a successful non-zero response, so existence means the oracle genuinely worked once.
- Wires it into the completeness indicator via a `use-missing-prices` composable that filters the zero-priced assets through the endpoint and caches results per asset.

### 2. Resolve missing prices from the indicator

The missing-prices chip navigated to the Latest Prices manager, which lists only manually-added prices and gives no hint which assets are actually missing one. Now the chip opens a dialog that:

- lists the exact affected assets,
- offers a per-row **Add price** action that opens the latest-price form pre-filled with that asset (locked From Asset, To Asset defaulted to the user currency),
- re-prices the asset on save so the row clears once resolved, and shows a resolved empty-state when the list is empty.

A `prefill` prop was added to `LatestPriceFormDialog` so the add form can be seeded without taking on edit semantics or the "Edit" title.

## Testing

- `use-missing-prices`, `DashboardCompletenessIndicator`, `DashboardMissingPricesDialog`, and `LatestPriceFormDialog` specs (new coverage for the identifier list, the dialog trigger, per-row add + re-price, the resolved state, and the prefill/title behavior).
- Frontend typecheck and lint clean; Colibri `cargo build`/`clippy` clean.
- Verified in-app: chip count reflects only oracle-priced assets, the dialog lists them, and adding a price clears the row.