### PR TITLE
Cut dev server memory and unblock parallel e2e runs

### DIFF
--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -64,6 +64,38 @@ function detectSystemChromium(): string | undefined {
 
 const systemChromium = detectSystemChromium();
 
+/**
+ * Interactive runs (`--ui`, `--headed`, `--debug`) keep the Vite dev server so HMR and
+ * un-minified sources are available while poking at a failing spec. Every other local
+ * run builds once and serves the output with `vite preview`: the dev server holds the
+ * whole module graph plus its transform cache in memory (multiple GB on this codebase),
+ * while preview only serves static files. CI already builds in a separate workflow step,
+ * so there the command is a bare `vite preview`.
+ */
+function isInteractiveRun(): boolean {
+  if (process.env.PWDEBUG)
+    return true;
+
+  return process.argv.some(arg => arg === '--headed' || arg === '--debug' || arg === '--ui' || arg.startsWith('--ui-'));
+}
+
+const interactive = isInteractiveRun();
+
+function buildFrontendCommand(): string {
+  // --no-open: this is a test harness, don't pop a browser tab (serve.ts
+  // auto-opens in web mode by default). Playwright drives its own browser.
+  if (interactive)
+    return `tsx scripts/serve.ts --web --no-open --port ${FRONTEND_PORT}`;
+
+  // --strictPort: fail loudly instead of silently serving on another port, which would
+  // leave the tests pointing at a URL nothing is listening on.
+  const preview = `vite preview --port ${FRONTEND_PORT} --strictPort`;
+  // CI builds the frontend in its own workflow job and downloads the artifact.
+  return process.env.CI ? preview : `pnpm run build:app --mode e2e && ${preview}`;
+}
+
+const frontendCommand = buildFrontendCommand();
+
 // Get the test group from environment (app or balances)
 const testGroup = process.env.GROUP;
 const testDirPath = testGroup ? `./tests/e2e/specs/${testGroup}` : './tests/e2e/specs';
@@ -144,14 +176,12 @@ export default defineConfig({
       timeout: 180_000,
     },
     {
-      command: process.env.CI
-        ? `vite preview --port ${FRONTEND_PORT}`
-        // --no-open: this is a test harness, don't pop a browser tab (serve.ts
-        // auto-opens in web mode by default) — Playwright drives its own browser.
-        : `tsx scripts/serve.ts --web --no-open --port ${FRONTEND_PORT}`,
+      command: frontendCommand,
       url: frontendUrl,
       reuseExistingServer: !process.env.CI,
-      timeout: 180_000,
+      // The local non-interactive path builds before serving (~15s on a warm machine),
+      // so it gets more headroom than starting a dev server or serving an existing dist.
+      timeout: interactive || process.env.CI ? 180_000 : 300_000,
       env: {
         VITE_BACKEND_URL: backendUrl,
         VITE_COLIBRI_URL: colibriUrl,

--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -1,19 +1,72 @@
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { defineConfig, devices } from '@playwright/test';
 
-const FRONTEND_PORT = 30301;
-const BACKEND_PORT = 30302;
-const COLIBRI_PORT = 30303;
-const MOCK_RPC_PORT = 30304;
+const BASE_FRONTEND_PORT = 30301;
+const BASE_BACKEND_PORT = 30302;
+const BASE_COLIBRI_PORT = 30303;
+const BASE_MOCK_RPC_PORT = 30304;
+
+const BASE_PORTS = [BASE_FRONTEND_PORT, BASE_BACKEND_PORT, BASE_COLIBRI_PORT, BASE_MOCK_RPC_PORT];
+const PORT_BLOCK_STRIDE = 10;
+const MAX_PORT_BLOCKS = 10;
+
+/**
+ * Synchronously check whether a port can be bound. Playwright config files are loaded
+ * synchronously, so this shells out to a short-lived node instead of using an async
+ * `net.createServer` probe.
+ */
+function isPortFree(port: number): boolean {
+  const probe = 'const net = require("node:net");'
+    + 'const server = net.createServer();'
+    + 'server.once("error", () => process.exit(1));'
+    + 'server.once("listening", () => server.close(() => process.exit(0)));'
+    + `server.listen(${port}, "127.0.0.1");`;
+  return spawnSync(process.execPath, ['-e', probe], { stdio: 'ignore' }).status === 0;
+}
+
+/**
+ * The four services use fixed ports, so a second checkout running e2e at the same time
+ * would collide (or worse, silently reuse the other checkout's servers via
+ * `reuseExistingServer`). Move the whole block up in steps of 10 until every port in it
+ * is free. CI is pinned to the base block: the build job bakes the backend/colibri URLs
+ * into the frontend bundle from its own env, so the ports cannot be chosen here.
+ */
+function resolvePortOffset(): number {
+  if (process.env.CI)
+    return 0;
+
+  for (let block = 0; block < MAX_PORT_BLOCKS; block++) {
+    const offset = block * PORT_BLOCK_STRIDE;
+    if (BASE_PORTS.every(port => isPortFree(port + offset))) {
+      if (offset > 0)
+        console.log(`[e2e] ports ${BASE_FRONTEND_PORT}-${BASE_MOCK_RPC_PORT} are busy, using +${offset}`);
+
+      return offset;
+    }
+  }
+
+  throw new Error(
+    `Could not find a free block of e2e ports after ${MAX_PORT_BLOCKS} attempts starting at ${BASE_FRONTEND_PORT}`,
+  );
+}
+
+const portOffset = resolvePortOffset();
+
+const FRONTEND_PORT = BASE_FRONTEND_PORT + portOffset;
+const BACKEND_PORT = BASE_BACKEND_PORT + portOffset;
+const COLIBRI_PORT = BASE_COLIBRI_PORT + portOffset;
+const MOCK_RPC_PORT = BASE_MOCK_RPC_PORT + portOffset;
 
 const frontendUrl = `http://localhost:${FRONTEND_PORT}`;
 const backendUrl = `http://127.0.0.1:${BACKEND_PORT}`;
 const colibriUrl = `http://127.0.0.1:${COLIBRI_PORT}`;
 const mockRpcUrl = `http://127.0.0.1:${MOCK_RPC_PORT}`;
 
+// `.e2e` is resolved from the cwd, so parallel runs in different worktrees already get
+// their own data and log directories.
 const testDir = path.join(process.cwd(), '.e2e');
 const dataDir = path.join(testDir, 'data');
 const logDir = path.join(testDir, 'logs');

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -111,7 +111,13 @@ if (envPath)
 if (!hmrEnabled)
   console.info('HMR is disabled');
 
-const enableChecker = !((process.env.CI ?? isTest) || process.env.VITEST);
+// vue-tsc in the dev server is expensive (it type-checks the whole project on every
+// change), so it is opt-in: set ENABLE_TYPE_CHECKER=1 when you want inline type errors.
+// `pnpm run typecheck` remains the canonical check and CI runs it separately.
+const enableChecker = !!process.env.ENABLE_TYPE_CHECKER && !((process.env.CI ?? isTest) || process.env.VITEST);
+
+if (enableChecker)
+  console.info('Type checker is enabled');
 
 /**
  * These modules are required by walletconnect
@@ -159,13 +165,13 @@ export default defineConfig({
       dts: './src/route-map.d.ts',
     }),
     vue(),
-    checker(enableChecker
-      ? {
+    ...(enableChecker
+      ? [checker({
           vueTsc: {
             tsconfigPath: 'tsconfig.app.json',
           },
-        }
-      : {}),
+        })]
+      : []),
     AutoImport({
       include: [
         /\.[jt]sx?$/, // .ts, .tsx, .js, .jsx


### PR DESCRIPTION
Three changes to how the frontend dev server and the e2e harness are started.

### `vite-plugin-checker` is now opt-in

`vue-tsc` ran on every dev server start unless the run was CI/test/vitest. Measured on this branch with the login page loaded and no backend:

| dev server | RSS |
|---|---|
| checker off | 731 MB |
| `ENABLE_TYPE_CHECKER=1` | 3148 MB |

So it cost ~2.4 GB, plus a full project re-check on every change. It is now gated behind `ENABLE_TYPE_CHECKER`, following the existing `ENABLE_DEV_TOOLS` flag, and the plugin is only registered when the flag is set instead of being registered with an empty config.

```bash
ENABLE_TYPE_CHECKER=1 pnpm run dev   # logs "Type checker is enabled"
```

`pnpm run typecheck` and CI are untouched and stay the canonical check, and Volar still gives per-file feedback in the editor.

### Local e2e serves a build instead of the dev server

Non-interactive local e2e ran against the dev server (731 MB) while CI already used `vite preview` (90 MB serving the same app). Local runs now build once and preview, unless the run is `--ui`, `--headed`, `--debug`, or has `PWDEBUG` set, where HMR and readable sources are still worth the memory. CI keeps its bare `vite preview` because it builds in a separate job.

`--strictPort` was added to the preview command so a busy port fails loudly instead of silently serving elsewhere while the tests point at nothing.

### The e2e port block moves when it is busy

The four services (frontend, backend, colibri, mock RPC) used hardcoded ports 30301-30304, so only one worktree could run the suite at a time, and `reuseExistingServer` would silently attach to another checkout's servers. The config now probes the block at load and moves it up in steps of 10 until all four ports are free.

CI stays pinned to the base block: its build job bakes the backend and colibri URLs into the bundle from its own env, so the ports cannot be chosen at config load there.

Two consequences worth knowing:

- `reuseExistingServer` no longer fires locally in practice. If a stack is already up, the run picks a fresh block rather than attaching to it, which costs a backend and colibri startup per run.
- `.e2e/data` is still resolved from the cwd, so parallel runs in different worktrees stay isolated. Two runs in the *same* worktree would now get different ports but share one data directory.

### Verified

- Both RSS numbers measured with `ps` against the running dev server; preview measured at 90 MB serving HTTP 200.
- `pnpm run build:app --mode e2e` (11s) then `vite preview --port 30301 --strictPort` serves the built app.
- Port shifting: occupying 30301 selects `+10`, additionally occupying 30313 selects `+20`.
- `playwright test --list` resolves the config (175 tests in 28 files); `pnpm run typecheck` and `lint-staged` clean.

Not run: the full e2e suite, since the machine had another stack live on those ports. The changed pieces (build, preview, port resolution, config load) are covered above and the rest of the harness is untouched.