### PR TITLE
Fix two pre-existing Docker bugs: dead websockets and failed respawn

### DIFF
--- a/crates/starling-core/src/process.rs
+++ b/crates/starling-core/src/process.rs
@@ -122,7 +122,22 @@ impl Spawner for OsSpawner {
             // child before exec, so the backend runs unprivileged even though
             // the supervisor spawned it as root. Order matters — supplementary
             // groups and gid must be set before uid, while still privileged.
-            if let Some(run_as) = spec.run_as {
+            //
+            // Only meaningful while the supervisor is still root. Docker drops
+            // starling itself to the same uid once the tree is up, and from then
+            // on setgroups/setgid are EPERM for an unprivileged process — which
+            // made every *re*spawn (restart, or a crash-loop backoff) fail with
+            // "Operation not permitted" and tear the tree down for good. The
+            // child inherits our ids anyway, so once we already are `run_as`
+            // there is nothing left to drop.
+            //
+            // Both ids are compared, not just the uid: skipping on a uid match
+            // alone would silently leave a mismatched gid in place, and this is
+            // the check that decides whether a privilege drop happens.
+            if let Some(run_as) = spec.run_as.filter(|target| {
+                nix::unistd::geteuid().as_raw() != target.uid
+                    || nix::unistd::getegid().as_raw() != target.gid
+            }) {
                 let (uid, gid) = (run_as.uid, run_as.gid);
                 // SAFETY: `pre_exec` runs in the child after fork, before exec.
                 // Only async-signal-safe syscalls are used (setgroups/setgid/

--- a/crates/starling-core/tests/posix_lifecycle.rs
+++ b/crates/starling-core/tests/posix_lifecycle.rs
@@ -186,3 +186,48 @@ async fn terminate_targets_the_child_process_group() {
 
     let _ = std::fs::remove_dir_all(&temp);
 }
+
+/// Respawning must work once the supervisor has already dropped itself to the
+/// uid it spawns backends as.
+///
+/// Docker runs starling as root, spawns the backends with `run_as` so they drop
+/// in the forked child, and then drops *itself* to that same uid. From that
+/// point on the child-side `setgroups`/`setgid` are `EPERM` for an unprivileged
+/// process, so every later respawn — a control `restart`, or a crash-loop
+/// backoff — failed with "Operation not permitted" and left the tree down for
+/// good. Nothing caught it because the drop is skipped entirely when not root,
+/// which is every test and every non-container run.
+///
+/// This reproduces it without root: spawning as our *own* uid is the same
+/// already-dropped situation. Negative control — restoring the unconditional
+/// `pre_exec` drop makes this fail with EPERM.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spawns_when_already_running_as_the_target_uid() {
+    let temp = unique_temp_dir("run-as-self");
+    let pidfile = temp.join("graceful.pid");
+
+    let exe = env!("CARGO_BIN_EXE_fake_bootloader");
+    let spec = ServiceSpec::new("fake_bootloader", exe)
+        .args([
+            "--graceful".to_string(),
+            pidfile.to_string_lossy().to_string(),
+        ])
+        .run_as(starling_core::RunAs {
+            uid: nix::unistd::geteuid().as_raw(),
+            gid: nix::unistd::getegid().as_raw(),
+        });
+
+    let proc = OsSpawner
+        .spawn(&spec)
+        .await
+        .expect("spawning as the uid we already run as must not attempt a drop");
+    wait_for_file(&pidfile, Duration::from_secs(10)).await;
+
+    proc.terminate().await.expect("terminate");
+    tokio::time::timeout(Duration::from_secs(10), proc.wait())
+        .await
+        .expect("child did not exit")
+        .expect("wait");
+
+    let _ = std::fs::remove_dir_all(&temp);
+}

--- a/frontend/app/src/modules/shell/app/use-websocket-connection.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-websocket-connection.spec.ts
@@ -2,6 +2,11 @@ import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@test/i18n';
 
+// `api.serverUrl` is a read-only getter on the real client, so the mock exposes
+// one over a cell the tests can move; assigning to the property directly would
+// not typecheck.
+const { mockServerUrl } = vi.hoisted(() => ({ mockServerUrl: { value: 'http://localhost:4242' } }));
+
 const mockHandleMessage = vi.fn();
 const mockDelay = vi.fn();
 const mockLoggerDebug = vi.fn();
@@ -9,7 +14,9 @@ const mockLoggerError = vi.fn();
 
 vi.mock('@/modules/core/api/rotki-api', () => ({
   api: {
-    serverUrl: 'http://localhost:4242',
+    get serverUrl(): string {
+      return mockServerUrl.value;
+    },
   },
 }));
 
@@ -75,9 +82,12 @@ function createMockWebSocket(): MockWebSocketInstance {
   return ws;
 }
 
+let latestWsUrl: string | undefined;
+
 // Use a class-based mock so `new WebSocket()` works correctly
 class MockWebSocket {
-  constructor() {
+  constructor(url?: string) {
+    latestWsUrl = url;
     const ws = createMockWebSocket();
     latestMockWs = ws;
     return ws;
@@ -98,6 +108,8 @@ describe('useWebsocketConnection', () => {
     vi.clearAllMocks();
     mockDelay.mockResolvedValue(undefined);
     latestMockWs = null;
+    latestWsUrl = undefined;
+    mockServerUrl.value = 'http://localhost:4242';
     vi.stubGlobal('WebSocket', MockWebSocket);
     scope = effectScope();
   });
@@ -106,6 +118,60 @@ describe('useWebsocketConnection', () => {
     scope.stop();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  describe('the websocket url', () => {
+    /**
+     * Same-origin deployments (docker, plain web) resolve the base to
+     * `location.host + location.pathname`, and with hash routing the pathname is
+     * `/`. Appending `/ws/` to that produced `ws://host//ws/`, which matches no
+     * route: in docker it fell through to the SPA history fallback, so the
+     * handshake was answered with 200/index.html and the socket never connected.
+     *
+     * Negative control: dropping the trailing-slash strip makes this assert
+     * `ws://localhost:3000//ws/`.
+     */
+    it('should not double the slash when the app is served from the origin root', async () => {
+      mockServerUrl.value = '';
+      const { useWebsocketConnection } = await loadComposable();
+
+      await scope.run(async () => {
+        const connectPromise = useWebsocketConnection().connect();
+        latestMockWs?.triggerOpen();
+        await connectPromise;
+      });
+
+      expect(latestWsUrl).not.toContain('//ws/');
+      expect(latestWsUrl).toBe(`ws://${window.location.host}/ws/`);
+    });
+
+    it('should build the url from an explicit backend url', async () => {
+      mockServerUrl.value = 'http://localhost:4242';
+      const { useWebsocketConnection } = await loadComposable();
+
+      await scope.run(async () => {
+        const connectPromise = useWebsocketConnection().connect();
+        latestMockWs?.triggerOpen();
+        await connectPromise;
+      });
+
+      expect(latestWsUrl).toBe('ws://localhost:4242/ws/');
+    });
+
+    // Only *trailing* slashes are stripped, so an instance served under a
+    // sub-path still addresses its own socket rather than the origin root.
+    it('should keep a sub-path when one is configured', async () => {
+      mockServerUrl.value = 'http://localhost:4242/rotki/';
+      const { useWebsocketConnection } = await loadComposable();
+
+      await scope.run(async () => {
+        const connectPromise = useWebsocketConnection().connect();
+        latestMockWs?.triggerOpen();
+        await connectPromise;
+      });
+
+      expect(latestWsUrl).toBe('ws://localhost:4242/rotki/ws/');
+    });
   });
 
   it('should create a WebSocket connection and resolve true on open', async () => {

--- a/frontend/app/src/modules/shell/app/use-websocket-connection.ts
+++ b/frontend/app/src/modules/shell/app/use-websocket-connection.ts
@@ -32,7 +32,14 @@ function resolveBaseUrl(serverUrl: string): string {
 function buildWebsocketUrl(): string {
   const serverUrl = api.serverUrl;
   const protocol = isSecureConnection(serverUrl) ? 'wss' : 'ws';
-  const baseUrl = resolveBaseUrl(serverUrl);
+  // The trailing slash has to go before `/ws/` is appended. Same-origin
+  // deployments (docker, plain web) resolve the base to
+  // `location.host + location.pathname`, and with hash routing the pathname is
+  // `/` — which produced `ws://host//ws/`. No route matches that doubled slash,
+  // so in docker it fell through to the SPA history fallback and the handshake
+  // got 200/index.html instead of an upgrade: websockets never connected.
+  // Stripping only *trailing* slashes keeps a sub-path deployment working.
+  const baseUrl = resolveBaseUrl(serverUrl).replace(/\/+$/, '');
   return `${protocol}://${baseUrl}/ws/`;
 }
 


### PR DESCRIPTION
Two pre-existing bugs, both reachable on develop today and neither introduced by any recent change. They were found while building the `/_control` endpoint (#12774) and were the bottom two commits of that branch; they are independent of it, so they are split out here to be reviewed and merged on their own.

Both only bite a **Docker** deployment, which is why neither was noticed.

## Websockets were dead in Docker

Same-origin deployments (Docker, plain web) resolve the websocket base to `location.host + location.pathname`, and with hash routing the pathname is `/`. Appending `/ws/` produced `ws://host//ws/` — a doubled slash, matching no route. In Docker it fell through to the SPA history fallback, so the handshake was answered with `200` and `index.html`, and the socket never connected at all: no task progress, no backend messages, for the entire life of the deployment.

The desktop app is unaffected: its server url contains `://` and takes the other branch.

The fix strips trailing slashes before appending. Only trailing ones, so an instance served under a sub-path keeps addressing its own socket — that case was broken too.

## Starling could not respawn a backend after dropping privileges

Docker runs starling as root, spawns the backends with `run_as` so they drop to uid 10001 in the forked child, and then drops itself to that same uid. From that point the child-side `setgroups`/`setgid` are `EPERM` for an unprivileged process, so every *re*spawn failed with "Operation not permitted" — a control restart, or a crash-loop backoff. The controller then tore the tree down and gave up, leaving core dead with no recovery short of recreating the container.

The child inherits our ids anyway, so once the supervisor already *is* `run_as` there is nothing left to drop. The fix skips the `pre_exec` drop in that case, comparing both uid and gid so a mismatched gid cannot be skipped silently.

## Why no test caught the second one

The privilege drop is skipped entirely when not root, which is every unit test and every non-container run. It only reproduces in a real privilege-separated container — it was found by running the actual Docker image, not the test suite.

The new test recreates it without root by spawning as our own uid, which is the same already-dropped state. It fails on the unfixed code.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

Bug fixes to existing behaviour, no user-facing feature change.
