### PR TITLE
fix: make the history sync wait for the account walk

### DIFF
--- a/frontend/app/src/modules/accounts/use-account-load-state.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-load-state.spec.ts
@@ -115,6 +115,68 @@ describe('useAccountLoadState', () => {
     expect(pending()).toBeUndefined();
   });
 
+  describe('the unstarted-read bound', () => {
+    /**
+     * `release()` normally ends the wait, but its caller sits behind
+     * `allSettled([fetchCached(), …])`, and `allSettled` cannot settle if `fetchCached` never does.
+     * Observed in the app: a poisoned `prices:exchange-rates` id stalled `fetchCached` on its first
+     * await, and the history sync waited forever.
+     */
+    it('should release a gate whose read never starts', async () => {
+      vi.useFakeTimers();
+      const { useAccountLoadState } = await importModule();
+      const { arm, pending } = useAccountLoadState();
+
+      arm();
+      const waiting = pending();
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await expect(waiting).resolves.toBeUndefined();
+      expect(pending()).toBeUndefined();
+      vi.useRealTimers();
+    });
+
+    /**
+     * The bound covers "promised but never started" only. A read that is genuinely in flight must
+     * be waited out however long it takes — expiring mid-read releases waiters into a half-filled
+     * store, which is the bug this composable exists to prevent.
+     */
+    it('should not expire while a read is actually in flight', async () => {
+      vi.useFakeTimers();
+      const { useAccountLoadState } = await importModule();
+      const { arm, pending, track } = useAccountLoadState();
+      let finish = (): void => {};
+      const read = new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+
+      arm();
+      const tracked = track(read);
+      // Well past the bound, with the read still running.
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(pending()).toBeDefined();
+
+      finish();
+      await tracked;
+      expect(pending()).toBeUndefined();
+      vi.useRealTimers();
+    });
+
+    it('should not fire after the gate was already released', async () => {
+      vi.useFakeTimers();
+      const { useAccountLoadState } = await importModule();
+      const { arm, pending, release } = useAccountLoadState();
+
+      arm();
+      release();
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      // A late timer must not resurrect or re-settle anything.
+      expect(pending()).toBeUndefined();
+      vi.useRealTimers();
+    });
+  });
+
   it('should join a second arm to the waiter the first one created', async () => {
     const { useAccountLoadState } = await importModule();
     const { arm, pending, release } = useAccountLoadState();

--- a/frontend/app/src/modules/accounts/use-account-load-state.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-load-state.spec.ts
@@ -1,3 +1,4 @@
+import { flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 async function importModule(): Promise<typeof import('./use-account-load-state')> {
@@ -45,6 +46,86 @@ describe('useAccountLoadState', () => {
 
     await expect(waiting).resolves.toBeUndefined();
     expect(pending()).toBeUndefined();
+  });
+
+  // The whole point of the third state: at session start the store is empty rather than partial,
+  // and nothing is in flight yet because the load is still awaiting the exchange rates.
+  it('should report pending once armed, before any read starts', async () => {
+    const { useAccountLoadState } = await importModule();
+    const { arm, pending } = useAccountLoadState();
+
+    expect(pending()).toBeUndefined();
+    arm();
+    expect(pending()).toBeDefined();
+  });
+
+  it('should keep an armed waiter waiting until the first read finishes', async () => {
+    const { useAccountLoadState } = await importModule();
+    const { arm, pending, track } = useAccountLoadState();
+    let finish = (): void => {};
+    const read = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+
+    arm();
+    const waiting = pending();
+    let settled = false;
+    const observer = waiting?.then(() => {
+      settled = true;
+    });
+
+    // Armed but not started: a waiter must not be released by the arming itself. Draining the
+    // microtask queue is enough — if the gate were already open, `observer` would have run by now.
+    await flushPromises();
+    expect(settled).toBe(false);
+
+    const tracked = track(read);
+    finish();
+    await tracked;
+    await observer;
+
+    expect(settled).toBe(true);
+    expect(pending()).toBeUndefined();
+  });
+
+  // 🔴 The deadlock case. A resumed session restores balances without re-reading accounts, so the
+  // read the gate was armed for never happens. Without the release the waiter hangs forever.
+  it('should release an armed waiter when no read ever happens', async () => {
+    const { useAccountLoadState } = await importModule();
+    const { arm, pending, release } = useAccountLoadState();
+
+    arm();
+    const waiting = pending();
+    release();
+
+    await expect(waiting).resolves.toBeUndefined();
+    expect(pending()).toBeUndefined();
+  });
+
+  // A waiter belongs to the session that armed it; logging out must not strand it on the next user.
+  it('should release an armed waiter on reset', async () => {
+    const { useAccountLoadState } = await importModule();
+    const { arm, pending, reset } = useAccountLoadState();
+
+    arm();
+    const waiting = pending();
+    reset();
+
+    await expect(waiting).resolves.toBeUndefined();
+    expect(pending()).toBeUndefined();
+  });
+
+  it('should join a second arm to the waiter the first one created', async () => {
+    const { useAccountLoadState } = await importModule();
+    const { arm, pending, release } = useAccountLoadState();
+
+    arm();
+    const first = pending();
+    arm();
+    expect(pending()).toBe(first);
+
+    release();
+    await expect(first).resolves.toBeUndefined();
   });
 
   it('should track the newer read when one starts while another is finishing', async () => {

--- a/frontend/app/src/modules/accounts/use-account-load-state.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-load-state.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function importModule(): Promise<typeof import('./use-account-load-state')> {
+  return import('./use-account-load-state');
+}
+
+describe('useAccountLoadState', () => {
+  beforeEach(() => {
+    // `createSharedComposable` keeps one instance per module, so each test needs a fresh module.
+    vi.resetModules();
+  });
+
+  // Returning `undefined` rather than a resolved promise is the point: an idle caller must not even
+  // yield a microtask, or it reorders everything after it.
+  it('should report nothing pending when no read is running', async () => {
+    const { useAccountLoadState } = await importModule();
+
+    expect(useAccountLoadState().pending()).toBeUndefined();
+  });
+
+  it('should report a running read as pending until it finishes', async () => {
+    const { useAccountLoadState } = await importModule();
+    const { pending, track } = useAccountLoadState();
+    let finish = (): void => {};
+    const read = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+
+    const tracked = track(read);
+    expect(pending()).toBeDefined();
+
+    finish();
+    await tracked;
+    expect(pending()).toBeUndefined();
+  });
+
+  // A read that throws must not leave every later waiter stuck on it.
+  it('should settle waiters when the read rejects', async () => {
+    const { useAccountLoadState } = await importModule();
+    const { pending, track } = useAccountLoadState();
+
+    const tracked = track(Promise.reject(new Error('boom')));
+    const waiting = pending();
+    await expect(tracked).rejects.toThrow('boom');
+
+    await expect(waiting).resolves.toBeUndefined();
+    expect(pending()).toBeUndefined();
+  });
+
+  it('should track the newer read when one starts while another is finishing', async () => {
+    const { useAccountLoadState } = await importModule();
+    const { pending, track } = useAccountLoadState();
+    let finishFirst = (): void => {};
+    const first = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+
+    const trackedFirst = track(first);
+    const trackedSecond = track(Promise.resolve());
+    await trackedSecond;
+
+    // The first settling must not clear the entry the second one owns.
+    finishFirst();
+    await trackedFirst;
+    expect(pending()).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/accounts/use-account-load-state.ts
+++ b/frontend/app/src/modules/accounts/use-account-load-state.ts
@@ -1,3 +1,5 @@
+import { logger } from '@/modules/core/common/logging/logging';
+
 interface UseAccountLoadStateReturn {
   arm: () => void;
   release: () => void;
@@ -28,16 +30,36 @@ interface UseAccountLoadStateReturn {
  * read is coming, and says so. Not every session loads accounts — a resumed one restores balances
  * without re-reading them — and a gate armed by hope would wait forever on exactly those.
  */
+/**
+ * How long the gate will wait for a read that has been promised but never starts.
+ *
+ * Bounds only the arm→`track` window — everything the session load does before it reaches the
+ * accounts (the ignored/whitelisted lists, then the exchange rates). Generous for that stretch,
+ * because expiring early is not free: it releases a waiter into a store that really is still
+ * filling, which is the bug this composable exists to prevent.
+ */
+const UNSTARTED_READ_TIMEOUT_MS = 30_000;
+
 export const useAccountLoadState = createSharedComposable((): UseAccountLoadStateReturn => {
   let current: Promise<void> | undefined;
   let gate: Promise<void> | undefined;
   let openGate: (() => void) | undefined;
+  let unstarted: ReturnType<typeof setTimeout> | undefined;
+
+  const clearTimer = (): void => {
+    if (unstarted === undefined)
+      return;
+
+    clearTimeout(unstarted);
+    unstarted = undefined;
+  };
 
   /**
    * Resolves the gate rather than dropping it: a waiter holds the promise itself, so replacing the
    * reference without resolving it would strand that waiter for the life of the process.
    */
   const settle = (): void => {
+    clearTimer();
     openGate?.();
     gate = undefined;
     openGate = undefined;
@@ -46,23 +68,46 @@ export const useAccountLoadState = createSharedComposable((): UseAccountLoadStat
   /**
    * Declares that a full read is coming, before the first `await` on the way to it. Idempotent, so
    * a second caller joins the existing gate instead of replacing one that already has waiters.
+   *
+   * 🔴 The wait is bounded here and only here, because "promised but never started" is the only
+   * state that can hang forever. Once {@link track} holds a real promise the wait is safe to leave
+   * open: that promise settles on rejection too, and every request under it carries its own
+   * timeout. An unstarted read has no such guarantee — `release()` is normally what ends it, but
+   * its caller sits behind `allSettled([fetchCached(), …])`, and `allSettled` cannot settle if
+   * `fetchCached` never does. That is not hypothetical: a poisoned `prices:exchange-rates` id
+   * stalled `fetchCached` on its first await, and without this the history sync waited forever.
    */
   const arm = (): void => {
-    gate ??= new Promise<void>((resolve) => {
+    if (gate)
+      return;
+
+    gate = new Promise<void>((resolve) => {
       openGate = resolve;
     });
+    unstarted = setTimeout(() => {
+      logger.warn(
+        `Accounts were not read within ${UNSTARTED_READ_TIMEOUT_MS}ms of the session load starting. `
+        + 'Releasing readiness: consumers proceed against whatever the store holds, which may be incomplete.',
+      );
+      settle();
+    }, UNSTARTED_READ_TIMEOUT_MS);
   };
 
   /**
    * Ends the wait without a read having happened. The counterpart to {@link arm} for the paths that
-   * turn out not to load accounts, and the safety net for a load that dies before reaching
-   * {@link track}.
+   * turn out not to load accounts.
+   *
+   * ⚠️ NOT the guarantee — its caller can itself fail to run. The bound is the timer in {@link arm}.
    */
   const release = (): void => {
     settle();
   };
 
   const track = async (load: Promise<void>): Promise<void> => {
+    // A real read exists now, so the unstarted-read bound no longer applies: this promise settles
+    // on rejection too, and the requests under it carry their own timeouts. Expiring mid-read would
+    // release waiters into a half-filled store, which is exactly what the gate is for.
+    clearTimer();
     // Settles on rejection too, so a failed read cannot leave a waiter stuck forever.
     const tracked = load.finally(() => {
       if (current === tracked)

--- a/frontend/app/src/modules/accounts/use-account-load-state.ts
+++ b/frontend/app/src/modules/accounts/use-account-load-state.ts
@@ -1,10 +1,13 @@
 interface UseAccountLoadStateReturn {
+  arm: () => void;
+  release: () => void;
   track: (load: Promise<void>) => Promise<void>;
   pending: () => Promise<void> | undefined;
+  reset: () => void;
 }
 
 /**
- * When a full account read is in progress, and a way to wait for it.
+ * Whether the account store can be trusted to be complete, and a way to wait until it is.
  *
  * The store is filled one chain at a time, so anything that snapshots the account set while a read
  * is running sees a partial one. The history sync freezes that snapshot as its scope, which silently
@@ -12,27 +15,84 @@ interface UseAccountLoadStateReturn {
  *
  * ⚠️ This hands out a promise for *timing*, never for data. A caller that needs accounts must read
  * them itself afterwards.
+ *
+ * ⭐ There are three states, not two, and the third is the one that matters. Tracking only the
+ * in-flight read answers "is a read running?", when the question a consumer is really asking is
+ * "has a read happened yet?". Those differ in exactly one window — session start — which is the
+ * only window where the store is empty rather than partial. The window is wide: `fetchCached()`
+ * awaits the exchange rates before it ever calls `refreshAccounts()`, and for that whole round trip
+ * nothing is in flight, so an in-flight-only gate is a no-op over an empty store.
+ *
+ * 🔴 Blocking on "not started yet" is where a deadlock becomes possible, so arming is explicit and
+ * every arm is paired with a guaranteed {@link release}: the session decides up front whether a
+ * read is coming, and says so. Not every session loads accounts — a resumed one restores balances
+ * without re-reading them — and a gate armed by hope would wait forever on exactly those.
  */
 export const useAccountLoadState = createSharedComposable((): UseAccountLoadStateReturn => {
   let current: Promise<void> | undefined;
+  let gate: Promise<void> | undefined;
+  let openGate: (() => void) | undefined;
+
+  /**
+   * Resolves the gate rather than dropping it: a waiter holds the promise itself, so replacing the
+   * reference without resolving it would strand that waiter for the life of the process.
+   */
+  const settle = (): void => {
+    openGate?.();
+    gate = undefined;
+    openGate = undefined;
+  };
+
+  /**
+   * Declares that a full read is coming, before the first `await` on the way to it. Idempotent, so
+   * a second caller joins the existing gate instead of replacing one that already has waiters.
+   */
+  const arm = (): void => {
+    gate ??= new Promise<void>((resolve) => {
+      openGate = resolve;
+    });
+  };
+
+  /**
+   * Ends the wait without a read having happened. The counterpart to {@link arm} for the paths that
+   * turn out not to load accounts, and the safety net for a load that dies before reaching
+   * {@link track}.
+   */
+  const release = (): void => {
+    settle();
+  };
 
   const track = async (load: Promise<void>): Promise<void> => {
     // Settles on rejection too, so a failed read cannot leave a waiter stuck forever.
     const tracked = load.finally(() => {
       if (current === tracked)
         current = undefined;
+
+      // The first read to finish opens the gate: from here the store is as complete as this session
+      // is going to make it, and a later targeted read is scoped to what it changed.
+      settle();
     });
     current = tracked;
     return tracked;
   };
 
   /**
-   * ⚠️ Returns `undefined` rather than a resolved promise when nothing is running, so an idle
-   * caller does not even yield a microtask. Awaiting unconditionally reorders everything after it.
+   * ⚠️ Returns `undefined` rather than a resolved promise once accounts are ready, so an idle caller
+   * does not even yield a microtask. Awaiting unconditionally reorders everything after it.
    *
    * The rejection is swallowed: a waiter only cares that the read finished, not that it worked.
    */
-  const pending = (): Promise<void> | undefined => current?.catch(() => {});
+  const pending = (): Promise<void> | undefined => gate ?? current?.catch(() => {});
 
-  return { pending, track };
+  /**
+   * ⚠️ Must be called on logout. This is app-scoped, not a pinia store, so `resetState` does not
+   * reach it — the same reason the orchestrator needs an explicit reset. A read left here belongs
+   * to a session that has ended, and the next user would wait on it.
+   */
+  const reset = (): void => {
+    settle();
+    current = undefined;
+  };
+
+  return { arm, pending, release, reset, track };
 });

--- a/frontend/app/src/modules/accounts/use-account-load-state.ts
+++ b/frontend/app/src/modules/accounts/use-account-load-state.ts
@@ -1,0 +1,38 @@
+interface UseAccountLoadStateReturn {
+  track: (load: Promise<void>) => Promise<void>;
+  pending: () => Promise<void> | undefined;
+}
+
+/**
+ * When a full account read is in progress, and a way to wait for it.
+ *
+ * The store is filled one chain at a time, so anything that snapshots the account set while a read
+ * is running sees a partial one. The history sync freezes that snapshot as its scope, which silently
+ * drops the chains that have not arrived yet.
+ *
+ * ⚠️ This hands out a promise for *timing*, never for data. A caller that needs accounts must read
+ * them itself afterwards.
+ */
+export const useAccountLoadState = createSharedComposable((): UseAccountLoadStateReturn => {
+  let current: Promise<void> | undefined;
+
+  const track = async (load: Promise<void>): Promise<void> => {
+    // Settles on rejection too, so a failed read cannot leave a waiter stuck forever.
+    const tracked = load.finally(() => {
+      if (current === tracked)
+        current = undefined;
+    });
+    current = tracked;
+    return tracked;
+  };
+
+  /**
+   * ⚠️ Returns `undefined` rather than a resolved promise when nothing is running, so an idle
+   * caller does not even yield a microtask. Awaiting unconditionally reorders everything after it.
+   *
+   * The rejection is swallowed: a waiter only cares that the read finished, not that it worked.
+   */
+  const pending = (): Promise<void> | undefined => current?.catch(() => {});
+
+  return { pending, track };
+});

--- a/frontend/app/src/modules/accounts/use-account-operations.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.ts
@@ -2,13 +2,14 @@ import type { MaybeRef } from 'vue';
 import type { AddressBookSimplePayload } from '@/modules/accounts/address-book/eth-names';
 import { Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
+import { Semaphore } from 'es-toolkit';
 import { isErr, map as mapResult, type Result } from 'plainfp/result';
 import { useEnsOperations } from '@/modules/accounts/address-book/use-ens-operations';
 import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-accounts-api';
 import { useAccountFetching } from '@/modules/accounts/use-account-fetching';
+import { useAccountLoadState } from '@/modules/accounts/use-account-load-state';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
-import { awaitParallelExecution } from '@/modules/core/common/async/await-parallel-execution';
 import { uniqueStrings } from '@/modules/core/common/data/data';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -38,9 +39,27 @@ export function useAccountOperations(): UseAccountOperationsReturn {
   const { isEvm, supportedChains, supportsTransactions } = useSupportedChains();
   const { getAddresses } = useAccountAddresses();
 
+  const { track } = useAccountLoadState();
   const { submitTask } = useNativeTask();
   const { notifyError } = useNotifications();
   const { t } = useI18n({ useScope: 'global' });
+
+  /**
+   * Two chains at a time. `fetch` reports its own failures, so one chain failing must not abandon
+   * the rest.
+   */
+  const readChains = async (chains: string[]): Promise<void> => {
+    const permits = new Semaphore(2);
+    await Promise.all(chains.map(async (chain) => {
+      await permits.acquire();
+      try {
+        await fetch(chain);
+      }
+      finally {
+        permits.release();
+      }
+    }));
+  };
 
   const fetchAccounts = async (blockchain?: string | string[], refreshEns: boolean = false): Promise<void> => {
     let chains: string[];
@@ -48,7 +67,11 @@ export function useAccountOperations(): UseAccountOperationsReturn {
       chains = Array.isArray(blockchain) ? blockchain : [blockchain];
     else
       chains = get(supportedChains).map(chain => chain.id);
-    await awaitParallelExecution(chains, chain => chain, fetch, 2);
+
+    // Only a full read is tracked: that is the one that leaves the store partially filled for long
+    // enough for a consumer to snapshot it. A targeted read is already scoped to what it changed.
+    const read = readChains(chains);
+    await (blockchain ? read : track(read));
 
     const namesPayload: AddressBookSimplePayload[] = [];
 

--- a/frontend/app/src/modules/auth/use-session-load.ts
+++ b/frontend/app/src/modules/auth/use-session-load.ts
@@ -1,5 +1,6 @@
 import { Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
+import { useAccountLoadState } from '@/modules/accounts/use-account-load-state';
 import { usePriceRefresh } from '@/modules/assets/prices/use-price-refresh';
 import { usePriceSeed } from '@/modules/assets/prices/use-price-seed';
 import { useIgnoredAssetOperations } from '@/modules/assets/use-ignored-asset-operations';
@@ -32,6 +33,7 @@ export function useDataLoader(): UseDataLoaderReturn {
   const { refreshPrices } = usePriceRefresh();
   const { seedFromHistoric } = usePriceSeed();
   const { markCompleted } = useTaskOrchestrator();
+  const { arm: armAccountLoad, release: releaseAccountLoad } = useAccountLoadState();
 
   /**
    * Nothing is fetched on this path: the balances are already in the DB and were restored with the
@@ -56,10 +58,18 @@ export function useDataLoader(): UseDataLoaderReturn {
       fetchIgnoredAssets(),
       fetchWhitelistedAssets(),
     ]);
-    await Promise.allSettled([
-      fetchCached(),
-      fetchNetValue(),
-    ]);
+    try {
+      await Promise.allSettled([
+        fetchCached(),
+        fetchNetValue(),
+      ]);
+    }
+    finally {
+      // The bound on the account gate. `fetchAccounts` normally opens it much earlier, the moment
+      // its read settles; this is the guarantee for the case where the read never happens at all,
+      // so a waiter cannot outlive the load that was supposed to satisfy it.
+      releaseAccountLoad();
+    }
     await seedFromHistoric();
     startPromise(refreshPrices());
     startPromise(refreshFromChain());
@@ -78,6 +88,12 @@ export function useDataLoader(): UseDataLoaderReturn {
       markRestored();
     }
     else if (get(shouldFetchData)) {
+      // Armed here, synchronously, rather than inside the read. `refreshData` awaits the
+      // ignored/whitelisted lists and then the exchange rates before it ever reaches the accounts,
+      // and a consumer that snapshots the store during that stretch sees it empty. Navigating
+      // straight into history is fast enough to land there, which is why the sync could report
+      // complete over a scope of nothing.
+      armAccountLoad();
       startPromise(refreshData());
     }
     else {

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
@@ -210,6 +210,39 @@ describe('useRefreshTransactions', () => {
   });
 
   describe('basic refresh flow', () => {
+    // The account store fills one chain at a time. Scoping the sync off a snapshot taken mid-read
+    // drops whatever has not arrived, and the sync then reports complete over chains it never
+    // covered. Waiting for the read is what makes the scope whole.
+    it('should wait for a running account read before taking its scope', async () => {
+      const { useAccountLoadState } = await import('@/modules/accounts/use-account-load-state');
+      let finishRead = (): void => {};
+      const read = new Promise<void>((resolve) => {
+        finishRead = resolve;
+      });
+      const tracked = useAccountLoadState().track(read);
+
+      // Mid-read the store holds only the EVM chains.
+      mockHistoryTransactionAccounts.getAllAccounts.mockReturnValue([...mockEvmAccounts]);
+
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+      const refreshing = refreshTransactions();
+      await Promise.resolve();
+
+      // The rest of the chains land, then the read finishes.
+      mockHistoryTransactionAccounts.getAllAccounts.mockReturnValue([...mockEvmAccounts, ...mockBitcoinAccounts]);
+      finishRead();
+      await tracked;
+
+      await refreshing;
+      await settleRefresh();
+
+      expect(mockTransactionSync.syncTransactionsByChains).toHaveBeenCalledWith(
+        expect.arrayContaining([...mockEvmAccounts, ...mockBitcoinAccounts]),
+        expect.anything(),
+        HISTORY_SYNC_ID,
+      );
+    });
+
     it('should perform full refresh when called without parameters', async () => {
       const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
@@ -2,6 +2,7 @@ import type { RefreshTransactionsParams } from './types';
 import type { TaskError } from '@/modules/core/tasks/task-result';
 import { startPromise } from '@shared/utils';
 import { ok, type Result } from 'plainfp/result';
+import { useAccountLoadState } from '@/modules/accounts/use-account-load-state';
 import { logger } from '@/modules/core/common/logging/logging';
 import { sigilBus } from '@/modules/core/sigil/event-bus';
 import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
@@ -52,6 +53,7 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     resolveRefreshTargets,
     shouldNotRefresh,
   } = useHistoryRefreshPolicy();
+  const { pending: accountsPending } = useAccountLoadState();
   const { queryAllExchangeEvents, queryOnlineEvent, resetOnlineWarnings } = useRefreshHandlers();
   const { onHistoryFinished, onHistoryStarted } = useSchedulerState();
   const { t } = useI18n({ useScope: 'global' });
@@ -217,6 +219,14 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
   async function refreshOnce(params: RefreshTransactionsParams, wave: RefreshWave): Promise<void> {
     const { chains = [], disableEvmEvents = false, payload = {}, userInitiated = false } = params;
     const fullRefresh = Object.keys(payload).length === 0;
+
+    // The scope below is a snapshot of the account store, and the store is filled one chain at a
+    // time. Taking it mid-read drops whatever has not arrived, and the sync then reports complete
+    // over a scope that never covered those chains. Guarded rather than awaited unconditionally, so
+    // the common idle path keeps its current ordering.
+    const accountRead = accountsPending();
+    if (accountRead)
+      await accountRead;
 
     const usedExchanges = filterSyncingExchanges(payload.exchanges);
     // Filter before novelty detection so disabled-chain accounts are not flagged as newly

--- a/frontend/app/src/modules/session/use-session-state-cleaner.ts
+++ b/frontend/app/src/modules/session/use-session-state-cleaner.ts
@@ -1,3 +1,4 @@
+import { useAccountLoadState } from '@/modules/accounts/use-account-load-state';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { api } from '@/modules/core/api/rotki-api';
 import { useSync } from '@/modules/session/use-session-sync';
@@ -13,6 +14,7 @@ export function useSessionStateCleaner(): void {
   const { start, stop } = useMonitorService();
   const orchestrator = useTaskOrchestrator();
   const { reset: resetNativeTasks } = useNativeTask();
+  const { reset: resetAccountLoad } = useAccountLoadState();
 
   function cleanup(): void {
     clearUploadStatus();
@@ -28,6 +30,8 @@ export function useSessionStateCleaner(): void {
     // `prices:exchange-rates` stalled `fetchCached` on its first await after a re-login, leaving
     // the new session with no exchange rates, no accounts and no balances.
     resetNativeTasks();
+    // Same reason, same scope: a read tracked here outlives the session that started it.
+    resetAccountLoad();
     resetState();
   }
 


### PR DESCRIPTION
Reopens #12817, which was closed when its base branch (#12816) was merged and deleted. Same commits, rebased onto `develop`.

The history sync freezes its scope from the account store, and the store is filled one chain at a time. Navigating into History fast enough takes that snapshot mid-walk, so the sync covers whatever had landed and reports **"Sync Complete"** over chains it never touched.

The drop is a *contiguous suffix of the fetch order*, which is what proves it a race rather than an exclusion:

| pos | chain | |
|---|---|---|
| 0-13 | eth … scroll | synced |
| 14 | `binance_sc` | synced, but **1 of 9 addresses** — caught mid-flight |
| 15 | `monad` | **dropped** |
| 16 | `zksync_lite` | **dropped** |

A logical exclusion is all-or-nothing per chain. Only a race gives 1-of-9 on exactly one chain with a clean cut after it, and a later manual refresh picks them all up.

## The fix

The account read gets an explicit readiness state, and consumers wait for the *first completed* read rather than for whatever is currently in flight.

Tracking only the in-flight read answers "is a read running?", when the question is "has a read happened yet?". Those differ at session start — the only window where the store is empty rather than partial — and that window is wide: `fetchCached` awaits the exchange rates before it ever reaches the accounts, so nothing is in flight for that whole round trip and an in-flight-only gate is a no-op over an empty store.

So arming is explicit and paired with a release: the session says up front that a read is coming. Not every session loads accounts — a resumed one restores balances without re-reading them — and a gate armed by hope would wait forever on exactly those.

The wait is also **bounded**, and only where it can hang: the arm→track window. Once a real read is in flight the wait stays open, because that promise settles on rejection too and its requests carry their own timeouts; expiring mid-read would release waiters into a half-filled store, which is the bug this prevents.

## Verification

On this branch, a fresh login navigating straight into History resolved the scope as the full **11 chains**, with `binance_sc` showing all **9** addresses and `monad` and `zksync_lite` present and queued — the inverse of the failure signature above.

⚠️ Not a controlled comparison: the same steps have not been run on `develop` to watch the suffix drop, so this does not formally separate "the gate held" from "the race did not fire on this machine". The unit tests are the stronger evidence — each was verified to fail without its fix, including the two deadlock paths (`VITE_NO_AUTO_FETCH`, and a resumed session where `loaded.fetchData` is false) where a naive block-until-first-read hangs forever.
