### PR TITLE
refactor: type the starling control vocabulary

### DIFF
--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -1,5 +1,5 @@
 import type { AppConfig } from '@electron/main/app-config';
-import type { McpServerStatus, McpServiceState } from '@shared/ipc';
+import type { McpServerStatus, StarlingServiceStatus } from '@shared/ipc';
 import process from 'node:process';
 import { IpcCommands } from '@electron/ipc-commands';
 import { protectHtmlAssociation } from '@electron/main/html-mime-protection';
@@ -211,7 +211,7 @@ export class Application {
     });
   }
 
-  private async getMcpServerStatus(state?: McpServiceState): Promise<McpServerStatus> {
+  private async getMcpServerStatus(state?: StarlingServiceStatus): Promise<McpServerStatus> {
     return {
       autoStart: this.settings.appSettings.mcpAutoStart,
       endpoint: this.processHandler.getMcpServerEndpoint(),

--- a/frontend/app/electron/main/starling-handler-types.ts
+++ b/frontend/app/electron/main/starling-handler-types.ts
@@ -1,6 +1,6 @@
-import type { BackendCode, McpServiceState } from '@shared/ipc';
+import type { BackendCode, StarlingServiceStatus } from '@shared/ipc';
 
 export interface StarlingErrorListener {
-  onMcpState?: (state: McpServiceState) => void;
+  onMcpState?: (state: StarlingServiceStatus) => void;
   onProcessError: (message: string | Error, code: BackendCode) => void;
 }

--- a/frontend/app/electron/main/starling-handler.spec.ts
+++ b/frontend/app/electron/main/starling-handler.spec.ts
@@ -2,8 +2,9 @@ import type { AppConfig } from '@electron/main/app-config';
 import type { LogService } from '@electron/main/log-service';
 import { EventEmitter } from 'node:events';
 import { PassThrough, Writable } from 'node:stream';
-import { BackendCode } from '@shared/ipc';
+import { BackendCode, StarlingServiceStatus } from '@shared/ipc';
 import { LogLevel } from '@shared/log-level';
+import { StarlingEvent, StarlingMethod, StarlingService } from '@shared/starling/starling-protocol';
 import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { StarlingHandler } from './starling-handler';
@@ -86,7 +87,10 @@ const nullResponder: RequestHandler = (message, stdout): void => {
 
 /** Push the controller's initial `ready` event, as starling does once the tree is up. */
 function emitReady(child: FakeChild): void {
-  writeMessage(child.stdout, { method: 'event.ready', params: { services: ['core', 'colibri'] } });
+  writeMessage(child.stdout, {
+    method: StarlingEvent.READY,
+    params: { services: [StarlingService.CORE, StarlingService.COLIBRI] },
+  });
 }
 
 function makeLogger(): LogService {
@@ -135,7 +139,7 @@ describe('starlingHandler', () => {
     await handler.restartBackend({ dataDirectory: '/data' }, { onProcessError });
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
-    expect(methods).toContain('start'); // renderer drives the first bring-up
+    expect(methods).toContain(StarlingMethod.START); // renderer drives the first bring-up
     expect(onProcessError).not.toHaveBeenCalled();
     // Single-origin posture: both URLs point at the proxy port; colibri sits
     // under /colibri. The direct core/colibri ports are the proxy's upstreams.
@@ -168,7 +172,7 @@ describe('starlingHandler', () => {
   it('should forward the MCP auto-start option during initial bring-up', async () => {
     let startParams: Record<string, unknown> | undefined;
     const child = makeFakeChild((message, stdout) => {
-      if (message.method === 'start')
+      if (message.method === StarlingMethod.START)
         startParams = message.params;
       writeMessage(stdout, { id: message.id, result: null });
     });
@@ -181,18 +185,23 @@ describe('starlingHandler', () => {
   });
 
   it('should start and stop MCP independently through starling', async () => {
-    let mcpState = 'Idle';
+    let mcpState: StarlingServiceStatus = StarlingServiceStatus.IDLE;
     const methods: string[] = [];
     const child = makeFakeChild((message, stdout) => {
       if (message.method)
         methods.push(message.method);
-      if (message.method === 'startService')
-        mcpState = 'Ready';
-      else if (message.method === 'stopService')
-        mcpState = 'Stopped';
+      if (message.method === StarlingMethod.START_SERVICE)
+        mcpState = StarlingServiceStatus.READY;
+      else if (message.method === StarlingMethod.STOP_SERVICE)
+        mcpState = StarlingServiceStatus.STOPPED;
 
-      const result = message.method === 'status'
-        ? { services: [{ name: 'core', state: 'Ready' }, { name: 'mcp', state: mcpState }] }
+      const result = message.method === StarlingMethod.STATUS
+        ? {
+            services: [
+              { name: StarlingService.CORE, state: StarlingServiceStatus.READY },
+              { name: StarlingService.MCP, state: mcpState },
+            ],
+          }
         : null;
       writeMessage(stdout, { id: message.id, result });
     });
@@ -200,25 +209,25 @@ describe('starlingHandler', () => {
     const handler = new StarlingHandler(makeLogger(), makeConfig());
     await handler.restartBackend({}, { onProcessError: vi.fn() });
 
-    expect(await handler.setMcpServerRunning(true)).toBe('Ready');
-    expect(await handler.setMcpServerRunning(false)).toBe('Stopped');
-    expect(methods).toContain('startService');
-    expect(methods).toContain('stopService');
+    expect(await handler.setMcpServerRunning(true)).toBe(StarlingServiceStatus.READY);
+    expect(await handler.setMcpServerRunning(false)).toBe(StarlingServiceStatus.STOPPED);
+    expect(methods).toContain(StarlingMethod.START_SERVICE);
+    expect(methods).toContain(StarlingMethod.STOP_SERVICE);
   });
 
   it('should restart a live MCP service to clear its session on logout', async () => {
-    let mcpState = 'Ready';
+    let mcpState: StarlingServiceStatus = StarlingServiceStatus.READY;
     const methods: string[] = [];
     const child = makeFakeChild((message, stdout) => {
       if (message.method)
         methods.push(message.method);
-      if (message.method === 'stopService')
-        mcpState = 'Stopped';
-      else if (message.method === 'startService')
-        mcpState = 'Ready';
+      if (message.method === StarlingMethod.STOP_SERVICE)
+        mcpState = StarlingServiceStatus.STOPPED;
+      else if (message.method === StarlingMethod.START_SERVICE)
+        mcpState = StarlingServiceStatus.READY;
 
-      const result = message.method === 'status'
-        ? { services: [{ name: 'mcp', state: mcpState }] }
+      const result = message.method === StarlingMethod.STATUS
+        ? { services: [{ name: StarlingService.MCP, state: mcpState }] }
         : null;
       writeMessage(stdout, { id: message.id, result });
     });
@@ -228,9 +237,9 @@ describe('starlingHandler', () => {
 
     await handler.resetMcpSession();
 
-    expect(methods.filter(method => method === 'stopService')).toHaveLength(1);
-    expect(methods.filter(method => method === 'startService')).toHaveLength(1);
-    expect(methods.indexOf('stopService')).toBeLessThan(methods.indexOf('startService'));
+    expect(methods.filter(method => method === StarlingMethod.STOP_SERVICE)).toHaveLength(1);
+    expect(methods.filter(method => method === StarlingMethod.START_SERVICE)).toHaveLength(1);
+    expect(methods.indexOf(StarlingMethod.STOP_SERVICE)).toBeLessThan(methods.indexOf(StarlingMethod.START_SERVICE));
   });
 
   it('should preserve an intentionally stopped MCP service on logout', async () => {
@@ -238,8 +247,8 @@ describe('starlingHandler', () => {
     const child = makeFakeChild((message, stdout) => {
       if (message.method)
         methods.push(message.method);
-      const result = message.method === 'status'
-        ? { services: [{ name: 'mcp', state: 'Stopped' }] }
+      const result = message.method === StarlingMethod.STATUS
+        ? { services: [{ name: StarlingService.MCP, state: StarlingServiceStatus.STOPPED }] }
         : null;
       writeMessage(stdout, { id: message.id, result });
     });
@@ -249,16 +258,16 @@ describe('starlingHandler', () => {
 
     await handler.resetMcpSession();
 
-    expect(methods).not.toContain('stopService');
-    expect(methods).not.toContain('startService');
+    expect(methods).not.toContain(StarlingMethod.STOP_SERVICE);
+    expect(methods).not.toContain(StarlingMethod.START_SERVICE);
   });
 
   it('should report MCP as unavailable when starling is not running', async () => {
     const handler = new StarlingHandler(makeLogger(), makeConfig());
 
-    expect(await handler.getMcpServerState()).toBe('Unavailable');
-    expect(await handler.setMcpServerRunning(true)).toBe('Unavailable');
-    expect(await handler.setMcpServerRunning(false)).toBe('Unavailable');
+    expect(await handler.getMcpServerState()).toBe(StarlingServiceStatus.UNAVAILABLE);
+    expect(await handler.setMcpServerRunning(true)).toBe(StarlingServiceStatus.UNAVAILABLE);
+    expect(await handler.setMcpServerRunning(false)).toBe(StarlingServiceStatus.UNAVAILABLE);
   });
 
   it('should map an unsupported macOS version to MACOS_VERSION', async () => {
@@ -295,7 +304,7 @@ describe('starlingHandler', () => {
     const onProcessError = vi.fn();
 
     await handler.restartBackend({ dataDirectory: '/data' }, { onProcessError });
-    writeMessage(child.stdout, { method: 'event.crashed', params: { lastError: 'core died' } });
+    writeMessage(child.stdout, { method: StarlingEvent.CRASHED, params: { lastError: 'core died' } });
 
     await vi.waitFor(() => expect(onProcessError).toHaveBeenCalledWith('core died', BackendCode.TERMINATED));
   });
@@ -309,13 +318,32 @@ describe('starlingHandler', () => {
 
     await handler.restartBackend({}, { onMcpState, onProcessError });
     writeMessage(child.stdout, {
-      method: 'event.crashed',
-      params: { lastError: 'mcp died', service: 'mcp' },
+      method: StarlingEvent.CRASHED,
+      params: { lastError: 'mcp died', service: StarlingService.MCP },
     });
     await new Promise<void>(resolve => queueMicrotask(() => resolve()));
 
-    expect(onMcpState).toHaveBeenCalledWith('Failed');
+    expect(onMcpState).toHaveBeenCalledWith(StarlingServiceStatus.FAILED);
     expect(onProcessError).not.toHaveBeenCalled();
+  });
+
+  it('should handle every lifecycle event starling can push', async () => {
+    const child = makeFakeChild(nullResponder);
+    spawnMock.mockImplementation(() => child);
+    const logger = makeLogger();
+    const handler = new StarlingHandler(logger, makeConfig());
+
+    await handler.restartBackend({}, { onProcessError: vi.fn() });
+    // The crash event has its own tests; the rest are informational, so the log
+    // line is the only evidence they were routed rather than falling through.
+    for (const method of [StarlingEvent.READY, StarlingEvent.RESTARTING, StarlingEvent.STOPPED])
+      writeMessage(child.stdout, { method });
+    writeMessage(child.stdout, { method: 'event.unknown' });
+
+    await vi.waitFor(() => expect(logger.debug).toHaveBeenCalledWith('Unhandled control event: event.unknown'));
+    expect(logger.info).toHaveBeenCalledWith(`Backend event: ${StarlingEvent.READY}`);
+    expect(logger.info).toHaveBeenCalledWith(`Backend event: ${StarlingEvent.RESTARTING}`);
+    expect(logger.info).toHaveBeenCalledWith(`Backend event: ${StarlingEvent.STOPPED}`);
   });
 
   it('should surface the data-dir-in-use exit code as a TERMINATED error', async () => {
@@ -345,7 +373,7 @@ describe('starlingHandler', () => {
     const reason = 'failed to start the backend: service \'core\' exited before becoming ready: '
       + 'ERROR at initialization: Tables {\'asset_flags\'} are missing from your global database';
     const child = makeFakeChild((message, stdout) => {
-      if (message.method === 'start') {
+      if (message.method === StarlingMethod.START) {
         writeMessage(stdout, { id: message.id, error: { message: reason } });
         return;
       }

--- a/frontend/app/electron/main/starling-handler.ts
+++ b/frontend/app/electron/main/starling-handler.ts
@@ -7,11 +7,12 @@ import path from 'node:path';
 import process from 'node:process';
 import { resolveLogLevel } from '@electron/main/resolve-log-level';
 import { forwardStarlingLine } from '@electron/main/starling-log';
-import { eventLastError, getMcpServerState, isMcpCrash, setMcpServerRunning } from '@electron/main/starling-mcp';
-import { BackendCode, type BackendOptions, type McpServiceState } from '@shared/ipc';
+import { eventLastError, getMcpServerState, isMcpCrash, isServiceLive, setMcpServerRunning } from '@electron/main/starling-mcp';
+import { BackendCode, type BackendOptions, StarlingServiceStatus } from '@shared/ipc';
 import { selectPort } from '@shared/port-utils';
 import { buildStarlingInvocation, SHUTDOWN_GRACE_SECS, type StarlingInvocation } from '@shared/starling/starling-args';
 import { definedOptions, spawnStarling } from '@shared/starling/starling-launch';
+import { StarlingEvent, StarlingMethod, StarlingService } from '@shared/starling/starling-protocol';
 import { StarlingRpc } from '@shared/starling/starling-rpc';
 import { wait } from '@shared/utils';
 
@@ -110,7 +111,7 @@ export class StarlingHandler {
   private async restartInPlace(options: Partial<BackendOptions>, listener: StarlingErrorListener): Promise<void> {
     this.logger.info('Restarting backend in place via control RPC');
     try {
-      await this.rpc.request('restart', this.restartParams(options));
+      await this.rpc.request(StarlingMethod.RESTART, this.restartParams(options));
     }
     catch (error: any) {
       this.logger.error('Backend restart failed', error);
@@ -132,10 +133,10 @@ export class StarlingHandler {
     this.logger.updateLogDirectory(options.logDirectory);
     this.exiting = false;
 
-    const corePort = await this.resolvePort('core');
-    const colibriPort = await this.resolvePort('colibri');
-    const mcpPort = await this.resolvePort('mcp');
-    const proxyPort = await this.resolvePort('proxy');
+    const corePort = await this.resolvePort(StarlingService.CORE);
+    const colibriPort = await this.resolvePort(StarlingService.COLIBRI);
+    const mcpPort = await this.resolvePort(StarlingService.MCP);
+    const proxyPort = await this.resolvePort(StarlingService.PROXY);
     const logsDir = this.logsDirectory();
 
     // Collapse the renderer onto the single proxy origin: `/api/1/*` and `/ws/`
@@ -167,7 +168,7 @@ export class StarlingHandler {
     // (log level, tunables, data dir) the CLI no longer passes. It resolves once
     // the whole tree is ready, and rejects on a failed bring-up or early exit.
     try {
-      await this.rpc.request('start', this.startParams(options));
+      await this.rpc.request(StarlingMethod.START, this.startParams(options));
     }
     catch (error) {
       // Report only while the child is still alive: an already-exited child had its
@@ -240,23 +241,23 @@ export class StarlingHandler {
   private onEvent(method: string, params: unknown): void {
     const listener = this.currentListener;
     switch (method) {
-      case 'event.ready':
+      case StarlingEvent.READY:
         // The whole backend tree is up. Initial readiness is gated on the `start`
         // request's reply, not this event, so this is purely informational (it
         // also fires after a restart brings the tree back up).
         this.logger.info('Backend event: event.ready');
         break;
-      case 'event.crashed': {
+      case StarlingEvent.CRASHED: {
         const lastError = eventLastError(params);
         this.logger.error(`Backend service crashed: ${lastError}`);
         if (isMcpCrash(params))
-          listener?.onMcpState?.('Failed');
+          listener?.onMcpState?.(StarlingServiceStatus.FAILED);
         else if (!this.exiting)
           listener?.onProcessError(lastError, BackendCode.TERMINATED);
         break;
       }
-      case 'event.restarting':
-      case 'event.stopped':
+      case StarlingEvent.RESTARTING:
+      case StarlingEvent.STOPPED:
         this.logger.info(`Backend event: ${method}`);
         break;
       default:
@@ -264,20 +265,20 @@ export class StarlingHandler {
     }
   }
 
-  async getMcpServerState(): Promise<McpServiceState> {
+  async getMcpServerState(): Promise<StarlingServiceStatus> {
     return this.child
       ? getMcpServerState(async (method, params) => this.rpc.request(method, params))
-      : 'Unavailable';
+      : StarlingServiceStatus.UNAVAILABLE;
   }
 
   getMcpServerEndpoint(): string {
     return `http://${API_HOST}:${this.config.ports.mcpPort}/mcp`;
   }
 
-  async setMcpServerRunning(running: boolean): Promise<McpServiceState> {
+  async setMcpServerRunning(running: boolean): Promise<StarlingServiceStatus> {
     return this.child
       ? setMcpServerRunning(async (method, params) => this.rpc.request(method, params), running)
-      : 'Unavailable';
+      : StarlingServiceStatus.UNAVAILABLE;
   }
 
   /**
@@ -285,8 +286,7 @@ export class StarlingHandler {
    * Preserve an intentionally stopped service: only a live MCP process is restarted.
    */
   async resetMcpSession(): Promise<void> {
-    const state = await this.getMcpServerState();
-    if (state !== 'Ready' && state !== 'Degraded')
+    if (!isServiceLive(await this.getMcpServerState()))
       return;
 
     await this.setMcpServerRunning(false);
@@ -310,7 +310,7 @@ export class StarlingHandler {
     this.exiting = true;
     this.logger.debug('Stopping starling');
     try {
-      await Promise.race([this.rpc.request('stop').catch(() => undefined), wait(STOP_REQUEST_TIMEOUT)]);
+      await Promise.race([this.rpc.request(StarlingMethod.STOP).catch(() => undefined), wait(STOP_REQUEST_TIMEOUT)]);
     }
     catch {
       // best-effort; fall through to wait/kill
@@ -338,12 +338,12 @@ export class StarlingHandler {
    * The renderer-facing origins are set from the proxy port by the caller; here
    * only `mcp` records its resolved port, which `mcpServerUrl()` reads back.
    */
-  private async resolvePort(name: 'core' | 'colibri' | 'mcp' | 'proxy'): Promise<number> {
+  private async resolvePort(name: StarlingService): Promise<number> {
     const defaultPort = this.config.ports[`${name}Port`];
     const port = await selectPort(defaultPort, API_HOST);
     if (port !== defaultPort)
       this.logger.warn(`Using non-default port ${port} for ${name}`);
-    if (name === 'mcp')
+    if (name === StarlingService.MCP)
       this.config.ports.mcpPort = port;
     return port;
   }

--- a/frontend/app/electron/main/starling-mcp.ts
+++ b/frontend/app/electron/main/starling-mcp.ts
@@ -1,41 +1,38 @@
-import type { McpServiceState } from '@shared/ipc';
+import { StarlingServiceStatus } from '@shared/ipc';
+import { StarlingMethod, StarlingService } from '@shared/starling/starling-protocol';
 
 type StarlingRequest = (
-  method: string,
+  method: StarlingMethod,
   params?: Record<string, unknown>,
 ) => Promise<unknown>;
 
-const MCP_SERVICE_STATES: ReadonlySet<string> = new Set([
-  'Degraded',
-  'Failed',
-  'Idle',
-  'Ready',
-  'Restarting',
-  'Spawning',
-  'Stopped',
-  'Stopping',
-  'WaitingReady',
-]);
+/**
+ * Statuses starling itself reports. `Unavailable` is our own sentinel for
+ * "starling is not running", so it never arrives over the wire.
+ */
+const REPORTED_STATUSES: ReadonlySet<string> = new Set(
+  Object.values(StarlingServiceStatus).filter(status => status !== StarlingServiceStatus.UNAVAILABLE),
+);
 
-function isMcpServiceState(value: unknown): value is McpServiceState {
-  return typeof value === 'string' && MCP_SERVICE_STATES.has(value);
+function isServiceStatus(value: unknown): value is StarlingServiceStatus {
+  return typeof value === 'string' && REPORTED_STATUSES.has(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object';
 }
 
-function mcpState(service: unknown): McpServiceState | undefined {
-  if (!isRecord(service) || service.name !== 'mcp')
+function mcpState(service: unknown): StarlingServiceStatus | undefined {
+  if (!isRecord(service) || service.name !== StarlingService.MCP)
     return undefined;
-  return isMcpServiceState(service.state) ? service.state : undefined;
+  return isServiceStatus(service.state) ? service.state : undefined;
 }
 
 export function isMcpCrash(params: unknown): boolean {
   return params !== null
     && typeof params === 'object'
     && 'service' in params
-    && params.service === 'mcp';
+    && params.service === StarlingService.MCP;
 }
 
 export function eventLastError(params: unknown): string {
@@ -51,23 +48,34 @@ export function eventLastError(params: unknown): string {
   return 'The rotki backend stopped unexpectedly. Please check the logs for more details.';
 }
 
-export async function getMcpServerState(request: StarlingRequest): Promise<McpServiceState> {
-  const status = await request('status');
+export async function getMcpServerState(request: StarlingRequest): Promise<StarlingServiceStatus> {
+  const status = await request(StarlingMethod.STATUS);
   if (!isRecord(status) || !Array.isArray(status.services))
-    return 'Unavailable';
+    return StarlingServiceStatus.UNAVAILABLE;
 
   for (const service of status.services) {
     const state = mcpState(service);
     if (state)
       return state;
   }
-  return 'Unavailable';
+  return StarlingServiceStatus.UNAVAILABLE;
+}
+
+/**
+ * A service is live once starling has it serving requests. `Degraded` still
+ * counts: the process is up, just not fully healthy.
+ */
+export function isServiceLive(status: StarlingServiceStatus): boolean {
+  return status === StarlingServiceStatus.READY || status === StarlingServiceStatus.DEGRADED;
 }
 
 export async function setMcpServerRunning(
   request: StarlingRequest,
   running: boolean,
-): Promise<McpServiceState> {
-  await request(running ? 'startService' : 'stopService', { service: 'mcp' });
+): Promise<StarlingServiceStatus> {
+  await request(
+    running ? StarlingMethod.START_SERVICE : StarlingMethod.STOP_SERVICE,
+    { service: StarlingService.MCP },
+  );
   return getMcpServerState(request);
 }

--- a/frontend/app/scripts/start-starling.ts
+++ b/frontend/app/scripts/start-starling.ts
@@ -4,6 +4,7 @@ import { cac } from 'cac';
 import consola from 'consola';
 import { buildStarlingInvocation, describeResolvedCore, SHUTDOWN_GRACE_SECS, type StarlingBackendOptions, type StarlingInvocation } from '../shared/starling/starling-args';
 import { requestStarlingStart, spawnStarling } from '../shared/starling/starling-launch';
+import { StarlingMethod } from '../shared/starling/starling-protocol';
 import { StarlingRpc } from '../shared/starling/starling-rpc';
 
 /**
@@ -112,7 +113,7 @@ async function startStarling(options: StarlingE2eOptions): Promise<void> {
     // and killing the supervisor early strands both. Escalate only once its own
     // grace has elapsed. The `exited` await below holds this process open until
     // the tree is actually down.
-    rpc.request('stop').catch(() => undefined);
+    rpc.request(StarlingMethod.STOP).catch(() => undefined);
     setTimeout(() => {
       if (child.exitCode === null) {
         consola.warn('starling did not exit within its grace period, killing it');

--- a/frontend/app/shared/ipc.ts
+++ b/frontend/app/shared/ipc.ts
@@ -17,22 +17,25 @@ export interface StartupError {
 
 export interface ApiUrls { coreApiUrl: string; colibriApiUrl: string }
 
-export type McpServiceState =
-  | 'Degraded'
-  | 'Failed'
-  | 'Idle'
-  | 'Ready'
-  | 'Restarting'
-  | 'Spawning'
-  | 'Stopped'
-  | 'Stopping'
-  | 'Unavailable'
-  | 'WaitingReady';
+export const StarlingServiceStatus = {
+  DEGRADED: 'Degraded',
+  FAILED: 'Failed',
+  IDLE: 'Idle',
+  READY: 'Ready',
+  RESTARTING: 'Restarting',
+  SPAWNING: 'Spawning',
+  STOPPED: 'Stopped',
+  STOPPING: 'Stopping',
+  UNAVAILABLE: 'Unavailable',
+  WAITING_READY: 'WaitingReady',
+} as const;
+
+export type StarlingServiceStatus = typeof StarlingServiceStatus[keyof typeof StarlingServiceStatus];
 
 export interface McpServerStatus {
   autoStart: boolean;
   endpoint: string;
-  state: McpServiceState;
+  state: StarlingServiceStatus;
 }
 
 interface MetamaskImportError {
@@ -121,7 +124,7 @@ export interface Listeners {
   onError: (backendOutput: string, code: BackendCode) => void;
   onAbout: () => void;
   onRestart: () => void;
-  onMcpState?: (state: McpServiceState) => void;
+  onMcpState?: (state: StarlingServiceStatus) => void;
   onOAuthCallback?: (oAuthResult: OAuthResult) => void;
   /**
    * Invoked when the main process is about to quit, before the backend

--- a/frontend/app/shared/starling/starling-launch.spec.ts
+++ b/frontend/app/shared/starling/starling-launch.spec.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { definedOptions, requestStarlingStart, spawnStarling } from './starling-launch';
+import { StarlingMethod } from './starling-protocol';
 import { StarlingRpc } from './starling-rpc';
 
 const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
@@ -95,7 +96,7 @@ describe('spawnStarling', () => {
       child.stdin.once('data', chunk => resolve(chunk.toString()));
     });
     // Nothing answers it, so it is settled by hand once the write is observed.
-    const pending = rpc.request('status').catch(() => undefined);
+    const pending = rpc.request(StarlingMethod.STATUS).catch(() => undefined);
 
     expect(JSON.parse(await written)).toMatchObject({ method: 'status' });
 
@@ -126,7 +127,7 @@ describe('spawnStarling', () => {
     const rpc = makeRpc();
     spawnStarling({ invocation, rpc, onStderr: vi.fn() });
 
-    const pending = rpc.request('start');
+    const pending = rpc.request(StarlingMethod.START);
     child.emit('exit', 1, null);
 
     await expect(pending).rejects.toThrow('starling exited');
@@ -138,7 +139,7 @@ describe('spawnStarling', () => {
 
     child.emit('exit', 0, null);
 
-    await expect(rpc.request('status')).rejects.toThrow('starling is not running');
+    await expect(rpc.request(StarlingMethod.STATUS)).rejects.toThrow('starling is not running');
   });
 
   it('should refuse a child that came back without its stdio pipes', () => {

--- a/frontend/app/shared/starling/starling-launch.ts
+++ b/frontend/app/shared/starling/starling-launch.ts
@@ -3,6 +3,7 @@ import type { StarlingRpc } from './starling-rpc';
 import { type ChildProcess, spawn } from 'node:child_process';
 import process from 'node:process';
 import readline from 'node:readline';
+import { StarlingMethod } from './starling-protocol';
 
 /** How the supervisor went away: an exit code, or the signal that killed it. */
 interface StarlingExit {
@@ -85,7 +86,7 @@ export async function requestStarlingStart(
   options: StarlingBackendOptions,
   loglevel: string,
 ): Promise<void> {
-  await rpc.request('start', { ...definedOptions(options), loglevel });
+  await rpc.request(StarlingMethod.START, { ...definedOptions(options), loglevel });
 }
 
 /**

--- a/frontend/app/shared/starling/starling-protocol.ts
+++ b/frontend/app/shared/starling/starling-protocol.ts
@@ -1,0 +1,42 @@
+/**
+ * The wire vocabulary of the starling control channel: the methods we may call,
+ * the events starling pushes back, and the services both address.
+ *
+ * Every one of these is a string starling matches exactly, so a typo is only
+ * discoverable at runtime as an unknown-method error. Naming them here lets the
+ * compiler reject a bad one at the call site instead.
+ */
+
+export const StarlingMethod = {
+  RESTART: 'restart',
+  START: 'start',
+  START_SERVICE: 'startService',
+  STATUS: 'status',
+  STOP: 'stop',
+  STOP_SERVICE: 'stopService',
+} as const;
+
+export type StarlingMethod = typeof StarlingMethod[keyof typeof StarlingMethod];
+
+/**
+ * Notifications starling pushes without an id. These arrive over the wire, so a
+ * received method is a plain string until it is matched against one of these —
+ * an unrecognised event is logged and ignored, never trusted.
+ */
+export const StarlingEvent = {
+  CRASHED: 'event.crashed',
+  READY: 'event.ready',
+  RESTARTING: 'event.restarting',
+  STOPPED: 'event.stopped',
+} as const;
+
+export type StarlingEvent = typeof StarlingEvent[keyof typeof StarlingEvent];
+
+export const StarlingService = {
+  COLIBRI: 'colibri',
+  CORE: 'core',
+  MCP: 'mcp',
+  PROXY: 'proxy',
+} as const;
+
+export type StarlingService = typeof StarlingService[keyof typeof StarlingService];

--- a/frontend/app/shared/starling/starling-rpc.spec.ts
+++ b/frontend/app/shared/starling/starling-rpc.spec.ts
@@ -1,5 +1,6 @@
 import { PassThrough } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
+import { StarlingEvent, StarlingMethod } from './starling-protocol';
 import { StarlingRpc, type StarlingRpcLogger } from './starling-rpc';
 
 function makeLogger(): StarlingRpcLogger {
@@ -21,7 +22,7 @@ describe('starlingRpc', () => {
     rpc.attach(stdin);
     autoRespond(stdin, rpc, () => ({ result: { ok: true } }));
 
-    await expect(rpc.request('status')).resolves.toEqual({ ok: true });
+    await expect(rpc.request(StarlingMethod.STATUS)).resolves.toEqual({ ok: true });
   });
 
   it('should reject a request when the response carries an error', async () => {
@@ -30,16 +31,16 @@ describe('starlingRpc', () => {
     rpc.attach(stdin);
     autoRespond(stdin, rpc, () => ({ error: { code: 1, message: 'boom' } }));
 
-    await expect(rpc.request('start')).rejects.toThrow('boom');
+    await expect(rpc.request(StarlingMethod.START)).rejects.toThrow('boom');
   });
 
   it('should forward an id-less notification to the handler', () => {
     const onNotification = vi.fn();
     const rpc = new StarlingRpc(makeLogger(), onNotification);
 
-    rpc.handleLine(JSON.stringify({ jsonrpc: '2.0', method: 'event.crashed', params: { lastError: 'x' } }));
+    rpc.handleLine(JSON.stringify({ jsonrpc: '2.0', method: StarlingEvent.CRASHED, params: { lastError: 'x' } }));
 
-    expect(onNotification).toHaveBeenCalledWith('event.crashed', { lastError: 'x' });
+    expect(onNotification).toHaveBeenCalledWith(StarlingEvent.CRASHED, { lastError: 'x' });
   });
 
   it('should reject a request once detached from the child', async () => {
@@ -47,14 +48,14 @@ describe('starlingRpc', () => {
     rpc.attach(new PassThrough());
     rpc.detach();
 
-    await expect(rpc.request('status')).rejects.toThrow('starling is not running');
+    await expect(rpc.request(StarlingMethod.STATUS)).rejects.toThrow('starling is not running');
   });
 
   it('should reject every in-flight request on rejectAll', async () => {
     const rpc = new StarlingRpc(makeLogger(), () => {});
     rpc.attach(new PassThrough());
 
-    const pending = rpc.request('status');
+    const pending = rpc.request(StarlingMethod.STATUS);
     rpc.rejectAll(new Error('starling exited'));
 
     await expect(pending).rejects.toThrow('starling exited');
@@ -70,7 +71,7 @@ describe('starlingRpc', () => {
     rpc.attach(stdin);
     stdin.destroy();
 
-    await expect(rpc.request('start')).rejects.toThrow();
+    await expect(rpc.request(StarlingMethod.START)).rejects.toThrow();
   });
 
   it('should report a broken pipe through the logger', async () => {

--- a/frontend/app/shared/starling/starling-rpc.ts
+++ b/frontend/app/shared/starling/starling-rpc.ts
@@ -1,4 +1,5 @@
 import type { Writable } from 'node:stream';
+import type { StarlingMethod } from './starling-protocol';
 
 /** One decoded line of the control channel: a response, or an event notification. */
 interface JsonRpcResponse {
@@ -56,7 +57,7 @@ export class StarlingRpc {
   }
 
   /** Send a JSON-RPC request over stdin and await its correlated response. */
-  async request<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
+  async request<T = unknown>(method: StarlingMethod, params?: Record<string, unknown>): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const stdin = this.stdin;
       if (!stdin) {

--- a/frontend/app/src/modules/settings/backend/McpServerSetting.spec.ts
+++ b/frontend/app/src/modules/settings/backend/McpServerSetting.spec.ts
@@ -1,4 +1,4 @@
-import type { McpServerStatus } from '@shared/ipc';
+import { type McpServerStatus, StarlingServiceStatus } from '@shared/ipc';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import McpServerSetting from '@/modules/settings/backend/McpServerSetting.vue';
@@ -28,7 +28,7 @@ vi.mock('@/modules/shell/app/use-electron-interop', () => ({
 const stoppedStatus: McpServerStatus = {
   autoStart: false,
   endpoint: 'http://127.0.0.1:4445/mcp',
-  state: 'Idle',
+  state: StarlingServiceStatus.IDLE,
 };
 
 function createWrapper(): VueWrapper<InstanceType<typeof McpServerSetting>> {
@@ -80,7 +80,7 @@ describe('mcpServerSetting', () => {
       ...stoppedStatus,
       autoStart: enabled,
     }));
-    mocks.startMcpServer.mockResolvedValue({ ...stoppedStatus, state: 'Ready' });
+    mocks.startMcpServer.mockResolvedValue({ ...stoppedStatus, state: StarlingServiceStatus.READY });
     mocks.stopMcpServer.mockResolvedValue(stoppedStatus);
   });
 
@@ -119,7 +119,7 @@ describe('mcpServerSetting', () => {
   });
 
   it('should disable lifecycle control when MCP is unavailable', async () => {
-    mocks.getMcpServerStatus.mockResolvedValueOnce({ ...stoppedStatus, state: 'Unavailable' });
+    mocks.getMcpServerStatus.mockResolvedValueOnce({ ...stoppedStatus, state: StarlingServiceStatus.UNAVAILABLE });
     const wrapper = createWrapper();
     await flushPromises();
 
@@ -135,7 +135,7 @@ describe('mcpServerSetting', () => {
     const wrapper = createWrapper();
     await flushPromises();
 
-    setMcpServerState('Failed');
+    setMcpServerState(StarlingServiceStatus.FAILED);
     await nextTick();
 
     expect(wrapper.text()).toContain('backend_settings.settings.mcp_server.status.failed');

--- a/frontend/app/src/modules/settings/backend/McpServerSetting.vue
+++ b/frontend/app/src/modules/settings/backend/McpServerSetting.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { McpServerStatus, McpServiceState } from '@shared/ipc';
 import type { McpToken } from '@/modules/settings/types/mcp';
+import { type McpServerStatus, StarlingServiceStatus } from '@shared/ipc';
 import { startPromise } from '@shared/utils';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useMcpApi } from '@/modules/settings/api/use-mcp-api';
@@ -29,14 +29,14 @@ const tokenError = ref<string>();
 const tokenVisible = ref<boolean>(false);
 const mcpServerState = useMcpServerState();
 
-const transitioningStates: ReadonlySet<McpServiceState> = new Set([
-  'Restarting',
-  'Spawning',
-  'Stopping',
-  'WaitingReady',
+const transitioningStates: ReadonlySet<StarlingServiceStatus> = new Set([
+  StarlingServiceStatus.RESTARTING,
+  StarlingServiceStatus.SPAWNING,
+  StarlingServiceStatus.STOPPING,
+  StarlingServiceStatus.WAITING_READY,
 ]);
 
-const isRunning = computed<boolean>(() => get(status)?.state === 'Ready');
+const isRunning = computed<boolean>(() => get(status)?.state === StarlingServiceStatus.READY);
 const dockerEndpoint = computed<string>(() => `${window.location.origin}/mcp`);
 const tokenDisplay = computed<string>(() => (
   get(tokenVisible) ? get(token)?.accessToken ?? '' : '••••••••••••••••'
@@ -46,27 +46,27 @@ const tokenVisibilityLabel = computed<string>(() => (
     ? t('backend_settings.settings.mcp_server.hide_token')
     : t('backend_settings.settings.mcp_server.reveal_token')
 ));
-const statusLabels = computed<Record<McpServiceState, string>>(() => ({
-  Degraded: t('backend_settings.settings.mcp_server.status.failed'),
-  Failed: t('backend_settings.settings.mcp_server.status.failed'),
-  Idle: t('backend_settings.settings.mcp_server.status.stopped'),
-  Ready: t('backend_settings.settings.mcp_server.status.running'),
-  Restarting: t('backend_settings.settings.mcp_server.status.starting'),
-  Spawning: t('backend_settings.settings.mcp_server.status.starting'),
-  Stopped: t('backend_settings.settings.mcp_server.status.stopped'),
-  Stopping: t('backend_settings.settings.mcp_server.status.stopping'),
-  Unavailable: t('backend_settings.settings.mcp_server.status.unavailable'),
-  WaitingReady: t('backend_settings.settings.mcp_server.status.starting'),
+const statusLabels = computed<Record<StarlingServiceStatus, string>>(() => ({
+  [StarlingServiceStatus.DEGRADED]: t('backend_settings.settings.mcp_server.status.failed'),
+  [StarlingServiceStatus.FAILED]: t('backend_settings.settings.mcp_server.status.failed'),
+  [StarlingServiceStatus.IDLE]: t('backend_settings.settings.mcp_server.status.stopped'),
+  [StarlingServiceStatus.READY]: t('backend_settings.settings.mcp_server.status.running'),
+  [StarlingServiceStatus.RESTARTING]: t('backend_settings.settings.mcp_server.status.starting'),
+  [StarlingServiceStatus.SPAWNING]: t('backend_settings.settings.mcp_server.status.starting'),
+  [StarlingServiceStatus.STOPPED]: t('backend_settings.settings.mcp_server.status.stopped'),
+  [StarlingServiceStatus.STOPPING]: t('backend_settings.settings.mcp_server.status.stopping'),
+  [StarlingServiceStatus.UNAVAILABLE]: t('backend_settings.settings.mcp_server.status.unavailable'),
+  [StarlingServiceStatus.WAITING_READY]: t('backend_settings.settings.mcp_server.status.starting'),
 }));
 const isLifecycleDisabled = computed<boolean>(() => {
   const state = get(status)?.state;
-  return state === undefined || state === 'Unavailable' || transitioningStates.has(state);
+  return state === undefined || state === StarlingServiceStatus.UNAVAILABLE || transitioningStates.has(state);
 });
 
-function statusLabel(state: McpServiceState | undefined): string {
+function statusLabel(state: StarlingServiceStatus | undefined): string {
   if (!state && get(loading))
     return t('backend_settings.settings.mcp_server.status.loading');
-  return get(statusLabels)[state ?? 'Unavailable'];
+  return get(statusLabels)[state ?? StarlingServiceStatus.UNAVAILABLE];
 }
 
 async function loadStatus(): Promise<void> {

--- a/frontend/app/src/modules/settings/backend/use-mcp-server-state.ts
+++ b/frontend/app/src/modules/settings/backend/use-mcp-server-state.ts
@@ -1,12 +1,12 @@
-import type { McpServiceState } from '@shared/ipc';
+import type { StarlingServiceStatus } from '@shared/ipc';
 import type { Ref } from 'vue';
 
-const mcpServerState = shallowRef<McpServiceState>();
+const mcpServerState = shallowRef<StarlingServiceStatus>();
 
-export function setMcpServerState(state: McpServiceState | undefined): void {
+export function setMcpServerState(state: StarlingServiceStatus | undefined): void {
   set(mcpServerState, state);
 }
 
-export function useMcpServerState(): Readonly<Ref<McpServiceState | undefined>> {
+export function useMcpServerState(): Readonly<Ref<StarlingServiceStatus | undefined>> {
   return readonly(mcpServerState);
 }

--- a/frontend/scripts/dev/starling.ts
+++ b/frontend/scripts/dev/starling.ts
@@ -3,6 +3,7 @@ import process from 'node:process';
 import { DEFAULT_MCP_PORT, DEFAULT_PROXY_PORT, selectPort } from '../../app/shared/port-utils';
 import { buildStarlingInvocation, SHUTDOWN_GRACE_SECS, type StarlingBackendOptions } from '../../app/shared/starling/starling-args';
 import { requestStarlingStart, spawnStarling } from '../../app/shared/starling/starling-launch';
+import { StarlingMethod } from '../../app/shared/starling/starling-protocol';
 import { StarlingRpc } from '../../app/shared/starling/starling-rpc';
 import { createDevLogger, formatDevLine } from './logger';
 import { registerShutdownHook } from './process-pool';
@@ -110,7 +111,7 @@ export async function startStarlingSupervisor(options: StarlingDevOptions): Prom
     logger.info('stopping starling');
     // Ask for the ordered teardown, then outwait the grace starling gives its
     // own children. Killing it earlier orphans the very processes it reaps.
-    await Promise.race([rpc.request('stop').catch(() => undefined), wait(STOP_REQUEST_TIMEOUT_MS)]);
+    await Promise.race([rpc.request(StarlingMethod.STOP).catch(() => undefined), wait(STOP_REQUEST_TIMEOUT_MS)]);
     if (child.exitCode === null)
       child.kill('SIGKILL');
   });


### PR DESCRIPTION
Follow-up to #12747, which added `resetMcpSession`. Reviewing it surfaced that neither half of the starling control channel is typed.

## Service statuses

`McpServiceState` was a bare string union in `shared/ipc.ts`. The same nine values were restated by hand in three more places the compiler could not keep in sync:

- `MCP_SERVICE_STATES` in `starling-mcp.ts`, typed `ReadonlySet<string>`, so drift in either direction was invisible
- `transitioningStates` and the `statusLabels` keys in `McpServerSetting.vue`

Replaced with an `as const` object named `StarlingServiceStatus`. The rename is deliberate: starling reports the same status vocabulary for every service in its `status.services` array, we just happen to only read `mcp`'s. Naming it per-service means it's reusable the day core's status is consumed.

The runtime guard now derives from the const rather than restating it. That also makes explicit something the old set only implied by omission: `Unavailable` is our own sentinel for "starling isn't running" and never arrives over the wire.

Every raw comparison is gone: `=== 'Ready'`, `=== 'Unavailable'`, `'Failed'`, the `?? 'Unavailable'` fallback, and the literals in both spec files.

## Control-channel methods

`StarlingRpc.request` took `method: string`, so `'startServce'` type-checked and failed at runtime as an unknown-method rejection. `shared/starling/starling-protocol.ts` now names the methods, the `event.*` notifications and the four services; `request()` is narrowed to `StarlingMethod`, and `resolvePort`'s inline `'core' | 'colibri' | 'mcp' | 'proxy'` union becomes `StarlingService`. The two dev launchers were sending raw `'stop'` too and are converted.

Inbound notifications keep `method: string` on purpose: that value comes off the wire and is untrusted. The handler's `switch` matches it against `StarlingEvent` members and logs anything unrecognised.

## Also

- `isServiceLive` extracts the `Ready`-or-`Degraded` check `resetMcpSession` was making with inline literals, and lives next to the other status predicates rather than in the handler.
- New test for the lifecycle events. Only `event.crashed` had coverage; `ready`, `restarting` and `stopped` went through the `switch` untested. Verified non-vacuous with a negative control: removing `case StarlingEvent.RESTARTING` fails it.

Note the outbound narrowing is a compile-time guarantee, so no test can observe it directly. A typo stops being expressible rather than starting to fail.

## Not addressed

Left alone as separate concerns, happy to fold any in:

- `logoutRemoteSession` calls `resetMcpSession()` unguarded, so an MCP restart failure fails the whole remote logout, unlike the interactive path which catches
- `showErrorMessage('MCP logout failed', ...)` shows the user an error for something they did not ask for, as they are being sent to the login screen
- `setMcpServerRunning(false)` then `(true)` may race if `stopService` returns before the process is actually down
- `BackendCode` in `shared/ipc.ts` is written in the enumerified shape but is missing `as const`, so its type resolves to plain `number` and any number satisfies it
- `statusLabels` maps `Degraded` to the *failed* label while `isServiceLive` treats it as live; both defensible, but they disagree

## Checklist

- [x] Typecheck, lint, typos clean
- [x] 85 unit tests pass across the 9 affected files
- [ ] No user guide changes needed (no user-visible behaviour change)