### PR TITLE
Fix the colibri login/logout session desync

### DIFF
--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-steps.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-steps.spec.ts
@@ -250,6 +250,9 @@ describe('useUnlockSteps', () => {
       expect(result).toEqual({ ok: true, value: undefined });
       expect(runTaskResult).toHaveBeenCalled();
       expect(colibriLogin).toHaveBeenCalledWith({ password: 'p', username: 'bob' });
+      // Unlock order is core first, then colibri (locking runs the other way round).
+      expect(runTaskResult.mock.invocationCallOrder[0])
+        .toBeLessThan(colibriLogin.mock.invocationCallOrder[0]);
     });
 
     it('should return err(wrongPassword) on a non-actionable login failure', async () => {

--- a/frontend/app/src/modules/auth/use-users-api.spec.ts
+++ b/frontend/app/src/modules/auth/use-users-api.spec.ts
@@ -294,6 +294,83 @@ describe('composables/api/session/users', () => {
         password: 'colibripass',
       });
     });
+
+    it('should relock and retry when colibri still holds a db', async () => {
+      const calls: string[] = [];
+      let unlockAttempts = 0;
+
+      // colibri refuses to unlock while it holds any client, and cannot say whose it is.
+      server.use(
+        http.post(`${colibriUrl}/user`, () => {
+          calls.push('unlock');
+          unlockAttempts += 1;
+          if (unlockAttempts === 1) {
+            return HttpResponse.json({
+              result: null,
+              message: 'The DB is already unlocked',
+            }, { status: 400 });
+          }
+          return HttpResponse.json({ result: true, message: '' });
+        }),
+        http.post(`${colibriUrl}/user/logout`, () => {
+          calls.push('lock');
+          return HttpResponse.json({ result: true, message: '' });
+        }),
+      );
+
+      const { colibriLogin } = useUsersApi();
+      const result = await colibriLogin({ username: 'bob', password: 'pw' });
+
+      expect(result).toBe(true);
+      expect(calls).toEqual(['unlock', 'lock', 'unlock']);
+    });
+
+    it('should reject when the retried unlock also fails', async () => {
+      let unlockAttempts = 0;
+
+      server.use(
+        http.post(`${colibriUrl}/user`, () => {
+          unlockAttempts += 1;
+          return HttpResponse.json({
+            result: null,
+            message: 'The DB is already unlocked',
+          }, { status: 400 });
+        }),
+        http.post(`${colibriUrl}/user/logout`, () =>
+          HttpResponse.json({ result: true, message: '' })),
+      );
+
+      const { colibriLogin } = useUsersApi();
+
+      await expect(colibriLogin({ username: 'bob', password: 'pw' }))
+        .rejects
+        .toThrow('The DB is already unlocked');
+      // retried exactly once, never looped
+      expect(unlockAttempts).toBe(2);
+    });
+
+    it('should not relock when the unlock fails for another reason', async () => {
+      let lockCalled = false;
+
+      server.use(
+        http.post(`${colibriUrl}/user`, () =>
+          HttpResponse.json({
+            result: null,
+            message: 'Failed to open database at /data/users/bob/rotkehlchen.db',
+          }, { status: 400 })),
+        http.post(`${colibriUrl}/user/logout`, () => {
+          lockCalled = true;
+          return HttpResponse.json({ result: true, message: '' });
+        }),
+      );
+
+      const { colibriLogin } = useUsersApi();
+
+      await expect(colibriLogin({ username: 'bob', password: 'pw' }))
+        .rejects
+        .toThrow('Failed to open database');
+      expect(lockCalled).toBe(false);
+    });
   });
 
   describe('logout', () => {

--- a/frontend/app/src/modules/auth/use-users-api.spec.ts
+++ b/frontend/app/src/modules/auth/use-users-api.spec.ts
@@ -328,6 +328,71 @@ describe('composables/api/session/users', () => {
       });
     });
 
