### PR TITLE
Ignore assets in netvalueworth

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`12764` Ignored assets should now be ignored from the snapshot values shown in the dashboard. 
 * :feature:`12735` KittenSwap swaps on HyperEVM are now properly decoded.
 * :feature:`12735` Project X swaps and liquidity position activity on HyperEVM are now properly decoded.
 * :feature:`-` Filtering blockchain accounts now uses the same filter bar as history events: each filter is a pill, the tag selector that sat beside the bar is a tag pill inside it, and a set of filters can be saved as a named view. Filters you had already saved for this table are carried over the first time you open the views menu. Accounts are now picked from a list that shows each one's avatar, name and address, and several accounts can be filtered at once, where before you typed part of an address or label and could filter by only one account at a time. A saved link to the accounts page that carried an account filter needs to be taken again, since the filters are written into the address differently now.

--- a/frontend/app/src/modules/auth/use-session-load.spec.ts
+++ b/frontend/app/src/modules/auth/use-session-load.spec.ts
@@ -150,6 +150,42 @@ describe('composables::session::load', () => {
       expect(seedOrder).toBeLessThan(chainOrder);
     });
 
+    it('should not fetch the balances until the ignored assets have arrived', async () => {
+      // the balances must not land before the lists that decide what they count, otherwise the
+      // net worth briefly includes ignored assets. https://github.com/rotki/rotki/issues/12764
+      let resolveIgnoredAssets: () => void = (): void => {};
+      mockFetchIgnoredAssets.mockReturnValue(new Promise<void>((resolve) => {
+        resolveIgnoredAssets = (): void => {
+          resolve();
+        };
+      }));
+
+      const { load } = useDataLoader();
+
+      load();
+      await flushPromises();
+
+      expect(mockFetchCached).not.toHaveBeenCalled();
+
+      resolveIgnoredAssets();
+      await flushPromises();
+
+      expect(mockFetchCached).toHaveBeenCalled();
+      expect(mockOnBalancesLoaded).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still fetch the balances when the ignored assets fetch fails', async () => {
+      mockFetchIgnoredAssets.mockRejectedValue(new Error('Fetch failed'));
+
+      const { load } = useDataLoader();
+
+      load();
+      await flushPromises();
+
+      expect(mockFetchCached).toHaveBeenCalled();
+      expect(mockOnBalancesLoaded).toHaveBeenCalledTimes(1);
+    });
+
     it('should not call onBalancesLoaded when shouldFetchData is false', async () => {
       set(mockShouldFetchData, false);
 

--- a/frontend/app/src/modules/auth/use-session-load.ts
+++ b/frontend/app/src/modules/auth/use-session-load.ts
@@ -38,9 +38,15 @@ export function useDataLoader(): UseDataLoaderReturn {
   const refreshData = async (): Promise<void> => {
     logger.info('Refreshing data');
 
+    // The ignored/whitelisted lists decide which assets are counted towards the totals, so
+    // they have to be in place before the balances land. Fetching them alongside the balances
+    // makes the net worth briefly include the ignored assets, until the lists arrive.
+    // https://github.com/rotki/rotki/issues/12764
     await Promise.allSettled([
       fetchIgnoredAssets(),
       fetchWhitelistedAssets(),
+    ]);
+    await Promise.allSettled([
       fetchCached(),
       fetchNetValue(),
     ]);

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -3195,31 +3195,50 @@ class DBHandler:
             from_ts: Timestamp,
             include_nfts: bool = True,
     ) -> tuple[list[str], list[str]]:
-        """Get all entries of net value data from the DB"""
+        """Get all entries of net value data from the DB
+
+        Ignored assets are subtracted from the stored snapshot totals here, at query time,
+        instead of being left out when the snapshot is taken. Ignoring is reversible, so the
+        per-asset rows have to stay in timed_balances for the value to come back if the asset
+        is unignored later.
+        """
         with self.conn.read_ctx() as cursor:
             cursor.execute(  # Get the total location ("H") entries in ascending time
                 "SELECT timestamp, usd_value FROM timed_location_data "
                 "WHERE location='H' AND timestamp >= ? ORDER BY timestamp ASC;",
                 (from_ts,),
             )
-            if not include_nfts:
-                with self.conn.read_ctx() as nft_cursor:
-                    nft_cursor.execute(
-                        'SELECT timestamp, SUM(usd_value) FROM timed_balances WHERE '
-                        'timestamp >= ? AND currency LIKE ? GROUP BY timestamp',
-                        (from_ts, f'{NFT_DIRECTIVE}%'),
-                    )
-                    nft_values = dict(nft_cursor)
+            # An ignored NFT matches both conditions but each row is still returned once, so
+            # its value can't get subtracted twice. The subtraction itself is exact since the
+            # "H" total and these rows are written by save_balances_data in the same call with
+            # the same usd rate, and that total is exactly the asset rows minus the liability
+            # rows of the snapshot.
+            query = (
+                'SELECT timestamp, category, usd_value FROM timed_balances WHERE timestamp >= ? '
+                "AND (currency IN (SELECT value FROM multisettings WHERE name='ignored_asset')"
+            )
+            bindings: list[Any] = [from_ts]
+            if include_nfts is False:
+                query += ' OR currency LIKE ?'
+                bindings.append(f'{NFT_DIRECTIVE}%')
+
+            asset_category = BalanceType.ASSET.serialize_for_db()  # pylint: disable=no-member
+            excluded_values: defaultdict[Timestamp, FVal] = defaultdict(FVal)
+            with self.conn.read_ctx() as excluded_cursor:
+                for timestamp, category, usd_value in excluded_cursor.execute(f'{query})', bindings):  # noqa: E501
+                    # the total is assets minus liabilities, so an excluded liability adds back
+                    if category == asset_category:
+                        excluded_values[timestamp] += FVal(usd_value)
+                    else:
+                        excluded_values[timestamp] -= FVal(usd_value)
 
             data, times_int = [], []
             for entry in cursor:
                 times_int.append(entry[0])
-                if include_nfts:
-                    total = entry[1]
-                else:
-                    total = str(FVal(entry[1]) - FVal(nft_values.get(entry[0], 0)))  # pyright: ignore  # nft_values is populated when include_nfts is False
-
-                data.append(total)
+                data.append(
+                    entry[1] if (excluded := excluded_values.get(entry[0])) is None
+                    else str(FVal(entry[1]) - excluded),
+                )
 
         return times_int, data
 

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -3201,39 +3201,45 @@ class DBHandler:
         instead of being left out when the snapshot is taken. Ignoring is reversible, so the
         per-asset rows have to stay in timed_balances for the value to come back if the asset
         is unignored later.
+
+        Summing in sqlite goes through a float since usd_value is TEXT, which is the same
+        tradeoff the nft exclusion already made. The error is ~1e-16 relative and the stored
+        total it gets subtracted from stays exact, so it can't show up in a rendered graph.
         """
         with self.conn.read_ctx() as cursor:
-            cursor.execute(  # Get the total location ("H") entries in ascending time
-                "SELECT timestamp, usd_value FROM timed_location_data "
-                "WHERE location='H' AND timestamp >= ? ORDER BY timestamp ASC;",
-                (from_ts,),
-            )
-            # An ignored NFT matches both conditions but each row is still returned once, so
-            # its value can't get subtracted twice. The subtraction itself is exact since the
-            # "H" total and these rows are written by save_balances_data in the same call with
-            # the same usd rate, and that total is exactly the asset rows minus the liability
-            # rows of the snapshot.
-            query = (
-                'SELECT timestamp, category, usd_value FROM timed_balances WHERE timestamp >= ? '
-                "AND (currency IN (SELECT value FROM multisettings WHERE name='ignored_asset')"
-            )
-            bindings: list[Any] = [from_ts]
-            if include_nfts is False:
-                query += ' OR currency LIKE ?'
-                bindings.append(f'{NFT_DIRECTIVE}%')
-
-            asset_category = BalanceType.ASSET.serialize_for_db()  # pylint: disable=no-member
             excluded_values: defaultdict[Timestamp, FVal] = defaultdict(FVal)
-            with self.conn.read_ctx() as excluded_cursor:
-                for timestamp, category, usd_value in excluded_cursor.execute(f'{query})', bindings):  # noqa: E501
-                    # the total is assets minus liabilities, so an excluded liability adds back
+            # scanning timed_balances is the expensive part of this query, so skip it when
+            # there is nothing to take out. Note a fresh DB already ships with the default
+            # spam assets ignored, so this mostly helps users who cleared that list.
+            if len(self.get_ignored_asset_ids(cursor)) != 0 or include_nfts is False:
+                # An ignored NFT matches both conditions but is still summed once, so its value
+                # can't get subtracted twice.
+                query = (
+                    'SELECT timestamp, category, SUM(usd_value) FROM timed_balances '
+                    'WHERE timestamp >= ? AND (currency IN '
+                    "(SELECT value FROM multisettings WHERE name='ignored_asset')"
+                )
+                bindings: list[Any] = [from_ts]
+                if include_nfts is False:
+                    query += ' OR currency LIKE ?'
+                    bindings.append(f'{NFT_DIRECTIVE}%')
+
+                asset_category = BalanceType.ASSET.serialize_for_db()  # pylint: disable=no-member
+                for timestamp, category, usd_value in cursor.execute(
+                    f'{query}) GROUP BY timestamp, category',
+                    bindings,
+                ):  # the total is assets minus liabilities, so an excluded liability adds back
                     if category == asset_category:
                         excluded_values[timestamp] += FVal(usd_value)
                     else:
                         excluded_values[timestamp] -= FVal(usd_value)
 
             data, times_int = [], []
-            for entry in cursor:
+            for entry in cursor.execute(  # the total ("H") entries in ascending time
+                "SELECT timestamp, usd_value FROM timed_location_data "
+                "WHERE location='H' AND timestamp >= ? ORDER BY timestamp ASC;",
+                (from_ts,),
+            ):
                 times_int.append(entry[0])
                 data.append(
                     entry[1] if (excluded := excluded_values.get(entry[0])) is None

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -1259,6 +1259,99 @@ def test_get_netvalue_without_nfts(data_dir, username, sql_vm_instructions_cb):
     data.logout()
 
 
+def test_get_netvalue_data_with_ignored_assets(data_dir, username, sql_vm_instructions_cb):
+    """Test that ignored assets are subtracted from the stored snapshot totals at query time.
+
+    Regression test for https://github.com/rotki/rotki/issues/12764 where the net value graph
+    kept showing the value of an asset that the user had already ignored. The subtraction has
+    to happen when reading, so that unignoring the asset brings the value back.
+    """
+    data = DataHandler(data_dir, MessagesAggregator(), sql_vm_instructions_cb)
+    data.unlock(username, '123', create_new=True, resume_from_backup=False)
+    with data.db.user_write() as write_cursor:
+        data.db.add_multiple_balances(write_cursor, [DBAssetBalance(
+            category=BalanceType.ASSET,
+            time=Timestamp(1488326400),
+            asset=A_BTC,
+            amount=FVal('1'),
+            usd_value=FVal('1000'),
+        ), DBAssetBalance(
+            category=BalanceType.ASSET,
+            time=Timestamp(1488326400),
+            asset=A_ETH,
+            amount=FVal('10'),
+            usd_value=FVal('500'),
+        ), DBAssetBalance(
+            category=BalanceType.LIABILITY,
+            time=Timestamp(1488326400),
+            asset=A_EUR,
+            amount=FVal('100'),
+            usd_value=FVal('100'),
+        ), DBAssetBalance(
+            category=BalanceType.ASSET,
+            time=Timestamp(1488426400),
+            asset=A_BTC,
+            amount=FVal('1'),
+            usd_value=FVal('1200'),
+        ), DBAssetBalance(
+            category=BalanceType.ASSET,
+            time=Timestamp(1488426400),
+            asset=A_ETH,
+            amount=FVal('10'),
+            usd_value=FVal('600'),
+        )])
+        data.db.add_multiple_location_data(write_cursor, [LocationData(
+            time=Timestamp(1488326400),
+            location=Location.TOTAL.serialize_for_db(),  # pylint: disable=no-member
+            usd_value='1400',  # 1000 + 500 - 100 of liability
+        ), LocationData(
+            time=Timestamp(1488426400),
+            location=Location.TOTAL.serialize_for_db(),  # pylint: disable=no-member
+            usd_value='1800',
+        )])
+
+    assert data.db.get_netvalue_data(Timestamp(0)) == (
+        [1488326400, 1488426400], ['1400', '1800'],
+    )
+    with data.db.user_write() as write_cursor:  # ignoring an asset removes it from the totals
+        data.db.add_to_ignored_assets(write_cursor=write_cursor, asset=A_ETH)
+
+    assert data.db.get_netvalue_data(Timestamp(0)) == (
+        [1488326400, 1488426400], ['900', '1200'],
+    )
+    with data.db.user_write() as write_cursor:  # an ignored liability adds back to the total
+        data.db.add_to_ignored_assets(write_cursor=write_cursor, asset=A_EUR)
+
+    assert data.db.get_netvalue_data(Timestamp(0)) == (
+        [1488326400, 1488426400], ['1000', '1200'],
+    )
+    with data.db.user_write() as write_cursor:  # unignoring restores the original totals
+        data.db.remove_from_ignored_assets(write_cursor=write_cursor, asset=A_ETH)
+        data.db.remove_from_ignored_assets(write_cursor=write_cursor, asset=A_EUR)
+
+    assert data.db.get_netvalue_data(Timestamp(0)) == (
+        [1488326400, 1488426400], ['1400', '1800'],
+    )
+    data.logout()
+
+
+def test_get_netvalue_data_with_ignored_nft(data_dir, username, sql_vm_instructions_cb):
+    """Test that an ignored NFT is only subtracted once when NFTs are also excluded"""
+    data = DataHandler(data_dir, MessagesAggregator(), sql_vm_instructions_cb)
+    data.unlock(username, '123', create_new=True, resume_from_backup=False)
+    add_starting_nfts(data)
+    with data.db.user_write() as write_cursor:
+        data.db.add_to_ignored_assets(write_cursor=write_cursor, asset=Asset('_nft_pickle'))
+
+    start_ts = Timestamp(1488326400)
+    assert data.db.get_netvalue_data(start_ts)[1] == ['2000', '3000', '3000', '4500']
+    assert data.db.get_netvalue_data(
+        from_ts=start_ts,
+        include_nfts=False,
+    )[1] == ['2000', '3000', '3000', '4500']
+    data.logout()
+
+
 def test_add_margin_positions(data_dir, username, caplog, sql_vm_instructions_cb):
     """Test that adding and retrieving margin positions from the DB works fine.
 


### PR DESCRIPTION
Fix #12764 

- Fixes the backend code so that ignored assets are skipped when showing net worth. This ... may make the query a bit slow
- Tries a fix for the flickering of the snapshot loading. Commit ecb58bae45b10158a033203982929ca4aa33d759 . @kelsos should have a look if it makes sense.