### PR TITLE
fix: resolve bridge legs individually in matching

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7008,9 +7008,10 @@ Match the two legs of cross-chain bridge transfers
 
 .. http:get:: /api/(version)/history/events/match/bridges
 
-   Get a list of group identifiers of unmatched bridge events. Contains both source chain
+   Get a list of unmatched bridge legs as event identifier / group identifier pairs. Contains both source chain
    deposits awaiting their destination leg and destination chain withdrawals whose source
-   leg is unknown. This endpoint does not require premium.
+   leg is unknown. Legs are reported individually since a single transaction group can carry
+   several bridge legs that are matched or ignored independently. This endpoint does not require premium.
 
    **Example Request**:
 
@@ -7019,7 +7020,7 @@ Match the two legs of cross-chain bridge transfers
       GET /api/1/history/events/match/bridges?only_ignored=false HTTP/1.1
       Host: localhost:5042
 
-   :reqquery bool[optional] only_ignored: Flag indicating whether to return a list of the ignored bridge events, or the list of all bridge events that have not been matched or ignored yet.
+   :reqquery bool[optional] only_ignored: Flag indicating whether to return a list of the ignored bridge legs, or the list of all bridge legs that have not been matched or ignored yet.
 
    **Example Response**:
 
@@ -7030,13 +7031,13 @@ Match the two legs of cross-chain bridge transfers
 
       {
           "result": [
-              "10x0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8",
-              "421610x9f8e7d6c5b4a30219f8e7d6c5b4a30219f8e7d6c5b4a30219f8e7d6c5b4a3021"
+              {"identifier": 123, "group_identifier": "10x0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8"},
+              {"identifier": 456, "group_identifier": "421610x9f8e7d6c5b4a30219f8e7d6c5b4a30219f8e7d6c5b4a30219f8e7d6c5b4a3021"}
           ],
           "message": ""
       }
 
-   :resjson list result: A list of group identifiers for the unmatched bridge events.
+   :resjson list result: A list of entries, one per unmatched bridge leg, each holding the leg event's DB identifier and its group identifier.
    :resjson str message: Error message if any errors occurred.
    :statuscode 200: List of group identifiers returned successfully
    :statuscode 400: Provided JSON is in some way malformed
@@ -7059,13 +7060,13 @@ Match the two legs of cross-chain bridge transfers
       Content-Type: application/json;charset=UTF-8
 
       {
-          "bridge_event": "10x0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8",
+          "bridge_event": 123,
           "time_range": 7200,
           "only_expected_assets": true,
           "tolerance": "0.01"
       }
 
-   :reqjson string bridge_event: Group identifier of the bridge deposit to find matches for.
+   :reqjson int bridge_event: DB identifier of the bridge leg (deposit or withdrawal) to find matches for.
    :reqjson int time_range: Time range in seconds to search for matches.
    :reqjson bool[optional] only_expected_assets: Flag indicating whether to limit the possible matches to only events with assets in the same collection as the deposit's asset. True by default.
    :reqjson string tolerance: The tolerance value used when matching amounts. Must be a positive decimal number.

--- a/frontend/app/src/modules/history/api/events/use-bridge-matching-api.spec.ts
+++ b/frontend/app/src/modules/history/api/events/use-bridge-matching-api.spec.ts
@@ -29,11 +29,11 @@ describe('use-bridge-matching-api', () => {
     vi.clearAllMocks();
   });
 
