### PR TITLE
Reserve starling's ports per dev instance

### DIFF
--- a/frontend/scripts/dev-instance/instance.ts
+++ b/frontend/scripts/dev-instance/instance.ts
@@ -49,11 +49,17 @@ function envKeysDiverge(
 }
 
 function computeDesiredManagedEnv(name: string, slot: number, ports: PortSet, useProxy: boolean): Record<string, string> {
+  // Nothing addresses core or colibri directly any more: starling fronts both
+  // behind its reverse proxy, and the premium dev-proxy (when on) fronts that
+  // in turn. Only the core API URL is routed through the dev-proxy; colibri is
+  // always addressed as `<starling proxy>/colibri` (the dev-proxy forwards
+  // every path, so this is a routing choice here, not a limit of the proxy).
+  const starlingOrigin = `http://127.0.0.1:${ports.starlingProxy}`;
   return {
     INSTANCE_NAME: name,
     INSTANCE_PORT_SLOT: String(slot),
-    VITE_BACKEND_URL: `http://127.0.0.1:${useProxy ? ports.proxy : ports.restApi}`,
-    VITE_COLIBRI_URL: `http://127.0.0.1:${ports.colibri}`,
+    VITE_BACKEND_URL: useProxy ? `http://127.0.0.1:${ports.proxy}` : starlingOrigin,
+    VITE_COLIBRI_URL: `${starlingOrigin}/colibri`,
     DEV_PORT: String(ports.dev),
   };
 }
@@ -66,7 +72,7 @@ async function refuseIfSlotLive(name: string, slot: number): Promise<void> {
     `Instance "${name}" is already live on slot ${slot}:`,
     ...live.map((entry) => {
       const pid = entry.pid !== undefined ? ` (PID ${entry.pid})` : '';
-      return `  ${entry.name.padEnd(8)} ${formatHostPort('localhost', entry.port)}${pid}`;
+      return `  ${entry.name.padEnd(14)} ${formatHostPort('localhost', entry.port)}${pid}`;
     }),
     'Pass --instance <other-name> for a fresh slot or stop the running one.',
   ];
