### PR TITLE
Make pnpm run copy skip backups and report per-directory progress

### DIFF
--- a/frontend/scripts/copy-data.ts
+++ b/frontend/scripts/copy-data.ts
@@ -4,21 +4,73 @@ import process from 'node:process';
 import { cancel, intro, isCancel, multiselect, outro } from '@clack/prompts';
 import { cac } from 'cac';
 import consola from 'consola';
-import { baseDataDir, copyTree } from './dev-instance';
+import { baseDataDir, buildSeedSkip, copyTree, type CopyTreeOptions, type WalkSkip } from './dev-instance';
 
 const APP_NAME = 'rotki';
 const DATA_DIR = 'data';
 const DEVELOP_DATA_DIR = 'develop_data';
 const USER_DIR = 'users';
 
-function copyAndLog(src: string, dst: string): void {
-  copyTree(src, dst, {
+/**
+ * Copying uses the same skip list as seeding: live logs and SQLite WAL/SHM
+ * companions are never carried over (copying WAL/SHM would corrupt the copied
+ * DB), and `*.backup` files are skipped unless `--include-backups` is passed.
+ */
+function copyTreeOptions(includeBackups: boolean): CopyTreeOptions {
+  return {
     preserveMtime: true,
+    skip: buildSeedSkip({ includeBackups }),
+  };
+}
+
+/** Sorted names of the entries in `dir` that the skip list does not reject. */
+function listCopyable(dir: string, skip: WalkSkip): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true })
+    .filter(entry => !skip(entry.name, entry.isDirectory()))
+    .map(entry => entry.name)
+    .sort();
+}
+
+function logSkipNotice(includeBackups: boolean): void {
+  consola.info(includeBackups
+    ? 'Skipping logs and SQLite WAL/SHM files'
+    : 'Skipping logs, SQLite WAL/SHM and *.backup files (pass --include-backups to copy backups)');
+}
+
+/**
+ * Copies a single entry, which may be a directory tree or a lone file.
+ *
+ * `copyTree` only applies `skip` to entries *inside* the root it is given, so
+ * the root itself is checked here. Otherwise copying a selected `logs/` would
+ * carry over the very tree the skip list exists to exclude.
+ */
+function copyPath(src: string, dst: string, options: CopyTreeOptions): void {
+  const isDir = fs.statSync(src).isDirectory();
+  if (options.skip?.(path.basename(src), isDir)) {
+    return;
+  }
+  if (isDir) {
+    copyTree(src, dst, options);
+    return;
+  }
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.copyFileSync(src, dst);
+  const size = fs.statSync(dst).size;
+  if (options.preserveMtime) {
+    const stat = fs.statSync(src);
+    fs.utimesSync(dst, stat.atime, stat.mtime);
+  }
+  options.onFile?.({ src, dst, size });
+}
+
+function copyAndLog(src: string, dst: string, includeBackups: boolean): void {
+  copyPath(src, dst, {
+    ...copyTreeOptions(includeBackups),
     onFile: ({ src: s, dst: d }) => consola.info(`Copying ${s} to ${d}`),
   });
 }
 
