### PR TITLE
chore(deps): bump @rotki/ui-library to 2.23.0

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.5.0
       version: 1.5.0
     '@rotki/ui-library':
-      specifier: 2.22.2
-      version: 2.22.2
+      specifier: 2.23.0
+      version: 2.23.0
     '@tsconfig/node24':
       specifier: 24.0.4
       version: 24.0.4
@@ -369,7 +369,7 @@ importers:
         version: link:../common
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.22.2(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.1)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+        version: 2.23.0(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.1)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
@@ -1375,14 +1375,14 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@floating-ui/core@1.7.5':
-    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
 
-  '@floating-ui/dom@1.7.6':
-    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
-  '@floating-ui/utils@0.2.11':
-    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@fontsource/roboto-mono@5.3.0':
     resolution: {integrity: sha512-yhwplHMHW9dCk+1pZuERfcJe+K3rosGVZEoK0XktkxRSqQ9qsipSwwiuW2/8Qmtp9lzu3Ixa/ie4BMH3i8CkZQ==}
@@ -1996,8 +1996,8 @@ packages:
     peerDependencies:
       eslint: ^9.20.0 || ^10.0.0
 
-  '@rotki/ui-library@2.22.2':
-    resolution: {integrity: sha512-4sKB+rV9C3ApKoIZ46fnmuZX6XLFXPFr+Cqchb+P1xI7juVdOucFUMs9PIKSoB5Vaqbk4Ckq3+QSfGisLaQrUA==}
+  '@rotki/ui-library@2.23.0':
+    resolution: {integrity: sha512-y7qkmAcc0vvMZWDX8OVxgnVbCCrrSsru2iS83pRqs8E26J99IVvHoNnQeplBd4tz2V2SuUhbfnUF+VWAlJH5ug==}
     engines: {node: '>=24 <25', pnpm: '>=11 <12'}
     peerDependencies:
       dayjs: '>=1.11.13 <12'
@@ -7303,16 +7303,16 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@floating-ui/core@1.7.5':
+  '@floating-ui/core@1.8.0':
     dependencies:
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/dom@1.7.6':
+  '@floating-ui/dom@1.8.0':
     dependencies:
-      '@floating-ui/core': 1.7.5
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/utils@0.2.11': {}
+  '@floating-ui/utils@0.2.12': {}
 
   '@fontsource/roboto-mono@5.3.0': {}
 
@@ -7854,9 +7854,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rotki/ui-library@2.22.2(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.1)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
+  '@rotki/ui-library@2.23.0(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.1)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
-      '@floating-ui/dom': 1.7.6
+      '@floating-ui/dom': 1.8.0
       '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
       '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@6.0.3))
       dayjs: 1.11.21

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ catalog:
   '@playwright/test': 1.61.1
   '@rotki/eslint-config': 7.0.0
   '@rotki/eslint-plugin': 1.5.0
-  '@rotki/ui-library': 2.22.2
+  '@rotki/ui-library': 2.23.0
   '@tsconfig/node24': 24.0.4
   '@types/body-parser': 1.19.6
   '@types/express': 5.0.6


### PR DESCRIPTION
Bumps `@rotki/ui-library` from 2.22.2 to 2.23.0 (catalog entry).

## What we pick up

The release is a full pass over `RuiDateTimePicker` and the calendar grid underneath it:

- **A date crossing a DST boundary no longer shifts the time by an hour.** The new value was built by mutating a `dayjs.tz()` created from the *previous* value, which pins that value's UTC offset. This hit every timestamp edited through the calendar.
- **Values no longer carry a wall clock below their accuracy.** The current second and millisecond leaked in, so with `minute` accuracy a value picked up a stray `:45.500`, and with type `epoch` it came out fractional. We bind epochs, so this reached our filters.
- **The field stops swallowing keys it does not own** — copy, paste and select-all were dead, and Escape and Enter were swallowed.
- **The field and the day grid are reachable from the keyboard.** The menu was mouse-only, the wrapper was a dead tab stop, and the grid was 42 tab stops with no arrow keys and no `aria-selected`.
- A year being typed no longer throws on each keystroke (an unpadded year produced an invalid date string).
- Bound errors are written in the field's own format instead of the browser locale, and they keep the bound's time.
- `spellcheck` and autocorrect are off, so the browser stops underlining `DD/MM/YYYY` and every value.
- `autofocus` and an exposed `focus()` exist now, which means a template ref calling `focus?.()` is no longer a silent no-op.

## Two visible changes in our picker

`DateTimePicker.vue` wraps the library component, so both land in our UI:

1. **The timezone select is gone from the popover.** It is now opt-in behind `showTimezone`, and we never passed the old prop. This is the release's breaking change, and the rationale applies to us directly: we bind an epoch, so the picked timezone never survived a round trip.

2. **A footer strip with a `Now` action renders under the popover.** `actions` defaults to `['now']`.

I checked the composition in a browser rather than assuming, because we pass a `menu-content` slot. **Our quick options are unaffected** — they keep their own column to the right of the clock, and the footer is a separate full-width strip beneath all three columns:

```
┌──────────────┬─────────────┬──────────────────┐
│  calendar    │    clock    │  1 day before    │
│              │             │  Week before     │
│              │             │  Month before    │
│              │             │  90 days before  │
│              │             │  6 months before │
│              │             │  Year before     │
├──────────────┴─────────────┴──────────────────┤
│                                    🕐 Now     │
└───────────────────────────────────────────────┘
```

If the `Now` action reads as redundant next to our relative shortcuts, `:actions="[]"` on the wrapper removes the footer entirely. I left the default in place.

## Verification

`pnpm run typecheck` clean, `pnpm run lint` 0 errors (20 warnings, unchanged), `pnpm run test:unit` **6215 passed across 661 files**.
