### PR TITLE
Surface real backend startup errors and polish the error screen

### DIFF
--- a/crates/starling-core/src/control/controller.rs
+++ b/crates/starling-core/src/control/controller.rs
@@ -622,7 +622,7 @@ impl<S: Spawner> Controller<S> {
 
     /// Execute a `start`: rate-limit, apply the initial options, rebuild specs
     /// from the merged layout, and bring the tree up, emitting `ready` (or
-    /// returning [`ControlError::RestartFailed`] on a failed bring-up). Unlike
+    /// returning [`ControlError::StartFailed`] on a failed bring-up). Unlike
     /// `restart` there is nothing to tear down: the supervisor is idle, so no
     /// `restarting` event and no shutdown. `reconfigure` resets every service to
     /// `Idle` for the fresh `start_all`.
@@ -669,7 +669,7 @@ impl<S: Spawner> Controller<S> {
                 if let Some(guard) = self.datadir_guard.as_mut() {
                     if let Err(err) = guard.relock(&new_path) {
                         self.audit("start", transport, "datadir-locked");
-                        return Err(ControlError::RestartFailed(format!(
+                        return Err(ControlError::StartFailed(format!(
                             "data directory {new_dir} is already in use by another rotki instance: {err}",
                         )));
                     }
@@ -682,7 +682,7 @@ impl<S: Spawner> Controller<S> {
         let specs = (self.build)(&self.layout);
         if let Err(err) = self.supervisor.reconfigure(specs) {
             self.audit("start", transport, "reconfigure-failed");
-            return Err(ControlError::RestartFailed(err.to_string()));
+            return Err(ControlError::StartFailed(err.to_string()));
         }
 
         match self.supervisor.start_all().await {
@@ -702,7 +702,7 @@ impl<S: Spawner> Controller<S> {
             Err(err) => {
                 self.publish();
                 self.audit("start", transport, "failed");
-                Err(ControlError::RestartFailed(err.to_string()))
+                Err(ControlError::StartFailed(err.to_string()))
             }
         }
     }

--- a/crates/starling-core/src/control/protocol.rs
+++ b/crates/starling-core/src/control/protocol.rs
@@ -302,6 +302,11 @@ pub enum ControlError {
     /// A `restart` tore down the backend but failed to bring it back up.
     #[error("restart failed: {0}")]
     RestartFailed(String),
+    /// The initial `start` (from idle) failed to bring the backend up. Kept
+    /// distinct from `RestartFailed` so a first-start failure does not tell the
+    /// user a "restart" failed when nothing was running to restart.
+    #[error("failed to start the backend: {0}")]
+    StartFailed(String),
     /// Starting or stopping one optional service failed.
     #[error("service operation failed: {0}")]
     ServiceOperationFailed(String),

--- a/crates/starling-core/src/error.rs
+++ b/crates/starling-core/src/error.rs
@@ -1,5 +1,14 @@
 use thiserror::Error;
 
+/// Render an [`SupervisorError::EarlyExit`] detail as a `": <detail>"` suffix, or
+/// nothing when the dead service left no captured stderr.
+fn early_exit_suffix(detail: &Option<String>) -> String {
+    match detail {
+        Some(detail) => format!(": {detail}"),
+        None => String::new(),
+    }
+}
+
 /// Errors surfaced by the supervisor lifecycle core.
 #[derive(Error, Debug)]
 pub enum SupervisorError {
@@ -11,9 +20,14 @@ pub enum SupervisorError {
     ReadinessTimeout { service: String, attempts: u32 },
 
     /// A service process exited before it became ready (the ping-gate equivalent
-    /// of `entrypoint.py`'s early-exit guard).
-    #[error("service '{service}' exited before becoming ready")]
-    EarlyExit { service: String },
+    /// of `entrypoint.py`'s early-exit guard). `detail` carries the tail of the
+    /// dead service's own stderr when captured, so the reason it died (e.g. a
+    /// global-db schema error) travels with the error instead of only its logs.
+    #[error("service '{service}' exited before becoming ready{}", early_exit_suffix(.detail))]
+    EarlyExit {
+        service: String,
+        detail: Option<String>,
+    },
 
     /// A service declared a dependency that is not part of the service set.
     #[error("service '{service}' depends on unknown service '{dependency}'")]

--- a/crates/starling-core/src/lifecycle.rs
+++ b/crates/starling-core/src/lifecycle.rs
@@ -283,7 +283,11 @@ impl<S: Spawner> Supervisor<S> {
         let mut attempt = 0;
         loop {
             if let Some(dead) = self.first_exited(name).await? {
-                return Err(SupervisorError::EarlyExit { service: dead });
+                let detail = self.captured_error(&dead).await;
+                return Err(SupervisorError::EarlyExit {
+                    service: dead,
+                    detail,
+                });
             }
             if probe_once(readiness).await {
                 return Ok(());
@@ -328,6 +332,28 @@ impl<S: Spawner> Supervisor<S> {
             }
         }
         Ok(None)
+    }
+
+    /// The tail of a just-exited service's captured stderr, if any — the text it
+    /// printed as it died (a global-db schema error, a bad config), so callers
+    /// can report *why* it exited rather than only that it did. Returns `None`
+    /// when stderr was not captured (inherited/docker) or nothing was written.
+    async fn captured_error(&self, service: &str) -> Option<String> {
+        // Let the reader task append whatever the child wrote on its way out
+        // before we sample the tail.
+        tokio::time::sleep(STDERR_DRAIN_GRACE).await;
+        let process = self.services.get(service)?.process.as_ref()?;
+        let lines = process.recent_stderr();
+        if lines.is_empty() {
+            return None;
+        }
+        let joined = lines.join("\n");
+        // Keep the tail: the fatal line is the last thing written before exit.
+        let detail = match joined.char_indices().nth_back(MAX_DETAIL_CHARS - 1) {
+            Some((idx, _)) if idx > 0 => format!("…{}", &joined[idx..]),
+            _ => joined,
+        };
+        Some(detail)
     }
 
     /// Whether a service is really gone: its direct child has exited *and* nothing
@@ -469,6 +495,15 @@ const TREE_DRAIN_POLL: Duration = Duration::from_millis(50);
 /// five-minute wait looks identical to a hang.
 const READINESS_LOG_EVERY: u32 = 15;
 
+/// Grace to let a dead service's stderr reader drain before reading its tail. The
+/// fatal line is often written immediately before exit, so without this beat the
+/// tail can be sampled just before the reader task appends it.
+const STDERR_DRAIN_GRACE: Duration = Duration::from_millis(100);
+
+/// Cap on the surfaced stderr detail (kept from the tail, where the fatal line
+/// is) so a chatty debug log can't blow up an error dialog.
+const MAX_DETAIL_CHARS: usize = 2_000;
+
 /// Resolves once the service is *actually* gone: its direct child has exited and
 /// nothing is left in its process tree.
 ///
@@ -569,12 +604,18 @@ mod tests {
         /// direct child has exited. 0 (the default) means no stragglers.
         tree_probes_left: AtomicU32,
         killed: KillSwitch,
+        /// Stderr tail a captured child would expose; empty for inherited stderr.
+        stderr: Vec<String>,
     }
 
     #[async_trait]
     impl Process for MockProcess {
         fn pid(&self) -> Option<u32> {
             Some(self.pid)
+        }
+
+        fn recent_stderr(&self) -> Vec<String> {
+            self.stderr.clone()
         }
 
         async fn try_status(&self) -> io::Result<Option<ExitInfo>> {
@@ -634,6 +675,8 @@ mod tests {
         /// Stragglers each spawned process reports after its direct child exits.
         tree_probes: u32,
         killed: KillSwitch,
+        /// Per-service captured stderr tail handed to the spawned `MockProcess`.
+        stderr: HashMap<String, Vec<String>>,
     }
 
     impl MockSpawner {
@@ -644,7 +687,17 @@ mod tests {
                 next_pid: Mutex::new(1000),
                 tree_probes: 0,
                 killed: Arc::new(Mutex::new(HashSet::new())),
+                stderr: HashMap::new(),
             }
+        }
+
+        /// Give a service a captured stderr tail, as a piped child would have.
+        fn with_stderr(mut self, name: &str, lines: &[&str]) -> Self {
+            self.stderr.insert(
+                name.to_string(),
+                lines.iter().map(|s| s.to_string()).collect(),
+            );
+            self
         }
 
         /// Handle for killing a service out from under the supervisor later.
@@ -683,6 +736,7 @@ mod tests {
                 log: self.log.clone(),
                 tree_probes_left: AtomicU32::new(self.tree_probes),
                 killed: self.killed.clone(),
+                stderr: self.stderr.get(&spec.name).cloned().unwrap_or_default(),
             }))
         }
     }
@@ -900,11 +954,48 @@ mod tests {
 
         let err = sup.start_all().await.unwrap_err();
         match err {
-            SupervisorError::EarlyExit { service } => assert_eq!(
+            SupervisorError::EarlyExit { service, .. } => assert_eq!(
                 service, "core",
                 "the dead service should be named, not the one that was gating",
             ),
             other => panic!("expected core's death to fail the bring-up, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn early_exit_carries_the_dead_service_stderr_tail() {
+        let log: EventLog = Arc::new(Mutex::new(Vec::new()));
+        let spawner = MockSpawner::new(log).with_dead(&["core"]).with_stderr(
+            "core",
+            &[
+                "some earlier log line",
+                "ERROR at initialization: Tables {'asset_flags'} are missing",
+            ],
+        );
+        // A probing readiness so the gate runs the early-exit guard (Immediate
+        // returns Ready without ever checking whether the process is still alive).
+        let core = ServiceSpec::new("core", "/bin/true").readiness(Readiness::PortOpen {
+            host: "127.0.0.1".to_string(),
+            port: 1,
+            retries: 2,
+            interval: Duration::from_millis(10),
+        });
+        let mut sup = Supervisor::new(spawner, vec![core]).unwrap();
+
+        let err = sup.start_all().await.unwrap_err();
+        // The rendered form is what the control channel relays to the renderer.
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("exited before becoming ready:") && rendered.contains("asset_flags"),
+            "the dead service's stderr should ride along in the message: {rendered}",
+        );
+        match err {
+            SupervisorError::EarlyExit { service, detail } => {
+                assert_eq!(service, "core");
+                let detail = detail.expect("captured stderr should be attached");
+                assert!(detail.contains("asset_flags"), "detail was: {detail}");
+            }
+            other => panic!("expected an early exit, got {other:?}"),
         }
     }
 

--- a/crates/starling-core/src/process.rs
+++ b/crates/starling-core/src/process.rs
@@ -2,11 +2,20 @@
 //! unit-tested headless with a fake spawner and the real OS implementation can
 //! carry platform-specific process-tree termination.
 
+use std::collections::VecDeque;
 use std::io;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::config::{ServiceSpec, StdioMode};
+
+/// How many trailing stderr lines a captured child keeps. A fatal startup error
+/// (e.g. core's global-db schema check) is the last thing written before exit,
+/// so the tail is what carries it; the bound keeps a chatty debug log from
+/// growing without limit.
+const STDERR_TAIL_LINES: usize = 50;
 
 /// The outcome of a process that has exited.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -54,6 +63,15 @@ pub trait Process: Send + Sync {
     /// Forcibly kill the whole process tree
     /// (SIGKILL to the process group on unix, TerminateJobObject on windows).
     async fn kill(&self) -> io::Result<()>;
+
+    /// The most recent lines the child wrote to stderr, oldest first.
+    ///
+    /// Only populated when the spawner captured stderr (embedded/detached mode);
+    /// empty for inherited stderr and for test fakes. Used to surface a service's
+    /// own failure text (not just its exit code) when it dies during bring-up.
+    fn recent_stderr(&self) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 /// Spawns [`Process`]es from [`ServiceSpec`]s.
@@ -80,11 +98,16 @@ impl Spawner for OsSpawner {
 
         // §S7: when the supervisor's stdout is a private control channel, detach
         // the child's stdin+stdout so it can neither read control requests nor
-        // corrupt the response stream. stderr stays inherited for diagnostics.
+        // corrupt the response stream. stderr is piped (not inherited) so we can
+        // both forward it — preserving the diagnostics that used to flow straight
+        // through — and keep a tail of it to surface as the service's own error
+        // when it dies during bring-up. Docker's inherit mode keeps stderr
+        // untouched so the container runtime still captures it directly.
         if spec.stdio == StdioMode::Detached {
             std_cmd
                 .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null());
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::piped());
         }
 
         // Put the child in its own process group so we can signal the whole tree
@@ -141,8 +164,26 @@ impl Spawner for OsSpawner {
         // shutdown, don't leak the child.
         cmd.kill_on_drop(true);
 
-        let child = cmd.spawn()?;
+        let mut child = cmd.spawn()?;
         let pid = child.id();
+
+        // Tee the piped stderr to the supervisor's own stderr (where it landed
+        // before, via inheritance) while keeping a bounded tail for diagnostics.
+        let stderr_tail: Arc<Mutex<VecDeque<String>>> = Arc::new(Mutex::new(VecDeque::new()));
+        if let Some(stderr) = child.stderr.take() {
+            let tail = stderr_tail.clone();
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    eprintln!("{line}");
+                    let mut buf = tail.lock().expect("stderr tail mutex poisoned");
+                    if buf.len() == STDERR_TAIL_LINES {
+                        buf.pop_front();
+                    }
+                    buf.push_back(line);
+                }
+            });
+        }
 
         #[cfg(windows)]
         let job = platform::create_job_and_assign(&child)?;
@@ -150,6 +191,7 @@ impl Spawner for OsSpawner {
         Ok(Box::new(OsProcess {
             child: tokio::sync::Mutex::new(child),
             pid,
+            stderr_tail,
             #[cfg(windows)]
             job,
         }))
@@ -160,6 +202,9 @@ impl Spawner for OsSpawner {
 struct OsProcess {
     child: tokio::sync::Mutex<tokio::process::Child>,
     pid: Option<u32>,
+    /// Bounded tail of the child's captured stderr, filled by the reader task.
+    /// Empty when stderr was inherited rather than piped.
+    stderr_tail: Arc<Mutex<VecDeque<String>>>,
     /// Windows Job Object that owns the child's process tree.
     /// `KILL_ON_JOB_CLOSE` means dropping this handle reaps the whole tree —
     /// that's the auto-reap safety net if the supervisor dies.
@@ -202,6 +247,15 @@ impl Process for OsProcess {
 
     async fn tree_alive(&self) -> io::Result<bool> {
         platform::tree_alive(self).await
+    }
+
+    fn recent_stderr(&self) -> Vec<String> {
+        self.stderr_tail
+            .lock()
+            .expect("stderr tail mutex poisoned")
+            .iter()
+            .cloned()
+            .collect()
     }
 }
 

--- a/crates/starling/src/control/jsonrpc.rs
+++ b/crates/starling/src/control/jsonrpc.rs
@@ -73,9 +73,9 @@ fn error_code(err: &ControlError) -> i64 {
         // A precondition failure, not a malformed request: the caller asked for a
         // valid thing at a moment it does not apply.
         ControlError::AlreadyStarted => ERR_RESTART_FAILED,
-        ControlError::RestartFailed(_) | ControlError::ServiceOperationFailed(_) => {
-            ERR_RESTART_FAILED
-        }
+        ControlError::RestartFailed(_)
+        | ControlError::StartFailed(_)
+        | ControlError::ServiceOperationFailed(_) => ERR_RESTART_FAILED,
         ControlError::ControllerStopped => INTERNAL_ERROR,
     }
 }

--- a/frontend/app/electron/main/starling-handler.spec.ts
+++ b/frontend/app/electron/main/starling-handler.spec.ts
@@ -288,4 +288,30 @@ describe('starlingHandler', () => {
     // The exit reason is reported once; the readiness path must not double it.
     expect(onProcessError).toHaveBeenCalledTimes(1);
   });
+
+  it('should surface the actual start-failure reason instead of a generic message', async () => {
+    // starling stays alive (it supervises), but the `start` RPC rejects with the
+    // dead core's own error text. The handler must relay that so the renderer's
+    // error screen shows why it failed and the user can exit manually.
+    const reason = 'failed to start the backend: service \'core\' exited before becoming ready: '
+      + 'ERROR at initialization: Tables {\'asset_flags\'} are missing from your global database';
+    const child = makeFakeChild((message, stdout) => {
+      if (message.method === 'start') {
+        writeMessage(stdout, { id: message.id, error: { message: reason } });
+        return;
+      }
+      // Answer `stop` and let the child exit so teardown does not hit the kill timeout.
+      writeMessage(stdout, { id: message.id, result: null });
+      if (message.method === 'stop')
+        queueMicrotask(() => child.emit('exit', 0, null));
+    });
+    spawnMock.mockImplementation(() => child);
+    const handler = new StarlingHandler(makeLogger(), makeConfig());
+    const onProcessError = vi.fn();
+
+    await handler.restartBackend({ dataDirectory: '/data' }, { onProcessError });
+
+    expect(onProcessError).toHaveBeenCalledWith(reason, BackendCode.TERMINATED);
+    expect(onProcessError).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/app/electron/main/starling-handler.ts
+++ b/frontend/app/electron/main/starling-handler.ts
@@ -1,6 +1,6 @@
 import type { AppConfig } from '@electron/main/app-config';
 import type { LogService } from '@electron/main/log-service';
-import type { JsonRpcResponse, StarlingErrorListener } from '@electron/main/starling-handler-types';
+import type { StarlingErrorListener } from '@electron/main/starling-handler-types';
 import { type ChildProcess, spawn } from 'node:child_process';
 import * as os from 'node:os';
 import path from 'node:path';
@@ -11,6 +11,7 @@ import { resolveLogLevel } from '@electron/main/resolve-log-level';
 import { buildStarlingInvocation, SHUTDOWN_GRACE_SECS, type StarlingInvocation } from '@electron/main/starling-args';
 import { forwardStarlingLine } from '@electron/main/starling-log';
 import { eventLastError, getMcpServerState, isMcpCrash, setMcpServerRunning } from '@electron/main/starling-mcp';
+import { StarlingRpc } from '@electron/main/starling-rpc';
 import { BackendCode, type BackendOptions, type McpServiceState } from '@shared/ipc';
 import { wait } from '@shared/utils';
 
@@ -45,12 +46,15 @@ export class StarlingHandler {
   private currentDataDir: string | undefined;
   private currentLogDir: string | undefined;
 
-  // --- JSON-RPC client state ---
-  private nextId: number = 1;
-  private readonly pending = new Map<number, { resolve: (value: any) => void; reject: (error: Error) => void }>();
+  /** The listener for the live child, so control-channel events can reach it. */
+  private currentListener: StarlingErrorListener | undefined;
+
+  /** The NDJSON JSON-RPC client over the child's stdio. */
+  private readonly rpc: StarlingRpc;
 
   constructor(private readonly logger: LogService, private readonly config: AppConfig) {
     this.logger.info('Starting rotki (starling supervisor)');
+    this.rpc = new StarlingRpc(logger, (method, params) => this.onEvent(method, params));
   }
 
   private checkIfMacOsVersionIsSupported(): boolean {
@@ -105,7 +109,7 @@ export class StarlingHandler {
   private async restartInPlace(options: Partial<BackendOptions>, listener: StarlingErrorListener): Promise<void> {
     this.logger.info('Restarting backend in place via control RPC');
     try {
-      await this.request('restart', this.restartParams(options));
+      await this.rpc.request('restart', this.restartParams(options));
     }
     catch (error: any) {
       this.logger.error('Backend restart failed', error);
@@ -156,18 +160,18 @@ export class StarlingHandler {
     // (log level, tunables, data dir) the CLI no longer passes. It resolves once
     // the whole tree is ready, and rejects on a failed bring-up or early exit.
     try {
-      await this.request('start', this.startParams(options));
+      await this.rpc.request('start', this.startParams(options));
     }
     catch (error) {
-      // Report only while the child is still alive: if it already exited, its
-      // `exit` handler reported the precise reason (data-dir lock / non-zero
-      // exit) and rejected this request as a side effect — re-reporting doubles it.
+      // Report only while the child is still alive: an already-exited child had its
+      // precise reason reported by the `exit` handler, and re-reporting doubles it.
       if (!this.exiting && this.child) {
         this.logger.error('Backend start failed', error);
-        listener.onProcessError(
-          'Failed to start the rotki backend. Please check the logs for more details.',
-          BackendCode.TERMINATED,
-        );
+        // Relay starling's real reason (now carrying the dead core's stderr tail).
+        const message = error instanceof Error && error.message.length > 0
+          ? error.message
+          : 'Failed to start the rotki backend. Please check the logs for more details.';
+        listener.onProcessError(message, BackendCode.TERMINATED);
         await this.stop();
       }
     }
@@ -196,13 +200,15 @@ export class StarlingHandler {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     this.child = child;
+    this.currentListener = listener;
 
     if (!child.stdout || !child.stderr || !child.stdin)
       throw new Error('starling child is missing its stdio pipes');
 
     // stdout is the NDJSON control channel (responses + event notifications).
+    this.rpc.attach(child.stdin);
     const rl = readline.createInterface({ input: child.stdout });
-    rl.on('line', line => this.onLine(line, listener));
+    rl.on('line', line => this.rpc.handleLine(line));
 
     // stderr carries starling's own logs and the inherited backend stderr, so
     // supervisor diagnostics land in the Electron log (gotcha 2).
@@ -222,8 +228,10 @@ export class StarlingHandler {
         errReader.close();
         // Rejecting the pending requests also unblocks the initial `start`
         // request if the child died before replying.
-        this.rejectAllPending(new Error('starling exited'));
+        this.rpc.rejectAll(new Error('starling exited'));
+        this.rpc.detach();
         this.child = undefined;
+        this.currentListener = undefined;
         if (!this.exiting && code === EXIT_DATADIR_IN_USE) {
           listener.onProcessError(
             'Another rotki instance is already using this data directory. Please close it and try again.',
@@ -241,37 +249,9 @@ export class StarlingHandler {
     });
   }
 
-  /** Parse one NDJSON line: an id-correlated response, or an event notification. */
-  private onLine(line: string, listener: StarlingErrorListener): void {
-    const trimmed = line.trim();
-    if (!trimmed)
-      return;
-    let message: JsonRpcResponse;
-    try {
-      message = JSON.parse(trimmed);
-    }
-    catch {
-      this.logger.warn(`Ignoring non-JSON line from starling: ${trimmed}`);
-      return;
-    }
-
-    if (typeof message.id === 'number') {
-      const pending = this.pending.get(message.id);
-      if (!pending)
-        return;
-      this.pending.delete(message.id);
-      if (message.error)
-        pending.reject(new Error(message.error.message));
-      else
-        pending.resolve(message.result);
-      return;
-    }
-
-    if (message.method)
-      this.onEvent(message.method, message.params, listener);
-  }
-
-  private onEvent(method: string, params: unknown, listener: StarlingErrorListener): void {
+  /** React to a control-channel notification from starling (an `event.*`). */
+  private onEvent(method: string, params: unknown): void {
+    const listener = this.currentListener;
     switch (method) {
       case 'event.ready':
         // The whole backend tree is up. Initial readiness is gated on the `start`
@@ -283,9 +263,9 @@ export class StarlingHandler {
         const lastError = eventLastError(params);
         this.logger.error(`Backend service crashed: ${lastError}`);
         if (isMcpCrash(params))
-          listener.onMcpState?.('Failed');
+          listener?.onMcpState?.('Failed');
         else if (!this.exiting)
-          listener.onProcessError(lastError, BackendCode.TERMINATED);
+          listener?.onProcessError(lastError, BackendCode.TERMINATED);
         break;
       }
       case 'event.restarting':
@@ -299,7 +279,7 @@ export class StarlingHandler {
 
   async getMcpServerState(): Promise<McpServiceState> {
     return this.child
-      ? getMcpServerState(async (method, params) => this.request(method, params))
+      ? getMcpServerState(async (method, params) => this.rpc.request(method, params))
       : 'Unavailable';
   }
 
@@ -309,34 +289,8 @@ export class StarlingHandler {
 
   async setMcpServerRunning(running: boolean): Promise<McpServiceState> {
     return this.child
-      ? setMcpServerRunning(async (method, params) => this.request(method, params), running)
+      ? setMcpServerRunning(async (method, params) => this.rpc.request(method, params), running)
       : 'Unavailable';
-  }
-
-  /** Send a JSON-RPC request over the child's stdin and await its response. */
-  private async request<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
-    return new Promise<T>((resolve, reject) => {
-      const child = this.child;
-      if (!child?.stdin) {
-        reject(new Error('starling is not running'));
-        return;
-      }
-      const id = this.nextId++;
-      this.pending.set(id, { resolve, reject });
-      const payload = JSON.stringify({ jsonrpc: '2.0', id, method, ...(params ? { params } : {}) });
-      child.stdin.write(`${payload}\n`, (error) => {
-        if (error) {
-          this.pending.delete(id);
-          reject(error);
-        }
-      });
-    });
-  }
-
-  private rejectAllPending(error: Error): void {
-    for (const { reject } of this.pending.values())
-      reject(error);
-    this.pending.clear();
   }
 
   /**
@@ -356,7 +310,7 @@ export class StarlingHandler {
     this.exiting = true;
     this.logger.debug('Stopping starling');
     try {
-      await Promise.race([this.request('stop').catch(() => undefined), wait(STOP_REQUEST_TIMEOUT)]);
+      await Promise.race([this.rpc.request('stop').catch(() => undefined), wait(STOP_REQUEST_TIMEOUT)]);
     }
     catch {
       // best-effort; fall through to wait/kill

--- a/frontend/app/electron/main/starling-rpc.spec.ts
+++ b/frontend/app/electron/main/starling-rpc.spec.ts
@@ -1,0 +1,73 @@
+import type { LogService } from '@electron/main/log-service';
+import { PassThrough } from 'node:stream';
+import { createMock } from '@test/utils/create-mock';
+import { describe, expect, it, vi } from 'vitest';
+import { StarlingRpc } from './starling-rpc';
+
+function makeLogger(): LogService {
+  return createMock<LogService>({ warn: vi.fn() });
+}
+
+/** Answer each written request by feeding a response line back through the rpc. */
+function autoRespond(stdin: PassThrough, rpc: StarlingRpc, reply: (id: number) => Record<string, unknown>): void {
+  stdin.on('data', (chunk) => {
+    const { id } = JSON.parse(chunk.toString());
+    rpc.handleLine(JSON.stringify({ jsonrpc: '2.0', id, ...reply(id) }));
+  });
+}
+
+describe('starlingRpc', () => {
+  it('should correlate a response back to its request', async () => {
+    const stdin = new PassThrough();
+    const rpc = new StarlingRpc(makeLogger(), () => {});
+    rpc.attach(stdin);
+    autoRespond(stdin, rpc, () => ({ result: { ok: true } }));
+
+    await expect(rpc.request('status')).resolves.toEqual({ ok: true });
+  });
+
+  it('should reject a request when the response carries an error', async () => {
+    const stdin = new PassThrough();
+    const rpc = new StarlingRpc(makeLogger(), () => {});
+    rpc.attach(stdin);
+    autoRespond(stdin, rpc, () => ({ error: { code: 1, message: 'boom' } }));
+
+    await expect(rpc.request('start')).rejects.toThrow('boom');
+  });
+
+  it('should forward an id-less notification to the handler', () => {
+    const onNotification = vi.fn();
+    const rpc = new StarlingRpc(makeLogger(), onNotification);
+
+    rpc.handleLine(JSON.stringify({ jsonrpc: '2.0', method: 'event.crashed', params: { lastError: 'x' } }));
+
+    expect(onNotification).toHaveBeenCalledWith('event.crashed', { lastError: 'x' });
+  });
+
+  it('should reject a request once detached from the child', async () => {
+    const rpc = new StarlingRpc(makeLogger(), () => {});
+    rpc.attach(new PassThrough());
+    rpc.detach();
+
+    await expect(rpc.request('status')).rejects.toThrow('starling is not running');
+  });
+
+  it('should reject every in-flight request on rejectAll', async () => {
+    const rpc = new StarlingRpc(makeLogger(), () => {});
+    rpc.attach(new PassThrough());
+
+    const pending = rpc.request('status');
+    rpc.rejectAll(new Error('starling exited'));
+
+    await expect(pending).rejects.toThrow('starling exited');
+  });
+
+  it('should ignore a non-JSON line and warn', () => {
+    const logger = makeLogger();
+    const rpc = new StarlingRpc(logger, () => {});
+
+    rpc.handleLine('not json');
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/frontend/app/electron/main/starling-rpc.ts
+++ b/frontend/app/electron/main/starling-rpc.ts
@@ -1,0 +1,90 @@
+import type { LogService } from '@electron/main/log-service';
+import type { JsonRpcResponse } from '@electron/main/starling-handler-types';
+import type { Writable } from 'node:stream';
+
+/** Dispatch for an id-less notification (an `event.*` method + its params). */
+export type StarlingNotificationHandler = (method: string, params: unknown) => void;
+
+/**
+ * The NDJSON JSON-RPC client half of the starling control channel: it correlates
+ * id-tagged responses back to their pending requests and forwards id-less
+ * notifications to the handler. It owns nothing about the child's lifecycle — the
+ * handler `attach`es it to each spawned child's stdin and `detach`es on exit.
+ */
+export class StarlingRpc {
+  private nextId: number = 1;
+  private stdin: Writable | undefined;
+  private readonly pending = new Map<number, { resolve: (value: any) => void; reject: (error: Error) => void }>();
+
+  constructor(
+    private readonly logger: LogService,
+    private readonly onNotification: StarlingNotificationHandler,
+  ) {}
+
+  /** Point the client at the current child's stdin. Called once per spawn. */
+  attach(stdin: Writable): void {
+    this.stdin = stdin;
+  }
+
+  /** Drop the channel so later requests reject instead of writing to a dead pipe. */
+  detach(): void {
+    this.stdin = undefined;
+  }
+
+  /** Send a JSON-RPC request over stdin and await its correlated response. */
+  async request<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const stdin = this.stdin;
+      if (!stdin) {
+        reject(new Error('starling is not running'));
+        return;
+      }
+      const id = this.nextId++;
+      this.pending.set(id, { resolve, reject });
+      const payload = JSON.stringify({ jsonrpc: '2.0', id, method, ...(params ? { params } : {}) });
+      stdin.write(`${payload}\n`, (error) => {
+        if (error) {
+          this.pending.delete(id);
+          reject(error);
+        }
+      });
+    });
+  }
+
+  /** Parse one NDJSON line: an id-correlated response, or an event notification. */
+  handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed)
+      return;
+    let message: JsonRpcResponse;
+    try {
+      message = JSON.parse(trimmed);
+    }
+    catch {
+      this.logger.warn(`Ignoring non-JSON line from starling: ${trimmed}`);
+      return;
+    }
+
+    if (typeof message.id === 'number') {
+      const pending = this.pending.get(message.id);
+      if (!pending)
+        return;
+      this.pending.delete(message.id);
+      if (message.error)
+        pending.reject(new Error(message.error.message));
+      else
+        pending.resolve(message.result);
+      return;
+    }
+
+    if (message.method)
+      this.onNotification(message.method, message.params);
+  }
+
+  /** Reject every in-flight request — the child died before replying. */
+  rejectAll(error: Error): void {
+    for (const { reject } of this.pending.values())
+      reject(error);
+    this.pending.clear();
+  }
+}

--- a/frontend/app/src/modules/shell/components/error/ErrorScreen.vue
+++ b/frontend/app/src/modules/shell/components/error/ErrorScreen.vue
@@ -28,48 +28,48 @@ const errorText = computed(() => !error ? message : `${message}\n\n${error}`);
 </script>
 
 <template>
-  <div class="py-6 bg-white dark:bg-black h-full w-full z-[99999] flex flex-col items-center justify-center">
-    <div>
-      <RuiIcon
-        size="120"
-        color="error"
-        name="lu-circle-alert"
-      />
-    </div>
-    <div
+  <div class="py-10 px-4 bg-white dark:bg-black h-full w-full z-[99999] flex flex-col items-center justify-center">
+    <RuiIcon
+      size="96"
+      color="error"
+      name="lu-circle-alert"
+    />
+    <h1
       v-if="header"
-      class="mt-6 mb-5"
+      class="text-h4 font-bold text-center mt-6"
     >
-      <div class="text-h4">
-        {{ header }}
-      </div>
-    </div>
+      {{ header }}
+    </h1>
 
     <slot />
 
     <RuiCard
       v-if="!alternative"
-      class="flex-1 my-6 overflow-hidden max-w-[80%]"
-      content-class="h-full"
+      class="w-full max-w-4xl mt-8"
     >
       <template #header>
-        {{ title }}
-
-        <CopyButton
-          :tooltip="t('error_screen.copy_tooltip')"
-          :value="errorText"
-        />
+        <div class="flex items-center gap-2">
+          <span>{{ title }}</span>
+          <CopyButton
+            :tooltip="t('error_screen.copy_tooltip')"
+            :value="errorText"
+          />
+        </div>
       </template>
       <template #subheader>
         {{ subtitle }}
       </template>
-      <div class="font-light text-rui-text-secondary text-caption">
-        <pre v-text="message" />
+      <div class="max-h-[50vh] overflow-y-auto rounded-md bg-rui-grey-100 dark:bg-rui-grey-900 p-4">
+        <pre
+          class="font-mono text-caption leading-relaxed text-rui-text-secondary whitespace-pre-wrap break-words"
+          v-text="message"
+        />
         <template v-if="error">
-          <RuiDivider
-            class="mt-4 mb-2"
+          <RuiDivider class="my-3" />
+          <pre
+            class="font-mono text-caption leading-relaxed text-rui-text-secondary whitespace-pre-wrap break-words"
+            v-text="error"
           />
-          <pre v-text="error" />
         </template>
         <textarea
           v-model="errorText"
@@ -79,10 +79,16 @@ const errorText = computed(() => !error ? message : `${message}\n\n${error}`);
     </RuiCard>
     <div
       v-else
-      class="text-h5 mt-12"
+      class="text-h5 text-center max-w-2xl mt-8"
     >
       {{ alternative }}
     </div>
-    <slot name="bottom" />
+
+    <div
+      v-if="$slots.bottom"
+      class="mt-8"
+    >
+      <slot name="bottom" />
+    </div>
   </div>
 </template>

--- a/frontend/app/src/modules/shell/components/error/MacOsVersionUnsupported.vue
+++ b/frontend/app/src/modules/shell/components/error/MacOsVersionUnsupported.vue
@@ -12,12 +12,14 @@ const { closeApp } = useInterop();
     :header="t('macos_unsupported.header')"
     :alternative="t('macos_unsupported.message')"
   >
-    <RuiButton
-      depressed
-      color="primary"
-      @click="closeApp()"
-    >
-      {{ t('common.actions.terminate') }}
-    </RuiButton>
+    <template #bottom>
+      <RuiButton
+        depressed
+        color="primary"
+        @click="closeApp()"
+      >
+        {{ t('common.actions.terminate') }}
+      </RuiButton>
+    </template>
   </ErrorScreen>
 </template>

--- a/frontend/app/src/modules/shell/components/error/StartupErrorScreen.vue
+++ b/frontend/app/src/modules/shell/components/error/StartupErrorScreen.vue
@@ -18,11 +18,13 @@ const { closeApp } = useInterop();
     :subtitle="t('error_screen.message')"
     :message="message"
   >
-    <RuiButton
-      color="primary"
-      @click="closeApp()"
-    >
-      {{ t('common.actions.terminate') }}
-    </RuiButton>
+    <template #bottom>
+      <RuiButton
+        color="primary"
+        @click="closeApp()"
+      >
+        {{ t('common.actions.terminate') }}
+      </RuiButton>
+    </template>
   </ErrorScreen>
 </template>

--- a/frontend/app/src/modules/shell/components/error/WinVersionUnsupported.vue
+++ b/frontend/app/src/modules/shell/components/error/WinVersionUnsupported.vue
@@ -12,12 +12,14 @@ const { closeApp } = useInterop();
     :header="t('win_unsupported.header')"
     :alternative="t('win_unsupported.message')"
   >
-    <RuiButton
-      depressed
-      color="primary"
-      @click="closeApp()"
-    >
-      {{ t('common.actions.terminate') }}
-    </RuiButton>
+    <template #bottom>
+      <RuiButton
+        depressed
+        color="primary"
+        @click="closeApp()"
+      >
+        {{ t('common.actions.terminate') }}
+      </RuiButton>
+    </template>
   </ErrorScreen>
 </template>


### PR DESCRIPTION
## Problem

When the backend fails to start — for example core hitting a global-db schema error such as a missing `asset_flags` table — the user landed on a "rotki failed to start" screen that:

- showed a **generic** "Failed to start the rotki backend" message with nothing about the actual cause,
- worded a *first* start failure as **"restart failed: …"** even though nothing was running to restart,
- rendered the backend output as a single **unwrapped line** overflowing a mostly-empty card with only a horizontal scrollbar.

The real reason (e.g. `Tables {'asset_flags'} are missing from your global database`) only reached the logs, so the screen was effectively a dead end.

## Changes

**1. `feat(starling): surface real backend startup error`**
- Capture the detached child's stderr into a bounded tail (teed to the supervisor's stderr, so log forwarding is unchanged) and attach it to the `EarlyExit` error.
- Relay starling's real failure message from the electron handler instead of the hardcoded generic string. The window still stays on the error screen for a manual exit.
- Extract the NDJSON JSON-RPC client out of `StarlingHandler` into a dedicated `StarlingRpc`.

**2. `fix(starling): distinguish start failure from restart`**
- New `StartFailed` control error for `handle_start`, so a first-start failure reads "failed to start the backend: …" (mapped to the same JSON-RPC code as `RestartFailed`).

**3. `feat(frontend): improve the error screen layout`**
- Wrap long lines; render the backend output as a contained, scrollable monospace log block; size the card to its content with a sensible reading width; move the terminate action below the error; tidy header typography; route every error screen's action through one `#bottom` slot.

## Testing

- `cargo test -p starling-core -p starling` (incl. a new test that `EarlyExit` carries the dead service's stderr tail) and `cargo clippy` — clean.
- Frontend: new `starling-rpc.spec.ts` + a new start-failure handler test; `test:unit`, `lint`, and `typecheck` — green.