### PR TITLE
fix: mark skipped EVM transactions as decoded

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :feature:`-` Yearn vesting escrows are now supported. All related transactions are understood and decoded and balances in escrow automatically detected. Calendar entries with reminders are also created for the cliff and full vesting dates of your escrows.
+* :bug:`-` Monerium v1-to-v2 migration transactions are no longer repeatedly processed as undecoded, allowing history decoding to finish normally.
 * :bug:`-` Automatically removing a calendar entry, like an airdrop claim deadline after the airdrop is claimed, no longer also deletes the reminder of an unrelated calendar entry. 
 * :feature:`-` Solana native staking program events should now be properly decoded and appear under rotki's events.
 * :bug:`-` Without a premium subscription, the asset movement matching actions (Ignore Selected, Ignore All Fiat and Restore Selected) no longer appear available. Previously these buttons looked clickable but did nothing, since asset movement matching is a premium feature.

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -626,6 +626,12 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
 
             decoding_output = self.decode_by_address_rules(context)
             if decoding_output.stop_processing is True:
+                self._write_new_tx_events_to_the_db(
+                    events=[],
+                    action_id=transaction.identifier,
+                    db_id=tx_id,
+                    write_buffer=write_buffer,
+                )
                 return [], False, None  # We determined this transaction is full of unnecessary log events and should all be skipped. Saves processing time.  # noqa: E501
             if decoding_output.refresh_balances is True:
                 refresh_balances = True

--- a/rotkehlchen/tests/unit/decoders/test_monerium.py
+++ b/rotkehlchen/tests/unit/decoders/test_monerium.py
@@ -8,6 +8,7 @@ from rotkehlchen.chain.arbitrum_one.modules.monerium.constants import ARBITRUM_M
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.chain.evm.decoding.monerium.decoder import MoneriumCommonDecoder
 from rotkehlchen.constants.assets import A_ETH_EURE
+from rotkehlchen.db.constants import TX_DECODED
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -315,11 +316,19 @@ def test_burn_eure_on_arbitrum(
 @pytest.mark.parametrize('gnosis_accounts', [['0x4A551b4ADddB4CDBA24612bCbb543c9aD4DAE4B6']])
 def test_monerium_token_migration(gnosis_inquirer: GnosisInquirer):
     """Test that mints on the v1 to v2 migration are skipped correctly"""
+    tx_hash = deserialize_evm_tx_hash('0x6241b6ef81b50e87585741362247852e6b325eb4401e5bde83e6c52ef9f2f097')  # noqa: E501
     events, _ = get_decoded_events_of_transaction(
         evm_inquirer=gnosis_inquirer,
-        tx_hash=deserialize_evm_tx_hash('0x6241b6ef81b50e87585741362247852e6b325eb4401e5bde83e6c52ef9f2f097'),
+        tx_hash=tx_hash,
     )
     assert events == []
+    with gnosis_inquirer.database.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM evm_tx_mappings WHERE tx_id IN ('
+            'SELECT identifier FROM evm_transactions WHERE tx_hash=? AND chain_id=?) '
+            'AND value=?',
+            (tx_hash, gnosis_inquirer.chain_id.serialize_for_db(), TX_DECODED),
+        ).fetchone()[0] == 1
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])


### PR DESCRIPTION
Monerium v1-to-v2 migration transactions return stop_processing to avoid recording their batch mints. The early return bypassed the normal event write path, so TX_DECODED was never persisted and the periodic decoder selected the same transactions on every cycle. Persist an empty decoded result before returning and cover the decoded mapping with a regression test.


