### PR TITLE
Fix the backend logout where nothing restarts, and scope the control grace

### DIFF
--- a/crates/starling-proxy/src/control.rs
+++ b/crates/starling-proxy/src/control.rs
@@ -219,6 +219,7 @@ fn session_cookie(header: &HeaderValue) -> Option<&str> {
 pub struct ControlDispatch {
     methods: Arc<[&'static str]>,
     dispatch: Arc<dyn Fn(String) -> BoxFuture + Send + Sync>,
+    is_restart: Arc<dyn Fn(&str) -> bool + Send + Sync>,
     grace: AuthGrace,
     budget: AuthBudget,
 }
@@ -231,14 +232,22 @@ impl ControlDispatch {
     /// `methods` is what the capability document advertises. The caller derives
     /// it from the authorization matrix rather than restating a list here, so the
     /// advertised surface cannot drift from the enforced one.
-    pub fn new<F, Fut>(methods: Vec<&'static str>, dispatch: F) -> Self
+    ///
+    /// `is_restart` answers "is this frame a `restart`?", which scopes the
+    /// [`AuthGrace`] window to the method it exists for. It is supplied rather than
+    /// decided here for the same reason `dispatch` is: this crate stays free of
+    /// `starling-core` and `serde_json`, and the caller can answer with the very parse
+    /// the dispatcher performs, so the two cannot disagree about what a frame is.
+    pub fn new<F, Fut, R>(methods: Vec<&'static str>, dispatch: F, is_restart: R) -> Self
     where
         F: Fn(String) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = String> + Send + 'static,
+        R: Fn(&str) -> bool + Send + Sync + 'static,
     {
         Self {
             methods: methods.into(),
             dispatch: Arc::new(move |line| Box::pin(dispatch(line)) as BoxFuture),
+            is_restart: Arc::new(is_restart),
             grace: AuthGrace::default(),
             budget: AuthBudget::default(),
         }
@@ -326,7 +335,13 @@ pub(crate) async fn rpc(State(state): State<ProxyState>, req: Request) -> Respon
         return (StatusCode::BAD_REQUEST, "control frame must be utf-8").into_response();
     };
 
-    match authorize(&state, &control.grace, &control.budget, cookie).await {
+    // The grace window exists for one sequence: a `restart` tore core down, so the retry
+    // that would fix it can no longer be authorized by core. Deciding that here, before
+    // authorization, keeps the window to that sequence — an ordinary `status` poll can no
+    // longer arm it, and it can no longer be spent on `startService`/`stopService`.
+    let is_restart = (control.is_restart)(&line);
+
+    match authorize(&state, &control.grace, &control.budget, cookie, is_restart).await {
         Authorization::Allowed => {}
         Authorization::Denied => {
             return (StatusCode::UNAUTHORIZED, "authentication required").into_response()
@@ -365,11 +380,15 @@ enum Authorization {
 
 /// Ask core whether `cookie` is a live session, falling back to [`AuthGrace`]
 /// only when core cannot answer at all.
+///
+/// `is_restart` scopes that fallback to the method it exists for: only a `restart`
+/// seeds the window, and only a `restart` may be authorized by it.
 async fn authorize(
     state: &ProxyState,
     grace: &AuthGrace,
     budget: &AuthBudget,
     cookie: Option<HeaderValue>,
+    is_restart: bool,
 ) -> Authorization {
     // No cookie at all is a denial we can make without troubling core. It also
     // never reaches the grace check: there is nothing to match against.
@@ -389,7 +408,12 @@ async fn authorize(
 
     match ask_core(state, &cookie).await {
         Authorization::Allowed => {
-            grace.remember(&cookie);
+            // Only a `restart` can leave core unreachable, so only a `restart` arms the
+            // window. Remembering every allowed call let a `status` poll arm a fallback
+            // that a later, different method could then spend.
+            if is_restart {
+                grace.remember(&cookie);
+            }
             Authorization::Allowed
         }
         // Core is alive and said no. Drop any remembered validation immediately,
@@ -403,8 +427,10 @@ async fn authorize(
         // down and the one useful action is to retry the restart. Honour a
         // validation core itself granted moments ago, and nothing else.
         Authorization::Unavailable => {
-            if grace.honours(&cookie) {
-                warn!("core is unreachable; authorizing control from the recent-validation grace");
+            if is_restart && grace.honours(&cookie) {
+                warn!(
+                    "core is unreachable; authorizing a restart from the recent-validation grace"
+                );
                 Authorization::Allowed
             } else {
                 Authorization::Unavailable

--- a/crates/starling-proxy/src/lib.rs
+++ b/crates/starling-proxy/src/lib.rs
@@ -1755,9 +1755,13 @@ mod tests {
     }
 
     fn echo_dispatch() -> ControlDispatch {
-        ControlDispatch::new(vec!["status", "restart"], |line| async move {
-            format!("dispatched:{line}")
-        })
+        ControlDispatch::new(
+            vec!["status", "restart"],
+            |line| async move { format!("dispatched:{line}") },
+            // Mirrors what `starling`'s dispatcher answers, without pulling a JSON
+            // parser into this crate's tests: these frames are built here.
+            |line: &str| line.contains("\"method\":\"restart\""),
+        )
     }
 
     fn control_post(body: &str) -> Request {
@@ -2154,13 +2158,19 @@ mod tests {
         let app = control_router(port, Some(echo_dispatch()));
 
         app.clone()
-            .oneshot(control_post_with("rotki_session=live", "{}"))
+            .oneshot(control_post_with(
+                "rotki_session=live",
+                r#"{"method":"restart"}"#,
+            ))
             .await
             .unwrap();
 
         core.set(None);
         let resp = app
-            .oneshot(control_post_with("theme=dark; rotki_session=live", "{}"))
+            .oneshot(control_post_with(
+                "theme=dark; rotki_session=live",
+                r#"{"method":"restart"}"#,
+            ))
             .await
             .unwrap();
         assert_eq!(
@@ -2176,7 +2186,10 @@ mod tests {
         let app = control_router(port, Some(echo_dispatch()));
 
         app.clone()
-            .oneshot(control_post_with("rotki_session=live", "{}"))
+            .oneshot(control_post_with(
+                "rotki_session=live",
+                r#"{"method":"restart"}"#,
+            ))
             .await
             .unwrap();
 
@@ -2184,7 +2197,10 @@ mod tests {
         core.set(None);
         let resp = app
             .clone()
-            .oneshot(control_post_with("rotki_session=other", "{}"))
+            .oneshot(control_post_with(
+                "rotki_session=other",
+                r#"{"method":"restart"}"#,
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
@@ -2198,14 +2214,20 @@ mod tests {
         let app = control_router(port, Some(echo_dispatch()));
 
         app.clone()
-            .oneshot(control_post_with("rotki_session=live", "{}"))
+            .oneshot(control_post_with(
+                "rotki_session=live",
+                r#"{"method":"restart"}"#,
+            ))
             .await
             .unwrap();
 
         core.set(Some(StatusCode::UNAUTHORIZED));
         let resp = app
             .clone()
-            .oneshot(control_post_with("rotki_session=live", "{}"))
+            .oneshot(control_post_with(
+                "rotki_session=live",
+                r#"{"method":"restart"}"#,
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
@@ -2213,7 +2235,10 @@ mod tests {
         core.set(None);
         let resp = app
             .clone()
-            .oneshot(control_post_with("rotki_session=live", "{}"))
+            .oneshot(control_post_with(
+                "rotki_session=live",
+                r#"{"method":"restart"}"#,
+            ))
             .await
             .unwrap();
         assert_eq!(
@@ -2221,6 +2246,71 @@ mod tests {
             StatusCode::SERVICE_UNAVAILABLE,
             "a revoked session must not be resurrected by core going down"
         );
+    }
+
+    #[tokio::test]
+    async fn a_status_call_does_not_arm_the_grace() {
+        // The window exists for the retry that recovers a failed restart, so only a
+        // restart may arm it. Arming on any allowed call meant the SPA's routine status
+        // poll left a fallback behind that a later, different method could spend.
+        let (port, core) = spawn_switchable_core(StatusCode::OK).await;
+        let app = control_router(port, Some(echo_dispatch()));
+
+        app.clone()
+            .oneshot(control_post_with(
+                "rotki_session=live",
+                r#"{"method":"status"}"#,
+            ))
+            .await
+            .unwrap();
+
+        core.set(None);
+        let resp = app
+            .oneshot(control_post_with(
+                "rotki_session=live",
+                r#"{"method":"restart"}"#,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "only a restart may leave a window behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_grace_authorizes_nothing_but_a_restart() {
+        // Even a window a restart armed itself must not be spendable on another method:
+        // during an outage the only capability it may confer is restarting something
+        // that is already down.
+        let (port, core) = spawn_switchable_core(StatusCode::OK).await;
+        let app = control_router(port, Some(echo_dispatch()));
+
+        app.clone()
+            .oneshot(control_post_with(
+                "rotki_session=live",
+                r#"{"method":"restart"}"#,
+            ))
+            .await
+            .unwrap();
+
+        core.set(None);
+        for method in ["status", "startService", "stopService"] {
+            let resp = app
+                .clone()
+                .oneshot(control_post_with(
+                    "rotki_session=live",
+                    &format!(r#"{{"method":"{method}"}}"#),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::SERVICE_UNAVAILABLE,
+                "{method} must not ride the restart grace window"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/starling/src/control/jsonrpc.rs
+++ b/crates/starling/src/control/jsonrpc.rs
@@ -111,6 +111,19 @@ fn to_value<T: Serialize>(value: T) -> Value {
     serde_json::to_value(value).unwrap_or(Value::Null)
 }
 
+/// Whether `line` asks for `restart`.
+///
+/// The HTTP control endpoint needs this *before* it authorizes, to scope its
+/// unreachable-core grace window to the one method that window exists for. It is
+/// decided by the same parse `handle_line` uses, so what authorization believes it is
+/// allowing and what the dispatcher then executes cannot drift apart. A frame that does
+/// not parse is not a restart, which is the safe answer: it neither seeds nor spends the
+/// window, and the dispatcher still rejects it on its own terms.
+pub fn is_restart_frame(line: &str) -> bool {
+    serde_json::from_str::<Request>(line)
+        .is_ok_and(|request| request.method == Method::Restart.wire())
+}
+
 /// Parse one NDJSON line, route it to the control handle, and render the reply
 /// line. Returns the serialized response (always, for our request/response
 /// clients). Never panics: malformed input becomes a JSON-RPC error response.
@@ -308,6 +321,29 @@ mod tests {
         let out = parse(&handle_line(&handle, Transport::Stdio, "{not json").await);
         assert_eq!(out["error"]["code"], PARSE_ERROR);
         assert_eq!(out["id"], Value::Null);
+    }
+
+    #[test]
+    fn only_a_restart_frame_is_recognised_as_one() {
+        // What the HTTP control endpoint scopes its grace window on. A frame it cannot
+        // read has to answer `false`: that neither arms nor spends the window, which is
+        // the safe direction, and the dispatcher still refuses the frame on its own.
+        assert!(is_restart_frame(
+            &json!({"jsonrpc":"2.0","id":1,"method":"restart"}).to_string()
+        ));
+        assert!(is_restart_frame(&json!({"method":"restart"}).to_string()));
+
+        for line in [
+            json!({"method":"status"}).to_string(),
+            json!({"method":"startService"}).to_string(),
+            json!({"method":"stopService"}).to_string(),
+            json!({"method":"Restart"}).to_string(),
+            json!({"id":1}).to_string(),
+            "{not json".to_owned(),
+            String::new(),
+        ] {
+            assert!(!is_restart_frame(&line), "{line} is not a restart");
+        }
     }
 
     #[tokio::test]

--- a/crates/starling/src/main.rs
+++ b/crates/starling/src/main.rs
@@ -880,12 +880,16 @@ async fn main() -> std::process::ExitCode {
         let control = cookie_auth.then(|| {
             let methods = http_control_methods();
             let control_handle = controller.handle();
-            starling_proxy::ControlDispatch::new(methods, move |line| {
-                let handle = control_handle.clone();
-                async move {
-                    control::jsonrpc::handle_line(&handle, Transport::HttpControl, &line).await
-                }
-            })
+            starling_proxy::ControlDispatch::new(
+                methods,
+                move |line| {
+                    let handle = control_handle.clone();
+                    async move {
+                        control::jsonrpc::handle_line(&handle, Transport::HttpControl, &line).await
+                    }
+                },
+                control::jsonrpc::is_restart_frame,
+            )
         });
         let config = ProxyConfig {
             port,

--- a/frontend/app/src/modules/shell/app/use-backend-reload.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-reload.spec.ts
@@ -92,15 +92,20 @@ describe('useBackendReload', () => {
     expect(notify.mock.calls[0][0].message).toContain('control is rate-limited; retry shortly');
   });
 
-  // No runtime could restart anything, which is how the plain web build has always
-  // behaved. The change was still applied, so the flow completes as it always did.
-  it('should complete normally where no restart is possible at all', async () => {
+  /**
+   * No runtime could restart anything, which is how the plain web build has always
+   * behaved. The change was still applied, so the flow completes as it always did - but
+   * the logout has to reach the backend. Nothing restarted, so nothing logged the user
+   * out on that side, and skipping the HTTP call left the backend holding a session the
+   * frontend had already discarded.
+   */
+  it('should still log out of the backend where no restart is possible at all', async () => {
     restartBackend.mockResolvedValue({ status: BackendRestartStatus.unavailable });
 
     const result = await useBackendReload().reload();
 
     expect(notify).not.toHaveBeenCalled();
-    expect(logout).toHaveBeenCalledWith(true, { skipBackendCall: true });
+    expect(logout).toHaveBeenCalledWith(true, { skipBackendCall: false });
     expect(connect).toHaveBeenCalled();
     expect(result.status).toBe(BackendRestartStatus.unavailable);
   });

--- a/frontend/app/src/modules/shell/app/use-backend-reload.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-reload.ts
@@ -56,11 +56,16 @@ export function useBackendReload(): UseBackendReloadReturn {
       return result;
     }
 
-    // `unavailable` lands here too, and should: no restart was possible, but the change
-    // was still applied, so the flow completes exactly as it did before this runtime
-    // could restart anything at all.
+    // Only a restart that actually happened is itself a logout: core's graceful shutdown
+    // runs `Rotkehlchen.logout()`, so calling the HTTP logout on top of it would reach a
+    // backend with nobody logged in and surface a spurious failure.
+    //
+    // `unavailable` restarted nothing. The backend is still up and still holds the
+    // session, so it needs the real logout - the one this runtime has always done. Sending
+    // `skipBackendCall` there signed the user out of the frontend alone and left the
+    // backend logged in, so the next login came back "user is already logged in".
     if (get(logged))
-      await logout(true, { skipBackendCall: true });
+      await logout(true, { skipBackendCall: result.status === BackendRestartStatus.restarted });
 
     connect();
     return result;


### PR DESCRIPTION
Two follow-ups to #12774, from a review of the outcomes the control endpoint introduced. One is a regression that PR shipped; the other is a scope that is wider than its own documentation claims.

## The backend stayed logged in where nothing could restart

A restart is itself a logout: core's graceful shutdown runs the same `Rotkehlchen.logout()` that settles the user database, so the client-side logout that follows only has to do frontend cleanup. That is what `skipBackendCall` is for.

`unavailable` took that branch too. It means no restart was possible at all — the plain web build, or docker without the session cookie configured — so nothing tore core down and nothing logged the user out on that side. Skipping the HTTP logout there signed the user out of the frontend alone and left the backend holding the session, so the next login came back "user is already logged in".

This is a regression rather than a long-standing gap. Before the restart became a real operation, `AssetUpdate` and `RestoreAssetDbButton` logged out first, unconditionally and through the API; the reordering the control endpoint needed is what dropped the call on this path.

`skipBackendCall` is now sent only for a restart that actually happened. The existing spec asserted the broken behaviour, so it is corrected rather than added to; reverting the fix fails exactly that assertion and leaves the other four passing.

## The authorization grace covered more than restart

The grace window exists for one sequence: a restart tears core down, the bring-up fails, and the retry that would fix it can no longer be authorized by core, because core is what authorizes. Without it that is a dead end reachable only with `docker exec`.

Authorization only ever received the cookie, never the method. So any allowed call armed the window — including the SPA's routine `status` poll — and once armed it authorized whatever came next while core was unreachable: `status`, `startService`, `stopService`, not only the restart it was opened for. The module comment already claimed the narrower behaviour ("Honour a validation core itself granted moments ago, and nothing else"); this makes the code match it.

It is not purely theoretical. The `Denied` branch clears the window immediately, so a revoked session cannot normally ride it, but a cookie revoked *after* its last successful call still can if core becomes unreachable before the next one returns a 401.

Whether the frame is a restart is now decided before authorization and used on both halves: only a restart arms the window, only a restart may be authorized by one.

The predicate is supplied by the caller rather than computed in the proxy, for the same reason the dispatcher is: `starling-proxy` deliberately builds without `starling-core` and without `serde_json`, and both of those are documented choices in that file. It comes from the very parse the dispatcher performs, so what authorization believes it is allowing and what then executes cannot drift apart. A frame that does not parse is not a restart, which is the safe answer: it neither arms nor spends the window, and the dispatcher still refuses it on its own terms.

## Tests

* The `unavailable` path must reach the backend logout (negative control: reverting the fix fails only this).
* A `status` call must not arm the window.
* A window a restart armed must not be spendable on `status`, `startService` or `stopService`.
* `is_restart_frame` recognises a restart and nothing else, including a case-different method, a frame with no method, malformed JSON and an empty string.
* The four existing grace tests drove the window with an empty frame, which no longer arms it. They now use a restart, which is what they always meant to exercise — they are about *which cookie* is honoured, not which method.

## Not in this PR

Two further findings from the same review are deliberately left out.

**A failed bring-up is still reported as a plain refusal.** `starling` distinguishes `RestartFailed` (the tree was torn down and did not come back) from `AlreadyStarted` and the rest, but `error_code` maps all of them to `ERR_RESTART_FAILED`, so the frontend cannot tell them apart. On the teardown case the backend session is gone while the UI stays signed in. Fixing it properly means a new wire code and a fourth restart outcome, and the right UI response to "the backend is down and is not coming back" is a product decision rather than something to settle in a follow-up patch.

**A restart does not revoke the session credentials.** Raised in review on #12774 and still true: after an asset update or restore the cookie and any MCP bearer stay valid. #12777 closed the part that mattered — a credential is refused unless its user is the unlocked one, so it cannot read another user's data — and same-user continuity across a restart was a deliberate choice, since the bearer lives in an external MCP client that should not break on every routine restart. Worth revisiting on its own if that trade-off is no longer wanted.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

Bug fixes to existing behaviour, no user-facing feature change.
