### PR TITLE
Run the e2e core as the frozen binary

### DIFF
--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -119,14 +119,16 @@ jobs:
         with:
           env_file: .github/.env.ci
 
-      # Keyed on everything the freeze reads: the spec, the dependency set and
-      # the package itself. Most runs restore this and never pay the freeze.
+      # Keyed on everything the freeze bundles: the spec, the dependency set,
+      # the package and `rotkehlchen/data`. That data is not .py, so a global.db
+      # or nodes.json change would otherwise restore a stale core and the suite
+      # would test the old data without failing.
       - name: Cache frozen core
         id: core-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: target/backend
-          key: ${{ runner.os }}-rotki-core-${{ hashFiles('uv.lock', 'pyproject.toml', 'rotkehlchen.spec', 'rotkehlchen/**/*.py') }}
+          key: ${{ runner.os }}-rotki-core-${{ hashFiles('uv.lock', 'pyproject.toml', 'rotkehlchen.spec', 'rotkehlchen/**/*.py', 'rotkehlchen/data/**') }}
 
       - name: Setup python
         if: steps.core-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -102,9 +102,67 @@ jobs:
             target/release/starling
           retention-days: 1
 
+  build-backend:
+    name: 'Build Backend'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Load env
+        uses: rotki/action-env@49f59e650cfdc8796c4ac6533ec044b190d83f9a  # v4.0.0
+        with:
+          env_file: .github/.env.ci
+
+      # Keyed on everything the freeze reads: the spec, the dependency set and
+      # the package itself. Most runs restore this and never pay the freeze.
+      - name: Cache frozen core
+        id: core-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: target/backend
+          key: ${{ runner.os }}-rotki-core-${{ hashFiles('uv.lock', 'pyproject.toml', 'rotkehlchen.spec', 'rotkehlchen/**/*.py') }}
+
+      - name: Setup python
+        if: steps.core-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        if: steps.core-cache.outputs.cache-hit != 'true'
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+          version: ${{ env.UV_VERSION }}
+          cache-dependency-glob: "uv.lock"
+
+      # The same spec release packaging uses, so the e2e run exercises the
+      # binary that ships rather than the source tree. Invoked directly instead
+      # of through package.py, which would also build the Rust services that
+      # `build-rust-services` already covers.
+      - name: Freeze core
+        if: steps.core-cache.outputs.cache-hit != 'true'
+        run: |
+          uv sync --locked
+          uv run --with "pyinstaller==${PYINSTALLER_VERSION}" \
+            pyinstaller --noconfirm --clean --distpath target/backend rotkehlchen.spec
+
+      - name: Upload frozen core
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: backend-binary
+          path: target/backend
+          retention-days: 1
+
   e2e:
     name: 'shard-${{ matrix.shard }}'
-    needs: [ build-frontend, build-rust-services ]
+    needs: [ build-frontend, build-rust-services, build-backend ]
     env:
       CI: true
     runs-on: ubuntu-latest
@@ -160,6 +218,9 @@ jobs:
           version: ${{ env.UV_VERSION }}
           cache-dependency-glob: "uv.lock"
 
+      # Still needed with a frozen core: the suite seeds user and global DBs
+      # through `uv run python tests/e2e/scripts/seed-db.py`, which opens them
+      # with the venv's SQLCipher. Only core's own launch moves to the binary.
       - name: Setup backend
         run: uv sync --locked
 
@@ -181,6 +242,18 @@ jobs:
 
       - name: Make Rust binaries executable
         run: chmod +x target/release/colibri target/release/starling
+
+      # starling launches this instead of the interpreter once it is present
+      # (see `devCoreLauncherArgs`), so the suite drives the shipping binary.
+      - name: Download frozen core
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: backend-binary
+          path: target/backend
+
+      # upload-artifact drops the exec bit, same as the Rust binaries above.
+      - name: Make frozen core executable
+        run: chmod +x target/backend/rotki-core/rotki-core-*
 
       - name: Cache Playwright browsers
         id: playwright-cache

