### PR TITLE
Serialise frontend settings writes so concurrent ones stop clobbering

### DIFF
--- a/frontend/app/src/modules/settings/use-frontend-settings-writer.spec.ts
+++ b/frontend/app/src/modules/settings/use-frontend-settings-writer.spec.ts
@@ -69,6 +69,71 @@ describe('useFrontendSettingsWriter', () => {
     expect(useSettingsRepo().frontend.notificationSchedule).toStrictEqual({});
   });
 
+  // The wire format is the whole settings blob, rebuilt from the repo. If two writes are in flight
+  // at once they both build it from the pre-update repo, so each carries the other's stale value
+  // and the later response wins. Any two settings changed within one round trip hit this, even from
+  // different components.
+  it('should not drop a concurrent write of another setting', async () => {
+    const sent: Record<string, unknown>[] = [];
+    let release = (): void => {};
+    const firstInFlight = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mockSetSettings.mockImplementation(async (payload: { frontendSettings: string }) => {
+      sent.push(JSON.parse(payload.frontendSettings));
+      // Hold the first request open so the second one starts while it is still unresolved.
+      if (sent.length === 1)
+        await firstInFlight;
+      return {};
+    });
+
+    const { updateFrontendSetting } = useFrontendSettingsWriter();
+    const first = updateFrontendSetting({ decimalSeparator: '#' });
+    const second = updateFrontendSetting({ thousandSeparator: '@' });
+    release();
+    await Promise.all([first, second]);
+
+    const repo = useSettingsRepo();
+    expect(repo.frontend.decimalSeparator).toBe('#');
+    expect(repo.frontend.thousandSeparator).toBe('@');
+    // Both changes have to reach the backend, and the last blob sent is what it stores.
+    expect(sent.at(-1)).toMatchObject({ decimal_separator: '#', thousand_separator: '@' });
+  });
+
+  // Two settings on one page are written by two different components, so each holds its own writer.
+  // The queue is shared at module scope precisely so that case is covered too.
+  it('should serialise writes issued from separate writer instances', async () => {
+    const sent: Record<string, unknown>[] = [];
+    let release = (): void => {};
+    const firstInFlight = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mockSetSettings.mockImplementation(async (payload: { frontendSettings: string }) => {
+      sent.push(JSON.parse(payload.frontendSettings));
+      if (sent.length === 1)
+        await firstInFlight;
+      return {};
+    });
+
+    const first = useFrontendSettingsWriter().updateFrontendSetting({ decimalSeparator: '#' });
+    const second = useFrontendSettingsWriter().updateFrontendSetting({ thousandSeparator: '@' });
+    release();
+    await Promise.all([first, second]);
+
+    expect(sent.at(-1)).toMatchObject({ decimal_separator: '#', thousand_separator: '@' });
+  });
+
+  it('should keep writing after a failed write', async () => {
+    mockSetSettings.mockRejectedValueOnce(new Error('backend is down'));
+    const { updateFrontendSetting } = useFrontendSettingsWriter();
+
+    const failed = await updateFrontendSetting({ decimalSeparator: '#' });
+    const next = await updateFrontendSetting({ thousandSeparator: '@' });
+
+    expect(failed.success).toBe(false);
+    expect(next.success).toBe(true);
+  });
+
   it('should reject an empty payload', async () => {
     const { updateFrontendSetting } = useFrontendSettingsWriter();
 

--- a/frontend/app/src/modules/settings/use-frontend-settings-writer.ts
+++ b/frontend/app/src/modules/settings/use-frontend-settings-writer.ts
@@ -12,6 +12,21 @@ export interface UseFrontendSettingsWriterReturn {
 }
 
 /**
+ * Serialises every frontend-settings write, app-wide.
+ *
+ * The wire format is the whole settings blob, rebuilt from the repo, and the repo is only updated
+ * once the request resolves. Two writes in flight at the same time would therefore both build the
+ * blob from the pre-update repo, each carrying the other's stale value, and the later response
+ * would win. That needs no unusual timing: any two settings changed within one round trip hit it,
+ * including from different components, and it leaves the merged local repo looking correct while
+ * the backend holds the loser.
+ *
+ * Module scope on purpose - the callers are separate composable instances and the queue has to be
+ * shared by all of them.
+ */
+let pendingWrite: Promise<unknown> = Promise.resolve();
+
+/**
  * Persists a patch of frontend settings.
  *
  * Split out of `useSettingsOperations` because that composable resolves the notification surface,
@@ -24,10 +39,10 @@ export function useFrontendSettingsWriter(): UseFrontendSettingsWriterReturn {
   const repo = useSettingsRepo();
   const api = useSettingsApi();
 
-  async function updateFrontendSetting(payload: FrontendSettingsPayload): Promise<ActionStatus> {
-    const props = Object.keys(payload);
-    assert(props.length > 0, 'Payload must be not-empty');
+  async function write(payload: FrontendSettingsPayload): Promise<ActionStatus> {
     try {
+      // Read the repo here, inside the queued turn, so this write builds on whatever the previous
+      // one persisted rather than on a snapshot taken before it ran.
       const updatedSettings = { ...repo.frontend, ...payload };
       await api.setSettings({
         frontendSettings: JSON.stringify(snakeCaseTransformer(updatedSettings)),
@@ -48,6 +63,17 @@ export function useFrontendSettingsWriter(): UseFrontendSettingsWriterReturn {
         success: false,
       };
     }
+  }
+
+  async function updateFrontendSetting(payload: FrontendSettingsPayload): Promise<ActionStatus> {
+    const props = Object.keys(payload);
+    // Rejects before queueing, so a caller's bug cannot stall every later write.
+    assert(props.length > 0, 'Payload must be not-empty');
+
+    const queued = pendingWrite.then(async () => write(payload));
+    // `write` never rejects, but keep the chain alive regardless: one failure must not block the app.
+    pendingWrite = queued.catch(() => undefined);
+    return queued;
   }
 
   return { updateFrontendSetting };


### PR DESCRIPTION
#12770 fixed one component that persisted two settings through two writers, and put two identical numeric separators on the backend. This is the audit of the rest of that class, and the central fix.

## What the audit found

**Only the frontend channel is affected.** The general and accounting channel sends a real patch that the backend merges (`useSettingsOperations.update` posts only the payload), and the session channel never leaves the client. The frontend channel is different: its wire format is the whole settings blob, rebuilt client-side from the repo.

Within that channel the problem is wider than multi-setting components:

- `updateFrontendSetting` builds `{ ...repo.frontend, ...payload }` **before** its `await`
- it calls `repo.updateFrontend(payload)` **after** the request resolves

So two writes in flight at the same time each build the blob from the pre-update repo, each carries the other key's stale value, and the later response wins. **The local repo merges both patches, so the UI keeps looking correct until the next login.**

This needs no unusual timing and no multi-setting component. Any two frontend settings changed within one request round trip hit it — rounding mode and privacy mode live in different components and race exactly the same way.

Components that hold two frontend-channel setting models (`PrivacyModeDropdown`, `TimeFrameSetting`, `NftImageRenderingSetting`, `RoundingSettings`) write one key per user action, so they are instances of this general race rather than of the #12770 bug. They need no changes once the writer is safe. The general-channel pairs — `PriceOracleSettings`, `IndexerOrderSetting`, `InternalTxConflictRepullSettings`, `AssetMovementMatchingSettingsMenu` — were never at risk.

## The fix

Frontend writes queue on a module-scoped chain, and the repo is read **inside** the queued turn so each write builds on what the previous one persisted. Module scope is deliberate: the callers are separate composable instances and the queue has to be shared by all of them.

A failed write does not block the writes behind it (covered by a test). An empty payload still rejects before queueing, so a caller's bug cannot stall the chain.

## Trade-off

Frontend settings writes are now serialised rather than concurrent, so a slow request delays the ones behind it. These writes are user-initiated and infrequent, and the alternative is silent data loss, but it is a real behaviour change worth naming.

## Tests

Three new tests on `useFrontendSettingsWriter`:

- a concurrent write of another setting is not dropped
- writes from **separate writer instances** serialise, which is what module scope is for
- a failed write does not block the next one

With the queue removed, the first two fail and every other test in the file still passes.

Full suite 719 files / 6890 tests, typecheck, lint and typos clean. One run had a single failure I did not capture the name of; it did not reproduce across two further full runs, and I cannot attribute it either way.
