### PR TITLE
Mcp improvements

### DIFF
--- a/rotkehlchen/mcp/analytics.py
+++ b/rotkehlchen/mcp/analytics.py
@@ -13,11 +13,14 @@ from typing import TYPE_CHECKING, Any, Final
 
 import pandas as pd
 
+from rotkehlchen.constants.timing import HOUR_IN_SECONDS
 from rotkehlchen.mcp.backend import (
     BackendQueryError,
     get_backend_config,
     query_all_balances,
+    query_historical_prices,
     query_history_events_page,
+    query_settings,
 )
 
 if TYPE_CHECKING:
@@ -35,6 +38,15 @@ AVAILABLE_TABLES: Final = ('history_events', 'balances')
 # millisecond timestamp is ~1.7e12. Used to accept either unit for the time-range filter:
 # the event ``timestamp`` column is in ms, so an LLM naturally passes ms here too.
 MS_THRESHOLD: Final = 10**11
+# Valuation batches this many (asset, timestamp) pairs per backend request. The endpoint is
+# linear in pair count (~8.4s per 1000 against a real history), so the chunk size only bounds
+# request size, not total cost -- which is why valuation is opt-in.
+PRICE_LOOKUP_CHUNK_SIZE: Final = 500
+# Prices are matched within an hour of the event, the same tolerance rotki's own CSV export
+# uses, so bucketing event timestamps to the hour costs no accuracy while roughly halving the
+# number of distinct lookups (measured: 64,936 exact-second pairs vs 31,878 hourly ones).
+PRICE_TOLERANCE_SECONDS: Final = HOUR_IN_SECONDS
+DEFAULT_VALUE_CURRENCY: Final = 'USD'
 
 # --- privacy classification -------------------------------------------------------------
 # Free-text columns: never emitted verbatim outside ``raw`` mode (only a ``has_<col>``
