### PR TITLE
Let e2e specs seed the user DB, and make coverage measure our code

### DIFF
--- a/frontend/app/.c8rc.json
+++ b/frontend/app/.c8rc.json
@@ -5,13 +5,17 @@
     "dist/**/*.js"
   ],
   "exclude": [
-    "node_modules",
+    "**/node_modules/**",
+    "../node_modules/**",
+    "../../node_modules/**",
+    "dist/**",
     "tests/",
     "**/*.d.ts",
     "src/main.ts",
     "src/router/index.ts"
   ],
   "all": false,
+  "excludeAfterRemap": true,
   "reporter": [
     "lcov",
     "text-summary"

--- a/frontend/app/tests/e2e/fixtures/test-fixtures.ts
+++ b/frontend/app/tests/e2e/fixtures/test-fixtures.ts
@@ -36,7 +36,7 @@ export interface LoginOptions {
   /**
    * Logs in through the form instead of `fasterLogin`, which authenticates over the API first.
    * With the backend already holding that session the form submit does not take and the suite
-   * sits on "Unlock account" - a failure that only shows up once the spec runs after others.
+   * sits on "Unlock account" — a failure that only shows up once the spec runs after others.
    *
    * Implied by `seed`, which needs the account created and released before login anyway.
    */
@@ -163,7 +163,21 @@ export async function cleanupContext(ctx: SharedTestContext | undefined): Promis
 }
 
 /**
- * Extended test fixture with shared context support.
- * Re-exports the base test for consistency.
+ * The base test with coverage armed on Playwright's own `page` fixture.
+ *
+ * A spec that drives `page` directly rather than building a context gets no coverage otherwise:
+ * the arming lives in `createLoggedInContext`, which such a spec never calls. Overriding the
+ * fixture here means a spec only has to import `test` from this module to be counted, and a spec
+ * that does not touch `page` never instantiates it, so this costs those nothing.
  */
-export { base as test };
+export const test = base.extend({
+  page: async ({ page }: { page: Page }, use: (page: Page) => Promise<void>): Promise<void> => {
+    if (isCoverageEnabled())
+      await startCoverage(page);
+
+    await use(page);
+
+    if (isCoverageEnabled())
+      await stopCoverage(page);
+  },
+});

--- a/frontend/app/tests/e2e/fixtures/test-fixtures.ts
+++ b/frontend/app/tests/e2e/fixtures/test-fixtures.ts
@@ -1,5 +1,6 @@
 import { type APIRequestContext, test as base, type Browser, type BrowserContext, type Page } from '@playwright/test';
 import { isCoverageEnabled, startCoverage, stopCoverage } from '../coverage';
+import { apiCreateAccount, apiDisableModules, apiLogout } from '../helpers/api';
 import { apiConfigureRpcMocks, saveMockRpcCassette } from '../helpers/rpc-mock';
 import { generateUsername } from '../helpers/utils';
 import { RotkiApp } from '../pages/rotki-app';
@@ -32,6 +33,23 @@ export interface LoginOptions {
    * Defaults to ['ETH'].
    */
   rpcMockChains?: string[];
+  /**
+   * Logs in through the form instead of `fasterLogin`, which authenticates over the API first.
+   * With the backend already holding that session the form submit does not take and the suite
+   * sits on "Unlock account" - a failure that only shows up once the spec runs after others.
+   *
+   * Implied by `seed`, which needs the account created and released before login anyway.
+   */
+  formLogin?: boolean;
+  /**
+   * Writes fixture data straight into the user database.
+   *
+   * The callback runs after the account is created and logged back out, so nothing holds the
+   * database open while it writes. The backend does not reliably see rows written into a user DB
+   * it already has open, which is why the seam exists at all; anything the helpers in
+   * `helpers/seed-db` write belongs here rather than after login.
+   */
+  seed?: (username: string) => void | Promise<void>;
 }
 
 /**
@@ -77,11 +95,41 @@ export async function createLoggedInContext(
 
   // Login once for all tests
   const app = new RotkiApp(sharedPage, request);
-  await app.fasterLogin(username, '1234', options.disableModules ?? false);
 
-  // Replace default RPC nodes with mock server (if cassette specified)
-  if (options.rpcMockCassette) {
-    await apiConfigureRpcMocks(request, options.rpcMockCassette, options.rpcMockChains);
+  if (options.seed || options.formLogin) {
+    await apiLogout(request);
+    await apiCreateAccount(request, username, '1234');
+
+    // The mock has to be in place before login rather than after it: seeded tracked addresses make
+    // the app query balances the moment it logs in, and against real nodes that query outlives the
+    // test timeout.
+    if (options.rpcMockCassette) {
+      await apiConfigureRpcMocks(request, options.rpcMockCassette, options.rpcMockChains);
+    }
+
+    if (options.disableModules) {
+      await apiDisableModules(request);
+    }
+
+    // Release the database so the seeding writes land somewhere the backend will read them back.
+    await apiLogout(request);
+    await options.seed?.(username);
+
+    // Deliberately not `fasterLogin`, which authenticates over the API first: with the backend
+    // already holding that session the form submit does not take and the suite sits on "Unlock
+    // account". `checkGetPremiumButton` is the actual assertion that the app came up, since
+    // `login()` assumes success when neither post-login dialog appears in time.
+    await app.visit();
+    await app.login(username, '1234');
+    await app.checkGetPremiumButton();
+  }
+  else {
+    await app.fasterLogin(username, '1234', options.disableModules ?? false);
+
+    // Replace default RPC nodes with mock server (if cassette specified)
+    if (options.rpcMockCassette) {
+      await apiConfigureRpcMocks(request, options.rpcMockCassette, options.rpcMockChains);
+    }
   }
 
   return {

--- a/frontend/app/tests/e2e/specs/app/account-creation.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/account-creation.spec.ts
@@ -1,5 +1,6 @@
-import { type APIRequestContext, type BrowserContext, type Page, request, test } from '@playwright/test';
+import { type APIRequestContext, type BrowserContext, type Page, request } from '@playwright/test';
 import { isCoverageEnabled, startCoverage, stopCoverage } from '../../coverage';
+import { test } from '../../fixtures/test-fixtures';
 import { TEST_TIMEOUT_STANDARD, VIEWPORTS } from '../../helpers/constants';
 import { generateUsername } from '../../helpers/utils';
 import { RotkiApp } from '../../pages/rotki-app';

--- a/frontend/app/tests/e2e/specs/app/address-book.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/address-book.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { expect } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { AddressBookPage } from '../../pages/address-book-page';
 
 const ADDR_PRIVATE = '0x1111111111111111111111111111111111111111';

--- a/frontend/app/tests/e2e/specs/app/airdrops.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/airdrops.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { expect } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { AirdropsPage } from '../../pages/airdrops-page';
 
 test.describe.serial('airdrops', () => {

--- a/frontend/app/tests/e2e/specs/app/api-keys.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/api-keys.spec.ts
@@ -1,6 +1,5 @@
-import { test } from '@playwright/test';
 import { testEnv } from '../../fixtures';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { ApiKeysPage } from '../../pages/api-keys-page';
 
 test.describe.serial('api keys', () => {

--- a/frontend/app/tests/e2e/specs/app/assets.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/assets.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { expect } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { apiEnsureSymbolsNotIgnored } from '../../helpers/api';
 import { apiConfigureRpcMock } from '../../helpers/rpc-mock';
 import { AssetsManagerPage } from '../../pages/assets-manager-page';

--- a/frontend/app/tests/e2e/specs/app/calendar.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/calendar.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import dayjs from 'dayjs';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { CalendarPage } from '../../pages/calendar-page';
 
 test.describe.serial('calendar', () => {

--- a/frontend/app/tests/e2e/specs/app/exchange-purge.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/exchange-purge.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { expect } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import {
   apiCountExchangeEventsByCategory,
   apiPurgeExchangeData,

--- a/frontend/app/tests/e2e/specs/app/external-services.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/external-services.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { ExternalServicesPage } from '../../pages/external-services-page';
 
 test.describe.serial('api-keys::external-services', () => {

--- a/frontend/app/tests/e2e/specs/app/login-error-flows.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/login-error-flows.spec.ts
@@ -1,5 +1,9 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { test } from '../../fixtures/test-fixtures';
 import { mockLoginResult, submitLogin } from '../../helpers/mock-login';
+
+// `test` comes from the fixtures module rather than from playwright directly: that is where
+// coverage is armed on the `page` fixture this spec drives.
 
 // Drives the real login UI + unlock flow with the login handshake intercepted, exercising
 // the response -> error-mapping integration (use-unlock-steps -> useUsersApi ->

--- a/frontend/app/tests/e2e/specs/app/price-manager.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/price-manager.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { HistoricPricePage, LatestPricePage, OraclePricePage } from '../../pages/price-manager-page';
 
 test.describe('price manager', () => {

--- a/frontend/app/tests/e2e/specs/app/snapshot-edit.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/snapshot-edit.spec.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
-import { expect, test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { expect } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { seedHistoricPrices } from '../../helpers/seed-db';
 import { apiGetSnapshot } from '../../helpers/snapshot-api';
 import { type SnapshotFixturePaths, writeFixturesToTmp } from '../../helpers/snapshot-csv';

--- a/frontend/app/tests/e2e/specs/app/tag-manager.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/tag-manager.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { expect } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { TagManagerPage } from '../../pages/tag-manager';
 
 test.describe.serial('tag manager', () => {

--- a/frontend/app/tests/e2e/specs/balances/blockchain-balances.spec.ts
+++ b/frontend/app/tests/e2e/specs/balances/blockchain-balances.spec.ts
@@ -1,9 +1,9 @@
 import type { FixtureBlockchainAccount } from '../../pages/types';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { Blockchain } from '@rotki/common';
 import { testEnv } from '../../fixtures';
 import blockchainAccountsFixture from '../../fixtures/account-balances/blockchain-accounts.json' with { type: 'json' };
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { waitForNoRunningTasks } from '../../helpers/api';
 import { BALANCE_PRECISION, TEST_TIMEOUT_BLOCKCHAIN } from '../../helpers/constants';
 import { BlockchainAccountsPage } from '../../pages/blockchain-accounts-page';

--- a/frontend/app/tests/e2e/specs/balances/manual-balances.spec.ts
+++ b/frontend/app/tests/e2e/specs/balances/manual-balances.spec.ts
@@ -1,7 +1,7 @@
 import type { FixtureManualBalance } from '../../pages/types';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import manualBalancesFixture from '../../fixtures/account-balances/manual-balances.json' with { type: 'json' };
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { waitForNoRunningTasks } from '../../helpers/api';
 import { BALANCE_PRECISION } from '../../helpers/constants';
 import { DashboardPage } from '../../pages/dashboard-page';

--- a/frontend/app/tests/e2e/specs/balances/solana-accounts.spec.ts
+++ b/frontend/app/tests/e2e/specs/balances/solana-accounts.spec.ts
@@ -1,8 +1,8 @@
 import type { FixtureBlockchainAccount } from '../../pages/types';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { BigNumber, Blockchain } from '@rotki/common';
 import { testEnv } from '../../fixtures';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { waitForNoRunningTasks } from '../../helpers/api';
 import { TEST_TIMEOUT_BLOCKCHAIN } from '../../helpers/constants';
 import { BlockchainAccountsPage } from '../../pages/blockchain-accounts-page';

--- a/frontend/app/tests/e2e/specs/balances/substrate-accounts.spec.ts
+++ b/frontend/app/tests/e2e/specs/balances/substrate-accounts.spec.ts
@@ -1,8 +1,8 @@
 import type { FixtureBlockchainAccount } from '../../pages/types';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { BigNumber, Blockchain } from '@rotki/common';
 import { testEnv } from '../../fixtures';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { waitForNoRunningTasks } from '../../helpers/api';
 import { TEST_TIMEOUT_BLOCKCHAIN } from '../../helpers/constants';
 import { BlockchainAccountsPage } from '../../pages/blockchain-accounts-page';

--- a/frontend/app/tests/e2e/specs/history/history-events.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/history-events.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import {
   assetMovementEventFixture,
   ethBlockEventFixture,
@@ -14,10 +14,9 @@ import {
   TEST_EVENT_TIMESTAMP,
   TEST_PRICE_ENTRIES,
 } from '../../fixtures/history-events';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { waitForNoRunningTasks } from '../../helpers/api';
 import { seedEvmTransaction, seedHistoricPrices } from '../../helpers/seed-db';
-import { generateUsername } from '../../helpers/utils';
 import { HistoryEventsPage } from '../../pages/history-events-page';
 import { RotkiApp } from '../../pages/rotki-app';
 
@@ -346,24 +345,21 @@ test.describe.serial('evm history events', () => {
   let page: HistoryEventsPage;
 
   test.beforeAll(async ({ browser, request }) => {
-    const username = generateUsername();
+    ctx = await createLoggedInContext(browser, request, {
+      seed: (username) => {
+        // Historic prices go into the global DB, which is plain SQLite with no lock concerns. The
+        // transactions go into the user DB, so they are written here, while the account is created
+        // but logged back out, rather than afterwards.
+        seedHistoricPrices(TEST_PRICE_ENTRIES, TEST_EVENT_TIMESTAMP);
 
-    const sharedContext = await browser.newContext();
-    const sharedPage = await sharedContext.newPage();
-    const app = new RotkiApp(sharedPage, request);
-    await app.fasterLogin(username);
+        seedEvmTransaction(username, evmEventFixture.txRef);
+        seedEvmTransaction(username, evmSwapEventFixture.txRef);
+        seedEvmTransaction(username, evmMultiSwapEventFixture.txRef);
+        seedEvmTransaction(username, ethDepositEventFixture.txHash);
+      },
+    });
 
-    // Seed historic prices into the global DB (plain SQLite, no lock concerns)
-    seedHistoricPrices(TEST_PRICE_ENTRIES, TEST_EVENT_TIMESTAMP);
-
-    // Seed EVM transactions while logged in (WAL mode allows concurrent writes)
-    seedEvmTransaction(username, evmEventFixture.txRef);
-    seedEvmTransaction(username, evmSwapEventFixture.txRef);
-    seedEvmTransaction(username, evmMultiSwapEventFixture.txRef);
-    seedEvmTransaction(username, ethDepositEventFixture.txHash);
-
-    ctx = { sharedContext, sharedPage, sharedRequest: request, app, username };
-    page = new HistoryEventsPage(sharedPage);
+    page = new HistoryEventsPage(ctx.sharedPage);
   });
 
   test.afterAll(async () => {

--- a/frontend/app/tests/e2e/specs/import/csv-import.spec.ts
+++ b/frontend/app/tests/e2e/specs/import/csv-import.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { expect } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { waitForNoRunningTasks } from '../../helpers/api';
 import { TIMEOUT_MEDIUM } from '../../helpers/constants';
 import { HistoryEventsPage } from '../../pages/history-events-page';

--- a/frontend/app/tests/e2e/specs/settings/account.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/account.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { AccountSettingsPage } from '../../pages/account-settings-page';
 
 test.describe.serial('settings::data & security', () => {

--- a/frontend/app/tests/e2e/specs/settings/accounting.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/accounting.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { AccountingSettingsPage } from '../../pages/accounting-settings-page';
 
 test.describe.serial('settings::accounting', () => {

--- a/frontend/app/tests/e2e/specs/settings/database.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/database.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { DatabaseSettingsPage } from '../../pages/database-settings-page';
 
 test.describe.serial('settings::database', () => {

--- a/frontend/app/tests/e2e/specs/settings/evm.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/evm.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { expect } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { EvmSettingsPage } from '../../pages/evm-settings-page';
 
 test.describe.serial('settings::evm', () => {

--- a/frontend/app/tests/e2e/specs/settings/general.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/general.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { confirmInlineSuccess } from '../../helpers/utils';
 import { GeneralSettingsPage } from '../../pages/general-settings-page';
 

--- a/frontend/app/tests/e2e/specs/settings/interface.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/interface.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { InterfaceSettingsPage } from '../../pages/interface-settings-page';
 
 test.describe.serial('settings::interface', () => {

--- a/frontend/app/tests/e2e/specs/settings/modules.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/modules.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { ModulesSettingsPage } from '../../pages/modules-settings-page';
 
 test.describe.serial('settings::modules', () => {

--- a/frontend/app/tests/e2e/specs/settings/oracle.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/oracle.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { OracleSettingsPage } from '../../pages/oracle-settings-page';
 
 test.describe.serial('settings::oracle', () => {

--- a/frontend/app/tests/e2e/specs/settings/rpc.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/rpc.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { RpcSettingsPage } from '../../pages/rpc-settings-page';
 
 test.describe.serial('settings::rpc', () => {

--- a/frontend/app/tests/e2e/specs/settings/settings-search.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/settings-search.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
-import { cleanupContext, createLoggedInContext, type SharedTestContext } from '../../fixtures/test-fixtures';
+import { expect } from '@playwright/test';
+import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { SettingsSearchPage } from '../../pages/settings-search-page';
 
 test.describe.serial('settings::search', () => {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -180,6 +180,21 @@ export default rotki({
     'vue/max-template-depth': 'warn',
   },
 }, {
+  // Coverage is armed on the `page` fixture in `tests/e2e/fixtures/test-fixtures`, so a spec that
+  // takes `test` straight from playwright silently contributes nothing to the coverage report.
+  // That failure is invisible - the spec passes, it is just never counted - so it is worth a rule
+  // rather than a convention. `expect` and the types are unaffected.
+  files: ['**/tests/e2e/specs/**/*.ts'],
+  rules: {
+    'no-restricted-imports': ['error', {
+      paths: [{
+        importNames: ['test'],
+        message: 'Import `test` from `tests/e2e/fixtures/test-fixtures`, which arms coverage on the page fixture.',
+        name: '@playwright/test',
+      }],
+    }],
+  },
+}, {
   files: ['**/locales/**/*.json'],
   rules: {
     'jsonc/sort-keys': ['error', 'asc', {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,8 @@
     "test:unit": "pnpm run --filter rotki test:unit:run",
     "test:unit:watch": "pnpm run --filter rotki test:unit",
     "test:e2e": "pnpm run --filter rotki test:e2e",
+    "test:e2e:coverage": "pnpm run --filter rotki test:e2e:coverage",
+    "test:e2e:coverage:report": "pnpm run --filter rotki test:e2e:coverage:report",
     "typecheck": "pnpm run --filter rotki typecheck",
     "dev:web": "tsx scripts/start-dev.ts --web",
     "setup:hooks": "cd .. && husky frontend/.husky",


### PR DESCRIPTION
Three related fixes to the e2e test infrastructure. No product code changes.

## Seeding the user database

The backend does not reliably see rows written into a user DB it already holds open, so a spec that seeds one has to create the account, log out, write, then log in. `createLoggedInContext` creates and logs in as one step with no seam for that, so specs needing it built their own context by hand — and drifted, skipping the coverage arming the fixture does and reimplementing the login.

`LoginOptions.seed` provides the seam. It runs while nothing holds the database open, and switches to the form login, because `fasterLogin` authenticates over the API first and leaves the backend holding the very session the seeding needs released. `formLogin` exposes that independently for a spec that needs the form login without seeding.

`history-events.spec.ts`'s evm block moves onto it. That block previously seeded while logged in; it now seeds before login and gains coverage arming it never had.

## Coverage on the `page` fixture

A spec driving playwright's own `page` was never counted, since the arming lives in `createLoggedInContext`. The failure is invisible: the spec passes and is simply absent from the report. `login-error-flows.spec.ts` was in this state.

The `page` fixture is now overridden to arm coverage, so importing `test` from the fixtures module is enough. A spec that never touches `page` does not instantiate it. A `no-restricted-imports` rule stops `test` being taken straight from `@playwright/test` so a new spec cannot reintroduce the gap, and the existing specs are swept to the new import.

## Making the report meaningful

The report counted 1893 files: 696 dependencies and 4 unmapped rolldown chunks accounting for 40% of every line counted. Cause is that c8 filters on the pre-sourcemap URL, so nothing mapped out of a bundle was ever tested against `exclude`. `excludeAfterRemap` is what makes those patterns apply. With it set, 609 first-party files remain.

`test:e2e:coverage` and `test:e2e:coverage:report` were also unreachable from `frontend/`, where the contributing guide says to run everything. Both are forwarded now.

### Caveat worth knowing

Statement and line coverage are **not** a measure of how much is tested. V8 reports byte ranges, so importing a module marks its top level covered — 538 of the 609 files read as ~100%, and only 730 branches are recorded across all of them. **Function coverage (currently 55.83%) is the figure that reflects what actually ran.**

One known gap left: `@rotki/common` is not counted. Its sources map to `../../common/src/...` and `test-exclude` will not match `..`-crossing globs in either `include` or `exclude` — the same root cause as the dependency bug, but not solvable from the include side.

## Verification

- typecheck clean; lint clean (0 errors / 21 warnings, unchanged baseline)
- full e2e suite: **175 passed / 0 failed**
- full e2e suite with coverage enabled: **175 passed / 0 failed**, 43 coverage dumps, no `stopCoverage` failures — every spec can now run under coverage