### PR TITLE
ci: split frontend checks into named steps

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -116,7 +116,7 @@ jobs:
           category: "/language:javascript"
 
   lint-frontend:
-    name: 'Frontend lint'
+    name: 'Frontend checks'
     needs: [ 'check-changes', 'check-typos' ]
     if: ${{ needs.check-changes.outputs.frontend_tasks }}
     runs-on: ubuntu-latest
@@ -147,19 +147,38 @@ jobs:
           cache-dependency-path: 'frontend/pnpm-lock.yaml'
 
       - name: Install dependencies
+        id: install
         working-directory: ./frontend
         run: pnpm install --frozen-lockfile
 
-      - name: Build
+      # Each check is its own step so the failure annotation names what actually broke: a
+      # vue-tsc error reports as "Typecheck", not as a generic lint failure. The condition
+      # keeps later checks running after an earlier one fails, so a single run reports every
+      # problem, while still skipping them all if the install itself never succeeded.
+      - name: Typecheck
+        if: ${{ steps.install.outcome == 'success' && github.event_name != 'push' }}
         working-directory: ./frontend
-        run: |
-          if [ ${{ github.event_name }} != 'push' ]; then
-            pnpm run build
-          fi
+        run: pnpm run typecheck
 
-      - name: Lint code
+      - name: Build
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && github.event_name != 'push' }}
         working-directory: ./frontend
-        run: pnpm run lint:all
+        run: pnpm run --filter rotki build:app
+
+      - name: ESLint
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        working-directory: ./frontend
+        run: pnpm run lint
+
+      - name: Stylelint
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        working-directory: ./frontend
+        run: pnpm run lint:style
+
+      - name: Linked i18n keys
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        working-directory: ./frontend
+        run: pnpm run --filter rotki check:linked-keys
 
   check-backend-mapping-keys:
     name: 'Backend mapping keys'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "build:preview": "pnpm run --filter rotki build:preview",
     "docker:build": "pnpm run --filter rotki build:app --mode docker && pnpm run --filter rotki typecheck",
     "lint": "eslint .",
-    "lint:all": "run-p lint \"lint:style {@}\" check:linked-keys --",
+    "lint:all": "run-p -l --aggregate-output lint \"lint:style {@}\" check:linked-keys --",
     "check:linked-keys": "pnpm run --filter rotki check:linked-keys",
     "lint:style": "pnpm run --filter rotki lint:style",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
The `Frontend lint` job also built and typechecked, so a `vue-tsc` error reported as a lint failure. Its two `run` steps also each bundled several checks behind `run-p`, which interleaved their output, so even within "lint" you could not tell eslint from stylelint from the linked-key check.

Give typecheck, build, eslint, stylelint and the linked-key check a step each, so the failure annotation names what actually broke (`Frontend checks / Typecheck`), and rename the job to `Frontend checks`.

The checks run even after an earlier one fails, so a single run reports every problem instead of stopping at the first, but they are skipped if the install itself never succeeded rather than producing four cascading failures. The existing `github.event_name != 'push'` guard on build/typecheck is preserved, so push runs behave as before.

`lint:all` is no longer referenced by CI (that workflow line was its only user). Kept for local runs, with `-l --aggregate-output` so its output is labelled and no longer interleaved.

Verified locally: `typecheck`, `build:app`, `lint:style` and `check:linked-keys` all pass standalone; `lint` reports 0 errors.