@@ -70,6 +82,7 @@ SAFE_PASSTHROUGH_COLUMN_NAMES: Final = frozenset({
     'location',
     'percentage_of_net_value',
     'price',
+    'price_missing',
     'product',
     'sequence_index',
     'timestamp',
@@ -116,6 +129,7 @@ class AnalyticsScope:
     to_timestamp: int | None
     include_ignored_assets: bool
     privacy_mode: PrivacyMode
+    include_values: bool = False
 
 
 def _hash_identifier(value: Any) -> str | None:
@@ -231,6 +245,82 @@ def _promote_entry(raw: dict[str, Any]) -> dict[str, Any]:
     return {**{key: value for key, value in raw.items() if key != 'entry'}, **inner}
 
 
+def _resolve_prices(
+        pairs: list[tuple[str, int]],
+        target_asset: str,
+) -> dict[tuple[str, int], float]:
+    """Look up unit prices for ``(asset, unix_second)`` pairs, cache-only and chunked.
+
+    ``max_seconds_distance`` maps to the endpoint's ``only_cache_period``, which is what
+    keeps the query inside rotki's stored price history: the MCP must never trigger a remote
+    oracle fetch on an agent's behalf. The response is keyed by the timestamp we *asked*
+    for (the backend rewrites the matched row's timestamp to the queried one), so pairs join
+    straight back without a nearest-match search.
+    """
+    resolved: dict[tuple[str, int], float] = {}
+    for start in range(0, len(pairs), PRICE_LOOKUP_CHUNK_SIZE):
+        result = query_historical_prices(
+            asset_timestamps=pairs[start:start + PRICE_LOOKUP_CHUNK_SIZE],
+            target_asset=target_asset,
+            max_seconds_distance=PRICE_TOLERANCE_SECONDS,
+        )
+        for asset, by_timestamp in result['assets'].items():
+            if not isinstance(by_timestamp, dict):
+                continue
+            for timestamp, price in by_timestamp.items():
+                # Both levels arrive as strings over JSON (object keys always are, and prices
+                # are serialized decimals), so neither can be trusted to convert.
+                if (
+                    (second := _to_float(timestamp)) is not None and
+                    (unit_price := _to_float(price)) is not None
+                ):
+                    resolved[asset, int(second)] = unit_price
+
+    return resolved
+
+
+def _add_fiat_values(frame: pd.DataFrame) -> dict[str, Any]:
+    """Add ``price``/``value``/``price_missing`` to a loaded history frame, in place.
+
+    Mirrors how rotki itself values events for the CSV export (dedupe the lookups, read them
+    from the price cache, multiply by the amount) minus the oracle fallback. Rows whose price
+    is not cached get a null ``value``, never 0 -- a zero would silently understate every
+    total an agent computes over the column.
+    """
+    target_asset = str(query_settings().get('main_currency') or DEFAULT_VALUE_CURRENCY)
+    summary: dict[str, Any] = {
+        'value_currency': target_asset,
+        'priced_rows': 0,
+        'unpriced_rows': len(frame),
+        'lookup_count': 0,
+    }
+    if not {'asset', 'timestamp', 'amount_float'} <= set(frame.columns):
+        return summary  # nothing to join on (empty history, or a fully ragged one)
+
+    # Bucket to the hour the tolerance already spans; ``to_numeric`` keeps a ragged timestamp
+    # column (missing on some entry types -> object dtype) from blowing up the arithmetic.
+    seconds: pd.Series = pd.to_numeric(frame['timestamp'], errors='coerce')
+    buckets = seconds // 1000 // PRICE_TOLERANCE_SECONDS * PRICE_TOLERANCE_SECONDS
+    keys = [
+        (asset, int(bucket)) if isinstance(asset, str) and pd.notna(bucket) else None
+        for asset, bucket in zip(frame['asset'], buckets, strict=True)
+    ]
+    if len(pairs := sorted({key for key in keys if key is not None})) == 0:
+        return summary
+
+    resolved = _resolve_prices(pairs=pairs, target_asset=target_asset)
+    frame['price'] = [resolved.get(key) if key is not None else None for key in keys]
+    # NaN propagates through the multiplication, so an unpriced row lands as NULL in sqlite.
+    amounts: pd.Series = pd.to_numeric(frame['amount_float'], errors='coerce')
+    frame['value'] = amounts * frame['price']
+    frame['price_missing'] = frame['price'].isna()
+    return summary | {
+        'priced_rows': int((~frame['price_missing']).sum()),
+        'unpriced_rows': int(frame['price_missing'].sum()),
+        'lookup_count': len(pairs),
+    }
+
+
 def _load_history_events(scope: AnalyticsScope) -> TableData:
     # No cap by default: load the complete (time-scoped) set so the user gets complete data
     # unless they explicitly bound it with --max-events to limit load time on a huge history.
@@ -277,6 +367,9 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
         frame['datetime'] = dt.dt.strftime('%Y-%m-%dT%H:%M:%SZ')
         frame['year'] = dt.dt.year
 
+    # Valuation runs here, in the loader, so its minutes of price lookups stay outside the
+    # connection lock and queries keep serving the previous snapshot meanwhile.
+    values = _add_fiat_values(frame) if scope.include_values else {}
     return TableData(
         frame=frame,
         source={
@@ -288,6 +381,7 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
             'entries_total': entries_total,
             'entries_limit': entries_limit,
             'privacy_mode': scope.privacy_mode,
+            **values,
         },
     )
 
@@ -381,12 +475,14 @@ class AnalyticsSession:
             from_timestamp: int,
             to_timestamp: int,
             include_ignored_assets: bool,
+            include_values: bool,
     ) -> AnalyticsScope:
         return AnalyticsScope(
             from_timestamp=_filter_seconds(from_timestamp),
             to_timestamp=_filter_seconds(to_timestamp),
             include_ignored_assets=include_ignored_assets,
             privacy_mode=get_backend_config().privacy_mode,
+            include_values=include_values,
         )
 
     def refresh(
@@ -395,9 +491,15 @@ class AnalyticsSession:
             from_timestamp: int,
             to_timestamp: int,
             include_ignored_assets: bool,
+            include_values: bool = False,
     ) -> dict[str, Any]:
         with self._refresh_lock:
-            scope = self._current_scope(from_timestamp, to_timestamp, include_ignored_assets)
+            scope = self._current_scope(
+                from_timestamp=from_timestamp,
+                to_timestamp=to_timestamp,
+                include_ignored_assets=include_ignored_assets,
+                include_values=include_values,
+            )
             loaded: dict[str, Any] = {}
             errors: dict[str, str] = {}
             pending: dict[str, TableData] = {}
@@ -474,10 +576,12 @@ class AnalyticsSession:
             try:
                 with closing(self._connection.cursor()) as cursor:
                     cursor.execute(sql)
-                    result_frame = pd.DataFrame(
-                        cursor.fetchall(),
-                        columns=[desc[0] for desc in cursor.description],
-                    )
+                    # Read the rows straight from sqlite rather than through a DataFrame: a
+                    # NULL in a numeric result column would come back out of pandas as NaN,
+                    # which is not valid JSON and would corrupt the tool response. sqlite
+                    # already hands back None/int/float/str natives.
+                    columns = [description[0] for description in cursor.description]
+                    fetched = cursor.fetchall()
             except sqlite3.Error as e:
                 return _error(
                     'sql_execution_error',
@@ -489,13 +593,13 @@ class AnalyticsSession:
                 )
 
         bounded = min(max(max_rows, 1), MAX_RESULT_ROWS)
-        result_rows = result_frame.head(bounded).to_dict('records')
+        result_rows = [dict(zip(columns, row, strict=True)) for row in fetched[:bounded]]
         return {
-            'columns': list(result_frame.columns),
+            'columns': columns,
             'rows': result_rows,
-            'row_count': len(result_frame),
+            'row_count': len(fetched),
             'returned_rows': len(result_rows),
-            'result_truncated': len(result_frame) > bounded,
+            'result_truncated': len(fetched) > bounded,
             'privacy_mode': get_backend_config().privacy_mode,
         }
 

--- a/rotkehlchen/mcp/analytics.py
+++ b/rotkehlchen/mcp/analytics.py
@@ -24,7 +24,7 @@ from rotkehlchen.mcp.backend import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
     from rotkehlchen.mcp.constants import PrivacyMode
 
@@ -139,6 +139,7 @@ class AnalyticsScope:
     include_ignored_assets: bool
     privacy_mode: PrivacyMode
     include_values: bool = False
+    aggregate_by_group_ids: bool = False
 
 
 def _hash_identifier(value: Any) -> str | None:
@@ -256,6 +257,22 @@ def _sanitize_row(row: dict[str, Any], privacy_mode: PrivacyMode) -> dict[str, A
     return sanitized
 
 
+def _iter_entries(entries: list[Any]) -> Iterator[dict[str, Any]]:
+    """Yield every event in a page, including the ones the API nests.
+
+    Without ``aggregate_by_group_ids`` the endpoint returns a *sub-list* per group for EVM
+    and Solana swaps and for matched asset movements, so a page mixes plain event dicts with
+    lists of them. Keeping only the dicts silently dropped every on-chain swap and matched
+    deposit/withdrawal from the loaded table -- and, because a grouped sub-list still counts
+    as one entry against the page limit, made pages look short for no visible reason.
+    """
+    for entry in entries:
+        if isinstance(entry, dict):
+            yield entry
+        elif isinstance(entry, list):
+            yield from (grouped for grouped in entry if isinstance(grouped, dict))
+
+
 def _promote_entry(raw: dict[str, Any]) -> dict[str, Any]:
     """The history/events API wraps each event's fields in an ``entry`` sub-object next to
     sibling metadata. Promote those fields to the top level so SQL columns read as
@@ -358,6 +375,7 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
             from_timestamp=scope.from_timestamp,
             to_timestamp=scope.to_timestamp,
             exclude_ignored_assets=scope.include_ignored_assets is False,
+            aggregate_by_group_ids=scope.aggregate_by_group_ids,
         )
         entries_found = result.get('entries_found')
         entries_total = result.get('entries_total')
@@ -367,7 +385,7 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
 
         rows.extend(
             _sanitize_row(_flatten(_promote_entry(entry)), scope.privacy_mode)
-            for entry in entries if isinstance(entry, dict)
+            for entry in _iter_entries(entries)
         )
         offset += PAGE_SIZE
         if isinstance(entries_found, int) and offset >= entries_found:
@@ -497,6 +515,7 @@ class AnalyticsSession:
             to_timestamp: int,
             include_ignored_assets: bool,
             include_values: bool,
+            aggregate_by_group_ids: bool,
     ) -> AnalyticsScope:
         return AnalyticsScope(
             from_timestamp=_filter_seconds(from_timestamp),
@@ -504,6 +523,7 @@ class AnalyticsSession:
             include_ignored_assets=include_ignored_assets,
             privacy_mode=get_backend_config().privacy_mode,
             include_values=include_values,
+            aggregate_by_group_ids=aggregate_by_group_ids,
         )
 
     def refresh(
@@ -513,6 +533,7 @@ class AnalyticsSession:
             to_timestamp: int,
             include_ignored_assets: bool,
             include_values: bool = False,
+            aggregate_by_group_ids: bool = False,
     ) -> dict[str, Any]:
         with self._refresh_lock:
             scope = self._current_scope(
@@ -520,6 +541,7 @@ class AnalyticsSession:
                 to_timestamp=to_timestamp,
                 include_ignored_assets=include_ignored_assets,
                 include_values=include_values,
+                aggregate_by_group_ids=aggregate_by_group_ids,
             )
             loaded: dict[str, Any] = {}
             errors: dict[str, str] = {}

--- a/rotkehlchen/mcp/analytics.py
+++ b/rotkehlchen/mcp/analytics.py
@@ -332,10 +332,16 @@ def _resolve_prices(
     for (the backend rewrites the matched row's timestamp to the queried one), so pairs join
     straight back without a nearest-match search.
     """
-    resolved: dict[tuple[str, int], float] = {}
-    for start in range(0, len(pairs), PRICE_LOOKUP_CHUNK_SIZE):
+    # The main currency is worth exactly one of itself, and the price endpoint has no
+    # such pair cached, so asking for it leaves every fiat leg of an exchange trade
+    # unpriced. Resolve those locally and keep them out of the request entirely.
+    resolved: dict[tuple[str, int], float] = {
+        pair: 1.0 for pair in pairs if pair[0] == target_asset
+    }
+    remaining = [pair for pair in pairs if pair[0] != target_asset]
+    for start in range(0, len(remaining), PRICE_LOOKUP_CHUNK_SIZE):
         result = query_historical_prices(
-            asset_timestamps=pairs[start:start + PRICE_LOOKUP_CHUNK_SIZE],
+            asset_timestamps=remaining[start:start + PRICE_LOOKUP_CHUNK_SIZE],
             target_asset=target_asset,
             max_seconds_distance=PRICE_TOLERANCE_SECONDS,
         )

--- a/rotkehlchen/mcp/analytics.py
+++ b/rotkehlchen/mcp/analytics.py
@@ -49,10 +49,19 @@ PRICE_TOLERANCE_SECONDS: Final = HOUR_IN_SECONDS
 DEFAULT_VALUE_CURRENCY: Final = 'USD'
 
 # --- privacy classification -------------------------------------------------------------
-# Free-text columns: never emitted verbatim outside ``raw`` mode (only a ``has_<col>``
-# flag). ``auto_notes`` is rotki's decoded description and routinely embeds addresses, so
-# it is treated as free text rather than a safe value.
-TEXT_COLUMN_NAMES: Final = frozenset({'notes', 'user_notes', 'auto_notes'})
+# User-authored / decoder-written free text: never emitted verbatim outside ``raw`` mode
+# (only a ``has_<col>`` flag). Despite its name ``user_notes`` is the one that carries
+# decoder output with addresses in it ("Burn 0.0001 XDAI for gas") *and* is user-editable,
+# so its provenance is mixed and it stays redacted.
+USER_TEXT_COLUMN_NAMES: Final = frozenset({'notes', 'user_notes'})
+# Text rotki generates at serialization time from a fixed set of templates over amount,
+# asset symbol and location name -- no identifier is ever interpolated into one. Redacting
+# these threw away readable descriptions for no privacy gain, so in ``balanced`` they pass
+# through scrubbed (an asset *name* is attacker-controlled on a scam token, so the scrub is
+# what keeps the no-identifier property true rather than merely likely). ``strict`` still
+# redacts them outright.
+GENERATED_TEXT_COLUMN_NAMES: Final = frozenset({'auto_notes'})
+TEXT_COLUMN_NAMES: Final = USER_TEXT_COLUMN_NAMES | GENERATED_TEXT_COLUMN_NAMES
 # Identifier columns that are always personally identifying: hashed (never raw) outside
 # ``raw`` mode. ``location_label`` is special-cased in ``balanced`` (see _sanitize_identifier).
 PII_COLUMN_NAMES: Final = frozenset({
@@ -138,6 +147,13 @@ def _hash_identifier(value: Any) -> str | None:
     return f'anon_{hmac.new(_session_seed, str(value).encode(), sha256).hexdigest()[:16]}'
 
 
+def _scrub_identifiers(value: str) -> str:
+    """Replace any identifier embedded in otherwise-safe text with the same hash the column
+    level hashing would produce, so the text stays cross-referenceable with hashed columns.
+    """
+    return SENSITIVE_IDENTIFIER_RE.sub(lambda match: str(_hash_identifier(match.group())), value)
+
+
 _KNOWN_COLUMN_NAMES: Final = tuple(sorted(
     TEXT_COLUMN_NAMES | STRICT_IDENTIFIER_COLUMN_NAMES | SAFE_PASSTHROUGH_COLUMN_NAMES,
     key=len,
@@ -209,7 +225,12 @@ def _sanitize_row(row: dict[str, Any], privacy_mode: PrivacyMode) -> dict[str, A
         if base in TEXT_COLUMN_NAMES:
             has_value = value not in (None, '')
             sanitized[f'has_{column}'] = has_value
-            sanitized[column] = REDACTED_TEXT if has_value else None
+            if not has_value:
+                sanitized[column] = None
+            elif base in GENERATED_TEXT_COLUMN_NAMES and privacy_mode == 'balanced':
+                sanitized[column] = _scrub_identifiers(str(value))
+            else:
+                sanitized[column] = REDACTED_TEXT
         elif base in identifier_columns:
             sanitized[f'{column}_hash'] = _hash_identifier(value)
             # In balanced mode a human-friendly account label (e.g. "Kraken main") that is

--- a/rotkehlchen/mcp/analytics.py
+++ b/rotkehlchen/mcp/analytics.py
@@ -45,6 +45,10 @@ PRICE_LOOKUP_CHUNK_SIZE: Final = 500
 # How many consecutive empty pages to tolerate before giving up on a load. Empty windows are
 # normal mid-range; an endless run of them is a backend fault and must not spin forever.
 MAX_CONSECUTIVE_EMPTY_PAGES: Final = 5
+# describe_table lists a string column's actual values when there are few enough for the set
+# to be a useful hint (an enum) rather than a data dump.
+MAX_DISTINCT_VALUES_SCANNED: Final = 50
+MAX_DISTINCT_VALUES_REPORTED: Final = 10
 # Prices are matched within an hour of the event, the same tolerance rotki's own CSV export
 # uses, so bucketing event timestamps to the hour costs no accuracy while roughly halving the
 # number of distinct lookups (measured: 64,936 exact-second pairs vs 31,878 hourly ones).
@@ -431,6 +435,15 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
     if cache_truncated:
         completeness = 'truncated_by_max_events'
     frame = pd.DataFrame(rows) if rows else pd.DataFrame()
+    for column in frame.columns:
+        if str(column).startswith('has_'):
+            # These flags are only emitted for rows that carry the underlying field, so
+            # ragged event types leave gaps and the column ends up object dtype -- which then
+            # reaches SQL as a confusing 0/1/NULL mix. A missing flag means the field was
+            # absent on that event type, which is exactly false, so fill it and keep a real
+            # bool.
+            frame[column] = frame[column].fillna(value=False).astype(bool)
+
     if 'timestamp' in frame.columns and pd.api.types.is_integer_dtype(frame['timestamp']):
         # Add readable date columns derived from the ms timestamp so an LLM can filter on
         # `year` / `datetime` instead of computing error-prone unix-millisecond bounds.
@@ -522,6 +535,61 @@ def _validate_sql(sql: str) -> str | None:
     if disallowed := tokens & DENIED_SQL_TOKENS:
         return f'Disallowed SQL token(s): {", ".join(sorted(disallowed))}'
     return None
+
+
+def _hashed_reason(column: str, privacy_mode: PrivacyMode) -> str | None:
+    """Why a column holds opaque hashes instead of values, or None if it is readable.
+
+    ``pii`` means the column was always going to be hashed (an address, a tx hash);
+    ``unrecognized`` means it hit the fail-closed branch -- a column the allowlist does not
+    know, hashed rather than leaked. The distinction tells an agent whether a column is
+    hidden by policy or merely unclassified. Which set applies depends on the mode the data
+    was loaded under, since ``strict`` also treats user-authored labels as identifiers.
+    """
+    if not column.endswith('_hash'):
+        return None
+    identifier_columns = (
+        STRICT_IDENTIFIER_COLUMN_NAMES if privacy_mode == 'strict' else PII_COLUMN_NAMES
+    )
+    base = _base_column_name(column.removesuffix('_hash'))
+    return 'pii' if base in identifier_columns else 'unrecognized'
+
+
+def _describe_column(
+        name: str,
+        series: pd.Series,
+        sqlite_type: str | None,
+        privacy_mode: PrivacyMode,
+) -> dict[str, Any]:
+    """Describe one column: how SQL sees it, how empty it is, and -- for small enums -- what
+    is actually in it, so an agent does not have to spend a round trip on SELECT DISTINCT.
+    """
+    column: dict[str, Any] = {
+        'name': name,
+        # The pandas dtype is not what the query sees: everything goes through to_sql, so a
+        # bool lands as an integer and an all-null object column as a float.
+        'dtype': str(series.dtype),
+        'sqlite_type': sqlite_type,
+        'null_fraction': round(float(series.isna().mean()), 4) if len(series) > 0 else None,
+    }
+    if column['null_fraction'] == 1.0:
+        column['all_null'] = True  # present but carries nothing; do not build a query on it
+    if (reason := _hashed_reason(name, privacy_mode)) is not None:
+        # Never list hashed values: pages of anon_ strings are pure noise to an agent.
+        return column | {'hashed': True, 'hashed_reason': reason}
+
+    # pandas gives string columns a dedicated ``str`` dtype and only falls back to ``object``
+    # for ragged/mixed ones, so both are candidates for a value listing.
+    is_texty = pd.api.types.is_string_dtype(series) or pd.api.types.is_object_dtype(series)
+    if is_texty and len(counts := series.value_counts()) <= MAX_DISTINCT_VALUES_SCANNED:
+        column['distinct_count'] = len(counts)
+        column['top_values'] = [
+            {'value': value, 'rows': int(rows)}
+            for value, rows in counts.head(MAX_DISTINCT_VALUES_REPORTED).items()
+            # defence in depth: a hash must never reach the agent through this path either
+            if not (isinstance(value, str) and value.startswith('anon_'))
+        ]
+    return column
 
 
 def _error(error_type: str, message: str, **details: Any) -> dict[str, Any]:
@@ -633,11 +701,24 @@ class AnalyticsSession:
                     f'Table {table!r} is not loaded. Call refresh_analytics_data first.',
                     available_tables=list(AVAILABLE_TABLES),
                 )
+            with closing(self._connection.cursor()) as cursor:
+                # The declared sqlite types are the ones the query actually sees, so report
+                # them next to the pandas dtypes rather than instead of them.
+                sqlite_types = {
+                    row[1]: row[2]
+                    for row in cursor.execute(f'PRAGMA table_info("{table}")')
+                }
             return {
                 'table': table,
                 'columns': [
-                    {'name': name, 'dtype': str(dtype)}
-                    for name, dtype in table_data.frame.dtypes.items()
+                    _describe_column(
+                        name=str(name),
+                        series=table_data.frame[name],
+                        sqlite_type=sqlite_types.get(str(name)),
+                        # the mode the frame was built under, not the current config
+                        privacy_mode=table_data.source.get('privacy_mode', 'balanced'),
+                    )
+                    for name in table_data.frame.columns
                 ],
                 'rows': len(table_data.frame),
                 'source': table_data.source,

--- a/rotkehlchen/mcp/analytics.py
+++ b/rotkehlchen/mcp/analytics.py
@@ -22,6 +22,7 @@ from rotkehlchen.mcp.backend import (
     query_history_events_page,
     query_settings,
 )
+from rotkehlchen.mcp.taxonomy import resolve_direction
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -271,6 +272,28 @@ def _sanitize_row(row: dict[str, Any], privacy_mode: PrivacyMode) -> dict[str, A
     return sanitized
 
 
+def _add_directions(frame: pd.DataFrame) -> None:
+    """Add rotki's own ``in``/``out``/``neutral`` direction for each event, in place.
+
+    The serialized event carries no direction, so without this an agent has to infer income
+    from ``event_type`` -- the guess that double counts MEV rewards. Deriving it here from
+    the same function the rest of rotki uses makes the correct aggregation a plain
+    ``group by direction``. Resolution is cached per type/subtype/location because a large
+    history has ~100 distinct combinations across six figures of rows.
+    """
+    if not {'event_type', 'event_subtype', 'location'} <= set(frame.columns):
+        return
+
+    cache: dict[tuple[Any, Any, Any], str | None] = {}
+    directions: list[str | None] = []
+    for key in zip(frame['event_type'], frame['event_subtype'], frame['location'], strict=True):
+        if key not in cache:
+            cache[key] = resolve_direction(*key)
+        directions.append(cache[key])
+
+    frame['direction'] = directions
+
+
 def _iter_entries(entries: list[Any]) -> Iterator[dict[str, Any]]:
     """Yield every event in a page, including the ones the API nests.
 
@@ -450,6 +473,8 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
         dt = pd.to_datetime(frame['timestamp'], unit='ms', utc=True)
         frame['datetime'] = dt.dt.strftime('%Y-%m-%dT%H:%M:%SZ')
         frame['year'] = dt.dt.year
+
+    _add_directions(frame)
 
     # Valuation runs here, in the loader, so its minutes of price lookups stay outside the
     # connection lock and queries keep serving the previous snapshot meanwhile.

--- a/rotkehlchen/mcp/analytics.py
+++ b/rotkehlchen/mcp/analytics.py
@@ -42,6 +42,9 @@ MS_THRESHOLD: Final = 10**11
 # linear in pair count (~8.4s per 1000 against a real history), so the chunk size only bounds
 # request size, not total cost -- which is why valuation is opt-in.
 PRICE_LOOKUP_CHUNK_SIZE: Final = 500
+# How many consecutive empty pages to tolerate before giving up on a load. Empty windows are
+# normal mid-range; an endless run of them is a backend fault and must not spin forever.
+MAX_CONSECUTIVE_EMPTY_PAGES: Final = 5
 # Prices are matched within an hour of the event, the same tolerance rotki's own CSV export
 # uses, so bucketing event timestamps to the hour costs no accuracy while roughly halving the
 # number of distinct lookups (measured: 64,936 exact-second pairs vs 31,878 hourly ones).
@@ -100,10 +103,17 @@ SAFE_PASSTHROUGH_COLUMN_NAMES: Final = frozenset({
 })
 
 ALLOWED_SQL_PREFIXES: Final = ('select ', 'with ')
+# ``replace`` is deliberately absent: it is a perfectly ordinary read-only scalar function
+# (``select replace(counterparty, '-', ' ')``) and SQLite's ``REPLACE INTO`` is already
+# blocked by the select/with prefix requirement. The denylist is defence in depth on top of
+# that prefix check and the read-only in-memory connection, not the primary guard.
 DENIED_SQL_TOKENS: Final = frozenset({
     'alter', 'attach', 'copy', 'create', 'delete', 'drop',
-    'insert', 'replace', 'truncate', 'update',
+    'insert', 'truncate', 'update',
 })
+# Quoted strings and identifiers are stripped before tokenising, so a denied word appearing
+# inside a literal (or a semicolon inside one) does not get mistaken for a statement.
+SQL_QUOTED_RE: Final = re.compile(r"'(?:[^']|'')*'|\"(?:[^\"]|\"\")*\"")
 SQL_ERROR_HINT: Final = (
     'Use list_tables() and describe_table(table) to inspect the schema, then query, e.g. '
     '`select * from history_events limit 1`.'
@@ -368,6 +378,8 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
     entries_found: int | None = None
     entries_total: int | None = None
     entries_limit: int | None = None
+    consecutive_empty = 0
+    completeness = 'complete'
     while max_events is None or len(rows) < max_events:
         result = query_history_events_page(
             limit=PAGE_SIZE,
@@ -380,13 +392,31 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
         entries_found = result.get('entries_found')
         entries_total = result.get('entries_total')
         entries_limit = result.get('entries_limit')
-        if not isinstance(entries := result.get('entries'), list) or len(entries) == 0:
+        if not isinstance(entries := result.get('entries'), list):
+            completeness = 'stopped_early'
             break
 
-        rows.extend(
-            _sanitize_row(_flatten(_promote_entry(entry)), scope.privacy_mode)
-            for entry in _iter_entries(entries)
-        )
+        if len(entries) == 0:
+            # A window can legitimately come back empty (every event in it filtered out), so
+            # an empty page means "skip this window", not "end of data" -- stopping here was
+            # cutting loads short while still reporting them as complete. Bounded so a
+            # backend that only ever returns nothing cannot spin forever, and if we give up
+            # with ground still to cover the load is reported as incomplete.
+            consecutive_empty += 1
+            if (
+                consecutive_empty >= MAX_CONSECUTIVE_EMPTY_PAGES or
+                not isinstance(entries_found, int)
+            ):
+                if isinstance(entries_found, int) and offset < entries_found:
+                    completeness = 'stopped_early'
+                break
+        else:
+            consecutive_empty = 0
+            rows.extend(
+                _sanitize_row(_flatten(_promote_entry(entry)), scope.privacy_mode)
+                for entry in _iter_entries(entries)
+            )
+
         offset += PAGE_SIZE
         if isinstance(entries_found, int) and offset >= entries_found:
             break
@@ -398,6 +428,8 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
         isinstance(entries_found, int) and
         entries_found > len(rows)
     )
+    if cache_truncated:
+        completeness = 'truncated_by_max_events'
     frame = pd.DataFrame(rows) if rows else pd.DataFrame()
     if 'timestamp' in frame.columns and pd.api.types.is_integer_dtype(frame['timestamp']):
         # Add readable date columns derived from the ms timestamp so an LLM can filter on
@@ -414,11 +446,16 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
         source={
             'endpoint': 'history/events',
             'range_scoped': True,
-            'cached_rows': len(rows),
+            'rows_loaded': len(rows),
+            'completeness': completeness,
             'cache_truncated': cache_truncated,
-            'entries_found': entries_found,
-            'entries_total': entries_total,
-            'entries_limit': entries_limit,
+            # The backend's own counters, which do not agree with rows_loaded and are not
+            # meant to: entries_found is its pre-serialization estimate of matching events.
+            'backend_metadata': {
+                'entries_found': entries_found,
+                'entries_total': entries_total,
+                'entries_limit': entries_limit,
+            },
             'privacy_mode': scope.privacy_mode,
             **values,
         },
@@ -447,7 +484,7 @@ def _load_balances(scope: AnalyticsScope) -> TableData:
         source={
             'endpoint': 'balances',
             'range_scoped': False,
-            'cached_rows': len(rows),
+            'rows_loaded': len(rows),
             'net_value': result.get('net_value'),
             'privacy_mode': scope.privacy_mode,
         },
@@ -478,9 +515,10 @@ def _validate_sql(sql: str) -> str | None:
     normalized = ' '.join(sql.strip().lower().split())
     if not normalized.startswith(ALLOWED_SQL_PREFIXES):
         return 'Only read-only SELECT/WITH queries over analytics tables are allowed'
-    if ';' in normalized.rstrip(';'):
+    unquoted = SQL_QUOTED_RE.sub(' ', normalized)
+    if ';' in unquoted.rstrip(';'):
         return 'Only a single SQL statement is allowed'
-    tokens = set(normalized.replace(',', ' ').replace('(', ' ').replace(')', ' ').split())
+    tokens = set(unquoted.replace(',', ' ').replace('(', ' ').replace(')', ' ').split())
     if disallowed := tokens & DENIED_SQL_TOKENS:
         return f'Disallowed SQL token(s): {", ".join(sorted(disallowed))}'
     return None

--- a/rotkehlchen/mcp/backend.py
+++ b/rotkehlchen/mcp/backend.py
@@ -125,6 +125,22 @@ def query_history_events_page(
     return payload['result']
 
 
+def query_settings() -> dict[str, Any]:
+    """Return the user's settings. The analytics layer reads ``main_currency`` from here so
+    that valued events are denominated the same way the rest of rotki denominates them.
+    """
+    backend_config = get_backend_config()
+    payload = request_api(
+        base_url=backend_config.base_url,
+        endpoint='settings',
+        timeout=backend_config.timeout,
+    )
+    if not isinstance(result := payload['result'], dict):
+        raise BackendQueryError('rotki backend returned an unexpected settings response')
+
+    return result
+
+
 def query_all_balances(refresh: bool, timeout: int) -> dict[str, Any]:
     """Return the current balances snapshot. ``refresh=True`` forces a slow live query of
     every exchange and chain; otherwise the cached snapshot is returned. Read-only: never

--- a/rotkehlchen/mcp/backend.py
+++ b/rotkehlchen/mcp/backend.py
@@ -100,9 +100,14 @@ def query_history_events_page(
         from_timestamp: int | None = None,
         to_timestamp: int | None = None,
         exclude_ignored_assets: bool = True,
+        aggregate_by_group_ids: bool = False,
 ) -> dict[str, Any]:
     """Fetch one page of decoded history events. Used by the analytics loader to page the
     full (time-scoped) set into a local frame. Returns the backend ``result`` dict.
+
+    ``aggregate_by_group_ids`` collapses each group to its first event plus a
+    ``grouped_events_num`` count; it is only sent when set, so the default request body is
+    unchanged.
     """
     backend_config = get_backend_config()
     body: dict[str, Any] = {
@@ -110,6 +115,8 @@ def query_history_events_page(
         'offset': offset,
         'exclude_ignored_assets': exclude_ignored_assets,
     }
+    if aggregate_by_group_ids:
+        body['aggregate_by_group_ids'] = True
     if from_timestamp is not None:
         body['from_timestamp'] = from_timestamp
     if to_timestamp is not None:

--- a/rotkehlchen/mcp/taxonomy.py
+++ b/rotkehlchen/mcp/taxonomy.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from operator import itemgetter
+from typing import Any, Final
+
+from rotkehlchen.accounting.constants import (
+    DEFAULT,
+    EVENT_CATEGORY_DETAILS,
+    EVENT_CATEGORY_MAPPINGS,
+    EVENT_GROUPING_ORDER,
+    EXCHANGE,
+)
+from rotkehlchen.history.events.structures.base import get_event_direction
+from rotkehlchen.types import Location
+
+# Representative exchange used to resolve the ``EXCHANGE`` reading of the few type/subtype
+# combos that mean something different on a centralized exchange than they do on chain.
+EXCHANGE_LOCATION: Final = Location.KRAKEN
+
+# Rules an agent cannot infer from the data and gets wrong every time without them.
+TAXONOMY_RULES: Final = (
+    (
+        'direction is the field to aggregate on, and it is authoritative: it is resolved by '
+        'the same rotki function the rest of the app uses, not guessed from event_type. "in" '
+        'means value entered the portfolio, "out" that it left, "neutral" that nothing moved.'
+    ),
+    (
+        'Every event_type = "informational" row resolves to direction "neutral", including '
+        'MEV and block-production rewards. Those rows are the relayer/beacon-chain report of '
+        'a reward whose actual value arrives separately as its own event, so summing them '
+        'alongside the real ones double counts the reward. Filter on direction, not on '
+        'event_type, and this is handled for you.'
+    ),
+    (
+        'Subtypes containing "wrapped" (receive wrapped / return wrapped) are protocol '
+        'wrapping: the user exchanges a token for its wrapped representation. They are '
+        'transfers, not income or expense, even though value moves.'
+    ),
+    (
+        'Sum a single currency. Use the value column (main currency, present only when the '
+        'session was refreshed with include_values=true) for money questions; amount_float '
+        'is denominated in each row own asset, so summing it across assets is meaningless.'
+    ),
+)
+
+
+def _describe(
+        event_type: Any,
+        event_subtype: Any,
+        category: Any,
+        location: Location | None = None,
+) -> dict[str, Any]:
+    """Describe one type/subtype/category combination.
+
+    ``direction`` comes from ``get_event_direction`` rather than straight off the category,
+    because that function carries overrides the raw mapping does not -- most importantly that
+    an ``informational`` event is always neutral, which is what stops an agent double
+    counting MEV rewards. Reading the enum directly would report those as incoming.
+    """
+    details = EVENT_CATEGORY_DETAILS[category][DEFAULT]
+    direction = get_event_direction(
+        event_type=event_type,
+        event_subtype=event_subtype,
+        location=location,
+    )
+    return {
+        'category': category.serialize(),
+        'label': details.label,
+        'direction': direction.serialize() if direction is not None else None,
+        'group': category.group.serialize(),
+    }
+
+
+def get_event_taxonomy() -> dict[str, Any]:
+    """Derive the full event type/subtype taxonomy from rotki's own mappings.
+
+    Everything is generated at call time, so a subtype added upstream shows up here without
+    touching any MCP code.
+    """
+    entries: list[dict[str, Any]] = []
+    for event_type, subtypes in EVENT_CATEGORY_MAPPINGS.items():
+        for event_subtype, by_key in subtypes.items():
+            entry = {
+                'event_type': event_type.serialize(),
+                'event_subtype': event_subtype.serialize(),
+            } | _describe(event_type, event_subtype, by_key[DEFAULT])
+            if (exchange_category := by_key.get(EXCHANGE)) is not None:
+                entry['exchange'] = _describe(
+                    event_type=event_type,
+                    event_subtype=event_subtype,
+                    category=exchange_category,
+                    location=EXCHANGE_LOCATION,
+                )
+            entries.append(entry)
+
+    return {
+        'rules': list(TAXONOMY_RULES),
+        'entries': entries,
+        'exchange_note': (
+            'An entry carrying an "exchange" block reads differently depending on where it '
+            'happened: use that block for rows whose location is a centralized exchange, and '
+            'the top-level reading otherwise.'
+        ),
+        'grouped_event_types': {
+            event_type.serialize(): {
+                subtype.serialize(): order
+                for subtype, order in sorted(order_by_subtype.items(), key=itemgetter(1))
+            }
+            for event_type, order_by_subtype in EVENT_GROUPING_ORDER.items()
+        },
+        'grouping_note': (
+            'The event types in grouped_event_types span several rows sharing one '
+            'group_identifier, ordered by sequence_index as shown. One trade is a row for '
+            'what was spent, a row for what was received and a row for the fee, each in its '
+            'own asset -- so summing amount_float over event_type = "trade" adds unrelated '
+            'currencies together. Self-join on group_identifier to recover both sides.'
+        ),
+    }

--- a/rotkehlchen/mcp/taxonomy.py
+++ b/rotkehlchen/mcp/taxonomy.py
@@ -69,12 +69,22 @@ RECIPES: Final[tuple[dict[str, Any], ...]] = (
         'sql': (
             'select year, sum(value) as income, count(*) as events '
             "from history_events where event_type = 'staking' and direction = 'in' "
+            "and event_subtype in ('reward', 'mev reward', 'block production') "
             'group by year order by year'
         ),
         'excludes': (
             'Filtering on direction = "in" drops the informational rows, which are the '
             'relayer/beacon-chain report of a reward that also arrives as a real event. '
-            'Without that filter every MEV and block-production reward is counted twice.'
+            'Without that filter every MEV and block-production reward is counted twice. '
+            'The event_subtype filter then drops unstaking: "remove asset" and '
+            '"redeem wrapped" are direction "in" but return principal, not income, so '
+            'including them overstates this total by whatever was unstaked -- which on an '
+            'account with validator exits or large LST redemptions is far larger than the '
+            'income itself. It is deliberately conservative and therefore understates ETH '
+            'staking: rotki records beacon-chain withdrawals as "remove asset" whether they '
+            'are a partial reward withdrawal (is_exit = 0) or a full exit (is_exit = 1), so '
+            'the reward-like partials are excluded here too. To include them, add '
+            "entry_type = 'eth withdrawal event' and is_exit = 0 as a separate union branch."
         ),
     },
     {

--- a/rotkehlchen/mcp/taxonomy.py
+++ b/rotkehlchen/mcp/taxonomy.py
@@ -10,7 +10,9 @@ from rotkehlchen.accounting.constants import (
     EVENT_GROUPING_ORDER,
     EXCHANGE,
 )
+from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.base import get_event_direction
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import Location
 
 # Representative exchange used to resolve the ``EXCHANGE`` reading of the few type/subtype
@@ -44,6 +46,88 @@ TAXONOMY_RULES: Final = (
 )
 
 
+# Worked SQLite queries over the loaded tables. Each says what it answers and what it leaves
+# out, because the exclusion is usually the part an agent gets wrong.
+RECIPES: Final[tuple[dict[str, Any], ...]] = (
+    {
+        'question': 'What did I pay in gas fees each year, in my main currency?',
+        'requires': ['history_events (refreshed with include_values=true)'],
+        'sql': (
+            'select year, sum(value) as gas_cost, count(*) as events, '
+            'sum(price_missing) as unpriced '
+            "from history_events where event_subtype = 'fee' and counterparty = 'gas' "
+            'group by year order by year'
+        ),
+        'excludes': (
+            'Only counterparty "gas" fees, so exchange and protocol fees are not in this '
+            'total. Check the unpriced count: those rows contribute nothing to the sum.'
+        ),
+    },
+    {
+        'question': 'What were my staking rewards worth per year?',
+        'requires': ['history_events (refreshed with include_values=true)'],
+        'sql': (
+            'select year, sum(value) as income, count(*) as events '
+            "from history_events where event_type = 'staking' and direction = 'in' "
+            'group by year order by year'
+        ),
+        'excludes': (
+            'Filtering on direction = "in" drops the informational rows, which are the '
+            'relayer/beacon-chain report of a reward that also arrives as a real event. '
+            'Without that filter every MEV and block-production reward is counted twice.'
+        ),
+    },
+    {
+        'question': 'What did each swap actually trade, both sides together?',
+        'requires': ['history_events'],
+        'sql': (
+            'select spent.datetime, spent.asset as sold_asset, '
+            'spent.amount_float as sold_amount, received.asset as bought_asset, '
+            'received.amount_float as bought_amount '
+            'from history_events spent join history_events received '
+            'on received.group_identifier_hash = spent.group_identifier_hash '
+            "where spent.event_subtype = 'spend' and received.event_subtype = 'receive' "
+            'and received.sequence_index > spent.sequence_index '
+            'order by spent.timestamp desc limit 50'
+        ),
+        'excludes': (
+            'The fee leg is a third row in the same group and is not joined here. Join on '
+            'group_identifier_hash, not group_identifier: identifiers are hashed, and the '
+            'hash is stable within this session so joins and GROUP BY still work.'
+        ),
+    },
+    {
+        'question': 'Which counterparties did most of my value leave to?',
+        'requires': ['history_events (refreshed with include_values=true)'],
+        'sql': (
+            'select counterparty, sum(value) as total_out, count(*) as events '
+            "from history_events where direction = 'out' and value is not null "
+            'group by counterparty order by total_out desc limit 10'
+        ),
+        'excludes': (
+            'Rows with no cached price are skipped rather than counted as zero, so this '
+            'ranks only what could be valued. Events with no counterparty group under null.'
+        ),
+    },
+    {
+        'question': 'Does my net historical flow per asset line up with my current balance?',
+        'requires': ['history_events', 'balances'],
+        'sql': (
+            "select h.asset, sum(case when h.direction = 'in' then h.amount_float "
+            "when h.direction = 'out' then -h.amount_float else 0 end) as net_amount, "
+            'b.amount_float as current_balance '
+            'from history_events h left join balances b on b.asset = h.asset '
+            'group by h.asset order by abs(net_amount) desc limit 20'
+        ),
+        'excludes': (
+            'Neutral-direction events contribute nothing, which is intended. A gap between '
+            'net_amount and current_balance usually means the history is incomplete for '
+            'that asset rather than that the balance is wrong -- check source.completeness.'
+        ),
+    },
+)
+
+
 def _describe(
         event_type: Any,
         event_subtype: Any,
@@ -71,6 +155,34 @@ def _describe(
     }
 
 
+def resolve_direction(
+        event_type: Any,
+        event_subtype: Any,
+        location: Any = None,
+) -> str | None:
+    """Resolve one serialized event to rotki's own ``in``/``out``/``neutral`` direction.
+
+    Takes the serialized strings as they appear in the analytics frame and returns None for
+    anything that does not parse, so a single unrecognized event cannot fail a whole load.
+    """
+    try:
+        parsed_type = HistoryEventType.deserialize(event_type)
+        parsed_subtype = (
+            HistoryEventSubType.deserialize(event_subtype)
+            if isinstance(event_subtype, str) else HistoryEventSubType.NONE
+        )
+        parsed_location = Location.deserialize(location) if isinstance(location, str) else None
+    except DeserializationError:
+        return None
+
+    direction = get_event_direction(
+        event_type=parsed_type,
+        event_subtype=parsed_subtype,
+        location=parsed_location,
+    )
+    return direction.serialize() if direction is not None else None
+
+
 def get_event_taxonomy() -> dict[str, Any]:
     """Derive the full event type/subtype taxonomy from rotki's own mappings.
 
@@ -95,6 +207,7 @@ def get_event_taxonomy() -> dict[str, Any]:
 
     return {
         'rules': list(TAXONOMY_RULES),
+        'recipes': [dict(recipe) for recipe in RECIPES],
         'entries': entries,
         'exchange_note': (
             'An entry carrying an "exchange" block reads differently depending on where it '

--- a/rotkehlchen/mcp/tools/analytics.py
+++ b/rotkehlchen/mcp/tools/analytics.py
@@ -75,12 +75,24 @@ async def list_tables() -> dict[str, Any]:
 
 @register_tool(name='describe_table')
 async def describe_table(table: str) -> dict[str, Any]:
-    """Describe a loaded analytics table: its columns (name + dtype), row count and source.
+    """Describe a loaded analytics table: its columns, row count and source metadata.
 
-    Use this to discover the schema before writing SQL. Note that identifier columns are
-    privacy-filtered: addresses/hashes appear as ``<col>_hash`` (consistent within a
-    session so you can still GROUP BY / JOIN on them) and free-text ``notes`` are redacted
-    to a ``has_notes`` flag, unless the server was started in ``raw`` privacy mode.
+    Use this to discover the schema before writing SQL. Each column reports:
+
+    - ``sqlite_type``, which is what your query actually sees, alongside the pandas
+      ``dtype`` it was built from. They differ: booleans arrive as 0/1 integers.
+    - ``null_fraction``, and ``all_null`` for columns that are present but carry nothing —
+      many ``extra_data_*`` columns exist only for one protocol and are empty otherwise.
+    - ``distinct_count`` and ``top_values`` for small enum-like columns (``event_type``,
+      ``location``, ``entry_type``, ``counterparty``), so you do not need a SELECT DISTINCT
+      round trip to learn the valid values.
+    - ``hashed`` with a ``hashed_reason`` of ``pii`` (an address or hash, hidden by policy)
+      or ``unrecognized`` (a column the allowlist does not know, hashed rather than leaked).
+
+    Identifier columns are privacy-filtered: they appear as ``<col>_hash``, consistent within
+    a session so you can still GROUP BY / JOIN on them but not reversible and not stable
+    across sessions. Their values are never listed. Free-text ``notes``/``user_notes`` are
+    redacted to a ``has_<col>`` flag, unless the server was started in ``raw`` privacy mode.
     """
     return await asyncio.to_thread(get_analytics_session().describe_table, table=table)
 

--- a/rotkehlchen/mcp/tools/analytics.py
+++ b/rotkehlchen/mcp/tools/analytics.py
@@ -73,15 +73,31 @@ async def describe_table(table: str) -> dict[str, Any]:
 async def query_sql(sql: str, max_rows: int = DEFAULT_MAX_RESULT_ROWS) -> dict[str, Any]:
     """Run a read-only SQL query over the loaded, privacy-filtered analytics tables.
 
-    Polars SQL runs the query, so aggregations, joins, grouping, ordering and window
-    functions are all available and computed exactly — use it for the math (sums, cost
-    basis candidates, rolling balances, per-asset/per-counterparty rollups, fee totals)
-    rather than doing arithmetic yourself. Only a single ``SELECT``/``WITH`` statement is
-    allowed; writes and DDL are rejected.
+    The query runs against **SQLite**, so write SQLite-flavoured SQL. Aggregations, joins,
+    grouping, ordering and window functions are all available and computed exactly — use it
+    for the math (sums, cost basis candidates, rolling balances, per-asset/per-counterparty
+    rollups, fee totals) rather than doing arithmetic yourself. Only a single
+    ``SELECT``/``WITH`` statement is allowed; writes and DDL are rejected.
 
     Call ``refresh_analytics_data`` first to load data, and ``describe_table`` to learn the
     columns. The default table is ``history_events``. ``max_rows`` caps returned rows; the
     result reports ``result_truncated`` and the true ``row_count`` when more matched.
+
+    Rules that decide whether an aggregate is right or quietly wrong:
+
+    - Call ``get_event_taxonomy`` before any aggregate over ``event_type`` — it explains all
+      30+ type/subtype combinations and gives each a ``direction``.
+    - Aggregate on ``direction`` rather than ``event_type``. Every ``informational`` row is
+      neutral: those are annotations whose value arrives as a separate real event, so
+      including them double counts MEV and block-production rewards.
+    - ``amount`` is a decimal string — do arithmetic on ``amount_float``. But it is in each
+      row's own asset, so only sum it per-asset; for money questions use ``value``, which
+      exists only after refreshing with ``include_values=true``.
+    - ``timestamp`` is in **milliseconds**; the ``datetime`` and ``year`` columns are derived
+      from it, so filter on those instead of doing unix math.
+    - One trade is several rows sharing a ``group_identifier`` (spend, receive, fee — each in
+      a different asset), ordered by ``sequence_index``. Self-join on ``group_identifier`` to
+      see both sides; never sum across the legs.
     """
     return await asyncio.to_thread(
         get_analytics_session().query_sql,

--- a/rotkehlchen/mcp/tools/analytics.py
+++ b/rotkehlchen/mcp/tools/analytics.py
@@ -11,6 +11,7 @@ async def refresh_analytics_data(
         from_timestamp: int = 0,
         to_timestamp: int = 0,
         include_ignored_assets: bool = False,
+        include_values: bool = False,
 ) -> dict[str, Any]:
     """Load the user's rotki data into the local, privacy-filtered analytics session.
 
@@ -27,6 +28,16 @@ async def refresh_analytics_data(
       returned source metadata reports ``cache_truncated`` when that happens — narrow the
       range to load everything.
     - ``include_ignored_assets``: include events for assets the user has marked ignored.
+    - ``include_values``: also value every event in the user's main currency, adding the
+      ``value``, ``price`` and ``price_missing`` columns needed for any "how much was this
+      worth" question. **Off by default because it is slow**: it costs roughly 8 seconds per
+      1000 distinct (asset, hour) pairs, so a single year of history takes ~20-90s while a
+      full multi-year history takes several minutes. Scope it with ``from_timestamp`` /
+      ``to_timestamp`` whenever you can. Prices are read only from rotki's local cache, never
+      fetched from an oracle, so some events may be unpriced: those get ``value = NULL`` and
+      ``price_missing = 1`` rather than 0, and the returned source metadata reports
+      ``value_currency``, ``priced_rows``, ``unpriced_rows`` and ``lookup_count``. Check
+      ``unpriced_rows`` before reporting any total, or you will understate it.
 
     Returns the per-table row counts and source metadata, plus the active ``privacy_mode``.
     """
@@ -36,6 +47,7 @@ async def refresh_analytics_data(
         from_timestamp=from_timestamp,
         to_timestamp=to_timestamp,
         include_ignored_assets=include_ignored_assets,
+        include_values=include_values,
     )
 
 

--- a/rotkehlchen/mcp/tools/analytics.py
+++ b/rotkehlchen/mcp/tools/analytics.py
@@ -123,9 +123,16 @@ async def query_sql(sql: str, max_rows: int = DEFAULT_MAX_RESULT_ROWS) -> dict[s
       exists only after refreshing with ``include_values=true``.
     - ``timestamp`` is in **milliseconds**; the ``datetime`` and ``year`` columns are derived
       from it, so filter on those instead of doing unix math.
-    - One trade is several rows sharing a ``group_identifier`` (spend, receive, fee — each in
-      a different asset), ordered by ``sequence_index``. Self-join on ``group_identifier`` to
-      see both sides; never sum across the legs.
+    - One trade is several rows sharing a group (spend, receive, fee — each in a different
+      asset), ordered by ``sequence_index``. Self-join on ``group_identifier_hash`` to see
+      both sides; never sum across the legs.
+    - Identifier columns arrive as ``<col>_hash`` holding ``anon_…`` values. They are stable
+      within this session, so joining and grouping on them works, but they are not reversible
+      and not stable across sessions — never quote one to the user as if it were an address.
+    - ``value`` is denominated in ``source.value_currency`` from the refresh result, not
+      necessarily USD.
+
+    ``get_event_taxonomy`` carries worked queries for the common questions under ``recipes``.
     """
     return await asyncio.to_thread(
         get_analytics_session().query_sql,

--- a/rotkehlchen/mcp/tools/analytics.py
+++ b/rotkehlchen/mcp/tools/analytics.py
@@ -12,6 +12,7 @@ async def refresh_analytics_data(
         to_timestamp: int = 0,
         include_ignored_assets: bool = False,
         include_values: bool = False,
+        aggregate_by_group_ids: bool = False,
 ) -> dict[str, Any]:
     """Load the user's rotki data into the local, privacy-filtered analytics session.
 
@@ -38,6 +39,12 @@ async def refresh_analytics_data(
       ``price_missing = 1`` rather than 0, and the returned source metadata reports
       ``value_currency``, ``priced_rows``, ``unpriced_rows`` and ``lookup_count``. Check
       ``unpriced_rows`` before reporting any total, or you will understate it.
+    - ``aggregate_by_group_ids``: load one row per group instead of one row per event, each
+      carrying a ``grouped_events_num`` count. Use it to count distinct transactions or
+      trades. **The rows are representatives, not merged legs**: each is the *first* event of
+      its group, so a trade loaded this way shows only what was spent, with no trace of what
+      was received. It is not a substitute for self-joining on ``group_identifier`` when you
+      need both sides of a swap, and you should not sum amounts over it.
 
     Returns the per-table row counts and source metadata, plus the active ``privacy_mode``.
     """
@@ -48,6 +55,7 @@ async def refresh_analytics_data(
         to_timestamp=to_timestamp,
         include_ignored_assets=include_ignored_assets,
         include_values=include_values,
+        aggregate_by_group_ids=aggregate_by_group_ids,
     )
 
 

--- a/rotkehlchen/mcp/tools/analytics.py
+++ b/rotkehlchen/mcp/tools/analytics.py
@@ -47,6 +47,14 @@ async def refresh_analytics_data(
       need both sides of a swap, and you should not sum amounts over it.
 
     Returns the per-table row counts and source metadata, plus the active ``privacy_mode``.
+
+    On coverage, check ``source.completeness`` before trusting any aggregate: ``complete``
+    means everything in range was loaded, ``truncated_by_max_events`` that the server's
+    ``--max-events`` cap cut the load short, and ``stopped_early`` that paging gave up with
+    data still outstanding. ``source.rows_loaded`` is the authoritative count of what is
+    actually queryable. The counters under ``source.backend_metadata`` are the backend's own
+    and will not match it — ``entries_found`` in particular is a pre-serialization estimate,
+    so do not compute coverage from it.
     """
     return await asyncio.to_thread(
         get_analytics_session().refresh,

--- a/rotkehlchen/mcp/tools/taxonomy.py
+++ b/rotkehlchen/mcp/tools/taxonomy.py
@@ -23,5 +23,8 @@ async def get_event_taxonomy() -> dict[str, Any]:
       (``in`` / ``out`` / ``neutral``). ``direction`` is the field to aggregate on.
     - ``grouped_event_types``: which event types span several rows sharing a
       ``group_identifier``, and in what leg order.
+    - ``recipes``: worked SQLite queries for the common questions (yearly gas cost, staking
+      income, swap round-trips, top counterparties by outflow, balance reconciliation), each
+      stating what it deliberately excludes.
     """
     return await asyncio.to_thread(build_event_taxonomy)

--- a/rotkehlchen/mcp/tools/taxonomy.py
+++ b/rotkehlchen/mcp/tools/taxonomy.py
@@ -1,0 +1,27 @@
+import asyncio
+from typing import Any
+
+from rotkehlchen.mcp.registry import register_tool
+from rotkehlchen.mcp.taxonomy import get_event_taxonomy as build_event_taxonomy
+
+
+@register_tool(name='get_event_taxonomy')
+async def get_event_taxonomy() -> dict[str, Any]:
+    """Explain what rotki's history event types and subtypes mean, and which way value moves.
+
+    **Call this before any aggregate over ``event_type``, ``event_subtype`` or ``direction``.**
+    A ``GROUP BY event_type, event_subtype`` returns 30+ combinations whose names do not say
+    whether they are income, expense or a bookkeeping annotation, and guessing produces
+    confidently wrong totals -- most commonly by double counting MEV and block-production
+    rewards, which appear both as an ``informational`` report and as the real event.
+
+    Returns, all derived from rotki's own definitions rather than restated here:
+
+    - ``rules``: the handful of semantics you cannot read off the data.
+    - ``entries``: every valid ``(event_type, event_subtype)`` with its category, label,
+      ``group`` (income / expense / trade / staking ...) and ``direction``
+      (``in`` / ``out`` / ``neutral``). ``direction`` is the field to aggregate on.
+    - ``grouped_event_types``: which event types span several rows sharing a
+      ``group_identifier``, and in what leg order.
+    """
+    return await asyncio.to_thread(build_event_taxonomy)

--- a/rotkehlchen/tests/mcp/test_analytics.py
+++ b/rotkehlchen/tests/mcp/test_analytics.py
@@ -195,6 +195,14 @@ def test_hash_is_stable_within_session_for_grouping() -> None:
     ('drop table history_events', False),
     ('select 1; select 2', False),
     ('update history_events set amount = 0', False),
+    # read-only scalar functions and literals must not be mistaken for writes
+    ("select replace(counterparty, '-', ' ') from history_events limit 1", True),
+    ("select * from history_events where auto_notes like '%update%'", True),
+    ("select * from history_events where auto_notes = 'a; drop table x'", True),
+    ('select "update" from history_events', True),
+    # ... while real writes stay rejected
+    ('insert into history_events values (1)', False),
+    ('select 1; insert into history_events values (1)', False),
 ])
 def test_validate_sql(sql: str, valid: bool) -> None:
     assert (_validate_sql(sql) is None) is valid
@@ -700,6 +708,85 @@ def test_aggregate_by_group_ids_should_be_opt_in(monkeypatch) -> None:
         'select grouped_events_num from history_events',
         max_rows=10,
     )['rows'] == [{'grouped_events_num': 3}]
+
+
+def _paged_backend(monkeypatch, pages: list[list[dict[str, Any]]], entries_found: int) -> None:
+    """Serve pre-baked pages by offset, so a page can be empty mid-range."""
+    def fake_page(limit, offset, **kwargs):
+        index = offset // limit
+        return {
+            'entries': pages[index] if index < len(pages) else [],
+            'entries_found': entries_found,
+            'entries_total': entries_found,
+            'entries_limit': -1,
+        }
+    monkeypatch.setattr(analytics, 'query_history_events_page', fake_page)
+    monkeypatch.setattr(analytics, 'PAGE_SIZE', 2)
+
+
+def _event(identifier: int) -> dict[str, Any]:
+    return {'identifier': identifier, 'asset': 'ETH', 'amount': '1', 'event_type': 'spend'}
+
+
+def test_complete_load_should_report_completeness(monkeypatch) -> None:
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _paged_backend(monkeypatch, [[_event(1), _event(2)], [_event(3)]], entries_found=3)
+
+    source = AnalyticsSession().refresh(
+        tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False,
+    )['tables']['history_events']['source']
+
+    assert source['completeness'] == 'complete'
+    assert source['rows_loaded'] == 3
+    assert source['backend_metadata']['entries_found'] == 3
+
+
+def test_empty_middle_page_should_not_end_the_load(monkeypatch) -> None:
+    """Pages come back short and a whole window can filter out, so stopping at the first
+    empty page silently truncated the load while still reporting it as complete.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _paged_backend(
+        monkeypatch,
+        [[_event(1), _event(2)], [], [_event(3), _event(4)]],
+        entries_found=6,
+    )
+
+    source = AnalyticsSession().refresh(
+        tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False,
+    )['tables']['history_events']['source']
+
+    assert source['rows_loaded'] == 4  # the events after the empty window are not lost
+    assert source['completeness'] == 'complete'
+
+
+def test_persistently_empty_pages_should_stop_and_say_so(monkeypatch) -> None:
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _paged_backend(monkeypatch, [[_event(1), _event(2)]], entries_found=1000)
+
+    source = AnalyticsSession().refresh(
+        tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False,
+    )['tables']['history_events']['source']
+
+    assert source['rows_loaded'] == 2
+    assert source['completeness'] == 'stopped_early'  # never claim complete coverage
+
+
+def test_max_events_cap_should_report_truncation(monkeypatch) -> None:
+    configure_backend(base_url='http://backend/api/1', timeout=5, max_events=3)
+    _paged_backend(
+        monkeypatch,
+        [[_event(1), _event(2)], [_event(3), _event(4)], [_event(5), _event(6)]],
+        entries_found=6,
+    )
+
+    source = AnalyticsSession().refresh(
+        tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False,
+    )['tables']['history_events']['source']
+
+    assert source['rows_loaded'] == 3
+    assert source['completeness'] == 'truncated_by_max_events'
+    assert source['cache_truncated'] is True
 
 
 def test_query_sql_without_loaded_tables_errors() -> None:

--- a/rotkehlchen/tests/mcp/test_analytics.py
+++ b/rotkehlchen/tests/mcp/test_analytics.py
@@ -789,6 +789,76 @@ def test_max_events_cap_should_report_truncation(monkeypatch) -> None:
     assert source['cache_truncated'] is True
 
 
+def _described(session: AnalyticsSession, table: str = 'history_events') -> dict[str, Any]:
+    return {column['name']: column for column in session.describe_table(table)['columns']}
+
+
+def test_describe_should_report_sqlite_type_beside_pandas_dtype(monkeypatch) -> None:
+    """The pandas dtype is not what SQL sees; reporting it alone misled every query."""
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'identifier': 1, 'asset': 'ETH', 'amount': '1', 'event_type': 'spend',
+         'auto_notes': 'Deposit 1 ETH to kraken'},
+        {'identifier': 2, 'asset': 'BTC', 'amount': '2', 'event_type': 'receive'},
+    ])
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False)
+    columns = _described(session)
+
+    assert all(column['sqlite_type'] for column in columns.values())
+    assert columns['asset']['sqlite_type'] == 'TEXT'
+    # the has_ flag is a real bool filled for the event that lacked the field entirely
+    assert columns['has_auto_notes']['dtype'] == 'bool'
+    assert session.query_sql(
+        'select has_auto_notes, count(*) as count from history_events '
+        'group by has_auto_notes order by has_auto_notes',
+        max_rows=10,
+    )['rows'] == [{'has_auto_notes': 0, 'count': 1}, {'has_auto_notes': 1, 'count': 1}]
+
+
+def test_describe_should_list_enum_values_and_null_fractions(monkeypatch) -> None:
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'identifier': 1, 'asset': 'ETH', 'amount': '1', 'event_type': 'spend'},
+        {'identifier': 2, 'asset': 'ETH', 'amount': '2', 'event_type': 'spend'},
+        {'identifier': 3, 'asset': 'BTC', 'amount': '3', 'event_type': 'receive',
+         'extra_data_cdp_id': None},
+    ])
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False)
+    columns = _described(session)
+
+    assert columns['event_type']['distinct_count'] == 2
+    assert columns['event_type']['top_values'] == [
+        {'value': 'spend', 'rows': 2},
+        {'value': 'receive', 'rows': 1},
+    ]
+    assert columns['asset']['null_fraction'] == 0.0
+    # a column that exists but carries nothing is called out rather than looking substantial
+    assert columns['extra_data_cdp_id']['all_null'] is True
+    assert columns['extra_data_cdp_id']['null_fraction'] == 1.0
+
+
+def test_describe_should_never_emit_hashed_values(monkeypatch) -> None:
+    """Listing anon_ values would be noise at best and defeats the point at worst."""
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'identifier': 1, 'asset': 'ETH', 'amount': '1', 'address': ADDRESS,
+         'ens_name': 'vitalik.eth'},
+    ])
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False)
+    described = session.describe_table('history_events')
+    columns = _described(session)
+
+    assert 'anon_' not in str(described)
+    assert columns['address_hash']['hashed'] is True
+    assert columns['address_hash']['hashed_reason'] == 'pii'
+    assert 'top_values' not in columns['address_hash']
+    # a column the allowlist does not know is hashed too, but for a different reason
+    assert columns['ens_name_hash']['hashed_reason'] == 'unrecognized'
+
+
 def test_query_sql_without_loaded_tables_errors() -> None:
     assert AnalyticsSession().query_sql('select 1', max_rows=10)['error']['type'] == (
         'no_tables_loaded'

--- a/rotkehlchen/tests/mcp/test_analytics.py
+++ b/rotkehlchen/tests/mcp/test_analytics.py
@@ -1,3 +1,4 @@
+import json
 from concurrent.futures import ThreadPoolExecutor
 from threading import Event
 from typing import Any
@@ -375,6 +376,219 @@ def test_load_is_uncapped_by_default_and_respects_max_events(monkeypatch) -> Non
                                         include_ignored_assets=False)
     assert capped['tables']['history_events']['rows'] == 3
     assert capped['tables']['history_events']['source']['cache_truncated'] is True
+
+
+def _mock_prices(monkeypatch, prices: dict[str, dict[int, str]], currency: str = 'EUR') -> list:
+    """Mock the settings + historical-price backends, recording every price call made."""
+    calls: list[dict[str, Any]] = []
+
+    def fake_prices(asset_timestamps, target_asset, max_seconds_distance):
+        calls.append({
+            'pairs': list(asset_timestamps),
+            'target_asset': target_asset,
+            'max_seconds_distance': max_seconds_distance,
+        })
+        assets: dict[str, dict[str, str]] = {}
+        for asset, timestamp in asset_timestamps:
+            if (price := prices.get(asset, {}).get(timestamp)) is not None:
+                # both levels come back as strings over JSON, as the real endpoint does
+                assets.setdefault(asset, {})[str(timestamp)] = price
+        return {'assets': assets, 'target_asset': target_asset}
+
+    monkeypatch.setattr(analytics, 'query_settings', lambda: {'main_currency': currency})
+    monkeypatch.setattr(analytics, 'query_historical_prices', fake_prices)
+    return calls
+
+
+def _valued_event(identifier: int, asset: str, amount: str, timestamp: int) -> dict[str, Any]:
+    return {
+        'identifier': identifier,
+        'asset': asset,
+        'amount': amount,
+        'timestamp': timestamp,
+        'event_type': 'spend',
+    }
+
+
+def test_include_values_off_should_not_query_prices(monkeypatch) -> None:
+    """Valuation costs minutes on a real history, so it must never happen implicitly."""
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [_valued_event(1, 'ETH', '2', 1614556800000)])
+    calls = _mock_prices(monkeypatch, {'ETH': {1614556800: '1500'}})
+
+    session = AnalyticsSession()
+    loaded = session.refresh(
+        tables=None,
+        from_timestamp=0,
+        to_timestamp=0,
+        include_ignored_assets=False,
+    )['tables']['history_events']
+
+    assert calls == []
+    assert 'value_currency' not in loaded['source']
+    names = {column['name'] for column in session.describe_table('history_events')['columns']}
+    assert names.isdisjoint({'value', 'price', 'price_missing'})
+
+
+def test_include_values_should_multiply_amount_by_cached_price(monkeypatch) -> None:
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        _valued_event(1, 'ETH', '2', 1614556800000),    # priced: 2 * 1500
+        _valued_event(2, 'BTC', '0.5', 1614556800000),  # priced: 0.5 * 40000
+        _valued_event(3, 'DOGE', '100', 1614556800000),  # no cached price
+    ])
+    calls = _mock_prices(monkeypatch, {
+        'ETH': {1614556800: '1500'},
+        'BTC': {1614556800: '40000'},
+    })
+    session = AnalyticsSession()
+    loaded = session.refresh(
+        tables=None,
+        from_timestamp=0,
+        to_timestamp=0,
+        include_ignored_assets=False,
+        include_values=True,
+    )['tables']['history_events']
+
+    assert loaded['source']['value_currency'] == 'EUR'
+    assert loaded['source']['priced_rows'] == 2
+    assert loaded['source']['unpriced_rows'] == 1
+    assert loaded['source']['lookup_count'] == 3
+    # only_cache_period must always be sent, so no remote oracle fetch can be triggered
+    assert all(call['max_seconds_distance'] == 3600 for call in calls)
+    assert all(call['target_asset'] == 'EUR' for call in calls)
+
+    rows = session.query_sql(
+        'select asset, value, price, price_missing from history_events order by asset',
+        max_rows=10,
+    )['rows']
+    assert rows == [
+        {'asset': 'BTC', 'value': 20000.0, 'price': 40000.0, 'price_missing': 0},
+        {'asset': 'DOGE', 'value': None, 'price': None, 'price_missing': 1},
+        {'asset': 'ETH', 'value': 3000.0, 'price': 1500.0, 'price_missing': 0},
+    ]
+
+
+def test_unpriced_events_should_be_null_never_zero(monkeypatch) -> None:
+    """A 0 would silently understate every total an agent sums over ``value``."""
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [_valued_event(1, 'DOGE', '100', 1614556800000)])
+    _mock_prices(monkeypatch, {})
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0,
+                    include_ignored_assets=False, include_values=True)
+
+    assert session.query_sql(
+        'select sum(value) as total, count(value) as priced from history_events',
+        max_rows=10,
+    )['rows'] == [{'total': None, 'priced': 0}]
+
+
+def test_null_results_should_stay_json_serializable(monkeypatch) -> None:
+    """A NULL in a numeric result column must reach the agent as ``null``. Reading results
+    back through a DataFrame turned it into NaN, which ``json.dumps`` emits as a bare ``NaN``
+    token -- invalid JSON, so the whole tool response fails to parse on the client.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        _valued_event(1, 'ETH', '2', 1614556800000),
+        _valued_event(2, 'DOGE', '100', 1614556800000),
+    ])
+    _mock_prices(monkeypatch, {'ETH': {1614556800: '1500'}})
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0,
+                    include_ignored_assets=False, include_values=True)
+
+    result = session.query_sql('select asset, value from history_events order by asset', 10)
+    assert result['rows'] == [{'asset': 'DOGE', 'value': None}, {'asset': 'ETH', 'value': 3000.0}]
+    assert 'NaN' not in json.dumps(result)  # strict JSON has no NaN literal
+
+
+def test_price_lookups_should_dedupe_into_hour_buckets(monkeypatch) -> None:
+    """100 events in one asset-hour cost exactly one lookup, not 100."""
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        # spread across one hour: 1614556800000 is exactly 2021-03-01T00:00:00Z
+        _valued_event(i, 'ETH', '1', 1614556800000 + i * 30_000) for i in range(100)
+    ])
+    calls = _mock_prices(monkeypatch, {'ETH': {1614556800: '1500'}})
+    loaded = AnalyticsSession().refresh(
+        tables=None,
+        from_timestamp=0,
+        to_timestamp=0,
+        include_ignored_assets=False,
+        include_values=True,
+    )['tables']['history_events']
+
+    assert len(calls) == 1
+    assert calls[0]['pairs'] == [('ETH', 1614556800)]
+    assert loaded['source']['lookup_count'] == 1
+    assert loaded['source']['priced_rows'] == 100  # all 100 rows still get the bucket's price
+
+
+def test_price_lookups_should_chunk_at_500_pairs(monkeypatch) -> None:
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        # 1200 distinct asset-hours -> 500 + 500 + 200
+        _valued_event(i, f'ASSET{i}', '1', 1614556800000 + i * 3_600_000) for i in range(1200)
+    ])
+    calls = _mock_prices(monkeypatch, {})
+    loaded = AnalyticsSession().refresh(
+        tables=None,
+        from_timestamp=0,
+        to_timestamp=0,
+        include_ignored_assets=False,
+        include_values=True,
+    )['tables']['history_events']
+
+    assert [len(call['pairs']) for call in calls] == [500, 500, 200]
+    assert loaded['source']['lookup_count'] == 1200
+
+
+def test_valuation_should_not_block_queries(monkeypatch) -> None:
+    """Price resolution takes minutes; it must run outside the connection lock so the
+    previous snapshot stays queryable, exactly like the event paging above it.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [_valued_event(1, 'ETH', '2', 1614556800000)])
+    session = AnalyticsSession()
+    assert session.refresh(tables=None, from_timestamp=0, to_timestamp=0,
+                           include_ignored_assets=False)['errors'] == {}
+
+    started, proceed = Event(), Event()
+
+    def blocking_prices(asset_timestamps, target_asset, max_seconds_distance):
+        started.set()
+        assert proceed.wait(timeout=5)
+        return {'assets': {'ETH': {'1614556800': '1500'}}, 'target_asset': target_asset}
+
+    monkeypatch.setattr(analytics, 'query_settings', lambda: {'main_currency': 'EUR'})
+    monkeypatch.setattr(analytics, 'query_historical_prices', blocking_prices)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        refresh_future = executor.submit(
+            session.refresh,
+            tables=None,
+            from_timestamp=0,
+            to_timestamp=0,
+            include_ignored_assets=False,
+            include_values=True,
+        )
+        assert started.wait(timeout=5)
+        query_future = executor.submit(
+            session.query_sql,
+            'select count(*) as count from history_events',
+            10,
+        )
+        try:  # the un-valued snapshot answers while valuation is still in flight
+            assert query_future.result(timeout=5)['rows'] == [{'count': 1}]
+        finally:
+            proceed.set()
+        assert refresh_future.result(timeout=5)['errors'] == {}
+
+    assert session.query_sql('select value from history_events', max_rows=10)['rows'] == [
+        {'value': 3000.0},
+    ]
 
 
 def test_query_sql_without_loaded_tables_errors() -> None:

