### PR TITLE
fix: mcp analytics taxonomy, privacy and pricing

### DIFF
--- a/rotkehlchen/mcp/analytics.py
+++ b/rotkehlchen/mcp/analytics.py
@@ -16,13 +16,15 @@ import pandas as pd
 from rotkehlchen.constants.timing import HOUR_IN_SECONDS
 from rotkehlchen.mcp.backend import (
     BackendQueryError,
+    balances_timeout,
     get_backend_config,
     query_all_balances,
     query_historical_prices,
     query_history_events_page,
     query_settings,
 )
-from rotkehlchen.mcp.taxonomy import resolve_direction
+from rotkehlchen.mcp.taxonomy import resolve_direction, resolve_group
+from rotkehlchen.types import Location
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -50,11 +52,29 @@ MAX_CONSECUTIVE_EMPTY_PAGES: Final = 5
 # to be a useful hint (an enum) rather than a data dump.
 MAX_DISTINCT_VALUES_SCANNED: Final = 50
 MAX_DISTINCT_VALUES_REPORTED: Final = 10
+# ``counterparty`` is the column whose vocabulary an agent most needs -- protocol names are
+# not guessable the way event types are -- yet any real account carries well over the general
+# scan cap (105 distinct on the account this was measured against), so it was the one
+# documented column that never got a listing. Scan far more of it; MAX_DISTINCT_VALUES_REPORTED
+# still bounds what is returned, so the payload does not grow.
+WIDE_SCAN_COLUMN_LIMITS: Final = {'counterparty': 500}
 # Prices are matched within an hour of the event, the same tolerance rotki's own CSV export
 # uses, so bucketing event timestamps to the hour costs no accuracy while roughly halving the
 # number of distinct lookups (measured: 64,936 exact-second pairs vs 31,878 hourly ones).
 PRICE_TOLERANCE_SECONDS: Final = HOUR_IN_SECONDS
+# The lookup radius has to be *twice* the bucket width, not equal to it. The backend matches
+# a price with `timestamp BETWEEN queried - distance AND queried + distance`, and what we
+# query is the bucket, not the event: an event sitting 59 minutes into its bucket asks from
+# an hour behind itself, so with an equal radius its window ran from 2 hours before the event
+# to 1 second after it -- a cached price minutes *later* than the event was missed even
+# though it was well inside the intended tolerance. Doubling restores a full +/- hour around
+# every event in the bucket while keeping the ~2x lookup saving bucketing buys.
+PRICE_LOOKUP_RADIUS_SECONDS: Final = 2 * PRICE_TOLERANCE_SECONDS
 DEFAULT_VALUE_CURRENCY: Final = 'USD'
+# Beacon-chain withdrawals: the entry type rotki files them under, and the taxonomy group a
+# partial one belongs to. See _add_partial_withdrawal_income.
+ETH_WITHDRAWAL_ENTRY_TYPE: Final = 'eth withdrawal event'
+INCOME_GROUP: Final = 'income'
 
 # --- privacy classification -------------------------------------------------------------
 # User-authored / decoder-written free text: never emitted verbatim outside ``raw`` mode
@@ -82,6 +102,13 @@ PII_COLUMN_NAMES: Final = frozenset({
 })
 # In ``strict`` mode, user-authored labels and names are treated as identifiers too.
 STRICT_IDENTIFIER_COLUMN_NAMES: Final = PII_COLUMN_NAMES | frozenset({'label', 'name', 'tag'})
+# ``location_label`` on an exchange row is the *account name*, which defaults to the venue
+# name but is user-editable ("Coinbase 1", "mom's savings"). In ``balanced`` only a value that
+# is exactly a rotki location name passes through readable; anything else is the user's own
+# text and gets hashed like every other identifier. This costs no venue information -- the
+# ``location`` column already carries it -- only the ability to tell two accounts on the same
+# venue apart *by name*, and their hashes still distinguish them for grouping.
+READABLE_LOCATION_LABELS: Final = frozenset(str(location) for location in Location)
 # The ONLY columns allowed through verbatim outside ``raw`` mode. This is the core of the
 # fail-closed design: anything whose base name is not here, and that is not handled by the
 # text/identifier paths above, is hashed (if a string) rather than leaked. Adding a new
