### PR TITLE
Migrate the data security settings forms to zod

### DIFF
--- a/frontend/app/src/modules/settings/HideSmallBalances.spec.ts
+++ b/frontend/app/src/modules/settings/HideSmallBalances.spec.ts
@@ -1,0 +1,131 @@
+import { DOMWrapper, flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, assert, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import HideSmallBalances from '@/modules/settings/HideSmallBalances.vue';
+import { BalanceSource } from '@/modules/settings/types/frontend-settings';
+
+const { updateFrontendSetting } = vi.hoisted(() => ({
+  updateFrontendSetting: vi.fn(),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): { updateFrontendSetting: typeof updateFrontendSetting } => ({ updateFrontendSetting }),
+}));
+
+type HideSmallBalancesInstance = InstanceType<typeof HideSmallBalances>;
+
+describe('settings/HideSmallBalances.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<HideSmallBalancesInstance>;
+
+  beforeAll(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  beforeEach(() => {
+    updateFrontendSetting.mockReset();
+    updateFrontendSetting.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    // The menu is teleported into the body; leaving it behind would let the next test find a stale
+    // control and pass without rendering anything of its own.
+    document.body.innerHTML = '';
+  });
+
+  /** The controls live in a menu, so it has to be opened before anything is reachable. */
+  async function createWrapper(): Promise<VueWrapper<HideSmallBalancesInstance>> {
+    const mounted = mount(HideSmallBalances, {
+      attachTo: document.body,
+      global: {
+        plugins: [pinia],
+      },
+      props: {
+        source: BalanceSource.BLOCKCHAIN,
+      },
+    });
+
+    await mounted.find('button').trigger('click');
+    await vi.waitUntil(() => document.body.querySelector('[data-testid=hide-small-balances-apply]') !== null);
+    return mounted;
+  }
+
+  /** The menu content is teleported out of the wrapper, so it is reached through the document. */
+  function inBody<T extends Element>(selector: string): DOMWrapper<T> {
+    const element = document.body.querySelector<T>(selector);
+    assert(element, `${selector} is not rendered`);
+    return new DOMWrapper(element);
+  }
+
+  function thresholdInput(): DOMWrapper<HTMLInputElement> {
+    return inBody<HTMLInputElement>('[data-testid=hide-small-balances-threshold] input');
+  }
+
+  function hideToggle(): DOMWrapper<HTMLInputElement> {
+    return inBody<HTMLInputElement>('[data-testid=hide-small-balances-toggle] input');
+  }
+
+  function applyButton(): DOMWrapper<HTMLButtonElement> {
+    return inBody<HTMLButtonElement>('[data-testid=hide-small-balances-apply]');
+  }
+
+  function hasError(): boolean {
+    return document.body.querySelector('[data-testid=hide-small-balances-threshold] .text-rui-error') !== null;
+  }
+
+  it('should apply the threshold to every source by default', async () => {
+    wrapper = await createWrapper();
+
+    await hideToggle().setValue(true);
+    await thresholdInput().setValue('5');
+    await applyButton().trigger('click');
+    await flushPromises();
+
+    expect(updateFrontendSetting).toHaveBeenCalledWith({
+      balanceValueThreshold: {
+        [BalanceSource.BLOCKCHAIN]: '5',
+        [BalanceSource.EXCHANGES]: '5',
+        [BalanceSource.MANUAL]: '5',
+      },
+    });
+  });
+
+  it('should clear every threshold when hiding is switched off', async () => {
+    wrapper = await createWrapper();
+
+    await applyButton().trigger('click');
+    await flushPromises();
+
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ balanceValueThreshold: {} });
+  });
+
+  it('should reject a negative threshold', async () => {
+    wrapper = await createWrapper();
+
+    await hideToggle().setValue(true);
+    await thresholdInput().setValue('-1');
+
+    expect(hasError()).toBe(true);
+
+    await applyButton().trigger('click');
+    await flushPromises();
+
+    expect(updateFrontendSetting).not.toHaveBeenCalled();
+  });
+
+  it('should reject an empty threshold', async () => {
+    wrapper = await createWrapper();
+
+    await hideToggle().setValue(true);
+    await thresholdInput().setValue('');
+
+    expect(hasError()).toBe(true);
+
+    await applyButton().trigger('click');
+    await flushPromises();
+
+    expect(updateFrontendSetting).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/settings/HideSmallBalances.vue
+++ b/frontend/app/src/modules/settings/HideSmallBalances.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { minValue, required } from '@vuelidate/validators';
-import { omit } from 'es-toolkit';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import type { ZodType } from 'zod';
+import { useForm } from '@/modules/core/form/use-form';
+import {
+  DEFAULT_THRESHOLD,
+  type HideSmallBalancesFormState,
+  hideSmallBalancesSchema,
+  toThresholds,
+} from '@/modules/settings/hide-small-balances-form';
 import { BalanceSource, type BalanceValueThreshold } from '@/modules/settings/types/frontend-settings';
 import { useSetting } from '@/modules/settings/use-setting';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
@@ -17,9 +21,6 @@ const { source } = defineProps<{
 const { t } = useI18n({ useScope: 'global' });
 
 const open = ref<boolean>(false);
-const hide = ref<boolean>(false);
-const hideBelow = ref<string>('1');
-const applyToAllBalances = ref<boolean>(true);
 
 const currencySymbol = useSetting('currencySymbol');
 const balanceValueThreshold = useSetting('balanceValueThreshold');
@@ -30,87 +31,60 @@ const isManualBalancesLoading = useIsActive(ActivityKind.MANUAL_BALANCES);
 const isExchangeLoading = useIsActive(ActivityKind.EXCHANGE_BALANCES);
 const isQueryingBlockchain = useIsActive(ActivityKind.BLOCKCHAIN_BALANCES);
 
-const v$ = useVuelidate(
-  {
-    hideBelow: {
-      minValue: minValue(0),
-      required,
-    },
-  },
-  {
-    hideBelow,
-  },
-  {
-    $autoDirty: true,
-  },
-);
+const schema = computed<ZodType>(() => hideSmallBalancesSchema({
+  min: t('settings.validation.number.min', { min: 0 }),
+  required: t('settings.validation.number.non_empty'),
+}));
 
-const loading = computed(() => {
+const form = useForm<HideSmallBalancesFormState, BalanceValueThreshold>({
+  initial: (): HideSmallBalancesFormState => ({
+    applyToAllBalances: true,
+    hide: false,
+    hideBelow: DEFAULT_THRESHOLD,
+  }),
+  schema,
+  submit: async (payload: BalanceValueThreshold): Promise<{ success: boolean }> => {
+    await updateFrontendSetting({ balanceValueThreshold: payload });
+    return { success: true };
+  },
+  transform: (state): BalanceValueThreshold => toThresholds(state, source, get(balanceValueThreshold)),
+});
+
+const loading = computed<boolean>(() => {
   const loadingStates = {
     [BalanceSource.BLOCKCHAIN]: get(isQueryingBlockchain),
     [BalanceSource.EXCHANGES]: get(isExchangeLoading),
     [BalanceSource.MANUAL]: get(isManualBalancesLoading),
   };
 
-  return get(applyToAllBalances)
+  return form.state.applyToAllBalances
     ? Object.values(loadingStates).some(Boolean)
     : loadingStates[source];
 });
 
-const hint = computed(() => {
-  if (get(hideBelow) !== '0') {
+const hint = computed<string>(() => {
+  if (form.state.hideBelow !== '0') {
     return t('hide_small_balances.hint', {
       symbol: get(currencySymbol),
-      value: get(hideBelow),
+      value: form.state.hideBelow,
     });
   }
   return t('hide_small_balances.hint_zero');
 });
 
-async function applyChanges(): Promise<void> {
-  if (!(await get(v$).$validate())) {
-    return;
-  }
-  const usedNumber = get(hide) ? get(hideBelow) : undefined;
-  let newState: BalanceValueThreshold;
-
-  if (get(applyToAllBalances)) {
-    newState = usedNumber
-      ? {
-          [BalanceSource.BLOCKCHAIN]: usedNumber,
-          [BalanceSource.EXCHANGES]: usedNumber,
-          [BalanceSource.MANUAL]: usedNumber,
-        }
-      : {};
-  }
-  else {
-    newState = {
-      ...omit(get(balanceValueThreshold), [source]),
-      ...(usedNumber ? { [source]: usedNumber } : {}),
-    };
-  }
-
-  updateFrontendSetting({ balanceValueThreshold: newState });
-}
-
-watchImmediate([balanceValueThreshold, open], ([balanceValueThreshold]) => {
-  const data = balanceValueThreshold[source];
-
-  if (data) {
-    set(hide, true);
-    set(hideBelow, data);
-  }
-  else {
-    set(hide, false);
-    set(hideBelow, '1');
-  }
+watchImmediate([balanceValueThreshold, open], ([thresholds]) => {
+  const threshold = thresholds[source];
+  form.state.hide = Boolean(threshold);
+  form.state.hideBelow = threshold ?? DEFAULT_THRESHOLD;
 });
 
-watch(hide, (hide) => {
-  if (!hide) {
-    set(hideBelow, '1');
-  }
-  get(v$).$reset();
+watch(() => form.state.hide, (hide) => {
+  // Switching hiding off puts the field back to a value that cannot be blocking the save.
+  form.reset({
+    applyToAllBalances: form.state.applyToAllBalances,
+    hide,
+    hideBelow: hide ? form.state.hideBelow : DEFAULT_THRESHOLD,
+  });
 });
 </script>
 
@@ -131,25 +105,28 @@ watch(hide, (hide) => {
     </template>
     <div class="p-3 pt-4 flex flex-col gap-3">
       <RuiSwitch
-        v-model="hide"
+        v-model="form.state.hide"
         class="mb-2"
         size="sm"
+        data-testid="hide-small-balances-toggle"
         :label="t('hide_small_balances.hide')"
         hide-details
         color="primary"
       />
       <RuiTextField
-        v-model="hideBelow"
+        v-model="form.state.hideBelow"
+        data-testid="hide-small-balances-threshold"
         :label="t('hide_small_balances.hide_under')"
         variant="outlined"
         color="primary"
         min="0"
         step="0.1"
-        :disabled="!hide"
+        :disabled="!form.state.hide"
         type="number"
         :hint="hint"
-        :error-messages="toMessages(v$.hideBelow)"
+        :error-messages="form.errors('hideBelow')"
         dense
+        @update:model-value="form.touch('hideBelow')"
       >
         <template #prepend>
           {{ t('hide_small_balances.lt') }}
@@ -160,7 +137,7 @@ watch(hide, (hide) => {
       </RuiTextField>
       <div class="flex gap-2 items-center">
         <RuiCheckbox
-          v-model="applyToAllBalances"
+          v-model="form.state.applyToAllBalances"
           hide-details
           :disabled="loading"
           color="primary"
@@ -176,7 +153,8 @@ watch(hide, (hide) => {
         <RuiButton
           :loading="loading"
           color="primary"
-          @click="applyChanges()"
+          data-testid="hide-small-balances-apply"
+          @click="form.submit()"
         >
           {{ t('hide_small_balances.apply_changes') }}
         </RuiButton>

--- a/frontend/app/src/modules/settings/data-security/ChangePassword.spec.ts
+++ b/frontend/app/src/modules/settings/data-security/ChangePassword.spec.ts
@@ -1,0 +1,108 @@
+import { type DOMWrapper, flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import ChangePassword from '@/modules/settings/data-security/ChangePassword.vue';
+
+const { changePassword } = vi.hoisted(() => ({
+  changePassword: vi.fn(),
+}));
+
+vi.mock('@/modules/auth/use-change-password', () => ({
+  useChangePassword: (): { changePassword: typeof changePassword } => ({ changePassword }),
+}));
+
+type ChangePasswordInstance = InstanceType<typeof ChangePassword>;
+
+describe('settings/data-security/ChangePassword.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<ChangePasswordInstance>;
+
+  beforeAll(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  beforeEach(() => {
+    changePassword.mockReset();
+    changePassword.mockResolvedValue({ success: true });
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function createWrapper(): VueWrapper<ChangePasswordInstance> {
+    return mount(ChangePassword, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+  }
+
+  function field(name: 'current-password' | 'new-password' | 'confirm-password'): DOMWrapper<HTMLInputElement> {
+    return wrapper.find<HTMLInputElement>(`[data-cy=${name}] input`);
+  }
+
+  function submitButton(): DOMWrapper<HTMLButtonElement> {
+    return wrapper.find<HTMLButtonElement>('[data-cy=change-password-button]');
+  }
+
+  async function fill(current: string, next: string, confirm: string): Promise<void> {
+    await field('current-password').setValue(current);
+    await field('new-password').setValue(next);
+    await field('confirm-password').setValue(confirm);
+  }
+
+  it('should disable the submit button until every field is filled', async () => {
+    wrapper = createWrapper();
+
+    expect(submitButton().attributes('disabled')).toBeDefined();
+
+    await fill('old', 'new', 'new');
+
+    expect(submitButton().attributes('disabled')).toBeUndefined();
+  });
+
+  it('should reject a confirmation that does not match the new password', async () => {
+    wrapper = createWrapper();
+
+    await fill('old', 'new', 'different');
+
+    expect(wrapper.find('[data-cy=confirm-password] .details .text-rui-error').text())
+      .toBe('change_password.validation.password_mismatch');
+    expect(submitButton().attributes('disabled')).toBeDefined();
+  });
+
+  it('should submit the current and the new password', async () => {
+    wrapper = createWrapper();
+
+    await fill('old', 'new', 'new');
+    await wrapper.find('form').trigger('submit');
+
+    expect(changePassword).toHaveBeenCalledWith({ currentPassword: 'old', newPassword: 'new' });
+  });
+
+  it('should clear the form once the password was changed', async () => {
+    wrapper = createWrapper();
+
+    await fill('old', 'new', 'new');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(field('current-password').element.value).toBe('');
+    expect(field('new-password').element.value).toBe('');
+    expect(field('confirm-password').element.value).toBe('');
+  });
+
+  it('should keep what was typed when the change failed', async () => {
+    changePassword.mockResolvedValue({ message: 'wrong password', success: false });
+    wrapper = createWrapper();
+
+    await fill('old', 'new', 'new');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(field('current-password').element.value).toBe('old');
+    expect(field('new-password').element.value).toBe('new');
+  });
+});

--- a/frontend/app/src/modules/settings/data-security/ChangePassword.vue
+++ b/frontend/app/src/modules/settings/data-security/ChangePassword.vue
@@ -1,53 +1,45 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, required, sameAs } from '@vuelidate/validators';
+import type { ZodType } from 'zod';
 import { useChangePassword } from '@/modules/auth/use-change-password';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
 import { usePremiumStore } from '@/modules/premium/use-premium-store';
 import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
-
-const currentPassword = ref<string>('');
-const newPassword = ref<string>('');
-const newPasswordConfirm = ref<string>('');
-const loading = ref<boolean>(false);
+import {
+  type ChangePasswordFormState,
+  changePasswordSchema,
+  emptyChangePasswordState,
+} from '@/modules/settings/data-security/change-password-form';
 
 const { t } = useI18n({ useScope: 'global' });
-
-const rules = {
-  currentPassword: {
-    required: helpers.withMessage(t('change_password.validation.empty_password'), required),
-  },
-  newPassword: {
-    required: helpers.withMessage(t('change_password.validation.empty_password'), required),
-  },
-  newPasswordConfirm: {
-    required: helpers.withMessage(t('change_password.validation.empty_confirmation'), required),
-    same: helpers.withMessage(t('change_password.validation.password_mismatch'), sameAs(newPassword)),
-  },
-};
-
-const v$ = useVuelidate(rules, { currentPassword, newPassword, newPasswordConfirm }, { $autoDirty: true });
 
 const { premiumSync } = storeToRefs(usePremiumStore());
 const { changePassword } = useChangePassword();
 
-function reset(): void {
-  set(currentPassword, '');
-  set(newPassword, '');
-  set(newPasswordConfirm, '');
-  get(v$).$reset();
-}
+const schema = computed<ZodType>(() => changePasswordSchema({
+  emptyConfirmation: t('change_password.validation.empty_confirmation'),
+  emptyPassword: t('change_password.validation.empty_password'),
+  mismatch: t('change_password.validation.password_mismatch'),
+}));
+
+const form = useForm<ChangePasswordFormState, { currentPassword: string; newPassword: string }>({
+  initial: emptyChangePasswordState,
+  schema,
+  submit: async payload => changePassword(payload),
+  transform: (state): { currentPassword: string; newPassword: string } => ({
+    currentPassword: state.currentPassword,
+    newPassword: state.newPassword,
+  }),
+});
+
+const invalid = computed<boolean>(() => !get(form.valid));
+
+const loading = computed<boolean>(() => get(form.submitting));
 
 async function change(): Promise<void> {
-  set(loading, true);
-  const result = await changePassword({
-    currentPassword: get(currentPassword),
-    newPassword: get(newPassword),
-  });
-  set(loading, false);
-
-  if (result.success)
-    reset();
+  const result = await form.submit();
+  // Only a completed change should wipe what the user typed; a rejected one is worth correcting.
+  if (result.outcome === 'success')
+    form.reset();
 }
 </script>
 
@@ -74,30 +66,33 @@ async function change(): Promise<void> {
       @submit.stop.prevent="change()"
     >
       <RuiRevealableTextField
-        v-model="currentPassword"
+        v-model="form.state.currentPassword"
         color="primary"
         data-cy="current-password"
         :label="t('change_password.labels.password')"
-        :error-messages="toMessages(v$.currentPassword)"
+        :error-messages="form.errors('currentPassword')"
         variant="outlined"
+        @update:model-value="form.touch('currentPassword')"
       />
       <RuiRevealableTextField
-        v-model="newPassword"
+        v-model="form.state.newPassword"
         color="primary"
         data-cy="new-password"
         :label="t('change_password.labels.new_password')"
         prepend-icon="lu-lock-keyhole"
-        :error-messages="toMessages(v$.newPassword)"
+        :error-messages="form.errors('newPassword')"
         variant="outlined"
+        @update:model-value="form.touch('newPassword')"
       />
       <RuiRevealableTextField
-        v-model="newPasswordConfirm"
+        v-model="form.state.newPasswordConfirm"
         color="primary"
         data-cy="confirm-password"
         :label="t('change_password.labels.confirm_password')"
         prepend-icon="lu-repeat"
-        :error-messages="toMessages(v$.newPasswordConfirm)"
+        :error-messages="form.errors('newPasswordConfirm')"
         variant="outlined"
+        @update:model-value="form.touch('newPasswordConfirm')"
       />
       <div class="flex justify-end">
         <RuiButton
@@ -105,7 +100,7 @@ async function change(): Promise<void> {
           color="primary"
           :loading="loading"
           type="submit"
-          :disabled="v$.$invalid || loading"
+          :disabled="invalid || loading"
         >
           {{ t('change_password.button') }}
         </RuiButton>

--- a/frontend/app/src/modules/settings/data-security/PasswordConfirmationSetting.spec.ts
+++ b/frontend/app/src/modules/settings/data-security/PasswordConfirmationSetting.spec.ts
@@ -1,0 +1,147 @@
+import { DOMWrapper, flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, assert, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import PasswordConfirmationSetting from '@/modules/settings/data-security/PasswordConfirmationSetting.vue';
+
+const { updateFrontendSetting } = vi.hoisted(() => ({
+  updateFrontendSetting: vi.fn(),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): { updateFrontendSetting: typeof updateFrontendSetting } => ({ updateFrontendSetting }),
+}));
+
+type SettingInstance = InstanceType<typeof PasswordConfirmationSetting>;
+
+const SECONDS_PER_DAY = 86400;
+
+describe('settings/data-security/PasswordConfirmationSetting.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<SettingInstance>;
+
+  beforeAll(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  beforeEach(() => {
+    updateFrontendSetting.mockReset();
+    updateFrontendSetting.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    // The confirm dialog is teleported into the body; a leftover one would let the next test click a
+    // stale button and pass without rendering its own.
+    document.body.innerHTML = '';
+  });
+
+  function createWrapper(): VueWrapper<SettingInstance> {
+    return mount(PasswordConfirmationSetting, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+  }
+
+  function intervalInput(): DOMWrapper<HTMLInputElement> {
+    return wrapper.find<HTMLInputElement>('[data-cy=password-confirmation-interval-input] input');
+  }
+
+  function saveButton(): DOMWrapper<HTMLButtonElement> {
+    return wrapper.find<HTMLButtonElement>('[data-cy=save-password-confirmation-settings]');
+  }
+
+  function errorMessage(): string {
+    return wrapper.find('[data-cy=password-confirmation-interval-input] .details .text-rui-error').text();
+  }
+
+  function toggle(): DOMWrapper<HTMLInputElement> {
+    return wrapper.find<HTMLInputElement>('[data-cy=enable-password-confirmation-toggle] input');
+  }
+
+  /** The confirm dialog is teleported to the body, so it is reached through the document. */
+  async function confirmDisable(): Promise<void> {
+    const confirm = document.body.querySelector<HTMLButtonElement>('[data-cy=button-confirm]');
+    assert(confirm, 'the disable warning is not showing');
+    await new DOMWrapper(confirm).trigger('click');
+    await flushPromises();
+  }
+
+  it('should not offer to save while nothing has changed', () => {
+    wrapper = createWrapper();
+
+    expect(saveButton().attributes('disabled')).toBeDefined();
+  });
+
+  it('should persist a changed interval in seconds', async () => {
+    wrapper = createWrapper();
+
+    await intervalInput().setValue('14');
+    expect(saveButton().attributes('disabled')).toBeUndefined();
+
+    await saveButton().trigger('click');
+    await flushPromises();
+
+    expect(updateFrontendSetting).toHaveBeenCalledWith({
+      enablePasswordConfirmation: true,
+      passwordConfirmationInterval: 14 * SECONDS_PER_DAY,
+    });
+  });
+
+  it('should reject an interval outside the allowed range', async () => {
+    wrapper = createWrapper();
+
+    await intervalInput().setValue('9999');
+
+    expect(errorMessage()).toBe('password_confirmation_setting.validation.range');
+    expect(saveButton().attributes('disabled')).toBeDefined();
+  });
+
+  it('should reject an empty interval', async () => {
+    wrapper = createWrapper();
+
+    await intervalInput().setValue('');
+
+    expect(errorMessage()).toBe('password_confirmation_setting.validation.range');
+    expect(saveButton().attributes('disabled')).toBeDefined();
+  });
+
+  // Turning the confirmation off weakens the account, so it goes through a ConfirmDialog rather than
+  // applying straight away.
+  it('should not disable the confirmation until the warning is accepted', async () => {
+    wrapper = createWrapper();
+
+    await toggle().setValue(false);
+
+    // The interval field follows the setting, so it staying editable is what proves nothing changed.
+    expect(intervalInput().attributes('disabled')).toBeUndefined();
+    expect(saveButton().attributes('disabled')).toBeDefined();
+  });
+
+  it('should disable the confirmation once the warning is accepted', async () => {
+    wrapper = createWrapper();
+
+    await toggle().setValue(false);
+    await confirmDisable();
+
+    expect(intervalInput().attributes('disabled')).toBeDefined();
+
+    await saveButton().trigger('click');
+    await flushPromises();
+
+    expect(updateFrontendSetting).toHaveBeenCalledWith(expect.objectContaining({
+      enablePasswordConfirmation: false,
+    }));
+  });
+
+  it('should not save an invalid interval even if the button is reached', async () => {
+    wrapper = createWrapper();
+
+    await intervalInput().setValue('9999');
+    await saveButton().trigger('click');
+    await flushPromises();
+
+    expect(updateFrontendSetting).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/settings/data-security/PasswordConfirmationSetting.vue
+++ b/frontend/app/src/modules/settings/data-security/PasswordConfirmationSetting.vue
@@ -1,12 +1,22 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { between, helpers, required } from '@vuelidate/validators';
+import type { ZodType } from 'zod';
 import { Constraints } from '@/modules/core/common/constraints';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
 import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
+import {
+  type PasswordConfirmationFormState,
+  passwordConfirmationSchema,
+  toIntervalDays,
+  toIntervalSeconds,
+} from '@/modules/settings/data-security/password-confirmation-form';
 import { useSetting } from '@/modules/settings/use-setting';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
 import ConfirmDialog from '@/modules/shell/components/dialogs/ConfirmDialog.vue';
+
+interface PasswordConfirmationPayload {
+  enablePasswordConfirmation: boolean;
+  passwordConfirmationInterval: number;
+}
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -14,47 +24,43 @@ const { updateFrontendSetting } = useSettingsOperations();
 const enablePasswordConfirmation = useSetting('enablePasswordConfirmation');
 const passwordConfirmationInterval = useSetting('passwordConfirmationInterval');
 
-const passwordConfirmationIntervalDays = ref<string>('7');
 const enabled = ref<boolean>(true);
-const loading = ref<boolean>(false);
 const showDisableWarning = ref<boolean>(false);
 
-const rules = {
-  passwordConfirmationIntervalDays: {
-    between: helpers.withMessage(
-      t('password_confirmation_setting.validation.range'),
-      between(Constraints.MIN_PASSWORD_CONFIRMATION_DAYS, Constraints.MAX_PASSWORD_CONFIRMATION_DAYS),
-    ),
-    required: helpers.withMessage(
-      t('password_confirmation_setting.validation.range'),
-      required,
-    ),
+const schema = computed<ZodType>(() => passwordConfirmationSchema(
+  get(enabled),
+  t('password_confirmation_setting.validation.range'),
+));
+
+const form = useForm<PasswordConfirmationFormState, PasswordConfirmationPayload>({
+  initial: (): PasswordConfirmationFormState => ({ intervalDays: toIntervalDays(get(passwordConfirmationInterval)) }),
+  schema,
+  submit: async (payload: PasswordConfirmationPayload): Promise<{ success: boolean }> => {
+    await updateFrontendSetting(payload);
+    return { success: true };
   },
-};
-
-const v$ = useVuelidate(rules, { passwordConfirmationIntervalDays }, { $autoDirty: true });
-
-watchImmediate([passwordConfirmationInterval, enablePasswordConfirmation], ([intervalInSeconds, enable]) => {
-  set(passwordConfirmationIntervalDays, String(intervalInSeconds / Constraints.SECONDS_PER_DAY));
-  set(enabled, enable);
+  transform: (state): PasswordConfirmationPayload => ({
+    enablePasswordConfirmation: get(enabled),
+    passwordConfirmationInterval: toIntervalSeconds(state.intervalDays),
+  }),
 });
 
+const invalid = computed<boolean>(() => !get(form.valid));
+
+const loading = computed<boolean>(() => get(form.submitting));
+
 const hasChanged = computed<boolean>(() => {
-  const currentDays = Number.parseFloat(get(passwordConfirmationIntervalDays));
+  const currentDays = Number.parseFloat(form.state.intervalDays);
   const storedDays = get(passwordConfirmationInterval) / Constraints.SECONDS_PER_DAY;
-  const intervalChanged = currentDays !== storedDays;
-  const enabledChanged = get(enabled) !== get(enablePasswordConfirmation);
-  return intervalChanged || enabledChanged;
+  return currentDays !== storedDays || get(enabled) !== get(enablePasswordConfirmation);
 });
 
 function handleToggleChange(value: boolean): void {
-  if (!value) {
-    // User is trying to disable password confirmation, show warning
+  // Turning the confirmation off weakens the account, so it is confirmed rather than just applied.
+  if (!value)
     set(showDisableWarning, true);
-  }
-  else {
+  else
     set(enabled, value);
-  }
 }
 
 function confirmDisable(): void {
@@ -66,20 +72,10 @@ function cancelDisable(): void {
   set(showDisableWarning, false);
 }
 
-async function saveSettings(): Promise<void> {
-  const isEnabled = get(enabled);
-  if (isEnabled && !await get(v$).$validate())
-    return;
-
-  set(loading, true);
-  const days = Number.parseFloat(get(passwordConfirmationIntervalDays));
-  const intervalInSeconds = Math.round(days * Constraints.SECONDS_PER_DAY);
-  await updateFrontendSetting({
-    enablePasswordConfirmation: isEnabled,
-    passwordConfirmationInterval: intervalInSeconds,
-  });
-  set(loading, false);
-}
+watchImmediate([passwordConfirmationInterval, enablePasswordConfirmation], ([intervalInSeconds, enable]) => {
+  form.state.intervalDays = toIntervalDays(intervalInSeconds);
+  set(enabled, enable);
+});
 </script>
 
 <template>
@@ -104,7 +100,7 @@ async function saveSettings(): Promise<void> {
     />
 
     <RuiTextField
-      v-model="passwordConfirmationIntervalDays"
+      v-model="form.state.intervalDays"
       variant="outlined"
       color="primary"
       type="number"
@@ -113,9 +109,10 @@ async function saveSettings(): Promise<void> {
       :max="Constraints.MAX_PASSWORD_CONFIRMATION_DAYS"
       :label="t('password_confirmation_setting.label')"
       :hint="t('password_confirmation_setting.hint')"
-      :error-messages="toMessages(v$.passwordConfirmationIntervalDays)"
+      :error-messages="form.errors('intervalDays')"
       :disabled="!enabled"
       data-cy="password-confirmation-interval-input"
+      @update:model-value="form.touch('intervalDays')"
     />
 
     <div class="flex justify-end mt-4">
@@ -123,8 +120,8 @@ async function saveSettings(): Promise<void> {
         data-cy="save-password-confirmation-settings"
         color="primary"
         :loading="loading"
-        :disabled="loading || !hasChanged || (enabled && v$.$invalid)"
-        @click="saveSettings()"
+        :disabled="loading || !hasChanged || invalid"
+        @click="form.submit()"
       >
         {{ t('common.actions.save') }}
       </RuiButton>

--- a/frontend/app/src/modules/settings/data-security/change-password-form.ts
+++ b/frontend/app/src/modules/settings/data-security/change-password-form.ts
@@ -1,0 +1,48 @@
+import { z, type ZodType } from 'zod';
+
+export interface ChangePasswordFormState {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+}
+
+export interface ChangePasswordFormMessages {
+  emptyPassword: string;
+  emptyConfirmation: string;
+  mismatch: string;
+}
+
+export function emptyChangePasswordState(): ChangePasswordFormState {
+  return {
+    currentPassword: '',
+    newPassword: '',
+    newPasswordConfirm: '',
+  };
+}
+
+/** Whitespace-only counts as missing, as the rule this replaces did. */
+function isEmpty(value: string): boolean {
+  return value.trim() === '';
+}
+
+export function changePasswordSchema(messages: ChangePasswordFormMessages): ZodType {
+  return z.object({
+    currentPassword: z.string(),
+    newPassword: z.string(),
+    newPasswordConfirm: z.string(),
+  }).superRefine((state, ctx) => {
+    if (isEmpty(state.currentPassword))
+      ctx.addIssue({ code: 'custom', message: messages.emptyPassword, path: ['currentPassword'] });
+
+    if (isEmpty(state.newPassword))
+      ctx.addIssue({ code: 'custom', message: messages.emptyPassword, path: ['newPassword'] });
+
+    if (isEmpty(state.newPasswordConfirm))
+      ctx.addIssue({ code: 'custom', message: messages.emptyConfirmation, path: ['newPasswordConfirm'] });
+
+    // Reported independently of the rule above, as vuelidate did: a blank confirmation against a
+    // filled new password is both empty and different, and both messages were shown.
+    if (state.newPasswordConfirm !== state.newPassword)
+      ctx.addIssue({ code: 'custom', message: messages.mismatch, path: ['newPasswordConfirm'] });
+  });
+}

--- a/frontend/app/src/modules/settings/data-security/password-confirmation-form.ts
+++ b/frontend/app/src/modules/settings/data-security/password-confirmation-form.ts
@@ -1,0 +1,34 @@
+import { z, type ZodType } from 'zod';
+import { Constraints } from '@/modules/core/common/constraints';
+import { numberSettingField } from '@/modules/settings/controls/setting-field-schemas';
+
+export interface PasswordConfirmationFormState {
+  /** Days, as typed. Converted to the seconds the setting stores only on save. */
+  intervalDays: string;
+}
+
+export function toIntervalSeconds(intervalDays: string): number {
+  return Math.round(Number.parseFloat(intervalDays) * Constraints.SECONDS_PER_DAY);
+}
+
+export function toIntervalDays(intervalSeconds: number): string {
+  return String(intervalSeconds / Constraints.SECONDS_PER_DAY);
+}
+
+/**
+ * The interval is only worth validating while the confirmation is on: a disabled setting is saved
+ * with whatever is in the field, exactly as before.
+ */
+export function passwordConfirmationSchema(enabled: boolean, rangeMessage: string): ZodType {
+  if (!enabled)
+    return z.object({ intervalDays: z.string() });
+
+  return z.object({
+    intervalDays: numberSettingField({
+      max: Constraints.MAX_PASSWORD_CONFIRMATION_DAYS,
+      messages: { between: rangeMessage, required: rangeMessage },
+      min: Constraints.MIN_PASSWORD_CONFIRMATION_DAYS,
+      required: true,
+    }),
+  });
+}

--- a/frontend/app/src/modules/settings/hide-small-balances-form.spec.ts
+++ b/frontend/app/src/modules/settings/hide-small-balances-form.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { toThresholds } from '@/modules/settings/hide-small-balances-form';
+import { BalanceSource } from '@/modules/settings/types/frontend-settings';
+
+const existing = {
+  [BalanceSource.BLOCKCHAIN]: '1',
+  [BalanceSource.EXCHANGES]: '2',
+};
+
+describe('settings/hide-small-balances-form', () => {
+  describe('applying to every source', () => {
+    it('should set the same threshold on all three sources', () => {
+      const thresholds = toThresholds(
+        { applyToAllBalances: true, hide: true, hideBelow: '5' },
+        BalanceSource.BLOCKCHAIN,
+        existing,
+      );
+
+      expect(thresholds).toEqual({
+        [BalanceSource.BLOCKCHAIN]: '5',
+        [BalanceSource.EXCHANGES]: '5',
+        [BalanceSource.MANUAL]: '5',
+      });
+    });
+
+    it('should clear every threshold when hiding is off', () => {
+      const thresholds = toThresholds(
+        { applyToAllBalances: true, hide: false, hideBelow: '5' },
+        BalanceSource.BLOCKCHAIN,
+        existing,
+      );
+
+      expect(thresholds).toEqual({});
+    });
+  });
+
+  describe('applying to one source', () => {
+    it('should set this source and leave the others untouched', () => {
+      const thresholds = toThresholds(
+        { applyToAllBalances: false, hide: true, hideBelow: '5' },
+        BalanceSource.BLOCKCHAIN,
+        existing,
+      );
+
+      expect(thresholds).toEqual({
+        [BalanceSource.BLOCKCHAIN]: '5',
+        [BalanceSource.EXCHANGES]: '2',
+      });
+    });
+
+    // Absence is how the setting expresses "do not hide", so the key has to go rather than be zeroed.
+    it('should drop only this source when hiding is off', () => {
+      const thresholds = toThresholds(
+        { applyToAllBalances: false, hide: false, hideBelow: '5' },
+        BalanceSource.BLOCKCHAIN,
+        existing,
+      );
+
+      expect(thresholds).toEqual({ [BalanceSource.EXCHANGES]: '2' });
+    });
+
+    it('should add a source that had no threshold before', () => {
+      const thresholds = toThresholds(
+        { applyToAllBalances: false, hide: true, hideBelow: '3' },
+        BalanceSource.MANUAL,
+        existing,
+      );
+
+      expect(thresholds).toEqual({
+        [BalanceSource.BLOCKCHAIN]: '1',
+        [BalanceSource.EXCHANGES]: '2',
+        [BalanceSource.MANUAL]: '3',
+      });
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/hide-small-balances-form.ts
+++ b/frontend/app/src/modules/settings/hide-small-balances-form.ts
@@ -1,0 +1,58 @@
+import { omit } from 'es-toolkit';
+import { z, type ZodType } from 'zod';
+import { numberSettingField } from '@/modules/settings/controls/setting-field-schemas';
+import { BalanceSource, type BalanceValueThreshold } from '@/modules/settings/types/frontend-settings';
+
+export interface HideSmallBalancesFormState {
+  hide: boolean;
+  /** The threshold as typed; the setting stores it as a string too. */
+  hideBelow: string;
+  applyToAllBalances: boolean;
+}
+
+export interface HideSmallBalancesMessages {
+  required: string;
+  min: string;
+}
+
+export const DEFAULT_THRESHOLD = '1';
+
+export function hideSmallBalancesSchema(messages: HideSmallBalancesMessages): ZodType {
+  return z.object({
+    applyToAllBalances: z.boolean(),
+    hide: z.boolean(),
+    hideBelow: numberSettingField({
+      messages: { min: messages.min, required: messages.required },
+      min: 0,
+      required: true,
+    }),
+  });
+}
+
+/**
+ * The thresholds as they should be stored. Hiding switched off clears this source (or all of them),
+ * which the setting expresses by the key being absent rather than by a zero.
+ */
+export function toThresholds(
+  state: HideSmallBalancesFormState,
+  source: BalanceSource,
+  current: BalanceValueThreshold,
+): BalanceValueThreshold {
+  const threshold = state.hide ? state.hideBelow : undefined;
+
+  if (state.applyToAllBalances) {
+    if (!threshold)
+      return {};
+
+    return {
+      [BalanceSource.BLOCKCHAIN]: threshold,
+      [BalanceSource.EXCHANGES]: threshold,
+      [BalanceSource.MANUAL]: threshold,
+    };
+  }
+
+  return {
+    ...omit(current, [source]),
+    ...(threshold ? { [source]: threshold } : {}),
+  };
+}


### PR DESCRIPTION
Fourth batch of the Vuelidate -> zod migration, covering the data security settings. Follows #12760, #12770 and #12789. Takes the app from 42 to 39 `useVuelidate` roots, and `modules/settings/` from 6 down to 3 (only `AccountingRuleForm`, `ExchangeKeysForm` and `OnboardingSettings` are left).

One commit per form, each carrying its own pure module and its own spec. Every spec was written against the Vuelidate version first and passes unchanged against the migrated one, so it pins existing behaviour rather than describing the rewrite.

### `ChangePassword`
Three rules into one pure `change-password-form.ts`. The confirmation-mismatch rule is refined on the object since it compares two fields. `required` still trims, so a whitespace-only password stays rejected, and `required`/`sameAs` still report independently, so a blank confirmation against a filled password produces both messages as before.

### `PasswordConfirmationSetting`
Reuses the shared number field for the interval. The rule stays conditional on the toggle: a disabled confirmation saves whatever is in the field, exactly as `if (isEnabled && !await $validate())` did. The new spec also covers the confirm dialog that guards turning the setting off, which had no coverage at all.

### `HideSmallBalances`
The threshold rules and the payload shape move into a pure `hide-small-balances-form.ts`, so what the setting stores for a source is derived in one place instead of being assembled in the click handler. Both the apply-to-all and the per-source path are covered.

Its menu controls are teleported out of the component and had no stable handle, so they gained `data-testid`s.

### Checks

- typecheck clean
- unit: 756 files / 7152 tests pass
- lint: 0 errors, 20 warnings, matching develop's baseline exactly
- typos clean
- e2e `specs/settings/account`: 7/7 on cleared `.e2e/data`, which exercises the real password change and the re-login that proves it

Note on coverage: the password change is covered end to end by the e2e above. `PasswordConfirmationSetting` and `HideSmallBalances` are covered by unit tests only, with the settings write mocked, so persistence for those two is not proven by a browser.
