### PR TITLE
Cover the app while the backend is down, and stop polling it

### DIFF
--- a/frontend/app/src/modules/shell/app/AppCore.vue
+++ b/frontend/app/src/modules/shell/app/AppCore.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
+import { useMainStore } from '@/modules/core/common/use-main-store';
 import NotificationPopup from '@/modules/core/notifications/NotificationPopup.vue';
 import SettingsSuggestionsDialog from '@/modules/settings/suggestions/SettingsSuggestionsDialog.vue';
 import { useSettingsSuggestions } from '@/modules/settings/suggestions/use-settings-suggestions';
@@ -19,7 +20,27 @@ const visibilityStore = useAreaVisibilityStore();
 const { expanded, isMini, pinnedDragging, pinnedWidth, showPinned } = storeToRefs(visibilityStore);
 const { overall } = storeToRefs(useStatisticsStore());
 const { logged } = storeToRefs(useSessionAuthStore());
+const { connected } = storeToRefs(useMainStore());
 const { toggleDrawer } = visibilityStore;
+
+/**
+ * The blocking overlay covers two situations, not one.
+ *
+ * Signing out is the obvious one. The other is a backend that is deliberately
+ * down: every restart path clears `connected` before bouncing the tree, and
+ * until it comes back the page behind is inert — its data is stale and every
+ * request it makes fails. Leaving it visible and interactive for the whole
+ * window (seconds, for a core restart) reads as a frozen app rather than a
+ * deliberate operation.
+ */
+const busy = computed<boolean>(() => !get(logged) || !get(connected));
+
+// `logged` is still true across a restart that keeps the session (the desktop
+// settings form, and the window before the asset-update flows log out), so the
+// message has to follow the reason rather than assume a sign-out.
+const busyMessage = computed<string>(() =>
+  get(logged) ? t('connection_loading.restarting') : t('connection_loading.logging_out'),
+);
 
 const { updateTray } = useInterop();
 const { scrollToTop, shouldShowScrollToTopButton } = useCoreScroll();
