### PR TITLE
fix(mcp): correct the privacy mode preview and copy

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1690,21 +1690,24 @@
         "premium_title": "MCP requires a rotki premium subscription",
         "privacy_mode": {
           "balanced": {
-            "description": "Masks addresses, transaction hashes, group identifiers, and unknown fields, but keeps readable account names and generated descriptions.",
+            "description": "Masks addresses, transaction hashes, group identifiers, and unknown fields, but keeps generated descriptions and the venue name of exchange accounts. Account names you chose yourself are still masked.",
             "title": "Balanced"
           },
           "default": "Default",
-          "error": "Failed to update the MCP privacy mode",
-          "hint": "Choose how much of your data is masked before it reaches an AI assistant. Changes apply to every request without restarting MCP.",
+          "error": "Failed to update the MCP privacy mode: {message}",
+          "hint": "Choose how much of your data is masked before it reaches an AI assistant. The new mode applies without restarting MCP, but a connected assistant has to reload its analytics data before it can query again.",
           "label": "Privacy mode",
           "preview": {
             "deposit": "Kraken deposit",
             "field": "Field",
             "footer": {
-              "balanced": "Identifiers remain masked while useful generated descriptions and account names stay readable.",
+              "balanced": "Identifiers remain masked while generated descriptions stay readable, and an exchange account keeps its venue name. A name you assigned yourself is masked like any other identifier.",
               "raw": "Nothing is masked. Addresses, hashes, account names, and notes reach the assistant verbatim.",
               "strict": "Identifiers become session-stable anonymous hashes so grouping still works. Free text is replaced by a flag indicating whether it existed."
             },
+            "group_affected": "Decided by this mode",
+            "group_always": "Sent in every mode",
+            "not_sent": "column not sent",
             "not_set": "not set",
             "swap": "On-chain swap",
             "title": "Example of what the assistant receives"

--- a/frontend/app/src/modules/settings/backend/McpPrivacyPreview.vue
+++ b/frontend/app/src/modules/settings/backend/McpPrivacyPreview.vue
@@ -7,49 +7,134 @@ const { mode } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
+/**
+ * A single cell. `plain` reaches the assistant verbatim, `hash` is the session-stable `anon_`
+ * identifier, and `redacted` is free text replaced by a `has_<field>` flag.
+ *
+ * The two empty states are not the same and must not render alike: `undefined` means this event
+ * carried no such value while the column still exists (another event fills it, so the assistant
+ * reads null), whereas `absent` means the mode emits no such column at all and querying it fails.
+ */
+type PreviewValue =
+  | { readonly kind: 'plain'; readonly text: string; readonly flag?: string }
+  | { readonly kind: 'hash'; readonly text: string }
+  | { readonly kind: 'redacted'; readonly text: string; readonly flag: string }
+  | { readonly kind: 'absent' };
+
 interface PreviewRow {
   readonly field: string;
-  readonly deposit?: string;
-  readonly swap?: string;
+  readonly deposit?: PreviewValue;
+  readonly swap?: PreviewValue;
 }
 
+function plain(text: string): PreviewValue {
+  return { kind: 'plain', text };
+}
+
+// A text column always ships its `has_<column>` companion, whatever the mode leaves in the column
+// itself. Not translated: these are literal values the assistant receives, not prose.
+function flagged(text: string, field: string): PreviewValue {
+  return { flag: `has_${field}: true`, kind: 'plain', text };
+}
+
+function hash(text: string): PreviewValue {
+  return { kind: 'hash', text };
+}
+
+function absent(): PreviewValue {
+  return { kind: 'absent' };
+}
+
+function redacted(field: string): PreviewValue {
+  return { flag: `has_${field}: true`, kind: 'redacted', text: '[redacted]' };
+}
+
+// The sample values below mirror `_sanitize_row` in rotkehlchen/mcp/analytics.py. Keep them in
+// step with it: `GENERATED_TEXT_COLUMN_NAMES` decides whether `auto_notes` survives balanced, and
+// `READABLE_LOCATION_LABELS` decides which `location_label` values stay readable there (only a
+// value that is exactly a rotki location name -- a user-assigned account name is hashed).
 const commonRows: PreviewRow[] = [
-  { deposit: '1754425840000', field: 'timestamp', swap: '1754431200000' },
-  { deposit: 'kraken', field: 'location', swap: 'ethereum' },
-  { deposit: 'deposit', field: 'event_type', swap: 'trade' },
-  { deposit: 'BTC', field: 'asset', swap: 'ETH' },
-  { deposit: '0.4', field: 'amount', swap: '1.25' },
-  { field: 'counterparty', swap: 'uniswap-v3' },
+  { deposit: plain('1754425840000'), field: 'timestamp', swap: plain('1754431200000') },
+  { deposit: plain('kraken'), field: 'location', swap: plain('ethereum') },
+  { deposit: plain('deposit'), field: 'event_type', swap: plain('trade') },
+  { deposit: plain('BTC'), field: 'asset', swap: plain('ETH') },
+  { deposit: plain('0.4'), field: 'amount', swap: plain('1.25') },
+  { field: 'counterparty', swap: plain('uniswap-v3') },
 ];
 
 const modeRows = computed<PreviewRow[]>(() => {
+  // Raw is the only mode where an identifier keeps its own column name; everywhere else the value
+  // moves to `<column>_hash` and the original column is dropped, except the one balanced case where
+  // a venue-name label also stays readable under `location_label`.
   if (mode === PrivacyMode.RAW) {
     return [
-      { deposit: 'Kraken main', field: 'location_label', swap: '0x9C5083…5dAC5' },
-      { field: 'tx_hash', swap: '0x3f1a…9d2c' },
-      { deposit: 'Deposit 0.4 BTC to Kraken', field: 'auto_notes', swap: 'Swap 1.25 ETH for 4381.25 USDC' },
-      { field: 'user_notes', swap: 'quarterly rebalance' },
+      { deposit: plain('kraken'), field: 'location_label', swap: plain('0x9C5083…5dAC5') },
+      { field: 'tx_hash', swap: plain('0x3f1a…9d2c') },
+      {
+        deposit: plain('Deposit 0.4 BTC to Kraken'),
+        field: 'auto_notes',
+        swap: plain('Swap 1.25 ETH for 4381.25 USDC'),
+      },
+      { field: 'user_notes', swap: plain('quarterly rebalance') },
     ];
   }
 
   if (mode === PrivacyMode.BALANCED) {
     return [
-      { deposit: 'Kraken main', field: 'location_label', swap: 'anon_5c4efe77c7146ef8' },
-      { field: 'tx_hash', swap: 'anon_61b73c8e638bc34c' },
-      { deposit: 'Deposit 0.4 BTC to Kraken', field: 'auto_notes', swap: 'Swap 1.25 ETH for 4381.25 USDC' },
-      { field: 'user_notes', swap: '[redacted] · has_user_notes: true' },
+      {
+        deposit: hash('anon_b43a5d4cd838add9'),
+        field: 'location_label_hash',
+        swap: hash('anon_5c4efe77c7146ef8'),
+      },
+      { deposit: plain('kraken'), field: 'location_label' },
+      { field: 'tx_hash_hash', swap: hash('anon_61b73c8e638bc34c') },
+      {
+        deposit: flagged('Deposit 0.4 BTC to Kraken', 'auto_notes'),
+        field: 'auto_notes',
+        swap: flagged('Swap 1.25 ETH for 4381.25 USDC', 'auto_notes'),
+      },
+      { field: 'user_notes', swap: redacted('user_notes') },
     ];
   }
 
   return [
-    { deposit: 'anon_b43a5d4cd838add9', field: 'location_label', swap: 'anon_5c4efe77c7146ef8' },
-    { field: 'tx_hash', swap: 'anon_61b73c8e638bc34c' },
-    { deposit: '[redacted] · has_auto_notes: true', field: 'auto_notes', swap: '[redacted] · has_auto_notes: true' },
-    { field: 'user_notes', swap: '[redacted] · has_user_notes: true' },
+    {
+      deposit: hash('anon_b43a5d4cd838add9'),
+      field: 'location_label_hash',
+      swap: hash('anon_5c4efe77c7146ef8'),
+    },
+    // Strict emits no readable label column at all. The row stays so switching to balanced does not
+    // reflow the table, but it says "not sent" rather than "not set": querying it would fail.
+    { deposit: absent(), field: 'location_label', swap: absent() },
+    { field: 'tx_hash_hash', swap: hash('anon_61b73c8e638bc34c') },
+    { deposit: redacted('auto_notes'), field: 'auto_notes', swap: redacted('auto_notes') },
+    { field: 'user_notes', swap: redacted('user_notes') },
   ];
 });
 
-const rows = computed<PreviewRow[]>(() => [...commonRows, ...get(modeRows)]);
+/** A row flattened to the column order the table renders, so each cell binds to a narrowable alias. */
+interface PreviewLine {
+  readonly field: string;
+  readonly cells: readonly (PreviewValue | undefined)[];
+}
+
+function toLines(rows: PreviewRow[]): PreviewLine[] {
+  return rows.map(({ deposit, field, swap }) => ({ cells: [swap, deposit], field }));
+}
+
+// The split is the point: the first group is what every mode sends, the second is what the chosen
+// mode decides.
+const groups = computed<{ label: string; lines: PreviewLine[] }[]>(() => [
+  {
+    label: t('backend_settings.settings.mcp_server.privacy_mode.preview.group_always'),
+    lines: toLines(commonRows),
+  },
+  {
+    label: t('backend_settings.settings.mcp_server.privacy_mode.preview.group_affected'),
+    lines: toLines(get(modeRows)),
+  },
+]);
+
 const footers = computed<Record<McpPrivacyMode, string>>(() => ({
   [PrivacyMode.BALANCED]: t('backend_settings.settings.mcp_server.privacy_mode.preview.footer.balanced'),
   [PrivacyMode.RAW]: t('backend_settings.settings.mcp_server.privacy_mode.preview.footer.raw'),
@@ -66,7 +151,7 @@ const modeLabel = computed<string>(() => get(modeLabels)[mode]);
 
 <template>
   <div class="overflow-hidden rounded-lg border border-default bg-rui-grey-50 dark:bg-rui-grey-900">
-    <div class="flex items-center justify-between border-b border-default px-4 py-3">
+    <div class="flex items-center justify-between gap-4 border-b border-default px-4 py-3">
       <span class="text-xs font-medium uppercase tracking-wider text-rui-text-secondary">
         {{ t('backend_settings.settings.mcp_server.privacy_mode.preview.title') }}
       </span>
@@ -75,52 +160,110 @@ const modeLabel = computed<string>(() => get(modeLabels)[mode]);
       </span>
     </div>
     <div class="overflow-x-auto">
-      <table class="w-full min-w-[42rem] text-left font-mono text-xs">
+      <!-- table-fixed, because auto layout sizes the columns from their content: the values differ
+           per mode, so the columns slid sideways on every switch. -->
+      <table class="w-full min-w-[42rem] table-fixed text-left font-mono text-xs">
+        <colgroup>
+          <col class="w-40" />
+          <col />
+          <col />
+        </colgroup>
         <thead class="text-rui-text-secondary">
           <tr class="border-b border-default">
-            <th class="px-4 py-2 font-medium">
+            <th
+              scope="col"
+              class="px-4 py-2 font-medium"
+            >
               {{ t('backend_settings.settings.mcp_server.privacy_mode.preview.field') }}
             </th>
-            <th class="px-4 py-2 font-medium">
+            <th
+              scope="col"
+              class="px-4 py-2 font-medium"
+            >
               {{ t('backend_settings.settings.mcp_server.privacy_mode.preview.swap') }}
             </th>
-            <th class="px-4 py-2 font-medium">
+            <th
+              scope="col"
+              class="px-4 py-2 font-medium"
+            >
               {{ t('backend_settings.settings.mcp_server.privacy_mode.preview.deposit') }}
             </th>
           </tr>
         </thead>
-        <tbody>
+        <tbody
+          v-for="group in groups"
+          :key="group.label"
+        >
+          <tr>
+            <td
+              colspan="3"
+              class="border-b border-default px-4 pb-1 pt-3 font-sans text-[0.65rem] font-medium uppercase tracking-wider text-rui-text-secondary"
+            >
+              {{ group.label }}
+            </td>
+          </tr>
           <tr
-            v-for="row in rows"
-            :key="row.field"
-            class="border-b border-default last:border-b-0"
+            v-for="line in group.lines"
+            :key="line.field"
+            class="h-9 border-b border-default last:border-b-0"
           >
-            <th class="px-4 py-2 font-medium text-rui-text-secondary">
-              {{ row.field }}
+            <!-- Fixed row height and a reserved footer below: a chip is taller than a bare value,
+                 so without them the card resizes on every mode switch and the page jumps. -->
+            <th
+              scope="row"
+              class="whitespace-nowrap px-4 align-middle font-medium text-rui-text-secondary"
+            >
+              {{ line.field }}
             </th>
-            <td class="px-4 py-2">
-              <span v-if="row.swap">{{ row.swap }}</span>
+            <td
+              v-for="(value, index) in line.cells"
+              :key="index"
+              class="whitespace-nowrap px-4 align-middle"
+            >
               <span
-                v-else
+                v-if="!value"
                 class="italic text-rui-text-secondary"
               >
                 {{ t('backend_settings.settings.mcp_server.privacy_mode.preview.not_set') }}
               </span>
-            </td>
-            <td class="px-4 py-2">
-              <span v-if="row.deposit">{{ row.deposit }}</span>
+              <span
+                v-else-if="value.kind === 'absent'"
+                class="italic text-rui-text-disabled"
+              >
+                {{ t('backend_settings.settings.mcp_server.privacy_mode.preview.not_sent') }}
+              </span>
+              <!-- No wrapping anywhere in here: a cell that breaks onto a second line would undo
+                   the fixed row height and bring back the jump on mode switch. -->
+              <span
+                v-else-if="value.kind === 'hash'"
+                class="rounded bg-rui-grey-200 px-1.5 py-0.5 text-rui-text-secondary dark:bg-rui-grey-800"
+              >
+                {{ value.text }}
+              </span>
               <span
                 v-else
-                class="italic text-rui-text-secondary"
+                class="inline-flex items-center gap-x-2"
               >
-                {{ t('backend_settings.settings.mcp_server.privacy_mode.preview.not_set') }}
+                <span
+                  v-if="value.kind === 'redacted'"
+                  class="rounded bg-rui-grey-300 px-1.5 py-0.5 text-rui-text-secondary dark:bg-rui-grey-700"
+                >
+                  {{ value.text }}
+                </span>
+                <span v-else>{{ value.text }}</span>
+                <span
+                  v-if="value.flag"
+                  class="text-rui-success"
+                >
+                  {{ value.flag }}
+                </span>
               </span>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
-    <p class="border-t border-default px-4 py-3 text-sm text-rui-text-secondary">
+    <p class="min-h-16 border-t border-default px-4 py-3 font-sans text-sm text-rui-text-secondary">
       {{ footer }}
     </p>
   </div>

--- a/frontend/app/src/modules/settings/backend/McpServerSetting.spec.ts
+++ b/frontend/app/src/modules/settings/backend/McpServerSetting.spec.ts
@@ -1,3 +1,4 @@
+import { assert } from '@rotki/common';
 import { type McpServerStatus, StarlingServiceStatus } from '@shared/ipc';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { setActivePinia } from 'pinia';
@@ -117,6 +118,26 @@ function createWrapper(): VueWrapper<InstanceType<typeof McpServerSetting>> {
   });
 }
 
+/**
+ * The privacy preview's cells for one field, as [on-chain swap, exchange deposit]. Anchored on the
+ * field name rather than a row index so a reordered preview fails loudly instead of silently
+ * asserting the wrong row.
+ */
+function previewRow(wrapper: VueWrapper<InstanceType<typeof McpServerSetting>>, field: string): string[] {
+  // The group caption rows carry no header cell, hence the exists() guard before reading it.
+  const row = wrapper.findAll('tbody tr').find((entry) => {
+    const header = entry.find('th');
+    return header.exists() && header.text() === field;
+  });
+  assert(row, `the privacy preview has no ${field} row`);
+  return row.findAll('td').map(cell => cell.text());
+}
+
+/** Every column name the preview claims the assistant receives, in render order. */
+function previewFields(wrapper: VueWrapper<InstanceType<typeof McpServerSetting>>): string[] {
+  return wrapper.findAll('tbody tr th').map(header => header.text());
+}
+
 function grantMcpAccess(enabled: boolean, minimumTier = 'Basic'): void {
   const { capabilities, premium } = storeToRefs(usePremiumStore());
   set(premium, true);
@@ -179,12 +200,59 @@ describe('mcpServerSetting', () => {
     expect(selector.text()).toContain('backend_settings.settings.mcp_server.privacy_mode.balanced.description');
     expect(selector.text()).toContain('backend_settings.settings.mcp_server.privacy_mode.raw.description');
     expect(wrapper.text()).toContain('backend_settings.settings.mcp_server.privacy_mode.preview.title');
-    expect(wrapper.text()).toContain('anon_5c4efe77c7146ef8');
-    expect(wrapper.text()).toContain('Kraken main');
+    // Balanced keeps the venue name readable under its own column, alongside the hash every
+    // identifier gets.
+    expect(previewRow(wrapper, 'location_label')).toStrictEqual([
+      'backend_settings.settings.mcp_server.privacy_mode.preview.not_set',
+      'kraken',
+    ]);
+    expect(previewRow(wrapper, 'location_label_hash')).toStrictEqual([
+      'anon_5c4efe77c7146ef8',
+      'anon_b43a5d4cd838add9',
+    ]);
     expect(selector.findAll('.rui-radio')).toHaveLength(3);
     expect(selector.findAll('.rui-radio').every(radio => (
       radio.element.parentElement === selector.element
     ))).toBe(true);
+  });
+
+  /**
+   * The one field that separates balanced from strict. `READABLE_LOCATION_LABELS` in
+   * rotkehlchen/mcp/analytics.py lets a location label through only when it is exactly a rotki
+   * location name, so the exchange row stays readable in balanced and is hashed in strict; the
+   * on-chain row is address-shaped and is hashed in both.
+   */
+  it('should mask the exchange account label only in strict mode', async () => {
+    const repo = useSettingsRepo();
+    repo.updateGeneral({ ...repo.general, mcpPrivacyMode: McpPrivacyMode.STRICT });
+
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    // "not sent", not "not set": strict emits no such column, so querying it would fail rather
+    // than return null.
+    expect(previewRow(wrapper, 'location_label')).toStrictEqual([
+      'backend_settings.settings.mcp_server.privacy_mode.preview.not_sent',
+      'backend_settings.settings.mcp_server.privacy_mode.preview.not_sent',
+    ]);
+    expect(previewRow(wrapper, 'location_label_hash')).toStrictEqual([
+      'anon_5c4efe77c7146ef8',
+      'anon_b43a5d4cd838add9',
+    ]);
+  });
+
+  /**
+   * Outside raw an identifier moves to `<column>_hash` and its own column is dropped, so a preview
+   * that still labelled the hash `tx_hash` would send someone to write SQL against a column the
+   * assistant never received.
+   */
+  it('should name masked identifier columns as the assistant sees them', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    const fields = previewFields(wrapper);
+    expect(fields).toContain('tx_hash_hash');
+    expect(fields).not.toContain('tx_hash');
   });
 
   it('should warn and preview unmasked fields in raw mode', async () => {

--- a/frontend/app/src/modules/settings/backend/McpServerSetting.vue
+++ b/frontend/app/src/modules/settings/backend/McpServerSetting.vue
@@ -33,49 +33,64 @@ const tokenVisible = ref<boolean>(false);
 const mcpServerState = useMcpServerState();
 const {
   error: privacyModeError,
-  model: privacyModeModel,
+  model: privacyMode,
   pending: privacyModePending,
   success: privacyModeSuccess,
 } = useSettingModel('mcpPrivacyMode');
 
-const privacyMode = computed<McpPrivacyModeValue>({
-  get: () => get(privacyModeModel),
-  set: value => set(privacyModeModel, value),
-});
+// `useSettingModel` keeps `success` true until the next write, which beside a heading would read as
+// a permanent label rather than a confirmation. Show it only for as long as it is news.
+const savedVisible = ref<boolean>(false);
+const { start: hideSaved } = useTimeoutFn(() => {
+  set(savedVisible, false);
+}, 4000, { immediate: false });
 
 interface PrivacyModeOption {
+  readonly classes: string;
   readonly description: string;
+  /** The backend default, and the one the copy points at. */
+  readonly recommended: boolean;
   readonly title: string;
   readonly value: McpPrivacyModeValue;
 }
 
-const privacyModes = computed<PrivacyModeOption[]>(() => [
-  {
-    description: t('backend_settings.settings.mcp_server.privacy_mode.strict.description'),
-    title: t('backend_settings.settings.mcp_server.privacy_mode.strict.title'),
-    value: McpPrivacyMode.STRICT,
-  },
-  {
-    description: t('backend_settings.settings.mcp_server.privacy_mode.balanced.description'),
-    title: t('backend_settings.settings.mcp_server.privacy_mode.balanced.title'),
-    value: McpPrivacyMode.BALANCED,
-  },
-  {
-    description: t('backend_settings.settings.mcp_server.privacy_mode.raw.description'),
-    title: t('backend_settings.settings.mcp_server.privacy_mode.raw.title'),
-    value: McpPrivacyMode.RAW,
-  },
-]);
-const privacyModeErrorMessages = computed<string[]>(() => (
-  get(privacyModeError)
-    ? [`${t('backend_settings.settings.mcp_server.privacy_mode.error')}: ${get(privacyModeError)}`]
-    : []
-));
-const privacyModeSuccessMessages = computed<string[]>(() => (
-  get(privacyModeSuccess)
-    ? [t('backend_settings.settings.mcp_server.privacy_mode.success')]
-    : []
-));
+// Raw is the only mode that sends anything unmasked, so selecting it carries the warning tone
+// rather than the ordinary selected tint.
+function optionClasses(value: McpPrivacyModeValue, selected: McpPrivacyModeValue): string {
+  if (value !== selected)
+    return 'border-default';
+
+  return value === McpPrivacyMode.RAW
+    ? 'border-rui-warning/50 bg-rui-warning/10'
+    : 'border-rui-primary bg-rui-primary/5';
+}
+
+const privacyModes = computed<PrivacyModeOption[]>(() => {
+  const selected = get(privacyMode);
+  return [
+    {
+      classes: optionClasses(McpPrivacyMode.STRICT, selected),
+      description: t('backend_settings.settings.mcp_server.privacy_mode.strict.description'),
+      recommended: false,
+      title: t('backend_settings.settings.mcp_server.privacy_mode.strict.title'),
+      value: McpPrivacyMode.STRICT,
+    },
+    {
+      classes: optionClasses(McpPrivacyMode.BALANCED, selected),
+      description: t('backend_settings.settings.mcp_server.privacy_mode.balanced.description'),
+      recommended: true,
+      title: t('backend_settings.settings.mcp_server.privacy_mode.balanced.title'),
+      value: McpPrivacyMode.BALANCED,
+    },
+    {
+      classes: optionClasses(McpPrivacyMode.RAW, selected),
+      description: t('backend_settings.settings.mcp_server.privacy_mode.raw.description'),
+      recommended: false,
+      title: t('backend_settings.settings.mcp_server.privacy_mode.raw.title'),
+      value: McpPrivacyMode.RAW,
+    },
+  ];
+});
 
 const transitioningStates: ReadonlySet<StarlingServiceStatus> = new Set([
   StarlingServiceStatus.RESTARTING,
@@ -212,6 +227,12 @@ function toggleTokenVisibility(): void {
   set(tokenVisible, !get(tokenVisible));
 }
 
+watch(privacyModeSuccess, (saved) => {
+  set(savedVisible, saved);
+  if (saved)
+    hideSaved();
+});
+
 watch(mcpServerState, (pushed) => {
   if (pushed)
     set(state, pushed);
@@ -266,7 +287,7 @@ onBeforeMount(() => {
         {{ t('backend_settings.settings.mcp_server.error', { message: serverError }) }}
       </RuiAlert>
 
-      <div class="flex flex-col gap-3 rounded-lg bg-rui-grey-50 p-4 dark:bg-rui-grey-900 sm:flex-row sm:items-center">
+      <div class="flex max-w-4xl flex-col gap-3 rounded-lg border border-default bg-rui-grey-50 p-4 dark:bg-rui-grey-900 sm:flex-row sm:items-center">
         <RuiChip
           data-testid="mcp-status"
           size="sm"
@@ -314,45 +335,57 @@ onBeforeMount(() => {
 
       <section class="flex max-w-4xl flex-col gap-4">
         <div>
-          <h6 class="text-h6 font-semibold">
-            {{ t('backend_settings.settings.mcp_server.privacy_mode.label') }}
-          </h6>
+          <div class="flex flex-wrap items-baseline justify-between gap-x-4">
+            <h6 class="text-h6 font-semibold">
+              {{ t('backend_settings.settings.mcp_server.privacy_mode.label') }}
+            </h6>
+            <!-- Beside the heading rather than under the last option: the group's own detail slot
+                 renders below Raw, where a confirmation reads as if it belonged to Raw. -->
+            <span
+              v-if="savedVisible"
+              class="text-sm text-rui-success"
+            >
+              {{ t('backend_settings.settings.mcp_server.privacy_mode.success') }}
+            </span>
+          </div>
           <p class="text-sm text-rui-text-secondary">
             {{ t('backend_settings.settings.mcp_server.privacy_mode.hint') }}
           </p>
         </div>
 
+        <RuiAlert
+          v-if="privacyModeError"
+          type="error"
+        >
+          {{ t('backend_settings.settings.mcp_server.privacy_mode.error', { message: privacyModeError }) }}
+        </RuiAlert>
+
         <RuiRadioGroup
           v-model="privacyMode"
           data-testid="mcp-privacy-mode"
           color="primary"
+          hide-details
           :disabled="privacyModePending"
-          :success-messages="privacyModeSuccessMessages"
-          :error-messages="privacyModeErrorMessages"
         >
           <RuiRadio
             v-for="option in privacyModes"
             :key="option.value"
             :value="option.value"
-            class="mb-2 w-full rounded border px-3 py-2 transition-colors last:mb-0"
-            :class="privacyMode === option.value
-              ? option.value === McpPrivacyMode.RAW
-                ? 'border-rui-warning/50 bg-rui-warning/10'
-                : 'border-rui-primary bg-rui-primary/5'
-              : 'border-default'"
+            class="mb-2 w-full rounded border pl-4 transition-colors last:mb-0"
+            :class="option.classes"
           >
-            <div>
+            <div class="py-2 pr-3">
               <div class="flex items-center gap-2 font-medium">
                 {{ option.title }}
                 <RuiChip
-                  v-if="option.value === McpPrivacyMode.BALANCED"
+                  v-if="option.recommended"
                   size="sm"
                   color="success"
                 >
                   {{ t('backend_settings.settings.mcp_server.privacy_mode.default') }}
                 </RuiChip>
               </div>
-              <div class="mt-0.5 text-sm text-rui-text-secondary">
+              <div class="mt-0.5 max-w-prose text-sm text-rui-text-secondary">
                 {{ option.description }}
               </div>
             </div>
@@ -372,7 +405,7 @@ onBeforeMount(() => {
         <McpPrivacyPreview :mode="privacyMode" />
       </section>
 
-      <div class="flex flex-wrap items-center gap-4 border-t border-default pt-4">
+      <div class="flex max-w-4xl flex-wrap items-center gap-4 border-t border-default pt-4">
         <RuiSwitch
           v-if="supportsOptions"
           data-testid="mcp-auto-start"


### PR DESCRIPTION
Follow-up to #12803.

The privacy preview described a redaction that `_sanitize_row` does not perform, in three ways. Each was verified by running `rotkehlchen/mcp/analytics.py::_sanitize_row` over the two sample events in all three modes and diffing every cell against what the component rendered.

### Column names the assistant never receives

Outside `raw`, an identifier is emitted as `sanitized[f'{column}_hash']` and the original column is dropped. The preview labelled those rows `tx_hash` and `location_label`, so someone writing `select tx_hash` from what the preview showed would hit a missing column. They are now `tx_hash_hash` and `location_label_hash`, with a separate `location_label` row for the one balanced case where the readable venue name is emitted as well.

### `location_label` in balanced

The sample used `Kraken main`, but `READABLE_LOCATION_LABELS` only lets a label through when it is exactly a rotki location name, so a user-assigned account name is hashed there too. The sample now uses the venue name, which is also what makes the strict/balanced boundary visible in the table.

### The `has_<column>` companion

Every text column ships `has_<column>` in every non-raw mode. Balanced's `auto_notes` cell showed the text alone, reading as though free text passes through untouched in the one mode where it is both scrubbed and flagged.

### Copy

- `balanced.description` and `preview.footer.balanced` both claimed account names stay readable. Only the venue name does, and `location` already carries it.
- `privacy_mode.hint` said the mode applies without restarting MCP, omitting that `describe_table` and the query path return `privacy_mode_changed` until the assistant calls `refresh_analytics_data`.

### Presentation

- Rows are grouped into what every mode sends and what the mode decides, since only four of the ten are actually at stake.
- Masked values are styled apart from values that pass through, and a column the mode does not emit reads "column not sent" rather than "not set": querying it fails rather than returning null.
- The table is fixed-layout with a fixed row height. It was auto-layout, so column widths were computed from content and every mode switch slid the columns sideways.
- The status strip, privacy section and autostart row share one max width; the strip gains a border so it reads as one bar.
- The saved confirmation moved beside the section heading and now times out. `useSettingModel` holds `success` until the next write, and the radio group renders its detail slot under the last option, so a confirmation for Strict appeared under Raw and stayed there.

### Also

- Dropped the identity `computed` around the `useSettingModel` ref.
- The failure message goes through the i18n placeholder instead of being concatenated onto the label.
- Added the missing `scope` attributes on the preview's table headers.

### Tests

`McpServerSetting.spec.ts` asserted `toContain('Kraken main')`, pinning the incorrect value. Assertions are now anchored on the named preview row rather than a substring, with a strict/balanced pair covering the field that separates the two modes and a check that a masked identifier is named as the assistant sees it. The balanced assertion was confirmed to fail against the previous value before the fix landed.

23 unit tests, eslint, stylelint, vue-tsc and typos all pass. Not yet exercised end to end against a live MCP session.