### PR TITLE
Serve a public /health endpoint on the starling proxy

### DIFF
--- a/crates/starling-core/src/control/controller.rs
+++ b/crates/starling-core/src/control/controller.rs
@@ -58,20 +58,42 @@ pub struct ControllerSnapshot {
 }
 
 impl ControllerSnapshot {
-    /// The minimal boolean health safe for the public surface (§S3): `ok` once
-    /// every service is `Ready`, `degraded` if any has failed or degraded while
-    /// the supervisor is still alive to answer.
+    /// The minimal boolean health safe for the public surface (§S3).
+    ///
+    /// `ok` means "serving": every autostarted service is `Ready`, or is
+    /// `Degraded`, which by definition is a service the tree keeps running
+    /// without (today only `mcp`, whose `OnCrash` is `ReportOnly`). Treating that
+    /// as not-ok would have a container marked unhealthy — and restarted — over
+    /// an optional service, while rotki itself served every request fine.
+    ///
+    /// `degraded` means "something that should be up is down": a service is dead
+    /// (`Degraded`/`Failed`) or bouncing (`Restarting`). Those three states are
+    /// only reachable by a service that was actually started, which is what makes
+    /// this "down" rather than "not enabled" — a service nobody started is `Idle`
+    /// and one deliberately stopped is `Stopped`, and neither is a complaint.
+    /// Note that it is therefore **not** filtered by `autostart`: an optional
+    /// service started by hand and since dead is exactly the case this reports.
+    ///
+    /// The two flags are independent, and the pair is what separates a tree in
+    /// trouble (`false`/`true`) from one merely still starting (`false`/`false`).
+    ///
+    /// core and colibri carry the default `ExitSupervisor` policy, so their death
+    /// ends the supervisor and this endpoint stops answering entirely rather than
+    /// reporting on it.
     pub fn health(&self) -> HealthResult {
-        let autostart_services = self.services.iter().filter(|service| service.autostart);
-        let ok = autostart_services.clone().next().is_some()
-            && autostart_services
-                .clone()
-                .all(|service| service.state == ServiceState::Ready);
-        let degraded = self
+        let mut autostart = self
             .services
             .iter()
             .filter(|service| service.autostart)
-            .any(|s| matches!(s.state, ServiceState::Failed | ServiceState::Degraded));
+            .peekable();
+        let ok = autostart.peek().is_some()
+            && autostart.all(|s| matches!(s.state, ServiceState::Ready | ServiceState::Degraded));
+        let degraded = self.services.iter().any(|s| {
+            matches!(
+                s.state,
+                ServiceState::Degraded | ServiceState::Failed | ServiceState::Restarting
+            )
+        });
         HealthResult { ok, degraded }
     }
 
@@ -529,14 +551,18 @@ impl<S: Spawner> Controller<S> {
                                     policy.on_crash,
                                     OnCrash::Restart | OnCrash::RestartOrReport
                                 ) {
+                                    // `ReportOnly`: it is staying down and the tree
+                                    // carries on, which is `Degraded`, not `Failed`.
+                                    self.degrade(&service);
                                     continue;
                                 }
                                 if policy.max_retries == 0 {
                                     if policy.on_crash == OnCrash::RestartOrReport {
                                         error!(
                                             service,
-                                            "restart policy has no attempts; leaving service failed",
+                                            "restart policy has no attempts; leaving service degraded",
                                         );
+                                        self.degrade(&service);
                                         continue;
                                     }
                                     error!(service, "restart policy has no attempts");
@@ -588,8 +614,9 @@ impl<S: Spawner> Controller<S> {
                                         error!(
                                             service,
                                             max_retries = policy.max_retries,
-                                            "restart attempts exhausted; leaving service failed",
+                                            "restart attempts exhausted; leaving service degraded",
                                         );
+                                        self.degrade(&service);
                                         continue;
                                     }
                                     error!(
@@ -881,6 +908,18 @@ impl<S: Spawner> Controller<S> {
     }
 
     /// Emit a `crashed` event per newly-dead service, carrying its last error.
+    /// Move a crashed service the tree survives without from `Failed` to
+    /// `Degraded`, and republish so the health surface sees it. The crash was
+    /// already logged and emitted by the caller; this only records that we are
+    /// done reacting to it.
+    fn degrade(&mut self, service: &str) {
+        if let Err(err) = self.supervisor.mark_degraded(service) {
+            error!(service, %err, "failed to mark crashed service degraded");
+            return;
+        }
+        self.publish();
+    }
+
     fn emit_crashes(&self, dead: &[String]) {
         for status in self.supervisor.status() {
             if dead.contains(&status.name) {
@@ -1050,6 +1089,62 @@ mod tests {
                 .depends_on("core")
                 .readiness(Readiness::Immediate),
         ]
+    }
+
+    fn snapshot_of(services: &[(ServiceState, bool)]) -> ControllerSnapshot {
+        ControllerSnapshot {
+            services: services
+                .iter()
+                .enumerate()
+                .map(|(index, (state, autostart))| ServiceStatus {
+                    name: format!("service-{index}"),
+                    state: *state,
+                    pid: None,
+                    restarts: 0,
+                    last_error: None,
+                    autostart: *autostart,
+                })
+                .collect(),
+            started_at: None,
+            proxy_url: None,
+        }
+    }
+
+    #[test]
+    fn health_separates_serving_from_troubled_from_starting() {
+        use ServiceState::{Degraded, Failed, Idle, Ready, Restarting, Stopped, WaitingReady};
+
+        /// `(services as (state, autostart), expected ok, expected degraded)`.
+        type Case = (&'static [(ServiceState, bool)], bool, bool);
+
+        let cases: [Case; 10] = [
+            // Nothing configured is not "healthy" — an empty tree serves nothing.
+            (&[], false, false),
+            (&[(Ready, true), (Ready, true)], true, false),
+            // Still coming up: not ready, but nothing is wrong yet. This is the
+            // case a readiness gate must not confuse with a broken tree.
+            (&[(Ready, true), (WaitingReady, true)], false, false),
+            // An optional service down for good: still serving, but say so.
+            (&[(Ready, true), (Degraded, true)], true, true),
+            // Dead and awaiting a retry, or bouncing: not serving right now.
+            (&[(Ready, true), (Failed, true)], false, true),
+            (&[(Ready, true), (Restarting, true)], false, true),
+            // Disabled (mcp with `mcp_autostart` off) is `Idle`, and deliberately
+            // stopped is `Stopped`. Neither is "down" — nothing should be running.
+            (&[(Ready, true), (Idle, false)], true, false),
+            (&[(Ready, true), (Stopped, false)], true, false),
+            // But an optional service that WAS started and has since died is down
+            // when it should be up, so it is reported even though it is not
+            // autostarted and does not hold `ok` back.
+            (&[(Ready, true), (Degraded, false)], true, true),
+            (&[(Ready, true), (Failed, false)], true, true),
+        ];
+
+        for (services, ok, degraded) in cases {
+            let health = snapshot_of(services).health();
+            assert_eq!(health.ok, ok, "ok for {services:?}");
+            assert_eq!(health.degraded, degraded, "degraded for {services:?}");
+        }
     }
 
     fn specs_with_optional_mcp() -> Vec<ServiceSpec> {
@@ -1762,7 +1857,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn exhausted_mcp_restarts_leave_only_mcp_failed() {
+    async fn exhausted_mcp_restarts_leave_only_mcp_degraded() {
         let spawner = TestSpawner::new();
         let mut services = specs_with_optional_mcp();
         let mcp = services
@@ -1803,7 +1898,7 @@ mod tests {
                         let status = status_handle.status(Transport::Stdio).unwrap();
                         if status.services.iter().any(|service| {
                             service.name == "mcp"
-                                && service.state == ServiceState::Failed
+                                && service.state == ServiceState::Degraded
                                 && service.restarts == 3
                         }) {
                             break;
@@ -1825,6 +1920,14 @@ mod tests {
             .iter()
             .filter(|service| service.name != "mcp")
             .all(|service| service.state == ServiceState::Ready));
+
+        // The whole point of `Degraded`: with an optional service down for good,
+        // the tree is still serving, so health stays `ok` and says why it is not
+        // clean. Reporting `ok: false` here would have a container restarted over
+        // a service rotki does not need to answer requests.
+        let health = handle.health(Transport::PublicHealth).unwrap();
+        assert!(health.ok, "an optional service being down is still serving");
+        assert!(health.degraded, "but it is not a clean bill of health");
     }
 
     #[tokio::test]
@@ -1868,7 +1971,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn zero_mcp_restart_attempts_leave_service_failed() {
+    async fn zero_mcp_restart_attempts_leave_service_degraded() {
         let spawner = TestSpawner::new();
         let mut services = specs_with_optional_mcp();
         let mcp = services
@@ -1907,7 +2010,7 @@ mod tests {
                     loop {
                         let status = status_handle.status(Transport::Stdio).unwrap();
                         if status.services.iter().any(|service| {
-                            service.name == "mcp" && service.state == ServiceState::Failed
+                            service.name == "mcp" && service.state == ServiceState::Degraded
                         }) {
                             break;
                         }
@@ -1931,7 +2034,7 @@ mod tests {
                 .find(|service| service.name == "mcp")
                 .unwrap()
                 .state,
-            ServiceState::Failed,
+            ServiceState::Degraded,
         );
     }
 

--- a/crates/starling-core/src/control/controller.rs
+++ b/crates/starling-core/src/control/controller.rs
@@ -553,7 +553,7 @@ impl<S: Spawner> Controller<S> {
                                 ) {
                                     // `ReportOnly`: it is staying down and the tree
                                     // carries on, which is `Degraded`, not `Failed`.
-                                    self.degrade(&service);
+                                    self.degrade(&service).await;
                                     continue;
                                 }
                                 if policy.max_retries == 0 {
@@ -562,7 +562,7 @@ impl<S: Spawner> Controller<S> {
                                             service,
                                             "restart policy has no attempts; leaving service degraded",
                                         );
-                                        self.degrade(&service);
+                                        self.degrade(&service).await;
                                         continue;
                                     }
                                     error!(service, "restart policy has no attempts");
@@ -616,7 +616,7 @@ impl<S: Spawner> Controller<S> {
                                             max_retries = policy.max_retries,
                                             "restart attempts exhausted; leaving service degraded",
                                         );
-                                        self.degrade(&service);
+                                        self.degrade(&service).await;
                                         continue;
                                     }
                                     error!(
@@ -912,8 +912,8 @@ impl<S: Spawner> Controller<S> {
     /// `Degraded`, and republish so the health surface sees it. The crash was
     /// already logged and emitted by the caller; this only records that we are
     /// done reacting to it.
-    fn degrade(&mut self, service: &str) {
-        if let Err(err) = self.supervisor.mark_degraded(service) {
+    async fn degrade(&mut self, service: &str) {
+        if let Err(err) = self.supervisor.mark_degraded(service, self.grace).await {
             error!(service, %err, "failed to mark crashed service degraded");
             return;
         }

--- a/crates/starling-core/src/lifecycle.rs
+++ b/crates/starling-core/src/lifecycle.rs
@@ -204,20 +204,28 @@ impl<S: Spawner> Supervisor<S> {
         self.start_one(name).await
     }
 
-    /// Mark a crashed service as `Degraded`: dead, and staying that way because
-    /// its policy says the tree carries on without it.
+    /// Mark a service as `Degraded`: down, and staying that way because its
+    /// policy says the tree carries on without it.
     ///
-    /// The process handle is dropped along with the state, which is load-bearing:
-    /// [`poll_exits`](Self::poll_exits) re-reports any service it finds exited, so
-    /// a `Degraded` service that kept its handle would be rediscovered as newly
-    /// dead on every poll tick, forever.
-    pub fn mark_degraded(&mut self, name: &str) -> Result<()> {
-        let rt = self
-            .services
+    /// It stops the service first, because it cannot assume the process is
+    /// already gone. `RestartOrReport` also exhausts its attempts on a *readiness
+    /// timeout*, and that path leaves the last spawn **running** (`start_one`
+    /// records `Failed` without touching the process). Reporting a service as
+    /// down while its process still runs would leave it unwatched, holding its
+    /// port.
+    ///
+    /// Stopping goes through [`stop_one`](Self::stop_one) for the tree-aware
+    /// terminate → drain → kill path. Simply dropping the handle instead would
+    /// fall back to `kill_on_drop` (`process.rs`), which signals only the direct
+    /// child — for a service started through a launcher (`uv run …`) that strands
+    /// every descendant, which is the whole reason the supervisor tracks trees.
+    /// An already-exited process makes this a no-op.
+    pub async fn mark_degraded(&mut self, name: &str, grace: Duration) -> Result<()> {
+        self.stop_one(name, Instant::now() + grace).await?;
+        self.services
             .get_mut(name)
-            .ok_or_else(|| SupervisorError::NotFound(name.to_string()))?;
-        rt.state = ServiceState::Degraded;
-        rt.process.take();
+            .ok_or_else(|| SupervisorError::NotFound(name.to_string()))?
+            .state = ServiceState::Degraded;
         Ok(())
     }
 
@@ -1139,13 +1147,44 @@ mod tests {
         assert_eq!(sup.poll_exits().await.unwrap(), vec!["core"]);
 
         // Once the crash has been reacted to, every later tick must stay quiet:
-        // the process is gone for good, so a `Degraded` service that still held
-        // its handle would be rediscovered as newly dead forever.
-        sup.mark_degraded("core").unwrap();
+        // `poll_exits` only reports a service that was `Ready`, so an
+        // already-known-dead one is never rediscovered as newly dead.
+        sup.mark_degraded("core", Duration::from_secs(1))
+            .await
+            .unwrap();
         assert_eq!(sup.status()[0].state, ServiceState::Degraded);
         assert!(sup.poll_exits().await.unwrap().is_empty());
         assert!(sup.poll_exits().await.unwrap().is_empty());
         assert_eq!(sup.status()[0].state, ServiceState::Degraded);
+    }
+
+    #[tokio::test]
+    async fn degrading_a_still_running_service_stops_its_tree() {
+        // `RestartOrReport` also gives up on a *readiness timeout*, and that path
+        // leaves the last spawn running. Degrading it must go through the
+        // tree-aware stop: dropping the handle would fall back to
+        // `kill_on_drop`, which signals the direct child only and strands a
+        // launcher's descendants.
+        let log: EventLog = Arc::new(Mutex::new(Vec::new()));
+        let specs = vec![spec("core", &[])];
+        let mut sup = Supervisor::new(MockSpawner::new(log.clone()), specs).unwrap();
+        sup.start_all().await.unwrap();
+        assert!(
+            sup.status()[0].pid.is_some(),
+            "the process is still running"
+        );
+
+        sup.mark_degraded("core", Duration::from_secs(1))
+            .await
+            .unwrap();
+
+        assert!(
+            log.lock().unwrap().iter().any(|e| e == "terminate:core"),
+            "a live process must be terminated, not dropped: {:?}",
+            log.lock().unwrap(),
+        );
+        assert_eq!(sup.status()[0].state, ServiceState::Degraded);
+        assert!(sup.status()[0].pid.is_none(), "and its handle released");
     }
 
     #[tokio::test]
@@ -1157,7 +1196,9 @@ mod tests {
         sup.start_all().await.unwrap();
         sup.shutdown_one_for_test("mcp").await;
         sup.poll_exits().await.unwrap();
-        sup.mark_degraded("mcp").unwrap();
+        sup.mark_degraded("mcp", Duration::from_secs(1))
+            .await
+            .unwrap();
 
         // `Degraded` is a dead service, so the manual control that exists for the
         // optional services has to accept it as startable.

--- a/crates/starling-core/src/lifecycle.rs
+++ b/crates/starling-core/src/lifecycle.rs
@@ -22,10 +22,18 @@ use crate::readiness::probe_once;
 /// The per-service state machine:
 ///
 /// ```text
-/// Idle → Spawning → WaitingReady → Ready → (Degraded ⇄ Restarting) → Stopping → Stopped
-///                        │
+/// Idle → Spawning → WaitingReady → Ready → (Failed ⇄ Restarting) → Stopping → Stopped
+///                        │            │
+///                        │            └─ crashed, policy says do not restart → Degraded
 ///                        └─ ping-gate fails / exits early → Failed
 /// ```
+///
+/// `Failed` and `Degraded` are both "dead", and differ only in what the policy
+/// says to do about it: `Failed` is on its way to a restart or to taking the
+/// supervisor down, while `Degraded` is a service the tree is expected to keep
+/// running without ([`OnCrash::ReportOnly`], or `RestartOrReport` once its
+/// attempts are spent). The distinction is what lets the public health endpoint
+/// answer "up, minus an optional service" instead of "down".
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub enum ServiceState {
@@ -178,7 +186,10 @@ impl<S: Spawner> Supervisor<S> {
         }
         if !matches!(
             rt.state,
-            ServiceState::Idle | ServiceState::Stopped | ServiceState::Failed
+            ServiceState::Idle
+                | ServiceState::Stopped
+                | ServiceState::Failed
+                | ServiceState::Degraded
         ) {
             return Err(SupervisorError::AlreadyRunning(name.to_string()));
         }
@@ -191,6 +202,23 @@ impl<S: Spawner> Supervisor<S> {
             }
         }
         self.start_one(name).await
+    }
+
+    /// Mark a crashed service as `Degraded`: dead, and staying that way because
+    /// its policy says the tree carries on without it.
+    ///
+    /// The process handle is dropped along with the state, which is load-bearing:
+    /// [`poll_exits`](Self::poll_exits) re-reports any service it finds exited, so
+    /// a `Degraded` service that kept its handle would be rediscovered as newly
+    /// dead on every poll tick, forever.
+    pub fn mark_degraded(&mut self, name: &str) -> Result<()> {
+        let rt = self
+            .services
+            .get_mut(name)
+            .ok_or_else(|| SupervisorError::NotFound(name.to_string()))?;
+        rt.state = ServiceState::Degraded;
+        rt.process.take();
+        Ok(())
     }
 
     /// Restart a service already marked `Failed` by the crash poll.
@@ -321,10 +349,10 @@ impl<S: Spawner> Supervisor<S> {
             if name == gating {
                 continue;
             }
-            // Only services that got up: the ones after this in the graph are
-            // still `Idle` and have no process yet.
-            let state = self.services[name].state;
-            if !matches!(state, ServiceState::Ready | ServiceState::Degraded) {
+            // Only services that got up and are still up: the ones after this in
+            // the graph are still `Idle` and have no process yet, and a `Degraded`
+            // one is already known to be dead.
+            if self.services[name].state != ServiceState::Ready {
                 continue;
             }
             if self.process_exited(name).await? {
@@ -390,7 +418,9 @@ impl<S: Spawner> Supervisor<S> {
                 continue;
             }
             let rt = self.services.get_mut(&name).expect("service exists");
-            if rt.state == ServiceState::Ready || rt.state == ServiceState::Degraded {
+            // `Ready` only: a `Degraded` service is already-known-dead, and
+            // re-reporting it here would re-emit its crash on every tick.
+            if rt.state == ServiceState::Ready {
                 let info = match &rt.process {
                     Some(p) => p.try_status().await.ok().flatten(),
                     None => None,
@@ -437,12 +467,13 @@ impl<S: Spawner> Supervisor<S> {
         if let Some(dependent) = self.order.iter().find(|candidate| {
             let rt = &self.services[*candidate];
             rt.spec.deps.iter().any(|dependency| dependency == name)
+                // A `Degraded` dependent is dead, so it needs nothing kept alive
+                // on its behalf.
                 && matches!(
                     rt.state,
                     ServiceState::Spawning
                         | ServiceState::WaitingReady
                         | ServiceState::Ready
-                        | ServiceState::Degraded
                         | ServiceState::Restarting
                 )
         }) {
@@ -1095,6 +1126,43 @@ mod tests {
             "a tree that outlasts the grace must be force-killed: {events:?}",
         );
         assert_eq!(sup.status()[0].state, ServiceState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn a_degraded_service_is_not_re_reported_as_newly_dead() {
+        let log: EventLog = Arc::new(Mutex::new(Vec::new()));
+        let specs = vec![spec("core", &[])];
+        let mut sup = Supervisor::new(MockSpawner::new(log), specs).unwrap();
+        sup.start_all().await.unwrap();
+
+        sup.shutdown_one_for_test("core").await;
+        assert_eq!(sup.poll_exits().await.unwrap(), vec!["core"]);
+
+        // Once the crash has been reacted to, every later tick must stay quiet:
+        // the process is gone for good, so a `Degraded` service that still held
+        // its handle would be rediscovered as newly dead forever.
+        sup.mark_degraded("core").unwrap();
+        assert_eq!(sup.status()[0].state, ServiceState::Degraded);
+        assert!(sup.poll_exits().await.unwrap().is_empty());
+        assert!(sup.poll_exits().await.unwrap().is_empty());
+        assert_eq!(sup.status()[0].state, ServiceState::Degraded);
+    }
+
+    #[tokio::test]
+    async fn a_degraded_service_can_be_started_again() {
+        let log: EventLog = Arc::new(Mutex::new(Vec::new()));
+        let mut spec = spec("mcp", &[]);
+        spec.allow_manual_control = true;
+        let mut sup = Supervisor::new(MockSpawner::new(log), vec![spec]).unwrap();
+        sup.start_all().await.unwrap();
+        sup.shutdown_one_for_test("mcp").await;
+        sup.poll_exits().await.unwrap();
+        sup.mark_degraded("mcp").unwrap();
+
+        // `Degraded` is a dead service, so the manual control that exists for the
+        // optional services has to accept it as startable.
+        sup.start_service("mcp").await.unwrap();
+        assert_eq!(sup.status()[0].state, ServiceState::Ready);
     }
 
     #[tokio::test]

--- a/crates/starling-proxy/src/lib.rs
+++ b/crates/starling-proxy/src/lib.rs
@@ -11,6 +11,7 @@
 //! | `/ws/*`      | `core` (127.0.0.1:4242)   | preserved + WS upgrade |
 //! | `/colibri/*` | `colibri` (127.0.0.1:4343)| prefix **stripped**    |
 //! | `/mcp`       | `mcp` (127.0.0.1:4445)    | preserved              |
+//! | `/health`    | served here               | supervisor liveness    |
 //! | everything   | static SPA on disk        | SPA fallback to index  |
 //!
 //! Unlike nginx, the proxy **streams** request/response bodies without buffering,
@@ -40,7 +41,7 @@ use axum::{
     http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri},
     middleware::{from_fn, from_fn_with_state, Next},
     response::{IntoResponse, Response},
-    routing::any,
+    routing::{any, get},
     Router,
 };
 
@@ -97,6 +98,45 @@ const MAX_CONCURRENT_CONNECTIONS: usize = 1024;
 /// never cut off. `/ws` is exempt (it carries no request body).
 const BODY_READ_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// The public, unauthenticated view of the supervised tree: two booleans and
+/// nothing else. Deliberately not the detailed status — pids, per-service state
+/// and `lastError` stay on the authenticated control surfaces (§S3), because
+/// this one answers anyone who can reach the published port.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Health {
+    /// True once every autostarted service is ready.
+    pub ok: bool,
+    /// True if any of them has failed or is restarting while the supervisor is
+    /// still alive to answer.
+    pub degraded: bool,
+}
+
+/// Reads the current [`Health`] on demand. Boxed rather than typed as the
+/// supervisor's control handle so this crate keeps its independence from
+/// `starling-core`, the same arrangement the access log's probe agent uses.
+#[derive(Clone)]
+pub struct HealthProbe(Arc<dyn Fn() -> Health + Send + Sync>);
+
+impl HealthProbe {
+    /// Wrap a closure reading the supervisor's health.
+    pub fn new<F>(probe: F) -> Self
+    where
+        F: Fn() -> Health + Send + Sync + 'static,
+    {
+        Self(Arc::new(probe))
+    }
+
+    fn read(&self) -> Health {
+        (self.0)()
+    }
+}
+
+impl std::fmt::Debug for HealthProbe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("HealthProbe(..)")
+    }
+}
+
 /// Where to bind and what to proxy to.
 #[derive(Clone, Debug)]
 pub struct ProxyConfig {
@@ -126,6 +166,10 @@ pub struct ProxyConfig {
     /// is passed in rather than imported so this crate keeps its independence
     /// from `starling-core`, which owns the probe.
     pub access_log: access_log::AccessLog,
+    /// Source for the public `/health` endpoint. `None` leaves the route
+    /// unregistered entirely, so a config that cannot answer honestly serves a
+    /// 404 rather than a hardcoded "fine".
+    pub health: Option<HealthProbe>,
 }
 
 /// A pooled HTTP/1 client whose request body is the same streaming `Body` axum
@@ -139,6 +183,7 @@ struct ProxyState {
     colibri_addr: String,
     mcp_addr: String,
     mcp_enabled: bool,
+    health: Option<HealthProbe>,
 }
 
 /// Bind the proxy listener on `host`. Done before serving so a bind failure
@@ -270,6 +315,7 @@ fn router(config: &ProxyConfig) -> Router {
         colibri_addr: format!("127.0.0.1:{}", config.colibri_port),
         mcp_addr: format!("127.0.0.1:{}", config.mcp_port),
         mcp_enabled: config.mcp_enabled,
+        health: config.health.clone(),
     };
 
     // nginx `location /prefix/` is a prefix match that also matches the bare
@@ -309,6 +355,17 @@ fn router(config: &ProxyConfig) -> Router {
         .route("/ws", any(proxy_ws))
         .route("/ws/", any(proxy_ws))
         .route("/ws/{*rest}", any(proxy_ws));
+
+    // The public health endpoint, answered here rather than proxied: it reports
+    // on the *supervisor's* view of the tree, which no backend can speak for.
+    // Registered only when a probe was supplied, and after the body layers above
+    // (it takes no request body, and the ceilings stay scoped to the proxied
+    // routes). It precedes the SPA fallback, so in docker `/health` is the
+    // endpoint and not the index page.
+    let routes = match &config.health {
+        Some(_) => routes.route("/health", get(health)),
+        None => routes,
+    };
 
     // SPA static serving with history-mode fallback: unknown paths return
     // index.html so client-side routing works (mirrors nginx `try_files`).
@@ -440,6 +497,41 @@ fn is_fingerprinted(file: &str) -> bool {
     bytes[dot - 8..dot]
         .iter()
         .all(|&b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+/// `GET /health` → the supervisor's boolean health, served by the proxy itself.
+///
+/// `200` once the tree is up, `503` while it is still coming up or after a
+/// service has died, which is the contract a container `HEALTHCHECK` and a test
+/// harness's readiness gate both want: the listener answers from the moment it
+/// binds, but it does not claim readiness until the supervisor has it. `degraded`
+/// rides along for a tree that is answering but has a service down.
+///
+/// The body is written by hand instead of via `serde_json` to keep that
+/// dependency out of the crate's build for two booleans.
+async fn health(State(state): State<ProxyState>) -> Response {
+    // Unreachable while the route is registered only alongside a probe; kept
+    // total so a future caller cannot turn a missing probe into a claim of
+    // health.
+    let Some(probe) = state.health.as_ref() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let Health { ok, degraded } = probe.read();
+    let status = if ok {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (
+        status,
+        [
+            (header::CONTENT_TYPE, "application/json"),
+            // A cached health answer is a wrong health answer.
+            (header::CACHE_CONTROL, "no-store"),
+        ],
+        format!("{{\"ok\":{ok},\"degraded\":{degraded}}}"),
+    )
+        .into_response()
 }
 
 /// `/api/1/*` → core, path preserved.
@@ -817,6 +909,7 @@ mod tests {
             frontend_dir: None,
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
         let resp = app
             .oneshot(
@@ -890,6 +983,132 @@ mod tests {
         String::from_utf8(bytes.to_vec()).unwrap()
     }
 
+    /// A proxy pointed at no backends, configured with a fixed health answer.
+    fn health_router(health: Option<Health>, frontend_dir: Option<PathBuf>) -> Router {
+        router(&ProxyConfig {
+            port: 0,
+            core_port: 1,
+            colibri_port: 1,
+            mcp_port: 1,
+            mcp_enabled: true,
+            frontend_dir,
+            max_body_bytes: 50 * 1024 * 1024,
+            access_log: Default::default(),
+            health: health.map(|health| HealthProbe::new(move || health)),
+        })
+    }
+
+    async fn get_health(app: Router) -> Response {
+        app.oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn health_is_200_when_the_tree_is_up() {
+        let resp = get_health(health_router(
+            Some(Health {
+                ok: true,
+                degraded: false,
+            }),
+            None,
+        ))
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
+        );
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+        assert_eq!(body_string(resp).await, r#"{"ok":true,"degraded":false}"#);
+    }
+
+    #[tokio::test]
+    async fn health_is_503_before_the_tree_is_ready() {
+        // The listener answers from the moment it binds, which is exactly why a
+        // readiness gate needs this to be a failure rather than a 200.
+        let resp = get_health(health_router(
+            Some(Health {
+                ok: false,
+                degraded: false,
+            }),
+            None,
+        ))
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body_string(resp).await, r#"{"ok":false,"degraded":false}"#);
+    }
+
+    #[tokio::test]
+    async fn health_reports_a_degraded_tree() {
+        let resp = get_health(health_router(
+            Some(Health {
+                ok: false,
+                degraded: true,
+            }),
+            None,
+        ))
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body_string(resp).await, r#"{"ok":false,"degraded":true}"#);
+    }
+
+    #[tokio::test]
+    async fn health_is_not_served_without_a_probe() {
+        let resp = get_health(health_router(None, None)).await;
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn health_wins_over_the_spa_fallback() {
+        // In docker every unknown path returns index.html, so the route has to be
+        // registered ahead of the static service or `/health` silently serves the
+        // SPA shell with a 200 — the worst possible answer for a probe.
+        let dir = unique_temp_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("index.html"), "<html>SPA</html>").unwrap();
+
+        let app = health_router(
+            Some(Health {
+                ok: true,
+                degraded: false,
+            }),
+            Some(dir.clone()),
+        );
+
+        // Negative control: an unknown path really does fall through to the SPA.
+        let spa = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/some/client/route")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(spa.status(), StatusCode::OK);
+        assert_eq!(body_string(spa).await, "<html>SPA</html>");
+
+        let resp = get_health(app).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_string(resp).await, r#"{"ok":true,"degraded":false}"#);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
     #[tokio::test]
     async fn api_path_is_preserved() {
         let port = spawn_echo_upstream().await;
@@ -902,6 +1121,7 @@ mod tests {
             frontend_dir: Some(unique_temp_dir()),
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
         let resp = app
             .oneshot(
@@ -928,6 +1148,7 @@ mod tests {
             frontend_dir: Some(unique_temp_dir()),
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
         let resp = app
             .oneshot(
@@ -982,6 +1203,7 @@ mod tests {
             frontend_dir: None,
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
 
         let response = app
@@ -1016,6 +1238,7 @@ mod tests {
             frontend_dir: None,
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
 
         let response = app
@@ -1044,6 +1267,7 @@ mod tests {
             frontend_dir: Some(unique_temp_dir()),
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
 
         let response = app
@@ -1072,6 +1296,7 @@ mod tests {
             frontend_dir: Some(dir.clone()),
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
 
         // Fingerprinted asset → immutable + security headers.
@@ -1145,6 +1370,7 @@ mod tests {
             frontend_dir: Some(dir.clone()),
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
         let resp = app
             .oneshot(
@@ -1175,6 +1401,7 @@ mod tests {
             frontend_dir: None,
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
         let resp = app
             .oneshot(
@@ -1208,6 +1435,7 @@ mod tests {
             frontend_dir: Some(dir.clone()),
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
         let resp = app
             .oneshot(
@@ -1240,6 +1468,7 @@ mod tests {
             frontend_dir: Some(unique_temp_dir()),
             max_body_bytes: 16,
             access_log: Default::default(),
+            health: None,
         });
         let resp = app
             .oneshot(
@@ -1267,6 +1496,7 @@ mod tests {
             frontend_dir: Some(unique_temp_dir()),
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         });
         let resp = app
             .oneshot(
@@ -1334,6 +1564,7 @@ mod tests {
             frontend_dir: Some(unique_temp_dir()),
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         };
         tokio::spawn(async move {
             serve(proxy_listener, config, std::future::pending::<()>())
@@ -1373,6 +1604,7 @@ mod tests {
             frontend_dir: Some(unique_temp_dir()),
             max_body_bytes: 50 * 1024 * 1024,
             access_log: Default::default(),
+            health: None,
         };
         tokio::spawn(async move {
             serve_with_header_timeout(

--- a/crates/starling-proxy/src/lib.rs
+++ b/crates/starling-proxy/src/lib.rs
@@ -1033,6 +1033,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_serving_tree_with_an_optional_service_down_is_still_200() {
+        // `ok` and `degraded` are independent: an optional service being dead is
+        // reported, but it must not fail the probe and get the container
+        // restarted while rotki is answering every request.
+        let resp = get_health(health_router(
+            Some(Health {
+                ok: true,
+                degraded: true,
+            }),
+            None,
+        ))
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_string(resp).await, r#"{"ok":true,"degraded":true}"#);
+    }
+
+    #[tokio::test]
     async fn health_is_503_before_the_tree_is_ready() {
         // The listener answers from the moment it binds, which is exactly why a
         // readiness gate needs this to be a failure rather than a 200.

--- a/crates/starling/src/healthcheck.rs
+++ b/crates/starling/src/healthcheck.rs
@@ -4,12 +4,21 @@
 //! start the supervisor. It reuses the core crate's hand-rolled `http_ping`
 //! (`HTTP/1.1 GET`, 200-only) so the image needs no `curl`.
 //!
-//! The default target is `http://localhost:<port>/api/1/ping`, i.e. *through*
-//! starling's own proxy, preserving entrypoint.py's full-chain semantics: the
-//! external listener is up **and** successfully proxying to core. The port is
-//! resolved the same way the server resolves it (`ROTKI_HTTP_PORT` env >
-//! `--port` > 80) so `-e ROTKI_HTTP_PORT=8080` keeps the probe and the server
-//! in agreement. Both are overridable: `--url` wins outright, else `--port`.
+//! By default it probes **two** URLs on starling's own listener and requires
+//! both:
+//!
+//! - `/health` — the supervisor's own view of the tree. This is what covers
+//!   **colibri**: a container whose colibri died answered the old probe happily,
+//!   because nothing in the chain below ever touched it.
+//! - `/api/1/ping` — the proxy actually forwarding to core, entrypoint.py's
+//!   full-chain semantics. `/health` alone cannot show this: it is answered by
+//!   the proxy itself, so a broken forward path would still report `ok`.
+//!
+//! Neither subsumes the other, hence both. The port is resolved the same way the
+//! server resolves it (`ROTKI_HTTP_PORT` env > `--port` > 80) so
+//! `-e ROTKI_HTTP_PORT=8080` keeps the probe and the server in agreement. Both
+//! are overridable: `--url` wins outright and probes that one URL alone, else
+//! `--port`.
 
 use std::time::Duration;
 
@@ -21,15 +30,18 @@ use crate::config;
 /// One-shot probe timeout (parity with `curl --fail`'s short check).
 const TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Resolve the probe URL, fire a single `GET`, and exit `0` on `200` else `1`.
+/// Resolve the probe URLs, `GET` each, and exit `0` only if every one answered
+/// `200`.
 pub async fn run(url: Option<String>, port: Option<u16>) -> std::process::ExitCode {
-    let url = match url {
-        Some(url) => url,
+    let urls = match url {
+        // An explicit `--url` is the operator saying exactly what to probe; do
+        // not silently add a second request to a target they did not name.
+        Some(url) => vec![url],
         None => {
             // Resolve the port like the server (env > --port > 80) so the probe
             // hits the same listener even when ROTKI_HTTP_PORT overrides the CMD.
             match config::resolve_port(port, true) {
-                Ok(port) => default_url(port),
+                Ok(port) => default_urls(port),
                 Err(err) => {
                     error!(%err, "invalid configuration");
                     return std::process::ExitCode::FAILURE;
@@ -38,18 +50,36 @@ pub async fn run(url: Option<String>, port: Option<u16>) -> std::process::ExitCo
         }
     };
 
-    if probe(&url).await {
-        info!(%url, "healthcheck passed");
-        std::process::ExitCode::SUCCESS
-    } else {
-        error!(%url, "healthcheck failed");
-        std::process::ExitCode::FAILURE
+    if let Some(failed) = first_failure(&urls).await {
+        error!(url = %failed, "healthcheck failed");
+        return std::process::ExitCode::FAILURE;
     }
+
+    info!(urls = urls.join(" "), "healthcheck passed");
+    std::process::ExitCode::SUCCESS
 }
 
-/// The full-chain probe URL through starling's own proxy for a given port.
-fn default_url(port: u16) -> String {
-    format!("http://localhost:{port}/api/1/ping")
+/// Probe each URL in turn, returning the first that did not answer `200`.
+///
+/// Sequential and short-circuiting: a healthy container pays two sub-millisecond
+/// loopback requests, and an unhealthy one names the first thing that failed
+/// instead of a generic "unhealthy".
+async fn first_failure(urls: &[String]) -> Option<&String> {
+    for url in urls {
+        if !probe(url).await {
+            return Some(url);
+        }
+    }
+    None
+}
+
+/// The default probe URLs on starling's own listener: supervisor health first
+/// (it fails earliest during bring-up), then the full chain through to core.
+fn default_urls(port: u16) -> Vec<String> {
+    vec![
+        format!("http://localhost:{port}/health"),
+        format!("http://localhost:{port}/api/1/ping"),
+    ]
 }
 
 /// A single 200-only probe with the one-shot timeout.
@@ -63,10 +93,27 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
+    /// One of the default URLs, for the probe tests that only need a target.
+    fn health_url(port: u16) -> String {
+        default_urls(port).swap_remove(0)
+    }
+
     #[test]
-    fn default_url_targets_ping_through_proxy() {
-        assert_eq!(default_url(80), "http://localhost:80/api/1/ping");
-        assert_eq!(default_url(8080), "http://localhost:8080/api/1/ping");
+    fn default_urls_cover_the_supervisor_and_the_full_chain() {
+        assert_eq!(
+            default_urls(80),
+            [
+                "http://localhost:80/health",
+                "http://localhost:80/api/1/ping"
+            ]
+        );
+        assert_eq!(
+            default_urls(8080),
+            [
+                "http://localhost:8080/health",
+                "http://localhost:8080/api/1/ping"
+            ]
+        );
     }
 
     async fn serve_one(listener: TcpListener, response: &'static [u8]) {
@@ -80,7 +127,7 @@ mod tests {
     #[tokio::test]
     async fn probe_true_on_200() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let url = default_url(listener.local_addr().unwrap().port());
+        let url = health_url(listener.local_addr().unwrap().port());
         let handle = tokio::spawn(serve_one(
             listener,
             b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
@@ -92,7 +139,7 @@ mod tests {
     #[tokio::test]
     async fn probe_false_on_500() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let url = default_url(listener.local_addr().unwrap().port());
+        let url = health_url(listener.local_addr().unwrap().port());
         let handle = tokio::spawn(serve_one(
             listener,
             b"HTTP/1.1 500 Internal Server Error\r\n\r\n",
@@ -102,10 +149,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_single_failing_url_fails_the_whole_check() {
+        // The point of probing two URLs: a container answering `/api/1/ping`
+        // perfectly is still unhealthy if `/health` says a service is down.
+        let unhealthy = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let healthy = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let unhealthy_url = health_url(unhealthy.local_addr().unwrap().port());
+        let healthy_url = health_url(healthy.local_addr().unwrap().port());
+        let served = tokio::spawn(serve_one(
+            unhealthy,
+            b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+        ));
+
+        // The failing URL is named, and the check short-circuits: the second
+        // listener is never accepted from, so a `serve_one` for it would hang.
+        assert_eq!(
+            first_failure(&[unhealthy_url.clone(), healthy_url]).await,
+            Some(&unhealthy_url)
+        );
+        served.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn probe_false_when_nothing_listens() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
-        assert!(!probe(&default_url(port)).await);
+        assert!(!probe(&health_url(port)).await);
     }
 }

--- a/crates/starling/src/main.rs
+++ b/crates/starling/src/main.rs
@@ -31,7 +31,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use clap::{Parser, Subcommand, ValueEnum};
 use starling_core::{
     build_services, Controller, Launcher, OnCrash, OsSpawner, Outcome, RestartPolicy,
-    ServiceLayout, ServiceSpec, Startup, StdioMode, Supervisor,
+    ServiceLayout, ServiceSpec, Startup, StdioMode, Supervisor, Transport,
 };
 use starling_proxy::ProxyConfig;
 use std::sync::Arc;
@@ -810,6 +810,29 @@ async fn main() -> std::process::ExitCode {
     // Serve the SPA + reverse-proxy on the already-bound listener.
     let proxy = if let Some((listener, port)) = bound {
         controller.set_proxy_url(Some(format!("http://127.0.0.1:{port}")));
+        // The public `/health` endpoint reads the supervisor's own view of the
+        // tree through the ordinary control handle, on the public-health
+        // transport — so the §S9 matrix gates it exactly as it gates every other
+        // surface, and this route can never widen to `status`. An authorization
+        // error is impossible for `health` there, but it is reported as unhealthy
+        // rather than unwrapped: a health endpoint must not be able to panic the
+        // supervisor.
+        let health_handle = controller.handle();
+        let health = starling_proxy::HealthProbe::new(move || {
+            match health_handle.health(Transport::PublicHealth) {
+                Ok(health) => starling_proxy::Health {
+                    ok: health.ok,
+                    degraded: health.degraded,
+                },
+                Err(err) => {
+                    error!(%err, "health probe was refused by the control gate");
+                    starling_proxy::Health {
+                        ok: false,
+                        degraded: true,
+                    }
+                }
+            }
+        });
         let config = ProxyConfig {
             port,
             core_port: cli.core_port,
@@ -840,6 +863,11 @@ async fn main() -> std::process::ExitCode {
                 // entries a day and bury the real traffic.
                 probe_user_agent: Some(starling_core::PROBE_USER_AGENT.to_string()),
             },
+            // Both modes: docker's HEALTHCHECK probes it, and the e2e harness
+            // gates the suite on it (embedded starling boots idle, so a route
+            // that only answers after `start` is what tells the runner the whole
+            // tree is up, not just the listener).
+            health: Some(health),
         };
         let notify = Arc::new(Notify::new());
         let stop = notify.clone();

--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -246,10 +246,13 @@ export default defineConfig({
     },
     {
       // One supervisor brings up core and colibri and fronts both behind its
-      // proxy. The probe hits core through that proxy, so a pass means the whole
-      // tree plus the routing is live.
+      // proxy. The gate is the supervisor's own `/health`, which answers 200 only
+      // once every service has passed its readiness probe (core `/api/1/ping`,
+      // colibri `/health`). Probing core through the proxy instead let the suite
+      // start with colibri still coming up: the proxy binds and serves before the
+      // tree is brought up, so core answering says nothing about the rest.
       command: `tsx scripts/start-starling.ts --port ${PROXY_PORT} --core-port ${BACKEND_PORT} --colibri-port ${COLIBRI_PORT} --mcp-port ${MCP_PORT} --data ${dataDir} --logs ${logDir}`,
-      url: `${backendUrl}/api/1/ping`,
+      url: `${backendUrl}/health`,
       reuseExistingServer: !process.env.CI,
       // Covers a cold `cargo run` for both Rust services on a fresh checkout.
       timeout: 180_000,

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -117,10 +117,30 @@ revert on the next restart. To change configuration, recreate the container.
 HEALTHCHECK CMD ["/opt/rotki/starling", "healthcheck"]
 ```
 
-The probe goes through starling's own proxy to `/api/1/ping`, so a pass means the
-external listener is up *and* successfully reaching core. It needs no `curl`, and
-resolves `ROTKI_HTTP_PORT` the same way the server does, so a custom port keeps
-the two in agreement automatically.
+The probe checks two things on starling's own listener, and both must pass:
+
+- `/health`, the supervisor's view of the tree. It answers `200` only once every
+  service has passed its readiness probe, so a colibri that died is reported —
+  which a core-only check never saw.
+- `/api/1/ping`, through the proxy to core, so a pass also means the external
+  listener is actually routing.
+
+It needs no `curl`, and resolves `ROTKI_HTTP_PORT` the same way the server does,
+so a custom port keeps the two in agreement automatically. `--url` overrides both
+with a single target of your choosing.
+
+`/health` is also reachable directly, unauthenticated, for an external monitor:
+
+```
+$ curl -s localhost/health
+{"ok":true,"degraded":false}
+```
+
+It is `200` when every service is up and `503` otherwise, with `degraded` marking
+a tree that is answering but has a service down. It deliberately carries nothing
+else — pids, per-service state and error text stay on the authenticated control
+socket (`starling ctl status`), since anything on the published port is readable
+by whoever can reach it.
 
 ## Logs
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -136,11 +136,27 @@ $ curl -s localhost/health
 {"ok":true,"degraded":false}
 ```
 
-It is `200` when every service is up and `503` otherwise, with `degraded` marking
-a tree that is answering but has a service down. It deliberately carries nothing
-else — pids, per-service state and error text stay on the authenticated control
-socket (`starling ctl status`), since anything on the published port is readable
-by whoever can reach it.
+The two flags are independent:
+
+| Answer | Meaning |
+|---|---|
+| `200 {"ok":true,"degraded":false}` | everything up |
+| `200 {"ok":true,"degraded":true}` | serving, but something that should be up is down |
+| `503 {"ok":false,"degraded":true}` | a service is dead or bouncing |
+| `503 {"ok":false,"degraded":false}` | still starting |
+| no answer | the container is down, or a required service took the supervisor with it |
+
+`degraded` means a service that *was* running is now down, not that a service is
+switched off: an mcp you never enabled is simply not running, and reports
+nothing.
+
+An optional service staying down keeps the container **healthy** on purpose:
+rotki answers every request without it, and failing the probe would have the
+container restarted over something it does not need.
+
+The endpoint deliberately carries nothing else — pids, per-service state and
+error text stay on the authenticated control socket (`starling ctl status`),
+since anything on the published port is readable by whoever can reach it.
 
 ## Logs
 


### PR DESCRIPTION
Adds the public `/health` endpoint the supervisor could always answer but never exposed, and wires the `Degraded` service state it depends on.

## `/health`

`Transport::PublicHealth` was already in the `authorize()` matrix with tests, and nothing constructed it; the proxy router had no such route.

`GET /health` now returns `{"ok":…,"degraded":…}` — 200 when the tree is serving, 503 otherwise, `cache-control: no-store`. The proxy answers it itself from a probe closure over the control handle, so:

- it goes through the ordinary `authorize()` gate on the public-health transport, and can never widen past the two booleans to detailed status;
- `starling-proxy` keeps its independence from `starling-core`, the same arrangement already used for the access log's probe agent.

The route is registered ahead of the SPA fallback. Without that, docker would serve `index.html` with a 200 for `/health` — the worst possible answer for a probe. There is a negative-control test for it.

## `Degraded`

`ServiceState::Degraded` was declared and read in three places but never assigned, so `degraded: true` only ever meant "a service is `Failed`", and a crashed optional service left the tree reporting `ok: false` forever. In docker that is a container marked unhealthy — and restarted — over a service rotki does not need to answer a single request.

A crashed service the tree carries on without is now marked `Degraded` (`ReportOnly`, or `RestartOrReport` once its attempts are spent). core and colibri keep the default `ExitSupervisor`, so their death still ends the supervisor rather than degrading it.

- `ok` = every autostarted service is `Ready` or `Degraded` — serving.
- `degraded` = any service is `Degraded`, `Failed` or `Restarting` — something that should be up is down.

`degraded` is deliberately not filtered by `autostart`: those three states are only reachable by a service that was actually started. An optional service started by hand and since dead counts; one that was never enabled sits in `Idle` and reports nothing. So a disabled mcp is `{ok:true,degraded:false}` and a dead one is `{ok:true,degraded:true}`, still 200.

That also separates a tree in trouble (`false`/`true`) from one merely still starting (`false`/`false`) — the case a readiness gate must not confuse with a broken tree.

Degrading a service stops it rather than assuming it is already dead. `RestartOrReport` also exhausts its attempts on a *readiness timeout*, and that path records `Failed` without touching the process, so the last spawn can still be running when the controller gives up. The stop goes through the tree-aware `terminate` -> drain -> `kill` path; dropping the handle instead would fall back to `kill_on_drop`, which signals only the direct child and strands a launcher's descendants. An already-exited process makes it a no-op, which is the common case. (Thanks @yabirgb for catching this in review.)

## Consumers

**`starling healthcheck`** now probes `/health` *and* `/api/1/ping`, requiring both. Neither subsumes the other: the ping never touched colibri, so a dead colibri passed; `/health` is answered by the proxy, so it cannot show that the forward path to core still works. `--url` still overrides with a single target.

In docker this cannot trip `--start-period`: `controller.start()` runs before the proxy binds, so the port is not open until the tree is ready. The value there is catching a colibri that dies later.

**The e2e harness** gates on `/health` instead of core's ping. In embedded mode the proxy binds and serves *before* the tree is brought up, so a core-only probe let the suite start with colibri still coming up.

## Testing

`cargo test -p starling-core -p starling -p starling-proxy` — 181 tests, clippy clean.

Verified live rather than only in unit tests. `tag-manager.spec.ts` passes 5/5 on the new gate, and polling both endpoints through one bring-up measures the gap the change closes:

```
15:35:54.817  ping=502  health=503     proxy up, nothing behind it yet
15:35:55.776  ping=200  health=503   <- the old gate released the suite here
15:35:57.674  ping=200  health=200   <- colibri actually ready, 1.9s later
```

A standalone supervisor also confirms the three-way distinction end to end: no listener, then `503 {"ok":false,"degraded":false}` while starting, then `200 {"ok":true,"degraded":false}`.

