### PR TITLE
Add e2e coverage for the date input format and explorer settings

### DIFF
--- a/frontend/app/src/modules/settings/explorers/Explorers.vue
+++ b/frontend/app/src/modules/settings/explorers/Explorers.vue
@@ -134,6 +134,7 @@ onMounted(() => {
 
       <ExplorerInput
         v-model="address"
+        data-testid="explorer-address-input"
         :label="t('explorers.address')"
         :hint="t('explorers.address_url', { addressUrl })"
         :placeholder="addressUrl"
@@ -143,6 +144,7 @@ onMounted(() => {
       <ExplorerInput
         v-if="txUrl"
         v-model="tx"
+        data-testid="explorer-tx-input"
         :label="t('explorers.tx')"
         :hint="t('explorers.tx_url', { txUrl })"
         :placeholder="txUrl"
@@ -152,6 +154,7 @@ onMounted(() => {
       <ExplorerInput
         v-if="blockUrl"
         v-model="block"
+        data-testid="explorer-block-input"
         :label="t('explorers.block')"
         :hint="t('explorers.block_url', { blockUrl })"
         :placeholder="blockUrl"
@@ -161,6 +164,7 @@ onMounted(() => {
       <ExplorerInput
         v-if="tokenUrl"
         v-model="token"
+        data-testid="explorer-token-input"
         :label="t('explorers.token')"
         :hint="t('explorers.token_url', { tokenUrl })"
         :placeholder="tokenUrl"

--- a/frontend/app/src/modules/settings/general/DateInputFormatSetting.vue
+++ b/frontend/app/src/modules/settings/general/DateInputFormatSetting.vue
@@ -60,6 +60,7 @@ watch(writeError, (message) => {
 <template>
   <DateInputFormatSelector
     v-model="form.state.value"
+    data-testid="date-input-format-input"
     :label="t('general_settings.labels.date_input_format')"
     :success-messages="success ? [success] : []"
     :error-messages="error ? [error] : form.errors(SETTING_FIELD)"

--- a/frontend/app/tests/e2e/pages/general-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/general-settings-page.ts
@@ -43,6 +43,12 @@ export class GeneralSettingsPage {
     await this.setInputFieldValue('[data-cy=date-display-format-input]', value);
   }
 
+  /** The input format is a menu select, not a free-text field: pick the option by its value. */
+  async selectDateInputFormat(value: string): Promise<void> {
+    await this.page.locator('[data-testid=date-input-format-input]').click();
+    await this.page.locator('[role=menu]').getByText(value, { exact: true }).click();
+  }
+
   async setThousandSeparator(value: string): Promise<void> {
     await this.setInputFieldValue('[data-cy=thousand-separator-input]', value);
   }
@@ -67,6 +73,7 @@ export class GeneralSettingsPage {
     anonymousUsageStatistics: boolean;
     floatingPrecision: string;
     dateDisplayFormat: string;
+    dateInputFormat: string;
     thousandSeparator: string;
     decimalSeparator: string;
     currencyLocation: 'after' | 'before';
@@ -86,6 +93,7 @@ export class GeneralSettingsPage {
     await expect(this.page.locator('[data-testid=balance-save-frequency-input] input')).toHaveValue(settings.balanceSaveFrequency);
 
     await expect(this.page.locator('[data-cy=date-display-format-input] input')).toHaveValue(settings.dateDisplayFormat);
+    await expect(this.page.locator('[data-testid=date-input-format-input] input')).toHaveValue(settings.dateInputFormat);
     await expect(this.page.locator('[data-cy=thousand-separator-input] input')).toHaveValue(settings.thousandSeparator);
     await expect(this.page.locator('[data-cy=decimal-separator-input] input')).toHaveValue(settings.decimalSeparator);
 

--- a/frontend/app/tests/e2e/pages/interface-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/interface-settings-page.ts
@@ -17,6 +17,44 @@ export class InterfaceSettingsPage {
       await expect(this.page.locator(`#${id}`)).toBeVisible();
   }
 
+  /**
+   * The explorer field. Its save button is a sibling of the field rather than a child, so it is
+   * reached relative to the field instead of carrying a test id of its own.
+   */
+  private explorer(field: 'address' | 'tx' | 'block' | 'token') {
+    const input = this.page.locator(`[data-testid=explorer-${field}-input]`);
+    return {
+      input,
+      messages: input.locator('.details'),
+      save: input.locator('xpath=following-sibling::button'),
+      textbox: input.locator('input'),
+    };
+  }
+
+  async setExplorerUrl(field: 'address' | 'tx' | 'block' | 'token', url: string): Promise<void> {
+    const { textbox } = this.explorer(field);
+    await textbox.scrollIntoViewIfNeeded();
+    await textbox.clear();
+    await textbox.fill(url);
+    await textbox.blur();
+  }
+
+  async saveExplorerUrl(field: 'address' | 'tx' | 'block' | 'token'): Promise<void> {
+    await this.explorer(field).save.click();
+  }
+
+  async explorerMessages(field: 'address' | 'tx' | 'block' | 'token'): Promise<string> {
+    return this.explorer(field).messages.innerText();
+  }
+
+  async explorerSaveDisabled(field: 'address' | 'tx' | 'block' | 'token'): Promise<boolean> {
+    return this.explorer(field).save.isDisabled();
+  }
+
+  async explorerValue(field: 'address' | 'tx' | 'block' | 'token'): Promise<string> {
+    return this.explorer(field).textbox.inputValue();
+  }
+
   async toggleAnimations(): Promise<void> {
     const control = this.page.getByTestId('animations-enabled');
     await control.scrollIntoViewIfNeeded();

--- a/frontend/app/tests/e2e/specs/settings/general.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/general.spec.ts
@@ -13,6 +13,7 @@ test.describe.serial('settings::general', () => {
     currency: 'JPY',
     balanceSaveFrequency: '48',
     dateDisplayFormat: '%d-%m-%Y %H:%M:%S %z',
+    dateInputFormat: '%m/%d/%Y %H:%M:%S',
     thousandSeparator: ',',
     decimalSeparator: '.',
     currencyLocation: 'after' as const,
@@ -63,6 +64,15 @@ test.describe.serial('settings::general', () => {
       ctx.sharedPage,
       '[data-cy=date-display-format-input] .details',
       settings.dateDisplayFormat,
+    );
+  });
+
+  test('change date input format and validate UI message', async () => {
+    await pageGeneral.selectDateInputFormat(settings.dateInputFormat);
+    await confirmInlineSuccess(
+      ctx.sharedPage,
+      '[data-testid=date-input-format-input] .details',
+      settings.dateInputFormat,
     );
   });
 

--- a/frontend/app/tests/e2e/specs/settings/interface.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/interface.spec.ts
@@ -1,5 +1,8 @@
+import { expect } from '@playwright/test';
 import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { InterfaceSettingsPage } from '../../pages/interface-settings-page';
+
+const explorerUrl = 'https://example.com/address/';
 
 test.describe.serial('settings::interface', () => {
   let ctx: SharedTestContext;
@@ -21,5 +24,31 @@ test.describe.serial('settings::interface', () => {
 
   test('toggles the animations setting and shows inline success', async () => {
     await page.toggleAnimations();
+  });
+
+  test('rejects an explorer url that is not https', async () => {
+    await page.setExplorerUrl('address', 'http://example.com/address/');
+    expect(await page.explorerMessages('address')).toContain('Only https urls are allowed');
+    expect(await page.explorerSaveDisabled('address')).toBe(true);
+  });
+
+  // 'https://' passes the https rule and fails only the url rule, so this covers the url check
+  // instead of duplicating the test above. A value failing BOTH rules would prove nothing here.
+  test('rejects an explorer url that is only a scheme', async () => {
+    await page.setExplorerUrl('address', 'https://');
+    expect(await page.explorerMessages('address')).not.toBe('');
+    expect(await page.explorerSaveDisabled('address')).toBe(true);
+  });
+
+  test('saves a valid explorer url and keeps it after re-login', async () => {
+    await page.setExplorerUrl('address', explorerUrl);
+    expect(await page.explorerSaveDisabled('address')).toBe(false);
+    await page.saveExplorerUrl('address');
+
+    // Explorers are frontend settings: only a fresh login proves what was persisted, since
+    // navigating re-reads the in-memory settings repo.
+    await ctx.app.relogin(ctx.username);
+    await page.visit();
+    expect(await page.explorerValue('address')).toBe(explorerUrl);
   });
 });


### PR DESCRIPTION
Follow-up to #12770. Two of the settings migrated there had unit tests only; this adds the e2e coverage they were missing, before the next migration batch touches the same area.

## What is covered now

**Date input format** (`specs/settings/general`) — it is a menu select rather than a text field, so it needed its own page-object step. The value is folded into the shared `verify`, so both the navigate-back and the re-login checks assert it.

**Explorer urls** (`specs/settings/interface`) — previously no coverage at all. Three tests: a non-https url is rejected, a url-invalid value is rejected, and a valid url saves and survives a re-login.

Production changes are six `data-testid` attributes at the call sites. Both leaf components already forward `$attrs`, so no component internals changed.

## Separating the two explorer rules

`ExplorerInput` has two rules — `https` and vuelidate's `url` — and a naive rejection test cannot tell them apart. Measured acceptance:

| input | `url` | `https` | accepted |
|---|---|---|---|
| `https://example.com/address/` | pass | pass | **yes** |
| `https://` | fail | pass | no, url rule only |
| `http://example.com/address/` | pass | fail | no, https rule only |
| `not a url` | fail | fail | no, both |
| `''` | pass | pass | **yes** |

The first version of the second test used `not a url`, which trips both rules — it stayed green with the `url` validator deleted, so it was the first test under another name. It now uses `https://`, which fails only the `url` rule.

Each rejection test was verified against a deliberately broken component:

- `isHttps` forced true → the https test fails
- `url` rule removed → the https test still passes, the scheme test fails

The third test asserts a positive outcome (the value is there after a fresh login), which cannot pass vacuously, so it needs no such control.

Note that an empty value is accepted by both rules — that is the clear-the-override path, and any future change to these rules has to preserve it.

## Not covered, and why

`SsfGraphMultiplierSetting` was also migrated in #12770 with unit tests only, and it stays that way. Its parent `StatisticsGraphSettings` is registered in `modules/premium/register-components.ts` and rendered by the premium bundle, so CI cannot reach it without a subscription. A test that navigated there would assert nothing.

## Tests

`specs/settings/general` + `specs/settings/interface`: 14/14 on cleared `.e2e/data`. Typecheck, lint and typos clean.
