### PR TITLE
Migrate the general display settings to zod

### DIFF
--- a/frontend/app/src/modules/settings/SsfGraphMultiplierSetting.spec.ts
+++ b/frontend/app/src/modules/settings/SsfGraphMultiplierSetting.spec.ts
@@ -1,0 +1,107 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import SsfGraphMultiplierSetting from '@/modules/settings/SsfGraphMultiplierSetting.vue';
+
+const { useSettingMock, useSettingModelMock } = vi.hoisted(() => ({
+  useSettingMock: vi.fn(),
+  useSettingModelMock: vi.fn(),
+}));
+vi.mock('@/modules/settings/use-setting-model', () => ({ useSettingModel: useSettingModelMock }));
+vi.mock('@/modules/settings/use-setting', () => ({ useSetting: useSettingMock }));
+
+const RuiTextFieldStub = {
+  props: ['modelValue', 'successMessages', 'errorMessages', 'label'],
+  emits: ['update:model-value'],
+  template: `<div>
+    <span class="model">{{ modelValue }}</span>
+    <span class="success">{{ successMessages }}</span>
+    <span class="error">{{ errorMessages }}</span>
+    <span class="error-count">{{ Array.isArray(errorMessages) ? errorMessages.length : (errorMessages ? 1 : 0) }}</span>
+  </div>`,
+};
+
+describe('ssfGraphMultiplierSetting', () => {
+  let model: Ref<number>;
+  let error: Ref<string>;
+  let success: Ref<boolean>;
+
+  function createWrapper(): VueWrapper {
+    return mount(SsfGraphMultiplierSetting, {
+      global: { stubs: { RuiCardHeader: true, RuiTextField: RuiTextFieldStub } },
+    });
+  }
+
+  async function input(wrapper: VueWrapper, value: string): Promise<void> {
+    await wrapper.findComponent(RuiTextFieldStub).vm.$emit('update:model-value', value);
+    await nextTick();
+  }
+
+  beforeEach(() => {
+    model = ref<number>(0);
+    error = ref<string>('');
+    success = ref<boolean>(false);
+    useSettingMock.mockReturnValue(ref(3600));
+    useSettingModelMock.mockReturnValue({ error, flush: vi.fn(), model, pending: ref(false), success });
+  });
+
+  it('should render the field with the current value', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.model').text()).toBe('0');
+  });
+
+  it('should persist a positive multiplier as a number', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, '10');
+    expect(get(model)).toBe(10);
+    expect(wrapper.find('.error-count').text()).toBe('0');
+  });
+
+  it('should not persist a negative multiplier', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, '-1');
+    expect(get(model)).toBe(0);
+    expect(wrapper.find('.error').text()).toContain('statistics_graph_settings.multiplier.validations.positive_number');
+  });
+
+  it('should persist an empty value as zero', async () => {
+    set(model, 10);
+    const wrapper = createWrapper();
+    await input(wrapper, '');
+    expect(get(model)).toBe(0);
+    expect(wrapper.find('.error-count').text()).toBe('0');
+  });
+
+  it('should report the period as off while the multiplier is zero', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.text()).toContain('statistics_graph_settings.multiplier.off');
+  });
+
+  it('should report the period as the multiplier times the save frequency', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, '10');
+    expect(wrapper.text()).toContain('statistics_graph_settings.multiplier.on::36000');
+  });
+
+  it('should reflect an external change of the setting', async () => {
+    const wrapper = createWrapper();
+    set(model, 7);
+    await nextTick();
+    expect(wrapper.find('.model').text()).toBe('7');
+  });
+
+  it('should emit updated and show success once the write lands', async () => {
+    const wrapper = createWrapper();
+    set(success, true);
+    await nextTick();
+    expect(wrapper.emitted('updated')).toHaveLength(1);
+    expect(wrapper.find('.success').text()).toContain('settings.saved');
+  });
+
+  it('should show the write error unprefixed by a setting-specific message', async () => {
+    const wrapper = createWrapper();
+    set(error, 'boom');
+    await nextTick();
+    expect(wrapper.find('.error').text()).toContain('settings.not_saved: boom');
+  });
+});

--- a/frontend/app/src/modules/settings/SsfGraphMultiplierSetting.vue
+++ b/frontend/app/src/modules/settings/SsfGraphMultiplierSetting.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, minValue } from '@vuelidate/validators';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import type { ZodType } from 'zod';
+import { useForm } from '@/modules/core/form/use-form';
+import { numberSettingSchema, SETTING_FIELD, type SettingFieldState } from '@/modules/settings/controls/setting-field-schemas';
 import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
 import { useSetting } from '@/modules/settings/use-setting';
 import { useSettingModel } from '@/modules/settings/use-setting-model';
@@ -17,20 +16,33 @@ const balanceSaveFrequency = useSetting('balanceSaveFrequency');
 const { error: writeError, model, success: writeSuccess } = useSettingModel('ssfGraphMultiplier', { debounce: 1500 });
 const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
 
