### PR TITLE
Anchor the asset movement e2e row by content

### DIFF
--- a/frontend/app/tests/e2e/specs/history/history-events.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/history-events.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { expect, type Locator } from '@playwright/test';
 import {
   assetMovementEventFixture,
   ethBlockEventFixture,
@@ -20,6 +20,17 @@ import { seedEvmTransaction, seedHistoricPrices } from '../../helpers/seed-db';
 import { HistoryEventsPage } from '../../pages/history-events-page';
 import { PillFilterBar } from '../../pages/pill-filter-bar';
 import { RotkiApp } from '../../pages/rotki-app';
+
+/**
+ * The asset movement renders either as a matched movement or as a regular event row depending on
+ * whether it pairs with another movement, so both selectors are in play. Its notes are unique to
+ * this fixture, which makes them a stable anchor across either rendering and across re-sorts.
+ */
+function assetMovementRow(ctx: SharedTestContext): Locator {
+  return ctx.sharedPage
+    .locator('[data-cy=history-event-row], [data-cy=history-event-movement]')
+    .filter({ hasText: assetMovementEventFixture.notes });
+}
 
 test.describe.serial('history events', () => {
   let ctx: SharedTestContext;
@@ -139,38 +150,29 @@ test.describe.serial('history events', () => {
     await page.fillAssetMovementForm(assetMovementEventFixture);
     await page.saveForm();
 
-    // Asset movements may show as matched movements or regular event rows
-    await expect(async () => {
-      const movements = await page.getMovementRows();
-      const events = await page.getEventRows();
-      expect(movements + events).toBeGreaterThanOrEqual(2);
-    }).toPass({ timeout: 10000 });
+    // Wait for the deposit itself. A row count cannot serve as the gate here: the swap expanded by
+    // the previous test leaves its sub-events in the table under the same `history-event-row`
+    // selector, so any `>= n` guard is already satisfied before this event arrives.
+    await expect(assetMovementRow(ctx)).toHaveCount(1);
   });
 
   test('edit asset movement event', async () => {
     const updatedAmount = '0.75';
 
-    // Find the event that contains our deposit notes
-    const movementRows = await page.getMovementRows();
-    const eventRows = await page.getEventRows();
-
-    if (movementRows > 0) {
-      await page.editEvent('[data-cy=history-event-movement]', 0);
-    }
-    else if (eventRows > 0) {
-      // The last event row should be the deposit event
-      await page.editEvent('[data-cy=history-event-row]', eventRows - 1);
-    }
+    // Anchor on the deposit's notes rather than on a row index. The movement sorts to the top of the
+    // table (it is the newest timestamp), so every index shifts by one the moment it renders, and an
+    // index picked before that would land on a swap sub-event, which carries no edit action.
+    const row = assetMovementRow(ctx);
+    await row.hover();
+    await row.locator('[data-cy=row-edit]').click();
+    await ctx.sharedPage.locator('[data-cy=bottom-dialog]').waitFor({ state: 'visible' });
 
     await ctx.sharedPage.locator('[data-cy=amount] input').clear();
     await ctx.sharedPage.locator('[data-cy=amount] input').fill(updatedAmount);
 
     await page.saveForm();
 
-    if (movementRows > 0)
-      await page.verifyEventAmount('[data-cy=history-event-movement]', 0, updatedAmount);
-    else
-      await page.verifyEventAmount('[data-cy=history-event-row]', eventRows - 1, updatedAmount);
+    await expect(row.locator('[data-cy=event-amount]').first()).toContainText(updatedAmount);
   });
 
   test('delete history event', async () => {


### PR DESCRIPTION
## Problem

`history-events.spec.ts` located the asset movement deposit by row index, which is unsound in this
file:

- `getEventRows()` also counts the sub-events of an **expanded** swap, and `delete fee sub-event
  from online swap` leaves its swap expanded. The `add asset movement event` guard
  (`movements + events >= 2`) is therefore already satisfied before the deposit renders, so it
  returns immediately.
- `edit asset movement event` then computed an index from that stale count. The movement has the
  newest timestamp and the table sorts descending, so it lands at the top and shifts every index
  the moment it renders. The index picked before that pointed at a swap sub-event, which renders
  no edit action (`hideEditAction` hides it for `index !== 0`), and the `row-edit` click timed out
  after 60s.

Because the file is `describe.serial`, that timeout aborted the group and left the remaining tests
unrun.

There is a second, quieter defect: on the branch where movements rendered as regular event rows,
the index version edited the **airdrop** event and passed without ever touching the asset movement.

## Fix

Locate the movement by its fixture notes over both the event-row and matched-movement selectors,
since it renders as either depending on whether it pairs with another movement. The add test gates
on `toHaveCount(1)`; the edit test hovers that row, clicks its `row-edit`, and asserts the updated
amount on the same row.

## Testing

`pnpm run test:e2e specs/history/history-events` — **30/30 pass, 2.1 min**. `edit asset movement
event` now runs in 423ms instead of timing out at 60s.