@@ -82,7 +88,7 @@ function refuseOnEnvDivergence(
   desiredEnv: Record<string, string>,
 ): void {
   const { name, slot, ports } = context;
-  const portLine = `backend=${formatPort(ports.restApi)} proxy=${formatPort(ports.proxy)} colibri=${formatPort(ports.colibri)} dev=${formatPort(ports.dev)}`;
+  const portLine = `backend=${formatPort(ports.restApi)} proxy=${formatPort(ports.proxy)} colibri=${formatPort(ports.colibri)} dev=${formatPort(ports.dev)} starling=${formatPort(ports.starlingProxy)} mcp=${formatPort(ports.mcp)}`;
   const lines = [
     `Instance "${name}" → slot ${slot} (${portLine})`,
     `Detected user-customized managed env keys in ${envFile}:`,

--- a/frontend/scripts/dev-instance/lifecycle.ts
+++ b/frontend/scripts/dev-instance/lifecycle.ts
@@ -106,7 +106,7 @@ export async function refuseIfLive(name: string, slot: number): Promise<boolean>
     `Instance "${name}" is live on slot ${slot}:`,
     ...live.map((entry) => {
       const pid = entry.pid !== undefined ? ` (PID ${entry.pid})` : '';
-      return `  ${entry.name.padEnd(8)} ${formatHostPort('localhost', entry.port)}${pid}`;
+      return `  ${entry.name.padEnd(14)} ${formatHostPort('localhost', entry.port)}${pid}`;
     }),
     'Stop the running instance before continuing.',
   ];

--- a/frontend/scripts/dev-instance/port-probe.ts
+++ b/frontend/scripts/dev-instance/port-probe.ts
@@ -52,7 +52,7 @@ export interface LiveProbeResult {
   pid?: number;
 }
 
-const ALL_PORT_NAMES: readonly PortName[] = ['restApi', 'proxy', 'colibri', 'dev'];
+const ALL_PORT_NAMES: readonly PortName[] = ['restApi', 'proxy', 'colibri', 'dev', 'starlingProxy', 'mcp'];
 
 export async function probePortsLive(slot: number): Promise<LiveProbeResult[]> {
   const ports = portsForSlot(slot);

--- a/frontend/scripts/dev-instance/port-registry.ts
+++ b/frontend/scripts/dev-instance/port-registry.ts
@@ -2,15 +2,23 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { z } from 'zod/v4';
+import { DEFAULT_COLIBRI_PORT, DEFAULT_MCP_PORT, DEFAULT_PORT, DEFAULT_PROXY_PORT } from '../../app/shared/port-utils';
 import { createDevLogger } from '../dev/logger';
 import { errorCode, errorMessage } from './format';
 import { ensureInstanceParent, resolveInstanceParent, sanitizeName } from './paths';
 
+/**
+ * Note the two distinct proxies: `proxy` is the optional premium dev-proxy
+ * (@rotki/dev-proxy), `starlingProxy` is the reverse proxy starling itself
+ * serves — the single origin the renderer talks to. Both need their own port.
+ */
 export const DEFAULT_PORTS = {
-  restApi: 4242,
+  restApi: DEFAULT_PORT,
   proxy: 4243,
-  colibri: 4343,
+  colibri: DEFAULT_COLIBRI_PORT,
   dev: 8080,
+  starlingProxy: DEFAULT_PROXY_PORT,
+  mcp: DEFAULT_MCP_PORT,
 } as const;
 
 export type PortName = keyof typeof DEFAULT_PORTS;
@@ -30,10 +38,10 @@ export const MAX_PORT = 65_535;
 export const INSTANCE_BASE_PORT = 13_000;
 
 /**
- * Each slot owns 4 contiguous ports (backend, proxy, colibri, dev). A step of
- * 10 leaves 6 ports of slack between neighbours so TIME_WAIT sockets from one
- * slot can't bleed into the next. With the 1000-slot cap below, the highest
- * port we'd ever pick is 13_000 + 999*10 + 3 = 22_993.
+ * Each slot owns 6 contiguous ports (dev, backend, dev-proxy, colibri, starling
+ * proxy, mcp). A step of 10 leaves 4 ports of slack between neighbours so
+ * TIME_WAIT sockets from one slot can't bleed into the next. With the 1000-slot
+ * cap below, the highest port we'd ever pick is 13_000 + 999*10 + 5 = 22_995.
  */
 export const INSTANCE_SLOT_STEP = 10;
 
@@ -59,6 +67,10 @@ export interface PortSet {
   proxy: number;
   colibri: number;
   dev: number;
+  /** starling's own reverse proxy — the origin the renderer addresses. */
+  starlingProxy: number;
+  /** starling's MCP server. */
+  mcp: number;
 }
 
 const PortIndexSchema = z.object({
@@ -75,14 +87,18 @@ export function portsForSlot(slot: number): PortSet {
     return { ...DEFAULT_PORTS };
   }
   // Layout within a slot's block: dev sits on the base port so the URL you
-  // open in the browser is the "round" number (e.g. 13000), and the three
-  // backend services follow in order python → proxy → colibri.
+  // open in the browser is the "round" number (e.g. 13000), and the backend
+  // services follow in order python → dev-proxy → colibri → starling proxy →
+  // mcp. The first four keep the offsets they have always had, so an instance
+  // created before starling joined the block stays on the same ports.
   const base = INSTANCE_BASE_PORT + (slot - 1) * INSTANCE_SLOT_STEP;
   return {
     dev: base,
     restApi: base + 1,
     proxy: base + 2,
     colibri: base + 3,
+    starlingProxy: base + 4,
+    mcp: base + 5,
   };
 }
 

--- a/frontend/scripts/dev/services.ts
+++ b/frontend/scripts/dev/services.ts
@@ -164,8 +164,8 @@ export interface DevEnvironmentOptions {
  * Bring the backend tree up for web mode. starling supervises core and colibri
  * and fronts both behind its own proxy, so there is no readiness polling here:
  * the `start` control request it is driven with resolves only once the whole
- * tree is up. In instance mode the reserved core/colibri ports are handed down
- * so the slot still owns them; starling's proxy port is probed from its default.
+ * tree is up. In instance mode every port starling binds — core, colibri, its
+ * own proxy and mcp — comes from the reserved slot, so the slot owns them all.
  */
 async function startBackendForMode(
   instance: InstanceRuntime | null,
@@ -180,6 +180,8 @@ async function startBackendForMode(
     dataDir: instance?.dir,
     corePort: instance ? instance.ports.restApi : opts.webPort,
     colibriPort: instance ? instance.ports.colibri : opts.colibriPort,
+    proxyPort: instance ? instance.ports.starlingProxy : DEFAULT_PORTS.starlingProxy,
+    mcpPort: instance ? instance.ports.mcp : DEFAULT_PORTS.mcp,
     // An instance owns its slot outright; otherwise the defaults are only a
     // starting point and a busy port walks up, as it did before starling.
     strictPorts: instance !== null,
@@ -224,6 +226,8 @@ function instanceEnvForElectron(instance: InstanceRuntime | null): Record<string
   return {
     ROTKI_INSTANCE_CORE_PORT: String(instance.ports.restApi),
     ROTKI_INSTANCE_COLIBRI_PORT: String(instance.ports.colibri),
+    ROTKI_INSTANCE_PROXY_PORT: String(instance.ports.starlingProxy),
+    ROTKI_INSTANCE_MCP_PORT: String(instance.ports.mcp),
     ROTKI_INSTANCE_DATA_DIR: instance.dir,
   };
 }

--- a/frontend/scripts/dev/starling.ts
+++ b/frontend/scripts/dev/starling.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import process from 'node:process';
-import { DEFAULT_MCP_PORT, DEFAULT_PROXY_PORT, selectPort } from '../../app/shared/port-utils';
+import { selectPort } from '../../app/shared/port-utils';
 import { buildStarlingInvocation, SHUTDOWN_GRACE_SECS, type StarlingBackendOptions } from '../../app/shared/starling/starling-args';
 import { requestStarlingStart, spawnStarling } from '../../app/shared/starling/starling-launch';
 import { StarlingMethod } from '../../app/shared/starling/starling-protocol';
@@ -22,9 +22,13 @@ export interface StarlingDevOptions {
   corePort: number;
   /** Port colibri binds, or starts probing from when `strictPorts` is false. */
   colibriPort: number;
+  /** Port starling's reverse proxy binds, or starts probing from. */
+  proxyPort: number;
+  /** Port starling's MCP server binds, or starts probing from. */
+  mcpPort: number;
   /**
-   * Bind the given core/colibri ports exactly rather than probing upward. Set
-   * for `--instance` runs, which reserve a slot and must land on it.
+   * Bind the given ports exactly rather than probing upward. Set for
+   * `--instance` runs, which reserve a slot and must land on it.
    */
   strictPorts: boolean;
 }
@@ -50,14 +54,32 @@ async function wait(ms: number): Promise<void> {
  * tree is up — so there is nothing here to poll.
  */
 export async function startStarlingSupervisor(options: StarlingDevOptions): Promise<StarlingDevEnv> {
-  const corePort = options.strictPorts ? options.corePort : await selectPort(options.corePort, API_HOST);
-  const colibriPort = options.strictPorts ? options.colibriPort : await selectPort(options.colibriPort, API_HOST);
-  // The two ports the caller does not choose come from the same defaults the
-  // Electron main process uses. Both are probed, so a busy default walks up,
-  // which is how two concurrent dev:web runs stay off each other without
-  // reserving a slot in the instance port registry.
-  const mcpPort = await selectPort(DEFAULT_MCP_PORT, API_HOST);
-  const proxyPort = await selectPort(DEFAULT_PROXY_PORT, API_HOST);
+  // In instance mode every port is reserved by the slot, so bind it exactly and
+  // fail loudly if something else holds it. Otherwise the caller's values are
+  // only a starting point and a busy port walks up, which is how two concurrent
+  // plain `dev:web` runs stay off each other without reserving a slot.
+  //
+  // `selectPort` closes its probe socket before returning and nothing binds
+  // until starling spawns, so two services whose start values converge would
+  // otherwise be handed the same port (e.g. `--web-port 4141`, which collides
+  // with the proxy default). Track what we've handed out and keep walking.
+  const taken = new Set<number>();
+  const resolve = async (port: number): Promise<number> => {
+    if (options.strictPorts) {
+      taken.add(port);
+      return port;
+    }
+    let candidate = await selectPort(port, API_HOST);
+    while (taken.has(candidate))
+      candidate = await selectPort(candidate + 1, API_HOST);
+    taken.add(candidate);
+    return candidate;
+  };
+
+  const corePort = await resolve(options.corePort);
+  const colibriPort = await resolve(options.colibriPort);
+  const proxyPort = await resolve(options.proxyPort);
+  const mcpPort = await resolve(options.mcpPort);
 
   const backendOptions: StarlingBackendOptions = {
     logDirectory: options.logDir,

--- a/frontend/scripts/start-dev.ts
+++ b/frontend/scripts/start-dev.ts
@@ -305,7 +305,8 @@ async function runDevAction(options: DevCliOptions): Promise<void> {
     logger.info(`Instance "${instance.name}" → slot ${instance.slot}, dir ${instance.dir}`);
     logger.info(
       `  ports: backend=${formatPort(instance.ports.restApi)} proxy=${formatPort(instance.ports.proxy)} `
-      + `colibri=${formatPort(instance.ports.colibri)} dev=${formatPort(instance.ports.dev)}`,
+      + `colibri=${formatPort(instance.ports.colibri)} dev=${formatPort(instance.ports.dev)} `
+      + `starling=${formatPort(instance.ports.starlingProxy)} mcp=${formatPort(instance.ports.mcp)}`,
     );
     propagateInstanceEnv();
   }


### PR DESCRIPTION
## Problem

Every dev service takes its port from the instance slot registry except starling. Its reverse proxy and MCP server were probed upward from the hardcoded `4141`/`4445` in `scripts/dev/starling.ts`:

```ts
const mcpPort = await selectPort(DEFAULT_MCP_PORT, API_HOST);
const proxyPort = await selectPort(DEFAULT_PROXY_PORT, API_HOST);
```

Those ports are never reserved in `.port-index.json`, so two concurrent `--instance` runs raced for them and landed non-deterministically. The proxy port is the origin the renderer actually addresses, so it is the one you least want floating.

## Change

starling already accepts `--proxy-port` and `--mcp-port`, so nothing changes in the Rust crate. A slot block grows from 4 to 6 ports:

```
dev = base, restApi = +1, proxy = +2, colibri = +3, starlingProxy = +4, mcp = +5
```

The original four offsets are kept, so existing instances stay on the ports they already use. `INSTANCE_SLOT_STEP` stays at 10, leaving 4 ports of slack between neighbours. Slot 0 (plain `dev:web`) is unchanged at 4141/4445.

Note `proxy` (+2) is the premium dev-proxy and `starlingProxy` (+4) is starling's own reverse proxy; they are two different things and the constant block now says so.

Three things came along with it:

- `computeDesiredManagedEnv` wrote `VITE_BACKEND_URL` at core's port and `VITE_COLIBRI_URL` at colibri's port directly. Nothing addresses those anymore now that starling fronts both. The runtime `process.env` masked this in web dev, but the written value is what electron seeds from.
- `ROTKI_INSTANCE_PROXY_PORT` / `ROTKI_INSTANCE_MCP_PORT` were already read by `electron/main/application.ts` and set by nothing. They are now exported, so electron instances stop probing from the shared defaults too.
- `selectPort` closes its probe socket before returning and nothing binds until starling spawns, so services with converging start values were handed the same port (`--web-port 4141` gave core and the proxy both 4141). Handed-out ports are now tracked so the next probe walks past them.

## Verification

Two instances side by side, slot 6 and slot 7. The clearest evidence is what each Vite dev server actually bakes into the renderer, fetched from the running servers:

```
vite 13050 -> "http://127.0.0.1:13054"  "http://127.0.0.1:13054/colibri"
vite 13060 -> "http://127.0.0.1:13064"  "http://127.0.0.1:13064/colibri"
```

Also confirmed: separate `starling`/`python3`/`colibri` processes per slot with the flags carrying slot values; `/api/1/users` returning disjoint user lists per instance (separate DBs, no bleed); `/ws/` upgrading `101` through both proxies; colibri reachable through both.

Negative control for the convergent-probe fix, using the real `selectPort`:

```
start values : 4141 4343 4141 4445
OLD resolved : 4141 4343 4141 4445   duplicates: 1
NEW resolved : 4141 4343 4142 4445   duplicates: 0
```

## Known unfixed

Both pre-existing, both out of scope here, flagging so they are not lost:

- `spawnProxyForElectron` (`services.ts`) points the dev-proxy at the raw core port, and `starling-handler.ts` then overwrites the renderer's `coreApiUrl` with starling's origin (`use-backend-connection.ts` prefers `window.interop.apiUrls()`). So electron + `--proxy` silently bypasses the dev-proxy, and premium components / `async-mock.json` do nothing.
- `DEFAULT_PORTS.proxy` (4243) is the one port never probed and never reserved. Two plain `dev:web` runs with the proxy on: run 2's dev-proxy dies `EADDRINUSE` while `VITE_BACKEND_URL` already points at run 1's proxy, so run 2's renderer quietly drives run 1's data dir.

No UI login was performed as part of the verification above; the checks were at the API, websocket and bundler level.