### PR TITLE
fix: free the session state the orchestrator leaked on logout

### DIFF
--- a/frontend/app/src/modules/session/use-session-state-cleaner.spec.ts
+++ b/frontend/app/src/modules/session/use-session-state-cleaner.spec.ts
@@ -10,6 +10,7 @@ const stop = vi.fn();
 const reset = vi.fn();
 const resetState = vi.fn();
 const cancelByTag = vi.fn();
+const resetNativeTasks = vi.fn();
 
 vi.mock('@/modules/auth/use-session-auth-store', () => ({
   useSessionAuthStore: (): object => ({ logged }),
@@ -25,6 +26,11 @@ vi.mock('@/modules/shell/app/use-monitor-service', () => ({
 
 vi.mock('@/modules/task-center/use-task-orchestrator', () => ({
   useTaskOrchestrator: (): object => ({ reset }),
+}));
+
+// Mocked rather than left real: it reaches `useTaskHandler`, which needs an active pinia.
+vi.mock('@/modules/task-center/use-native-task', () => ({
+  useNativeTask: (): object => ({ reset: resetNativeTasks }),
 }));
 
 vi.mock('@/modules/shell/app/store-plugins', () => ({
@@ -64,6 +70,9 @@ describe('useSessionStateCleaner', () => {
     expect(stop).toHaveBeenCalledOnce();
     expect(clearUploadStatus).toHaveBeenCalledOnce();
     expect(reset).toHaveBeenCalledOnce();
+    // An id left in the submission map outlives the session, and submitTask dedups by id, so the
+    // next session would join a promise that can never resolve.
+    expect(resetNativeTasks).toHaveBeenCalledOnce();
     expect(resetState).toHaveBeenCalledOnce();
     // The login-time suggestion probes are not awaited by the login, so they can outlive it.
     expect(cancelByTag).toHaveBeenCalledWith(SUGGESTION_PROBE_TAG);
@@ -75,6 +84,7 @@ describe('useSessionStateCleaner', () => {
     await nextTick();
     expect(clearUploadStatus).not.toHaveBeenCalled();
     expect(reset).not.toHaveBeenCalled();
+    expect(resetNativeTasks).not.toHaveBeenCalled();
     expect(resetState).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/modules/session/use-session-state-cleaner.ts
+++ b/frontend/app/src/modules/session/use-session-state-cleaner.ts
@@ -4,6 +4,7 @@ import { useSync } from '@/modules/session/use-session-sync';
 import { SUGGESTION_PROBE_TAG } from '@/modules/settings/suggestions/use-suggestion-probes';
 import { resetState } from '@/modules/shell/app/store-plugins';
 import { useMonitorService } from '@/modules/shell/app/use-monitor-service';
+import { useNativeTask } from '@/modules/task-center/use-native-task';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
 
 export function useSessionStateCleaner(): void {
@@ -11,6 +12,7 @@ export function useSessionStateCleaner(): void {
   const { clearUploadStatus } = useSync();
   const { start, stop } = useMonitorService();
   const orchestrator = useTaskOrchestrator();
+  const { reset: resetNativeTasks } = useNativeTask();
 
   function cleanup(): void {
     clearUploadStatus();
@@ -20,6 +22,12 @@ export function useSessionStateCleaner(): void {
     // Drop native activities and the completion ledger so freshness/liveness never leak across
     // users (the orchestrator is app-scoped, not a pinia store reset by resetState).
     orchestrator.reset();
+    // After the orchestrator, so its emit gets the chance to settle each caller normally and this
+    // only sweeps up what that missed. An id left in the submission map outlives the session and
+    // `submitTask` dedups by id, so the next session joins a promise that can never resolve — how
+    // `prices:exchange-rates` stalled `fetchCached` on its first await after a re-login, leaving
+    // the new session with no exchange rates, no accounts and no balances.
+    resetNativeTasks();
     resetState();
   }
 

--- a/frontend/app/src/modules/task-center/core/orchestrator/scheduler.spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/scheduler.spec.ts
@@ -213,4 +213,56 @@ describe('createScheduler', () => {
       expect(scheduler.runningCount('balances')).toBe(2);
     });
   });
+
+  describe('clear', () => {
+    /**
+     * A slot is freed from `run()`'s `finally`, and a reset abandons those runs rather than
+     * resolving them. Leaving the slots occupied meant a lane stayed full for the life of the
+     * process, so the next session's work queued behind jobs belonging to a session that had ended
+     * and never started at all.
+     */
+    it('should free the slots of running jobs, not just the queue', () => {
+      const scheduler = createScheduler({ decode: 2 });
+      const running = [1, 2].map(n => controllableJob(`old-${n}`, 'decode'));
+      running.forEach(({ job }) => scheduler.submit(job));
+      // A third job cannot start: the lane is at its cap of 2.
+      scheduler.submit(controllableJob('old-3', 'decode').job);
+      expect(scheduler.runningCount('decode')).toBe(2);
+
+      // The session ends. The abandoned runs are never resolved.
+      scheduler.clear();
+
+      expect(scheduler.runningCount('decode')).toBe(0);
+      expect(scheduler.isQueued('old-3')).toBe(false);
+    });
+
+    it('should let the next session start work on a lane that was full', () => {
+      const scheduler = createScheduler({ decode: 2 });
+      const stuck = [1, 2].map(n => controllableJob(`old-${n}`, 'decode'));
+      stuck.forEach(({ job }) => scheduler.submit(job));
+
+      scheduler.clear();
+      scheduler.submit(controllableJob('new-1', 'decode').job);
+
+      expect(scheduler.isRunning('new-1')).toBe(true);
+    });
+
+    /**
+     * The abandoned run may still settle later. Its `finally` deletes a job the map no longer holds
+     * and pumps, and neither may disturb the session that replaced it.
+     */
+    it('should ignore an abandoned run settling after the clear', async () => {
+      const scheduler = createScheduler({ decode: 2 });
+      const old = controllableJob('old-1', 'decode');
+      scheduler.submit(old.job);
+
+      scheduler.clear();
+      scheduler.submit(controllableJob('new-1', 'decode').job);
+      old.finish();
+      await flush();
+
+      expect(scheduler.runningCount('decode')).toBe(1);
+      expect(scheduler.isRunning('new-1')).toBe(true);
+    });
+  });
 });

--- a/frontend/app/src/modules/task-center/core/orchestrator/scheduler.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/scheduler.ts
@@ -21,7 +21,13 @@ export interface Scheduler {
   readonly pump: () => void;
   /** Remove a still-queued job (returns true if it was queued; running jobs are unaffected). */
   readonly drop: (id: string) => boolean;
-  /** Drop every queued job (running jobs settle and free their slots). Used by orchestrator reset. */
+  /**
+   * Drop every queued job *and* release every running job's lane slot. Used by orchestrator reset.
+   *
+   * ⚠️ The slots must go too. A slot is freed from `run()`'s `finally`, and a reset abandons those
+   * runs rather than resolving them, so anything live at reset would hold its lane for the life of
+   * the process and the work submitted after it would queue forever.
+   */
   readonly clear: () => void;
   readonly isRunning: (id: string) => boolean;
   readonly isQueued: (id: string) => boolean;
@@ -134,6 +140,15 @@ export function createScheduler(
   return {
     clear(): void {
       queue.length = 0;
+      // 🔴 The slots too, not just the queue. A slot is freed from `run()`'s `finally`, and a reset
+      // abandons those runs rather than resolving them — so anything live when a session ended held
+      // its lane forever, and lane caps are 1-2. The next session's work then queued behind ghosts
+      // and never started: observed as `prices:exchange-rates` being submitted and never running
+      // after a re-login, which stalled the whole session load on its first await.
+      //
+      // Safe against the abandoned run settling later: its `finally` deletes a job that is no
+      // longer in the map (a no-op) and pumps, which is what we want anyway.
+      running.clear();
     },
     drop(id: string): boolean {
       const index = queue.findIndex(job => job.id === id);

--- a/frontend/app/src/modules/task-center/use-native-task.spec.ts
+++ b/frontend/app/src/modules/task-center/use-native-task.spec.ts
@@ -129,5 +129,48 @@ describe('useNativeTask', () => {
 
       expect(run).toHaveBeenCalledOnce();
     });
+
+    /**
+     * 🔴 The two tests above prove the *abandoned* caller settles and its id is freed. Neither
+     * proves the *next* session can start anything, and that is where this actually broke: a lane
+     * slot is released from `run()`'s `finally`, and a reset abandons those runs rather than
+     * resolving them, so every activity live at logout held its lane for the life of the process.
+     * With the lane full, the next session's submit queued behind jobs belonging to a session that
+     * no longer existed and never ran at all.
+     *
+     * In the app: `prices:exchange-rates` was submitted after a re-login and never started, which
+     * stalled `fetchCached()` on its first await — no exchange rates, no account read, no balances.
+     */
+    it('should start new work after reset even when every lane slot was taken', async () => {
+      const { submitTask } = useNativeTask();
+      const orchestrator = useTaskOrchestrator();
+
+      // Saturate the default lane with work only the orchestrator can settle.
+      const abandoned = [1, 2, 3, 4].map(async n => submitTask({
+        id: makeActivityId(ActivityKind.PRICES, `slot-${n}`),
+        kind: ActivityKind.PRICES,
+        run: neverSettles,
+        title: 'prices',
+      }));
+
+      orchestrator.reset();
+      await Promise.all(abandoned);
+
+      const run = vi.fn(async () => ok(undefined));
+      const raced = await Promise.race([
+        submitTask({
+          id: makeActivityId(ActivityKind.PRICES, 'after-reset'),
+          kind: ActivityKind.PRICES,
+          run,
+          title: 'prices',
+        }).then(() => 'settled'),
+        new Promise<string>((resolve) => {
+          setTimeout(resolve, 50, 'HUNG');
+        }),
+      ]);
+
+      expect(raced).toBe('settled');
+      expect(run).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/frontend/app/src/modules/task-center/use-native-task.ts
+++ b/frontend/app/src/modules/task-center/use-native-task.ts
@@ -92,6 +92,12 @@ interface UseNativeTaskReturn {
    */
   readonly submitTask: <T = void>(spec: NativeActivitySpec<T>) => Promise<TaskOutcome<T>>;
   /**
+   * Settle and drop every in-flight submission. Called when a session ends, so no id survives into
+   * the next one — `submitTask` dedups by id, and a surviving id hands the next session a promise
+   * that can never resolve.
+   */
+  readonly reset: () => void;
+  /**
    * Cancel one activity by identity — `orchestrator.cancel(makeActivityId(kind, ...parts))`. The
    * replacement for the old imperative cancel-by-task-type at producer call sites: it settles the
    * activity terminal *immediately* (so awaiting readers and `useWorkStatus` spinners unblock even
@@ -150,6 +156,33 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
    */
   const inflight = new Map<ActivityId, Promise<TaskOutcome<never>>>();
 
+  /**
+   * How to settle each in-flight submission from the outside. Held beside {@link inflight} because
+   * the promise alone cannot be resolved by anyone but its own closure, and a session ending must
+   * be able to settle every caller it is about to abandon.
+   */
+  const inflightFinish = new Map<ActivityId, (outcome: TaskOutcome<never>) => void>();
+
+  /**
+   * Drop every in-flight submission, settling its callers first.
+   *
+   * 🔴 Must run when a session ends. This map is app-scoped, so an id left here outlives the
+   * session that submitted it, and `submitTask` dedups on id identity — so the *next* session's
+   * caller is handed a promise belonging to a session that is gone and can never resolve. Observed
+   * as `prices:exchange-rates` joining an 11.7s-old promise after a re-login, which stalled
+   * `fetchCached` on its first await: no exchange rates, so no account read, so no balances.
+   *
+   * Settled as cancelled rather than merely cleared, because an abandoned caller is still awaiting
+   * this promise; dropping the reference alone would suspend it forever.
+   */
+  function reset(): void {
+    for (const finishInflight of inflightFinish.values())
+      finishInflight(err(Cancelled({ message: 'session ended' })));
+
+    inflight.clear();
+    inflightFinish.clear();
+  }
+
   function cancelActivity(kind: ActivityKind, ...parts: (string | number)[]): void {
     // The Result is deliberately dropped: "nothing to cancel" (unknown id / already terminal) is
     // the normal case at a supersede site, not an error the caller can act on.
@@ -178,6 +211,7 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
       settled = true;
       stop();
       inflight.delete(spec.id);
+      inflightFinish.delete(spec.id);
       settle(outcome);
     }
 
@@ -230,6 +264,7 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
     // is why the map is keyed to `never` rather than `unknown`.
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- a per-entry key/value type correlation TypeScript cannot express without existential types; contained to this line
     inflight.set(spec.id, promise as Promise<TaskOutcome<never>>);
+    inflightFinish.set(spec.id, finish);
     orchestrator.submit({ ...spec, cancel, run });
     return promise;
   }
@@ -240,6 +275,7 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
     cancelByPrefix,
     reportProgress,
     statusOf,
+    reset,
     submitTask,
     useIsActive,
     useWorkStatus,


### PR DESCRIPTION
Two leaks on the logout path that break the **next** login. Both reproduce as: log in, log out, log in again, in one process.

## The scheduler kept the lanes it was told to clear

`scheduler.clear()` emptied the queue but not `running`. A lane slot is only released from `run()`'s `finally`, and a reset *abandons* those runs rather than resolving them — so every activity live at logout held its lane for the life of the process. Caps are 1-2, so the next session's work queued behind jobs belonging to a session that no longer existed, and never started.

The interface comment asserted the invariant that turns out to be false ("running jobs settle and free their slots"); it is corrected.

## The submission map outlived the session

`submitTask` dedups by activity id, and its map is app-scoped. An id left there outlives its session, so the next session's caller was handed a promise belonging to a session that is gone and can never resolve.

Seen in the app as `prices:exchange-rates` joining an 11.7s-old promise after a re-login: `fetchCached` stalled on its first await, so the session fetched no exchange rates, never read accounts and never loaded balances.

Callers are settled as cancelled rather than dropped — an abandoned caller is still awaiting that promise, and clearing the reference alone would suspend it forever.

## Verification

Both were found in the browser, not by tests. Verified there on this branch alone, with none of the follow-up work present: across **three sessions in one process**, `exchange_rates` resolves immediately and all 17 chains' accounts and balances load. Before, a re-login produced zero balance requests, and the damage was cumulative — the second re-login was worse than the first.

Unit tests cover both, each verified to fail without its fix. One of them closes a gap the existing suite had: the previous `reset` tests proved the abandoned *caller* settles, but nothing proved the *next* session could start work at all — which is exactly what was broken.