@@ -249,13 +276,14 @@ def _sanitize_row(row: dict[str, Any], privacy_mode: PrivacyMode) -> dict[str, A
                 sanitized[column] = REDACTED_TEXT
         elif base in identifier_columns:
             sanitized[f'{column}_hash'] = _hash_identifier(value)
-            # In balanced mode a human-friendly account label (e.g. "Kraken main") that is
-            # not itself an address stays readable; anything address-shaped is hashed only.
+            # In balanced mode a location label that is exactly a venue name (e.g. "kraken")
+            # stays readable; a user-assigned account name ("Coinbase 1") is the user's own
+            # text and is hashed like any other identifier. See READABLE_LOCATION_LABELS.
             if (
                 privacy_mode == 'balanced' and
                 base == 'location_label' and
                 isinstance(value, str) and
-                SENSITIVE_IDENTIFIER_RE.search(value) is None
+                value.lower() in READABLE_LOCATION_LABELS
             ):
                 sanitized[column] = value
         elif base in SAFE_PASSTHROUGH_COLUMN_NAMES:
@@ -272,26 +300,59 @@ def _sanitize_row(row: dict[str, Any], privacy_mode: PrivacyMode) -> dict[str, A
     return sanitized
 
 
-def _add_directions(frame: pd.DataFrame) -> None:
-    """Add rotki's own ``in``/``out``/``neutral`` direction for each event, in place.
+def _add_partial_withdrawal_income(frame: pd.DataFrame) -> None:
+    """Reclassify partial beacon-chain withdrawals as ``income``, in place.
 
-    The serialized event carries no direction, so without this an agent has to infer income
-    from ``event_type`` -- the guess that double counts MEV rewards. Deriving it here from
-    the same function the rest of rotki uses makes the correct aggregation a plain
-    ``group by direction``. Resolution is cached per type/subtype/location because a large
-    history has ~100 distinct combinations across six figures of rows.
+    rotki records every beacon-chain withdrawal as ``staking``/``remove asset``, which the
+    taxonomy groups as ``staking`` -- returned principal. That is right for a full validator
+    exit and wrong for a partial withdrawal: the consensus layer only ever skims the balance
+    *above* the validator's effective balance, so a partial withdrawal is reward in its
+    entirety. rotki's own PnL engine agrees --
+    ``DBEth2.process_non_accumulating_validators_balances_and_pnl`` counts every partial
+    withdrawal as profit and subtracts principal only on an exit. Without this an account
+    with validator exits has its whole ETH staking income written off as principal.
+
+    Known imprecision: on an accumulating (0x02) validator a *requested* partial withdrawal
+    does return principal, unlike an automatic skim. Telling the two apart needs the running
+    per-validator deposit ledger (``process_accumulating_validators_balances_and_pnl``), not
+    anything on the row, so those are counted as income here. The recipe says so.
+    """
+    if not {'entry_type', 'is_exit', 'event_group'} <= set(frame.columns):
+        return
+
+    # NaN on every non-withdrawal row, and ``eq`` resolves those to False rather than raising.
+    frame.loc[
+        frame['entry_type'].eq(ETH_WITHDRAWAL_ENTRY_TYPE) & frame['is_exit'].eq(False),
+        'event_group',
+    ] = INCOME_GROUP
+
+
+def _add_taxonomy_columns(frame: pd.DataFrame) -> None:
+    """Add rotki's own ``direction`` and ``event_group`` for each event, in place.
+
+    The serialized event carries neither, so without them an agent has to infer income from
+    ``event_type`` -- the guess that double counts MEV rewards -- and hand-maintain subtype
+    lists to separate reward from returned principal. Deriving both here from the same
+    mappings the rest of rotki uses makes the correct aggregation a plain ``group by``.
+    Resolution is cached per type/subtype/location because a large history has ~100 distinct
+    combinations across six figures of rows.
+
+    The column is ``event_group`` rather than ``group`` because ``group`` is a SQL keyword
+    and every query touching it would need quoting.
     """
     if not {'event_type', 'event_subtype', 'location'} <= set(frame.columns):
         return
 
-    cache: dict[tuple[Any, Any, Any], str | None] = {}
-    directions: list[str | None] = []
+    cache: dict[tuple[Any, Any, Any], tuple[str | None, str | None]] = {}
+    resolved: list[tuple[str | None, str | None]] = []
     for key in zip(frame['event_type'], frame['event_subtype'], frame['location'], strict=True):
         if key not in cache:
-            cache[key] = resolve_direction(*key)
-        directions.append(cache[key])
+            cache[key] = (resolve_direction(*key), resolve_group(*key))
+        resolved.append(cache[key])
 
-    frame['direction'] = directions
+    frame['direction'] = [direction for direction, _ in resolved]
+    frame['event_group'] = [group for _, group in resolved]
+    _add_partial_withdrawal_income(frame)
 
 
 def _iter_entries(entries: list[Any]) -> Iterator[dict[str, Any]]:
@@ -328,9 +389,13 @@ def _resolve_prices(
 
     ``max_seconds_distance`` maps to the endpoint's ``only_cache_period``, which is what
     keeps the query inside rotki's stored price history: the MCP must never trigger a remote
-    oracle fetch on an agent's behalf. The response is keyed by the timestamp we *asked*
-    for (the backend rewrites the matched row's timestamp to the queried one), so pairs join
-    straight back without a nearest-match search.
+    oracle fetch on an agent's behalf. It is a search *radius*, not an exactness requirement
+    -- the backend takes the closest stored row inside the window -- so it has to account for
+    the hour of bucketing already applied to the timestamp. See PRICE_LOOKUP_RADIUS_SECONDS.
+
+    The response is keyed by the timestamp we *asked* for (the backend rewrites the matched
+    row's timestamp to the queried one), so pairs join straight back without a nearest-match
+    search -- but that also means a hit says nothing about how stale the matched price is.
     """
     # The main currency is worth exactly one of itself, and the price endpoint has no
     # such pair cached, so asking for it leaves every fiat leg of an exchange trade
@@ -343,7 +408,7 @@ def _resolve_prices(
         result = query_historical_prices(
             asset_timestamps=remaining[start:start + PRICE_LOOKUP_CHUNK_SIZE],
             target_asset=target_asset,
-            max_seconds_distance=PRICE_TOLERANCE_SECONDS,
+            max_seconds_distance=PRICE_LOOKUP_RADIUS_SECONDS,
         )
         for asset, by_timestamp in result['assets'].items():
             if not isinstance(by_timestamp, dict):
@@ -480,7 +545,7 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
         frame['datetime'] = dt.dt.strftime('%Y-%m-%dT%H:%M:%SZ')
         frame['year'] = dt.dt.year
 
-    _add_directions(frame)
+    _add_taxonomy_columns(frame)
 
     # Valuation runs here, in the loader, so its minutes of price lookups stay outside the
     # connection lock and queries keep serving the previous snapshot meanwhile.
@@ -509,7 +574,7 @@ def _load_history_events(scope: AnalyticsScope) -> TableData:
 def _load_balances(scope: AnalyticsScope) -> TableData:
     # Never force a refresh here: recalculating balances is slow and should stay an explicit
     # user action in the app. The analytics layer reads the latest cached snapshot.
-    result = query_all_balances(refresh=False, timeout=get_backend_config().timeout)
+    result = query_all_balances(refresh=False, timeout=balances_timeout())
     rows: list[dict[str, Any]] = []
     for category in ('assets', 'liabilities'):
         holdings = result.get(category)
@@ -612,14 +677,21 @@ def _describe_column(
     # pandas gives string columns a dedicated ``str`` dtype and only falls back to ``object``
     # for ragged/mixed ones, so both are candidates for a value listing.
     is_texty = pd.api.types.is_string_dtype(series) or pd.api.types.is_object_dtype(series)
-    if is_texty and len(counts := series.value_counts()) <= MAX_DISTINCT_VALUES_SCANNED:
+    scan_limit = WIDE_SCAN_COLUMN_LIMITS.get(name, MAX_DISTINCT_VALUES_SCANNED)
+    if is_texty and len(counts := series.value_counts()) <= scan_limit:
         column['distinct_count'] = len(counts)
-        column['top_values'] = [
-            {'value': value, 'rows': int(rows)}
-            for value, rows in counts.head(MAX_DISTINCT_VALUES_REPORTED).items()
-            # defence in depth: a hash must never reach the agent through this path either
-            if not (isinstance(value, str) and value.startswith('anon_'))
-        ]
+        # A long tail of values that each occur once is not an enum -- it is per-row data
+        # that happens to be sparse, like extra_data_amount holding one distinct amount per
+        # row. Listing those puts row-level financial detail in what should be a schema
+        # summary and tells an agent nothing about the vocabulary. A short list is still
+        # worth showing even if nothing repeats: it is cheap and it is the whole domain.
+        if len(counts) <= MAX_DISTINCT_VALUES_REPORTED or int(counts.iloc[0]) > 1:
+            column['top_values'] = [
+                {'value': value, 'rows': int(rows)}
+                for value, rows in counts.head(MAX_DISTINCT_VALUES_REPORTED).items()
+                # defence in depth: a hash must never reach the agent through this path
+                if not (isinstance(value, str) and value.startswith('anon_'))
+            ]
     return column
 
 

--- a/rotkehlchen/mcp/backend.py
+++ b/rotkehlchen/mcp/backend.py
@@ -16,6 +16,8 @@ DEFAULT_BACKEND_HOST: Final = '127.0.0.1'
 DEFAULT_BACKEND_PORT: Final = 4242
 DEFAULT_BACKEND_URL: Final = f'http://{DEFAULT_BACKEND_HOST}:{DEFAULT_BACKEND_PORT}/api/1'
 DEFAULT_PRIVACY_MODE: Final[PrivacyMode] = 'balanced'
+# Floor for the balances endpoint only -- see balances_timeout().
+BALANCES_MIN_TIMEOUT_SECONDS: Final = 60
 
 
 @dataclass(frozen=True)
@@ -170,6 +172,19 @@ def query_settings() -> dict[str, Any]:
         raise BackendQueryError('rotki backend returned an unexpected settings response')
 
     return result
+
+
+def balances_timeout() -> int:
+    """The read timeout to give the balances endpoint.
+
+    It aggregates every connected exchange and chain, so it is in a different cost class
+    from an ordinary call: on a first, uncached load it routinely blew through the global
+    default and made the analytics ``balances`` table fail on a fresh agent's first attempt
+    (an immediate retry then succeeded). It gets its own floor rather than raising the
+    global default, which exists to keep the ordinary calls responsive. An explicitly
+    configured timeout above the floor still wins.
+    """
+    return max(get_backend_config().timeout, BALANCES_MIN_TIMEOUT_SECONDS)
 
 
 def query_all_balances(refresh: bool, timeout: int) -> dict[str, Any]:

--- a/rotkehlchen/mcp/taxonomy.py
+++ b/rotkehlchen/mcp/taxonomy.py
@@ -11,6 +11,7 @@ from rotkehlchen.accounting.constants import (
     EXCHANGE,
 )
 from rotkehlchen.errors.serialization import DeserializationError
+from rotkehlchen.exchanges.constants import ALL_SUPPORTED_EXCHANGES
 from rotkehlchen.history.events.structures.base import get_event_direction
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.types import Location
@@ -37,6 +38,16 @@ TAXONOMY_RULES: Final = (
         'Subtypes containing "wrapped" (receive wrapped / return wrapped) are protocol '
         'wrapping: the user exchanges a token for its wrapped representation. They are '
         'transfers, not income or expense, even though value moves.'
+    ),
+    (
+        'event_group is the semantic grouping of each row and is the column to filter income '
+        'questions on: "income" is earnings, while "staking" is principal moving in or out of '
+        'a stake and "transfer"/"bridge" are value changing form rather than being earned or '
+        'spent. It is resolved from rotki own category mapping, so "staking" event_type rows '
+        'split correctly -- a reward is group "income", an unstake is group "staking" -- and '
+        'you never have to hand-maintain a list of subtypes. Combine it with direction rather '
+        'than replacing it: event_group says what a row means, direction says which way value '
+        'moved, and informational rows keep their group while being neutral.'
     ),
     (
         'Sum a single currency. Use the value column (main currency, present only when the '
@@ -68,23 +79,25 @@ RECIPES: Final[tuple[dict[str, Any], ...]] = (
         'requires': ['history_events (refreshed with include_values=true)'],
         'sql': (
             'select year, sum(value) as income, count(*) as events '
-            "from history_events where event_type = 'staking' and direction = 'in' "
-            "and event_subtype in ('reward', 'mev reward', 'block production') "
+            "from history_events where event_group = 'income' and direction = 'in' "
             'group by year order by year'
         ),
         'excludes': (
-            'Filtering on direction = "in" drops the informational rows, which are the '
-            'relayer/beacon-chain report of a reward that also arrives as a real event. '
-            'Without that filter every MEV and block-production reward is counted twice. '
-            'The event_subtype filter then drops unstaking: "remove asset" and '
-            '"redeem wrapped" are direction "in" but return principal, not income, so '
-            'including them overstates this total by whatever was unstaked -- which on an '
-            'account with validator exits or large LST redemptions is far larger than the '
-            'income itself. It is deliberately conservative and therefore understates ETH '
-            'staking: rotki records beacon-chain withdrawals as "remove asset" whether they '
-            'are a partial reward withdrawal (is_exit = 0) or a full exit (is_exit = 1), so '
-            'the reward-like partials are excluded here too. To include them, add '
-            "entry_type = 'eth withdrawal event' and is_exit = 0 as a separate union branch."
+            'event_group = "income" is what separates earnings from principal: an unstake '
+            '("remove asset") and an LST redemption ("redeem wrapped") are direction "in" '
+            'but group "staking", because they return principal rather than earn it. On an '
+            'account with validator exits or large LST redemptions the principal dwarfs the '
+            'income, so grouping on event_type = "staking" instead overstates this wildly. '
+            'Partial beacon-chain withdrawals (is_exit = 0) are counted: the consensus layer '
+            'only skims the balance above the effective balance, so they are pure reward, '
+            'while full exits (is_exit = 1) stay group "staking" as returned principal. '
+            'Keeping direction = "in" still drops the informational rows that mirror MEV and '
+            'block-production rewards, which would otherwise double count them. Two known '
+            'imprecisions: a *requested* partial withdrawal on an accumulating (0x02) '
+            'validator does return principal but is counted as income here, and an LST '
+            'redemption earns through the token appreciating rather than through any row, so '
+            'that income is not in history events at all -- it shows up as a capital gain '
+            'against cost basis in a tax report instead.'
         ),
     },
     {
@@ -112,11 +125,23 @@ RECIPES: Final[tuple[dict[str, Any], ...]] = (
         'sql': (
             'select counterparty, sum(value) as total_out, count(*) as events '
             "from history_events where direction = 'out' and value is not null "
+            'and counterparty is not null '
+            "and event_group not in ('transfer', 'bridge', 'defi deposit withdraw') "
+            "and event_subtype != 'return wrapped' "
             'group by counterparty order by total_out desc limit 10'
         ),
         'excludes': (
-            'Rows with no cached price are skipped rather than counted as zero, so this '
-            'ranks only what could be valued. Events with no counterparty group under null.'
+            'Value that only changes form is excluded, or it dominates the ranking: wrapping '
+            'ETH into WETH is an "out" leg whose value returns immediately as the wrapped '
+            'token (its out leg groups as "defi deposit withdraw" going in and carries '
+            'subtype "return wrapped" coming back), bridging is an "out" on one chain and an '
+            '"in" on another, and a plain transfer between your own accounts never left. '
+            'Depositing into a protocol is excluded on the same grounds -- you still own the '
+            'position. What remains is value that genuinely went somewhere: spends, fees, '
+            'repayments, donations and losses. Rows with no counterparty are dropped rather '
+            'than ranked, since "no counterparty" is not an answer to this question; drop '
+            'that clause to see how much they account for. Rows with no cached price are '
+            'skipped rather than counted as zero, so this ranks only what could be valued.'
         ),
     },
     {
@@ -165,32 +190,75 @@ def _describe(
     }
 
 
+def _parse_event_key(
+        event_type: Any,
+        event_subtype: Any,
+        location: Any,
+) -> tuple[HistoryEventType, HistoryEventSubType, Location | None] | None:
+    """Parse the serialized type/subtype/location as they appear in the analytics frame.
+
+    Returns None for anything that does not parse, so a single unrecognized event cannot
+    fail a whole load.
+    """
+    try:
+        return (
+            HistoryEventType.deserialize(event_type),
+            HistoryEventSubType.deserialize(event_subtype)
+            if isinstance(event_subtype, str) else HistoryEventSubType.NONE,
+            Location.deserialize(location) if isinstance(location, str) else None,
+        )
+    except DeserializationError:
+        return None
+
+
 def resolve_direction(
         event_type: Any,
         event_subtype: Any,
         location: Any = None,
 ) -> str | None:
-    """Resolve one serialized event to rotki's own ``in``/``out``/``neutral`` direction.
-
-    Takes the serialized strings as they appear in the analytics frame and returns None for
-    anything that does not parse, so a single unrecognized event cannot fail a whole load.
-    """
-    try:
-        parsed_type = HistoryEventType.deserialize(event_type)
-        parsed_subtype = (
-            HistoryEventSubType.deserialize(event_subtype)
-            if isinstance(event_subtype, str) else HistoryEventSubType.NONE
-        )
-        parsed_location = Location.deserialize(location) if isinstance(location, str) else None
-    except DeserializationError:
+    """Resolve one serialized event to rotki's own ``in``/``out``/``neutral`` direction."""
+    if (parsed := _parse_event_key(event_type, event_subtype, location)) is None:
         return None
 
     direction = get_event_direction(
-        event_type=parsed_type,
-        event_subtype=parsed_subtype,
-        location=parsed_location,
+        event_type=parsed[0],
+        event_subtype=parsed[1],
+        location=parsed[2],
     )
     return direction.serialize() if direction is not None else None
+
+
+def resolve_group(
+        event_type: Any,
+        event_subtype: Any,
+        location: Any = None,
+) -> str | None:
+    """Resolve one serialized event to its taxonomy group (``income``, ``staking``, ...).
+
+    The group is what separates ``staking``/``reward`` (group ``income``) from
+    ``staking``/``remove asset`` (group ``staking``, i.e. returned principal) -- the
+    distinction an agent has to reconstruct by hand from subtype lists otherwise, and gets
+    wrong. Exchange rows resolve through the ``EXCHANGE`` reading of the mapping, the same
+    override ``get_event_direction`` applies, so a CEX deposit does not read as a DeFi one.
+    """
+    if (parsed := _parse_event_key(event_type, event_subtype, location)) is None:
+        return None
+
+    try:
+        category_mapping = EVENT_CATEGORY_MAPPINGS[parsed[0]][parsed[1]]
+    except KeyError:
+        return None
+
+    if (
+        (parsed_location := parsed[2]) is not None and
+        EXCHANGE in category_mapping and
+        parsed_location in ALL_SUPPORTED_EXCHANGES
+    ):
+        category = category_mapping[EXCHANGE]
+    else:
+        category = category_mapping[DEFAULT]
+
+    return category.group.serialize()
 
 
 def get_event_taxonomy() -> dict[str, Any]:

--- a/rotkehlchen/mcp/tools/analytics.py
+++ b/rotkehlchen/mcp/tools/analytics.py
@@ -83,9 +83,12 @@ async def describe_table(table: str) -> dict[str, Any]:
       ``dtype`` it was built from. They differ: booleans arrive as 0/1 integers.
     - ``null_fraction``, and ``all_null`` for columns that are present but carry nothing —
       many ``extra_data_*`` columns exist only for one protocol and are empty otherwise.
-    - ``distinct_count`` and ``top_values`` for small enum-like columns (``event_type``,
-      ``location``, ``entry_type``, ``counterparty``), so you do not need a SELECT DISTINCT
-      round trip to learn the valid values.
+    - ``distinct_count`` and ``top_values`` for enum-like columns (``event_type``,
+      ``location``, ``entry_type``, ``event_group``, ``counterparty``), so you do not need a
+      SELECT DISTINCT round trip to learn the valid values. ``top_values`` holds only the
+      most common few, so on a wide column like ``counterparty`` check ``distinct_count`` to
+      see how much of the vocabulary you are being shown. A column whose values never repeat
+      reports ``distinct_count`` alone: it is per-row data, not an enum.
     - ``hashed`` with a ``hashed_reason`` of ``pii`` (an address or hash, hidden by policy)
       or ``unrecognized`` (a column the allowlist does not know, hashed rather than leaked).
 
@@ -118,6 +121,11 @@ async def query_sql(sql: str, max_rows: int = DEFAULT_MAX_RESULT_ROWS) -> dict[s
     - Aggregate on ``direction`` rather than ``event_type``. Every ``informational`` row is
       neutral: those are annotations whose value arrives as a separate real event, so
       including them double counts MEV and block-production rewards.
+    - For "what did I earn" questions filter on ``event_group = 'income'``, not on
+      ``event_type``. ``event_type = 'staking'`` spans both rewards (group ``income``) and
+      principal coming back out of a stake (group ``staking``), and both are direction
+      ``in`` — so summing the event type counts unstaked principal as earnings, which on an
+      account with validator exits is far larger than the income itself.
     - ``amount`` is a decimal string — do arithmetic on ``amount_float``. But it is in each
       row's own asset, so only sum it per-asset; for money questions use ``value``, which
       exists only after refreshing with ``include_values=true``.

--- a/rotkehlchen/tests/mcp/test_analytics.py
+++ b/rotkehlchen/tests/mcp/test_analytics.py
@@ -111,16 +111,21 @@ def test_sanitize_should_hash_identifiers_and_redact_notes() -> None:
     assert sanitized['has_notes'] is True
 
 
-def test_sanitize_balanced_keeps_named_label_but_strict_hashes_it() -> None:
-    row = {'location_label': 'Kraken main', 'label': 'my tag'}
-    balanced = _sanitize_row(row, privacy_mode='balanced')
-    # a human-friendly account name (not address-shaped) stays readable in balanced mode
-    assert balanced['location_label'] == 'Kraken main'
-    # but an address-shaped location_label is hashed even in balanced mode
-    assert 'location_label' not in _sanitize_row({'location_label': ADDRESS}, 'balanced')
+def test_sanitize_balanced_keeps_venue_label_but_strict_hashes_it() -> None:
+    row = {'location_label': 'kraken', 'label': 'my tag'}
+    # a bare venue name carries no user-authored text, so it stays readable in balanced mode
+    assert _sanitize_row(row, privacy_mode='balanced')['location_label'] == 'kraken'
+    # capitalisation of the venue name is not user information either
+    assert _sanitize_row({'location_label': 'Kraken'}, 'balanced')['location_label'] == 'Kraken'
+    for user_assigned in ('Coinbase 1', 'Kraken main', ADDRESS):
+        # anything the user typed themselves is hashed only, even in balanced mode
+        assert 'location_label' not in (
+            sanitized := _sanitize_row({'location_label': user_assigned}, 'balanced')
+        )
+        assert sanitized['location_label_hash'].startswith('anon_')
 
     strict = _sanitize_row(row, privacy_mode='strict')
-    assert 'location_label' not in strict
+    assert 'location_label' not in strict  # not even the venue name in strict mode
     assert strict['location_label_hash'].startswith('anon_')
     assert 'label' not in strict  # user-authored label is an identifier in strict mode
 
@@ -519,7 +524,9 @@ def test_include_values_should_multiply_amount_by_cached_price(monkeypatch) -> N
     assert loaded['source']['unpriced_rows'] == 1
     assert loaded['source']['lookup_count'] == 3
     # only_cache_period must always be sent, so no remote oracle fetch can be triggered
-    assert all(call['max_seconds_distance'] == 3600 for call in calls)
+    assert all(
+        call['max_seconds_distance'] == analytics.PRICE_LOOKUP_RADIUS_SECONDS for call in calls
+    )
     assert all(call['target_asset'] == 'EUR' for call in calls)
 
     rows = session.query_sql(
@@ -840,6 +847,50 @@ def test_describe_should_list_enum_values_and_null_fractions(monkeypatch) -> Non
     assert columns['extra_data_cdp_id']['null_fraction'] == 1.0
 
 
+def test_describe_should_list_counterparty_values_beyond_the_general_scan_cap(
+        monkeypatch,
+) -> None:
+    """describe_table documents counterparty as one of the columns it lists values for, but
+    every real account has far more than the general cap, so it never got a listing at all.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'identifier': index, 'asset': 'ETH', 'amount': '1', 'event_type': 'spend',
+         # one dominant counterparty so the column still reads as an enum, plus a long tail
+         # comfortably past MAX_DISTINCT_VALUES_SCANNED
+         'counterparty': 'gas' if index % 2 == 0 else f'protocol_{index}'}
+        for index in range(160)
+    ])
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False)
+
+    assert (counterparty := _described(session)['counterparty'])['distinct_count'] == 81
+    assert counterparty['top_values'][0] == {'value': 'gas', 'rows': 80}
+    # the report cap still bounds the payload, so listing more does not make it bigger
+    assert len(counterparty['top_values']) == analytics.MAX_DISTINCT_VALUES_REPORTED
+
+
+def test_describe_should_not_list_values_of_a_column_where_nothing_repeats(
+        monkeypatch,
+) -> None:
+    """A sparse column holding a distinct amount per row is not an enum. Listing its "top
+    values" put per-row financial data in what is meant to be a schema summary.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'identifier': index, 'asset': 'ETH', 'amount': '1', 'event_type': 'spend',
+         'extra_data_amount': f'{index}.38752450{index}'}
+        for index in range(28)
+    ])
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False)
+
+    assert (column := _described(session)['extra_data_amount'])['distinct_count'] == 28
+    assert 'top_values' not in column  # the count is the useful part; the amounts are not
+    # a short domain is still listed even when nothing repeats -- it is the whole vocabulary
+    assert _described(session)['event_type']['top_values'] == [{'value': 'spend', 'rows': 28}]
+
+
 def test_describe_should_never_emit_hashed_values(monkeypatch) -> None:
     """Listing anon_ values would be noise at best and defeats the point at worst."""
     configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
@@ -886,6 +937,63 @@ def test_direction_column_should_use_rotki_resolution(monkeypatch) -> None:
     ]
 
 
+def test_event_group_should_separate_income_from_returned_principal(monkeypatch) -> None:
+    """The whole point of the column: every row below is event_type "staking" and direction
+    "in", so nothing else on the row tells earnings apart from principal coming back.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'identifier': 1, 'asset': 'ETH', 'amount': '1', 'location': 'ethereum',
+         'event_type': 'staking', 'event_subtype': 'reward'},
+        {'identifier': 2, 'asset': 'ETH', 'amount': '32', 'location': 'ethereum',
+         'event_type': 'staking', 'event_subtype': 'remove asset'},
+        {'identifier': 3, 'asset': 'ETH', 'amount': '10', 'location': 'ethereum',
+         'event_type': 'staking', 'event_subtype': 'redeem wrapped'},
+    ])
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False)
+
+    assert session.query_sql(
+        'select event_subtype, direction, event_group from history_events order by identifier',
+        max_rows=10,
+    )['rows'] == [
+        {'event_subtype': 'reward', 'direction': 'in', 'event_group': 'income'},
+        # an unstake returns principal: direction "in", but not income
+        {'event_subtype': 'remove asset', 'direction': 'in', 'event_group': 'staking'},
+        # so does an LST redemption -- its earnings are appreciation, not any row here
+        {'event_subtype': 'redeem wrapped', 'direction': 'in', 'event_group': 'staking'},
+    ]
+
+
+def test_partial_beacon_withdrawal_should_be_income_but_exit_should_not(monkeypatch) -> None:
+    """rotki files both under staking/remove asset, so only is_exit tells them apart. A
+    partial withdrawal is a skim of the balance above 32 ETH and therefore pure reward.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
+    _mock_history_pages(monkeypatch, [
+        {'identifier': 1, 'asset': 'ETH', 'amount': '0.03', 'location': 'ethereum',
+         'event_type': 'staking', 'event_subtype': 'remove asset',
+         'entry_type': 'eth withdrawal event', 'validator_index': 42, 'is_exit': False},
+        {'identifier': 2, 'asset': 'ETH', 'amount': '32.1', 'location': 'ethereum',
+         'event_type': 'staking', 'event_subtype': 'remove asset',
+         'entry_type': 'eth withdrawal event', 'validator_index': 42, 'is_exit': True},
+        # a non-withdrawal row carries no is_exit at all and must keep its taxonomy group
+        {'identifier': 3, 'asset': 'ETH', 'amount': '5', 'location': 'ethereum',
+         'event_type': 'staking', 'event_subtype': 'remove asset', 'entry_type': 'evm event'},
+    ])
+    session = AnalyticsSession()
+    session.refresh(tables=None, from_timestamp=0, to_timestamp=0, include_ignored_assets=False)
+
+    assert session.query_sql(
+        'select identifier, event_group from history_events order by identifier',
+        max_rows=10,
+    )['rows'] == [
+        {'identifier': 1, 'event_group': 'income'},   # partial withdrawal: reward
+        {'identifier': 2, 'event_group': 'staking'},  # full exit: returned principal
+        {'identifier': 3, 'event_group': 'staking'},
+    ]
+
+
 def test_unparsable_event_should_not_fail_the_load(monkeypatch) -> None:
     configure_backend(base_url='http://backend/api/1', timeout=5, privacy_mode='balanced')
     _mock_history_pages(monkeypatch, [
@@ -895,8 +1003,8 @@ def test_unparsable_event_should_not_fail_the_load(monkeypatch) -> None:
     session = AnalyticsSession()
     assert session.refresh(tables=None, from_timestamp=0, to_timestamp=0,
                            include_ignored_assets=False)['errors'] == {}
-    assert session.query_sql('select direction from history_events', 10)['rows'] == [
-        {'direction': None},
+    assert session.query_sql('select direction, event_group from history_events', 10)['rows'] == [
+        {'direction': None, 'event_group': None},
     ]
 
 
@@ -950,3 +1058,20 @@ def test_query_sql_without_loaded_tables_errors() -> None:
 
 def test_describe_unknown_table_errors() -> None:
     assert AnalyticsSession().describe_table('nope')['error']['type'] == 'unknown_table'
+
+
+def test_price_lookup_radius_should_cover_a_full_hour_around_every_bucketed_event() -> None:
+    """Timestamps are floored to the hour before being priced, but the backend centres its
+    ``BETWEEN queried - distance AND queried + distance`` search on what we send. An equal
+    radius therefore searched two hours *behind* an event late in its bucket and barely one
+    second ahead of it, missing cached prices minutes later than the event itself.
+    """
+    latest_offset = analytics.PRICE_TOLERANCE_SECONDS - 1  # the worst case within a bucket
+    window_start = -analytics.PRICE_LOOKUP_RADIUS_SECONDS
+    window_end = analytics.PRICE_LOOKUP_RADIUS_SECONDS
+
+    # relative to the bucket, the event wants prices from one hour before to one hour after
+    assert window_start <= latest_offset - analytics.PRICE_TOLERANCE_SECONDS
+    assert window_end >= latest_offset + analytics.PRICE_TOLERANCE_SECONDS
+    # and the equal radius the fix replaced could not cover that
+    assert latest_offset + analytics.PRICE_TOLERANCE_SECONDS > analytics.PRICE_TOLERANCE_SECONDS

--- a/rotkehlchen/tests/mcp/test_backend.py
+++ b/rotkehlchen/tests/mcp/test_backend.py
@@ -7,7 +7,9 @@ from mcp.server.auth.provider import AccessToken
 
 from rotkehlchen.api.session_token import MCP_BACKEND_PROOF_HEADER, create_mcp_backend_proof
 from rotkehlchen.mcp.backend import (
+    BALANCES_MIN_TIMEOUT_SECONDS,
     BackendQueryError,
+    balances_timeout,
     configure_backend,
     get_backend_config,
     query_historical_prices,
@@ -186,3 +188,16 @@ def test_historical_prices_should_always_send_only_cache_period(monkeypatch) -> 
         'target_asset': 'EUR',
         'only_cache_period': 3600,
     }
+
+
+def test_balances_should_get_a_longer_timeout_than_ordinary_calls() -> None:
+    """The balances endpoint aggregates every exchange and chain, so on a first uncached
+    load it exceeded the global default and made the analytics table fail outright.
+    """
+    configure_backend(base_url='http://backend/api/1', timeout=5)
+    assert get_backend_config().timeout == 5  # ordinary calls stay responsive
+    assert balances_timeout() == BALANCES_MIN_TIMEOUT_SECONDS
+
+    # an explicitly configured timeout above the floor is the user's call and still wins
+    configure_backend(base_url='http://backend/api/1', timeout=BALANCES_MIN_TIMEOUT_SECONDS * 2)
+    assert balances_timeout() == BALANCES_MIN_TIMEOUT_SECONDS * 2

--- a/rotkehlchen/tests/mcp/test_taxonomy.py
+++ b/rotkehlchen/tests/mcp/test_taxonomy.py
@@ -3,7 +3,7 @@ import sys
 
 from rotkehlchen.accounting.constants import DEFAULT, EVENT_CATEGORY_MAPPINGS
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.mcp.taxonomy import get_event_taxonomy
+from rotkehlchen.mcp.taxonomy import get_event_taxonomy, resolve_group
 
 
 def _entry(taxonomy: dict, event_type: str, event_subtype: str) -> dict:
@@ -23,6 +23,22 @@ def test_taxonomy_should_cover_every_mapped_combination() -> None:
         for event_type, subtypes in EVENT_CATEGORY_MAPPINGS.items()
         for event_subtype in subtypes
     }
+
+
+def test_resolve_group_should_agree_with_the_advertised_taxonomy() -> None:
+    """The event_group column is built from resolve_group while get_event_taxonomy reads the
+    category enum directly. If the two ever drift, an agent that looked the group up in the
+    taxonomy would write SQL that silently matches nothing.
+    """
+    assert all(
+        resolve_group(entry['event_type'], entry['event_subtype']) == entry['group']
+        for entry in get_event_taxonomy()['entries']
+    )
+    assert resolve_group('not_a_real_type', 'nonsense') is None
+    # exchange rows resolve through the EXCHANGE reading of the mapping, as direction does.
+    # No combination currently groups differently there, so this pins the parity rather than
+    # a difference -- an upstream split would then reach the column with no MCP change.
+    assert resolve_group('deposit', 'deposit asset', 'kraken') == 'cex'
 
 
 def test_every_combination_should_have_a_direction() -> None:


### PR DESCRIPTION
Follow-up fixes from the first live verification of the MCP analytics layer.

- Add an event_group column derived from rotki's own category mapping, so income questions filter on it instead of hand-maintained subtype lists. Named event_group because group is a SQL keyword.
- Count partial beacon-chain withdrawals (is_exit = 0) as income: the consensus layer only skims above the effective balance, so they are pure reward. Full exits stay principal.
- Widen the price lookup radius to twice the bucket width. Timestamps are floored to the hour but the backend centres its match window on what it is sent, so an event late in its bucket searched two hours behind itself and one second ahead, missing prices cached shortly after the event.
- Give the balances endpoint a 60s timeout floor. It aggregates every chain and exchange and was failing on a fresh agent's first attempt at the 5s global default.
- Raise the describe_table scan cap for counterparty, which every real account exceeded, so the documented value listing works.
- Stop listing top_values for columns where nothing repeats: a sparse per-row column is not an enum and its values are row-level data.
- Restrict readable location_label in balanced mode to venue names, so user-assigned account names are hashed like other identifiers.
- Rewrite recipe 4 to drop null counterparties and value that only changes form (wrapping, bridging, protocol deposits).

---------

Needs a live MCP session against a real account — all of this was verified only against mocks.

  1. Price coverage (the one with an unknown outcome)
  Refresh with include_values=true over a wide range and compare unpriced rates against the pre-fix baseline: ETH was 8.7% (2,858/33,011), USDC 10.1%, eth withdrawal event 9.6%, 13% overall. The fix strictly widens the search window, but how much it recovers depends on   
  what that account has cached. If ETH is still not well under a few percent, the next lever is day-bucketing — deliberately not done, since it trades accuracy for coverage.

  2. event_group on real data
  - select event_group, count(*) from history_events group by event_group — sanity-check the distribution.
  - Recipe 2 (where event_group = 'income') vs the old subtype-list version. The delta should be roughly +1,578 ETH of partial withdrawals, and should not include the ~1,094 ETH of full exits.
  - Confirm staking/remove asset with is_exit = 1 and redeem wrapped both stay group staking.

  3. describe_table
  - counterparty should now report distinct_count: 105 with 10 top_values (previously neither).
  - extra_data_amount should report its count with no top_values.

  4. Balances timeout — refresh_analytics_data(tables=["balances"]) on a cold start, first attempt, no retry.

  5. Recipe 4 — the null row and weth/hop should be gone; eth2 and pendle should remain. Worth eyeballing whether excluding protocol deposits matches your intent — that's slightly wider than the brief asked for.

  6. Privacy — expected behavior change, not a regression
  "Coinbase 1" is no longer readable in balanced; "kraken"/"binance" still are. Anyone diffing against the brief's "verified good" list will see this and should know it's intended.