--- a/rotkehlchen/tests/mcp/test_analytics.py
+++ b/rotkehlchen/tests/mcp/test_analytics.py
@@ -16,6 +16,7 @@ from rotkehlchen.mcp.analytics import (
     _validate_sql,
 )
 from rotkehlchen.mcp.backend import configure_backend
+from rotkehlchen.mcp.taxonomy import RECIPES
 
 ADDRESS = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65'
 TX_HASH = '0x' + 'ab' * 32
@@ -857,6 +858,88 @@ def test_describe_should_never_emit_hashed_values(monkeypatch) -> None:
     assert 'top_values' not in columns['address_hash']
     # a column the allowlist does not know is hashed too, but for a different reason
     assert columns['ens_name_hash']['hashed_reason'] == 'unrecognized'
+
+
+def test_direction_column_should_use_rotki_resolution(monkeypatch) -> None:
+    """The serialized event carries no direction, so it is derived locally -- otherwise the
+    "aggregate on direction" guidance refers to a column that does not exist.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'identifier': 1, 'asset': 'ETH', 'amount': '1', 'location': 'ethereum',
+         'event_type': 'staking', 'event_subtype': 'mev reward'},
+        {'identifier': 2, 'asset': 'ETH', 'amount': '1', 'location': 'ethereum',
+         'event_type': 'informational', 'event_subtype': 'mev reward'},
+        {'identifier': 3, 'asset': 'ETH', 'amount': '1', 'location': 'ethereum',
+         'event_type': 'spend', 'event_subtype': 'fee'},
+    ])
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False)
+
+    assert session.query_sql(
+        'select event_type, direction from history_events order by identifier',
+        max_rows=10,
+    )['rows'] == [
+        {'event_type': 'staking', 'direction': 'in'},
+        {'event_type': 'informational', 'direction': 'neutral'},  # not counted twice
+        {'event_type': 'spend', 'direction': 'out'},
+    ]
+
+
+def test_unparsable_event_should_not_fail_the_load(monkeypatch) -> None:
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'identifier': 1, 'asset': 'ETH', 'amount': '1', 'location': 'ethereum',
+         'event_type': 'not_a_real_type', 'event_subtype': 'nonsense'},
+    ])
+    session = AnalyticsSession()
+    assert session.refresh(tables=None, from_timestamp=0, to_timestamp=0,
+                           include_ignored_assets=False)['errors'] == {}
+    assert session.query_sql('select direction from history_events', 10)['rows'] == [
+        {'direction': None},
+    ]
+
+
+def test_every_shipped_recipe_should_execute(monkeypatch) -> None:
+    """Doubles as regression coverage: a recipe breaks the moment the schema drifts."""
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'entry': {'identifier': 1, 'asset': 'ETH', 'amount': '0.01',
+                   'timestamp': 1614556800000, 'location': 'ethereum', 'event_type': 'spend',
+                   'event_subtype': 'fee', 'counterparty': 'gas', 'sequence_index': 0,
+                   'group_identifier': '0xaaa'}},
+        {'entry': {'identifier': 2, 'asset': 'ETH', 'amount': '1',
+                   'timestamp': 1614556800000, 'location': 'ethereum',
+                   'event_type': 'staking', 'event_subtype': 'mev reward',
+                   'sequence_index': 0, 'group_identifier': '0xbbb'}},
+        {'entry': {'identifier': 3, 'asset': 'ETH', 'amount': '2',
+                   'timestamp': 1614556800000, 'location': 'kraken', 'event_type': 'trade',
+                   'event_subtype': 'spend', 'sequence_index': 0,
+                   'group_identifier': '0xccc'}},
+        {'entry': {'identifier': 4, 'asset': 'USDC', 'amount': '6000',
+                   'timestamp': 1614556800000, 'location': 'kraken', 'event_type': 'trade',
+                   'event_subtype': 'receive', 'sequence_index': 1,
+                   'group_identifier': '0xccc'}},
+    ])
+    _mock_prices(monkeypatch, {'ETH': {1614556800: '1500'}, 'USDC': {1614556800: '1'}})
+    monkeypatch.setattr(analytics, 'query_all_balances', lambda refresh, timeout: {
+        'assets': {'ETH': {'amount': '3', 'usd_value': '4500'}},
+        'liabilities': {},
+        'net_value': '4500',
+    })
+    session = AnalyticsSession()
+    assert session.refresh(
+        tables=['history_events', 'balances'],
+        from_timestamp=0,
+        to_timestamp=0,
+        include_ignored_assets=False,
+        include_values=True,
+    )['errors'] == {}
+
+    for recipe in RECIPES:
+        result = session.query_sql(recipe['sql'], max_rows=100)
+        assert 'error' not in result, f'recipe failed: {recipe["question"]}: {result}'
+        assert 'excludes' in recipe and 'requires' in recipe
 
 
 def test_query_sql_without_loaded_tables_errors() -> None:

--- a/rotkehlchen/tests/mcp/test_analytics.py
+++ b/rotkehlchen/tests/mcp/test_analytics.py
@@ -124,6 +124,57 @@ def test_sanitize_balanced_keeps_named_label_but_strict_hashes_it() -> None:
     assert 'label' not in strict  # user-authored label is an identifier in strict mode
 
 
+@pytest.mark.parametrize('identifier', [
+    ADDRESS,                                        # EVM address
+    TX_HASH,                                        # EVM tx hash
+    'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',   # bech32 BTC
+    '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',           # base58 BTC
+    '7EYnhQoR9YM3N7UoaKRoA44Uy8JeaZV3qyouov87awMs',  # base58 Solana
+])
+def test_generated_notes_should_never_carry_an_identifier(identifier: str) -> None:
+    """The templates interpolate no address today, but an asset *name* is attacker
+    controlled on a scam token, so the scrub is what keeps that true rather than assumed.
+    """
+    balanced = _sanitize_row(
+        {'auto_notes': f'Receive 1.0 {identifier} after a swap in kraken'},
+        privacy_mode='balanced',
+    )
+    assert identifier not in balanced['auto_notes']
+    assert 'anon_' in balanced['auto_notes']
+    assert balanced['auto_notes'].startswith('Receive 1.0 ')  # still readable
+    # strict keeps redacting outright
+    assert _sanitize_row(
+        {'auto_notes': f'Receive 1.0 {identifier} after a swap in kraken'},
+        privacy_mode='strict',
+    )['auto_notes'] == analytics.REDACTED_TEXT
+
+
+def test_generated_notes_readable_but_user_notes_still_redacted() -> None:
+    """``auto_notes`` is template-generated and safe; ``user_notes`` is decoder-written *and*
+    user-editable, so its mixed provenance keeps it redacted in every non-raw mode.
+    """
+    row = {
+        'auto_notes': 'Deposit 5 ETH to kraken',
+        'user_notes': f'Burn 0.00013 XDAI for gas at {ADDRESS}',
+        'notes': 'my private note',
+    }
+    for privacy_mode in ('balanced', 'strict'):
+        sanitized = _sanitize_row(row, privacy_mode=privacy_mode)
+        assert sanitized['user_notes'] == analytics.REDACTED_TEXT
+        assert sanitized['notes'] == analytics.REDACTED_TEXT
+        assert sanitized['has_auto_notes'] is True
+        assert ADDRESS not in str(sanitized)
+
+    assert _sanitize_row(row, 'balanced')['auto_notes'] == 'Deposit 5 ETH to kraken'
+    assert _sanitize_row(row, 'strict')['auto_notes'] == analytics.REDACTED_TEXT
+
+
+def test_empty_generated_notes_stay_null() -> None:
+    sanitized = _sanitize_row({'auto_notes': ''}, privacy_mode='balanced')
+    assert sanitized['auto_notes'] is None
+    assert sanitized['has_auto_notes'] is False
+
+
 def test_sanitize_raw_passes_everything_through() -> None:
     row = {'address': ADDRESS, 'notes': 'secret', 'ens_name': 'vitalik.eth'}
     assert _sanitize_row(row, privacy_mode='raw') == row
@@ -299,9 +350,10 @@ def test_overlapping_refreshes_should_not_publish_out_of_order(monkeypatch) -> N
     )['rows'] == [{'asset': 'NEW'}]
 
 
-def test_history_events_promote_entry_and_redact_auto_notes(monkeypatch) -> None:
+def test_history_events_promote_entry_and_scrub_auto_notes(monkeypatch) -> None:
     """The API wraps fields in an ``entry`` envelope; columns must read as ``timestamp``/
