### PR TITLE
Gate the MCP settings page behind premium

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -685,6 +685,9 @@ Querying premium capabilities
    - `asset_movement_matching`: Object with:
      - `enabled` (Boolean): Enables automatic matching of exchange asset movements with onchain events when triggering the matching task. Also gates the automatic matching of the two legs of cross-chain bridge transfers.
      - `minimum_tier` (String): The minimum tier required to unlock this capability.
+   - `mcp`: Object with:
+     - `enabled` (Boolean): Enables the MCP server's tools. The `info` tool is always available; every other tool refuses to answer without this capability.
+     - `minimum_tier` (String): The minimum tier required to unlock this capability.
    - `minimum_tier` can be `null` if the key is not present in the unlocks response from the server.
    - `current_tier`: String. Current user tier name. As of this writing the possible values are `Free` (no active subscription), `Supporter`, `Basic` and `Advanced`. The tier names are defined server-side, not in this repository, so the authoritative and up-to-date list can be fetched with an unauthenticated ``GET`` at ``https://rotki.com/webapi/2/available-tiers`` (the ``tier_name`` field of each entry). Paid tiers are ordered `Supporter` < `Basic` < `Advanced`.
    - `limit_of_devices`: Integer. Maximum number of connected devices.
@@ -730,6 +733,10 @@ Querying premium capabilities
               "minimum_tier": "Basic"
             },
             "asset_movement_matching": {
+              "enabled": true,
+              "minimum_tier": "Basic"
+            },
+            "mcp": {
               "enabled": true,
               "minimum_tier": "Basic"
             }

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1680,6 +1680,9 @@
         "hide_token": "Hide bearer token",
         "hint": "Manage the local MCP server used by AI assistants.",
         "label": "MCP Server",
