### PR TITLE
Fix failed-status regressions and log the e2e core

### DIFF
--- a/frontend/app/scripts/start-starling.ts
+++ b/frontend/app/scripts/start-starling.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { cac } from 'cac';
 import consola from 'consola';
-import { buildStarlingInvocation, SHUTDOWN_GRACE_SECS, type StarlingBackendOptions, type StarlingInvocation } from '../shared/starling/starling-args';
+import { buildStarlingInvocation, describeResolvedCore, SHUTDOWN_GRACE_SECS, type StarlingBackendOptions, type StarlingInvocation } from '../shared/starling/starling-args';
 import { requestStarlingStart, spawnStarling } from '../shared/starling/starling-launch';
 import { StarlingRpc } from '../shared/starling/starling-rpc';
 
@@ -63,10 +63,29 @@ function resolveInvocation(options: StarlingE2eOptions, root: string): StarlingI
   return invocation;
 }
 
+/**
+ * Name the core the launcher actually resolved.
+ *
+ * The fallback to the interpreter is silent, so a wrong artifact path produces a run that looks
+ * exactly like a passing one. Nothing else records which was used: the backend log holds no
+ * executable path, and Playwright suppresses `webServer` stdout unless the run fails.
+ */
+function logResolvedCore(invocation: StarlingInvocation): void {
+  const { binary, kind } = describeResolvedCore(invocation.args);
+
+  if (binary === undefined) {
+    consola.warn('starling invocation names no core binary');
+    return;
+  }
+
+  consola.info(`Core: ${kind === 'frozen' ? 'frozen binary' : 'interpreter'} (${binary})`);
+}
+
 async function startStarling(options: StarlingE2eOptions): Promise<void> {
   const root = repoRoot();
   const invocation = resolveInvocation(options, root);
   consola.info(`Starting starling (proxy ${options.port}, core ${options.corePort}, colibri ${options.colibriPort}) via ${invocation.command}`);
+  logResolvedCore(invocation);
 
   const rpc = new StarlingRpc({ warn: message => consola.warn(message) }, (method) => {
     if (method === 'event.crashed')

--- a/frontend/app/shared/starling/starling-args.spec.ts
+++ b/frontend/app/shared/starling/starling-args.spec.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describeResolvedCore } from './starling-args';
 
 // The dev launchers probe the filesystem (is the warm-up build there?) and shell
 // out to uv (which interpreter?). Both are mocked so these run identically on a
@@ -118,6 +119,11 @@ describe('buildStarlingInvocation (dev launchers)', () => {
       expect(args).toContain('--core-prefix=-m');
       expect(args).toContain('--core-prefix=rotkehlchen');
     });
+
+    it('should report the interpreter as the resolved core', async () => {
+      const { args } = await buildDevInvocation();
+      expect(describeResolvedCore(args)).toStrictEqual({ binary: VENV_PYTHON, kind: 'interpreter' });
+    });
   });
 
   // The e2e run ships a frozen core the same way it ships the Rust binaries, so
