### PR TITLE
fix(lint): stop linting e2e coverage output

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -26,7 +26,17 @@ const i18nIgnoreKeys = [
 ];
 
 export default rotki({
-  ignores: ['app/backend-icons.generated.ts', 'app/tests/e2e/test-results/**'],
+  // Test output directories are gitignored, but only by the nested `app/.gitignore`. The gitignore
+  // integration reads just the root `.gitignore` next to this config, so it never sees those rules
+  // and the generated files stay visible to eslint. `.v8-coverage` holds the Playwright V8 coverage
+  // dumps, several megabytes of JSON that this config parses because it loads `jsonc-eslint-parser`,
+  // which turns a full lint run into minutes. List them here instead. The vitest report directory
+  // (`app/tests/unit/coverage`) is already covered by the shared config's `**/coverage` default.
+  ignores: [
+    'app/backend-icons.generated.ts',
+    'app/tests/e2e/.v8-coverage/**',
+    'app/tests/e2e/test-results/**',
+  ],
   vue: true,
   typescript: {
     tsconfigPath: 'tsconfig.json',


### PR DESCRIPTION
The Playwright V8 coverage run writes multi-megabyte JSON dumps to `frontend/app/tests/e2e/.v8-coverage`. That directory is gitignored, but only by the nested `frontend/app/.gitignore`; the eslint gitignore integration reads just the root `frontend/.gitignore`, so the dumps stay visible to eslint. The config loads `jsonc-eslint-parser`, so they are actually parsed and linted, which drags a full `pnpm run lint` out to minutes once a coverage run has happened.

Fix is at the eslint level, matching how `app/tests/e2e/test-results/**` is already handled.

Verified by dropping a placeholder JSON at that path and running `pnpm run lint:file:check` on it: linted before the change, reported as "File ignored because of a matching ignore pattern" after. The vitest report directory (`app/tests/unit/coverage`) was checked too and is already covered by the shared config's `**/coverage` default, so it needed no entry.