+        "premium_description": "Subscribe to rotki premium to let AI assistants query your rotki data over MCP.",
+        "premium_plan_title": "MCP is not included in your current plan",
+        "premium_title": "MCP requires a rotki premium subscription",
         "reveal_token": "Reveal bearer token",
         "status": {
           "failed": "Failed",

--- a/frontend/app/src/modules/premium/use-feature-access.spec.ts
+++ b/frontend/app/src/modules/premium/use-feature-access.spec.ts
@@ -200,6 +200,61 @@ describe('modules/premium/use-feature-access', () => {
       expect(get(minimumTier)).toBeNull();
     });
 
+    it('should return allowed=true for MCP when the capability is enabled', () => {
+      const store = usePremiumStore();
+      const { capabilities, premium } = storeToRefs(store);
+      set(premium, true);
+      set(capabilities, {
+        currentTier: 'Basic',
+        mcp: cap(true, 'Basic'),
+      });
+
+      const { allowed, minimumTier } = useFeatureAccess(PremiumFeature.MCP);
+
+      expect(get(allowed)).toBe(true);
+      expect(get(minimumTier)).toBe('Basic');
+    });
+
+    it('should return allowed=false for MCP when the capability is disabled', () => {
+      const store = usePremiumStore();
+      const { capabilities, premium } = storeToRefs(store);
+      set(premium, true);
+      set(capabilities, {
+        currentTier: 'Supporter',
+        mcp: cap(false, 'Basic'),
+      });
+
+      const { allowed, minimumTier } = useFeatureAccess(PremiumFeature.MCP);
+
+      expect(get(allowed)).toBe(false);
+      expect(get(minimumTier)).toBe('Basic');
+    });
+
+    it('should return allowed=false for MCP when user is not premium', () => {
+      const store = usePremiumStore();
+      const { capabilities, premium } = storeToRefs(store);
+      set(premium, false);
+      set(capabilities, {
+        currentTier: 'Basic',
+        mcp: cap(true, 'Basic'),
+      });
+
+      const { allowed } = useFeatureAccess(PremiumFeature.MCP);
+
+      expect(get(allowed)).toBe(false);
+    });
+
+    it('should return allowed=false for MCP when capabilities are not loaded', () => {
+      const store = usePremiumStore();
+      const { premium } = storeToRefs(store);
+      set(premium, true);
+
+      const { allowed, minimumTier } = useFeatureAccess(PremiumFeature.MCP);
+
+      expect(get(allowed)).toBe(false);
+      expect(get(minimumTier)).toBeNull();
+    });
+
     it('should work with reactive feature parameter', async () => {
       const store = usePremiumStore();
       const { capabilities, premium } = storeToRefs(store);
@@ -367,6 +422,30 @@ describe('modules/premium/use-feature-access', () => {
       expect(get(ethStakingAllowed)).toBe(true);
       expect(get(graphsAllowed)).toBe(true);
       expect(get(eventAnalysisAllowed)).toBe(false);
+    });
+
+    it('should parse the mcp capability from the backend payload', async () => {
+      const mockCapabilities: PremiumCapabilities = {
+        currentTier: 'Basic',
+        [PremiumFeature.MCP]: cap(true, 'Basic'),
+      };
+
+      server.use(mockPremiumCapabilities(mockCapabilities));
+      const { fetchCapabilities } = usePremiumWatchers();
+
+      const store = usePremiumStore();
+      const { capabilities, premium } = storeToRefs(store);
+
+      const { allowed, minimumTier } = useFeatureAccess(PremiumFeature.MCP);
+
+      expect(get(allowed)).toBe(false);
+
+      set(premium, true);
+      await fetchCapabilities();
+
+      expect(get(capabilities)).toEqual(mockCapabilities);
+      expect(get(allowed)).toBe(true);
+      expect(get(minimumTier)).toBe('Basic');
     });
 
     it('should handle gnosis pay and monerium capabilities', async () => {

--- a/frontend/app/src/modules/session/types.ts
+++ b/frontend/app/src/modules/session/types.ts
@@ -118,6 +118,7 @@ export enum PremiumFeature {
   ASSET_MOVEMENT_MATCHING = 'assetMovementMatching',
   GNOSIS_PAY = 'gnosispay',
   MONERIUM = 'monerium',
+  MCP = 'mcp',
 }
 
 export const PremiumFeatureCapability = z.object({
@@ -138,6 +139,7 @@ export const PremiumCapabilities = z.object({
   historyEventsLimit: z.number().optional(),
   limitOfDevices: z.number().optional(),
   maxBackupSizeMb: z.number().optional(),
+  mcp: PremiumFeatureCapability.optional(),
   monerium: PremiumFeatureCapability.optional(),
   pnlEventsLimit: z.number().optional(),
   reportsLookupLimit: z.number().optional(),

--- a/frontend/app/src/modules/settings/backend/McpServerSetting.spec.ts
+++ b/frontend/app/src/modules/settings/backend/McpServerSetting.spec.ts
@@ -1,6 +1,9 @@
 import { type McpServerStatus, StarlingServiceStatus } from '@shared/ipc';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePremiumStore } from '@/modules/premium/use-premium-store';
+import { PremiumFeature } from '@/modules/session/types';
 import McpServerSetting from '@/modules/settings/backend/McpServerSetting.vue';
 import { setMcpServerState } from '@/modules/settings/backend/use-mcp-server-state';
 
@@ -92,6 +95,10 @@ function createWrapper(): VueWrapper<InstanceType<typeof McpServerSetting>> {
           props: ['disabled', 'modelValue'],
           template: '<button v-bind="$attrs" class="rui-switch" :disabled="disabled" @click="$emit(\'update:modelValue\', !modelValue)" />',
         },
+        GetPremiumPlaceholder: {
+          props: ['description', 'minimumTier', 'title'],
+          template: '<div class="get-premium-placeholder" :data-minimum-tier="minimumTier">{{ title }}{{ description }}</div>',
+        },
         SettingsItem: {
           template: '<section><slot name="title" /><slot name="subtitle" /><slot /></section>',
         },
@@ -100,10 +107,27 @@ function createWrapper(): VueWrapper<InstanceType<typeof McpServerSetting>> {
   });
 }
 
+function grantMcpAccess(enabled: boolean, minimumTier = 'Basic'): void {
+  const { capabilities, premium } = storeToRefs(usePremiumStore());
+  set(premium, true);
+  set(capabilities, {
+    currentTier: enabled ? 'Basic' : 'Supporter',
+    [PremiumFeature.MCP]: { enabled, minimumTier },
+  });
+}
+
+function revokePremium(): void {
+  const { capabilities, premium } = storeToRefs(usePremiumStore());
+  set(premium, false);
+  set(capabilities, undefined);
+}
+
 describe('mcpServerSetting', () => {
   beforeEach(() => {
+    setActivePinia(createPinia());
     vi.clearAllMocks();
     vi.stubEnv('VITE_DOCKER', 'false');
+    grantMcpAccess(true);
     mocks.isPackaged = true;
     controlAvailable(true);
     control.serviceState.mockResolvedValue(StarlingServiceStatus.IDLE);
@@ -284,5 +308,91 @@ describe('mcpServerSetting', () => {
     );
     expect(wrapper.text()).toContain('token failed');
     expect(wrapper.text()).not.toContain('backend_settings.settings.mcp_server.error');
+  });
+
+  it('should not show the premium gate when MCP is unlocked', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="mcp-premium-gate"]').exists()).toBe(false);
+  });
+
+  it('should tell a premium user their plan is insufficient, with the required tier', async () => {
+    grantMcpAccess(false);
+
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    const gate = wrapper.find('[data-testid="mcp-premium-gate"]');
+    expect(gate.exists()).toBe(true);
+    expect(gate.text()).toContain('backend_settings.settings.mcp_server.premium_plan_title');
+    expect(gate.text()).not.toContain('backend_settings.settings.mcp_server.premium_title');
+    expect(gate.find('.get-premium-placeholder').attributes('data-minimum-tier')).toBe('Basic');
+  });
+
+  it('should ask a user without a subscription to subscribe', async () => {
+    revokePremium();
+
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    const gate = wrapper.find('[data-testid="mcp-premium-gate"]');
+    expect(gate.exists()).toBe(true);
+    expect(gate.text()).toContain('backend_settings.settings.mcp_server.premium_title');
+    expect(gate.text()).not.toContain('backend_settings.settings.mcp_server.premium_plan_title');
+    // no capabilities are fetched without a subscription, so there is no tier to name
+    expect(gate.text()).toContain('backend_settings.settings.mcp_server.premium_description');
+  });
+
+  it('should hide the lifecycle controls when MCP is locked', async () => {
+    grantMcpAccess(false);
+
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="mcp-lifecycle"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="mcp-auto-start"]').exists()).toBe(false);
+  });
+
+  it('should hide token generation in Docker when MCP is locked', async () => {
+    vi.stubEnv('VITE_DOCKER', 'true');
+    mocks.isPackaged = false;
+    grantMcpAccess(false);
+
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="mcp-premium-gate"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="mcp-generate-token"]').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('backend_settings.settings.mcp_server.docker_description');
+  });
+
+  it('should show the desktop-only message instead of the gate in the web build', async () => {
+    grantMcpAccess(false);
+    mocks.isPackaged = false;
+    controlUnavailable();
+
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    // there is no server to run here for anyone, so the answer is "not here", not "buy premium"
+    expect(wrapper.text()).toContain('backend_settings.settings.mcp_server.desktop_only');
+    expect(wrapper.find('[data-testid="mcp-premium-gate"]').exists()).toBe(false);
+  });
+
+  it('should reveal working controls once capabilities unlock MCP after mount', async () => {
+    grantMcpAccess(false);
+
+    const wrapper = createWrapper();
+    await flushPromises();
+    expect(wrapper.find('[data-testid="mcp-lifecycle"]').exists()).toBe(false);
+
+    // capabilities arrive after mount, so the status is loaded regardless of the gate:
+    // unlocking must not leave the user with controls that have no state to act on
+    grantMcpAccess(true);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="mcp-lifecycle"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="mcp-lifecycle"]').attributes('disabled')).toBeUndefined();
   });
 });

--- a/frontend/app/src/modules/settings/backend/McpServerSetting.vue
+++ b/frontend/app/src/modules/settings/backend/McpServerSetting.vue
@@ -5,10 +5,12 @@ import { StarlingService } from '@shared/starling/starling-protocol';
 import { startPromise } from '@shared/utils';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useControl } from '@/modules/core/control/use-control';
+import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { useMcpApi } from '@/modules/settings/api/use-mcp-api';
 import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
 import CopyTooltip from '@/modules/shell/components/CopyTooltip.vue';
+import GetPremiumPlaceholder from '@/modules/shell/components/GetPremiumPlaceholder.vue';
 import { useMcpServerState } from './use-mcp-server-state';
 
 const { t } = useI18n({ useScope: 'global' });
@@ -17,6 +19,7 @@ const isDocker = import.meta.env.VITE_DOCKER === 'true';
 const { getMcpServerStatus, isPackaged, setMcpAutoStart } = useInterop();
 const { available, probe, serviceState, setServiceRunning, supportsOptions } = useControl();
 const { generateMcpToken } = useMcpApi();
+const { allowed: mcpAllowed, minimumTier: mcpMinimumTier, premium } = useFeatureAccess(PremiumFeature.MCP);
 
 const state = ref<StarlingServiceStatus>();
 const autoStart = ref<boolean>(false);
@@ -72,6 +75,13 @@ const unavailableMessage = computed<string>(() => (
   isPackaged || isDocker
     ? t('backend_settings.settings.mcp_server.control_unavailable')
     : t('backend_settings.settings.mcp_server.desktop_only')
+));
+// a premium subscriber whose tier is too low needs a different answer than someone
+// with no subscription at all: one has to upgrade, the other has to subscribe.
+const gateTitle = computed<string>(() => (
+  get(premium)
+    ? t('backend_settings.settings.mcp_server.premium_plan_title')
+    : t('backend_settings.settings.mcp_server.premium_title')
 ));
 
 function statusLabel(current: StarlingServiceStatus | undefined): string {
@@ -160,6 +170,9 @@ watch(mcpServerState, (pushed) => {
     set(state, pushed);
 });
 
+// Runs regardless of the premium gate: the probe is what decides whether there is a
+// supervisor at all, and that answer is shown ahead of any upsell. Gating it on
+// `mcpAllowed` would also leave a user who unlocks mid-session without a status.
 onBeforeMount(() => {
   startPromise(loadStatus());
 });
@@ -174,12 +187,26 @@ onBeforeMount(() => {
       {{ t('backend_settings.settings.mcp_server.hint') }}
     </template>
 
+    <!-- the environment check comes first: where there is no server to reach, the answer is
+         "not here", not "buy premium". Offering premium there would be selling nothing. -->
     <RuiAlert
       v-if="!available && !loading"
       type="info"
     >
       {{ unavailableMessage }}
     </RuiAlert>
+
+    <div
+      v-else-if="!loading && !mcpAllowed"
+      class="max-w-2xl rounded-lg border border-default bg-rui-grey-50 dark:bg-rui-grey-900 px-4 py-5"
+      data-testid="mcp-premium-gate"
+    >
+      <GetPremiumPlaceholder
+        :title="gateTitle"
+        :description="t('backend_settings.settings.mcp_server.premium_description')"
+        :minimum-tier="mcpMinimumTier"
+      />
+    </div>
 
     <div
       v-else

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -61,6 +61,7 @@ UNKNOWN_CONTAINER_FALLBACK_ID_PREFIX: Final = 'unknown-container'
 ASSET_MOVEMENT_MATCHING_CAPABILITY: Final = 'asset_movement_matching'
 GNOSIS_PAY_CAPABILITY: Final = 'gnosispay'
 MONERIUM_CAPABILITY: Final = 'monerium'
+MCP_CAPABILITY: Final = 'mcp'
 
 
 class RemoteMetadata(NamedTuple):
@@ -97,6 +98,7 @@ class UserLimits(TypedDict):
     asset_movement_matching: bool
     gnosispay: bool
     monerium: bool
+    mcp: bool
     # minimum tier required to unlock each capability
     unlocks: dict[str, str]
 
@@ -121,6 +123,7 @@ class PremiumCapabilities(TypedDict):
     asset_movement_matching: PremiumFeatureCapability
     gnosispay: PremiumFeatureCapability
     monerium: PremiumFeatureCapability
+    mcp: PremiumFeatureCapability
 
 
 class UserLimitType(Enum):
@@ -270,6 +273,10 @@ def get_free_capabilities() -> PremiumCapabilities:
         monerium=PremiumFeatureCapability(
             enabled=False,
             minimum_tier=unlocks.get(MONERIUM_CAPABILITY),
+        ),
+        mcp=PremiumFeatureCapability(
+            enabled=False,
+            minimum_tier=unlocks.get(MCP_CAPABILITY),
         ),
     )
 
@@ -1054,6 +1061,10 @@ class Premium:
             monerium=PremiumFeatureCapability(
                 enabled=limits.get(MONERIUM_CAPABILITY, False),
                 minimum_tier=unlocks.get(MONERIUM_CAPABILITY),
+            ),
+            mcp=PremiumFeatureCapability(
+                enabled=limits.get(MCP_CAPABILITY, False),
+                minimum_tier=unlocks.get(MCP_CAPABILITY),
             ),
         )
 

--- a/rotkehlchen/tests/api/test_premium.py
+++ b/rotkehlchen/tests/api/test_premium.py
@@ -10,6 +10,7 @@ import requests
 
 from rotkehlchen.accounting.constants import FREE_PNL_EVENTS_LIMIT, FREE_REPORTS_LOOKUP_LIMIT
 from rotkehlchen.constants.limits import FREE_HISTORY_EVENTS_LIMIT
+from rotkehlchen.premium.premium import get_free_capabilities
 from rotkehlchen.tests.utils.api import (
     api_url_for,
     assert_error_response,
@@ -321,6 +322,7 @@ def test_get_premium_capabilities(rotkehlchen_api_server: APIServer) -> None:
             'asset_movement_matching': True,
             'gnosispay': True,
             'monerium': False,
+            'mcp': True,
             'unlocks': {
                 'eth_staking_view': 'Basic',
                 'graphs_view': 'Basic',
@@ -328,6 +330,7 @@ def test_get_premium_capabilities(rotkehlchen_api_server: APIServer) -> None:
                 'asset_movement_matching': 'Basic',
                 'gnosispay': 'Advanced',
                 'monerium': 'Advanced',
+                'mcp': 'Basic',
             },
         },
     ):
@@ -368,6 +371,10 @@ def test_get_premium_capabilities(rotkehlchen_api_server: APIServer) -> None:
             'monerium': {
                 'enabled': False,
                 'minimum_tier': 'Advanced',
+            },
+            'mcp': {
+                'enabled': True,
+                'minimum_tier': 'Basic',
             },
         }
 
