### PR TITLE
fix(ci): send a User-Agent from the Discord notifier

### DIFF
--- a/.github/scripts/notifier.py
+++ b/.github/scripts/notifier.py
@@ -11,6 +11,9 @@ from urllib.request import Request, urlopen
 
 ALL_DEVS = '1105142033590526052'
 BACKEND_DEVS = '983289520000737330'
+# Discord sits behind Cloudflare, which rejects urllib's default `Python-urllib/x.y`
+# User-Agent with a 403 (error code 1010). Any explicit agent gets through.
+USER_AGENT = 'rotki-github-actions-notifier/1.0 (+https://github.com/rotki/rotki)'
 
 logger = logging.getLogger(__name__)
 
@@ -89,24 +92,35 @@ def main() -> None:
     request = Request(  # noqa: S310  # scheme validated above
         url=url,
         data=urlencode(data).encode(),
-        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        headers={
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': USER_AGENT,
+        },
         method='POST',
     )
+    response_body = ''
     try:
         with urlopen(request, timeout=30) as response:  # noqa: S310  # scheme validated above
             response_status = response.status
     except HTTPError as e:
         response_status = e.code
+        # The body carries the actual reason (Discord's JSON error, or a Cloudflare
+        # `error code: NNNN` page). Without it a bare status is undiagnosable.
+        try:
+            response_body = e.read().decode('utf8', errors='replace').strip()
+        except OSError as read_error:
+            response_body = f'<could not read response body: {read_error}>'
     except URLError as e:
         logger.error('Failed to notify %s group for %s job: %s', group_key, job_type, e.reason)
         sys.exit(1)
 
     if response_status not in {HTTPStatus.OK, HTTPStatus.NO_CONTENT}:
         logger.error(
-            'Failed to notify %s group for %s job. Status code: %s',
+            'Failed to notify %s group for %s job. Status code: %s. Response: %s',
             group_key,
             job_type,
             response_status,
+            response_body[:500] if response_body != '' else '<empty>',
         )
         sys.exit(1)
 


### PR DESCRIPTION
### Cause

The nightly and benchmark `notify` jobs have been failing with a `403` from Discord.

It is not the webhook URL. Discord sits behind Cloudflare, and Cloudflare bans
`urllib`'s default `Python-urllib/x.y` User-Agent, answering `403` with the body
`error code: 1010` before the request ever reaches Discord.

This began when the notifier dropped `requests` for `urllib` (9664854f5, landed
alongside the benchmark notifications). `requests` sends `python-requests/x.y`,
which is not blocked, so the change was invisible until the next failing nightly.

f5ef2952e read the same `403` as shell truncation of the webhook URL and quoted the
secret. The quoting is worth keeping on its own merits, but it was not the cause and
the `403` persisted.

`bugfixes` is unaffected: its notifier still uses `requests`.

### Fix

- Send an explicit `User-Agent`.
- Log the `HTTPError` response body next to the status code. A bare `Status code: 403`
  carries no reason, which is precisely what sent the first fix after the wrong
  suspect. With the body, the log names Cloudflare's `error code: 1010` outright.

### Verification

Posting to a deliberately fake webhook (`.../webhooks/000000000000000000/definitely-not-a-real-token`),
which isolates the edge from the endpoint:

| User-Agent | Status | Body |
|---|---|---|
| `Python-urllib/3.14` (before) | `403` | `error code: 1010` |
| explicit agent (after) | `404` | `{"message": "Unknown Webhook", "code": 10015}` |

`404` is the correct answer for a webhook that does not exist: the request reached
Discord itself, so the Cloudflare block is gone. Content type (form-urlencoded vs
JSON) makes no difference to either result.

The other two failure paths still report correctly:

```
ERROR: Invalid webhook URL scheme for backend devs group tests job
ERROR: Failed to notify backend devs group for tests job: [Errno -2] Name or service not known
```

`ruff` and `typos` are clean on the changed file.

The success path cannot be exercised without the real secret, so the first green
nightly is the final confirmation.
