### PR TITLE
Allow to save assets without cryptocompare API key

### DIFF
--- a/rotkehlchen/serialization/schemas.py
+++ b/rotkehlchen/serialization/schemas.py
@@ -105,7 +105,7 @@ class AssetWithOraclesSchema(BaseAssetSchema):
             raise ValidationError(message='Asset identifier should be given', field_name='identifier')  # noqa: E501
         if self.coingecko_obj is not None:
             _validate_single_oracle_id(data, 'coingecko', self.coingecko_obj)
-        if self.cryptocompare_obj is not None:
+        if self.cryptocompare_obj is not None and self.cryptocompare_obj.has_api_key() is True:
             _validate_single_oracle_id(data, 'cryptocompare', self.cryptocompare_obj)
 
 
@@ -439,7 +439,7 @@ class AssetSchema(Schema):
         If identifier_required is True then the identifier field is required.
         Provided asset_type must not be in disallowed_asset_types list.
         If coingecko is not None then the coingecko identifier has to be valid.
-        If cryptocompare is not None then the cryptocompare identifier has to be valid.
+        If cryptocompare has an API key then the cryptocompare identifier has to be valid.
         """
         super().__init__(**kwargs)
         self.identifier_required = identifier_required

--- a/rotkehlchen/tests/api/test_user_assets.py
+++ b/rotkehlchen/tests/api/test_user_assets.py
@@ -217,7 +217,7 @@ def test_add_user_assets(
         contained_in_msg=expected_msg,
         status_code=HTTPStatus.BAD_REQUEST,
     )
-    # try to add invalid cryptocompare
+    # try to add invalid cryptocompare with an API key configured
     bad_id = 'dsadsad'
     bad_asset = {
         'asset_type': 'omni token',
@@ -232,20 +232,19 @@ def test_add_user_assets(
         ),
         json=bad_asset,
     )
-    expected_msg = f'Given cryptocompare identifier {bad_id} is not valid'
     assert_error_response(
         response=response,
-        contained_in_msg=expected_msg,
+        contained_in_msg=f'Given cryptocompare identifier {bad_id} is not valid',
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('start_with_logged_in_user', [True])
+@pytest.mark.parametrize('include_cryptocompare_key', [False])
 @pytest.mark.parametrize('coingecko_cache_coinlist', [{
     'internet-computer': {'symbol': 'ICP', 'name': 'Internet computer'},
 }])
-@pytest.mark.parametrize('cryptocompare_cache_coinlist', [{'ICP': {}}])
 def test_editing_user_assets(
         rotkehlchen_api_server: APIServer,
         globaldb: GlobalDBHandler,
@@ -416,28 +415,27 @@ def test_editing_user_assets(
         contained_in_msg=expected_msg,
         status_code=HTTPStatus.BAD_REQUEST,
     )
-    # try to add invalid cryptocompare
-    bad_id = 'dsadsad'
-    bad_asset = {
-        'identifier': 'EUR',
-        'asset_type': 'omni token',
-        'name': 'Euro',
-        'symbol': 'EUR',
-        'cryptocompare': bad_id,
+    # cryptocompare identifiers are accepted without remote validation since its coin list API
+    # requires an API key
+    cryptocompare_id = 'dsadsad'
+    edited_asset = {
+        'identifier': user_asset1_id,
+        'asset_type': 'own chain',
+        'name': user_asset1['name'],
+        'symbol': user_asset1['symbol'],
+        'cryptocompare': cryptocompare_id,
     }
     response = requests.patch(
         api_url_for(
             rotkehlchen_api_server,
             'allassetsresource',
         ),
-        json=bad_asset,
+        json=edited_asset,
     )
-    expected_msg = f'Given cryptocompare identifier {bad_id} is not valid'
-    assert_error_response(
-        response=response,
-        contained_in_msg=expected_msg,
-        status_code=HTTPStatus.BAD_REQUEST,
-    )
+    assert_proper_response(response)
+    data = globaldb.get_asset_data(identifier=user_asset1_id, form_with_incomplete_data=False)
+    assert data is not None
+    assert data.cryptocompare == cryptocompare_id
 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])

--- a/rotkehlchen/tests/api/test_user_evm_tokens.py
+++ b/rotkehlchen/tests/api/test_user_evm_tokens.py
@@ -293,7 +293,7 @@ def test_adding_user_tokens(
         contained_in_msg=f'Given coingecko identifier {bad_identifier} is not valid',
         status_code=HTTPStatus.BAD_REQUEST,
     )
-    # test that adding invalid cryptocompare fails
+    # test that adding invalid cryptocompare fails with an API key configured
     bad_token_2['cryptocompare'] = bad_identifier
     bad_token_2['coingecko'] = None
     response = requests.put(
@@ -314,10 +314,10 @@ def test_adding_user_tokens(
 @pytest.mark.parametrize('start_with_logged_in_user', [True])
 @pytest.mark.parametrize('generatable_user_ethereum_tokens', [True])
 @pytest.mark.parametrize('user_ethereum_tokens', [create_initial_globaldb_test_tokens])
+@pytest.mark.parametrize('include_cryptocompare_key', [False])
 @pytest.mark.parametrize('coingecko_cache_coinlist', [{
     'internet-computer': {'symbol': 'ICP', 'name': 'Internet computer'},
 }])
-@pytest.mark.parametrize('cryptocompare_cache_coinlist', [{'ICP': {}}])
 def test_editing_user_tokens(
         rotkehlchen_api_server: APIServer,
         cache_coinlist: list[dict[str, dict]],
@@ -400,7 +400,8 @@ def test_editing_user_tokens(
         status_code=HTTPStatus.BAD_REQUEST,
     )
 
-    # test that editing with an invalid cryptocompare identifier is handled
+    # cryptocompare identifiers are accepted without remote validation since its coin list API
+    # requires an API key
     bad_token = new_token.copy()
     bad_identifier = 'INVALIDID'
     bad_token['cryptocompare'] = bad_identifier
@@ -411,10 +412,9 @@ def test_editing_user_tokens(
         ),
         json=bad_token,
     )
-    assert_error_response(
-        response=response,
-        contained_in_msg=f'Given cryptocompare identifier {bad_identifier} is not valid',
-        status_code=HTTPStatus.BAD_REQUEST,
+    assert_proper_response(response)
+    assert (
+        Asset(expected_tokens[0].identifier).resolve_to_evm_token().cryptocompare == bad_identifier
     )
 
 


### PR DESCRIPTION
Closes #(issue_number)

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