@@ -452,3 +459,32 @@ def test_get_free_user_capabilities(rotkehlchen_api_server: APIServer) -> None:
                 'minimum_tier': 'Advanced',
             },
         }
+
+
+def test_free_capabilities_expose_every_unlock() -> None:
+    """get_free_capabilities() must surface a block for each known capability.
+
+    The endpoint test above patches this function out, so without this test the real
+    implementation never runs and a capability missing from it goes unnoticed.
+    """
+    unlocks = {
+        'eth_staking_view': 'Supporter',
+        'graphs_view': 'Basic',
+        'event_analysis_view': 'Basic',
+        'asset_movement_matching': 'Basic',
+        'gnosispay': 'Basic',
+        'monerium': 'Basic',
+        'mcp': 'Basic',
+    }
+    with patch(
+        'rotkehlchen.premium.premium.fetch_capability_unlocks',
+        return_value=unlocks,
+    ):
+        capabilities = get_free_capabilities()
+
+    assert capabilities['current_tier'] == 'Free'
+    for name, minimum_tier in unlocks.items():
+        assert capabilities[name] == {  # type: ignore[literal-required]  # keys are capability names
+            'enabled': False,
+            'minimum_tier': minimum_tier,
+        }, f'free capability {name} missing or not matching its unlock tier'

