### PR TITLE
fix(history): extend sync progress across waves instead of resetting it

### DIFF
--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
@@ -34,7 +34,7 @@ const mockExchanges: Exchange[] = [
 
 // Mock stores and composables
 const mockTxQueryStatusStore = {
-  initializeQueryStatus: vi.fn<(accounts: ChainAddress[]) => void>(),
+  initializeQueryStatus: vi.fn<(accounts: ChainAddress[], options?: { extend?: boolean }) => void>(),
   resetQueryStatus: vi.fn(),
   stopSyncing: vi.fn(),
 };
@@ -112,6 +112,7 @@ const mockUndecodedTransactionsStatus = {
 
 const mockDecodingStatusStore = {
   resetDecodingSyncProgress: vi.fn(),
+  resumeDecodingSyncProgress: vi.fn(),
   resetUndecodedTransactionsStatus: vi.fn(),
   stopDecodingSyncProgress: vi.fn(),
 };
@@ -297,7 +298,7 @@ describe('useRefreshTransactions', () => {
         payload: { exchanges: mockExchanges },
       });
 
-      expect(mockEventsQueryStatusStore.initializeQueryStatus).toHaveBeenCalledWith(mockExchanges);
+      expect(mockEventsQueryStatusStore.initializeQueryStatus).toHaveBeenCalledWith(mockExchanges, { extend: false });
       expect(mockRefreshHandlers.queryAllExchangeEvents).toHaveBeenCalledWith(mockExchanges, HISTORY_SYNC_ID);
     });
 
