### PR TITLE
test(e2e): record video for shared-context specs

### DIFF
--- a/frontend/app/tests/e2e/fixtures/test-fixtures.ts
+++ b/frontend/app/tests/e2e/fixtures/test-fixtures.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { type APIRequestContext, test as base, type Browser, type BrowserContext, type Page } from '@playwright/test';
 import { isCoverageEnabled, startCoverage, stopCoverage } from '../coverage';
 import { apiCreateAccount, apiDisableModules, apiLogout } from '../helpers/api';
@@ -53,6 +54,61 @@ export interface LoginOptions {
 }
 
 /**
+ * Set by the auto fixture below whenever a test in the current file does not end in its
+ * expected state, and cleared when a suite builds its context. `retain-on-failure` is a
+ * per-test decision Playwright can only make for contexts it owns; a shared context spans the
+ * whole file, so the file is the smallest unit we can decide on.
+ */
+let suiteHadFailure = false;
+
+/**
+ * The directory Playwright should record this suite's video into, or undefined when video is
+ * off for the run.
+ *
+ * `use.video` is only applied to contexts Playwright builds itself for the `page`/`context`
+ * fixtures. These suites build their own context in beforeAll so it can outlive a single
+ * test, which silently opted every one of them out of video capture: the setting looked
+ * repo-wide but only ever covered the specs driving the built-in fixture. Read the resolved
+ * project setting and pass `recordVideo` by hand so the config means what it reads like.
+ */
+function videoRecordingDir(): string | undefined {
+  const info = test.info();
+  const video = info.project.use.video;
+  const mode = typeof video === 'string' ? video : video?.mode;
+
+  if (!mode || mode === 'off')
+    return undefined;
+
+  return path.join(info.project.outputDir, 'videos');
+}
+
+/**
+ * Keeps the suite's video only when it is worth keeping, mirroring what `retain-on-failure`
+ * does for fixture-owned contexts. Named after the spec file, since one video now covers the
+ * whole file rather than a single test.
+ */
+async function retainSuiteVideo(sharedPage: Page): Promise<void> {
+  const video = sharedPage.video();
+  if (!video)
+    return;
+
+  const mode = test.info().project.use.video;
+  const keepAlways = (typeof mode === 'string' ? mode : mode?.mode) === 'on';
+
+  if (!keepAlways && !suiteHadFailure) {
+    await video.delete();
+    return;
+  }
+
+  const specName = path.basename(test.info().file).replace(/\.spec\.ts$/, '');
+  const target = path.join(path.dirname(await video.path()), `${specName}.webm`);
+
+  // saveAs waits for the recording to be fully written, which a plain rename would not.
+  await video.saveAs(target);
+  await video.delete();
+}
+
+/**
  * Creates a shared test context with a logged-in user.
  * Use this in beforeAll to set up shared state for serial tests.
  *
@@ -84,8 +140,11 @@ export async function createLoggedInContext(
 ): Promise<SharedTestContext> {
   const username = generateUsername();
 
+  suiteHadFailure = false;
+
   // Create shared browser context and page
-  const sharedContext = await browser.newContext();
+  const recordVideoDir = videoRecordingDir();
+  const sharedContext = await browser.newContext(recordVideoDir ? { recordVideo: { dir: recordVideoDir } } : {});
   const sharedPage = await sharedContext.newPage();
 
   // Start coverage collection if enabled
@@ -160,6 +219,11 @@ export async function cleanupContext(ctx: SharedTestContext | undefined): Promis
   }
 
   await sharedContext?.close();
+
+  // Only after close: the recording is not complete until the context that owns it is gone.
+  if (sharedPage) {
+    await retainSuiteVideo(sharedPage);
+  }
 }
 
 /**
@@ -170,7 +234,7 @@ export async function cleanupContext(ctx: SharedTestContext | undefined): Promis
  * fixture here means a spec only has to import `test` from this module to be counted, and a spec
  * that does not touch `page` never instantiates it, so this costs those nothing.
  */
-export const test = base.extend({
+export const test = base.extend<{ trackSuiteFailures: void }>({
   page: async ({ page }: { page: Page }, use: (page: Page) => Promise<void>): Promise<void> => {
     if (isCoverageEnabled())
       await startCoverage(page);
@@ -180,4 +244,16 @@ export const test = base.extend({
     if (isCoverageEnabled())
       await stopCoverage(page);
   },
+
+  /**
+   * Records whether anything in the file failed, so `cleanupContext` can decide in afterAll
+   * whether the suite's video is worth keeping. Automatic because a spec cannot opt into it:
+   * the tests that most need the video are the ones failing before they reach any fixture.
+   */
+  trackSuiteFailures: [async ({}, use: () => Promise<void>, testInfo): Promise<void> => {
+    await use();
+
+    if (testInfo.status !== testInfo.expectedStatus)
+      suiteHadFailure = true;
+  }, { auto: true }],
 });


### PR DESCRIPTION
`use.video` only reaches contexts Playwright builds for its own `page`/`context` fixtures. 27 of the 29 e2e specs build their context by hand in `beforeAll` via `createLoggedInContext` so it can outlive a single test, and a hand-made `browser.newContext()` does not pick up `recordVideo`. The setting reads as repo-wide but only ever covered the two specs driving the built-in fixture.

Surfaced while removing the Playwright browser install (#12771): a missing ffmpeg failed only shard-1, which is what exposed how few specs actually record video.

### Change

Read the resolved `project.use.video` and pass `recordVideo` through by hand, then decide in `cleanupContext` whether the result is worth keeping. An auto fixture records whether anything in the file failed; it is automatic because the tests that most need a video are the ones failing before they reach a fixture they opted into.

`retain-on-failure` is a per-test decision, but a shared context spans the whole file, so the file is the smallest unit available: one video per spec file, named after it, kept only when that file had a failure. Per-test video would require a page per test, which these serial suites cannot do since they deliberately carry page state across tests.

### Verified locally

Three runs of `settings/rpc.spec.ts` against the real stack:

| Run | Setup | Expected | Result |
|---|---|---|---|
| Positive control | fix applied, spec green (9/9) | no video kept | 0 `.webm` |
| Negative control | fix applied, failure injected | video kept, named | `test-results/videos/rpc.webm`, 235531 bytes |
| Baseline | **fix reverted**, same injected failure | no video, as today | 0 `.webm` |

The third run is the one that matters: it shows the video comes from this change rather than from something Playwright was already doing.

### Scope note

Traces and failure screenshots were never affected. A failing shared-context test already produces them per test:

```
settings-rpc-...-chromium/trace.zip         (3086952 bytes)
settings-rpc-...-chromium/test-failed-1.png (111701 bytes)
settings-rpc-...-chromium/error-context.md    (31418 bytes)
videos/rpc.webm                              (403180 bytes)   <- new
```

Playwright instruments hand-made contexts for tracing and failure screenshots; `recordVideo` is the only one that has to be passed at creation time, which is why video alone fell through. The video is ~7.6x smaller than the trace it sits beside, and `Upload test artifacts` is `if: failure()`, so nothing extra is uploaded on green runs.

### Cost

Recording is on for 27 more specs in CI. Paired local runs of `settings/rpc.spec.ts` came out at 1.4m / 52.1s with video off and 1.1m / 1.2m with video on: the ranges overlap, so any cost is below the noise floor at that sample size. Worth a glance at shard wall-clock on the first run against the recent baseline (median 364s, p90 544s per shard).