### PR TITLE
test: stub JsonInput once instead of per spec

### DIFF
--- a/frontend/app/src/modules/history/management/forms/EthDepositEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EthDepositEventForm.spec.ts
@@ -12,10 +12,6 @@ import { setupDayjs } from '@/modules/core/common/data/date';
 import { useHistoryEvents } from '@/modules/history/events/use-history-events';
 import EthDepositEventForm from '@/modules/history/management/forms/EthDepositEventForm.vue';
 
-vi.mock('json-editor-vue', () => ({
-  template: '<input />',
-}));
-
 vi.mock('@/modules/history/events/use-history-events', () => ({
   useHistoryEvents: vi.fn(),
 }));

--- a/frontend/app/src/modules/history/management/forms/EvmEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EvmEventForm.spec.ts
@@ -15,10 +15,6 @@ import { useHistoryEventCounterpartyMappings } from '@/modules/history/events/ma
 import { useHistoryEvents } from '@/modules/history/events/use-history-events';
 import EvmEventForm from '@/modules/history/management/forms/EvmEventForm.vue';
 
-vi.mock('json-editor-vue', () => ({
-  template: '<input />',
-}));
-
 vi.mock('@/modules/history/events/use-history-events', () => ({
   useHistoryEvents: vi.fn(),
 }));

--- a/frontend/app/src/modules/history/management/forms/SolanaEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/SolanaEventForm.spec.ts
@@ -15,10 +15,6 @@ import { useHistoryEventCounterpartyMappings } from '@/modules/history/events/ma
 import { useHistoryEvents } from '@/modules/history/events/use-history-events';
 import SolanaEventForm from '@/modules/history/management/forms/SolanaEventForm.vue';
 
-vi.mock('json-editor-vue', () => ({
-  template: '<input />',
-}));
-
 vi.mock('@/modules/history/events/use-history-events', () => ({
   useHistoryEvents: vi.fn(),
 }));

--- a/frontend/app/src/modules/history/management/forms/history-event-form.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/history-event-form.spec.ts
@@ -7,10 +7,6 @@ import { setupDayjs } from '@/modules/core/common/data/date';
 import HistoryEventForm from '@/modules/history/events/HistoryEventForm.vue';
 import { isEvmTypeEvent } from '@/modules/history/management/forms/form-guards';
 
-vi.mock('json-editor-vue', () => ({
-  template: '<input />',
-}));
-
 const formTypesYouCanAddTo = Object.values(HistoryEventEntryType).filter(type => !isEvmTypeEvent(type));
 
 type Wrapper = VueWrapper<InstanceType<typeof HistoryEventForm>>;

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -193,3 +193,6 @@ config.global.stubs.RuiAutoComplete = RuiAutoCompleteStub;
 config.global.stubs.RuiIcon = RuiIconStub;
 config.global.stubs.RuiTooltip = RuiTooltipStub;
 config.global.stubs.I18nT = true;
+// JsonInput lazy-loads the heavy `vanilla-jsoneditor` on mount; no spec asserts its
+// DOM, so stub it globally to keep form mounts fast.
+config.global.stubs.JsonInput = true;


### PR DESCRIPTION
Four history form specs each carried the same mock to keep the heavy `vanilla-jsoneditor` out of the mount:

```ts
vi.mock('json-editor-vue', () => ({
  template: '<input />',
}));
```

`JsonInput` lazy-loads that editor on mount and no spec asserts its DOM, so the stub belongs in the shared test setup rather than being restated, and kept in step, in every file that happens to mount a form. Any new spec mounting a form gets it for free instead of rediscovering the need for it.

Replaces the four copies with one `config.global.stubs.JsonInput = true` in `tests/unit/setup-files/setup.ts`.

No behavior change, and nothing outside tests is touched.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

No user-guide change: test-only.