### PR TITLE
feat: decode solana stake program transactions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 
 * :feature:`-` Yearn vesting escrows are now supported. All related transactions are understood and decoded and balances in escrow automatically detected. Calendar entries with reminders are also created for the cliff and full vesting dates of your escrows.
 * :bug:`-` Automatically removing a calendar entry, like an airdrop claim deadline after the airdrop is claimed, no longer also deletes the reminder of an unrelated calendar entry. 
+* :feature:`-` Solana native staking program events should now be properly decoded and appear under rotki's events.
 * :bug:`-` Without a premium subscription, the asset movement matching actions (Ignore Selected, Ignore All Fiat and Restore Selected) no longer appear available. Previously these buttons looked clickable but did nothing, since asset movement matching is a premium feature.
 * :bug:`-` Searching for zksync lite assets should now show you ethereum mainnet assets and you should be able to easily select relevant assets when adding/editing events.
 * :bug:`-` Omnibridge events containing fee payments will now be properly decoded.

--- a/rotkehlchen/chain/solana/modules/stake/constants.py
+++ b/rotkehlchen/chain/solana/modules/stake/constants.py
@@ -1,0 +1,38 @@
+from enum import IntEnum
+from typing import Final
+
+from rotkehlchen.types import SolanaAddress
+
+CPT_SOLANA_STAKE: Final = 'solana-stake'
+STAKE_PROGRAM: Final = SolanaAddress('Stake11111111111111111111111111111111111111')
+
+
+class StakeInstructionTag(IntEnum):
+    """Stake program instruction enum tags, serialized as 4-byte little-endian values.
+    https://github.com/solana-program/stake/blob/main/interface/src/instruction.rs
+    """
+    INITIALIZE = 0
+    AUTHORIZE = 1
+    DELEGATE_STAKE = 2
+    SPLIT = 3
+    WITHDRAW = 4
+    DEACTIVATE = 5
+    SET_LOCKUP = 6
+    MERGE = 7
+    AUTHORIZE_WITH_SEED = 8
+    INITIALIZE_CHECKED = 9
+    AUTHORIZE_CHECKED = 10
+    AUTHORIZE_CHECKED_WITH_SEED = 11
+    SET_LOCKUP_CHECKED = 12
+    GET_MINIMUM_DELEGATION = 13
+    DEACTIVATE_DELINQUENT = 14
+    REDELEGATE = 15
+    MOVE_STAKE = 16
+    MOVE_LAMPORTS = 17
+
+
+# System program instruction discriminators (4-byte little-endian enum tags) used to
+# fund new stake accounts.
+# https://github.com/solana-program/system/blob/main/interface/src/instruction.rs
+SYSTEM_CREATE_ACCOUNT_DISCRIMINATOR: Final = b'\x00\x00\x00\x00'
+SYSTEM_CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR: Final = b'\x03\x00\x00\x00'

