### PR TITLE
Fix locale HMR in dev and split the vue devtools flag

### DIFF
--- a/frontend/app/src/i18n.ts
+++ b/frontend/app/src/i18n.ts
@@ -20,6 +20,20 @@ export const i18n = createI18n({
   silentTranslationWarn: import.meta.env.VITE_SILENT_TRANSLATION_WARN === 'true',
 });
 
+/**
+ * `@intlify/unplugin-vue-i18n` precompiles the locale JSON into a module whose default
+ * export is an object of compiled message functions, but it neither self-accepts nor
+ * handles hot updates for directly imported resources. Without an accept handler the
+ * update propagates up to the root and Vite falls back to a full page reload, which
+ * throws away the app state. Accepting here swaps the messages in place instead.
+ */
+if (import.meta.hot) {
+  import.meta.hot.accept('./locales/en.json', (mod) => {
+    if (mod)
+      i18n.global.setLocaleMessage('en', mod.default);
+  });
+}
+
 export async function loadLocaleMessages(locale: string): Promise<void> {
   if (loadedLocales.has(locale))
     return;

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -1,6 +1,6 @@
 import type { ComponentResolver } from 'unplugin-vue-components';
 import { builtinModules } from 'node:module';
-import { join, relative, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import process from 'node:process';
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite';
 import { ruiIconsPlugin } from '@rotki/ui-library/vite-plugin';
@@ -56,25 +56,33 @@ if (process.env.ROTKI_ACCOUNTING_UPDATE === 'True')
   process.env.VITE_ACCOUNTING_UPDATE = 'true';
 
 /**
- * Force a full page reload when a locale JSON changes. @intlify/unplugin-vue-i18n
- * precompiles the messages and self-accepts the compiled module, so edits to
- * src/locales are silently swallowed (no reload, stale text) and an
- * `import.meta.hot.accept` + `setLocaleMessage` fallback no-ops. A full reload
- * re-fetches the recompiled messages and re-initialises i18n from scratch.
+ * Hot-swap locale messages instead of losing the app state on every en.json edit.
+ *
+ * Vite 8 no longer ships a JS `vite:json` plugin, so @intlify/unplugin-vue-i18n falls
+ * back to its virtual-module path and serves each locale as `virtual:intlify-i18n-N`.
+ * That path has no HMR wiring: the compiled module is cached and never invalidated, so
+ * locale edits are invisible even across a full page reload until the dev server is
+ * restarted. Invalidating those virtual modules here re-runs the message compiler and
+ * lets the `import.meta.hot.accept` handler in src/i18n.ts swap the messages in place.
  */
-function reloadOnLocaleChange(): Plugin {
+function hmrLocaleMessages(): Plugin {
   const localeDir = resolve(PACKAGE_ROOT, './src/locales');
+  const virtualPrefix = 'virtual:intlify-i18n-';
   return {
-    name: 'rotki:reload-on-locale-change',
-    handleHotUpdate({ file, server }) {
-      if (file.startsWith(localeDir) && file.endsWith('.json')) {
-        server.config.logger.info(
-          `[locale] ${relative(PACKAGE_ROOT, file)} changed, reloading page...`,
-          { clear: true, timestamp: true },
-        );
-        server.ws.send({ path: '*', type: 'full-reload' });
-        return [];
-      }
+    name: 'rotki:hmr-locale-messages',
+    hotUpdate({ file, modules }) {
+      if (!file.startsWith(localeDir) || !file.endsWith('.json'))
+        return;
+
+      const graph = this.environment.moduleGraph;
+      const virtualModules = [...graph.idToModuleMap.entries()]
+        .filter(([id]) => id.startsWith(virtualPrefix))
+        .map(([, mod]) => mod);
+
+      for (const mod of virtualModules)
+        graph.invalidateModule(mod);
+
+      return [...modules, ...virtualModules];
     },
   };
 }
@@ -218,7 +226,7 @@ export default defineConfig({
     VueI18nPlugin({
       include: [resolve(PACKAGE_ROOT, './src/locales/**')],
     }),
-    reloadOnLocaleChange(),
+    hmrLocaleMessages(),
     ...(!isTest && process.env.ENABLE_DEV_TOOLS ? [vueDevTools()] : []),
   ],
   server: {

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -227,7 +227,11 @@ export default defineConfig({
       include: [resolve(PACKAGE_ROOT, './src/locales/**')],
     }),
     hmrLocaleMessages(),
-    ...(!isTest && process.env.ENABLE_DEV_TOOLS ? [vueDevTools()] : []),
+    // Opt-in and deliberately NOT tied to ENABLE_DEV_TOOLS (which only opens Electron's
+    // Chrome DevTools, see electron/main/window-manager.ts): vite-plugin-vue-devtools
+    // breaks Vue SFC hot reload, so every .vue edit needs a manual page reload while it
+    // is installed. Enable it only when you actually need the Vue DevTools panel.
+    ...(!isTest && process.env.ENABLE_VUE_DEVTOOLS ? [vueDevTools()] : []),
   ],
   server: {
     port: 8080,


### PR DESCRIPTION
## Problem

Editing `frontend/app/src/locales/en.json` during development did not show the new text. The dev config worked around this by forcing a full page reload on every locale change, which threw away the app state (you had to log in again) and still did not show the edit.

The reload was pointless because the root cause is server-side. Vite 8 no longer ships a JS `vite:json` plugin, so `@intlify/unplugin-vue-i18n` takes its `!hasViteJsonPlugin` fallback and serves each locale as a virtual module (`virtual:intlify-i18n-N`). That path has no HMR wiring: the compiled module is cached and never invalidated, so locale edits were invisible **even across a full reload**, and only a dev server restart picked them up.

Related upstream reports: intlify/bundle-tools#299 and intlify/bundle-tools#553.

## Changes

- `vite.config.ts`: replace the full-reload plugin with `hmrLocaleMessages()`, a `hotUpdate` hook that invalidates the `virtual:intlify-i18n-*` modules so the message compiler re-runs.
- `src/i18n.ts`: accept the updated locale module and swap it in with `setLocaleMessage`.
- `vite.config.ts`: give `vite-plugin-vue-devtools` its own `ENABLE_VUE_DEVTOOLS` flag.

The flag split is a separate finding from the same investigation: `ENABLE_DEV_TOOLS` was driving both the Vue DevTools Vite plugin and Electron's `webContents.openDevTools()`. That Vite plugin breaks Vue SFC hot reload (every `.vue` edit needs a manual page reload while it is installed), and there was no way to keep the Electron devtools without paying that cost. Verified by A/B: devtools off + checker on hot-applies fine; devtools on breaks it regardless of `vite-plugin-checker` or `componentInspector`. The new flag is deliberately not added to the managed dev flags, which default to on for instance runs, so the panel is opt-in.

## Verification

Manual, against `pnpm dev:web`, using a `window` marker to tell a hot swap from a reload:

- editing an existing `en.json` value swaps the text live, no reload, no restart
- adding a new key and using it in a component works
- `ENABLE_DEV_TOOLS=true` no longer loads the Vue DevTools plugin, and SFC hot reload applies
- `ENABLE_VUE_DEVTOOLS=true` brings the panel back at `/__devtools__/`

`pnpm run lint` and `pnpm run typecheck` are clean.

## Notes

Only `en` hot-swaps. The other locales are pulled in through the dynamic `import()` in `loadLocaleMessages`, so editing them still falls back to a reload.