-    ``location`` (not ``entry_timestamp``), and ``auto_notes`` must be redacted, not raw.
+    ``location`` (not ``entry_timestamp``), and ``auto_notes`` stays readable in balanced
+    mode with any embedded identifier scrubbed.
     """
     configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
     _mock_history_pages(monkeypatch, [
@@ -329,8 +381,8 @@ def test_history_events_promote_entry_and_redact_auto_notes(monkeypatch) -> None
     row = session.query_sql('select * from history_events', max_rows=10)['rows'][0]
     assert row['year'] == 2021  # 1614556800000 ms -> 2021-03-01
     assert row['datetime'] == '2021-03-01T00:00:00Z'
-    # the address embedded in auto_notes never leaks
-    assert row['auto_notes'] == analytics.REDACTED_TEXT
+    # the description stays readable, but the address embedded in it never leaks
+    assert row['auto_notes'].startswith('Send 1.5 ETH to anon_')
     assert ADDRESS not in str(row)
 
 

--- a/rotkehlchen/tests/mcp/test_analytics.py
+++ b/rotkehlchen/tests/mcp/test_analytics.py
@@ -200,7 +200,10 @@ def test_validate_sql(sql: str, valid: bool) -> None:
     assert (_validate_sql(sql) is None) is valid
 
 
-def _mock_history_pages(monkeypatch, entries: list[dict[str, Any]]) -> None:
+def _mock_history_pages(monkeypatch, entries: list[Any]) -> None:
+    """``entries`` may hold plain event dicts or, as the real endpoint returns for grouped
+    swaps and matched movements, sub-lists of them.
+    """
     def fake_page(limit, offset, **kwargs):
         page = entries[offset:offset + limit]
         return {
@@ -641,6 +644,62 @@ def test_valuation_should_not_block_queries(monkeypatch) -> None:
     assert session.query_sql('select value from history_events', max_rows=10)['rows'] == [
         {'value': 3000.0},
     ]
+
+
+def test_grouped_sublist_entries_should_not_be_dropped(monkeypatch) -> None:
+    """Without aggregate_by_group_ids the API nests each EVM/Solana swap and each matched
+    asset movement in a sub-list, so a page mixes dicts with lists of dicts. Keeping only the
+    dicts silently lost every on-chain swap -- exactly the trades an agent asks about.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    swap_legs = [
+        {'entry': {'identifier': 2, 'asset': 'ETH', 'amount': '1', 'event_subtype': 'spend',
+                   'group_identifier': '0xswap', 'sequence_index': 0}},
+        {'entry': {'identifier': 3, 'asset': 'USDC', 'amount': '3000',
+                   'event_subtype': 'receive', 'group_identifier': '0xswap',
+                   'sequence_index': 1}},
+    ]
+    _mock_history_pages(monkeypatch, [
+        {'entry': {'identifier': 1, 'asset': 'BTC', 'amount': '1', 'event_subtype': 'receive'}},
+        swap_legs,  # a grouped sub-list, as the endpoint really returns it
+    ])
+    session = AnalyticsSession()
+    loaded = session.refresh(tables=None, from_timestamp=0, to_timestamp=0,
+                             include_ignored_assets=False)
+
+    assert loaded['tables']['history_events']['rows'] == 3  # not 1
+    assert session.query_sql(
+        'select asset from history_events order by asset',
+        max_rows=10,
+    )['rows'] == [{'asset': 'BTC'}, {'asset': 'ETH'}, {'asset': 'USDC'}]
+
+
+def test_aggregate_by_group_ids_should_be_opt_in(monkeypatch) -> None:
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    captured: list[Any] = []
+
+    def fake_page(limit, offset, aggregate_by_group_ids=False, **kwargs):
+        captured.append(aggregate_by_group_ids)
+        return {'entries': [] if offset else [
+            {'identifier': 1, 'asset': 'ETH', 'amount': '1', 'grouped_events_num': 3},
+        ], 'entries_found': 1, 'entries_total': 1, 'entries_limit': -1}
+
+    monkeypatch.setattr(analytics, 'query_history_events_page', fake_page)
+
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0,
+                    include_ignored_assets=False)
+    assert captured == [False]  # default request is unchanged
+
+    captured.clear()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0,
+                    include_ignored_assets=False, aggregate_by_group_ids=True)
+    assert captured == [True]
+    # the count survives flattening and is queryable
+    assert session.query_sql(
+        'select grouped_events_num from history_events',
+        max_rows=10,
+    )['rows'] == [{'grouped_events_num': 3}]
 
 
 def test_query_sql_without_loaded_tables_errors() -> None:

