### PR TITLE
Migrate the rpc and explorer settings forms to zod

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3120,7 +3120,8 @@
   },
   "explorer_input": {
     "validation": {
-      "https": "Only https urls are allowed"
+      "https": "Only https urls are allowed",
+      "url": "The value is not a valid url"
     }
   },
   "explorers": {

--- a/frontend/app/src/modules/core/form/server-errors.ts
+++ b/frontend/app/src/modules/core/form/server-errors.ts
@@ -1,0 +1,20 @@
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+
+/**
+ * The api reports a field's errors as either one message or a list of them, while the form core
+ * takes a list per path. An empty message carries no information and would only reserve space under
+ * the field, so it is dropped.
+ */
+export function toMessageList(value: ValidationErrors[string] | undefined): string[] {
+  if (value === undefined)
+    return [];
+
+  return (Array.isArray(value) ? value : [value]).filter(message => message !== '');
+}
+
+/** Api validation errors as `setServerErrors` takes them, assuming field names match state keys. */
+export function toServerErrors(errors: ValidationErrors): Record<string, string[]> {
+  return Object.fromEntries(
+    Object.entries(errors).map(([field, messages]) => [field, toMessageList(messages)]),
+  );
+}

--- a/frontend/app/src/modules/settings/controls/setting-field-schemas.ts
+++ b/frontend/app/src/modules/settings/controls/setting-field-schemas.ts
@@ -43,23 +43,28 @@ function isBlank(value: string): boolean {
   return value.trim() === '';
 }
 
-export function textSettingSchema(rules: TextSettingRules): ZodType {
+/** The rules alone, for forms that hold a text field among others rather than a lone setting. */
+export function textSettingField(rules: TextSettingRules): ZodType<string> {
   const { maxLength, messages, required = false } = rules;
 
+  return z.string().superRefine((value, ctx) => {
+    if (isBlank(value)) {
+      // A blank value is the required rule's business alone: an optional field that is empty must
+      // not also trip the length rule.
+      if (required)
+        ctx.addIssue({ code: 'custom', message: messages.required });
+
+      return;
+    }
+
+    if (maxLength !== undefined && value.length > maxLength)
+      ctx.addIssue({ code: 'custom', message: messages.maxLength });
+  });
+}
+
+export function textSettingSchema(rules: TextSettingRules): ZodType {
   return z.object({
-    value: z.string().superRefine((value, ctx) => {
-      if (isBlank(value)) {
-        // A blank value is the required rule's business alone: an optional field that is empty must
-        // not also trip the length rule.
-        if (required)
-          ctx.addIssue({ code: 'custom', message: messages.required });
-
-        return;
-      }
-
-      if (maxLength !== undefined && value.length > maxLength)
-        ctx.addIssue({ code: 'custom', message: messages.maxLength });
-    }),
+    value: textSettingField(rules),
   });
 }
 
@@ -82,27 +87,32 @@ function rangeMessage(numeric: number, rules: NumberSettingRules): string | unde
   return undefined;
 }
 
-export function numberSettingSchema(rules: NumberSettingRules): ZodType {
+/** The rules alone, for forms that hold a numeric field among others rather than a lone setting. */
+export function numberSettingField(rules: NumberSettingRules): ZodType<string> {
   const { messages, required = true } = rules;
 
-  return z.object({
-    value: z.string().superRefine((value, ctx) => {
-      if (isBlank(value)) {
-        if (required)
-          ctx.addIssue({ code: 'custom', message: messages.required });
-
-        return;
-      }
-
-      const numeric = Number(value);
-      if (Number.isNaN(numeric)) {
+  return z.string().superRefine((value, ctx) => {
+    if (isBlank(value)) {
+      if (required)
         ctx.addIssue({ code: 'custom', message: messages.required });
-        return;
-      }
 
-      const message = rangeMessage(numeric, rules);
-      if (message !== undefined)
-        ctx.addIssue({ code: 'custom', message });
-    }),
+      return;
+    }
+
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) {
+      ctx.addIssue({ code: 'custom', message: messages.required });
+      return;
+    }
+
+    const message = rangeMessage(numeric, rules);
+    if (message !== undefined)
+      ctx.addIssue({ code: 'custom', message });
+  });
+}
+
+export function numberSettingSchema(rules: NumberSettingRules): ZodType {
+  return z.object({
+    value: numberSettingField(rules),
   });
 }

--- a/frontend/app/src/modules/settings/explorers/ExplorerInput.spec.ts
+++ b/frontend/app/src/modules/settings/explorers/ExplorerInput.spec.ts
@@ -1,0 +1,91 @@
+import { type DOMWrapper, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, describe, expect, it } from 'vitest';
+import ExplorerInput from '@/modules/settings/explorers/ExplorerInput.vue';
+
+type ExplorerInputInstance = InstanceType<typeof ExplorerInput>;
+
+describe('settings/explorers/ExplorerInput.vue', () => {
+  let wrapper: VueWrapper<ExplorerInputInstance>;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function createWrapper(modelValue: string = ''): VueWrapper<ExplorerInputInstance> {
+    return mount(ExplorerInput, {
+      props: {
+        modelValue,
+        'onUpdate:modelValue': async (value: string): Promise<void> => wrapper.setProps({ modelValue: value }),
+      },
+    });
+  }
+
+  /**
+   * The save button carries no test id: the e2e page object reaches it as the field's sibling, and it
+   * is the last button in the component (the clear button sits inside the text field).
+   */
+  function saveButton(): DOMWrapper<HTMLButtonElement> {
+    const button = wrapper.findAll<HTMLButtonElement>('button').at(-1);
+    assert(button, 'the save button is missing');
+    return button;
+  }
+
+  function errorMessage(): string {
+    return wrapper.find('.details .text-rui-error').text();
+  }
+
+  it('should allow saving an empty url, which clears the override', () => {
+    wrapper = createWrapper();
+
+    expect(saveButton().attributes('disabled')).toBeUndefined();
+  });
+
+  it('should allow saving a valid https url', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.find('input').setValue('https://example.com/address/');
+
+    expect(wrapper.find('.details .text-rui-error').exists()).toBe(false);
+    expect(saveButton().attributes('disabled')).toBeUndefined();
+  });
+
+  it('should reject a url that is not https', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.find('input').setValue('http://example.com/address/');
+
+    expect(errorMessage()).toBe('explorer_input.validation.https');
+    expect(saveButton().attributes('disabled')).toBeDefined();
+  });
+
+  // 'https://' passes the https rule and fails only the url rule, so it covers the url check rather
+  // than duplicating the test above; an input failing both rules would prove nothing here.
+  it('should reject a url that is only a scheme', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.find('input').setValue('https://');
+
+    expect(wrapper.find('.details .text-rui-error').exists()).toBe(true);
+    expect(saveButton().attributes('disabled')).toBeDefined();
+  });
+
+  it('should emit the current url when saving', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.find('input').setValue('https://example.com/address/');
+    await saveButton().trigger('click');
+
+    expect(wrapper.emitted('save-data')).toEqual([['https://example.com/address/']]);
+  });
+
+  // Documents a defect: the field is emptied but nothing is persisted, because the template listens
+  // for `click:clear` while RuiTextField emits `clear`. Fixed in the next commit.
+  it('should empty the field but emit nothing when cleared', async () => {
+    wrapper = createWrapper('https://example.com/address/');
+
+    await wrapper.find('[data-id=clear-btn]').trigger('click');
+
+    expect(wrapper.props('modelValue')).toBe('');
+    expect(wrapper.emitted('save-data')).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/settings/explorers/ExplorerInput.spec.ts
+++ b/frontend/app/src/modules/settings/explorers/ExplorerInput.spec.ts
@@ -78,14 +78,12 @@ describe('settings/explorers/ExplorerInput.vue', () => {
     expect(wrapper.emitted('save-data')).toEqual([['https://example.com/address/']]);
   });
 
-  // Documents a defect: the field is emptied but nothing is persisted, because the template listens
-  // for `click:clear` while RuiTextField emits `clear`. Fixed in the next commit.
-  it('should empty the field but emit nothing when cleared', async () => {
+  it('should empty the field and emit no value when cleared', async () => {
     wrapper = createWrapper('https://example.com/address/');
 
     await wrapper.find('[data-id=clear-btn]').trigger('click');
 
     expect(wrapper.props('modelValue')).toBe('');
-    expect(wrapper.emitted('save-data')).toBeUndefined();
+    expect(wrapper.emitted('save-data')).toEqual([[undefined]]);
   });
 });

--- a/frontend/app/src/modules/settings/explorers/ExplorerInput.vue
+++ b/frontend/app/src/modules/settings/explorers/ExplorerInput.vue
@@ -47,7 +47,7 @@ const v$ = useVuelidate(
       clearable
       :error-messages="toMessages(v$.url)"
       v-bind="$attrs"
-      @click:clear="saveData()"
+      @clear="saveData()"
     />
     <RuiButton
       variant="text"

--- a/frontend/app/src/modules/settings/explorers/ExplorerInput.vue
+++ b/frontend/app/src/modules/settings/explorers/ExplorerInput.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, url as urlValidator } from '@vuelidate/validators';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import type { ZodType } from 'zod';
+import { useForm } from '@/modules/core/form/use-form';
+import { EXPLORER_URL_FIELD, explorerUrlSchema, type ExplorerUrlState } from '@/modules/settings/explorers/explorer-url-schema';
 
 defineOptions({
   inheritAttrs: false,
@@ -15,46 +15,56 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
+const schema = computed<ZodType>(() => explorerUrlSchema({
+  https: t('explorer_input.validation.https'),
+  url: t('explorer_input.validation.url'),
+}));
+
+/** The parent owns the persist and listens for `save-data`, so submitting here is a no-op. */
+const form = useForm<ExplorerUrlState, ExplorerUrlState>({
+  initial: (): ExplorerUrlState => ({ url: get(url) }),
+  schema,
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): ExplorerUrlState => ({ url: state.url }),
+});
+
+/** The form api is a plain object, so its refs only unwrap in the template through a local one. */
+const invalid = computed<boolean>(() => !get(form.valid));
+
 function saveData(value?: string) {
   emit('save-data', value);
 }
 
-const isHttps = (value: string) => !value || value.startsWith('https');
+watch(() => form.state.url, (value) => {
+  set(url, value);
+});
 
-const rules = {
-  url: {
-    https: helpers.withMessage(t('explorer_input.validation.https'), isHttps),
-    urlValidator,
-  },
-};
-
-const v$ = useVuelidate(
-  rules,
-  {
-    url,
-  },
-  { $autoDirty: true },
-);
+// The settings page reseeds every field when the user switches chain.
+watch(url, (value) => {
+  if (value !== form.state.url)
+    form.state.url = value;
+});
 </script>
 
 <template>
   <div class="flex items-start gap-4">
     <RuiTextField
-      v-model="url"
+      v-model="form.state.url"
       class="flex-1"
       variant="outlined"
       color="primary"
       clearable
-      :error-messages="toMessages(v$.url)"
+      :error-messages="form.errors(EXPLORER_URL_FIELD)"
       v-bind="$attrs"
+      @update:model-value="form.touch(EXPLORER_URL_FIELD)"
       @clear="saveData()"
     />
     <RuiButton
       variant="text"
       class="mt-1"
       icon
-      :disabled="v$.$invalid"
-      @click="saveData(modelValue)"
+      :disabled="invalid"
+      @click="saveData(form.state.url)"
     >
       <RuiIcon name="lu-save" />
     </RuiButton>

--- a/frontend/app/src/modules/settings/explorers/explorer-url-schema.spec.ts
+++ b/frontend/app/src/modules/settings/explorers/explorer-url-schema.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { explorerUrlSchema } from '@/modules/settings/explorers/explorer-url-schema';
+
+const schema = explorerUrlSchema({ https: 'not https', url: 'not a url' });
+
+function messagesFor(url: string): string[] {
+  const result = schema.safeParse({ url });
+  return result.success ? [] : result.error.issues.map(issue => issue.message);
+}
+
+describe('settings/explorers/explorer-url-schema', () => {
+  // The acceptance of the vuelidate rules this schema replaces, measured input by input. Each
+  // rejected row names the single rule it trips, so a dropped rule cannot hide behind the other one.
+  it.each([
+    ['https://example.com/address/', []],
+    ['https://example.com', []],
+    ['https://example.com/address/{address}', []],
+    ['http://example.com/address/', ['not https']],
+    ['https://', ['not a url']],
+    ['https:// example.com', ['not a url']],
+    ['https://exa mple.com', ['not a url']],
+    ['httpsfoo', ['not a url']],
+    ['not a url', ['not https', 'not a url']],
+  ])('should report %o as %o', (url, expected) => {
+    expect(messagesFor(url)).toEqual(expected);
+  });
+
+  it('should accept an empty url, which is how an override is cleared', () => {
+    expect(messagesFor('')).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/settings/explorers/explorer-url-schema.ts
+++ b/frontend/app/src/modules/settings/explorers/explorer-url-schema.ts
@@ -1,0 +1,38 @@
+import { z, type ZodType } from 'zod';
+
+/** The single field an explorer override holds; errors are reported under this path. */
+export const EXPLORER_URL_FIELD = 'url';
+
+export interface ExplorerUrlState {
+  url: string;
+}
+
+export interface ExplorerUrlMessages {
+  https: string;
+  url: string;
+}
+
+/**
+ * An empty value is accepted: emptying the field is how an override is cleared, so it must reach the
+ * save path rather than being rejected as invalid.
+ */
+function isHttps(value: string): boolean {
+  return value === '' || value.startsWith('https');
+}
+
+/** Vuelidate skipped its rules on blank input, and a whitespace-only url is not worth two messages. */
+function isBlank(value: string): boolean {
+  return value.trim() === '';
+}
+
+export function explorerUrlSchema(messages: ExplorerUrlMessages): ZodType {
+  return z.object({
+    url: z.string().superRefine((value, ctx) => {
+      if (!isHttps(value))
+        ctx.addIssue({ code: 'custom', message: messages.https });
+
+      if (!isBlank(value) && !z.url().safeParse(value).success)
+        ctx.addIssue({ code: 'custom', message: messages.url });
+    }),
+  });
+}

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeForm.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeForm.spec.ts
@@ -61,13 +61,13 @@ describe('settings/general/rpc/BlockchainRpcNodeForm.vue', () => {
   it('should accept a fully filled node', async () => {
     wrapper = createWrapper();
 
-    expect(await wrapper.vm.validate()).toBe(true);
+    expect(wrapper.vm.validate()).toBe(true);
   });
 
   it('should reject a node without a name', async () => {
     wrapper = createWrapper(stateFor({ name: '' }));
 
-    expect(await wrapper.vm.validate()).toBe(false);
+    expect(wrapper.vm.validate()).toBe(false);
     await nextTick();
     expect(wrapper.find('[data-cy=node-name] .details .text-rui-error').exists()).toBe(true);
   });
@@ -75,7 +75,7 @@ describe('settings/general/rpc/BlockchainRpcNodeForm.vue', () => {
   it('should reject a node without an endpoint', async () => {
     wrapper = createWrapper(stateFor({ endpoint: '' }));
 
-    expect(await wrapper.vm.validate()).toBe(false);
+    expect(wrapper.vm.validate()).toBe(false);
     await nextTick();
     expect(wrapper.find('[data-cy=node-endpoint] .details .text-rui-error').exists()).toBe(true);
   });
@@ -85,13 +85,13 @@ describe('settings/general/rpc/BlockchainRpcNodeForm.vue', () => {
   it('should accept an etherscan node without an endpoint', async () => {
     wrapper = createWrapper(stateFor({ endpoint: '', name: 'etherscan' }));
 
-    expect(await wrapper.vm.validate()).toBe(true);
+    expect(wrapper.vm.validate()).toBe(true);
   });
 
   it('should reject a weight above one hundred', async () => {
     wrapper = createWrapper(stateFor({ weight: 101 }));
 
-    expect(await wrapper.vm.validate()).toBe(false);
+    expect(wrapper.vm.validate()).toBe(false);
   });
 
   // The dialog reports the server's rejection after a failed save, which is the only time the form

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeForm.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeForm.spec.ts
@@ -1,0 +1,128 @@
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { Blockchain } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import BlockchainRpcNodeForm from '@/modules/settings/general/rpc/BlockchainRpcNodeForm.vue';
+import { type BlockchainRpcNode, type BlockchainRpcNodeManageState, getPlaceholderNode } from '@/modules/settings/types/rpc';
+
+type FormInstance = InstanceType<typeof BlockchainRpcNodeForm>;
+
+describe('settings/general/rpc/BlockchainRpcNodeForm.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<FormInstance>;
+
+  beforeAll(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function stateFor(node: Partial<BlockchainRpcNode> = {}): BlockchainRpcNodeManageState {
+    return {
+      mode: 'add',
+      node: {
+        ...getPlaceholderNode(Blockchain.ETH),
+        endpoint: 'https://node.example.com',
+        name: 'my node',
+        weight: 50,
+        ...node,
+      },
+    };
+  }
+
+  function createWrapper(
+    modelValue: BlockchainRpcNodeManageState = stateFor(),
+    errorMessages: ValidationErrors = {},
+  ): VueWrapper<FormInstance> {
+    return mount(BlockchainRpcNodeForm, {
+      global: {
+        plugins: [pinia],
+      },
+      props: {
+        'errorMessages': errorMessages,
+        'modelValue': modelValue,
+        'onUpdate:errorMessages': async (value: ValidationErrors): Promise<void> => wrapper.setProps({ errorMessages: value }),
+        'onUpdate:modelValue': async (value: BlockchainRpcNodeManageState): Promise<void> => wrapper.setProps({ modelValue: value }),
+        'onUpdate:stateUpdated': async (value: boolean): Promise<void> => wrapper.setProps({ stateUpdated: value }),
+        'stateUpdated': false,
+      },
+    });
+  }
+
+  it('should accept a fully filled node', async () => {
+    wrapper = createWrapper();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should reject a node without a name', async () => {
+    wrapper = createWrapper(stateFor({ name: '' }));
+
+    expect(await wrapper.vm.validate()).toBe(false);
+    await nextTick();
+    expect(wrapper.find('[data-cy=node-name] .details .text-rui-error').exists()).toBe(true);
+  });
+
+  it('should reject a node without an endpoint', async () => {
+    wrapper = createWrapper(stateFor({ endpoint: '' }));
+
+    expect(await wrapper.vm.validate()).toBe(false);
+    await nextTick();
+    expect(wrapper.find('[data-cy=node-endpoint] .details .text-rui-error').exists()).toBe(true);
+  });
+
+  // Etherscan is reached through the api key rather than an endpoint, so it is the one node whose
+  // endpoint may stay empty.
+  it('should accept an etherscan node without an endpoint', async () => {
+    wrapper = createWrapper(stateFor({ endpoint: '', name: 'etherscan' }));
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should reject a weight above one hundred', async () => {
+    wrapper = createWrapper(stateFor({ weight: 101 }));
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  // The dialog reports the server's rejection after a failed save, which is the only time the form
+  // sees external errors.
+  it('should display externally reported errors on the field they name', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.setProps({ errorMessages: { name: ['Node name already taken'] } });
+    await nextTick();
+    await nextTick();
+
+    expect(wrapper.find('[data-cy=node-name] .details .text-rui-error').text()).toBe('Node name already taken');
+  });
+
+  it('should write an edited name back to the model', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.find('[data-cy=node-name] input').setValue('renamed node');
+
+    expect(wrapper.props('modelValue').node.name).toBe('renamed node');
+  });
+
+  it('should report the state as updated once a field is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.props('stateUpdated')).toBe(false);
+
+    await wrapper.find('[data-cy=node-name] input').setValue('renamed node');
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.props('stateUpdated')).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeForm.vue
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeForm.vue
@@ -1,12 +1,19 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { BlockchainRpcNodeManageState } from '@/modules/settings/types/rpc';
-import useVuelidate from '@vuelidate/core';
-import { between, required, requiredIf } from '@vuelidate/validators';
-import { isEmpty } from 'es-toolkit/compat';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { toServerErrors } from '@/modules/core/form/server-errors';
+import { useForm } from '@/modules/core/form/use-form';
+import {
+  type BlockchainRpcNodeFormState,
+  blockchainRpcNodeSchema,
+  isEtherscanNode,
+  MAX_WEIGHT,
+  MIN_WEIGHT,
+  stateFromNode,
+  toNodeFields,
+  toWeight,
+} from '@/modules/settings/general/rpc/blockchain-rpc-node-form';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
@@ -15,111 +22,101 @@ const modelValue = defineModel<BlockchainRpcNodeManageState>({ required: true })
 
 const { t } = useI18n({ useScope: 'global' });
 
-const node = useRefPropVModel(modelValue, 'node');
-const owned = useRefPropVModel(node, 'owned');
-const name = useRefPropVModel(node, 'name');
-const endpoint = useRefPropVModel(node, 'endpoint');
-const active = useRefPropVModel(node, 'active');
-const numericWeight = useRefPropVModel(node, 'weight');
+const schema = computed<ZodType>(() => blockchainRpcNodeSchema({
+  endpointRequired: t('settings.validation.text.non_empty'),
+  nameRequired: t('settings.validation.text.non_empty'),
+  weightBetween: t('settings.validation.number.between', { max: MAX_WEIGHT, min: MIN_WEIGHT }),
+  weightRequired: t('settings.validation.number.non_empty'),
+}));
 
-function getWeight(value?: string): number {
-  if (!value)
-    return 0;
+/** The dialog owns the persist and reads the node off the model, so submitting here is a no-op. */
+const form = useForm<BlockchainRpcNodeFormState, BlockchainRpcNodeFormState>({
+  initial: (): BlockchainRpcNodeFormState => stateFromNode(get(modelValue).node),
+  schema,
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): BlockchainRpcNodeFormState => ({ ...state }),
+});
 
-  const parsedValue = parseInt(value);
-  return Number.isNaN(parsedValue) ? 0 : parsedValue;
-}
+const isEtherscan = computed<boolean>(() => isEtherscanNode(form.state));
 
-const weight = computed<string>({
+/** The slider edits the weight as a number, the field next to it as text. */
+const numericWeight = computed<number>({
   get() {
-    return get(numericWeight).toString();
+    return toWeight(form.state.weight);
   },
-  set(value?: string) {
-    set(numericWeight, getWeight(value));
+  set(value: number) {
+    form.state.weight = value.toString();
   },
 });
 
-const isEtherscan = computed<boolean>(() => {
-  const rpcNode = get(node);
-  return !rpcNode.endpoint && rpcNode.name.includes('etherscan');
+// The dialog reads the node it saves straight off the model, so every edit is written back to it.
+watch(() => form.state, (state) => {
+  const current = get(modelValue);
+  set(modelValue, {
+    ...current,
+    node: { ...current.node, ...toNodeFields(state) },
+  });
+}, { deep: true });
+
+watch(errors, (value) => {
+  form.setServerErrors(toServerErrors(value));
+}, { deep: true });
+
+watch(form.dirty, (dirty) => {
+  set(stateUpdated, dirty);
 });
 
-const rules = {
-  endpoint: { required: requiredIf(logicNot(isEtherscan)) },
-  name: { required },
-  weight: { between: between(0, 100), required },
-};
-
-const states = {
-  active,
-  endpoint,
-  name,
-  owned,
-  weight,
-};
-
-const v$ = useVuelidate(
-  rules,
-  states,
-  {
-    $autoDirty: true,
-    $externalResults: errors,
-  },
-);
-
-useFormStateWatcher(states, stateUpdated);
-
-watch(errors, (errors) => {
-  if (!isEmpty(errors))
-    get(v$).$validate();
+// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
+onUnmounted(() => {
+  set(stateUpdated, false);
 });
 
 defineExpose({
-  validate: async () => await get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
 <template>
   <div class="flex flex-col gap-2">
     <RuiTextField
-      v-model="name"
+      v-model="form.state.name"
       variant="outlined"
       color="primary"
       data-cy="node-name"
       :disabled="isEtherscan"
       :label="t('common.name')"
-      :error-messages="toMessages(v$.name)"
-      @blur="v$.name.$touch()"
+      :error-messages="form.errors('name')"
+      @blur="form.touch('name')"
     />
     <RuiTextField
-      v-model="endpoint"
+      v-model="form.state.endpoint"
       variant="outlined"
       color="primary"
       data-cy="node-endpoint"
       :disabled="isEtherscan"
-      :error-messages="toMessages(v$.endpoint)"
+      :error-messages="form.errors('endpoint')"
       :label="t('rpc_node_form.endpoint')"
-      @blur="v$.endpoint.$touch()"
+      @blur="form.touch('endpoint')"
     />
 
     <div class="flex items-center gap-4">
       <RuiSlider
         v-model="numericWeight"
         class="flex-1"
-        :disabled="owned"
-        :error-messages="toMessages(v$.weight)"
+        :disabled="form.state.owned"
+        :error-messages="form.errors('weight')"
         :label="t('rpc_node_form.weight')"
-        :min="0"
-        :max="100"
-        :hint="t('rpc_node_form.weight_hint', { weight })"
+        :min="MIN_WEIGHT"
+        :max="MAX_WEIGHT"
+        :hint="t('rpc_node_form.weight_hint', { weight: form.state.weight })"
         :step="1"
         show-thumb-label
-        @blur="v$.weight.$touch()"
+        @blur="form.touch('weight')"
       />
       <AmountInput
-        v-model="weight"
-        :disabled="owned"
-        :error-messages="toMessages(v$.weight).length > 0 ? [''] : []"
+        v-model="form.state.weight"
+        :disabled="form.state.owned"
+        :error-messages="form.errors('weight').length > 0 ? [''] : []"
         variant="outlined"
         hide-details
         class="w-[8rem] [&>div]:min-w-0"
@@ -131,7 +128,7 @@ defineExpose({
     </div>
 
     <RuiSwitch
-      v-model="owned"
+      v-model="form.state.owned"
       color="primary"
       class="mt-4"
       :label="t('rpc_node_form.owned')"
@@ -139,7 +136,7 @@ defineExpose({
       :hint="t('rpc_node_form.owned_hint')"
     />
     <RuiSwitch
-      v-model="active"
+      v-model="form.state.active"
       color="primary"
       class="mt-4"
       :label="t('rpc_node_form.active')"

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeFormDialog.vue
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeFormDialog.vue
@@ -54,7 +54,7 @@ const api = useEvmNodesApi(chain);
 const { setMessage } = useMessageStore();
 
 async function save() {
-  if (!(await get(form)?.validate()))
+  if (!get(form)?.validate())
     return;
 
   const state = get(model);

--- a/frontend/app/src/modules/settings/general/rpc/blockchain-rpc-node-form.ts
+++ b/frontend/app/src/modules/settings/general/rpc/blockchain-rpc-node-form.ts
@@ -1,0 +1,82 @@
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { z, type ZodType } from 'zod';
+import { numberSettingField, textSettingField } from '@/modules/settings/controls/setting-field-schemas';
+
+export interface BlockchainRpcNodeFormState {
+  active: boolean;
+  endpoint: string;
+  name: string;
+  owned: boolean;
+  /** Text, because the slider and the numeric field edit the same value through two controls. */
+  weight: string;
+}
+
+export interface BlockchainRpcNodeFormMessages {
+  endpointRequired: string;
+  nameRequired: string;
+  weightBetween: string;
+  weightRequired: string;
+}
+
+export const MIN_WEIGHT = 0;
+
+export const MAX_WEIGHT = 100;
+
+export function toWeight(value?: string): number {
+  if (!value)
+    return 0;
+
+  const parsed = Number.parseInt(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export function stateFromNode(node: BlockchainRpcNode): BlockchainRpcNodeFormState {
+  return {
+    active: node.active,
+    endpoint: node.endpoint,
+    name: node.name,
+    owned: node.owned,
+    weight: node.weight.toString(),
+  };
+}
+
+/** The form's half of a node, ready to be merged over the one the dialog holds. */
+export function toNodeFields(state: BlockchainRpcNodeFormState): Pick<BlockchainRpcNode, 'active' | 'endpoint' | 'name' | 'owned' | 'weight'> {
+  return {
+    active: state.active,
+    endpoint: state.endpoint,
+    name: state.name,
+    owned: state.owned,
+    weight: toWeight(state.weight),
+  };
+}
+
+/**
+ * Etherscan is queried through an api key rather than a url, so it is the one node that is valid
+ * without an endpoint. It identifies itself by name, since it has no endpoint to identify it by.
+ */
+export function isEtherscanNode(state: Pick<BlockchainRpcNodeFormState, 'endpoint' | 'name'>): boolean {
+  return !state.endpoint && state.name.includes('etherscan');
+}
+
+export function blockchainRpcNodeSchema(messages: BlockchainRpcNodeFormMessages): ZodType {
+  return z.object({
+    active: z.boolean(),
+    // The endpoint rule depends on the name, so it is refined on the object rather than the field.
+    endpoint: z.string(),
+    name: textSettingField({
+      messages: { required: messages.nameRequired },
+      required: true,
+    }),
+    owned: z.boolean(),
+    weight: numberSettingField({
+      max: MAX_WEIGHT,
+      messages: { between: messages.weightBetween, required: messages.weightRequired },
+      min: MIN_WEIGHT,
+      required: true,
+    }),
+  }).superRefine((state, ctx) => {
+    if (state.endpoint.trim() === '' && !isEtherscanNode(state))
+      ctx.addIssue({ code: 'custom', message: messages.endpointRequired, path: ['endpoint'] });
+  });
+}

--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue
@@ -37,7 +37,7 @@ function edit(item: string) {
 }
 
 async function save(force: boolean = false) {
-  if (!(await get(form)?.validate()) && !force)
+  if (!get(form)?.validate() && !force)
     return;
 
   const value = get(inputUrl);

--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.spec.ts
@@ -47,16 +47,14 @@ describe('settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue', () => {
     wrapper = createWrapper('');
     await vi.advanceTimersToNextTimerAsync();
 
-    const valid = await wrapper.vm.validate();
-    expect(valid).toBe(false);
+    expect(wrapper.vm.validate()).toBe(false);
   });
 
   it('should pass validation with a non-empty url', async () => {
     wrapper = createWrapper('https://example.com');
     await vi.advanceTimersToNextTimerAsync();
 
-    const valid = await wrapper.vm.validate();
-    expect(valid).toBe(true);
+    expect(wrapper.vm.validate()).toBe(true);
   });
 
   it('should clear external error messages when the url changes', async () => {
@@ -96,7 +94,7 @@ describe('settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue', () => {
 
     expect(wrapper.find('.details .text-rui-error').exists()).toBe(false);
 
-    await wrapper.vm.validate();
+    wrapper.vm.validate();
     await nextTick();
 
     expect(wrapper.find('.details .text-rui-error').exists()).toBe(true);

--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.spec.ts
@@ -33,10 +33,12 @@ describe('settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue', () => {
         plugins: [pinia],
       },
       props: {
-        errorMessages,
-        modelValue,
+        'errorMessages': errorMessages,
+        'modelValue': modelValue,
+        'stateUpdated': false,
         'onUpdate:errorMessages': async (value: ValidationErrors): Promise<void> => wrapper.setProps({ errorMessages: value }),
         'onUpdate:modelValue': async (value: string): Promise<void> => wrapper.setProps({ modelValue: value }),
+        'onUpdate:stateUpdated': async (value: boolean): Promise<void> => wrapper.setProps({ stateUpdated: value }),
       },
     });
   }
@@ -75,5 +77,40 @@ describe('settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue', () => {
     await vi.advanceTimersToNextTimerAsync();
 
     expect(wrapper.props('errorMessages')).toEqual({ modelValue: ['Invalid endpoint'] });
+  });
+
+  it('should display an externally reported error on the field', async () => {
+    wrapper = createWrapper('https://example.com');
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.find('input').setValue('https://bad-url');
+    await wrapper.setProps({ errorMessages: { modelValue: ['Invalid endpoint'] } });
+    await nextTick();
+
+    expect(wrapper.find('.details .text-rui-error').text()).toBe('Invalid endpoint');
+  });
+
+  it('should reveal the error on the field when validation fails', async () => {
+    wrapper = createWrapper('');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.find('.details .text-rui-error').exists()).toBe(false);
+
+    await wrapper.vm.validate();
+    await nextTick();
+
+    expect(wrapper.find('.details .text-rui-error').exists()).toBe(true);
+  });
+
+  it('should report the state as updated once the url is edited', async () => {
+    wrapper = createWrapper('https://example.com');
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.props('stateUpdated')).toBe(false);
+
+    await wrapper.find('input').setValue('https://example.com/rpc');
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.props('stateUpdated')).toBe(true);
   });
 });

--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import type { RuiTextField } from '@rotki/ui-library';
+import type { ZodType } from 'zod';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import useVuelidate from '@vuelidate/core';
-import { required } from '@vuelidate/validators';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
+import { SETTING_FIELD, type SettingFieldState, textSettingSchema } from '@/modules/settings/controls/setting-field-schemas';
 
+/**
+ * The endpoint is one setting field, so it reuses the shared setting schema; the surrounding dialog
+ * owns the persist, which is why `submit` here is a no-op.
+ */
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 const modelValue = defineModel<string>({ required: true });
@@ -14,40 +16,65 @@ const { disabled = false } = defineProps<{
   disabled?: boolean;
 }>();
 
+/** The key the dialog reports its save failures under, mapped onto the single form field. */
+const ERROR_KEY = 'modelValue';
+
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  modelValue: { required },
-};
-
-const states = {
-  modelValue,
-};
-
-const v$ = useVuelidate(
-  rules,
-  states,
-  {
-    $autoDirty: true,
-    $externalResults: errors,
+const schema = computed<ZodType>(() => textSettingSchema({
+  messages: {
+    required: t('settings.validation.text.non_empty'),
   },
-);
+  required: true,
+}));
 
-useFormStateWatcher(states, stateUpdated);
+const form = useForm<SettingFieldState, SettingFieldState>({
+  initial: (): SettingFieldState => ({ value: get(modelValue) }),
+  schema,
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): SettingFieldState => ({ value: state.value }),
+});
 
-watch(modelValue, () => {
+function toMessages(value: ValidationErrors[string] | undefined): string[] {
+  if (value === undefined)
+    return [];
+
+  return (Array.isArray(value) ? value : [value]).filter(message => message !== '');
+}
+
+watch(() => form.state.value, (value) => {
+  set(modelValue, value);
   if (Object.keys(get(errors)).length > 0)
     set(errors, {});
 });
 
+// The dialog reseeds the field when it opens a different endpoint for editing.
+watch(modelValue, (value) => {
+  if (value !== form.state.value)
+    form.state.value = value;
+});
+
+watch(errors, (value) => {
+  form.setServerErrors({ [SETTING_FIELD]: toMessages(value[ERROR_KEY]) });
+}, { deep: true, immediate: true });
+
+watch(form.dirty, (dirty) => {
+  set(stateUpdated, dirty);
+});
+
+// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
+onUnmounted(() => {
+  set(stateUpdated, false);
+});
+
 defineExpose({
-  validate: async () => await get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
 <template>
   <RuiTextField
-    v-model="modelValue"
+    v-model="form.state.value"
     variant="outlined"
     color="primary"
     class="pt-2"
@@ -55,6 +82,6 @@ defineExpose({
     type="text"
     clearable
     :disabled="disabled"
-    :error-messages="toMessages(v$.modelValue)"
+    :error-messages="form.errors(SETTING_FIELD)"
   />
 </template>


### PR DESCRIPTION
Third batch of the Vuelidate -> zod migration, covering the RPC and explorer settings forms. Follows #12760 (shared setting controls) and #12770 (general display settings). Takes the app from 45 to 42 `useVuelidate` roots.

Each form is two commits: a characterization spec proven green against the Vuelidate code, then the migration, so the spec is a safety net rather than a description of the new code.

### `SimpleRpcNodeManagerForm`
Reuses `textSettingSchema` from batch 1 for its single endpoint field. `$externalResults` becomes `setServerErrors`, `useFormStateWatcher` becomes `form.dirty`, and the exposed `validate` is now synchronous.

### `ExplorerInput`
The two rules (`https` + vuelidate's `url`) become a pure `explorer-url-schema.ts`. Its spec is table-driven over every input measured against the old rules, including the ones that isolate a single rule, so neither rule can be dropped unnoticed. An empty value stays valid, since emptying the field is how an override is cleared.

**Includes a bug fix.** The clear button listened for `@click:clear`, an event `RuiTextField` does not emit (it emits `clear`). Clearing an explorer url emptied the field without saving anything, so the stale override came back on the next visit. Fixed in its own commit.

### `BlockchainRpcNodeForm`
Rules move into a pure `blockchain-rpc-node-form.ts`. Whether the endpoint is required depends on the name (etherscan is reached by api key, not a url), so that rule is refined on the object rather than the field. The `useRefPropVModel` wrappers are replaced by one form state written back to the model.

Batch 1's builders grew field-level twins (`textSettingField` / `numberSettingField`) so a multi-field form can reuse them; the existing `*SettingSchema` functions just wrap them in `z.object({ value })` and their spec passes unchanged.

### Checks

- typecheck clean
- unit: 750 files / 7118 tests pass
- lint: 0 errors, 20 warnings, matching develop's baseline exactly
- typos clean
- e2e `specs/settings/rpc` + `specs/settings/interface`: 14/14 on cleared `.e2e/data`

All re-run on the rebased tip.