--- a/rotkehlchen/tests/integration/test_premium.py
+++ b/rotkehlchen/tests/integration/test_premium.py
@@ -893,6 +893,7 @@ def test_limits_caching(rotkehlchen_instance: Rotkehlchen) -> None:
         'history_events_limit': 10000,
         'limit_of_devices': 3,
         'max_backup_size_mb': 100,
+        'mcp': True,
         'monerium': True,
         'pnl_events_limit': 10000,
         'reports_lookup_limit': 50,


### PR DESCRIPTION
The MCP server gates every tool except `info` behind a subscription (`rotkehlchen/mcp/premium.py`: `NON_MCP_TIERS = {Free, Supporter}`, so Basic and up). The settings page knew nothing about that, so without a subscription you could start a server, generate a bearer token, wire up a client, and only then discover that every useful tool answers `premium_required`.

## Backend

`/premium/capabilities` carried no `mcp` entry, so clients had no way to know. `get_capabilities()` builds its response field by field rather than passing the limits payload through, so the `mcp` key rotki.com already ships was being dropped.

Added `mcp` alongside the other capabilities in both builders. `minimum_tier` comes from rotki.com's `limits/unlocks`, which already returns `mcp: Basic` — no rotki.com change was needed.

## Frontend

`useFeatureAccess(PremiumFeature.MCP)` now drives a gate on the MCP setting, using the same path as the other five gated features (no special case needed).