@@ -145,6 +151,15 @@ describe('buildStarlingInvocation (dev launchers)', () => {
       const { args } = await buildDevInvocation();
       expect(args).not.toContain('--core-prefix=-m');
       expect(args).not.toContain('--core-prefix=rotkehlchen');
+    });
+
+    // What the launcher logs, so a silent fall back to the interpreter is visible in a CI run
+    // rather than looking exactly like a frozen one.
+    it('should report the frozen binary as the resolved core', async () => {
+      const { args } = await buildDevInvocation();
+      const resolved = describeResolvedCore(args);
+      expect(resolved.kind).toBe('frozen');
+      expect(resolved.binary).toContain(path.join(frozenDir, FROZEN_CORE));
     });
 
     it('should run it from its own directory, as the packaged build does', async () => {
@@ -241,9 +256,8 @@ describe('buildStarlingInvocation (dev launchers)', () => {
       const invocation = await buildDevInvocation();
       expect(invocation.command).toBe('cargo');
       expect(invocation.args.slice(0, 4)).toEqual(['run', '--locked', '-p', 'starling']);
-      if (invocation.cwd === undefined)
-        throw new Error('Expected the cargo invocation to set a working directory');
-      expect(invocation.cwd.endsWith('crates')).toBe(false);
+      expect(invocation.cwd).toBeDefined();
+      expect(invocation.cwd?.endsWith('crates')).toBe(false);
     });
 
     it('should fall back to running colibri through cargo', async () => {

--- a/frontend/app/shared/starling/starling-args.ts
+++ b/frontend/app/shared/starling/starling-args.ts
@@ -233,6 +233,29 @@ function prefixFlags(flag: string, tokens: string[]): string[] {
   return tokens.map(token => `${flag}=${token}`);
 }
 
+/** Which core a built invocation resolved to, for launchers that want to report it. */
+export interface ResolvedCore {
+  kind: 'frozen' | 'interpreter';
+  binary?: string;
+}
+
+/**
+ * Read back the core an invocation resolved to.
+ *
+ * `devCoreLauncherArgs` falls back to the interpreter silently when it finds no frozen build, and
+ * nothing downstream records which one ran, so a wrong artifact path yields a passing run that
+ * looks identical to a real one. The interpreter branch is the only one needing a prefix, since it
+ * has to say `-m rotkehlchen`; the frozen binary is its own entrypoint. Prefix tokens arrive one
+ * per flag as `--core-prefix=<token>`, so this matches the `=` form and not a bare flag.
+ */
+export function describeResolvedCore(args: string[]): ResolvedCore {
+  const index = args.indexOf('--core-binary');
+  return {
+    binary: index === -1 ? undefined : args[index + 1],
+    kind: args.some(arg => arg.startsWith('--core-prefix=')) ? 'interpreter' : 'frozen',
+  };
+}
+
 /**
  * The dev core launcher: a profiling command, the interpreter uv resolves, or a
  * bare `python -m rotkehlchen` - whichever the dev environment dictates. Every

--- a/frontend/app/src/modules/dashboard/progress/use-history-query-progress.spec.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-history-query-progress.spec.ts
@@ -117,6 +117,24 @@ describe('useHistoryQueryProgress', () => {
     expect(value?.percentage).toBe(100);
   });
 
+  it('should count failed transactions as finished and skip them as active', () => {
+    // A failed address is done, not still querying. Counting it active pinned the indicator on
+    // "Query failed" and kept it short of 100% for the rest of the session.
+    setTxStatuses({
+      a: evmTx(TransactionsQueryStatus.FAILED, '0x1'),
+      b: evmTx(TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED, '0x2'),
+    });
+
+    const { progress } = useHistoryQueryProgress();
+    const value = get(progress);
+
+    expect(value?.currentOperation).toBeNull();
+    expect(value?.currentOperationData).toBeNull();
+    expect(value?.currentStep).toBe(2);
+    expect(value?.totalSteps).toBe(2);
+    expect(value?.percentage).toBe(100);
+  });
+
   // eslint-disable-next-line complexity
   it('should fall back to an active event when no transactions are active', () => {
     setTxStatuses({

--- a/frontend/app/src/modules/dashboard/progress/use-history-query-progress.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-history-query-progress.ts
@@ -62,8 +62,14 @@ interface EventProgressData {
   currentOperationData: HistoryQueryProgressOperationData;
 }
 
+/** Cancelled and failed are both terminal: no further progress is coming for that address. */
+function isTerminal(status: TxQueryStatusData): boolean {
+  return status.status === TransactionsQueryStatus.CANCELLED
+    || status.status === TransactionsQueryStatus.FAILED;
+}
+
 function isTransactionActive(status: TxQueryStatusData): boolean {
-  if (status.status === TransactionsQueryStatus.CANCELLED)
+  if (isTerminal(status))
     return false;
 
   if (status.subtype === 'bitcoin') {
@@ -73,7 +79,7 @@ function isTransactionActive(status: TxQueryStatusData): boolean {
 }
 
 function isTransactionFinished(status: TxQueryStatusData): boolean {
-  if (status.status === TransactionsQueryStatus.CANCELLED)
+  if (isTerminal(status))
     return true;
 
   if (status.subtype === 'bitcoin') {

--- a/frontend/app/src/modules/history/events/tx/use-transaction-sync.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-transaction-sync.spec.ts
@@ -128,4 +128,36 @@ describe('useTransactionSync', () => {
       expect(mocks.setEvmlikeStatus).toHaveBeenNthCalledWith(2, account, 'finished');
     });
   });
+
+  /**
+   * Against the real store rather than the mock above.
+   *
+   * A failing evmlike query calls `markAddressFailed` and then the unconditional `finished` tail,
+   * and the defect was in what the second call did to the first one's result. Every assertion in
+   * this file's other tests is on the mock recording that a call happened, which is true either
+   * way, so none of them can see it. This one asserts the status the address is actually left in.
+   */
+  describe('evmlike failure against the real query-status store', () => {
+    const evmlikeAccount: ChainAddress = { address: '0xABC', chain: 'zksync_lite' };
+
+    beforeEach(() => {
+      vi.resetModules();
+      vi.doUnmock('@/modules/history/use-tx-query-status-store');
+      setActivePinia(createPinia());
+    });
+
+    it('should leave a failed evmlike address failed, not complete', async () => {
+      const { useTxQueryStatusStore } = await import('@/modules/history/use-tx-query-status-store');
+      const { TransactionsQueryStatus } = await import('@/modules/core/messaging/types');
+      const { useTransactionSync: useRealStoreSync } = await import('./use-transaction-sync');
+
+      mocks.runTask.mockResolvedValue(failure({}));
+      const store = useTxQueryStatusStore();
+
+      const { syncTransactionTask } = useRealStoreSync();
+      await syncTransactionTask(evmlikeAccount, TransactionChainType.EVMLIKE);
+
+      expect(get(store.queryStatus)['0xABCzksync_lite'].status).toBe(TransactionsQueryStatus.FAILED);
+    });
+  });
 });

--- a/frontend/app/src/modules/history/use-tx-query-status-store.spec.ts
+++ b/frontend/app/src/modules/history/use-tx-query-status-store.spec.ts
@@ -375,6 +375,18 @@ describe('store/history/query-status/tx-query-status', () => {
       store.setEvmlikeStatus({ address: '0x123', chain: 'scroll' }, 'finished');
       expect(get(store.queryStatus)['0x123scroll'].status).toBe(TransactionsQueryStatus.CANCELLED);
     });
+
+    it('should not overwrite failed entries', () => {
+      const store = useTxQueryStatusStore();
+
+      store.setEvmlikeStatus({ address: '0x123', chain: 'scroll' }, 'started');
+      store.markAddressFailed({ address: '0x123', chain: 'scroll' }, 'evmlike');
+
+      // The caller marks the query failed and then runs its unconditional `finished` tail. Without
+      // the guard that tail reports the failed address as complete.
+      store.setEvmlikeStatus({ address: '0x123', chain: 'scroll' }, 'finished');
+      expect(get(store.queryStatus)['0x123scroll'].status).toBe(TransactionsQueryStatus.FAILED);
+    });
   });
 
   describe('markAddressCancelled', () => {

--- a/frontend/app/src/modules/history/use-tx-query-status-store.ts
+++ b/frontend/app/src/modules/history/use-tx-query-status-store.ts
@@ -206,8 +206,13 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
     const chain = account.chain.toLowerCase();
     const key = createKey({ address: account.address, chain });
 
-    // Guard: don't overwrite cancelled entries
-    if (status[key]?.status === TransactionsQueryStatus.CANCELLED)
+    // Don't overwrite an entry that has already reached a terminal state. The caller runs its
+    // `finished` tail unconditionally, so without this a query that failed reports success: the
+    // address renders as a green "Complete", its chain's `failed` count stays 0 and no warning is
+    // raised. Evmlike is the one case where nothing else corrects that, since these chains send no
+    // websocket messages of their own.
+    const current = status[key]?.status;
+    if (current === TransactionsQueryStatus.CANCELLED || current === TransactionsQueryStatus.FAILED)
       return;
 
     const now = millisecondsToSeconds(Date.now());

--- a/frontend/app/src/modules/shell/sync-progress/components/ChainProgressList.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/ChainProgressList.spec.ts
@@ -37,6 +37,25 @@ describe('modules/sync-progress/components/ChainProgressList', () => {
     };
   }
 
+  /** A chain whose every address failed: terminal, but none of them completed. */
+  function createFailedChainProgress(chain: string, total: number): ChainProgress {
+    return {
+      addresses: Array.from({ length: total }, (_, i) => ({
+        address: `0x${chain}${i.toString().padStart(38, '0')}`,
+        status: AddressStatus.FAILED,
+        subtype: AddressSubtype.EVM,
+      })),
+      cancelled: 0,
+      chain,
+      completed: 0,
+      failed: total,
+      inProgress: 0,
+      pending: 0,
+      progress: 100,
+      total,
+    };
+  }
+
   function createWrapper(chains: ChainProgress[]): VueWrapper<InstanceType<typeof ChainProgressList>> {
     return mount(ChainProgressList, {
       global: {
@@ -91,6 +110,16 @@ describe('modules/sync-progress/components/ChainProgressList', () => {
       wrapper = createWrapper(chains);
 
       expect(wrapper.findAll('[data-testid="chain-item"]')).toHaveLength(0);
+    });
+
+    it('should treat a chain whose addresses all failed as settled', () => {
+      // Failed is terminal, so this chain is finished, just not cleanly. Counting it as still in
+      // progress stranded it at 0/3 forever while the header reported the sync complete.
+      const chains = [createFailedChainProgress('gnosis', 3)];
+      wrapper = createWrapper(chains);
+
+      expect(wrapper.findAll('[data-testid="chain-item"]')).toHaveLength(0);
+      expect(wrapper.text()).toContain('sync_progress.completed_chains');
     });
   });
 

--- a/frontend/app/src/modules/shell/sync-progress/components/ChainProgressList.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/ChainProgressList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ChainProgress } from '../types';
+import { isChainSettled } from '../use-chain-progress';
 import ChainProgressItem from './ChainProgressItem.vue';
 
 const { chains } = defineProps<{
@@ -10,22 +11,28 @@ const { t } = useI18n({ useScope: 'global' });
 
 const showCompleted = ref<boolean>(false);
 
+// Split on the same definition of "settled" the rest of the panel uses, so a chain cannot be in
+// progress here while the header counts it complete.
 const inProgressChains = computed<ChainProgress[]>(() =>
-  chains.filter(c => (c.completed + c.cancelled) < c.total || c.total === 0),
+  chains.filter(chain => !isChainSettled(chain)),
 );
 
 const completedChains = computed<ChainProgress[]>(() =>
-  chains.filter(c => (c.completed + c.cancelled) === c.total && c.total > 0),
+  chains.filter(chain => isChainSettled(chain)),
 );
 
 const hasInProgress = computed<boolean>(() => get(inProgressChains).length > 0);
 const completedCount = computed<number>(() => get(completedChains).length);
 const hasCompleted = computed<boolean>(() => !!get(completedCount));
-const hasCancelledChains = computed<boolean>(() => get(completedChains).some(c => c.cancelled > 0));
+const hasFailedChains = computed<boolean>(() => get(completedChains).some(chain => chain.failed > 0));
+const hasCancelledChains = computed<boolean>(() => get(completedChains).some(chain => chain.cancelled > 0));
 
-const completedIconColor = computed<string>(() =>
-  get(hasCancelledChains) ? 'text-rui-warning' : 'text-rui-success',
-);
+const completedIconColor = computed<string>(() => {
+  if (get(hasFailedChains))
+    return 'text-rui-error';
+
+  return get(hasCancelledChains) ? 'text-rui-warning' : 'text-rui-success';
+});
 
 function toggleCompleted(): void {
   set(showCompleted, !get(showCompleted));


### PR DESCRIPTION
Follow-ups to #12740. Three of these are defects in that PR's own code, found by review and each confirmed by reading the code; the fourth is the log line owed from the frozen-core e2e work (#12739).

Every fix has a test that was verified to **fail without it**, and the first one is also confirmed in the running app.

### 1. A failed evmlike query reported success

`setEvmlikeStatus` guarded only against overwriting a cancelled entry, but the caller runs its `finished` tail unconditionally, right after the failure branch marked the address failed. The second call won, so the address rendered as a green "Complete", its chain's failed count stayed 0, and no warning was raised.

Evmlike is the one case where nothing else corrects that, since those chains send no websocket messages of their own, and it is exactly the case the failure handling was added for.

The existing tests could not catch it: they mock the query-status store wholesale, so they assert that `markAddressFailed` and `setEvmlikeStatus` were *called*, which stayed true with the bug present. The defect was in what the second call did to the first one's result. Both new tests run against the real store and assert the status the address is left in.

**Verified in the app.** New account, one ZKSync Lite address, failure injected into the task outcome on the initial history sync. The store now holds `zksync_lite -> status: "failed", subtype: "evmlike"` and the panel reads "Sync Complete with warnings". Before this change the same run leaves `querying_transactions_finished` and shows a green "Complete".

### 2. A chain whose addresses all failed never settled

The sync panel's list still split chains on `completed + cancelled`, the hand-written arithmetic that `isChainSettled` was extracted to replace. Two of the four sites were updated; this one was missed, and only its spec appeared in the diff, which is what hid it.

Such a chain has completed 0, cancelled 0, failed 3 of 3, so the list kept it under "in progress" permanently at 0/3 while the header, which does count failures, reported the sync complete. The completed section's icon also never turned red for it.

### 3. The dashboard indicator never settled on a failure

`FAILED` was added to the status descriptions but not to the two predicates deciding whether an address is still working. A failed address therefore stayed active: the indicator stuck on "Query failed" and never reached 100%, since the failure counted towards the total but never towards the completed steps. Both predicates now share one `isTerminal` helper.

### 4. Log which core the e2e run launched

The launcher prefers a frozen core and falls back to the interpreter silently when it finds none. Nothing downstream records which ran: the backend log holds no executable path, and Playwright suppresses `webServer` stdout unless the run fails. A wrong artifact path therefore produces a passing run indistinguishable from a real one, and it has never been confirmed at runtime that CI ran the binary at all.

`describeResolvedCore` reads the resolved core back off the built invocation and the launcher logs it. Worth noting for review: prefix tokens arrive as `--core-prefix=<token>`, one per token, so matching a bare `--core-prefix` reports every run as frozen. The specs cover both branches and fail on that mistake.

Also replaces an `if`-throw in that spec with an assertion, clearing the `test/no-conditional-in-test` warning it carried.

### Testing

691 files / 6595 tests green, typecheck clean, lint unchanged from develop's baseline (0 errors), typos clean.

No changelog entry: #12740 has not shipped, so these correct its behaviour before release rather than changing anything users have seen.
