### PR TITLE
Show per-event redecode loading state

### DIFF
--- a/frontend/app/src/modules/history/events/HistoryEventsAction.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsAction.vue
@@ -263,6 +263,8 @@ function confirmIgnoreDuplicate(): void {
           icon
           size="sm"
           class="!p-2"
+          :disabled="loading"
+          :loading="loading"
           v-bind="attrs"
         >
           <RuiIcon

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -244,6 +244,11 @@ async function handleRedecode(event?: PullLocationTransactionPayload): Promise<v
   }
 }
 
+const redecodeHandlers = {
+  onRedecode: handleRedecode,
+  onRedecodeBlock: actions.redecode.blocks,
+};
+
 async function handleMovementChanged(): Promise<void> {
   await refreshUnmatchedAssetMovements();
   await actions.fetch.dataAndLocations();
@@ -384,6 +389,7 @@ watchDebounced(route, async () => {
               :highlight-types="highlightTypes"
               :selection="selectionMode"
               :duplicate-handling-status="duplicateHandlingStatus"
+              :redecode-handlers="redecodeHandlers"
               @clear-filters="clearFilters()"
               @show:dialog="dialogContainer?.show($event)"
               @refresh="handleRedecode($event)"

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -9,7 +9,7 @@ import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/even
 import UpgradeRow from '@/modules/history/UpgradeRow.vue';
 import { useHistoryEventsData } from '../use-history-events-data';
 import { useHistoryEventsForms } from '../use-history-events-forms';
-import { useHistoryEventsOperations } from '../use-history-events-operations';
+import { type HistoryEventRedecodeHandlers, useHistoryEventsOperations } from '../use-history-events-operations';
 import { useVirtualRows } from '../use-virtual-rows';
 import { useVirtualScrollHighlight } from '../use-virtual-scroll-highlight';
 import HistoryEventsDetailItem from './HistoryEventsDetailItem.vue';
@@ -38,6 +38,7 @@ const {
   hideActions,
   selection,
   duplicateHandlingStatus,
+  redecodeHandlers,
 } = defineProps<{
   groups: Collection<HistoryEventRow>;
   requestPayload: HistoryEventRequestPayload | undefined;
@@ -53,6 +54,7 @@ const {
   hideActions?: boolean;
   selection?: UseHistoryEventsSelectionModeReturn;
   duplicateHandlingStatus?: DuplicateHandlingStatus;
+  redecodeHandlers?: HistoryEventRedecodeHandlers;
 }>();
 
 const emit = defineEmits<HistoryEventsTableEmits>();
@@ -138,6 +140,7 @@ const {
   confirmRedecode,
   confirmTxAndEventsDelete,
   confirmUnlink,
+  isRedecodePending,
   unlinkGroup,
   hasCustomEvents,
   redecode,
@@ -150,6 +153,7 @@ const {
 } = useHistoryEventsOperations({
   completeEventsMapped,
   flattenedEvents: events,
+  ...(redecodeHandlers ?? {}),
 }, emit);
 
 // Form operations
@@ -295,7 +299,7 @@ function ignoredAssetsState(groupId: string): 'hidden' | 'showing' | undefined {
             :group="row.data"
             :group-events="getGroupEvents(row.groupId)"
             :hide-actions="hideActions"
-            :loading="eventsLoading"
+            :loading="eventsLoading || isRedecodePending(row.data.groupIdentifier)"
             :duplicate-handling-status="duplicateHandlingStatus"
             :ignored-assets="ignoredAssetsState(row.groupId)"
             :highlight-type="isGroupHighlighted(row.groupId) ? getHighlightType(row.data) : undefined"

--- a/frontend/app/src/modules/history/events/use-history-events-operations.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-operations.spec.ts
@@ -1,4 +1,8 @@
-import type { PullEventPayload } from '@/modules/history/events/event-payloads';
+import type {
+  PullEthBlockEventPayload,
+  PullEventPayload,
+  PullLocationTransactionPayload,
+} from '@/modules/history/events/event-payloads';
 import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
 import type { HistoryEventsTableEmitFn } from '@/modules/history/events/types';
 import { HistoryEventEntryType } from '@rotki/common';
@@ -58,15 +62,29 @@ vi.mock('@/modules/history/event-utils', async () => {
 
 const emit: HistoryEventsTableEmitFn = vi.fn();
 
-function setup(flattened: HistoryEventEntry[] = []): ReturnType<typeof useHistoryEventsOperations> {
+function setup(
+  flattened: HistoryEventEntry[] = [],
+  onRedecode: (payload: PullLocationTransactionPayload) => Promise<void> = async () => Promise.resolve(),
+  onRedecodeBlock?: (payload: PullEthBlockEventPayload) => Promise<void>,
+): ReturnType<typeof useHistoryEventsOperations> {
   return useHistoryEventsOperations({
     completeEventsMapped: computed<Record<string, HistoryEventRow[]>>(() => ({})),
     flattenedEvents: computed<HistoryEventEntry[]>(() => flattened),
+    onRedecode,
+    onRedecodeBlock,
   }, emit);
 }
 
 const evmPayload: PullEventPayload = { data: { location: 'ethereum', txRef: '0x1' }, type: HistoryEventEntryType.EVM_EVENT };
 const blockPayload: PullEventPayload = { data: [123], type: HistoryEventEntryType.ETH_BLOCK_EVENT };
+
+function createDeferredPromise(): { promise: Promise<void>; resolve: () => void } {
+  let resolvePromise = (): void => {};
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = (): void => resolve();
+  });
+  return { promise, resolve: resolvePromise };
+}
 
 describe('useHistoryEventsOperations', () => {
   beforeEach(() => {
@@ -103,30 +121,79 @@ describe('useHistoryEventsOperations', () => {
     expect(ops.suggestNextSequenceId(createMock<HistoryEventEntry>({ groupIdentifier: 'g1', sequenceIndex: 7 }))).toBe('8');
   });
 
-  it('should emit a block-event refresh when redecoding a block payload', () => {
-    setup().redecode(blockPayload, 'g1');
+  it('should emit a block-event refresh when redecoding a block payload', async () => {
+    await setup().redecode(blockPayload, 'g1');
     expect(emit).toHaveBeenCalledWith('refresh:block-event', { blockNumbers: [123] });
   });
 
-  it('should open the confirmation dialog when the group has custom events', () => {
+  it('should keep only the target block-event group pending until redecode succeeds', async () => {
+    const { promise, resolve } = createDeferredPromise();
+    const onRedecodeBlock = vi.fn(async () => promise);
+    const ops = setup([], undefined, onRedecodeBlock);
+
+    const request = ops.redecode(blockPayload, 'g1');
+
+    expect(ops.isRedecodePending('g1')).toBe(true);
+    expect(ops.isRedecodePending('g2')).toBe(false);
+    expect(onRedecodeBlock).toHaveBeenCalledWith({ blockNumbers: [123] });
+
+    resolve();
+    await request;
+
+    expect(ops.isRedecodePending('g1')).toBe(false);
+  });
+
+  it('should clear the target block-event pending state when redecode fails', async () => {
+    const ops = setup([], undefined, vi.fn(async () => Promise.reject(new Error('boom'))));
+
+    await expect(ops.redecode(blockPayload, 'g1')).rejects.toThrow('boom');
+
+    expect(ops.isRedecodePending('g1')).toBe(false);
+  });
+
+  it('should open the confirmation dialog when the group has custom events', async () => {
     spies.getGroupEvents.mockReturnValue([createMock<HistoryEventEntry>({})]);
     spies.isCustomizedEvent.mockReturnValue(true);
     const ops = setup();
-    ops.redecode(evmPayload, 'g1');
+    await ops.redecode(evmPayload, 'g1');
     expect(get(ops.hasCustomEvents)).toBe(true);
     expect(get(ops.modelShowRedecodeConfirmation)).toBe(true);
     expect(get(ops.redecodePayload)).toEqual(evmPayload);
     expect(emit).not.toHaveBeenCalledWith('refresh', expect.anything());
   });
 
-  it('should redecode directly when there are no custom events', () => {
+  it('should redecode directly when there are no custom events', async () => {
     spies.getGroupEvents.mockReturnValue([createMock<HistoryEventEntry>({})]);
-    setup().redecode(evmPayload, 'g1');
-    expect(emit).toHaveBeenCalledWith('refresh', {
+    const onRedecode = vi.fn(async () => Promise.resolve());
+    await setup([], onRedecode).redecode(evmPayload, 'g1');
+    expect(onRedecode).toHaveBeenCalledWith({
       deleteCustom: false,
       linkedMovement: undefined,
       transactions: [evmPayload.data],
     });
+  });
+
+  it('should only mark the target group pending until a direct redecode succeeds', async () => {
+    const { promise, resolve } = createDeferredPromise();
+    const ops = setup([], vi.fn(async () => promise));
+
+    const request = ops.redecode(evmPayload, 'g1');
+
+    expect(ops.isRedecodePending('g1')).toBe(true);
+    expect(ops.isRedecodePending('g2')).toBe(false);
+
+    resolve();
+    await request;
+
+    expect(ops.isRedecodePending('g1')).toBe(false);
+  });
+
+  it('should clear the target pending state when a direct redecode fails', async () => {
+    const ops = setup([], vi.fn(async () => Promise.reject(new Error('boom'))));
+
+    await expect(ops.redecode(evmPayload, 'g1')).rejects.toThrow('boom');
+
+    expect(ops.isRedecodePending('g1')).toBe(false);
   });
 
   it('should show indexer options for EVM redecode-with-options', () => {
@@ -138,13 +205,35 @@ describe('useHistoryEventsOperations', () => {
     expect(get(ops.redecodePayload)).toEqual(evmPayload);
   });
 
-  it('should emit refresh and reset payload on confirm-redecode', () => {
-    const ops = setup();
-    ops.confirmRedecode({ deleteCustom: true, payload: evmPayload });
-    expect(emit).toHaveBeenCalledWith('refresh', expect.objectContaining({
+  it('should redecode the target group and reset payload on confirm', async () => {
+    const { promise, resolve } = createDeferredPromise();
+    const onRedecode = vi.fn(async () => promise);
+    const ops = setup([], onRedecode);
+    ops.redecodeWithOptions(evmPayload, 'g1');
+
+    const request = ops.confirmRedecode({ deleteCustom: true, payload: evmPayload });
+
+    expect(ops.isRedecodePending('g1')).toBe(true);
+    expect(ops.isRedecodePending('g2')).toBe(false);
+    expect(onRedecode).toHaveBeenCalledWith(expect.objectContaining({
       deleteCustom: true,
       transactions: [evmPayload.data],
     }));
+
+    resolve();
+    await request;
+
+    expect(ops.isRedecodePending('g1')).toBe(false);
+    expect(get(ops.redecodePayload)).toBeUndefined();
+  });
+
+  it('should clear target state when a confirmed redecode fails', async () => {
+    const ops = setup([], vi.fn(async () => Promise.reject(new Error('boom'))));
+    ops.redecodeWithOptions(evmPayload, 'g1');
+
+    await expect(ops.confirmRedecode({ deleteCustom: false, payload: evmPayload })).rejects.toThrow('boom');
+
+    expect(ops.isRedecodePending('g1')).toBe(false);
     expect(get(ops.redecodePayload)).toBeUndefined();
   });
 

--- a/frontend/app/src/modules/history/events/use-history-events-operations.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-operations.ts
@@ -2,7 +2,9 @@ import type { ComputedRef, Ref } from 'vue';
 import type {
   LinkedMovementMatch,
   LocationAndTxRef,
+  PullEthBlockEventPayload,
   PullEventPayload,
+  PullLocationTransactionPayload,
 } from '@/modules/history/events/event-payloads';
 import type {
   HistoryEventEntry,
@@ -23,7 +25,14 @@ import { useHistoryEvents } from '@/modules/history/events/use-history-events';
 import { useUnmatchedAssetMovements } from '@/modules/history/events/use-unmatched-asset-movements';
 import { useIgnore } from '@/modules/history/use-ignore';
 
-interface UseHistoryEventsOperationsOptions {
+export interface HistoryEventRedecodeHandlers {
+  /** Runs the targeted redecode and resolves after the refreshed event data has settled. */
+  onRedecode?: (payload: PullLocationTransactionPayload) => Promise<void>;
+  /** Runs the targeted block-event redecode and resolves after the refreshed event data has settled. */
+  onRedecodeBlock?: (payload: PullEthBlockEventPayload) => Promise<void>;
+}
+
+interface UseHistoryEventsOperationsOptions extends HistoryEventRedecodeHandlers {
   /** Events per group identifier including ignored-asset ones, so redecode and unlink act on the full group rather than what the table shows. */
   completeEventsMapped: ComputedRef<Record<string, HistoryEventRow[]>>;
   /** Flat list of all loaded events, scanned to find the highest sequence index within a group when suggesting the next one. */
@@ -39,14 +48,15 @@ interface UseHistoryEventsOperationsReturn {
 
   // Functions
   getItemClass: (item: HistoryEventEntry) => '' | 'opacity-50';
+  isRedecodePending: (groupIdentifier: string) => boolean;
   confirmDelete: (payload: HistoryEventDeletePayload) => void;
   confirmUnlink: (payload: HistoryEventUnlinkPayload) => void;
   unlinkGroup: (groupId: string) => void;
   suggestNextSequenceId: (group: HistoryEventEntry) => string;
   confirmTxAndEventsDelete: (payload: LocationAndTxRef) => void;
-  redecode: (payload: PullEventPayload, eventIdentifier: string) => void;
+  redecode: (payload: PullEventPayload, groupIdentifier: string) => Promise<void>;
   redecodeWithOptions: (payload: PullEventPayload, groupIdentifier: string) => void;
-  confirmRedecode: (event: { payload: PullEventPayload; deleteCustom: boolean; customIndexersOrder?: string[] }) => void;
+  confirmRedecode: (event: { payload: PullEventPayload; deleteCustom: boolean; customIndexersOrder?: string[] }) => Promise<void>;
   toggle: (event: HistoryEventEntry) => Promise<void>;
 }
 
@@ -56,6 +66,14 @@ export function useHistoryEventsOperations(
 ): UseHistoryEventsOperationsReturn {
   const { completeEventsMapped, flattenedEvents } = options;
   const { getGroupEvents } = useCompleteEvents(completeEventsMapped);
+  const onRedecode = options.onRedecode ?? (async (payload: PullLocationTransactionPayload): Promise<void> => {
+    emit('refresh', payload);
+    return Promise.resolve();
+  });
+  const onRedecodeBlock = options.onRedecodeBlock ?? (async (payload: PullEthBlockEventPayload): Promise<void> => {
+    emit('refresh:block-event', payload);
+    return Promise.resolve();
+  });
 
   const selected = ref<HistoryEventEntry[]>([]);
   const modelShowRedecodeConfirmation = shallowRef<boolean>(false);
@@ -63,6 +81,8 @@ export function useHistoryEventsOperations(
   const hasCustomEvents = shallowRef<boolean>(false);
   const showIndexerOptions = shallowRef<boolean>(false);
   const pendingLinkedMovement = ref<LinkedMovementMatch>();
+  const redecodeGroupIdentifier = ref<string>();
+  const pendingRedecodeGroupIdentifiers = shallowRef<Set<string>>(new Set());
 
   const { t } = useI18n({ useScope: 'global' });
 
@@ -116,6 +136,32 @@ export function useHistoryEventsOperations(
 
   function getItemClass(item: HistoryEventEntry): '' | 'opacity-50' {
     return item.ignoredInAccounting ? 'opacity-50' : '';
+  }
+
+  function isRedecodePending(groupIdentifier: string): boolean {
+    return get(pendingRedecodeGroupIdentifiers).has(groupIdentifier);
+  }
+
+  function setRedecodePending(groupIdentifier: string, pending: boolean): void {
+    const identifiers = new Set(get(pendingRedecodeGroupIdentifiers));
+    if (pending)
+      identifiers.add(groupIdentifier);
+    else
+      identifiers.delete(groupIdentifier);
+    set(pendingRedecodeGroupIdentifiers, identifiers);
+  }
+
+  async function executeRedecode(
+    groupIdentifier: string,
+    handler: () => Promise<void>,
+  ): Promise<void> {
+    setRedecodePending(groupIdentifier, true);
+    try {
+      await handler();
+    }
+    finally {
+      setRedecodePending(groupIdentifier, false);
+    }
   }
 
   function confirmDelete(payload: HistoryEventDeletePayload): void {
@@ -220,9 +266,9 @@ export function useHistoryEventsOperations(
       || payload.type === HistoryEventEntryType.EVM_SWAP_EVENT;
   }
 
-  function redecode(payload: PullEventPayload, groupIdentifier: string): void {
+  async function redecode(payload: PullEventPayload, groupIdentifier: string): Promise<void> {
     if (payload.type === HistoryEventEntryType.ETH_BLOCK_EVENT) {
-      emit('refresh:block-event', { blockNumbers: payload.data });
+      await executeRedecode(groupIdentifier, async () => onRedecodeBlock({ blockNumbers: payload.data }));
       return;
     }
 
@@ -235,25 +281,26 @@ export function useHistoryEventsOperations(
       set(hasCustomEvents, true);
       set(showIndexerOptions, false);
       set(redecodePayload, payload);
+      set(redecodeGroupIdentifier, groupIdentifier);
       set(modelShowRedecodeConfirmation, true);
       return;
     }
 
     // No custom events - just redecode directly without dialog
-    emit('refresh', {
+    await executeRedecode(groupIdentifier, async () => onRedecode({
       deleteCustom: false,
       linkedMovement: movementEvent ? buildLinkedMovement(movementEvent, groupEvents) : undefined,
       transactions: [payload.data],
-    });
+    }));
   }
 
-  function redecodeWithOptions(payload: PullEventPayload, eventIdentifier: string): void {
+  function redecodeWithOptions(payload: PullEventPayload, groupIdentifier: string): void {
     if (payload.type === HistoryEventEntryType.ETH_BLOCK_EVENT) {
       emit('refresh:block-event', { blockNumbers: payload.data });
       return;
     }
 
-    const groupEvents = getGroupEvents(eventIdentifier);
+    const groupEvents = getGroupEvents(groupIdentifier);
     const isAnyCustom = groupEvents.some(item => isCustomizedEvent(item));
     const movementEvent = groupEvents.find(item => isAssetMovementEvent(item));
     set(pendingLinkedMovement, movementEvent ? buildLinkedMovement(movementEvent, groupEvents) : undefined);
@@ -262,26 +309,35 @@ export function useHistoryEventsOperations(
     set(hasCustomEvents, isAnyCustom);
     set(showIndexerOptions, isEvmPayload(payload));
     set(redecodePayload, payload);
+    set(redecodeGroupIdentifier, groupIdentifier);
     set(modelShowRedecodeConfirmation, true);
   }
 
-  function confirmRedecode(event: { payload: PullEventPayload; deleteCustom: boolean; customIndexersOrder?: string[] }): void {
+  async function confirmRedecode(event: { payload: PullEventPayload; deleteCustom: boolean; customIndexersOrder?: string[] }): Promise<void> {
     const { customIndexersOrder, deleteCustom, payload } = event;
-    if (payload.type === HistoryEventEntryType.ETH_BLOCK_EVENT) {
-      emit('refresh:block-event', {
-        blockNumbers: payload.data,
-      });
+    try {
+      if (payload.type === HistoryEventEntryType.ETH_BLOCK_EVENT) {
+        emit('refresh:block-event', {
+          blockNumbers: payload.data,
+        });
+      }
+      else {
+        const groupIdentifier = get(redecodeGroupIdentifier);
+        if (groupIdentifier) {
+          await executeRedecode(groupIdentifier, async () => onRedecode({
+            customIndexersOrder,
+            deleteCustom,
+            linkedMovement: get(pendingLinkedMovement),
+            transactions: [payload.data],
+          }));
+        }
+      }
     }
-    else {
-      emit('refresh', {
-        customIndexersOrder,
-        deleteCustom,
-        linkedMovement: get(pendingLinkedMovement),
-        transactions: [payload.data],
-      });
+    finally {
+      set(redecodePayload, undefined);
+      set(redecodeGroupIdentifier, undefined);
+      set(pendingLinkedMovement, undefined);
     }
-    set(redecodePayload, undefined);
-    set(pendingLinkedMovement, undefined);
   }
 
   return {
@@ -290,6 +346,7 @@ export function useHistoryEventsOperations(
     confirmTxAndEventsDelete,
     confirmUnlink,
     getItemClass,
+    isRedecodePending,
     unlinkGroup,
     hasCustomEvents: readonly(hasCustomEvents),
     redecode,


### PR DESCRIPTION
Fixes #12677.

## Summary

- track redecode loading per event and event group
- cover direct, options-menu, and block-redecode flows
- clear loading state reliably in finally blocks
- add focused unit coverage

## Validation

- 17 focused unit tests passed
- lint-staged and stylelint passed
- frontend typecheck passed
- git diff --check passed

OpenAI Codex assisted with implementation, tests, and validation; I reviewed the final diff and test output.