### PR TITLE
Stop background requests from starving the request queue

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/use-addresses-names-api.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-addresses-names-api.spec.ts
@@ -2,6 +2,7 @@ import type { AddressBookEntry, AddressBookLocation, AddressBookSimplePayload } 
 import { server } from '@test/setup-files/server';
 import { type DefaultBodyType, http, HttpResponse } from 'msw';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '@/modules/core/api/rotki-api';
 import { useAddressesNamesApi } from './use-addresses-names-api';
 
 const backendUrl = process.env.VITE_BACKEND_URL;
@@ -494,6 +495,83 @@ describe('composables/api/blockchain/addresses-names', () => {
       await expect(clearEnsAvatarCache(null))
         .rejects
         .toThrow('Cache clear failed');
+    });
+  });
+
+  describe('queue pressure', () => {
+    /**
+     * Reverse lookups fire on every render that shows an address, so a table that refetches
+     * repeatedly asks for the same address over and over. The request queue allows six requests in
+     * flight; a slow backend once parked all six on identical lookups and every other request in
+     * the app stopped, including the DELETE behind a user's confirmed delete
+     * (`history-events.spec.ts:334`, CI only). Identical lookups must therefore share one request.
+     */
+    it('should share one request between identical concurrent lookups', async () => {
+      let started = 0;
+      let release = (): void => {};
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      server.use(
+        http.post(`${backendUrl}/api/1/names/ens/reverse`, async () => {
+          started += 1;
+          await held;
+          return HttpResponse.json({
+            message: '',
+            result: { '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045': 'vitalik.eth' },
+          });
+        }),
+        http.get(`${backendUrl}/api/1/ping`, () => HttpResponse.json({
+          message: '',
+          result: true,
+        })),
+      );
+
+      const { getEnsNames } = useAddressesNamesApi();
+      const lookups = Array.from(
+        { length: 6 },
+        async () => getEnsNames(['0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045']),
+      );
+
+      await vi.waitFor(() => {
+        expect(started).toBeGreaterThan(0);
+      });
+
+      // The lookups are still unresolved, so this is the assertion that matters: an unrelated
+      // request must not be stuck behind them. Raced rather than awaited outright, so starvation
+      // reports itself instead of hanging until the test times out.
+      const starved = new Promise<string>((resolve) => {
+        setTimeout(resolve, 1000, 'starved behind the ens lookups');
+      });
+      await expect(Promise.race([api.get<boolean>('/ping'), starved])).resolves.toBe(true);
+
+      expect(started).toBe(1);
+
+      release();
+      await Promise.all(lookups);
+    });
+
+    it('should bound how long a synchronous lookup can hold its slot', async () => {
+      const post = vi.spyOn(api, 'post').mockResolvedValue({});
+
+      const { getEnsNames, getEnsNamesTask } = useAddressesNamesApi();
+
+      await getEnsNames(['0x123']).catch(() => {});
+      expect(post).toHaveBeenLastCalledWith(
+        '/names/ens/reverse',
+        expect.anything(),
+        expect.objectContaining({ dedupe: true, timeout: expect.any(Number) }),
+      );
+
+      await getEnsNamesTask(['0x123']).catch(() => {});
+      expect(post).toHaveBeenLastCalledWith(
+        '/names/ens/reverse',
+        expect.anything(),
+        expect.objectContaining({ dedupe: false, timeout: undefined }),
+      );
+
+      post.mockRestore();
     });
   });
 });

--- a/frontend/app/src/modules/accounts/address-book/use-addresses-names-api.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-addresses-names-api.spec.ts
@@ -1,7 +1,8 @@
 import type { AddressBookEntry, AddressBookLocation, AddressBookSimplePayload } from '@/modules/accounts/address-book/eth-names';
 import { server } from '@test/setup-files/server';
 import { type DefaultBodyType, http, HttpResponse } from 'msw';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequestPriority } from '@/modules/core/api/request-queue/request-priority';
 import { api } from '@/modules/core/api/rotki-api';
 import { useAddressesNamesApi } from './use-addresses-names-api';
 
@@ -10,6 +11,12 @@ const backendUrl = process.env.VITE_BACKEND_URL;
 describe('composables/api/blockchain/addresses-names', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  // Restored here rather than at the end of each test: a failing assertion throws past an inline
+  // restore, and the leaked spy then fails unrelated tests further down the file.
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe('getEnsNamesTask', () => {
@@ -561,17 +568,32 @@ describe('composables/api/blockchain/addresses-names', () => {
       expect(post).toHaveBeenLastCalledWith(
         '/names/ens/reverse',
         expect.anything(),
-        expect.objectContaining({ dedupe: true, timeout: expect.any(Number) }),
+        expect.objectContaining({
+          dedupe: true,
+          priority: RequestPriority.LOW,
+          timeout: expect.any(Number),
+        }),
       );
 
       await getEnsNamesTask(['0x123']).catch(() => {});
       expect(post).toHaveBeenLastCalledWith(
         '/names/ens/reverse',
         expect.anything(),
-        expect.objectContaining({ dedupe: false, timeout: undefined }),
+        expect.objectContaining({ dedupe: false, priority: undefined, timeout: undefined }),
       );
+    });
 
-      post.mockRestore();
+    it('should resolve address names as background work', async () => {
+      const post = vi.spyOn(api, 'post').mockResolvedValue([]);
+
+      const { getAddressesNames } = useAddressesNamesApi();
+      await getAddressesNames([{ address: '0x123', blockchain: 'eth' }]).catch(() => {});
+
+      expect(post).toHaveBeenLastCalledWith(
+        '/names',
+        expect.anything(),
+        expect.objectContaining({ priority: RequestPriority.LOW }),
+      );
     });
   });
 });

