### PR TITLE
Allowlist writable RPC node fields on write

### DIFF
--- a/frontend/app/src/modules/settings/api/use-evm-nodes-api.spec.ts
+++ b/frontend/app/src/modules/settings/api/use-evm-nodes-api.spec.ts
@@ -117,7 +117,7 @@ describe('composables/api/settings/evm-nodes-api', () => {
       });
     });
 
-    it('should strip the read-only fields from the payload', async () => {
+    it('should only send the writable fields, dropping any other server field', async () => {
       let requestBody: DefaultBodyType = null;
 
       server.use(
@@ -141,13 +141,20 @@ describe('composables/api/settings/evm-nodes-api', () => {
         isArchive: true,
         runtimeStatus: 'cooling_down' as const,
         cooldownUntil: 1785655945,
+        // a runtime field the backend may add later, which the frontend knows nothing about
+        lastErrorKind: 'connection',
       };
 
       await addEvmNode(newNode);
 
-      expect(requestBody).not.toHaveProperty('isArchive');
-      expect(requestBody).not.toHaveProperty('runtime_status');
-      expect(requestBody).not.toHaveProperty('cooldown_until');
+      expect(requestBody).toEqual({
+        name: 'Archive Node',
+        endpoint: 'https://archive.example.com',
+        active: true,
+        owned: true,
+        weight: 100,
+        blockchain: 'ETH',
+      });
     });
   });
 
@@ -190,7 +197,7 @@ describe('composables/api/settings/evm-nodes-api', () => {
       });
     });
 
