### PR TITLE
fix(curve): don't claim aggregator swap events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Swaps in Gnosis chain that paraswap routes through a curve pool are properly decoded again.
 * :bug:`-` Bridging DAI from Ethereum to Gnosis chain is again seen as a bridge, instead of being mistaken for a DAI to USDS migration.
 * :feature:`-` Filtering the address book now uses the same filter bar as the rest of rotki. The chain selector and the strict-chain checkbox that sat beside it are now pills in that one bar, so there is a single place to filter from, and a chain is shown with its logo and name.
 * :feature:`-` Filtering manual balances now uses the same filter bar as the rest of rotki, and the tag selector beside it is now a tag pill in the same bar, drawn in the colours you gave each tag. Locations are shown with their icon and name, and assets with their icon and symbol.

--- a/rotkehlchen/chain/evm/decoding/curve/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/curve/decoder.py
@@ -122,6 +122,14 @@ class CurveCommonDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoderMix
         self.curve_swap_routers = curve_swap_routers
         self.crv_minter_addresses = crv_minter_addresses
 
+    def _is_curve_address(self, address: ChecksumEvmAddress | None) -> bool:
+        """Whether funds moving to or from this address are moving within curve"""
+        return (
+            address in self.pools or
+            address in self.curve_deposit_contracts or
+            address in self.curve_swap_routers
+        )
+
     def _read_curve_asset(
             self: CurveCommonDecoder,
             asset_address: ChecksumEvmAddress | None,
@@ -353,6 +361,14 @@ class CurveCommonDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoderMix
                 event.location_label is not None and (
                     transaction.from_address == user_or_contract_address or
                     self.base.is_tracked(string_to_evm_address(event.location_label))
+                ) and (
+                    # The removal may be done by a zap or a router on behalf of the tracked
+                    # address, but it may equally be an aggregator routing a swap through the
+                    # pool, in which case the tracked address receives from the aggregator and
+                    # never from curve. Require the funds to have come from curve, or the
+                    # transaction to target it, before claiming the receive as a withdrawal.
+                    self._is_curve_address(event.address) or
+                    self._is_curve_address(transaction.to_address)
                 )
             ):
                 notes = f'Remove {event.amount} {crypto_asset.symbol} from {tx_log.address} curve pool'  # noqa: E501
@@ -460,6 +476,15 @@ class CurveCommonDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoderMix
     ) -> EvmDecodingOutput:
         """Decode information related to depositing assets in curve pools"""
         is_direct_pool_interaction = transaction.to_address == tx_log.address
