### PR TITLE
Bind a session credential to the user that issued it

### DIFF
--- a/rotkehlchen/api/asgi.py
+++ b/rotkehlchen/api/asgi.py
@@ -18,7 +18,7 @@ import asyncio
 import logging
 from contextlib import suppress
 from http.cookies import SimpleCookie
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Final, cast
 
 from a2wsgi import WSGIMiddleware
 
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from flask import Flask
 
     from rotkehlchen.api.rest import RestAPI
+    from rotkehlchen.api.session_token import SessionClaims
     from rotkehlchen.api.websockets.notifier import RotkiNotifier
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,12 @@ WSGI_BRIDGE_WORKERS = 64
 # disconnected, which is strictly better than silent unbounded lag.
 WS_QUEUE_MAXSIZE = 4096
 
+# Close codes. 1013 (try again later) asks the frontend to reconnect, which a lagging
+# client should; 1008 (policy violation) is for a connection whose session died under
+# it, where a reconnect is expected to be refused at the handshake.
+WS_CLOSE_TRY_AGAIN_LATER: Final = 1013
+WS_CLOSE_POLICY_VIOLATION: Final = 1008
+
 
 class AsgiWebsocketSubscriber:
     """A websocket client of the asyncio server, as seen by RotkiNotifier.
@@ -63,15 +70,26 @@ class AsgiWebsocketSubscriber:
     Duck-types the parts of geventwebsocket's WebSocket that the notifier
     touches: a ``closed`` attribute and a ``send()`` that may be called from
     any greenlet/thread and raises on a dead client.
+
+    ``username``/``sid`` are the credential the handshake was accepted under, kept so
+    the connection can be dropped when that session stops being the live one. Both are
+    None when the cookie gate is off (Electron/dev), where there is nothing to revoke.
     """
 
-    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+    def __init__(
+            self,
+            loop: asyncio.AbstractEventLoop,
+            username: str | None = None,
+            sid: str | None = None,
+    ) -> None:
         self.loop = loop
+        self.username = username
+        self.sid = sid
         self.queue: asyncio.Queue[str] = asyncio.Queue(maxsize=WS_QUEUE_MAXSIZE)
         self.closed = False
-        # set by _serve_websocket; invoked on the event-loop thread when the
-        # queue overflows, to tear the lagging connection down
-        self.overflow_callback: Callable[[], None] | None = None
+        # set by _serve_websocket; invoked on the event-loop thread with a close code,
+        # to tear this connection down
+        self.close_callback: Callable[[int], None] | None = None
         # messages that found the queue full, retained so teardown hands them to
         # the notifier along with the queued ones instead of losing them
         self._overflowed: list[str] = []
@@ -91,8 +109,21 @@ class AsgiWebsocketSubscriber:
         except asyncio.QueueFull:
             self._overflowed.append(message)
             self.closed = True