-    it('should strip the read-only fields from the payload', async () => {
+    it('should only send the writable fields, dropping any other server field', async () => {
       let requestBody: DefaultBodyType = null;
 
       server.use(
@@ -204,7 +211,7 @@ describe('composables/api/settings/evm-nodes-api', () => {
       );
 
       const { editEvmNode } = useEvmNodesApi();
-      const editedNode: BlockchainRpcNode = {
+      const editedNode = {
         identifier: 1,
         name: 'Archive Node',
         endpoint: 'https://archive.example.com',
@@ -213,15 +220,23 @@ describe('composables/api/settings/evm-nodes-api', () => {
         weight: 100,
         blockchain: 'ETH',
         isArchive: true,
-        runtimeStatus: 'cooling_down',
+        runtimeStatus: 'cooling_down' as const,
         cooldownUntil: 1785655945,
+        // a runtime field the backend may add later, which the frontend knows nothing about
+        lastErrorKind: 'connection',
       };
 
       await editEvmNode(editedNode);
 
-      expect(requestBody).not.toHaveProperty('isArchive');
-      expect(requestBody).not.toHaveProperty('runtime_status');
-      expect(requestBody).not.toHaveProperty('cooldown_until');
+      expect(requestBody).toEqual({
+        identifier: 1,
+        name: 'Archive Node',
+        endpoint: 'https://archive.example.com',
+        active: true,
+        owned: true,
+        weight: 100,
+        blockchain: 'ETH',
+      });
     });
   });
 

--- a/frontend/app/src/modules/settings/api/use-evm-nodes-api.ts
+++ b/frontend/app/src/modules/settings/api/use-evm-nodes-api.ts
@@ -1,11 +1,12 @@
 import type { MaybeRefOrGetter } from 'vue';
 import { Blockchain } from '@rotki/common';
-import { omit } from 'es-toolkit';
 import { api } from '@/modules/core/api/rotki-api';
-import { type BlockchainRpcNode, BlockchainRpcNodeList } from '@/modules/settings/types/rpc';
-
-// server-derived fields that come back on GET but are rejected by the add/edit schemas
-const READ_ONLY_FIELDS = ['isArchive', 'runtimeStatus', 'cooldownUntil'] as const;
+import {
+  type BlockchainRpcNode,
+  BlockchainRpcNodeAddPayload,
+  BlockchainRpcNodeEditPayload,
+  BlockchainRpcNodeList,
+} from '@/modules/settings/types/rpc';
 
 interface UseEvmNodesApiReturn {
   fetchEvmNodes: () => Promise<BlockchainRpcNodeList>;
@@ -23,9 +24,9 @@ export function useEvmNodesApi(chain: MaybeRefOrGetter<string> = Blockchain.ETH)
     return BlockchainRpcNodeList.parse(response);
   };
 
-  const addEvmNode = async (node: Omit<BlockchainRpcNode, 'identifier'>): Promise<boolean> => api.put<boolean>(get(url), omit(node, READ_ONLY_FIELDS));
+  const addEvmNode = async (node: Omit<BlockchainRpcNode, 'identifier'>): Promise<boolean> => api.put<boolean>(get(url), BlockchainRpcNodeAddPayload.parse(node));
 
-  const editEvmNode = async (node: BlockchainRpcNode): Promise<boolean> => api.patch<boolean>(get(url), omit(node, READ_ONLY_FIELDS));
+  const editEvmNode = async (node: BlockchainRpcNode): Promise<boolean> => api.patch<boolean>(get(url), BlockchainRpcNodeEditPayload.parse(node));
 
   const deleteEvmNode = async (identifier: number): Promise<boolean> => api.delete<boolean>(get(url), {
     body: { identifier },

--- a/frontend/app/src/modules/settings/types/rpc.ts
+++ b/frontend/app/src/modules/settings/types/rpc.ts
@@ -20,6 +20,24 @@ export const BlockchainRpcNodeList = z.array(BlockchainRpcNode);
 
 export type BlockchainRpcNodeList = z.infer<typeof BlockchainRpcNodeList>;
 
+/**
+ * The fields the backend add/edit schemas accept. Everything else the GET response carries is
+ * read-only runtime state, and marshmallow rejects it with `Unknown field`. Parsing a node through
+ * these schemas keeps the payload an allowlist: fields the server grows later are dropped without
+ * anyone having to maintain a list of them here.
+ */
+export const BlockchainRpcNodeEditPayload = BlockchainRpcNode.pick({
+  active: true,
+  blockchain: true,
+  endpoint: true,
+  identifier: true,
+  name: true,
+  owned: true,
+  weight: true,
+});
+
+export const BlockchainRpcNodeAddPayload = BlockchainRpcNodeEditPayload.omit({ identifier: true });
+
 export function getPlaceholderNode(chain: Blockchain): BlockchainRpcNode {
   return {
     active: true,


### PR DESCRIPTION
Follow-up to the discussion on #12743.

## Problem

`GET /blockchains/{chain}/nodes` returns a flat node object that mixes the seven writable fields with read-only runtime state bolted on after `serialize()` (`is_archive`, `runtime_status`, `ready`, `cooldown_until`, `last_error`, `last_error_kind`, `last_success_timestamp`). PUT/PATCH accept only the writable ones and marshmallow defaults to `unknown = RAISE`, but nothing in the JSON shape marks which is which.

That breaks read-modify-write, which is the natural way to write a toggle and what `BlockchainRpcNodeManager.vue` does:

```ts
const state = { ...node, active };
await api.editEvmNode(state);
```

The frontend defended against it with a blocklist in `use-evm-nodes-api.ts`. That blocklist has now failed twice: `is_archive` caused the bug once, then `runtime_status`/`cooldown_until` in #12743. Each time a backend Python change silently invalidated a TypeScript constant, with no compile error and no failing test, and it surfaced when a user clicked a switch.

## Change

Replace the blocklist with an allowlist, expressed as the zod schema itself rather than a key array, so there is no second list to keep in sync:

```ts
export const BlockchainRpcNodeEditPayload = BlockchainRpcNode.pick({
  active: true, blockchain: true, endpoint: true,
  identifier: true, name: true, owned: true, weight: true,
});
export const BlockchainRpcNodeAddPayload = BlockchainRpcNodeEditPayload.omit({ identifier: true });
```

The API composable parses the payload through these instead of `omit`-ing read-only keys. zod objects strip unknown keys, so read-modify-write stays the natural way to write a toggle, and any field the backend grows later can never reach a write, whether or not the read schema declares it.

No API change, no response-shape change, one module touched.

## Tests

Both "strip read-only fields" specs now assert the **exact** payload and include `lastErrorKind`, a field the frontend does not declare anywhere, standing in for the next backend addition.

Negative control: with the old blocklist restored, both specs fail with `+ "last_error_kind": "connection"`. The old code genuinely leaks unknown fields; the new code does not.

`use-evm-nodes-api`, rpc and archive-nodes specs pass (13 files / 110 tests), typecheck and lint clean.

## Not done here

Nesting runtime state under a `runtime` key in the GET response would make the boundary structural rather than a convention, which is better for any non-frontend consumer. It is a breaking response-shape change touching docs, the zod schema, `RpcNodeStatusCell`, `use-archive-nodes.ts` and backend tests. Since the frontend is currently the only consumer, this makes the client immune without it. `api.rst` still documents only `is_archive`; the other four runtime fields remain undocumented.