--- a/frontend/app/src/modules/accounts/address-book/use-addresses-names-api.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-addresses-names-api.ts
@@ -29,6 +29,14 @@ interface UseAddressesNamesApiReturn {
   resolveEnsNames: (name: string) => Promise<string>;
 }
 
+/**
+ * A resolved name is advisory - the row already renders the raw address - so the lookup is not
+ * worth holding a request slot for the default 30s. The request queue allows six requests in
+ * flight, and reverse lookups fire on every render that shows an address, so a slow backend can
+ * park all six and stop every other request in the app, user actions included.
+ */
+const ENS_REVERSE_TIMEOUT = 10_000;
+
 export function useAddressesNamesApi(): UseAddressesNamesApiReturn {
   const internalEnsNames = async <T>(ethereumAddresses: string[], asyncQuery = false): Promise<T> => api.post<T>(
     '/names/ens/reverse',
@@ -38,6 +46,11 @@ export function useAddressesNamesApi(): UseAddressesNamesApiReturn {
       ignoreCache: asyncQuery,
     },
     {
+      // Only the synchronous read is bounded and shared. The task variant is user-initiated
+      // (an explicit refresh), returns a task id rather than the names, and is not what a
+      // re-render repeats.
+      dedupe: !asyncQuery,
+      timeout: asyncQuery ? undefined : ENS_REVERSE_TIMEOUT,
       validStatuses: VALID_WITH_SESSION_AND_EXTERNAL_SERVICE,
     },
   );

--- a/frontend/app/src/modules/accounts/address-book/use-addresses-names-api.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-addresses-names-api.ts
@@ -11,6 +11,7 @@ import {
   type EthNames,
   EthNamesSchema,
 } from '@/modules/accounts/address-book/eth-names';
+import { RequestPriority } from '@/modules/core/api/request-queue/request-priority';
 import { api } from '@/modules/core/api/rotki-api';
 import { VALID_TASK_STATUS, VALID_WITH_SESSION_AND_EXTERNAL_SERVICE } from '@/modules/core/api/utils';
 import { mapCollectionResponse } from '@/modules/core/common/data/collection-utils';
@@ -50,6 +51,7 @@ export function useAddressesNamesApi(): UseAddressesNamesApiReturn {
       // (an explicit refresh), returns a task id rather than the names, and is not what a
       // re-render repeats.
       dedupe: !asyncQuery,
+      priority: asyncQuery ? undefined : RequestPriority.LOW,
       timeout: asyncQuery ? undefined : ENS_REVERSE_TIMEOUT,
       validStatuses: VALID_WITH_SESSION_AND_EXTERNAL_SERVICE,
     },
@@ -126,6 +128,9 @@ export function useAddressesNamesApi(): UseAddressesNamesApiReturn {
       '/names',
       { addresses },
       {
+        // Decoration for rows that already render without it, resolved on every render that
+        // shows an address. It must never be the reason a user action waits.
+        priority: RequestPriority.LOW,
         validStatuses: VALID_WITH_SESSION_AND_EXTERNAL_SERVICE,
       },
     );

--- a/frontend/app/src/modules/balances/api/use-price-api.spec.ts
+++ b/frontend/app/src/modules/balances/api/use-price-api.spec.ts
@@ -3,7 +3,7 @@ import type { HistoricPricesPayload } from '@/modules/assets/prices/price-types'
 import { BigNumber } from '@rotki/common';
 import { server } from '@test/setup-files/server';
 import { type DefaultBodyType, http, HttpResponse } from 'msw';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PriceOracle } from '@/modules/settings/types/price-oracle';
 
 vi.unmock('@/modules/balances/api/use-price-api');