-const multiplier = ref<string>(String(get(model)));
-
-const rules = {
-  multiplier: {
-    min: helpers.withMessage(t('statistics_graph_settings.multiplier.validations.positive_number'), minValue(0)),
+// A blank field is not an error: it persists as zero, which turns the graph off.
+const schema = computed<ZodType>(() => numberSettingSchema({
+  messages: {
+    min: t('statistics_graph_settings.multiplier.validations.positive_number'),
+    required: t('statistics_graph_settings.multiplier.validations.positive_number'),
   },
-};
-const v$ = useVuelidate(rules, { multiplier }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
+  min: 0,
+  required: false,
+}));
 
-const numericMultiplier = computed<number>(() => {
-  const multi = Number.parseInt(get(multiplier));
+function toMultiplier(value: string): number {
+  const multi = Number.parseInt(value);
   return isNaN(multi) ? 0 : multi;
+}
+
+/** Submitting is the persist: the core runs it only when the field parses, as `callIfValid` did. */
+const form = useForm<SettingFieldState, SettingFieldState>({
+  initial: (): SettingFieldState => ({ value: String(get(model)) }),
+  schema,
+  submit: async (payload: SettingFieldState): Promise<{ success: boolean }> => {
+    set(model, toMultiplier(payload.value));
+    return Promise.resolve({ success: true });
+  },
+  transform: (state): SettingFieldState => ({ value: state.value }),
 });
+
+const numericMultiplier = computed<number>(() => toMultiplier(form.state.value));
 
 const period = computed<number>(() => {
   const multi = get(numericMultiplier);
@@ -40,18 +52,16 @@ const period = computed<number>(() => {
   return multi * get(balanceSaveFrequency);
 });
 
-function persist(): void {
-  set(model, get(numericMultiplier));
-}
-
-function onInput(value: string): void {
+async function onInput(value: string): Promise<void> {
   clearAll();
-  callIfValid(value, persist);
+  form.state.value = value;
+  await form.submit();
 }
 
+// Reflect external changes into the field, but ignore the echo of our own writes (same string).
 watch(model, (value) => {
-  if (String(value) !== get(multiplier))
-    set(multiplier, String(value));
+  if (String(value) !== form.state.value)
+    form.state.value = String(value);
 });
 
 watch(writeSuccess, (saved) => {
@@ -78,14 +88,14 @@ watch(writeError, (message) => {
       </template>
     </RuiCardHeader>
     <RuiTextField
-      v-model="multiplier"
+      v-model="form.state.value"
       variant="outlined"
       color="primary"
       min="0"
       :label="t('statistics_graph_settings.multiplier.label')"
       type="number"
       :success-messages="success"
-      :error-messages="error || toMessages(v$.multiplier)"
+      :error-messages="error || form.errors(SETTING_FIELD)"
       @update:model-value="onInput($event)"
     />
 

--- a/frontend/app/src/modules/settings/general/DateDisplayFormatSetting.spec.ts
+++ b/frontend/app/src/modules/settings/general/DateDisplayFormatSetting.spec.ts
@@ -1,0 +1,118 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import DateDisplayFormatSetting from '@/modules/settings/general/DateDisplayFormatSetting.vue';
+
+const { flushMock, useSettingModelMock } = vi.hoisted(() => ({ flushMock: vi.fn(), useSettingModelMock: vi.fn() }));
+vi.mock('@/modules/settings/use-setting-model', () => ({ useSettingModel: useSettingModelMock }));
+
+const RuiTextFieldStub = {
+  props: ['modelValue', 'successMessages', 'errorMessages', 'label', 'hint'],
+  emits: ['update:model-value'],
+  template: `<div>
+    <span class="model">{{ modelValue }}</span>
+    <span class="success">{{ successMessages }}</span>
+    <span class="error">{{ errorMessages }}</span>
+    <span class="error-count">{{ Array.isArray(errorMessages) ? errorMessages.length : (errorMessages ? 1 : 0) }}</span>
+    <span class="hint">{{ hint }}</span>
+  </div>`,
+};
+
+const ResetStub = {
+  emits: ['confirm'],
+  template: `<button class="reset" @click="$emit('confirm')" />`,
+};
+
+describe('dateDisplayFormatSetting', () => {
+  let model: Ref<string>;
+  let error: Ref<string>;
+  let success: Ref<boolean>;
+
+  function createWrapper(): VueWrapper {
+    return mount(DateDisplayFormatSetting, {
+      global: {
+        stubs: {
+          DateFormatHelp: true,
+          RuiTextField: RuiTextFieldStub,
+          SettingResetConfirmButton: ResetStub,
+        },
+      },
+    });
+  }
+
+  async function input(wrapper: VueWrapper, value: string): Promise<void> {
+    await wrapper.findComponent(RuiTextFieldStub).vm.$emit('update:model-value', value);
+    await nextTick();
+  }
+
+  beforeEach(() => {
+    flushMock.mockClear();
+    model = ref<string>('%d/%m/%Y');
+    error = ref<string>('');
+    success = ref<boolean>(false);
+    useSettingModelMock.mockReturnValue({ error, flush: flushMock, model, pending: ref(false), success });
+  });
+
+  it('should render the field with the current value', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.model').text()).toBe('%d/%m/%Y');
+  });
+
+  it('should persist a format that contains valid directives', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, '%Y-%m-%d');
+    expect(get(model)).toBe('%Y-%m-%d');
+    expect(wrapper.find('.error-count').text()).toBe('0');
+  });
+
+  it('should not persist a format without valid directives', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 'not a format');
+    expect(get(model)).toBe('%d/%m/%Y');
+    expect(wrapper.find('.error').text()).toContain('general_settings.date_display.validation.invalid');
+  });
+
+  it('should not persist an empty format', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, '');
+    expect(get(model)).toBe('%d/%m/%Y');
+    expect(wrapper.find('.error').text()).toContain('general_settings.date_display.validation.empty');
+    // A blank value trips both rules under Vuelidate; the count is pinned so the migration keeps it.
+    expect(wrapper.find('.error-count').text()).toBe('2');
+  });
+
+  it('should reset to the default format and flush immediately', async () => {
+    const wrapper = createWrapper();
+    await wrapper.find('.reset').trigger('click');
+    await nextTick();
+    expect(get(model)).toBe('%d/%m/%Y %H:%M:%S %Z');
+    expect(wrapper.find('.model').text()).toBe('%d/%m/%Y %H:%M:%S %Z');
+    expect(flushMock).toHaveBeenCalledOnce();
+  });
+
+  it('should reflect an external change of the setting', async () => {
+    const wrapper = createWrapper();
+    set(model, '%Y');
+    await nextTick();
+    expect(wrapper.find('.model').text()).toBe('%Y');
+  });
+
+  it('should show a success message once the write lands', async () => {
+    const wrapper = createWrapper();
+    set(success, true);
+    await nextTick();
+    expect(wrapper.find('.success').text()).toContain('general_settings.validation.date_display_format.success');
+  });
+
+  it('should show a prefixed error message when the write fails', async () => {
+    const wrapper = createWrapper();
+    set(error, 'boom');
+    await nextTick();
+    expect(wrapper.find('.error').text()).toBe('settings.not_saved: general_settings.validation.date_display_format.error: boom');
+  });
+
+  it('should render the formatted example as the hint', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.hint').text()).toContain('general_settings.date_display_format_hint::');
+  });
+});

--- a/frontend/app/src/modules/settings/general/DateDisplayFormatSetting.vue
+++ b/frontend/app/src/modules/settings/general/DateDisplayFormatSetting.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
+import type { ZodType } from 'zod';
 import { displayDateFormatter } from '@/modules/core/common/date-formatter';
 import { Defaults } from '@/modules/core/common/defaults';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
 import DateFormatHelp from '@/modules/settings/controls/DateFormatHelp.vue';
+import { SETTING_FIELD, type SettingFieldState } from '@/modules/settings/controls/setting-field-schemas';
+import { dateFormatSchema } from '@/modules/settings/general/date-format-schema';
 import SettingResetConfirmButton from '@/modules/settings/SettingResetConfirmButton.vue';
 import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
 import { useSettingModel } from '@/modules/settings/use-setting-model';
@@ -15,28 +15,27 @@ const { t } = useI18n({ useScope: 'global' });
 const { error: writeError, flush, model, success: writeSuccess } = useSettingModel('dateDisplayFormat', { debounce: 1500 });
 const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
 
-const dateDisplayFormat = ref<string>(get(model));
 const formatHelp = ref<boolean>(false);
 const now = new Date();
 const defaultDateDisplayFormat = Defaults.DEFAULT_DATE_DISPLAY_FORMAT;
 
-function containsValidDirectives(v: string): boolean {
-  return displayDateFormatter.containsValidDirectives(v);
-}
+const schema = computed<ZodType>(() => dateFormatSchema({
+  empty: t('general_settings.date_display.validation.empty'),
+  invalid: t('general_settings.date_display.validation.invalid'),
+}));
 
-const rules = {
-  dateDisplayFormat: {
-    containsValidDirectives: helpers.withMessage(
-      t('general_settings.date_display.validation.invalid'),
-      containsValidDirectives,
-    ),
-    required: helpers.withMessage(t('general_settings.date_display.validation.empty'), required),
+/** Submitting is the persist: the core runs it only when the field parses, as `callIfValid` did. */
+const form = useForm<SettingFieldState, SettingFieldState>({
+  initial: (): SettingFieldState => ({ value: get(model) }),
+  schema,
+  submit: async (payload: SettingFieldState): Promise<{ success: boolean }> => {
+    set(model, payload.value);
+    return Promise.resolve({ success: true });
   },
-};
+  transform: (state): SettingFieldState => ({ value: state.value }),
+});
 
-const v$ = useVuelidate(rules, { dateDisplayFormat }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
-const dateDisplayFormatExample = computed<string>(() => displayDateFormatter.format(now, get(dateDisplayFormat)));
+const dateDisplayFormatExample = computed<string>(() => displayDateFormatter.format(now, form.state.value));
 
 function successMessage(dateFormat: string): string {
   return t('general_settings.validation.date_display_format.success', {
@@ -44,22 +43,22 @@ function successMessage(dateFormat: string): string {
   });
 }
 
-function onInput(value: string): void {
+async function onInput(value: string): Promise<void> {
   clearAll();
-  callIfValid(value, (format: string) => {
-    set(model, format);
-  });
+  form.state.value = value;
+  await form.submit();
 }
 
 async function reset(): Promise<void> {
-  set(dateDisplayFormat, defaultDateDisplayFormat);
+  form.state.value = defaultDateDisplayFormat;
   set(model, defaultDateDisplayFormat);
   await flush();
 }
 
+// Reflect external changes into the field, but ignore the echo of our own writes (same string).
 watch(model, (value) => {
-  if (value !== get(dateDisplayFormat))
-    set(dateDisplayFormat, value);
+  if (value !== form.state.value)
+    form.state.value = value;
 });
 
 watch(writeSuccess, (saved) => {
@@ -78,7 +77,7 @@ watch(writeError, (message) => {
     <DateFormatHelp v-model="formatHelp" />
     <div class="flex items-start w-full">
       <RuiTextField
-        v-model="dateDisplayFormat"
+        v-model="form.state.value"
         variant="outlined"
         color="primary"
         data-cy="date-display-format-input"
@@ -86,7 +85,7 @@ watch(writeError, (message) => {
         :label="t('general_settings.labels.date_display_format')"
         type="text"
         :success-messages="success"
-        :error-messages="error || toMessages(v$.dateDisplayFormat)"
+        :error-messages="error || form.errors(SETTING_FIELD)"
         :hint="
           t('general_settings.date_display_format_hint', {
             format: dateDisplayFormatExample,

--- a/frontend/app/src/modules/settings/general/DateInputFormatSetting.spec.ts
+++ b/frontend/app/src/modules/settings/general/DateInputFormatSetting.spec.ts
@@ -1,0 +1,92 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import DateInputFormatSetting from '@/modules/settings/general/DateInputFormatSetting.vue';
+
+const { useSettingModelMock } = vi.hoisted(() => ({ useSettingModelMock: vi.fn() }));
+vi.mock('@/modules/settings/use-setting-model', () => ({ useSettingModel: useSettingModelMock }));
+
+const SelectorStub = {
+  props: ['modelValue', 'successMessages', 'errorMessages', 'label'],
+  emits: ['update:model-value'],
+  template: `<div>
+    <span class="model">{{ modelValue }}</span>
+    <span class="success">{{ successMessages }}</span>
+    <span class="error">{{ errorMessages }}</span>
+    <span class="error-count">{{ errorMessages.length }}</span>
+  </div>`,
+};
+
+describe('dateInputFormatSetting', () => {
+  let model: Ref<string>;
+  let error: Ref<string>;
+  let success: Ref<boolean>;
+
+  function createWrapper(): VueWrapper {
+    return mount(DateInputFormatSetting, {
+      global: { stubs: { DateInputFormatSelector: SelectorStub } },
+    });
+  }
+
+  async function input(wrapper: VueWrapper, value: string): Promise<void> {
+    await wrapper.findComponent(SelectorStub).vm.$emit('update:model-value', value);
+    await nextTick();
+  }
+
+  beforeEach(() => {
+    model = ref<string>('%d/%m/%Y %H:%M:%S');
+    error = ref<string>('');
+    success = ref<boolean>(false);
+    useSettingModelMock.mockReturnValue({ error, flush: vi.fn(), model, pending: ref(false), success });
+  });
+
+  it('should render the selector with the current value', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('.model').text()).toBe('%d/%m/%Y %H:%M:%S');
+  });
+
+  it('should persist a format that contains valid directives', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, '%Y-%m-%d');
+    expect(get(model)).toBe('%Y-%m-%d');
+    expect(wrapper.find('.error-count').text()).toBe('0');
+  });
+
+  it('should not persist a format without valid directives', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 'nonsense');
+    expect(get(model)).toBe('%d/%m/%Y %H:%M:%S');
+    expect(wrapper.find('.error').text()).toContain('general_settings.date_display.validation.invalid');
+  });
+
+  it('should not persist an empty format', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, '');
+    expect(get(model)).toBe('%d/%m/%Y %H:%M:%S');
+    expect(wrapper.find('.error').text()).toContain('general_settings.date_display.validation.empty');
+    // A blank value trips both rules under Vuelidate; the count is pinned so the migration keeps it.
+    expect(wrapper.find('.error-count').text()).toBe('2');
+  });
+
+  it('should reflect an external change of the setting', async () => {
+    const wrapper = createWrapper();
+    set(model, '%Y');
+    await nextTick();
+    expect(wrapper.find('.model').text()).toBe('%Y');
+  });
+
+  it('should show a success message once the write lands', async () => {
+    const wrapper = createWrapper();
+    set(success, true);
+    await nextTick();
+    expect(wrapper.find('.success').text()).toContain('general_settings.validation.date_input_format.success');
+  });
+
+  it('should show the write error alone, replacing the validation messages', async () => {
+    const wrapper = createWrapper();
+    set(error, 'boom');
+    await nextTick();
+    expect(wrapper.find('.error').text()).toContain('settings.not_saved: general_settings.validation.date_input_format.error: boom');
+    expect(wrapper.find('.error-count').text()).toBe('1');
+  });
+});

--- a/frontend/app/src/modules/settings/general/DateInputFormatSetting.vue
+++ b/frontend/app/src/modules/settings/general/DateInputFormatSetting.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
-import { displayDateFormatter } from '@/modules/core/common/date-formatter';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import type { ZodType } from 'zod';
+import { useForm } from '@/modules/core/form/use-form';
+import { SETTING_FIELD, type SettingFieldState } from '@/modules/settings/controls/setting-field-schemas';
+import { dateFormatSchema } from '@/modules/settings/general/date-format-schema';
 import DateInputFormatSelector from '@/modules/settings/general/DateInputFormatSelector.vue';
 import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
 import { useSettingModel } from '@/modules/settings/use-setting-model';
@@ -13,24 +12,21 @@ const { t } = useI18n({ useScope: 'global' });
 const { error: writeError, model, success: writeSuccess } = useSettingModel('dateInputFormat', { debounce: 0 });
 const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
 
-const dateInputFormat = ref<string>(get(model));
+const schema = computed<ZodType>(() => dateFormatSchema({
+  empty: t('general_settings.date_display.validation.empty'),
+  invalid: t('general_settings.date_display.validation.invalid'),
+}));
 
-function containsValidDirectives(v: string): boolean {
-  return displayDateFormatter.containsValidDirectives(v);
-}
-
-const rules = {
-  dateInputFormat: {
-    containsValidDirectives: helpers.withMessage(
-      t('general_settings.date_display.validation.invalid'),
-      containsValidDirectives,
-    ),
-    required: helpers.withMessage(t('general_settings.date_display.validation.empty'), required),
+/** Submitting is the persist: the core runs it only when the field parses, as `callIfValid` did. */
+const form = useForm<SettingFieldState, SettingFieldState>({
+  initial: (): SettingFieldState => ({ value: get(model) }),
+  schema,
+  submit: async (payload: SettingFieldState): Promise<{ success: boolean }> => {
+    set(model, payload.value);
+    return Promise.resolve({ success: true });
   },
-};
-
-const v$ = useVuelidate(rules, { dateInputFormat }, { $autoDirty: true });
-const { callIfValid } = useValidation(v$);
+  transform: (state): SettingFieldState => ({ value: state.value }),
+});
 
 function successMessage(dateFormat: string): string {
   return t('general_settings.validation.date_input_format.success', {
@@ -38,16 +34,16 @@ function successMessage(dateFormat: string): string {
   });
 }
 
-function onInput(value: string): void {
+async function onInput(value: string): Promise<void> {
   clearAll();
-  callIfValid(value, (format: string) => {
-    set(model, format);
-  });
+  form.state.value = value;
+  await form.submit();
 }
 
+// Reflect external changes into the field, but ignore the echo of our own writes (same string).
 watch(model, (value) => {
-  if (value !== get(dateInputFormat))
-    set(dateInputFormat, value);
+  if (value !== form.state.value)
+    form.state.value = value;
 });
 
 watch(writeSuccess, (saved) => {
@@ -63,10 +59,10 @@ watch(writeError, (message) => {
 
 <template>
   <DateInputFormatSelector
-    v-model="dateInputFormat"
+    v-model="form.state.value"
     :label="t('general_settings.labels.date_input_format')"
     :success-messages="success ? [success] : []"
-    :error-messages="error ? [error] : toMessages(v$.dateInputFormat)"
+    :error-messages="error ? [error] : form.errors(SETTING_FIELD)"
     @update:model-value="onInput($event)"
   />
 </template>

--- a/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.spec.ts
+++ b/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.spec.ts
@@ -117,6 +117,17 @@ describe('numericSeparatorsSettings', () => {
     expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.cannot_be_the_same');
   });
 
+  // Regression: a rejected value stays in the field it was typed into. If that draft is what the
+  // other field is compared against, the pair can be walked into two identical separators.
+  it('should not persist identical separators through a rejected draft', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 0, '.');
+    expect(get(thousandModel)).toBe(',');
+
+    await input(wrapper, 1, ',');
+    expect(get(thousandModel)).not.toBe(get(decimalModel));
+  });
+
   it('should keep the two fields error messages apart', async () => {
     const wrapper = createWrapper();
     await input(wrapper, 0, '1');

--- a/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.spec.ts
+++ b/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.spec.ts
@@ -1,0 +1,143 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type Ref, ref } from 'vue';
+import NumericSeparatorsSettings from '@/modules/settings/general/amount/NumericSeparatorsSettings.vue';
+
+const { useSettingModelMock } = vi.hoisted(() => ({ useSettingModelMock: vi.fn() }));
+vi.mock('@/modules/settings/use-setting-model', () => ({ useSettingModel: useSettingModelMock }));
+
+const RuiTextFieldStub = defineComponent({
+  props: ['modelValue', 'successMessages', 'errorMessages', 'label'],
+  emits: ['update:model-value'],
+  template: `<div>
+    <span class="model">{{ modelValue }}</span>
+    <span class="success">{{ successMessages }}</span>
+    <span class="error">{{ errorMessages }}</span>
+    <span class="error-count">{{ Array.isArray(errorMessages) ? errorMessages.length : (errorMessages ? 1 : 0) }}</span>
+  </div>`,
+});
+
+describe('numericSeparatorsSettings', () => {
+  let thousandModel: Ref<string>;
+  let decimalModel: Ref<string>;
+  let thousandError: Ref<string>;
+  let decimalError: Ref<string>;
+  let thousandSuccess: Ref<boolean>;
+  let decimalSuccess: Ref<boolean>;
+
+  function createWrapper(): VueWrapper {
+    return mount(NumericSeparatorsSettings, {
+      global: { stubs: { RuiTextField: RuiTextFieldStub } },
+    });
+  }
+
+  function field(wrapper: VueWrapper, index: 0 | 1): VueWrapper {
+    return wrapper.findAllComponents(RuiTextFieldStub)[index];
+  }
+
+  async function input(wrapper: VueWrapper, index: 0 | 1, value: string): Promise<void> {
+    field(wrapper, index).vm.$emit('update:model-value', value);
+    await nextTick();
+  }
+
+  function messages(wrapper: VueWrapper, index: 0 | 1): string {
+    return field(wrapper, index).find('.error').text();
+  }
+
+  beforeEach(() => {
+    thousandModel = ref<string>(',');
+    decimalModel = ref<string>('.');
+    thousandError = ref<string>('');
+    decimalError = ref<string>('');
+    thousandSuccess = ref<boolean>(false);
+    decimalSuccess = ref<boolean>(false);
+    useSettingModelMock.mockImplementation((key: string) => (key === 'thousandSeparator'
+      ? { error: thousandError, flush: vi.fn(), model: thousandModel, pending: ref(false), success: thousandSuccess }
+      : { error: decimalError, flush: vi.fn(), model: decimalModel, pending: ref(false), success: decimalSuccess }));
+  });
+
+  it('should render both fields with their current values', () => {
+    const wrapper = createWrapper();
+    expect(field(wrapper, 0).find('.model').text()).toBe(',');
+    expect(field(wrapper, 1).find('.model').text()).toBe('.');
+  });
+
+  it('should persist a valid thousand separator', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 0, ' ');
+    expect(get(thousandModel)).toBe(' ');
+    expect(field(wrapper, 0).find('.error-count').text()).toBe('0');
+  });
+
+  it('should persist a valid decimal separator', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 1, '\'');
+    expect(get(decimalModel)).toBe('\'');
+  });
+
+  it('should reject a numeric separator', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 0, '1');
+    expect(get(thousandModel)).toBe(',');
+    expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.cannot_be_numeric_character');
+  });
+
+  it('should reject an empty separator', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 0, '');
+    expect(get(thousandModel)).toBe(',');
+    expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.empty');
+    expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.single_character');
+  });
+
+  it('should reject more than one visual character', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 0, '..');
+    expect(get(thousandModel)).toBe(',');
+    expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.single_character');
+  });
+
+  it('should accept a multi-code-point emoji as one visual character', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 0, '👩‍💻');
+    expect(get(thousandModel)).toBe('👩‍💻');
+  });
+
+  it('should reject a decimal separator equal to the thousand separator', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 1, ',');
+    expect(get(decimalModel)).toBe('.');
+    expect(messages(wrapper, 1)).toContain('general_settings.decimal_separator.validation.cannot_be_the_same');
+  });
+
+  it('should not persist a thousand separator equal to the decimal one', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 0, '.');
+    expect(get(thousandModel)).toBe(',');
+    expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.cannot_be_the_same');
+  });
+
+  it('should keep the two fields error messages apart', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 0, '1');
+    expect(field(wrapper, 1).find('.error-count').text()).toBe('0');
+  });
+
+  it('should reflect external changes of both settings', async () => {
+    const wrapper = createWrapper();
+    set(thousandModel, '_');
+    set(decimalModel, '-');
+    await nextTick();
+    expect(field(wrapper, 0).find('.model').text()).toBe('_');
+    expect(field(wrapper, 1).find('.model').text()).toBe('-');
+  });
+
+  it('should show per-field success and error messages from the writer', async () => {
+    const wrapper = createWrapper();
+    set(thousandSuccess, true);
+    set(decimalError, 'boom');
+    await nextTick();
+    expect(field(wrapper, 0).find('.success').text()).toContain('general_settings.validation.thousand_separator.success');
+    expect(field(wrapper, 1).find('.error').text()).toContain('settings.not_saved: general_settings.validation.decimal_separator.error: boom');
+  });
+});