--- a/rotkehlchen/tests/mcp/test_backend.py
+++ b/rotkehlchen/tests/mcp/test_backend.py
@@ -9,6 +9,7 @@ from rotkehlchen.mcp.backend import (
     configure_backend,
     get_backend_config,
     query_historical_prices,
+    query_history_events_page,
     query_settings,
     request_api,
 )
@@ -82,6 +83,24 @@ def test_request_api_should_post_json_body(monkeypatch) -> None:
     ) == {'result': {'entries': []}, 'message': ''}
     assert captured['url'] == 'http://backend/api/1/history/events'
     assert captured['json'] == {'limit': 10}
+
+
+def test_aggregate_flag_should_only_be_sent_when_set(monkeypatch) -> None:
+    """The default request body must stay byte-identical to before the flag existed."""
+    captured: dict[str, Any] = {}
+
+    def mock_post(url: str, **kwargs: Any) -> MockResponse:
+        captured['json'] = kwargs.get('json')
+        return MockResponse({'result': {'entries': []}, 'message': ''})
+
+    monkeypatch.setattr(requests, 'post', mock_post)
+    configure_backend(base_url='http://backend/api/1', timeout=5)
+
+    query_history_events_page(limit=10, offset=0)
+    assert 'aggregate_by_group_ids' not in captured['json']
+
+    query_history_events_page(limit=10, offset=0, aggregate_by_group_ids=True)
+    assert captured['json']['aggregate_by_group_ids'] is True
 
 
 def test_query_settings_should_return_main_currency(monkeypatch) -> None:

