### PR TITLE
Read the addition summary at every caller

### DIFF
--- a/frontend/app/src/modules/accounts/blockchain/addition-outcome.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/addition-outcome.spec.ts
@@ -1,0 +1,56 @@
+import type { AccountAdditionFailure, AdditionSummary } from '@/modules/accounts/use-account-addition-service';
+import { describe, expect, it } from 'vitest';
+import { additionError, isNothingButCancelled } from '@/modules/accounts/blockchain/addition-outcome';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+import { Cancelled, TaskFailed } from '@/modules/core/tasks/task-result';
+
+function failure(error: AccountAdditionFailure['error']): AccountAdditionFailure {
+  return { account: { address: '0xabc', tags: null }, error };
+}
+
+function summary(partial: Partial<AdditionSummary>): AdditionSummary {
+  return { added: [], cancelled: false, failed: [], ...partial };
+}
+
+describe('additionError', () => {
+  it('should return the cause of a lone failure so a validation error survives', () => {
+    const cause = new ApiValidationError('{"address": ["not a valid solana address"]}');
+
+    const error = additionError([failure(TaskFailed({ cause, message: 'wrapped' }))], 'fallback');
+
+    // Identity, not just shape: `handleErrors` branches on `instanceof ApiValidationError` to fill
+    // in per-field errors, and a re-wrapped copy would lose that.
+    expect(error).toBe(cause);
+  });
+
+  it('should use the fallback when a lone failure carries no Error cause', () => {
+    expect(additionError([failure(TaskFailed({ message: 'boom' }))], 'fallback'))
+      .toStrictEqual(new Error('boom'));
+  });
+
+  it('should use the fallback for several failures, since no one field is at fault', () => {
+    const cause = new ApiValidationError('{"address": ["bad"]}');
+    const failed = [failure(TaskFailed({ cause, message: 'wrapped' })), failure(TaskFailed({ message: 'boom' }))];
+
+    expect(additionError(failed, '2 addresses failed')).toStrictEqual(new Error('2 addresses failed'));
+  });
+});
+
+describe('isNothingButCancelled', () => {
+  it('should be true when every unit was cancelled', () => {
+    expect(isNothingButCancelled(summary({ cancelled: true }))).toBe(true);
+  });
+
+  it('should be false when something was added', () => {
+    expect(isNothingButCancelled(summary({ added: [{ address: '0xabc', chain: 'eth' }], cancelled: true }))).toBe(false);
+  });
+
+  // A real failure alongside a cancellation is still worth reporting, so this must not swallow it.
+  it('should be false when something failed for real', () => {
+    expect(isNothingButCancelled(summary({ cancelled: true, failed: [failure(Cancelled({ message: 'x' }))] }))).toBe(false);
+  });
+
+  it('should be false for a plain empty summary', () => {
+    expect(isNothingButCancelled(summary({}))).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/accounts/blockchain/addition-outcome.ts
+++ b/frontend/app/src/modules/accounts/blockchain/addition-outcome.ts
@@ -1,0 +1,35 @@
+import type { AccountAdditionFailure, AdditionSummary } from '@/modules/accounts/use-account-addition-service';
+import { errorOf } from '@/modules/core/tasks/task-result';
+
+/**
+ * Reading an {@link AdditionSummary} the way a form has to. Additions report every outcome as a
+ * value rather than a throw, so a caller that only wraps the call in `try/catch` sees success for
+ * all three of "added", "rejected" and "cancelled".
+ *
+ * Pure and message-agnostic: the caller supplies the already-translated fallback, so this stays
+ * free of `useI18n` and can be tested without one.
+ */
+
+/**
+ * The error to report when an addition added nothing. A single failure hands back its own cause, so
+ * a backend field-level rejection still reaches the form as an `ApiValidationError` and highlights
+ * the offending field; flattening it into a bare `Error` would show one generic toast instead.
+ *
+ * Several failures have no single field to highlight, so they get `fallback` and the mechanism's own
+ * notification lists the addresses.
+ */
+export function additionError(failed: readonly AccountAdditionFailure[], fallback: string): Error {
+  if (failed.length === 1)
+    return errorOf(failed[0].error);
+
+  return new Error(fallback);
+}
+
+/**
+ * Nothing was added and every unit was cancelled. Not a success: treating it as one closes the
+ * dialog, emits `complete` and refreshes for an account that was never added, discarding what the
+ * user typed. Not an error either — the user asked for it, so nothing is reported.
+ */
+export function isNothingButCancelled(summary: AdditionSummary): boolean {
+  return summary.added.length === 0 && summary.failed.length === 0 && summary.cancelled;
+}

--- a/frontend/app/src/modules/accounts/blockchain/use-account-manage.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-manage.spec.ts
@@ -5,6 +5,7 @@ import { type Pinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type BlockchainAccountBalance, XpubKeyType } from '@/modules/accounts/blockchain-accounts';
 import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
+import { TaskFailed } from '@/modules/core/tasks/task-result';
 
 const mockAddAccounts = vi.fn();
 const mockAddEvmAccounts = vi.fn();
@@ -277,6 +278,71 @@ describe('composables/accounts/blockchain/use-account-manage', () => {
         'account_form.error.title',
         expect.stringContaining('{}'),
       );
+    });
+
+    it('should map a resolved failure cause to inline form errors', async () => {
+      mockAddAccounts.mockResolvedValueOnce({
+        added: [],
+        cancelled: false,
+        failed: [{
+          account: { address: 'Hasda78TSaT9bjiPxDBvP4GpohFpP3TDTaJEcCYK', tags: null },
+          error: TaskFailed({
+            cause: new ApiValidationError('{"address": ["Given value Hasda78TSaT9bjiPxDBvP4GpohFpP3TDTaJEcCYK is not a valid solana address"]}'),
+            message: 'validation failed',
+          }),
+        }],
+      });
+
+      const { modelErrorMessages, save } = useAccountManage();
+      const result = await save(createSolanaAccountState());
+
+      expect(result).toBe(false);
+      expect(get(modelErrorMessages)).toEqual({
+        address: ['Given value Hasda78TSaT9bjiPxDBvP4GpohFpP3TDTaJEcCYK is not a valid solana address'],
+      });
+      expect(mockShowErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it('should report the count when several addresses fail', async () => {
+      mockAddAccounts.mockResolvedValueOnce({
+        added: [],
+        cancelled: false,
+        failed: [
+          {
+            account: { address: '0xone', tags: null },
+            error: TaskFailed({ cause: new ApiValidationError('{"address": ["bad"]}'), message: 'validation failed' }),
+          },
+          {
+            account: { address: '0xtwo', tags: null },
+            error: TaskFailed({ message: 'boom' }),
+          },
+        ],
+      });
+
+      const { modelErrorMessages, save } = useAccountManage();
+      const result = await save(createSolanaAccountState());
+
+      expect(result).toBe(false);
+      // No single field to highlight across two addresses.
+      expect(get(modelErrorMessages)).toEqual({});
+      expect(mockShowErrorMessage).toHaveBeenCalledWith(
+        'account_form.error.title',
+        expect.stringContaining('account_form.error.addition_failed'),
+      );
+    });
+
+    // Cancelling produces neither an addition nor a failure. Returning true there closed the dialog
+    // and emitted `complete` for an account that was never added.
+    it('should not report a fully cancelled addition as saved', async () => {
+      mockAddAccounts.mockResolvedValueOnce({ added: [], cancelled: true, failed: [] });
+
+      const { modelErrorMessages, save } = useAccountManage();
+      const result = await save(createSolanaAccountState());
+
+      expect(result).toBe(false);
+      // The user asked for the cancellation, so nothing is reported.
+      expect(get(modelErrorMessages)).toEqual({});
+      expect(mockShowErrorMessage).not.toHaveBeenCalled();
     });
 
     it('should not double-parse an existing ApiValidationError', async () => {

--- a/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
@@ -12,6 +12,7 @@ import { assert, bigNumberify, Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { getAccountAddress, getChain } from '@/modules/accounts/account-utils';
 import { EVM_PSEUDO_CHAIN } from '@/modules/accounts/accounts.activity';
+import { additionError, isNothingButCancelled } from '@/modules/accounts/blockchain/addition-outcome';
 import { useAccountEdits } from '@/modules/accounts/use-account-edits';
 import { useBlockchainAccountManagement } from '@/modules/accounts/use-blockchain-account-management';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
@@ -205,6 +206,9 @@ export function useAccountManage(): UseAccountManageReturn {
     }
   }
 
+  const additionFallback = (count: number): string =>
+    t('account_form.error.addition_failed', { count }, count);
+
   async function saveAccount(state: AccountManage): Promise<boolean> {
     const edit = state.mode === 'edit';
     const isEth = state.chain === Blockchain.ETH;
@@ -228,9 +232,12 @@ export function useAccountManage(): UseAccountManageReturn {
       // accounts that did land are real. Previously the count decided this: one address threw, and
       // two or more closed the dialog as a success even when some of them had failed.
       if (summary.added.length === 0 && summary.failed.length > 0) {
-        handleErrors(new Error(t('account_form.error.addition_failed', { count: summary.failed.length }, summary.failed.length)));
+        handleErrors(additionError(summary.failed, additionFallback(summary.failed.length)));
         return false;
       }
+
+      if (isNothingButCancelled(summary))
+        return false;
     }
     catch (error: unknown) {
       handleErrors(error);
@@ -274,12 +281,15 @@ export function useAccountManage(): UseAccountManageReturn {
         // in per-field errors.
         const summary = await addAccounts(chain, state.data, { wait: true });
         if (summary.added.length === 0 && summary.failed.length > 0) {
-          handleErrors(new Error(t('account_form.error.addition_failed', { count: 1 }, 1)), {
+          handleErrors(additionError(summary.failed, additionFallback(summary.failed.length)), {
             derivationPath: '',
             xpub: '',
           });
           return false;
         }
+
+        if (isNothingButCancelled(summary))
+          return false;
       }
     }
     catch (error: unknown) {

--- a/frontend/app/src/modules/accounts/import-export/use-account-import.ts
+++ b/frontend/app/src/modules/accounts/import-export/use-account-import.ts
@@ -110,11 +110,14 @@ export function useAccountImport(): UseAccountImportReturn {
     await runImportBatch(
       additions,
       async ([chain, account], parent) => {
-        increment();
         // Both kinds of row take the same call with the same contract. The EVM loop previously had
         // no `try/catch` while the chain one did, so a failed EVM row aborted the whole import and
         // a failed chain row did not — accidental, not chosen. Neither throws now.
         await addAccounts(chain, account, { parent, wait: true });
+        // Counted after the row lands, not before. The batch starts every row's callback in the
+        // same tick, so incrementing first drove the bar to 100% before a single account had been
+        // submitted and left it parked there while the lanes drained.
+        increment();
       },
     );
 

--- a/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
@@ -214,12 +214,18 @@ describe('useAccountAdditionService', () => {
       expect(h.notifyFailedToAddAddress).not.toHaveBeenCalled();
     });
 
-    it('should notify about failed additions and report them in the summary', async () => {
-      h.addAccount.mockResolvedValue(err(TaskFailed({ message: 'nope' })));
+    // The reason travels with the payload: a form caller reads the cause off it to fill in
+    // per-field errors, which a payload-only summary cannot support.
+    it('should notify about failed additions and report them with their reason', async () => {
+      const cause = new Error('{"address": ["invalid"]}');
+      h.addAccount.mockResolvedValue(err(TaskFailed({ cause, message: 'nope' })));
       const { useAccountAdditionService } = await importModule();
       const summary = await useAccountAdditionService().addAccounts('eth', [{ address: '0xabc', tags: null }], undefined, onComplete);
 
-      expect(summary.failed).toStrictEqual([{ address: '0xabc', tags: null }]);
+      expect(summary.failed).toStrictEqual([{
+        account: { address: '0xabc', tags: null },
+        error: TaskFailed({ cause, message: 'nope' }),
+      }]);
       expect(h.notifyFailedToAddAddress).toHaveBeenCalledOnce();
     });
 
@@ -271,7 +277,10 @@ describe('useAccountAdditionService', () => {
       const { useAccountAdditionService } = await importModule();
       const summary = await useAccountAdditionService().addAccounts('btc', xpubPayload, undefined, onComplete);
 
-      expect(summary.failed).toStrictEqual([xpubPayload]);
+      expect(summary.failed).toStrictEqual([{
+        account: xpubPayload,
+        error: TaskFailed({ message: 'nope' }),
+      }]);
       expect(h.notifyFailedToAddAddress).not.toHaveBeenCalled();
     });
   });

--- a/frontend/app/src/modules/accounts/use-account-addition-service.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.ts
@@ -25,7 +25,7 @@ import { useTagOperations } from '@/modules/tags/use-tag-operations';
  * hand, and (because `addAccount` signalled failure with `''`) the success branch also absorbed
  * cancellations.
  */
-interface AccountAdditionFailure<T = AccountPayload | XpubAccountPayload> {
+export interface AccountAdditionFailure<T = AccountPayload | XpubAccountPayload> {
   error: TaskError;
   account: T;
 }
@@ -46,8 +46,12 @@ export interface AccountAdditionParams {
  */
 export interface AdditionSummary {
   readonly added: Account[];
-  /** Both payload kinds: an xpub can fail too, and the caller still has to hear about it. */
-  readonly failed: (AccountPayload | XpubAccountPayload)[];
+  /**
+   * Both payload kinds: an xpub can fail too, and the caller still has to hear about it. Each entry
+   * keeps its `TaskError`, so a form caller can still reach an `ApiValidationError` cause and fill
+   * in per-field errors instead of flattening every rejection into one generic message.
+   */
+  readonly failed: AccountAdditionFailure[];
   /** True when every failure was a cancellation, so nothing is worth reporting. */
   readonly cancelled: boolean;
 }
@@ -227,7 +231,7 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
     options?: AdditionOptions,
   ): Promise<AdditionSummary> => {
     const addedAccounts: Account[] = [];
-    const failed: (AccountPayload | XpubAccountPayload)[] = [];
+    const failed: AccountAdditionFailure[] = [];
     let cancelled = false;
 
     const isXpub = 'xpub' in payload;
@@ -246,7 +250,7 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
         return;
       }
 
-      failed.push(result.error.account);
+      failed.push(result.error);
     };
 
     if (isXpub) {
@@ -281,7 +285,9 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
 
     // The notification lists addresses, so an xpub failure is not one of its rows — the caller
     // reports that from the summary instead.
-    const failedAddresses = failed.filter((account): account is AccountPayload => !('xpub' in account));
+    const failedAddresses = failed
+      .map(failure => failure.account)
+      .filter((account): account is AccountPayload => !('xpub' in account));
     if (failedAddresses.length > 0)
       notifyFailedToAddAddress(failedAddresses, isXpub ? 1 : payload.length, everyEvmChain ? undefined : chain);
 

--- a/frontend/app/src/modules/accounts/use-account-additions.ts
+++ b/frontend/app/src/modules/accounts/use-account-additions.ts
@@ -63,8 +63,8 @@ export function useAccountAdditions(): UseAccountAdditionsReturn {
       if (result === true)
         return ok(address);
 
-      // Translated, because this message is user-facing: `throwIfActionable` rethrows it and the
-      // account form renders `error.message` in its dialog.
+      // Translated, because this message is user-facing: `errorOf` hands it back and the account
+      // form renders `error.message` in its dialog.
       return result.length > 0
         ? ok(result[0])
         : err(TaskFailed({ message: t('actions.balances.blockchain_accounts_add.error.nothing_added', { address }) }));

--- a/frontend/app/src/modules/core/tasks/task-result.spec.ts
+++ b/frontend/app/src/modules/core/tasks/task-result.spec.ts
@@ -3,6 +3,7 @@ import { assert, describe, expect, it, vi } from 'vitest';
 import {
   BackendCancelled,
   Cancelled,
+  errorOf,
   isActionable,
   isCancellation,
   onActionableError,
@@ -35,6 +36,29 @@ describe('isActionable', () => {
   it('should be false for either cancellation', () => {
     expect(isActionable(Cancelled({ message: 'boom' }))).toBe(false);
     expect(isActionable(BackendCancelled({ message: 'boom' }))).toBe(false);
+  });
+});
+
+describe('errorOf', () => {
+  it('should return the original cause so a subclass survives', () => {
+    class ApiError extends Error {
+      override name = 'ApiError';
+    }
+    const cause = new ApiError('{"address": ["invalid"]}');
+
+    const error = errorOf(TaskFailed({ cause, message: 'wrapped' }));
+
+    expect(error).toBe(cause);
+    expect(error).toBeInstanceOf(ApiError);
+  });
+
+  it('should wrap the message when the cause is not an Error', () => {
+    expect(errorOf(TaskFailed({ cause: 'a string', message: 'wrapped' }))).toStrictEqual(new Error('wrapped'));
+    expect(errorOf(TaskFailed({ message: 'wrapped' }))).toStrictEqual(new Error('wrapped'));
+  });
+
+  it('should wrap the message for a cancellation, which carries no cause', () => {
+    expect(errorOf(Cancelled({ message: 'cancelled' }))).toStrictEqual(new Error('cancelled'));
   });
 });
 

--- a/frontend/app/src/modules/core/tasks/task-result.ts
+++ b/frontend/app/src/modules/core/tasks/task-result.ts
@@ -48,21 +48,19 @@ export function isActionable(error: TaskError): error is Extract<TaskError, { _t
 }
 
 /**
- * Re-raise an actionable failure as a throw, for the form-facing callers whose dialog has to stay
- * open. `cause` is rethrown as-is when it is an `Error`, so a caller that branches on
- * `ApiValidationError` to fill in per-field errors still gets it; wrapping the message in a bare
- * `Error` would flatten every validation failure into one generic toast.
+ * The `Error` a form-facing caller should report for a failure. The original `cause` is returned
+ * as-is when it is an `Error`, so a caller that branches on `ApiValidationError` to fill in
+ * per-field errors still gets it; wrapping the message in a bare `Error` would flatten every
+ * validation failure into one generic toast.
  *
- * A cancellation is not actionable, so this returns and the caller continues silently.
+ * Returned rather than thrown: producers report failures as values now, so the caller is not
+ * inside a `try` that a throw could unwind to.
  */
-export function throwIfActionable(error: TaskError): void {
-  if (!isActionable(error))
-    return;
+export function errorOf(error: TaskError): Error {
+  if (isActionable(error) && error.cause instanceof Error)
+    return error.cause;
 
-  if (error.cause instanceof Error)
-    throw error.cause;
-
-  throw new Error(error.message);
+  return new Error(error.message);
 }
 
 /**

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.spec.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.spec.ts
@@ -3,6 +3,7 @@ import { Blockchain } from '@rotki/common';
 import dayjs from 'dayjs';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskFailed } from '@/modules/core/tasks/task-result';
 
 const WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
 const NEW_SAFE = '0xabcdef1234567890abcdef1234567890abcdef12';
@@ -62,7 +63,13 @@ describe('useGnosisPaySafeMigration', () => {
     vi.resetModules();
     setActivePinia(createPinia());
     fetchGnosisPaySafeMigration.mockReset();
-    addAccounts.mockReset().mockResolvedValue(undefined);
+    // The real `addAccounts` resolves an `AdditionSummary` and does not throw on a failed add, so
+    // `undefined` here let the composable claim success for an addition that never happened.
+    addAccounts.mockReset().mockResolvedValue({
+      added: [{ address: NEW_SAFE, chain: Blockchain.GNOSIS }],
+      cancelled: false,
+      failed: [],
+    });
     notify.mockReset();
     showErrorMessage.mockReset();
     showSuccessMessage.mockReset();
@@ -147,6 +154,38 @@ describe('useGnosisPaySafeMigration', () => {
     await composable.addMissingSafe();
 
     expect(showErrorMessage).toHaveBeenCalled();
+    expect(get(composable.untrackedSafe)).toEqual({ address: OLD_SAFE, type: 'old' });
+  });
+
+  // Additions report failure as a value, not a throw. Without reading the summary the Safe was
+  // announced as added and the suggestion dismissed while nothing had been stored.
+  it('should surface an error and keep the safe when the addition reports a failure', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: OLD_SAFE, type: 'old' }]));
+    addAccounts.mockResolvedValue({
+      added: [],
+      cancelled: false,
+      failed: [{ account: { address: OLD_SAFE, tags: null }, error: TaskFailed({ message: 'node unreachable' }) }],
+    });
+    const { composable } = await setup();
+    await composable.checkMigration();
+
+    await composable.addMissingSafe();
+
+    expect(showSuccessMessage).not.toHaveBeenCalled();
+    expect(showErrorMessage).toHaveBeenCalled();
+    expect(get(composable.untrackedSafe)).toEqual({ address: OLD_SAFE, type: 'old' });
+  });
+
+  it('should keep the safe and stay silent when the addition is cancelled', async () => {
+    fetchGnosisPaySafeMigration.mockResolvedValue(migration([{ address: OLD_SAFE, type: 'old' }]));
+    addAccounts.mockResolvedValue({ added: [], cancelled: true, failed: [] });
+    const { composable } = await setup();
+    await composable.checkMigration();
+
+    await composable.addMissingSafe();
+
+    expect(showSuccessMessage).not.toHaveBeenCalled();
+    expect(showErrorMessage).not.toHaveBeenCalled();
     expect(get(composable.untrackedSafe)).toEqual({ address: OLD_SAFE, type: 'old' });
   });
 

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.ts
@@ -7,6 +7,7 @@ import { useBlockchainAccountManagement } from '@/modules/accounts/use-blockchai
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
+import { errorOf } from '@/modules/core/tasks/task-result';
 import { useGnosisPaySiweApi } from '@/modules/integrations/gnosis-pay/use-gnosis-pay-api';
 import { useExternalApiKeys } from '@/modules/settings/api-keys/external/use-external-api-keys';
 import { useSetting } from '@/modules/settings/use-setting';
@@ -89,13 +90,30 @@ export const useGnosisPaySafeMigration = createSharedComposable((): UseGnosisPay
 
     set(adding, true);
     try {
-      await addAccounts(Blockchain.GNOSIS, {
+      const summary = await addAccounts(Blockchain.GNOSIS, {
         payload: [{
           address: safe.address,
           label: t('external_services.gnosispay.safe_migration.account_label'),
           tags: null,
         }],
       }, { wait: true });
+
+      // Additions report failure as a value, not a throw, so the `catch` below no longer sees a
+      // rejected add. Without this the Safe was announced as added and the suggestion dismissed
+      // while the account was never stored. A cancellation leaves the suggestion in place to retry
+      // and says nothing, because the user asked for it.
+      if (summary.added.length === 0) {
+        if (summary.failed.length > 0) {
+          showErrorMessage(
+            t('external_services.gnosispay.safe_migration.title'),
+            t('external_services.gnosispay.safe_migration.add_error', {
+              error: errorOf(summary.failed[0].error).message,
+            }),
+          );
+        }
+        return;
+      }
+
       set(untrackedSafe, undefined);
       showSuccessMessage(
         t('external_services.gnosispay.safe_migration.title'),


### PR DESCRIPTION
Last of three stacked PRs, after #12804 and #12805. Those made additions report every outcome as a value instead of throwing; this fixes the callers that were still reading them as if they threw.

Every bug here is the same shape: **a caller that only asks "did this throw?" now sees success for all three outcomes** — added, rejected, and cancelled.

### The account form lost per-field errors

The old path rethrew the task's `cause` as-is, so an `ApiValidationError` reached `handleErrors` and filled in the field errors. The summary carried payloads only, so the form synthesized a generic error: a backend field-level rejection showed a toast instead of highlighting the address.

`AdditionSummary.failed` now carries each failure's `TaskError` alongside its payload. A single failure reports its own cause; several report the count, since there is no one field to highlight and the mechanism already names the addresses.

### A cancelled addition closed the dialog as saved

Cancelling yields nothing added and nothing failed, so `save` returned true, `complete` fired, and a refresh ran for an account that was never added — discarding whatever the user had typed. `AdditionSummary.cancelled` existed for exactly this and had no readers anywhere in the codebase.

### Gnosis Pay announced a failed Safe add as success

`addMissingSafe` discarded the return value entirely, so its `try/catch` was dead for addition failures. A rejected Safe cleared the untracked safe and showed "Safe added successfully" for an account that was never stored.

⚠️ Its spec mocked `addAccounts` as resolving `undefined`, which is why this stayed green. It now resolves a real summary.

### CSV import jumped straight to 100%

`increment()` ran first in the row callback, and the batch starts every row's callback in the same tick, so a 200-row import showed `200/200` before a single account had been submitted, then sat there while the lanes drained.

### Notes for review

- `throwIfActionable` becomes `errorOf`, which returns the error rather than throwing it. Throwing no longer fits: producers report failures as values, so the caller is not inside a `try` for a throw to unwind to.
- The two summary helpers live in `blockchain/addition-outcome.ts`, pure and message-agnostic (the caller passes the translated fallback), so they are testable without an i18n instance.
- The existing form-error tests all mocked a rejection — a path additions can no longer take. That is why these regressions passed unnoticed, and it is worth a look at any other caller that still does the same.

### Verification

- `typecheck` clean, `typos` clean, lint 0 errors (20 pre-existing `vue/max-props` / `max-template-depth` warnings in files this branch does not touch).
- Unit suite green on this branch alone: **774 files / 7297 tests**.
- The per-field validation fix was checked in a running app with a negative control: an address the frontend accepts and the backend rejects now outlines the field with the backend's own message and keeps the dialog open, where the pre-fix code showed a generic "The address could not be added" modal.
- **The other three are covered by unit tests only.** Gnosis Pay needs a real SIWE session and a genuinely untracked Safe; the CSV progress ordering was not exercised in the app; and I could not catch a live cancellation, since a local addition completes faster than the cancel window.