--- a/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.spec.ts
+++ b/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.spec.ts
@@ -3,8 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, type Ref, ref } from 'vue';
 import NumericSeparatorsSettings from '@/modules/settings/general/amount/NumericSeparatorsSettings.vue';
 
-const { useSettingModelMock } = vi.hoisted(() => ({ useSettingModelMock: vi.fn() }));
-vi.mock('@/modules/settings/use-setting-model', () => ({ useSettingModel: useSettingModelMock }));
+const { useSettingMock, writeManyMock } = vi.hoisted(() => ({
+  useSettingMock: vi.fn(),
+  writeManyMock: vi.fn(),
+}));
+vi.mock('@/modules/settings/settings-writer', () => ({ useSettingsWriter: (): Record<string, unknown> => ({ writeMany: writeManyMock }) }));
+vi.mock('@/modules/settings/use-setting', () => ({ useSetting: useSettingMock }));
 
 const RuiTextFieldStub = defineComponent({
   props: ['modelValue', 'successMessages', 'errorMessages', 'label'],
@@ -18,12 +22,8 @@ const RuiTextFieldStub = defineComponent({
 });
 
 describe('numericSeparatorsSettings', () => {
-  let thousandModel: Ref<string>;
-  let decimalModel: Ref<string>;
-  let thousandError: Ref<string>;
-  let decimalError: Ref<string>;
-  let thousandSuccess: Ref<boolean>;
-  let decimalSuccess: Ref<boolean>;
+  let thousandSource: Ref<string>;
+  let decimalSource: Ref<string>;
 
   function createWrapper(): VueWrapper {
     return mount(NumericSeparatorsSettings, {
@@ -35,25 +35,36 @@ describe('numericSeparatorsSettings', () => {
     return wrapper.findAllComponents(RuiTextFieldStub)[index];
   }
 
+  /** Types a value and lets the debounced persist run. */
   async function input(wrapper: VueWrapper, index: 0 | 1, value: string): Promise<void> {
     field(wrapper, index).vm.$emit('update:model-value', value);
     await nextTick();
+    await vi.advanceTimersByTimeAsync(1600);
   }
 
   function messages(wrapper: VueWrapper, index: 0 | 1): string {
     return field(wrapper, index).find('.error').text();
   }
 
+  /** The settings patch of the last write, or undefined when nothing was written. */
+  function lastWrite(): Record<string, string> | undefined {
+    return writeManyMock.mock.calls.at(-1)?.[0];
+  }
+
   beforeEach(() => {
-    thousandModel = ref<string>(',');
-    decimalModel = ref<string>('.');
-    thousandError = ref<string>('');
-    decimalError = ref<string>('');
-    thousandSuccess = ref<boolean>(false);
-    decimalSuccess = ref<boolean>(false);
-    useSettingModelMock.mockImplementation((key: string) => (key === 'thousandSeparator'
-      ? { error: thousandError, flush: vi.fn(), model: thousandModel, pending: ref(false), success: thousandSuccess }
-      : { error: decimalError, flush: vi.fn(), model: decimalModel, pending: ref(false), success: decimalSuccess }));
+    vi.useFakeTimers();
+    thousandSource = ref<string>(',');
+    decimalSource = ref<string>('.');
+    writeManyMock.mockReset();
+    writeManyMock.mockImplementation(async (patch: Record<string, string>) => {
+      // Mirror the repo: a successful write becomes the new source of truth.
+      if (patch.thousandSeparator !== undefined)
+        set(thousandSource, patch.thousandSeparator);
+      if (patch.decimalSeparator !== undefined)
+        set(decimalSource, patch.decimalSeparator);
+      return { success: true };
+    });
+    useSettingMock.mockImplementation((key: string) => (key === 'thousandSeparator' ? thousandSource : decimalSource));
   });
 
   it('should render both fields with their current values', () => {
@@ -65,27 +76,27 @@ describe('numericSeparatorsSettings', () => {
   it('should persist a valid thousand separator', async () => {
     const wrapper = createWrapper();
     await input(wrapper, 0, ' ');
-    expect(get(thousandModel)).toBe(' ');
+    expect(get(thousandSource)).toBe(' ');
     expect(field(wrapper, 0).find('.error-count').text()).toBe('0');
   });
 
   it('should persist a valid decimal separator', async () => {
     const wrapper = createWrapper();
     await input(wrapper, 1, '\'');
-    expect(get(decimalModel)).toBe('\'');
+    expect(get(decimalSource)).toBe('\'');
   });
 
   it('should reject a numeric separator', async () => {
     const wrapper = createWrapper();
     await input(wrapper, 0, '1');
-    expect(get(thousandModel)).toBe(',');
+    expect(get(thousandSource)).toBe(',');
     expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.cannot_be_numeric_character');
   });
 
   it('should reject an empty separator', async () => {
     const wrapper = createWrapper();
     await input(wrapper, 0, '');
-    expect(get(thousandModel)).toBe(',');
+    expect(get(thousandSource)).toBe(',');
     expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.empty');
     expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.single_character');
   });
@@ -93,27 +104,27 @@ describe('numericSeparatorsSettings', () => {
   it('should reject more than one visual character', async () => {
     const wrapper = createWrapper();
     await input(wrapper, 0, '..');
-    expect(get(thousandModel)).toBe(',');
+    expect(get(thousandSource)).toBe(',');
     expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.single_character');
   });
 
   it('should accept a multi-code-point emoji as one visual character', async () => {
     const wrapper = createWrapper();
     await input(wrapper, 0, '👩‍💻');
-    expect(get(thousandModel)).toBe('👩‍💻');
+    expect(get(thousandSource)).toBe('👩‍💻');
   });
 
   it('should reject a decimal separator equal to the thousand separator', async () => {
     const wrapper = createWrapper();
     await input(wrapper, 1, ',');
-    expect(get(decimalModel)).toBe('.');
+    expect(get(decimalSource)).toBe('.');
     expect(messages(wrapper, 1)).toContain('general_settings.decimal_separator.validation.cannot_be_the_same');
   });
 
   it('should not persist a thousand separator equal to the decimal one', async () => {
     const wrapper = createWrapper();
     await input(wrapper, 0, '.');
-    expect(get(thousandModel)).toBe(',');
+    expect(get(thousandSource)).toBe(',');
     expect(messages(wrapper, 0)).toContain('general_settings.thousand_separator.validation.cannot_be_the_same');
   });
 
@@ -122,10 +133,36 @@ describe('numericSeparatorsSettings', () => {
   it('should not persist identical separators through a rejected draft', async () => {
     const wrapper = createWrapper();
     await input(wrapper, 0, '.');
-    expect(get(thousandModel)).toBe(',');
+    expect(writeManyMock).not.toHaveBeenCalled();
 
     await input(wrapper, 1, ',');
-    expect(get(thousandModel)).not.toBe(get(decimalModel));
+    expect(get(thousandSource)).not.toBe(get(decimalSource));
+  });
+
+  // Two separate writes would each snapshot the whole settings blob before their request and merge
+  // only their own key, so the second would carry the other separator's pre-edit value.
+  it('should persist both separators in a single patch', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 0, '.');
+    await input(wrapper, 1, ',');
+
+    expect(writeManyMock).toHaveBeenCalledTimes(1);
+    expect(lastWrite()).toStrictEqual({ decimalSeparator: ',', thousandSeparator: '.' });
+  });
+
+  it('should not write when the pair is unchanged', async () => {
+    const wrapper = createWrapper();
+    await input(wrapper, 0, ',');
+    expect(writeManyMock).not.toHaveBeenCalled();
+  });
+
+  it('should restore the stored pair when the write fails', async () => {
+    writeManyMock.mockResolvedValue({ message: 'boom', success: false });
+    const wrapper = createWrapper();
+    await input(wrapper, 0, ';');
+
+    expect(field(wrapper, 0).find('.model').text()).toBe(',');
+    expect(field(wrapper, 0).find('.error').text()).toContain('settings.not_saved: general_settings.validation.thousand_separator.error: boom');
   });
 
   it('should keep the two fields error messages apart', async () => {
@@ -136,19 +173,17 @@ describe('numericSeparatorsSettings', () => {
 
   it('should reflect external changes of both settings', async () => {
     const wrapper = createWrapper();
-    set(thousandModel, '_');
-    set(decimalModel, '-');
+    set(thousandSource, '_');
+    set(decimalSource, '-');
     await nextTick();
     expect(field(wrapper, 0).find('.model').text()).toBe('_');
     expect(field(wrapper, 1).find('.model').text()).toBe('-');
   });
 
-  it('should show per-field success and error messages from the writer', async () => {
+  it('should show a success message on both fields once the pair is written', async () => {
     const wrapper = createWrapper();
-    set(thousandSuccess, true);
-    set(decimalError, 'boom');
-    await nextTick();
+    await input(wrapper, 0, ';');
     expect(field(wrapper, 0).find('.success').text()).toContain('general_settings.validation.thousand_separator.success');
-    expect(field(wrapper, 1).find('.error').text()).toContain('settings.not_saved: general_settings.validation.decimal_separator.error: boom');
+    expect(field(wrapper, 1).find('.success').text()).toContain('general_settings.validation.decimal_separator.success');
   });
 });

--- a/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.vue
+++ b/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.vue
@@ -1,14 +1,20 @@
 <script setup lang="ts">
 import type { ZodType } from 'zod';
+import { startPromise } from '@shared/utils';
 import { useForm } from '@/modules/core/form/use-form';
 import { numericSeparatorsSchema, type NumericSeparatorsState } from '@/modules/settings/general/amount/numeric-separators';
+import { useSettingsWriter } from '@/modules/settings/settings-writer';
 import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
-import { useSettingModel } from '@/modules/settings/use-setting-model';
+import { useSetting } from '@/modules/settings/use-setting';
+
+/** Matches the debounce the shared text setting controls persist with. */
+const PERSIST_DEBOUNCE = 1500;
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { error: thousandWriteError, model: thousandModel, success: thousandWriteSuccess } = useSettingModel('thousandSeparator', { debounce: 1500 });
-const { error: decimalWriteError, model: decimalModel, success: decimalWriteSuccess } = useSettingModel('decimalSeparator', { debounce: 1500 });
+const { writeMany } = useSettingsWriter();
+const thousandSource = useSetting('thousandSeparator');
+const decimalSource = useSetting('decimalSeparator');
 const { clearAll: clearThousandMessages, error: thousandError, setError: setThousandError, setSuccess: setThousandSuccess, success: thousandSuccess } = useClearableMessages();
 const { clearAll: clearDecimalMessages, error: decimalError, setError: setDecimalError, setSuccess: setDecimalSuccess, success: decimalSuccess } = useClearableMessages();
 
@@ -28,20 +34,54 @@ const schema = computed<ZodType>(() => numericSeparatorsSchema({
 }));
 
 /**
- * One form for both separators. Submitting writes both models: the pair only persists when it
- * parses as a pair, which is what stops a rejected draft of one field from being the value the
- * other is compared against. The write of the unchanged field is a no-op in `useSettingModel`.
+ * One form for both separators: the pair only persists when it parses as a pair, which is what stops
+ * a rejected draft of one field from being the value the other is compared against. Persistence is
+ * driven from the input handlers rather than `submit`, so the write can be debounced without the
+ * form and the writer having to reference each other.
  */
 const form = useForm<NumericSeparatorsState, NumericSeparatorsState>({
-  initial: (): NumericSeparatorsState => ({ decimal: get(decimalModel), thousand: get(thousandModel) }),
+  initial: (): NumericSeparatorsState => ({ decimal: get(decimalSource), thousand: get(thousandSource) }),
   schema,
-  submit: async (payload: NumericSeparatorsState): Promise<{ success: boolean }> => {
-    set(thousandModel, payload.thousand);
-    set(decimalModel, payload.decimal);
-    return Promise.resolve({ success: true });
-  },
+  // Unused: `submitPair` below owns the write so it can be debounced. The core requires a submit.
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
   transform: (state): NumericSeparatorsState => ({ decimal: state.decimal, thousand: state.thousand }),
 });
+
+/**
+ * Persists the pair in ONE patch. Two independent writes cannot be used here: each snapshots the
+ * whole frontend-settings blob before its request and merges only its own key, so two in flight at
+ * once both send the other key's pre-edit value and the later response wins. Swapping the separators
+ * that way put two identical characters on the backend while the merged local repo looked correct.
+ */
+async function persist(state: NumericSeparatorsState): Promise<void> {
+  if (state.thousand === get(thousandSource) && state.decimal === get(decimalSource))
+    return;
+
+  const status = await writeMany({
+    decimalSeparator: state.decimal,
+    thousandSeparator: state.thousand,
+  });
+
+  if (status.success) {
+    setThousandSuccess(thousandsSuccessMessage(state.thousand), true);
+    setDecimalSuccess(decimalsSuccessMessage(state.decimal), true);
+    return;
+  }
+
+  // Keep the fields showing what is stored rather than a pair that was rejected.
+  form.state.thousand = get(thousandSource);
+  form.state.decimal = get(decimalSource);
+  setThousandError(`${t('general_settings.validation.thousand_separator.error')}: ${status.message ?? ''}`, true);
+  setDecimalError(`${t('general_settings.validation.decimal_separator.error')}: ${status.message ?? ''}`, true);
+}
+
+const schedulePersist = useDebounceFn(persist, PERSIST_DEBOUNCE);
+
+/** Reveals the pair's errors and schedules the write only when it parses, as `callIfValid` did. */
+function submitPair(): void {
+  if (form.validate())
+    startPromise(schedulePersist({ decimal: form.state.decimal, thousand: form.state.thousand }));
+}
 
 function thousandsSuccessMessage(thousandSeparator: string): string {
   return t('general_settings.validation.thousand_separator.success', {
@@ -55,47 +95,27 @@ function decimalsSuccessMessage(decimalSeparator: string): string {
   });
 }
 
-async function onThousandInput(value: string): Promise<void> {
+function onThousandInput(value: string): void {
   clearThousandMessages();
   form.state.thousand = value;
-  await form.submit();
+  submitPair();
 }
 
-async function onDecimalInput(value: string): Promise<void> {
+function onDecimalInput(value: string): void {
   clearDecimalMessages();
   form.state.decimal = value;
-  await form.submit();
+  submitPair();
 }
 
 // Reflect external changes into the fields, but ignore the echo of our own writes (same string).
-watch(thousandModel, (value) => {
+watch(thousandSource, (value) => {
   if (value !== form.state.thousand)
     form.state.thousand = value;
 });
 
-watch(decimalModel, (value) => {
+watch(decimalSource, (value) => {
   if (value !== form.state.decimal)
     form.state.decimal = value;
-});
-
-watch(thousandWriteSuccess, (saved) => {
-  if (saved)
-    setThousandSuccess(thousandsSuccessMessage(get(thousandModel)), true);
-});
-
-watch(thousandWriteError, (message) => {
-  if (message)
-    setThousandError(`${t('general_settings.validation.thousand_separator.error')}: ${message}`, true);
-});
-
-watch(decimalWriteSuccess, (saved) => {
-  if (saved)
-    setDecimalSuccess(decimalsSuccessMessage(get(decimalModel)), true);
-});
-
-watch(decimalWriteError, (message) => {
-  if (message)
-    setDecimalError(`${t('general_settings.validation.decimal_separator.error')}: ${message}`, true);
 });
 </script>
 

--- a/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.vue
+++ b/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, not, numeric, sameAs } from '@vuelidate/validators';
-import { useValidation } from '@/modules/core/common/use-validation';
-import { isSingleVisualCharacter, toMessages } from '@/modules/core/common/validation/validation';
+import type { ZodType } from 'zod';
+import { useForm } from '@/modules/core/form/use-form';
+import { numericSeparatorsSchema, type NumericSeparatorsState } from '@/modules/settings/general/amount/numeric-separators';
 import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
 import { useSettingModel } from '@/modules/settings/use-setting-model';
 
@@ -13,67 +12,36 @@ const { error: decimalWriteError, model: decimalModel, success: decimalWriteSucc
 const { clearAll: clearThousandMessages, error: thousandError, setError: setThousandError, setSuccess: setThousandSuccess, success: thousandSuccess } = useClearableMessages();
 const { clearAll: clearDecimalMessages, error: decimalError, setError: setDecimalError, setSuccess: setDecimalSuccess, success: decimalSuccess } = useClearableMessages();
 
-const thousandSeparator = ref<string>(get(thousandModel));
-const decimalSeparator = ref<string>(get(decimalModel));
-
-// Custom validator that allows spaces but not empty strings
-const notEmpty = (value: any): boolean => value?.length > 0;
-
-// Custom validator for single visual character
-const singleVisualChar = (value: any): boolean => isSingleVisualCharacter(value);
-
-const rules = {
-  decimalSeparator: {
-    notANumber: helpers.withMessage(
-      t('general_settings.decimal_separator.validation.cannot_be_numeric_character'),
-      not(numeric),
-    ),
-    notEmpty: helpers.withMessage(t('general_settings.decimal_separator.validation.empty'), notEmpty),
-    notTheSame: helpers.withMessage(
-      t('general_settings.decimal_separator.validation.cannot_be_the_same'),
-      not(sameAs(thousandSeparator)),
-    ),
-    singleChar: helpers.withMessage(
-      t('general_settings.decimal_separator.validation.single_character'),
-      singleVisualChar,
-    ),
+const schema = computed<ZodType>(() => numericSeparatorsSchema({
+  decimal: {
+    empty: t('general_settings.decimal_separator.validation.empty'),
+    numeric: t('general_settings.decimal_separator.validation.cannot_be_numeric_character'),
+    sameAsOther: t('general_settings.decimal_separator.validation.cannot_be_the_same'),
+    singleCharacter: t('general_settings.decimal_separator.validation.single_character'),
   },
-  thousandSeparator: {
-    notANumber: helpers.withMessage(
-      t('general_settings.thousand_separator.validation.cannot_be_numeric_character'),
-      not(numeric),
-    ),
-    notEmpty: helpers.withMessage(t('general_settings.thousand_separator.validation.empty'), notEmpty),
-    notTheSame: helpers.withMessage(
-      t('general_settings.thousand_separator.validation.cannot_be_the_same'),
-      not(sameAs(decimalSeparator)),
-    ),
-    singleChar: helpers.withMessage(
-      t('general_settings.thousand_separator.validation.single_character'),
-      singleVisualChar,
-    ),
+  thousand: {
+    empty: t('general_settings.thousand_separator.validation.empty'),
+    numeric: t('general_settings.thousand_separator.validation.cannot_be_numeric_character'),
+    sameAsOther: t('general_settings.thousand_separator.validation.cannot_be_the_same'),
+    singleCharacter: t('general_settings.thousand_separator.validation.single_character'),
   },
-};
+}));
 
-const v$ = useVuelidate(rules, { decimalSeparator, thousandSeparator }, { $autoDirty: true });
-
-const { callIfValid } = useValidation(v$);
-
-function onThousandInput(value: string): void {
-  clearThousandMessages();
-  const validator = get(v$);
-  callIfValid(value, (separator: string) => {
-    set(thousandModel, separator);
-  }, () => validator.thousandSeparator.$error);
-}
-
-function onDecimalInput(value: string): void {
-  clearDecimalMessages();
-  const validator = get(v$);
-  callIfValid(value, (separator: string) => {
-    set(decimalModel, separator);
-  }, () => validator.decimalSeparator.$error);
-}
+/**
+ * One form for both separators. Submitting writes both models: the pair only persists when it
+ * parses as a pair, which is what stops a rejected draft of one field from being the value the
+ * other is compared against. The write of the unchanged field is a no-op in `useSettingModel`.
+ */
+const form = useForm<NumericSeparatorsState, NumericSeparatorsState>({
+  initial: (): NumericSeparatorsState => ({ decimal: get(decimalModel), thousand: get(thousandModel) }),
+  schema,
+  submit: async (payload: NumericSeparatorsState): Promise<{ success: boolean }> => {
+    set(thousandModel, payload.thousand);
+    set(decimalModel, payload.decimal);
+    return Promise.resolve({ success: true });
+  },
+  transform: (state): NumericSeparatorsState => ({ decimal: state.decimal, thousand: state.thousand }),
+});
 
 function thousandsSuccessMessage(thousandSeparator: string): string {
   return t('general_settings.validation.thousand_separator.success', {
@@ -87,14 +55,27 @@ function decimalsSuccessMessage(decimalSeparator: string): string {
   });
 }
 
+async function onThousandInput(value: string): Promise<void> {
+  clearThousandMessages();
+  form.state.thousand = value;
+  await form.submit();
+}
+
+async function onDecimalInput(value: string): Promise<void> {
+  clearDecimalMessages();
+  form.state.decimal = value;
+  await form.submit();
+}
+
+// Reflect external changes into the fields, but ignore the echo of our own writes (same string).
 watch(thousandModel, (value) => {
-  if (value !== get(thousandSeparator))
-    set(thousandSeparator, value);
+  if (value !== form.state.thousand)
+    form.state.thousand = value;
 });
 
 watch(decimalModel, (value) => {
-  if (value !== get(decimalSeparator))
-    set(decimalSeparator, value);
+  if (value !== form.state.decimal)
+    form.state.decimal = value;
 });
 
 watch(thousandWriteSuccess, (saved) => {
@@ -120,26 +101,26 @@ watch(decimalWriteError, (message) => {
 
 <template>
   <RuiTextField
-    v-model="thousandSeparator"
+    v-model="form.state.thousand"
     variant="outlined"
     color="primary"
     data-cy="thousand-separator-input"
     :label="t('general_settings.amount.label.thousand_separator')"
     type="text"
     :success-messages="thousandSuccess"
-    :error-messages="thousandError || toMessages(v$.thousandSeparator)"
+    :error-messages="thousandError || form.errors('thousand')"
     @update:model-value="onThousandInput($event)"
   />
 
   <RuiTextField
-    v-model="decimalSeparator"
+    v-model="form.state.decimal"
     variant="outlined"
     color="primary"
     data-cy="decimal-separator-input"
     :label="t('general_settings.amount.label.decimal_separator')"
     type="text"
     :success-messages="decimalSuccess"
-    :error-messages="decimalError || toMessages(v$.decimalSeparator)"
+    :error-messages="decimalError || form.errors('decimal')"
     @update:model-value="onDecimalInput($event)"
   />
 </template>

--- a/frontend/app/src/modules/settings/general/amount/numeric-separators.spec.ts
+++ b/frontend/app/src/modules/settings/general/amount/numeric-separators.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { type NumericSeparatorsMessages, numericSeparatorsSchema } from '@/modules/settings/general/amount/numeric-separators';
+
+const messages: NumericSeparatorsMessages = {
+  decimal: {
+    empty: 'decimal.empty',
+    numeric: 'decimal.numeric',
+    sameAsOther: 'decimal.same',
+    singleCharacter: 'decimal.single',
+  },
+  thousand: {
+    empty: 'thousand.empty',
+    numeric: 'thousand.numeric',
+    sameAsOther: 'thousand.same',
+    singleCharacter: 'thousand.single',
+  },
+};
+
+function messagesFor(thousand: string, decimal: string): Record<string, string[]> {
+  const result = numericSeparatorsSchema(messages).safeParse({ decimal, thousand });
+  if (result.success)
+    return {};
+
+  const map: Record<string, string[]> = {};
+  for (const issue of result.error.issues)
+    (map[issue.path.join('.')] ??= []).push(issue.message);
+
+  return map;
+}
+
+describe('numericSeparatorsSchema', () => {
+  it('should accept two different single characters', () => {
+    expect(messagesFor(',', '.')).toStrictEqual({});
+  });
+
+  it('should accept a space as a separator', () => {
+    expect(messagesFor(' ', '.')).toStrictEqual({});
+  });
+
+  it('should accept a multi-code-point emoji as one visual character', () => {
+    expect(messagesFor('👩‍💻', '.')).toStrictEqual({});
+  });
+
+  it('should reject a digit', () => {
+    expect(messagesFor('1', '.').thousand).toStrictEqual(['thousand.numeric']);
+  });
+
+  it('should reject an empty separator with both the empty and the length message', () => {
+    expect(messagesFor('', '.').thousand).toStrictEqual(['thousand.empty', 'thousand.single']);
+  });
+
+  it('should reject more than one visual character', () => {
+    expect(messagesFor('..', ',').thousand).toStrictEqual(['thousand.single']);
+  });
+
+  it('should report an equal pair on both fields', () => {
+    expect(messagesFor(',', ',')).toStrictEqual({
+      decimal: ['decimal.same'],
+      thousand: ['thousand.same'],
+    });
+  });
+
+  it('should keep each field messages under its own path', () => {
+    const result = messagesFor('1', '..');
+    expect(result.thousand).toStrictEqual(['thousand.numeric']);
+    expect(result.decimal).toStrictEqual(['decimal.single']);
+  });
+});

--- a/frontend/app/src/modules/settings/general/amount/numeric-separators.ts
+++ b/frontend/app/src/modules/settings/general/amount/numeric-separators.ts
@@ -1,0 +1,63 @@
+import { z, type ZodType } from 'zod';
+import { isSingleVisualCharacter } from '@/modules/core/common/validation/validation';
+
+/**
+ * Both separators live in one state object so the "they must differ" rule can be a property of the
+ * pair rather than of either field. Validating them separately is what let a rejected draft of one
+ * field be used as the comparison value for the other, persisting two identical separators.
+ */
+export interface NumericSeparatorsState {
+  thousand: string;
+  decimal: string;
+}
+
+interface SeparatorMessages {
+  /** Shown when the value is a digit. */
+  numeric: string;
+  empty: string;
+  singleCharacter: string;
+  /** Shown on BOTH fields: neither may persist while the pair is equal. */
+  sameAsOther: string;
+}
+
+export interface NumericSeparatorsMessages {
+  thousand: SeparatorMessages;
+  decimal: SeparatorMessages;
+}
+
+/** Vuelidate's `numeric`: digits only. A separator may not be one. */
+function isNumeric(value: string): boolean {
+  return /^\d+$/.test(value);
+}
+
+/**
+ * Issues for one separator, in the order the Vuelidate rules were declared, so a field that trips
+ * several rules keeps reporting the same messages in the same order.
+ */
+function addFieldIssues(value: string, field: keyof NumericSeparatorsState, messages: SeparatorMessages, ctx: z.RefinementCtx): void {
+  if (isNumeric(value))
+    ctx.addIssue({ code: 'custom', message: messages.numeric, path: [field] });
+
+  if (value.length === 0)
+    ctx.addIssue({ code: 'custom', message: messages.empty, path: [field] });
+
+  if (!isSingleVisualCharacter(value))
+    ctx.addIssue({ code: 'custom', message: messages.singleCharacter, path: [field] });
+}
+
+export function numericSeparatorsSchema(messages: NumericSeparatorsMessages): ZodType {
+  return z.object({
+    decimal: z.string(),
+    thousand: z.string(),
+  }).superRefine((state, ctx) => {
+    addFieldIssues(state.thousand, 'thousand', messages.thousand, ctx);
+    addFieldIssues(state.decimal, 'decimal', messages.decimal, ctx);
+
+    // The pair rule reports on both fields: the submit is all-or-nothing, so blaming only the field
+    // that was last edited would leave the other looking persistable when it is not.
+    if (state.thousand === state.decimal) {
+      ctx.addIssue({ code: 'custom', message: messages.thousand.sameAsOther, path: ['thousand'] });
+      ctx.addIssue({ code: 'custom', message: messages.decimal.sameAsOther, path: ['decimal'] });
+    }
+  });
+}

--- a/frontend/app/src/modules/settings/general/date-format-schema.spec.ts
+++ b/frontend/app/src/modules/settings/general/date-format-schema.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { dateFormatSchema } from '@/modules/settings/general/date-format-schema';
+
+const schema = dateFormatSchema({ empty: 'empty', invalid: 'invalid' });
+
+function messagesFor(value: string): string[] {
+  const result = schema.safeParse({ value });
+  return result.success ? [] : result.error.issues.map(issue => issue.message);
+}
+
+describe('dateFormatSchema', () => {
+  it('should accept a pattern with a valid directive', () => {
+    expect(messagesFor('%d/%m/%Y %H:%M:%S')).toStrictEqual([]);
+  });
+
+  it('should accept a pattern whose only directive is valid', () => {
+    expect(messagesFor('%Y')).toStrictEqual([]);
+  });
+
+  it('should reject a pattern with no directives', () => {
+    expect(messagesFor('not a format')).toStrictEqual(['invalid']);
+  });
+
+  it('should reject a blank pattern with both messages', () => {
+    expect(messagesFor('')).toStrictEqual(['invalid', 'empty']);
+  });
+});

--- a/frontend/app/src/modules/settings/general/date-format-schema.ts
+++ b/frontend/app/src/modules/settings/general/date-format-schema.ts
@@ -1,0 +1,26 @@
+import { z, type ZodType } from 'zod';
+import { displayDateFormatter } from '@/modules/core/common/date-formatter';
+
+export interface DateFormatMessages {
+  /** The pattern holds no directive the formatter understands. */
+  invalid: string;
+  empty: string;
+}
+
+/**
+ * Schema for a date format pattern, addressing the value under the setting-control field key. Shared
+ * by the display and the input format settings, which validate identically.
+ *
+ * A blank pattern reports both messages, as it holds no valid directive either.
+ */
+export function dateFormatSchema(messages: DateFormatMessages): ZodType {
+  return z.object({
+    value: z.string().superRefine((value, ctx) => {
+      if (!displayDateFormatter.containsValidDirectives(value))
+        ctx.addIssue({ code: 'custom', message: messages.invalid });
+
+      if (value.length === 0)
+        ctx.addIssue({ code: 'custom', message: messages.empty });
+    }),
+  });
+}

--- a/frontend/app/tests/e2e/pages/general-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/general-settings-page.ts
@@ -43,6 +43,26 @@ export class GeneralSettingsPage {
     await this.setInputFieldValue('[data-cy=date-display-format-input]', value);
   }
 
+  async setThousandSeparator(value: string): Promise<void> {
+    await this.setInputFieldValue('[data-cy=thousand-separator-input]', value);
+  }
+
+  async setDecimalSeparator(value: string): Promise<void> {
+    await this.setInputFieldValue('[data-cy=decimal-separator-input]', value);
+  }
+
+  /** The messages shown under a separator field, validation or writer alike. */
+  async separatorMessages(field: 'thousand' | 'decimal'): Promise<string> {
+    return this.page.locator(`[data-cy=${field}-separator-input] .details`).innerText();
+  }
+
+  async separatorValues(): Promise<{ thousand: string; decimal: string }> {
+    return {
+      decimal: await this.page.locator('[data-cy=decimal-separator-input] input').inputValue(),
+      thousand: await this.page.locator('[data-cy=thousand-separator-input] input').inputValue(),
+    };
+  }
+
   async verify(settings: {
     anonymousUsageStatistics: boolean;
     floatingPrecision: string;

--- a/frontend/app/tests/e2e/specs/settings/general.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/general.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { confirmInlineSuccess } from '../../helpers/utils';
 import { GeneralSettingsPage } from '../../pages/general-settings-page';
@@ -75,5 +76,26 @@ test.describe.serial('settings::general', () => {
     await ctx.app.relogin(ctx.username);
     await pageGeneral.visit();
     await pageGeneral.verify(settings);
+  });
+
+  // A rejected separator stays in its input. If the other field is validated against that value
+  // rather than against the pair, both settings can be walked into the same character, which makes
+  // every amount ambiguous. Runs last: it deliberately leaves the separators changed.
+  test('cannot persist identical separators through a rejected value', async () => {
+    await pageGeneral.setThousandSeparator(settings.decimalSeparator);
+    await expect
+      .poll(async () => pageGeneral.separatorMessages('thousand'))
+      .toContain('cannot be the same as the decimal separator');
+
+    // The rejected '.' is still sitting in the thousand field. Setting the decimal separator to the
+    // thousand one must not slip past on that stale value.
+    await pageGeneral.setDecimalSeparator(settings.thousandSeparator);
+    await confirmInlineSuccess(ctx.sharedPage, '[data-cy=decimal-separator-input] .details');
+
+    await pageGeneral.navigateAway();
+    await pageGeneral.visit();
+
+    const persisted = await pageGeneral.separatorValues();
+    expect(persisted.thousand).not.toBe(persisted.decimal);
   });
 });

--- a/frontend/app/tests/e2e/specs/settings/general.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/general.spec.ts
@@ -92,10 +92,14 @@ test.describe.serial('settings::general', () => {
     await pageGeneral.setDecimalSeparator(settings.thousandSeparator);
     await confirmInlineSuccess(ctx.sharedPage, '[data-cy=decimal-separator-input] .details');
 
-    await pageGeneral.navigateAway();
+    // Re-login rather than navigate: navigating re-reads the in-memory settings repo, which merges
+    // both patches locally even if what reached the backend did not. Only a fresh login proves what
+    // was persisted.
+    await ctx.app.relogin(ctx.username);
     await pageGeneral.visit();
 
     const persisted = await pageGeneral.separatorValues();
     expect(persisted.thousand).not.toBe(persisted.decimal);
+    expect(persisted).toStrictEqual({ decimal: settings.thousandSeparator, thousand: settings.decimalSeparator });
   });
 });


### PR DESCRIPTION
Second batch of the Vuelidate → zod migration, after #12760 (the shared setting controls). Migrates the four general display settings and fixes a settings-persistence bug found on the way.

`useVuelidate` roots: 49 → 45 app-wide, 13 → 9 in settings.

## Characterize first

None of these four had a unit spec, so there was nothing to migrate against. The first commit adds characterization specs against the **current Vuelidate code** (37 tests, verified green before any migration), then each migration follows. Worth doing: it is what surfaced the bug below.

Three behaviours the specs pinned that a naive port would have changed silently:

- a blank date format reports **two** messages (invalid + empty), not one
- a blank separator reports **two** (empty + single-character)
- writer errors are prefixed `settings.not_saved:` by `useClearableMessages`

## Bug fixed: identical thousand/decimal separators could persist

Two independent defects, one visible symptom — both separators ending up as the same character, with no error shown and every amount rendered ambiguously.

**1. The cross-field rule compared against the other field's local draft.** A rejected value stays in its input, so:

```
persisted ,/.  → type '.' into thousand → rejected, not persisted, draft is now '.'
               → type ',' into decimal  → compared against the draft '.' → passes → PERSISTS
persisted ,/,  ← identical, both fields showing zero errors
```

Nothing revalidated the sibling field either, and the 1500 ms debounce opened the same hole a second way. Fixed by putting both fields in one `useForm`: any edit revalidates the pair, and the write only runs when the pair parses.

**2. The pair still persisted through two independent writes.** `updateFrontendSetting` sends the whole frontend-settings blob, snapshotted *before* its request and merged into the repo *after*. Two writes in flight at once therefore each carry the other key's pre-edit value, and the later response wins — so swapping the separators put two identical characters on the backend while the merged local repo looked correct. Fixed by persisting both keys in one `useSettingsWriter.writeMany` patch, which also makes a partial failure impossible.

Any component owning more than one setting has this second problem. This PR only fixes the separators; it does not audit other multi-setting components.

## Tests

- unit: 716 files / 6870 tests
- e2e `specs/settings/general`: 8/8, including a new test for the regression
- typecheck clean, lint 0 errors / 20 warnings (develop's baseline, none added), typos clean

The regression test was proven to fail without each fix — for the persistence half, the e2e fails against the first fix. It reads the values back **after a re-login**: navigating away and returning re-reads the in-memory settings repo, which merges both patches locally and cannot see the bug at all.

## Deliberate behaviour changes

- **Editing one separator now persists the other's on-screen value too.** The pair is saved as a unit, so what is displayed is what is stored. Previously the thousand box could show `.` while `,` was stored.
- **A pair error shows on both fields**, since neither can persist while they are equal.

## Known, not fixed here

`SsfGraphMultiplierSetting` validates with `Number()` but persists with `Number.parseInt()`, so `1.5` is accepted and silently truncated to `1`. Pre-existing behaviour carried over from the Vuelidate version; aligning it would change which inputs are accepted, so it is left alone.

## Not verified

Not exercised by hand in the running app. The e2e drives a real browser against a real backend for the date display format and the separators; the SSF graph multiplier and the date *input* format are covered by unit tests only.
