### PR TITLE
Avoid etherscan notification on object init

### DIFF
--- a/rotkehlchen/externalapis/etherscan.py
+++ b/rotkehlchen/externalapis/etherscan.py
@@ -10,7 +10,10 @@ from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.misc import ChainNotSupported, RemoteError
 from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.externalapis.etherscan_like import EtherscanLikeApi
-from rotkehlchen.externalapis.interface import ExternalServiceWithRecommendedApiKey
+from rotkehlchen.externalapis.interface import (
+    ExternalServiceWithApiKey,
+    ExternalServiceWithRecommendedApiKey,
+)
 from rotkehlchen.externalapis.utils import maybe_read_integer
 from rotkehlchen.history.events.structures.eth2 import EthWithdrawalEvent
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -153,7 +156,9 @@ class Etherscan(ExternalServiceWithRecommendedApiKey, EtherscanLikeApi):
         Free and Lite are indistinguishable (both 100k/day), so the 100k bucket stays at the
         documented Free tier of 3 rps.
         """
-        if (api_key := self._get_api_key()) is None:
+        # Tier detection runs during user initialization, before Etherscan is actually needed.
+        # Bypass the recommended-key warning so new users are notified only on real usage.
+        if (api_key := ExternalServiceWithApiKey._get_api_key(self)) is None:
             self._rate_limiter.reset(
                 rps=FREE_ETHERSCAN_RATE_LIMIT_RPS,
                 capacity=FREE_ETHERSCAN_RATE_LIMIT_BURST,

--- a/rotkehlchen/tests/external_apis/test_etherscan.py
+++ b/rotkehlchen/tests/external_apis/test_etherscan.py
@@ -138,6 +138,26 @@ def test_detect_api_key_tier_caches_and_reuses_value(temp_etherscan: Etherscan) 
     assert temp_etherscan._rate_limiter.capacity == 20
 
 
+def test_detect_api_key_tier_does_not_warn_for_missing_key(
+        function_scope_messages_aggregator,
+        tmpdir_factory,
+        sql_vm_instructions_cb,
+) -> None:
+    database = DBHandler(
+        user_data_dir=tmpdir_factory.mktemp('keyless-userdata'),
+        password='123',
+        msg_aggregator=function_scope_messages_aggregator,
+        initial_settings=None,
+        sql_vm_instructions_cb=sql_vm_instructions_cb,
+        resume_from_backup=False,
+    )
+    with patch.object(database.msg_aggregator, 'add_missing_key_message') as warning_mock:
+        etherscan = Etherscan(database=database, msg_aggregator=database.msg_aggregator)
+        warning_mock.assert_not_called()
+        assert etherscan._get_api_key_for_chain(ChainID.ETHEREUM) is None
+        warning_mock.assert_called_once_with(ExternalService.ETHERSCAN)
+
+
 def test_api_key_change_invalidates_cached_tier(temp_etherscan: Etherscan) -> None:
     temp_etherscan._cache_api_key_tier(tier=ETHERSCAN_TIER_BY_DAILY_LIMIT[500000])
     with patch.object(temp_etherscan, '_query', return_value={'creditLimit': 200000}):


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
