### PR TITLE
Resolve the e2e port block only once

### DIFF
--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -33,10 +33,23 @@ function isPortFree(port: number): boolean {
  * `reuseExistingServer`). Move the whole block up in steps of 10 until every port in it
  * is free. CI is pinned to the base block: the build job bakes the backend/colibri URLs
  * into the frontend bundle from its own env, so the ports cannot be chosen here.
+ *
+ * The offset must be resolved exactly once per run. Playwright loads this config in the
+ * main process and again in every worker, and by the time a worker loads it the servers
+ * the main process started are occupying the block it picked. A second probe would see
+ * them as busy and shift, leaving the helpers that import `backendUrl` pointing at a port
+ * nothing is listening on. Publishing the result to the env makes the workers - which are
+ * children of the main process - inherit the decision instead of re-deciding.
  */
 function resolvePortOffset(): number {
   if (process.env.CI)
     return 0;
+
+  // A non-empty value is either inherited from the main process or set deliberately in the
+  // shell to pin a block; `'0'` is truthy, so the base block still round-trips.
+  const inherited = process.env.E2E_PORT_OFFSET;
+  if (inherited && Number.isInteger(Number(inherited)))
+    return Number(inherited);
 
   for (let block = 0; block < MAX_PORT_BLOCKS; block++) {
     const offset = block * PORT_BLOCK_STRIDE;
@@ -44,6 +57,7 @@ function resolvePortOffset(): number {
       if (offset > 0)
         console.log(`[e2e] ports ${BASE_FRONTEND_PORT}-${BASE_MOCK_RPC_PORT} are busy, using +${offset}`);
 
+      process.env.E2E_PORT_OFFSET = String(offset);
       return offset;
     }
   }


### PR DESCRIPTION
Follow-up to #12711, which added local port shifting for the e2e services.

## The bug

`resolvePortOffset()` runs at module load, and Playwright loads `playwright.config.ts` in the main process *and* again in every worker process. The main process probes the base block while it is still free, starts the four servers there, and then the worker re-probes, finds those same ports busy (its own run's servers), and shifts the whole block up by 10.

Everything that imports a URL from the config then points at a port nothing is listening on:

- `tests/e2e/helpers/api.ts` (`backendUrl`, `colibriUrl`)
- `tests/e2e/helpers/rpc-mock.ts`, `snapshot-api.ts`, `exchange-api.ts`

`use.baseURL` is unaffected because Playwright resolves `use` in the main process and serializes it to workers, so page navigation keeps working and only the direct API calls fail. `dataDir` in `seed-db.ts` carries no offset, so it is fine too.

CI never hit this: `resolvePortOffset()` returns 0 early when `CI` is set.

## The fix

Publish the resolved offset to `E2E_PORT_OFFSET`. Workers are children of the main process, so they inherit the decision instead of re-deciding it. Exporting the variable by hand also pins a block for a run.

## Verification

A probe config that imports the real `playwright.config.ts`, then occupies 30301-30304 in `globalSetup` to stand in for the servers the main process starts:

Before:

```
[e2e] ports 30301-30304 are busy, using +10
[probe] main-process eval: backendUrl=http://127.0.0.1:30302
[probe] worker eval:       backendUrl=http://127.0.0.1:30312   <- mismatch
```

After:

```
[probe] main-process eval: backendUrl=http://127.0.0.1:30302
[probe] worker eval:       backendUrl=http://127.0.0.1:30302
```

## Follow-up, not in this PR

The structural fix is to stop exporting URLs from the config module and pass the ports through `use` as custom options consumed via a fixture, the same mechanism that already keeps `baseURL` correct. That touches four helpers and their call sites, so it is better as its own change.