### PR TITLE
Split find-match sheet by layout

### DIFF
--- a/frontend/app/src/modules/history/events/PotentialMatchSubjectTable.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchSubjectTable.vue
@@ -2,7 +2,6 @@
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
-import PotentialMatchSubjectCard from '@/modules/history/events/PotentialMatchSubjectCard.vue';
 import ShowInEventsButton from '@/modules/history/events/ShowInEventsButton.vue';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
@@ -12,7 +11,6 @@ defineProps<{
   entry: HistoryEventEntry;
   typeLabel: string;
   locationHeader: string;
-  isPinned?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -23,22 +21,13 @@ const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <PotentialMatchSubjectCard
-    v-if="isPinned"
-    :entry="entry"
-    :type-label="typeLabel"
-    @show-in-events="emit('show-in-events')"
-  />
-
-  <SimpleTable v-else>
+  <!-- the row being matched, as a summary table; `PotentialMatchSubjectCard` is the pinned-width half -->
+  <SimpleTable data-testid="potential-match-subject">
     <thead>
       <tr>
         <th>{{ t('common.datetime') }}</th>
         <th>{{ t('common.type') }}</th>
-        <th
-          v-if="!isPinned"
-          class="!text-center"
-        >
+        <th class="!text-center">
           {{ locationHeader }}
         </th>
         <th>{{ t('common.asset') }}</th>
@@ -46,7 +35,7 @@ const { t } = useI18n({ useScope: 'global' });
       </tr>
     </thead>
     <tbody>
-      <tr :class="{ 'bg-rui-warning/15': isPinned }">
+      <tr>
         <td>
           <DateDisplay
             :timestamp="entry.timestamp"
@@ -54,21 +43,11 @@ const { t } = useI18n({ useScope: 'global' });
           />
         </td>
         <td>
-          <BadgeDisplay :class="{ '!leading-6 mb-1': isPinned }">
+          <BadgeDisplay>
             {{ typeLabel }}
           </BadgeDisplay>
-          <LocationDisplay
-            v-if="isPinned"
-            class="[&_div]:!justify-start"
-            size="16px"
-            :identifier="entry.location"
-            horizontal
-          />
         </td>
-        <td
-          v-if="!isPinned"
-          class="text-center"
-        >
+        <td class="text-center">
           <LocationDisplay
             horizontal
             :identifier="entry.location"
@@ -76,7 +55,6 @@ const { t } = useI18n({ useScope: 'global' });
         </td>
         <td>
           <HistoryEventAsset
-            :dense="isPinned"
             disable-options
             :event="entry"
           />

--- a/frontend/app/src/modules/history/events/PotentialMatchesList.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesList.vue
@@ -1,21 +1,13 @@
 <script setup lang="ts">
-import type { DataTableColumn } from '@rotki/ui-library';
 import type { PotentialMatchRow, UnmatchedEventGroup } from '@/modules/history/events/matching/types';
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
-import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
-import HistoryEventAccount from '@/modules/history/events/HistoryEventAccount.vue';
-import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
-import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
 import PotentialMatchesCards from '@/modules/history/events/PotentialMatchesCards.vue';
 import PotentialMatchesEmpty from '@/modules/history/events/PotentialMatchesEmpty.vue';
-import PotentialMatchSubject from '@/modules/history/events/PotentialMatchSubject.vue';
-import RecommendedMatchIcon from '@/modules/history/events/RecommendedMatchIcon.vue';
-import ShowInEventsButton from '@/modules/history/events/ShowInEventsButton.vue';
+import PotentialMatchesTable from '@/modules/history/events/PotentialMatchesTable.vue';
+import PotentialMatchSubjectCard from '@/modules/history/events/PotentialMatchSubjectCard.vue';
+import PotentialMatchSubjectTable from '@/modules/history/events/PotentialMatchSubjectTable.vue';
 import { getAssetMovementsType } from '@/modules/history/management/forms/utils';
-import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
-import LocationIcon from '@/modules/shell/components/display/LocationIcon.vue';
-import HashLink from '@/modules/shell/components/HashLink.vue';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 
 const selectedMatchIds = defineModel<number[]>('selectedMatchIds', { required: true });
@@ -51,38 +43,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const { getHistoryEventSubTypeName, getHistoryEventTypeName } = useHistoryEventMappings();
-
-const [DefineRowActions, ReuseRowActions] = createReusableTemplate<{ row: PotentialMatchRow }>();
-
-// dialog-only: the pinned panel renders `PotentialMatchesCards` instead
-const columns = computed<DataTableColumn<PotentialMatchRow>[]>(() => [
-  { key: 'timestamp', label: t('common.datetime') },
-  { class: 'min-w-32', key: 'eventTypeAndSubtype', label: t('asset_movement_matching.dialog.event_column') },
-  { class: 'min-w-32', key: 'txRef', label: t('asset_movement_matching.dialog.transaction_column') },
-  { key: 'asset', label: t('common.asset') },
-  { key: 'actions', label: '' },
-]);
-
-function isSelected(row: PotentialMatchRow): boolean {
-  return get(selectedMatchIds).includes(row.entry.identifier);
-}
-
-function toggleSelection(row: PotentialMatchRow): void {
-  const ids = get(selectedMatchIds);
-  const identifier = row.entry.identifier;
-  if (ids.includes(identifier)) {
-    set(selectedMatchIds, ids.filter(id => id !== identifier));
-  }
-  else {
-    set(selectedMatchIds, [...ids, identifier]);
-  }
-}
-
-function getRowClass(row: PotentialMatchRow): string {
-  return row.entry.identifier === highlightedIdentifier ? '!bg-rui-success/15' : '';
-}
 
 const movementEntry = computed<HistoryEventEntry>(() => {
   const { entry, ...meta } = getEventEntryFromCollection(movement.events);
@@ -130,46 +90,24 @@ watchDebounced(onlyExpectedAssets, () => {
 </script>
 
 <template>
-  <DefineRowActions #default="{ row }">
-    <div class="flex items-center justify-end gap-2">
-      <RecommendedMatchIcon v-if="row.isCloseMatch" />
-      <ShowInEventsButton
-        @click="emit('show-in-events', { identifier: row.entry.identifier, groupIdentifier: row.entry.groupIdentifier })"
-      />
-      <RuiButton
-        size="sm"
-        :color="isSelected(row) ? 'success' : 'primary'"
-        :variant="isSelected(row) ? 'default' : 'outlined'"
-        class="min-w-24"
-        @click="toggleSelection(row)"
-      >
-        <template
-          v-if="isSelected(row)"
-          #prepend
-        >
-          <RuiIcon
-            name="lu-check"
-            size="12"
-          />
-        </template>
-        {{ isSelected(row)
-          ? t('asset_movement_matching.dialog.selected')
-          : t('asset_movement_matching.dialog.select')
-        }}
-      </RuiButton>
-    </div>
-  </DefineRowActions>
-
   <div class="flex flex-col gap-4">
     <div>
       <p class="text-body-2 font-medium mb-2">
         {{ entryLabels?.matchingFor ?? t('asset_movement_matching.dialog.matching_for') }}
       </p>
-      <PotentialMatchSubject
+      <!-- kept as two components rather than one that branches: the card has no column headers,
+           so it takes no `locationHeader` -->
+      <PotentialMatchSubjectCard
+        v-if="isPinned"
+        :entry="movementEntry"
+        :type-label="usedTypeLabel"
+        @show-in-events="emit('show-unmatched-in-events')"
+      />
+      <PotentialMatchSubjectTable
+        v-else
         :entry="movementEntry"
         :type-label="usedTypeLabel"
         :location-header="usedLocationHeader"
-        :is-pinned="isPinned"
         @show-in-events="emit('show-unmatched-in-events')"
       />
     </div>
@@ -269,8 +207,9 @@ watchDebounced(onlyExpectedAssets, () => {
         @widen="widenSearch()"
       />
 
-      <PotentialMatchesCards
-        v-if="isPinned && (matches.length > 0 || loading)"
+      <Component
+        :is="isPinned ? PotentialMatchesCards : PotentialMatchesTable"
+        v-if="matches.length > 0 || loading"
         v-model:selected-ids="selectedMatchIds"
         :matches="matches"
         :highlighted-identifier="highlightedIdentifier"
@@ -279,71 +218,6 @@ watchDebounced(onlyExpectedAssets, () => {
         :empty-label="t('asset_movement_matching.dialog.no_matches_found')"
         @show-in-events="emit('show-in-events', $event)"
       />
-
-      <ScrollableDialogContent
-        v-else-if="!isPinned && (matches.length > 0 || loading)"
-        :max-height="tableMaxHeight"
-      >
-        <RuiDataTable
-          :cols="columns"
-          :rows="matches"
-          row-attr="identifier"
-          :item-class="getRowClass"
-          dense
-          outlined
-          hide-default-header
-          :empty="{ label: t('asset_movement_matching.dialog.no_matches_found') }"
-          :loading="loading"
-        >
-          <template #item.timestamp="{ row }">
-            <DateDisplay
-              :timestamp="row.entry.timestamp"
-              milliseconds
-            />
-          </template>
-          <template #item.eventTypeAndSubtype="{ row }">
-            <div>{{ getHistoryEventTypeName(row.entry.eventType) }} -</div>
-            <div>{{ getHistoryEventSubTypeName(row.entry.eventSubtype) }}</div>
-          </template>
-          <template #item.txRef="{ row }">
-            <div
-              v-if="'txRef' in row.entry && row.entry.txRef"
-              class="flex items-center gap-1"
-            >
-              <LocationIcon
-                horizontal
-                icon
-                size="1.25rem"
-                :item="row.entry.location"
-              />
-              <HashLink
-                :text="row.entry.txRef"
-                type="transaction"
-                :location="row.entry.location"
-              />
-            </div>
-            <div>
-              <span v-if="!row.entry.locationLabel">-</span>
-              <HistoryEventAccount
-                v-else
-                :location="row.entry.location"
-                :location-label="row.entry.locationLabel"
-              />
-            </div>
-          </template>
-          <template #item.asset="{ row }">
-            <div class="flex items-center gap-2">
-              <HistoryEventAsset
-                disable-options
-                :event="row.entry"
-              />
-            </div>
-          </template>
-          <template #item.actions="{ row }">
-            <ReuseRowActions :row="row" />
-          </template>
-        </RuiDataTable>
-      </ScrollableDialogContent>
     </div>
   </div>
 </template>

--- a/frontend/app/src/modules/history/events/PotentialMatchesTable.spec.ts
+++ b/frontend/app/src/modules/history/events/PotentialMatchesTable.spec.ts
@@ -1,0 +1,115 @@
+import type { PotentialMatchRow } from '@/modules/history/events/matching/types';
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import { createMock } from '@test/utils/create-mock';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PotentialMatchesCards from '@/modules/history/events/PotentialMatchesCards.vue';
+import PotentialMatchesTable from '@/modules/history/events/PotentialMatchesTable.vue';
+
+vi.mock('@/modules/history/events/mapping/use-history-event-mappings', () => ({
+  useHistoryEventMappings: (): Record<string, (value: string) => string> => ({
+    getHistoryEventSubTypeName: (value: string): string => value,
+    getHistoryEventTypeName: (value: string): string => value,
+  }),
+}));
+
+/** The children below only display an entry; stubbing them keeps the spec on selection and wiring. */
+const stubs = {
+  DateDisplay: true,
+  HashLink: true,
+  HistoryEventAccount: true,
+  HistoryEventAsset: true,
+  LocationIcon: true,
+};
+
+function createRow(identifier: number, isCloseMatch = false): PotentialMatchRow {
+  return {
+    entry: createMock<HistoryEventEntry>({
+      eventSubtype: 'receive',
+      eventType: 'receive',
+      groupIdentifier: `group-${identifier}`,
+      identifier,
+      location: 'kraken',
+      timestamp: 1700000000000,
+    }),
+    identifier,
+    isCloseMatch,
+  };
+}
+
+const selected = ref<number[]>([]);
+
+type Layout = typeof PotentialMatchesCards | typeof PotentialMatchesTable;
+
+function mountLayout(layout: Layout, matches: PotentialMatchRow[]): VueWrapper {
+  return mount(layout, {
+    global: { provide: libraryDefaults, stubs },
+    props: {
+      'emptyLabel': 'Nothing found',
+      matches,
+      'maxHeight': '20rem',
+      'onUpdate:selectedIds': (value: number[]): void => set(selected, value),
+      'selectedIds': get(selected),
+    },
+  });
+}
+
+describe('modules/history/events/PotentialMatchesTable', () => {
+  beforeEach(() => {
+    set(selected, []);
+  });
+
+  it('should render a row per match', () => {
+    const wrapper = mountLayout(PotentialMatchesTable, [createRow(1), createRow(2)]);
+
+    expect(wrapper.findAll('[data-testid^=potential-match-select-]')).toHaveLength(2);
+  });
+
+  it('should show the empty label when a search returns nothing', () => {
+    const wrapper = mountLayout(PotentialMatchesTable, []);
+
+    expect(wrapper.text()).toContain('Nothing found');
+  });
+
+  it('should flag a close match as recommended', () => {
+    const wrapper = mountLayout(PotentialMatchesTable, [createRow(1, true), createRow(2)]);
+
+    expect(wrapper.findAllComponents({ name: 'RecommendedMatchIcon' })).toHaveLength(1);
+  });
+
+  /**
+   * The table and the cards are the two halves of one fork, picked by `isPinned` in the host.
+   * Anything a caller relies on has to behave the same in both, so both are driven here rather
+   * than only the layout whoever wrote the change happened to have open.
+   */
+  describe('parity with the card layout', () => {
+    const layouts: [string, Layout][] = [
+      ['cards', PotentialMatchesCards],
+      ['table', PotentialMatchesTable],
+    ];
+
+    it.each(layouts)('should select and deselect a match in the %s layout', async (_name, layout) => {
+      const wrapper = mountLayout(layout, [createRow(1), createRow(2)]);
+
+      await wrapper.find('[data-testid=potential-match-select-2]').trigger('click');
+
+      expect(get(selected)).toEqual([2]);
+
+      await wrapper.setProps({ selectedIds: get(selected) });
+      await wrapper.find('[data-testid=potential-match-select-2]').trigger('click');
+
+      expect(get(selected)).toEqual([]);
+    });
+
+    it.each(layouts)('should ask for the event in history from the %s layout', async (_name, layout) => {
+      const wrapper = mountLayout(layout, [createRow(7)]);
+
+      // the button's own element, not the component root: that root is the tooltip wrapping it,
+      // and a click there never reaches the handler below it
+      await wrapper.findComponent({ name: 'ShowInEventsButton' }).find('button').trigger('click');
+
+      expect(wrapper.emitted('show-in-events')).toEqual([[{ groupIdentifier: 'group-7', identifier: 7 }]]);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/PotentialMatchesTable.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesTable.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import type { DataTableColumn } from '@rotki/ui-library';
+import type { PotentialMatchRow } from '@/modules/history/events/matching/types';
+import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
+import HistoryEventAccount from '@/modules/history/events/HistoryEventAccount.vue';
+import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
+import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
+import RecommendedMatchIcon from '@/modules/history/events/RecommendedMatchIcon.vue';
+import ShowInEventsButton from '@/modules/history/events/ShowInEventsButton.vue';
+import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
+import LocationIcon from '@/modules/shell/components/display/LocationIcon.vue';
+import HashLink from '@/modules/shell/components/HashLink.vue';
+
+const selectedIds = defineModel<number[]>('selectedIds', { required: true });
+
+const { matches, highlightedIdentifier, loading, maxHeight } = defineProps<{
+  matches: PotentialMatchRow[];
+  highlightedIdentifier?: number;
+  loading?: boolean;
+  maxHeight: string;
+  emptyLabel: string;
+}>();
+
+const emit = defineEmits<{
+  'show-in-events': [data: { identifier: number; groupIdentifier: string }];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const { getHistoryEventSubTypeName, getHistoryEventTypeName } = useHistoryEventMappings();
+
+const columns = computed<DataTableColumn<PotentialMatchRow>[]>(() => [
+  { key: 'timestamp', label: t('common.datetime') },
+  { class: 'min-w-32', key: 'eventTypeAndSubtype', label: t('asset_movement_matching.dialog.event_column') },
+  { class: 'min-w-32', key: 'txRef', label: t('asset_movement_matching.dialog.transaction_column') },
+  { key: 'asset', label: t('common.asset') },
+  { key: 'actions', label: '' },
+]);
+
+function isSelected(row: PotentialMatchRow): boolean {
+  return get(selectedIds).includes(row.entry.identifier);
+}
+
+function toggle(row: PotentialMatchRow): void {
+  const identifier = row.entry.identifier;
+  const ids = get(selectedIds);
+  set(selectedIds, ids.includes(identifier) ? ids.filter(id => id !== identifier) : [...ids, identifier]);
+}
+
+function getRowClass(row: PotentialMatchRow): string {
+  return row.entry.identifier === highlightedIdentifier ? '!bg-rui-success/15' : '';
+}
+</script>
+
+<template>
+  <ScrollableDialogContent :max-height="maxHeight">
+    <RuiDataTable
+      :cols="columns"
+      :rows="matches"
+      row-attr="identifier"
+      :item-class="getRowClass"
+      dense
+      outlined
+      hide-default-header
+      :empty="{ label: emptyLabel }"
+      :loading="loading"
+    >
+      <template #item.timestamp="{ row }">
+        <DateDisplay
+          :timestamp="row.entry.timestamp"
+          milliseconds
+        />
+      </template>
+      <template #item.eventTypeAndSubtype="{ row }">
+        <div>{{ getHistoryEventTypeName(row.entry.eventType) }} -</div>
+        <div>{{ getHistoryEventSubTypeName(row.entry.eventSubtype) }}</div>
+      </template>
+      <template #item.txRef="{ row }">
+        <div
+          v-if="'txRef' in row.entry && row.entry.txRef"
+          class="flex items-center gap-1"
+        >
+          <LocationIcon
+            horizontal
+            icon
+            size="1.25rem"
+            :item="row.entry.location"
+          />
+          <HashLink
+            :text="row.entry.txRef"
+            type="transaction"
+            :location="row.entry.location"
+          />
+        </div>
+        <div>
+          <span v-if="!row.entry.locationLabel">-</span>
+          <HistoryEventAccount
+            v-else
+            :location="row.entry.location"
+            :location-label="row.entry.locationLabel"
+          />
+        </div>
+      </template>
+      <template #item.asset="{ row }">
+        <div class="flex items-center gap-2">
+          <HistoryEventAsset
+            disable-options
+            :event="row.entry"
+          />
+        </div>
+      </template>
+      <template #item.actions="{ row }">
+        <div class="flex items-center justify-end gap-2">
+          <RecommendedMatchIcon v-if="row.isCloseMatch" />
+          <ShowInEventsButton
+            @click="emit('show-in-events', { groupIdentifier: row.entry.groupIdentifier, identifier: row.entry.identifier })"
+          />
+          <RuiButton
+            size="sm"
+            :color="isSelected(row) ? 'success' : 'primary'"
+            :variant="isSelected(row) ? 'default' : 'outlined'"
+            class="min-w-24"
+            :data-testid="`potential-match-select-${row.entry.identifier}`"
+            @click="toggle(row)"
+          >
+            <template
+              v-if="isSelected(row)"
+              #prepend
+            >
+              <RuiIcon
+                name="lu-check"
+                size="12"
+              />
+            </template>
+            {{ isSelected(row)
+              ? t('asset_movement_matching.dialog.selected')
+              : t('asset_movement_matching.dialog.select')
+            }}
+          </RuiButton>
+        </div>
+      </template>
+    </RuiDataTable>
+  </ScrollableDialogContent>
+</template>


### PR DESCRIPTION
Follow-up to #12701, which gave the unmatched lists a per-layout presentation with `isPinned` owned by the host. The find-match sheet only got half of that treatment.

## What changed

- **`PotentialMatchesTable` extracted** from the inline `v-if="isPinned"` fork in `PotentialMatchesList`. It takes the same props and emits as its existing sibling `PotentialMatchesCards`, so the host picks one instead of holding both. The `createReusableTemplate` row-actions indirection went with it: it had exactly one consumer.
- **`PotentialMatchSubject` removed**, replaced by `PotentialMatchSubjectTable`. It was a presentation that branched on `isPinned`, and every read inside its `v-else` arm was dead code (unreachable when the flag was set), so the branches simply drop out. It now pairs with the existing `PotentialMatchSubjectCard` the same way the results components do.

The two subject halves stay a `v-if`/`v-else` rather than a dynamic component: the card renders no column headers, so it takes no `locationHeader`, and `:is` would leak that prop onto its root as an attribute.

The `isPinned` reads left in `PotentialMatchesList` are the two layout picks plus the search controls' responsive sizing (field widths, short vs long labels, button size), which legitimately belongs to a layout.

## Tests

New `PotentialMatchesTable.spec.ts` with a parity block that drives **both** result layouts through selection and the history link, so one cannot quietly lose an action the other has.

## Verified

Both layouts checked in-app against real data: the dialog table (columns, selection, confirm enablement) and the pinned cards (subject card, compact search controls, selection), plus the widen-search ceiling still disappearing at 168h/100%.