+        # A deposit zap is also the AddLiquidity provider when an aggregator routes a swap
+        # through a curve pool. There the transaction sender never deposits: their funds go to
+        # the aggregator, which happens to add liquidity with the exact same amount, so the
+        # amount check below can't tell the two apart. Only take the zap as evidence that the
+        # sender deposited when the transaction itself targets curve.
+        deposits_through_zap = (
+            user_or_contract_address in self.curve_deposit_contracts and
+            self._is_curve_address(transaction.to_address)
+        )
         display_pool_address = tx_log.address
         if (
             user_or_contract_address in self.curve_deposit_contracts and
@@ -531,7 +556,7 @@ class CurveCommonDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoderMix
                         (
                             event.location_label == transaction.from_address and
                             (
-                                user_or_contract_address in self.curve_deposit_contracts or
+                                deposits_through_zap or
                                 event.address in self.curve_deposit_contracts
                             )
                         )

--- a/rotkehlchen/tests/unit/decoders/test_paraswap_v6.py
+++ b/rotkehlchen/tests/unit/decoders/test_paraswap_v6.py
@@ -1000,3 +1000,115 @@ def test_curve_deposit_interfering_with_paraswap_swap(
         counterparty=CPT_PARASWAP,
         address=PARASWAP_AUGUSTUS_V6_ROUTER,
     )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
+@pytest.mark.parametrize('gnosis_accounts', [['0x98E393228A1C69F8631c5a7278d83a1599165326']])
+def test_native_swap_routed_through_curve_zap(
+        gnosis_inquirer: GnosisInquirer,
+        gnosis_accounts: list[ChecksumEvmAddress],
+        load_global_caches,
+        allow_gnosis_etherscan: None,
+) -> None:
+    """Regression test for a bug where paraswap routing a swap through the curve EURe zap made
+    the curve decoder claim the sender's spend as a deposit, since the zap is the AddLiquidity
+    provider and adds liquidity with exactly the amount the sender swapped."""
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=gnosis_inquirer,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xbe029b6a84a3f310ca8bb692225c4a2b19a47b9a7f053bfaa765738c7592143f')),  # noqa: E501
+        load_global_caches=load_global_caches,
+    )
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1785777775000)),
+        location=Location.GNOSIS,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_XDAI,
+        amount=FVal(gas_amount := '0.00000004654072516'),
+        location_label=(user_address := gnosis_accounts[0]),
+        notes=f'Burn {gas_amount} XDAI for gas',
+        counterparty=CPT_GAS,
+    ), EvmSwapEvent(
+        tx_ref=tx_hash,
+        sequence_index=1,
+        timestamp=timestamp,
+        location=Location.GNOSIS,
+        event_subtype=HistoryEventSubType.SPEND,
+        asset=A_XDAI,
+        amount=FVal(spend_amount := '1156'),
+        location_label=user_address,
+        notes=f'Swap {spend_amount} XDAI in paraswap',
+        counterparty=CPT_PARASWAP,
+        address=PARASWAP_AUGUSTUS_V6_ROUTER,
+    ), EvmSwapEvent(
+        tx_ref=tx_hash,
+        sequence_index=2,
+        timestamp=timestamp,
+        location=Location.GNOSIS,
+        event_subtype=HistoryEventSubType.RECEIVE,
+        asset=Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430'),  # EURe
+        amount=FVal(receive_amount := '1003.92719024870398872'),
+        location_label=user_address,
+        notes=f'Receive {receive_amount} EURe as the result of a swap in paraswap',
+        counterparty=CPT_PARASWAP,
+        address=PARASWAP_AUGUSTUS_V6_ROUTER,
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('load_global_caches', [[CPT_CURVE]])
+@pytest.mark.parametrize('gnosis_accounts', [['0xDd036474388108B3b1304Db2C88C951D6d95038C']])
+def test_native_receive_swap_routed_through_curve_zap(
+        gnosis_inquirer: GnosisInquirer,
+        gnosis_accounts: list[ChecksumEvmAddress],
+        load_global_caches,
+        allow_gnosis_etherscan: None,
+) -> None:
+    """Regression test for the withdrawal side of the same bug: paraswap routing a swap out of a
+    curve pool made the curve decoder claim the receive of any tracked address in the transaction
+    as a withdrawal, even though the funds came from paraswap and never from curve."""
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=gnosis_inquirer,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xf14f1ec5f36ad62d9791c58202fab061775f7a95edb1ac2c80a1ff7b4732e1de')),  # noqa: E501
+        load_global_caches=load_global_caches,
+    )
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1785700545000)),
+        location=Location.GNOSIS,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_XDAI,
+        amount=FVal(gas_amount := '0.000000006688898758'),
+        location_label=(user_address := gnosis_accounts[0]),
+        notes=f'Burn {gas_amount} XDAI for gas',
+        counterparty=CPT_GAS,
+    ), EvmSwapEvent(
+        tx_ref=tx_hash,
+        sequence_index=1,
+        timestamp=timestamp,
+        location=Location.GNOSIS,
+        event_subtype=HistoryEventSubType.SPEND,
+        asset=Asset('eip155:100/erc20:0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0'),  # USDC.e
+        amount=FVal(spend_amount := '12.057476'),
+        location_label=user_address,
+        notes=f'Swap {spend_amount} USDC.e in paraswap',
+        counterparty=CPT_PARASWAP,
+        address=PARASWAP_AUGUSTUS_V6_ROUTER,
+    ), EvmSwapEvent(
+        tx_ref=tx_hash,
+        sequence_index=2,
+        timestamp=timestamp,
+        location=Location.GNOSIS,
+        event_subtype=HistoryEventSubType.RECEIVE,
+        asset=A_XDAI,
+        amount=FVal(receive_amount := '12.058107620013985682'),
+        location_label=user_address,
+        notes=f'Receive {receive_amount} XDAI as the result of a swap in paraswap',
+        counterparty=CPT_PARASWAP,
+        address=PARASWAP_AUGUSTUS_V6_ROUTER,
+    )]


### PR DESCRIPTION
When paraswap routes a swap through a curve pool on gnosis, the curve decoder was claiming half of the swap, so paraswap post decoding could no longer find both sides and the swap was left undecoded.

Two branches were too loose:

- Deposits. A deposit zap is the AddLiquidity provider even when it is adding liquidity for an aggregator, and it does so with exactly the amount the sender swapped, so the amount check could not tell the two apart. Only trust the zap when the transaction targets curve.
- Withdrawals. The receive branch claimed any receive by any tracked address whenever a known pool emitted a removal, with no amount check at all. Require the funds to have come from curve, or the transaction to target it.

Checking where the funds came from rather than only what the transaction targets keeps withdrawals made through a safe working, since there the transaction targets the safe and not curve.