--- a/frontend/app/shared/starling/starling-args.spec.ts
+++ b/frontend/app/shared/starling/starling-args.spec.ts
@@ -4,8 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // The dev launchers probe the filesystem (is the warm-up build there?) and shell
 // out to uv (which interpreter?). Both are mocked so these run identically on a
 // CI box with no rust target dir and no uv installed.
-const { existsSyncMock, execSyncMock, buildCargoEnvMock } = vi.hoisted(() => ({
+const { existsSyncMock, statSyncMock, readdirSyncMock, execSyncMock, buildCargoEnvMock } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
+  statSyncMock: vi.fn(),
+  readdirSyncMock: vi.fn(),
   execSyncMock: vi.fn(),
   buildCargoEnvMock: vi.fn(),
 }));
@@ -18,9 +20,13 @@ vi.mock('@shared/cargo-env', () => ({
   STRAWBERRY_MISSING_WARNING: 'strawberry missing',
 }));
 
+// `statSync`/`readdirSync` are stubbed alongside `existsSync` because the core
+// launcher probes for a frozen build, not just a file: with only `existsSync`
+// mocked, a broad `true` sends the real `statSync` at a path that is not there.
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
-  return { ...actual, default: { ...actual, existsSync: existsSyncMock }, existsSync: existsSyncMock };
+  const stubs = { existsSync: existsSyncMock, statSync: statSyncMock, readdirSync: readdirSyncMock };
+  return { ...actual, ...stubs, default: { ...actual, ...stubs } };
 });
 
 vi.mock('node:child_process', async (importOriginal) => {
@@ -64,6 +70,10 @@ describe('buildStarlingInvocation (dev launchers)', () => {
     delete process.env.ROTKI_BACKEND_PROFILING_ARGS;
     delete process.env.ROTKI_GIL;
     buildCargoEnvMock.mockReturnValue(CARGO_ENV);
+    statSyncMock.mockReturnValue({ isDirectory: () => true });
+    // No frozen core unless a case says so, so the default stays the dev
+    // interpreter every branch below asserts on.
+    readdirSyncMock.mockReturnValue([]);
     execSyncMock.mockImplementation((cmd: string) => {
       if (cmd.includes('--version'))
         return '';
@@ -107,6 +117,39 @@ describe('buildStarlingInvocation (dev launchers)', () => {
       expect(args).not.toContain('--core-prefix=run');
       expect(args).toContain('--core-prefix=-m');
       expect(args).toContain('--core-prefix=rotkehlchen');
+    });
+  });
+
+  // The e2e run ships a frozen core the same way it ships the Rust binaries, so
+  // the suite drives the binary that actually ships: a missing hidden import or
+  // data file then fails the run rather than a release.
+  describe('when a frozen core is present', () => {
+    const FROZEN_CORE = 'rotki-core-1.43.0-linux';
+    const frozenDir = path.join('target', 'backend', 'rotki-core');
+
+    beforeEach(() => {
+      existsSyncMock.mockReturnValue(true);
+      readdirSyncMock.mockImplementation((probed: string) =>
+        String(probed).includes(frozenDir) ? [FROZEN_CORE] : []);
+    });
+
+    it('should launch the frozen binary rather than an interpreter', async () => {
+      const { args } = await buildDevInvocation();
+      expect(flagValue(args, '--core-binary')).toContain(path.join(frozenDir, FROZEN_CORE));
+      expect(flagValue(args, '--core-binary')).not.toBe(VENV_PYTHON);
+    });
+
+    // The binary is the entrypoint; passing `-m rotkehlchen` would have it
+    // treat the module flags as its own CLI args and refuse to start.
+    it('should not pass the module prefix', async () => {
+      const { args } = await buildDevInvocation();
+      expect(args).not.toContain('--core-prefix=-m');
+      expect(args).not.toContain('--core-prefix=rotkehlchen');
+    });
+
+    it('should run it from its own directory, as the packaged build does', async () => {
+      const { args } = await buildDevInvocation();
+      expect(flagValue(args, '--core-cwd')).toContain(frozenDir);
     });
   });
 

--- a/frontend/app/shared/starling/starling-args.ts
+++ b/frontend/app/shared/starling/starling-args.ts
@@ -4,10 +4,19 @@ import path from 'node:path';
 import process from 'node:process';
 import { buildCargoEnv } from '../cargo-env';
 import { shouldUseUv } from '../uv';
+import { BACKEND_DIRECTORY, findCoreBinary, resolveCoreBinary, resourcesDir } from './starling-paths';
 
-const BACKEND_DIRECTORY = 'backend';
 const COLIBRI_DIRECTORY = 'colibri';
 const STARLING_DIRECTORY = 'starling';
+
+/**
+ * Where a frozen core lands outside a packaged build, repo-root relative. Under
+ * `target/` alongside the Rust binaries because that is where CI already drops
+ * the artifacts it builds once and ships to the jobs that consume them, and it
+ * is gitignored. Nothing writes here by default: a dev run without a freeze
+ * falls through to the interpreter.
+ */
+const DEV_BACKEND_DIRECTORY = path.join('target', BACKEND_DIRECTORY);
 
 /**
  * Grace period starling gives the backend tree to exit before escalating to a
@@ -148,33 +157,6 @@ function repoRoot(): string {
   return path.resolve(process.cwd(), '..', '..');
 }
 
-/** The packaged-build resource root holding the bundled backend binaries. */
-function resourcesDir(): string {
-  return process.resourcesPath ? process.resourcesPath : import.meta.dirname;
-}
-
-/**
- * Locate the single packaged `rotki-core-*` binary. Mirrors the resolution the
- * old core launcher used: prefer `<resources>/backend/rotki-core/`, fall back to
- * `<resources>/backend/`. Returns the binary path and its directory (the cwd the
- * backend expects).
- */
-function resolveCoreBinary(): { binary: string; dir: string } {
-  const backendDirectory = path.join(resourcesDir(), BACKEND_DIRECTORY);
-  const candidates = [path.join(backendDirectory, 'rotki-core'), backendDirectory];
-  const dir = candidates.find(directory => fs.existsSync(directory) && fs.statSync(directory).isDirectory());
-  if (!dir)
-    throw new Error(`No backend directory found. Searched: ${candidates.join(', ')}`);
-
-  const binaries = fs.readdirSync(dir).filter(file => file.startsWith('rotki-core-'));
-  if (binaries.length === 0)
-    throw new Error('No rotki-core binary found');
-  if (binaries.length > 1)
-    throw new Error(`Expected one rotki-core binary but found: ${binaries.join(', ')}. This might indicate a problematic upgrade.`);
-
-  return { binary: path.join(dir, binaries[0]), dir };
-}
-
 /** The bundled `starling` supervisor binary path for packaged builds. */
 function resolveStarlingBinary(): string {
   const binary = process.platform === 'win32' ? 'starling.exe' : 'starling';
@@ -258,6 +240,16 @@ function prefixFlags(flag: string, tokens: string[]): string[] {
  * `uvPythonPath`); with a venv active, `python` is already the venv's own.
  */
 function devCoreLauncherArgs(root: string): string[] {
+  // A frozen core, when the build job shipped one (see DEV_BACKEND_DIRECTORY).
+  // Preferred over the interpreter for the same reason the packaged build uses
+  // it: it exercises what actually ships, so a missing hidden import or data
+  // file fails the e2e run rather than a release. No prefix - the binary is the
+  // entrypoint, so `-m rotkehlchen` must not be passed - and its own directory
+  // is the cwd, exactly as `packagedLauncherArgs` does.
+  const frozen = findCoreBinary(path.join(root, DEV_BACKEND_DIRECTORY));
+  if (frozen)
+    return ['--core-binary', frozen.binary, '--core-cwd', frozen.dir];
+
   const profilingCmd = process.env.ROTKI_BACKEND_PROFILING_CMD;
   const profilingArgs = process.env.ROTKI_BACKEND_PROFILING_ARGS;
   // Interpreter args, so they precede `-m`: opt out of the GIL on a free-threaded

--- a/frontend/app/shared/starling/starling-paths.ts
+++ b/frontend/app/shared/starling/starling-paths.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+export const BACKEND_DIRECTORY = 'backend';
+
+/** The packaged-build resource root holding the bundled backend binaries. */
+export function resourcesDir(): string {
+  return process.resourcesPath ? process.resourcesPath : import.meta.dirname;
+}
+
+/**
+ * The single frozen `rotki-core-*` binary under a backend directory: prefer
+ * `<base>/rotki-core/`, fall back to `<base>` itself. Returns the binary and its
+ * directory (the cwd the backend expects), or undefined when there is no frozen
+ * build there - absence is fatal only for a packaged build, so the callers
+ * decide. Two binaries is ambiguous either way and always throws.
+ */
+export function findCoreBinary(backendDirectory: string): { binary: string; dir: string } | undefined {
+  const candidates = [path.join(backendDirectory, 'rotki-core'), backendDirectory];
+  const dir = candidates.find(directory => fs.existsSync(directory) && fs.statSync(directory).isDirectory());
+  if (!dir)
+    return undefined;
+
+  const binaries = fs.readdirSync(dir).filter(file => file.startsWith('rotki-core-'));
+  if (binaries.length === 0)
+    return undefined;
+  if (binaries.length > 1)
+    throw new Error(`Expected one rotki-core binary but found: ${binaries.join(', ')}. This might indicate a problematic upgrade.`);
+
+  return { binary: path.join(dir, binaries[0]), dir };
+}
+
+/** The packaged core binary; a packaged build without one cannot start. */
+export function resolveCoreBinary(): { binary: string; dir: string } {
+  const backendDirectory = path.join(resourcesDir(), BACKEND_DIRECTORY);
+  const resolved = findCoreBinary(backendDirectory);
+  if (!resolved)
+    throw new Error(`No rotki-core binary found under ${backendDirectory}`);
+
+  return resolved;
+}


### PR DESCRIPTION
## Problem

The e2e suite launches core as `python -m rotkehlchen` from the source tree, which is not what ships. Packaging regressions (a missing hidden import, a data file left out of the spec) can only surface in a release build, never in the suite meant to catch them.

## Change

Freeze core in its own job and let starling launch that binary instead.

starling already drives a frozen core for packaged builds, so this extends the same resolution to the dev launcher: `devCoreLauncherArgs` prefers a frozen build under `target/backend` when one is present, passing no module prefix and using the binary's own directory as cwd, exactly as `packagedLauncherArgs` does. With no frozen build present it falls back to the interpreter, so a local dev run is unchanged.

The build job invokes pyinstaller on `rotkehlchen.spec` directly rather than through `package.py`, which would also build the Rust services that `build-rust-services` already covers. It caches on the spec, the lockfile and the package itself, so most runs restore rather than freeze.

Binary resolution moves to `starling-paths.ts` because `starling-args.ts` was at 386 of its 400-line cap.

## Cost

This is bought for fidelity, not speed. Measured on the linux nightly build:

| | |
|---|---|
| freeze (`pyinstaller`) | 70s on CI, 41s locally |
| `dist` size | 217 MB, 552 files |
| artifact (zipped) | ~91 MB |

`build-backend` runs alongside `build-rust-services` (3m12s), so it adds nothing to the critical path. The shards pay the artifact download, roughly 10-15s each.

python and uv stay in the e2e job: the suite seeds its user and global DBs through `uv run python seed-db.py`, which needs the venv's SQLCipher. Only core's own launch moves to the binary. Porting that seed script to a node SQLCipher driver would let the shards drop python entirely, but that is separate work with its own risk (the driver must match `KDF_ITER = 64000` and SQLCipher 3 parameters).

## Verification

`starling-args.spec.ts` covers the new branch: the frozen binary is launched, no module prefix is passed, and its own directory is the cwd. `statSync`/`readdirSync` join the `node:fs` mock, since the existing broad `existsSync -> true` otherwise sent the real `statSync` at a path that does not exist.

The point of opening this is the e2e timings. Worth comparing shard wall-clock against a develop run before merging.