--- a/rotkehlchen/chain/solana/modules/stake/decoder.py
+++ b/rotkehlchen/chain/solana/modules/stake/decoder.py
@@ -1,0 +1,481 @@
+import logging
+from typing import TYPE_CHECKING, Any
+
+from rotkehlchen.chain.decoding.types import CounterpartyDetails
+from rotkehlchen.chain.solana.decoding.constants import (
+    NATIVE_TRANSFER_DISCRIMINATOR,
+    SYSTEM_PROGRAM,
+)
+from rotkehlchen.chain.solana.decoding.interfaces import SolanaDecoderInterface
+from rotkehlchen.chain.solana.decoding.structures import (
+    DEFAULT_SOLANA_DECODING_OUTPUT,
+    SolanaDecodingOutput,
+)
+from rotkehlchen.chain.solana.modules.stake.constants import (
+    CPT_SOLANA_STAKE,
+    STAKE_PROGRAM,
+    SYSTEM_CREATE_ACCOUNT_DISCRIMINATOR,
+    SYSTEM_CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR,
+    StakeInstructionTag,
+)
+from rotkehlchen.chain.solana.utils import lamports_to_sol
+from rotkehlchen.constants.assets import A_SOL
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.utils.misc import bytes_to_solana_address
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from rotkehlchen.chain.solana.decoding.structures import SolanaDecoderContext
+    from rotkehlchen.chain.solana.types import SolanaInstruction
+    from rotkehlchen.fval import FVal
+    from rotkehlchen.history.events.structures.solana_event import SolanaEvent
+    from rotkehlchen.types import SolanaAddress
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+class StakeDecoder(SolanaDecoderInterface):
+    """Decoder for the native Solana Stake program.
+
+    Covers the full user-signed instruction set: funding + delegation, deactivation,
+    withdrawal, splitting, merging, moving stake/lamports between accounts, authority
+    changes and lockup updates. GetMinimumDelegation carries no user action, and
+    DeactivateDelinquent/Redelegate are permissionless/retired instructions that do
+    not appear in a tracked user's own transactions, so they produce no events.
+    """
+
+    def _check_min_accounts(
+            self,
+            context: SolanaDecoderContext,
+            tag: StakeInstructionTag,
+            minimum: int,
+    ) -> bool:
+        """Returns True if the instruction has at least the expected number of accounts,
+        logging an error otherwise."""
+        if len(accounts := context.instruction.accounts) < minimum:
+            log.error(
+                'Solana stake %s instruction in %s has %d accounts. Expected at least %d. Skipping',  # noqa: E501
+                tag.name,
+                context.transaction.signature,
+                len(accounts),
+                minimum,
+            )
+            return False
+
+        return True
+
+    @staticmethod
+    def _get_funding_amount(
+            instruction: SolanaInstruction,
+            stake_account: SolanaAddress,
+    ) -> tuple[FVal, SolanaAddress] | None:
+        """Extract the funding amount and funder of the given stake account from a system
+        program instruction, if it is a transfer/create targeting that account.
+        Returns the amount in SOL and the funder address, or None if it doesn't match.
+        """
+        if (
+            instruction.program_id != SYSTEM_PROGRAM or
+            len(instruction.accounts) < 2 or
+            instruction.accounts[1] != stake_account
+        ):
+            return None
+
+        if (discriminator := instruction.data[:4]) in (
+            SYSTEM_CREATE_ACCOUNT_DISCRIMINATOR,
+            NATIVE_TRANSFER_DISCRIMINATOR,
+        ):  # for both, a u64 lamports amount follows the discriminator
+            raw_amount = int.from_bytes(instruction.data[4:12], byteorder='little')
+        elif discriminator == SYSTEM_CREATE_ACCOUNT_WITH_SEED_DISCRIMINATOR:
+            # layout: discriminator (4) + base pubkey (32) + seed string (8-byte length
+            # prefix + bytes) + lamports (8) + space (8) + owner pubkey (32)
+            seed_len = int.from_bytes(instruction.data[36:44], byteorder='little')
+            raw_amount = int.from_bytes(
+                instruction.data[44 + seed_len:52 + seed_len],
+                byteorder='little',
+            )
+        else:
+            return None
+
+        return lamports_to_sol(raw_amount), instruction.accounts[0]
+
+    def _maybe_decode_funding_deposit(
+            self,
+            context: SolanaDecoderContext,
+            stake_account: SolanaAddress,
+            notes_fn: Callable[[FVal], str],
+    ) -> tuple[SolanaEvent, bool] | None:
+        """Decode the system program instruction funding the given stake account in this
+        transaction into a staking deposit event, transforming an already-decoded plain
+        transfer if that is how the account was funded. Returns the event and whether it
+        is newly created (a transformed transfer is already in the decoded events), or
+        None when no funding by a tracked address is found.
+        """
+        for event in context.decoded_events:  # a plain transfer funding the stake account has already been decoded as a spend  # noqa: E501
+            if (
+                event.address == stake_account and
+                event.event_type == HistoryEventType.SPEND and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.asset == A_SOL
+            ):
+                event.event_type = HistoryEventType.STAKING
+                event.event_subtype = HistoryEventSubType.DEPOSIT_ASSET
+                event.counterparty = CPT_SOLANA_STAKE
+                event.notes = notes_fn(event.amount)
+                return event, False
+
+        for instruction in context.transaction.instructions:
+            if (funding_result := self._get_funding_amount(
+                instruction=instruction,
+                stake_account=stake_account,
+            )) is not None:
+                amount, funder = funding_result
+                if not self.base.is_tracked(funder):
+                    return None
+
+                return self.base.make_event_from_instruction(
+                    instruction=context.instruction,
+                    tx_ref=context.transaction.signature,
+                    timestamp=context.transaction.block_time,
+                    event_type=HistoryEventType.STAKING,
+                    event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
+                    asset=A_SOL,
+                    amount=amount,
+                    location_label=funder,
+                    notes=notes_fn(amount),
+                    counterparty=CPT_SOLANA_STAKE,
+                    address=stake_account,
+                ), True
+
+        return None
+
+    def _make_informational_event(
+            self,
+            context: SolanaDecoderContext,
+            location_label: SolanaAddress,
+            notes: str,
+            address: SolanaAddress,
+            amount: FVal | None = None,
+    ) -> SolanaDecodingOutput:
+        return SolanaDecodingOutput(events=[self.base.make_event_from_instruction(
+            instruction=context.instruction,
+            tx_ref=context.transaction.signature,
+            timestamp=context.transaction.block_time,
+            event_type=HistoryEventType.INFORMATIONAL,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_SOL,
+            amount=amount if amount is not None else ZERO,
+            location_label=location_label,
+            notes=notes,
+            counterparty=CPT_SOLANA_STAKE,
+            address=address,
+        )])
+
+    def _decode_initialize(self, context: SolanaDecoderContext) -> SolanaDecodingOutput:
+        """Decode an Initialize/InitializeChecked instruction, creating a deposit event
+        for the SOL funding the new stake account. When the account is also delegated in
+        the same transaction the delegation decoding emits the deposit instead, with the
+        validator in the notes."""
+        stake_account = context.instruction.accounts[0]
+        for instruction in context.transaction.instructions:
+            if (
+                instruction.program_id == STAKE_PROGRAM and
+                int.from_bytes(instruction.data[:4], byteorder='little') == StakeInstructionTag.DELEGATE_STAKE and  # noqa: E501
+                len(instruction.accounts) > 0 and
+                instruction.accounts[0] == stake_account
+            ):
+                return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        if (deposit_result := self._maybe_decode_funding_deposit(
+            context=context,
+            stake_account=stake_account,
+            notes_fn=lambda amount: f'Deposit {amount} SOL into stake account {stake_account}',
+        )) is not None and deposit_result[1] is True:
+            return SolanaDecodingOutput(events=[deposit_result[0]])
+
+        return DEFAULT_SOLANA_DECODING_OUTPUT
+
+    def _decode_delegate(self, context: SolanaDecoderContext) -> SolanaDecodingOutput:
+        """Decode a DelegateStake instruction.
+
+        The delegated amount is not part of the instruction, so it is taken from the
+        system program instruction funding the stake account in the same transaction
+        (create account with/without seed, or a plain transfer). A delegation of a
+        stake account funded in an earlier transaction gets an informational event
+        instead, since the staked amount is not knowable from this transaction alone.
+        """
+        if not self._check_min_accounts(context, StakeInstructionTag.DELEGATE_STAKE, 6):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        accounts = context.instruction.accounts
+        stake_account, vote_account, stake_authority = accounts[0], accounts[1], accounts[5]
+        if (deposit_result := self._maybe_decode_funding_deposit(
+            context=context,
+            stake_account=stake_account,
+            notes_fn=lambda amount: f'Stake {amount} SOL to validator {vote_account}',
+        )) is not None:
+            deposit_event, is_new = deposit_result
+            return SolanaDecodingOutput(events=[deposit_event]) if is_new else DEFAULT_SOLANA_DECODING_OUTPUT  # noqa: E501
+
+        if not self.base.is_tracked(stake_authority):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        return self._make_informational_event(
+            context=context,
+            location_label=stake_authority,
+            notes=f'Delegate stake account {stake_account} to validator {vote_account}',
+            address=stake_account,
+        )
+
+    def _decode_authorize(
+            self,
+            context: SolanaDecoderContext,
+            tag: StakeInstructionTag,
+    ) -> SolanaDecodingOutput:
+        """Decode the Authorize instruction family, changing the staker or withdrawer
+        authority of a stake account. The new authority and the authority type come from
+        the instruction data in the plain/seed variants and from the accounts in the
+        checked variants."""
+        accounts, data = context.instruction.accounts, context.instruction.data
+        if tag == StakeInstructionTag.AUTHORIZE:
+            if not self._check_min_accounts(context, tag, 3):
+                return DEFAULT_SOLANA_DECODING_OUTPUT
+            # data layout: discriminator (4) + new authority pubkey (32) + authority type (4)
+            authority, new_authority = accounts[2], bytes_to_solana_address(data[4:36])
+            authority_type = int.from_bytes(data[36:40], byteorder='little')
+        elif tag == StakeInstructionTag.AUTHORIZE_WITH_SEED:
+            if not self._check_min_accounts(context, tag, 2):
+                return DEFAULT_SOLANA_DECODING_OUTPUT
+            authority, new_authority = accounts[1], bytes_to_solana_address(data[4:36])
+            authority_type = int.from_bytes(data[36:40], byteorder='little')
+        else:  # AUTHORIZE_CHECKED or AUTHORIZE_CHECKED_WITH_SEED
+            if not self._check_min_accounts(context, tag, 4):
+                return DEFAULT_SOLANA_DECODING_OUTPUT
+            authority = accounts[2] if tag == StakeInstructionTag.AUTHORIZE_CHECKED else accounts[1]  # noqa: E501
+            new_authority = accounts[3]
+            authority_type = int.from_bytes(data[4:8], byteorder='little')
+
+        if authority_type not in (0, 1):
+            log.error(
+                'Solana stake %s instruction in %s has unknown authority type %d. Skipping',
+                tag.name,
+                context.transaction.signature,
+                authority_type,
+            )
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        stake_account = accounts[0]
+        if self.base.is_tracked(authority):
+            location_label = authority
+        elif self.base.is_tracked(new_authority):
+            location_label = new_authority
+        else:
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        return self._make_informational_event(
+            context=context,
+            location_label=location_label,
+            notes=f'Set the {"staker" if authority_type == 0 else "withdrawer"} of stake account {stake_account} to {new_authority}',  # noqa: E501
+            address=stake_account,
+        )
+
+    def _decode_split(self, context: SolanaDecoderContext) -> SolanaDecodingOutput:
+        """Decode a Split instruction moving part of a stake account into a new one.
+        The rent-exempt reserve funding the new account in the same transaction is
+        decoded as a deposit, since that SOL also moves from the wallet into the
+        stake account."""
+        if not self._check_min_accounts(context, StakeInstructionTag.SPLIT, 3):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        accounts = context.instruction.accounts
+        source_account, destination_account, authority = accounts[0], accounts[1], accounts[2]
+        if not self.base.is_tracked(authority):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        events = []
+        if (deposit_result := self._maybe_decode_funding_deposit(
+            context=context,
+            stake_account=destination_account,
+            notes_fn=lambda amount: f'Deposit {amount} SOL into stake account {destination_account}',  # noqa: E501
+        )) is not None and deposit_result[1] is True:
+            events.append(deposit_result[0])
+
+        amount = lamports_to_sol(int.from_bytes(context.instruction.data[4:12], byteorder='little'))  # noqa: E501
+        split_output = self._make_informational_event(
+            context=context,
+            location_label=authority,
+            notes=f'Split {amount} SOL from stake account {source_account} into stake account {destination_account}',  # noqa: E501
+            address=destination_account,
+            amount=amount,
+        )
+        return SolanaDecodingOutput(events=events + (split_output.events or []))
+
+    def _decode_withdraw(self, context: SolanaDecoderContext) -> SolanaDecodingOutput:
+        """Decode a Withdraw instruction, returning SOL from a stake account."""
+        if not self._check_min_accounts(context, StakeInstructionTag.WITHDRAW, 5):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        accounts = context.instruction.accounts
+        stake_account, recipient = accounts[0], accounts[1]
+        if not self.base.is_tracked(recipient):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        if (raw_amount := int.from_bytes(
+            context.instruction.data[4:12],
+            byteorder='little',
+        )) == 0:
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        amount = lamports_to_sol(raw_amount)
+        return SolanaDecodingOutput(events=[self.base.make_event_from_instruction(
+            instruction=context.instruction,
+            tx_ref=context.transaction.signature,
+            timestamp=context.transaction.block_time,
+            event_type=HistoryEventType.STAKING,
+            event_subtype=HistoryEventSubType.REMOVE_ASSET,
+            asset=A_SOL,
+            amount=amount,
+            location_label=recipient,
+            notes=f'Unstake {amount} SOL from stake account {stake_account}',
+            counterparty=CPT_SOLANA_STAKE,
+            address=stake_account,
+        )])
+
+    def _decode_deactivate(self, context: SolanaDecoderContext) -> SolanaDecodingOutput:
+        """Decode a Deactivate instruction. The stake becomes withdrawable after the
+        cooldown, so this only marks the start of unstaking and moves no funds."""
+        if not self._check_min_accounts(context, StakeInstructionTag.DEACTIVATE, 3):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        accounts = context.instruction.accounts
+        stake_account, stake_authority = accounts[0], accounts[2]
+        if not self.base.is_tracked(stake_authority):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        return self._make_informational_event(
+            context=context,
+            location_label=stake_authority,
+            notes=f'Deactivate stake account {stake_account}',
+            address=stake_account,
+        )
+
+    def _decode_set_lockup(
+            self,
+            context: SolanaDecoderContext,
+            tag: StakeInstructionTag,
+    ) -> SolanaDecodingOutput:
+        if not self._check_min_accounts(context, tag, 2):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        accounts = context.instruction.accounts
+        stake_account, authority = accounts[0], accounts[1]
+        if not self.base.is_tracked(authority):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        return self._make_informational_event(
+            context=context,
+            location_label=authority,
+            notes=f'Update the lockup of stake account {stake_account}',
+            address=stake_account,
+        )
+
+    def _decode_merge(self, context: SolanaDecoderContext) -> SolanaDecodingOutput:
+        """Decode a Merge instruction combining two stake accounts. The merged amount is
+        not part of the instruction data, so the event is purely informational."""
+        if not self._check_min_accounts(context, StakeInstructionTag.MERGE, 5):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        accounts = context.instruction.accounts
+        destination_account, source_account, authority = accounts[0], accounts[1], accounts[4]
+        if not self.base.is_tracked(authority):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        return self._make_informational_event(
+            context=context,
+            location_label=authority,
+            notes=f'Merge stake account {source_account} into stake account {destination_account}',
+            address=destination_account,
+        )
+
+    def _decode_move(
+            self,
+            context: SolanaDecoderContext,
+            tag: StakeInstructionTag,
+    ) -> SolanaDecodingOutput:
+        """Decode MoveStake/MoveLamports, shifting value between two stake accounts of
+        the same authority."""
+        if not self._check_min_accounts(context, tag, 3):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        accounts = context.instruction.accounts
+        source_account, destination_account, authority = accounts[0], accounts[1], accounts[2]
+        if not self.base.is_tracked(authority):
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        amount = lamports_to_sol(int.from_bytes(context.instruction.data[4:12], byteorder='little'))  # noqa: E501
+        subject = 'SOL of stake' if tag == StakeInstructionTag.MOVE_STAKE else 'SOL'
+        return self._make_informational_event(
+            context=context,
+            location_label=authority,
+            notes=f'Move {amount} {subject} from stake account {source_account} to stake account {destination_account}',  # noqa: E501
+            address=destination_account,
+            amount=amount,
+        )
+
+    def decode_stake_instruction(self, context: SolanaDecoderContext) -> SolanaDecodingOutput:
+        if len(context.instruction.data) < 4 or len(context.instruction.accounts) == 0:
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        try:
+            tag = StakeInstructionTag(int.from_bytes(
+                context.instruction.data[:4],
+                byteorder='little',
+            ))
+        except ValueError:
+            log.error(
+                'Unknown solana stake program instruction tag in transaction %s. Skipping',
+                context.transaction.signature,
+            )
+            return DEFAULT_SOLANA_DECODING_OUTPUT
+
+        if tag in (StakeInstructionTag.INITIALIZE, StakeInstructionTag.INITIALIZE_CHECKED):
+            return self._decode_initialize(context)
+        if tag in (
+            StakeInstructionTag.AUTHORIZE,
+            StakeInstructionTag.AUTHORIZE_WITH_SEED,
+            StakeInstructionTag.AUTHORIZE_CHECKED,
+            StakeInstructionTag.AUTHORIZE_CHECKED_WITH_SEED,
+        ):
+            return self._decode_authorize(context, tag)
+        if tag == StakeInstructionTag.DELEGATE_STAKE:
+            return self._decode_delegate(context)
+        if tag == StakeInstructionTag.SPLIT:
+            return self._decode_split(context)
+        if tag == StakeInstructionTag.WITHDRAW:
+            return self._decode_withdraw(context)
+        if tag == StakeInstructionTag.DEACTIVATE:
+            return self._decode_deactivate(context)
+        if tag in (StakeInstructionTag.SET_LOCKUP, StakeInstructionTag.SET_LOCKUP_CHECKED):
+            return self._decode_set_lockup(context, tag)
+        if tag == StakeInstructionTag.MERGE:
+            return self._decode_merge(context)
+        if tag in (StakeInstructionTag.MOVE_STAKE, StakeInstructionTag.MOVE_LAMPORTS):
+            return self._decode_move(context, tag)
+
+        # GET_MINIMUM_DELEGATION, DEACTIVATE_DELINQUENT and REDELEGATE carry no
+        # user-visible action for tracked accounts.
+        return DEFAULT_SOLANA_DECODING_OUTPUT
+
+    def addresses_to_decoders(self) -> dict[SolanaAddress, tuple[Any, ...]]:
+        return {STAKE_PROGRAM: (self.decode_stake_instruction,)}
+
+    @staticmethod
+    def counterparties() -> tuple[CounterpartyDetails, ...]:
+        return (CounterpartyDetails(
+            identifier=CPT_SOLANA_STAKE,
+            label='Solana staking',
+            image='solana.svg',
+        ),)