--- a/rotkehlchen/tests/mcp/test_backend.py
+++ b/rotkehlchen/tests/mcp/test_backend.py
@@ -8,6 +8,8 @@ from rotkehlchen.mcp.backend import (
     BackendQueryError,
     configure_backend,
     get_backend_config,
+    query_historical_prices,
+    query_settings,
     request_api,
 )
 
@@ -80,3 +82,52 @@ def test_request_api_should_post_json_body(monkeypatch) -> None:
     ) == {'result': {'entries': []}, 'message': ''}
     assert captured['url'] == 'http://backend/api/1/history/events'
     assert captured['json'] == {'limit': 10}
+
+
+def test_query_settings_should_return_main_currency(monkeypatch) -> None:
+    monkeypatch.setattr(
+        requests,
+        'get',
+        lambda url, **kwargs: MockResponse({'result': {'main_currency': 'EUR'}, 'message': ''}),
+    )
+    configure_backend(base_url='http://backend/api/1', timeout=5)
+
+    assert query_settings()['main_currency'] == 'EUR'
+
+
+def test_query_settings_should_reject_non_dict_result(monkeypatch) -> None:
+    monkeypatch.setattr(
+        requests,
+        'get',
+        lambda url, **kwargs: MockResponse({'result': True, 'message': ''}),
+    )
+    configure_backend(base_url='http://backend/api/1', timeout=5)
+
+    with pytest.raises(BackendQueryError, match='unexpected settings response'):
+        query_settings()
+
+
+def test_historical_prices_should_always_send_only_cache_period(monkeypatch) -> None:
+    """``only_cache_period`` is what confines the endpoint to rotki's stored prices. Without
+    it the backend falls through to ``query_multiple_prices`` and hits remote oracles, which
+    the MCP must never do on an agent's behalf.
+    """
+    captured: dict[str, Any] = {}
+
+    def mock_post(url: str, **kwargs: Any) -> MockResponse:
+        captured['json'] = kwargs.get('json')
+        return MockResponse({'result': {'assets': {}, 'target_asset': 'EUR'}, 'message': ''})
+
+    monkeypatch.setattr(requests, 'post', mock_post)
+    configure_backend(base_url='http://backend/api/1', timeout=5)
+
+    query_historical_prices(
+        asset_timestamps=[('ETH', 1614556800)],
+        target_asset='EUR',
+        max_seconds_distance=3600,
+    )
+    assert captured['json'] == {
+        'assets_timestamp': [('ETH', 1614556800)],
+        'target_asset': 'EUR',
+        'only_cache_period': 3600,
+    }

