### PR TITLE
test: cut real-clock waits and dead imports from the unit suite

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/use-address-book-deletion.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-book-deletion.spec.ts
@@ -14,10 +14,11 @@ const { spies } = vi.hoisted(() => ({
 vi.mock('@/modules/core/common/use-confirm-store', () => ({
   useConfirmStore: (): object => ({ show: spies.show }),
 }));
-vi.mock('@/modules/core/notifications/use-notifications', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
-  return { ...actual, useNotifications: (): object => ({ notifyError: spies.notifyError }) };
-});
+// Mocked outright rather than spread over `...actual`: importActual evaluates the real
+// notifications graph, which costs ~1.2s to import.
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: (): object => ({ notifyError: spies.notifyError }),
+}));
 vi.mock('@/modules/accounts/address-book/use-address-book-operations', () => ({
   useAddressBookOperations: (): object => ({ deleteAddressBook: spies.deleteAddressBook }),
 }));

--- a/frontend/app/src/modules/accounts/blockchain/use-account-manage.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-manage.spec.ts
@@ -19,19 +19,19 @@ vi.mock('@/modules/accounts/use-blockchain-account-management', () => ({
   })),
 }));
 
-vi.mock('@/modules/core/notifications/use-notifications', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>(
-    '@/modules/core/notifications/use-notifications',
-  );
-  return {
-    ...actual,
-    useNotifications: (): object => ({
-      removeMatching: vi.fn(),
-      showErrorMessage: mockShowErrorMessage,
-      showSuccessMessage: vi.fn(),
-    }),
-  };
-});
+// Mocked outright rather than spread over `...actual`: importActual evaluates the real
+// notifications graph, which costs ~1.2s to import.
+// `getErrorMessage` is a pure helper re-exported from a light module, so take it from there.
+vi.mock('@/modules/core/notifications/use-notifications', async () => ({
+  getErrorMessage: (await vi.importActual<typeof import('@/modules/core/common/logging/error-handling')>(
+    '@/modules/core/common/logging/error-handling',
+  )).getErrorMessage,
+  useNotifications: (): object => ({
+    removeMatching: vi.fn(),
+    showErrorMessage: mockShowErrorMessage,
+    showSuccessMessage: vi.fn(),
+  }),
+}));
 
 vi.mock('@/modules/accounts/use-blockchain-accounts', () => ({
   useBlockchainAccounts: vi.fn(() => ({

--- a/frontend/app/src/modules/assets/admin/use-managed-asset-operations.spec.ts
+++ b/frontend/app/src/modules/assets/admin/use-managed-asset-operations.spec.ts
@@ -22,10 +22,11 @@ const { spies } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('@/modules/core/notifications/use-notifications', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
-  return { ...actual, useNotifications: (): object => ({ showErrorMessage: spies.showErrorMessage }) };
-});
+// Mocked outright rather than spread over `...actual`: importActual evaluates the real
+// notifications graph, which costs ~1.2s to import.
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: (): object => ({ showErrorMessage: spies.showErrorMessage }),
+}));
 vi.mock('@/modules/assets/use-ignored-asset-confirmation', () => ({
   useIgnoredAssetConfirmation: (): object => ({ ignoreAssetWithConfirmation: spies.ignoreAssetWithConfirmation }),
 }));

--- a/frontend/app/src/modules/assets/detection/use-newly-detected-tokens-db.spec.ts
+++ b/frontend/app/src/modules/assets/detection/use-newly-detected-tokens-db.spec.ts
@@ -1,4 +1,3 @@
-import { wait } from '@shared/utils';
 import { flushPromises } from '@vue/test-utils';
 import { get, set } from '@vueuse/core';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -103,15 +102,20 @@ describe('useNewlyDetectedTokensDb', () => {
 
       const originalToken = await db().newlyDetectedTokens.where('tokenIdentifier').equals('eip155:1/erc20:0x1234').first();
       const originalDetectedAt = originalToken?.detectedAt;
+      expect(originalDetectedAt).toBeDefined();
 
-      // Wait a bit and update
-      await wait(10);
+      // `detectedAt` defaults to `Date.now()`, so the update can only be shown to
+      // preserve the original if a fresh default would differ. Move the clock
+      // rather than sleeping on it.
+      const advanced = vi.spyOn(Date, 'now').mockReturnValue(originalDetectedAt! + 10_000);
 
       await addToken({
         tokenIdentifier: 'eip155:1/erc20:0x1234',
         tokenKind: NewDetectedTokenKind.EVM,
         seenDescription: 'Updated',
       });
+
+      advanced.mockRestore();
 
       const updatedToken = await db().newlyDetectedTokens.where('tokenIdentifier').equals('eip155:1/erc20:0x1234').first();
       expect(updatedToken?.detectedAt).toBe(originalDetectedAt);

--- a/frontend/app/src/modules/balances/non-fungible/use-nft-asset-ignoring.spec.ts
+++ b/frontend/app/src/modules/balances/non-fungible/use-nft-asset-ignoring.spec.ts
@@ -13,10 +13,11 @@ const { spies } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('@/modules/core/notifications/use-notifications', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
-  return { ...actual, useNotifications: (): object => ({ showErrorMessage: spies.showErrorMessage }) };
-});
+// Mocked outright rather than spread over `...actual`: importActual evaluates the real
+// notifications graph, which costs ~1.2s to import.
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: (): object => ({ showErrorMessage: spies.showErrorMessage }),
+}));
 vi.mock('@/modules/assets/use-ignored-asset-confirmation', () => ({
   useIgnoredAssetConfirmation: (): object => ({ ignoreAssetWithConfirmation: spies.ignoreAssetWithConfirmation }),
 }));

