### PR TITLE
Fix boolean shorthand attribute regressions

### DIFF
--- a/frontend/app/src/modules/history/LocationLabelSelector.spec.ts
+++ b/frontend/app/src/modules/history/LocationLabelSelector.spec.ts
@@ -1,3 +1,4 @@
+import type { LocationLabel } from '@/modules/core/common/location';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -16,20 +17,29 @@ vi.mock('@/modules/accounts/address-book/use-address-name-resolution', () => ({
   useAddressNameResolution: (): object => ({ getAddressName: (): undefined => undefined }),
 }));
 
+const address = '0x1234567890abcdef1234567890abcdef12345678';
+
 const stubs = {
   AccountDisplay: true,
+  EnsAvatar: true,
   LocationIcon: true,
   RuiAutoComplete: {
     props: ['menuClass', 'options'],
-    template: '<div data-testid="autocomplete" :data-menu-class="menuClass"><slot /></div>',
+    template: `<div data-testid="autocomplete" :data-menu-class="menuClass">
+      <slot />
+      <template v-if="options.length > 0">
+        <div data-testid="selection-slot"><slot name="selection" :item="options[0]" /></div>
+        <div data-testid="item-slot"><slot name="item" :item="options[0]" /></div>
+      </template>
+    </div>`,
   },
   TagDisplay: true,
 };
 
-function createWrapper(): VueWrapper {
+function createWrapper(options: LocationLabel[] = []): VueWrapper {
   return mount(LocationLabelSelector, {
     global: { stubs },
-    props: { modelValue: '', options: [] },
+    props: { modelValue: '', options },
   });
 }
 
@@ -44,5 +54,14 @@ describe('locationLabelSelector', () => {
     const wrapper = createWrapper();
 
     expect(wrapper.find('[data-testid=autocomplete]').attributes('data-menu-class')).toBe('!min-w-full');
+  });
+
+  it('should render the selection compactly and the dropdown item in full', () => {
+    // The `dense` binding decides between the one-line chip and the two-line dropdown row. It is
+    // forwarded through a reusable template, which drops boolean casting unless props are declared.
+    const wrapper = createWrapper([{ location: 'eth', locationLabel: address }]);
+
+    expect(wrapper.find('[data-testid=selection-slot]').text()).toBe('0x1234...5678');
+    expect(wrapper.find('[data-testid=item-slot]').text()).toBe('0x1234567890...ef12345678');
   });
 });

--- a/frontend/app/src/modules/history/LocationLabelSelector.vue
+++ b/frontend/app/src/modules/history/LocationLabelSelector.vue
@@ -32,7 +32,17 @@ const {
   locationLabelOptions,
 } = useLocationLabels(() => options);
 
-const [DefineLocationItem, ReuseLocationItem] = createReusableTemplate<{ item: LocationLabel; dense: boolean }>();
+// The props declaration is required: without it the reuse component forwards raw attrs, so a
+// boolean shorthand (`dense`) arrives as an empty string instead of `true`.
+const [DefineLocationItem, ReuseLocationItem] = createReusableTemplate<{ item: LocationLabel; dense: boolean }>({
+  props: {
+    dense: Boolean,
+    item: {
+      required: true,
+      type: Object,
+    },
+  },
+});
 </script>
 
 <template>

