### PR TITLE
Drop unused premium component registrations

### DIFF
--- a/frontend/app/src/modules/premium/register-components.ts
+++ b/frontend/app/src/modules/premium/register-components.ts
@@ -1,8 +1,5 @@
-/* eslint-disable @rotki/max-dependencies */
 import type { App } from 'vue';
 import {
-  RuiAccordion,
-  RuiAccordions,
   RuiAlert,
   RuiButton,
   RuiButtonGroup,
@@ -20,38 +17,21 @@ import {
   RuiTextField,
   RuiTooltip,
 } from '@rotki/ui-library';
-import BlockchainAccountSelector from '@/modules/accounts/BlockchainAccountSelector.vue';
 import {
-  AssetAmountDisplay,
-  AssetValueDisplay,
   FiatDisplay,
   ValueDisplay,
 } from '@/modules/assets/amount-display/components';
-import AssetDetails from '@/modules/assets/AssetDetails.vue';
-import AssetLink from '@/modules/assets/AssetLink.vue';
 import { logger } from '@/modules/core/common/logging/logging';
-import TableFilter from '@/modules/core/table/TableFilter.vue';
 import ExportSnapshotDialog from '@/modules/dashboard/ExportSnapshotDialog.vue';
-import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import HistoryEventsView from '@/modules/history/events/HistoryEventsView.vue';
-import LocationDisplay from '@/modules/history/LocationDisplay.vue';
-import RangeSelector from '@/modules/reports/RangeSelector.vue';
 import AssetBalanceStatisticSourceSetting from '@/modules/settings/AssetBalanceStatisticSourceSetting.vue';
 import StatisticsGraphSettings from '@/modules/settings/StatisticsGraphSettings.vue';
-import AssetIcon from '@/modules/shell/components/AssetIcon.vue';
-import CardTitle from '@/modules/shell/components/CardTitle.vue';
-import ConfirmDialog from '@/modules/shell/components/dialogs/ConfirmDialog.vue';
 import BalanceDisplay from '@/modules/shell/components/display/BalanceDisplay.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import PercentageDisplay from '@/modules/shell/components/display/PercentageDisplay.vue';
 import HashLink from '@/modules/shell/components/HashLink.vue';
-import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
-import DateTimePicker from '@/modules/shell/components/inputs/DateTimePicker.vue';
 import MenuTooltipButton from '@/modules/shell/components/MenuTooltipButton.vue';
-import PaginatedCards from '@/modules/shell/components/PaginatedCards.vue';
-import RefreshButton from '@/modules/shell/components/RefreshButton.vue';
-import RowAppend from '@/modules/shell/components/RowAppend.vue';
 import MissingDailyPrices from '@/modules/statistics/MissingDailyPrices.vue';
 import NewGraphTooltipWrapper from '@/modules/statistics/NewGraphTooltipWrapper.vue';
 
@@ -71,9 +51,8 @@ function ruiRegister(app: App): void {
   app.component('RuiDialog', RuiDialog);
   app.component('RuiColorPicker', RuiColorPicker);
   app.component('RuiProgress', RuiProgress);
-  app.component('RuiAccordions', RuiAccordions);
-  app.component('RuiAccordion', RuiAccordion);
   app.component('RuiDateTimePicker', RuiDateTimePicker);
+  // RuiAccordion(s) removed at 1.44
 }
 
 export function registerComponents(app: App): void {
@@ -81,7 +60,7 @@ export function registerComponents(app: App): void {
   // AmountDisplay was removed at 1.42;
   // version: 1
   app.component('HashLink', HashLink);
-  app.component('AssetDetails', AssetDetails);
+  // AssetDetails removed at 1.44
   // DefiProtocolIcon was removed in 1.37;
   // version: 2
   //  CryptoIcon was replaced with AssetIcon on v11
@@ -89,32 +68,30 @@ export function registerComponents(app: App): void {
   // version: 3
   app.component('PercentageDisplay', PercentageDisplay);
   // version: 4
-  app.component('BlockchainAccountSelector', BlockchainAccountSelector);
+  // BlockchainAccountSelector removed at 1.44
   app.component('DateDisplay', DateDisplay);
-  app.component('LocationDisplay', LocationDisplay);
+  // LocationDisplay removed at 1.44
   // version 5
   app.component('AssetSelect', AssetSelect);
   // version 6
-  app.component('DateTimePicker', DateTimePicker);
+  // DateTimePicker removed at 1.44
   // version 8
-  app.component('CardTitle', CardTitle);
+  // CardTitle removed at 1.44
   // version 9
   // LiquidityPoolSelector removed at 1.37
-  app.component('TableFilter', TableFilter);
+  // TableFilter removed at 1.44
   // version 11
-  app.component('AssetIcon', AssetIcon);
+  // AssetIcon removed at 1.44
   // version 12 - 1.19
-  app.component('RangeSelector', RangeSelector);
-  app.component('ConfirmDialog', ConfirmDialog);
+  // RangeSelector and ConfirmDialog removed at 1.44
   // Version 13 - 1.20
   // UniswapPoolDetails was removed at 1.37
   // Version 14 - 1.21
-  app.component('PaginatedCards', PaginatedCards);
-  app.component('AssetLink', AssetLink);
+  // PaginatedCards and AssetLink removed at 1.44
   // Version 15 - 1.21.2
   app.component('StatisticsGraphSettings', StatisticsGraphSettings);
   // Version 16 - 1.23
-  app.component('AmountInput', AmountInput);
+  // AmountInput removed at 1.44
   // Version 17 - 1.24
   app.component('ExportSnapshotDialog', ExportSnapshotDialog);
   // Version 18 - 1.25
@@ -123,16 +100,16 @@ export function registerComponents(app: App): void {
   // Version 19 - 1.26
   // LpPoolIcon was removed at 1.37
   // Version 20 - 1.27
-  app.component('BadgeDisplay', BadgeDisplay);
+  // BadgeDisplay removed at 1.44
   // Version 21 - 1.28
   app.component('HistoryEventsView', HistoryEventsView);
   // Version 24 - 1.31
   // LpPoolHeader was removed at 1.37
-  app.component('RowAppend', RowAppend);
+  // RowAppend removed at 1.44
   // Version 25 - 1.32
   // UniswapPoolAssetBalance was removed at 1.37
   // Version 26 - 1.34
-  app.component('RefreshButton', RefreshButton);
+  // RefreshButton removed at 1.44
   app.component('AssetBalanceStatisticSourceSetting', AssetBalanceStatisticSourceSetting);
 
   app.component('MissingDailyPrices', MissingDailyPrices);
@@ -141,8 +118,7 @@ export function registerComponents(app: App): void {
 
   // Version 27 - Amount display components
   app.component('FiatDisplay', FiatDisplay);
-  app.component('AssetValueDisplay', AssetValueDisplay);
-  app.component('AssetAmountDisplay', AssetAmountDisplay);
+  // AssetValueDisplay and AssetAmountDisplay removed at 1.44
   app.component('ValueDisplay', ValueDisplay);
 
   ruiRegister(app);


### PR DESCRIPTION
`register-components.ts` hands 49 components to the premium bundle. **19 of them are not used by it.**

## How that was established

The premium bundle is fetched fresh from the server on every login (`query_premium_components` → `statistics_rendererv2`; the frontend injects the returned JS as a `<script>`), and the backend signs that request with `COMPONENTS_VERSION: Final = 15` (`rotkehlchen/premium/premium.py:150`). So the 15.x line is the only one this rotki can ever receive — nothing older is cached or reachable.

Every registered name was checked against the `v15.1.0` tag of `rotki/rotki-premium`, in both PascalCase and kebab-case (Vue templates resolve globals either way), with word-boundary matching so `AssetDetails` does not match `AssetDetailsBase`.

| | |
|---|---|
| `TableFilter`, `BadgeDisplay` | never referenced in that repo's entire history |
| `BlockchainAccountSelector`, `PaginatedCards` | went with the defi section, `9cfdeed` 2025-02-24, released v12.5.0 |
| `AssetDetails` | `869ecdb` 2022-02-11, ~v2.0.0 |
| the other 14 | unused in v15.1.0 |

Removed: `AmountInput`, `AssetAmountDisplay`, `AssetDetails`, `AssetIcon`, `AssetLink`, `AssetValueDisplay`, `BadgeDisplay`, `BlockchainAccountSelector`, `CardTitle`, `ConfirmDialog`, `DateTimePicker`, `LocationDisplay`, `PaginatedCards`, `RangeSelector`, `RefreshButton`, `RowAppend`, `RuiAccordion`, `RuiAccordions`, `TableFilter`.

Each is left as a comment beside the version marker it was added under, matching how earlier removals (`AmountDisplay was removed at 1.42`, `DefiProtocolIcon was removed in 1.37`) are already recorded in this file.

## Why this is safe for rotki's own templates

Registration here also makes a component global to rotki itself, so that was checked separately:

- No rotki template uses any of the 19 without importing it (checked both `<AssetIcon>` and `<asset-icon>` forms; the only two hits were usage examples inside doc comments in the components' own files).
- The `Rui*` pair is auto-imported from `@rotki/ui-library/components` by `RuiComponentResolver` in `vite.config.ts:90`, so `ruiRegister` only ever served the premium bundle.

The import count drops below the cap, so the `/* eslint-disable @rotki/max-dependencies */` at the top goes with it.

## Testing

`pnpm run typecheck`, `pnpm run lint` (0 errors, 20 warnings — unchanged), `typos`, and `pnpm run test:unit` over `src/modules/premium`, `src/modules/statistics` and `src/modules/dashboard` (519 tests).

No changelog entry: nothing user-facing changes.

## Note for whoever owns the premium side

This is a contract in both directions. It is safe for the 15.x line by the pin above, but **when `COMPONENTS_VERSION` is bumped to 16, this list should be re-checked against the 16.x bundle** before that bundle relies on any of these being present again.