### PR TITLE
Move the shared setting controls to zod

### DIFF
--- a/frontend/app/src/modules/assets/detection/settings/NewlyDetectedTokensMaxCountSetting.vue
+++ b/frontend/app/src/modules/assets/detection/settings/NewlyDetectedTokensMaxCountSetting.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { between, helpers, required } from '@vuelidate/validators';
 import { Constraints } from '@/modules/core/common/constraints';
+import { numberSettingSchema } from '@/modules/settings/controls/setting-field-schemas';
 import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 
 const { t } = useI18n({ useScope: 'global' });
@@ -8,25 +8,24 @@ const { t } = useI18n({ useScope: 'global' });
 const minCount = Constraints.NEWLY_DETECTED_TOKENS_MIN_COUNT;
 const maxCountLimit = Constraints.NEWLY_DETECTED_TOKENS_MAX_COUNT;
 
-const rules = {
-  value: {
-    between: helpers.withMessage(
-      t('frontend_settings.newly_detected_tokens.max_count.validation.invalid_range', {
-        max: maxCountLimit,
-        min: minCount,
-      }),
-      between(minCount, maxCountLimit),
-    ),
-    required: helpers.withMessage(t('frontend_settings.newly_detected_tokens.max_count.validation.non_empty'), required),
+const schema = numberSettingSchema({
+  max: maxCountLimit,
+  messages: {
+    between: t('frontend_settings.newly_detected_tokens.max_count.validation.invalid_range', {
+      max: maxCountLimit,
+      min: minCount,
+    }),
+    required: t('frontend_settings.newly_detected_tokens.max_count.validation.non_empty'),
   },
-};
+  min: minCount,
+});
 </script>
 
 <template>
   <SettingNumber
     class="mt-1"
     setting="newlyDetectedTokensMaxCount"
-    :rules="rules"
+    :schema="schema"
     :label="t('frontend_settings.newly_detected_tokens.max_count.label')"
     :hint="t('frontend_settings.newly_detected_tokens.max_count.hint')"
     :error-message="t('frontend_settings.newly_detected_tokens.max_count.validation.error')"

--- a/frontend/app/src/modules/assets/detection/settings/NewlyDetectedTokensTtlSetting.vue
+++ b/frontend/app/src/modules/assets/detection/settings/NewlyDetectedTokensTtlSetting.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { between, helpers, required } from '@vuelidate/validators';
 import { Constraints } from '@/modules/core/common/constraints';
+import { numberSettingSchema } from '@/modules/settings/controls/setting-field-schemas';
 import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 
 const { t } = useI18n({ useScope: 'global' });
@@ -8,25 +8,24 @@ const { t } = useI18n({ useScope: 'global' });
 const minTtlDays = Constraints.NEWLY_DETECTED_TOKENS_MIN_TTL_DAYS;
 const maxTtlDays = Constraints.NEWLY_DETECTED_TOKENS_MAX_TTL_DAYS;
 
-const rules = {
-  value: {
-    between: helpers.withMessage(
-      t('frontend_settings.newly_detected_tokens.ttl_days.validation.invalid_range', {
-        max: maxTtlDays,
-        min: minTtlDays,
-      }),
-      between(minTtlDays, maxTtlDays),
-    ),
-    required: helpers.withMessage(t('frontend_settings.newly_detected_tokens.ttl_days.validation.non_empty'), required),
+const schema = numberSettingSchema({
+  max: maxTtlDays,
+  messages: {
+    between: t('frontend_settings.newly_detected_tokens.ttl_days.validation.invalid_range', {
+      max: maxTtlDays,
+      min: minTtlDays,
+    }),
+    required: t('frontend_settings.newly_detected_tokens.ttl_days.validation.non_empty'),
   },
-};
+  min: minTtlDays,
+});
 </script>
 
 <template>
   <SettingNumber
     class="mt-1"
     setting="newlyDetectedTokensTtlDays"
-    :rules="rules"
+    :schema="schema"
     :label="t('frontend_settings.newly_detected_tokens.ttl_days.label')"
     :hint="t('frontend_settings.newly_detected_tokens.ttl_days.hint')"
     :error-message="t('frontend_settings.newly_detected_tokens.ttl_days.validation.error')"

--- a/frontend/app/src/modules/settings/controls/SettingNumber.vue
+++ b/frontend/app/src/modules/settings/controls/SettingNumber.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { WritableSettingKeyOf } from '@/modules/settings/settings-writer';
-import useVuelidate, { type ValidationArgs } from '@vuelidate/core';
-import { between, helpers, maxValue, minValue, required as requiredRule } from '@vuelidate/validators';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
+import { numberSettingSchema, SETTING_FIELD, type SettingFieldState } from '@/modules/settings/controls/setting-field-schemas';
 import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
 import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
 import { useSettingModel } from '@/modules/settings/use-setting-model';
@@ -13,7 +12,7 @@ import { useSettingModel } from '@/modules/settings/use-setting-model';
  * validation from props and persists through `useSettingModel` (debounced while typing, immediate on
  * reset). Renders only the field + optional reset button; put it inside a `SettingsItem` for the header.
  * For settings whose validation is not min/max/required (single-character, cross-field, custom formats),
- * pass a full vuelidate `rules` object keyed under `value` to replace the baked rules.
+ * pass a `schema` addressing the value under `SETTING_FIELD` to replace the baked one.
  */
 defineOptions({ inheritAttrs: false });
 
@@ -24,7 +23,7 @@ const {
   max,
   default: defaultValue,
   required = true,
-  rules,
+  schema,
   transform = (value: string): number => Number.parseInt(value),
   successMessage = '',
   errorMessage = '',
@@ -37,8 +36,8 @@ const {
   /** When provided, shows a reset-to-default button that writes this value immediately. */
   default?: number;
   required?: boolean;
-  /** Escape hatch: a vuelidate rules object keyed under `value`, replacing the baked min/max/required. */
-  rules?: ValidationArgs;
+  /** Escape hatch: a zod schema addressing the field under `SETTING_FIELD`, replacing the baked one. */
+  schema?: ZodType;
   /** Maps the field string to the stored number. Defaults to `Number.parseInt`; override for floats. */
   transform?: (value: string) => number;
   /** Static text, or a callback given the persisted value. */
@@ -58,36 +57,34 @@ const { t } = useI18n({ useScope: 'global' });
 const { error: writeError, flush, model, success: writeSuccess } = useSettingModel(setting, { debounce });
 const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
 
-const input = ref<string>(String(get(model)));
+const bakedSchema = computed<ZodType>(() => numberSettingSchema({
+  max,
+  messages: {
+    between: t('settings.validation.number.between', { max, min }),
+    max: t('settings.validation.number.max', { max }),
+    min: t('settings.validation.number.min', { min }),
+    required: t('settings.validation.number.non_empty'),
+  },
+  min,
+  required,
+}));
 
-const bakedRules = computed<ValidationArgs>(() => {
-  const valueRules: Record<string, ReturnType<typeof helpers.withMessage>> = {};
-  if (required)
-    valueRules.required = helpers.withMessage(t('settings.validation.number.non_empty'), requiredRule);
-
-  if (min !== undefined && max !== undefined)
-    valueRules.between = helpers.withMessage(t('settings.validation.number.between', { max, min }), between(min, max));
-  else if (min !== undefined)
-    valueRules.min = helpers.withMessage(t('settings.validation.number.min', { min }), minValue(min));
-  else if (max !== undefined)
-    valueRules.max = helpers.withMessage(t('settings.validation.number.max', { max }), maxValue(max));
-
-  return { value: valueRules };
+const form = useForm<SettingFieldState, SettingFieldState>({
+  initial: (): SettingFieldState => ({ value: String(get(model)) }),
+  schema: () => schema ?? get(bakedSchema),
+  submit: async (payload: SettingFieldState): Promise<{ success: boolean }> => {
+    set(model, transform(payload.value));
+    return Promise.resolve({ success: true });
+  },
+  transform: (state): SettingFieldState => ({ value: state.value }),
 });
-
-const activeRules = computed<ValidationArgs>(() => rules ?? get(bakedRules));
-
-const states = computed(() => ({ value: get(input) }));
-
-const v$ = useVuelidate(activeRules, states, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
 
 const hasDefault = computed<boolean>(() => defaultValue !== undefined);
 
 // Reflect external changes into the field, but ignore the echo of our own writes (same string).
 watch(model, (value) => {
-  if (String(value) !== get(input))
-    set(input, String(value));
+  if (String(value) !== form.state.value)
+    form.state.value = String(value);
 });
 
 watch(writeSuccess, (saved) => {
@@ -104,20 +101,18 @@ watch(writeError, (message) => {
   }
 });
 
-function persistValue(value: string): void {
-  set(model, transform(value));
-}
-
-function onInput(value: string): void {
+/** Submitting is the persist: the core runs it only when the field parses, as `callIfValid` did. */
+async function onInput(value: string): Promise<void> {
   clearAll();
-  callIfValid(value, persistValue);
+  form.state.value = value;
+  await form.submit();
 }
 
 async function reset(): Promise<void> {
   if (defaultValue === undefined)
     return;
 
-  set(input, String(defaultValue));
+  form.state.value = String(defaultValue);
   set(model, transform(String(defaultValue)));
   await flush();
 }
@@ -127,14 +122,14 @@ async function reset(): Promise<void> {
   <div class="flex items-start w-full">
     <RuiTextField
       v-bind="$attrs"
-      v-model="input"
+      v-model="form.state.value"
       type="number"
       variant="outlined"
       color="primary"
       class="w-full"
       :label="label"
       :success-messages="success"
-      :error-messages="error || toMessages(v$.value)"
+      :error-messages="error || form.errors(SETTING_FIELD)"
       @update:model-value="onInput($event)"
     />
 

--- a/frontend/app/src/modules/settings/controls/SettingText.spec.ts
+++ b/frontend/app/src/modules/settings/controls/SettingText.spec.ts
@@ -1,7 +1,7 @@
 import { mount, type VueWrapper } from '@vue/test-utils';
-import { helpers } from '@vuelidate/validators';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type Ref, ref } from 'vue';
+import { z } from 'zod';
 import SettingText from '@/modules/settings/controls/SettingText.vue';
 
 const { flushMock, useSettingModelMock } = vi.hoisted(() => ({ flushMock: vi.fn(), useSettingModelMock: vi.fn() }));
@@ -64,9 +64,9 @@ describe('settingText', () => {
     expect(wrapper.find('.error').text()).not.toBe('');
   });
 
-  it('should gate on a custom rules escape hatch', async () => {
-    const rules = { value: { onlyDash: helpers.withMessage('dash only', (v: string) => v === '-') } };
-    const wrapper = createWrapper({ rules });
+  it('should gate on a custom schema escape hatch', async () => {
+    const schema = z.object({ value: z.string().refine(value => value === '-', 'dash only') });
+    const wrapper = createWrapper({ schema });
     await wrapper.findComponent(RuiTextFieldStub).vm.$emit('update:model-value', 'x');
     await nextTick();
     expect(get(model)).toBe(',');

--- a/frontend/app/src/modules/settings/controls/SettingText.vue
+++ b/frontend/app/src/modules/settings/controls/SettingText.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { WritableSettingKeyOf } from '@/modules/settings/settings-writer';
-import useVuelidate, { type ValidationArgs } from '@vuelidate/core';
-import { helpers, maxLength as maxLengthRule, required as requiredRule } from '@vuelidate/validators';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
+import { SETTING_FIELD, type SettingFieldState, textSettingSchema } from '@/modules/settings/controls/setting-field-schemas';
 import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
 import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
 import { useSettingModel } from '@/modules/settings/use-setting-model';
@@ -12,8 +11,8 @@ import { useSettingModel } from '@/modules/settings/use-setting-model';
  * Generic owning component for a string setting. Bakes in optional `required` + `maxLength` validation
  * from props and persists through `useSettingModel` (debounced while typing, immediate on reset). Renders
  * only the field + optional reset button; put it inside a `SettingsItem` for the header. For settings
- * with bespoke validation (format directives, custom checks), pass a full vuelidate `rules` object keyed
- * under `value` to replace the baked rules.
+ * with bespoke validation (format directives, custom checks), pass a `schema` addressing the value
+ * under `SETTING_FIELD` to replace the baked one.
  */
 defineOptions({ inheritAttrs: false });
 
@@ -23,7 +22,7 @@ const {
   default: defaultValue,
   required = false,
   maxLength,
-  rules,
+  schema,
   transform = (value: string): string => value,
   successMessage = '',
   errorMessage = '',
@@ -35,8 +34,8 @@ const {
   default?: string;
   required?: boolean;
   maxLength?: number;
-  /** Escape hatch: a vuelidate rules object keyed under `value`, replacing the baked required/maxLength. */
-  rules?: ValidationArgs;
+  /** Escape hatch: a zod schema addressing the field under `SETTING_FIELD`, replacing the baked one. */
+  schema?: ZodType;
   /** Maps the field string to the stored value. Defaults to identity. */
   transform?: (value: string) => string;
   /** Static text, or a callback given the persisted value. */
@@ -55,32 +54,31 @@ const { t } = useI18n({ useScope: 'global' });
 const { error: writeError, flush, model, success: writeSuccess } = useSettingModel(setting, { debounce });
 const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
 
-const input = ref<string>(get(model));
+const bakedSchema = computed<ZodType>(() => textSettingSchema({
+  maxLength,
+  messages: {
+    maxLength: t('settings.validation.text.max_length', { max: maxLength }),
+    required: t('settings.validation.text.non_empty'),
+  },
+  required,
+}));
 
-const bakedRules = computed<ValidationArgs>(() => {
-  const valueRules: Record<string, ReturnType<typeof helpers.withMessage>> = {};
-  if (required)
-    valueRules.required = helpers.withMessage(t('settings.validation.text.non_empty'), requiredRule);
-
-  if (maxLength !== undefined)
-    valueRules.maxLength = helpers.withMessage(t('settings.validation.text.max_length', { max: maxLength }), maxLengthRule(maxLength));
-
-  return { value: valueRules };
+const form = useForm<SettingFieldState, SettingFieldState>({
+  initial: (): SettingFieldState => ({ value: get(model) }),
+  schema: () => schema ?? get(bakedSchema),
+  submit: async (payload: SettingFieldState): Promise<{ success: boolean }> => {
+    set(model, transform(payload.value));
+    return Promise.resolve({ success: true });
+  },
+  transform: (state): SettingFieldState => ({ value: state.value }),
 });
-
-const activeRules = computed<ValidationArgs>(() => rules ?? get(bakedRules));
-
-const states = computed(() => ({ value: get(input) }));
-
-const v$ = useVuelidate(activeRules, states, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
 
 const hasDefault = computed<boolean>(() => defaultValue !== undefined);
 
 // Reflect external changes into the field, but ignore the echo of our own writes (same string).
 watch(model, (value) => {
-  if (value !== get(input))
-    set(input, value);
+  if (value !== form.state.value)
+    form.state.value = value;
 });
 
 watch(writeSuccess, (saved) => {
@@ -95,20 +93,18 @@ watch(writeError, (message) => {
     setError(errorMessage ? `${errorMessage}: ${message}` : message, true);
 });
 
-function persistValue(value: string): void {
-  set(model, transform(value));
-}
-
-function onInput(value: string): void {
+/** Submitting is the persist: the core runs it only when the field parses, as `callIfValid` did. */
+async function onInput(value: string): Promise<void> {
   clearAll();
-  callIfValid(value, persistValue);
+  form.state.value = value;
+  await form.submit();
 }
 
 async function reset(): Promise<void> {
   if (defaultValue === undefined)
     return;
 
-  set(input, defaultValue);
+  form.state.value = defaultValue;
   set(model, transform(defaultValue));
   await flush();
 }
@@ -118,14 +114,14 @@ async function reset(): Promise<void> {
   <div class="flex items-start w-full">
     <RuiTextField
       v-bind="$attrs"
-      v-model="input"
+      v-model="form.state.value"
       type="text"
       variant="outlined"
       color="primary"
       class="w-full"
       :label="label"
       :success-messages="success"
-      :error-messages="error || toMessages(v$.value)"
+      :error-messages="error || form.errors(SETTING_FIELD)"
       @update:model-value="onInput($event)"
     />
 

--- a/frontend/app/src/modules/settings/controls/SettingToggleNumber.vue
+++ b/frontend/app/src/modules/settings/controls/SettingToggleNumber.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { WritableSettingKeyOf } from '@/modules/settings/settings-writer';
-import useVuelidate from '@vuelidate/core';
-import { between, helpers, minValue, requiredIf } from '@vuelidate/validators';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
+import { numberSettingSchema, SETTING_FIELD, type SettingFieldState } from '@/modules/settings/controls/setting-field-schemas';
 import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
 import { useSettingModel } from '@/modules/settings/use-setting-model';
 
@@ -69,24 +68,38 @@ function fieldFor(value: number | null | undefined): string {
 
 const initial = get(model);
 const enabled = ref<boolean>(!!initial && initial > 0);
-const field = ref<string>(fieldFor(initial));
 const pendingSuccess = ref<string>('');
 
-const rules = {
-  field: {
-    ...(max !== undefined
-      ? { between: helpers.withMessage(validation.invalid, between(min, max)) }
-      : { minValue: helpers.withMessage(validation.invalid, minValue(min)) }),
-    required: helpers.withMessage(validation.empty, requiredIf(enabled)),
+/**
+ * The value is only required while the toggle is on, and the toggle is not part of the field state,
+ * so the schema is a getter rather than a value.
+ */
+const schema = computed<ZodType>(() => numberSettingSchema({
+  max,
+  messages: {
+    between: validation.invalid,
+    max: validation.invalid,
+    min: validation.invalid,
+    required: validation.empty,
   },
-};
+  min,
+  required: get(enabled),
+}));
 
-const v$ = useVuelidate(rules, { field }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
+const form = useForm<SettingFieldState, SettingFieldState>({
+  initial: (): SettingFieldState => ({ value: fieldFor(initial) }),
+  schema,
+  submit: async (payload: SettingFieldState): Promise<{ success: boolean }> => {
+    set(pendingSuccess, success?.onValue ? success.onValue(payload.value) : '');
+    set(model, payload.value ? fromField(payload.value) : offValue);
+    return Promise.resolve({ success: true });
+  },
+  transform: (state): SettingFieldState => ({ value: state.value }),
+});
 
 watch(model, (value) => {
   set(enabled, !!value && value > 0);
-  set(field, fieldFor(value));
+  form.state.value = fieldFor(value);
 });
 
 watch(writeSuccess, (saved) => {
@@ -106,12 +119,11 @@ async function toggle(value: boolean): Promise<void> {
   await flush();
 }
 
-function updateField(value: string): void {
+/** Submitting is the persist: the core runs it only when the field parses, as `callIfValid` did. */
+async function updateField(value: string): Promise<void> {
   clearAll();
-  callIfValid(value, (input: string) => {
-    set(pendingSuccess, success?.onValue ? success.onValue(input) : '');
-    set(model, input ? fromField(input) : offValue);
-  });
+  form.state.value = value;
+  await form.submit();
 }
 </script>
 
@@ -127,7 +139,7 @@ function updateField(value: string): void {
       @update:model-value="toggle($event)"
     />
     <RuiTextField
-      v-model="field"
+      v-model="form.state.value"
       variant="outlined"
       color="primary"
       :data-testid="fieldTestId"
@@ -139,7 +151,7 @@ function updateField(value: string): void {
       :label="fieldLabel"
       :hint="fieldHint"
       :success-messages="successMessage"
-      :error-messages="enabled ? (error || toMessages(v$.field)) : []"
+      :error-messages="enabled ? (error || form.errors(SETTING_FIELD)) : []"
       @update:model-value="updateField($event)"
     />
   </div>

--- a/frontend/app/src/modules/settings/controls/setting-field-schemas.spec.ts
+++ b/frontend/app/src/modules/settings/controls/setting-field-schemas.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { numberSettingSchema, textSettingSchema } from '@/modules/settings/controls/setting-field-schemas';
+
+function messagesOf(schema: ReturnType<typeof textSettingSchema>, value: string): string[] {
+  const result = schema.safeParse({ value });
+  return result.success ? [] : result.error.issues.map(issue => issue.message);
+}
+
+describe('textSettingSchema', () => {
+  const messages = { maxLength: 'too long', required: 'needed' };
+
+  it('should accept any value when nothing is required', () => {
+    expect(messagesOf(textSettingSchema({ messages }), '')).toStrictEqual([]);
+  });
+
+  it('should reject a blank value when required', () => {
+    const schema = textSettingSchema({ messages, required: true });
+
+    expect(messagesOf(schema, '')).toStrictEqual(['needed']);
+    // Vuelidate's `required` trims, so whitespace alone counts as empty.
+    expect(messagesOf(schema, '   ')).toStrictEqual(['needed']);
+    expect(messagesOf(schema, 'a')).toStrictEqual([]);
+  });
+
+  it('should reject a value over the maximum length', () => {
+    const schema = textSettingSchema({ maxLength: 3, messages });
+
+    expect(messagesOf(schema, 'abcd')).toStrictEqual(['too long']);
+    expect(messagesOf(schema, 'abc')).toStrictEqual([]);
+  });
+
+  it('should not report a length error for an optional blank value', () => {
+    // Reporting both would show "too long" on an empty field the user never has to fill in.
+    expect(messagesOf(textSettingSchema({ maxLength: 3, messages }), '')).toStrictEqual([]);
+  });
+});
+
+describe('numberSettingSchema', () => {
+  const messages = { between: 'out of range', max: 'too big', min: 'too small', required: 'needed' };
+
+  it('should reject a blank value by default', () => {
+    expect(messagesOf(numberSettingSchema({ messages }), '')).toStrictEqual(['needed']);
+  });
+
+  it('should accept a blank value when not required', () => {
+    expect(messagesOf(numberSettingSchema({ messages, required: false }), '')).toStrictEqual([]);
+  });
+
+  it('should reject a value below the minimum', () => {
+    const schema = numberSettingSchema({ messages, min: 2 });
+
+    expect(messagesOf(schema, '1')).toStrictEqual(['too small']);
+    expect(messagesOf(schema, '2')).toStrictEqual([]);
+  });
+
+  it('should reject a value above the maximum', () => {
+    const schema = numberSettingSchema({ max: 5, messages });
+
+    expect(messagesOf(schema, '6')).toStrictEqual(['too big']);
+    expect(messagesOf(schema, '5')).toStrictEqual([]);
+  });
+
+  it('should report the between message when both bounds are given', () => {
+    // One message rather than two: the field says "between 2 and 5", not "too small" and "too big".
+    const schema = numberSettingSchema({ max: 5, messages, min: 2 });
+
+    expect(messagesOf(schema, '1')).toStrictEqual(['out of range']);
+    expect(messagesOf(schema, '6')).toStrictEqual(['out of range']);
+    expect(messagesOf(schema, '3')).toStrictEqual([]);
+  });
+
+  it('should reject a value that is not a number', () => {
+    expect(messagesOf(numberSettingSchema({ messages, min: 1 }), 'abc')).toStrictEqual(['needed']);
+  });
+});

--- a/frontend/app/src/modules/settings/controls/setting-field-schemas.ts
+++ b/frontend/app/src/modules/settings/controls/setting-field-schemas.ts
@@ -1,0 +1,108 @@
+import { z, type ZodType } from 'zod';
+
+/**
+ * The setting controls hold exactly one field, and both the baked schemas here and any schema a
+ * caller passes in address it under this key.
+ */
+export const SETTING_FIELD = 'value';
+
+/** The one field a setting control validates. Its input is always the raw string from the field. */
+export interface SettingFieldState {
+  value: string;
+}
+
+export interface TextSettingRules {
+  required?: boolean;
+  maxLength?: number;
+  /**
+   * Already-translated messages rather than i18n keys: the range messages interpolate their own
+   * bounds, which a bare key cannot carry. The form core passes anything that is not a key through
+   * untouched.
+   */
+  messages: {
+    required?: string;
+    maxLength?: string;
+  };
+}
+
+export interface NumberSettingRules {
+  required?: boolean;
+  min?: number;
+  max?: number;
+  /** See `TextSettingRules.messages`. `between` is used when both bounds are given. */
+  messages: {
+    required?: string;
+    min?: string;
+    max?: string;
+    between?: string;
+  };
+}
+
+/** Vuelidate treats a whitespace-only string as empty; keep that so nothing changes under the user. */
+function isBlank(value: string): boolean {
+  return value.trim() === '';
+}
+
+export function textSettingSchema(rules: TextSettingRules): ZodType {
+  const { maxLength, messages, required = false } = rules;
+
+  return z.object({
+    value: z.string().superRefine((value, ctx) => {
+      if (isBlank(value)) {
+        // A blank value is the required rule's business alone: an optional field that is empty must
+        // not also trip the length rule.
+        if (required)
+          ctx.addIssue({ code: 'custom', message: messages.required });
+
+        return;
+      }
+
+      if (maxLength !== undefined && value.length > maxLength)
+        ctx.addIssue({ code: 'custom', message: messages.maxLength });
+    }),
+  });
+}
+
+/**
+ * The message for a value that is outside its bounds, or `undefined` when it is within them. Two
+ * bounds report one `between` message rather than a separate min and max.
+ */
+function rangeMessage(numeric: number, rules: NumberSettingRules): string | undefined {
+  const { max, messages, min } = rules;
+
+  if (min !== undefined && max !== undefined)
+    return numeric < min || numeric > max ? messages.between : undefined;
+
+  if (min !== undefined)
+    return numeric < min ? messages.min : undefined;
+
+  if (max !== undefined)
+    return numeric > max ? messages.max : undefined;
+
+  return undefined;
+}
+
+export function numberSettingSchema(rules: NumberSettingRules): ZodType {
+  const { messages, required = true } = rules;
+
+  return z.object({
+    value: z.string().superRefine((value, ctx) => {
+      if (isBlank(value)) {
+        if (required)
+          ctx.addIssue({ code: 'custom', message: messages.required });
+
+        return;
+      }
+
+      const numeric = Number(value);
+      if (Number.isNaN(numeric)) {
+        ctx.addIssue({ code: 'custom', message: messages.required });
+        return;
+      }
+
+      const message = rangeMessage(numeric, rules);
+      if (message !== undefined)
+        ctx.addIssue({ code: 'custom', message });
+    }),
+  });
+}

--- a/frontend/app/src/modules/settings/general/AutoDetectTokensCooldownSetting.vue
+++ b/frontend/app/src/modules/settings/general/AutoDetectTokensCooldownSetting.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { between, helpers, required } from '@vuelidate/validators';
 import { Constraints } from '@/modules/core/common/constraints';
+import { numberSettingSchema } from '@/modules/settings/controls/setting-field-schemas';
 import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 
 const { t } = useI18n({ useScope: 'global' });
@@ -8,18 +8,17 @@ const { t } = useI18n({ useScope: 'global' });
 const minHours = Constraints.AUTO_DETECT_TOKENS_COOLDOWN_MIN_HOURS;
 const maxHours = Constraints.AUTO_DETECT_TOKENS_COOLDOWN_MAX_HOURS;
 
-const rules = {
-  value: {
-    between: helpers.withMessage(
-      t('general_settings.auto_detect_tokens_cooldown.validation.invalid_value', {
-        end: maxHours,
-        start: minHours,
-      }),
-      between(minHours, maxHours),
-    ),
-    required: helpers.withMessage(t('general_settings.auto_detect_tokens_cooldown.validation.non_empty'), required),
+const schema = numberSettingSchema({
+  max: maxHours,
+  messages: {
+    between: t('general_settings.auto_detect_tokens_cooldown.validation.invalid_value', {
+      end: maxHours,
+      start: minHours,
+    }),
+    required: t('general_settings.auto_detect_tokens_cooldown.validation.non_empty'),
   },
-};
+  min: minHours,
+});
 </script>
 
 <template>
@@ -27,7 +26,7 @@ const rules = {
     setting="autoDetectTokensCooldownHours"
     class="w-full"
     data-testid="auto-detect-tokens-cooldown-input"
-    :rules="rules"
+    :schema="schema"
     :label="t('general_settings.auto_detect_tokens_cooldown.label')"
     :error-message="t('general_settings.auto_detect_tokens_cooldown.validation.error')"
     :success-message="t('general_settings.auto_detect_tokens_cooldown.validation.success')"

--- a/frontend/app/src/modules/settings/general/amount/FloatingPrecisionSetting.vue
+++ b/frontend/app/src/modules/settings/general/amount/FloatingPrecisionSetting.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
-import { helpers, required } from '@vuelidate/validators';
+import { numberSettingSchema } from '@/modules/settings/controls/setting-field-schemas';
 import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  value: {
-    required: helpers.withMessage(t('general_settings.validation.floating_precision.non_empty'), required),
-  },
-};
+const schema = numberSettingSchema({
+  messages: { required: t('general_settings.validation.floating_precision.non_empty') },
+});
 
 function errorMessage(precision: number): string {
   return t('general_settings.validation.floating_precision.error', { precision });
@@ -23,7 +21,7 @@ function successMessage(precision: number): string {
   <SettingNumber
     setting="floatingPrecision"
     data-testid="floating-precision-settings"
-    :rules="rules"
+    :schema="schema"
     :label="t('general_settings.amount.labels.floating_precision')"
     :error-message="errorMessage"
     :success-message="successMessage"

--- a/frontend/app/src/modules/settings/general/external-services/CommonExternalServiceSetting.vue
+++ b/frontend/app/src/modules/settings/general/external-services/CommonExternalServiceSetting.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { helpers, minValue, required } from '@vuelidate/validators';
+import type { ZodType } from 'zod';
+import { numberSettingSchema } from '@/modules/settings/controls/setting-field-schemas';
 import SettingNumber from '@/modules/settings/controls/SettingNumber.vue';
 import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
 import { useMonitorService } from '@/modules/shell/app/use-monitor-service';
@@ -24,12 +25,10 @@ const {
 
 const { restart } = useMonitorService();
 
-const rules = {
-  value: {
-    min: helpers.withMessage(minValueMessage(min), minValue(min)),
-    required: helpers.withMessage(requiredMessage, required),
-  },
-};
+const schema = computed<ZodType>(() => numberSettingSchema({
+  messages: { min: minValueMessage(min), required: requiredMessage },
+  min,
+}));
 </script>
 
 <template>
@@ -43,7 +42,7 @@ const rules = {
     <SettingNumber
       class="mt-1"
       :setting="setting"
-      :rules="rules"
+      :schema="schema"
       :default="defaultValue"
       @updated="restart()"
     />


### PR DESCRIPTION
First batch of the Vuelidate → zod migration outside history, following #12753.
Small on purpose: three shared controls plus the five callers that reach through their
validation escape hatch.

## What changes

- **`setting-field-schemas.ts`** — pure builders for the two rule shapes the controls bake in:
  required + max length for text, required + min/max/between for numbers. No Vue, no i18n, no
  API, so they are tested directly: **10 tests, nothing mounted**.
- **`SettingNumber`, `SettingText`, `SettingToggleNumber`** hold a `useForm` over the single field
  and persist through its `submit`. The core runs `submit` only when the field parses, which is
  exactly what `callIfValid` did, so persistence behaviour is unchanged. `useValidation`,
  `toMessages` and the `v$` naming are gone from all three.
- **The escape hatch changes shape with the validator**: `rules?: ValidationArgs` becomes
  `schema?: ZodType`, addressing the field under the same key. The five callers that passed custom
  rules were each hand-rolling required + a range with `helpers.withMessage`; they now call the
  shared builder with their own messages.

`SettingToggleNumber` passes its schema as a getter: the value is only required while the toggle is
on, and the toggle is not part of the field state.

Two behaviours the old rules had implicitly are now pinned by tests: a blank *optional* field must
not also report a length error, and a field with both bounds reports one "between" message rather
than a separate min and max.

## Note on messages

The builders take already-translated strings rather than i18n keys, because the range messages
interpolate their own bounds. That relies on the core change in #12755 — messages that are not keys
now pass through untouched instead of being handed to `t()`.

## Testing

- The three controls' pre-existing specs pass **unchanged**, except one: `should gate on a custom
  rules escape hatch` is now `...custom schema escape hatch`, since it exercises the renamed prop.
  58 tests across the controls directory.
- Full unit suite: **709 files / 6791 tests pass**.
- typecheck, lint (0 errors, warnings at develop's baseline) and `typos` clean.