@@ -374,6 +375,59 @@ describe('useRefreshTransactions', () => {
       // Twice: the first refresh over every account, then the drain over the late arrival alone.
       expect(mockTransactionSync.syncTransactionsByChains).toHaveBeenCalledTimes(2);
       expect(mockTransactionSync.syncTransactionsByChains).toHaveBeenLastCalledWith([addedMidRefresh], expect.anything(), HISTORY_SYNC_ID);
+
+      vi.useRealTimers();
+    });
+
+    it('should extend the progress panel on the drained wave instead of replacing it', async () => {
+      vi.useFakeTimers();
+
+      const addedMidRefresh: ChainAddress = { address: '0x9531C059098e3d194fF87FebB587aB07B30B1306', chain: 'eth' };
+
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+      const firstRefresh = refreshTransactions();
+
+      mockHistoryTransactionAccounts.getAllAccounts.mockReturnValue([...mockEvmAccounts, ...mockBitcoinAccounts, addedMidRefresh]);
+
+      await refreshTransactions({ payload: { accounts: [addedMidRefresh] } });
+      await firstRefresh;
+      await vi.advanceTimersByTimeAsync(150);
+      await settleRefresh();
+
+      // The drained wave carries only the late arrival. Seeding it as a fresh panel dropped every
+      // address the first wave had already finished, so the bar's denominator fell mid-sync
+      // (the reported 6/7 -> 3/3) with nothing to signal that a second wave had begun.
+      const [initial, drained] = mockTxQueryStatusStore.initializeQueryStatus.mock.calls;
+      expect(initial).toEqual([mockEvmAccounts, { extend: false }]);
+      expect(drained).toEqual([[addedMidRefresh], { extend: true }]);
+
+      // One reset for the sync as a whole, not one per wave.
+      expect(mockTxQueryStatusStore.resetQueryStatus).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it('should reopen the decoding progress gate on the drained wave', async () => {
+      vi.useFakeTimers();
+
+      const addedMidRefresh: ChainAddress = { address: '0x9531C059098e3d194fF87FebB587aB07B30B1306', chain: 'eth' };
+
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+      const firstRefresh = refreshTransactions();
+
+      mockHistoryTransactionAccounts.getAllAccounts.mockReturnValue([...mockEvmAccounts, ...mockBitcoinAccounts, addedMidRefresh]);
+
+      await refreshTransactions({ payload: { accounts: [addedMidRefresh] } });
+      await firstRefresh;
+      await vi.advanceTimersByTimeAsync(150);
+      await settleRefresh();
+
+      // `decodingSyncing` is the only gate on both decode-progress writers, and the first wave's
+      // `finally` turns it off. Without re-arming it the drained wave decodes invisibly: the panel
+      // keeps the first wave's finished rows and reads complete while work is still running.
+      expect(mockDecodingStatusStore.resumeDecodingSyncProgress).toHaveBeenCalledTimes(1);
+      // Re-armed without discarding what the first wave recorded.
+      expect(mockDecodingStatusStore.resetDecodingSyncProgress).toHaveBeenCalledTimes(1);
 
       vi.useRealTimers();
     });
@@ -568,7 +622,7 @@ describe('useRefreshTransactions', () => {
 
       await refreshTransactions();
 
-      expect(mockTxQueryStatusStore.initializeQueryStatus).toHaveBeenCalledWith(mockEvmAccounts);
+      expect(mockTxQueryStatusStore.initializeQueryStatus).toHaveBeenCalledWith(mockEvmAccounts, { extend: false });
     });
 
     it('should reset query status when no accounts to refresh', async () => {

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
@@ -22,6 +22,18 @@ interface UseRefreshTransactionsReturn {
   refreshTransactions: (params?: RefreshTransactionsParams) => Promise<void>;
 }
 
+/**
+ * Which wave of a sync a run is. `CONTINUATION` is the drained follow-up: it belongs to the sync
+ * already on screen, so it adds to that progress rather than starting its own, and it does not
+ * drain again (see {@link drainPending} for why one wave per run is the bound).
+ */
+const RefreshWave = {
+  CONTINUATION: 'continuation',
+  INITIAL: 'initial',
+} as const;
+
+type RefreshWave = (typeof RefreshWave)[keyof typeof RefreshWave];
+
 export function useRefreshTransactions(): UseRefreshTransactionsReturn {
   let timeout: NodeJS.Timeout;
 
@@ -30,7 +42,7 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
   const { filterDisabledChainAccounts } = useHistoryTransactionAccounts();
   const { statusOf, submitTask } = useNativeTask();
   const { fetchUndecodedTransactionsBreakdown } = useUndecodedTransactionsStatus();
-  const { resetDecodingSyncProgress, resetUndecodedTransactionsStatus, stopDecodingSyncProgress } = useDecodingStatusStore();
+  const { resetDecodingSyncProgress, resetUndecodedTransactionsStatus, resumeDecodingSyncProgress, stopDecodingSyncProgress } = useDecodingStatusStore();
 
   const { syncTransactionsByChains } = useTransactionSync();
   const {
@@ -44,9 +56,19 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
   const { onHistoryFinished, onHistoryStarted } = useSchedulerState();
   const { t } = useI18n({ useScope: 'global' });
 
-  function initializeRefresh(targets: RefreshTargets): void {
-    resetQueryStatus();
-    resetOnlineWarnings();
+  /**
+   * A continuation carries only what the previous wave did not know about, so everything here that
+   * clears state has to be skipped for it: the first wave's finished addresses and its online
+   * warnings belong to the same sync, and wiping them is what made the progress bar restart with a
+   * smaller denominator instead of growing.
+   */
+  function initializeRefresh(targets: RefreshTargets, wave: RefreshWave): void {
+    const continuation = wave === RefreshWave.CONTINUATION;
+
+    if (!continuation) {
+      resetQueryStatus();
+      resetOnlineWarnings();
+    }
 
     if (!(targets.accounts.length > 0 || targets.exchanges.length > 0)) {
       return;
@@ -58,7 +80,16 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
       return;
     }
 
-    initializeQueryStatus(targets.decodableAccounts);
+    initializeQueryStatus(targets.decodableAccounts, { extend: continuation });
+
+    if (continuation) {
+      // ⚠️ Re-arm, do not reset. The decode section is gated by a single flag that the previous
+      // wave's `finally` turned off, so skipping this entirely would drop every decode message this
+      // wave produces and leave the section reading complete over the previous wave's rows.
+      resumeDecodingSyncProgress();
+      return;
+    }
+
     resetUndecodedTransactionsStatus();
     resetDecodingSyncProgress();
   }
@@ -73,19 +104,28 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     return queries ?? [];
   }
 
+  /** Same continuation rule as {@link initializeRefresh}, for the exchange half of the panel. */
+  function seedExchangeProgress(targets: RefreshTargets, wave: RefreshWave): void {
+    const continuation = wave === RefreshWave.CONTINUATION;
+
+    if (!continuation)
+      resetExchangesQueryStatus();
+
+    if (targets.queryExchanges && targets.shouldShowSyncProgress)
+      initializeExchangeEventsQueryStatus(targets.usedExchanges, { extend: continuation });
+  }
+
   async function executeOperations(
     targets: RefreshTargets,
     disableEvmEvents: boolean,
     queries: OnlineHistoryEventsQueryType[] | undefined,
     umbrella: ActivityId,
+    wave: RefreshWave,
   ): Promise<void> {
     if (targets.fullRefresh || targets.decodableAccounts.length > 0)
       await fetchUndecodedTransactionsBreakdown();
 
-    resetExchangesQueryStatus();
-
-    if (targets.queryExchanges && targets.shouldShowSyncProgress)
-      initializeExchangeEventsQueryStatus(targets.usedExchanges);
+    seedExchangeProgress(targets, wave);
 
     // The shape of the refresh comes off the declaration rather than being rebuilt here, so what a
     // test asserts about `historySyncFlow` is what actually runs. Everything is a child of the
@@ -170,11 +210,11 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
           accounts: newAccounts.length > 0 ? newAccounts : undefined,
           exchanges: newExchanges.length > 0 ? newExchanges : undefined,
         },
-      }, false));
+      }, RefreshWave.CONTINUATION));
     }, 100);
   }
 
