### PR TITLE
fix(history): gate data issues behind build flag

### DIFF
--- a/frontend/app/src/modules/core/common/feature-flags.ts
+++ b/frontend/app/src/modules/core/common/feature-flags.ts
@@ -1,0 +1,26 @@
+import type { RouteName } from '@/types/router';
+
+/**
+ * Build-time feature flags.
+ *
+ * The backend gates the accounting refactor behind ROTKI_ACCOUNTING_UPDATE and
+ * `vite.config.ts` mirrors that same shell var into VITE_ACCOUNTING_UPDATE, so the
+ * frontend never declares a flag of its own. Every surface that has to hide the
+ * feature (drawer, search palette, router, dashboard, pinned rail) reads it from
+ * here so the gates cannot drift apart.
+ *
+ * Read through the function rather than a module-level constant: the value is then
+ * resolved per call, which keeps `vi.stubEnv` usable in tests.
+ */
+export function isAccountingUpdateEnabled(): boolean {
+  return !!import.meta.env.VITE_ACCOUNTING_UPDATE;
+}
+
+/**
+ * Routes that only exist in accounting-update builds. Their page files are always
+ * compiled in, so the router registers them either way; the global guard turns a
+ * direct hit into a redirect when the flag is off.
+ */
+export const ACCOUNTING_UPDATE_ROUTES: ReadonlySet<string> = new Set<RouteName>([
+  '/history/data-issues/',
+]);

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.spec.ts
@@ -2,7 +2,7 @@ import { bigNumberify } from '@rotki/common';
 import { createCustomPinia } from '@test/utils/create-pinia';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { setActivePinia } from 'pinia';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { computed, ref } from 'vue';
 import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
 import DashboardCompletenessIndicator from '@/modules/dashboard/DashboardCompletenessIndicator.vue';
@@ -14,12 +14,14 @@ interface MockState {
   actionableCount: number;
   processing: boolean;
   assetsWithoutOracleHistory: Set<string>;
+  refreshSummary: ReturnType<typeof vi.fn>;
 }
 
 const state = vi.hoisted((): MockState => ({
   actionableCount: 0,
   assetsWithoutOracleHistory: new Set<string>(),
   processing: false,
+  refreshSummary: vi.fn(),
 }));
 
 vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
@@ -32,7 +34,7 @@ vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
 vi.mock('@/modules/history/data-issues/use-data-issues-summary', () => ({
   useDataIssuesSummary: (): Record<string, unknown> => ({
     actionableCount: ref(state.actionableCount),
-    refreshSummary: vi.fn().mockResolvedValue(undefined),
+    refreshSummary: state.refreshSummary,
   }),
 }));
 
