### PR TITLE
fix: bitcoin change output cost basis and balances

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Bitcoin transactions that send to an external address and return the remainder to one of your own addresses (a change output) are now decoded correctly. 
 * :feature:`-` You can now silence notification popups from the notification area, so rotki stops interrupting you while you work. Nothing is lost: every notification still arrives in the notification area with its actions. The setting stays as you left it the next time you log in.
 * :bug:`-` The "No indexers available" and missing API key warnings no longer pop up at every login. Each one now goes quiet for a day, then two days, then a week, and finally stops interrupting you. It stays in the notification sidebar with its action so you can still deal with it, and starts over if you change that chain's indexer order or that service's key. Chains and services are also tracked separately now, so one no longer replaces or silences another.
 * :feature:`-` The "Actions needed" button in history events is now a single actions center. It counts the categories needing attention rather than every item, and lists each as a row with its own count and action, including categories with nothing to do so you can re-check them at any time. The duplicate "Check ..." entries in the overflow menu are gone.

--- a/rotkehlchen/chain/bitcoin/manager.py
+++ b/rotkehlchen/chain/bitcoin/manager.py
@@ -21,13 +21,14 @@ from rotkehlchen.chain.decoding.utils import decode_transfer_direction
 from rotkehlchen.chain.manager import ChainManagerWithTransactions
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.db.utils import get_query_chunks
 from rotkehlchen.errors.misc import RemoteError, UnableToDecryptRemoteData
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import BTCAddress, Location, SupportedBlockchain, Timestamp
+from rotkehlchen.types import BTCAddress, BTCTxId, Location, SupportedBlockchain, Timestamp
 from rotkehlchen.utils.misc import ts_now, ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
     from rotkehlchen.assets.asset import Asset
     from rotkehlchen.db.cache import DBCacheDynamic
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.db.drivers.sqlite import DBCursor
     from rotkehlchen.fval import FVal
 
 logger = logging.getLogger(__name__)
@@ -241,10 +243,15 @@ class BitcoinCommonManager(ChainManagerWithTransactions[BTCAddress]):
             addresses=addresses,
             status=TransactionStatusStep.DECODING_TRANSACTIONS_STARTED,
         )
-        events = []
+        events, decoded_tx_ids = [], set()
         for tx in tx_list:
+            if tx.tx_id in decoded_tx_ids:
+                continue  # the same tx is returned once per queried address it touches
+
+            decoded_tx_ids.add(BTCTxId(tx.tx_id))
             events.extend(self.decode_transaction(tx))
 
+        dbevents = DBHistoryEvents(self.database)
         with self.database.conn.write_ctx() as write_cursor:
             for address in addresses:
                 self.database.set_dynamic_cache(
@@ -254,15 +261,54 @@ class BitcoinCommonManager(ChainManagerWithTransactions[BTCAddress]):
                     address=address,
                 )
 
