### PR TITLE
Route the Electron renderer through the starling proxy

### DIFF
--- a/crates/starling-proxy/src/lib.rs
+++ b/crates/starling-proxy/src/lib.rs
@@ -185,9 +185,12 @@ where
     F: std::future::Future<Output = ()> + Send + 'static,
 {
     let app = router(&config);
+    // The SPA is served in docker only; embedded is a data-plane-only front, so
+    // say which of the two this is rather than always claiming both.
     info!(
         port = config.port,
-        "starting in-process HTTP server (SPA + proxy)"
+        spa = config.frontend_dir.is_some(),
+        "starting in-process HTTP server"
     );
 
     let connections = Arc::new(Semaphore::new(MAX_CONCURRENT_CONNECTIONS));

--- a/crates/starling/src/config.rs
+++ b/crates/starling/src/config.rs
@@ -171,7 +171,12 @@ pub fn resolve_port(cli: Option<u16>, layered: bool) -> Result<u16, String> {
     } else {
         (DEFAULT_HTTP_PORT, Source::Default)
     };
-    info!(value = port, source = %source, "resolved http port");
+    // Only docker publishes this port; embedded resolves it and throws it away,
+    // so logging it there just invites the reader to mistake it for the port the
+    // supervisor is actually listening on.
+    if layered {
+        info!(value = port, source = %source, "resolved http port");
+    }
     Ok(port)
 }
 

