### PR TITLE
feat(snapshots): isolate zero-value rows from the warning

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2456,7 +2456,8 @@
           "search": "Search asset",
           "share": "% Net worth",
           "share_percent": "{percent}%",
-          "title": "Balances"
+          "title": "Balances",
+          "zero_value_only": "Showing zero-value only"
         },
         "changes": {
           "added": "Added",
@@ -2545,6 +2546,7 @@
           "negative_balance": "{asset} has a negative value",
           "net_worth_swing": "Net worth changed by {percent}% versus the previous snapshot",
           "nft_amount": "{asset} is an NFT but its amount is not 1",
+          "show_zero_value": "Show them",
           "title": "Check these entries",
           "zero_value": "no balances have value | {count} balance has no value | {count} balances have no value"
         }

--- a/frontend/app/src/modules/dashboard/snapshots.ts
+++ b/frontend/app/src/modules/dashboard/snapshots.ts
@@ -12,6 +12,18 @@ export const BalanceSnapshotSchema = z.object({
 
 export type BalanceSnapshot = z.infer<typeof BalanceSnapshotSchema>;
 
+/**
+ * Visibility of zero-value rows in the snapshot balances table. `ONLY` isolates
+ * them and is entered from the summary's zero-value warning.
+ */
+export const ZeroValueFilter = {
+  ALL: 'all',
+  HIDE: 'hide',
+  ONLY: 'only',
+} as const;
+
+export type ZeroValueFilter = typeof ZeroValueFilter[keyof typeof ZeroValueFilter];
+
 export interface BalanceSnapshotPayload {
   timestamp: number;
   category: BalanceType;

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalancesTable.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalancesTable.spec.ts
@@ -1,4 +1,3 @@
-import type { Snapshot } from '@/modules/dashboard/snapshots';
 import type { BalanceMutation } from '@/modules/dashboard/snapshots/utils/snapshot-math';
 import { bigNumberify } from '@rotki/common';
 import { libraryDefaults } from '@test/utils/provide-defaults';
@@ -7,6 +6,7 @@ import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
 import { BalanceType } from '@/modules/balances/types/balances';
+import { type Snapshot, ZeroValueFilter } from '@/modules/dashboard/snapshots';
 import SnapshotBalanceEntryDialog from '@/modules/dashboard/snapshots/components/SnapshotBalanceEntryDialog.vue';
 import SnapshotBalancesTable from '@/modules/dashboard/snapshots/components/SnapshotBalancesTable.vue';
 
@@ -151,6 +151,45 @@ describe('modules/dashboard/snapshots/components/SnapshotBalancesTable', () => {
     await wrapper.find('[data-testid=snapshot-balances-hide-zero-value] input').setValue(false);
     await nextTick();
     expect(wrapper.findAll('tbody tr')).toHaveLength(before + 1);
+  });
+
+  it('should show only the zero-value rows when the filter is set to only', async () => {
+    wrapper = mount(SnapshotBalancesTable, {
+      global: { plugins: [pinia], provide: libraryDefaults, stubs },
+      props: { snapshot: createSnapshot(), timestamp: TS, zeroValueFilter: ZeroValueFilter.ONLY },
+    });
+
+    // USDC is the only zero-value row of the five; everything else is filtered out.
+    expect(wrapper.findAll('tbody tr')).toHaveLength(1);
+    expect(wrapper.text()).not.toContain('100.00');
+    expect(wrapper.find('[data-testid=snapshot-balances-zero-value-only]').exists()).toBe(true);
+    // The hidden-count chip is suppressed while isolating.
+    expect(wrapper.find('[data-testid=snapshot-balances-hidden-count]').exists()).toBe(false);
+  });
+
+  it('should leave the only mode when the isolate chip is closed', async () => {
+    wrapper = mount(SnapshotBalancesTable, {
+      global: { plugins: [pinia], provide: libraryDefaults, stubs },
+      props: { snapshot: createSnapshot(), timestamp: TS, zeroValueFilter: ZeroValueFilter.ONLY },
+    });
+
+    await wrapper.find('[data-testid=snapshot-balances-zero-value-only] button').trigger('click');
+
+    expect(wrapper.emitted('update:zeroValueFilter')).toEqual([[ZeroValueFilter.HIDE]]);
+  });
+
+  it('should leave the only mode when the hide checkbox is ticked', async () => {
+    wrapper = mount(SnapshotBalancesTable, {
+      global: { plugins: [pinia], provide: libraryDefaults, stubs },
+      props: { snapshot: createSnapshot(), timestamp: TS, zeroValueFilter: ZeroValueFilter.ONLY },
+    });
+
+    // The checkbox reads unchecked while isolating, so ticking it means "hide".
+    const checkbox = wrapper.find<HTMLInputElement>('[data-testid=snapshot-balances-hide-zero-value] input');
+    expect(checkbox.element.checked).toBe(false);
+    await checkbox.setValue(true);
+
+    expect(wrapper.emitted('update:zeroValueFilter')).toEqual([[ZeroValueFilter.HIDE]]);
   });
 
   it('should hide ignored rows by default and reveal them when toggled off', async () => {

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalancesTable.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalancesTable.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
-import type { BalanceSnapshot, Snapshot } from '@/modules/dashboard/snapshots';
 import type { BalanceMutation, LocationAttribution } from '@/modules/dashboard/snapshots/utils/snapshot-math';
 import { type BigNumber, toSentenceCase } from '@rotki/common';
 import { ValueDisplay } from '@/modules/assets/amount-display/components';
@@ -11,6 +10,7 @@ import NftDetails from '@/modules/balances/nft/NftDetails.vue';
 import { BalanceType } from '@/modules/balances/types/balances';
 import TableStatusFilter from '@/modules/core/table/TableStatusFilter.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
+import { type BalanceSnapshot, type Snapshot, ZeroValueFilter } from '@/modules/dashboard/snapshots';
 import SnapshotBalanceDeleteDialog from '@/modules/dashboard/snapshots/components/SnapshotBalanceDeleteDialog.vue';
 import SnapshotBalanceEntryDialog from '@/modules/dashboard/snapshots/components/SnapshotBalanceEntryDialog.vue';
 import SnapshotFiatDisplay from '@/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue';
@@ -23,6 +23,12 @@ import RowActions from '@/modules/shell/components/RowActions.vue';
 type CategoryFilter = 'all' | 'asset' | 'liability' | 'nft';
 
 type IndexedBalanceSnapshot = BalanceSnapshot & { index: number; categoryLabel: string };
+
+/**
+ * Zero-value visibility. Owned by the page so the summary's zero-value warning
+ * can switch the table to `only` and isolate the rows it is complaining about.
+ */
+const zeroValueFilter = defineModel<ZeroValueFilter>('zeroValueFilter', { default: ZeroValueFilter.HIDE });
 
 const { locked = false, snapshot, timestamp } = defineProps<{
   snapshot: Snapshot;
@@ -52,13 +58,22 @@ const categoryFilter = ref<CategoryFilter>('all');
 const filterMenu = ref<boolean>(false);
 const hideSpam = ref<boolean>(true);
 const hideIgnored = ref<boolean>(true);
-const hideZeroValue = ref<boolean>(true);
 const sort = ref<DataTableSortData<BalanceSnapshot>>({
   column: 'usdValue',
   direction: 'desc',
 });
 const entryDialog = useTemplateRef<InstanceType<typeof SnapshotBalanceEntryDialog>>('entryDialog');
 const deleteDialog = useTemplateRef<InstanceType<typeof SnapshotBalanceDeleteDialog>>('deleteDialog');
+
+/**
+ * The menu checkbox only toggles between hiding and showing zero-value rows;
+ * isolating them (`ONLY`) is entered from the summary warning, and ticking the
+ * box again is one of the two ways back out of it.
+ */
+const hideZeroValue = computed<boolean>({
+  get: () => get(zeroValueFilter) === ZeroValueFilter.HIDE,
+  set: (value: boolean) => { set(zeroValueFilter, value ? ZeroValueFilter.HIDE : ZeroValueFilter.ALL); },
+});
 
 const categoryOptions = computed<{ key: CategoryFilter; label: string }[]>(() => [
   { key: 'all', label: t('dashboard.snapshot.detail.balances.all') },
@@ -120,28 +135,49 @@ const spamCount = computed<number>(() => get(data).filter(item => isSpamAsset(it
 const ignoredCount = computed<number>(() => get(data).filter(item => isIgnoredAsset(item.assetIdentifier)).length);
 const zeroValueCount = computed<number>(() => get(data).filter(item => item.usdValue.isZero()).length);
 
+function matchesZeroValue(item: IndexedBalanceSnapshot, mode: ZeroValueFilter): boolean {
+  switch (mode) {
+    case ZeroValueFilter.HIDE:
+      return !item.usdValue.isZero();
+    case ZeroValueFilter.ONLY:
+      return item.usdValue.isZero();
+    case ZeroValueFilter.ALL:
+    default:
+      return true;
+  }
+}
+
 const filteredData = computed<IndexedBalanceSnapshot[]>(() => {
   const text = get(debouncedSearch).toLowerCase().trim();
   const hideSpamRows = get(hideSpam);
   const hideIgnoredRows = get(hideIgnored);
-  const hideZeroValueRows = get(hideZeroValue);
+  const zeroValueMode = get(zeroValueFilter);
   return get(data).filter(item =>
     matchesCategory(item)
     && (!hideSpamRows || !isSpamAsset(item.assetIdentifier))
     && (!hideIgnoredRows || !isIgnoredAsset(item.assetIdentifier))
-    && (!hideZeroValueRows || !item.usdValue.isZero())
+    && matchesZeroValue(item, zeroValueMode)
     && (!text || haystack(item.assetIdentifier).includes(text)),
   );
 });
 
 const total = computed<BigNumber>(() => getTotalValue(snapshot.locationDataSnapshot));
 
-/** Rows hidden by the active hide-filters, surfaced next to the filter button. */
-const hiddenCount = computed<number>(() => get(data).filter(item =>
-  (get(hideSpam) && isSpamAsset(item.assetIdentifier))
-  || (get(hideIgnored) && isIgnoredAsset(item.assetIdentifier))
-  || (get(hideZeroValue) && item.usdValue.isZero()),
-).length);
+/**
+ * Rows hidden by the active hide-filters, surfaced next to the filter button.
+ * Suppressed while isolating zero-value rows — there the point is what is shown,
+ * not what is hidden, and its own chip says so.
+ */
+const hiddenCount = computed<number>(() => {
+  if (get(zeroValueFilter) === ZeroValueFilter.ONLY)
+    return 0;
+
+  return get(data).filter(item =>
+    (get(hideSpam) && isSpamAsset(item.assetIdentifier))
+    || (get(hideIgnored) && isIgnoredAsset(item.assetIdentifier))
+    || (get(hideZeroValue) && item.usdValue.isZero()),
+  ).length;
+});
 
 const emptyDescription = computed<string>(() =>
   get(data).length > 0 && get(filteredData).length === 0
@@ -339,6 +375,18 @@ function onDelete(payload: { index: number; location: LocationAttribution }): vo
             data-testid="snapshot-balances-hidden-count"
           >
             {{ t('dashboard.snapshot.detail.balances.hidden', { count: hiddenCount }, hiddenCount) }}
+          </RuiChip>
+          <RuiChip
+            v-if="zeroValueFilter === ZeroValueFilter.ONLY"
+            size="sm"
+            color="warning"
+            variant="outlined"
+            closeable
+            class="whitespace-nowrap"
+            data-testid="snapshot-balances-zero-value-only"
+            @click:close="zeroValueFilter = ZeroValueFilter.HIDE"
+          >
+            {{ t('dashboard.snapshot.detail.balances.zero_value_only') }}
           </RuiChip>
           <RuiMenuSelect
             v-model="categoryFilter"

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotSummary.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotSummary.spec.ts
@@ -104,6 +104,19 @@ describe('snapshotSummary', () => {
     expect(warnings.text()).not.toContain('ETH');
   });
 
+  it('should offer an action that isolates the zero-value rows', async () => {
+    const wrapper = mountSummary({ snapshot: snapshot([balance('ETH', 0), balance('DAI', 0)], [location('total', 0)]) });
+    await wrapper.find('[data-testid=snapshot-summary-show-zero-value]').trigger('click');
+    expect(wrapper.emitted('show-zero-value')).toHaveLength(1);
+  });
+
+  it('should not offer the isolate action without zero-value rows', () => {
+    const wrapper = mountSummary({ snapshot: snapshot([balance('ETH', -5)], [location('total', -5)]) });
+    // The negative-balance warning is shown, but it names its own asset.
+    expect(wrapper.find('[data-testid=snapshot-summary-warnings]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid=snapshot-summary-show-zero-value]').exists()).toBe(false);
+  });
+
   it('should list a genuine sanity warning with its asset', () => {
     const wrapper = mountSummary({ snapshot: snapshot([balance('ETH', -5)], [location('total', -5)]) });
     const warnings = wrapper.find('[data-testid=snapshot-summary-warnings]');

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotSummary.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotSummary.vue
@@ -32,6 +32,7 @@ const {
 const emit = defineEmits<{
   'edit-locations': [];
   'reconcile-locations': [location: string];
+  'show-zero-value': [];
 }>();
 
 /** Number of location rows shown in the allocation glance before "+N more". */
@@ -133,20 +134,28 @@ function warningMessage(warning: SnapshotWarning): string {
 
 // Zero-value rows are overwhelmingly valueless spam/airdrop tokens, not edit
 // mistakes — listing each would bury the genuine warnings. Collapse them into a
-// single count and keep every other warning one-to-one.
-const warningMessages = computed<string[]>(() => {
+// single count (carrying an action that isolates those rows in the balances
+// table, since the collapsed line names none of them) and keep every other
+// warning one-to-one.
+const warningMessages = computed<{ action: boolean; text: string }[]>(() => {
   const all = get(warnings);
-  const messages = all.filter(warning => warning.code !== 'zero-value').map(warningMessage);
+  const messages = all
+    .filter(warning => warning.code !== 'zero-value')
+    .map(warning => ({ action: false, text: warningMessage(warning) }));
   const zeroValueCount = all.filter(warning => warning.code === 'zero-value').length;
-  if (zeroValueCount > 0)
-    messages.push(t('dashboard.snapshot.detail.warnings.zero_value', { count: zeroValueCount }, zeroValueCount));
+  if (zeroValueCount > 0) {
+    messages.push({
+      action: true,
+      text: t('dashboard.snapshot.detail.warnings.zero_value', { count: zeroValueCount }, zeroValueCount),
+    });
+  }
   return messages;
 });
 
 // The sanity warnings are advisory, so let the user dismiss them. Re-surface when
 // the set of warnings changes (an edit introduced or resolved something).
 const warningsDismissed = ref<boolean>(false);
-watch(() => get(warningMessages).join(' '), () => {
+watch(() => get(warningMessages).map(message => message.text).join(' '), () => {
   set(warningsDismissed, false);
 });
 </script>
@@ -354,7 +363,18 @@ watch(() => get(warningMessages).join(' '), () => {
           v-for="(message, index) in warningMessages"
           :key="index"
         >
-          {{ message }}
+          <span>{{ message.text }}</span>
+          <RuiButton
+            v-if="message.action"
+            variant="text"
+            size="sm"
+            color="warning"
+            class="ml-1 !py-0"
+            data-testid="snapshot-summary-show-zero-value"
+            @click="emit('show-zero-value')"
+          >
+            {{ t('dashboard.snapshot.detail.warnings.show_zero_value') }}
+          </RuiButton>
         </li>
       </ul>
     </RuiAlert>

--- a/frontend/app/src/pages/statistics/snapshots/[timestamp].vue
+++ b/frontend/app/src/pages/statistics/snapshots/[timestamp].vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { Snapshot } from '@/modules/dashboard/snapshots';
 import { type BigNumber, Zero } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { msg } from '@/message-key';
@@ -7,6 +6,7 @@ import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { NoteLocation } from '@/modules/core/common/notes';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import ExportSnapshotDialog from '@/modules/dashboard/ExportSnapshotDialog.vue';
+import { type Snapshot, ZeroValueFilter } from '@/modules/dashboard/snapshots';
 import SnapshotBalancesTable from '@/modules/dashboard/snapshots/components/SnapshotBalancesTable.vue';
 import SnapshotEditorToolbar from '@/modules/dashboard/snapshots/components/SnapshotEditorToolbar.vue';
 import SnapshotLocationsDrawer from '@/modules/dashboard/snapshots/components/SnapshotLocationsDrawer.vue';
@@ -42,6 +42,9 @@ const saveSuccess = ref<boolean>(false);
 const loaded = ref<Snapshot>();
 const exportDialog = ref<boolean>(false);
 const locationsDrawer = ref<boolean>(false);
+// Owned here so the summary's zero-value warning can isolate those rows in the
+// balances table below it.
+const zeroValueFilter = ref<ZeroValueFilter>(ZeroValueFilter.HIDE);
 
 const { fetchSnapshot, persist, remove } = useSnapshotStore();
 // `rows` (and the prev/next order + deltas derived from them) come from the cached
@@ -337,9 +340,11 @@ useEventListener(window, 'beforeunload', (event: BeforeUnloadEvent) => {
         :previous="previous"
         @edit-locations="locationsDrawer = true"
         @reconcile-locations="reconcileLocations($event)"
+        @show-zero-value="zeroValueFilter = ZeroValueFilter.ONLY"
       />
 
       <SnapshotBalancesTable
+        v-model:zero-value-filter="zeroValueFilter"
         :snapshot="draft"
         :timestamp="timestamp"
         :locked="!!mismatch"


### PR DESCRIPTION
The snapshot editor's summary warns that N balances have no value, but it
collapses every offending row into a single count, so it names none of them.
The balances table hides those rows by default, so acting on the warning meant
opening the filter menu and unticking hide-zero-value, which reveals them mixed
back in with everything else.

This adds a `Show them` action to that warning line which switches the table to
a zero-value-only view.

- `hideZeroValue` (boolean) becomes `ZeroValueFilter` (`all` / `hide` / `only`),
  owned by the page as a `v-model` on the table so the summary can drive it.
- The filter-menu checkbox still toggles hide, reading unchecked while
  isolating, so ticking it is one way back out.
- A closeable chip marks the isolated view and clears it. The hidden-count chip
  is suppressed there, since what matters is what is shown.
- Filtering moved into a `matchesZeroValue(item, mode)` switch; the other
  filters (search, category, hide spam, hide ignored) compose with it unchanged.

Because hide-spam stays on, the isolated rows match the warning's count exactly:
the warning already excludes spam, which is expected to be valueless.

Unit tests cover the only-mode row set, both exits from it, and the summary
emitting the action only when zero-value rows exist.
