### PR TITLE
Cut complexity in production code (offenders ≥14)

### DIFF
--- a/frontend/app/src/modules/accounts/blockchain/use-account-manage.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-manage.spec.ts
@@ -1,8 +1,9 @@
 import type { AccountManage, StakingValidatorManage } from './use-account-manage';
 import type { ActionStatus } from '@/modules/core/common/action';
-import { Blockchain } from '@rotki/common';
+import { Blockchain, Zero } from '@rotki/common';
 import { type Pinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type BlockchainAccountBalance, XpubKeyType } from '@/modules/accounts/blockchain-accounts';
 import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
 
 const mockAddAccounts = vi.fn();
@@ -63,7 +64,7 @@ vi.mock('@/modules/accounts/use-eth-staking', () => ({
   })),
 }));
 
-const { useAccountManage } = await import('./use-account-manage');
+const { editBlockchainAccount, useAccountManage } = await import('./use-account-manage');
 
 function createValidatorState(mode: 'add' | 'edit' = 'add'): StakingValidatorManage {
   return {
@@ -287,6 +288,106 @@ describe('composables/accounts/blockchain/use-account-manage', () => {
       expect(result).toBe(false);
       expect(get(modelErrorMessages)).toEqual({ address: ['already typed'] });
       expect(mockShowErrorMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('editBlockchainAccount', () => {
+    it('should build a validator edit state from validator data', () => {
+      const account: BlockchainAccountBalance = {
+        amount: Zero,
+        chain: Blockchain.ETH2,
+        data: { index: 12345, ownershipPercentage: '50', publicKey: '0xabc', status: 'active', type: 'validator' },
+        label: 'My validator',
+        nativeAsset: 'ETH',
+        type: 'account',
+        value: Zero,
+      };
+
+      expect(editBlockchainAccount(account)).toEqual({
+        chain: Blockchain.ETH2,
+        data: { ownershipPercentage: '50', publicKey: '0xabc', validatorIndex: '12345' },
+        mode: 'edit',
+        type: 'validator',
+      });
+    });
+
+    it('should default the validator ownership to 100 when missing', () => {
+      const account: BlockchainAccountBalance = {
+        amount: Zero,
+        chain: Blockchain.ETH2,
+        data: { index: 7, publicKey: '0xdef', status: 'active', type: 'validator' },
+        nativeAsset: 'ETH',
+        type: 'account',
+        value: Zero,
+      };
+
+      expect(editBlockchainAccount(account)).toMatchObject({
+        data: { ownershipPercentage: '100', validatorIndex: '7' },
+        type: 'validator',
+      });
+    });
+
+    it('should build an xpub edit state from xpub data', () => {
+      const account: BlockchainAccountBalance = {
+        amount: Zero,
+        chain: Blockchain.BTC,
+        data: { derivationPath: 'm/0', type: 'xpub', xpub: 'xpubSomeKey' },
+        label: 'My xpub',
+        nativeAsset: 'BTC',
+        tags: ['cold'],
+        type: 'account',
+        value: Zero,
+      };
+
+      expect(editBlockchainAccount(account)).toEqual({
+        chain: Blockchain.BTC,
+        data: {
+          label: 'My xpub',
+          tags: ['cold'],
+          xpub: { derivationPath: 'm/0', xpub: 'xpubSomeKey', xpubType: XpubKeyType.XPUB },
+        },
+        mode: 'edit',
+        type: 'xpub',
+      });
+    });
+
+    it('should build an agnostic group edit state for multi-chain groups', () => {
+      const account: BlockchainAccountBalance = {
+        category: 'evm',
+        chains: [Blockchain.ETH, Blockchain.OPTIMISM],
+        data: { address: '0xADDRESS', type: 'address' },
+        label: '0xADDRESS',
+        type: 'group',
+        value: Zero,
+      };
+
+      expect(editBlockchainAccount(account)).toEqual({
+        category: 'evm',
+        chain: undefined,
+        data: { address: '0xADDRESS', label: undefined, tags: null },
+        mode: 'edit',
+        type: 'group',
+      });
+    });
+
+    it('should build a single-account edit state and keep a distinct label', () => {
+      const account: BlockchainAccountBalance = {
+        amount: Zero,
+        chain: Blockchain.ETH,
+        data: { address: '0xABC', type: 'address' },
+        label: 'Main wallet',
+        nativeAsset: 'ETH',
+        tags: ['hot'],
+        type: 'account',
+        value: Zero,
+      };
+
+      expect(editBlockchainAccount(account)).toEqual({
+        chain: Blockchain.ETH,
+        data: { address: '0xABC', label: 'Main wallet', tags: ['hot'] },
+        mode: 'edit',
+        type: 'account',
+      });
     });
   });
 });

--- a/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
@@ -2,7 +2,9 @@ import type { Ref } from 'vue';
 import type {
   AccountPayload,
   BlockchainAccountBalance,
+  ValidatorData,
   XpubAccountPayload,
+  XpubData,
 } from '@/modules/accounts/blockchain-accounts';
 import type { Eth2Validator } from '@/modules/balances/types/balances';
 import type { Module } from '@/modules/core/common/modules';
@@ -79,69 +81,83 @@ export function createNewBlockchainAccount(): AccountManageAdd {
   };
 }
 
+function buildValidatorManage(data: ValidatorData): StakingValidatorManage {
+  const { index, ownershipPercentage = '100', publicKey } = data;
+  return {
+    chain: Blockchain.ETH2,
+    data: {
+      ownershipPercentage: ownershipPercentage || '100',
+      publicKey,
+      validatorIndex: index.toString(),
+    },
+    mode: 'edit',
+    type: 'validator',
+  };
+}
+
+function buildXpubManage(account: BlockchainAccountBalance, data: XpubData): XpubManage {
+  const chain = getChain(account);
+  assert(chain && isBtcChain(chain));
+  const prefix = guessPrefix(data.xpub);
+  return {
+    chain,
+    data: {
+      label: account.label,
+      tags: account.tags ?? null,
+      xpub: {
+        derivationPath: data.derivationPath ?? '',
+        xpub: data.xpub,
+        xpubType: getKeyType(prefix),
+      },
+    },
+    mode: 'edit',
+    type: 'xpub',
+  };
+}
+
+function buildGroupManage(account: BlockchainAccountBalance): AccountAgnosticManage {
+  assert(account.category);
+  const address = getAccountAddress(account);
+  return {
+    category: account.category,
+    chain: undefined,
+    data: {
+      address,
+      label: account.label === address ? undefined : account.label,
+      tags: account.tags ?? null,
+    },
+    mode: 'edit',
+    type: 'group',
+  };
+}
+
+function buildAddressManage(account: BlockchainAccountBalance): AccountManageEdit {
+  const chain = getChain(account);
+  assert(chain);
+  const address = getAccountAddress(account);
+  return {
+    chain,
+    data: {
+      address,
+      label: account.label === address ? undefined : account.label,
+      tags: account.tags ?? null,
+    },
+    mode: 'edit',
+    type: 'account',
+  };
+}
+
 export function editBlockchainAccount(account: BlockchainAccountBalance): AccountManageState {
-  if ('publicKey' in account.data) {
-    const { index, ownershipPercentage = '100', publicKey } = account.data;
-    return {
-      chain: Blockchain.ETH2,
-      data: {
-        ownershipPercentage: ownershipPercentage || '100',
-        publicKey,
-        validatorIndex: index.toString(),
-      },
-      mode: 'edit',
-      type: 'validator',
-    } satisfies StakingValidatorManage;
-  }
-  else if ('xpub' in account.data) {
-    const chain = getChain(account);
-    assert(chain && isBtcChain(chain));
-    const prefix = guessPrefix(account.data.xpub);
-    return {
-      chain,
-      data: {
-        label: account.label,
-        tags: account.tags ?? null,
-        xpub: {
-          derivationPath: account.data.derivationPath ?? '',
-          xpub: account.data.xpub,
-          xpubType: getKeyType(prefix),
-        },
-      },
-      mode: 'edit',
-      type: 'xpub',
-    } satisfies XpubManage;
-  }
-  else if (account.type === 'group' && account.chains.length > 1) {
-    assert(account.category);
-    const address = getAccountAddress(account);
-    return {
-      category: account.category,
-      chain: undefined,
-      data: {
-        address,
-        label: account.label === address ? undefined : account.label,
-        tags: account.tags ?? null,
-      },
-      mode: 'edit',
-      type: 'group',
-    } satisfies AccountAgnosticManage;
-  }
-  else {
-    const chain = getChain(account);
-    assert(chain);
-    const address = getAccountAddress(account);
-    return {
-      chain,
-      data: {
-        address,
-        label: account.label === address ? undefined : account.label,
-        tags: account.tags ?? null,
-      },
-      mode: 'edit',
-      type: 'account',
-    } satisfies AccountManageEdit;
-  }
+  if ('publicKey' in account.data)
+    return buildValidatorManage(account.data);
+
+  if ('xpub' in account.data)
+    return buildXpubManage(account, account.data);
+
+  if (account.type === 'group' && account.chains.length > 1)
+    return buildGroupManage(account);
+
+  return buildAddressManage(account);
 }
 
 interface UseAccountManageReturn {

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationDialog.vue
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { isSolanaTokenIdentifier } from '@rotki/common';
 import { externalLinks } from '@shared/external-links';
 import { useTemplateRef } from 'vue';
+import { extractTargetAssetFromError, isUniqueConstraintError } from '@/modules/assets/admin/solana-token-migration/solana-migration-error';
 import { useSolanaTokenMigrationApi } from '@/modules/assets/admin/solana-token-migration/solana-token-migration';
 import { useSolanaTokenMigrationStore } from '@/modules/assets/admin/solana-token-migration/use-solana-token-migration-store';
 import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
@@ -90,51 +90,49 @@ async function save(): Promise<boolean> {
     }
   }
   catch (error: unknown) {
-    let errors: ValidationErrors | string = getErrorMessage(error);
-    if (error instanceof ApiValidationError) {
-      errors = error.getValidationErrors({});
-    }
-
-    if (typeof errors === 'string') {
-      // Check if this is a unique constraint error and suggest merge
-      if (isUniqueConstraintError(errors)) {
-        const targetAsset = extractTargetAssetFromError(errors);
-        if (targetAsset && assetToMigrate) {
-          emit('suggest-merge', { sourceAsset: assetToMigrate, targetAsset });
-          set(modelValue, undefined);
-          set(oldAsset, undefined);
-          return false;
-        }
-      }
-
-      setMessage({
-        description: errors,
-        title: t('asset_management.solana_token_migration.migration_error'),
-      });
-    }
-    else {
-      set(errorMessages, errors);
-      formRef?.validate();
-    }
-    return false;
+    return handleSaveException(error, assetToMigrate, formRef);
   }
   finally {
     set(loading, false);
   }
 }
 
-function extractTargetAssetFromError(errorMessage: string): string | null {
-  const words = errorMessage.split(/\s+/);
-  for (const word of words) {
-    if (isSolanaTokenIdentifier(word)) {
-      return word;
-    }
-  }
-  return null;
+type MigrationFormRef = InstanceType<typeof SolanaTokenMigrationForm> | null | undefined;
+
+// Suggests a merge for a unique-constraint conflict; returns true when handled.
+function suggestMergeOnConflict(message: string, assetToMigrate: string): boolean {
+  if (!isUniqueConstraintError(message))
+    return false;
+
+  const targetAsset = extractTargetAssetFromError(message);
+  if (!targetAsset)
+    return false;
+
+  emit('suggest-merge', { sourceAsset: assetToMigrate, targetAsset });
+  set(modelValue, undefined);
+  set(oldAsset, undefined);
+  return true;
 }
 
-function isUniqueConstraintError(errorMessage: string): boolean {
-  return errorMessage.includes('UNIQUE constraint failed: assets.identifier');
+function handleSaveException(error: unknown, assetToMigrate: string, formRef: MigrationFormRef): boolean {
+  let errors: ValidationErrors | string = getErrorMessage(error);
+  if (error instanceof ApiValidationError)
+    errors = error.getValidationErrors({});
+
+  if (typeof errors === 'string') {
+    if (suggestMergeOnConflict(errors, assetToMigrate))
+      return false;
+
+    setMessage({
+      description: errors,
+      title: t('asset_management.solana_token_migration.migration_error'),
+    });
+  }
+  else {
+    set(errorMessages, errors);
+    formRef?.validate();
+  }
+  return false;
 }
 </script>
 

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/solana-migration-error.spec.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/solana-migration-error.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { extractTargetAssetFromError, isUniqueConstraintError } from './solana-migration-error';
+
+const TARGET = 'solana/token:7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK';
+
+describe('isUniqueConstraintError', () => {
+  it('should detect the unique-constraint failure message', () => {
+    expect(isUniqueConstraintError('UNIQUE constraint failed: assets.identifier')).toBe(true);
+    expect(isUniqueConstraintError(`some prefix UNIQUE constraint failed: assets.identifier and ${TARGET}`)).toBe(true);
+  });
+
+  it('should return false for unrelated messages', () => {
+    expect(isUniqueConstraintError('some other error')).toBe(false);
+    expect(isUniqueConstraintError('UNIQUE constraint failed: assets.name')).toBe(false);
+  });
+});
+
+describe('extractTargetAssetFromError', () => {
+  it('should return the first solana token identifier in the message', () => {
+    expect(extractTargetAssetFromError(`conflict with ${TARGET} already present`)).toBe(TARGET);
+  });
+
+  it('should return null when no solana token identifier is present', () => {
+    expect(extractTargetAssetFromError('UNIQUE constraint failed: assets.identifier')).toBeNull();
+    expect(extractTargetAssetFromError('')).toBeNull();
+  });
+});

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/solana-migration-error.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/solana-migration-error.ts
@@ -1,0 +1,21 @@
+import { isSolanaTokenIdentifier } from '@rotki/common';
+
+/**
+ * Returns the first Solana token identifier found in a backend error message,
+ * used to suggest merging into the conflicting asset.
+ */
+export function extractTargetAssetFromError(errorMessage: string): string | null {
+  const words = errorMessage.split(/\s+/);
+  for (const word of words) {
+    if (isSolanaTokenIdentifier(word))
+      return word;
+  }
+  return null;
+}
+
+/**
+ * Detects the unique-constraint failure raised when the target asset already exists.
+ */
+export function isUniqueConstraintError(errorMessage: string): boolean {
+  return errorMessage.includes('UNIQUE constraint failed: assets.identifier');
+}

--- a/frontend/app/src/modules/assets/detection/use-newly-detected-tokens-db.ts
+++ b/frontend/app/src/modules/assets/detection/use-newly-detected-tokens-db.ts
@@ -29,6 +29,24 @@ interface UseNewlyDetectedTokensDbReturn {
 
 const PRUNE_DEBOUNCE_MS = 20000; // 20 seconds debounce for auto-prune
 
+interface ResolvedTokenQuery {
+  orderBy: keyof NewDetectedTokenRecord;
+  order: 'asc' | 'desc';
+  filter?: ItemFilter<NewDetectedTokenRecord>;
+}
+
+function resolveTokenQuery(payload: NewDetectedTokensRequestPayload): ResolvedTokenQuery {
+  const { ascending = [], orderByAttributes = [], tokenKind } = payload;
+
+  // Convert from snake_case (from useServerTable) to camelCase for IndexedDB
+  const snakeCaseOrderBy = orderByAttributes.length > 0 ? orderByAttributes[0] : 'detected_at';
+  const orderBy = transformCase(snakeCaseOrderBy, true) as keyof NewDetectedTokenRecord;
+  const order = ascending.length > 0 && ascending[0] ? 'asc' : 'desc';
+  const filter = tokenKind ? (t: NewDetectedTokenRecord): boolean => t.tokenKind === tokenKind : undefined;
+
+  return { filter, order, orderBy };
+}
+
 export const useNewlyDetectedTokensDb = createSharedComposable((): UseNewlyDetectedTokensDbReturn => {
   const isPruning = ref<boolean>(false);
 
@@ -57,24 +75,9 @@ export const useNewlyDetectedTokensDb = createSharedComposable((): UseNewlyDetec
       return emptyResult;
 
     try {
-      const {
-        ascending = [],
-        limit,
-        offset,
-        orderByAttributes = [],
-        tokenKind,
-      } = get(payload);
-
-      // Convert from snake_case (from useServerTable) to camelCase for IndexedDB
-      const snakeCaseOrderBy = orderByAttributes.length > 0 ? orderByAttributes[0] : 'detected_at';
-      const orderBy = transformCase(snakeCaseOrderBy, true) as keyof NewDetectedTokenRecord;
-      const order = ascending.length > 0 && ascending[0] ? 'asc' : 'desc';
-
-      // Build filter function if needed
-      let filter: ItemFilter<NewDetectedTokenRecord> | undefined;
-      if (tokenKind) {
-        filter = (t): boolean => t.tokenKind === tokenKind;
-      }
+      const payloadValue = get(payload);
+      const { limit, offset } = payloadValue;
+      const { filter, order, orderBy } = resolveTokenQuery(payloadValue);
 
       // Get total count (unfiltered)
       const total = await db().newlyDetectedTokens.count();

--- a/frontend/app/src/modules/balances/nft/use-nft-gallery-filters.ts
+++ b/frontend/app/src/modules/balances/nft/use-nft-gallery-filters.ts
@@ -5,6 +5,33 @@ import { assert, BigNumber } from '@rotki/common';
 import { getAccountAddress } from '@/modules/accounts/account-utils';
 import { uniqueStrings } from '@/modules/core/common/data/data';
 
+type NftSortKey = 'name' | 'price' | 'collection';
+
+type NftSortValue = string | BigNumber | null;
+
+function getSortValue(nft: GalleryNft, sortProp: NftSortKey): NftSortValue {
+  return sortProp === 'collection' ? nft.collection.name : nft[sortProp];
+}
+
+function compareNullableNft(a: NftSortValue, b: NftSortValue, desc: boolean): number {
+  if (a && !b)
+    return desc ? 1 : -1;
+  if (!a && b)
+    return desc ? -1 : 1;
+  return 0;
+}
+
+function compareNftValues(a: NftSortValue, b: NftSortValue, desc: boolean): number {
+  if (typeof a === 'string' && typeof b === 'string') {
+    return desc
+      ? b.localeCompare(a, 'en', { sensitivity: 'base' })
+      : a.localeCompare(b, 'en', { sensitivity: 'base' });
+  }
+  if (a instanceof BigNumber && b instanceof BigNumber)
+    return (desc ? b.minus(a) : a.minus(b)).toNumber();
+  return compareNullableNft(a, b, desc);
+}
+
 interface UseNftGalleryFiltersReturn {
   availableAddresses: ComputedRef<string[]>;
   collections: ComputedRef<string[]>;
@@ -64,35 +91,14 @@ export function useNftGalleryFilters(
   }
 
   function sortNfts(
-    sortProperty: Ref<'name' | 'price' | 'collection'>,
+    sortProperty: Ref<NftSortKey>,
     sortDesc: Ref<boolean>,
     a: GalleryNft,
     b: GalleryNft,
   ): number {
     const sortProp = get(sortProperty);
     const desc = get(sortDesc);
-    const isCollection = sortProp === 'collection';
-    const aElement = isCollection ? a.collection.name : a[sortProp];
-    const bElement = isCollection ? b.collection.name : b[sortProp];
-
-    if (typeof aElement === 'string' && typeof bElement === 'string') {
-      return desc
-        ? bElement.localeCompare(aElement, 'en', { sensitivity: 'base' })
-        : aElement.localeCompare(bElement, 'en', { sensitivity: 'base' });
-    }
-    else if (aElement instanceof BigNumber && bElement instanceof BigNumber) {
-      return (desc ? bElement.minus(aElement) : aElement.minus(bElement)).toNumber();
-    }
-    else if (aElement === null && bElement === null) {
-      return 0;
-    }
-    else if (aElement && !bElement) {
-      return desc ? 1 : -1;
-    }
-    else if (!aElement && bElement) {
-      return desc ? -1 : 1;
-    }
-    return 0;
+    return compareNftValues(getSortValue(a, sortProp), getSortValue(b, sortProp), desc);
   }
 
   return {

--- a/frontend/app/src/modules/balances/use-asset-balances-breakdown.ts
+++ b/frontend/app/src/modules/balances/use-asset-balances-breakdown.ts
@@ -1,5 +1,6 @@
 import type { ComputedRef } from 'vue';
-import type { Accounts, AssetBreakdown, Balances } from '@/modules/accounts/blockchain-accounts';
+import type { Accounts, AssetBreakdown, Balances, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import type { EthBalance } from '@/modules/balances/types/blockchain-balances';
 import type { ExchangeData } from '@/modules/balances/types/exchanges';
 import type { ManualBalanceWithValue } from '@/modules/balances/types/manual-balances';
 import { Zero } from '@rotki/common';
@@ -78,11 +79,40 @@ export function useAssetBalancesBreakdown(): UseAssetBalancesBreakdownReturn {
     return breakdown;
   }
 
+  function collectAddressBreakdown(
+    chain: string,
+    address: string,
+    balance: EthBalance,
+    chainAccounts: BlockchainAccount[],
+    asset: string,
+    isLiability: boolean,
+  ): AssetBreakdown[] {
+    const result: AssetBreakdown[] = [];
+    const resolved = resolveAssetIdentifier(asset);
+    const identifiers = resolved !== asset ? [asset, resolved] : [asset];
+
+    for (const identifier of identifiers) {
+      const assetBalance = balance[isLiability ? 'liabilities' : 'assets'][identifier];
+      if (!assetBalance)
+        continue;
+
+      const summedBalance = perProtocolBalanceSum({ amount: Zero, value: Zero }, assetBalance);
+      result.push({
+        address,
+        location: getEvmChainName(chain) ?? chain,
+        ...summedBalance,
+        tags: chainAccounts.find(account => getAccountAddress(account) === address && account.chain === chain)?.tags,
+      });
+    }
+
+    return result;
+  }
+
   function getBlockchainAssetBreakdown(
     data: BreakdownData,
     asset: string,
-    isLiability: boolean = false,
-    filters: BreakdownFilters = {},
+    isLiability: boolean,
+    filters: BreakdownFilters,
   ): AssetBreakdown[] {
     const breakdown: AssetBreakdown[] = [];
     const { chains = [], groupId } = filters;
@@ -91,36 +121,23 @@ export function useAssetBalancesBreakdown(): UseAssetBalancesBreakdownReturn {
     const chainList = chains.length > 0 ? chains : Object.keys(accountData);
 
     for (const chain of chainList) {
-      const chainAccounts = accountData[chain] ?? {};
       const chainBalanceData = balanceData[chain];
       if (!chainBalanceData)
         continue;
 
+      const chainAccounts = accountData[chain] ?? [];
       for (const address in chainBalanceData) {
         if (groupId && address !== groupId)
           continue;
 
-        const balance = chainBalanceData[address];
-        const resolved = resolveAssetIdentifier(asset);
-        const identifiers = resolved !== asset ? [asset, resolved] : [asset];
-        for (const identifier of identifiers) {
-          const assetBalance = balance[isLiability ? 'liabilities' : 'assets'][identifier];
-          if (!assetBalance)
-            continue;
-
-          const summedBalance = perProtocolBalanceSum({
-            amount: Zero,
-            value: Zero,
-          }, assetBalance);
-
-          breakdown.push({
-            address,
-            location: getEvmChainName(chain) ?? chain,
-            ...summedBalance,
-            tags: chainAccounts.find(account => getAccountAddress(account) === address && account.chain === chain)
-              ?.tags,
-          });
-        }
+        breakdown.push(...collectAddressBreakdown(
+          chain,
+          address,
+          chainBalanceData[address],
+          chainAccounts,
+          asset,
+          isLiability,
+        ));
       }
     }
 

--- a/frontend/app/src/modules/core/table/pagination-filter-utils.spec.ts
+++ b/frontend/app/src/modules/core/table/pagination-filter-utils.spec.ts
@@ -1,6 +1,6 @@
 import type { Sorting } from '@/modules/core/table/pagination-filter-types';
 import { describe, expect, it } from 'vitest';
-import { applySortingDefaults, getApiSortingParams, getSorting } from '@/modules/core/table/pagination-filter-utils';
+import { applySortingDefaults, getApiSortingParams, getSorting, parseQueryHistory } from '@/modules/core/table/pagination-filter-utils';
 
 interface EventDetails {
   date: string;
@@ -106,6 +106,37 @@ describe('use-pagination-filter.utils.ts', () => {
         column: 'id',
         direction: 'desc',
       });
+    });
+  });
+
+  describe('parseQueryHistory', () => {
+    it('should return the defaults when the query has no sort or order', () => {
+      const defaults: Sorting<EventDetails> = { column: 'name', direction: 'asc' };
+      expect(parseQueryHistory<EventDetails>({}, defaults)).toBe(defaults);
+    });
+
+    it('should parse a single-column sort from the query when the default is not an array', () => {
+      const defaults: Sorting<EventDetails> = { column: 'name', direction: 'asc' };
+      expect(parseQueryHistory<EventDetails>({ sort: 'date', sortOrder: 'desc' }, defaults)).toEqual({
+        column: 'date',
+        direction: 'desc',
+      });
+    });
+
+    it('should parse multiple sort columns when the default is an array', () => {
+      const defaults: Sorting<EventDetails> = [{ column: 'name', direction: 'asc' }];
+      expect(parseQueryHistory<EventDetails>({ sort: ['date', 'name'], sortOrder: ['asc', 'desc'] }, defaults)).toEqual([
+        { column: 'date', direction: 'asc' },
+        { column: 'name', direction: 'desc' },
+      ]);
+    });
+
+    it('should apply the fallback column to multi-sort entries missing a column', () => {
+      const defaults: Sorting<EventDetails> = [{ column: 'name', direction: 'asc' }];
+      expect(parseQueryHistory<EventDetails>({ sortOrder: ['asc', 'desc'] }, defaults, 'id')).toEqual([
+        { column: 'id', direction: 'asc' },
+        { column: 'id', direction: 'desc' },
+      ]);
     });
   });
 });

--- a/frontend/app/src/modules/core/table/pagination-filter-utils.ts
+++ b/frontend/app/src/modules/core/table/pagination-filter-utils.ts
@@ -26,39 +26,42 @@ export function getSorting<T extends NonNullable<unknown>>(
   };
 }
 
+function parseMultiSort<T extends NonNullable<unknown>>(
+  sort: string[] | undefined,
+  order: ('asc' | 'desc')[] | undefined,
+  fallbackColumn: string,
+): SingleColumnSorting<T>[] {
+  const length = sort?.length || order?.length || 0;
+  const sorting: SingleColumnSorting<T>[] = [];
+
+  for (let i = 0; i < length; i++) {
+    sorting.push(getSorting({
+      column: sort?.[i],
+      direction: order?.[i],
+    }, undefined, fallbackColumn));
+  }
+
+  return sorting;
+}
+
 export function parseQueryHistory<T extends NonNullable<unknown>>(
   query: LocationQuery,
   defaults: Sorting<T>,
   fallbackColumn: string = DEFAULT_FALLBACK_SORT_COLUMN,
 ): Sorting<T> {
-  const singleSort = !Array.isArray(defaults);
-  const sorting = HistorySortOrderSchema.parse(query);
+  const { sort, sortOrder: order } = HistorySortOrderSchema.parse(query);
 
-  const sort = sorting.sort;
-  const order = sorting.sortOrder;
-  if (!sort && !order) {
+  if (!sort && !order)
     return defaults;
-  }
 
-  if (singleSort) {
+  if (!Array.isArray(defaults)) {
     return getSorting({
       column: sort?.[0],
       direction: order?.[0],
     }, defaults, fallbackColumn);
   }
-  else {
-    const length = sort?.length || order?.length || 0;
-    const sorting: SingleColumnSorting<T>[] = [];
 
-    for (let i = 0; i < length; i++) {
-      sorting.push(getSorting({
-        column: sort?.[i],
-        direction: order?.[i],
-      }, undefined, fallbackColumn));
-    }
-
-    return sorting;
-  }
+  return parseMultiSort<T>(sort, order, fallbackColumn);
 }
 
 export function parseQueryPagination(query: LocationQuery, pagination: TablePaginationData): TablePaginationData {

--- a/frontend/app/src/modules/history/events/dialog-manager/use-history-events-dialog-manager.ts
+++ b/frontend/app/src/modules/history/events/dialog-manager/use-history-events-dialog-manager.ts
@@ -1,7 +1,9 @@
 import type { Ref } from 'vue';
 import type { DialogState } from './types';
+import type { AddTransactionHashPayload } from '@/modules/history/events/event-payloads';
+import type { AccountingRuleIdentifier } from '@/modules/settings/types/accounting';
 import { set } from '@vueuse/core';
-import { DIALOG_TYPES, type DialogShowOptions } from '@/modules/history/events/dialog-types';
+import { DIALOG_TYPES, type DialogShowOptions, type DialogType } from '@/modules/history/events/dialog-types';
 import { PinnedNames } from '@/modules/session/types';
 import { usePinnedPanel } from '@/modules/shell/pinned/use-pinned-panel';
 
@@ -11,13 +13,67 @@ interface UseHistoryEventsDialogManager {
   closeDialog: () => void;
 }
 
+type OpenDialogState = Exclude<DialogState, { type: 'closed' }>;
+
+type DatalessDialogType =
+  | typeof DIALOG_TYPES.CUSTOMIZED_EVENT_DUPLICATES
+  | typeof DIALOG_TYPES.INTERNAL_TX_CONFLICTS
+  | typeof DIALOG_TYPES.MATCH_ASSET_MOVEMENTS
+  | typeof DIALOG_TYPES.MATCH_BRIDGE_TRANSACTIONS
+  | typeof DIALOG_TYPES.PROTOCOL_CACHE
+  | typeof DIALOG_TYPES.REPULLING_TRANSACTION;
+
+const DATALESS_DIALOG_TYPES = new Set<DialogType>([
+  DIALOG_TYPES.CUSTOMIZED_EVENT_DUPLICATES,
+  DIALOG_TYPES.INTERNAL_TX_CONFLICTS,
+  DIALOG_TYPES.MATCH_ASSET_MOVEMENTS,
+  DIALOG_TYPES.MATCH_BRIDGE_TRANSACTIONS,
+  DIALOG_TYPES.PROTOCOL_CACHE,
+  DIALOG_TYPES.REPULLING_TRANSACTION,
+]);
+
+function isDatalessDialogType(type: DialogType): type is DatalessDialogType {
+  return DATALESS_DIALOG_TYPES.has(type);
+}
+
+function buildTransactionForm(data?: AddTransactionHashPayload): OpenDialogState {
+  return {
+    data: data ?? { associatedAddress: '', blockchain: '', txRef: '' },
+    type: DIALOG_TYPES.TRANSACTION_FORM,
+  };
+}
+
+/**
+ * Maps show options to the dialog state to open, or `undefined` for options that
+ * do not open a dialog directly (handled by the caller, e.g. add-missing-rule).
+ */
+function resolveDialogState(options: DialogShowOptions): OpenDialogState | undefined {
+  if (isDatalessDialogType(options.type))
+    return { data: undefined, type: options.type };
+
+  switch (options.type) {
+    case DIALOG_TYPES.EVENT_FORM:
+      return { data: options.data, type: DIALOG_TYPES.EVENT_FORM };
+    case DIALOG_TYPES.TRANSACTION_FORM:
+      return buildTransactionForm(options.data);
+    case DIALOG_TYPES.ADD_TRANSACTION:
+      return buildTransactionForm();
+    case DIALOG_TYPES.MISSING_RULES:
+      return { data: options.data, type: DIALOG_TYPES.MISSING_RULES };
+    case DIALOG_TYPES.DECODING_STATUS:
+      return { data: { persistent: Boolean(options.persistent) }, type: DIALOG_TYPES.DECODING_STATUS };
+    case DIALOG_TYPES.ADD_MISSING_RULE:
+      return undefined;
+  }
+}
+
 export function useHistoryEventsDialogManager(): UseHistoryEventsDialogManager {
   const router = useRouter();
   const internalTxConflicts = usePinnedPanel(PinnedNames.INTERNAL_TX_CONFLICTS);
 
   const currentDialog = ref<DialogState>({ type: 'closed' });
 
-  function openDialog(state: Exclude<DialogState, { type: 'closed' }>): void {
+  function openDialog(state: OpenDialogState): void {
     set(currentDialog, state);
   }
 
@@ -25,71 +81,29 @@ export function useHistoryEventsDialogManager(): UseHistoryEventsDialogManager {
     set(currentDialog, { type: 'closed' });
   }
 
+  async function navigateToAddRule(data: AccountingRuleIdentifier): Promise<void> {
+    const { eventIds, ...restData } = data;
+    await router.push({
+      path: '/settings/accounting',
+      query: { 'add-rule': 'true', 'eventId': eventIds ? eventIds[0].toString() : undefined, ...restData },
+    });
+  }
+
   async function show(options: DialogShowOptions): Promise<void> {
-    switch (options.type) {
-      case DIALOG_TYPES.EVENT_FORM:
-        openDialog({ data: options.data, type: DIALOG_TYPES.EVENT_FORM });
-        break;
-      case DIALOG_TYPES.TRANSACTION_FORM:
-        openDialog({
-          data: options.data || {
-            associatedAddress: '',
-            blockchain: '',
-            txRef: '',
-          },
-          type: DIALOG_TYPES.TRANSACTION_FORM,
-        });
-        break;
-      case DIALOG_TYPES.REPULLING_TRANSACTION:
-        openDialog({ data: undefined, type: DIALOG_TYPES.REPULLING_TRANSACTION });
-        break;
-      case DIALOG_TYPES.MISSING_RULES:
-        openDialog({ data: options.data, type: DIALOG_TYPES.MISSING_RULES });
-        break;
-      case DIALOG_TYPES.DECODING_STATUS:
-        openDialog({ data: { persistent: options.persistent || false }, type: DIALOG_TYPES.DECODING_STATUS });
-        break;
-      case DIALOG_TYPES.PROTOCOL_CACHE:
-        openDialog({ data: undefined, type: DIALOG_TYPES.PROTOCOL_CACHE });
-        break;
-      case DIALOG_TYPES.ADD_TRANSACTION:
-        openDialog({
-          data: {
-            associatedAddress: '',
-            blockchain: '',
-            txRef: '',
-          },
-          type: DIALOG_TYPES.TRANSACTION_FORM,
-        });
-        break;
-      case DIALOG_TYPES.ADD_MISSING_RULE: {
-        const { eventIds, ...restData } = options.data;
-        await router.push({
-          path: '/settings/accounting',
-          query: { 'add-rule': 'true', 'eventId': eventIds ? eventIds[0].toString() : undefined, ...restData },
-        });
-        break;
-      }
-      case DIALOG_TYPES.CUSTOMIZED_EVENT_DUPLICATES:
-        openDialog({ data: undefined, type: DIALOG_TYPES.CUSTOMIZED_EVENT_DUPLICATES });
-        break;
-      case DIALOG_TYPES.INTERNAL_TX_CONFLICTS:
-        // Already pinned: bring its tab to the front instead of reopening the dialog.
-        if (get(internalTxConflicts.isPinned)) {
-          internalTxConflicts.focus();
-          return;
-        }
-        openDialog({ data: undefined, type: DIALOG_TYPES.INTERNAL_TX_CONFLICTS });
-        break;
-      case DIALOG_TYPES.MATCH_ASSET_MOVEMENTS:
-        openDialog({ data: undefined, type: DIALOG_TYPES.MATCH_ASSET_MOVEMENTS });
-        break;
-      case DIALOG_TYPES.MATCH_BRIDGE_TRANSACTIONS:
-        openDialog({ data: undefined, type: DIALOG_TYPES.MATCH_BRIDGE_TRANSACTIONS });
-        break;
-      default:
-        break;
+    if (options.type === DIALOG_TYPES.ADD_MISSING_RULE) {
+      await navigateToAddRule(options.data);
+      return;
     }
+
+    // Already pinned: bring its tab to the front instead of reopening the dialog.
+    if (options.type === DIALOG_TYPES.INTERNAL_TX_CONFLICTS && get(internalTxConflicts.isPinned)) {
+      internalTxConflicts.focus();
+      return;
+    }
+
+    const state = resolveDialogState(options);
+    if (state)
+      openDialog(state);
   }
 
   return {

--- a/frontend/app/src/modules/history/events/use-deletion-strategies.ts
+++ b/frontend/app/src/modules/history/events/use-deletion-strategies.ts
@@ -23,56 +23,67 @@ export interface ConfirmationMessage {
   title: string;
 }
 
+type Translate = (key: string, params?: any) => string;
+
+function buildDeleteTransactionsMessage(strategy: DeletionStrategy, t: Translate): ConfirmationMessage {
+  const count = strategy.transactions?.size ?? 0;
+  const message = count === 1
+    ? t('transactions.events.confirmation.delete.complete_transaction_single')
+    : t('transactions.events.confirmation.delete.complete_transaction_multiple', { count });
+  return {
+    message: `${message}\n\n${t('transactions.events.confirmation.delete.complete_transaction_options')}`,
+    primaryAction: t('transactions.events.confirmation.delete.delete_transaction'),
+    secondaryAction: t('transactions.events.confirmation.ignore.action_short'),
+    title: t('transactions.events.confirmation.delete.complete_transaction_title'),
+  };
+}
+
+function buildDeleteEventsMessage(strategy: DeletionStrategy, t: Translate): ConfirmationMessage {
+  return {
+    message: t('transactions.events.confirmation.delete.message_multiple', {
+      count: strategy.eventIds?.length ?? 0,
+    }),
+    primaryAction: t('common.actions.confirm'),
+    title: t('transactions.events.confirmation.delete.title'),
+  };
+}
+
+function buildDeletePartialSwapMessage(strategy: DeletionStrategy, t: Translate): ConfirmationMessage {
+  const totalEvents = strategy.partialSwapGroups?.reduce((sum, group) => sum + group.groupIds.length, 0) ?? 0;
+  const selectedEvents = strategy.partialSwapGroups?.reduce((sum, group) => sum + group.selectedIds.length, 0) ?? 0;
+  return {
+    message: t('transactions.events.confirmation.delete.partial_swap_warning', {
+      groupCount: strategy.partialSwapGroups?.length ?? 0,
+      selectedCount: selectedEvents,
+      totalCount: totalEvents,
+    }),
+    primaryAction: t('common.actions.confirm'),
+    title: t('transactions.events.confirmation.delete.partial_swap_title'),
+  };
+}
+
+function buildIgnoreEventsMessage(strategy: DeletionStrategy, t: Translate): ConfirmationMessage {
+  const count = strategy.transactions?.size ?? 0;
+  return {
+    message: t('transactions.events.confirmation.ignore.message_multiple', { count }),
+    primaryAction: t('transactions.events.confirmation.ignore.confirm'),
+    title: t('transactions.events.confirmation.ignore.title'),
+  };
+}
+
 export function buildDeletionConfirmationMessage(
   strategy: DeletionStrategy,
-  t: (key: string, params?: any) => string,
+  t: Translate,
 ): ConfirmationMessage {
   switch (strategy.type) {
-    case DELETION_STRATEGY_TYPE.DELETE_TRANSACTIONS: {
-      const count = strategy.transactions?.size ?? 0;
-      const message = count === 1
-        ? t('transactions.events.confirmation.delete.complete_transaction_single')
-        : t('transactions.events.confirmation.delete.complete_transaction_multiple', { count });
-      return {
-        message: `${message}\n\n${t('transactions.events.confirmation.delete.complete_transaction_options')}`,
-        primaryAction: t('transactions.events.confirmation.delete.delete_transaction'),
-        secondaryAction: t('transactions.events.confirmation.ignore.action_short'),
-        title: t('transactions.events.confirmation.delete.complete_transaction_title'),
-      };
-    }
-
+    case DELETION_STRATEGY_TYPE.DELETE_TRANSACTIONS:
+      return buildDeleteTransactionsMessage(strategy, t);
     case DELETION_STRATEGY_TYPE.DELETE_EVENTS:
-      return {
-        message: t('transactions.events.confirmation.delete.message_multiple', {
-          count: strategy.eventIds?.length ?? 0,
-        }),
-        primaryAction: t('common.actions.confirm'),
-        title: t('transactions.events.confirmation.delete.title'),
-      };
-
-    case DELETION_STRATEGY_TYPE.DELETE_PARTIAL_SWAP: {
-      const totalEvents = strategy.partialSwapGroups?.reduce((sum, group) => sum + group.groupIds.length, 0) ?? 0;
-      const selectedEvents = strategy.partialSwapGroups?.reduce((sum, group) => sum + group.selectedIds.length, 0) ?? 0;
-      return {
-        message: t('transactions.events.confirmation.delete.partial_swap_warning', {
-          groupCount: strategy.partialSwapGroups?.length ?? 0,
-          selectedCount: selectedEvents,
-          totalCount: totalEvents,
-        }),
-        primaryAction: t('common.actions.confirm'),
-        title: t('transactions.events.confirmation.delete.partial_swap_title'),
-      };
-    }
-
-    case DELETION_STRATEGY_TYPE.IGNORE_EVENTS: {
-      const count = strategy.transactions?.size ?? 0;
-      return {
-        message: t('transactions.events.confirmation.ignore.message_multiple', { count }),
-        primaryAction: t('transactions.events.confirmation.ignore.confirm'),
-        title: t('transactions.events.confirmation.ignore.title'),
-      };
-    }
-
+      return buildDeleteEventsMessage(strategy, t);
+    case DELETION_STRATEGY_TYPE.DELETE_PARTIAL_SWAP:
+      return buildDeletePartialSwapMessage(strategy, t);
+    case DELETION_STRATEGY_TYPE.IGNORE_EVENTS:
+      return buildIgnoreEventsMessage(strategy, t);
     default:
       throw new Error('Unknown deletion strategy');
   }

--- a/frontend/app/src/modules/history/events/use-history-matched-movement-item.ts
+++ b/frontend/app/src/modules/history/events/use-history-matched-movement-item.ts
@@ -108,6 +108,21 @@ export function useHistoryMatchedMovementItem(
     return !!ev.actualGroupIdentifier;
   });
 
+  function resolveEventLabel(event?: HistoryEventEntry): string {
+    if (!event)
+      return '';
+    return event.locationLabel || getLocationData(event.location)?.name || '';
+  }
+
+  function appendFeeNotes(notes: string): string {
+    const fee = get(events).filter(item => item.eventSubtype === 'fee');
+    if (fee.length === 0)
+      return notes;
+
+    const feeText = fee.map(item => `${item.amount.toFixed()} ${getAssetField(item.asset, 'symbol', ASSET_RESOLUTION_OPTIONS)}`).join('; ');
+    return t('history_events_list_swap.fee_description', { feeText, notes });
+  }
+
   // Build compact notes for asset movements with fee
   const compactNotes = computed<string | undefined>(() => {
     const primary = get(primaryEvent);
@@ -115,8 +130,8 @@ export function useHistoryMatchedMovementItem(
 
     const amount = primary.amount;
     const asset = getAssetField(primary.asset, 'symbol', ASSET_RESOLUTION_OPTIONS);
-    const exchangeLabel = primary.locationLabel || getLocationData(primary.location)?.name || '';
-    const addressLabel = secondary?.locationLabel || (secondary && getLocationData(secondary.location)?.name) || '';
+    const exchangeLabel = resolveEventLabel(primary);
+    const addressLabel = resolveEventLabel(secondary);
 
     const isDeposit = primary.eventSubtype === 'receive';
     // For deposits: to = exchange, from = address
@@ -131,13 +146,7 @@ export function useHistoryMatchedMovementItem(
       ? t('asset_movement_matching.compact_notes.deposit', { amount, asset, to, from })
       : t('asset_movement_matching.compact_notes.withdraw', { amount, asset, from, to });
 
-    // Append fee if exists
-    const fee = get(events).filter(item => item.eventSubtype === 'fee');
-    if (fee.length === 0)
-      return notes;
-
-    const feeText = fee.map(item => `${item.amount.toFixed()} ${getAssetField(item.asset, 'symbol', ASSET_RESOLUTION_OPTIONS)}`).join('; ');
-    return t('history_events_list_swap.fee_description', { feeText, notes });
+    return appendFeeNotes(notes);
   });
 
   const eventTypeLabel = computed<string>(() => {

--- a/frontend/app/src/modules/settings/use-settings-scroll-spy.ts
+++ b/frontend/app/src/modules/settings/use-settings-scroll-spy.ts
@@ -45,15 +45,20 @@ export function useSettingsScrollSpy({ navigation, scroller }: UseSettingsScroll
     );
   }
 
+  function resolveEdgeId(parent: HTMLDivElement): string | undefined {
+    if (parent.scrollTop === 0)
+      return navItems.at(0)?.id ?? '';
+    if (parent.scrollTop + parent.clientHeight >= parent.scrollHeight - 10)
+      return navItems.at(-1)?.id ?? '';
+    return undefined;
+  }
+
   function checkVisibility(): void {
     const parent = get(scroller);
     if (parent) {
-      if (parent.scrollTop === 0) {
-        set(currentId, navItems.at(0)?.id ?? '');
-        return;
-      }
-      if (parent.scrollTop + parent.clientHeight >= parent.scrollHeight - 10) {
-        set(currentId, navItems.at(-1)?.id ?? '');
+      const edgeId = resolveEdgeId(parent);
+      if (edgeId !== undefined) {
+        set(currentId, edgeId);
         return;
       }
     }

--- a/frontend/common/src/text/index.ts
+++ b/frontend/common/src/text/index.ts
@@ -250,33 +250,48 @@ export function isValidBchAddress(address?: string): boolean {
   return /^[pq][02-9ac-hj-np-z]{41,}$/.test(address);
 }
 
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const BASE58_BASE = 58;
+
+function createBase58Map(alphabet: string): Uint8Array {
+  const map = new Uint8Array(256).fill(255);
+  for (let i = 0; i < alphabet.length; i++)
+    map[alphabet.charCodeAt(i)] = i;
+  return map;
+}
+
+function countLeadingChars(str: string, leader: string): number {
+  let count = 0;
+  while (str[count] === leader)
+    count++;
+  return count;
+}
+
+// Trim leading zero bytes from the base256 buffer, then prepend the counted zeros.
+function buildDecodedResult(b256: Uint8Array, length: number, zeroes: number): Uint8Array {
+  const size = b256.length;
+  let it = size - length;
+  while (it !== size && b256[it] === 0)
+    it++;
+  const vch = new Uint8Array(zeroes + (size - it));
+  let j = zeroes;
+  while (it !== size)
+    vch[j++] = b256[it++];
+  return vch;
+}
+
 // Logic taken from https://github.com/cryptocoinjs/base-x/blob/master/src/esm/index.js
 function decodeBase58(str: string): Uint8Array {
-  const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-  const BASE = 58;
-  const LEADER = ALPHABET.charAt(0);
-  const FACTOR = Math.log(BASE) / Math.log(256);
-
-  // Create lookup map indexed by character code
-  const BASE_MAP = new Uint8Array(256);
-  for (let j = 0; j < BASE_MAP.length; j++) {
-    BASE_MAP[j] = 255;
-  }
-  for (let i = 0; i < ALPHABET.length; i++) {
-    BASE_MAP[ALPHABET.charCodeAt(i)] = i;
-  }
-
   if (str.length === 0)
     return new Uint8Array();
 
+  const BASE_MAP = createBase58Map(BASE58_ALPHABET);
+  const FACTOR = Math.log(BASE58_BASE) / Math.log(256);
+
   // Skip and count leading '1's (zeros)
-  let psz = 0;
-  let zeroes = 0;
+  const zeroes = countLeadingChars(str, BASE58_ALPHABET.charAt(0));
+  let psz = zeroes;
   let length = 0;
-  while (str[psz] === LEADER) {
-    zeroes++;
-    psz++;
-  }
 
   // Allocate enough space in big-endian base256 representation
   const size = (((str.length - psz) * FACTOR) + 1) >>> 0;
@@ -299,7 +314,7 @@ function decodeBase58(str: string): Uint8Array {
 
     let i = 0;
     for (let it = size - 1; (carry !== 0 || i < length) && (it !== -1); it--, i++) {
-      carry += (BASE * b256[it]) >>> 0;
+      carry += (BASE58_BASE * b256[it]) >>> 0;
       b256[it] = (carry % 256) >>> 0;
       carry = (carry / 256) >>> 0;
     }
@@ -311,20 +326,7 @@ function decodeBase58(str: string): Uint8Array {
     psz++;
   }
 
-  // Skip leading zeroes in b256
-  let it = size - length;
-  while (it !== size && b256[it] === 0) {
-    it++;
-  }
-
-  // Construct result with leading zeros
-  const vch = new Uint8Array(zeroes + (size - it));
-  let j = zeroes;
-  while (it !== size) {
-    vch[j++] = b256[it++];
-  }
-
-  return vch;
+  return buildDecodedResult(b256, length, zeroes);
 }
 
 export function isValidSolanaAddress(address?: string): boolean {


### PR DESCRIPTION
Continues the complexity cleanup. Clears every production `complexity` offender scoring **≥14** that is not owned by another in-flight branch: **11 files, 53 → 42 warnings, 0 errors.**

Each change is a behavior-preserving extraction (helpers kept under the threshold), verified test-first. Where the refactored function had no coverage, tests were added.

## Files
| File | was | how |
|------|-----|-----|
| `use-deletion-strategies.ts` | 18 | one builder per deletion strategy |
| `dialog-manager/use-history-events-dialog-manager.ts` | 17 | dataless type-guard + single exhaustive dispatch |
| `use-asset-balances-breakdown.ts` | 17 | per-address breakdown helper |
| `nft/use-nft-gallery-filters.ts` | 17 | extracted sort comparators |
| `common/src/text/index.ts` (base58) | 15 | map / leading-zero / result helpers |
| `use-history-matched-movement-item.ts` | 15 | label + fee-append helpers |
| `SolanaTokenMigrationDialog.vue` | 15 | pure `solana-migration-error.ts` module (+ spec) |
| `pagination-filter-utils.ts` | 14 | multi-sort parse helper (+ tests) |
| `use-settings-scroll-spy.ts` | 14 | edge-detection helper |
| `use-newly-detected-tokens-db.ts` | 14 | query resolver |
| `blockchain/use-account-manage.ts` | 14 | 4 state builders (+ tests) |

## Tests added where coverage was missing
- `solana-migration-error.spec.ts` (new) — unique-constraint detection + target-asset extraction
- `pagination-filter-utils.spec.ts` — `parseQueryHistory` single/multi-sort branches
- `use-account-manage.spec.ts` — `editBlockchainAccount` for all four account shapes

## Checks
- `pnpm run lint` — 0 errors (42 complexity warnings remain, down from 53)
- `pnpm run typecheck` — clean
- All touched specs green (149 tests across 11 files)
