### PR TITLE
fix: skip settings suggestions on new accounts

### DIFF
--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-steps.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-steps.ts
@@ -30,6 +30,8 @@ interface LoadedAccount {
   exchanges: Exchange[];
   fetchData: boolean;
   username: string;
+  /** set by `createUnlock`; suppresses the settings-suggestions dialog for a fresh account */
+  newAccount?: boolean;
 }
 
 export interface UseUnlockStepsReturn {
@@ -178,7 +180,7 @@ export function useUnlockSteps(): UseUnlockStepsReturn {
       return err({ kind: UnlockErrorKind.unknown, message: 'no unlocked account to load' });
 
     try {
-      await initialize(loaded.settings, loaded.exchanges);
+      await initialize(loaded.settings, loaded.exchanges, loaded.newAccount);
       set(username, loaded.username);
       set(logged, true);
       if (loaded.fetchData)
@@ -251,9 +253,14 @@ export function useUnlockSteps(): UseUnlockStepsReturn {
 
       const { exchanges, settings } = UserAccount.parse(outcome.result);
       await colibriLogin({ password: payload.credentials.password, username: payload.credentials.username });
+      // Restoring a premium backup is not a fresh account: the pulled database carries the
+      // settings (and the applied-suggestions version) of the account it came from, so the
+      // recommendations still apply to it.
+      const syncDatabase = payload.premiumSetup?.syncDatabase ?? false;
       loaded = {
         exchanges,
-        fetchData: payload.premiumSetup?.syncDatabase ?? false,
+        fetchData: syncDatabase,
+        newAccount: !syncDatabase,
         settings,
         username: payload.credentials.username,
       };

--- a/frontend/app/src/modules/session/use-session-settings.spec.ts
+++ b/frontend/app/src/modules/session/use-session-settings.spec.ts
@@ -3,6 +3,7 @@ import type { FrontendSettings } from '@/modules/settings/types/frontend-setting
 import type { UserSettingsModel } from '@/modules/settings/types/user-settings';
 import { TimeFramePeriod, TimeFramePersist } from '@rotki/common';
 import { createMock } from '@test/utils/create-mock';
+import flushPromises from 'flush-promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PrivacyMode } from '@/modules/session/types';
 import { useSessionSettings } from '@/modules/session/use-session-settings';
@@ -108,7 +109,36 @@ describe('useSessionSettings', () => {
     expect(mockUpdateFrontend).toHaveBeenCalledOnce();
     expect(mockSetConnectedExchanges).toHaveBeenCalledWith(exchanges);
     expect(mockCheckDefaultThemeVersion).toHaveBeenCalledOnce();
-    expect(mockCheckForSuggestions).toHaveBeenCalledOnce();
+    expect(mockCheckForSuggestions).toHaveBeenCalledWith(expect.anything(), expect.anything(), false);
+  });
+
+  it('should flag a new account when checking for suggestions', async () => {
+    const { initialize } = useSessionSettings();
+    await initialize(buildModel(), [], true);
+
+    expect(mockCheckForSuggestions).toHaveBeenCalledWith(expect.anything(), expect.anything(), true);
+  });
+
+  it('should await the suggestions check before resetting privacy settings', async () => {
+    let release: () => void = () => {};
+    mockCheckForSuggestions.mockReturnValue(new Promise<void>((resolve) => {
+      release = resolve;
+    }));
+
+    const { initialize } = useSessionSettings();
+    const pending = initialize(buildModel({ frontendSettings: frontend({ persistPrivacySettings: false }) }), [], true);
+    await flushPromises();
+
+    // both writes rewrite the whole settings blob, so the privacy reset must not overlap
+    expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
+
+    release();
+    await pending;
+
+    expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({
+      privacyMode: PrivacyMode.NORMAL,
+      scrambleData: false,
+    });
   });
 
   it('should use the explicit timeframe when it is not REMEMBER', async () => {

--- a/frontend/app/src/modules/session/use-session-settings.ts
+++ b/frontend/app/src/modules/session/use-session-settings.ts
@@ -11,7 +11,7 @@ import { useSettingsOperations } from '@/modules/settings/use-settings-operation
 import { useThemeMigration } from '@/modules/settings/use-theme-migration';
 
 interface UseSessionSettingsReturn {
-  initialize: (model: UserSettingsModel, exchanges: Exchange[]) => Promise<void>;
+  initialize: (model: UserSettingsModel, exchanges: Exchange[], newAccount?: boolean) => Promise<void>;
 }
 
 export function useSessionSettings(): UseSessionSettingsReturn {
@@ -35,6 +35,7 @@ export function useSessionSettings(): UseSessionSettingsReturn {
       other: { frontendSettings, havePremium, premiumShouldSync },
     }: UserSettingsModel,
     exchanges: Exchange[],
+    newAccount = false,
   ): Promise<void> => {
     if (frontendSettings) {
       const { lastKnownTimeframe, persistPrivacySettings, timeframeSetting } = frontendSettings;
@@ -48,7 +49,9 @@ export function useSessionSettings(): UseSessionSettingsReturn {
       setConnectedExchanges(exchanges);
       updateSessionSettings({ timeframe });
       checkDefaultThemeVersion();
-      checkForSuggestions(frontendSettings, general);
+      // Awaited before the privacy reset below: both go through the same read-modify-write of
+      // the settings blob, so overlapping them can lose the applied-suggestions version.
+      await checkForSuggestions(frontendSettings, general, newAccount);
 
       if (!persistPrivacySettings) {
         await updateFrontendSetting({

--- a/frontend/app/src/modules/settings/suggestions/use-settings-suggestions.spec.ts
+++ b/frontend/app/src/modules/settings/suggestions/use-settings-suggestions.spec.ts
@@ -318,41 +318,53 @@ describe('useSettingsSuggestions', () => {
   });
 
   describe('checkForSuggestions', () => {
-    it('should do nothing on a development version', () => {
+    it('should do nothing on a development version', async () => {
       set(mockAppVersion, '1.43.0-dev');
       const { checkForSuggestions } = useSettingsSuggestions();
-      checkForSuggestions(createFrontendSettings(), createGeneralSettings());
+      await checkForSuggestions(createFrontendSettings(), createGeneralSettings());
 
       expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
       expect(mockStore.showSuggestionsDialog).toBe(false);
     });
 
-    it('should do nothing when the app version is empty', () => {
+    it('should do nothing when the app version is empty', async () => {
       set(mockAppVersion, '');
       const { checkForSuggestions } = useSettingsSuggestions();
-      checkForSuggestions(createFrontendSettings(), createGeneralSettings());
+      await checkForSuggestions(createFrontendSettings(), createGeneralSettings());
 
       expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
     });
 
-    it('should open the dialog when there are pending suggestions', () => {
+    it('should open the dialog when there are pending suggestions', async () => {
       mockRegistry.value = [
         { suggestions: [{ description: 'd', key: 'submitUsageAnalytics', settingType: 'general', suggestedValue: true }], version: '1.43.0' },
       ];
       const { checkForSuggestions } = useSettingsSuggestions();
-      checkForSuggestions(createFrontendSettings(), createGeneralSettings({ submitUsageAnalytics: false }));
+      await checkForSuggestions(createFrontendSettings(), createGeneralSettings({ submitUsageAnalytics: false }));
 
       expect(mockStore.showSuggestionsDialog).toBe(true);
       expect(mockStore.pendingSuggestions).toHaveLength(1);
       expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
     });
 
-    it('should mark the version applied when there are no suggestions', () => {
+    it('should mark the version applied when there are no suggestions', async () => {
       const { checkForSuggestions } = useSettingsSuggestions();
-      checkForSuggestions(createFrontendSettings(), createGeneralSettings());
+      await checkForSuggestions(createFrontendSettings(), createGeneralSettings());
 
       expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({ lastAppliedSettingsVersion: '1.43.0' });
       expect(mockStore.showSuggestionsDialog).toBe(false);
+    });
+
+    it('should skip the dialog for a new account and mark the version applied', async () => {
+      mockRegistry.value = [
+        { suggestions: [{ description: 'd', key: 'submitUsageAnalytics', settingType: 'general', suggestedValue: true }], version: '1.43.0' },
+      ];
+      const { checkForSuggestions } = useSettingsSuggestions();
+      await checkForSuggestions(createFrontendSettings(), createGeneralSettings({ submitUsageAnalytics: false }), true);
+
+      expect(mockStore.showSuggestionsDialog).toBe(false);
+      expect(mockStore.pendingSuggestions).toEqual([]);
+      expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({ lastAppliedSettingsVersion: '1.43.0' });
     });
   });
 

--- a/frontend/app/src/modules/settings/suggestions/use-settings-suggestions.ts
+++ b/frontend/app/src/modules/settings/suggestions/use-settings-suggestions.ts
@@ -1,6 +1,5 @@
 import type { FrontendSettings, FrontendSettingsPayload } from '@/modules/settings/types/frontend-settings';
 import type { GeneralSettings, SettingsUpdate } from '@/modules/settings/types/user-settings';
-import { startPromise } from '@shared/utils';
 import { isEqual } from 'es-toolkit';
 import { useMainStore } from '@/modules/core/common/use-main-store';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
@@ -86,7 +85,8 @@ interface UseSettingsSuggestionsReturn {
   checkForSuggestions: (
     frontendSettings: FrontendSettings,
     generalSettings: GeneralSettings,
-  ) => void;
+    newAccount?: boolean,
+  ) => Promise<void>;
 }
 
 export function useSettingsSuggestions(): UseSettingsSuggestionsReturn {
@@ -95,13 +95,26 @@ export function useSettingsSuggestions(): UseSettingsSuggestionsReturn {
   const { appVersion } = storeToRefs(useMainStore());
   const { t } = useI18n({ useScope: 'global' });
 
-  function checkForSuggestions(
+  // Awaited by `initialize` rather than fire-and-forget: `updateFrontendSetting` rewrites the
+  // whole settings blob from a snapshot of the repo, so a concurrent write (the privacy reset
+  // that follows in `initialize`) would snapshot the pre-stamp version and put it back.
+  async function checkForSuggestions(
     frontendSettings: FrontendSettings,
     generalSettings: GeneralSettings,
-  ): void {
+    newAccount = false,
+  ): Promise<void> {
     const version = get(appVersion);
     if (!version || version.includes('dev'))
       return;
+
+    // A freshly created account is already on the current defaults, so recommendations from
+    // past versions never apply to it. Stamp the version instead of replaying them — the
+    // stored `0.0.0` default would otherwise make every historical suggestion pending, and
+    // applying one would move the account *off* the defaults it was just created with.
+    if (newAccount) {
+      await updateFrontendSetting({ lastAppliedSettingsVersion: version });
+      return;
+    }
 
     const registry = createSettingsSuggestions(t);
     const items = collectPendingSuggestions(frontendSettings, generalSettings, version, registry);
@@ -111,7 +124,7 @@ export function useSettingsSuggestions(): UseSettingsSuggestionsReturn {
       suggestionsStore.showSuggestionsDialog = true;
     }
     else {
-      startPromise(updateFrontendSetting({ lastAppliedSettingsVersion: version }));
+      await updateFrontendSetting({ lastAppliedSettingsVersion: version });
     }
   }
 


### PR DESCRIPTION
## Problem

A newly created account is shown the "New recommended settings" dialog on its very first login.

`lastAppliedSettingsVersion` defaults to `0.0.0`, so a fresh account looks like one that has never seen any recommendation and every entry in the registry for the current and earlier versions becomes pending. The account was just created on the current defaults, so applying a suggestion moves it *away* from them.

It is visible today: `a045885624` put `kraken` at the front of `DEFAULT_CURRENT_PRICE_ORACLES_ORDER`, while the 1.43 `currentPriceOracles` suggestion is a full replacement list without it. A brand-new account is therefore offered a change that removes the kraken oracle it was just created with.

## Fix

Account creation stamps the running version instead of showing the dialog, so a new account gets no suggestions for its own version or any earlier one. Later versions still prompt normally.

Restoring a premium backup is excluded: the pulled database belongs to an existing account, so its recommendations still apply.

The stamp is awaited rather than fire-and-forget. `updateFrontendSetting` rewrites the whole settings blob from a snapshot of the repo, and `initialize` writes again right after (the privacy reset, which runs whenever `persistPrivacySettings` is false, the default). Overlapping them could snapshot the pre-stamp version and put it back, bringing the dialog around again on the next login.

## Not addressed here

The 1.43 `currentPriceOracles` suggestion is itself stale for genuine upgraders: accepting it leaves them without the kraken oracle every fresh 1.43 account gets. Fixing that is a separate call (amend the 1.43 entry vs. add a 1.43.x one that re-prompts people who already dismissed it).

## Tests

`use-settings-suggestions.spec.ts` and `use-session-settings.spec.ts`; the ordering test was confirmed to fail without the `await`.