### PR TITLE
ci: use runner-provided chromium for e2e

### DIFF
--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -257,9 +257,16 @@ jobs:
       - name: Make frozen core executable
         run: chmod +x target/backend/rotki-core/rotki-core-*
 
-      # No Playwright browser install: the config points executablePath at the Chromium the
-      # runner image already ships (/usr/bin/chromium), so there is nothing to download and
-      # no apt step to stall on.
+      # No browser install: the config points executablePath at the Chromium the runner image
+      # already ships (/usr/bin/chromium), so there is nothing to download and no apt step to
+      # stall on. ffmpeg is the exception. `video: retain-on-failure` needs Playwright's own
+      # build, which the runner image does not provide, and specs that use the built-in `page`
+      # fixture fail at context creation without it. This is a 2.3 MB CDN download, not apt.
+      - name: Install Playwright ffmpeg
+        timeout-minutes: 5
+        working-directory: ./frontend/app
+        run: npx playwright install ffmpeg
+
       - name: Run e2e tests
         timeout-minutes: 20
         env:

--- a/.github/workflows/task_e2e_tests.yml
+++ b/.github/workflows/task_e2e_tests.yml
@@ -257,24 +257,9 @@ jobs:
       - name: Make frozen core executable
         run: chmod +x target/backend/rotki-core/rotki-core-*
 
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/pnpm-lock.yaml') }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 10
-        working-directory: ./frontend/app
-        run: npx playwright install chromium
-
-      - name: Install Playwright system dependencies
-        timeout-minutes: 10
-        working-directory: ./frontend/app
-        run: npx playwright install-deps chromium
-
+      # No Playwright browser install: the config points executablePath at the Chromium the
+      # runner image already ships (/usr/bin/chromium), so there is nothing to download and
+      # no apt step to stall on.
       - name: Run e2e tests
         timeout-minutes: 20
         env:

--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -146,7 +146,26 @@ function detectSystemChromium(): string | undefined {
   return undefined;
 }
 
-const systemChromium = detectSystemChromium();
+/**
+ * CI runs against the browser the runner image already ships. runner-images symlinks its
+ * Chromium to /usr/bin/chromium, so detectSystemChromium() finds it and no `playwright
+ * install` step is needed. That binary tracks the runner image rather than the Playwright
+ * release, so the browser version is deliberately not pinned. If a future image drops the
+ * symlink, fail here with a named error instead of silently falling back to a bundled
+ * browser that CI never downloads.
+ */
+function resolveChromium(): string | undefined {
+  const detected = detectSystemChromium();
+  if (!detected && process.env.CI) {
+    throw new Error(
+      'No system Chromium found. CI runs against the runner-provided browser at '
+      + '/usr/bin/chromium and does not run `playwright install`.',
+    );
+  }
+  return detected;
+}
+
+const systemChromium = resolveChromium();
 
 /**
  * Interactive runs (`--ui`, `--headed`, `--debug`) keep the Vite dev server so HMR and


### PR DESCRIPTION
The e2e job cached and installed a Playwright chromium that nothing launches.

`frontend/app/playwright.config.ts` already prefers a system chromium via `executablePath` (`detectSystemChromium()`), and `actions/runner-images` symlinks its own Chromium build to `/usr/bin/chromium`:

```
ln -s $chromium_bin /usr/bin/chromium
ln -s $chromium_bin /usr/bin/chromium-browser
```

So the shards have been running against the runner's browser all along, not the one being downloaded and cached.

### Measurements

Sampled the 70 most recent `Rotki CI` runs, 140 e2e shard jobs that ran these steps:

| Step | n | min | med | p90 | p99 | max |
|---|---|---|---|---|---|---|
| Cache Playwright browsers (restore) | 140 | 2s | 3s | 6s | 7s | 16s |
| **Install Playwright browsers** | **skipped 140/140** | | | | | |
| Install Playwright system dependencies | 140 | 11s | 14s | 21s | 80s | **613s** |

`playwright install` never executes; the lockfile-keyed cache hits every time.

What did run on every shard is `install-deps`, and it is the step that stalls: 4/140 shards exceeded 60s, and one hit the 10-minute timeout and failed the job outright (run 30936808648, shard-2). That failure is plain apt slowness against the Azure mirror:

```
0 upgraded, 9 newly installed, 0 to remove
Need to get 21.1 MB of archives.
Get:3 ... fonts-freefont-ttf [5641 kB]   18:09:04 -> 18:11:47   (163s)
Get:6 ... fonts-wqy-zenhei   [7472 kB]   18:13:17 -> 18:16:52   (215s)
##[error]The action 'Install Playwright system dependencies' has timed out after 10 minutes.
```

Every library it wanted was already `"is already the newest version"`. The entire net effect of the step on the runner is nine font packages.

### Change

Drop all three steps. Nothing asserts on rendered pixels (`grep -rl "toHaveScreenshot\|toMatchSnapshot" tests/e2e` is empty), so the fonts only affect how non-Latin text renders inside failure screenshots and videos.

The browser now tracks the runner image rather than the Playwright release. That was already true in practice; this makes it explicit, and makes resolution fail loudly under `CI` so a future runner image dropping the symlink is a named error instead of a silent fallback to a browser CI no longer downloads.

**The browser that runs the tests does not change.** It is `/usr/bin/chromium` before and after, which is what makes this low risk: the deleted steps produced output nothing consumed.

### Verified locally

| Arm | Expected | Result |
|---|---|---|
| `CI=1`, chromium present | config loads | `Total: 218 tests in 29 files` |
| `CI=1`, no chromium reachable | named throw | `Error: No system Chromium found. CI runs against the runner-provided browser...` |
| `CI` unset, no chromium reachable | silent fallback, local behaviour unchanged | `Total: 218 tests in 29 files` |

The middle arm needed the fallback path list repointed in a throwaway copy of the config, because clearing `PATH` is not enough on a machine that has `/usr/bin/chromium`.

### Accepted tradeoffs

- **Version drift.** The runner's Chromium moves when GitHub rebuilds the image. Already the case today; documented rather than introduced.
- **Non-GitHub runners.** Anything running this workflow outside `ubuntu-latest` (a container, self-hosted) now fails fast with the named error rather than silently downloading a browser. Intended.
- **Fonts.** Failure artifacts may show tofu boxes for CJK/emoji text. No assertion depends on it.

### Not verified

CI on this branch has not run yet at the time of opening. The point of the PR is to exercise it.