--- a/rotkehlchen/tests/unit/solana_decoders/test_stake.py
+++ b/rotkehlchen/tests/unit/solana_decoders/test_stake.py
@@ -1,0 +1,266 @@
+from typing import TYPE_CHECKING
+
+import pytest
+
+from rotkehlchen.chain.decoding.constants import CPT_GAS
+from rotkehlchen.chain.solana.modules.stake.constants import CPT_SOLANA_STAKE
+from rotkehlchen.constants.assets import A_SOL
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.solana_event import SolanaEvent
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.serialization.deserialize import deserialize_tx_signature
+from rotkehlchen.tests.utils.solana import get_decoded_events_of_solana_tx
+from rotkehlchen.types import SolanaAddress, TimestampMS
+
+if TYPE_CHECKING:
+    from rotkehlchen.chain.solana.node_inquirer import SolanaInquirer
+
+
+@pytest.mark.vcr
+@pytest.mark.parametrize('solana_accounts', [['HuUpZe8dH1ttFoEtwpGjatcaoQrJ7PpeSUpBZH1Hh2G3']])
+def test_stake_creation_and_delegation(
+        solana_inquirer: SolanaInquirer,
+        solana_accounts: list[SolanaAddress],
+) -> None:
+    """A transaction creating a stake account via createAccountWithSeed, initializing
+    it and delegating it to a validator in one go."""
+    signature = deserialize_tx_signature('2BhH7DcQJMPBZfLQDjLCSqhygzzwXiviGmLaLaojNUm3StihhLZaD1A7TXdfm6V8vR76VVsXvXmqTdVy2KPwYJau')  # noqa: E501
+    events = get_decoded_events_of_solana_tx(solana_inquirer=solana_inquirer, signature=signature)
+    assert events == [SolanaEvent(
+        tx_ref=signature,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1784920595000)),
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_SOL,
+        amount=FVal(fee_amount := '0.000017733'),
+        location_label=(user := solana_accounts[0]),
+        notes=f'Spend {fee_amount} SOL as transaction fee',
+        counterparty=CPT_GAS,
+    ), SolanaEvent(
+        tx_ref=signature,
+        sequence_index=1,
+        timestamp=timestamp,
+        event_type=HistoryEventType.STAKING,
+        event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
+        asset=A_SOL,
+        amount=FVal(staked_amount := '1.98528288'),
+        location_label=user,
+        notes=f'Stake {staked_amount} SOL to validator EXhYxF25PJEHb3v5G1HY8Jn8Jm7bRjJtaxEghGrUuhQw',  # noqa: E501
+        counterparty=CPT_SOLANA_STAKE,
+        address=SolanaAddress('HhJKd8G1gbvhPEiC4Aa3ZH9p4E9yze3ziYYq5A2ZLKjA'),
+    )]
+
+
+@pytest.mark.vcr
+@pytest.mark.parametrize('solana_accounts', [['9TT3YkWkLxU1DxJSsUHvmtbWtFJd9E7jkvxz1nBRq172']])
+def test_stake_deactivation(
+        solana_inquirer: SolanaInquirer,
+        solana_accounts: list[SolanaAddress],
+) -> None:
+    signature = deserialize_tx_signature('5jgnWXmTHWwpvFnCkciye7XhTCdRqDduUNUoSSRWoMh5bGxniFstMUAV2err7k6D3Dw59ocFijb8G1xNBv11nHsf')  # noqa: E501
+    events = get_decoded_events_of_solana_tx(solana_inquirer=solana_inquirer, signature=signature)
+    assert events == [SolanaEvent(
+        tx_ref=signature,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1784920737000)),
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_SOL,
+        amount=FVal(fee_amount := '0.000005'),
+        location_label=(user := solana_accounts[0]),
+        notes=f'Spend {fee_amount} SOL as transaction fee',
+        counterparty=CPT_GAS,
+    ), SolanaEvent(
+        tx_ref=signature,
+        sequence_index=1,
+        timestamp=timestamp,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_SOL,
+        amount=ZERO,
+        location_label=user,
+        notes=f'Deactivate stake account {SolanaAddress("7kf6dqRzRTAACPd7dDDrYVFMHSGgZzJY2tZVS3ZfuKMw")}',  # noqa: E501
+        counterparty=CPT_SOLANA_STAKE,
+        address=SolanaAddress('7kf6dqRzRTAACPd7dDDrYVFMHSGgZzJY2tZVS3ZfuKMw'),
+    )]
+
+
+@pytest.mark.vcr
+@pytest.mark.parametrize('solana_accounts', [['CQ3gvU4vKvFGevho9TkG1FEdTCHQKiLC1AcWLwPv4ek4']])
+def test_stake_authorize(
+        solana_inquirer: SolanaInquirer,
+        solana_accounts: list[SolanaAddress],
+) -> None:
+    """A stake account sale through a marketplace: both the staker and the withdrawer
+    authorities are handed to the buyer and the seller receives the payment."""
+    signature = deserialize_tx_signature('5R9M9ZviLoQ378G38zUi4dn6xQSSP51vvLEw2vzZjki1y6FzueuKNiDc5xaFxDh82dSzWw85eaQRVT93XzCqeQyw')  # noqa: E501
+    events = get_decoded_events_of_solana_tx(solana_inquirer=solana_inquirer, signature=signature)
+    stake_account, new_authority = SolanaAddress('9rJXVkHewWzuBh7wPErqhuwy3H5YN9znNVgWJDoEGhnD'), SolanaAddress('5PxxoU93A4KLr23rXvYrYMFZDAw5DY8XZiyX6NsW7Hkk')  # noqa: E501
+    assert events == [SolanaEvent(
+        tx_ref=signature,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1784922230000)),
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_SOL,
+        amount=FVal(fee_amount := '0.00081'),
+        location_label=(user := solana_accounts[0]),
+        notes=f'Spend {fee_amount} SOL as transaction fee',
+        counterparty=CPT_GAS,
+    ), SolanaEvent(
+        tx_ref=signature,
+        sequence_index=1,
+        timestamp=timestamp,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_SOL,
+        amount=FVal(received_amount := '0.022336188'),
+        location_label=user,
+        notes=f'Receive {received_amount} SOL from {new_authority}',
+        address=new_authority,
+    ), SolanaEvent(
+        tx_ref=signature,
+        sequence_index=2,
+        timestamp=timestamp,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_SOL,
+        amount=ZERO,
+        location_label=user,
+        notes=f'Set the staker of stake account {stake_account} to {new_authority}',
+        counterparty=CPT_SOLANA_STAKE,
+        address=stake_account,
+    ), SolanaEvent(
+        tx_ref=signature,
+        sequence_index=3,
+        timestamp=timestamp,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_SOL,
+        amount=ZERO,
+        location_label=user,
+        notes=f'Set the withdrawer of stake account {stake_account} to {new_authority}',
+        counterparty=CPT_SOLANA_STAKE,
+        address=stake_account,
+    )]
+
+
+@pytest.mark.vcr
+@pytest.mark.parametrize('solana_accounts', [['BG1MAyPvJsPP3BoSwkbDzTah2zW7NGu1VpteKi9Utqxo']])
+def test_stake_split(
+        solana_inquirer: SolanaInquirer,
+        solana_accounts: list[SolanaAddress],
+) -> None:
+    """Splitting part of a stake account into a new one, whose rent-exempt reserve is
+    funded via createAccountWithSeed in the same transaction."""
+    signature = deserialize_tx_signature('5s3aSkoBkoc9xQW83vepG2zMhz2YA75NLyqdYWqDHWnZrBNYawnifZGr4Ui3jS6zWj3z7FGfpcWQLa5kAFTTrFC8')  # noqa: E501
+    events = get_decoded_events_of_solana_tx(solana_inquirer=solana_inquirer, signature=signature)
+    source_account, destination_account = SolanaAddress('E6Qz4Fkxukhxm6ubGdLihCnUUhmYLa12WQj2NaykFgt1'), SolanaAddress('4dyK7o1KewvaH7b6inweQxMvULCExAgXm9SmMqWreFzb')  # noqa: E501
+    assert events == [SolanaEvent(
+        tx_ref=signature,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1784921316000)),
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_SOL,
+        amount=FVal(fee_amount := '0.000013445'),
+        location_label=(user := solana_accounts[0]),
+        notes=f'Spend {fee_amount} SOL as transaction fee',
+        counterparty=CPT_GAS,
+    ), SolanaEvent(
+        tx_ref=signature,
+        sequence_index=1,
+        timestamp=timestamp,
+        event_type=HistoryEventType.STAKING,
+        event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
+        asset=A_SOL,
+        amount=FVal(rent_amount := '0.00228288'),
+        location_label=user,
+        notes=f'Deposit {rent_amount} SOL into stake account {destination_account}',
+        counterparty=CPT_SOLANA_STAKE,
+        address=destination_account,
+    ), SolanaEvent(
+        tx_ref=signature,
+        sequence_index=2,
+        timestamp=timestamp,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_SOL,
+        amount=FVal(split_amount := '30'),
+        location_label=user,
+        notes=f'Split {split_amount} SOL from stake account {source_account} into stake account {destination_account}',  # noqa: E501
+        counterparty=CPT_SOLANA_STAKE,
+        address=destination_account,
+    )]
+
+
+@pytest.mark.vcr
+@pytest.mark.parametrize('solana_accounts', [['36kaqVpcbSSJ55rP48uGQWtQs3eNaa6SbX8qbhPxHGJf']])
+def test_stake_merge(
+        solana_inquirer: SolanaInquirer,
+        solana_accounts: list[SolanaAddress],
+) -> None:
+    signature = deserialize_tx_signature('k78n39QMtVDUFHDFGgyZRvHqxArVVhqP7ZhD4RjrYyjaCvNyXPwnWNg6ofYXMpzgXDAVAw7ghnktjduSLhqqw8V')  # noqa: E501
+    events = get_decoded_events_of_solana_tx(solana_inquirer=solana_inquirer, signature=signature)
+    assert events == [SolanaEvent(
+        tx_ref=signature,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1784921283000)),
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_SOL,
+        amount=FVal(fee_amount := '0.000005'),
+        location_label=(user := solana_accounts[0]),
+        notes=f'Spend {fee_amount} SOL as transaction fee',
+        counterparty=CPT_GAS,
+    ), SolanaEvent(
+        tx_ref=signature,
+        sequence_index=1,
+        timestamp=timestamp,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_SOL,
+        amount=ZERO,
+        location_label=user,
+        notes='Merge stake account 5adkBxExn2nPL7PVD1snpvjvaY7BwvtFtpxL6QmCvdUi into stake account 2R9YrpeXNXyne2gPrC3tKwJosScsuausNTmZ16LYfaFD',  # noqa: E501
+        counterparty=CPT_SOLANA_STAKE,
+        address=SolanaAddress('2R9YrpeXNXyne2gPrC3tKwJosScsuausNTmZ16LYfaFD'),
+    )]
+
+
+@pytest.mark.vcr
+@pytest.mark.parametrize('solana_accounts', [['npN8zCyQGPaAFNk95zJs2SAQ8GSjGcfhRDo6eiN57a9']])
+def test_stake_withdrawal(
+        solana_inquirer: SolanaInquirer,
+        solana_accounts: list[SolanaAddress],
+) -> None:
+    """Withdraw from a deactivated stake account back to the withdraw authority,
+    in a transaction that uses a durable nonce before the withdraw instruction."""
+    signature = deserialize_tx_signature('4j2wEyeo2gFrV4xUBVM5YukW1ZW2976osDofBJfUUTLbHKEkiTo7WtCdmLQa33Eo45xCs4M3XcZeSSMST2NtPrhM')  # noqa: E501
+    events = get_decoded_events_of_solana_tx(solana_inquirer=solana_inquirer, signature=signature)
+    assert events == [SolanaEvent(
+        tx_ref=signature,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1784920793000)),
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_SOL,
+        amount=FVal(fee_amount := '0.00001'),
+        location_label=(user := solana_accounts[0]),
+        notes=f'Spend {fee_amount} SOL as transaction fee',
+        counterparty=CPT_GAS,
+    ), SolanaEvent(
+        tx_ref=signature,
+        sequence_index=1,
+        timestamp=timestamp,
+        event_type=HistoryEventType.STAKING,
+        event_subtype=HistoryEventSubType.REMOVE_ASSET,
+        asset=A_SOL,
+        amount=FVal(unstaked_amount := '92.204933944'),
+        location_label=user,
+        notes=f'Unstake {unstaked_amount} SOL from stake account fqR3jkizg36JsGgfcSB6ZiRQWGMYdNW3bPZ4UtG44VC',  # noqa: E501
+        counterparty=CPT_SOLANA_STAKE,
+        address=SolanaAddress('fqR3jkizg36JsGgfcSB6ZiRQWGMYdNW3bPZ4UtG44VC'),
+    )]