--- a/rotkehlchen/tests/mcp/test_taxonomy.py
+++ b/rotkehlchen/tests/mcp/test_taxonomy.py
@@ -1,0 +1,89 @@
+import subprocess  # noqa: S404  -- fresh interpreter is the only way to assert import weight
+import sys
+
+from rotkehlchen.accounting.constants import DEFAULT, EVENT_CATEGORY_MAPPINGS
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.mcp.taxonomy import get_event_taxonomy
+
+
+def _entry(taxonomy: dict, event_type: str, event_subtype: str) -> dict:
+    return next(
+        entry for entry in taxonomy['entries']
+        if entry['event_type'] == event_type and entry['event_subtype'] == event_subtype
+    )
+
+
+def test_taxonomy_should_cover_every_mapped_combination() -> None:
+    """Derived, not hand-written: adding a subtype upstream must surface it here untouched."""
+    taxonomy = get_event_taxonomy()
+    assert {
+        (entry['event_type'], entry['event_subtype']) for entry in taxonomy['entries']
+    } == {
+        (event_type.serialize(), event_subtype.serialize())
+        for event_type, subtypes in EVENT_CATEGORY_MAPPINGS.items()
+        for event_subtype in subtypes
+    }
+
+
+def test_every_combination_should_have_a_direction() -> None:
+    taxonomy = get_event_taxonomy()
+    assert all(
+        entry['direction'] in {'in', 'out', 'neutral'} for entry in taxonomy['entries']
+    )
+    assert all(entry['category'] and entry['label'] and entry['group']
+               for entry in taxonomy['entries'])
+
+
+def test_informational_events_should_be_neutral() -> None:
+    """The double-count guard. rotki reports the same MEV reward twice -- once as the
+    relayer's ``informational`` note and once as the real ``staking`` event -- so the
+    informational row must read as moving no value. Taking direction off the category enum
+    instead of rotki's resolver reports it as ``in`` and silently inflates staking income.
+    """
+    taxonomy = get_event_taxonomy()
+    assert _entry(taxonomy, 'informational', 'mev reward')['direction'] == 'neutral'
+    assert _entry(taxonomy, 'informational', 'block production')['direction'] == 'neutral'
+    assert _entry(taxonomy, 'staking', 'mev reward')['direction'] == 'in'
+    # every informational combination, not just the two that bite
+    assert all(
+        entry['direction'] == 'neutral'
+        for entry in taxonomy['entries'] if entry['event_type'] == 'informational'
+    )
+    # ... and the raw mapping really does disagree, which is why the resolver is used
+    assert EVENT_CATEGORY_MAPPINGS[HistoryEventType.INFORMATIONAL][
+        HistoryEventSubType.MEV_REWARD
+    ][DEFAULT].direction.serialize() == 'in'
+
+
+def test_taxonomy_should_expose_swap_leg_order() -> None:
+    grouped = get_event_taxonomy()['grouped_event_types']
+    assert grouped['trade'] == {'spend': 0, 'receive': 1, 'fee': 2}
+    assert grouped['exchange transfer'] == {'spend': 0, 'receive': 0, 'fee': 1}
+
+
+def test_taxonomy_should_expose_exchange_specific_reading() -> None:
+    """A deposit means something different on an exchange than on chain; both are exposed."""
+    entry = _entry(get_event_taxonomy(), 'deposit', 'deposit asset')
+    assert entry['exchange']['category'] == 'cex deposit'
+    assert entry['exchange']['direction'] in {'in', 'out', 'neutral'}
+
+
+def test_mcp_import_should_stay_free_of_flask_gevent_and_web3() -> None:
+    """The MCP runs as its own lightweight process next to the app. Pulling the web stack in
+    through a taxonomy import was a blocking review point on the original MCP PR.
+    """
+    result = subprocess.run(
+        [
+            sys.executable, '-c',
+            (
+                'import sys; import rotkehlchen.mcp.taxonomy; '
+                'import rotkehlchen.mcp.tools.taxonomy; '
+                "print(sorted({m.split('.')[0] for m in sys.modules} & "
+                "{'flask', 'gevent', 'web3'}))"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == '[]'


### PR DESCRIPTION
# MCP analytics layer improvements

Implements the seven tasks in `MCP_ANALYTICS_IMPROVEMENTS.md`. All changes are confined to
`rotkehlchen/mcp/` and `rotkehlchen/tests/mcp/`; nothing outside the MCP package is touched.

`uv run make lint` passes clean. 112 tests pass in `rotkehlchen/tests/mcp/`.

**Everything here is verified against mocked backends only, as the brief scoped it. No number
in this branch has been confirmed against a real instance.** The verification plan at the end
is the outstanding work, and its first two items are ship/no-ship gates rather than polish.

---

## What is in the branch

Seven commits, in dependency order (Task 3 needs 2, Task 4 needs 6, Task 7 needs all).

| Commit | Task | What it does |
|---|---|---|
| `feat: value mcp history events in main currency` | 1 | Opt-in `include_values` adds `value`, `price`, `price_missing` columns |
| `feat: expose rotki event taxonomy over mcp` | 2 | New `get_event_taxonomy` tool; rules in the `query_sql` description |
| `fix: stop redacting generated mcp auto notes` | 5 | `auto_notes` becomes readable in `balanced`, scrubbed |
| `fix: load grouped history events in mcp analytics` | 3 | Loads grouped sub-list events; opt-in `aggregate_by_group_ids` |
| `fix: mcp analytics load completeness and sql checks` | 6 | `rows_loaded` + `completeness`; empty-page paging; SQL validator |
| `fix: report mcp analytics column values and types` | 4 | `describe_table` reports sqlite types, null fractions, enum values |
| `docs: guide mcp agents through tool descriptions` | 7 | Five worked recipes; adds the `direction` column |

### Task 1 — valuation

`refresh_analytics_data(include_values=true)` prices every event in the user's main currency,
following the same path rotki's CSV export uses (`api/services/history.py`): read
`main_currency` from settings, dedupe the lookups, resolve them from the price cache,
multiply by the amount. It deliberately stops short of the export's oracle fallback — prices
come only from what rotki has already stored, so an agent can never trigger a remote fetch.

Unpriced rows get `value = NULL`, never `0`, and the table `source` reports `value_currency`,
`priced_rows`, `unpriced_rows` and `lookup_count` so a total is never quoted without its
coverage. Lookups are bucketed to the hour the price tolerance already spans and chunked 500
per request. Resolution runs in the loader, outside the connection lock, so queries keep
serving the previous snapshot while it is in flight.

Off by default: it costs roughly 8s per 1000 pairs, which is minutes on a full history.

### Task 2 — event taxonomy

New premium-gated `get_event_taxonomy` tool returning every `(event_type, event_subtype)`
combination with its category, label, group and direction, plus the grouping/leg order and
the rules an agent cannot infer from the data. All of it derived at call time from
`EVENT_CATEGORY_MAPPINGS`, `EVENT_CATEGORY_DETAILS` and `EVENT_GROUPING_ORDER`, so a subtype
added upstream appears without touching MCP code.

### Task 3 — grouped events

Adds opt-in `aggregate_by_group_ids`, and fixes a data-loss bug found while implementing it
(see divergence 3 below).

### Task 4 — `describe_table`

Each column now reports the declared sqlite type alongside the pandas dtype, its
`null_fraction`, and `all_null` for columns that exist but carry nothing. Small enum-like
columns list their distinct values so learning them costs no `SELECT DISTINCT` round trip.
Hashed columns are labelled `pii` (hidden by policy) or `unrecognized` (unknown to the
allowlist, hashed rather than leaked); their values are never listed.

`has_*` flags are filled and cast to real booleans in the loader — they were only emitted for
rows carrying the underlying field, so ragged event types left gaps that reached SQL as a
confusing `0`/`1`/`NULL` mix.

### Task 5 — `auto_notes`

The constant justifying redaction claimed `auto_notes` "routinely embeds addresses". That is
not true of current code: it is generated at serialization time by eight f-string templates
across `swap.py`, `asset_movement.py` and `base.py`, over amount, asset symbol and location
name only. The field that *does* carry decoder output with addresses is `user_notes`, which
despite the name is decoder-written for EVM events and also user-editable — that mixed
provenance is why it stays redacted.

Split accordingly: user text keeps today's behaviour unchanged; generated text passes through
in `balanced` with any identifier replaced by the same hash column-level hashing produces, so
notes stay cross-referenceable. `strict` still redacts outright and its output is unchanged.

The scrub is not merely belt-and-braces: the templates interpolate `symbol_or_name()`, which
falls back to the asset's *name*, and that is attacker-controlled on a scam token.

### Task 6 — completeness and SQL validation

Three fixes. A refresh now reports an authoritative `rows_loaded` plus an explicit
`completeness` of `complete` / `truncated_by_max_events` / `stopped_early`, with the backend's
own counters kept under `backend_metadata` and documented as the pre-serialization estimate
they are. Paging no longer stops at the first empty page — an empty window is skipped, bounded
by a consecutive-empty guard, and giving up with data outstanding reports `stopped_early`
rather than silently claiming completeness. The SQL validator strips quoted strings and
identifiers before tokenising, so a denied word inside a literal is no longer read as a write.

### Task 7 — guidance

Five worked SQLite recipes on `get_event_taxonomy` (yearly gas cost, staking income, swap
round-trips, top counterparties by outflow, balance reconciliation), each stating what it
deliberately excludes. A test executes every one against a loaded session, which doubles as
regression coverage for the schema.

---

## Where this diverges from the brief, and why

Five places the brief was inaccurate. Each is a deliberate departure, not an oversight.

### 1. The prescribed `direction` derivation would have caused the exact bug Task 2 prevents

The brief specifies deriving direction as
`EVENT_CATEGORY_MAPPINGS[type][subtype][DEFAULT].direction`, and calls it "the field that
prevents the double-count".

That mapping gives `informational`/`mev reward` a direction of **`in`**.
`history/events/structures/base.py:77` overrides *every* informational event to `NEUTRAL`, and
`get_event_direction()` is the function the rest of rotki uses. rotki's accounting agrees:
`EthBlockEvent.process()` skips non-`STAKING` block events explicitly "so that we do not
double count anything", because the informational row is the relayer's report of a reward
whose value arrives separately as its own event.

Following the brief verbatim would have shipped a taxonomy asserting that MEV relayer reports
are incoming value — inflating staking income rather than fixing it. This branch uses
`get_event_direction()`. A test pins the disagreement between the two so it cannot regress.

### 2. The `direction` column did not exist

The brief's rules, and four of the five recipes it asks for, aggregate on `direction`. The
serialized event has no such field (`base.py:353`), so that guidance referred to a column that
did not exist.

Task 7 adds it: derived per row through `get_event_direction`, cached per
type/subtype/location because a large history has ~100 distinct combinations across all its
rows. Events that fail to deserialize get a `NULL` direction rather than failing the load.

### 3. A pre-existing data-loss bug the brief did not know about

Without `aggregate_by_group_ids`, `/history/events` returns a **sub-list per group** for EVM
and Solana swaps and for matched asset movements — a page mixes event dicts with lists of
them. The loader filtered with `if isinstance(entry, dict)`, silently discarding every one.
On-chain swaps and matched deposits/withdrawals never reached the table an agent queries.

This also explains the short pages the brief attributed to the backend ("offset=144500,
limit=1000 returns 998 entries"): a grouped sub-list still counts as one entry against the
page limit.

Fixed in the Task 3 commit. This is arguably a larger correctness win than Task 3 as
specified, and it is the change most in need of live confirmation — see Gate A.

### 4. `NaN` would have corrupted the tool response

`to_sql` stores NULL correctly, but query results were read back through a DataFrame, which
turns a NULL in a numeric column into `NaN`. `json.dumps` emits that as a bare `NaN` token —
invalid JSON, so the entire tool response fails to parse client-side. Latent before; Task 1's
nullable `value`/`price` columns made it routine. Results now come straight from sqlite, which
already returns `None`/`int`/`float`/`str` natives.

### 5. Two stale environment facts

- The brief says to run tests via `uv run python pytestgeventwrapper.py`. That file no longer
  exists — it was removed in the gevent→threads migration. Tests run with plain
  `uv run pytest`, per `CLAUDE.md`.
- The brief describes string columns as having pandas dtype `object`. This repo is on pandas
  3.0.3, which gives them a dedicated `str` dtype, so Task 4's detection needed different
  predicates than the brief's symptom description implies.

Two smaller notes: the brief says `test_analytics.py` is 148 lines (it was 387 before this
branch), and describes `EventCategory` members as `(id, EventDirection)` when they are
now `(id, EventDirection, EventCategoryGroup)` — the extra `group` is exposed in the taxonomy
output since it was free and useful.

### Import-weight go/no-go (Task 2's blocking question)

Both clean. `accounting.constants` pulls 22 modules, zero heavy.
`history.events.structures.base` pulls 585 but no Flask, gevent or web3. A test asserts this
in a fresh interpreter, so no enum extraction or build-time generation was needed.

---

## Deliberately not done

- No new or modified backend endpoints, no core schema changes. Task 1 goes through the
  existing REST API.
- No synthesised `swaps` table; no MCP resource registered.
- No `user_notes` unredaction. No loosening of loopback validation or transport security.
- No `premium=False` on new tools — `get_event_taxonomy` is gated like the rest.
- `SAFE_PASSTHROUGH_COLUMN_NAMES` gains only `price_missing`, as the brief instructed.
  **Judgment call to review:** `direction` was *not* added. Neither column needs it, since
  both are added after sanitization, and each addition widens matching for any nested upstream
  field ending in that name — which the brief lists as needing maintainer sign-off. If you
  would rather the two were consistent, say which way.

---

## Live verification

### Prerequisites

- A **Basic tier or above** subscription on the unlocked account. Every tool except `info` is
  premium-gated, so on Free or Supporter they all return a gate message rather than data —
  which looks identical to a broken build. Tier is cached for 60s.
- A backend running with a real unlocked history.
- MCP server (both invocations work; the second is what `--help` prints):
  ```
  python -m rotkehlchen mcp --transport streamable-http --host 127.0.0.1 --port 4445
  python -m rotkehlchen.mcp --transport streamable-http --host 127.0.0.1 --port 4445
  ```

**Two renames matter when comparing against `develop`:** `source.cached_rows` is now
`source.rows_loaded`, and `entries_found` / `entries_total` / `entries_limit` moved under
`source.backend_metadata`. They are not the same keys.

---

### Gate A — grouped events are no longer dropped

The highest-risk change in the branch. Blocking.

Run on `develop` first, then on this branch:

```
refresh_analytics_data()
```

**Expect:** `rows_loaded` on the branch is materially **higher** than `cached_rows` on
`develop` — by roughly the number of on-chain swap legs plus matched deposit/withdrawal
events — and much closer to `backend_metadata.entries_found` than the previously observed
144,544 vs 153,124 gap.

Then confirm the recovered rows are the expected kind:

```sql
select entry_type, count(*) from history_events group by entry_type order by 2 desc
```

**Expect:** `evm swap event` (and `solana swap event` where applicable) present with
non-trivial counts. On `develop` they should be absent or badly undercounted.

**If row counts do not move:** the sub-list flattening is not firing and the serializer has
been misread. That is a code bug, not a doc issue.

### Gate B — price coverage is good enough to ship

Blocking.

```
refresh_analytics_data(from_timestamp=<jan 1>, to_timestamp=<dec 31>, include_values=true)
```

**Expect:** `source.value_currency` matches the account's main currency, and
`unpriced_rows / rows_loaded` is a small fraction.

**If most events are unpriced,** `include_values` is misleading as built and needs rethinking
rather than shipping — the cache-only design may be too strict. This is the explicit
ship/no-ship gate from the brief.

Record wall-clock time and `lookup_count` against the ~8.4s/1000-pair estimate. Note the pair
count will be higher than previously measured, because Gate A restores events that were being
dropped — re-derive the timings rather than comparing them directly to the brief's table.

---

### 1. The double-count, end to end

The behavioural test the taxonomy work exists for.

Ask a **fresh** agent, with no hints, against the live server:

> what were my staking rewards worth in 2024?

**Expect:** it calls `get_event_taxonomy`, filters on `direction = 'in'` (or otherwise
excludes `informational`), and does not sum the informational MEV rows.

Cross-check by hand:

```sql
select event_type, direction, count(*), sum(value)
from history_events
where event_subtype in ('mev reward', 'block production')
group by event_type, direction
```

**Expect:** every `informational` row is `neutral`; `staking` rows are `in`. The correct 2024
total counts only the `staking` rows.

**If it still double-counts:** the derivation is right but the wording is not. That is an
iteration on `TAXONOMY_RULES` and the `query_sql` description — the brief predicts at least
two such rounds, and no unit test can assert it.

### 2. `direction` is populated

```sql
select direction, count(*) from history_events group by direction
```

**Expect:** `in` / `out` / `neutral` all populated, with few or no NULLs. A NULL means an
event type/subtype that failed to deserialize. A large NULL count means the derivation is
missing real cases — report back with examples.

### 3. Grouped aggregation

```
refresh_analytics_data(aggregate_by_group_ids=true)
```

**Expect:** roughly 88,350 entries against 153,124 un-aggregated, with `grouped_events_num`
present and queryable:

```sql
select grouped_events_num, count(*) from history_events group by 1 order by 1 desc limit 10
```

Confirm the rows are representatives, not merged legs — a trade should show only its spend
side. The parameter description says so; check it is true.

### 4. `describe_table` quality and latency

```
describe_table('history_events')
```

**Expect:**

- every column has a `sqlite_type`;
- `event_type`, `location`, `entry_type`, `counterparty` carry `distinct_count` and
  `top_values` with real values;
- empty `extra_data_*` columns are marked `all_null`;
- hashed columns show `hashed_reason` of `pii` or `unrecognized`;
- **no `anon_` value anywhere in the output** — grep for it;
- it returns without noticeable delay on a full-size frame. The distinct-value scan is new
  cost; if it is slow that is a real regression.

### 5. `auto_notes` privacy eyeball

**The one item that genuinely needs human eyes.** In `balanced`:

```sql
select auto_notes from history_events where has_auto_notes = 1 limit 50
```

**Expect:** readable descriptions ("Deposit 5 ETH to kraken") with any embedded identifier
replaced by an `anon_…` hash. Scan for anything identifier-shaped the regex missed.

Then restart with `--privacy-mode strict` and confirm `auto_notes` is `[redacted]` and strict
output is otherwise unchanged from `develop`. Confirm `user_notes` is `[redacted]` in **both**
modes.

### 6. SQL validation false positives

These must now succeed:

```sql
select replace(counterparty, '-', ' ') from history_events limit 1
select * from history_events where auto_notes like '%update%' limit 1
```

These must still be rejected:

```sql
insert into history_events values (1)
drop table history_events
select 1; insert into history_events values (1)
```

### 7. Completeness reporting reconciles

After a plain refresh, `source.completeness` should be `complete`, and `rows_loaded` should no
longer look arbitrarily short against `backend_metadata.entries_found`.

Force the other two states:

- start with `--max-events` below the history size → `truncated_by_max_events`;
- a range yielding empty middle pages should still load everything after them. Previously the
  load stopped at the first empty page while reporting nothing was truncated.

### 8. Recipes against real data

Run all five `recipes` returned by `get_event_taxonomy` verbatim.

**Expect:** each executes without error **and returns plausible rows** — not an empty result
set, which would pass a smoke test while being useless. Sanity-check the gas total and the
swap round-trip pairing against transactions you recognise.

---

## Cosmetic, not blocking

`mcp/__main__.py` sets `prog='python -m rotkehlchen.mcp'` while the observed invocation is
`python -m rotkehlchen mcp`. Both work — the subcommand is dispatched in
`rotkehlchen/__main__.py:5` — so this only affects the `--help` banner. The brief flagged it
as a possible staleness; it is not.