-  async function refreshOnce(params: RefreshTransactionsParams, mayDrain: boolean): Promise<void> {
+  async function refreshOnce(params: RefreshTransactionsParams, wave: RefreshWave): Promise<void> {
     const { chains = [], disableEvmEvents = false, payload = {}, userInitiated = false } = params;
     const fullRefresh = Object.keys(payload).length === 0;
 
@@ -216,10 +256,10 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
       rerunnable: false,
       staleAfter: HISTORY_STALE_AFTER,
       run: async (): Promise<Result<void, TaskError>> => {
-        initializeRefresh(targets);
+        initializeRefresh(targets, wave);
 
         try {
-          await executeOperations(targets, disableEvmEvents, payload.queries, umbrellaId);
+          await executeOperations(targets, disableEvmEvents, payload.queries, umbrellaId, wave);
         }
         catch (error) {
           logger.error(error);
@@ -237,12 +277,12 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
       title: t('task_center.group.history_sync'),
     });
 
-    if (mayDrain)
+    if (wave === RefreshWave.INITIAL)
       drainPending(params);
   }
 
   async function refreshTransactions(params: RefreshTransactionsParams = {}): Promise<void> {
-    await refreshOnce(params, true);
+    await refreshOnce(params, RefreshWave.INITIAL);
   }
 
   onScopeDispose(() => {

--- a/frontend/app/src/modules/history/use-decoding-status-store.spec.ts
+++ b/frontend/app/src/modules/history/use-decoding-status-store.spec.ts
@@ -66,6 +66,30 @@ describe('useDecodingStatusStore', () => {
     });
   });
 
+  describe('resumeDecodingSyncProgress', () => {
+    it('should reopen the progress gate a stopped sync closed', () => {
+      const store = useDecodingStatusStore();
+      store.resetDecodingSyncProgress();
+      store.stopDecodingSyncProgress();
+
+      store.resumeDecodingSyncProgress();
+      store.setUndecodedTransactionsStatus(createStatus('eth', 100, 50));
+
+      expect(get(store.decodingSyncProgress).eth).toEqual({ chain: 'eth', processed: 50, total: 100 });
+    });
+
+    it('should keep the progress an earlier wave recorded', () => {
+      const store = useDecodingStatusStore();
+      store.resetDecodingSyncProgress();
+      store.setUndecodedTransactionsStatus(createStatus('eth', 100, 100));
+      store.stopDecodingSyncProgress();
+
+      store.resumeDecodingSyncProgress();
+
+      expect(get(store.decodingSyncProgress).eth).toEqual({ chain: 'eth', processed: 100, total: 100 });
+    });
+  });
+
   describe('updateUndecodedTransactionsStatus', () => {
     it('should batch update multiple chain statuses', () => {
       const store = useDecodingStatusStore();

--- a/frontend/app/src/modules/history/use-decoding-status-store.ts
+++ b/frontend/app/src/modules/history/use-decoding-status-store.ts
@@ -84,6 +84,20 @@ export const useDecodingStatusStore = defineStore('history/decoding-status', () 
     set(decodingSyncing, true);
   };
 
+  /**
+   * Re-arm the progress gate without discarding what is already recorded.
+   *
+   * ⚠️ `decodingSyncing` is the only gate on both writers of `decodingSyncProgress`, and
+   * `stopDecodingSyncProgress` runs whenever a sync's run settles. A follow-up wave of the *same*
+   * sync therefore has to turn it back on or its decode is invisible — the panel would sit on the
+   * earlier wave's finished rows and read complete while work was still running. It must not clear
+   * `decodingSyncProgress`, which is exactly what makes this distinct from
+   * {@link resetDecodingSyncProgress}.
+   */
+  const resumeDecodingSyncProgress = (): void => {
+    set(decodingSyncing, true);
+  };
+
   const stopDecodingSyncProgress = (): void => {
     set(decodingSyncing, false);
   };
@@ -100,6 +114,7 @@ export const useDecodingStatusStore = defineStore('history/decoding-status', () 
     markDecodingCancelled,
     resetDecodingSyncProgress,
     resetUndecodedTransactionsStatus,
+    resumeDecodingSyncProgress,
     setUndecodedTransactionsStatus,
     stopDecodingSyncProgress,
     undecodedTransactionsStatus,

--- a/frontend/app/src/modules/history/use-events-query-status-store.spec.ts
+++ b/frontend/app/src/modules/history/use-events-query-status-store.spec.ts
@@ -34,6 +34,21 @@ describe('useEventsQueryStatusStore', () => {
     expect(get(store.isAllFinished)).toBe(false);
   });
 
+  it('should keep a finished exchange untouched when extending', () => {
+    const store = useEventsQueryStatusStore();
+    store.initializeQueryStatus([{ location: 'eth', name: 'a' }]);
+    store.setQueryStatus(data('eth', 'a', HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED));
+    store.stopSyncing();
+
+    store.initializeQueryStatus([{ location: 'eth', name: 'a' }, { location: 'btc', name: 'b' }], { extend: true });
+
+    const status = get(store.queryStatus);
+    expect(Object.keys(status)).toHaveLength(2);
+    expect(status.etha.status).toBe(HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED);
+    expect(status.btcb.status).toBe(HistoryEventsQueryStatus.QUERYING_EVENTS_STARTED);
+    expect(get(store.syncing)).toBe(true);
+  });
+
   it('should ignore status updates while not syncing', () => {
     const store = useEventsQueryStatusStore();
     store.setQueryStatus(data('eth', 'a', HistoryEventsQueryStatus.QUERYING_EVENTS_STARTED));

--- a/frontend/app/src/modules/history/use-events-query-status-store.ts
+++ b/frontend/app/src/modules/history/use-events-query-status-store.ts
@@ -12,14 +12,26 @@ export const useEventsQueryStatusStore = defineStore('history/events-query-statu
   const { isAllFinished, markTerminal, queryStatus, removeQueryStatus, resetQueryStatus, stopSyncing, syncing }
     = createQueryStatusState<HistoryEventsQueryData>(isStatusFinished, createKey);
 
-  const initializeQueryStatus = (data: { location: string; name: string }[]): void => {
-    resetQueryStatus();
+  /**
+   * Seed the panel with the exchanges a sync is about to query.
+   *
+   * ⚠️ `extend` carries the same meaning as its counterpart in `useTxQueryStatusStore`: a drained
+   * follow-up wave belongs to the sync already on screen, so it must not clear what the first wave
+   * finished, and must not restart an exchange that is already recorded.
+   */
+  const initializeQueryStatus = (data: { location: string; name: string }[], { extend = false }: { extend?: boolean } = {}): void => {
+    if (!extend)
+      resetQueryStatus();
+
     set(syncing, true);
 
     const status = { ...get(queryStatus) };
     const now = millisecondsToSeconds(Date.now());
     for (const item of data) {
       const key = createKey(item);
+      if (extend && status[key])
+        continue;
+
       status[key] = {
         eventType: '',
         location: item.location,

--- a/frontend/app/src/modules/history/use-tx-query-status-store.spec.ts
+++ b/frontend/app/src/modules/history/use-tx-query-status-store.spec.ts
@@ -60,6 +60,47 @@ describe('store/history/query-status/tx-query-status', () => {
       expect(Object.keys(get(store.queryStatus))).toHaveLength(1);
       expect(get(store.queryStatus)['0x123eth']).toBeUndefined();
     });
+
+    it('should keep the earlier entries when extending', () => {
+      const store = useTxQueryStatusStore();
+
+      store.initializeQueryStatus([{ address: '0x123', chain: 'eth' }]);
+      store.initializeQueryStatus([{ address: '0x456', chain: 'optimism' }], { extend: true });
+
+      const status = get(store.queryStatus);
+      expect(Object.keys(status)).toHaveLength(2);
+      expect(status['0x123eth']).toBeDefined();
+      expect(status['0x456optimism']).toBeDefined();
+    });
+
+    it('should not walk a finished address back to ACCOUNT_CHANGE when extending', () => {
+      const store = useTxQueryStatusStore();
+      const account = { address: '0x123', chain: 'eth' };
+
+      store.initializeQueryStatus([account]);
+      store.setUnifiedTxQueryStatus({
+        address: '0x123',
+        chain: 'eth',
+        period: [0, 1000],
+        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED,
+        subtype: 'evm',
+      });
+
+      store.initializeQueryStatus([account], { extend: true });
+
+      expect(get(store.queryStatus)['0x123eth'].status).toBe(TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED);
+    });
+
+    it('should resume syncing when extending', () => {
+      const store = useTxQueryStatusStore();
+
+      store.initializeQueryStatus([{ address: '0x123', chain: 'eth' }]);
+      store.stopSyncing();
+
+      store.initializeQueryStatus([{ address: '0x456', chain: 'optimism' }], { extend: true });
+
+      expect(get(store.syncing)).toBe(true);
+    });
   });
 
   describe('setUnifiedTxQueryStatus', () => {

--- a/frontend/app/src/modules/history/use-tx-query-status-store.ts
+++ b/frontend/app/src/modules/history/use-tx-query-status-store.ts
@@ -122,14 +122,31 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
     syncing,
   } = createQueryStatusState<TxQueryStatusData>(isStatusFinished, createKey);
 
-  const initializeQueryStatus = (data: ChainAddress[]): void => {
-    resetQueryStatus();
+  /**
+   * Seed the panel with the addresses a sync is about to query.
+   *
+   * ⚠️ `extend` keeps what an earlier wave of the *same* sync already produced. A history refresh
+   * can run in more than one wave: accounts that were not yet loaded when the umbrella opened are
+   * drained into a follow-up run, and each wave carries only its own accounts. Replacing the map on
+   * the second wave dropped every address the first had finished, so the bar's denominator fell
+   * mid-sync (6/7 -> 3/3) with nothing to say a new wave had begun.
+   *
+   * ⚠️ An address already present is left alone. Re-seeding it as `ACCOUNT_CHANGE` would walk a
+   * finished chain's progress backwards, which is the same lie in the other direction.
+   */
+  const initializeQueryStatus = (data: ChainAddress[], { extend = false }: { extend?: boolean } = {}): void => {
+    if (!extend)
+      resetQueryStatus();
+
     set(syncing, true);
 
     const status = { ...get(queryStatus) };
     const now = millisecondsToSeconds(Date.now());
     for (const item of data) {
       const key = createKey(item);
+      if (extend && status[key])
+        continue;
+
       status[key] = {
         address: item.address,
         chain: item.chain,


### PR DESCRIPTION
## Problem

The history sync progress bar counted up, then **reset and started over from a lower total**. Observed live: `5/6 → 5/7 → 6/7 → 7/7 → 0/5 … 5/5`. The denominator ends lower than a value it already displayed, and the panel wipes mid-sync.

The cause is that a sync can run in more than one wave. `refreshTransactions` drains a pending follow-up run, and that drained run went through the same `initializeRefresh` as a brand new sync: it reset the query status, the exchange status and the decoding progress, and re-seeded the panel with only its own targets. So the second wave threw away everything the first wave had recorded, even though both waves belong to the sync the user is already watching.

## Fix

Give a run an explicit wave, and treat the drained follow-up as a continuation of the sync on screen rather than a new one.

- `RefreshWave` (`INITIAL` / `CONTINUATION`) replaces the previous `mayDrain: boolean`. Only `INITIAL` drains, which keeps one wave per run as the bound.
- A continuation skips the resets and instead **extends** the existing progress. `initializeQueryStatus` / `initializeExchangeEventsQueryStatus` take an `{ extend }` option: when set they keep what is already there and add only keys they have not seen.
- The decode section needed care. `decodingSyncing` is the single gate on both writers of `decodingSyncProgress`, and the previous wave's `finally` turns it off. Skipping the reset entirely would silently drop every decode message the continuation produces and leave the section reading complete over the previous wave's rows. So a continuation calls a new `resumeDecodingSyncProgress()`, which re-arms the flag **without** clearing what is recorded.

## Verification

Control vs fix at runtime, same instance, same user, same data, with a DOM sampler polling the panel every 300ms:

```
before: 0/6 … 5/6 → 5/7 → 6/7 → 7/7 → 0/5 … 5/5    reset, two "Sync Complete"
after:  0/8 … 7/8 → 7/9 → 8/9 → 8/10 → 9/10 → 10/10  extends, one "Sync Complete"
```

The denominator grows twice in the fixed run, so the two-wave case did fire. It now accumulates instead of restarting.

Gates: typecheck, eslint, `typos`, unit suite.

## Not in scope

The waves themselves still happen, because the first refresh can be scoped from a partially loaded account store. That is a separate scope bug and is being handled on its own.
