### PR TITLE
Silence notification popups on demand

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` You can now silence notification popups from the notification area, so rotki stops interrupting you while you work. Nothing is lost: every notification still arrives in the notification area with its actions. The setting stays as you left it the next time you log in.
 * :bug:`-` The "No indexers available" and missing API key warnings no longer pop up at every login. Each one now goes quiet for a day, then two days, then a week, and finally stops interrupting you. It stays in the notification sidebar with its action so you can still deal with it, and starts over if you change that chain's indexer order or that service's key. Chains and services are also tracked separately now, so one no longer replaces or silences another.
 * :feature:`-` The "Actions needed" button in history events is now a single actions center. It counts the categories needing attention rather than every item, and lists each as a row with its own count and action, including categories with nothing to do so you can re-check them at any time. The duplicate "Check ..." entries in the overflow menu are gone.
 * :feature:`-` Yearn vesting escrows are now supported. All related transactions are understood and decoded and balances in escrow automatically detected. Calendar entries with reminders are also created for the cliff and full vesting dates of your escrows.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -4856,7 +4856,8 @@
     "tooltip": "Notes"
   },
   "notification_indicator": {
-    "tooltip": "Notifications"
+    "tooltip": "Notifications",
+    "tooltip_silent": "Notifications (silent)"
   },
   "notification_messages": {
     "accounting_rule_conflict": {
@@ -4994,6 +4995,10 @@
     },
     "message_overflow": "The total amount of notifications received has exceeded the limit of 200. Older notifications have been removed.",
     "no_messages": "No messages!",
+    "silent": {
+      "off": "Silence notification popups",
+      "on": "Popups silenced. Click to allow them again"
+    },
     "tabs": {
       "error": "Error",
       "needs_action": "Needs Action",

--- a/frontend/app/src/modules/assets/detection/use-newly-detected-tokens-db.spec.ts
+++ b/frontend/app/src/modules/assets/detection/use-newly-detected-tokens-db.spec.ts
@@ -319,6 +319,14 @@ describe('useNewlyDetectedTokensDb', () => {
   describe('prune', () => {
     const SECONDS_PER_DAY = 86400;
 
+    /**
+     * Margin between the cutoff and a token that must survive it. `prune` recomputes the cutoff
+     * from its own clock read, several awaited IndexedDB round trips after the one here, so a
+     * token placed a second inside the window can fall outside it on a slow machine. The clock
+     * cannot simply be frozen: prune's in-progress guard then latches across cases.
+     */
+    const TTL_MARGIN_MS = 60_000;
+
     beforeEach(() => {
       const settingsStore = useSettingsRepo();
       settingsStore.updateFrontend({
@@ -344,7 +352,7 @@ describe('useNewlyDetectedTokensDb', () => {
       await db().newlyDetectedTokens.bulkAdd([
         { tokenIdentifier: 'expired-1', tokenKind: NewDetectedTokenKind.EVM, detectedAt: cutoffTime - 1000 },
         { tokenIdentifier: 'expired-2', tokenKind: NewDetectedTokenKind.EVM, detectedAt: cutoffTime - 2000 },
-        { tokenIdentifier: 'valid-1', tokenKind: NewDetectedTokenKind.EVM, detectedAt: cutoffTime + 1000 },
+        { tokenIdentifier: 'valid-1', tokenKind: NewDetectedTokenKind.EVM, detectedAt: cutoffTime + TTL_MARGIN_MS },
         { tokenIdentifier: 'valid-2', tokenKind: NewDetectedTokenKind.EVM, detectedAt: now },
       ]);
 
@@ -402,7 +410,7 @@ describe('useNewlyDetectedTokensDb', () => {
 
       await db().newlyDetectedTokens.bulkAdd([
         { tokenIdentifier: 'expired-1', tokenKind: NewDetectedTokenKind.EVM, detectedAt: cutoffTime - 1000 },
-        { tokenIdentifier: 'valid-oldest', tokenKind: NewDetectedTokenKind.EVM, detectedAt: cutoffTime + 1000 },
+        { tokenIdentifier: 'valid-oldest', tokenKind: NewDetectedTokenKind.EVM, detectedAt: cutoffTime + TTL_MARGIN_MS },
         { tokenIdentifier: 'valid-middle', tokenKind: NewDetectedTokenKind.EVM, detectedAt: now - 2000 },
         { tokenIdentifier: 'valid-newest', tokenKind: NewDetectedTokenKind.EVM, detectedAt: now - 1000 },
       ]);

--- a/frontend/app/src/modules/auth/use-account-management.spec.ts
+++ b/frontend/app/src/modules/auth/use-account-management.spec.ts
@@ -151,11 +151,19 @@ describe('useAccount', () => {
   describe('password confirmation', () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      // Freeze the clock. These cases assert on an interval boundary, but the timestamp they store
+      // and the one `use-password-confirmation` compares it against are two independent reads of
+      // the wall clock. Crossing a second between them makes the elapsed time one greater than the
+      // interval, which flipped the boundary assertions at random on a loaded machine. Only `Date`
+      // is faked, so the async paths under test keep real timers.
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
       mockInterop.isPackaged = true;
       localStorage.setItem(REMEMBER_PASSWORD_KEY, 'true');
     });
 
     afterEach(() => {
+      vi.useRealTimers();
       localStorage.removeItem(REMEMBER_PASSWORD_KEY);
     });
 

--- a/frontend/app/src/modules/core/notifications/NotificationSidebar.vue
+++ b/frontend/app/src/modules/core/notifications/NotificationSidebar.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { type NotificationData, Priority, Severity } from '@rotki/common';
+import { startPromise } from '@shared/utils';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import Notification from '@/modules/core/notifications/Notification.vue';
 import PendingTasks from '@/modules/core/notifications/PendingTasks.vue';
 import { useNotificationsStore } from '@/modules/core/notifications/use-notifications-store';
+import { useSilentNotifications } from '@/modules/core/notifications/use-silent-notifications';
 import { useTaskStore } from '@/modules/core/tasks/use-task-store';
 import LazyLoader from '@/modules/shell/components/LazyLoader.vue';
 
@@ -31,6 +33,7 @@ const notificationStore = useNotificationsStore();
 const { messageOverflow, prioritized: allNotifications } = storeToRefs(notificationStore);
 const { remove } = notificationStore;
 const { hasRunningTasks } = storeToRefs(useTaskStore());
+const { silent, toggle: toggleSilent } = useSilentNotifications();
 const [DefineNoMessages, ReuseNoMessages] = createReusableTemplate();
 const { y } = useScroll(contentWrapper);
 
@@ -60,6 +63,10 @@ const selectedNotifications = computed(() => {
 
 function close() {
   set(display, false);
+}
+
+function toggleSilentMode(): void {
+  startPromise(toggleSilent());
 }
 
 function clear() {
@@ -121,13 +128,29 @@ watch(
         <div class="text-h6">
           {{ t('notification_sidebar.title') }}
         </div>
-        <RuiButton
-          variant="text"
-          icon
-          @click="close()"
-        >
-          <RuiIcon name="lu-x" />
-        </RuiButton>
+        <div class="flex items-center">
+          <RuiTooltip :open-delay="400">
+            <template #activator>
+              <RuiButton
+                variant="text"
+                icon
+                :color="silent ? 'primary' : undefined"
+                data-testid="silent-notifications-toggle"
+                @click="toggleSilentMode()"
+              >
+                <RuiIcon :name="silent ? 'lu-bell-off' : 'lu-bell'" />
+              </RuiButton>
+            </template>
+            {{ silent ? t('notification_sidebar.silent.on') : t('notification_sidebar.silent.off') }}
+          </RuiTooltip>
+          <RuiButton
+            variant="text"
+            icon
+            @click="close()"
+          >
+            <RuiIcon name="lu-x" />
+          </RuiButton>
+        </div>
       </div>
 
       <ReuseNoMessages v-if="!hasRunningTasks && allNotifications.length === 0" />

--- a/frontend/app/src/modules/core/notifications/use-notification-dispatcher.spec.ts
+++ b/frontend/app/src/modules/core/notifications/use-notification-dispatcher.spec.ts
@@ -1,6 +1,7 @@
 import { NotificationCategory, NotificationGroup, type NotificationPayload, Priority, Severity } from '@rotki/common';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useNotificationsStore } from '@/modules/core/notifications/use-notifications-store';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
 import { useNotificationDispatcher } from './use-notification-dispatcher';
 
 /** Matches NOTIFICATION_COOLDOWN_MS in use-notification-cooldown.ts */
@@ -212,5 +213,72 @@ describe('useNotificationDispatcher', () => {
 
     store.displayed([get(data)[0].id]);
     expect(get(data)[0]).toMatchObject({ display: false });
+  });
+
+  describe('silent mode', () => {
+    function silence(): void {
+      useSettingsRepo().updateFrontend({ silentNotifications: true });
+    }
+
+    function unsilence(): void {
+      useSettingsRepo().updateFrontend({ silentNotifications: false });
+    }
+
+    it('should keep a notification out of the popup queue', () => {
+      silence();
+      const { notify } = useNotificationDispatcher();
+      const { data, queue } = storeToRefs(useNotificationsStore());
+
+      notify({ display: true, message: 'msg', title: 'title' });
+
+      expect(get(queue)).toHaveLength(0);
+      expect(get(data)[0]).toMatchObject({ display: false, message: 'msg' });
+    });
+
+    it('should still deliver the notification to the notification area', () => {
+      silence();
+      const { notify } = useNotificationDispatcher();
+      const { data } = storeToRefs(useNotificationsStore());
+
+      notify({
+        action: { action: vi.fn(), label: 'Configure' },
+        display: true,
+        message: 'msg',
+        priority: Priority.ACTION,
+        title: 'title',
+      });
+
+      // Silenced, not suppressed: the row and its action have to survive.
+      expect(get(data)).toHaveLength(1);
+      expect(get(data)[0].action).toBeDefined();
+      expect(get(data)[0].priority).toBe(Priority.ACTION);
+    });
+
+    it('should still collapse grouped notifications while silent', () => {
+      silence();
+      const { notify } = useNotificationDispatcher();
+      const { data } = storeToRefs(useNotificationsStore());
+
+      notify({ display: true, group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'first', title: 'title' });
+      notify({ display: true, group: NotificationGroup.NEW_DETECTED_TOKENS, groupCount: 2, message: 'second', title: 'title' });
+
+      expect(get(data)).toHaveLength(1);
+      expect(get(data)[0]).toMatchObject({ display: false, groupCount: 2, message: 'second' });
+    });
+
+    it('should let notifications interrupt again once it is turned off', () => {
+      silence();
+      const { notify } = useNotificationDispatcher();
+      const { queue } = storeToRefs(useNotificationsStore());
+
+      notify({ display: true, message: 'quiet', title: 'title' });
+      unsilence();
+      notify({ display: true, message: 'loud', title: 'title' });
+
+      // Only the new one pops. The silenced notification must not be waiting in the queue to
+      // fire the moment silent mode is switched off.
+      expect(get(queue)).toHaveLength(1);
+      expect(get(queue)[0]).toMatchObject({ message: 'loud' });
+    });
   });
 });

--- a/frontend/app/src/modules/core/notifications/use-notification-dispatcher.ts
+++ b/frontend/app/src/modules/core/notifications/use-notification-dispatcher.ts
@@ -7,6 +7,7 @@ import { bulkDuplicateStrategy } from './strategies/bulk-duplicate';
 import { createDeserializationErrorStrategy } from './strategies/deserialization-error';
 import { createGroupUpdateStrategy } from './strategies/group-update';
 import { useNotificationCooldown } from './use-notification-cooldown';
+import { useSilentNotifications } from './use-silent-notifications';
 
 interface UseNotificationDispatcherReturn {
   notify: (payload: SemiPartial<NotificationPayload, 'title' | 'message'>) => void;
@@ -16,6 +17,7 @@ export function useNotificationDispatcher(): UseNotificationDispatcherReturn {
   const { t } = useI18n({ useScope: 'global' });
   const store = useNotificationsStore();
   const cooldown = useNotificationCooldown();
+  const { silent } = useSilentNotifications();
 
   const strategies: NotificationStrategy[] = [
     bulkDuplicateStrategy,
@@ -25,13 +27,21 @@ export function useNotificationDispatcher(): UseNotificationDispatcherReturn {
   ];
 
   function notify(payload: SemiPartial<NotificationPayload, 'title' | 'message'>): void {
+    // Silent mode is applied here, before the strategies, because this is the one entry point every
+    // notification passes through. Denying the display up front rather than filtering the popup
+    // queue matters: a stored notification keeps `display: true` until it is actually shown, so
+    // filtering downstream would leave a backlog that all pops at once when silent mode is
+    // switched off. Nothing is lost either way - the notification is still created, still updates
+    // its group, and still reaches the notification area with its actions.
+    const incoming = get(silent) ? { ...payload, display: false } : payload;
+
     const context: NotificationStrategyContext = {
       getNextId: store.getNextId,
       notifications: store.trimmedCopy(),
     };
 
     for (const strategy of strategies) {
-      const result = strategy.process(payload, context);
+      const result = strategy.process(incoming, context);
       if (result) {
         store.replace(result.notifications);
         return;
@@ -39,7 +49,7 @@ export function useNotificationDispatcher(): UseNotificationDispatcherReturn {
     }
 
     // No strategy matched — add as a plain new notification
-    store.add([createNotification(store.getNextId(), payload)]);
+    store.add([createNotification(store.getNextId(), incoming)]);
   }
 
   return { notify };

--- a/frontend/app/src/modules/core/notifications/use-silent-notifications.spec.ts
+++ b/frontend/app/src/modules/core/notifications/use-silent-notifications.spec.ts
@@ -1,0 +1,68 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSilentNotifications } from '@/modules/core/notifications/use-silent-notifications';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
+
+const { mockUpdateFrontendSetting } = vi.hoisted(() => ({ mockUpdateFrontendSetting: vi.fn() }));
+
+vi.mock('@/modules/settings/use-frontend-settings-writer', () => ({
+  useFrontendSettingsWriter: vi.fn(() => ({
+    updateFrontendSetting: mockUpdateFrontendSetting,
+  })),
+}));
+
+describe('useSilentNotifications', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockUpdateFrontendSetting.mockReset().mockResolvedValue({ success: true });
+  });
+
+  it('should be constructible without an active pinia', () => {
+    setActivePinia(undefined);
+
+    // The notification dispatcher builds this, and the dispatcher itself is built wherever
+    // notifications are used, including contexts that never set a pinia up. Resolving the settings
+    // stores eagerly makes those throw "no active Pinia" without a notification ever being sent.
+    expect(() => useSilentNotifications()).not.toThrow();
+  });
+
+  it('should be off by default', () => {
+    const { silent } = useSilentNotifications();
+
+    expect(get(silent)).toBe(false);
+  });
+
+  it('should read the persisted setting', () => {
+    useSettingsRepo().updateFrontend({ silentNotifications: true });
+    const { silent } = useSilentNotifications();
+
+    expect(get(silent)).toBe(true);
+  });
+
+  it('should follow the setting when it changes underneath', () => {
+    const { silent } = useSilentNotifications();
+
+    useSettingsRepo().updateFrontend({ silentNotifications: true });
+
+    // Read through a getter ref, so a change made elsewhere (another tab of the same account,
+    // a settings reload on login) is picked up without re-creating the composable.
+    expect(get(silent)).toBe(true);
+  });
+
+  it('should turn silent mode on', async () => {
+    const { toggle } = useSilentNotifications();
+
+    await toggle();
+
+    expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({ silentNotifications: true });
+  });
+
+  it('should turn silent mode off again', async () => {
+    useSettingsRepo().updateFrontend({ silentNotifications: true });
+    const { toggle } = useSilentNotifications();
+
+    await toggle();
+
+    expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({ silentNotifications: false });
+  });
+});

--- a/frontend/app/src/modules/core/notifications/use-silent-notifications.ts
+++ b/frontend/app/src/modules/core/notifications/use-silent-notifications.ts
@@ -1,0 +1,40 @@
+import type { Ref } from 'vue';
+import { once } from 'es-toolkit';
+import { useFrontendSettingsWriter } from '@/modules/settings/use-frontend-settings-writer';
+import { useSetting } from '@/modules/settings/use-setting';
+
+export interface UseSilentNotificationsReturn {
+  silent: Readonly<Ref<boolean>>;
+  toggle: () => Promise<void>;
+}
+
+/**
+ * Silent mode: nothing interrupts with a popup, everything still lands in the notification area
+ * with its actions intact.
+ *
+ * It is an account-wide frontend setting rather than a session flag, so it follows the user
+ * between logins and machines instead of quietly turning itself back on.
+ *
+ * ⚠️ The settings stores are resolved on first read, not at construction. This composable is built
+ * by the notification dispatcher, which is itself built wherever notifications are used - including
+ * contexts that never set up a pinia. Resolving up front makes those blow up with "no active
+ * Pinia" without ever having sent a notification.
+ *
+ * Writes go through `useFrontendSettingsWriter` rather than `useSettingsOperations`, since the read
+ * side is consumed by the dispatcher and routing it through the notification surface would close a
+ * cycle back onto notifications.
+ */
+export function useSilentNotifications(): UseSilentNotificationsReturn {
+  const settings = once(() => ({
+    setting: useSetting('silentNotifications'),
+    updateFrontendSetting: useFrontendSettingsWriter().updateFrontendSetting,
+  }));
+
+  const silent = computed<boolean>(() => get(settings().setting));
+
+  async function toggle(): Promise<void> {
+    await settings().updateFrontendSetting({ silentNotifications: !get(silent) });
+  }
+
+  return { silent, toggle };
+}

--- a/frontend/app/src/modules/settings/settings-registry-frontend.ts
+++ b/frontend/app/src/modules/settings/settings-registry-frontend.ts
@@ -171,6 +171,7 @@ export const frontendRegistry = {
   shouldShowAmount: frontend.projected(settings => settings.privacyMode < PrivacyMode.SEMI_PRIVATE),
   shouldShowPercentage: frontend.projected(settings => settings.privacyMode < PrivacyMode.PRIVATE),
   showGraphRangeSelector: frontend('showGraphRangeSelector'),
+  silentNotifications: frontend('silentNotifications'),
   subscriptDecimals: frontend('subscriptDecimals', {
     anchor: SettingsHighlightIds.SUBSCRIPT,
     search: {

--- a/frontend/app/src/modules/settings/settings-repo.spec.ts
+++ b/frontend/app/src/modules/settings/settings-repo.spec.ts
@@ -116,6 +116,7 @@ describe('useSettingsRepo frontend channel', () => {
       enableAliasNames: true,
       enablePasswordConfirmation: true,
       blockchainRefreshButtonBehaviour: BlockchainRefreshButtonBehaviour.ONLY_REFRESH_BALANCES,
+      silentNotifications: false,
       subscriptDecimals: false,
       savedFilters: {},
       balanceValueThreshold: {

--- a/frontend/app/src/modules/settings/types/frontend-settings.ts
+++ b/frontend/app/src/modules/settings/types/frontend-settings.ts
@@ -263,6 +263,7 @@ export const FrontendSettings = z.object({
   scrambleMultiplier: z.number().optional().default(generateRandomScrambleMultiplier()),
   selectedTheme: ThemeEnum.default(Theme.AUTO),
   showGraphRangeSelector: z.boolean().default(true),
+  silentNotifications: z.boolean().default(false),
   subscriptDecimals: z.boolean().default(false),
   suppressNoIndexerChains: z.array(z.string()).default([]),
   thousandSeparator: z.string().default(Defaults.DEFAULT_THOUSAND_SEPARATOR),

--- a/frontend/app/src/modules/settings/types/user-settings.spec.ts
+++ b/frontend/app/src/modules/settings/types/user-settings.spec.ts
@@ -83,6 +83,7 @@ describe('user-types', () => {
       enableAliasNames: true,
       enablePasswordConfirmation: true,
       blockchainRefreshButtonBehaviour: BlockchainRefreshButtonBehaviour.ONLY_REFRESH_BALANCES,
+      silentNotifications: false,
       subscriptDecimals: false,
       savedFilters: {},
       balanceValueThreshold: {},

--- a/frontend/app/src/modules/shell/components/NotificationIndicator.vue
+++ b/frontend/app/src/modules/shell/components/NotificationIndicator.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useNotificationsStore } from '@/modules/core/notifications/use-notifications-store';
+import { useSilentNotifications } from '@/modules/core/notifications/use-silent-notifications';
 import { useTaskStore } from '@/modules/core/tasks/use-task-store';
 import MenuTooltipButton from '@/modules/shell/components/MenuTooltipButton.vue';
 
@@ -17,8 +18,13 @@ function click() {
 }
 
 const { hasRunningTasks } = storeToRefs(useTaskStore());
+const { silent } = useSilentNotifications();
 
 const { t } = useI18n({ useScope: 'global' });
+
+const tooltip = computed<string>(() => get(silent)
+  ? t('notification_indicator.tooltip_silent')
+  : t('notification_indicator.tooltip'));
 </script>
 
 <template>
@@ -32,13 +38,14 @@ const { t } = useI18n({ useScope: 'global' });
     offset-x="-12"
   >
     <MenuTooltipButton
-      :tooltip="t('notification_indicator.tooltip')"
+      :tooltip="tooltip"
       @click="click()"
     >
       <RuiIcon
         v-if="!hasRunningTasks"
         :class="{ '-rotate-[25deg]': visible }"
-        name="lu-bell"
+        :name="silent ? 'lu-bell-off' : 'lu-bell'"
+        data-testid="notification-indicator-icon"
       />
       <div
         v-else


### PR DESCRIPTION
## Problem

Notifications interrupt with a popup whether or not you are in the middle of something, and there was no way to just turn that off. The only control available was "do not show again", which is per subject, permanent, and takes away the notification entirely, including the row that made it actionable.

## Changes

**`feat: silence notification popups on demand`**

A global silent mode, toggled from the notification area header, with the app bar bell switching to a crossed-out icon while it is on. Nothing pops while it is enabled: every notification is still created, still collapses into its group, and still reaches the notification area with its actions intact.

- Applied in `notify()` in `use-notification-dispatcher.ts`, forcing `display: false` on the payload before the strategy chain runs. That is the single entry point every notification passes through, so no handler or strategy needs to know about it.
- State is a new account-wide frontend setting, `silentNotifications`, so it follows the user between logins and machines rather than resetting each session.
- New `useSilentNotifications` composable, shared by the dispatcher, the sidebar toggle and the bell.

It silences everything, errors included. A toggle with hidden exceptions is one people stop trusting, and nothing is actually lost: every row is still in the notification area.

**`test: remove two wall-clock races in unit specs`**

Unrelated to the feature, included because the second one surfaced while running the suite. Both specs read the wall clock, then assert on a comparison the code under test makes against its own later read, so a slow enough machine crosses the threshold between the two.

- `use-account-management.spec.ts` password confirmation cases assert exactly on the interval boundary with no margin, so the clock is frozen for that block. Only `Date` is faked, to leave the async paths under test on real timers. This is the flake seen on CI during #12687.
- `use-newly-detected-tokens-db.spec.ts` prune cases place a token one second inside the TTL window, with several awaited IndexedDB round trips before `prune` recomputes the cutoff. Freezing the clock is not an option there: `prune`'s in-progress guard then latches across cases and breaks two sibling tests. The margin is widened instead.

## Why not filter the popup queue

Filtering the store's `queue` computed is the smaller change, but it is wrong. A stored notification keeps `display: true` until it is actually shown, so filtering downstream leaves a backlog that all pops at once the moment silent mode is switched off. Denying the display at entry means nothing ever enters the queue. There is a spec case for exactly this.

A useful side effect: because the display is denied, `group-update` never records one, so a silenced group keeps its unspent nag-schedule ramp steps instead of using them up while the user cannot see them.

## Verification

`pnpm run typecheck`, `pnpm run lint` (0 errors, 21 warnings, unchanged from develop) and `pnpm run test:unit` (655 files, 6136 tests) are clean. The two flake fixes were each re-run three times.

New coverage:

- `use-silent-notifications.spec.ts` (new, 6 cases) covers the default, reading the persisted setting, following a change made elsewhere, and toggling both ways.
- `use-notification-dispatcher.spec.ts` (+4 cases) covers that a silenced notification stays out of the popup queue, still arrives in the notification area with its action and priority, still collapses into its group, and that turning silent off lets new notifications pop without releasing a backlog.

In-app: the toggle, the bell icon and the setting persistence are confirmed. Whether popups are actually suppressed is **not** yet confirmed by hand, since no notification happened to fire during the check. `NotificationPopup` and the store's `queue` are untouched by this PR, so the change sits strictly upstream of them, but a reviewer may want to fire a calendar reminder with silent on and off before merging.

## Notes

`useSilentNotifications` resolves the settings stores on first read rather than at construction. The dispatcher builds it, and the dispatcher is itself built wherever notifications are used, including contexts that never set up a pinia. Resolving eagerly makes those fail with "no active Pinia" without a notification ever being sent. There is a spec case pinning it.
