### PR TITLE
One addition mechanism, and a lane for removals

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -408,7 +408,8 @@
             "no_activity": "No activity found on this chain yet"
           },
           "no_activity_hint": "Chains where the address has no activity yet are skipped. This is normal for a fresh wallet. Once the address has transactions, add it again, or add it now with a specific chain selected to track it anyway.",
-          "non_eth": "All non ETH chains"
+          "non_eth": "All non ETH chains",
+          "nothing_added": "No account was added for {address}"
         },
         "no_new": {
           "description": "The selected addresses are already tracked by rotki"

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -73,6 +73,7 @@
   "account_form": {
     "advanced_tooltip": "Display the advanced xpub options | Hide the advanced xpub options",
     "error": {
+      "addition_failed": "No account was added. | The address could not be added. | None of the {count} addresses could be added.",
       "description": "Error while adding account: {error}",
       "title": "Adding Account",
       "validator_needs_credentials": "Could not add the validator. Configure a consensus layer RPC or add a Beaconcha.in API key in settings, then try again."
@@ -6013,6 +6014,7 @@
         "add": "Adding {address}",
         "detect": "Detecting EVM accounts",
         "ens": "Resolving ENS names for {count} address | Resolving ENS names for {count} addresses",
+        "import": "Importing {count} account | Importing {count} accounts",
         "remove": "Removing {address}",
         "remove_count": "Removing {count} account | Removing {count} accounts",
         "remove_xpub": "Removing xpub {xpub}"

--- a/frontend/app/src/modules/accounts/accounts.activity.spec.ts
+++ b/frontend/app/src/modules/accounts/accounts.activity.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { accountAddActivity, accountRemoveActivity, type AccountSubject } from '@/modules/accounts/accounts.activity';
+
+function subject(chain: string, address: string): AccountSubject {
+  return { chain, target: { address, kind: 'address' } };
+}
+
+describe('account activity lanes', () => {
+  // The lane is what serializes removals now that `awaitParallelExecution(..., 1)` is gone. A
+  // removal that minted no lane would take the default one, which is uncapped, and the serial
+  // behaviour would be lost silently rather than loudly.
+  it('should put a removal on its chain lane', () => {
+    expect(accountRemoveActivity.laneOf?.(subject('eth', '0xabc'))).toBe('accounts-remove:eth');
+  });
+
+  // Per chain, not one lane for every removal: the family cap of 1 is what makes a chain serial,
+  // and a shared lane would serialize unrelated chains against each other instead.
+  it('should give each chain its own removal lane', () => {
+    const eth = accountRemoveActivity.laneOf?.(subject('eth', '0xabc'));
+    expect(accountRemoveActivity.laneOf?.(subject('gnosis', '0xabc'))).not.toBe(eth);
+  });
+
+  // Additions and removals are independent operations; pooling them would make a removal wait on
+  // an unrelated addition.
+  it('should not share a lane between an addition and a removal on one chain', () => {
+    const add = accountAddActivity.laneOf?.(subject('eth', '0xabc'));
+    expect(accountRemoveActivity.laneOf?.(subject('eth', '0xabc'))).not.toBe(add);
+  });
+});

--- a/frontend/app/src/modules/accounts/accounts.activity.ts
+++ b/frontend/app/src/modules/accounts/accounts.activity.ts
@@ -2,6 +2,7 @@ import type { AccountPayload, XpubAccountPayload } from '@/modules/accounts/bloc
 import { msg } from '@/message-key';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
 import { defineActivity } from '@/modules/task-center/core/activity-descriptor';
+import { ACCOUNTS_ADD_LANE_PREFIX, familyLane } from '@/modules/task-center/core/orchestrator/spec';
 import { ActivityKind, ActivityPart, type ActivityText } from '@/modules/task-center/core/types';
 
 /**
@@ -76,15 +77,28 @@ export function accountTargetOf(payload: AccountPayload[] | XpubAccountPayload):
  * dedups on id identity, so a chain-only id collapsed every address after the first onto the
  * first's promise and reported them added without ever sending them.
  *
- * ⚠️ No lane yet: `addMultipleAccounts` still throttles itself with
- * `awaitParallelExecution(..., 2)`. Declaring a lane cap here as well would put two mechanisms on
- * one piece of work, which is what the warning on `DECODE_LANE` is about. The lane arrives when
- * that limiter is removed, not before.
+ * The lane caps additions at 2 per chain, which is the parallelism `addMultipleAccounts` used to
+ * apply with `awaitParallelExecution(..., 2)`. That limiter is gone: one mechanism governs, as the
+ * warning on `DECODE_LANE` requires.
  */
 export const accountAddActivity = defineActivity<AccountSubject, readonly [string, string]>({
   key: subject => [subject.chain, targetKey(subject.target)],
   kind: ActivityKind.ACCOUNTS,
+  lane: subject => familyLane(ACCOUNTS_ADD_LANE_PREFIX, subject.chain),
   part: ActivityPart.ADD,
+});
+
+/**
+ * A CSV import, as one activity parenting every addition it makes. Keyed by source so two imports
+ * are two runs; there is only one source today, and naming it keeps the id from being kind-only.
+ *
+ * It is the outermost umbrella: an import fans out over rows, and a row with several addresses fans
+ * out again under its own per-chain umbrella.
+ */
+export const accountImportActivity = defineActivity<{ source: string }, readonly [string]>({
+  key: subject => [subject.source],
+  kind: ActivityKind.ACCOUNTS,
+  part: ActivityPart.IMPORT,
 });
 
 /**

--- a/frontend/app/src/modules/accounts/accounts.activity.ts
+++ b/frontend/app/src/modules/accounts/accounts.activity.ts
@@ -103,11 +103,13 @@ export const accountRemoveActivity = defineActivity<AccountSubject, readonly [st
  * subject: the broad component is a category, not a chain. Its own descriptor rather than a reuse
  * of {@link accountRemoveActivity}, so the subject stays honest about what it holds.
  *
- * ⚠️ It shares the `accounts:remove` keyspace with the chain-scoped removals. Nothing collides
- * today because no chain is named after a category, but the two are only kept apart by that.
+ * The key opens with the literal `category` part so these ids cannot be confused with chain-scoped
+ * ones by a prefix reader. Keying straight off the category name would have left the two apart only
+ * because no chain happens to be called `evm` — incidental, and invisible once it stopped being
+ * true.
  */
-export const accountAgnosticRemoveActivity = defineActivity<{ category: string; address: string }, readonly [string, string]>({
-  key: subject => [subject.category, subject.address],
+export const accountAgnosticRemoveActivity = defineActivity<{ category: string; address: string }, readonly [ActivityPart, string, string]>({
+  key: subject => [ActivityPart.CATEGORY, subject.category, subject.address],
   kind: ActivityKind.ACCOUNTS,
   part: ActivityPart.REMOVE,
 });

--- a/frontend/app/src/modules/accounts/accounts.activity.ts
+++ b/frontend/app/src/modules/accounts/accounts.activity.ts
@@ -2,7 +2,7 @@ import type { AccountPayload, XpubAccountPayload } from '@/modules/accounts/bloc
 import { msg } from '@/message-key';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
 import { defineActivity } from '@/modules/task-center/core/activity-descriptor';
-import { ACCOUNTS_ADD_LANE_PREFIX, familyLane } from '@/modules/task-center/core/orchestrator/spec';
+import { ACCOUNTS_ADD_LANE_PREFIX, ACCOUNTS_REMOVE_LANE_PREFIX, familyLane } from '@/modules/task-center/core/orchestrator/spec';
 import { ActivityKind, ActivityPart, type ActivityText } from '@/modules/task-center/core/types';
 
 /**
@@ -109,6 +109,7 @@ export const accountImportActivity = defineActivity<{ source: string }, readonly
 export const accountRemoveActivity = defineActivity<AccountSubject, readonly [string, string]>({
   key: subject => [subject.chain, targetKey(subject.target)],
   kind: ActivityKind.ACCOUNTS,
+  lane: subject => familyLane(ACCOUNTS_REMOVE_LANE_PREFIX, subject.chain),
   part: ActivityPart.REMOVE,
 });
 
@@ -125,5 +126,8 @@ export const accountRemoveActivity = defineActivity<AccountSubject, readonly [st
 export const accountAgnosticRemoveActivity = defineActivity<{ category: string; address: string }, readonly [ActivityPart, string, string]>({
   key: subject => [ActivityPart.CATEGORY, subject.category, subject.address],
   kind: ActivityKind.ACCOUNTS,
+  // Same family as the chain-scoped removal: the family caps one active lane, so an agnostic
+  // removal and a per-chain one still take turns rather than racing each other.
+  lane: subject => familyLane(ACCOUNTS_REMOVE_LANE_PREFIX, subject.category),
   part: ActivityPart.REMOVE,
 });

--- a/frontend/app/src/modules/accounts/accounts.activity.ts
+++ b/frontend/app/src/modules/accounts/accounts.activity.ts
@@ -97,3 +97,17 @@ export const accountRemoveActivity = defineActivity<AccountSubject, readonly [st
   kind: ActivityKind.ACCOUNTS,
   part: ActivityPart.REMOVE,
 });
+
+/**
+ * Removing one address across a whole account category ("every EVM chain"), which is a different
+ * subject: the broad component is a category, not a chain. Its own descriptor rather than a reuse
+ * of {@link accountRemoveActivity}, so the subject stays honest about what it holds.
+ *
+ * ⚠️ It shares the `accounts:remove` keyspace with the chain-scoped removals. Nothing collides
+ * today because no chain is named after a category, but the two are only kept apart by that.
+ */
+export const accountAgnosticRemoveActivity = defineActivity<{ category: string; address: string }, readonly [string, string]>({
+  key: subject => [subject.category, subject.address],
+  kind: ActivityKind.ACCOUNTS,
+  part: ActivityPart.REMOVE,
+});

--- a/frontend/app/src/modules/accounts/blockchain/use-account-delete.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-delete.spec.ts
@@ -1,13 +1,57 @@
-import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import type {
+  AddressData,
+  BlockchainAccount,
+  BlockchainAccountGroupWithBalance,
+} from '@/modules/accounts/blockchain-accounts';
 import { bigNumberify } from '@rotki/common';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccountDelete } from '@/modules/accounts/blockchain/use-account-delete';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import '@test/i18n';
+
+const mocks = vi.hoisted(() => ({
+  deleteXpub: vi.fn(),
+  removeAccount: vi.fn(async (_payload: { accounts: string[]; chain: string }): Promise<void> => {}),
+  removeAgnosticAccount: vi.fn(async (): Promise<void> => {}),
+}));
+
+vi.mock('@/modules/accounts/use-account-removals', () => ({
+  useAccountRemovals: vi.fn(() => ({
+    deleteXpub: mocks.deleteXpub,
+    removeAccount: mocks.removeAccount,
+    removeAgnosticAccount: mocks.removeAgnosticAccount,
+  })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({
+    getChainName: (chain: string): string => chain,
+  })),
+}));
+
+function groupAccount(chains: string[], allChains?: string[]): BlockchainAccountGroupWithBalance<AddressData> {
+  return {
+    allChains,
+    category: 'evm',
+    chains,
+    data: {
+      address: '0x123',
+      type: 'address',
+    },
+    type: 'group',
+    value: bigNumberify(0),
+  };
+}
 
 describe('useAccountDelete', () => {
   beforeAll(() => {
     setActivePinia(createPinia());
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   it('should remove any accounts and balances from state', () => {
@@ -61,5 +105,79 @@ describe('useAccountDelete', () => {
     removeAccounts({ addresses: ['0x123'], chains: ['eth'] });
     expect(accountStore.accounts).toMatchObject({ eth: [] });
     expect(store.balances).toMatchObject({ eth: {} });
+  });
+
+  describe('removeGroupAccounts', () => {
+    const seedChains = (chains: string[]): void => {
+      const accountStore = useBlockchainAccountsStore();
+      for (const chain of chains) {
+        accountStore.updateAccounts(chain, [{
+          chain,
+          data: { address: '0x123', type: 'address' },
+          nativeAsset: chain.toUpperCase(),
+        }]);
+      }
+    };
+
+    const confirmRemoval = async (account: BlockchainAccountGroupWithBalance<AddressData>): Promise<void> => {
+      const { showConfirmation } = useAccountDelete();
+      showConfirmation({ data: account, type: 'account' });
+      await useConfirmStore().confirm();
+    };
+
+    it('should remove a group showing all its chains agnostically', async () => {
+      seedChains(['eth', 'optimism']);
+
+      await confirmRemoval(groupAccount(['eth', 'optimism']));
+
+      expect(mocks.removeAgnosticAccount).toHaveBeenCalledWith('evm', '0x123');
+      expect(mocks.removeAccount).not.toHaveBeenCalled();
+      expect(useBlockchainAccountsStore().accounts).toMatchObject({ eth: [], optimism: [] });
+    });
+
+    it('should remove a partially shown group chain by chain', async () => {
+      seedChains(['eth', 'optimism', 'base']);
+
+      await confirmRemoval(groupAccount(['eth', 'optimism'], ['eth', 'optimism', 'base']));
+
+      expect(mocks.removeAgnosticAccount).not.toHaveBeenCalled();
+      expect(mocks.removeAccount).toHaveBeenCalledTimes(2);
+      expect(mocks.removeAccount).toHaveBeenCalledWith({ accounts: ['0x123'], chain: 'eth' });
+      expect(mocks.removeAccount).toHaveBeenCalledWith({ accounts: ['0x123'], chain: 'optimism' });
+      // The chains the group did not show keep their account.
+      expect(useBlockchainAccountsStore().accounts).toMatchObject({
+        base: [{ chain: 'base' }],
+        eth: [],
+        optimism: [],
+      });
+    });
+
+    it('should submit every chain removal before any of them settles', async () => {
+      seedChains(['eth', 'optimism']);
+
+      let release = (): void => {};
+      const started: string[] = [];
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      mocks.removeAccount.mockImplementation(async ({ chain }: { chain: string }): Promise<void> => {
+        started.push(chain);
+        return gate;
+      });
+
+      const removal = confirmRemoval(groupAccount(['eth', 'optimism'], ['eth', 'optimism', 'base']));
+      await vi.waitFor(() => {
+        // Both reach `removeAccount` before either resolves: this composable submits them together
+        // and holds no limiter of its own. Ordering them is the removal lane's job, one level down
+        // — asserted where it can actually be seen, on the spec `submitTask` receives
+        // (`use-account-removals.spec.ts`). Asserting it here would only re-measure the mock.
+        expect(started).toStrictEqual(['eth', 'optimism']);
+      });
+
+      release();
+      await removal;
+
+      expect(useBlockchainAccountsStore().accounts).toMatchObject({ eth: [], optimism: [] });
+    });
   });
 });

--- a/frontend/app/src/modules/accounts/blockchain/use-account-delete.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-delete.ts
@@ -9,7 +9,6 @@ import { useAccountRemovals } from '@/modules/accounts/use-account-removals';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useEthStaking } from '@/modules/accounts/use-eth-staking';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
-import { awaitParallelExecution } from '@/modules/core/common/async/await-parallel-execution';
 import { isBlockchain } from '@/modules/core/common/chains';
 import { uniqueStrings } from '@/modules/core/common/data/data';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
@@ -185,12 +184,10 @@ export function useAccountDelete(): UseAccountDeleteReturn {
       removeAccounts({ addresses: [address], chains });
     }
     else {
-      await awaitParallelExecution(
-        chains,
-        chain => chain,
-        async chain => removeAccount({ accounts: [address], chain }),
-        1,
-      );
+      // Submitted together, serialized by the removal lane rather than by a limiter here: one
+      // per chain and one active chain at a time is the shape this call always had, now declared
+      // once where the activity is, as the warning on `DECODE_LANE` requires.
+      await Promise.all(chains.map(async chain => removeAccount({ accounts: [address], chain })));
 
       removeAccounts({
         addresses: [address],

--- a/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
@@ -11,6 +11,7 @@ import type { Module } from '@/modules/core/common/modules';
 import { assert, bigNumberify, Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { getAccountAddress, getChain } from '@/modules/accounts/account-utils';
+import { EVM_PSEUDO_CHAIN } from '@/modules/accounts/accounts.activity';
 import { useAccountEdits } from '@/modules/accounts/use-account-edits';
 import { useBlockchainAccountManagement } from '@/modules/accounts/use-blockchain-account-management';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
@@ -178,7 +179,7 @@ export function useAccountManage(): UseAccountManageReturn {
   const { t } = useI18n({ useScope: 'global' });
 
   const { updateAccountData, updateAccounts } = useBlockchainAccountsStore();
-  const { addAccounts, addEvmAccounts, fetchAccounts, refreshAccounts } = useBlockchainAccountManagement();
+  const { addAccounts, fetchAccounts, refreshAccounts } = useBlockchainAccountManagement();
   const { addEth2Validator, editEth2Validator, updateEthStakingOwnership } = useEthStaking();
   const { editAccount, editAgnosticAccount } = useAccountEdits();
   const { showErrorMessage } = useNotifications();
@@ -212,20 +213,23 @@ export function useAccountManage(): UseAccountManageReturn {
       set(pending, true);
       if (edit) {
         updateAccounts(state.chain, await editAccount(state.data, state.chain));
+        return true;
       }
-      else {
-        if (state.chain === 'all') {
-          await addEvmAccounts({
-            modules: state.modules,
-            payload: state.data,
-          });
-        }
-        else {
-          await addAccounts(state.chain, {
-            modules: isEth ? state.modules : undefined,
-            payload: state.data,
-          });
-        }
+
+      // `'all'` is the form's word for every EVM chain; the mechanism's is the pseudo-chain.
+      const chain = state.chain === 'all' ? EVM_PSEUDO_CHAIN : state.chain;
+      const summary = await addAccounts(chain, {
+        modules: isEth || state.chain === 'all' ? state.modules : undefined,
+        payload: state.data,
+      }, { wait: true });
+
+      // Nothing added and something failed: keep the dialog open so the user can correct it. A
+      // partial success closes it — the failures were already reported by the mechanism, and the
+      // accounts that did land are real. Previously the count decided this: one address threw, and
+      // two or more closed the dialog as a success even when some of them had failed.
+      if (summary.added.length === 0 && summary.failed.length > 0) {
+        handleErrors(new Error(t('account_form.error.addition_failed', { count: summary.failed.length }, summary.failed.length)));
+        return false;
       }
     }
     catch (error: unknown) {
@@ -265,7 +269,17 @@ export function useAccountManage(): UseAccountManageReturn {
         startPromise(fetchAccounts(chain));
       }
       else {
-        await addAccounts(chain, state.data);
+        // Awaited, so an xpub that fails to add keeps its dialog open rather than closing as if it
+        // had worked. `handleErrors` is given the xpub props so `ApiValidationError` can still fill
+        // in per-field errors.
+        const summary = await addAccounts(chain, state.data, { wait: true });
+        if (summary.added.length === 0 && summary.failed.length > 0) {
+          handleErrors(new Error(t('account_form.error.addition_failed', { count: 1 }, 1)), {
+            derivationPath: '',
+            xpub: '',
+          });
+          return false;
+        }
       }
     }
     catch (error: unknown) {

--- a/frontend/app/src/modules/accounts/import-export/use-account-import.spec.ts
+++ b/frontend/app/src/modules/accounts/import-export/use-account-import.spec.ts
@@ -82,6 +82,9 @@ vi.mock('@/modules/accounts/blockchain/use-account-manage', () => {
 vi.mock('@/modules/accounts/use-account-addition-notifications', () => ({
   useAccountAdditionNotifications: vi.fn(() => ({
     createFailureNotification: vi.fn(),
+    // Reached now that every import row goes through the one addition path; the old single-address
+    // shortcut never called it.
+    notifyFailedToAddAddress: vi.fn(),
     notifyUser: vi.fn(),
   })),
 }));
@@ -137,17 +140,18 @@ describe('useAccountImport', () => {
     await importAccounts(mockFile);
 
     expect(addAccount).toHaveBeenCalledTimes(1);
+    // Several rows, so the import runs under one umbrella and every addition is parented to it.
     expect(addAccount).toHaveBeenCalledWith('eth', [{
       address: '0x124',
       label: 'Name2',
       tags: ['tag1', 'tag2'],
-    }]);
+    }], { parent: expect.any(String) });
     expect(addEvmAccount).toHaveBeenCalledTimes(1);
     expect(addEvmAccount).toHaveBeenCalledWith({
       address: '0x123',
       label: 'Name1',
       tags: ['tag1', 'tag2'],
-    });
+    }, { parent: expect.any(String) });
     expect(queryAddTag).toHaveBeenCalledTimes(2);
     expect(queryAddTag).toHaveBeenCalledWith(expect.objectContaining({ name: 'tag1' }));
     expect(queryAddTag).toHaveBeenCalledWith(expect.objectContaining({ name: 'tag2' }));
@@ -174,13 +178,13 @@ describe('useAccountImport', () => {
       address: '0x125',
       label: 'Name3',
       tags: ['tag1', 'tag2'],
-    }]);
+    }], { parent: expect.any(String) });
     expect(addEvmAccount).toHaveBeenCalledTimes(1);
     expect(addEvmAccount).toHaveBeenCalledWith({
       address: '0x123',
       label: 'Name1',
       tags: ['tag1', 'tag2'],
-    });
+    }, { parent: expect.any(String) });
     expect(queryAddTag).toHaveBeenCalledTimes(2);
     expect(queryAddTag).toHaveBeenCalledWith(expect.objectContaining({ name: 'tag1' }));
     expect(queryAddTag).toHaveBeenCalledWith(expect.objectContaining({ name: 'tag2' }));
@@ -215,6 +219,8 @@ describe('useAccountImport', () => {
     await importAccounts(mockFile);
 
     expect(addAccount).toHaveBeenCalledTimes(1);
+    // A one-row import needs no umbrella, so this addition has no parent — the batch suppresses the
+    // umbrella rather than showing a parent over a single child.
     expect(addAccount).toHaveBeenCalledWith('btc', {
       label: 'Test Pub',
       tags: ['tag1'],
@@ -223,7 +229,7 @@ describe('useAccountImport', () => {
         xpub: XPUB,
         xpubType: 'p2pkh',
       },
-    });
+    }, undefined);
 
     expect(queryAddTag).toHaveBeenCalledTimes(1);
     expect(queryAddTag).toHaveBeenCalledWith(expect.objectContaining({ name: 'tag1' }));

--- a/frontend/app/src/modules/accounts/import-export/use-account-import.ts
+++ b/frontend/app/src/modules/accounts/import-export/use-account-import.ts
@@ -1,13 +1,14 @@
 import type { AddAccountsPayload, XpubAccountPayload } from '@/modules/accounts/blockchain-accounts';
 import { Blockchain } from '@rotki/common';
 import { getAccountAddress, getXpubId } from '@/modules/accounts/account-utils';
-import { type StakingValidatorManage, useAccountManage } from '@/modules/accounts/blockchain/use-account-manage';
-import { createValidatorAction, type CSVRow, CSVSchema, csvToAccount, doesAccountExist, getChainType } from '@/modules/accounts/import-export/account-csv-schema';
+import { EVM_PSEUDO_CHAIN } from '@/modules/accounts/accounts.activity';
+import { type CSVRow, CSVSchema, csvToAccount, doesAccountExist, getChainType } from '@/modules/accounts/import-export/account-csv-schema';
+import { useValidatorImport } from '@/modules/accounts/import-export/use-validator-import';
+import { useAccountAdditionBatch } from '@/modules/accounts/use-account-addition-batch';
 import { useAccountImportProgressStore } from '@/modules/accounts/use-account-import-progress-store';
 import { useBlockchainAccountManagement } from '@/modules/accounts/use-blockchain-account-management';
 import { getKeyType, guessPrefix, isPrefixed } from '@/modules/accounts/xpub';
 import { useBlockchainAccountData } from '@/modules/balances/blockchain/use-blockchain-account-data';
-import { awaitParallelExecution } from '@/modules/core/common/async/await-parallel-execution';
 import { logger } from '@/modules/core/common/logging/logging';
 import { CSVMissingHeadersError, useCsvImportExport } from '@/modules/core/common/use-csv-import-export';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -26,9 +27,10 @@ export function useAccountImport(): UseAccountImportReturn {
   const { isEvmCompatible } = useSupportedChains();
   const { getAccounts } = useBlockchainAccountData();
   const { ethStakingValidators } = storeToRefs(useBlockchainValidatorsStore());
-  const { addAccounts, addEvmAccounts } = useBlockchainAccountManagement();
+  const { addAccounts } = useBlockchainAccountManagement();
+  const { runImportBatch } = useAccountAdditionBatch();
   const { attemptTagCreation } = useTagOperations();
-  const { save } = useAccountManage();
+  const { importValidators } = useValidatorImport();
   const { notifyError, notifyInfo } = useNotifications();
   const { parseCSV } = useCsvImportExport();
   const { t } = useI18n({ useScope: 'global' });
@@ -40,30 +42,6 @@ export function useAccountImport(): UseAccountImportReturn {
   const { useIsActive } = useTaskCenter();
   const blockchainLoading = useIsActive(ActivityKind.BLOCKCHAIN_BALANCES);
   const doneLoading = refDebounced(logicNot(blockchainLoading), 2000);
-
-  async function importValidators(validators: CSVRow[]): Promise<void> {
-    const validatorActions: StakingValidatorManage[] = [];
-
-    for (const validator of validators) {
-      const ownershipPercentage = validator.addressExtras.ownershipPercentage || '100';
-      const publicKey = validator.address;
-
-      validatorActions.push(createValidatorAction('add', {
-        ownershipPercentage,
-        publicKey,
-      }));
-    }
-
-    await awaitParallelExecution(
-      validatorActions,
-      item => item.data.publicKey!,
-      async (item) => {
-        increment();
-        await save(item);
-      },
-      1,
-    );
-  }
 
   async function handleAccountRestore(rows: CSVRow[]): Promise<void> {
     const tags: string[] = [];
@@ -119,29 +97,25 @@ export function useAccountImport(): UseAccountImportReturn {
 
     await Promise.all(tags.map(async tag => attemptTagCreation(tag)));
 
-    await awaitParallelExecution(
-      evmAccounts,
-      accounts => accounts.payload[0].address,
-      async (payload) => {
-        increment();
-        await addEvmAccounts(payload, { wait: true });
-      },
-      1,
-    );
+    // One umbrella for the whole import, and no limiter of its own: every row's addition already
+    // submits onto `accounts-add:<chain>`, capped at 2 per chain with 2 chains live, so a second
+    // mechanism here would be the trap documented on `DECODE_LANE` one layer up.
+    //
+    // ⚠️ This is a deliberate behaviour change: rows used to run strictly one at a time.
+    const additions = [
+      ...evmAccounts.map(payload => [EVM_PSEUDO_CHAIN, payload] as const),
+      ...accounts.map(([chain, _id, account]) => [chain, account] as const),
+    ];
 
-    await awaitParallelExecution(
-      accounts,
-      ([_chain, id]) => id,
-      async ([chain, _id, account]) => {
+    await runImportBatch(
+      additions,
+      async ([chain, account], parent) => {
         increment();
-        try {
-          await addAccounts(chain, account, { wait: true });
-        }
-        catch (error) {
-          logger.error(error);
-        }
+        // Both kinds of row take the same call with the same contract. The EVM loop previously had
+        // no `try/catch` while the chain one did, so a failed EVM row aborted the whole import and
+        // a failed chain row did not — accidental, not chosen. Neither throws now.
+        await addAccounts(chain, account, { parent, wait: true });
       },
-      1,
     );
 
     if (validators.length > 0) {
@@ -151,7 +125,7 @@ export function useAccountImport(): UseAccountImportReturn {
         await until(doneLoading).toBe(true);
       }
 
-      await importValidators(validators);
+      await importValidators(validators, increment);
     }
 
     const { skipped, total } = get(progress);

--- a/frontend/app/src/modules/accounts/import-export/use-validator-import.ts
+++ b/frontend/app/src/modules/accounts/import-export/use-validator-import.ts
@@ -1,0 +1,38 @@
+import { type StakingValidatorManage, useAccountManage } from '@/modules/accounts/blockchain/use-account-manage';
+import { createValidatorAction, type CSVRow } from '@/modules/accounts/import-export/account-csv-schema';
+import { awaitParallelExecution } from '@/modules/core/common/async/await-parallel-execution';
+
+interface UseValidatorImportReturn {
+  importValidators: (validators: CSVRow[], onProgress: () => void) => Promise<void>;
+}
+
+/**
+ * Validators are imported through the account form's `save`, not through the account addition
+ * mechanism, so they keep their own serial loop rather than joining the import umbrella. Folding
+ * them in would mean routing validator creation through `addAccounts`, which is a different change.
+ */
+export function useValidatorImport(): UseValidatorImportReturn {
+  const { save } = useAccountManage();
+
+  const importValidators = async (validators: CSVRow[], onProgress: () => void): Promise<void> => {
+    const validatorActions: StakingValidatorManage[] = validators.map((validator) => {
+      const ownershipPercentage = validator.addressExtras.ownershipPercentage || '100';
+      return createValidatorAction('add', {
+        ownershipPercentage,
+        publicKey: validator.address,
+      });
+    });
+
+    await awaitParallelExecution(
+      validatorActions,
+      item => item.data.publicKey!,
+      async (item) => {
+        onProgress();
+        await save(item);
+      },
+      1,
+    );
+  };
+
+  return { importValidators };
+}

--- a/frontend/app/src/modules/accounts/use-account-addition-batch.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-batch.ts
@@ -1,0 +1,97 @@
+import type { ActivityId } from '@/modules/task-center/core/types';
+import { msg } from '@/message-key';
+import { accountActivityLabel, accountAddActivity, accountImportActivity, EVM_PSEUDO_CHAIN } from '@/modules/accounts/accounts.activity';
+import { activityLabelFor } from '@/modules/task-center/activity-labels';
+import { useActivityBatch } from '@/modules/task-center/use-activity-batch';
+
+/**
+ * Whether a chain value means "every EVM chain" rather than a real chain. Lives here, beside the
+ * batch that knows the pseudo-chain, so a caller never has to import the sentinel to compare
+ * against it.
+ */
+export function isEveryEvmChain(chain: string): boolean {
+  return chain === EVM_PSEUDO_CHAIN;
+}
+
+interface UseAccountAdditionBatchReturn {
+  runAdditionBatch: <TItem, TResult>(
+    chain: string,
+    items: readonly TItem[],
+    addressOf: (item: TItem) => string,
+    run: (item: TItem, parent: ActivityId | undefined) => Promise<TResult>,
+    parent?: ActivityId,
+  ) => Promise<TResult[]>;
+  runEvmAdditionBatch: <TItem, TResult>(
+    items: readonly TItem[],
+    addressOf: (item: TItem) => string,
+    run: (item: TItem, parent: ActivityId | undefined) => Promise<TResult>,
+    parent?: ActivityId,
+  ) => Promise<TResult[]>;
+  runImportBatch: <TItem, TResult>(
+    items: readonly TItem[],
+    run: (item: TItem, parent: ActivityId | undefined) => Promise<TResult>,
+  ) => Promise<TResult[]>;
+}
+
+/**
+ * Fans a bulk addition out as one activity per address under a single umbrella row.
+ *
+ * It exists so the addition service never has to know what an umbrella id looks like: the id, the
+ * label and the pseudo-chain all come from `accounts.activity`, which is also where the children's
+ * ids come from. Building them at the call site is how the parent ends up under a different prefix
+ * than the children it claims to parent.
+ *
+ * Throttling is the lane's, not this function's — each child submits onto `accounts-add:<chain>`,
+ * capped at 2. That is the parallelism `addMultipleAccounts` used to apply itself with
+ * `awaitParallelExecution(..., 2)`; expressing it twice is the trap documented on `DECODE_LANE`.
+ */
+export function useAccountAdditionBatch(): UseAccountAdditionBatchReturn {
+  const { runActivityBatch } = useActivityBatch();
+  const { t } = useI18n({ useScope: 'global' });
+
+  const runAdditionBatch = async <TItem, TResult>(
+    chain: string,
+    items: readonly TItem[],
+    addressOf: (item: TItem) => string,
+    run: (item: TItem, parent: ActivityId | undefined) => Promise<TResult>,
+    parent?: ActivityId,
+  ): Promise<TResult[]> => runActivityBatch(
+    {
+      id: accountAddActivity.batchId([chain]),
+      kind: accountAddActivity.kind,
+      parent,
+      subtitle: accountActivityLabel.add(items.map(item => addressOf(item)).join(',\n')),
+      title: t('task_center.group.accounts'),
+    },
+    items,
+    run,
+  );
+
+  /**
+   * A whole CSV import as one umbrella over its rows. The outermost of the three: an import parents
+   * its rows, and a row with several addresses parents those under its own per-chain umbrella.
+   */
+  const runImportBatch = async <TItem, TResult>(
+    items: readonly TItem[],
+    run: (item: TItem, parent: ActivityId | undefined) => Promise<TResult>,
+  ): Promise<TResult[]> => runActivityBatch(
+    {
+      id: accountImportActivity.id({ source: 'csv' }),
+      kind: accountImportActivity.kind,
+      subtitle: activityLabelFor(msg.$t('task_center.activity.accounts.import'), { count: items.length }, items.length),
+      title: t('task_center.group.accounts'),
+    },
+    items,
+    run,
+  );
+
+  /** The same, for an "add to every EVM chain" request, which is tracked under the pseudo-chain. */
+  const runEvmAdditionBatch = async <TItem, TResult>(
+    items: readonly TItem[],
+    addressOf: (item: TItem) => string,
+    run: (item: TItem, parent: ActivityId | undefined) => Promise<TResult>,
+    parent?: ActivityId,
+  ): Promise<TResult[]> => runAdditionBatch(EVM_PSEUDO_CHAIN, items, addressOf, run, parent);
+
+  return { runAdditionBatch, runEvmAdditionBatch, runImportBatch };
+}

--- a/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
@@ -123,6 +123,19 @@ describe('useAccountAdditionService', () => {
   });
 
   describe('addSingleEvmAddress', () => {
+    // `added` is an optional record, so `{}` is a valid response: truthy, but with nothing to
+    // destructure. That threw `undefined is not iterable` out of the composable — surfacing as a
+    // raw type error in the add dialog, and in a bulk add being swallowed by the queue so the
+    // address landed in neither the added nor the failed list.
+    it('should handle an empty added record without throwing', async () => {
+      h.addEvmAccount.mockResolvedValue(ok({ added: {} }));
+      const { useAccountAdditionService } = await importModule();
+      const result = await useAccountAdditionService().addSingleEvmAddress({ address: '0xabc', tags: null });
+      assert(!isErr(result));
+      expect(result.value).toStrictEqual([]);
+      expect(h.notifyUser).not.toHaveBeenCalled();
+    });
+
     it('should expand added chains and notify the user', async () => {
       h.addEvmAccount.mockResolvedValue(ok({ added: { '0xabc': ['eth', 'optimism'] } }));
       const { useAccountAdditionService } = await importModule();

--- a/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
@@ -1,9 +1,10 @@
 import { Blockchain } from '@rotki/common';
 import { err, isErr, ok } from 'plainfp/result';
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EVM_PSEUDO_CHAIN } from '@/modules/accounts/accounts.activity';
 import { type XpubAccountPayload, XpubKeyType } from '@/modules/accounts/blockchain-accounts';
 import { Module } from '@/modules/core/common/modules';
-import { TaskFailed } from '@/modules/core/tasks/task-result';
+import { Cancelled, TaskFailed } from '@/modules/core/tasks/task-result';
 import '@test/i18n';
 
 const h = vi.hoisted(() => ({
@@ -22,6 +23,32 @@ const h = vi.hoisted(() => ({
 
 vi.mock('@/modules/accounts/use-account-additions', () => ({
   useAccountAdditions: vi.fn(() => ({ addAccount: h.addAccount, addEvmAccount: h.addEvmAccount })),
+}));
+
+// A faithful stand-in: every item runs, each gets a parent. The real one submits an activity, which
+// would drag the whole task layer (and pinia) into these specs; its own behaviour is covered in
+// use-activity-batch.spec.ts.
+async function runEach<TItem, TResult>(items: readonly TItem[], run: (item: TItem, parent: string) => Promise<TResult>): Promise<TResult[]> {
+  return Promise.all(items.map(async item => run(item, 'accounts:add:batch')));
+}
+
+vi.mock('@/modules/accounts/use-account-addition-batch', () => ({
+  // Not mocked: it is a pure comparison against the pseudo-chain, and stubbing it would let the
+  // spec disagree with the module about what "every EVM chain" means.
+  isEveryEvmChain: (chain: string): boolean => chain === 'EVM',
+  useAccountAdditionBatch: vi.fn(() => ({
+    runAdditionBatch: async <TItem, TResult>(
+      _chain: string,
+      items: readonly TItem[],
+      _addressOf: (item: TItem) => string,
+      run: (item: TItem, parent: string) => Promise<TResult>,
+    ): Promise<TResult[]> => runEach(items, run),
+    runEvmAdditionBatch: async <TItem, TResult>(
+      items: readonly TItem[],
+      _addressOf: (item: TItem) => string,
+      run: (item: TItem, parent: string) => Promise<TResult>,
+    ): Promise<TResult[]> => runEach(items, run),
+  })),
 }));
 
 vi.mock('@/modules/balances/blockchain/use-token-detection-orchestrator', () => ({
@@ -98,7 +125,8 @@ describe('useAccountAdditionService', () => {
       h.addAccount.mockResolvedValue(ok('0xabc'));
       const { useAccountAdditionService } = await importModule();
       const result = await useAccountAdditionService().addSingleAccount({ address: '0xabc', tags: null }, 'eth');
-      expect(h.addAccount).toHaveBeenCalledWith('eth', [{ address: '0xabc', tags: null }]);
+      // The third argument is the batch options; a single add has no umbrella to parent it to.
+      expect(h.addAccount).toHaveBeenCalledWith('eth', [{ address: '0xabc', tags: null }], undefined);
       expect(result).toStrictEqual(ok('0xabc'));
     });
 
@@ -110,7 +138,7 @@ describe('useAccountAdditionService', () => {
       };
       const { useAccountAdditionService } = await importModule();
       const result = await useAccountAdditionService().addSingleAccount(xpubPayload, 'btc');
-      expect(h.addAccount).toHaveBeenCalledWith('btc', xpubPayload);
+      expect(h.addAccount).toHaveBeenCalledWith('btc', xpubPayload, undefined);
       expect(result).toStrictEqual(ok('xpub123'));
     });
 
@@ -173,57 +201,78 @@ describe('useAccountAdditionService', () => {
     });
   });
 
-  describe('addMultipleAccounts', () => {
+  describe('addAccounts', () => {
+    const onComplete = vi.fn<() => Promise<void>>(async () => {});
+
     it('should collect added accounts and invoke the completion callback', async () => {
       h.addAccount.mockResolvedValue(ok('0xabc'));
-      const onComplete = vi.fn<() => Promise<void>>(async () => {});
       const { useAccountAdditionService } = await importModule();
-      await useAccountAdditionService().addMultipleAccounts(
-        [{ address: '0xabc', tags: null }],
-        'eth',
-        undefined,
-        onComplete,
-      );
-      expect(onComplete).toHaveBeenCalledWith({ addedAccounts: [{ address: '0xabc', chain: 'eth' }], chain: 'eth', modulesToEnable: undefined });
+      const summary = await useAccountAdditionService().addAccounts('eth', [{ address: '0xabc', tags: null }], undefined, onComplete);
+
+      expect(summary.added).toStrictEqual([{ address: '0xabc', chain: 'eth' }]);
+      expect(onComplete).toHaveBeenCalledWith({ addedAccounts: [{ address: '0xabc', chain: 'eth' }], chain: 'eth', isXpub: false, modulesToEnable: undefined });
       expect(h.notifyFailedToAddAddress).not.toHaveBeenCalled();
     });
 
-    it('should notify about failed additions', async () => {
+    it('should notify about failed additions and report them in the summary', async () => {
       h.addAccount.mockResolvedValue(err(TaskFailed({ message: 'nope' })));
-      const onComplete = vi.fn<() => Promise<void>>(async () => {});
       const { useAccountAdditionService } = await importModule();
-      await useAccountAdditionService().addMultipleAccounts(
-        [{ address: '0xabc', tags: null }],
-        'eth',
-        undefined,
-        onComplete,
-      );
+      const summary = await useAccountAdditionService().addAccounts('eth', [{ address: '0xabc', tags: null }], undefined, onComplete);
+
+      expect(summary.failed).toStrictEqual([{ address: '0xabc', tags: null }]);
       expect(h.notifyFailedToAddAddress).toHaveBeenCalledOnce();
     });
-  });
 
-  describe('addMultipleEvmAccounts', () => {
-    it('should collect added accounts and invoke the completion callback', async () => {
-      h.addEvmAccount.mockResolvedValue(ok({ added: { '0xabc': ['eth'] } }));
-      const onComplete = vi.fn<() => Promise<void>>(async () => {});
+    // A cancellation is neither added nor failed: reporting it would raise "failed to add" for work
+    // the user deliberately stopped.
+    it('should record a cancellation without reporting it as a failure', async () => {
+      h.addAccount.mockResolvedValue(err(Cancelled({ message: 'cancelled' })));
       const { useAccountAdditionService } = await importModule();
-      await useAccountAdditionService().addMultipleEvmAccounts(
-        { modules: undefined, payload: [{ address: '0xabc', tags: null }] },
-        onComplete,
-      );
-      expect(onComplete).toHaveBeenCalledWith({ addedAccounts: [{ address: '0xabc', chain: 'eth' }], modulesToEnable: undefined });
+      const summary = await useAccountAdditionService().addAccounts('eth', [{ address: '0xabc', tags: null }], undefined, onComplete);
+
+      expect(summary).toMatchObject({ added: [], cancelled: true, failed: [] });
       expect(h.notifyFailedToAddAddress).not.toHaveBeenCalled();
     });
 
-    it('should notify about failed evm additions', async () => {
-      h.addEvmAccount.mockResolvedValue(err(TaskFailed({ message: 'boom' })));
-      const onComplete = vi.fn<() => Promise<void>>(async () => {});
+    it('should route the pseudo-chain through the evm addition', async () => {
+      h.addEvmAccount.mockResolvedValue(ok({ added: { '0xabc': ['eth'] } }));
       const { useAccountAdditionService } = await importModule();
-      await useAccountAdditionService().addMultipleEvmAccounts(
-        { modules: undefined, payload: [{ address: '0xabc', tags: null }] },
-        onComplete,
-      );
-      expect(h.notifyFailedToAddAddress).toHaveBeenCalledOnce();
+      const summary = await useAccountAdditionService().addAccounts(EVM_PSEUDO_CHAIN, [{ address: '0xabc', tags: null }], undefined, onComplete);
+
+      expect(h.addEvmAccount).toHaveBeenCalledOnce();
+      expect(summary.added).toStrictEqual([{ address: '0xabc', chain: 'eth' }]);
+      // No `chain` on the completion params: the pseudo-chain is not one to refresh.
+      expect(onComplete).toHaveBeenCalledWith({ addedAccounts: [{ address: '0xabc', chain: 'eth' }], chain: undefined, isXpub: false, modulesToEnable: undefined });
+    });
+
+    // An xpub is one unit of work, so it never fans out — but it returns the same summary, which is
+    // what lets the caller have a single shape to handle.
+    it('should add an xpub through the same function and summary', async () => {
+      h.addAccount.mockResolvedValue(ok('xpub123'));
+      const xpubPayload: XpubAccountPayload = {
+        tags: null,
+        xpub: { derivationPath: '', xpub: 'xpub123', xpubType: XpubKeyType.XPUB },
+      };
+      const { useAccountAdditionService } = await importModule();
+      const summary = await useAccountAdditionService().addAccounts('btc', xpubPayload, undefined, onComplete);
+
+      expect(summary.added).toStrictEqual([{ address: 'xpub123', chain: 'btc' }]);
+      expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ isXpub: true }));
+    });
+
+    // The notification lists addresses, so an xpub has no row in it — but the summary must still
+    // carry the failure or the form would close as though the xpub had been added.
+    it('should report a failed xpub in the summary but not in the notification', async () => {
+      h.addAccount.mockResolvedValue(err(TaskFailed({ message: 'nope' })));
+      const xpubPayload: XpubAccountPayload = {
+        tags: null,
+        xpub: { derivationPath: '', xpub: 'xpub123', xpubType: XpubKeyType.XPUB },
+      };
+      const { useAccountAdditionService } = await importModule();
+      const summary = await useAccountAdditionService().addAccounts('btc', xpubPayload, undefined, onComplete);
+
+      expect(summary.failed).toStrictEqual([xpubPayload]);
+      expect(h.notifyFailedToAddAddress).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/app/src/modules/accounts/use-account-addition-service.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.ts
@@ -1,17 +1,17 @@
 import type { ResultAsync } from 'plainfp/result-async';
-import type { AccountPayload, AddAccountsPayload, XpubAccountPayload } from '@/modules/accounts/blockchain-accounts';
+import type { AccountPayload, XpubAccountPayload } from '@/modules/accounts/blockchain-accounts';
 import type { RefreshAccountsParams } from '@/modules/accounts/use-account-operations';
 import type { Module } from '@/modules/core/common/modules';
-import { type Account, assert, Blockchain } from '@rotki/common';
+import { type Account, Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { pipe } from 'plainfp';
-import { err, isErr, mapError, ok } from 'plainfp/result';
+import { err, isErr, mapError, map as mapResult, ok, type Result } from 'plainfp/result';
+import { isEveryEvmChain, useAccountAdditionBatch } from '@/modules/accounts/use-account-addition-batch';
 import { useAccountAdditionNotifications } from '@/modules/accounts/use-account-addition-notifications';
-import { useAccountAdditions } from '@/modules/accounts/use-account-additions';
+import { type AdditionOptions, useAccountAdditions } from '@/modules/accounts/use-account-additions';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
 import { useTokenDetectionOrchestrator } from '@/modules/balances/blockchain/use-token-detection-orchestrator';
-import { awaitParallelExecution } from '@/modules/core/common/async/await-parallel-execution';
 import { isBlockchain } from '@/modules/core/common/chains';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -31,37 +31,41 @@ interface AccountAdditionFailure<T = AccountPayload | XpubAccountPayload> {
 }
 
 // Callback types for account addition completion
-interface AccountAdditionParams {
+export interface AccountAdditionParams {
   addedAccounts: Account[];
   modulesToEnable?: Module[];
   chain?: string;
   isXpub?: boolean;
 }
 
-interface EvmAccountAdditionParams {
-  addedAccounts: Account[];
-  modulesToEnable?: Module[];
-}
-
-interface ChainAccountAdditionParams {
-  addedAccounts: Account[];
-  chain: string;
-  modulesToEnable?: Module[];
+/**
+ * What an addition did, for the caller to present. Returned rather than thrown, so the *caller*
+ * decides the experience instead of the address count deciding it: one address used to throw (form
+ * dialog stays open) while two reported through a toast and closed the dialog as a success, even
+ * when some of them failed.
+ */
+export interface AdditionSummary {
+  readonly added: Account[];
+  /** Both payload kinds: an xpub can fail too, and the caller still has to hear about it. */
+  readonly failed: (AccountPayload | XpubAccountPayload)[];
+  /** True when every failure was a cancellation, so nothing is worth reporting. */
+  readonly cancelled: boolean;
 }
 
 type RefreshAccountsCallback = (params: RefreshAccountsParams) => Promise<void>;
 
 type FetchAccountsCallback = (blockchain?: string | string[], refreshEns?: boolean) => Promise<void>;
 
-type EvmCompletionCallback = (params: EvmAccountAdditionParams) => Promise<void>;
-
-type ChainCompletionCallback = (params: ChainAccountAdditionParams) => Promise<void>;
+type CompletionCallback = (params: AccountAdditionParams) => Promise<void>;
 
 interface UseAccountAdditionServiceReturn {
-  addMultipleAccounts: (payload: AccountPayload[], chain: string, modules: Module[] | undefined, onComplete: ChainCompletionCallback) => Promise<void>;
-  addMultipleEvmAccounts: (payload: AddAccountsPayload, onComplete: EvmCompletionCallback) => Promise<void>;
-  addSingleAccount: (account: AccountPayload | XpubAccountPayload, chain: string) => ResultAsync<string, AccountAdditionFailure>;
-  addSingleEvmAddress: (account: AccountPayload) => ResultAsync<Account[], AccountAdditionFailure<AccountPayload>>;
+  /**
+   * Adds every payload entry to `chain`, which may be {@link EVM_PSEUDO_CHAIN} for "every EVM
+   * chain". One function, because that is one operation with one parameter varying.
+   */
+  addAccounts: (chain: string, payload: AccountPayload[] | XpubAccountPayload, modules: Module[] | undefined, onComplete: CompletionCallback, options?: AdditionOptions) => Promise<AdditionSummary>;
+  addSingleAccount: (account: AccountPayload | XpubAccountPayload, chain: string, options?: AdditionOptions) => ResultAsync<string, AccountAdditionFailure>;
+  addSingleEvmAddress: (account: AccountPayload, options?: AdditionOptions) => ResultAsync<Account[], AccountAdditionFailure<AccountPayload>>;
   completeAccountAddition: (params: AccountAdditionParams, onRefreshAccounts: RefreshAccountsCallback, onFetchAccounts?: FetchAccountsCallback) => Promise<void>;
   getNewAccountPayload: (chain: string, payload: AccountPayload[]) => AccountPayload[];
 }
@@ -74,6 +78,7 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
   const { enableModule } = useSettingsOperations();
   const { evmChains, supportsTransactions } = useSupportedChains();
   const { getAddresses } = useAccountAddresses();
+  const { runAdditionBatch, runEvmAdditionBatch } = useAccountAdditionBatch();
   const {
     createFailureNotification,
     notifyFailedToAddAddress,
@@ -143,10 +148,13 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
     }
   };
 
-  const addSingleEvmAddress = async (account: AccountPayload): ResultAsync<Account[], AccountAdditionFailure<AccountPayload>> => {
+  const addSingleEvmAddress = async (
+    account: AccountPayload,
+    options?: AdditionOptions,
+  ): ResultAsync<Account[], AccountAdditionFailure<AccountPayload>> => {
     const addedAccounts: Account[] = [];
 
-    const outcome = await addEvmAccount(account);
+    const outcome = await addEvmAccount(account, options);
     if (isErr(outcome)) {
       // Only a real failure is worth a log line. A cancelled bulk add would otherwise write one
       // console error per in-flight address, which is the noise this branch exists to avoid.
@@ -188,42 +196,12 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
     return ok(addedAccounts);
   };
 
-  const addMultipleEvmAccounts = async (
-    payload: AddAccountsPayload,
-    onComplete: EvmCompletionCallback,
-  ): Promise<void> => {
-    const addedAccounts: Account[] = [];
-    const failedToAddAccounts: AccountPayload[] = [];
-
-    await awaitParallelExecution(
-      payload.payload,
-      account => account.address,
-      async (account) => {
-        const result = await addSingleEvmAddress(account);
-        // Only a real failure is reported. Cancelling the group mid-add would otherwise raise
-        // "failed to add N of M addresses" for work the user deliberately stopped.
-        if (isErr(result)) {
-          if (isActionable(result.error.error))
-            failedToAddAccounts.push(result.error.account);
-        }
-        else {
-          addedAccounts.push(...result.value);
-        }
-      },
-      2,
-    );
-
-    if (failedToAddAccounts.length > 0)
-      notifyFailedToAddAddress(failedToAddAccounts, payload.payload.length);
-
-    startPromise(onComplete({ addedAccounts, modulesToEnable: payload.modules }));
-  };
-
   const addSingleAccount = async (
     account: AccountPayload | XpubAccountPayload,
     chain: string,
+    options?: AdditionOptions,
   ): ResultAsync<string, AccountAdditionFailure> => pipe(
-    await addAccount(chain, 'xpub' in account ? account : [account]),
+    await addAccount(chain, 'xpub' in account ? account : [account], options),
     mapError((error: TaskError) => {
       // As in `addSingleEvmAddress`: a cancellation is not a failure to log.
       if (isActionable(error))
@@ -233,43 +211,92 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
     }),
   );
 
-  const addMultipleAccounts = async (
-    payload: AccountPayload[],
+  /**
+   * The one addition path. Every entry fans out through the batch — including a single one, where
+   * the batch suppresses the umbrella — so the address count no longer changes the mechanism, only
+   * how it is presented.
+   *
+   * No limiter: the `accounts-add:<chain>` lane caps this at 2, which is what the old
+   * `awaitParallelExecution(..., 2)` did by hand around a call that already submits to a lane.
+   */
+  const addAccounts = async (
     chain: string,
+    payload: AccountPayload[] | XpubAccountPayload,
     modules: Module[] | undefined,
-    onComplete: ChainCompletionCallback,
-  ): Promise<void> => {
+    onComplete: CompletionCallback,
+    options?: AdditionOptions,
+  ): Promise<AdditionSummary> => {
     const addedAccounts: Account[] = [];
-    const failedToAddAccounts: AccountPayload[] = [];
+    const failed: (AccountPayload | XpubAccountPayload)[] = [];
+    let cancelled = false;
 
-    await awaitParallelExecution(
-      payload,
-      account => account.address,
-      async (account) => {
-        const result = await addSingleAccount(account, chain);
-        // As above: a cancellation is not a failure to report.
-        if (isErr(result)) {
-          if (isActionable(result.error.error)) {
-            assert(!('xpub' in result.error.account));
-            failedToAddAccounts.push(result.error.account);
-          }
-        }
-        else {
-          addedAccounts.push({ address: result.value, chain });
-        }
-      },
-      2,
-    );
+    const isXpub = 'xpub' in payload;
+    const everyEvmChain = isEveryEvmChain(chain);
 
-    if (failedToAddAccounts.length > 0)
-      notifyFailedToAddAddress(failedToAddAccounts, payload.length, chain);
+    const collect = (result: Result<Account[], AccountAdditionFailure<AccountPayload | XpubAccountPayload>>): void => {
+      if (!isErr(result)) {
+        addedAccounts.push(...result.value);
+        return;
+      }
 
-    startPromise(onComplete({ addedAccounts, chain, modulesToEnable: modules }));
+      // A cancellation is recorded, never reported: the user asked for it, so neither the failure
+      // list nor "failed to add N of M addresses" should mention it.
+      if (!isActionable(result.error.error)) {
+        cancelled = true;
+        return;
+      }
+
+      failed.push(result.error.account);
+    };
+
+    if (isXpub) {
+      // One xpub is one unit of work, so there is nothing to fan out — but it still returns the
+      // same summary, so the caller has one shape to handle.
+      collect(mapResult(
+        await addSingleAccount(payload, chain, options),
+        address => [{ address, chain }],
+      ));
+    }
+    else if (everyEvmChain) {
+      const results = await runEvmAdditionBatch(
+        payload,
+        account => account.address,
+        // No options object when there is no umbrella: a single-item batch with no outer parent has
+        // nothing to attach to, and `{ parent: undefined }` would only be noise on the way down.
+        async (account, parent) => addSingleEvmAddress(account, parent ? { parent } : undefined),
+        options?.parent,
+      );
+      results.forEach(result => collect(result));
+    }
+    else {
+      const results = await runAdditionBatch(
+        chain,
+        payload,
+        account => account.address,
+        async (account, parent) => addSingleAccount(account, chain, parent ? { parent } : undefined),
+        options?.parent,
+      );
+      results.forEach(result => collect(mapResult(result, address => [{ address, chain }])));
+    }
+
+    // The notification lists addresses, so an xpub failure is not one of its rows — the caller
+    // reports that from the summary instead.
+    const failedAddresses = failed.filter((account): account is AccountPayload => !('xpub' in account));
+    if (failedAddresses.length > 0)
+      notifyFailedToAddAddress(failedAddresses, isXpub ? 1 : payload.length, everyEvmChain ? undefined : chain);
+
+    startPromise(onComplete({
+      addedAccounts,
+      chain: everyEvmChain ? undefined : chain,
+      isXpub,
+      modulesToEnable: modules,
+    }));
+
+    return { added: addedAccounts, cancelled, failed };
   };
 
   return {
-    addMultipleAccounts,
-    addMultipleEvmAccounts,
+    addAccounts,
     addSingleAccount,
     addSingleEvmAddress,
     completeAccountAddition,

--- a/frontend/app/src/modules/accounts/use-account-addition-service.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.ts
@@ -148,14 +148,23 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
 
     const outcome = await addEvmAccount(account);
     if (isErr(outcome)) {
-      logger.error(outcome.error.message);
+      // Only a real failure is worth a log line. A cancelled bulk add would otherwise write one
+      // console error per in-flight address, which is the noise this branch exists to avoid.
+      if (isActionable(outcome.error))
+        logger.error(outcome.error.message);
+
       return err({ account, error: outcome.error });
     }
 
     const { added, ...result } = outcome.value;
 
-    if (added) {
-      const [address, chains] = Object.entries(added)[0];
+    // `added` is an optional record, so `{}` is a valid response: truthy, but with no entry to
+    // destructure. That threw `undefined is not iterable`, which the removed try/catch used to
+    // turn into a failure result and now escapes as a rejection.
+    const [addedEntry] = Object.entries(added ?? {});
+
+    if (addedEntry) {
+      const [address, chains] = addedEntry;
       const isAll = chains.length === 1 && chains[0] === 'all';
       const usedChains = isAll ? get(evmChains) : chains;
 
@@ -216,7 +225,10 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
   ): ResultAsync<string, AccountAdditionFailure> => pipe(
     await addAccount(chain, 'xpub' in account ? account : [account]),
     mapError((error: TaskError) => {
-      logger.error(error.message);
+      // As in `addSingleEvmAddress`: a cancellation is not a failure to log.
+      if (isActionable(error))
+        logger.error(error.message);
+
       return { account, error };
     }),
   );

--- a/frontend/app/src/modules/accounts/use-account-additions.ts
+++ b/frontend/app/src/modules/accounts/use-account-additions.ts
@@ -47,9 +47,11 @@ export function useAccountAdditions(): UseAccountAdditionsReturn {
       if (result === true)
         return ok(address);
 
+      // Translated, because this message is user-facing: `throwIfActionable` rethrows it and the
+      // account form renders `error.message` in its dialog.
       return result.length > 0
         ? ok(result[0])
-        : err(TaskFailed({ message: `no account was added for ${address}` }));
+        : err(TaskFailed({ message: t('actions.balances.blockchain_accounts_add.error.nothing_added', { address }) }));
     });
   };
 

--- a/frontend/app/src/modules/accounts/use-account-additions.ts
+++ b/frontend/app/src/modules/accounts/use-account-additions.ts
@@ -1,18 +1,29 @@
 import type { AccountPayload, XpubAccountPayload } from '@/modules/accounts/blockchain-accounts';
 import type { EvmAccountsResult } from '@/modules/core/api/types/accounts';
+import type { ActivityId } from '@/modules/task-center/core/types';
 import { err, flatMap as flatMapResult, map as mapResult, ok, type Result } from 'plainfp/result';
 import { accountActivityLabel, accountAddActivity, type AccountSubject, accountTargetOf, EVM_PSEUDO_CHAIN } from '@/modules/accounts/accounts.activity';
 import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-accounts-api';
 import { type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 
+/**
+ * `parent` is passed explicitly rather than picked up from ambient state. A module-scoped "current
+ * batch" would read more cleanly at the call sites, but it only works while every submit happens in
+ * the synchronous prologue of the batch callback — an `await` introduced anywhere above it would
+ * silently orphan the child from its umbrella, with nothing to report it.
+ */
+export interface AdditionOptions {
+  readonly parent?: ActivityId;
+}
+
 interface UseAccountAdditionsReturn {
   /**
    * The added address on success. Failure stays a value: `TaskError` distinguishes a cancelled
    * add from a failed one, which a bare string could not.
    */
-  addAccount: (chain: string, payload: AccountPayload[] | XpubAccountPayload) => Promise<Result<string, TaskError>>;
-  addEvmAccount: (payload: AccountPayload) => Promise<Result<EvmAccountsResult, TaskError>>;
+  addAccount: (chain: string, payload: AccountPayload[] | XpubAccountPayload, options?: AdditionOptions) => Promise<Result<string, TaskError>>;
+  addEvmAccount: (payload: AccountPayload, options?: AdditionOptions) => Promise<Result<EvmAccountsResult, TaskError>>;
 }
 
 export function useAccountAdditions(): UseAccountAdditionsReturn {
@@ -20,13 +31,18 @@ export function useAccountAdditions(): UseAccountAdditionsReturn {
   const { submitTask } = useNativeTask();
   const { t } = useI18n({ useScope: 'global' });
 
-  const addAccount = async (chain: string, payload: AccountPayload[] | XpubAccountPayload): Promise<Result<string, TaskError>> => {
+  const addAccount = async (
+    chain: string,
+    payload: AccountPayload[] | XpubAccountPayload,
+    options?: AdditionOptions,
+  ): Promise<Result<string, TaskError>> => {
     const address = Array.isArray(payload) ? payload.map(item => item.address).join(',\n') : payload.xpub.xpub;
     const subject = { chain, target: accountTargetOf(payload) };
     const outcome = await submitTask<string[] | true>({
       id: accountAddActivity.id(subject),
       kind: accountAddActivity.kind,
       lane: accountAddActivity.laneOf?.(subject),
+      parent: options?.parent,
       rerunnable: false,
       run: async ({ runTask }): Promise<Result<string[] | true, TaskError>> => mapResult(
         await runTask<string[] | true>(
@@ -55,13 +71,17 @@ export function useAccountAdditions(): UseAccountAdditionsReturn {
     });
   };
 
-  const addEvmAccount = async ({ address, label, tags }: AccountPayload): Promise<Result<EvmAccountsResult, TaskError>> => {
+  const addEvmAccount = async (
+    { address, label, tags }: AccountPayload,
+    options?: AdditionOptions,
+  ): Promise<Result<EvmAccountsResult, TaskError>> => {
     // The pseudo-chain, not a real one: this asks for every EVM chain at once.
     const subject: AccountSubject = { chain: EVM_PSEUDO_CHAIN, target: { address, kind: 'address' } };
     const outcome = await submitTask<EvmAccountsResult>({
       id: accountAddActivity.id(subject),
       kind: accountAddActivity.kind,
       lane: accountAddActivity.laneOf?.(subject),
+      parent: options?.parent,
       rerunnable: false,
       run: async ({ runTask }): Promise<Result<EvmAccountsResult, TaskError>> => mapResult(
         await runTask<EvmAccountsResult>(

--- a/frontend/app/src/modules/accounts/use-account-removals.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-removals.spec.ts
@@ -53,6 +53,8 @@ async function importModule(): Promise<typeof import('./use-account-removals')> 
   return import('./use-account-removals');
 }
 
+type Removals = ReturnType<Awaited<ReturnType<typeof importModule>>['useAccountRemovals']>;
+
 describe('useAccountRemovals', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -60,6 +62,27 @@ describe('useAccountRemovals', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  // Asserted on the *submitted spec*, not on the descriptor. Declaring `lane` on the activity and
+  // asserting `laneOf` there both passed while every removal still went out on the default lane,
+  // because no call site forwarded it — so the family caps were dead config and removals that used
+  // to run one at a time all raced. Only reading what `submitTask` received can catch that.
+  describe('lane', () => {
+    const cases: [string, (accounts: Removals) => Promise<void>, string][] = [
+      ['removeAccount', async (accounts): Promise<void> => accounts.removeAccount({ accounts: ['0xabc'], chain: 'eth' }), 'accounts-remove:eth'],
+      ['deleteXpub', async (accounts): Promise<void> => accounts.deleteXpub({ chain: 'btc', xpub: 'xpub123' }), 'accounts-remove:btc'],
+      ['removeAgnosticAccount', async (accounts): Promise<void> => accounts.removeAgnosticAccount('evm', '0xabc'), 'accounts-remove:evm'],
+    ];
+
+    it.each(cases)('should submit %s on its own removal lane', async (_name, act, lane) => {
+      whenOk({ perAccount: {}, totals: { assets: {}, liabilities: {} } }, false);
+      const { useAccountRemovals } = await importModule();
+
+      await act(useAccountRemovals());
+
+      expect(submitTask).toHaveBeenCalledWith(expect.objectContaining({ lane }));
+    });
   });
 
   describe('removeAccount', () => {

--- a/frontend/app/src/modules/accounts/use-account-removals.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-removals.spec.ts
@@ -94,6 +94,21 @@ describe('useAccountRemovals', () => {
   });
 
   describe('removeAgnosticAccount', () => {
+    // Keyed by the account category alone, two removals under one category were the same activity,
+    // so `submitTask` handed the second the first's promise and the second address was never sent
+    // while the UI dropped its row. The same collision the chain-scoped removals had.
+    it('should give each address its own activity id within a category', async () => {
+      whenOk({ perAccount: {}, totals: { assets: {}, liabilities: {} } }, false);
+      const { useAccountRemovals } = await importModule();
+      const accounts = useAccountRemovals();
+
+      await accounts.removeAgnosticAccount('evm', '0xabc');
+      await accounts.removeAgnosticAccount('evm', '0xdef');
+
+      const [first, second] = submitTask.mock.calls.map(([spec]) => spec.id);
+      expect(first).not.toBe(second);
+    });
+
     it('should notify on an actionable failure', async () => {
       whenActionable('agnostic failed');
       const { useAccountRemovals } = await importModule();

--- a/frontend/app/src/modules/accounts/use-account-removals.ts
+++ b/frontend/app/src/modules/accounts/use-account-removals.ts
@@ -1,12 +1,12 @@
 import type { DeleteBlockchainAccountParams, DeleteXpubParams } from '@/modules/accounts/blockchain-accounts';
 import type { BlockchainBalances } from '@/modules/balances/types/blockchain-balances';
 import { isErr, map as mapResult, type Result } from 'plainfp/result';
-import { accountActivityLabel, accountRemoveActivity, type AccountSubject } from '@/modules/accounts/accounts.activity';
+import { accountActivityLabel, accountAgnosticRemoveActivity, accountRemoveActivity, type AccountSubject } from '@/modules/accounts/accounts.activity';
 import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-accounts-api';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
-import { ActivityKind, ActivityPart, makeActivityId, useNativeTask } from '@/modules/task-center/use-native-task';
+import { useNativeTask } from '@/modules/task-center/use-native-task';
 
 interface UseAccountRemovalsReturn {
   removeAccount: (payload: DeleteBlockchainAccountParams) => Promise<void>;
@@ -61,16 +61,11 @@ export function useAccountRemovals(): UseAccountRemovalsReturn {
     }));
   };
 
-  /**
-   * ⚠️ Keyed by chain *type*, not chain, so it shares a keyspace with {@link removeAccount} without
-   * sharing its subject — which is why it has no descriptor. Two agnostic removals of different
-   * addresses under one chain type still collide, the same hazard the descriptors fixed elsewhere;
-   * left as-is here so this move stays a pure move.
-   */
   const removeAgnosticAccount = async (chainType: string, address: string): Promise<void> => {
+    const subject = { address, category: chainType };
     const outcome = await submitTask({
-      id: makeActivityId(ActivityKind.ACCOUNTS, ActivityPart.REMOVE, chainType),
-      kind: ActivityKind.ACCOUNTS,
+      id: accountAgnosticRemoveActivity.id(subject),
+      kind: accountAgnosticRemoveActivity.kind,
       rerunnable: false,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
         await runTask<BlockchainBalances>(

--- a/frontend/app/src/modules/accounts/use-account-removals.ts
+++ b/frontend/app/src/modules/accounts/use-account-removals.ts
@@ -44,6 +44,7 @@ export function useAccountRemovals(): UseAccountRemovalsReturn {
     const outcome = await submitTask({
       id: accountRemoveActivity.id(subject),
       kind: accountRemoveActivity.kind,
+      lane: accountRemoveActivity.laneOf?.(subject),
       rerunnable: false,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
         await runTask<BlockchainBalances>(
@@ -66,6 +67,7 @@ export function useAccountRemovals(): UseAccountRemovalsReturn {
     const outcome = await submitTask({
       id: accountAgnosticRemoveActivity.id(subject),
       kind: accountAgnosticRemoveActivity.kind,
+      lane: accountAgnosticRemoveActivity.laneOf?.(subject),
       rerunnable: false,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
         await runTask<BlockchainBalances>(
@@ -88,6 +90,7 @@ export function useAccountRemovals(): UseAccountRemovalsReturn {
     const outcome = await submitTask({
       id: accountRemoveActivity.id(subject),
       kind: accountRemoveActivity.kind,
+      lane: accountRemoveActivity.laneOf?.(subject),
       rerunnable: false,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
         await runTask<boolean>(

--- a/frontend/app/src/modules/accounts/use-blockchain-account-management.spec.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-account-management.spec.ts
@@ -1,17 +1,12 @@
 import type { ComputedRef } from 'vue';
-import type { WorkStatus } from '@/modules/task-center/core/types';
 import { flushPromises } from '@vue/test-utils';
-import { err, ok } from 'plainfp/result';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type AddAccountsPayload, type XpubAccountPayload, XpubKeyType } from '@/modules/accounts/blockchain-accounts';
-import { Cancelled, TaskFailed } from '@/modules/core/tasks/task-result';
+import { type XpubAccountPayload, XpubKeyType } from '@/modules/accounts/blockchain-accounts';
+import { ActivityKind, ActivityPart, makeActivityId, type WorkStatus } from '@/modules/task-center/core/types';
 import '@test/i18n';
 
 const h = vi.hoisted(() => ({
-  addMultipleAccounts: vi.fn(),
-  addMultipleEvmAccounts: vi.fn(),
-  addSingleAccount: vi.fn(),
-  addSingleEvmAddress: vi.fn(),
+  addAccounts: vi.fn(),
   completeAccountAddition: vi.fn(),
   detectEvmAccounts: vi.fn(),
   fetchAccounts: vi.fn(),
@@ -22,12 +17,11 @@ const h = vi.hoisted(() => ({
 
 const mockAddRunning = ref<boolean>(false);
 
+const NOTHING = { added: [], cancelled: false, failed: [] };
+
 vi.mock('@/modules/accounts/use-account-addition-service', () => ({
   useAccountAdditionService: vi.fn(() => ({
-    addMultipleAccounts: h.addMultipleAccounts,
-    addMultipleEvmAccounts: h.addMultipleEvmAccounts,
-    addSingleAccount: h.addSingleAccount,
-    addSingleEvmAddress: h.addSingleEvmAddress,
+    addAccounts: h.addAccounts,
     completeAccountAddition: h.completeAccountAddition,
     getNewAccountPayload: h.getNewAccountPayload,
   })),
@@ -71,104 +65,92 @@ describe('useBlockchainAccountManagement', () => {
     vi.clearAllMocks();
     set(mockAddRunning, false);
     h.completeAccountAddition.mockResolvedValue(undefined);
-    h.addMultipleEvmAccounts.mockResolvedValue(undefined);
-    h.addMultipleAccounts.mockResolvedValue(undefined);
+    h.addAccounts.mockResolvedValue(NOTHING);
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('addEvmAccounts', () => {
-    it('should add a single evm address and complete the addition', async () => {
-      h.addSingleEvmAddress.mockResolvedValue(ok([{ address: '0xabc', chain: 'eth' }]));
-      const { useBlockchainAccountManagement } = await importModule();
-      await useBlockchainAccountManagement().addEvmAccounts({ modules: undefined, payload: [{ address: '0xabc', tags: null }] });
-      expect(h.addSingleEvmAddress).toHaveBeenCalledWith({ address: '0xabc', tags: null });
-      await flushPromises();
-      expect(h.completeAccountAddition).toHaveBeenCalledWith(
-        { addedAccounts: [{ address: '0xabc', chain: 'eth' }], modulesToEnable: undefined },
-        h.refreshAccounts,
-        h.fetchAccounts,
-      );
-    });
-
-    it('should throw when a single evm addition fails', async () => {
-      h.addSingleEvmAddress.mockResolvedValue(err({ account: { address: '0xabc', tags: null }, error: TaskFailed({ message: 'boom' }) }));
-      const { useBlockchainAccountManagement } = await importModule();
-      await expect(
-        useBlockchainAccountManagement().addEvmAccounts({ modules: undefined, payload: [{ address: '0xabc', tags: null }] }),
-      ).rejects.toThrow('boom');
-    });
-
-    it('should await multiple evm additions when wait is set', async () => {
-      const payload: AddAccountsPayload = { modules: undefined, payload: [
-        { address: '0xabc', tags: null },
-        { address: '0xdef', tags: null },
-      ] };
-      const { useBlockchainAccountManagement } = await importModule();
-      await useBlockchainAccountManagement().addEvmAccounts(payload, { wait: true });
-      expect(h.addMultipleEvmAccounts).toHaveBeenCalledOnce();
-    });
-  });
-
   describe('addAccounts', () => {
+    const payload = { modules: undefined, payload: [{ address: '0xabc', tags: null }] };
+
     it('should skip when an add-account task is already running', async () => {
       set(mockAddRunning, true);
       const { useBlockchainAccountManagement } = await importModule();
-      await useBlockchainAccountManagement().addAccounts('eth', { modules: undefined, payload: [{ address: '0xabc', tags: null }] });
-      expect(h.addSingleAccount).not.toHaveBeenCalled();
+      await useBlockchainAccountManagement().addAccounts('eth', payload);
+      expect(h.addAccounts).not.toHaveBeenCalled();
+    });
+
+    // The guard stops a user submitting the form twice, not a batch from proceeding. A CSV import
+    // fans its rows out at once, so from row two onwards an addition is always already running —
+    // without this the import silently dropped every row but the first while its progress bar and
+    // completion message both still counted them.
+    it('should not skip a row of a batch that is already running', async () => {
+      set(mockAddRunning, true);
+      h.getNewAccountPayload.mockReturnValue([{ address: '0xabc', tags: null }]);
+      const { useBlockchainAccountManagement } = await importModule();
+
+      await useBlockchainAccountManagement().addAccounts('eth', payload, {
+        parent: makeActivityId(ActivityKind.ACCOUNTS, ActivityPart.ADD, 'batch'),
+        wait: true,
+      });
+
+      expect(h.addAccounts).toHaveBeenCalledOnce();
     });
 
     it('should notify when there are no new addresses to add', async () => {
       h.getNewAccountPayload.mockReturnValue([]);
       const { useBlockchainAccountManagement } = await importModule();
-      await useBlockchainAccountManagement().addAccounts('eth', { modules: undefined, payload: [{ address: '0xabc', tags: null }] });
+      await useBlockchainAccountManagement().addAccounts('eth', payload);
       expect(h.notifyInfo).toHaveBeenCalledOnce();
-      expect(h.addSingleAccount).not.toHaveBeenCalled();
+      expect(h.addAccounts).not.toHaveBeenCalled();
     });
 
-    it('should add a single new account and complete the addition', async () => {
-      h.getNewAccountPayload.mockReturnValue([{ address: '0xabc', tags: null }]);
-      h.addSingleAccount.mockResolvedValue(ok('0xabc'));
+    // The address count no longer selects a mechanism: one and many take the same call, and the
+    // batch decides whether an umbrella is warranted.
+    it('should delegate the filtered payload for one address and for many', async () => {
+      h.addAccounts.mockResolvedValue(NOTHING);
+      const many = [{ address: '0xabc', tags: null }, { address: '0xdef', tags: null }];
+      h.getNewAccountPayload.mockReturnValue(many);
       const { useBlockchainAccountManagement } = await importModule();
-      await useBlockchainAccountManagement().addAccounts('eth', { modules: undefined, payload: [{ address: '0xabc', tags: null }] });
-      expect(h.addSingleAccount).toHaveBeenCalledWith({ address: '0xabc', tags: null }, 'eth');
-      await flushPromises();
-      expect(h.completeAccountAddition).toHaveBeenCalledOnce();
+
+      await useBlockchainAccountManagement().addAccounts('eth', { modules: undefined, payload: many }, { wait: true });
+
+      expect(h.addAccounts).toHaveBeenCalledWith('eth', many, undefined, expect.any(Function), undefined);
     });
 
-    it('should add an xpub account directly', async () => {
+    it('should pass an xpub through unfiltered', async () => {
+      h.addAccounts.mockResolvedValue(NOTHING);
       const xpubPayload: XpubAccountPayload = {
         tags: null,
         xpub: { derivationPath: '', xpub: 'xpub123', xpubType: XpubKeyType.XPUB },
       };
-      h.addSingleAccount.mockResolvedValue(ok('xpub123'));
       const { useBlockchainAccountManagement } = await importModule();
-      await useBlockchainAccountManagement().addAccounts('btc', xpubPayload);
-      expect(h.addSingleAccount).toHaveBeenCalledWith(xpubPayload, 'btc');
+      await useBlockchainAccountManagement().addAccounts('btc', xpubPayload, { wait: true });
+
+      expect(h.addAccounts).toHaveBeenCalledWith('btc', xpubPayload, [], expect.any(Function), undefined);
       expect(h.getNewAccountPayload).not.toHaveBeenCalled();
     });
 
-    it('should throw when a single account addition fails', async () => {
+    // Without `wait` the addition is detached, so there is nothing to report back yet.
+    it('should return an empty summary when not awaiting', async () => {
       h.getNewAccountPayload.mockReturnValue([{ address: '0xabc', tags: null }]);
-      h.addSingleAccount.mockResolvedValue(err({ account: { address: '0xabc', tags: null }, error: TaskFailed({ message: 'nope' }) }));
+      h.addAccounts.mockResolvedValue({ added: [{ address: '0xabc', chain: 'eth' }], cancelled: false, failed: [] });
       const { useBlockchainAccountManagement } = await importModule();
-      await expect(
-        useBlockchainAccountManagement().addAccounts('eth', { modules: undefined, payload: [{ address: '0xabc', tags: null }] }),
-      ).rejects.toThrow('nope');
+
+      expect(await useBlockchainAccountManagement().addAccounts('eth', payload)).toStrictEqual(NOTHING);
+      await flushPromises();
+      expect(h.addAccounts).toHaveBeenCalledOnce();
     });
 
-    // A cancellation is not a failure: the user asked for it, so surfacing an error dialog for
-    // work they deliberately stopped is wrong. Only actionable failures reach the form.
-    it('should not throw when a single account addition is cancelled', async () => {
+    it('should return the summary when awaiting', async () => {
+      const summary = { added: [{ address: '0xabc', chain: 'eth' }], cancelled: false, failed: [] };
       h.getNewAccountPayload.mockReturnValue([{ address: '0xabc', tags: null }]);
-      h.addSingleAccount.mockResolvedValue(err({ account: { address: '0xabc', tags: null }, error: Cancelled({ message: 'Request cancelled' }) }));
+      h.addAccounts.mockResolvedValue(summary);
       const { useBlockchainAccountManagement } = await importModule();
-      await expect(
-        useBlockchainAccountManagement().addAccounts('eth', { modules: undefined, payload: [{ address: '0xabc', tags: null }] }),
-      ).resolves.toBeUndefined();
-      expect(h.completeAccountAddition).not.toHaveBeenCalled();
+
+      expect(await useBlockchainAccountManagement().addAccounts('eth', payload, { wait: true })).toStrictEqual(summary);
     });
   });
 

--- a/frontend/app/src/modules/accounts/use-blockchain-account-management.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-account-management.ts
@@ -1,23 +1,25 @@
-import type { AddAccountsPayload, XpubAccountPayload } from '@/modules/accounts/blockchain-accounts';
-import type { ChainAddress } from '@/modules/history/events/event-payloads';
+import type { AccountPayload, AddAccountsPayload, XpubAccountPayload } from '@/modules/accounts/blockchain-accounts';
 import { startPromise } from '@shared/utils';
-import { isErr } from 'plainfp/result';
-import { useAccountAdditionService } from '@/modules/accounts/use-account-addition-service';
+import { isEveryEvmChain } from '@/modules/accounts/use-account-addition-batch';
+import { type AccountAdditionParams, type AdditionSummary, useAccountAdditionService } from '@/modules/accounts/use-account-addition-service';
 import { type RefreshAccountsParams, useAccountOperations } from '@/modules/accounts/use-account-operations';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
-import { throwIfActionable } from '@/modules/core/tasks/task-result';
-import { ActivityKind, ActivityPart } from '@/modules/task-center/core/types';
+import { type ActivityId, ActivityKind, ActivityPart } from '@/modules/task-center/core/types';
 import { useTaskCenter } from '@/modules/task-center/use-task-center';
 
 interface AddAccountsOption {
   wait: boolean;
+  /** Set when this addition is one row of a larger operation, such as a CSV import. */
+  parent?: ActivityId;
 }
 
+/** Nothing was attempted: the add was refused, or it is running detached and has nothing to report. */
+const NOTHING_ADDED: AdditionSummary = { added: [], cancelled: false, failed: [] };
+
 interface UseBlockchainAccountManagementReturn {
-  addAccounts: (chain: string, data: AddAccountsPayload | XpubAccountPayload, options?: AddAccountsOption) => Promise<void>;
-  addEvmAccounts: (payload: AddAccountsPayload, options?: AddAccountsOption) => Promise<void>;
+  addAccounts: (chain: string, data: AddAccountsPayload | XpubAccountPayload, options?: AddAccountsOption) => Promise<AdditionSummary>;
   detectEvmAccounts: () => Promise<void>;
   fetchAccounts: (blockchain?: string | string[], refreshEns?: boolean) => Promise<void>;
   refreshAccounts: (params?: RefreshAccountsParams) => Promise<void>;
@@ -34,30 +36,6 @@ export function useBlockchainAccountManagement(): UseBlockchainAccountManagement
   const addRunning = useWorkStatusPrefix(ActivityKind.ACCOUNTS, ActivityPart.ADD);
   const { notifyInfo } = useNotifications();
   const { t } = useI18n({ useScope: 'global' });
-
-  const addEvmAccounts = async (payload: AddAccountsPayload, options?: AddAccountsOption): Promise<void> => {
-    const onComplete = async (params: { addedAccounts: any[]; modulesToEnable?: any[] }): Promise<void> =>
-      accountAdditionService.completeAccountAddition(params, refreshAccounts, fetchAccounts);
-
-    if (payload.payload.length === 1) {
-      const addResult = await accountAdditionService.addSingleEvmAddress(payload.payload[0]);
-      // The form awaits this call to keep its dialog open on failure, so a real error is still
-      // raised as a throw; only the internal plumbing carries it as a value. A cancellation
-      // returns silently: the user asked for it, so an error dialog would be wrong.
-      if (isErr(addResult)) {
-        throwIfActionable(addResult.error.error);
-        return;
-      }
-
-      startPromise(onComplete({ addedAccounts: addResult.value, modulesToEnable: payload.modules }));
-    }
-    else {
-      if (options?.wait)
-        await accountAdditionService.addMultipleEvmAccounts(payload, onComplete);
-      else
-        startPromise(accountAdditionService.addMultipleEvmAccounts(payload, onComplete));
-    }
-  };
 
   /**
    * An xpub is added as a single unit, so it has no per-account payload to filter against the existing
@@ -78,53 +56,69 @@ export function useBlockchainAccountManagement(): UseBlockchainAccountManagement
     };
   };
 
-  const addAccounts = async (chain: string, payload: AddAccountsPayload | XpubAccountPayload, options?: AddAccountsOption): Promise<void> => {
-    if (get(addRunning).active) {
+  /**
+   * Whether this request should not proceed, having said why.
+   *
+   * The running guard is against a user submitting the form twice, not against a batch proceeding.
+   * A row of a batch declares its parent, and from the second row onwards an addition is always
+   * already running — refusing those silently dropped every row but the first while the progress
+   * bar and the completion message still counted them.
+   */
+  const isRefused = (chain: string, filteredPayload: AccountPayload[], isXpub: boolean, parent?: ActivityId): boolean => {
+    if (!parent && get(addRunning).active) {
       logger.debug('account add is already running.');
-      return;
+      return true;
     }
 
+    if (filteredPayload.length > 0 || isXpub)
+      return false;
+
+    notifyInfo(
+      t('actions.balances.blockchain_accounts_add.task.title', {
+        blockchain: isEveryEvmChain(chain) ? chain : getChainName(chain),
+      }),
+      t('actions.balances.blockchain_accounts_add.no_new.description'),
+    );
+    return true;
+  };
+
+  /**
+   * The single addition entry point. `chain` may be {@link EVM_PSEUDO_CHAIN} for "every EVM chain",
+   * which is a chain value rather than a second function: the count of addresses no longer selects
+   * a different mechanism, a different error contract or a different completion shape.
+   *
+   * Returns what happened instead of throwing, so the caller decides how to present it — a form can
+   * keep its dialog open, a bulk import can just tally.
+   */
+  const addAccounts = async (chain: string, payload: AddAccountsPayload | XpubAccountPayload, options?: AddAccountsOption): Promise<AdditionSummary> => {
     const { filteredPayload, isXpub, modules } = resolveAdditionPayload(chain, payload);
-    if (filteredPayload.length === 0 && !isXpub) {
-      const title = t('actions.balances.blockchain_accounts_add.task.title', {
-        blockchain: getChainName(chain),
-      });
-      const message = t('actions.balances.blockchain_accounts_add.no_new.description');
-      notifyInfo(title, message);
-      return;
-    }
+    if (isRefused(chain, filteredPayload, isXpub, options?.parent))
+      return NOTHING_ADDED;
 
-    const onComplete = async (params: { addedAccounts: ChainAddress[]; chain: string; isXpub?: boolean; modulesToEnable?: any[] }): Promise<void> =>
+    const onComplete = async (params: AccountAdditionParams): Promise<void> =>
       accountAdditionService.completeAccountAddition(params, refreshAccounts, fetchAccounts);
 
-    if (filteredPayload.length === 1 || isXpub) {
-      // The `in` check rather than `isXpub`, so `payload` narrows to the xpub variant here.
-      const addResult = await accountAdditionService.addSingleAccount('xpub' in payload ? payload : filteredPayload[0], chain);
-      if (isErr(addResult)) {
-        throwIfActionable(addResult.error.error);
-        return;
-      }
+    // The `in` check rather than `isXpub`, so `payload` narrows to the xpub variant here.
+    const addition = accountAdditionService.addAccounts(
+      chain,
+      'xpub' in payload ? payload : filteredPayload,
+      modules,
+      onComplete,
+      options?.parent ? { parent: options.parent } : undefined,
+    );
 
-      startPromise(onComplete({
-        addedAccounts: [{ address: addResult.value, chain }],
-        chain,
-        isXpub,
-        modulesToEnable: modules,
-      }));
-      return;
+    // Only an explicit wait blocks the caller; otherwise the additions run in the background and
+    // there is nothing to report back yet.
+    if (!options?.wait) {
+      startPromise(addition);
+      return NOTHING_ADDED;
     }
 
-    const addition = accountAdditionService.addMultipleAccounts(filteredPayload, chain, modules, onComplete);
-    // Only an explicit wait blocks the caller; otherwise the additions run in the background.
-    if (options?.wait)
-      await addition;
-    else
-      startPromise(addition);
+    return addition;
   };
 
   return {
     addAccounts,
-    addEvmAccounts,
     detectEvmAccounts,
     fetchAccounts,
     refreshAccounts,

--- a/frontend/app/src/modules/task-center/core/activity-descriptor.ts
+++ b/frontend/app/src/modules/task-center/core/activity-descriptor.ts
@@ -1,5 +1,5 @@
 import type { Lane } from '@/modules/task-center/core/orchestrator/spec';
-import { type ActivityId, type ActivityKind, type ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
+import { type ActivityId, type ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
 
 /**
  * Every leading slice of a tuple, including the empty one: `[A, B]` gives `[] | [A] | [A, B]`.
@@ -50,6 +50,12 @@ export interface ActivityDescriptor<TSubject, TKey extends KeyParts> {
   readonly partsOf: (subject: TSubject) => KeyParts;
   /** As {@link partsOf}, for a prefix of the key: the coarse read. */
   readonly partsWithin: (prefix: Prefixes<TKey>) => KeyParts;
+  /**
+   * The id of the umbrella that parents a fan-out over `prefix` — one row per chain rather than one
+   * per address. It sits under the same prefix as its children, so a coarse reader covers both, and
+   * ends in a literal that no subject key part can produce.
+   */
+  readonly batchId: (prefix: Prefixes<TKey>) => ActivityId;
   /** The lane one subject's work runs in, when it declares one. */
   readonly laneOf?: (subject: TSubject) => Lane;
 }
@@ -71,6 +77,8 @@ export function defineActivity<TSubject, const TKey extends KeyParts>(
   const partsOf = (subject: TSubject): KeyParts => [input.part, ...input.key(subject)];
 
   return {
+    batchId: (prefix: Prefixes<TKey>): ActivityId =>
+      makeActivityId(input.kind, input.part, ...prefix, ActivityPart.BATCH),
     id: (subject: TSubject): ActivityId => makeActivityId(input.kind, ...partsOf(subject)),
     keyOf: input.key,
     kind: input.kind,

--- a/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
@@ -16,7 +16,7 @@ export type StaticLane = (typeof STATIC_LANES)[number];
  * (`tx-sync:<chain>`). Also a closed list, so a family cap cannot be keyed by a prefix no producer
  * ever mints.
  */
-export const LANE_FAMILIES = ['tx-sync:', 'exchange-events:', 'accounts-add:'] as const;
+export const LANE_FAMILIES = ['tx-sync:', 'exchange-events:', 'accounts-add:', 'accounts-remove:'] as const;
 
 export type LaneFamily = (typeof LANE_FAMILIES)[number];
 
@@ -92,6 +92,18 @@ export const EXCHANGE_EVENTS_LANE_PREFIX: LaneFamily = 'exchange-events:';
  * flat lane would serialize additions across chains instead, which is not what it replaced.
  */
 export const ACCOUNTS_ADD_LANE_PREFIX: LaneFamily = 'accounts-add:';
+
+/**
+ * Family prefix for the per-chain account-removal lanes (`accounts-remove:<chain>`). Capped at 1 per
+ * chain *and* 1 active lane, which together reproduce the fully serial `awaitParallelExecution(...,
+ * 1)` that removing one address from several chains used to apply by hand.
+ *
+ * Its own family rather than a share of {@link ACCOUNTS_ADD_LANE_PREFIX}: an addition and a removal
+ * are independent operations on different addresses, so pooling them would make a removal wait on an
+ * unrelated addition. They contend for the same chain only in the sense every chain call does, which
+ * is a per-chain budget question, not a reason to serialize the two against each other.
+ */
+export const ACCOUNTS_REMOVE_LANE_PREFIX: LaneFamily = 'accounts-remove:';
 
 /** Push live step progress for a running activity. Pure no-op-safe; calling after the spec
  *  settles is harmless (ignored by the orchestrator). */

--- a/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
@@ -16,7 +16,7 @@ export type StaticLane = (typeof STATIC_LANES)[number];
  * (`tx-sync:<chain>`). Also a closed list, so a family cap cannot be keyed by a prefix no producer
  * ever mints.
  */
-export const LANE_FAMILIES = ['tx-sync:', 'exchange-events:'] as const;
+export const LANE_FAMILIES = ['tx-sync:', 'exchange-events:', 'accounts-add:'] as const;
 
 export type LaneFamily = (typeof LANE_FAMILIES)[number];
 
@@ -84,6 +84,14 @@ export const ACCOUNT_SYNC_LANE_PREFIX: LaneFamily = 'tx-sync:';
  * A flat lane cap could not express it: two slots would happily go to the same exchange.
  */
 export const EXCHANGE_EVENTS_LANE_PREFIX: LaneFamily = 'exchange-events:';
+
+/**
+ * Family prefix for the per-chain account-addition lanes (`accounts-add:<chain>`). Capped at 2 per
+ * chain, which is the parallelism `addMultipleAccounts` used to apply itself with
+ * `awaitParallelExecution(..., 2)` — per chain, because that limiter wrapped a per-chain call. A
+ * flat lane would serialize additions across chains instead, which is not what it replaced.
+ */
+export const ACCOUNTS_ADD_LANE_PREFIX: LaneFamily = 'accounts-add:';
 
 /** Push live step progress for a running activity. Pure no-op-safe; calling after the spec
  *  settles is harmless (ignored by the orchestrator). */

--- a/frontend/app/src/modules/task-center/core/types.ts
+++ b/frontend/app/src/modules/task-center/core/types.ts
@@ -282,6 +282,12 @@ export const ActivityPart = {
   SUSHISWAP: 'sushiswap',
   FETCH: 'fetch',
   ADD: 'add',
+  /**
+   * Work scoped to an account *category* ("every EVM chain") rather than a chain. A literal part
+   * rather than a bare category name, so such an id can never be mistaken for a chain-scoped one
+   * by a prefix reader — a chain would have to be named `category` for them to overlap.
+   */
+  CATEGORY: 'category',
   EDIT: 'edit',
   PERFORMANCE: 'performance',
   VALIDATORS: 'validators',

--- a/frontend/app/src/modules/task-center/use-activity-batch.spec.ts
+++ b/frontend/app/src/modules/task-center/use-activity-batch.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ActivityKind, makeActivityId } from '@/modules/task-center/core/types';
+import { useActivityBatch } from '@/modules/task-center/use-activity-batch';
+import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
+
+// The orchestrator stays real; only the backend runner behind it is stubbed.
+vi.mock('@/modules/core/tasks/use-task-handler', () => ({
+  useTaskHandler: (): Record<string, unknown> => ({
+    cancelTaskById: vi.fn(async () => true),
+    runTaskResult: vi.fn(),
+  }),
+}));
+
+const umbrellaId = makeActivityId(ActivityKind.ACCOUNTS, 'add', 'eth', 'batch');
+
+function umbrella(): { id: typeof umbrellaId; kind: ActivityKind; title: string } {
+  return { id: umbrellaId, kind: ActivityKind.ACCOUNTS, title: 'accounts' };
+}
+
+describe('useActivityBatch', () => {
+  it('should run every item and return the results in order', async () => {
+    const { runActivityBatch } = useActivityBatch();
+    const results = await runActivityBatch(umbrella(), ['a', 'b', 'c'], async item => item.toUpperCase());
+
+    expect(results).toStrictEqual(['A', 'B', 'C']);
+  });
+
+  it('should give every child the umbrella as its parent', async () => {
+    const { runActivityBatch } = useActivityBatch();
+    const parents: (string | undefined)[] = [];
+
+    await runActivityBatch(umbrella(), ['a', 'b'], async (_item, parent) => {
+      parents.push(parent);
+    });
+
+    expect(parents).toStrictEqual([umbrellaId, umbrellaId]);
+  });
+
+  // One child needs no parent: an umbrella over a single activity is a second row describing the
+  // same work. This is what lets callers stop branching on the item count themselves.
+  it('should submit no umbrella for a single item', async () => {
+    const { runActivityBatch } = useActivityBatch();
+    const { statusOf } = useTaskOrchestrator();
+    const parents: (string | undefined)[] = [];
+    // Its own id: the orchestrator is a shared singleton, so an umbrella another test in this file
+    // already completed would make "no umbrella was submitted" read as false.
+    const soleId = makeActivityId(ActivityKind.ACCOUNTS, 'add', 'sole', 'batch');
+
+    const results = await runActivityBatch({ ...umbrella(), id: soleId }, ['only'], async (item, parent) => {
+      parents.push(parent);
+      return item;
+    });
+
+    expect(results).toStrictEqual(['only']);
+    expect(parents).toStrictEqual([undefined]);
+    expect(statusOf(ActivityKind.ACCOUNTS, 'add', 'sole', 'batch').everCompleted).toBe(false);
+  });
+
+  it('should submit no umbrella for an empty batch', async () => {
+    const { runActivityBatch } = useActivityBatch();
+    const run = vi.fn();
+
+    expect(await runActivityBatch(umbrella(), [], run)).toStrictEqual([]);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  // allSettled, not all: the umbrella must not abandon the rest of the batch because one item
+  // failed, and it settles complete either way — a failure belongs to the item that failed.
+  it('should still settle when one item rejects', async () => {
+    const { runActivityBatch } = useActivityBatch();
+    const seen: string[] = [];
+
+    const results = runActivityBatch(umbrella(), ['a', 'b', 'c'], async (item) => {
+      if (item === 'a')
+        throw new Error('boom');
+
+      seen.push(item);
+      return item;
+    });
+
+    await expect(results).rejects.toThrow('boom');
+    expect(seen).toStrictEqual(['b', 'c']);
+  });
+
+  // ⚠️ `await runActivityBatch(...)` resolves when the umbrella's own promise settles, which is a
+  // tick before the orchestrator records the activity terminal. Asserting straight after the await
+  // reads it as still active — the same settle lag the task centre shows in the panel.
+  it('should settle the umbrella activity itself', async () => {
+    const { runActivityBatch } = useActivityBatch();
+    const { statusOf } = useTaskOrchestrator();
+
+    await runActivityBatch(umbrella(), ['a'], async item => item);
+
+    await vi.waitFor(() => {
+      expect(statusOf(ActivityKind.ACCOUNTS, 'add', 'eth', 'batch').active).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/task-center/use-activity-batch.ts
+++ b/frontend/app/src/modules/task-center/use-activity-batch.ts
@@ -1,0 +1,101 @@
+import type { TaskError } from '@/modules/core/tasks/task-result';
+import type { ActivityId, ActivityKind, ActivityText } from '@/modules/task-center/core/types';
+import { ok, type Result } from 'plainfp/result';
+import { UMBRELLA_LANE } from '@/modules/task-center/core/orchestrator/spec';
+import { useNativeTask } from '@/modules/task-center/use-native-task';
+
+interface BatchLabels {
+  readonly title: string;
+  readonly subtitle?: ActivityText;
+}
+
+/**
+ * The umbrella row a fan-out runs under. The id is built by the caller from its descriptor
+ * (`descriptor.batchId([chain])`), where the key type is concrete and the prefix is still checked;
+ * taking the descriptor and the prefix here instead would put `Prefixes<TKey>` in an inference
+ * position it cannot be recovered from, and every call would collapse to the empty prefix.
+ */
+interface BatchUmbrella extends BatchLabels {
+  readonly id: ActivityId;
+  readonly kind: ActivityKind;
+  /**
+   * The umbrella's own parent, when this batch is itself part of a larger one — a CSV import fans
+   * out over rows, each of which fans out over addresses. Passed through to the children when the
+   * umbrella is suppressed, so a single-item batch does not orphan its child from the outer batch.
+   */
+  readonly parent?: ActivityId;
+}
+
+interface UseActivityBatchReturn {
+  runActivityBatch: <TItem, TResult>(
+    umbrella: BatchUmbrella,
+    items: readonly TItem[],
+    run: (item: TItem, parent: ActivityId | undefined) => Promise<TResult>,
+  ) => Promise<TResult[]>;
+}
+
+export function useActivityBatch(): UseActivityBatchReturn {
+  const { submitTask } = useNativeTask();
+
+  /**
+   * Runs one activity per subject under a single umbrella row.
+   *
+   * Throttling is the lane's job, not this function's — each subject's own submit carries the
+   * descriptor's lane. Wrapping this in a limiter as well would put two mechanisms on one piece of
+   * work, which is what the warning on `DECODE_LANE` is about.
+   *
+   * The umbrella runs on {@link UMBRELLA_LANE}, never the children's lane: a parent holding a slot
+   * in the lane it is waiting on throttles its own children, and at a cap of 1 deadlocks.
+   */
+  async function runActivityBatch<TItem, TResult>(
+    umbrella: BatchUmbrella,
+    items: readonly TItem[],
+    run: (item: TItem, parent: ActivityId | undefined) => Promise<TResult>,
+  ): Promise<TResult[]> {
+    if (items.length === 0)
+      return [];
+
+    // One item needs no umbrella: a parent over a single child is a second row in the task centre
+    // describing the same work. Suppressing it here is what lets the caller stop branching on the
+    // item count — the batch decides presentation, the caller always fans out.
+    if (items.length === 1)
+      return [await run(items[0], umbrella.parent)];
+
+    const batchId = umbrella.id;
+
+    // The umbrella is submitted before its children so the parent gate applies to them, but its
+    // `run` needs their promises, which only exist once submitted.
+    let declared!: (work: readonly Promise<TResult>[]) => void;
+    const subtree = new Promise<readonly Promise<TResult>[]>((resolve) => {
+      declared = resolve;
+    });
+
+    const batch = submitTask({
+      id: batchId,
+      kind: umbrella.kind,
+      lane: UMBRELLA_LANE,
+      parent: umbrella.parent,
+      rerunnable: false,
+      // allSettled, never all: one subject failing must not abandon the rest. The umbrella settles
+      // complete either way — a failure belongs to the subject that failed, and marking the parent
+      // failed would say the whole batch never happened.
+      run: async (): Promise<Result<void, TaskError>> => {
+        await Promise.allSettled(await subtree);
+        return ok(undefined);
+      },
+      subtitle: umbrella.subtitle,
+      title: umbrella.title,
+    });
+
+    const work = items.map(async item => run(item, batchId));
+    declared(work);
+
+    // Results come from the children, not through the umbrella: a second batch over the same prefix
+    // dedups onto the first umbrella, and reading its outcome would report the wrong run's work.
+    const results = await Promise.all(work);
+    await batch;
+    return results;
+  }
+
+  return { runActivityBatch };
+}

--- a/frontend/app/src/modules/task-center/use-task-orchestrator.ts
+++ b/frontend/app/src/modules/task-center/use-task-orchestrator.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { TaskOrchestrator } from './core/orchestrator/api';
 import { createTaskOrchestrator } from './core/orchestrator/orchestrator';
-import { ACCOUNT_SYNC_LANE_PREFIX, ACCOUNTS_ADD_LANE_PREFIX, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
+import { ACCOUNT_SYNC_LANE_PREFIX, ACCOUNTS_ADD_LANE_PREFIX, ACCOUNTS_REMOVE_LANE_PREFIX, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
 import { type Activity, type ActivityKind, makeActivityId, type WorkStatus } from './core/types';
 
 /**
@@ -65,11 +65,12 @@ export const useTaskOrchestrator = createSharedComposable((): UseTaskOrchestrato
       [UMBRELLA_LANE]: 16,
     },
     // Two accounts per chain, not two across every chain; one query per exchange location; two
-    // addresses added at once per chain, replacing `addMultipleAccounts`'s own limiter.
-    laneFamilies: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [ACCOUNTS_ADD_LANE_PREFIX]: 2, [EXCHANGE_EVENTS_LANE_PREFIX]: 1 },
+    // addresses added at once per chain, replacing `addMultipleAccounts`'s own limiter. Removals
+    // take 1 per chain and 1 active lane, which is the fully serial shape they always had.
+    laneFamilies: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [ACCOUNTS_ADD_LANE_PREFIX]: 2, [ACCOUNTS_REMOVE_LANE_PREFIX]: 1, [EXCHANGE_EVENTS_LANE_PREFIX]: 1 },
     // ...and only two chains' lanes live at once. The accounts of every chain are declared up
     // front now, so without this the per-chain cap alone would let all of them progress together.
-    laneFamilyActive: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [ACCOUNTS_ADD_LANE_PREFIX]: 2, [EXCHANGE_EVENTS_LANE_PREFIX]: 2 },
+    laneFamilyActive: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [ACCOUNTS_ADD_LANE_PREFIX]: 2, [ACCOUNTS_REMOVE_LANE_PREFIX]: 1, [EXCHANGE_EVENTS_LANE_PREFIX]: 2 },
   });
   const activities = shallowRef<Activity[]>([]);
   // Bumped on every orchestrator change so `useWorkStatus` computeds re-read the (non-reactive)

--- a/frontend/app/src/modules/task-center/use-task-orchestrator.ts
+++ b/frontend/app/src/modules/task-center/use-task-orchestrator.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { TaskOrchestrator } from './core/orchestrator/api';
 import { createTaskOrchestrator } from './core/orchestrator/orchestrator';
-import { ACCOUNT_SYNC_LANE_PREFIX, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
+import { ACCOUNT_SYNC_LANE_PREFIX, ACCOUNTS_ADD_LANE_PREFIX, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
 import { type Activity, type ActivityKind, makeActivityId, type WorkStatus } from './core/types';
 
 /**
@@ -64,11 +64,12 @@ export const useTaskOrchestrator = createSharedComposable((): UseTaskOrchestrato
       [SESSION_LANE]: 2,
       [UMBRELLA_LANE]: 16,
     },
-    // Two accounts per chain, not two across every chain; one query per exchange location.
-    laneFamilies: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [EXCHANGE_EVENTS_LANE_PREFIX]: 1 },
+    // Two accounts per chain, not two across every chain; one query per exchange location; two
+    // addresses added at once per chain, replacing `addMultipleAccounts`'s own limiter.
+    laneFamilies: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [ACCOUNTS_ADD_LANE_PREFIX]: 2, [EXCHANGE_EVENTS_LANE_PREFIX]: 1 },
     // ...and only two chains' lanes live at once. The accounts of every chain are declared up
     // front now, so without this the per-chain cap alone would let all of them progress together.
-    laneFamilyActive: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [EXCHANGE_EVENTS_LANE_PREFIX]: 2 },
+    laneFamilyActive: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [ACCOUNTS_ADD_LANE_PREFIX]: 2, [EXCHANGE_EVENTS_LANE_PREFIX]: 2 },
   });
   const activities = shallowRef<Activity[]>([]);
   // Bumped on every orchestrator change so `useWorkStatus` computeds re-read the (non-reactive)


### PR DESCRIPTION
Second of three stacked PRs, on top of #12804. With each activity now declared once, this makes additions take one path regardless of how many addresses they carry, and gives removals a lane instead of a hand-rolled limiter.

### One addition mechanism

Adding one address and adding many took different code paths, and the difference was accidental rather than chosen: the address count decided the experience. One address threw, so the form dialog stayed open; two or more reported through a toast and closed the dialog as a success **even when some of them had failed**.

Every entry now fans out through the same batch — including a single one, where the batch suppresses the umbrella — so the count only changes how the result is presented, never the mechanism. Additions return an `AdditionSummary` rather than throwing, so the caller decides the experience.

The CSV import path joins the same mechanism. Its EVM loop had no `try/catch` while its chain loop did, so a failed EVM row aborted the whole import and a failed chain row did not.

### Removals get a lane

`accounts-remove:<chain>`, capped at one per chain with one active chain at a time — the fully serial shape `awaitParallelExecution(..., 1)` gave by hand. Its own family, not shared with `accounts-add:`, so a removal never waits on an unrelated addition. The agnostic removal joins the same family keyed by category, so it and a per-chain removal take turns rather than racing.

The limiter inside the delete composable goes away: expressing concurrency in two places at once is the trap documented on `DECODE_LANE`.

⚠️ **The lane must be forwarded at the `submitTask` call site, not just declared on the activity.** Declaring it alone is invisible — the spec is what the orchestrator reads, so a declared-but-unforwarded lane leaves every removal on the default lane with the family caps as dead config. The tests assert the spec `submitTask` receives for exactly that reason; asserting `laneOf` on the descriptor passes either way.

### Also here

- The agnostic removal id opens with a literal `category` part, so it can never be read as a chain-scoped one by a prefix reader. Keying straight off the category name left the two apart only because no chain happens to be called `evm` — incidental, and invisible once it stopped being true.
- `EvmAccountsResult.added` is an optional record, so `{}` is a valid response: truthy, but with no entry to destructure. That threw `undefined is not iterable` out of the composable — a raw type error in the add dialog, and in a bulk add swallowed by the queue, so the address reached neither the added nor the failed list.
- Cancellations no longer write a log line per in-flight address.

### Verification

- `typecheck` clean, `typos` clean, lint 0 errors (20 pre-existing `vue/max-props` / `max-template-depth` warnings in files this branch does not touch).
- Unit suite green on this branch alone: **773 files / 7282 tests**.
- The removal lane was verified in a running app, not only in tests. Timing each `DELETE` for one address across three chains: serialized `0→12ms`, `2220→2229`, `6269→6279`. With the lane removed, all three start within 3ms of each other, before any has returned.