@@ -13,6 +13,12 @@ const backendUrl = process.env.VITE_BACKEND_URL;
 describe('composables/api/balances/price', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  // Restored here rather than at the end of each test: a failing assertion throws past an inline
+  // restore, and the leaked spy then fails unrelated tests further down the file.
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   async function getApi(): Promise<ReturnType<typeof import('./use-price-api').usePriceApi>> {
@@ -336,6 +342,25 @@ describe('composables/api/balances/price', () => {
       expect(result.assets.ETH['1700100000']).toBeInstanceOf(BigNumber);
       expect(result.assets.ETH['1700100000'].toString()).toBe('1520');
       expect(result.targetAsset).toBe('USD');
+    });
+
+    it('should seed the cache as background work', async () => {
+      const { api } = await import('@/modules/core/api/rotki-api');
+      const { RequestPriority } = await import('@/modules/core/api/request-queue/request-priority');
+      const post = vi.spyOn(api, 'post').mockResolvedValue({ assets: {}, targetAsset: 'USD' });
+
+      const { queryOnlyCacheHistoricalRates } = await getApi();
+      await queryOnlyCacheHistoricalRates({
+        assetsTimestamp: [['ETH', '1700000000']],
+        onlyCachePeriod: 3600,
+        targetAsset: 'USD',
+      }).catch(() => {});
+
+      expect(post).toHaveBeenLastCalledWith(
+        '/assets/prices/historical',
+        expect.anything(),
+        expect.objectContaining({ priority: RequestPriority.LOW }),
+      );
     });
 
     it('should throw error on failure', async () => {

--- a/frontend/app/src/modules/balances/api/use-price-api.ts
+++ b/frontend/app/src/modules/balances/api/use-price-api.ts
@@ -1,6 +1,7 @@
 import type { SupportedCurrency } from '@/modules/assets/amount-display/currencies';
 import type { PriceOracle } from '@/modules/settings/types/price-oracle';
 import { AssetPriceResponse, HistoricPrices, type HistoricPricesPayload, type OracleCacheMeta } from '@/modules/assets/prices/price-types';
+import { RequestPriority } from '@/modules/core/api/request-queue/request-priority';
 import { api } from '@/modules/core/api/rotki-api';
 import {
   VALID_WITH_SESSION_AND_EXTERNAL_SERVICE,
@@ -87,6 +88,9 @@ export function usePriceApi(): UsePriceApiReturn {
       '/assets/prices/historical',
       payload,
       {
+        // Seeds the price cache at session load, when the rest of the app is competing for the
+        // same slots. Prefetching by definition: nothing on screen is waiting for it.
+        priority: RequestPriority.LOW,
         validStatuses: VALID_WITH_SESSION_AND_EXTERNAL_SERVICE,
       },
     );

--- a/frontend/app/src/modules/core/api/abort-signals.spec.ts
+++ b/frontend/app/src/modules/core/api/abort-signals.spec.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { combineAbortSignals } from './abort-signals';
+
+describe('combineAbortSignals', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return the shared signal untouched when there is nothing to combine', () => {
+    const shared = new AbortController().signal;
+
+    expect(combineAbortSignals(shared).signal).toBe(shared);
+    expect(combineAbortSignals(shared, null).signal).toBe(shared);
+    expect(combineAbortSignals(shared, null, 0).signal).toBe(shared);
+  });
+
+  it('should abort when the shared signal aborts', () => {
+    const shared = new AbortController();
+    const request = new AbortController();
+
+    const { signal } = combineAbortSignals(shared.signal, request.signal);
+    expect(signal.aborted).toBe(false);
+
+    shared.abort();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('should abort when the request signal aborts', () => {
+    const shared = new AbortController();
+    const request = new AbortController();
+
+    const { signal } = combineAbortSignals(shared.signal, request.signal);
+    expect(signal.aborted).toBe(false);
+
+    request.abort();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('should start aborted when either signal already is', () => {
+    const shared = new AbortController();
+    const request = new AbortController();
+    request.abort();
+
+    expect(combineAbortSignals(shared.signal, request.signal).signal.aborted).toBe(true);
+  });
+
+  it('should abort once the timeout elapses', () => {
+    const { signal } = combineAbortSignals(new AbortController().signal, undefined, 10_000);
+
+    vi.advanceTimersByTime(9999);
+    expect(signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBeInstanceOf(DOMException);
+    expect(signal.reason.name).toBe('TimeoutError');
+  });
+
+  it('should not abort after dispose', () => {
+    const { dispose, signal } = combineAbortSignals(new AbortController().signal, undefined, 10_000);
+
+    dispose();
+    vi.advanceTimersByTime(60_000);
+
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('should leave no timer pending once disposed', () => {
+    const { dispose } = combineAbortSignals(new AbortController().signal, undefined, 600_000);
+    expect(vi.getTimerCount()).toBe(1);
+
+    dispose();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/frontend/app/src/modules/core/api/abort-signals.ts
+++ b/frontend/app/src/modules/core/api/abort-signals.ts
@@ -1,0 +1,55 @@
+export interface CombinedAbortSignal {
+  signal: AbortSignal;
+  /** Clears the timeout timer. Must be called once the request settles. */
+  dispose: () => void;
+}
+
+/**
+ * Combines the api-wide abort signal with a request's own and its timeout, so a request can be
+ * cancelled from any of the three.
+ *
+ * Only the api-wide one used to reach the fetch. The queue attached a per-request signal that was
+ * then overwritten, which made `cancelById`/`cancelByTag` reject the caller's promise while the
+ * connection kept running to completion; the queue freed the slot at the same time, so it could
+ * dispatch a replacement and oversubscribe the browser's own per-host connection limit.
+ *
+ * The timeout is composed here rather than left to ofetch, which only honours its `timeout` option
+ * when no signal is passed (`!context.options.signal && context.options.timeout`). Every call site
+ * passes one, so no request in the app was ever actually bounded by it.
+ *
+ * `setTimeout` rather than `AbortSignal.timeout`: the timer has to be clearable when the request
+ * settles first, or every request leaves one pending for its whole timeout - up to ten minutes for
+ * a download. It also keeps the behaviour reachable from tests, which fake the clock. Callers
+ * combine per attempt, so a retry gets its own budget rather than inheriting the first one's.
+ */
+export function combineAbortSignals(
+  shared: AbortSignal,
+  request?: AbortSignal | null,
+  timeoutMs?: number,
+): CombinedAbortSignal {
+  const signals: AbortSignal[] = [shared];
+
+  if (request)
+    signals.push(request);
+
+  if (timeoutMs === undefined || timeoutMs <= 0) {
+    return {
+      dispose: (): void => {},
+      signal: signals.length === 1 ? shared : AbortSignal.any(signals),
+    };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    const error = new DOMException(`Request timed out after ${timeoutMs}ms`, 'TimeoutError');
+    controller.abort(error);
+  }, timeoutMs);
+  signals.push(controller.signal);
+
+  return {
+    dispose: (): void => {
+      clearTimeout(timer);
+    },
+    signal: AbortSignal.any(signals),
+  };
+}

--- a/frontend/app/src/modules/core/api/constants.ts
+++ b/frontend/app/src/modules/core/api/constants.ts
@@ -4,6 +4,13 @@ export const DEFAULT_TIMEOUT = 30_000;
 /** Extended timeout for long-running task operations in milliseconds (90 seconds) */
 export const TASKS_TIMEOUT = 90_000;
 
+/**
+ * File downloads (reports, snapshots, skipped-event exports) in milliseconds (10 minutes).
+ * These stream a whole file the backend assembles on demand, so the 30s default is far too short.
+ * It only mattered once timeouts started being honoured at all - see {@link combineAbortSignals}.
+ */
+export const DOWNLOAD_TIMEOUT = 600_000;
+
 /** Default maximum number of retry attempts after the initial request fails */
 export const DEFAULT_MAX_RETRIES = 2;
 

--- a/frontend/app/src/modules/core/api/request-queue/queue.spec.ts
+++ b/frontend/app/src/modules/core/api/request-queue/queue.spec.ts
@@ -162,6 +162,95 @@ describe('requestQueue', () => {
     });
   });
 
+  describe('background slot cap', () => {
+    /**
+     * Six identical ENS reverse lookups once hung for ~100s each and filled every slot, so the
+     * DELETE behind a user's confirmed delete never left the queue and the app went silent
+     * (`history-events.spec.ts:334`, CI only). Priority cannot fix that on its own: it orders the
+     * queue, and by then there was nothing left to order. Background work must not be able to take
+     * the whole budget in the first place.
+     */
+    it('should keep a slot for other work while background requests hang', async () => {
+      const started: string[] = [];
+      mockFetch.mockImplementation(async (url: string) => {
+        started.push(url);
+        return new Promise(() => {}); // never settles, like the hanging lookups
+      });
+
+      const capped = new RequestQueue(mockFetchWrapper, {
+        maxBackgroundConcurrent: 2,
+        maxConcurrent: 6,
+        maxPerSecond: 100,
+      });
+
+      for (let i = 0; i < 6; i++)
+        startPromise(capped.enqueue(`/background${i}`, { priority: RequestPriority.LOW }));
+
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(started).toHaveLength(2);
+
+      startPromise(capped.enqueue('/user-action', { priority: RequestPriority.CRITICAL }));
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(started).toContain('/user-action');
+
+      capped.destroy();
+    });
+
+    it('should let background requests use every slot when nothing competes', async () => {
+      const started: string[] = [];
+      mockFetch.mockImplementation(async (url: string) => {
+        started.push(url);
+        return new Promise(() => {});
+      });
+
+      const capped = new RequestQueue(mockFetchWrapper, {
+        maxBackgroundConcurrent: 2,
+        maxConcurrent: 6,
+        maxPerSecond: 100,
+      });
+
+      for (let i = 0; i < 4; i++)
+        startPromise(capped.enqueue(`/normal${i}`, { priority: RequestPriority.NORMAL }));
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(started).toHaveLength(4);
+
+      capped.destroy();
+    });
+
+    it('should release the cap as background requests finish', async () => {
+      const started: string[] = [];
+      const resolvers = new Map<string, (value: { data: string }) => void>();
+      mockFetch.mockImplementation(async (url: string) => {
+        started.push(url);
+        return new Promise((resolve) => {
+          resolvers.set(url, resolve);
+        });
+      });
+
+      const capped = new RequestQueue(mockFetchWrapper, {
+        maxBackgroundConcurrent: 2,
+        maxConcurrent: 6,
+        maxPerSecond: 100,
+      });
+
+      for (let i = 0; i < 3; i++)
+        startPromise(capped.enqueue(`/background${i}`, { priority: RequestPriority.LOW }));
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(started).toHaveLength(2);
+
+      resolvers.get('/background0')!({ data: 'done' });
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(started).toContain('/background2');
+
+      capped.destroy();
+    });
+  });
+
   describe('deduplication', () => {
     it('should deduplicate identical requests', async () => {
       const promise1 = queue.enqueue('/test', { dedupe: true });

--- a/frontend/app/src/modules/core/api/request-queue/queue.spec.ts
+++ b/frontend/app/src/modules/core/api/request-queue/queue.spec.ts
@@ -162,6 +162,38 @@ describe('requestQueue', () => {
     });
   });
 
+  describe('retry backoff', () => {
+    it('should release the slot while a request waits to be retried', async () => {
+      const started: string[] = [];
+      const retrying = new RequestQueue(mockFetchWrapper, {
+        maxConcurrent: 1,
+        maxPerSecond: 100,
+        maxRetries: 1,
+        retryDelay: 1000,
+      });
+
+      mockFetch.mockImplementation(async (url: string) => {
+        started.push(url);
+        if (url === '/flaky' && started.filter(u => u === '/flaky').length === 1)
+          throw new TypeError('network down');
+
+        return new Promise(() => {}); // holds the slot once it does run
+      });
+
+      startPromise(retrying.enqueue('/flaky').catch(() => {}));
+      await vi.advanceTimersByTimeAsync(10);
+      expect(started).toEqual(['/flaky']);
+
+      // Still inside the 1000ms backoff: the slot the retry is waiting for must be usable.
+      startPromise(retrying.enqueue('/other'));
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(started).toContain('/other');
+
+      retrying.destroy();
+    });
+  });
+
   describe('background slot cap', () => {
     /**
      * Six identical ENS reverse lookups once hung for ~100s each and filled every slot, so the

--- a/frontend/app/src/modules/core/api/request-queue/queue.ts
+++ b/frontend/app/src/modules/core/api/request-queue/queue.ts
@@ -5,6 +5,7 @@ import { logger } from '@/modules/core/common/logging/logging';
 import { QueueOverflowError, QueueTimeoutError, RequestCancelledError } from './errors';
 import { createDedupeKey, generateId } from './request-identity';
 import { RequestPriority } from './request-priority';
+import { findEligibleIndex } from './slot-policy';
 
 export type QueueFetchFn = <T>(url: string, options?: BaseFetchOptions) => Promise<T>;
 
@@ -23,6 +24,7 @@ export class RequestQueue {
   constructor(fetchFn: QueueFetchFn, options?: QueueOptions) {
     this.fetchFn = fetchFn;
     this.options = {
+      maxBackgroundConcurrent: 2,
       maxConcurrent: 6,
       maxPerSecond: 30,
       maxQueueSize: 100,
@@ -231,6 +233,10 @@ export class RequestQueue {
     }
   }
 
+  private nextEligibleIndex(): number {
+    return findEligibleIndex(this.queue, this.activeRequests.values(), this.options.maxBackgroundConcurrent);
+  }
+
   private async processQueue(): Promise<void> {
     if (this.isProcessing)
       return;
@@ -244,7 +250,10 @@ export class RequestQueue {
           this.scheduleRateLimitRecovery();
           break;
         }
-        const request = this.queue.shift();
+        const index = this.nextEligibleIndex();
+        if (index === -1)
+          break;
+        const [request] = this.queue.splice(index, 1);
         if (!request)
           break;
         this.activeRequests.set(request.id, request);

--- a/frontend/app/src/modules/core/api/request-queue/queue.ts
+++ b/frontend/app/src/modules/core/api/request-queue/queue.ts
@@ -268,7 +268,6 @@ export class RequestQueue {
   }
 
   private async executeRequest<T>(request: QueuedRequest<T>): Promise<void> {
-    let shouldContinueProcessing = true;
     try {
       const response = await this.fetchFn<T>(request.url, request.options);
       this.cleanupRequest(request);
@@ -277,14 +276,16 @@ export class RequestQueue {
     catch (error) {
       if (this.shouldRetry(error, request)) {
         request.retries++;
-        shouldContinueProcessing = false;
-        const delay = this.options.retryDelay * (2 ** (request.retries - 1));
+        // The slot is released for the wait rather than after it. A request sleeping through its
+        // backoff is doing nothing, and holding one of the six in-flight budget while it sleeps
+        // starves everything else for the whole delay - which grows exponentially per attempt.
+        // Its dedupe key stays, so callers attached to it still settle from the retry.
+        this.activeRequests.delete(request.id);
         setTimeout(() => {
-          this.activeRequests.delete(request.id);
           this.insertByPriority(request);
           this.updateState();
           this.processQueue().catch(catchError => logger.error(catchError));
-        }, delay);
+        }, this.options.retryDelay * (2 ** (request.retries - 1)));
         return;
       }
       this.cleanupRequest(request);
@@ -292,8 +293,7 @@ export class RequestQueue {
     }
     finally {
       this.updateState();
-      if (shouldContinueProcessing)
-        this.processQueue().catch(error => logger.error(error));
+      this.processQueue().catch(error => logger.error(error));
     }
   }
 

--- a/frontend/app/src/modules/core/api/request-queue/request-priority.ts
+++ b/frontend/app/src/modules/core/api/request-queue/request-priority.ts
@@ -16,3 +16,26 @@ export const RequestPriority = {
   /** Analytics, telemetry, non-essential background work */
   BACKGROUND: 0,
 } as const;
+
+/**
+ * PUT, PATCH and DELETE are unambiguously a user changing something, and the user is waiting on the
+ * result, so they outrank reads. POST is deliberately not in the set: this API uses it for filtered
+ * reads (`/history/events`, `/names`, `/notes`) at least as often as for creation, so it says
+ * nothing about intent on its own. A POST that really is a user action can pass `priority`.
+ */
+const MUTATION_METHODS: ReadonlySet<string> = new Set(['PUT', 'PATCH', 'DELETE']);
+
+/**
+ * Derived from the method rather than tagged at every call site: a rule nobody has to remember is
+ * the only one that holds across ~300 of them.
+ */
+export function defaultPriorityFor(method?: string): number {
+  return method && MUTATION_METHODS.has(method.toUpperCase())
+    ? RequestPriority.CRITICAL
+    : RequestPriority.NORMAL;
+}
+
+/** Advisory work, subject to the queue's background slot cap. */
+export function isBackgroundPriority(priority: number): boolean {
+  return priority <= RequestPriority.LOW;
+}

--- a/frontend/app/src/modules/core/api/request-queue/slot-policy.spec.ts
+++ b/frontend/app/src/modules/core/api/request-queue/slot-policy.spec.ts
@@ -1,0 +1,70 @@
+import type { QueuedRequest } from './types';
+import { describe, expect, it, vi } from 'vitest';
+import { RequestPriority } from './request-priority';
+import { findEligibleIndex } from './slot-policy';
+
+let stubId = 0;
+
+/** A complete queued request, so the policy is exercised against the real shape. */
+function request(priority: number): QueuedRequest {
+  stubId += 1;
+  return {
+    abortController: new AbortController(),
+    dedupeKey: null,
+    id: `stub-${stubId}`,
+    maxQueueTime: 60_000,
+    maxRetries: 0,
+    options: {},
+    priority,
+    queuedAt: 0,
+    reject: vi.fn(),
+    resolve: vi.fn(),
+    retries: 0,
+    tags: [],
+    url: `/stub-${stubId}`,
+  };
+}
+
+describe('findEligibleIndex', () => {
+  const background = request(RequestPriority.LOW);
+  const normal = request(RequestPriority.NORMAL);
+  const critical = request(RequestPriority.CRITICAL);
+
+  it('should take the head while background work is under its cap', () => {
+    expect(findEligibleIndex([background, normal], [], 2)).toBe(0);
+    expect(findEligibleIndex([background, normal], [background], 2)).toBe(0);
+  });
+
+  it('should skip past background work once the cap is reached', () => {
+    const active = [background, background];
+
+    expect(findEligibleIndex([background, background, critical], active, 2)).toBe(2);
+  });
+
+  it('should report nothing eligible when only capped background work waits', () => {
+    const active = [background, background];
+
+    expect(findEligibleIndex([background, background], active, 2)).toBe(-1);
+  });
+
+  it('should report nothing eligible for an empty queue', () => {
+    expect(findEligibleIndex([], [], 2)).toBe(-1);
+    expect(findEligibleIndex([], [background, background], 2)).toBe(-1);
+  });
+
+  it('should not count foreground work against the background cap', () => {
+    const active = [normal, critical, normal, critical, normal];
+
+    expect(findEligibleIndex([background], active, 2)).toBe(0);
+  });
+
+  it('should treat BACKGROUND as capped alongside LOW', () => {
+    const active = [request(RequestPriority.BACKGROUND), request(RequestPriority.BACKGROUND)];
+
+    expect(findEligibleIndex([request(RequestPriority.BACKGROUND)], active, 2)).toBe(-1);
+  });
+
+  it('should let a cap of zero block background work entirely', () => {
+    expect(findEligibleIndex([background, normal], [], 0)).toBe(1);
+  });
+});

--- a/frontend/app/src/modules/core/api/request-queue/slot-policy.ts
+++ b/frontend/app/src/modules/core/api/request-queue/slot-policy.ts
@@ -1,0 +1,28 @@
+import type { QueuedRequest } from './types';
+import { isBackgroundPriority } from './request-priority';
+
+/**
+ * The first queued request allowed to start right now, which is not always the head: once
+ * background work holds its share of the slots, the queue is scanned past it for work that still
+ * may run. Returns -1 when only capped background requests are waiting.
+ *
+ * This is what priority alone cannot do. Priority orders the queue, and a queue cannot reorder
+ * slots that are already occupied - six advisory lookups that hang take every slot and stop the
+ * app, user actions included.
+ */
+export function findEligibleIndex(
+  queue: readonly QueuedRequest[],
+  active: Iterable<QueuedRequest>,
+  maxBackgroundConcurrent: number,
+): number {
+  let background = 0;
+  for (const request of active) {
+    if (isBackgroundPriority(request.priority))
+      background++;
+  }
+
+  if (background < maxBackgroundConcurrent)
+    return queue.length > 0 ? 0 : -1;
+
+  return queue.findIndex(request => !isBackgroundPriority(request.priority));
+}

--- a/frontend/app/src/modules/core/api/request-queue/types.ts
+++ b/frontend/app/src/modules/core/api/request-queue/types.ts
@@ -53,6 +53,13 @@ export interface QueuedRequest<T = any> {
 export interface QueueOptions {
   /** Maximum concurrent requests (default: 6, browser optimal) */
   maxConcurrent?: number;
+  /**
+   * How many of {@link maxConcurrent} may be held at once by requests at or below
+   * {@link RequestPriority.LOW} (default: 2). Priority alone cannot prevent starvation - it
+   * orders the queue, and a queue cannot reorder slots that are already occupied - so this is
+   * what keeps advisory background work from taking the whole budget and stopping the app.
+   */
+  maxBackgroundConcurrent?: number;
   /** Maximum requests per second (default: 30) */
   maxPerSecond?: number;
   /** Base retry delay in ms (default: 1000) */

--- a/frontend/app/src/modules/core/api/rotki-api.spec.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.spec.ts
@@ -996,6 +996,72 @@ describe('modules/api/rotki-api', () => {
     });
   });
 
+  describe('cancellation reaches the connection', () => {
+    /**
+     * The queue attached a per-request abort signal that `fetchDirect` then overwrote with the
+     * api-wide one, so cancelling rejected the caller's promise while the request carried on. The
+     * queue freed its slot at the same moment, so it could dispatch a replacement and hold more
+     * connections than the browser allows per host.
+     */
+    it('should abort the in-flight request, not just reject the caller', async () => {
+      let handlerSignal: AbortSignal | undefined;
+      let release = (): void => {};
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      server.use(
+        http.get(`${backendUrl}/api/1/slow`, async ({ request }) => {
+          handlerSignal = request.signal;
+          await held;
+          return HttpResponse.json({ message: '', result: true });
+        }),
+      );
+
+      const pending = api.get('slow', { tags: ['cancel-me'] });
+      const settled = expect(pending).rejects.toThrow(RequestCancelledError);
+
+      // The handler must have started: `active` flips before the request reaches the server, and
+      // cancelling a request the server has not seen proves nothing about the connection.
+      await vi.waitFor(() => {
+        expect(handlerSignal).toBeDefined();
+      });
+
+      api.cancelByTag('cancel-me');
+
+      await settled;
+      await vi.waitFor(() => {
+        expect(handlerSignal?.aborted).toBe(true);
+      });
+
+      release();
+    });
+
+    it('should abort a request that outlives its timeout', async () => {
+      let handlerSignal: AbortSignal | undefined;
+      let release = (): void => {};
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      server.use(
+        http.get(`${backendUrl}/api/1/slow`, async ({ request }) => {
+          handlerSignal = request.signal;
+          await held;
+          return HttpResponse.json({ message: '', result: true });
+        }),
+      );
+
+      await expect(api.get('slow', { timeout: 50 })).rejects.toThrow();
+
+      await vi.waitFor(() => {
+        expect(handlerSignal?.aborted).toBe(true);
+      });
+
+      release();
+    });
+  });
+
   describe('default request priority', () => {
     /**
      * Derived centrally rather than tagged at ~295 call sites: a rule nobody has to remember is the

--- a/frontend/app/src/modules/core/api/rotki-api.spec.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.spec.ts
@@ -1,8 +1,10 @@
 import { server } from '@test/setup-files/server';
 import { http, HttpResponse } from 'msw';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { apiUrls, defaultApiUrls } from '@/modules/core/api/api-urls';
 import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
+import { RequestQueue } from '@/modules/core/api/request-queue/queue';
+import { RequestPriority } from '@/modules/core/api/request-queue/request-priority';
 import { RotkiApi } from '@/modules/core/api/rotki-api';
 import { ApiValidationError } from '@/modules/core/api/types/errors';
 import { HTTPStatus } from '@/modules/core/api/types/http';
@@ -991,6 +993,54 @@ describe('modules/api/rotki-api', () => {
       api.setup(defaultApiUrls.coreApiUrl);
 
       await expect(api.get('test')).resolves.toEqual({ ok: true });
+    });
+  });
+
+  describe('default request priority', () => {
+    /**
+     * Derived centrally rather than tagged at ~295 call sites: a rule nobody has to remember is the
+     * only one that holds. The queue's background cap keys off priority, so a request that lands in
+     * the wrong band silently loses its protection.
+     */
+    let enqueue: MockInstance<RequestQueue['enqueue']>;
+
+    beforeEach(() => {
+      enqueue = vi.spyOn(RequestQueue.prototype, 'enqueue').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+      enqueue.mockRestore();
+    });
+
+    it.each([
+      ['put', RequestPriority.CRITICAL],
+      ['patch', RequestPriority.CRITICAL],
+      ['delete', RequestPriority.CRITICAL],
+    ] as const)('should treat %s as a user action', async (method, expected) => {
+      await api[method]('/test');
+
+      expect(enqueue).toHaveBeenCalledWith('/test', expect.objectContaining({ priority: expected }));
+    });
+
+    it.each([
+      ['get'],
+      ['post'],
+    ] as const)('should treat %s as a normal read', async (method) => {
+      await api[method]('/test');
+
+      expect(enqueue).toHaveBeenCalledWith(
+        '/test',
+        expect.objectContaining({ priority: RequestPriority.NORMAL }),
+      );
+    });
+
+    it('should let an explicit priority win', async () => {
+      await api.delete('/test', { priority: RequestPriority.BACKGROUND });
+
+      expect(enqueue).toHaveBeenCalledWith(
+        '/test',
+        expect.objectContaining({ priority: RequestPriority.BACKGROUND }),
+      );
     });
   });
 });

--- a/frontend/app/src/modules/core/api/rotki-api.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.ts
@@ -2,8 +2,9 @@ import type { ActionResult } from '@rotki/common';
 import type { QueueState } from '@/modules/core/api/request-queue/types';
 import type { RotkiFetchOptions } from '@/modules/core/api/types';
 import { ofetch } from 'ofetch';
+import { combineAbortSignals } from '@/modules/core/api/abort-signals';
 import { apiUrls, defaultApiUrls } from '@/modules/core/api/api-urls';
-import { DEFAULT_TIMEOUT } from '@/modules/core/api/constants';
+import { DEFAULT_TIMEOUT, DOWNLOAD_TIMEOUT } from '@/modules/core/api/constants';
 import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
 import { RequestQueue } from '@/modules/core/api/request-queue/queue';
 import { defaultPriorityFor } from '@/modules/core/api/request-queue/request-priority';
@@ -244,23 +245,24 @@ export class RotkiApi {
       filterEmptyProperties,
       retry,
       skipAuthHandler,
+      timeout = DEFAULT_TIMEOUT,
       ...fetchOptions
     } = options;
-
     const doFetch = async (): Promise<T> => {
       const body = transformRequestBody(fetchOptions.body, { skipSnakeCase, filterEmptyProperties });
       const query = transformRequestQuery(fetchOptions.query, { skipSnakeCase, filterEmptyProperties });
+      const { dispose, signal } = combineAbortSignals(this.abortController.signal, fetchOptions.signal, timeout);
 
       const response = await ofetch.raw<ActionResult<T>>(url, {
         ...fetchOptions,
         baseURL: fetchOptions.baseURL ?? this._baseURL,
-        timeout: fetchOptions.timeout ?? DEFAULT_TIMEOUT,
-        signal: this.abortController.signal,
+        timeout,
+        signal,
         ignoreResponseError: true,
         body,
         query,
         parseResponse: createResponseParser({ skipCamelCase, skipRootCamelCase }),
-      });
+      }).finally(dispose);
 
       this.checkResponseStatus<T>(response, { validStatuses, skipAuthHandler });
 
@@ -311,14 +313,14 @@ export class RotkiApi {
     if (this._stopped)
       throw new RequestCancelledError('Application is quitting');
 
-    const { validStatuses, skipSnakeCase, query: rawQuery, baseURL, timeout } = options;
+    const { validStatuses, skipSnakeCase, query: rawQuery, baseURL, timeout = DEFAULT_TIMEOUT } = options;
     const query = transformRequestQuery(rawQuery, { skipSnakeCase });
 
     const response = await ofetch.raw(url, {
       method: 'HEAD',
       baseURL: baseURL ?? this._baseURL,
-      timeout: timeout ?? DEFAULT_TIMEOUT,
-      signal: this.abortController.signal,
+      timeout,
+      signal: combineAbortSignals(this.abortController.signal, undefined, timeout).signal,
       ignoreResponseError: true,
       query,
     });
@@ -342,15 +344,15 @@ export class RotkiApi {
     if (this._stopped)
       throw new RequestCancelledError('Application is quitting');
 
-    const { validStatuses, skipSnakeCase, ...fetchOptions } = options;
+    const { validStatuses, skipSnakeCase, timeout = DOWNLOAD_TIMEOUT, ...fetchOptions } = options;
     const body = transformRequestBody(fetchOptions.body, { skipSnakeCase });
     const query = transformRequestQuery(fetchOptions.query, { skipSnakeCase });
 
     const response = await ofetch.raw<Blob, 'blob'>(url, {
       method: fetchOptions.method,
       baseURL: fetchOptions.baseURL ?? this._baseURL,
-      timeout: fetchOptions.timeout ?? DEFAULT_TIMEOUT,
-      signal: this.abortController.signal,
+      timeout,
+      signal: combineAbortSignals(this.abortController.signal, fetchOptions.signal, timeout).signal,
       responseType: 'blob',
       ignoreResponseError: true,
       body,

--- a/frontend/app/src/modules/core/api/rotki-api.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.ts
@@ -6,7 +6,7 @@ import { apiUrls, defaultApiUrls } from '@/modules/core/api/api-urls';
 import { DEFAULT_TIMEOUT } from '@/modules/core/api/constants';
 import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
 import { RequestQueue } from '@/modules/core/api/request-queue/queue';
-import { RequestPriority } from '@/modules/core/api/request-queue/request-priority';
+import { defaultPriorityFor } from '@/modules/core/api/request-queue/request-priority';
 import { transformRequestBody, transformRequestQuery } from '@/modules/core/api/request-transformers';
 import { createResponseParser, createStatusError, tryParseJson } from '@/modules/core/api/response-handlers';
 import { queryTransformer } from '@/modules/core/api/transformers';
@@ -165,7 +165,7 @@ export class RotkiApi {
 
     return queue.enqueue<T>(url, {
       ...restOptions,
-      priority: priority ?? RequestPriority.NORMAL,
+      priority: priority ?? defaultPriorityFor(restOptions.method),
       tags,
       dedupe,
       maxQueueTime,


### PR DESCRIPTION
Advisory background requests could take every slot in the request queue and stop the app.

## What happens

The queue allows six requests in flight and had no floor for foreground work. `POST /names/ens/reverse` fires on every render that shows an address, and the lookups are byte-identical, so a slow backend parks six copies of the same request and nothing else is ever dispatched.

Caught in CI, where the lookup hangs for ~100s. From the backend log of one session:

```
start 22:31:15  start 22:31:16  start 22:31:18  start 22:31:20  start 22:31:21  start 22:31:22
end   22:33:02  end   22:33:03  end   22:33:04  end   22:33:07  end   22:33:08  end   22:33:09
```

That sixth start is the last request of the entire session. The user's confirmed delete was enqueued and never left the queue: no DELETE reached the backend, nothing changed on screen, and no error was shown, because `deleteHistoryEvent` swallows the failure into `{ success: false }` and the caller ignores the message.

## The changes

**Identical lookups share one request, and are bounded.** Six concurrent copies become one, so five slots stay free.

**Background work is capped at two of the six slots.** Priority alone cannot fix this - it orders the queue, and a queue cannot reorder slots that are already occupied. Three call sites are tagged as background: ENS reverse lookups, address name resolution, and the session price-cache seed. Everything else that touches an external service is either user-navigated or foreground data and keeps its normal priority.

**Priority is derived from the method** rather than tagged at ~295 call sites, where in practice it was never set at all: `PUT`/`PATCH`/`DELETE` outrank reads. `POST` is deliberately excluded - this API uses it for filtered reads (`/history/events`, `/names`, `/notes`) as often as for creation, so it says nothing about intent. A `POST` that is genuinely a user action can pass `priority` explicitly.

**A retrying request releases its slot for the backoff** instead of holding one while it sleeps, for a delay that doubles per attempt. Inert today because nothing sets `queueRetries`, which is why it was worth fixing before something does.

**Cancellation now reaches the connection.** `fetchDirect` overwrote the queue's per-request abort signal with the api-wide one, so `cancelById`/`cancelByTag` rejected the caller while the request ran to completion - and since the queue freed the slot at the same moment, it could dispatch a replacement and hold more connections than the browser allows per host.

**Timeouts work for the first time.** The same override made them dead everywhere: ofetch only applies its `timeout` option when no signal is passed (`!context.options.signal && context.options.timeout`), and all three call sites pass one. A test demonstrates the old behaviour - a request with a 50ms timeout resolved successfully after 5004ms. The timeout is composed into the signal instead, per attempt, with a timer cleared when the request settles rather than left pending for its full duration.

## Verification

Every fix has a negative control that fails without it:

| Behaviour | Without the fix |
|---|---|
| six hanging identical lookups occupy one slot | 6 requests reach the server, an unrelated request is starved |
| a `CRITICAL` request runs while six `LOW` ones hang | `expected [Array(6)] to have a length of 2 but got 6` |
| `PUT`/`PATCH`/`DELETE` default to `CRITICAL` | all three fail |
| a retry frees its slot during backoff | `expected [ '/flaky' ] to include '/other'` |
| cancelling aborts the in-flight request | the server never sees the abort |
| a request is bounded by its timeout | resolves after 5004ms with a 50ms timeout |

Full frontend unit suite green (711 files / 6833 tests), typecheck, lint and typos clean.

The e2e failure this was found through (`history-events.spec.ts:334 delete swap event`, which had failed 5 CI runs out of 5 and never reproduced locally) passes with the first commit applied.

## Known unverified

- Not exercised in the running app, only under test. The behaviour changes that would show up there are real cancellation and live timeouts.
- The ten-minute download bound is a judgement call. Downloads stream a file the backend assembles on demand, and the 30s default only became reachable now that timeouts work; if a download legitimately runs longer, it will now be aborted where it previously was not.
- Why the backend takes ~100s to answer an ENS reverse lookup under CI is not addressed here.

## Follow-ups, not in this PR

- A failed delete is silent: `useHistoryEvents.deleteHistoryEvent` catches everything into `{ success: false, message }` and `onConfirmDelete` ignores `message`. No toast, no console error. This is what hid the bug for days and deserves its own change.
- `rotki-api.ts` sits at exactly the 400-line `max-lines` cap and wants splitting.