-            if self.overflow_callback is not None:
-                self.overflow_callback()
+            if self.close_callback is not None:
+                self.close_callback(WS_CLOSE_TRY_AGAIN_LATER)
+
+    def disconnect(self, code: int = WS_CLOSE_POLICY_VIOLATION) -> None:
+        """Tear this connection down. May be called from any thread.
+
+        Marking it closed first stops broadcasts from reaching it even before the
+        event loop gets to the close, so a revoked client sees nothing more from the
+        moment the caller returns.
+        """
+        self.closed = True
+        if self.close_callback is None:
+            return
+        with suppress(RuntimeError):  # the event loop is closed (server shutdown)
+            self.loop.call_soon_threadsafe(self.close_callback, code)
 
     def send(self, message: str) -> None:
         """Enqueue a message for delivery by the connection's sender coroutine.
@@ -127,6 +158,7 @@ async def _serve_websocket(
         notifier: RotkiNotifier,
         receive: Receive,
         send: Send,
+        claims: SessionClaims | None = None,
 ) -> None:
     """Serve one websocket connection: subscribe it to the notifier, drain its
     queue into the socket and echo back any client messages (parity with the
@@ -135,7 +167,11 @@ async def _serve_websocket(
     if message['type'] != 'websocket.connect':
         return
     await send({'type': 'websocket.accept'})
-    subscriber = AsgiWebsocketSubscriber(loop=asyncio.get_running_loop())
+    subscriber = AsgiWebsocketSubscriber(
+        loop=asyncio.get_running_loop(),
+        username=claims.username if claims is not None else None,
+        sid=claims.sid if claims is not None else None,
+    )
 
     async def drain_queue() -> None:
         while True:
@@ -144,18 +180,19 @@ async def _serve_websocket(
 
     sender_task = asyncio.create_task(drain_queue())
 
-    async def disconnect_lagging_client() -> None:
+    async def close_connection(code: int) -> None:
         sender_task.cancel()
         with suppress(BaseException):  # swallow CancelledError and any send failure
             await sender_task
         with suppress(Exception):  # the client may be gone already
-            await send({'type': 'websocket.close', 'code': 1013})  # 1013: try again later
+            await send({'type': 'websocket.close', 'code': code})
 
-    def on_overflow() -> None:  # runs on the event-loop thread
-        log.warning('Disconnecting a websocket client that stopped consuming messages')
-        asyncio.get_running_loop().create_task(disconnect_lagging_client())
+    def on_close_requested(code: int) -> None:  # runs on the event-loop thread
+        if code == WS_CLOSE_TRY_AGAIN_LATER:
+            log.warning('Disconnecting a websocket client that stopped consuming messages')
+        asyncio.get_running_loop().create_task(close_connection(code))
 
-    subscriber.overflow_callback = on_overflow
+    subscriber.close_callback = on_close_requested
     notifier.subscribe(subscriber)
     try:
         while True:
@@ -186,16 +223,20 @@ async def _handle_lifespan(receive: Receive, send: Send) -> None:
             return
 
 
-def _ws_session_allowed(rest_api: RestAPI, scope: Scope) -> bool:
+def _check_ws_session(rest_api: RestAPI, scope: Scope) -> tuple[bool, SessionClaims | None]:
     """Docker session-cookie gate for the /ws handshake (the ASGI equivalent of the
     Flask before_request gate, which does not see websocket upgrades). Inert without a
     key; otherwise the same-origin `rotki_session` cookie rides the handshake and must
     carry the user's active `sid` (a newer login kicks it — #3156). Rejected here
-    *before* accept, so an unauthenticated client never completes the handshake."""
+    *before* accept, so an unauthenticated client never completes the handshake.
+
+    Returns whether the handshake may proceed together with the claims it was accepted
+    under, which the connection keeps so a later revocation can drop it: this gate runs
+    once, and nothing re-reads the cookie for the life of the socket."""
     if rest_api.session_key is None:
-        return True  # feature off (Electron/dev)
+        return True, None  # feature off (Electron/dev)
     if rest_api.session_store is None:
-        return False
+        return False, None
     raw_cookie = ''
     # ASGI scope headers are an iterable of (name, value) byte pairs; the Scope union
     # types `.get` as `object`, so narrow it for the loop below.
@@ -206,7 +247,9 @@ def _ws_session_allowed(rest_api: RestAPI, scope: Scope) -> bool:
             break
     morsel = SimpleCookie(raw_cookie).get(SESSION_COOKIE_NAME)
     claims = read_session_token(rest_api.session_key, morsel.value if morsel is not None else '')
-    return claims is not None and rest_api.session_store.is_active(claims.username, claims.sid)
+    if claims is None or not rest_api.session_store.is_active(claims.username, claims.sid):
+        return False, None
+    return True, claims
 
 
 def create_asgi_app(
@@ -229,10 +272,19 @@ def create_asgi_app(
         if scope['type'] == 'lifespan':
             await _handle_lifespan(receive=receive, send=send)
         elif scope['type'] == 'websocket':
-            if scope['path'] not in {'/ws', '/ws/'} or not _ws_session_allowed(rest_api, scope):
+            if scope['path'] not in {'/ws', '/ws/'}:
                 await send({'type': 'websocket.close'})  # reject the handshake
                 return
-            await _serve_websocket(notifier=rotki_notifier, receive=receive, send=send)
+            allowed, claims = _check_ws_session(rest_api, scope)
+            if not allowed:
+                await send({'type': 'websocket.close'})  # reject the handshake
+                return
+            await _serve_websocket(
+                notifier=rotki_notifier,
+                receive=receive,
+                send=send,
+                claims=claims,
+            )
         else:
             await wsgi_app(scope, receive, send)
 

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -488,6 +488,26 @@ class RestAPI:
                 session_key=self.session_key,
             ) if self.session_key is not None else None
         )
+        if self.session_store is not None:
+            # The /ws gate only runs at the handshake, so a socket accepted under a
+            # session that is later revoked or displaced would keep receiving
+            # broadcasts. Sweeping on every store change covers logout, same-user
+            # takeover and displacement by another user in one place.
+            self.session_store.on_sessions_changed = self._disconnect_revoked_websockets
+
+    def _disconnect_revoked_websockets(self) -> None:
+        """Drop every websocket whose session is no longer the live one for its user.
+
+        A connection carries the username/sid its handshake was accepted under; None
+        for both means the cookie gate was off when it connected, so there is nothing
+        to revoke it against.
+        """
+        def is_authorized(username: str | None, sid: str | None) -> bool:
+            if username is None or sid is None:
+                return True
+            return self.session_store is not None and self.session_store.is_active(username, sid)
+
+        self.rotkehlchen.rotki_notifier.disconnect_deauthorized(is_authorized)
 
     @contextmanager
     def session_usage(self) -> Iterator[bool]:

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -599,6 +599,31 @@ class APIServer:
                     )
                 else:
                     claims = internal_claims
+
+                # A credential is only good for the user it was issued to. Validating it
+                # proves the session is live, not that it belongs to the data behind this
+                # request: core unlocks one user at a time and scopes nothing by the
+                # caller, so without this a credential for one user reads whichever
+                # database happens to be unlocked.
+                #
+                # That is reachable because a user change is not always preceded by a
+                # logout. A restart clears `user_is_logged_in` without revoking anything,
+                # so the next login can be a different user while the previous one's
+                # session row is still live and its bearer still in an MCP client.
+                #
+                # Only checked while a user is unlocked. With none, the credential can
+                # reach no user data anyway, and the checks that run then (session
+                # validation for the Docker control endpoint) have to keep working after
+                # a restart, which is exactly when nobody is logged in.
+                if (
+                        self.rest_api.rotkehlchen.user_is_logged_in and
+                        claims.username != self.rest_api.rotkehlchen.data.username
+                ):
+                    return api_response(
+                        wrap_in_fail_result('Authentication required'),
+                        HTTPStatus.UNAUTHORIZED,
+                    )
+
                 g.rotki_session_user = claims.username
                 g.rotki_session_sid = claims.sid
                 if cookie_is_active:

--- a/rotkehlchen/api/session_store.py
+++ b/rotkehlchen/api/session_store.py
@@ -94,7 +94,11 @@ class SessionStore:
 
     def login(self, username: str) -> str:
         """Start (or take over) the active session for ``username`` and return its token.
-        The UPSERT overwrites the user's prior session, so its old cookie is revoked."""
+        The UPSERT overwrites the user's prior session, so its old cookie is revoked, and
+        every other user's row goes with it: core unlocks one user at a time, so a second
+        row can only ever be a session that is no longer reachable. Leaving them behind is
+        what let a previous user's cookie and MCP bearer outlive the login that displaced
+        them, since the UPSERT alone only ever rewrites the row of the user logging in."""
         current_time = int(time.time())
         sid = secrets.token_hex(16)
         absolute_exp = current_time + SESSION_ABSOLUTE_TTL
@@ -103,6 +107,7 @@ class SessionStore:
         # logins can't leave one sid in memory and a different one in the DB. Write the
         # DB first, so a failed commit never leaves memory ahead of the durable mirror.
         with self._lock:
+            self._conn.execute('DELETE FROM active_sessions WHERE user != ?', (username,))
             self._conn.execute(
                 'INSERT INTO active_sessions(user, sid, abs) VALUES(?, ?, ?) '
                 'ON CONFLICT(user) DO UPDATE SET '
@@ -110,6 +115,8 @@ class SessionStore:
                 (username, sid, absolute_exp),
             )
             self._conn.commit()
+            for other in [user for user in self._active if user != username]:
+                del self._active[other]
             self._active[username] = ActiveSession(
                 sid=sid,
                 absolute_exp=absolute_exp,

--- a/rotkehlchen/api/session_store.py
+++ b/rotkehlchen/api/session_store.py
@@ -27,6 +27,7 @@ from rotkehlchen.api.session_token import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 SESSION_DB_NAME: Final = 'session.db'
@@ -55,6 +56,11 @@ class SessionStore:
         self._lock = Semaphore()
         # user -> ActiveSession; the hot authority (session.db is the durable mirror).
         self._active: dict[str, ActiveSession] = {}
+        # Invoked after any change to which sessions are live, so holders of a
+        # credential that is checked only once -- websockets, which are gated at the
+        # handshake and never again -- can be dropped. Wired by RestAPI at startup;
+        # None in tests that exercise the store on its own.
+        self.on_sessions_changed: Callable[[], None] | None = None
         with self._lock:
             self._conn.execute('PRAGMA journal_mode=WAL')
             self._initialize_schema()
@@ -123,7 +129,12 @@ class SessionStore:
                 exp=exp,
                 mcp_sid=None,
             )
+        self._notify_sessions_changed()  # outside the lock: the callback closes sockets
         return mint_session_token(self.session_key, username, sid, expires_at=exp)['token']
+
+    def _notify_sessions_changed(self) -> None:
+        if self.on_sessions_changed is not None:
+            self.on_sessions_changed()
 
     def reissue(self, username: str, sid: str) -> str | None:
         """Rolling refresh: re-mint the *same* sid with a fresh idle ``exp`` capped at
@@ -200,6 +211,7 @@ class SessionStore:
             self._conn.execute('DELETE FROM active_sessions WHERE user = ?', (username,))
             self._conn.commit()
             self._active.pop(username, None)
+        self._notify_sessions_changed()
 
     def close(self) -> None:
         """Close the underlying connection (test cleanup; the process shares one store)."""

--- a/rotkehlchen/api/websockets/notifier.py
+++ b/rotkehlchen/api/websockets/notifier.py
@@ -81,6 +81,34 @@ class RotkiNotifier:
 
         log.info('Websocket with hash id %s unsubscribed from rotki notifier', hash(websocket))
 
+    def disconnect_deauthorized(
+            self,
+            is_authorized: Callable[[str | None, str | None], bool],
+    ) -> None:
+        """Close every connection whose handshake credential no longer authorizes it.
+
+        The /ws gate runs once, at the handshake, and nothing re-reads the cookie for
+        the life of the socket. Without this an accepted connection outlives the
+        session that opened it and keeps receiving every broadcast -- including, after
+        a takeover, the next user's. Asking the predicate per connection means one
+        path covers logout, same-user takeover and displacement by a different user.
+
+        Connections drop themselves from the subscriber list through their normal
+        teardown once the close lands, so nothing is unsubscribed here.
+        """
+        with self.subscribers_lock:
+            subscribers = list(self.subscribers)
+
+        for websocket in subscribers:
+            if is_authorized(websocket.username, websocket.sid):
+                continue
+
+            log.info(
+                'Disconnecting websocket with hash id %s: its session is no longer active',
+                hash(websocket),
+            )
+            websocket.disconnect()
+
     def broadcast(
             self,
             message_type: WSMessageType,

--- a/rotkehlchen/tests/api/test_user_authenticate.py
+++ b/rotkehlchen/tests/api/test_user_authenticate.py
@@ -9,6 +9,7 @@ exercised end-to-end through real HTTP.
 """
 import time
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 from http import HTTPStatus
 from threading import Event
 from typing import TYPE_CHECKING, Any
@@ -16,6 +17,7 @@ from unittest.mock import patch
 
 import pytest
 import requests
+from websocket import WebSocket, WebSocketConnectionClosedException, create_connection
 
 from rotkehlchen.api.session_store import (
     SESSION_DB_NAME,
@@ -79,6 +81,7 @@ def _enable_session(api_server: APIServer) -> SessionStore:
         session_key=SESSION_KEY,
     )
     rest_api.session_store = store
+    store.on_sessions_changed = rest_api._disconnect_revoked_websockets
     return store
 
 
@@ -96,6 +99,13 @@ def _cookie_sid(token: str) -> str:
     claims = read_session_token(SESSION_KEY, token)
     assert claims is not None
     return claims.sid
+
+
+def _read_until_closed(websocket: WebSocket) -> None:
+    """Read until the server's close frame lands. Messages already in flight may trail
+    the close, so a single recv is not enough to see the disconnect."""
+    while True:
+        websocket.recv()
 
 
 def _logout(api_server: APIServer, username: str) -> None:
@@ -689,4 +699,45 @@ def test_login_displaces_every_other_users_session(
             sid=mcp_claims.sid,
         ) is False
     finally:
+        _disable_session(rotkehlchen_api_server)
+
+
+@pytest.mark.parametrize('start_with_logged_in_user', [True])
+@pytest.mark.parametrize('legacy_messages_via_websockets', [True])
+def test_websocket_is_dropped_when_its_session_stops_being_active(
+        rotkehlchen_api_server: APIServer,
+        rest_api_port: int,
+        username: str,
+) -> None:
+    """An open websocket must die with the session that opened it.
+
+    The /ws gate runs once, at the handshake, and nothing re-reads the cookie for the
+    life of the socket. Without a push from the session store's side, a connection
+    accepted under a session that is later revoked or displaced stays subscribed to a
+    notifier that scopes nothing by user, so it keeps receiving every broadcast --
+    after a takeover, the *next* user's. The client is under no obligation to notice
+    it has been logged out and hang up.
+    """
+    store = _enable_session(rotkehlchen_api_server)
+    msg_aggregator = rotkehlchen_api_server.rest_api.rotkehlchen.msg_aggregator
+    websocket = create_connection(
+        f'ws://127.0.0.1:{rest_api_port}/ws/',
+        cookie=f'{SESSION_COOKIE_NAME}={store.login(username)}',
+        timeout=10,
+    )
+    try:
+        msg_aggregator.add_error('while the session is live')
+        assert 'while the session is live' in websocket.recv()
+
+        store.login(f'{username}_next')  # a different user takes the session over
+
+        with pytest.raises(WebSocketConnectionClosedException):
+            _read_until_closed(websocket)
+
+        # and nothing broadcast afterwards was written to it
+        msg_aggregator.add_error('after the takeover')
+        assert websocket.connected is False
+    finally:
+        with suppress(WebSocketConnectionClosedException, OSError):
+            websocket.close()
         _disable_session(rotkehlchen_api_server)

--- a/rotkehlchen/tests/api/test_user_authenticate.py
+++ b/rotkehlchen/tests/api/test_user_authenticate.py
@@ -17,7 +17,11 @@ from unittest.mock import patch
 import pytest
 import requests
 
-from rotkehlchen.api.session_store import SESSION_DB_NAME, SessionStore
+from rotkehlchen.api.session_store import (
+    SESSION_DB_NAME,
+    SessionStore,
+    is_persisted_mcp_session_active,
+)
 from rotkehlchen.api.session_token import (
     MCP_BACKEND_PROOF_HEADER,
     SESSION_COOKIE_NAME,
@@ -585,3 +589,104 @@ def test_cookie_less_rules_pinned(rotkehlchen_api_server: APIServer) -> None:
         (f'{prefix}/users/<string:name>', 'POST'),
         (f'{prefix}/users/<string:name>/authenticate', 'POST'),
     })
+
+
+@pytest.mark.parametrize('start_with_logged_in_user', [True])
+def test_credentials_are_bound_to_the_user_that_issued_them(
+        rotkehlchen_api_server: APIServer,
+        username: str,
+) -> None:
+    """A cookie or bearer minted for one user must not read another user's data.
+
+    Validating a credential proves the session is live, not that it belongs to the data
+    behind the request: core unlocks one user at a time and scopes nothing by the caller.
+
+    The situation is reachable because a user change is not always preceded by a logout.
+    A restart clears `user_is_logged_in` without revoking anything, so the next login can
+    be a different user while the previous one's session row is still live, rehydrated
+    from the durable mirror, and its bearer still sitting in an MCP client. That is what
+    this reproduces: the unlocked user is `username`, while the only live session belongs
+    to someone else.
+    """
+    store = _enable_session(rotkehlchen_api_server)
+    try:
+        other = f'{username}_previous'
+        other_cookie = store.login(other)
+        other_claims = read_session_token(SESSION_KEY, other_cookie)
+        assert other_claims is not None
+        other_bearer = store.issue_mcp_token(username=other, sid=other_claims.sid)
+        assert other_bearer is not None
+
+        # Both credentials are live by the session store's own reckoning, which is
+        # exactly why validating them is not enough on its own.
+        assert store.is_active(other, other_claims.sid) is True
+        mcp_claims = read_mcp_token(SESSION_KEY, other_bearer)
+        assert mcp_claims is not None
+        assert store.is_mcp_active(username=other, sid=mcp_claims.sid) is True
+
+        settings_url = api_url_for(rotkehlchen_api_server, 'settingsresource')
+        assert requests.get(
+            settings_url,
+            cookies={SESSION_COOKIE_NAME: other_cookie},
+        ).status_code == HTTPStatus.UNAUTHORIZED
+        assert requests.get(
+            settings_url,
+            headers={
+                'Authorization': f'Bearer {other_bearer}',
+                MCP_BACKEND_PROOF_HEADER: create_mcp_backend_proof(
+                    key=SESSION_KEY,
+                    token=other_bearer,
+                ),
+            },
+        ).status_code == HTTPStatus.UNAUTHORIZED
+
+        # The unlocked user's own credential still works, so the check rejects the
+        # mismatch rather than simply everything.
+        assert requests.get(
+            settings_url,
+            cookies={SESSION_COOKIE_NAME: store.login(username)},
+        ).status_code == HTTPStatus.OK
+    finally:
+        _disable_session(rotkehlchen_api_server)
+
+
+@pytest.mark.parametrize('start_with_logged_in_user', [True])
+def test_login_displaces_every_other_users_session(
+        rotkehlchen_api_server: APIServer,
+        username: str,
+) -> None:
+    """A login must end every other user's session, not just overwrite its own row.
+
+    `active_sessions` is keyed by user, so the UPSERT only ever rewrites the row of the
+    user logging in. Core unlocks one user at a time, so any other row is a session that
+    can no longer be reached, and leaving it behind let a previous user's cookie and MCP
+    bearer outlive the login that displaced them. A bearer is handed to an external MCP
+    client, so it survives the browser losing its cookie.
+    """
+    store = _enable_session(rotkehlchen_api_server)
+    try:
+        other = f'{username}_previous'
+        other_cookie = store.login(other)
+        other_claims = read_session_token(SESSION_KEY, other_cookie)
+        assert other_claims is not None
+        other_bearer = store.issue_mcp_token(username=other, sid=other_claims.sid)
+        assert other_bearer is not None
+        mcp_claims = read_mcp_token(SESSION_KEY, other_bearer)
+        assert mcp_claims is not None
+
+        store.login(username)
+
+        assert store.is_active(other, other_claims.sid) is False
+        assert store.is_mcp_active(username=other, sid=mcp_claims.sid) is False
+        # Also gone from the durable mirror, which is the authority MCP reads in its
+        # own process and the one that survives a restart.
+        assert is_persisted_mcp_session_active(
+            db_path=(
+                rotkehlchen_api_server.rest_api.rotkehlchen.data_dir /
+                GLOBALDIR_NAME / SESSION_DB_NAME
+            ),
+            username=other,
+            sid=mcp_claims.sid,
+        ) is False
+    finally:
+        _disable_session(rotkehlchen_api_server)

--- a/rotkehlchen/tests/mcp/test_auth.py
+++ b/rotkehlchen/tests/mcp/test_auth.py
@@ -42,3 +42,28 @@ def test_session_token_verifier_should_reject_invalid_token(tmp_path: Path) -> N
     )
 
     assert asyncio.run(verifier.verify_token('not-a-token')) is None
+
+
+def test_session_token_verifier_should_reject_a_displaced_users_token(tmp_path: Path) -> None:
+    """A bearer must stop verifying once another user's login displaces its session.
+
+    This is the MCP transport's own front door, checked in the MCP process against the
+    durable mirror rather than the in-memory store. It matters on its own because a
+    bearer is handed to an external client by design: it lives in that client's config
+    and is untouched when a different user logs in and takes the browser's cookie.
+    """
+    session_db = tmp_path / 'session.db'
+    store = SessionStore(db_path=session_db, session_key=(session_key := b'test-key'))
+    session_token = store.login(username := 'alice')
+    assert (claims := read_session_token(session_key, session_token)) is not None
+    token = store.issue_mcp_token(username=username, sid=claims.sid)
+    assert token is not None
+    verifier = SessionTokenVerifier(session_key=session_key, session_db=session_db)
+    try:
+        assert asyncio.run(verifier.verify_token(token)) is not None
+
+        store.login('bob')
+
+        assert asyncio.run(verifier.verify_token(token)) is None
+    finally:
+        store.close()

--- a/rotkehlchen/tests/unit/test_session_store.py
+++ b/rotkehlchen/tests/unit/test_session_store.py
@@ -64,14 +64,34 @@ def test_is_active_rejects_unknown_user_and_wrong_sid(tmp_path):
 
 
 @pytest.mark.freeze_time(BASE)
-def test_login_is_per_user_isolated(tmp_path):
+def test_login_displaces_every_other_user(tmp_path):
+    """A login ends every other user's session, not just the row it upserts.
+
+    Core unlocks one user at a time, so any other row is a session that can no longer
+    be reached. Leaving it behind let a displaced user's cookie -- and the MCP bearer
+    minted from it, which lives in an external client and is untouched by the browser
+    losing its cookie -- outlive the login that displaced them.
+    """
     store = _store(tmp_path)
     alice = read_session_token(KEY, store.login('alice'))
+    assert alice is not None
+    alice_bearer = store.issue_mcp_token(username='alice', sid=alice.sid)
+    assert alice_bearer is not None
+    assert (alice_mcp := read_mcp_token(KEY, alice_bearer)) is not None
+
     bob = read_session_token(KEY, store.login('bob'))
-    assert alice is not None and bob is not None
-    # bob logging in does not disturb alice's session (per-user single-active)
-    assert store.is_active('alice', alice.sid) is True
+    assert bob is not None
+
+    assert store.is_active('alice', alice.sid) is False
+    assert store.is_mcp_active(username='alice', sid=alice_mcp.sid) is False
     assert store.is_active('bob', bob.sid) is True
+    # gone from the durable mirror too, which is the authority the MCP process reads
+    # and the one that survives a restart
+    assert is_persisted_mcp_session_active(
+        db_path=tmp_path / SESSION_DB_NAME,
+        username='alice',
+        sid=alice_mcp.sid,
+    ) is False
 
 
 def test_reissue_rolls_exp_and_caps_at_absolute(tmp_path):

--- a/rotkehlchen/tests/websocketsapi/test_misc.py
+++ b/rotkehlchen/tests/websocketsapi/test_misc.py
@@ -5,7 +5,13 @@ from unittest.mock import Mock
 
 import pytest
 
-from rotkehlchen.api.asgi import WS_QUEUE_MAXSIZE, AsgiWebsocketSubscriber
+from rotkehlchen.api.asgi import (
+    WS_CLOSE_POLICY_VIOLATION,
+    WS_CLOSE_TRY_AGAIN_LATER,
+    WS_QUEUE_MAXSIZE,
+    AsgiWebsocketSubscriber,
+)
+from rotkehlchen.api.websockets.notifier import RotkiNotifier
 from rotkehlchen.concurrency import spawn, wait
 from rotkehlchen.user_messages import MessagesAggregator
 
@@ -72,6 +78,42 @@ def test_requeue_undelivered_messages():
     assert msg_aggregator.consume_warnings() == ['a warning']
 
 
+def test_disconnect_deauthorized_drops_only_revoked_connections():
+    """The /ws gate runs once, at the handshake, so a revoked session's socket has to
+    be dropped from the outside or it keeps receiving broadcasts -- including, after a
+    takeover, the next user's. Connections opened with the cookie gate off carry no
+    credential and must be left alone."""
+    loop = asyncio.new_event_loop()
+    try:
+        notifier = RotkiNotifier()
+        revoked = AsgiWebsocketSubscriber(loop=loop, username='alice', sid='old-sid')
+        live = AsgiWebsocketSubscriber(loop=loop, username='bob', sid='live-sid')
+        ungated = AsgiWebsocketSubscriber(loop=loop)  # cookie gate off (Electron/dev)
+        for subscriber in (revoked, live, ungated):
+            subscriber.close_callback = Mock()
+            notifier.subscribe(subscriber)
+
+        notifier.disconnect_deauthorized(
+            lambda username, sid: (username, sid) in {(None, None), ('bob', 'live-sid')},
+        )
+        loop.run_until_complete(asyncio.sleep(0))  # flush the scheduled callbacks
+
+        assert revoked.closed is True
+        revoked.close_callback.assert_called_once_with(WS_CLOSE_POLICY_VIOLATION)
+        assert live.closed is False
+        live.close_callback.assert_not_called()
+        assert ungated.closed is False
+        ungated.close_callback.assert_not_called()
+
+        # and the revoked one receives nothing more, even before its close lands
+        notifier.broadcast(message_type='legacy', to_send_data={'value': 'after'})
+        loop.run_until_complete(asyncio.sleep(0))  # send() enqueues via the loop too
+        assert revoked.queue.qsize() == 0
+        assert live.queue.qsize() == 1
+    finally:
+        loop.close()
+
+
 def test_queue_overflow_retains_dropped_messages():
     """The message that finds the queue full must be kept for teardown: it is
     handed back to the notifier by drain_pending along with the queued ones, so
@@ -79,14 +121,14 @@ def test_queue_overflow_retains_dropped_messages():
     loop = asyncio.new_event_loop()
     try:
         subscriber = AsgiWebsocketSubscriber(loop=loop)
-        subscriber.overflow_callback = (overflow_callback := Mock())
+        subscriber.close_callback = (close_callback := Mock())
         for i in range(WS_QUEUE_MAXSIZE):
             subscriber.enqueue(f'message {i}')
         assert subscriber.closed is False
 
         subscriber.enqueue('the overflowing message')
         assert subscriber.closed is True
-        overflow_callback.assert_called_once()
+        close_callback.assert_called_once_with(WS_CLOSE_TRY_AGAIN_LATER)
         # an enqueue already scheduled before the overflow closed it is kept too
         subscriber.enqueue('a message scheduled before the disconnect')
 

--- a/rotkehlchen/tests/websocketsapi/test_session_cookie.py
+++ b/rotkehlchen/tests/websocketsapi/test_session_cookie.py
@@ -1,6 +1,6 @@
 from typing import NamedTuple
 
-from rotkehlchen.api.asgi import _ws_session_allowed
+from rotkehlchen.api.asgi import _check_ws_session
 from rotkehlchen.api.session_token import mint_session_token
 
 SESSION_KEY = b'ws-test-session-signing-key'
@@ -36,7 +36,7 @@ def test_ws_session_cookie_gate() -> None:
     False rejects the handshake *before* accept."""
     # disabled (no key) ⇒ allowed without a cookie
     disabled = _FakeRestAPI(session_key=None, session_store=None)
-    assert _ws_session_allowed(disabled, _scope()) is True  # type: ignore[arg-type]  # fake rest api
+    assert _check_ws_session(disabled, _scope()) == (True, None)  # type: ignore[arg-type]  # fake rest api
 
     rest_api = _FakeRestAPI(
         session_key=SESSION_KEY,
@@ -44,15 +44,19 @@ def test_ws_session_cookie_gate() -> None:
     )
 
     # key set, no cookie ⇒ rejected
-    assert _ws_session_allowed(rest_api, _scope()) is False  # type: ignore[arg-type]  # fake rest api
+    assert _check_ws_session(rest_api, _scope()) == (False, None)  # type: ignore[arg-type]  # fake rest api
 
     # key set, invalid cookie ⇒ rejected
-    assert _ws_session_allowed(rest_api, _scope('rotki_session=garbage')) is False  # type: ignore[arg-type]  # fake rest api
+    assert _check_ws_session(rest_api, _scope('rotki_session=garbage')) == (False, None)  # type: ignore[arg-type]  # fake rest api
 
     # key set, valid signature but a stale sid (a previous session) ⇒ rejected
     stale = mint_session_token(SESSION_KEY, 'alice', 'a-different-sid')['token']
-    assert _ws_session_allowed(rest_api, _scope(f'rotki_session={stale}')) is False  # type: ignore[arg-type]  # fake rest api
+    assert _check_ws_session(rest_api, _scope(f'rotki_session={stale}')) == (False, None)  # type: ignore[arg-type]  # fake rest api
 
-    # key set, valid cookie with the active sid (alongside other cookies) ⇒ allowed
+    # key set, valid cookie with the active sid (alongside other cookies) ⇒ allowed,
+    # and the claims come back so the accepted connection can be revoked later
     token = mint_session_token(SESSION_KEY, 'alice', ACTIVE_SID)['token']
-    assert _ws_session_allowed(rest_api, _scope(f'theme=dark; rotki_session={token}')) is True  # type: ignore[arg-type]  # fake rest api
+    allowed, claims = _check_ws_session(rest_api, _scope(f'theme=dark; rotki_session={token}'))  # type: ignore[arg-type]  # fake rest api
+    assert allowed is True
+    assert claims is not None
+    assert (claims.username, claims.sid) == (ACTIVE_USER, ACTIVE_SID)


### PR DESCRIPTION
A cookie or MCP bearer issued to one user could read another user's data.

Validating a credential proves the session is live. It does not prove the credential belongs to the data behind the request: core unlocks one user at a time and scopes nothing by the caller, so `g.rotki_session_user` was set and then never compared against the unlocked user.

## How it is reached

The credential lifecycle relies on an invariant that a user change is always preceded by a logout, and the logout is what revokes. That holds everywhere the design anticipated:

* A logs out, then B logs in: `revoke(A)` deletes A's row, both credentials die.
* B tries while A is logged in: 409, B never gets in.
* A re-logs in from a new browser: `login()` rotates the sid and nulls `mcp_sid`, so the old bearer dies.

A restart breaks the invariant. It clears `user_is_logged_in` without revoking anything, so the 409 that normally forces a logout is not there any more, and a different user can log in while the previous user's session row is still live, rehydrated from the durable mirror. `login(B)` then only rewrites B's row, because `active_sessions` is keyed by user, so A's row and `mcp_sid` survive untouched.

From there `is_active(A, ...)` and `is_mcp_active(A, ...)` both still return true, the gate authenticates the request as A, and core serves B's unlocked database.

The bearer is the sharp edge. The cookie is overwritten in the browser that logged in as B, so exploiting it needs a copy held elsewhere. The bearer is copied out of the browser by design, into an external MCP client's config, where it is untouched by any of this. That gives a mundane path with no attacker and no stolen credential: A generates a bearer for their AI client, the backend restarts for any reason, B logs in later, and A's client reads B's data.

## The fix

Either of the first two closes the read on its own; both are here because they do different jobs. The third covers a surface neither of them reaches.

**Reject a credential whose user is not the unlocked one.** This is the guarantee, and it fails closed, so it does not depend on revocation being correct in every flow. It is only checked while a user is unlocked: with none, the credential can reach no user data anyway, and the checks that run in that state have to keep working after a restart, which is exactly when nobody is logged in.

**Have a login end every other user's session.** This is the hygiene half. It bounds how long a displaced credential exists at all, rather than leaving it live but refused.

**Drop websockets whose session stops being the live one.** The two changes above cover requests, which are gated per call. `/ws` is not: it is gated once, at the handshake, in the ASGI app, and nothing re-reads the cookie for the life of the socket. An already-open connection therefore survived the session that opened it and stayed subscribed to a notifier that scopes nothing by user, so it kept receiving every broadcast: after a takeover, the next user's balances, addresses and task progress. Fail-closed only took effect if the client happened to reconnect, and a client is under no obligation to notice it has been logged out and hang up.

Each connection now keeps the username/sid its handshake was accepted under (both `None` when the cookie gate is off, on Electron and in dev, where there is nothing to revoke), and `SessionStore` fires an `on_sessions_changed` hook after `login()` and `revoke()`. One hook covers logout, same-user takeover and displacement by another user, instead of patching every call site that ends a session. It fires outside the store lock because the callback closes sockets, and a subscriber marks itself closed before its close frame is scheduled, so a revoked client sees nothing more from the moment the store change returns.

No frontend change is needed: the client only reconnects when the close was unclean, and a server close handshake is clean.

## Tests

Each test has a negative control confirming it fails when its own fix is reverted:

* A cookie and a bearer belonging to another user are both refused while a different user is unlocked, and the unlocked user's own cookie still works, so the check rejects the mismatch rather than simply everything.
* A login ends a previous user's session in the in-memory map and in the durable mirror that MCP reads from its own process.
* A real websocket, opened over HTTP with a valid cookie, receives a broadcast while its session is live, then is closed by the server once another user logs in, and receives nothing after that.
* At the unit level, a revocation sweep closes only the connections whose credential no longer authorizes them: a live session's connection and an ungated one are both left alone.

## Notes

Not introduced by any single change: it is reachable on develop today through a container restart or a crash followed by a different user logging in. It became easier to hit with the Docker control endpoint in #12774, which restarts the backend from a routine in-app asset update, and it was found while reviewing that.

Nothing here changes the wire format, the token contents, or colibri's validator.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

Backend only, no frontend changes.