--- a/frontend/app/src/modules/settings/AssetBalanceStatisticSourceSetting.spec.ts
+++ b/frontend/app/src/modules/settings/AssetBalanceStatisticSourceSetting.spec.ts
@@ -1,0 +1,60 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AssetBalanceStatisticSourceSetting from './AssetBalanceStatisticSourceSetting.vue';
+
+vi.mock('@/modules/settings/use-asset-statistic-state', async () => {
+  const { computed, shallowRef } = await import('vue');
+  return {
+    useAssetStatisticState: (): object => ({
+      getPreference: (): undefined => undefined,
+      modelUseHistoricalAssetBalances: shallowRef<boolean>(false),
+      name: computed<string>(() => 'Ether'),
+      rememberStateForAsset: shallowRef<boolean>(false),
+      suppressIfPerAsset: async (func: () => Promise<void>): Promise<void> => func(),
+    }),
+  };
+});
+
+vi.mock('@/modules/settings/use-setting-model', async () => {
+  const { shallowRef } = await import('vue');
+  return {
+    useSettingModel: (): object => ({ model: shallowRef<boolean>(false) }),
+  };
+});
+
+const stubs = {
+  MenuTooltipButton: true,
+  RuiCardHeader: { template: '<div><slot name="header" /></div>' },
+  RuiCheckbox: true,
+  RuiIcon: true,
+  RuiMenu: { template: '<div><slot /></div>' },
+  RuiRadio: {
+    props: ['value', 'label'],
+    template: '<div data-testid="radio" :data-value="String(value)" :data-value-type="typeof value">{{ label }}</div>',
+  },
+  RuiRadioGroup: { template: '<div><slot /></div>' },
+};
+
+function createWrapper(): VueWrapper {
+  return mount(AssetBalanceStatisticSourceSetting, { global: { stubs } });
+}
+
+describe('assetBalanceStatisticSourceSetting', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should give each radio a boolean value', () => {
+    // `value` is the radio payload, not a boolean prop, so a `value` shorthand would reach RuiRadio
+    // as an empty string: the events option would never match the setting and would persist ''.
+    const wrapper = createWrapper();
+    const radios = wrapper.findAll('[data-testid=radio]');
+
+    expect(radios).toHaveLength(2);
+    expect(radios[0].attributes('data-value-type')).toBe('boolean');
+    expect(radios[0].attributes('data-value')).toBe('false');
+    expect(radios[1].attributes('data-value-type')).toBe('boolean');
+    expect(radios[1].attributes('data-value')).toBe('true');
+  });
+});

--- a/frontend/app/src/modules/settings/AssetBalanceStatisticSourceSetting.vue
+++ b/frontend/app/src/modules/settings/AssetBalanceStatisticSourceSetting.vue
@@ -79,10 +79,12 @@ watchImmediate(() => asset, (asset) => {
           :label="t('statistics_graph_settings.source.snapshot')"
           :value="false"
         />
+        <!-- eslint-disable vue/prefer-true-attribute-shorthand -- `value` is the radio payload, not a boolean prop, so the shorthand would pass an empty string -->
         <RuiRadio
           :label="t('statistics_graph_settings.source.historical_events_processing')"
-          value
+          :value="true"
         />
+        <!-- eslint-enable vue/prefer-true-attribute-shorthand -->
       </RuiRadioGroup>
       <RuiCheckbox
         v-if="asset"


### PR DESCRIPTION
The true-attribute-shorthand sweep in `05668e0023` rewrote `:x="true"` to `x` in 14 files. Two of those targets do not declare the attribute as a `Boolean` prop, so Vue skipped boolean casting and they received an empty string instead of `true`.

### History events account filter

`LocationLabelSelector` forwards `dense` through a `createReusableTemplate` pair. The reuse component had no props declaration, so VueUse passed raw attrs and `dense` arrived as `""`, which is falsy. The selection chip took every `v-else` branch and rendered the dropdown layout instead of the compact one: a 28px avatar, the name and address stacked over two lines, `py-[5px]`, and a 10 character address. The visible symptom is a tall, oblong pill in the account filter.

Fixed by declaring `props` on the reusable template, which is the supported way to get boolean casting back. The shorthand stays.

### Asset balance statistic source setting

`RuiRadio`'s `value` is the radio payload, typed as a generic `TValue`, so it is compiled as `value: {}` and never gets boolean casting. The "historical events processing" option ended up with `value=""`, so it never showed as selected when the setting was on, and picking it called `persistSource("")`, persisting an empty string rather than `true`.

Here the shorthand is simply not applicable, so it goes back to `:value="true"` with a scoped lint exemption explaining why.

### Audit

All 28 `createReusableTemplate` sites were checked for bare attributes on the reuse component, and every target of the original sweep was checked against its runtime prop declaration. The rest are fine: the three `model-value` swaps all go to `RuiDialog` (`modelValue: { type: Boolean }`), and `RuiButton icon`, `RuiAlert closeable`, `RuiButtonGroup required`, `RuiMenuSelect hide-details`, `RuiAutoComplete auto-select-first`, `RuiDialog persistent` plus the local `TagDisplay` / `GnosisPayAuthStep` / `PrioritizedList` props are all declared `Boolean`.

### Tests

Both fixes get a unit test, and each was confirmed to fail against the unfixed component before being kept.

Note for reviewers: `vue/prefer-true-attribute-shorthand` cannot tell whether the receiving prop is `Boolean`, so its autofix can change runtime behaviour on generic-valued props and attr-forwarding components. That is what produced both of these.