### PR TITLE
Fix two zod form-core defects found in the app

### DIFF
--- a/frontend/app/src/modules/core/form/use-form.i18n.spec.ts
+++ b/frontend/app/src/modules/core/form/use-form.i18n.spec.ts
@@ -1,0 +1,58 @@
+import type { Ref } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { useForm } from '@/modules/core/form/use-form';
+
+// A separate spec because it needs its own `vue-i18n` mock: the global one returns the key from
+// both `t` and `te`, which cannot tell a translated key apart from an untranslated message.
+vi.mock('vue-i18n', () => ({
+  useI18n: (): { locale: Ref<string>; t: (key: string) => string; te: (key: string) => boolean } => ({
+    locale: ref(''),
+    t: (key: string): string => `translated:${key}`,
+    te: (key: string): boolean => key === 'amount_required',
+  }),
+}));
+
+interface State {
+  amount: string;
+  /** Typed as optional so the spec can seed the `undefined` a cleared input writes, without a cast. */
+  label: string | undefined;
+}
+
+const Schema = z.object({
+  amount: z.string().min(1, 'amount_required'),
+  // No message, so a missing value produces zod's own English default rather than a key.
+  label: z.string(),
+});
+
+describe('useForm i18n handling', () => {
+  it('should translate a schema message that is a key', () => {
+    const form = useForm<State, State>({
+      initial: (): State => ({ amount: '', label: '' }),
+      schema: Schema,
+      submit: async (): Promise<{ success: true }> => Promise.resolve({ success: true }),
+      transform: (state): State => state,
+    });
+
+    form.validate();
+
+    expect(form.errors('amount')).toStrictEqual(['translated:amount_required']);
+  });
+
+  it('should pass a zod default message through untranslated', () => {
+    const form = useForm<State, State>({
+      // A cleared autocomplete writes `undefined` into a field the schema types as a string.
+      initial: (): State => ({ amount: '1', label: undefined }),
+      schema: Schema,
+      submit: async (): Promise<{ success: true }> => Promise.resolve({ success: true }),
+      transform: (state): State => state,
+    });
+
+    form.validate();
+
+    // Asking intlify for this as a key logs a "Not found key" warning on every keystroke.
+    const [message] = form.errors('label');
+    expect(message).not.toContain('translated:');
+    expect(message).toContain('expected string');
+  });
+});

--- a/frontend/app/src/modules/core/form/use-form.ts
+++ b/frontend/app/src/modules/core/form/use-form.ts
@@ -86,7 +86,7 @@ interface ServerError {
 export function useForm<TState extends object, TPayload, TMessage = string>(
   options: FormOptions<TState, TPayload, TMessage>,
 ): FormApi<TState, TPayload, TMessage> {
-  const { t } = useI18n({ useScope: 'global' });
+  const i18n = useI18n({ useScope: 'global' });
 
   const state = reactive(options.initial());
   const busy = shallowRef<boolean>(false);
@@ -152,7 +152,9 @@ export function useForm<TState extends object, TPayload, TMessage = string>(
     const map: Record<string, string[]> = {};
     for (const issue of result.error.issues) {
       const path = issue.path.map(segment => String(segment)).join('.');
-      (map[path] ??= []).push(t(issue.message));
+      // Schema messages are i18n keys, but zod's own defaults are plain English. Translating those
+      // blindly asks intlify for a key that cannot exist and logs a warning for every keystroke.
+      (map[path] ??= []).push(i18n.te(issue.message) ? i18n.t(issue.message) : issue.message);
     }
     return map;
   });

--- a/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.spec.ts
@@ -330,6 +330,27 @@ describe('forms/AssetMovementEventForm.vue', () => {
     expect(editHistoryEventMock).not.toHaveBeenCalled();
   });
 
+  it('should not save the event when the historic price fails to write', async () => {
+    wrapper = createWrapper({
+      props: { data: { eventsInGroup: [event], type: 'edit-group' } },
+    });
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The event itself is edited too, so the save is only held back by the failed price write and
+    // not by the unchanged-in-edit-mode short circuit.
+    await wrapper.find('[data-cy=primary] input').setValue('1000');
+    await wrapper.find('[data-cy=amount] input').setValue('250');
+
+    addHistoricalPriceMock.mockRejectedValueOnce(new Error('price rejected'));
+
+    const saved = await wrapper.vm.save();
+    await nextTick();
+
+    expect(addHistoricalPriceMock).toHaveBeenCalled();
+    expect(editHistoryEventMock).not.toHaveBeenCalled();
+    expect(saved).toBe(false);
+  });
+
   it('should call editHistoryEvent when editing an event', async () => {
     wrapper = createWrapper({
       props: { data: { eventsInGroup: [event], type: 'edit-group' } },

--- a/frontend/app/src/modules/history/management/forms/common/EventLocationLabel.vue
+++ b/frontend/app/src/modules/history/management/forms/common/EventLocationLabel.vue
@@ -23,6 +23,18 @@ const { getAddressName } = useAddressNameResolution();
 
 const chain = computed<string | undefined>(() => matchChain(location));
 
+/**
+ * Clearing the autocomplete emits `undefined`, but the form state types this field as a string and
+ * validates it as one. Normalise on the way out so a cleared field reads as empty rather than
+ * missing.
+ */
+const label = computed<string | undefined>({
+  get: () => get(modelValue),
+  set: (value: string | undefined) => {
+    set(modelValue, value ?? '');
+  },
+});
+
 const addressSuggestions = computed<string[]>(() => {
   const matched = get(chain);
   if (!matched)
@@ -53,7 +65,7 @@ function filterAddress(item: string, queryText: string): boolean {
 
 <template>
   <RuiAutoComplete
-    v-model="modelValue"
+    v-model="label"
     :options="addressSuggestions"
     :filter="filterAddress"
     clearable


### PR DESCRIPTION
Three small follow-ups to #12753, both fixes found by using the forms in the app.

## 1. Zod's own messages were being translated

`useForm` resolves every schema message through `t()`, which is right for our
messages because they carry i18n keys. A rule with no custom message falls back to
zod's English default ("Invalid input: expected string, received undefined"), and
handing that to `t()` asks intlify for a key that cannot exist:

```
use-form.ts:155 [intlify] Not found 'Invalid input: expected string, received undefined' key in 'en' locale messages.
```

One warning per keystroke, and the user sees the raw message. Now only messages that
actually resolve are translated.

The spec for this lives in its own file: the global `vue-i18n` mock returns the key
from both `t` and `te`, which cannot tell a translated key apart from an untranslated
message, so this needs its own mock.

## 2. A cleared location label wrote `undefined`

Clearing `EventLocationLabel`'s autocomplete emits `undefined`, but the form state
types that field as a string and validates it with `z.string()`. Clearing it therefore
produced zod's type-error default instead of the field's own message — and that is
what surfaced the bug above. Normalised at the component, since its own model is
declared `string`.

## 3. A test for the price-write guard

`use-history-event-form.ts` refuses to save the event when the historic price write
fails. Both halves were covered, never the guard between them. The test fails if the
guard is replaced with a bare `await persistPrices()`.

## Testing

`src/modules/core/form/` + `src/modules/history/management/forms/`: 29 files / 317
tests pass. typecheck clean; lint 0 errors, warnings at develop's baseline. The same
three changes ran green through the full history e2e spec (30/30) before #12753 merged.