--- a/frontend/app/src/modules/balances/non-fungible/use-nft-price-management.spec.ts
+++ b/frontend/app/src/modules/balances/non-fungible/use-nft-price-management.spec.ts
@@ -12,10 +12,11 @@ const { spies } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('@/modules/core/notifications/use-notifications', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
-  return { ...actual, useNotifications: (): object => ({ notifyError: spies.notifyError }) };
-});
+// Mocked outright rather than spread over `...actual`: importActual evaluates the real
+// notifications graph, which costs ~1.2s to import.
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: (): object => ({ notifyError: spies.notifyError }),
+}));
 vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
   useAssetPricesApi: (): object => ({ deleteLatestPrice: spies.deleteLatestPrice }),
 }));

--- a/frontend/app/src/modules/balances/services/balance-queue.spec.ts
+++ b/frontend/app/src/modules/balances/services/balance-queue.spec.ts
@@ -1,4 +1,4 @@
-import { wait } from '@shared/utils';
+import { flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BalanceQueueService, type QueueItem, type QueueItemMetadata } from '@/modules/balances/services/balance-queue';
 import { TaskType } from '@/modules/core/tasks/task-type';
@@ -6,6 +6,24 @@ import { TaskType } from '@/modules/core/tasks/task-type';
 interface TestMetadata extends QueueItemMetadata {
   chain: string;
   address?: string;
+}
+
+interface Gate {
+  promise: Promise<void>;
+  open: () => void;
+}
+
+/**
+ * A manually released execution, used instead of sleeping inside `executeFn`.
+ * The queue only ever suspends at `await item.executeFn()`, so holding that
+ * await open gives the test exact control over how long an item stays running.
+ */
+function createGate(): Gate {
+  let open!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { open, promise };
 }
 
 describe('balanceQueueService', () => {
@@ -68,11 +86,16 @@ describe('balanceQueueService', () => {
 
     it('should respect max concurrency', async () => {
       const executionOrder: string[] = [];
-      const createExecuteFn = (id: string): (() => Promise<void>) => vi.fn(async () => {
-        executionOrder.push(`start-${id}`);
-        await wait(50);
-        executionOrder.push(`end-${id}`);
-      });
+      const gates: Gate[] = [];
+      const createExecuteFn = (id: string): (() => Promise<void>) => {
+        const gate = createGate();
+        gates.push(gate);
+        return vi.fn(async () => {
+          executionOrder.push(`start-${id}`);
+          await gate.promise;
+          executionOrder.push(`end-${id}`);
+        });
+      };
 
       const items: QueueItem<TestMetadata>[] = [
         {
@@ -98,11 +121,14 @@ describe('balanceQueueService', () => {
       // Start enqueueing items
       const promises = items.map(async item => queue.enqueue(item));
 
-      // Wait a bit to check concurrency
-      await wait(10);
-      expect(queue.getStats().running).toBeLessThanOrEqual(2);
+      // enqueue runs the items synchronously up to their first await, so the
+      // concurrency window is already open here — no need to sample it later.
+      expect(queue.getStats()).toMatchObject({ pending: 1, running: 2 });
+      expect(executionOrder).toEqual(['start-1', 'start-2']);
 
       // Wait for all to complete
+      for (const gate of gates)
+        gate.open();
       await Promise.all(promises);
 
       expect(executionOrder).toHaveLength(6);
@@ -183,9 +209,10 @@ describe('balanceQueueService', () => {
 
   describe('queue management', () => {
     it('should clear queue', async () => {
-      const executeFns = new Array(5).fill(null).map(() =>
+      const gates = new Array(5).fill(null).map(() => createGate());
+      const executeFns = gates.map(gate =>
         vi.fn(async () => {
-          await wait(100);
+          await gate.promise;
         }),
       );
 
@@ -198,7 +225,11 @@ describe('balanceQueueService', () => {
 
       const batchPromise = queue.enqueueBatch(items);
 
-      await wait(10);
+      // Two items are already running and the rest are pending at this point
+      expect(queue.getStats()).toMatchObject({
+        pending: 3,
+        running: 2,
+      });
 
       queue.clear();
 
@@ -208,6 +239,11 @@ describe('balanceQueueService', () => {
         pending: 0,
         running: 0,
       });
+
+      // Release the two in-flight executions so nothing dangles past the test
+      for (const gate of gates)
+        gate.open();
+      await flushPromises();
     });
 
     it('should clear completed items', async () => {
@@ -264,12 +300,9 @@ describe('balanceQueueService', () => {
     it('should track processing state', async () => {
       expect(queue.isProcessing()).toBe(false);
 
-      let resolveWait: (() => void) | null = null;
-      const waitPromise = new Promise<void>((resolve) => {
-        resolveWait = resolve;
-      });
+      const gate = createGate();
       const item: QueueItem<TestMetadata> = {
-        executeFn: async () => waitPromise,
+        executeFn: async () => gate.promise,
         id: 'test-1',
         metadata: { chain: 'eth' },
         type: TaskType.QUERY_BLOCKCHAIN_BALANCES,
@@ -277,18 +310,16 @@ describe('balanceQueueService', () => {
 
       const enqueuePromise = queue.enqueue(item);
 
-      // Wait a bit to ensure the item is running
-      await wait(10);
+      // The item is already running: enqueue does not yield before executeFn
       expect(queue.isProcessing()).toBe(true);
 
-      // Resolve the wait promise to complete the item
-      resolveWait!();
+      // Release the gate to complete the item
+      gate.open();
 
-      // Wait for the item to complete
+      // The item is removed from runningItems before its promise resolves,
+      // so awaiting it is enough — no cleanup delay needed.
       await enqueuePromise;
 
-      // Small delay to ensure cleanup
-      await wait(10);
       expect(queue.isProcessing()).toBe(false);
     });
   });
@@ -350,9 +381,8 @@ describe('balanceQueueService', () => {
       // Enqueue without awaiting since it will be blocked
       const enqueuePromise = queue.enqueue(item);
 
-      // Wait a bit to ensure processing attempt was made
-      await wait(50);
-
+      // The canProcess check happens synchronously inside enqueue, so the
+      // blocked state is observable immediately.
       // Item should be pending, not executed
       expect(executeFn).not.toHaveBeenCalled();
       expect(queue.getStats()).toMatchObject({
@@ -421,7 +451,6 @@ describe('balanceQueueService', () => {
       // Enqueue while "decoding" is true (canProcess returns false)
       const enqueuePromise = queue.enqueue(item);
 
-      await wait(50);
       expect(executeFn).not.toHaveBeenCalled();
 
       // Simulate decoding finished
@@ -438,15 +467,16 @@ describe('balanceQueueService', () => {
       queue.setCanProcess(() => canProcess);
 
       const executionOrder: string[] = [];
-      const createSlowExecuteFn = (id: string): (() => Promise<void>) => vi.fn(async () => {
-        executionOrder.push(`start-${id}`);
-        // First item takes time, during which we'll block
-        if (id === '1') {
-          await wait(50);
-          canProcess = false; // Block after first item starts
-        }
-        executionOrder.push(`end-${id}`);
-      });
+      const gates = new Map<string, Gate>();
+      const createSlowExecuteFn = (id: string): (() => Promise<void>) => {
+        const gate = createGate();
+        gates.set(id, gate);
+        return vi.fn(async () => {
+          executionOrder.push(`start-${id}`);
+          await gate.promise;
+          executionOrder.push(`end-${id}`);
+        });
+      };
 
       const items: QueueItem<TestMetadata>[] = [
         {
@@ -471,16 +501,26 @@ describe('balanceQueueService', () => {
 
       const batchPromise = queue.enqueueBatch(items);
 
-      // Wait for first two items to start (concurrency is 2)
-      await wait(100);
+      // The first two items start immediately (concurrency is 2), the third waits
+      expect(queue.getStats()).toMatchObject({ pending: 1, running: 2 });
 
-      // Third item should be blocked
-      const stats = queue.getStats();
-      expect(stats.pending).toBeGreaterThanOrEqual(0);
+      // Block, then let the first item finish: the slot it frees must not be
+      // filled while canProcess is false.
+      canProcess = false;
+      gates.get('1')!.open();
+      await flushPromises();
+
+      expect(queue.getStats()).toMatchObject({ completed: 1, pending: 1, running: 1 });
+      expect(executionOrder).not.toContain('start-3');
 
       // Unblock and complete
       canProcess = true;
       queue.retryProcessing();
+
+      expect(queue.getStats()).toMatchObject({ pending: 0, running: 2 });
+
+      gates.get('2')!.open();
+      gates.get('3')!.open();
 
       await batchPromise;
 

--- a/frontend/app/src/modules/calendar/use-calendar-data.spec.ts
+++ b/frontend/app/src/modules/calendar/use-calendar-data.spec.ts
@@ -103,6 +103,7 @@ describe('useCalendarData', () => {
 
   afterEach(() => {
     scope.stop();
+    vi.useRealTimers();
   });
 
   it('should expose state, pagination and isLoading from useServerTable', () => {
@@ -153,12 +154,13 @@ describe('useCalendarData', () => {
 
   describe('options to useServerTable', () => {
     it('should pass extraParams with address#chain entries', async () => {
+      vi.useFakeTimers();
       const accounts = ref<BlockchainAccount[]>([makeAccount('0xabc', 'eth'), makeAccount('0xdef', 'optimism')]);
       const { modelRange } = createCalendarData(accounts);
 
       set(modelRange, [100, 200]);
-      // debounced by 300ms — use fake timers to flush
-      await new Promise(resolve => setTimeout(resolve, 320));
+      // `refDebounced(modelRange, 300)` — drive the debounce instead of sleeping
+      await vi.advanceTimersByTimeAsync(300);
 
       // Accounts are shareable and round-trip through the URL.
       expect(sourceValues('both', 'accounts').accounts).toEqual(['0xabc#eth', '0xdef#optimism']);

--- a/frontend/app/src/modules/core/sigil/use-sigil-queue.spec.ts
+++ b/frontend/app/src/modules/core/sigil/use-sigil-queue.spec.ts
@@ -40,8 +40,8 @@ describe('use-sigil-queue', () => {
       await enqueue({ url: '/leftover', timestamp: Date.now() });
 
       startQueue();
-      // Allow the initial flush to settle
-      await new Promise<void>(resolve => setTimeout(resolve, 50));
+      // The initial flush is fire-and-forget: poll for it instead of sleeping
+      await vi.waitUntil(() => fetchSpy.mock.calls.length > 0, { interval: 1, timeout: 2000 });
 
       expect(fetchSpy).toHaveBeenCalled();
 
@@ -108,29 +108,35 @@ describe('use-sigil-queue', () => {
     it('should clear IndexedDB on stop for opt-out compliance', async () => {
       const { enqueue, stopQueue } = await import('@/modules/core/sigil/use-sigil-queue');
 
+      // Verify the DB was cleared by opening it and counting the records
+      async function countEvents(): Promise<number> {
+        const db = await new Promise<IDBDatabase>((resolve) => {
+          const req = indexedDB.open('sigil', 1);
+          req.onupgradeneeded = (): void => {
+            req.result.createObjectStore('events', { keyPath: 'id', autoIncrement: true });
+          };
+          req.onsuccess = (): void => resolve(req.result);
+        });
+
+        const count = await new Promise<number>((resolve) => {
+          const tx = db.transaction('events', 'readonly');
+          const req = tx.objectStore('events').count();
+          req.onsuccess = (): void => resolve(req.result);
+        });
+
+        db.close();
+        return count;
+      }
+
       await enqueue({ url: '/data', timestamp: Date.now() });
+      expect(await countEvents()).toBe(1);
+
       stopQueue();
 
-      // Allow the fire-and-forget clearAll to settle
-      await new Promise<void>(resolve => setTimeout(resolve, 50));
+      // clearAll is fire-and-forget: poll the store until it drains
+      await vi.waitUntil(async () => await countEvents() === 0, { interval: 1, timeout: 2000 });
 
-      // Verify DB was cleared by checking we can open and count 0 records
-      const db = await new Promise<IDBDatabase>((resolve) => {
-        const req = indexedDB.open('sigil', 1);
-        req.onupgradeneeded = (): void => {
-          req.result.createObjectStore('events', { keyPath: 'id', autoIncrement: true });
-        };
-        req.onsuccess = (): void => resolve(req.result);
-      });
-
-      const count = await new Promise<number>((resolve) => {
-        const tx = db.transaction('events', 'readonly');
-        const req = tx.objectStore('events').count();
-        req.onsuccess = (): void => resolve(req.result);
-      });
-
-      db.close();
-      expect(count).toBe(0);
+      expect(await countEvents()).toBe(0);
     });
   });
 

--- a/frontend/app/src/modules/history/events/use-history-events-deletion.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-deletion.spec.ts
@@ -25,10 +25,15 @@ vi.mock('@/modules/core/common/use-confirm-store', () => ({
 vi.mock('@/modules/core/common/use-supported-chains', () => ({
   useSupportedChains: (): object => ({ getChain: spies.getChain }),
 }));
-vi.mock('@/modules/core/notifications/use-notifications', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
-  return { ...actual, useNotifications: (): object => ({ showErrorMessage: spies.showErrorMessage, showSuccessMessage: spies.showSuccessMessage }) };
-});
+// Mocked outright rather than spread over `...actual`: importActual evaluates the real
+// notifications graph, which costs ~1.2s to import.
+// `getErrorMessage` is a pure helper re-exported from a light module, so take it from there.
+vi.mock('@/modules/core/notifications/use-notifications', async () => ({
+  getErrorMessage: (await vi.importActual<typeof import('@/modules/core/common/logging/error-handling')>(
+    '@/modules/core/common/logging/error-handling',
+  )).getErrorMessage,
+  useNotifications: (): object => ({ showErrorMessage: spies.showErrorMessage, showSuccessMessage: spies.showSuccessMessage }),
+}));
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
   useHistoryEventsApi: (): object => ({ deleteHistoryEvent: spies.deleteHistoryEventApi, deleteTransactions: spies.deleteTransactions }),
 }));

--- a/frontend/app/src/modules/history/events/use-history-events-operations.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-operations.spec.ts
@@ -26,10 +26,11 @@ const { spies } = vi.hoisted(() => ({
 vi.mock('@/modules/core/common/use-confirm-store', () => ({
   useConfirmStore: (): object => ({ show: spies.show }),
 }));
-vi.mock('@/modules/core/notifications/use-notifications', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>('@/modules/core/notifications/use-notifications');
-  return { ...actual, useNotifications: (): object => ({ notifyError: spies.notifyError }) };
-});
+// Mocked outright rather than spread over `...actual`: importActual evaluates the real
+// notifications graph, which costs ~1.2s to import.
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: (): object => ({ notifyError: spies.notifyError }),
+}));
 vi.mock('@/modules/core/common/use-supported-chains', () => ({
   useSupportedChains: (): object => ({ getChain: spies.getChain }),
 }));

--- a/frontend/app/src/modules/history/events/use-unmatched-asset-movements.spec.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-asset-movements.spec.ts
@@ -36,19 +36,19 @@ vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
   }),
 }));
 
-vi.mock('@/modules/core/notifications/use-notifications', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>(
-    '@/modules/core/notifications/use-notifications',
-  );
-  return {
-    ...actual,
-    useNotifications: (): object => ({
-      removeMatching: spies.removeMatching,
-      showErrorMessage: spies.showErrorMessage,
-      showSuccessMessage: spies.showSuccessMessage,
-    }),
-  };
-});
+// Mocked outright rather than spread over `...actual`: importActual evaluates the real
+// notifications graph, which costs ~1.2s to import.
+// `getErrorMessage` is a pure helper re-exported from a light module, so take it from there.
+vi.mock('@/modules/core/notifications/use-notifications', async () => ({
+  getErrorMessage: (await vi.importActual<typeof import('@/modules/core/common/logging/error-handling')>(
+    '@/modules/core/common/logging/error-handling',
+  )).getErrorMessage,
+  useNotifications: (): object => ({
+    removeMatching: spies.removeMatching,
+    showErrorMessage: spies.showErrorMessage,
+    showSuccessMessage: spies.showSuccessMessage,
+  }),
+}));
 
 vi.mock('@/modules/core/tasks/use-task-handler', async () => {
   const actual = await vi.importActual<typeof import('@/modules/core/tasks/use-task-handler')>(

--- a/frontend/app/src/modules/history/events/use-unmatched-bridge-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-bridge-transactions.spec.ts
@@ -34,29 +34,37 @@ vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
   }),
 }));
 
-vi.mock('@/modules/core/notifications/use-notifications', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>(
-    '@/modules/core/notifications/use-notifications',
-  );
-  return {
-    ...actual,
-    useNotifications: (): object => ({
-      removeMatching: spies.removeMatching,
-      showErrorMessage: spies.showErrorMessage,
-      showSuccessMessage: spies.showSuccessMessage,
-    }),
-  };
-});
+// Only `getErrorMessage` is needed besides the mocked composable, and it is a pure
+// helper re-exported from a light module. Taking it from its own home keeps the real
+// implementation without evaluating the notifications graph, which costs ~1.2s per
+// import - and this file re-imports once per test.
+vi.mock('@/modules/core/notifications/use-notifications', async () => ({
+  getErrorMessage: (await vi.importActual<typeof import('@/modules/core/common/logging/error-handling')>(
+    '@/modules/core/common/logging/error-handling',
+  )).getErrorMessage,
+  useNotifications: (): object => ({
+    removeMatching: spies.removeMatching,
+    showErrorMessage: spies.showErrorMessage,
+    showSuccessMessage: spies.showSuccessMessage,
+  }),
+}));
 
-vi.mock('@/modules/core/tasks/use-task-handler', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/tasks/use-task-handler')>(
-    '@/modules/core/tasks/use-task-handler',
-  );
-  return {
-    ...actual,
-    useTaskHandler: (): object => ({ runTask: spies.runTask }),
-  };
-});
+// Same reasoning: `isActionableFailure` is a two-line pure predicate over the task
+// outcome, so it is restated here rather than pulling in the real task handler.
+vi.mock('@/modules/core/tasks/use-task-handler', () => ({
+  isActionableFailure: (outcome: { success: boolean; cancelled?: boolean; skipped?: boolean }): boolean =>
+    !outcome.success && !outcome.cancelled && !outcome.skipped,
+  useTaskHandler: (): object => ({ runTask: spies.runTask }),
+}));
+
+// Read only by `useBridgeMatchingFlow`, which no test here exercises - but the static
+// import still pulls the settings registry in (~1.1s) on every re-import.
+vi.mock('@/modules/settings/use-bridge-match-settings', () => ({
+  useBridgeMatchSettings: (): object => ({
+    bridgeMatchAmountTolerance: ref(0.05),
+    bridgeMatchTimeRange: ref(3600),
+  }),
+}));
 
 vi.mock('@/modules/core/tasks/use-task-store', () => ({
   useTaskStore: (): object => ({ useIsTaskRunning: spies.useIsTaskRunning }),
@@ -66,18 +74,17 @@ vi.mock('@/modules/history/use-history-store', () => ({
   useHistoryStore: (): object => ({ signalEventsModified: spies.signalEventsModified }),
 }));
 
-vi.mock('@/modules/premium/use-feature-access', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/premium/use-feature-access')>(
-    '@/modules/premium/use-feature-access',
-  );
-  return {
-    ...actual,
-    useFeatureAccess: (): object => ({
-      allowed: ref(true),
-      minimumTier: ref(null),
-    }),
-  };
-});
+// `PremiumFeature` is only re-exported by use-feature-access, so take it from the
+// types module it actually lives in.
+vi.mock('@/modules/premium/use-feature-access', async () => ({
+  PremiumFeature: (await vi.importActual<typeof import('@/modules/session/types')>(
+    '@/modules/session/types',
+  )).PremiumFeature,
+  useFeatureAccess: (): object => ({
+    allowed: ref(true),
+    minimumTier: ref(null),
+  }),
+}));
 
 describe('use-unmatched-bridge-transactions', () => {
   beforeEach(() => {

--- a/frontend/app/src/modules/history/use-ignore.spec.ts
+++ b/frontend/app/src/modules/history/use-ignore.spec.ts
@@ -23,17 +23,17 @@ vi.mock('@/modules/history/api/use-history-ignoring-api', () => ({
   }),
 }));
 
-vi.mock('@/modules/core/notifications/use-notifications', async () => {
-  const actual = await vi.importActual<typeof import('@/modules/core/notifications/use-notifications')>(
-    '@/modules/core/notifications/use-notifications',
-  );
-  return {
-    ...actual,
-    useNotifications: (): object => ({
-      showErrorMessage: spies.showErrorMessage,
-    }),
-  };
-});
+// Mocked outright rather than spread over `...actual`: importActual evaluates the real
+// notifications graph, which costs ~1.2s to import.
+// `getErrorMessage` is a pure helper re-exported from a light module, so take it from there.
+vi.mock('@/modules/core/notifications/use-notifications', async () => ({
+  getErrorMessage: (await vi.importActual<typeof import('@/modules/core/common/logging/error-handling')>(
+    '@/modules/core/common/logging/error-handling',
+  )).getErrorMessage,
+  useNotifications: (): object => ({
+    showErrorMessage: spies.showErrorMessage,
+  }),
+}));
 
 function item(groupIdentifier: string, ignoredInAccounting = false): TestItem {
   return { groupIdentifier, ignoredInAccounting };

--- a/frontend/app/src/modules/user-data/use-database.spec.ts
+++ b/frontend/app/src/modules/user-data/use-database.spec.ts
@@ -1,10 +1,21 @@
 import type { MissingMapping } from '@/modules/user-data/schemas';
-import { wait } from '@shared/utils';
 import { get, set } from '@vueuse/core';
 import Dexie, { type EntityTable } from 'dexie';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { nextTick, ref } from 'vue';
+import { nextTick, type Ref, ref } from 'vue';
 import { NewDetectedTokenKind } from '@/modules/assets/detection/types';
+
+// `isReady` is only flipped to true after both migrations settle, so polling it is a
+// stronger signal than a fixed sleep - and it returns as soon as the work is done.
+const POLL_OPTIONS = { interval: 5, timeout: 2000 } as const;
+
+async function waitUntilReady(isReady: Ref<boolean>): Promise<void> {
+  await vi.waitUntil(() => get(isReady), POLL_OPTIONS);
+}
+
+async function waitUntilNotReady(isReady: Ref<boolean>): Promise<void> {
+  await vi.waitUntil(() => !get(isReady), POLL_OPTIONS);
+}
 
 // Old database structure (before migration)
 interface OldUserDB extends Dexie {
@@ -114,7 +125,7 @@ describe('useDatabase', () => {
 
       // Wait for watch to execute
       await nextTick();
-      await wait(50);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
     });
@@ -127,7 +138,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(50);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
       expect(db().name).toMatch(/^rotki\.data\.[\da-z]{6}\.testuser$/);
@@ -141,7 +152,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(50);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
 
@@ -161,7 +172,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(100);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
       expect(await db().missingMappings.count()).toBe(0);
@@ -192,7 +203,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(100);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
 
@@ -219,7 +230,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(100);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
       expect(await db().missingMappings.count()).toBe(0);
@@ -243,7 +254,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(100);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
 
@@ -273,7 +284,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(100);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
       expect(await db().newlyDetectedTokens.count()).toBe(0);
@@ -290,7 +301,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(100);
+      await waitUntilReady(isReady);
 
       // Should still be ready (migration failure is caught)
       expect(get(isReady)).toBe(true);
@@ -314,7 +325,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(100);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
       expect(await db().missingMappings.count()).toBe(0);
@@ -343,7 +354,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(100);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
       expect(await db().missingMappings.count()).toBe(1);
@@ -365,7 +376,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(100);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
       expect(await db().missingMappings.count()).toBe(0);
@@ -402,7 +413,7 @@ describe('useDatabase', () => {
       const { db, isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(100);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
 
@@ -428,7 +439,7 @@ describe('useDatabase', () => {
       const database = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(50);
+      await waitUntilReady(database.isReady);
 
       expect(get(database.isReady)).toBe(true);
       const firstDbName = database.db.name;
@@ -444,7 +455,7 @@ describe('useDatabase', () => {
       set(mockUserIdentifier, 'differentuser');
 
       await nextTick();
-      await wait(50);
+      await waitUntilReady(database.isReady);
 
       expect(get(database.isReady)).toBe(true);
       // Access database.db to re-evaluate the getter
@@ -463,7 +474,7 @@ describe('useDatabase', () => {
       const { isReady } = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(50);
+      await waitUntilReady(isReady);
 
       expect(get(isReady)).toBe(true);
 
@@ -471,7 +482,7 @@ describe('useDatabase', () => {
       set(mockUserIdentifier, undefined);
 
       await nextTick();
-      await wait(50);
+      await waitUntilNotReady(isReady);
 
       expect(get(isReady)).toBe(false);
     });
@@ -487,7 +498,7 @@ describe('useDatabase', () => {
       const database = scope.run(() => useDatabase())!;
 
       await nextTick();
-      await wait(50);
+      await waitUntilReady(database.isReady);
 
       expect(get(database.isReady)).toBe(true);
       const firstDbName = database.db.name;
@@ -496,7 +507,7 @@ describe('useDatabase', () => {
       set(mockDataDirectory, '/path/two');
 
       await nextTick();
-      await wait(50);
+      await waitUntilReady(database.isReady);
 
       expect(get(database.isReady)).toBe(true);
       // Access database.db to re-evaluate the getter

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-connection-state.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-connection-state.spec.ts
@@ -25,18 +25,19 @@ describe('useWalletConnectionState', () => {
   it('should set requesting=true during a tracked promise and reset to false on resolve', async () => {
     const { isRequestingAccounts, trackAccountsRequest } = useWalletConnectionState();
 
-    let observedDuringPromise = false;
+    // Hold the request open by hand instead of deferring it with a timer: the
+    // flag is then observed at a point the test controls, not one it races.
+    let completeRequest!: (value: string) => void;
     const promise = new Promise<string>((resolve) => {
-      setTimeout(() => {
-        observedDuringPromise = get(isRequestingAccounts);
-        resolve('done');
-      }, 0);
+      completeRequest = resolve;
     });
 
-    const result = await trackAccountsRequest(promise);
+    const tracked = trackAccountsRequest(promise);
+    expect(get(isRequestingAccounts)).toBe(true);
 
-    expect(result).toBe('done');
-    expect(observedDuringPromise).toBe(true);
+    completeRequest('done');
+
+    expect(await tracked).toBe('done');
     expect(get(isRequestingAccounts)).toBe(false);
   });
 

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -102,6 +102,16 @@ vi.mock('@vueuse/core', async () => {
   };
 });
 
+// `@/i18n` builds the real instance from `locales/en.json`, which costs ~835ms to import.
+// Nothing in a unit test uses it: `createI18n` is already mocked below, no spec imports the
+// module, and its only other consumer - the dev key-existence warning in `@/message-key` - is
+// compiled out under MODE === 'test'. It is reached transitively though (message-key is imported
+// by every settings registry slice), so leaving it real taxes any spec that touches a setting.
+vi.mock('@/i18n', () => ({
+  i18n: { global: { te: (): boolean => true } },
+  loadLocaleMessages: vi.fn(async () => Promise.resolve()),
+}));
+
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: mockT,

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -205,6 +205,29 @@ export default rotki({
     }],
   },
 }, {
+  // Unit specs must never wait on the real clock. A fixed sleep is a race, not a wait: it passes on an
+  // idle laptop and fails on a loaded CI box, and it costs its full duration even when the work it
+  // waits for finished immediately. Use what vitest gives you instead - `vi.useFakeTimers()` plus
+  // `vi.advanceTimersByTimeAsync()` to drive a debounce or interval, `vi.waitUntil`/`vi.waitFor` to poll
+  // a condition, or a promise the test resolves itself to hold an async call open.
+  //
+  // Both selectors target *awaiting* a sleep, which is the only form that stalls a test:
+  // - `await wait(50)` - the real-clock sleep from `@shared/utils`. Under fake timers this deadlocks
+  //   anyway, so it is always wrong at test level. Passing `wait` as simulated work (`async () =>
+  //   wait(1500)`) or asserting on it when mocked is untouched, since neither is awaited here.
+  // - `await new Promise(resolve => setTimeout(resolve, n))` - the same sleep spelled out. Scheduling a
+  //   `setTimeout` inside a mock that fake timers then advance is untouched for the same reason.
+  files: ['**/src/**/*.spec.ts', '**/shared/**/*.spec.ts', '**/electron/**/*.spec.ts'],
+  rules: {
+    'no-restricted-syntax': ['error', {
+      message: 'Do not sleep on the real clock in a spec. Use fake timers (vi.advanceTimersByTimeAsync), poll a condition (vi.waitUntil/vi.waitFor), or resolve a promise the test controls.',
+      selector: 'AwaitExpression > CallExpression[callee.name=\'wait\']',
+    }, {
+      message: 'Do not sleep on the real clock in a spec. Use fake timers (vi.advanceTimersByTimeAsync), poll a condition (vi.waitUntil/vi.waitFor), or resolve a promise the test controls.',
+      selector: 'AwaitExpression > NewExpression[callee.name=\'Promise\']:has(CallExpression[callee.name=\'setTimeout\'])',
+    }],
+  },
+}, {
   files: ['**/locales/**/*.json'],
   rules: {
     'jsonc/sort-keys': ['error', 'asc', {


### PR DESCRIPTION
Two unrelated-looking but connected cleanups in the frontend unit suite: removing real-clock sleeps, and removing module-graph imports the specs never use.

### Real-clock waits (commits 1-2)

Fixed `wait(50)`-style sleeps in specs are races, not waits: they pass on an idle laptop and fail on a loaded CI box, and they cost their full duration even when the work finished immediately. Every one is now a condition (`vi.waitUntil`, fake timers, or a promise the test resolves).

Two tests get *stronger* as a side effect:

- max concurrency now asserts exactly `{pending: 1, running: 2}` (was `running <= 2`)
- mid-batch blocking now proves the freed slot is not refilled; it previously asserted `pending >= 0`, which cannot fail

The balance-queue lever was a source insight rather than a timer trick: `enqueue` runs synchronously up to `await item.executeFn()`, so the "wait a bit, then sample concurrency" sleeps were reading state that had already settled. The assertions simply moved up.

A lint rule then blocks sleeps from creeping back, as two `no-restricted-syntax` selectors that match only an *awaited* sleep. That precision matters: `async () => wait(1500)` as simulated work under fake timers, `expect(wait).toHaveBeenCalledWith(1000)` on a mocked `wait`, and a `setTimeout` inside a mock driven by `advanceTimersByTimeAsync` are all legitimate and none of them trip it. **Zero `eslint-disable` comments were needed.**

Measured: balance-queue 351ms -> 17ms, calendar + token db 443ms -> 92ms, sigil queue 120ms -> 18ms.

### Import cost (commits 3-5)

Profiling showed the dominant per-file cost in slow specs is module-graph evaluation, not test logic (signature: test 1 takes 1.5-2.5s, the rest ~50ms flat).

- **`@/i18n` stub in unit setup.** `use-setting` cost 1194ms to import; drilling in, every settings-registry slice imports `@/message-key`, which statically imports `{ i18n } from '@/i18n'` -> `locales/en.json` = **835ms**. That edge is dead weight in tests: `message-key`'s only use of it is a dev key-existence `console.warn` guarded by `import.meta.env.MODE !== 'test'`, `createI18n` was already globally mocked, and no spec imports `@/i18n` directly. Measured after: `message-key` 835ms -> 8ms, `use-setting` 1194ms -> 317ms.
- **`importActual` spreads of `use-notifications`.** `{...actual, useX: mock}` reads as a cheap "keep the rest" but evaluates the whole real graph (1234ms), re-paid on every `importFresh()`. Nine specs did this; five needed nothing from the spread at all, four needed only `getErrorMessage`, taken from where it actually lives. A/B over those nine files, three runs each: import 5.1s -> 2.0s, transform 3.6 -> 2.3s.
- **Bridge spec** (`use-unmatched-bridge-transactions.spec.ts`): 2808ms -> **304ms**, first test 1811 -> 115ms, 20/20 still pass.

### On the numbers

Per-file timings in a parallel run are noisy: running the identical commit twice swings per-file totals by ±16-31%, so any single before/after comparison below ~35% is meaningless. Every figure above survived a repeat run.

**Total wall clock did not meaningfully move** (85.4s vs runs of 85.7/87.4/87.5s). Aggregate import work fell 365s -> 316s and transform 72.7 -> 67.5s, but the phases are parallel across workers and the total is bound elsewhere (the setup phase, ~288s aggregate). I am not claiming a wall-clock win here. The value is per-file cost, less flake, and a guard that keeps sleeps out.

### Verification

Full suite green (691 files / 6597 tests), typecheck clean, lint 0 errors.
