### PR TITLE
fix(tasks): let orchestrator reset settle its waiting callers

### DIFF
--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.ts
@@ -351,6 +351,15 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
         record.cleanedUp = true;
         record.spec.cleanup?.();
       }
+      // ⚠️ Emit while the cancelled records are still in the map. A caller awaiting `submitTask`
+      // is released by a resolver that looks its activity up in the snapshot and settles it when
+      // it reads terminal; clearing first makes that lookup miss, so the caller never settles.
+      // Worse, the id is held in `inflight` until it settles, so it stays poisoned for the life of
+      // the process and every later submit dedups onto a promise that can no longer resolve. In
+      // the app that stalls `fetchCached()` on its first await after a re-login, so accounts are
+      // never fetched and the session sits on a spinner with nothing running.
+      emit();
+
       records.clear();
       ledger.clear();
       staleEdges.clear();

--- a/frontend/app/src/modules/task-center/use-native-task.spec.ts
+++ b/frontend/app/src/modules/task-center/use-native-task.spec.ts
@@ -1,9 +1,11 @@
-import { err, isErr, isOk, ok } from 'plainfp/result';
+import type { ResultAsync } from 'plainfp/result-async';
+import { err, isErr, isOk, ok, type Result } from 'plainfp/result';
 import { hasTag } from 'plainfp/tagged';
 import { assert, describe, expect, it, vi } from 'vitest';
-import { TaskFailed } from '@/modules/core/tasks/task-result';
+import { type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { ActivityKind, makeActivityId } from './core/types';
 import { useNativeTask } from './use-native-task';
+import { useTaskOrchestrator } from './use-task-orchestrator';
 
 // The handler backs the runner the facade binds to each activity, and the backend abort behind
 // `cancel`; the orchestrator stays real.
@@ -68,5 +70,64 @@ describe('useNativeTask', () => {
     release();
     await Promise.all([first, second]);
     expect(run).toHaveBeenCalledOnce();
+  });
+
+  describe('reset', () => {
+    /** Only the orchestrator can settle this, which is the whole point of the two tests below. */
+    const neverSettles = async (): ResultAsync<void, TaskError> => new Promise<Result<void, TaskError>>(() => {});
+
+    // Logout resets the orchestrator while work is still in flight. The caller of that work is
+    // awaiting a promise only the orchestrator can settle, and the id is held in `inflight` until
+    // it settles — so if reset drops the record without settling the caller, that id is poisoned
+    // for the life of the process and every later submit dedups onto a promise that never
+    // resolves. In the app that stalls `fetchCached()` on its first await, so the accounts are
+    // never fetched and the whole post-login session sits on a spinner.
+    it('should settle a caller waiting on work that reset dropped', async () => {
+      const { submitTask } = useNativeTask();
+      const orchestrator = useTaskOrchestrator();
+      const id = makeActivityId(ActivityKind.PRICES, 'reset-settles');
+
+      // Nothing but the orchestrator can settle this.
+      const outcome = submitTask({
+        id,
+        kind: ActivityKind.PRICES,
+        run: neverSettles,
+        title: 'prices',
+      });
+
+      orchestrator.reset();
+
+      const raced = await Promise.race([
+        outcome.then(() => 'settled'),
+        new Promise<string>((resolve) => {
+          setTimeout(resolve, 50, 'HUNG');
+        }),
+      ]);
+
+      expect(raced).toBe('settled');
+    });
+
+    it('should let the same activity run again after reset', async () => {
+      const { submitTask } = useNativeTask();
+      const orchestrator = useTaskOrchestrator();
+      const id = makeActivityId(ActivityKind.PRICES, 'reset-reruns');
+
+      // Awaited only after the reset releases it; the assertion is about the SECOND submit.
+      const abandoned = submitTask({
+        id,
+        kind: ActivityKind.PRICES,
+        run: neverSettles,
+        title: 'prices',
+      });
+
+      orchestrator.reset();
+      await abandoned;
+
+      // The id must be free again, or this dedups onto the abandoned promise and never runs.
+      const run = vi.fn(async () => ok(undefined));
+      await submitTask({ id, kind: ActivityKind.PRICES, run, title: 'prices' });
+
+      expect(run).toHaveBeenCalledOnce();
+    });
   });
 });


### PR DESCRIPTION
## Problem

`orchestrator.reset()` cleared its records **before** emitting, so any caller awaiting `submitTask` was never released, and its activity id stayed poisoned for the life of the process.

1. `reset()` marked live records `CANCELLED` in place, then `records.clear()`, then `emit()`.
2. `use-native-task.ts` releases a waiting `submitTask` caller from an `onChange` handler that looks the activity up via `snapshot().find(id)` and settles it once terminal. With the records already gone the lookup misses, so `finish()` never runs.
3. `finish()` is the only place that does `inflight.delete(spec.id)`. The id therefore stays in `inflight` forever, and every later submit of that id is handed the same dead promise.

Logout calls `reset()`, so **logging out and back in within one process** left `fetchCached()` stalled on its first await. No exchange rates, no accounts, no balances, and history had nothing to sync.

The user-visible symptom is a spinner with *no pending tasks and nothing running*. The network tab is the tell: `GET /statistics/netvalue` fires but its sibling `GET /exchange_rates` in the same `Promise.allSettled` never does.

## Fix

Emit while the cancelled records are still in the map, then clear. One reordering.

## Tests

Two cases in `use-native-task.spec.ts`, both written failing first:

- a caller waiting on work that reset dropped must settle — failed with `expected 'HUNG' to be 'settled'`
- the same activity must run again after a reset — timed out at 15002ms before the fix, which is the poisoned-id signature: the re-submit deduped onto the dead promise

## Verification

Reproduced and confirmed fixed in the running app, not only in the spec.

Gates: typecheck, eslint, `typos`, unit suite.