### PR DESCRIPTION
Add a decoder module for the native Solana Stake program, covering its full instruction set. Previously staking transactions appeared as near-empty events (fee only), since the base decoder only handles plain system transfers and SPL token transfers.

Decoded events:
- Initialize(Checked)/DelegateStake: staking deposit with the amount recovered from the funding instruction in the same transaction (createAccount, createAccountWithSeed parsing the variable-length seed, or a plain transfer whose decoded spend event is transformed in place). Delegating an account funded earlier yields an informational event since the amount is not in the transaction.
- Withdraw: unstake event with the amount from the instruction data.
- Deactivate: informational start-of-unstaking event.
- Split: deposit for the new account's rent-exempt reserve plus an informational split event.
- Merge, SetLockup(Checked), MoveStake/MoveLamports and all four Authorize variants: informational events. Authority changes are emitted when either the old or the new authority is tracked, so both sides of a stake account sale see them.
- GetMinimumDelegation, DeactivateDelinquent and Redelegate produce no events (read-only, permissionless or retired).

Instruction tags are parsed as a bincode enum via an IntEnum. Events use the existing STAKING deposit/remove combos and a new solana-stake counterparty rendered with the existing solana.svg icon.

Tests cover six real mainnet transactions: create+delegate, deactivate, durable-nonce withdraw, a stake account sale (authorize x2 + payment), a split funded via createAccountWithSeed, and a merge. They are not yet VCRed and query mainnet-beta live.

Note: epoch rewards are credited by the runtime without transactions, so they cannot be decoded and would need a separate query task. SPL stake pool (liquid staking) deposits are a separate program and are not covered by this module.

Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
