### PR TITLE
Gate asset movement ignore actions behind premium

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Without a premium subscription, the asset movement matching actions (Ignore Selected, Ignore All Fiat and Restore Selected) no longer appear available. Previously these buttons looked clickable but did nothing, since asset movement matching is a premium feature.
 * :bug:`-` Searching for zksync lite assets should now show you ethereum mainnet assets and you should be able to easily select relevant assets when adding/editing events.
 * :bug:`-` Omnibridge events containing fee payments will now be properly decoded.
 * :bug:`12526` EVM transactions discovered through more than one tracked address now remain associated with every relevant address, even when the transaction was already cached.

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
@@ -133,7 +133,7 @@ onBeforeMount(async () => {
         :size="buttonSize"
         class="rounded-r-none"
         :class="{ 'h-[30px]': isPinned }"
-        :disabled="modelSelectedUnmatched.length === 0 || ignoreLoading"
+        :disabled="!isAutoMatchAllowed || modelSelectedUnmatched.length === 0 || ignoreLoading"
         :loading="ignoreLoading"
         @click="confirmIgnoreSelected()"
       >
@@ -159,7 +159,7 @@ onBeforeMount(async () => {
             :size="buttonSize"
             class="rounded-l-none -ml-[1px]"
             :class="{ 'h-[30px]': isPinned }"
-            :disabled="fiatMovements.length === 0 || ignoreLoading"
+            :disabled="!isAutoMatchAllowed || fiatMovements.length === 0 || ignoreLoading"
             :loading="ignoreLoading"
             @click="confirmIgnoreAllFiat()"
           >
@@ -208,7 +208,7 @@ onBeforeMount(async () => {
         variant="outlined"
         color="primary"
         :size="buttonSize"
-        :disabled="modelSelectedIgnored.length === 0 || ignoreLoading"
+        :disabled="!isAutoMatchAllowed || modelSelectedIgnored.length === 0 || ignoreLoading"
         :loading="ignoreLoading"
         @click="confirmRestoreSelected()"
       >


### PR DESCRIPTION
## Problem

A user reported that in the free tier the asset movement matching feature is locked behind premium, yet the **Ignore All Fiat** and **Ignore Selected** buttons are still clickable and clicking them does nothing.

The whole asset movement matching feature is premium (the `match/asset_movements` endpoint requires a subscription). Only the auto-match button and its group checked `isAutoMatchAllowed`. The **Ignore Selected**, **Ignore All Fiat** and **Restore Selected** buttons were gated only by selection count and loading state, so they stayed clickable for free users. Clicking them called the premium endpoint (which no-ops without premium), and the bulk handlers swallow the result, so nothing happened and there was no feedback.

## Fix

Add the `!isAutoMatchAllowed` check to the `disabled` binding of the three action buttons in `MatchAssetMovementsContent.vue`, so they gate the same way as the auto-match button. The paywall alert already explains why the feature is unavailable.

## Notes

- No behavior change for premium users.
- Changelog entry added.