The gate is deliberately **soft**: the lifecycle controls stay usable, because the server genuinely does run — only its tools are gated. The accompanying hint is shown only where there is something to start (desktop app or Docker); in the web build it would contradict the "lifecycle controls are desktop-app only" notice directly below it.

## Testing

- `test_get_premium_capabilities` extended with the new field.
- New `test_free_capabilities_expose_every_unlock`, which actually executes `get_free_capabilities()`. The existing endpoint test patches that function out, so its body was never run and a capability missing from it would have gone unnoticed. It loops over every unlock name, so the same gap in a future capability fails too.
- Frontend: 4 unit tests on the capability, 1 asserting `mcp` survives the zod parse on a real API round-trip, and 4 component tests covering gate shown/hidden, the conditional hint, and controls staying usable while gated.
- Verified end-to-end in the app against live rotki.com with a fresh free-tier account: the payload returns `"mcp": {"enabled": false, "minimum_tier": "Basic"}` and the page renders "requires a minimum of Basic tier".

## Known unverified

`get_capabilities()` reads `limits.get('mcp', False)`, matching its siblings. I confirmed `mcp` is present in rotki.com's `unlocks`, but could not confirm the authenticated per-user limits payload carries a **top-level** `mcp` boolean — the most recent local debug log predates the server-side addition. Every one of the six other unlock keys has a matching top-level bool, so this very likely holds for `mcp` too, but it is inference rather than proof.

If that key turns out to be absent, `enabled` is `False` for everyone and paying subscribers see the gate. The fix would be to default to the tier check instead of `False`:

```python
enabled=limits.get(MCP_CAPABILITY, current_tier not in NON_MCP_TIERS),
```

Worth confirming against a premium account before this is relied on.