--- a/crates/starling/src/main.rs
+++ b/crates/starling/src/main.rs
@@ -247,6 +247,15 @@ struct Cli {
     #[arg(long)]
     port: Option<u16>,
 
+    /// Loopback port for the in-process reverse proxy in embedded mode. When set,
+    /// starling binds the proxy on `127.0.0.1:<port>` and the renderer talks to
+    /// this single origin instead of hitting core and colibri directly. Unset
+    /// keeps the pre-proxy two-URL path (no proxy is started). Docker resolves its
+    /// externally-bound port via `--port`/`ROTKI_HTTP_PORT` instead, so this flag
+    /// is ignored there.
+    #[arg(long)]
+    proxy_port: Option<u16>,
+
     /// Directory holding the built SPA, served by the in-process HTTP server
     /// (docker mode only; defaults to `/opt/rotki/frontend`). Unused in embedded
     /// mode, where Electron loads the SPA itself.
@@ -288,14 +297,19 @@ struct Cli {
 /// which interface it binds:
 ///   - **docker**: always, it replaces nginx and *is* the published port, bound
 ///     on all interfaces (`0.0.0.0`) on the resolved external port.
-///   - **embedded**: never in this slice. E1 deliberately ships the renderer
-///     two-URL with no proxy; collapsing it to a single origin is a later slice.
+///   - **embedded**: only when `--proxy-port` is given, bound on loopback
+///     (`127.0.0.1`) so the renderer can talk to a single origin. Unset keeps the
+///     pre-proxy two-URL path alive as a fallback.
 ///
 /// `None` means no proxy is started.
-fn proxy_bind_addr(mode: Mode, docker_http_port: u16) -> Option<(IpAddr, u16)> {
+fn proxy_bind_addr(
+    mode: Mode,
+    docker_http_port: u16,
+    embedded_proxy_port: Option<u16>,
+) -> Option<(IpAddr, u16)> {
     match mode {
         Mode::Docker => Some((IpAddr::V4(Ipv4Addr::UNSPECIFIED), docker_http_port)),
-        Mode::Embedded => None,
+        Mode::Embedded => embedded_proxy_port.map(|port| (IpAddr::V4(Ipv4Addr::LOCALHOST), port)),
     }
 }
 
@@ -428,12 +442,12 @@ async fn main() -> std::process::ExitCode {
             return std::process::ExitCode::FAILURE;
         }
     };
-    let proxy_target = proxy_bind_addr(cli.mode, http_port);
+    let proxy_target = proxy_bind_addr(cli.mode, http_port, cli.proxy_port);
 
-    // The proxy, privilege separation and the control socket are docker-only, so
-    // their flags do nothing in embedded mode. Silently ignoring them sends anyone
-    // who passes `--port` in embedded hunting through the source for why no proxy
-    // appeared, so name them instead.
+    // Some flags belong to only one mode; ignoring the others silently sends
+    // anyone who passed them hunting through the source for why nothing happened,
+    // so name them instead. `--port`, `--frontend-dir`, `--trusted-proxy` and
+    // privilege separation are docker-only; `--proxy-port` is embedded-only.
     if !docker {
         let ignored: Vec<&str> = [
             ("--port", cli.port.is_some()),
@@ -449,6 +463,8 @@ async fn main() -> std::process::ExitCode {
                 "ignoring docker-only flags in embedded mode",
             );
         }
+    } else if cli.proxy_port.is_some() {
+        warn!("ignoring embedded-only flag --proxy-port in docker mode");
     }
 
     // Guard the MiB -> bytes conversion: clap accepts any usize, and an
@@ -791,11 +807,14 @@ async fn main() -> std::process::ExitCode {
             colibri_port: cli.colibri_port,
             mcp_port: cli.mcp_port,
             mcp_enabled: authenticated_mcp,
-            frontend_dir: Some(
+            // Docker serves the built SPA from disk; embedded loads it from
+            // `app://localhost` in Electron, so the proxy is data-plane only there
+            // (no `ServeDir`).
+            frontend_dir: docker.then(|| {
                 cli.frontend_dir
                     .clone()
-                    .unwrap_or_else(|| PathBuf::from(DEFAULT_FRONTEND_DIR)),
-            ),
+                    .unwrap_or_else(|| PathBuf::from(DEFAULT_FRONTEND_DIR))
+            }),
             max_body_bytes,
             // Core and colibri validate the session cookie themselves. MCP validates
             // its bearer token itself too, while `mcp_enabled` ensures the external
@@ -1036,4 +1055,35 @@ async fn shutdown_signal(os_deadline: Arc<AtomicBool>) {
 #[cfg(not(any(unix, windows)))]
 async fn shutdown_signal() {
     let _ = tokio::signal::ctrl_c().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn docker_binds_all_interfaces_on_the_external_port() {
+        assert_eq!(
+            proxy_bind_addr(Mode::Docker, 80, None),
+            Some((IpAddr::V4(Ipv4Addr::UNSPECIFIED), 80)),
+        );
+        // The embedded proxy port is irrelevant in docker mode.
+        assert_eq!(
+            proxy_bind_addr(Mode::Docker, 8080, Some(41234)),
+            Some((IpAddr::V4(Ipv4Addr::UNSPECIFIED), 8080)),
+        );
+    }
+
+    #[test]
+    fn embedded_binds_loopback_only_when_a_proxy_port_is_given() {
+        assert_eq!(
+            proxy_bind_addr(Mode::Embedded, 80, Some(41234)),
+            Some((IpAddr::V4(Ipv4Addr::LOCALHOST), 41234)),
+        );
+    }
+
+    #[test]
+    fn embedded_without_a_proxy_port_starts_no_proxy() {
+        assert_eq!(proxy_bind_addr(Mode::Embedded, 80, None), None);
+    }
 }

--- a/frontend/app/electron/main/app-config.ts
+++ b/frontend/app/electron/main/app-config.ts
@@ -8,5 +8,6 @@ export interface AppConfig {
     colibriPort: number;
     corePort: number;
     mcpPort: number;
+    proxyPort: number;
   };
 }

--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -7,7 +7,7 @@ import { IpcManager } from '@electron/main/ipc-setup';
 import { LogService } from '@electron/main/log-service';
 import { MenuManager } from '@electron/main/menu';
 import { parseToken } from '@electron/main/oauth-utils';
-import { DEFAULT_COLIBRI_PORT, DEFAULT_MCP_PORT, DEFAULT_PORT } from '@electron/main/port-utils';
+import { DEFAULT_COLIBRI_PORT, DEFAULT_MCP_PORT, DEFAULT_PORT, DEFAULT_PROXY_PORT } from '@electron/main/port-utils';
 import { resolveLogLevel } from '@electron/main/resolve-log-level';
 import { SettingsManager } from '@electron/main/settings-manager';
 import { StarlingHandler } from '@electron/main/starling-handler';
@@ -50,6 +50,7 @@ export class Application {
       colibriPort: instancePort('ROTKI_INSTANCE_COLIBRI_PORT', DEFAULT_COLIBRI_PORT),
       corePort: instancePort('ROTKI_INSTANCE_CORE_PORT', DEFAULT_PORT),
       mcpPort: instancePort('ROTKI_INSTANCE_MCP_PORT', DEFAULT_MCP_PORT),
+      proxyPort: instancePort('ROTKI_INSTANCE_PROXY_PORT', DEFAULT_PROXY_PORT),
     },
   };
 

--- a/frontend/app/electron/main/port-utils.ts
+++ b/frontend/app/electron/main/port-utils.ts
@@ -7,6 +7,8 @@ export const DEFAULT_COLIBRI_PORT = 4343;
 
 export const DEFAULT_MCP_PORT = 4445;
 
+export const DEFAULT_PROXY_PORT = 4141;
+
 async function checkAvailability(port: number, host: string): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     const server = net.createServer();

--- a/frontend/app/electron/main/starling-args.spec.ts
+++ b/frontend/app/electron/main/starling-args.spec.ts
@@ -34,6 +34,7 @@ const devInput = {
   corePort: 4242,
   colibriPort: 4343,
   mcpPort: 4445,
+  proxyPort: 4141,
   apiHost: '127.0.0.1',
   logsDir: '/tmp/logs',
   options: {},
@@ -132,6 +133,12 @@ describe('buildStarlingInvocation (dev launchers)', () => {
     existsSyncMock.mockReturnValue(true);
     const { args } = await buildDevInvocation();
     expect(flagValue(args, '--mcp-port')).toBe(devInput.mcpPort.toString());
+  });
+
+  it('should tell starling which proxy port to bind', async () => {
+    existsSyncMock.mockReturnValue(true);
+    const { args } = await buildDevInvocation();
+    expect(flagValue(args, '--proxy-port')).toBe(devInput.proxyPort.toString());
   });
 
   describe('when the warm-up builds are missing', () => {

--- a/frontend/app/electron/main/starling-args.ts
+++ b/frontend/app/electron/main/starling-args.ts
@@ -44,6 +44,8 @@ export interface StarlingLaunchInput {
   colibriPort: number;
   /** Port allocated for the MCP streamable HTTP server. */
   mcpPort: number;
+  /** Loopback port the in-process reverse proxy binds; the single renderer origin. */
+  proxyPort: number;
   /** Loopback host the backends bind (always 127.0.0.1 in embedded mode). */
   apiHost: string;
   /** Directory starling writes service logs to (owned by LogService). */
@@ -184,7 +186,7 @@ function corsOrigins(isDev: boolean): string {
  * mirrored on both CLI and RPC.
  */
 function commonStarlingArgs(input: StarlingLaunchInput): string[] {
-  const { options, corePort, colibriPort, mcpPort, apiHost, logsDir, isDev } = input;
+  const { options, corePort, colibriPort, mcpPort, proxyPort, apiHost, logsDir, isDev } = input;
 
   const args = [
     '--core-port',
@@ -193,6 +195,10 @@ function commonStarlingArgs(input: StarlingLaunchInput): string[] {
     colibriPort.toString(),
     '--mcp-port',
     mcpPort.toString(),
+    // Bind the reverse proxy on this loopback port; core and colibri (above) are
+    // its upstream targets. The renderer talks to this single origin.
+    '--proxy-port',
+    proxyPort.toString(),
     '--api-host',
     apiHost,
     '--api-cors',

--- a/frontend/app/electron/main/starling-handler.spec.ts
+++ b/frontend/app/electron/main/starling-handler.spec.ts
@@ -102,7 +102,7 @@ function makeConfig(): AppConfig {
   return {
     isDev: false,
     isMac: false,
-    ports: { corePort: 4242, colibriPort: 4343, mcpPort: 4445 },
+    ports: { corePort: 4242, colibriPort: 4343, mcpPort: 4445, proxyPort: 4141 },
     urls: { coreApiUrl: '', colibriApiUrl: '' },
   } satisfies AppConfig;
 }
@@ -118,7 +118,7 @@ describe('starlingHandler', () => {
     spawnMock.mockReset();
   });
 
-  it('should drive the initial bring-up via the start request and publish both loopback URLs', async () => {
+  it('should drive the initial bring-up via the start request and collapse the renderer onto the proxy origin', async () => {
     // starling boots idle; the handler drives the first start and resolves on
     // its reply (not on an event), so record which control methods it sends.
     const methods: string[] = [];
@@ -137,15 +137,17 @@ describe('starlingHandler', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(methods).toContain('start'); // renderer drives the first bring-up
     expect(onProcessError).not.toHaveBeenCalled();
-    // Two-URL posture: the renderer dials the allocated loopback ports directly.
-    expect(config.urls.coreApiUrl).toBe('http://127.0.0.1:4242');
-    expect(config.urls.colibriApiUrl).toBe('http://127.0.0.1:4343');
+    // Single-origin posture: both URLs point at the proxy port; colibri sits
+    // under /colibri. The direct core/colibri ports are the proxy's upstreams.
+    expect(config.urls.coreApiUrl).toBe('http://127.0.0.1:4141');
+    expect(config.urls.colibriApiUrl).toBe('http://127.0.0.1:4141/colibri');
     expect(handler.getMcpServerEndpoint()).toBe('http://127.0.0.1:4445/mcp');
     expect(selectPortMock).toHaveBeenCalledWith(4242, '127.0.0.1');
     expect(selectPortMock).toHaveBeenCalledWith(4343, '127.0.0.1');
     expect(selectPortMock).toHaveBeenCalledWith(4445, '127.0.0.1');
+    expect(selectPortMock).toHaveBeenCalledWith(4141, '127.0.0.1');
     expect(buildStarlingInvocationMock).toHaveBeenCalledWith(
-      expect.objectContaining({ mcpPort: 4445 }),
+      expect.objectContaining({ mcpPort: 4445, proxyPort: 4141 }),
     );
   });
 

--- a/frontend/app/electron/main/starling-handler.ts
+++ b/frontend/app/electron/main/starling-handler.ts
@@ -34,8 +34,9 @@ const EXIT_MARGIN = 5_000;
  * stdio. Replaces the old SubprocessHandler + two ProcessManagers: starling now
  * spawns/supervises/tree-kills core + colibri, and this class drives it.
  *
- * The renderer talks directly to the loopback URLs this handler fills in from
- * the ports it allocates before spawning. No reverse proxy is involved.
+ * The renderer talks to a single loopback origin: starling's in-process reverse
+ * proxy, which this handler binds on an allocated port and forwards to the core
+ * and colibri ports it also allocated.
  */
 export class StarlingHandler {
   private child: ChildProcess | undefined;
@@ -139,13 +140,23 @@ export class StarlingHandler {
     const corePort = await this.resolvePort('core');
     const colibriPort = await this.resolvePort('colibri');
     const mcpPort = await this.resolvePort('mcp');
+    const proxyPort = await this.resolvePort('proxy');
     const logsDir = this.logsDirectory();
+
+    // Collapse the renderer onto the single proxy origin: `/api/1/*` and `/ws/`
+    // reach core, `/colibri/*` reaches colibri (the proxy strips the prefix). The
+    // direct core/colibri ports stay the proxy's upstream targets, passed to
+    // starling above; the renderer never dials them.
+    const proxyOrigin = `http://${API_HOST}:${proxyPort}`;
+    this.config.urls.coreApiUrl = proxyOrigin;
+    this.config.urls.colibriApiUrl = `${proxyOrigin}/colibri`;
 
     const invocation = buildStarlingInvocation({
       isDev: this.config.isDev,
       corePort,
       colibriPort,
       mcpPort,
+      proxyPort,
       apiHost: API_HOST,
       logsDir,
       options,
@@ -334,20 +345,16 @@ export class StarlingHandler {
   }
 
   /**
-   * Allocate a free loopback port for a service from its configured default and
-   * publish the resulting origin the renderer dials directly.
+   * Allocate a free loopback port for a service from its configured default.
+   * The renderer-facing origins are set from the proxy port by the caller; here
+   * only `mcp` records its resolved port, which `mcpServerUrl()` reads back.
    */
-  private async resolvePort(name: 'core' | 'colibri' | 'mcp'): Promise<number> {
+  private async resolvePort(name: 'core' | 'colibri' | 'mcp' | 'proxy'): Promise<number> {
     const defaultPort = this.config.ports[`${name}Port`];
     const port = await selectPort(defaultPort, API_HOST);
     if (port !== defaultPort)
       this.logger.warn(`Using non-default port ${port} for ${name}`);
-    const url = `http://${API_HOST}:${port}`;
-    if (name === 'core')
-      this.config.urls.coreApiUrl = url;
-    else if (name === 'colibri')
-      this.config.urls.colibriApiUrl = url;
-    else
+    if (name === 'mcp')
       this.config.ports.mcpPort = port;
     return port;
   }

--- a/frontend/app/src/modules/assets/api/use-asset-icon-api.ts
+++ b/frontend/app/src/modules/assets/api/use-asset-icon-api.ts
@@ -1,4 +1,4 @@
-import { defaultApiUrls } from '@/modules/core/api/api-urls';
+import { apiUrls } from '@/modules/core/api/api-urls';
 import { api } from '@/modules/core/api/rotki-api';
 import { HTTPStatus } from '@/modules/core/api/types/http';
 
@@ -23,14 +23,14 @@ export function useAssetIconApi(): UseAssetIconApiReturn {
     if (randomString)
       params.set('t', String(randomString));
 
-    return `${defaultApiUrls.colibriApiUrl}/assets/icon?${params.toString()}`;
+    return `${apiUrls.colibriApiUrl}/assets/icon?${params.toString()}`;
   };
 
   const checkAsset = async (identifier: string, options: CheckAssetOptions): Promise<number> => {
     const params = new URLSearchParams();
     params.set('asset_id', identifier);
     return api.headStatus(`/assets/icon?${params.toString()}`, {
-      baseURL: defaultApiUrls.colibriApiUrl,
+      baseURL: apiUrls.colibriApiUrl,
       signal: options.abortController?.signal,
       validStatuses: [HTTPStatus.OK, HTTPStatus.ACCEPTED, HTTPStatus.NOT_FOUND],
     });

--- a/frontend/app/src/modules/assets/api/use-asset-ignore-api.ts
+++ b/frontend/app/src/modules/assets/api/use-asset-ignore-api.ts
@@ -1,5 +1,5 @@
 import { IgnoredAssetResponse } from '@/modules/assets/types';
-import { defaultApiUrls } from '@/modules/core/api/api-urls';
+import { apiUrls } from '@/modules/core/api/api-urls';
 import { api } from '@/modules/core/api/rotki-api';
 import { VALID_WITHOUT_SESSION_STATUS } from '@/modules/core/api/utils';
 
@@ -11,7 +11,7 @@ interface UseAssetIgnoreApiReturn {
 
 export function useAssetIgnoreApi(): UseAssetIgnoreApiReturn {
   const getIgnoredAssets = async (): Promise<string[]> => api.get<string[]>('/assets/ignored', {
-    baseURL: defaultApiUrls.colibriApiUrl,
+    baseURL: apiUrls.colibriApiUrl,
     validStatuses: VALID_WITHOUT_SESSION_STATUS,
   });
 

--- a/frontend/app/src/modules/assets/api/use-asset-info-api.ts
+++ b/frontend/app/src/modules/assets/api/use-asset-info-api.ts
@@ -1,6 +1,6 @@
 import type { EvmChainAddress } from '@/modules/history/events/event-payloads';
 import { AssetMap, AssetsWithId } from '@/modules/assets/types';
-import { defaultApiUrls } from '@/modules/core/api/api-urls';
+import { apiUrls } from '@/modules/core/api/api-urls';
 import { api } from '@/modules/core/api/rotki-api';
 import { VALID_WITHOUT_SESSION_STATUS } from '@/modules/core/api/utils';
 import { type PendingTask, PendingTaskSchema } from '@/modules/core/tasks/types';
@@ -27,7 +27,7 @@ export function useAssetInfoApi(): UseAssetInfoApiReturn {
       '/assets/mappings',
       { identifiers },
       {
-        baseURL: defaultApiUrls.colibriApiUrl,
+        baseURL: apiUrls.colibriApiUrl,
         retry: true,
       },
     );
@@ -47,7 +47,7 @@ export function useAssetInfoApi(): UseAssetInfoApiReturn {
         ...payload,
       },
       {
-        baseURL: defaultApiUrls.colibriApiUrl,
+        baseURL: apiUrls.colibriApiUrl,
         retry: true,
         signal,
       },

--- a/frontend/app/src/modules/assets/api/use-asset-prices-api.ts
+++ b/frontend/app/src/modules/assets/api/use-asset-prices-api.ts
@@ -14,7 +14,7 @@ import {
   OraclePricesCollectionResponse,
   type OraclePricesQuery,
 } from '@/modules/assets/prices/price-types';
-import { defaultApiUrls } from '@/modules/core/api/api-urls';
+import { apiUrls } from '@/modules/core/api/api-urls';
 import { api } from '@/modules/core/api/rotki-api';
 import { VALID_WITHOUT_SESSION_STATUS } from '@/modules/core/api/utils';
 import { mapCollectionResponse } from '@/modules/core/common/data/collection-utils';
@@ -66,7 +66,7 @@ export function useAssetPricesApi(): UseAssetPricesApiReturn {
 
   const fetchOraclePrices = async (query?: OraclePricesQuery): Promise<Collection<OraclePriceEntry>> => {
     const response = await api.get<OraclePricesCollectionResponse>('/prices/oracle', {
-      baseURL: defaultApiUrls.colibriApiUrl,
+      baseURL: apiUrls.colibriApiUrl,
       filterEmptyProperties: { removeEmptyString: true },
       query,
       retry: true,
@@ -80,7 +80,7 @@ export function useAssetPricesApi(): UseAssetPricesApiReturn {
       '/prices/oracle/existence',
       { identifiers },
       {
-        baseURL: defaultApiUrls.colibriApiUrl,
+        baseURL: apiUrls.colibriApiUrl,
         retry: true,
       },
     );

--- a/frontend/app/src/modules/core/api/rotki-api.spec.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.spec.ts
@@ -1,7 +1,7 @@
 import { server } from '@test/setup-files/server';
 import { http, HttpResponse } from 'msw';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { defaultApiUrls } from '@/modules/core/api/api-urls';
+import { apiUrls, defaultApiUrls } from '@/modules/core/api/api-urls';
 import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
 import { RotkiApi } from '@/modules/core/api/rotki-api';
 import { ApiValidationError } from '@/modules/core/api/types/errors';
@@ -48,6 +48,31 @@ describe('modules/api/rotki-api', () => {
       expect(api.serverUrl).toBe(customUrl);
       expect(api.baseURL).toBe(`${customUrl}/api/1/`);
       expect(api.defaultBackend).toBe(false);
+    });
+  });
+
+  describe('colibri request routing', () => {
+    it('should route by the IPC-updated colibri url, not the frozen default', async () => {
+      // In embedded the proxy origin arrives via IPC after startup, so the
+      // frozen `defaultApiUrls.colibriApiUrl` stays '' and would never match.
+      // The router must read the mutable `apiUrls` the asset-* APIs also use.
+      const previous = apiUrls.colibriApiUrl;
+      apiUrls.colibriApiUrl = 'http://127.0.0.1:4141/colibri';
+      try {
+        server.use(
+          http.get('http://127.0.0.1:4141/colibri/all', () =>
+            HttpResponse.json({ result: [], message: '' })),
+        );
+
+        await api.get('/all', { baseURL: apiUrls.colibriApiUrl });
+
+        // The request landed on the colibri queue, not the core one.
+        expect(api.getColibriQueueMetrics().requestsThisSecond).toBe(1);
+        expect(api.getQueueMetrics().requestsThisSecond).toBe(0);
+      }
+      finally {
+        apiUrls.colibriApiUrl = previous;
+      }
     });
   });
 

--- a/frontend/app/src/modules/core/api/rotki-api.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.ts
@@ -2,7 +2,7 @@ import type { ActionResult } from '@rotki/common';
 import type { QueueState } from '@/modules/core/api/request-queue/types';
 import type { RotkiFetchOptions } from '@/modules/core/api/types';
 import { ofetch } from 'ofetch';
-import { defaultApiUrls } from '@/modules/core/api/api-urls';
+import { apiUrls, defaultApiUrls } from '@/modules/core/api/api-urls';
 import { DEFAULT_TIMEOUT } from '@/modules/core/api/constants';
 import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
 import { RequestQueue } from '@/modules/core/api/request-queue/queue';
@@ -90,7 +90,10 @@ export class RotkiApi {
   private isColibriRequest(baseURL?: string): boolean {
     if (!baseURL)
       return false;
-    const colibriUrl = defaultApiUrls.colibriApiUrl;
+    // Read the mutable urls, not the frozen defaults: in embedded the proxy
+    // origin arrives via IPC after startup, so the frozen colibri url stays ''
+    // and would never match. The asset-* APIs set this same baseURL.
+    const colibriUrl = apiUrls.colibriApiUrl;
     return colibriUrl !== '' && baseURL.startsWith(colibriUrl);
   }
 


### PR DESCRIPTION
Routes the Electron renderer through starling's in-process reverse proxy, so core
and colibri are reachable under one loopback origin instead of two direct ports.

This is step 1 of 3 towards a single origin in every mode. The follow-ups are a
`starling proxy` subcommand for `dev:web` (the one mode still handing the renderer
two ports), and then collapsing the renderer's two ApiUrls into one origin plus a
`/colibri` path prefix. The payoff lands in step 3; this step is what makes it
possible, and it removes the frozen-vs-mutable colibri URL footgun on the way.

## Commits

**`fix(starling): log the http port in docker only`** predates this work. The
external HTTP port is a docker concept, but `resolve_port` logged it in both modes,
so an embedded log carried `resolved http port value=80` naming a port nothing
listens on. Confusing on its own, actively misleading now that embedded really does
start a server on a different port.

**`feat(starling): bind embedded proxy on loopback`** adds `--proxy-port`
(embedded-only). When set, starling binds the existing proxy on `127.0.0.1:<port>`;
unset keeps the current two-URL path as a fallback. `frontend_dir` is `None` in
embedded, since Electron loads the SPA from `app://localhost`, so the proxy is
data-plane only there. The startup log now reports which of the two it is instead
of always claiming to serve the SPA.

**`feat(electron): route renderer through the starling proxy`** allocates a proxy
port (default 4141) alongside the existing ones, passes `--proxy-port`, and points
both renderer URLs at it: `coreApiUrl` is the proxy origin, `colibriApiUrl` is
`<origin>/colibri`. The direct core and colibri ports stay as the proxy's upstream
targets; the renderer no longer dials them.

**`fix(assets): use the mutable colibri api url`** is a pre-existing bug this
uncovered. The four asset-* APIs and `isColibriRequest` read `defaultApiUrls`, which
is frozen at build time from `VITE_COLIBRI_URL` (`127.0.0.1:4343`), while colibri's
real port comes from `selectPort` at runtime. Whenever 4343 is already taken, the
icon, info, prices and ignore endpoints keep addressing 4343 and reach either
nothing or a second instance's colibri, and they queue on the wrong lane because
`isColibriRequest` matches the same stale origin. Reading the mutable `apiUrls`
that the backend connection fills over IPC fixes that, and is also what lets colibri
resolve under the proxy origin.

## What goes through the proxy

| Route | Upstream |
|---|---|
| `/api/1/*` | core, path preserved |
| `/ws/` | core, WebSocket upgrade bridged |
| `/colibri/*` | colibri, `/colibri` prefix stripped |

MCP stays on its own port and is not proxied: `mcp_enabled` is
`docker && !session_key.is_empty()`, so the `/mcp` route stays closed in embedded.
The control channel is unchanged, still NDJSON over stdio. CORS is unaffected,
since the renderer page is still `app://localhost` and that remains the `Origin`
core sees.

## Testing

Verified on Linux, both `pnpm dev` and a packaged AppImage:

- proxy binds 4141, renderer reaches it from `app://localhost`
- `/api/1/*` and `/colibri/*` both resolve, including the prefix strip
- WebSocket upgrade returns 101 on `ws://127.0.0.1:4141/ws/`
- a settings change (backend restart) keeps the port and reconnects the socket.
  `handle_restart` only reconfigures and restarts the children, so the proxy
  listener outlives it by construction

Not yet exercised: macOS and Windows packaging, and the premium dev-proxy chain
(frontend to dev-proxy to starling proxy to core).

Gates: `cargo fmt`, `clippy -D warnings`, and the starling / starling-core /
starling-proxy suites; frontend typecheck and unit tests.
