### PR TITLE
ci: SBOM and provenance attestation for docker images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,13 @@
   "dependencyDashboardAutoclose": false,
   "minimumReleaseAge": "7 days",
   "packageRules": [
+    // The runtime base is pinned by digest so the released image is byte-for-byte
+    // reproducible from the tag. Renovate keeps that digest current, otherwise the
+    // pin would silently freeze us on an unpatched distroless.
+    {
+      "matchManagers": ["dockerfile"],
+      "pinDigests": true
+    },
     // Group non-major (minor/patch) updates per subproject so the dependency
     // dashboard reads as a few per-stack buckets instead of a flat list.
     // Majors are intentionally left ungrouped (own PR each), and so are

--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -298,6 +298,7 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform.name }}
           provenance: mode=max
+          sbom: true
           build-args: |
             REVISION=${{ github.sha }}
             ROTKI_VERSION=${{ steps.rotki_version.outputs.version }}

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -547,8 +547,13 @@ jobs:
           digest=$(docker buildx imagetools inspect "${REPOSITORY}:${VERSION}" --format '{{json .Manifest}}' | jq -er '.digest')
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
+      # push-to-registry stores the attestation next to the image as an OCI
+      # referrer, so it is reachable with cosign and not only through GitHub's
+      # attestation API. Runs last: the image is already published at this point,
+      # so a referrers hiccup fails the job without leaving a half-pushed tag.
       - name: Attest the merged manifest
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-name: docker.io/${{ github.repository }}
           subject-digest: ${{ steps.inspect.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -424,9 +424,7 @@ jobs:
           - name: linux/arm64
             runner: ubuntu-24.04-arm
     permissions:
-      id-token: write
-      attestations: write
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -467,6 +465,7 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform.name }}
           provenance: mode=max
+          sbom: true
           tags: ${{ github.repository }}
           build-args: |
             REVISION=${{ github.sha }}
@@ -496,6 +495,10 @@ jobs:
     needs:
       - docker
     environment: docker
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -535,8 +538,17 @@ jobs:
             $(printf "${REPOSITORY}@sha256:%s " *)
 
       - name: Inspect image
+        id: inspect
         env:
           REPOSITORY: ${{ github.repository }}
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
           docker buildx imagetools inspect "${REPOSITORY}:${VERSION}"
+          digest=$(docker buildx imagetools inspect "${REPOSITORY}:${VERSION}" --format '{{json .Manifest}}' | jq -er '.digest')
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Attest the merged manifest
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
+        with:
+          subject-name: docker.io/${{ github.repository }}
+          subject-digest: ${{ steps.inspect.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,7 @@ RUN set -eux; \
 #     the PyInstaller bundle -- confirmed by reading the running process's memory
 #     maps, which resolve to _internal/, never /usr/lib. Copying the bundle keeps
 #     TLS working without shipping a CVE-tracked library nothing loads.
-FROM gcr.io/distroless/cc-debian12 AS runtime
+FROM gcr.io/distroless/cc-debian12:latest@sha256:e8e7ee4b8b106d4c5fde9e422a321b2b8a2d5cca546c97adcce927f3e1d36e36 AS runtime
 
 LABEL maintainer="Rotki Solutions GmbH <info@rotki.com>"
 


### PR DESCRIPTION
Adds an SBOM and a keyless provenance attestation to published docker images, and pins the runtime base by digest.

### What changes

- **`rotki_release.yaml`** — `sbom: true` on the per-platform build, and `actions/attest-build-provenance` against the **merged manifest digest** in `docker-merge` with `push-to-registry: true`. The attestation belongs in `docker-merge` because the per-platform digests are intermediate (`push-by-digest=true`); the merged manifest is the digest users actually pull. Its `id-token`/`attestations` permissions move there too, and the per-platform job drops the `id-token`, `attestations` and `contents: write` it never used.
- **`rotki_dev_builds.yml`** — `sbom: true` only. Nightly/edge images get an SBOM but no attestation.
- **`Dockerfile` + `renovate.json5`** — the distroless runtime base was floating on `:latest`. Pinned by digest, with `pinDigests` enabled for the dockerfile manager so renovate bumps the pin instead of it going stale on an unpatched base.

Keyless throughout: the attestation is signed with a short-lived Sigstore certificate minted from the job's OIDC token. **No new secrets**, nothing to rotate. This is deliberately not `cosign sign --key`, which needs a long-lived private key in repo secrets and proves only key possession rather than which commit and workflow produced the image. `cosign verify-attestation` works against what this publishes anyway, via the registry referrer.

### Verified locally

- `actionlint` on both workflows — only pre-existing shellcheck style warnings, none in the new steps.
- The digest capture, run against the real published `rotki/rotki:v1.43.2` with buildx 0.36:
  ```
  $ docker buildx imagetools inspect rotki/rotki:v1.43.2 --format '{{json .Manifest}}' | jq -er .digest
  sha256:4191bb890aa1ad39e84df5072d4c4d34c44c1736376706aaea0e540664aa7ab1
  ```
  `jq -e` fails loudly on a null rather than attesting a wrong digest.
- The current release already carries attestation manifests that survive `imagetools create`, so `sbom: true` is additive to a path that works today:
  ```
  linux/arm64      image
  unknown/unknown  attestation-manifest
  linux/amd64      image
  unknown/unknown  attestation-manifest
  ```
  `.SBOM` is `{}` on v1.43.2 today; `.Provenance` is populated.
- The pinned distroless digest resolves with `linux/amd64` and `linux/arm64` both present in the index.
- The pin is a no-op today: it is exactly what `:latest` currently resolves to, so this build is byte-identical to an unpinned one.

### Not verified — please read before merging

**The attestation half has never been executed.** `docker-merge` in the release workflow only runs on `push: tags` and the attestation needs that job's OIDC token, so there is no dry run. A push to `build` exercises the SBOM and the pinned base, but **not** the attestation. Specifically still unknown:

1. Whether `push-to-registry: true` works against Docker Hub (needs the referrers API).
2. Whether `subject-name: docker.io/rotki/rotki` is the form the action expects.
3. Whether `gh attestation verify oci://...` resolves afterwards.
4. Whether `rotki/rotki:latest` keeps the referrer, since it is produced by `regctl image copy` in `rotki_docker_publish.yaml` rather than by the release build.

Blast radius if any of those fail: the attest step is the **last** step of `docker-merge`, after tags are pushed. A failure gives a red run with correct images already published, and a rerun is idempotent. It cannot ship a broken image.

If you would rather not find this out on a live release, these can all be exercised ahead of time with a tag on a fork, which pushes to a different Docker Hub repo and never touches `rotki/rotki`. Happy to do that first if preferred.

### Follow-ups (not in this PR)

- **Docs.** `rotki/docs` → `requirement-and-installation/verify.md` needs a Docker section. It must carry a version floor, because verification fails on every image published to date and "no attestation found" reads identically to tampering. `nightly`/`edge` carry an SBOM but are not attested.
- The SBOM covers image layers. The Python backend ships as a PyInstaller bundle and colibri as a static Rust binary, so their dependencies do not decompose into per-package entries. A full dependency inventory would need `uv export` / `cargo cyclonedx` attached separately.
- Publishing to GHCR alongside Docker Hub using only `GITHUB_TOKEN` would give users an escape from Docker Hub pull limits and a registry with first-class referrer support.
