### PR TITLE
fix: unflake evm tx query scheduler test

### DIFF
--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -142,11 +142,15 @@ def test_maybe_query_ethereum_transactions(task_manager, ethereum_accounts):
     timeout = 8
     deadline = time.monotonic() + timeout
     with tx_query_patch as tx_mock:
-        # First two calls to schedule should handle the addresses
+        # The task is spawned for a single address at a time, and the next one is only
+        # scheduled once the previous task is out of running_tasks. Since the mock call
+        # count goes up before the task thread actually finishes, a single schedule() per
+        # address races the task's death, so keep ticking the scheduler -- as the real one
+        # does -- until each address has been queried.
         for i in range(2):
-            task_manager.schedule()
             while tx_mock.call_count != i + 1:
                 assert time.monotonic() < deadline, f'The transaction query was not scheduled within {timeout} seconds'  # noqa: E501
+                task_manager.schedule()
                 time.sleep(.2)
 
         task_manager.schedule()


### PR DESCRIPTION
test_maybe_query_ethereum_transactions scheduled once per address and then only polled the mock call count. The count goes up when the mocked query is entered, but the task handle stays in running_tasks until the thread actually unwinds, so the second schedule() could hit a still-alive task, do nothing and leave the test waiting for a tick that never comes. Gevent hid this: the sleep in the poll loop yielded to the hub and the task greenlet always died first.

Tick the scheduler inside the wait loop instead, as the real scheduler does. Re-ticking cannot double-query an address since last_evm_tx_query_ts is set at schedule time.


Fixes this failure:

```
FAILED rotkehlchen/tests/unit/test_tasks_manager.py::test_maybe_query_ethereum_transactions[5-2] - AssertionError: The transaction query was not scheduled within 8 seconds
assert 901.813528448 < 901.733697259
 +  where 901.813528448 = <built-in function monotonic>()
 +    where <built-in function monotonic> = time.monotonic
= 1 failed, 1830 passed, 78 skipped, 1 xpassed, 1784 warnings in 538.49s (0:08:58) =
```