-async function promptUser(appDataDir: string): Promise<void> {
+async function promptUser(appDataDir: string, includeBackups: boolean): Promise<void> {
   intro('Select which users and data directories to copy from data to develop_data.');
   const dataDir = path.join(appDataDir, DATA_DIR);
   const developDataDir = path.join(appDataDir, DEVELOP_DATA_DIR);
@@ -26,7 +78,9 @@ async function promptUser(appDataDir: string): Promise<void> {
   const userDataDir = path.join(dataDir, USER_DIR);
   const developUserDataDir = path.join(developDataDir, USER_DIR);
 
-  const availableUsers = fs.readdirSync(userDataDir).map(item => ({
+  const skip = buildSeedSkip({ includeBackups });
+
+  const availableUsers = listCopyable(userDataDir, skip).map(item => ({
     value: item,
     label: item,
   }));
@@ -42,7 +96,7 @@ async function promptUser(appDataDir: string): Promise<void> {
     process.exit(0);
   }
 
-  const dataDirs = fs.readdirSync(dataDir)
+  const dataDirs = listCopyable(dataDir, skip)
     .filter(x => x !== USER_DIR)
     .map(item => ({
       value: item,
@@ -60,6 +114,8 @@ async function promptUser(appDataDir: string): Promise<void> {
     process.exit(0);
   }
 
+  logSkipNotice(includeBackups);
+
   for (const user of selectedUsers) {
     const sourceUserDir = path.join(userDataDir, user);
     const targetUserDir = path.join(developUserDataDir, user);
@@ -68,7 +124,7 @@ async function promptUser(appDataDir: string): Promise<void> {
       fs.rmSync(targetUserDir, { recursive: true });
     }
     consola.info(`Copying ${sourceUserDir} to ${targetUserDir}`);
-    copyTree(sourceUserDir, targetUserDir, { preserveMtime: true });
+    copyAndLog(sourceUserDir, targetUserDir, includeBackups);
   }
 
   for (const selectedDir of selectedDataDirs) {
@@ -79,13 +135,13 @@ async function promptUser(appDataDir: string): Promise<void> {
       fs.rmSync(targetDataDir, { recursive: true });
     }
     consola.info(`Copying ${sourceDataDir} to ${targetDataDir}`);
-    copyTree(sourceDataDir, targetDataDir, { preserveMtime: true });
+    copyAndLog(sourceDataDir, targetDataDir, includeBackups);
   }
 
   outro('Copying is complete.');
 }
 
-function copyData(appDataDir: string): void {
+function copyData(appDataDir: string, includeBackups: boolean): void {
   const dataDir = path.join(appDataDir, DATA_DIR);
   const developDataDir = path.join(appDataDir, DEVELOP_DATA_DIR);
 
@@ -100,8 +156,9 @@ function copyData(appDataDir: string): void {
 
   const dirContents = fs.readdirSync(dataDir);
   consola.info(`Preparing to copy ${dirContents.length} files/directories from ${dataDir} to ${developDataDir}`);
+  logSkipNotice(includeBackups);
 
-  copyAndLog(dataDir, developDataDir);
+  copyAndLog(dataDir, developDataDir, includeBackups);
 
   consola.success(`Copied all content from ${dataDir} to ${developDataDir}`);
 }
@@ -117,17 +174,21 @@ function resolveDataDirectory(): string {
 const cli = cac();
 
 cli.command('', 'Copy data from the data folder to the develop_data folder')
-  .option('--replace', 'Replaces the existing data in the develop_data folder with data from the data folder', {
+  .option('-r, --replace', 'Replaces the existing data in the develop_data folder with data from the data folder', {
+    default: false,
+  })
+  .option('--include-backups', 'Include `*.backup` files in the copy (default: skipped to keep the copy lean)', {
     default: false,
   })
   .action(async (options) => {
     const dataDir = resolveDataDirectory();
+    const includeBackups = options.includeBackups === true;
 
     if (options.replace) {
-      copyData(dataDir);
+      copyData(dataDir, includeBackups);
     }
     else {
-      await promptUser(dataDir);
+      await promptUser(dataDir, includeBackups);
     }
   });
 

--- a/frontend/scripts/copy-data.ts
+++ b/frontend/scripts/copy-data.ts
@@ -1,15 +1,26 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import { cancel, intro, isCancel, multiselect, outro } from '@clack/prompts';
+import { cancel, intro, isCancel, multiselect, outro, spinner } from '@clack/prompts';
 import { cac } from 'cac';
 import consola from 'consola';
-import { baseDataDir, buildSeedSkip, copyTree, type CopyTreeOptions, type WalkSkip } from './dev-instance';
+import { baseDataDir, buildSeedSkip, copyTree, type CopyTreeOptions, humanBytes, type WalkSkip } from './dev-instance';
 
 const APP_NAME = 'rotki';
 const DATA_DIR = 'data';
 const DEVELOP_DATA_DIR = 'develop_data';
 const USER_DIR = 'users';
+const PROGRESS_INTERVAL_MS = 150;
+
+interface CopyOptions {
+  includeBackups: boolean;
+  verbose: boolean;
+}
+
+interface CopyStats {
+  files: number;
+  bytes: number;
+}
 
 /**
  * Copying uses the same skip list as seeding: live logs and SQLite WAL/SHM
@@ -41,8 +52,8 @@ function logSkipNotice(includeBackups: boolean): void {
  * Copies a single entry, which may be a directory tree or a lone file.
  *
  * `copyTree` only applies `skip` to entries *inside* the root it is given, so
- * the root itself is checked here. Otherwise copying a selected `logs/` would
- * carry over the very tree the skip list exists to exclude.
+ * the root itself is checked here. Otherwise copying `logs/` as its own unit
+ * would carry over the very tree the skip list exists to exclude.
  */
 function copyPath(src: string, dst: string, options: CopyTreeOptions): void {
   const isDir = fs.statSync(src).isDirectory();
@@ -63,14 +74,55 @@ function copyPath(src: string, dst: string, options: CopyTreeOptions): void {
   options.onFile?.({ src, dst, size });
 }
 
-function copyAndLog(src: string, dst: string, includeBackups: boolean): void {
-  copyPath(src, dst, {
-    ...copyTreeOptions(includeBackups),
-    onFile: ({ src: s, dst: d }) => consola.info(`Copying ${s} to ${d}`),
-  });
+/**
+ * Copies one labelled entry. Quiet by default: a single progress line per
+ * entry that ends with its file count and size. `--verbose` logs every file
+ * instead, as this script used to do unconditionally.
+ */
+function copyEntry(src: string, dst: string, label: string, options: CopyOptions): CopyStats {
+  const stats: CopyStats = { files: 0, bytes: 0 };
+  const progress = options.verbose ? undefined : spinner();
+  let lastEmit = 0;
+
+  progress?.start(`Copying ${label}`);
+  try {
+    copyPath(src, dst, {
+      ...copyTreeOptions(options.includeBackups),
+      onFile: ({ src: s, dst: d, size }) => {
+        stats.files += 1;
+        stats.bytes += size;
+        if (options.verbose) {
+          consola.info(`Copying ${s} to ${d}`);
+          return;
+        }
+        const now = Date.now();
+        if (now - lastEmit >= PROGRESS_INTERVAL_MS) {
+          lastEmit = now;
+          progress?.message(`Copying ${label} (${stats.files} files, ${humanBytes(stats.bytes)})`);
+        }
+      },
+    });
+  }
+  catch (error) {
+    progress?.stop(`Failed to copy ${label}`);
+    throw error;
+  }
+
+  const summary = `Copied ${label} (${stats.files} files, ${humanBytes(stats.bytes)})`;
+  if (progress) {
+    progress.stop(summary);
+  }
+  else {
+    consola.success(summary);
+  }
+  return stats;
 }
 
-async function promptUser(appDataDir: string, includeBackups: boolean): Promise<void> {
+function totalOf(stats: CopyStats[]): CopyStats {
+  return stats.reduce((acc, s) => ({ files: acc.files + s.files, bytes: acc.bytes + s.bytes }), { files: 0, bytes: 0 });
+}
+
+async function promptUser(appDataDir: string, options: CopyOptions): Promise<void> {
   intro('Select which users and data directories to copy from data to develop_data.');
   const dataDir = path.join(appDataDir, DATA_DIR);
   const developDataDir = path.join(appDataDir, DEVELOP_DATA_DIR);
@@ -78,7 +130,7 @@ async function promptUser(appDataDir: string, includeBackups: boolean): Promise<
   const userDataDir = path.join(dataDir, USER_DIR);
   const developUserDataDir = path.join(developDataDir, USER_DIR);
 
-  const skip = buildSeedSkip({ includeBackups });
+  const skip = buildSeedSkip({ includeBackups: options.includeBackups });
 
   const availableUsers = listCopyable(userDataDir, skip).map(item => ({
     value: item,
@@ -114,7 +166,9 @@ async function promptUser(appDataDir: string, includeBackups: boolean): Promise<
     process.exit(0);
   }
 
-  logSkipNotice(includeBackups);
+  logSkipNotice(options.includeBackups);
+
+  const stats: CopyStats[] = [];
 
   for (const user of selectedUsers) {
     const sourceUserDir = path.join(userDataDir, user);
@@ -123,8 +177,7 @@ async function promptUser(appDataDir: string, includeBackups: boolean): Promise<
       consola.info(`Removing ${targetUserDir}`);
       fs.rmSync(targetUserDir, { recursive: true });
     }
-    consola.info(`Copying ${sourceUserDir} to ${targetUserDir}`);
-    copyAndLog(sourceUserDir, targetUserDir, includeBackups);
+    stats.push(copyEntry(sourceUserDir, targetUserDir, `${USER_DIR}/${user}`, options));
   }
 
   for (const selectedDir of selectedDataDirs) {
@@ -134,14 +187,33 @@ async function promptUser(appDataDir: string, includeBackups: boolean): Promise<
       consola.info(`Removing ${targetDataDir}`);
       fs.rmSync(targetDataDir, { recursive: true });
     }
-    consola.info(`Copying ${sourceDataDir} to ${targetDataDir}`);
-    copyAndLog(sourceDataDir, targetDataDir, includeBackups);
+    stats.push(copyEntry(sourceDataDir, targetDataDir, selectedDir, options));
   }
 
-  outro('Copying is complete.');
+  const total = totalOf(stats);
+  outro(`Copying is complete (${total.files} files, ${humanBytes(total.bytes)}).`);
 }
 
-function copyData(appDataDir: string, includeBackups: boolean): void {
+/**
+ * The units the copy reports on: every top-level entry of the data dir, except
+ * `users/`, which is expanded so each user directory gets its own line. Entries
+ * the skip list rejects outright are dropped so they never get a progress line.
+ */
+function copyUnits(dataDir: string, includeBackups: boolean): string[] {
+  const skip = buildSeedSkip({ includeBackups });
+  const units: string[] = [];
+  for (const item of listCopyable(dataDir, skip)) {
+    const full = path.join(dataDir, item);
+    if (item === USER_DIR && fs.statSync(full).isDirectory()) {
+      units.push(...listCopyable(full, skip).map(user => path.join(USER_DIR, user)));
+      continue;
+    }
+    units.push(item);
+  }
+  return units;
+}
+
+function copyData(appDataDir: string, options: CopyOptions): void {
   const dataDir = path.join(appDataDir, DATA_DIR);
   const developDataDir = path.join(appDataDir, DEVELOP_DATA_DIR);
 
@@ -154,13 +226,19 @@ function copyData(appDataDir: string, includeBackups: boolean): void {
   }
   consola.success(`Removed content from ${developDataDir}`);
 
-  const dirContents = fs.readdirSync(dataDir);
-  consola.info(`Preparing to copy ${dirContents.length} files/directories from ${dataDir} to ${developDataDir}`);
-  logSkipNotice(includeBackups);
+  const units = copyUnits(dataDir, options.includeBackups);
+  consola.info(`Preparing to copy ${units.length} entries from ${dataDir} to ${developDataDir}`);
+  logSkipNotice(options.includeBackups);
 
-  copyAndLog(dataDir, developDataDir, includeBackups);
+  const stats = units.map(unit => copyEntry(
+    path.join(dataDir, unit),
+    path.join(developDataDir, unit),
+    unit,
+    options,
+  ));
 
-  consola.success(`Copied all content from ${dataDir} to ${developDataDir}`);
+  const total = totalOf(stats);
+  consola.success(`Copied ${total.files} files (${humanBytes(total.bytes)}) from ${dataDir} to ${developDataDir}`);
 }
 
 function resolveDataDirectory(): string {
@@ -180,15 +258,21 @@ cli.command('', 'Copy data from the data folder to the develop_data folder')
   .option('--include-backups', 'Include `*.backup` files in the copy (default: skipped to keep the copy lean)', {
     default: false,
   })
-  .action(async (options) => {
+  .option('-v, --verbose', 'Log every copied file instead of one progress line per directory', {
+    default: false,
+  })
+  .action(async (cliOptions) => {
     const dataDir = resolveDataDirectory();
-    const includeBackups = options.includeBackups === true;
+    const options: CopyOptions = {
+      includeBackups: cliOptions.includeBackups === true,
+      verbose: cliOptions.verbose === true,
+    };
 
-    if (options.replace) {
-      copyData(dataDir, includeBackups);
+    if (cliOptions.replace) {
+      copyData(dataDir, options);
     }
     else {
-      await promptUser(dataDir, includeBackups);
+      await promptUser(dataDir, options);
     }
   });
 

--- a/frontend/scripts/dev-instance/index.ts
+++ b/frontend/scripts/dev-instance/index.ts
@@ -13,13 +13,16 @@ export {
 } from './env-file';
 
 export {
+  buildSeedSkip,
   copyTree,
   type CopyTreeOptions,
   estimateSeedSize,
   freeDiskBytes,
   seedInstance,
   type SeedProgress,
+  type SeedSkipOptions,
   shouldSkipSeedEntry,
+  type WalkSkip,
 } from './fs-walk';
 
 export { type InstanceRuntime, prepareInstance, type PrepareInstanceOptions } from './instance';

--- a/frontend/scripts/dev-instance/index.ts
+++ b/frontend/scripts/dev-instance/index.ts
@@ -12,6 +12,8 @@ export {
   writeManagedEnv,
 } from './env-file';
 
+export { humanBytes } from './format';
+
 export {
   buildSeedSkip,
   copyTree,


### PR DESCRIPTION
`pnpm run copy` copied a real data dir verbatim and logged every file it touched. Two changes, one per commit.

### Skip backups, logs and WAL files by default

`copy` now uses the same skip list that instance seeding already used:

- `*.log` and `logs/` are never copied
- `*.db-wal` / `*.db-shm` (and the `.sqlite-` variants) are never copied, since carrying a WAL over would corrupt the copied DB
- `*.backup` files are skipped unless `--include-backups` is passed

Backups are the bulk of a real data dir and a develop copy has no use for them, so this matches the existing `--include-backups` flag on `start-dev`.

Entries the skip list rejects are also dropped from the interactive prompts, so `logs/` can no longer be picked as something to copy.

`--replace` additionally answers to `-r`.

### Per-directory progress instead of per-file logging

Copying a real data dir printed thousands of path lines. Now each top-level entry gets a single progress line, updated in place with a running file count and size, ending with that entry's totals:

```
i Preparing to copy 4 entries from .../data to .../develop_data
i Skipping logs, SQLite WAL/SHM and *.backup files (pass --include-backups to copy backups)
o  Copied global.db (1 files, 2.9 MB)
o  Copied images (1 files, 0 B)
o  Copied users/alice (1 files, 1.9 MB)
o  Copied users/bob (1 files, 488.3 KB)
v Copied 4 files (5.2 MB) from .../data to .../develop_data
```

`users/` is expanded so each user directory gets its own line rather than one lump entry. The interactive path gets the same treatment and a total on its outro.

Pass `--verbose` (`-v`) to restore the previous per-file logging.

### Notes

Splitting the copy into per-entry roots exposed a subtlety: `copyTree` only applies `skip` to entries *inside* the root it is given, so a root that is itself skippable (`logs/`) would be copied wholesale. `copyPath` now checks the root too. The same hole existed in the interactive path before this PR, where selecting `logs` copied it in full.

### Testing

Ran against a synthetic data dir via `XDG_DATA_HOME` covering `--replace`, `--replace -v --include-backups`, and the interactive path, verifying the resulting tree in each case; the prompt filtering was checked with a fixture whose only non-`users` entries were skippable, so the list had to render zero rows. Also verified against a real data dir.