-            DBHistoryEvents(self.database).add_history_events(
+            # Replace any previously decoded events for these transactions. Sequence indexes
+            # are positional, so when the tracked account set changed since the last decode
+            # (e.g. an xpub was added after a standalone address) the new events collide with
+            # the stale ones under UNIQUE(group_identifier, sequence_index). Inserting without
+            # purging first keeps outdated rows and silently drops the corrected ones.
+            dbevents.delete_events_by_tx_ref(
                 write_cursor=write_cursor,
-                history=events,
+                tx_refs=list(decoded_tx_ids),
+                location=self.location,
+                customized_handling='preserve_transactions',
             )
+            if len(customized := self._get_customized_group_identifiers(
+                cursor=write_cursor,
+                tx_ids=decoded_tx_ids,
+            )) != 0:  # these were kept above, so don't try to write over them
+                events = [x for x in events if x.group_identifier not in customized]
+
+            dbevents.add_history_events(write_cursor=write_cursor, history=events)
 
         self._send_tx_ws_status(
             addresses=addresses,
             status=TransactionStatusStep.DECODING_TRANSACTIONS_FINISHED,
         )
+
+    def _get_customized_group_identifiers(
+            self,
+            cursor: DBCursor,
+            tx_ids: set[BTCTxId],
+    ) -> set[str]:
+        """Get the group identifiers of the given txs that still have events in the DB.
+        Only called right after purging their events, so anything still present was
+        deliberately preserved for containing a customized event.
+
+        Chunked since a full history redecode passes every tx of every queried address.
+        """
+        customized: set[str] = set()
+        for chunk, placeholders in get_query_chunks(
+            data=[f'{self.group_identifier_prefix}{tx_id}' for tx_id in tx_ids],
+        ):
+            customized.update(
+                row[0] for row in cursor.execute(
+                    f'SELECT DISTINCT group_identifier FROM history_events '
+                    f'WHERE group_identifier IN ({placeholders})',
+                    chunk,
+                )
+            )
+
+        return customized
 
     def _process_raw_tx_lists(
             self,
@@ -535,39 +581,91 @@ class BitcoinCommonManager(ChainManagerWithTransactions[BTCAddress]):
             outputs: dict[BTCAddress, FVal],
     ) -> list[HistoryEvent]:
         """Decodes transfers in a transaction with multiple inputs and multiple outputs.
-        Since there's no direct mapping between specific inputs and outputs,
-        we decode events as follows:
-        1. Total amount sent from each input address to all outputs
-        2. Total amount received by each output address from all inputs
+        Since there's no direct mapping between specific inputs and outputs, each address'
+        amount is split across the opposite side proportionally to that side's totals.
+
+        The split is done per tracked/untracked side so that value staying inside the wallet
+        (most commonly a change output) is decoded as a TRANSFER rather than as a
+        SPEND/RECEIVE pair. Emitting the latter would report a disposal and an acquisition
+        that never happened, corrupting cost basis even though the net balance is unaffected.
+        This mirrors what `_decode_single_to_many_transfers` already does via
+        `decode_transfer_direction`.
 
         Note: The logic where this function is called in `decode_transaction` guarantees
-        that the `inputs` and `outputs` dicts both have multiple entries.
+        that the `inputs` and `outputs` dicts both have multiple entries, and that all the
+        amounts in them are non-zero.
+
+        Note: when `tx.multi_io` is set the API may have omitted TxIOs unrelated to the
+        queried addresses, so the totals below can be incomplete. Each address' own amount is
+        still fully allocated, but the tracked/untracked proportions are only as good as the
+        data the API returned.
 
         Returns a list of HistoryEvents.
         """
-        events: list[HistoryEvent] = []
-        for totals_dict, other_side_dict, event_type, notes in (
-            (inputs, outputs, HistoryEventType.SPEND, f'Send {{amount}} {self.asset.identifier} to {{other_addresses}}'),  # noqa: E501
-            (outputs, inputs, HistoryEventType.RECEIVE, f'Receive {{amount}} {self.asset.identifier} from {{other_addresses}}'),  # noqa: E501
-        ):
-            for address, amount in totals_dict.items():
-                if address not in self.tracked_accounts:
-                    continue
+        tracked_inputs, external_inputs = self._split_by_tracked(inputs)
+        tracked_outputs, external_outputs = self._split_by_tracked(outputs)
+        total_input, total_output = sum(inputs.values()), sum(outputs.values())
+        external_output_total = sum(external_outputs.values())
+        external_input_total = sum(external_inputs.values())
 
-                events.append(self.create_event(
+        spend_events: list[HistoryEvent] = []
+        transfer_events: list[HistoryEvent] = []
+        receive_events: list[HistoryEvent] = []
+        for address, amount in tracked_inputs.items():
+            if external_output_total != ZERO:  # the part that actually leaves the wallet
+                spend_events.append(self.create_event(
                     tx=tx,
-                    event_type=event_type,
+                    event_type=HistoryEventType.SPEND,
                     event_subtype=HistoryEventSubType.NONE,
-                    amount=amount,
-                    notes=notes.format(
-                        amount=amount,
-                        other_addresses=', '.join([self.get_display_address(x) for x in other_side_dict]),  # noqa: E501
-                    ),
+                    amount=(spend_amount := amount * external_output_total / total_output),
+                    notes=f'Send {spend_amount} {self.asset.identifier} to {self._display_addresses(external_outputs)}',  # noqa: E501
                     location_label=address,
-                    counterparty_addresses=list(other_side_dict.keys()),
+                    counterparty_addresses=list(external_outputs),
                 ))
 
-        return events
+            # The part staying in the wallet. One event per receiving address so that the
+            # per-address balance buckets get an exact counterparty to credit.
+            for output_address, output_amount in tracked_outputs.items():
+                transfer_events.append(self.create_event(
+                    tx=tx,
+                    event_type=HistoryEventType.TRANSFER,
+                    event_subtype=HistoryEventSubType.NONE,
+                    amount=(transfer_amount := amount * output_amount / total_output),
+                    notes=f'Transfer {transfer_amount} {self.asset.identifier} to {self.get_display_address(output_address)}',  # noqa: E501
+                    location_label=address,
+                    counterparty_addresses=[output_address],
+                ))
+
+        if external_input_total != ZERO:  # the part actually entering the wallet
+            for address, amount in tracked_outputs.items():
+                receive_events.append(self.create_event(
+                    tx=tx,
+                    event_type=HistoryEventType.RECEIVE,
+                    event_subtype=HistoryEventSubType.NONE,
+                    amount=(receive_amount := amount * external_input_total / total_input),
+                    notes=f'Receive {receive_amount} {self.asset.identifier} from {self._display_addresses(external_inputs)}',  # noqa: E501
+                    location_label=address,
+                    counterparty_addresses=list(external_inputs),
+                ))
+
+        return spend_events + transfer_events + receive_events
+
+    def _split_by_tracked(
+            self,
+            totals: dict[BTCAddress, FVal],
+    ) -> tuple[dict[BTCAddress, FVal], dict[BTCAddress, FVal]]:
+        """Split the given address totals into tracked and untracked ones."""
+        tracked, untracked = {}, {}
+        for address, amount in totals.items():
+            if address in self.tracked_accounts:
+                tracked[address] = amount
+            else:
+                untracked[address] = amount
+
+        return tracked, untracked
+
+    def _display_addresses(self, addresses: dict[BTCAddress, FVal]) -> str:
+        return ', '.join([self.get_display_address(x) for x in addresses])
 
     def decode_transaction(self, tx: BitcoinTx) -> list[HistoryEvent]:
         """Decode a BitcoinTx into HistoryEvents.

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -31,6 +31,7 @@ from rotkehlchen.db.constants import (
     HISTORY_BASE_ENTRY_FIELDS,
     HISTORY_BASE_ENTRY_LENGTH,
     HISTORY_MAPPING_KEY_STATE,
+    SQL_VARIABLE_CHUNK_SIZE,
     TX_DECODED,
     HistoryEventLinkType,
     HistoryMappingState,
@@ -105,7 +106,7 @@ NOTES_ADDRESS_MARKER_RE = re.compile(r'\b(?:to|from)\b\s+(.+)$')
 BITCOIN_COUNTERPARTY_ADDRESSES_METADATA_KEY = 'bitcoin_counterparty_addresses'
 
 
-def _get_bitcoin_counterparty_addresses(
+def get_bitcoin_counterparty_addresses(
         location: Location,
         notes: str | None,
 ) -> list[str]:
@@ -357,7 +358,7 @@ class DBHistoryEvents:
         if decoded_addresses is not None:
             addresses = decoded_addresses
         else:
-            addresses = _get_bitcoin_counterparty_addresses(
+            addresses = get_bitcoin_counterparty_addresses(
                 location=location,
                 notes=notes,
             )
@@ -1014,7 +1015,6 @@ class DBHistoryEvents:
             customized_handling: Literal['delete', 'preserve_events', 'preserve_transactions'] = 'preserve_events',  # noqa: E501
     ) -> None:
         """Delete all relevant (by transaction hash) history events.
-        Only use with limited number of transactions!!!
 
         customized_handling controls how customized events affect deletion:
         - 'delete': delete all events including customized ones.
@@ -1023,11 +1023,32 @@ class DBHistoryEvents:
           in that transaction is customized.
         Custom events without an associated blockchain transaction are unaffected.
 
-        If you want to reset all decoded events better use the _reset_decoded_events
-        code in v37 -> v38 upgrade as that is not limited to the number of transactions
-        and won't potentially raise a too many sql variables error
+        The tx refs are chunked, so this is safe for an arbitrary number of transactions,
+        such as the full history redecode that follows a transaction query cache reset.
         """
-        placeholders = ', '.join(['?'] * len(tx_refs))
+        for chunk, placeholders in get_query_chunks(
+            data=tx_refs,
+            # Each chunk binds its own customized exclusions on top of the tx refs,
+            # so only use half the budget for the refs themselves.
+            chunk_size=SQL_VARIABLE_CHUNK_SIZE // 2,
+        ):
+            self._delete_events_by_tx_ref_chunk(
+                write_cursor=write_cursor,
+                tx_refs=chunk,
+                placeholders=placeholders,
+                location=location,
+                customized_handling=customized_handling,
+            )
+
+    def _delete_events_by_tx_ref_chunk(
+            self,
+            write_cursor: DBCursor,
+            tx_refs: Sequence[EVMTxHash | BTCTxId | Signature],
+            placeholders: str,
+            location: BLOCKCHAIN_LOCATIONS_TYPE,
+            customized_handling: Literal['delete', 'preserve_events', 'preserve_transactions'],
+    ) -> None:
+        """Delete the events of a single chunk of tx refs. See delete_events_by_tx_ref."""
         bindings: list[str | bytes]
         if location.is_bitcoin():
             where_str = f'WHERE group_identifier IN ({placeholders})'

--- a/rotkehlchen/db/upgrades/v52_v53.py
+++ b/rotkehlchen/db/upgrades/v52_v53.py
@@ -256,6 +256,30 @@ DROP TABLE ens_mappings_old;
             "WHERE M.name='state' AND M.value=3 AND H.type='exchange adjustment'",
         )
 
+    @progress_step(description='Reset bitcoin transaction query range.')
+    def _reset_bitcoin_query_range(write_cursor: DBCursor) -> None:
+        """Bitcoin transactions with a change output were decoded as a spend of the entire
+        input plus a receive of the change, inventing a disposal and an acquisition that
+        never happened and corrupting cost basis. Transfers between owned addresses were
+        also never credited to the receiving address in historical balances.
+
+        Unlike EVM and Solana, raw bitcoin transactions are not stored locally, so they
+        cannot be redecoded offline here. Instead reset the per-address last queried block,
+        so the next transaction query refetches the full history from the explorers and
+        decodes it with the corrected logic.
+
+        The existing events are deliberately left in place rather than deleted here. The
+        query purges each transaction's events right before writing the new ones, so they
+        are replaced one transaction at a time and the user keeps a visible history in the
+        meantime. That purge is keyed on the group identifier, so it also clears the mixed
+        stale/new event sets left by the sequence index collisions this same release fixes.
+        """
+        write_cursor.execute(
+            "DELETE FROM key_value_cache WHERE "
+            "name LIKE 'last\\_btc\\_tx\\_block\\_%' ESCAPE '\\' OR "
+            "name LIKE 'last\\_bch\\_tx\\_block\\_%' ESCAPE '\\'",
+        )
+
     @progress_step(description='Remove obsolete airdrop parquet files.')
     def _remove_airdrop_parquet_files(write_cursor: DBCursor) -> None:
         """Remove parquet airdrop files left behind now that airdrops use compressed CSV files."""

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -10,7 +10,7 @@ from rotkehlchen.constants.assets import A_ETH, A_ETH2
 from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
-from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.db.history_events import DBHistoryEvents, get_bitcoin_counterparty_addresses
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.exchanges.constants import ALL_SUPPORTED_EXCHANGES
 from rotkehlchen.fval import FVal
@@ -145,6 +145,18 @@ class Bucket(NamedTuple):
         event_key = (event.event_type, event.event_subtype)
         counterparty = getattr(event, 'counterparty', None)
         address = getattr(event, 'address', None)
+        if (  # Bitcoin/BCH events are plain HistoryEvents with no address column, so recover the
+            # counterparty from the notes. Without it a transfer between two owned addresses
+            # would only debit the sender bucket and never credit the receiver.
+            address is None and
+            event_key in DUAL_BUCKET_TRANSFER_EVENTS and
+            event.location in (Location.BITCOIN, Location.BITCOIN_CASH) and
+            len(addresses := get_bitcoin_counterparty_addresses(
+                location=event.location,
+                notes=event.notes,
+            )) == 1
+        ):
+            address = addresses[0]
 
         if (
             event_key in COWSWAP_ORDER_EVENTS_TO_IGNORE and

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -4189,6 +4189,62 @@ def test_upgrade_db_52_to_53(
             ),
         )
 
+        # bitcoin events, which the upgrade leaves in place. They are replaced per
+        # transaction by the next transaction query, not deleted here.
+        for group_identifier, sequence_index, location in (
+            ('btc_resetme', 0, Location.BITCOIN.serialize_for_db()),
+            ('btc_resetme', 1, Location.BITCOIN.serialize_for_db()),
+            ('bch_resetme', 0, Location.BITCOIN_CASH.serialize_for_db()),
+            ('btc_customized', 0, Location.BITCOIN.serialize_for_db()),
+            ('manual_btc_event', 0, Location.BITCOIN.serialize_for_db()),
+        ):
+            write_cursor.execute(
+                'INSERT INTO history_events('
+                'entry_type, group_identifier, sequence_index, timestamp, location, '
+                'location_label, asset, amount, notes, type, subtype'
+                ') VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                (
+                    HistoryBaseEntryType.HISTORY_EVENT.serialize_for_db(),
+                    group_identifier,
+                    sequence_index,
+                    1730000000000,
+                    location,
+                    'bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0',
+                    'BTC',
+                    '1',
+                    'Send 1 BTC',
+                    HistoryEventType.SPEND.serialize(),
+                    HistoryEventSubType.NONE.serialize(),
+                ),
+            )
+            if group_identifier == 'btc_customized':
+                write_cursor.execute(
+                    'INSERT INTO history_events_mappings(parent_identifier, name, value) '
+                    'VALUES(?, ?, ?)',
+                    (write_cursor.lastrowid, 'state', 1),
+                )
+            elif group_identifier == 'btc_resetme' and sequence_index == 0:
+                btc_reset_identifier = write_cursor.lastrowid
+                write_cursor.execute(
+                    'INSERT INTO bitcoin_events_addresses(event_identifier, address) '
+                    'VALUES(?, ?)',
+                    (btc_reset_identifier, 'bc1qm4lpczdpkcs6j4twpzd2lgguy0sd8zzsm6puhl'),
+                )
+
+        assert write_cursor.execute(
+            'SELECT COUNT(*) FROM bitcoin_events_addresses WHERE event_identifier=?',
+            (btc_reset_identifier,),
+        ).fetchone()[0] == 1
+
+        write_cursor.executemany(
+            'INSERT OR REPLACE INTO key_value_cache(name, value) VALUES(?, ?)',
+            [
+                ('last_btc_tx_block_bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0', '700000'),
+                ('last_bch_tx_block_qzm47qz5ue99y9yl4aca7jnz7dwgdenl85jkfx3znl', '800000'),
+                ('last_query_ts_kraken_trades', '1730000000'),
+            ],
+        )
+
         # evm_internal_transactions has no source column yet at v52
         assert 'source' not in {
             row[1] for row in write_cursor.execute(
@@ -4383,6 +4439,34 @@ def test_upgrade_db_52_to_53(
             'SELECT COUNT(*) FROM history_events WHERE group_identifier=?',
             ('EVENT_METRICS_TEST_1',),
         ).fetchone()[0] == 1
+
+        # the bitcoin events survive the upgrade so the user keeps a visible history. They
+        # are purged and rewritten per transaction by the next transaction query.
+        assert cursor.execute(
+            'SELECT group_identifier FROM history_events '
+            "WHERE location IN ('q', 'r') ORDER BY group_identifier, sequence_index",
+        ).fetchall() == [
+            ('bch_resetme',),
+            ('btc_customized',),
+            ('btc_resetme',),
+            ('btc_resetme',),
+            ('manual_btc_event',),
+        ]
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM bitcoin_events_addresses WHERE event_identifier=?',
+            (btc_reset_identifier,),
+        ).fetchone()[0] == 1
+
+        # the last queried block was reset for bitcoin only, so the next query refetches
+        # the full history, while unrelated cache entries were left alone
+        assert cursor.execute(
+            'SELECT name FROM key_value_cache WHERE name IN (?, ?, ?)',
+            (
+                'last_btc_tx_block_bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0',
+                'last_bch_tx_block_qzm47qz5ue99y9yl4aca7jnz7dwgdenl85jkfx3znl',
+                'last_query_ts_kraken_trades',
+            ),
+        ).fetchall() == [('last_query_ts_kraken_trades',)]
 
         # the matched exchange adjustment gained the synthetic state (5); the
         # user-customized one was left alone

--- a/rotkehlchen/tests/db/test_db_upgrades.py
+++ b/rotkehlchen/tests/db/test_db_upgrades.py
@@ -4240,7 +4240,7 @@ def test_upgrade_db_52_to_53(
             'INSERT OR REPLACE INTO key_value_cache(name, value) VALUES(?, ?)',
             [
                 ('last_btc_tx_block_bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0', '700000'),
-                ('last_bch_tx_block_qzm47qz5ue99y9yl4aca7jnz7dwgdenl85jkfx3znl', '800000'),
+                ('last_bch_tx_block_qrfec2pytp47p5drvfsdexqd0ue4r3hrhv9tq7vj5z', '800000'),
                 ('last_query_ts_kraken_trades', '1730000000'),
             ],
         )
@@ -4463,7 +4463,7 @@ def test_upgrade_db_52_to_53(
             'SELECT name FROM key_value_cache WHERE name IN (?, ?, ?)',
             (
                 'last_btc_tx_block_bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0',
-                'last_bch_tx_block_qzm47qz5ue99y9yl4aca7jnz7dwgdenl85jkfx3znl',
+                'last_bch_tx_block_qrfec2pytp47p5drvfsdexqd0ue4r3hrhv9tq7vj5z',
                 'last_query_ts_kraken_trades',
             ),
         ).fetchall() == [('last_query_ts_kraken_trades',)]

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from rotkehlchen.api.v1.types import IncludeExcludeFilterData
+from rotkehlchen.chain.bitcoin.btc.constants import BTC_GROUP_IDENTIFIER_PREFIX
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.oneinch.constants import CPT_ONEINCH_V6
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -47,6 +48,7 @@ from rotkehlchen.tests.utils.factories import (
     make_evm_tx_hash,
 )
 from rotkehlchen.types import (
+    BTCTxId,
     ChainID,
     EvmTransaction,
     EVMTxHash,
@@ -1908,3 +1910,52 @@ def test_delete_events_and_track_removes_backups(database: DBHandler) -> None:
             'SELECT COUNT(*) FROM history_events WHERE identifier=?',
             (identifiers[1],),
         ).fetchone()[0] == 1
+
+
+def test_delete_events_by_tx_ref_chunks_bindings(database: DBHandler) -> None:
+    """Test that deleting by tx ref chunks its bindings instead of binding one variable
+    per transaction. A full history redecode, such as the one following a bitcoin
+    transaction query cache reset, passes every transaction of every queried address at
+    once and would otherwise risk exhausting the SQL variable limit.
+    """
+    db_events = DBHistoryEvents(database)
+    tx_ids = [BTCTxId(f'{idx:064x}') for idx in range(1, 10)]
+    with database.user_write() as write_cursor:
+        db_events.add_history_events(
+            write_cursor=write_cursor,
+            history=[HistoryEvent(
+                group_identifier=f'{BTC_GROUP_IDENTIFIER_PREFIX}{tx_id}',
+                sequence_index=0,
+                timestamp=TimestampMS(1631333672000),
+                location=Location.BITCOIN,
+                event_type=HistoryEventType.SPEND,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_BTC,
+                amount=ONE,
+                location_label='bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0',
+            ) for tx_id in tx_ids],
+        )
+        # customize one of them so the per chunk exclusion lookup is exercised too
+        write_cursor.execute(
+            'INSERT INTO history_events_mappings(parent_identifier, name, value) '
+            'SELECT identifier, ?, ? FROM history_events WHERE group_identifier=?',
+            (
+                HISTORY_MAPPING_KEY_STATE,
+                HistoryMappingState.CUSTOMIZED.serialize_for_db(),
+                f'{BTC_GROUP_IDENTIFIER_PREFIX}{tx_ids[4]}',
+            ),
+        )
+
+        # chunk size of 2 makes the 9 transactions span five chunks
+        with patch('rotkehlchen.db.history_events.SQL_VARIABLE_CHUNK_SIZE', 4):
+            db_events.delete_events_by_tx_ref(
+                write_cursor=write_cursor,
+                tx_refs=tx_ids,
+                location=Location.BITCOIN,
+                customized_handling='preserve_transactions',
+            )
+
+        assert write_cursor.execute(
+            'SELECT group_identifier FROM history_events WHERE location=?',
+            (Location.BITCOIN.serialize_for_db(),),
+        ).fetchall() == [(f'{BTC_GROUP_IDENTIFIER_PREFIX}{tx_ids[4]}',)]

--- a/rotkehlchen/tests/unit/test_bitcoin_transactions.py
+++ b/rotkehlchen/tests/unit/test_bitcoin_transactions.py
@@ -1,3 +1,4 @@
+import json
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -9,15 +10,24 @@ from rotkehlchen.constants.assets import A_BTC
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.db.utils import BlockchainAccountData, get_query_chunks
 from rotkehlchen.fval import FVal
-from rotkehlchen.history.events.structures.base import HistoryEvent
+from rotkehlchen.history.events.structures.base import HistoryBaseEntry, HistoryEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.utils.bitcoin import get_decoded_events_of_bitcoin_tx, string_to_btc_address
 from rotkehlchen.tests.utils.mock import MockResponse
-from rotkehlchen.types import BTCAddress, Location, Timestamp, TimestampMS
+from rotkehlchen.types import (
+    BTCAddress,
+    Location,
+    SupportedBlockchain,
+    Timestamp,
+    TimestampMS,
+)
 from rotkehlchen.utils.misc import ts_now
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from rotkehlchen.chain.bitcoin.btc.manager import BitcoinManager
 
 
@@ -424,11 +434,18 @@ def test_2input_1output(
 def test_3input_2output(bitcoin_manager: BitcoinManager, btc_accounts: list[BTCAddress]) -> None:
     """This tx actually has 4 inputs, but 1 input is also an output, with its output value being
     more than its input value, canceling it out as an input, and resulting in only 3 actual inputs.
+
+    Every output is tracked as well, so nothing actually leaves the wallet. The tx must cost
+    only the fee and decode into transfers. Decoding it as a spend of each input plus a receive
+    of each output would report a disposal and an acquisition that never happened, corrupting
+    cost basis while leaving the net balance looking correct.
     """
-    assert get_decoded_events_of_bitcoin_tx(
+    events = get_decoded_events_of_bitcoin_tx(
         bitcoin_manager=bitcoin_manager,
         tx_id=(tx_id := 'cccd3a9ce6c59fd0b5ae4244cb9b239387efa31c96e0d45c0c0b82c0d7ee3bd8'),
-    ) == [HistoryEvent(
+    )
+    address1, address2, address3, address4, address5 = btc_accounts
+    assert events[:3] == [HistoryEvent(
         group_identifier=(group_identifier := f'{BTC_GROUP_IDENTIFIER_PREFIX}{tx_id}'),
         sequence_index=0,
         timestamp=(timestamp := TimestampMS(1711929790000)),
@@ -437,7 +454,7 @@ def test_3input_2output(bitcoin_manager: BitcoinManager, btc_accounts: list[BTCA
         event_subtype=HistoryEventSubType.FEE,
         asset=A_BTC,
         amount=(fee_amount1 := FVal('0.0000349900109618287314696311430719520663908035422202581481970374366538300400020661')),  # noqa: E501
-        location_label=(address1 := btc_accounts[0]),
+        location_label=address1,
         notes=f'Spend {fee_amount1} BTC for fees',
     ), HistoryEvent(
         group_identifier=group_identifier,
@@ -448,7 +465,7 @@ def test_3input_2output(bitcoin_manager: BitcoinManager, btc_accounts: list[BTCA
         event_subtype=HistoryEventSubType.FEE,
         asset=A_BTC,
         amount=(fee_amount2 := FVal('0.0000000549945190856342651844284640239668045982288898709259014812816730849799989669482')),  # noqa: E501
-        location_label=(address2 := btc_accounts[1]),
+        location_label=address2,
         notes=f'Spend {fee_amount2} BTC for fees',
     ), HistoryEvent(
         group_identifier=group_identifier,
@@ -459,64 +476,41 @@ def test_3input_2output(bitcoin_manager: BitcoinManager, btc_accounts: list[BTCA
         event_subtype=HistoryEventSubType.FEE,
         asset=A_BTC,
         amount=(fee_amount3 := FVal('0.0000000549945190856342651844284640239668045982288898709259014812816730849799989669518')),  # noqa: E501
-        location_label=(address3 := btc_accounts[2]),
-        notes=f'Spend {fee_amount3} BTC for fees',
-    ), HistoryEvent(
-        group_identifier=group_identifier,
-        sequence_index=3,
-        timestamp=timestamp,
-        location=Location.BITCOIN,
-        event_type=HistoryEventType.SPEND,
-        event_subtype=HistoryEventSubType.NONE,
-        asset=A_BTC,
-        amount=(spend_amount1 := FVal('0.00343890998903817126853036885692804793360919645777974185180296256334616995999793')),  # noqa: E501
-        location_label=address1,
-        notes=f'Send {spend_amount1} BTC to {(address4 := btc_accounts[3])}, {(address5 := btc_accounts[4])}',  # noqa: E501
-    ), HistoryEvent(
-        group_identifier=group_identifier,
-        sequence_index=4,
-        timestamp=timestamp,
-        location=Location.BITCOIN,
-        event_type=HistoryEventType.SPEND,
-        event_subtype=HistoryEventSubType.NONE,
-        asset=A_BTC,
-        amount=(spend_amount2 := FVal('0.00000540500548091436573481557153597603319540177111012907409851871832691502000103305')),  # noqa: E501
-        location_label=address2,
-        notes=f'Send {spend_amount2} BTC to {address4}, {address5}',
-    ), HistoryEvent(
-        group_identifier=group_identifier,
-        sequence_index=5,
-        timestamp=timestamp,
-        location=Location.BITCOIN,
-        event_type=HistoryEventType.SPEND,
-        event_subtype=HistoryEventSubType.NONE,
-        asset=A_BTC,
-        amount=(spend_amount3 := FVal('0.00000540500548091436573481557153597603319540177111012907409851871832691502000103305')),  # noqa: E501
         location_label=address3,
-        notes=f'Send {spend_amount3} BTC to {address4}, {address5}',
-    ), HistoryEvent(
-        group_identifier=group_identifier,
-        sequence_index=6,
-        timestamp=timestamp,
-        location=Location.BITCOIN,
-        event_type=HistoryEventType.RECEIVE,
-        event_subtype=HistoryEventSubType.NONE,
-        asset=A_BTC,
-        amount=FVal('0.00031546'),
-        location_label=address4,
-        notes=f'Receive 0.00031546 BTC from {address1}, {address2}, {address3}',
-    ), HistoryEvent(
-        group_identifier=group_identifier,
-        sequence_index=7,
-        timestamp=timestamp,
-        location=Location.BITCOIN,
-        event_type=HistoryEventType.RECEIVE,
-        event_subtype=HistoryEventSubType.NONE,
-        asset=A_BTC,
-        amount=FVal('0.00313426'),
-        location_label=address5,
-        notes=f'Receive 0.00313426 BTC from {address1}, {address2}, {address3}',
+        notes=f'Spend {fee_amount3} BTC for fees',
     )]
+    assert fee_amount1 + fee_amount2 + fee_amount3 == FVal('0.0000351')
+
+    # The remaining events are one transfer per input/output pair. A single counterparty each
+    # so historical balance tracking knows exactly which address to credit.
+    assert len(transfers := events[3:]) == 6
+    assert all(
+        x.event_type == HistoryEventType.TRANSFER and
+        x.event_subtype == HistoryEventSubType.NONE and
+        x.group_identifier == group_identifier and
+        x.timestamp == timestamp and
+        len(getattr(x, BITCOIN_COUNTERPARTY_ADDRESSES_METADATA_KEY)) == 1
+        for x in transfers
+    )
+    for output_address, output_amount in (
+        (address4, FVal('0.00031546')),
+        (address5, FVal('0.00313426')),
+    ):  # each output is credited exactly what it received in the tx
+        assert sum(
+            (x.amount for x in transfers
+             if getattr(x, BITCOIN_COUNTERPARTY_ADDRESSES_METADATA_KEY) == [output_address]),
+            ZERO,
+        ).is_close(output_amount, max_diff='1e-20')
+
+    for input_address, input_amount in (
+        (address1, FVal('0.00343890998903817126853036885692804793')),
+        (address2, FVal('0.00000540500548091436573481557153597603')),
+        (address3, FVal('0.00000540500548091436573481557153597603')),
+    ):  # and each input sends out everything it put in, minus its fee share
+        assert sum(
+            (x.amount for x in transfers if x.location_label == input_address),
+            ZERO,
+        ).is_close(input_amount, max_diff='1e-20')
 
 
 @pytest.mark.vcr
@@ -579,3 +573,243 @@ def test_skip_unconfirmed_blockchain_info_txs(
     # Check that there is only one event present and that it's from the confirmed tx.
     assert len(events) == 1
     assert '821a49c9e315a03c7c7f2ab9f82d38caa622df7d331a11102af09bb0316fda2e' in events[0].group_identifier  # noqa: E501
+
+
+# Real mainnet transaction from block 700000. Two inputs pay 0.01 BTC to an external address
+# and send the remainder to a change address. Its raw blockchain.info payload is embedded so
+# the change-output tests stay deterministic without needing a cassette.
+CHANGE_TX_ID = '3281f96f3c458a4bee6248d6667c45e8481f51f4f79b878faedbf2e385dfdb95'
+CHANGE_TX_INPUT1 = string_to_btc_address('bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0')
+CHANGE_TX_INPUT2 = string_to_btc_address('bc1q5242kk7ut5nkyv74g765amvwqnglrya6xgj6mz')
+CHANGE_TX_EXTERNAL_OUTPUT = string_to_btc_address('3CXosf9wCHdSkGieziJ4BVg8g9HpwbX45t')
+CHANGE_TX_CHANGE_OUTPUT = string_to_btc_address('bc1qm4lpczdpkcs6j4twpzd2lgguy0sd8zzsm6puhl')
+CHANGE_TX_FEE = FVal('0.0003135')
+CHANGE_TX_EXTERNAL_AMOUNT = FVal('0.01')
+CHANGE_TX_CHANGE_AMOUNT = FVal('0.02543836')
+CHANGE_TX_RAW = f"""{{"txs":[
+    {{"hash":"{CHANGE_TX_ID}","ver":2,"vin_sz":2,"vout_sz":2,"fee":31350,"time":1631333672,"block_index":700000,"block_height":700000,
+    "inputs":[
+        {{"index":0,"prev_out":{{"value":113000,"n":0,"script":"00146fd6a90c3fb25ecf730cbde5783c09f60037c95e","addr":"{CHANGE_TX_INPUT1}"}}}},
+        {{"index":1,"prev_out":{{"value":3462186,"n":1,"script":"0014a2aaab5bdc5d276233d547b54eed8e04d1f193ba","addr":"{CHANGE_TX_INPUT2}"}}}}
+    ],
+    "out":[
+        {{"value":1000000,"n":0,"script":"a91476eb94d31cee6f54e6616ef2f31991dfa14d830087","addr":"{CHANGE_TX_EXTERNAL_OUTPUT}"}},
+        {{"value":2543836,"n":1,"script":"0014dd7e1c09a1b621a9556e089aafa11c23e0d38850","addr":"{CHANGE_TX_CHANGE_OUTPUT}"}}
+    ]}}
+],"info":{{"latest_block":{{"height":700000}}}}}}"""
+
+
+def _query_change_tx(bitcoin_manager: BitcoinManager, accounts: list[BTCAddress]) -> None:
+    """Run the change tx through the full query/decode/save path for the given accounts."""
+    with patch(
+        'rotkehlchen.chain.bitcoin.manager.requests.get',
+        return_value=MockResponse(200, CHANGE_TX_RAW),
+    ):
+        bitcoin_manager.query_transactions(
+            from_timestamp=Timestamp(0),
+            to_timestamp=ts_now(),
+            addresses=accounts,
+        )
+
+
+def _decode_change_tx(
+        bitcoin_manager: BitcoinManager,
+        accounts: list[BTCAddress],
+) -> list[HistoryEvent]:
+    """Decode the embedded change tx with the given accounts tracked."""
+    bitcoin_manager.tracked_accounts = accounts
+    tx = bitcoin_manager.deserialize_tx_from_blockchain_info(
+        data=json.loads(CHANGE_TX_RAW)['txs'][0],
+    )
+    assert tx is not None
+    return bitcoin_manager.decode_transaction(tx=tx)
+
+
+def _stored_change_tx_events(bitcoin_manager: BitcoinManager) -> list[HistoryBaseEntry]:
+    with bitcoin_manager.database.conn.read_ctx() as cursor:
+        return DBHistoryEvents(bitcoin_manager.database).get_history_events_internal(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(),
+        )
+
+
+def _sum_amounts(
+        events: Sequence[HistoryBaseEntry],
+        event_type: HistoryEventType,
+        event_subtype: HistoryEventSubType = HistoryEventSubType.NONE,
+) -> FVal:
+    return sum(
+        (x.amount for x in events
+         if x.event_type == event_type and x.event_subtype == event_subtype),
+        ZERO,
+    )
+
+
+@pytest.mark.parametrize('btc_accounts', [[
+    'bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0',
+    'bc1q5242kk7ut5nkyv74g765amvwqnglrya6xgj6mz',
+    'bc1qm4lpczdpkcs6j4twpzd2lgguy0sd8zzsm6puhl',
+]])
+def test_change_output_is_not_double_counted(
+        bitcoin_manager: BitcoinManager,
+        btc_accounts: list[BTCAddress],
+) -> None:
+    """Both inputs and the change output belong to the wallet, as happens with an xpub.
+
+    The change must never surface as a receive. Doing so reports a disposal of the whole
+    input and an acquisition of the change that never happened, which corrupts cost basis
+    even though the net balance stays correct.
+    """
+    events = _decode_change_tx(bitcoin_manager=bitcoin_manager, accounts=btc_accounts)
+    # Only the amount actually leaving the wallet is a spend, and it goes to the external
+    # address alone. The change stays inside the wallet, so it is a balance-only transfer.
+    assert _sum_amounts(events, HistoryEventType.SPEND) == CHANGE_TX_EXTERNAL_AMOUNT
+    assert _sum_amounts(events, HistoryEventType.TRANSFER) == CHANGE_TX_CHANGE_AMOUNT
+    assert _sum_amounts(events, HistoryEventType.SPEND, HistoryEventSubType.FEE) == CHANGE_TX_FEE
+    assert _sum_amounts(events, HistoryEventType.RECEIVE) == ZERO
+
+    for event in events:
+        if event.event_type == HistoryEventType.SPEND and event.event_subtype == HistoryEventSubType.NONE:  # noqa: E501
+            assert getattr(event, BITCOIN_COUNTERPARTY_ADDRESSES_METADATA_KEY) == [CHANGE_TX_EXTERNAL_OUTPUT]  # noqa: E501
+        elif event.event_type == HistoryEventType.TRANSFER:
+            # a single counterparty per transfer so balance tracking knows which
+            # address to credit
+            assert getattr(event, BITCOIN_COUNTERPARTY_ADDRESSES_METADATA_KEY) == [CHANGE_TX_CHANGE_OUTPUT]  # noqa: E501
+
+    # The wallet's net position must equal what it actually lost on chain.
+    assert (
+        _sum_amounts(events, HistoryEventType.RECEIVE) -
+        _sum_amounts(events, HistoryEventType.SPEND) -
+        _sum_amounts(events, HistoryEventType.SPEND, HistoryEventSubType.FEE)
+    ) == -(CHANGE_TX_EXTERNAL_AMOUNT + CHANGE_TX_FEE)
+
+
+@pytest.mark.parametrize('btc_accounts', [[
+    'bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0',
+    'bc1q5242kk7ut5nkyv74g765amvwqnglrya6xgj6mz',
+    '3CXosf9wCHdSkGieziJ4BVg8g9HpwbX45t',
+    'bc1qm4lpczdpkcs6j4twpzd2lgguy0sd8zzsm6puhl',
+]])
+def test_fully_internal_tx_only_costs_the_fee(
+        bitcoin_manager: BitcoinManager,
+        btc_accounts: list[BTCAddress],
+) -> None:
+    """When every output is owned the tx is a consolidation/self transfer.
+    It must cost the wallet the fee and nothing else - no spend and no receive.
+    """
+    events = _decode_change_tx(bitcoin_manager=bitcoin_manager, accounts=btc_accounts)
+    assert _sum_amounts(events, HistoryEventType.SPEND) == ZERO
+    assert _sum_amounts(events, HistoryEventType.RECEIVE) == ZERO
+    assert _sum_amounts(events, HistoryEventType.SPEND, HistoryEventSubType.FEE) == CHANGE_TX_FEE
+    assert _sum_amounts(events, HistoryEventType.TRANSFER) == (
+        CHANGE_TX_EXTERNAL_AMOUNT + CHANGE_TX_CHANGE_AMOUNT
+    )
+
+
+@pytest.mark.parametrize('btc_accounts', [['bc1qm4lpczdpkcs6j4twpzd2lgguy0sd8zzsm6puhl']])
+def test_receive_only_tx_is_not_charged_a_fee(
+        bitcoin_manager: BitcoinManager,
+        btc_accounts: list[BTCAddress],
+) -> None:
+    """The wallet owns none of the inputs, so the sender paid the fee.
+    Only the received amount should be recorded.
+    """
+    events = _decode_change_tx(bitcoin_manager=bitcoin_manager, accounts=btc_accounts)
+    assert _sum_amounts(events, HistoryEventType.RECEIVE) == CHANGE_TX_CHANGE_AMOUNT
+    assert _sum_amounts(events, HistoryEventType.SPEND) == ZERO
+    assert _sum_amounts(events, HistoryEventType.SPEND, HistoryEventSubType.FEE) == ZERO
+    assert _sum_amounts(events, HistoryEventType.TRANSFER) == ZERO
+
+
+@pytest.mark.parametrize('btc_accounts', [['bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0']])
+def test_redecoding_after_tracking_more_accounts(
+        bitcoin_manager: BitcoinManager,
+        btc_accounts: list[BTCAddress],
+) -> None:
+    """Query the tx with only one address tracked, then again after the rest of the wallet
+    is added, as happens when an xpub is added after a standalone address.
+
+    Sequence indexes are positional, so the second decode used to collide with the stale
+    events under UNIQUE(group_identifier, sequence_index). That silently kept outdated rows
+    and dropped the corrected ones, leaving duplicated spends and missing fee events.
+    """
+    _query_change_tx(bitcoin_manager=bitcoin_manager, accounts=btc_accounts)
+    assert len(_stored_change_tx_events(bitcoin_manager)) == 2  # one fee and one spend
+
+    all_accounts = [*btc_accounts, CHANGE_TX_INPUT2, CHANGE_TX_CHANGE_OUTPUT]
+    with bitcoin_manager.database.user_write() as write_cursor:
+        bitcoin_manager.database.add_blockchain_accounts(
+            write_cursor=write_cursor,
+            account_data=[
+                BlockchainAccountData(chain=SupportedBlockchain.BITCOIN, address=x)
+                for x in (CHANGE_TX_INPUT2, CHANGE_TX_CHANGE_OUTPUT)
+            ],
+        )
+
+    _query_change_tx(bitcoin_manager=bitcoin_manager, accounts=all_accounts)
+    events = _stored_change_tx_events(bitcoin_manager)
+
+    # No leftovers from the first decode: two fees, two spends and two transfers.
+    assert len(events) == 6
+    assert _sum_amounts(events, HistoryEventType.SPEND, HistoryEventSubType.FEE) == CHANGE_TX_FEE
+    assert _sum_amounts(events, HistoryEventType.SPEND) == CHANGE_TX_EXTERNAL_AMOUNT
+    assert _sum_amounts(events, HistoryEventType.TRANSFER) == CHANGE_TX_CHANGE_AMOUNT
+    assert len({x.sequence_index for x in events}) == len(events)  # no duplicate indexes
+
+
+@pytest.mark.parametrize('btc_accounts', [[
+    'bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0',
+    'bc1q5242kk7ut5nkyv74g765amvwqnglrya6xgj6mz',
+    'bc1qm4lpczdpkcs6j4twpzd2lgguy0sd8zzsm6puhl',
+]])
+def test_redecoding_chunks_the_purge(
+        bitcoin_manager: BitcoinManager,
+        btc_accounts: list[BTCAddress],
+) -> None:
+    """Resetting the query cache makes the next query return the entire history at once, so
+    the purge preceding the insert must not bind one variable per transaction. Patch the
+    chunk size down so a handful of transactions crosses several chunk boundaries.
+    """
+    tx_ids = [f'{idx:064x}' for idx in range(1, 8)]
+    raw = json.loads(CHANGE_TX_RAW)
+    template = raw['txs'][0]
+    raw['txs'] = [{**template, 'hash': tx_id} for tx_id in tx_ids]
+    response = json.dumps(raw)
+
+    def query_all() -> None:
+        with patch(
+            'rotkehlchen.chain.bitcoin.manager.requests.get',
+            return_value=MockResponse(200, response),
+        ):
+            bitcoin_manager.query_transactions(
+                from_timestamp=Timestamp(0),
+                to_timestamp=ts_now(),
+                addresses=btc_accounts,
+            )
+
+    with patch('rotkehlchen.db.history_events.SQL_VARIABLE_CHUNK_SIZE', 4), patch(
+        'rotkehlchen.chain.bitcoin.manager.get_query_chunks',
+        side_effect=lambda data: get_query_chunks(data=data, chunk_size=2),
+    ):
+        query_all()
+        assert len(first_pass := _stored_change_tx_events(bitcoin_manager)) == 6 * len(tx_ids)
+
+        # reset the cache the way the db upgrade does, then requery the full history
+        with bitcoin_manager.database.user_write() as write_cursor:
+            write_cursor.execute(
+                "DELETE FROM key_value_cache WHERE name LIKE 'last\\_btc\\_tx\\_block\\_%' "
+                "ESCAPE '\\'",
+            )
+
+        query_all()
+
+    # every transaction was purged and reinserted exactly once, with no duplicates left
+    assert len(second_pass := _stored_change_tx_events(bitcoin_manager)) == len(first_pass)
+    assert len({(x.group_identifier, x.sequence_index) for x in second_pass}) == len(second_pass)
+    for tx_id in tx_ids:
+        assert _sum_amounts(
+            events := [x for x in second_pass
+                       if x.group_identifier == f'{BTC_GROUP_IDENTIFIER_PREFIX}{tx_id}'],
+            event_type=HistoryEventType.SPEND,
+        ) == CHANGE_TX_EXTERNAL_AMOUNT
+        assert _sum_amounts(events, HistoryEventType.TRANSFER) == CHANGE_TX_CHANGE_AMOUNT

--- a/rotkehlchen/tests/unit/test_bitcoin_transactions.py
+++ b/rotkehlchen/tests/unit/test_bitcoin_transactions.py
@@ -1,4 +1,3 @@
-import json
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -10,7 +9,7 @@ from rotkehlchen.constants.assets import A_BTC
 from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
-from rotkehlchen.db.utils import BlockchainAccountData, get_query_chunks
+from rotkehlchen.db.utils import BlockchainAccountData
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.base import HistoryBaseEntry, HistoryEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
@@ -576,61 +575,17 @@ def test_skip_unconfirmed_blockchain_info_txs(
 
 
 # Real mainnet transaction from block 700000. Two inputs pay 0.01 BTC to an external address
-# and send the remainder to a change address. Its raw blockchain.info payload is embedded so
-# the change-output tests stay deterministic without needing a cassette.
+# and send the remainder back to a change address, which is the shape an xpub wallet produces
+# when spending to an exchange.
 CHANGE_TX_ID = '3281f96f3c458a4bee6248d6667c45e8481f51f4f79b878faedbf2e385dfdb95'
 CHANGE_TX_INPUT1 = string_to_btc_address('bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0')
 CHANGE_TX_INPUT2 = string_to_btc_address('bc1q5242kk7ut5nkyv74g765amvwqnglrya6xgj6mz')
 CHANGE_TX_EXTERNAL_OUTPUT = string_to_btc_address('3CXosf9wCHdSkGieziJ4BVg8g9HpwbX45t')
 CHANGE_TX_CHANGE_OUTPUT = string_to_btc_address('bc1qm4lpczdpkcs6j4twpzd2lgguy0sd8zzsm6puhl')
+CHANGE_TX_GROUP_IDENTIFIER = f'{BTC_GROUP_IDENTIFIER_PREFIX}{CHANGE_TX_ID}'
 CHANGE_TX_FEE = FVal('0.0003135')
 CHANGE_TX_EXTERNAL_AMOUNT = FVal('0.01')
 CHANGE_TX_CHANGE_AMOUNT = FVal('0.02543836')
-CHANGE_TX_RAW = f"""{{"txs":[
-    {{"hash":"{CHANGE_TX_ID}","ver":2,"vin_sz":2,"vout_sz":2,"fee":31350,"time":1631333672,"block_index":700000,"block_height":700000,
-    "inputs":[
-        {{"index":0,"prev_out":{{"value":113000,"n":0,"script":"00146fd6a90c3fb25ecf730cbde5783c09f60037c95e","addr":"{CHANGE_TX_INPUT1}"}}}},
-        {{"index":1,"prev_out":{{"value":3462186,"n":1,"script":"0014a2aaab5bdc5d276233d547b54eed8e04d1f193ba","addr":"{CHANGE_TX_INPUT2}"}}}}
-    ],
-    "out":[
-        {{"value":1000000,"n":0,"script":"a91476eb94d31cee6f54e6616ef2f31991dfa14d830087","addr":"{CHANGE_TX_EXTERNAL_OUTPUT}"}},
-        {{"value":2543836,"n":1,"script":"0014dd7e1c09a1b621a9556e089aafa11c23e0d38850","addr":"{CHANGE_TX_CHANGE_OUTPUT}"}}
-    ]}}
-],"info":{{"latest_block":{{"height":700000}}}}}}"""
-
-
-def _query_change_tx(bitcoin_manager: BitcoinManager, accounts: list[BTCAddress]) -> None:
-    """Run the change tx through the full query/decode/save path for the given accounts."""
-    with patch(
-        'rotkehlchen.chain.bitcoin.manager.requests.get',
-        return_value=MockResponse(200, CHANGE_TX_RAW),
-    ):
-        bitcoin_manager.query_transactions(
-            from_timestamp=Timestamp(0),
-            to_timestamp=ts_now(),
-            addresses=accounts,
-        )
-
-
-def _decode_change_tx(
-        bitcoin_manager: BitcoinManager,
-        accounts: list[BTCAddress],
-) -> list[HistoryEvent]:
-    """Decode the embedded change tx with the given accounts tracked."""
-    bitcoin_manager.tracked_accounts = accounts
-    tx = bitcoin_manager.deserialize_tx_from_blockchain_info(
-        data=json.loads(CHANGE_TX_RAW)['txs'][0],
-    )
-    assert tx is not None
-    return bitcoin_manager.decode_transaction(tx=tx)
-
-
-def _stored_change_tx_events(bitcoin_manager: BitcoinManager) -> list[HistoryBaseEntry]:
-    with bitcoin_manager.database.conn.read_ctx() as cursor:
-        return DBHistoryEvents(bitcoin_manager.database).get_history_events_internal(
-            cursor=cursor,
-            filter_query=HistoryEventFilterQuery.make(),
-        )
 
 
 def _sum_amounts(
@@ -645,6 +600,7 @@ def _sum_amounts(
     )
 
 
+@pytest.mark.vcr
 @pytest.mark.parametrize('btc_accounts', [[
     'bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0',
     'bc1q5242kk7ut5nkyv74g765amvwqnglrya6xgj6mz',
@@ -660,7 +616,10 @@ def test_change_output_is_not_double_counted(
     input and an acquisition of the change that never happened, which corrupts cost basis
     even though the net balance stays correct.
     """
-    events = _decode_change_tx(bitcoin_manager=bitcoin_manager, accounts=btc_accounts)
+    events = get_decoded_events_of_bitcoin_tx(
+        bitcoin_manager=bitcoin_manager,
+        tx_id=CHANGE_TX_ID,
+    )
     # Only the amount actually leaving the wallet is a spend, and it goes to the external
     # address alone. The change stays inside the wallet, so it is a balance-only transfer.
     assert _sum_amounts(events, HistoryEventType.SPEND) == CHANGE_TX_EXTERNAL_AMOUNT
@@ -684,6 +643,7 @@ def test_change_output_is_not_double_counted(
     ) == -(CHANGE_TX_EXTERNAL_AMOUNT + CHANGE_TX_FEE)
 
 
+@pytest.mark.vcr
 @pytest.mark.parametrize('btc_accounts', [[
     'bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0',
     'bc1q5242kk7ut5nkyv74g765amvwqnglrya6xgj6mz',
@@ -697,7 +657,10 @@ def test_fully_internal_tx_only_costs_the_fee(
     """When every output is owned the tx is a consolidation/self transfer.
     It must cost the wallet the fee and nothing else - no spend and no receive.
     """
-    events = _decode_change_tx(bitcoin_manager=bitcoin_manager, accounts=btc_accounts)
+    events = get_decoded_events_of_bitcoin_tx(
+        bitcoin_manager=bitcoin_manager,
+        tx_id=CHANGE_TX_ID,
+    )
     assert _sum_amounts(events, HistoryEventType.SPEND) == ZERO
     assert _sum_amounts(events, HistoryEventType.RECEIVE) == ZERO
     assert _sum_amounts(events, HistoryEventType.SPEND, HistoryEventSubType.FEE) == CHANGE_TX_FEE
@@ -706,6 +669,7 @@ def test_fully_internal_tx_only_costs_the_fee(
     )
 
 
+@pytest.mark.vcr
 @pytest.mark.parametrize('btc_accounts', [['bc1qm4lpczdpkcs6j4twpzd2lgguy0sd8zzsm6puhl']])
 def test_receive_only_tx_is_not_charged_a_fee(
         bitcoin_manager: BitcoinManager,
@@ -714,13 +678,17 @@ def test_receive_only_tx_is_not_charged_a_fee(
     """The wallet owns none of the inputs, so the sender paid the fee.
     Only the received amount should be recorded.
     """
-    events = _decode_change_tx(bitcoin_manager=bitcoin_manager, accounts=btc_accounts)
+    events = get_decoded_events_of_bitcoin_tx(
+        bitcoin_manager=bitcoin_manager,
+        tx_id=CHANGE_TX_ID,
+    )
     assert _sum_amounts(events, HistoryEventType.RECEIVE) == CHANGE_TX_CHANGE_AMOUNT
     assert _sum_amounts(events, HistoryEventType.SPEND) == ZERO
     assert _sum_amounts(events, HistoryEventType.SPEND, HistoryEventSubType.FEE) == ZERO
     assert _sum_amounts(events, HistoryEventType.TRANSFER) == ZERO
 
 
+@pytest.mark.vcr
 @pytest.mark.parametrize('btc_accounts', [['bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0']])
 def test_redecoding_after_tracking_more_accounts(
         bitcoin_manager: BitcoinManager,
@@ -733,10 +701,23 @@ def test_redecoding_after_tracking_more_accounts(
     events under UNIQUE(group_identifier, sequence_index). That silently kept outdated rows
     and dropped the corrected ones, leaving duplicated spends and missing fee events.
     """
-    _query_change_tx(bitcoin_manager=bitcoin_manager, accounts=btc_accounts)
-    assert len(_stored_change_tx_events(bitcoin_manager)) == 2  # one fee and one spend
+    def query_and_get_tx_events(accounts: list[BTCAddress]) -> list[HistoryBaseEntry]:
+        """Query the given accounts and return only the events of the change tx."""
+        bitcoin_manager.query_transactions(
+            from_timestamp=Timestamp(0),
+            to_timestamp=ts_now(),
+            addresses=accounts,
+        )
+        with bitcoin_manager.database.conn.read_ctx() as cursor:
+            return [
+                x for x in DBHistoryEvents(bitcoin_manager.database).get_history_events_internal(
+                    cursor=cursor,
+                    filter_query=HistoryEventFilterQuery.make(),
+                ) if x.group_identifier == CHANGE_TX_GROUP_IDENTIFIER
+            ]
 
-    all_accounts = [*btc_accounts, CHANGE_TX_INPUT2, CHANGE_TX_CHANGE_OUTPUT]
+    assert len(query_and_get_tx_events(btc_accounts)) == 2  # one fee event and one spend event
+
     with bitcoin_manager.database.user_write() as write_cursor:
         bitcoin_manager.database.add_blockchain_accounts(
             write_cursor=write_cursor,
@@ -746,70 +727,14 @@ def test_redecoding_after_tracking_more_accounts(
             ],
         )
 
-    _query_change_tx(bitcoin_manager=bitcoin_manager, accounts=all_accounts)
-    events = _stored_change_tx_events(bitcoin_manager)
+    events = query_and_get_tx_events(
+        accounts=[*btc_accounts, CHANGE_TX_INPUT2, CHANGE_TX_CHANGE_OUTPUT],
+    )
 
     # No leftovers from the first decode: two fees, two spends and two transfers.
     assert len(events) == 6
+    assert len({x.sequence_index for x in events}) == len(events)  # no duplicate indexes
     assert _sum_amounts(events, HistoryEventType.SPEND, HistoryEventSubType.FEE) == CHANGE_TX_FEE
     assert _sum_amounts(events, HistoryEventType.SPEND) == CHANGE_TX_EXTERNAL_AMOUNT
     assert _sum_amounts(events, HistoryEventType.TRANSFER) == CHANGE_TX_CHANGE_AMOUNT
-    assert len({x.sequence_index for x in events}) == len(events)  # no duplicate indexes
-
-
-@pytest.mark.parametrize('btc_accounts', [[
-    'bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0',
-    'bc1q5242kk7ut5nkyv74g765amvwqnglrya6xgj6mz',
-    'bc1qm4lpczdpkcs6j4twpzd2lgguy0sd8zzsm6puhl',
-]])
-def test_redecoding_chunks_the_purge(
-        bitcoin_manager: BitcoinManager,
-        btc_accounts: list[BTCAddress],
-) -> None:
-    """Resetting the query cache makes the next query return the entire history at once, so
-    the purge preceding the insert must not bind one variable per transaction. Patch the
-    chunk size down so a handful of transactions crosses several chunk boundaries.
-    """
-    tx_ids = [f'{idx:064x}' for idx in range(1, 8)]
-    raw = json.loads(CHANGE_TX_RAW)
-    template = raw['txs'][0]
-    raw['txs'] = [{**template, 'hash': tx_id} for tx_id in tx_ids]
-    response = json.dumps(raw)
-
-    def query_all() -> None:
-        with patch(
-            'rotkehlchen.chain.bitcoin.manager.requests.get',
-            return_value=MockResponse(200, response),
-        ):
-            bitcoin_manager.query_transactions(
-                from_timestamp=Timestamp(0),
-                to_timestamp=ts_now(),
-                addresses=btc_accounts,
-            )
-
-    with patch('rotkehlchen.db.history_events.SQL_VARIABLE_CHUNK_SIZE', 4), patch(
-        'rotkehlchen.chain.bitcoin.manager.get_query_chunks',
-        side_effect=lambda data: get_query_chunks(data=data, chunk_size=2),
-    ):
-        query_all()
-        assert len(first_pass := _stored_change_tx_events(bitcoin_manager)) == 6 * len(tx_ids)
-
-        # reset the cache the way the db upgrade does, then requery the full history
-        with bitcoin_manager.database.user_write() as write_cursor:
-            write_cursor.execute(
-                "DELETE FROM key_value_cache WHERE name LIKE 'last\\_btc\\_tx\\_block\\_%' "
-                "ESCAPE '\\'",
-            )
-
-        query_all()
-
-    # every transaction was purged and reinserted exactly once, with no duplicates left
-    assert len(second_pass := _stored_change_tx_events(bitcoin_manager)) == len(first_pass)
-    assert len({(x.group_identifier, x.sequence_index) for x in second_pass}) == len(second_pass)
-    for tx_id in tx_ids:
-        assert _sum_amounts(
-            events := [x for x in second_pass
-                       if x.group_identifier == f'{BTC_GROUP_IDENTIFIER_PREFIX}{tx_id}'],
-            event_type=HistoryEventType.SPEND,
-        ) == CHANGE_TX_EXTERNAL_AMOUNT
-        assert _sum_amounts(events, HistoryEventType.TRANSFER) == CHANGE_TX_CHANGE_AMOUNT
+    assert _sum_amounts(events, HistoryEventType.RECEIVE) == ZERO

--- a/rotkehlchen/tests/unit/test_historical_balances.py
+++ b/rotkehlchen/tests/unit/test_historical_balances.py
@@ -1749,3 +1749,57 @@ def test_unmatched_bridge_data_issues(
         filters=DataIssueFilters(kind=IssueKind.UNMATCHED_BRIDGE.value),
     )
     assert {issue.state for issue in issues} == {IssueState.RESOLVED.value}
+
+
+def test_bitcoin_transfer_updates_sender_and_receiver_buckets(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+) -> None:
+    """Test bitcoin TRANSFER/NONE events credit the receiving address too.
+
+    Bitcoin events are plain HistoryEvents with no address column, so the counterparty has to
+    come from the notes. Without it a change output would only be debited from the sending
+    address and never credited to the receiving one, understating the wallet by the full
+    change amount on every send.
+    """
+    sender = 'bc1qdlt2jrplkf0v7ucvhhjhs0qf7cqr0j27k7j7p0'
+    change = 'bc1qm4lpczdpkcs6j4twpzd2lgguy0sd8zzsm6puhl'
+    with database.user_write() as write_cursor:
+        DBHistoryEvents(database).add_history_events(
+            write_cursor=write_cursor,
+            history=[HistoryEvent(
+                group_identifier='btc_receive',
+                sequence_index=0,
+                timestamp=TimestampMS(1000),
+                location=Location.BITCOIN,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_BTC,
+                amount=FVal('10'),
+                location_label=sender,
+                notes='Receive 10 BTC from bc1q5242kk7ut5nkyv74g765amvwqnglrya6xgj6mz',
+            ), HistoryEvent(
+                group_identifier='btc_change',
+                sequence_index=0,
+                timestamp=TimestampMS(2000),
+                location=Location.BITCOIN,
+                event_type=HistoryEventType.TRANSFER,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_BTC,
+                amount=FVal('3'),
+                location_label=sender,
+                notes=f'Transfer 3 BTC to {change}',
+            )],
+        )
+
+    process_historical_balances(database, messages_aggregator)
+
+    with database.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT timestamp, asset, location_label, metric_value FROM event_metrics '
+            'ORDER BY timestamp, metric_value',
+        ).fetchall() == [
+            (1000, A_BTC.identifier, sender, '10'),
+            (2000, A_BTC.identifier, change, '3'),  # credited, not lost
+            (2000, A_BTC.identifier, sender, '7'),
+        ]


### PR DESCRIPTION
Bitcoin transactions with a change output were decoded as a spend of the entire input plus a receive of the change whenever the tx had more than one owned input address or blockchain.info flagged it multi_io. The net balance came out right but the phantom disposal and re-acquisition corrupted cost basis. Decode the value that stays in the wallet as a transfer instead, mirroring what the single input path already did.

Bitcoin transfers between owned addresses were also never dual bucketed in historical balances, since bitcoin events have no address column and the counterparty addresses are only ever written, never read back. Recover the counterparty from the notes so the receiving address gets credited.

Requerying a tx after the tracked account set changed collided with the stale events under UNIQUE(group_identifier, sequence_index), keeping outdated rows and dropping corrected ones. Purge a tx's events before writing the new ones and dedupe the queried tx list. Chunk the purge bindings so a full history redecode cannot exhaust the SQL variable limit.

Reset the bitcoin last queried block in the v52->v53 upgrade so existing histories are refetched and redecoded. The events are left in place and replaced per transaction by that query, so the history stays visible.