@@ -95,7 +116,7 @@ onBeforeMount(() => {
             leave-active-class="transition duration-100 h-0"
           >
             <div
-              v-if="!logged"
+              v-if="busy"
               class="fixed top-0 left-0 w-full h-full bg-white dark:bg-rui-grey-900 z-[999] flex items-center justify-center"
             >
               <div class="flex flex-col gap-4 justify-center items-center">
@@ -105,8 +126,11 @@ onBeforeMount(() => {
                   circular
                   size="48"
                 />
-                <p class="mb-0 text-rui-text-secondary text-center">
-                  {{ t('connection_loading.logging_out') }}
+                <p
+                  class="mb-0 text-rui-text-secondary text-center"
+                  data-testid="app-busy-message"
+                >
+                  {{ busyMessage }}
                 </p>
               </div>
             </div>

--- a/frontend/app/src/modules/shell/app/schedulers/use-task-polling-scheduler.spec.ts
+++ b/frontend/app/src/modules/shell/app/schedulers/use-task-polling-scheduler.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMainStore } from '@/modules/core/common/use-main-store';
 import { useTaskStore } from '@/modules/core/tasks/use-task-store';
 import { useTaskPollingScheduler } from './use-task-polling-scheduler';
 
@@ -19,6 +20,10 @@ describe('useTaskPollingScheduler', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     monitor.mockResolvedValue(undefined);
+    // The store starts disconnected, and polling is gated on the connection, so
+    // every test that expects a poll needs the connected baseline the app has
+    // by the time the scheduler is started (after login).
+    useMainStore().setConnected(true);
   });
 
   afterEach(() => {
@@ -28,6 +33,42 @@ describe('useTaskPollingScheduler', () => {
   const runTask = (): void => {
     useTaskStore().add({ id: 1, label: 'test' });
   };
+
+  /**
+   * A backend restart clears `connected` and takes seconds to come back. Polling
+   * through that window at the active pace produced a wall of failed requests in
+   * the console (CORS/502/FetchError, one every 500ms) with nothing to show for
+   * it.
+   *
+   * Negative control: dropping the `connected` guard in `tick` makes this see
+   * repeated calls while disconnected.
+   */
+  it('should not poll while the backend is deliberately down', async () => {
+    const { start } = useTaskPollingScheduler();
+    runTask();
+    start(false);
+
+    useMainStore().setConnected(false);
+
+    await vi.advanceTimersByTimeAsync(ACTIVE_POLLING_MS * 10);
+    expect(monitor).not.toHaveBeenCalled();
+  });
+
+  // Skipping, not stopping: nothing has to restart the scheduler once the
+  // backend is back, which is what makes it safe to gate on the connection.
+  it('should resume polling on its own once the backend is back', async () => {
+    const { start } = useTaskPollingScheduler();
+    runTask();
+    start(false);
+
+    useMainStore().setConnected(false);
+    await vi.advanceTimersByTimeAsync(ACTIVE_POLLING_MS * 4);
+    expect(monitor).not.toHaveBeenCalled();
+
+    useMainStore().setConnected(true);
+    await vi.advanceTimersByTimeAsync(IDLE_POLLING_MS);
+    expect(monitor).toHaveBeenCalled();
+  });
 
   it('should poll slowly while nothing is outstanding', async () => {
     const { start } = useTaskPollingScheduler();

--- a/frontend/app/src/modules/shell/app/schedulers/use-task-polling-scheduler.ts
+++ b/frontend/app/src/modules/shell/app/schedulers/use-task-polling-scheduler.ts
@@ -1,4 +1,5 @@
 import { startPromise } from '@shared/utils';
+import { useMainStore } from '@/modules/core/common/use-main-store';
 import { useTaskMonitor } from '@/modules/core/tasks/use-task-monitor';
 import { useTaskStore } from '@/modules/core/tasks/use-task-store';
 
@@ -48,6 +49,7 @@ interface UseTaskPollingSchedulerReturn {
 export function useTaskPollingScheduler(): UseTaskPollingSchedulerReturn {
   const { monitor } = useTaskMonitor();
   const { hasRunningTasks, hasUnknownTasks, tasks } = storeToRefs(useTaskStore());
+  const { connected } = storeToRefs(useMainStore());
 
   let timeoutId: NodeJS.Timeout | undefined;
   let running = false;
@@ -90,7 +92,14 @@ export function useTaskPollingScheduler(): UseTaskPollingSchedulerReturn {
 
   async function tick(): Promise<void> {
     try {
-      await monitor();
+      // Skip the pass while the backend is deliberately down — a restart in
+      // flight, or a backend being switched. It cannot answer, so polling it
+      // only fills the console with failed requests for the whole window (a
+      // core restart takes seconds, and the active pace is twice a second).
+      // Skipping rather than stopping means polling resumes on its own when the
+      // connection returns, with no one having to restart the scheduler.
+      if (get(connected))
+        await monitor();
     }
     finally {
       // Rescheduled even when the pass throws, or one failed poll ends polling for the session.

--- a/frontend/app/src/modules/shell/app/use-monitor-service.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-monitor-service.spec.ts
@@ -1,5 +1,6 @@
 import { createCustomPinia } from '@test/utils/create-pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMainStore } from '@/modules/core/common/use-main-store';
 
 const mockConnect = vi.fn();
 const mockDisconnect = vi.fn();
@@ -67,12 +68,17 @@ vi.mock('@/modules/shell/app/use-websocket-connection', () => ({
 }));
 
 vi.mock('@/modules/core/common/logging/logging', () => ({
+  // The task scheduler reads the connection from the main store, which pulls the
+  // rest of this module in; a partial mock fails at import time rather than in
+  // an assertion, so the whole surface has to be stubbed.
+  getDefaultLogLevel: vi.fn(() => 'debug'),
   logger: {
     debug: vi.fn(),
     error: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
   },
+  setLevel: vi.fn(),
 }));
 
 async function loadMonitorService(): Promise<typeof import('@/modules/shell/app/use-monitor-service')> {
@@ -99,6 +105,10 @@ describe('useMonitorService', () => {
     mockCheckIfPasswordConfirmationNeeded.mockResolvedValue(undefined);
 
     setActivePinia(createCustomPinia());
+    // Task polling is gated on the backend connection, and the store starts
+    // disconnected. The monitor is only ever started after login, when the app
+    // is connected, so that is the baseline these tests need.
+    useMainStore().setConnected(true);
 
     const { useMonitorService } = await loadMonitorService();
     scope.run(() => {


### PR DESCRIPTION
Two halves of the same gap, both reachable on the desktop app today. Split out of #12774, which needs them for the Docker restart path but does not cause them: the desktop settings form has always been able to restart the backend, and the asset-update and asset-restore flows have always taken it down.

## The page stays live while the backend is gone

The blocking overlay in `AppCore` was gated on `logged` alone, so it only ever covered a sign-out. A restart keeps the session, so for the seconds core is down the page stays fully rendered and interactive, its data stale and every request it makes failing, with nothing to say anything is happening. It reads as a frozen app rather than a deliberate operation.

Gate it on the connection too, and pick the message from the reason rather than assuming a sign-out. The `connection_loading.restarting` string already exists and is what the pre-login screens show for exactly this.

This does not make the overlay appear on ordinary network blips: `connected` is set true once, on the successful startup connect, and set false only by the flows that deliberately take the backend down (`use-backend-management`, `AssetUpdate`, `RestoreAssetDbButton`). A failed request never clears it.

## The task poller keeps hammering a backend that is down

The poller kept asking at up to twice a second for the whole window, filling the console with failed requests.

It now skips the pass while disconnected. Skipping rather than stopping means polling resumes on its own when the connection returns, and nothing has to restart the scheduler. The periodic scheduler already consults the connection this way.

## Tests

Two new specs on the poller, both with a negative control: removing the guard fails exactly those two and leaves the other nine passing.

Both spec files needed a connected baseline, since the store starts disconnected and the monitor is only ever started after login, when the app is connected.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

Fixes to existing behaviour, no user-facing feature change.