+    it('should lock colibri before logging out of core', async () => {
+      const calls: string[] = [];
+
+      server.use(
+        http.post(`${colibriUrl}/user/logout`, () => {
+          calls.push('colibri');
+          return HttpResponse.json({ result: true, message: '' });
+        }),
+        http.patch(`${backendUrl}/api/1/users/:username`, () => {
+          calls.push('core');
+          return HttpResponse.json({ result: true, message: '' });
+        }),
+      );
+
+      const { logout } = useUsersApi();
+      await logout('testuser');
+
+      expect(calls).toEqual(['colibri', 'core']);
+    });
+
+    it('should still log out of core when colibri is already locked', async () => {
+      let coreCalled = false;
+
+      // colibri answers 400 "DB not unlocked" whenever it holds no user db client,
+      // which is the normal state after a resumed session.
+      server.use(
+        http.post(`${colibriUrl}/user/logout`, () =>
+          HttpResponse.json({
+            result: null,
+            message: 'DB not unlocked',
+          }, { status: 400 })),
+        http.patch(`${backendUrl}/api/1/users/:username`, () => {
+          coreCalled = true;
+          return HttpResponse.json({ result: true, message: '' });
+        }),
+      );
+
+      const { logout } = useUsersApi();
+      const result = await logout('testuser');
+
+      expect(result).toBe(true);
+      expect(coreCalled).toBe(true);
+    });
+
+    it('should not log out of core when colibri fails for another reason', async () => {
+      let coreCalled = false;
+
+      server.use(
+        http.post(`${colibriUrl}/user/logout`, () =>
+          HttpResponse.json({
+            result: null,
+            message: 'Database error while closing the connection',
+          }, { status: 400 })),
+        http.patch(`${backendUrl}/api/1/users/:username`, () => {
+          coreCalled = true;
+          return HttpResponse.json({ result: true, message: '' });
+        }),
+      );
+
+      const { logout } = useUsersApi();
+
+      await expect(logout('testuser')).rejects.toThrow('Database error while closing the connection');
+      expect(coreCalled).toBe(false);
+    });
+
     it('should return true when logout returns 409 conflict', async () => {
       // Note: colibri logout uses baseURL override, so no /api/1 prefix
       server.use(

--- a/frontend/app/src/modules/auth/use-users-api.ts
+++ b/frontend/app/src/modules/auth/use-users-api.ts
@@ -6,8 +6,15 @@ import {
 } from '@/modules/auth/login';
 import { apiUrls } from '@/modules/core/api/api-urls';
 import { api } from '@/modules/core/api/rotki-api';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
 import { VALID_ACCOUNT_OPERATION_STATUS } from '@/modules/core/api/utils';
 import { type PendingTask, PendingTaskSchema } from '@/modules/core/tasks/types';
+
+/**
+ * The 400 body colibri answers with when it holds no unlocked user db
+ * (`logout_user` in `colibri/src/api/database.rs`).
+ */
+const COLIBRI_ALREADY_LOCKED = 'DB not unlocked';
 
 interface UseUsersApiReturn {
   authenticate: (credentials: BasicLoginCredentials) => Promise<void>;
@@ -46,15 +53,34 @@ export function useUsersApi(): UseUsersApiReturn {
     return loggedUsers;
   };
 
-  const colibriLogout = async (): Promise<boolean> => api.post<boolean>(
-    '/user/logout',
-    undefined,
-    {
-      baseURL: apiUrls.colibriApiUrl,
-      validStatuses: VALID_ACCOUNT_OPERATION_STATUS,
-      treat409AsSuccess: true,
-    },
-  );
+  /**
+   * Lock colibri's copy of the user db. Treats "already locked" as success: that is
+   * precisely the state this call aims for, and it is reached on every ordinary path —
+   * a resumed session (page reload while logged in) never unlocks colibri at all.
+   *
+   * Without this, the throw stops `logout` before it reaches core — colibri is locked
+   * first by design — so core keeps the session, `/users` still reports `loggedin`, and
+   * the user is stuck on "Logout failed / DB not unlocked" with no way out. Any other
+   * colibri failure still rejects: an account is locked only once both are locked.
+   */
+  const colibriLogout = async (): Promise<boolean> => {
+    try {
+      return await api.post<boolean>(
+        '/user/logout',
+        undefined,
+        {
+          baseURL: apiUrls.colibriApiUrl,
+          validStatuses: VALID_ACCOUNT_OPERATION_STATUS,
+          treat409AsSuccess: true,
+        },
+      );
+    }
+    catch (error: unknown) {
+      if (error instanceof ApiValidationError && error.message === COLIBRI_ALREADY_LOCKED)
+        return true;
+      throw error;
+    }
+  };
 
   const logout = async (username: string): Promise<boolean> => {
     await colibriLogout();

--- a/frontend/app/src/modules/auth/use-users-api.ts
+++ b/frontend/app/src/modules/auth/use-users-api.ts
@@ -16,6 +16,12 @@ import { type PendingTask, PendingTaskSchema } from '@/modules/core/tasks/types'
  */
 const COLIBRI_ALREADY_LOCKED = 'DB not unlocked';
 
+/**
+ * The 400 body colibri answers with when it already holds an unlocked user db,
+ * whoever it belongs to (`unlock_user` in `colibri/src/api/database.rs`).
+ */
+const COLIBRI_ALREADY_UNLOCKED = 'The DB is already unlocked';
+
 interface UseUsersApiReturn {
   authenticate: (credentials: BasicLoginCredentials) => Promise<void>;
   createAccount: (payload: CreateAccountPayload) => Promise<PendingTask>;
@@ -153,7 +159,7 @@ export function useUsersApi(): UseUsersApiReturn {
     return PendingTaskSchema.parse(response);
   };
 
-  const colibriLogin = async (payload: BasicLoginCredentials): Promise<boolean> => api.post<boolean>(
+  const unlockColibri = async (payload: BasicLoginCredentials): Promise<boolean> => api.post<boolean>(
     '/user',
     payload,
     {
@@ -161,6 +167,38 @@ export function useUsersApi(): UseUsersApiReturn {
       validStatuses: VALID_ACCOUNT_OPERATION_STATUS,
     },
   );
+
+  /**
+   * Unlock colibri's copy of the user db, relocking first if it still holds one.
+   *
+   * Colibri refuses to unlock while it holds any client and cannot say whose db that
+   * is: `unlock_user` never records the username, so a stale handle from a previous
+   * session and one belonging to another user are indistinguishable from here. Taking
+   * it fresh with our own credentials is the only way to know colibri ends up serving
+   * the user we just logged in as — colibri's gate authorizes any live session, so a
+   * handle left open would otherwise serve the previous user's assets to this one.
+   *
+   * Safe because this only ever runs on a fresh login or account creation, and core
+   * 409s those while any user is logged in. So core holds no unlocked user at this
+   * point, and whatever db colibri still has open is a leftover from a session that
+   * has already ended — never a live one. A resumed session takes the other branch and
+   * does not come through here at all. Should core ever allow two users to be logged
+   * in at once, this has to grow a real identity check before it relocks.
+   *
+   * Retried once. A second refusal is a genuine failure and rejects.
+   */
+  const colibriLogin = async (payload: BasicLoginCredentials): Promise<boolean> => {
+    try {
+      return await unlockColibri(payload);
+    }
+    catch (error: unknown) {
+      if (!(error instanceof ApiValidationError) || error.message !== COLIBRI_ALREADY_UNLOCKED)
+        throw error;
+
+      await colibriLogout();
+      return unlockColibri(payload);
+    }
+  };
 
   const changeUserPassword = async (username: string, currentPassword: string, newPassword: string): Promise<true> => api.patch<true>(
     `/users/${username}/password`,

--- a/frontend/app/tests/e2e/specs/app/colibri-session-sync.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/colibri-session-sync.spec.ts
@@ -1,0 +1,98 @@
+import { type APIRequestContext, type BrowserContext, expect, type Page, request } from '@playwright/test';
+import { backendUrl, colibriUrl } from '../../../../playwright.config';
+import { isCoverageEnabled, startCoverage, stopCoverage } from '../../coverage';
+import { test } from '../../fixtures/test-fixtures';
+import { TEST_TIMEOUT_STANDARD } from '../../helpers/constants';
+import { generateUsername } from '../../helpers/utils';
+import { RotkiApp } from '../../pages/rotki-app';
+
+// Core and colibri each hold their own view of the logged-in user, and colibri answers 400 to
+// both of its own no-ops: locking while it holds nothing, and unlocking while it holds
+// anything. Either one used to abort the flow that wraps it, stranding the app half-unlocked —
+// logged into core with colibri locked, which is unrecoverable without restarting the backend.
+//
+// These drive the real UI against a real colibri, putting it into each state out of band first,
+// because nothing in the app can produce them on demand.
+test.describe.serial('colibri session sync', () => {
+  test.setTimeout(TEST_TIMEOUT_STANDARD);
+
+  let username: string;
+  let sharedContext: BrowserContext;
+  let sharedPage: Page;
+  let apiContext: APIRequestContext;
+  let app: RotkiApp;
+
+  test.beforeAll(async ({ browser }) => {
+    username = generateUsername();
+    sharedContext = await browser.newContext();
+    sharedPage = await sharedContext.newPage();
+
+    if (isCoverageEnabled())
+      await startCoverage(sharedPage);
+
+    apiContext = await request.newContext();
+    app = new RotkiApp(sharedPage, apiContext);
+  });
+
+  test.afterAll(async () => {
+    if (isCoverageEnabled() && sharedPage)
+      await stopCoverage(sharedPage);
+
+    await apiContext?.dispose();
+    await sharedContext?.close();
+  });
+
+  test('logs out of core when colibri holds no database', async () => {
+    await app.createAccount(username);
+
+    // Lock colibri behind the app's back, which is where a resumed session leaves it.
+    const locked = await apiContext.post(`${colibriUrl}/user/logout`, { failOnStatusCode: false });
+    expect(locked.status()).toBe(200);
+
+    // Negative control: prove colibri really is locked now, so the logout below is exercising
+    // the failing call rather than a colibri that would have answered 200 anyway.
+    const alreadyLocked = await apiContext.post(`${colibriUrl}/user/logout`, { failOnStatusCode: false });
+    expect(alreadyLocked.status()).toBe(400);
+    expect((await alreadyLocked.json()).message).toBe('DB not unlocked');
+
+    // Logout locks colibri before it logs out of core, so that 400 used to abort the whole
+    // thing: core kept the session and the UI sat on "Logout failed". `logout` waits for the
+    // login form, so it fails here if that happens again.
+    await app.logout();
+
+    const users = await (await apiContext.get(`${backendUrl}/api/1/users`)).json();
+    expect(users.result[username]).toBe('loggedout');
+  });
+
+  test('logs in when colibri still holds a database from an earlier session', async () => {
+    await app.login(username);
+
+    // Log out of core only, leaving colibri's handle open — what a crash or a force-quit
+    // leaves behind, since nothing then tells colibri to let go.
+    await apiContext.patch(`${backendUrl}/api/1/users/${username}`, {
+      data: { action: 'logout' },
+      failOnStatusCode: false,
+    });
+
+    // Negative control: prove colibri is still holding one. This is itself a rejected unlock,
+    // so it reads the state without changing it.
+    const stillHeld = await apiContext.post(`${colibriUrl}/user`, {
+      data: { username, password: '1234' },
+      failOnStatusCode: false,
+    });
+    expect(stillHeld.status()).toBe(400);
+    expect((await stillHeld.json()).message).toBe('The DB is already unlocked');
+
+    // Logging in has to relock colibri and take it again, or the unlock is refused and the
+    // login fails with core already logged in — after which the retry resumes and never
+    // unlocks colibri at all.
+    await app.visit();
+    await app.login(username);
+
+    // Colibri now serves this user rather than refusing every request.
+    const ignored = await apiContext.get(`${colibriUrl}/assets/ignored`, { failOnStatusCode: false });
+    expect(ignored.status()).toBe(200);
+
+    await app.logout();
+  });
+});


### PR DESCRIPTION
Logging in and logging out could both break on docker, leaving the app half-unlocked: logged into core with colibri locked, unrecoverable without restarting the backend.

It is one loop, not two bugs. Colibri answers `400` to both of its own no-ops, and the client treated each as fatal:

| call | when | body |
|---|---|---|
| `POST /user/logout` | it holds no client | `{"result":null,"message":"DB not unlocked"}` |
| `POST /user` | it holds any client | `{"result":null,"message":"The DB is already unlocked"}` |

A session that ends without colibri being locked (a crash, a force-quit) leaves a stale handle. The next login's `colibriLogin` is refused, `guarded` turns that into a login-form error, but core is already logged in by then, so the retry takes the resume path, which never unlocks colibri. From there every colibri user-db route fails for the rest of the session, and logout is impossible too, because logout locks colibri *before* core and that call also 400s.

## Changes

- `colibriLogout` treats `"DB not unlocked"` as success. Already-locked is exactly the state locking aims for, so the client makes it idempotent.
- `colibriLogin` relocks and retries once on `"The DB is already unlocked"`. Colibri never records whose db it holds, so a stale handle and another user's are indistinguishable from the client; taking it fresh is the only way to know colibri serves the user we just logged in as.

Any other colibri failure still rejects, so an account is still only unlocked once both core and colibri are.

### Why the relock is safe

`colibriLogin` only runs on the fresh-login and create paths, and core `409`s both while any user is logged in (`api/rest.py:1386`, and `authenticate` `409`s on a name mismatch at `:1194`). So core holds no unlocked user at that point and whatever colibri still has open belongs to a session that has already ended, never a live one. A resumed session takes the other branch entirely. Should core ever allow two users logged in at once, this needs a real identity check first — noted in the code.

### Ordering

Unlock is core to colibri, lock is colibri to core, and that is forced rather than stylistic: colibri's gate validates the cookie core mints and revokes hard off core's `session.db`, so colibri has nothing to accept before core's `authenticate`, and after core's logout deletes the session row colibri `401`s everything.

## Verification

Both colibri responses were confirmed against a real colibri instance rather than inferred, including that a *different* user gets the identical `400` on unlock, and that lock then unlock recovers:

```
unlock user A            -> 200
unlock A again           -> 400 "The DB is already unlocked"
unlock a DIFFERENT user  -> 400 "The DB is already unlocked"
lock                     -> 200
unlock                   -> 200
```

Unit specs cover both directions, including negative controls that the retry happens exactly once and that an unrelated failure neither retries nor swallows. Reverting either fix alone fails its own spec and leaves the rest green.

The e2e spec has not been run locally — CI is its first real run.

## Not addressed

Pre-existing, unchanged by this PR, flagged rather than folded in:

- A colibri that is unreachable (a connection failure rather than a `400`) still wedges logout the same way.
- A `401` from colibri's gate triggers `handleAuthFailure()` mid-logout, cancelling in-flight requests and navigating away before core is told. A `401` provably means no live session, so there is nothing left to lock.
- Both message checks match Rust string literals with nothing on the colibri side pinning them.