@@ -67,6 +69,14 @@ describe('dashboardCompletenessIndicator', () => {
     state.actionableCount = 0;
     state.processing = false;
     state.assetsWithoutOracleHistory = new Set<string>();
+    state.refreshSummary = vi.fn().mockResolvedValue(undefined);
+    // The flag is only set when the shell exports ROTKI_ACCOUNTING_UPDATE, so pin it
+    // per test instead of inheriting whatever the developer's environment has.
+    vi.stubEnv('VITE_ACCOUNTING_UPDATE', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('should render nothing when there are no completeness issues', async () => {
@@ -119,8 +129,17 @@ describe('dashboardCompletenessIndicator', () => {
   });
 
   it('should show a button when data issues need attention', async () => {
+    vi.stubEnv('VITE_ACCOUNTING_UPDATE', 'true');
     state.actionableCount = 3;
     const wrapper = await createWrapper();
+    expect(state.refreshSummary).toHaveBeenCalledOnce();
     expect(wrapper.find('[data-testid=dashboard-completeness]').text()).toContain('data_issues');
+  });
+
+  it('should not query or show data issues when the accounting update flag is off', async () => {
+    state.actionableCount = 3;
+    const wrapper = await createWrapper();
+    expect(state.refreshSummary).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-testid=dashboard-completeness]').exists()).toBe(false);
   });
 });

--- a/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
+++ b/frontend/app/src/modules/dashboard/DashboardCompletenessIndicator.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { startPromise } from '@shared/utils';
+import { isAccountingUpdateEnabled } from '@/modules/core/common/feature-flags';
 import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
 import { useUndecodedTransactionsCount } from '@/modules/history/events/tx/use-undecoded-transactions-count';
 import DashboardMissingPricesDialog from './DashboardMissingPricesDialog.vue';
@@ -9,16 +10,27 @@ const { t } = useI18n({ useScope: 'global' });
 
 const missingPricesDialog = ref<boolean>(false);
 
+// The data issues inbox only exists in accounting-update builds (the same flag hides
+// it from the navigation drawer and the search palette), so without it we neither
+// query the endpoint nor link to a page the user cannot otherwise reach.
+const dataIssuesEnabled = isAccountingUpdateEnabled();
+
 const { missingPriceIdentifiers, missingPricesCount } = useMissingPrices();
 const { actionableCount, refreshSummary } = useDataIssuesSummary();
 const { fetchUndecodedTransactionsBreakdown, undecodedCount } = useUndecodedTransactionsCount();
 
+const dataIssuesCount = computed<number>(() => dataIssuesEnabled ? get(actionableCount) : 0);
+
 const hasIssues = computed<boolean>(() =>
-  get(missingPricesCount) > 0 || get(undecodedCount) > 0 || get(actionableCount) > 0,
+  get(missingPricesCount) > 0 || get(undecodedCount) > 0 || get(dataIssuesCount) > 0,
 );
 
 onMounted(() => {
-  startPromise(Promise.all([fetchUndecodedTransactionsBreakdown(), refreshSummary()]));
+  const pending: Promise<void>[] = [fetchUndecodedTransactionsBreakdown()];
+  if (dataIssuesEnabled)
+    pending.push(refreshSummary());
+
+  startPromise(Promise.all(pending));
 });
 </script>
 
@@ -64,7 +76,7 @@ onMounted(() => {
       </RuiButton>
     </RouterLink>
     <RouterLink
-      v-if="actionableCount > 0"
+      v-if="dataIssuesCount > 0"
       class="no-underline"
       :to="{ name: '/history/data-issues/' }"
     >
@@ -79,7 +91,7 @@ onMounted(() => {
             size="14"
           />
         </template>
-        {{ t('dashboard.completeness.data_issues', { count: actionableCount }, actionableCount) }}
+        {{ t('dashboard.completeness.data_issues', { count: dataIssuesCount }, dataIssuesCount) }}
       </RuiButton>
     </RouterLink>
   </div>

--- a/frontend/app/src/modules/shell/layout/use-navigation-menu.ts
+++ b/frontend/app/src/modules/shell/layout/use-navigation-menu.ts
@@ -2,6 +2,7 @@ import type { RuiIcons } from '@rotki/ui-library';
 import type { ComputedRef } from 'vue';
 import type { RouteRecordNameGeneric } from 'vue-router';
 import type { RouteName, RouteNavMeta } from '@/types/router';
+import { ACCOUNTING_UPDATE_ROUTES, isAccountingUpdateEnabled } from '@/modules/core/common/feature-flags';
 
 interface MenuEntry {
   readonly name: RouteName;
@@ -33,12 +34,10 @@ export interface MenuDivider {
 export type MenuItem = MenuNavItem | MenuNavGroup | MenuDivider;
 
 // The data-issues inbox is part of the accounting refactor and only served in builds where the
-// backend exposes it (ROTKI_ACCOUNTING_UPDATE, mirrored into VITE_ACCOUNTING_UPDATE in
-// vite.config.ts). When disabled, History collapses from a group into a single item that links
-// straight to Events.
+// backend exposes it (see `isAccountingUpdateEnabled`). When disabled, History collapses from a
+// group into a single item that links straight to Events.
 const HISTORY_ROUTE = '/history/';
 const HISTORY_EVENTS_ROUTE = '/history/events/';
-const HISTORY_DATA_ISSUES_ROUTE = '/history/data-issues/';
 
 interface UseNavigationMenuReturn {
   menuItems: ComputedRef<MenuItem[]>;
@@ -52,7 +51,7 @@ interface UseNavigationMenuReturn {
  */
 export function useNavigationMenu(): UseNavigationMenuReturn {
   const router = useRouter();
-  const dataIssuesEnabled = !!import.meta.env.VITE_ACCOUNTING_UPDATE;
+  const dataIssuesEnabled = isAccountingUpdateEnabled();
 
   // A name taken from the live router is always registered, so `hasRoute` both validates it and
   // narrows the generic route name to a typed RouteName. This is the type-safe alternative to a cast.
@@ -80,7 +79,7 @@ export function useNavigationMenu(): UseNavigationMenuReturn {
       const nav = route.meta.nav;
       if (nav?.drawer === undefined || !isRouteName(route.name))
         continue;
-      if (route.name === HISTORY_DATA_ISSUES_ROUTE && !dataIssuesEnabled)
+      if (ACCOUNTING_UPDATE_ROUTES.has(route.name) && !dataIssuesEnabled)
         continue;
 
       const entry: MenuEntry = { name: route.name, nav };

--- a/frontend/app/src/modules/shell/layout/use-route-search.ts
+++ b/frontend/app/src/modules/shell/layout/use-route-search.ts
@@ -2,6 +2,7 @@ import type { RuiIcons } from '@rotki/ui-library';
 import type { ComputedRef } from 'vue';
 import type { RouteRecordNameGeneric, RouteRecordNormalized } from 'vue-router';
 import type { RouteName } from '@/types/router';
+import { ACCOUNTING_UPDATE_ROUTES, isAccountingUpdateEnabled } from '@/modules/core/common/feature-flags';
 
 export interface RouteSearchEntry {
   /** Resolved path used as the navigation target. */
@@ -32,13 +33,11 @@ interface UseRouteSearchReturn {
  * (the superset of the drawer) unless it opts out with `searchable: false`; the breadcrumb is the
  * label of the route named by `nav.parent`.
  */
-// Kept in sync with the drawer gate in `useNavigationMenu`: the data-issues inbox only exists in
-// builds where VITE_ACCOUNTING_UPDATE is set, so it must be hidden from search there too.
-const HISTORY_DATA_ISSUES_ROUTE = '/history/data-issues/';
-
 export function useRouteSearch(): UseRouteSearchReturn {
   const router = useRouter();
-  const dataIssuesEnabled = !!import.meta.env.VITE_ACCOUNTING_UPDATE;
+  // Kept in sync with the drawer gate in `useNavigationMenu`: a page that only exists in
+  // accounting-update builds has to be hidden from search there too.
+  const dataIssuesEnabled = isAccountingUpdateEnabled();
 
   const isRouteName = (name: RouteRecordNameGeneric): name is RouteName =>
     name !== undefined && router.hasRoute(name);
@@ -58,7 +57,7 @@ export function useRouteSearch(): UseRouteSearchReturn {
     if (!nav || nav.searchable === false || !isRouteName(route.name))
       return false;
 
-    return route.name !== HISTORY_DATA_ISSUES_ROUTE || dataIssuesEnabled;
+    return !ACCOUNTING_UPDATE_ROUTES.has(route.name) || dataIssuesEnabled;
   }
 
   const searchEntries = computed<RouteSearchEntry[]>(() => {

--- a/frontend/app/src/modules/shell/pinned/pinned-registry.ts
+++ b/frontend/app/src/modules/shell/pinned/pinned-registry.ts
@@ -1,5 +1,6 @@
 import type { Component } from 'vue';
 import { type MessageKey, msg } from '@/message-key';
+import { isAccountingUpdateEnabled } from '@/modules/core/common/feature-flags';
 import { type PinnedName, PinnedNames } from '@/modules/session/types';
 
 /**
@@ -21,6 +22,11 @@ export interface PinnedPanelDef {
    * Panels that need live context (e.g. the report card needs a generated report)
    * opt out with `false`; the rest fetch their own data and restore safely. Defaults to true. */
   restorable?: boolean;
+  /** Whether the panel exists in this build at all. Panels behind a build flag report it
+   * here so a rail persisted by a build that had the flag does not bring the panel back
+   * in one that hides it. Called on use, not at import, so the flag stays stubbable.
+   * Defaults to available. */
+  available?: () => boolean;
 }
 
 export const PINNED_PANELS: Record<PinnedName, PinnedPanelDef> = {
@@ -30,6 +36,7 @@ export const PINNED_PANELS: Record<PinnedName, PinnedPanelDef> = {
     labelKey: msg.$t('balance_divergence.title'),
   },
   [PinnedNames.DATA_ISSUES]: {
+    available: isAccountingUpdateEnabled,
     component: defineAsyncComponent(async () => import('@/modules/history/data-issues/components/DataIssuesPinned.vue')),
     icon: 'lu-shield-alert',
     labelKey: msg.$t('data_issues.panel.title'),

--- a/frontend/app/src/modules/shell/pinned/use-pinned-persistence.spec.ts
+++ b/frontend/app/src/modules/shell/pinned/use-pinned-persistence.spec.ts
@@ -2,7 +2,7 @@ import type { Report } from '@/modules/reports/report-types';
 import { createMock } from '@test/utils/create-mock';
 import { get, set } from '@vueuse/core';
 import { createPinia, setActivePinia } from 'pinia';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type EffectScope, effectScope, nextTick } from 'vue';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
@@ -32,10 +32,15 @@ describe('usePinnedPersistence', () => {
     localStorage.clear();
     scope = effectScope();
     signIn();
+    // The data-issues panel is only available in accounting-update builds, and the flag is
+    // only set when the shell exports ROTKI_ACCOUNTING_UPDATE. Pin it so the cases using
+    // that panel do not depend on the developer's environment.
+    vi.stubEnv('VITE_ACCOUNTING_UPDATE', 'true');
   });
 
   afterEach(() => {
     scope.stop();
+    vi.unstubAllEnvs();
   });
 
   it('should restore the persisted rail width', () => {
@@ -77,6 +82,21 @@ describe('usePinnedPersistence', () => {
     // Report needs a live report, so only data-issues is restored and becomes active.
     expect(get(store.pinnedPanels).map(panel => panel.name)).toEqual([PinnedNames.DATA_ISSUES]);
     expect(get(store.activePinnedId)).toBe(PinnedNames.DATA_ISSUES);
+  });
+
+  it('should skip a panel that this build does not have', () => {
+    vi.stubEnv('VITE_ACCOUNTING_UPDATE', '');
+    localStorage.setItem(TABS_KEY, JSON.stringify({
+      activeId: PinnedNames.DATA_ISSUES,
+      names: [PinnedNames.MATCH_ASSET_MOVEMENTS, PinnedNames.DATA_ISSUES],
+    }));
+    const store = useAreaVisibilityStore();
+
+    scope.run(() => usePinnedPersistence());
+
+    // A rail persisted by an accounting-update build must not bring the inbox back here.
+    expect(get(store.pinnedPanels).map(panel => panel.name)).toEqual([PinnedNames.MATCH_ASSET_MOVEMENTS]);
+    expect(get(store.activePinnedId)).toBe(PinnedNames.MATCH_ASSET_MOVEMENTS);
   });
 
   it('should ignore a corrupt or legacy-shaped stored value instead of throwing', () => {

--- a/frontend/app/src/modules/shell/pinned/use-pinned-persistence.ts
+++ b/frontend/app/src/modules/shell/pinned/use-pinned-persistence.ts
@@ -25,12 +25,23 @@ function tabsKeyFor(username: string): string {
   return `${TABS_KEY_PREFIX}.${username}`;
 }
 
-const restorableNames = new Set<string>(
-  Object.values(PinnedNames).filter(name => PINNED_PANELS[name].restorable !== false),
-);
+const pinnedNames = new Set<string>(Object.values(PinnedNames));
 
+function isPinnedName(name: string): name is PinnedName {
+  return pinnedNames.has(name);
+}
+
+/**
+ * A panel survives a reload when it can rebuild itself from an empty payload and it still
+ * exists in this build. Availability is resolved per call rather than once at import so a
+ * flag-gated panel is not baked in at module load.
+ */
 function isRestorable(name: string): name is PinnedName {
-  return restorableNames.has(name);
+  if (!isPinnedName(name))
+    return false;
+
+  const panel = PINNED_PANELS[name];
+  return panel.restorable !== false && (panel.available?.() ?? true);
 }
 
 /** Falls back to the default when the stored width is corrupt (e.g. `NaN`). */

--- a/frontend/app/src/router/index.ts
+++ b/frontend/app/src/router/index.ts
@@ -1,7 +1,8 @@
 import { startPromise } from '@shared/utils';
-import { createRouter, createWebHashHistory, type RouteLocationRaw } from 'vue-router';
+import { createRouter, createWebHashHistory, type RouteLocationRaw, type RouteRecordNameGeneric } from 'vue-router';
 import { handleHotUpdate, routes } from 'vue-router/auto-routes';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { ACCOUNTING_UPDATE_ROUTES, isAccountingUpdateEnabled } from '@/modules/core/common/feature-flags';
 import NotFound from '@/pages/404.vue';
 
 const base = import.meta.env.VITE_PUBLIC_PATH ? window.location.pathname : '/';
@@ -56,6 +57,15 @@ export const router = createRouter({
 
 const userRoutes: RouteLocationRaw[] = ['/user/create', '/user/login', '/user'];
 
+/**
+ * A flag-gated page is hidden from the drawer and the search palette, but its route stays
+ * registered, so a bookmark, a restored location or a hand-typed hash would still open a
+ * feature the rest of the app treats as absent. Send those to History instead.
+ */
+function isDisabledByFlag(name: RouteRecordNameGeneric): boolean {
+  return typeof name === 'string' && ACCOUNTING_UPDATE_ROUTES.has(name) && !isAccountingUpdateEnabled();
+}
+
 router.beforeEach((to) => {
   document.title = to.meta?.title ? to.meta.title.toString() : 'rotki';
 
@@ -64,6 +74,9 @@ router.beforeEach((to) => {
   if (logged) {
     if (userRoutes.includes(to.path))
       return '/dashboard';
+
+    if (isDisabledByFlag(to.name))
+      return { name: '/history/events/' };
 
     return true;
   }


### PR DESCRIPTION
The data-issues inbox is served only in accounting-update builds (`ROTKI_ACCOUNTING_UPDATE`, mirrored into `VITE_ACCOUNTING_UPDATE` by `vite.config.ts`), but three surfaces reached it regardless of the flag:

- **Dashboard completeness indicator** queried `/data_issues` on every mount and rendered a link to the inbox. `refreshSummary()` is four requests, one per state bucket, so an unflagged build issued four calls per dashboard visit to a feature it otherwise hides.
- **Pinned rail** restored an inbox tab persisted by a build that had the flag, which then re-fetched on mount and kept polling.
- **Route** `/history/data-issues/` stayed reachable by deep link, bookmark or a restored location. The flag only removed it from the drawer and the search palette.

## Changes

- New `modules/core/common/feature-flags.ts` holds `isAccountingUpdateEnabled()` and the set of route names the feature owns, so the drawer, the search palette, the router, the dashboard and the pinned rail read one source instead of four copies of `!!import.meta.env.VITE_ACCOUNTING_UPDATE`. It is a function rather than a constant so the value is resolved per call and stays stubbable in tests.
- The dashboard indicator skips the fetch and reports a zero count when the flag is off, so neither the chip nor its link renders. The count is zeroed rather than just left unfetched, since the inbox store is shared and another surface could populate it.
- `PinnedPanelDef` gained `available?: () => boolean` next to `restorable`, and `use-pinned-persistence.ts` now resolves restorability per call instead of building a `Set` once at import, so a build flag is not baked in at module load.
- The global router guard redirects a flag-gated route to History Events.

## Notes

- In an unflagged build the pinned restore drops the inbox tab and the persistence watcher writes the pruned list back, so the tab does not return if the user later runs a flagged build again. That seemed better than leaving a ghost tab, but it is a deliberate choice worth a second opinion.
- Two specs now pin `VITE_ACCOUNTING_UPDATE` explicitly. Vitest inherits the flag from `vite.config.ts`, so cases touching the inbox were previously environment-dependent: they behaved differently for a developer who exports `ROTKI_ACCOUNTING_UPDATE=True`.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

No user-guide change: this hides a feature that is not documented as user-visible in unflagged builds.