-  it('should fetch unmatched bridge transactions with the only-ignored flag', async () => {
-    spies.get.mockResolvedValueOnce(['group-a']);
+  it('should fetch unmatched bridge legs with the only-ignored flag', async () => {
+    spies.get.mockResolvedValueOnce([{ groupIdentifier: 'group-a', identifier: 7 }]);
     const { getUnmatchedBridgeTransactions } = useBridgeMatchingApi();
 
-    await expect(getUnmatchedBridgeTransactions(true)).resolves.toEqual(['group-a']);
+    await expect(getUnmatchedBridgeTransactions(true)).resolves.toEqual([{ groupIdentifier: 'group-a', identifier: 7 }]);
 
     expect(spies.get).toHaveBeenCalledWith('/history/events/match/bridges', {
       params: { only_ignored: true },
@@ -55,13 +55,13 @@ describe('use-bridge-matching-api', () => {
     spies.post.mockResolvedValueOnce({ closeMatches: [1], otherEvents: [2] });
     const { getBridgeMatches } = useBridgeMatchingApi();
 
-    await expect(getBridgeMatches('group-a', 3600, true, '0.01')).resolves.toEqual({
+    await expect(getBridgeMatches(7, 3600, true, '0.01')).resolves.toEqual({
       closeMatches: [1],
       otherEvents: [2],
     });
 
     expect(spies.post).toHaveBeenCalledWith('/history/events/match/bridges', {
-      bridgeEvent: 'group-a',
+      bridgeEvent: 7,
       onlyExpectedAssets: true,
       timeRange: 3600,
       tolerance: '0.01',

--- a/frontend/app/src/modules/history/api/events/use-bridge-matching-api.ts
+++ b/frontend/app/src/modules/history/api/events/use-bridge-matching-api.ts
@@ -12,9 +12,19 @@ import { useTaskApi } from '@/modules/core/tasks/use-task-api';
  */
 export type BridgeLegResolution = 'external' | 'createCounterpart';
 
+/**
+ * An unresolved bridge leg as reported by the backend. Legs are reported individually
+ * since a single transaction group can carry several bridge legs that are matched or
+ * ignored independently.
+ */
+export interface UnmatchedBridgeLeg {
+  identifier: number;
+  groupIdentifier: string;
+}
+
 interface UseBridgeMatchingApiReturn {
-  getUnmatchedBridgeTransactions: (onlyIgnored?: boolean) => Promise<string[]>;
-  getBridgeMatches: (bridgeEvent: string, timeRange: number, onlyExpectedAssets: boolean, tolerance: string) => Promise<MatchSuggestions>;
+  getUnmatchedBridgeTransactions: (onlyIgnored?: boolean) => Promise<UnmatchedBridgeLeg[]>;
+  getBridgeMatches: (bridgeEvent: number, timeRange: number, onlyExpectedAssets: boolean, tolerance: string) => Promise<MatchSuggestions>;
   matchBridgeTransactions: (bridgeEvent: number, matchedEvents?: number[], resolution?: BridgeLegResolution) => Promise<boolean>;
   unlinkBridgeTransaction: (identifier: number) => Promise<boolean>;
   triggerBridgeMatching: () => Promise<PendingTask>;
@@ -23,12 +33,12 @@ interface UseBridgeMatchingApiReturn {
 export function useBridgeMatchingApi(): UseBridgeMatchingApiReturn {
   const { triggerTask } = useTaskApi();
 
-  const getUnmatchedBridgeTransactions = async (onlyIgnored?: boolean): Promise<string[]> =>
-    api.get<string[]>('/history/events/match/bridges', {
+  const getUnmatchedBridgeTransactions = async (onlyIgnored?: boolean): Promise<UnmatchedBridgeLeg[]> =>
+    api.get<UnmatchedBridgeLeg[]>('/history/events/match/bridges', {
       params: onlyIgnored !== undefined ? snakeCaseTransformer({ onlyIgnored }) : undefined,
     });
 
-  const getBridgeMatches = async (bridgeEvent: string, timeRange: number, onlyExpectedAssets: boolean, tolerance: string): Promise<MatchSuggestions> =>
+  const getBridgeMatches = async (bridgeEvent: number, timeRange: number, onlyExpectedAssets: boolean, tolerance: string): Promise<MatchSuggestions> =>
     api.post<MatchSuggestions>('/history/events/match/bridges', {
       bridgeEvent,
       onlyExpectedAssets,

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsPinned.vue
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsPinned.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { MatchingFlow } from '@/modules/history/events/matching/types';
 import { startPromise } from '@shared/utils';
-import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import MatchBridgeTransactionsContent from '@/modules/history/events/MatchBridgeTransactionsContent.vue';
 import PotentialMatchesContent from '@/modules/history/events/PotentialMatchesContent.vue';
 import { HighlightTargetTypes, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
@@ -56,7 +55,7 @@ const flow: MatchingFlow = useBridgeMatchingFlow();
 const { unmatchableExplanation: emptyExplanation } = useBridgeUnmatchableExplanation(potentialMatchTransaction);
 
 function selectTransaction(transaction: UnmatchedBridgeTransaction): void {
-  const identifier = transaction.identifier ?? getEventEntryFromCollection(transaction.events).entry.identifier;
+  const identifier = transaction.identifier;
 
   set(potentialMatchTransaction, transaction);
   set(showPotentialMatchesDrawer, true);
@@ -106,7 +105,7 @@ async function unpin(): Promise<void> {
 }
 
 function showInHistoryEvents(transaction: UnmatchedBridgeTransaction): void {
-  const identifier = transaction.identifier ?? getEventEntryFromCollection(transaction.events).entry.identifier;
+  const identifier = transaction.identifier;
 
   set(activeGroupIdentifier, transaction.groupIdentifier);
   set(activePotentialMatchIdentifier, undefined);
@@ -152,7 +151,7 @@ function navigateToHighlightedTransaction(targetGroupIdentifier: string): boolea
   if (transaction) {
     // If potential match identifier is also provided, open the drawer and navigate to potential match
     if (highlightedPotentialMatchIdentifier && potentialMatchGroupIdentifier) {
-      const identifier = transaction.identifier ?? getEventEntryFromCollection(transaction.events).entry.identifier;
+      const identifier = transaction.identifier;
       set(potentialMatchTransaction, transaction);
       set(showPotentialMatchesDrawer, true);
       set(activeGroupIdentifier, transaction.groupIdentifier);

--- a/frontend/app/src/modules/history/events/PotentialMatchesContent.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { MatchingFlow, PotentialMatchRow, UnmatchedEventGroup } from '@/modules/history/events/matching/types';
+import type { MatchingFlow, MatchSuggestions, PotentialMatchRow, UnmatchedEventGroup } from '@/modules/history/events/matching/types';
 import type { HistoryEventCollectionRow } from '@/modules/history/events/schemas';
 import { bigNumberify } from '@rotki/common';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -85,13 +85,13 @@ async function searchPotentialMatches(): Promise<void> {
   set(searchLoading, true);
 
   try {
-    const groupIdentifier = movement.groupIdentifier;
-
     const hours = Number.parseInt(get(searchTimeRange), 10) || getDefaultHourRange();
     const timeRangeInSeconds = hours * 60 * 60;
 
-    const getSuggestions = flow?.getSuggestions ?? getAssetMovementMatches;
-    const suggestions = await getSuggestions(groupIdentifier, timeRangeInSeconds, get(onlyExpectedAssets), percentageToDecimal(get(tolerancePercentage)));
+    const getSuggestions = flow?.getSuggestions
+      ?? (async (m: UnmatchedEventGroup, timeRange: number, onlyExpected: boolean, tolerance: string): Promise<MatchSuggestions> =>
+        getAssetMovementMatches(m.groupIdentifier, timeRange, onlyExpected, tolerance));
+    const suggestions = await getSuggestions(movement, timeRangeInSeconds, get(onlyExpectedAssets), percentageToDecimal(get(tolerancePercentage)));
     const allIdentifiers = [...suggestions.closeMatches, ...suggestions.otherEvents];
 
     if (allIdentifiers.length === 0) {

--- a/frontend/app/src/modules/history/events/UnmatchedBridgesList.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedBridgesList.vue
@@ -2,6 +2,7 @@
 import type { DataTableColumn } from '@rotki/ui-library';
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import type { UnmatchedBridgeTransaction } from '@/modules/history/events/use-unmatched-bridge-transactions';
+import { arrayify } from '@/modules/core/common/data/array';
 import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
@@ -15,6 +16,8 @@ import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 
 interface UnmatchedBridgeRow {
+  /** Row key: the leg event identifier, since a group can carry several bridge legs. */
+  id: string;
   groupIdentifier: string;
   entry: HistoryEventEntry;
   direction: 'deposit' | 'withdrawal';
@@ -129,9 +132,13 @@ const columns = computed<DataTableColumn<UnmatchedBridgeRow>[]>(() => createColu
 
 const rows = computed<UnmatchedBridgeRow[]>(() =>
   transactions.map((transaction) => {
-    const { entry, ...meta } = getEventEntryFromCollection(transaction.events);
+    // Show the leg's own event: the row's collection can hold several events and the
+    // first one is not necessarily the leg this row acts on.
+    const { entry, ...meta } = arrayify(transaction.events).find(event => event.entry.identifier === transaction.identifier)
+      ?? getEventEntryFromCollection(transaction.events);
     const eventEntry = { ...entry, ...meta };
     return {
+      id: transaction.identifier.toString(),
       canCreateCounterpart: !showRestore && getBridgeCounterpartChain(transaction) !== undefined,
       counterpartAddress: getBridgeCounterpartAddress(transaction),
       direction: transaction.direction,
@@ -244,7 +251,7 @@ function actionLabels(row: UnmatchedBridgeRow): UnmatchedRowActionLabels {
         v-model="selected"
         :cols="columns"
         :rows="rows"
-        row-attr="groupIdentifier"
+        row-attr="id"
         :item-class="getRowClass"
         outlined
         dense

--- a/frontend/app/src/modules/history/events/matching/types.ts
+++ b/frontend/app/src/modules/history/events/matching/types.ts
@@ -36,7 +36,7 @@ export interface PotentialMatchRow {
  */
 export interface MatchingFlow {
   getSuggestions: (
-    groupIdentifier: string,
+    movement: UnmatchedEventGroup,
     timeRangeSeconds: number,
     onlyExpectedAssets: boolean,
     tolerance: string,

--- a/frontend/app/src/modules/history/events/use-bridge-transaction-actions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-bridge-transaction-actions.spec.ts
@@ -56,10 +56,6 @@ vi.mock('@/modules/history/events/use-untracked-bridge-counterpart', () => ({
   }),
 }));
 
-vi.mock('@/modules/history/event-utils', () => ({
-  getEventEntryFromCollection: <T>(events: T): T => events,
-}));
-
 vi.mock('@/modules/core/notifications/use-notifications', () => ({
   getErrorMessage: (error: unknown): string => error instanceof Error ? error.message : String(error),
   useNotifications: (): object => ({
@@ -137,13 +133,13 @@ describe('use-bridge-transaction-actions', () => {
       expect(get(composable.ignoreLoading)).toBe(false);
     });
 
-    it('should drop the ignored transaction from the current selection', async () => {
+    it('should drop the ignored leg from the current selection', async () => {
       const composable = useBridgeTransactionActions();
-      set(composable.modelSelectedUnmatched, ['group1', 'group2']);
+      set(composable.modelSelectedUnmatched, ['42', '55']);
 
-      await composable.ignoreTransaction(createMockTransaction({ groupIdentifier: 'group1' }));
+      await composable.ignoreTransaction(createMockTransaction({ identifier: 42 }));
 
-      expect(get(composable.modelSelectedUnmatched)).toEqual(['group2']);
+      expect(get(composable.modelSelectedUnmatched)).toEqual(['55']);
     });
 
     it('should not use the gas fee event of the group as the bridge identifier', async () => {
@@ -356,7 +352,7 @@ describe('use-bridge-transaction-actions', () => {
       ]);
 
       const composable = useBridgeTransactionActions();
-      set(composable.modelSelectedUnmatched, ['g1', 'g3']);
+      set(composable.modelSelectedUnmatched, ['10', '30']);
       composable.confirmIgnoreSelected();
       await extractAndCallConfirmCallback();
 
@@ -375,7 +371,7 @@ describe('use-bridge-transaction-actions', () => {
       ]);
 
       const composable = useBridgeTransactionActions();
-      set(composable.modelSelectedIgnored, ['g2']);
+      set(composable.modelSelectedIgnored, ['20']);
       composable.confirmRestoreSelected();
       await extractAndCallConfirmCallback();
 

--- a/frontend/app/src/modules/history/events/use-bridge-transaction-actions.ts
+++ b/frontend/app/src/modules/history/events/use-bridge-transaction-actions.ts
@@ -4,7 +4,6 @@ import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { getErrorMessage, useNotifications } from '@/modules/core/notifications/use-notifications';
 import { useBridgeMatchingApi } from '@/modules/history/api/events/use-bridge-matching-api';
-import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import { type UnmatchedBridgeTransaction, useUnmatchedBridgeTransactions } from '@/modules/history/events/use-unmatched-bridge-transactions';
 import { useUntrackedBridgeCounterpart } from '@/modules/history/events/use-untracked-bridge-counterpart';
 
@@ -52,11 +51,13 @@ export function useBridgeTransactionActions(
 
   /**
    * A row that just left the list must not stay selected, otherwise the "ignore selected"
-   * count keeps counting a transaction that is no longer actionable.
+   * count keeps counting a leg that is no longer actionable. Rows are keyed by the leg
+   * event identifier, since a transaction group can carry several bridge legs.
    */
-  function deselect(groupIdentifier: string): void {
-    set(modelSelectedUnmatched, get(modelSelectedUnmatched).filter(id => id !== groupIdentifier));
-    set(modelSelectedIgnored, get(modelSelectedIgnored).filter(id => id !== groupIdentifier));
+  function deselect(transaction: UnmatchedBridgeTransaction): void {
+    const rowId = transaction.identifier.toString();
+    set(modelSelectedUnmatched, get(modelSelectedUnmatched).filter(id => id !== rowId));
+    set(modelSelectedIgnored, get(modelSelectedIgnored).filter(id => id !== rowId));
   }
 
   function notifyActionFailure(logMessage: string, error: unknown): void {
@@ -65,10 +66,6 @@ export function useBridgeTransactionActions(
       t('actions.bridge_matching.error.title'),
       t('actions.bridge_matching.error.description', { error: getErrorMessage(error) }),
     );
-  }
-
-  function getTransactionIdentifier(transaction: UnmatchedBridgeTransaction): number {
-    return transaction.identifier ?? getEventEntryFromCollection(transaction.events).entry.identifier;
   }
 
   function formatChain(chain: string | number | undefined): string | undefined {
@@ -80,8 +77,8 @@ export function useBridgeTransactionActions(
   async function ignoreTransaction(transaction: UnmatchedBridgeTransaction): Promise<void> {
     set(ignoreLoading, true);
     try {
-      await matchBridgeTransactions(getTransactionIdentifier(transaction));
-      deselect(transaction.groupIdentifier);
+      await matchBridgeTransactions(transaction.identifier);
+      deselect(transaction);
       await refreshUnmatchedBridgeTransactions();
       await onActionComplete?.();
     }
@@ -96,8 +93,8 @@ export function useBridgeTransactionActions(
   async function restoreTransaction(transaction: UnmatchedBridgeTransaction): Promise<void> {
     set(ignoreLoading, true);
     try {
-      await unlinkBridgeTransaction(getTransactionIdentifier(transaction));
-      deselect(transaction.groupIdentifier);
+      await unlinkBridgeTransaction(transaction.identifier);
+      deselect(transaction);
       await refreshUnmatchedBridgeTransactions();
       await onActionComplete?.();
     }
@@ -112,9 +109,9 @@ export function useBridgeTransactionActions(
   async function markExternal(transaction: UnmatchedBridgeTransaction): Promise<void> {
     set(ignoreLoading, true);
     try {
-      const result = await resolveExternal(getTransactionIdentifier(transaction));
+      const result = await resolveExternal(transaction.identifier);
       if (result.success) {
-        deselect(transaction.groupIdentifier);
+        deselect(transaction);
         await refreshUnmatchedBridgeTransactions();
         await onActionComplete?.();
       }
@@ -157,9 +154,9 @@ export function useBridgeTransactionActions(
   async function createCounterpart(transaction: UnmatchedBridgeTransaction): Promise<void> {
     set(ignoreLoading, true);
     try {
-      const result = await resolveCreateCounterpart(getTransactionIdentifier(transaction));
+      const result = await resolveCreateCounterpart(transaction.identifier);
       if (result.success) {
-        deselect(transaction.groupIdentifier);
+        deselect(transaction);
         await refreshUnmatchedBridgeTransactions();
         await onActionComplete?.();
       }
@@ -210,12 +207,12 @@ export function useBridgeTransactionActions(
     }, async () => markExternal(transaction));
   }
 
-  async function ignoreSelectedTransactions(groupIdentifiers: string[]): Promise<void> {
+  async function ignoreSelectedTransactions(rowIds: string[]): Promise<void> {
     set(ignoreLoading, true);
     try {
-      const transactions = get(unmatchedTransactions).filter(tx => groupIdentifiers.includes(tx.groupIdentifier));
+      const transactions = get(unmatchedTransactions).filter(tx => rowIds.includes(tx.identifier.toString()));
       for (const transaction of transactions)
-        await matchBridgeTransactions(getTransactionIdentifier(transaction));
+        await matchBridgeTransactions(transaction.identifier);
 
       await refreshUnmatchedBridgeTransactions();
       set(modelSelectedUnmatched, []);
@@ -228,12 +225,12 @@ export function useBridgeTransactionActions(
     }
   }
 
-  async function unignoreSelectedTransactions(groupIdentifiers: string[]): Promise<void> {
+  async function unignoreSelectedTransactions(rowIds: string[]): Promise<void> {
     set(ignoreLoading, true);
     try {
-      const transactions = get(ignoredTransactions).filter(tx => groupIdentifiers.includes(tx.groupIdentifier));
+      const transactions = get(ignoredTransactions).filter(tx => rowIds.includes(tx.identifier.toString()));
       for (const transaction of transactions)
-        await unlinkBridgeTransaction(getTransactionIdentifier(transaction));
+        await unlinkBridgeTransaction(transaction.identifier);
 
       await refreshUnmatchedBridgeTransactions();
       set(modelSelectedIgnored, []);

--- a/frontend/app/src/modules/history/events/use-unmatched-bridge-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-bridge-transactions.spec.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { spies } = vi.hoisted(() => ({
   spies: {
-    getUnmatchedBridgeTransactions: vi.fn<(onlyIgnored?: boolean) => Promise<string[]>>(),
+    getUnmatchedBridgeTransactions: vi.fn<(onlyIgnored?: boolean) => Promise<{ identifier: number; groupIdentifier: string }[]>>(),
     fetchHistoryEvents: vi.fn(),
     matchBridgeTransactions: vi.fn(),
     triggerBridgeMatching: vi.fn(),
@@ -120,8 +120,8 @@ describe('use-unmatched-bridge-transactions', () => {
       expect(spies.removeMatching).not.toHaveBeenCalled();
     });
 
-    it('should expand group identifiers to events with direction and bridge extra data', async () => {
-      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce(['group-a']);
+    it('should expand reported legs to events with direction and bridge extra data', async () => {
+      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce([{ groupIdentifier: 'group-a', identifier: 7 }]);
       spies.fetchHistoryEvents.mockResolvedValueOnce({
         entries: [{
           entry: {
@@ -154,7 +154,7 @@ describe('use-unmatched-bridge-transactions', () => {
     // real unmatched bridge group), so the gas fee event arrives as a separate row before the
     // bridge leg rather than alongside it in one array.
     it('should pick the bridge leg and not the gas fee event of the transaction group', async () => {
-      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce(['group-a']);
+      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce([{ groupIdentifier: 'group-a', identifier: 2 }]);
       spies.fetchHistoryEvents.mockResolvedValueOnce({
         entries: [{
           entry: {
@@ -191,7 +191,7 @@ describe('use-unmatched-bridge-transactions', () => {
     });
 
     it('should keep the withdrawal direction for an orphan withdrawal leg', async () => {
-      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce(['group-b']);
+      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce([{ groupIdentifier: 'group-b', identifier: 4 }]);
       spies.fetchHistoryEvents.mockResolvedValueOnce({
         entries: [{
           entry: {
@@ -225,7 +225,7 @@ describe('use-unmatched-bridge-transactions', () => {
     // A leg resolved as external is turned into a bridge spend/receive, so its direction can
     // no longer come from the event type and has to come from the recorded matchedBridge stamp.
     it('should derive the direction of an external-resolved leg from the matched bridge stamp', async () => {
-      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce(['group-d']);
+      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce([{ groupIdentifier: 'group-d', identifier: 6 }]);
       spies.fetchHistoryEvents.mockResolvedValueOnce({
         entries: [{
           entry: {
@@ -250,18 +250,20 @@ describe('use-unmatched-bridge-transactions', () => {
       });
     });
 
-    // A transaction can carry more than one bridge leg. Acting on a leg that was already
-    // resolved as external would send the backend an event that is no longer a bridge
-    // deposit/withdrawal, so the raw leg must win regardless of row order.
-    it('should prefer the raw bridge leg over a leg already resolved as external', async () => {
-      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce(['group-e']);
+    // A transaction can carry more than one bridge leg, each matched or ignored
+    // independently. Every reported leg must get its own row — collapsing them into one
+    // made ignoring a leg look like a no-op while the group as a whole stayed listed.
+    it('should create one row per reported leg of a multi-leg transaction', async () => {
+      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce([
+        { groupIdentifier: 'group-e', identifier: 7 },
+        { groupIdentifier: 'group-e', identifier: 8 },
+      ]);
       spies.fetchHistoryEvents.mockResolvedValueOnce({
         entries: [{
           entry: {
             asset: 'ETH',
             eventSubtype: 'bridge',
-            eventType: 'spend',
-            extraData: { matchedBridge: { direction: 'deposit', resolution: 'external' } },
+            eventType: 'deposit',
             groupIdentifier: 'group-e',
             identifier: 7,
           },
@@ -280,15 +282,19 @@ describe('use-unmatched-bridge-transactions', () => {
 
       await fetchUnmatchedBridgeTransactions(false);
 
-      expect(get(unmatchedTransactions)).toHaveLength(1);
-      expect(get(unmatchedTransactions)[0]).toMatchObject({
-        direction: 'deposit',
+      expect(spies.fetchHistoryEvents).toHaveBeenCalledWith(expect.objectContaining({
+        groupIdentifiers: ['group-e'],
+      }));
+      expect(get(unmatchedTransactions)).toHaveLength(2);
+      expect(get(unmatchedTransactions)[0]).toMatchObject({ asset: 'ETH', identifier: 7 });
+      expect(get(unmatchedTransactions)[1]).toMatchObject({
+        asset: 'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         identifier: 8,
       });
     });
 
-    it('should skip a group that contains no bridge event', async () => {
-      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce(['group-c']);
+    it('should skip a leg whose event is missing from the fetched rows', async () => {
+      spies.getUnmatchedBridgeTransactions.mockResolvedValueOnce([{ groupIdentifier: 'group-c', identifier: 5 }]);
       spies.fetchHistoryEvents.mockResolvedValueOnce({
         entries: [{
           entry: {
@@ -296,7 +302,7 @@ describe('use-unmatched-bridge-transactions', () => {
             eventSubtype: 'fee',
             eventType: 'spend',
             groupIdentifier: 'group-c',
-            identifier: 5,
+            identifier: 4,
           },
         }],
       });
@@ -403,7 +409,7 @@ describe('use-unmatched-bridge-transactions', () => {
       });
 
       expect(matched).toBe(true);
-      expect(spies.getBridgeMatches).toHaveBeenCalledWith('group-a', 3600, false, '0.01');
+      expect(spies.getBridgeMatches).toHaveBeenCalledWith(5, 3600, false, '0.01');
       expect(spies.matchBridgeTransactions).toHaveBeenCalledWith(5, [11, 12]);
     });
 

--- a/frontend/app/src/modules/history/events/use-unmatched-bridge-transactions.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-bridge-transactions.ts
@@ -14,6 +14,7 @@ import { isActionableFailure, useTaskHandler } from '@/modules/core/tasks/use-ta
 import { useTaskStore } from '@/modules/core/tasks/use-task-store';
 import { useBridgeMatchingApi } from '@/modules/history/api/events/use-bridge-matching-api';
 import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import { useHistoryStore } from '@/modules/history/use-history-store';
 import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { useBridgeMatchSettings } from '@/modules/settings/use-bridge-match-settings';
@@ -58,18 +59,9 @@ function deriveBridgeDirection(extraData: unknown, eventType?: string): 'deposit
 }
 
 export interface UnmatchedBridgeTransaction extends UnmatchedEventGroup {
+  identifier: number;
   direction: 'deposit' | 'withdrawal';
   bridge?: BridgeExtraData;
-}
-
-/** A raw (not yet resolved) bridge leg: a deposit/withdrawal with the `bridge` subtype. */
-function isRawBridgeLeg(entry: HistoryEventEntryWithMeta['entry']): boolean {
-  return entry.eventSubtype === 'bridge' && (entry.eventType === 'deposit' || entry.eventType === 'withdrawal');
-}
-
-/** A leg already resolved as external: turned into a bridge spend/receive but stamped. */
-function isResolvedBridgeLeg(entry: HistoryEventEntryWithMeta['entry']): boolean {
-  return getResolvedBridgeDirection('extraData' in entry ? entry.extraData : undefined) !== undefined;
 }
 
 interface BridgeEntryMatch {
@@ -78,25 +70,17 @@ interface BridgeEntryMatch {
 }
 
 /**
- * Picks the bridge leg out of a group's rows. A bridge group is keyed by the EVM
- * transaction hash, so it also contains the gas fee event (and possibly others). Only
- * the bridge leg is the one the matching endpoints accept, so it has to be selected
- * explicitly instead of taking the first event of the group.
- *
- * Raw legs are preferred over legs already resolved as external across ALL rows: a
- * transaction can carry more than one bridge leg (e.g. token + gas refuel), and once
- * one of them is resolved, acting on the resolved leg again would send the backend an
- * event that is no longer a bridge deposit/withdrawal. Resolved legs (recognized by
- * their `matchedBridge` stamp) are only picked when the group has no raw leg left,
- * which is what the ignored list needs to restore them.
+ * Locates a bridge leg's event across the fetched rows by its identifier. The backend
+ * reports unresolved legs per event, and the exact event has to be acted on: a
+ * transaction can carry more than one bridge leg (e.g. several bridged assets in one
+ * transaction), so picking a leg positionally or by type heuristics would act on the
+ * wrong — possibly already ignored — leg.
  */
-function findBridgeEntry(rows: HistoryEventCollectionRow[]): BridgeEntryMatch | undefined {
-  for (const matcher of [isRawBridgeLeg, isResolvedBridgeLeg]) {
-    for (const row of rows) {
-      const event = arrayify(row).find(({ entry }) => matcher(entry));
-      if (event)
-        return { event, row };
-    }
+function findBridgeEntry(rows: HistoryEventCollectionRow[], identifier: number): BridgeEntryMatch | undefined {
+  for (const row of rows) {
+    const event = arrayify(row).find(({ entry }) => entry.identifier === identifier);
+    if (event)
+      return { event, row };
   }
   return undefined;
 }
@@ -162,9 +146,9 @@ export const useUnmatchedBridgeTransactions = createSharedComposable((): UseUnma
 
     set(loadingRef, true);
     try {
-      const groupIdentifiers = await getUnmatchedBridgeTransactions(onlyIgnored);
+      const legs = await getUnmatchedBridgeTransactions(onlyIgnored);
 
-      if (groupIdentifiers.length === 0) {
+      if (legs.length === 0) {
         set(transactionsRef, []);
         if (!isIgnored)
           clearUnmatchedBridgeTransactionsNotification();
@@ -173,7 +157,7 @@ export const useUnmatchedBridgeTransactions = createSharedComposable((): UseUnma
 
       const response = await fetchHistoryEvents({
         aggregateByGroupIds: false,
-        groupIdentifiers,
+        groupIdentifiers: [...new Set(legs.map(leg => leg.groupIdentifier))],
         limit: -1,
         offset: 0,
         orderByAttributes: ['timestamp'],
@@ -182,34 +166,27 @@ export const useUnmatchedBridgeTransactions = createSharedComposable((): UseUnma
 
       const transactions: UnmatchedBridgeTransaction[] = [];
 
-      for (const groupId of groupIdentifiers) {
-        const eventsForGroup = response.entries.filter((row) => {
-          const events = arrayify(row);
-          return events.some(event => event.entry.groupIdentifier === groupId);
-        });
+      for (const leg of legs) {
+        // The events of a group come back as separate rows, so the leg's event has to
+        // be looked for across all of them by its identifier.
+        const bridgeMatch = findBridgeEntry(response.entries, leg.identifier);
 
-        if (eventsForGroup.length > 0) {
-          // The events of a group come back as separate rows, so the bridge leg has to be looked
-          // for across all of them: the first row is the gas fee event, not the bridge event.
-          const bridgeMatch = findBridgeEntry(eventsForGroup);
-
-          if (!bridgeMatch) {
-            logger.warn(`No bridge event found in group ${groupId}, skipping it`);
-            continue;
-          }
-
-          const entry = bridgeMatch.event.entry;
-          const extraData = 'extraData' in entry ? entry.extraData : undefined;
-
-          transactions.push({
-            asset: entry.asset,
-            bridge: getBridgeExtraData(extraData),
-            direction: deriveBridgeDirection(extraData, entry.eventType),
-            events: bridgeMatch.row,
-            groupIdentifier: groupId,
-            identifier: entry.identifier,
-          });
+        if (!bridgeMatch) {
+          logger.warn(`No event found for bridge leg ${leg.identifier} in group ${leg.groupIdentifier}, skipping it`);
+          continue;
         }
+
+        const entry = bridgeMatch.event.entry;
+        const extraData = 'extraData' in entry ? entry.extraData : undefined;
+
+        transactions.push({
+          asset: entry.asset,
+          bridge: getBridgeExtraData(extraData),
+          direction: deriveBridgeDirection(extraData, entry.eventType),
+          events: bridgeMatch.row,
+          groupIdentifier: leg.groupIdentifier,
+          identifier: leg.identifier,
+        });
       }
 
       set(transactionsRef, transactions);
@@ -314,8 +291,8 @@ export const useUnmatchedBridgeTransactions = createSharedComposable((): UseUnma
   };
 
   async function autoMatchBridgeTransaction(linkedTransaction: LinkedMovementMatch): Promise<boolean> {
-    const { groupIdentifier, identifier, timeRange, tolerance } = linkedTransaction;
-    const suggestions = await getBridgeMatches(groupIdentifier, timeRange, false, tolerance);
+    const { identifier, timeRange, tolerance } = linkedTransaction;
+    const suggestions = await getBridgeMatches(identifier, timeRange, false, tolerance);
     if (suggestions.closeMatches.length > 0) {
       await matchBridgeTransactionsApi(identifier, suggestions.closeMatches);
       return true;
@@ -355,7 +332,12 @@ export function useBridgeMatchingFlow(): MatchingFlow {
   return {
     defaultTimeRangeSeconds: get(bridgeMatchTimeRange),
     defaultTolerance: get(bridgeMatchAmountTolerance),
-    getSuggestions: getBridgeMatches,
+    getSuggestions: async (movement, timeRangeSeconds, onlyExpectedAssets, tolerance) => getBridgeMatches(
+      movement.identifier ?? getEventEntryFromCollection(movement.events).entry.identifier,
+      timeRangeSeconds,
+      onlyExpectedAssets,
+      tolerance,
+    ),
     match: matchBridgeTransaction,
     refresh: refreshUnmatchedBridgeTransactions,
   };

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -4560,15 +4560,17 @@ class RestAPI:
         }))
 
     def get_unmatched_bridge_transactions(self, only_ignored: bool) -> Response:
-        """Get the group identifiers of unmatched bridge events (both legs).
-        Gets the events marked as having no match if only_ignored is True, otherwise
-        all bridge events that have not been matched or ignored yet.
+        """Get the unresolved bridge legs as identifier/group identifier pairs.
+        Gets the legs marked as having no match if only_ignored is True, otherwise
+        all bridge legs that have not been matched or ignored yet. Legs are reported
+        individually since a single transaction group can carry several bridge legs
+        that are matched or ignored independently.
         """
         if only_ignored:
             with self.rotkehlchen.data.db.conn.read_ctx() as cursor:
-                group_ids = [x[0] for x in cursor.execute(
-                    'SELECT DISTINCT history_events.group_identifier FROM history_events '
-                    'JOIN history_event_link_ignores ON '
+                legs = [{'identifier': x[0], 'group_identifier': x[1]} for x in cursor.execute(
+                    'SELECT history_events.identifier, history_events.group_identifier '
+                    'FROM history_events JOIN history_event_link_ignores ON '
                     'history_events.identifier=history_event_link_ignores.event_id '
                     'WHERE history_event_link_ignores.link_type=? '
                     'ORDER BY timestamp, sequence_index',
@@ -4577,11 +4579,12 @@ class RestAPI:
         else:
             deposits, withdrawals = get_unmatched_bridge_events(database=self.rotkehlchen.data.db)
             # deposits first (they are actionable anchors), then orphan withdrawals
-            group_ids = list(dict.fromkeys(
-                event.group_identifier for event in deposits + withdrawals
-            ))
+            legs = [
+                {'identifier': event.identifier, 'group_identifier': event.group_identifier}
+                for event in deposits + withdrawals
+            ]
 
-        return api_response(_wrap_in_ok_result(result=group_ids))
+        return api_response(_wrap_in_ok_result(result=legs))
 
     def match_bridge_transactions(
             self,
@@ -4675,35 +4678,33 @@ class RestAPI:
 
     def get_matches_for_bridge_transaction(
             self,
-            bridge_group_identifier: str,
+            bridge_event_identifier: int,
             time_range: int,
             only_expected_assets: bool,
             tolerance: FVal,
     ) -> Response:
-        """Get possible counterpart-leg matches for the bridge leg in the given group,
-        within the given time range. Anchors on the group's bridge deposit if there is
-        one, otherwise on its bridge withdrawal."""
+        """Get possible counterpart-leg matches for the given bridge leg within the
+        given time range. Anchors on the exact leg since a transaction group can
+        carry several independently-matched bridge legs."""
         events_db = DBHistoryEvents(database=self.rotkehlchen.data.db)
-        bridge_event = None
         with self.rotkehlchen.data.db.conn.read_ctx() as cursor:
-            for event in events_db.get_history_events_internal(
+            events = events_db.get_history_events_internal(
                 cursor=cursor,
                 filter_query=HistoryEventFilterQuery.make(
-                    group_identifiers=[bridge_group_identifier],
+                    identifiers=[bridge_event_identifier],
                     type_and_subtype_combinations=[
                         (HistoryEventType.DEPOSIT, HistoryEventSubType.BRIDGE),
                         (HistoryEventType.WITHDRAWAL, HistoryEventSubType.BRIDGE),
                     ],
                 ),
-            ):
-                bridge_event = event
-                if event.event_type == HistoryEventType.DEPOSIT:
-                    break  # prefer the deposit anchor if the group has both legs
+            )
 
-        if bridge_event is None:
+        if len(events) != 1:
             return api_response(wrap_in_fail_result(
-                message=f'No bridge event found in the DB for group identifier {bridge_group_identifier}',  # noqa: E501
+                message=f'No bridge event found in the DB for identifier {bridge_event_identifier}',  # noqa: E501
             ), HTTPStatus.BAD_REQUEST)
+
+        bridge_event = events[0]
 
         assets_in_collection = GlobalDBHandler.get_assets_in_same_collection(
             identifier=bridge_event.asset.identifier,

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -4067,13 +4067,13 @@ class MatchBridgeTransactionsResource(BaseMethodView):
     @use_kwargs(post_schema, location='json')
     def post(
             self,
-            bridge_event: str,
+            bridge_event: int,
             time_range: int,
             only_expected_assets: bool,
             tolerance: FVal,
     ) -> Response:
         return self.rest_api.get_matches_for_bridge_transaction(
-            bridge_group_identifier=bridge_event,
+            bridge_event_identifier=bridge_event,
             time_range=time_range,
             only_expected_assets=only_expected_assets,
             tolerance=tolerance,

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -5326,7 +5326,7 @@ class MatchBridgeTransactionsSchema(Schema):
 
 
 class FindPossibleBridgeMatchesSchema(Schema):
-    bridge_event = fields.String(required=True)
+    bridge_event = fields.Integer(required=True)
     time_range = fields.Integer(required=True, validate=validate.Range(min=0, min_inclusive=False))
     only_expected_assets = fields.Boolean(required=False, load_default=True)
     tolerance = AmountField(required=True, validate=validate.Range(min=ZERO, min_inclusive=False))

--- a/rotkehlchen/tests/api/test_bridge_matching.py
+++ b/rotkehlchen/tests/api/test_bridge_matching.py
@@ -378,13 +378,16 @@ def test_get_unmatched_and_possible_bridge_matches(rotkehlchen_api_server: APISe
         ),
         rotkehlchen_api_server=rotkehlchen_api_server,
     )
-    assert result == [deposit.group_identifier, withdrawal.group_identifier]
+    assert result == [
+        {'identifier': deposit.identifier, 'group_identifier': deposit.group_identifier},
+        {'identifier': withdrawal.identifier, 'group_identifier': withdrawal.group_identifier},
+    ]
 
     result = assert_proper_response_with_result(
         response=requests.post(
             url=api_url_for(rotkehlchen_api_server, 'matchbridgetransactionsresource'),
             json={
-                'bridge_event': deposit.group_identifier,
+                'bridge_event': deposit.identifier,
                 'time_range': 3600,
                 'tolerance': '0.01',
             },
@@ -408,15 +411,76 @@ def test_get_unmatched_and_possible_bridge_matches(rotkehlchen_api_server: APISe
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
+def test_ignore_single_leg_of_multi_leg_transaction(rotkehlchen_api_server: APIServer) -> None:
+    """A transaction carrying several bridge legs reports each leg individually, and
+    ignoring one leg moves exactly that leg to the ignored list while the others stay
+    actionable. Regression test for ignoring a leg appearing to do nothing because
+    the group as a whole stayed listed as unmatched."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    dbevents = DBHistoryEvents(rotki.data.db)
+    user_address, deposit_tx = make_evm_address(), make_evm_tx_hash()
+    deposits = [EvmEvent(
+        identifier=identifier,
+        tx_ref=deposit_tx,
+        sequence_index=identifier - 1,
+        timestamp=TimestampMS(1700000000000),
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.DEPOSIT,
+        event_subtype=HistoryEventSubType.BRIDGE,
+        asset=A_ETH,
+        amount=FVal(identifier),
+        location_label=user_address,
+        counterparty=CPT_ACROSS,
+    ) for identifier in (1, 2, 3)]
+    with rotki.data.db.conn.write_ctx() as write_cursor:
+        dbevents.add_history_events(write_cursor=write_cursor, history=deposits)
+
+    group_identifier = deposits[0].group_identifier
+    result = assert_proper_response_with_result(
+        response=requests.get(
+            url=api_url_for(rotkehlchen_api_server, 'matchbridgetransactionsresource'),
+        ),
+        rotkehlchen_api_server=rotkehlchen_api_server,
+    )
+    assert result == [
+        {'identifier': identifier, 'group_identifier': group_identifier}
+        for identifier in (1, 2, 3)
+    ]
+
+    assert_simple_ok_response(requests.put(  # mark the first leg as having no match
+        url=api_url_for(rotkehlchen_api_server, 'matchbridgetransactionsresource'),
+        json={'bridge_event': 1, 'matched_events': []},
+    ))
+    result = assert_proper_response_with_result(
+        response=requests.get(
+            url=api_url_for(rotkehlchen_api_server, 'matchbridgetransactionsresource'),
+        ),
+        rotkehlchen_api_server=rotkehlchen_api_server,
+    )
+    assert result == [  # only the other two legs remain actionable
+        {'identifier': identifier, 'group_identifier': group_identifier}
+        for identifier in (2, 3)
+    ]
+    result = assert_proper_response_with_result(
+        response=requests.get(
+            url=api_url_for(rotkehlchen_api_server, 'matchbridgetransactionsresource'),
+            params={'only_ignored': 'true'},
+        ),
+        rotkehlchen_api_server=rotkehlchen_api_server,
+    )
+    assert result == [{'identifier': 1, 'group_identifier': group_identifier}]
+
+
+@pytest.mark.parametrize('start_with_valid_premium', [True])
 def test_get_possible_matches_from_withdrawal_leg(rotkehlchen_api_server: APIServer) -> None:
-    """A group holding only the withdrawal leg can anchor the search and finds
-    the source-chain deposit leg as a close match."""
+    """The withdrawal leg can anchor the search and finds the source-chain
+    deposit leg as a close match."""
     deposit, withdrawal = _add_bridge_pair(rotkehlchen_api_server)
     result = assert_proper_response_with_result(
         response=requests.post(
             url=api_url_for(rotkehlchen_api_server, 'matchbridgetransactionsresource'),
             json={
-                'bridge_event': withdrawal.group_identifier,
+                'bridge_event': withdrawal.identifier,
                 'time_range': 3600,
                 'tolerance': '0.01',
             },
@@ -448,7 +512,7 @@ def test_match_from_withdrawal_leg_rewrites_source(rotkehlchen_api_server: APISe
         response=requests.post(
             url=api_url_for(rotkehlchen_api_server, 'matchbridgetransactionsresource'),
             json={
-                'bridge_event': withdrawal.group_identifier,
+                'bridge_event': withdrawal.identifier,
                 'time_range': 3600,
                 'tolerance': '0.01',
             },
@@ -634,10 +698,10 @@ def test_match_bridge_transactions_errors(rotkehlchen_api_server: APIServer) -> 
     assert_error_response(
         response=requests.post(
             url=api_url_for(rotkehlchen_api_server, 'matchbridgetransactionsresource'),
-            json={'bridge_event': 'no-bridge-group', 'time_range': 3600, 'tolerance': '0.01'},
+            json={'bridge_event': 42, 'time_range': 3600, 'tolerance': '0.01'},
         ),
         status_code=HTTPStatus.BAD_REQUEST,
-        contained_in_msg='No bridge event found in the DB for group identifier no-bridge-group',
+        contained_in_msg='No bridge event found in the DB for identifier 42',
     )
 
 


### PR DESCRIPTION
Pressing Ignore on an unmatched bridge transaction appeared to do nothing when the transaction carried more than one bridge leg (e.g. three deposits in one tx). The backend only reported group identifiers of unresolved legs, so the frontend always acted on the first raw leg it found in the group: the first press ignored that leg but the group stayed listed (the other legs were still unresolved) and showed up in both the unmatched and ignored tabs, and every further press re-ignored the same leg via INSERT OR IGNORE, a permanent silent no-op.

Make the whole flow operate per leg instead of per group:

- GET /history/events/match/bridges now returns one identifier/group_identifier pair per unresolved leg, for both the unmatched and the only_ignored branches.
- POST (match suggestions) takes the leg event identifier instead of a group identifier, so searching matches for a specific leg no longer anchors on whichever leg the backend found first.
- The frontend renders one row per leg, located by its exact event identifier, each showing its own asset. Ignore/restore/mark-external/ create-counterpart and bulk selection key on the leg identifier, so each action affects exactly the clicked row.
- Update api.rst, adapt affected tests and add regression tests for ignoring a single leg of a multi-leg transaction on both backend and frontend.

