### PR TITLE
fix(task-center): cancel a subtree, not just its row

### DIFF
--- a/frontend/app/src/modules/task-center/core/orchestrator/lifecycle.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/lifecycle.ts
@@ -1,0 +1,89 @@
+import type { ActivitySpec, ReportProgress } from './spec';
+import { err, type Result } from 'plainfp/result';
+import { type ResultAsync, retry, timeout } from 'plainfp/result-async';
+import { hasTag } from 'plainfp/tagged';
+import { type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import { isTerminalStatus } from '../status';
+import { type ActivityId, type ActivityStatus, ActivityStatus as Status } from '../types';
+
+/**
+ * How a single activity runs and how its outcome becomes a status. Pure and orchestrator-agnostic,
+ * like {@link ./projection}: nothing here reads or writes orchestrator state, which keeps the
+ * orchestrator module about scheduling, control and the record map.
+ */
+
+/** The subset of a record these helpers need — structurally satisfied by `ActivityRecord`. */
+export interface LifecycleRecord {
+  readonly status: ActivityStatus;
+  readonly spec: { readonly parent?: ActivityId };
+}
+
+/**
+ * Terminal, but not a success — CANCELLED, FAILED or SKIPPED.
+ *
+ * The distinction the subtree cascade turns on: an activity that ends this way takes its children
+ * with it, while a COMPLETE one leaves them alone.
+ */
+export function endedIncomplete(record: LifecycleRecord): boolean {
+  return isTerminalStatus(record.status) && record.status !== Status.COMPLETE;
+}
+
+/** The live direct children of `id`, in insertion order. */
+export function liveChildrenOf<T extends LifecycleRecord>(
+  records: ReadonlyMap<ActivityId, T>,
+  id: ActivityId,
+): T[] {
+  const children: T[] = [];
+  for (const record of records.values()) {
+    if (record.spec.parent === id && !isTerminalStatus(record.status))
+      children.push(record);
+  }
+  return children;
+}
+
+/**
+ * Which terminal status an outcome lands on.
+ *
+ * `cancelRequested` wins over everything: a cancelled activity stays CANCELLED even when the work
+ * it was aborting goes on to settle `ok`, which is what lets a parent be cancelled while its own
+ * body is still resolving.
+ */
+export function terminalStatus(cancelRequested: boolean, outcome: Result<unknown, TaskError>): ActivityStatus {
+  if (cancelRequested)
+    return Status.CANCELLED;
+  if (outcome.ok)
+    return Status.COMPLETE;
+
+  const { error } = outcome;
+  if (hasTag(error, 'Cancelled') || hasTag(error, 'BackendCancelled'))
+    return Status.CANCELLED;
+  if (hasTag(error, 'Skipped'))
+    return Status.SKIPPED;
+
+  return Status.FAILED;
+}
+
+/**
+ * Run a spec's body under its declared timeout and retry policy, as a value.
+ *
+ * ⚠️ The catch is not defensive dressing: a producer's `ResultAsync` should never reject, and one
+ * that does would otherwise leave its activity RUNNING for the life of the process.
+ */
+export async function runActivity(
+  spec: ActivitySpec,
+  report: ReportProgress,
+): Promise<Result<unknown, TaskError>> {
+  const runOnce = async (): ResultAsync<unknown, TaskError> => {
+    const base = spec.run(report);
+    return spec.timeoutMs === undefined
+      ? base
+      : timeout(base, spec.timeoutMs, () => TaskFailed({ message: 'Timed out' }));
+  };
+
+  try {
+    return await (spec.retry ? retry(runOnce, spec.retry) : runOnce());
+  }
+  catch (error) {
+    return err(TaskFailed({ cause: error, message: 'Unexpected error' }));
+  }
+}

--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
@@ -788,6 +788,222 @@ describe('createTaskOrchestrator', () => {
     });
   });
 
+  describe('cancel cascade', () => {
+    /** An umbrella, one chain under it, two accounts under the chain — the history-refresh shape. */
+    function tree(orchestrator: TaskOrchestrator): {
+      root: Controllable;
+      chain: Controllable;
+      accounts: [Controllable, Controllable];
+    } {
+      const root = controllable('umbrella');
+      orchestrator.submit(root.spec);
+      const chain = controllable('chain', { parent: root.spec.id });
+      orchestrator.submit(chain.spec);
+      const accounts: [Controllable, Controllable] = [
+        controllable('0xaaa', { parent: chain.spec.id }),
+        controllable('0xbbb', { parent: chain.spec.id }),
+      ];
+      for (const account of accounts)
+        orchestrator.submit(account.spec);
+
+      return { accounts, chain, root };
+    }
+
+    /**
+     * 🔴 The bug this package exists for. Every native spec carries a cancel handle, so cancelling
+     * a parent always "succeeded" — but the handle only aborts that activity's own backend task,
+     * which an umbrella never has. The row settled CANCELLED and vanished while the whole subtree
+     * carried on working.
+     */
+    it('should cancel every descendant, not just the row', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 10 } });
+      const { accounts, chain, root } = tree(orchestrator);
+      await flush();
+
+      orchestrator.cancel(root.spec.id);
+      await flush();
+
+      expect(byId(orchestrator, root.spec.id)?.status).toBe(Status.CANCELLED);
+      expect(byId(orchestrator, chain.spec.id)?.status).toBe(Status.CANCELLED);
+      for (const account of accounts)
+        expect(byId(orchestrator, account.spec.id)?.status).toBe(Status.CANCELLED);
+    });
+
+    /** The handle is what actually stops the backend task, so every live node's must fire. */
+    it('should fire each descendant\'s cancel handle', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 10 } });
+      const { accounts, chain, root } = tree(orchestrator);
+      await flush();
+
+      orchestrator.cancel(root.spec.id);
+
+      expect(chain.cancelSpy).toHaveBeenCalledOnce();
+      for (const account of accounts)
+        expect(account.cancelSpy).toHaveBeenCalledOnce();
+    });
+
+    /**
+     * 🔴 `eligible` only refused a child whose parent was still PENDING, so a queued child of a
+     * cancelled parent started the moment a lane freed up — the cancel bought nothing.
+     */
+    it('should not start a queued child after its parent is cancelled', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 1 } });
+      const blocker = controllable('blocker');
+      orchestrator.submit(blocker.spec);
+      const parent = controllable('parent');
+      orchestrator.submit(parent.spec);
+      const child = controllable('child', { parent: parent.spec.id });
+      orchestrator.submit(child.spec);
+      await flush();
+
+      expect(byId(orchestrator, child.spec.id)?.status).toBe(Status.PENDING);
+
+      orchestrator.cancel(parent.spec.id);
+      // Freeing the only lane is what used to let the orphaned child through.
+      blocker.settle(ok(undefined));
+      await flush();
+
+      expect(byId(orchestrator, child.spec.id)?.status).toBe(Status.CANCELLED);
+    });
+
+    /**
+     * 🔴🔴 The wedge `eligible` alone would create. A child submitted after its parent ended can
+     * never become eligible, so leaving it PENDING would hold its caller's await open for the life
+     * of the process. It has to be *settled*, not merely refused.
+     */
+    it('should settle a child submitted after its parent was cancelled', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 10 } });
+      const parent = controllable('parent');
+      orchestrator.submit(parent.spec);
+      await flush();
+      orchestrator.cancel(parent.spec.id);
+
+      const late = controllable('late', { parent: parent.spec.id });
+      orchestrator.submit(late.spec);
+      await flush();
+
+      expect(byId(orchestrator, late.spec.id)?.status).toBe(Status.CANCELLED);
+    });
+
+    /**
+     * ⭐ The reason no new cancel handle is needed anywhere: a parent whose body awaits its
+     * children resolves on its own once they settle, and `cancelRequested` maps that outcome to
+     * CANCELLED however the body chose to return.
+     */
+    it('should keep a parent cancelled when its own body later settles ok', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 10 } });
+      const { root } = tree(orchestrator);
+      await flush();
+
+      orchestrator.cancel(root.spec.id);
+      root.settle(ok(undefined));
+      await flush();
+
+      expect(byId(orchestrator, root.spec.id)?.status).toBe(Status.CANCELLED);
+    });
+
+    /** Cancelling a chain must not touch its siblings, or "stop this chain" stops the refresh. */
+    it('should leave a sibling subtree running', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 10 } });
+      const root = controllable('umbrella');
+      orchestrator.submit(root.spec);
+      const doomed = controllable('doomed', { parent: root.spec.id });
+      const survivor = controllable('survivor', { parent: root.spec.id });
+      orchestrator.submit(doomed.spec);
+      orchestrator.submit(survivor.spec);
+      const doomedChild = controllable('doomed-child', { parent: doomed.spec.id });
+      const survivorChild = controllable('survivor-child', { parent: survivor.spec.id });
+      orchestrator.submit(doomedChild.spec);
+      orchestrator.submit(survivorChild.spec);
+      await flush();
+
+      orchestrator.cancel(doomed.spec.id);
+      await flush();
+
+      expect(byId(orchestrator, doomedChild.spec.id)?.status).toBe(Status.CANCELLED);
+      expect(byId(orchestrator, survivor.spec.id)?.status).toBe(Status.RUNNING);
+      expect(byId(orchestrator, survivorChild.spec.id)?.status).toBe(Status.RUNNING);
+      expect(byId(orchestrator, root.spec.id)?.status).toBe(Status.RUNNING);
+    });
+
+    /**
+     * 🔴🔴 The case an `eligible` guard could not have handled. `cancel` never runs here, so a
+     * cascade hung off cancellation would leave these children queued — and refusing them in
+     * `eligible` instead would wedge them PENDING for the life of the process, since nothing would
+     * ever settle them. Hanging the walk off the settle is what makes one rule cover both.
+     */
+    it('should cancel the subtree when a parent fails rather than being cancelled', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 1 } });
+      const blocker = controllable('blocker');
+      orchestrator.submit(blocker.spec);
+      const parent = controllable('parent');
+      orchestrator.submit(parent.spec);
+      const child = controllable('child', { parent: parent.spec.id });
+      orchestrator.submit(child.spec);
+      await flush();
+
+      // The parent reaches a terminal FAILED while its child is still queued behind the cap.
+      blocker.settle(ok(undefined));
+      await flush();
+      parent.settle(err(TaskFailed({ message: 'boom' })));
+      await flush();
+
+      expect(byId(orchestrator, parent.spec.id)?.status).toBe(Status.FAILED);
+      expect(byId(orchestrator, child.spec.id)?.status).toBe(Status.CANCELLED);
+    });
+
+    /** Same rule, the skipped flavour: a chain with nothing to do has no work beneath it either. */
+    it('should cancel the subtree when a parent is skipped', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 1 } });
+      const blocker = controllable('blocker');
+      orchestrator.submit(blocker.spec);
+      const parent = controllable('parent');
+      orchestrator.submit(parent.spec);
+      const child = controllable('child', { parent: parent.spec.id });
+      orchestrator.submit(child.spec);
+      await flush();
+
+      blocker.settle(ok(undefined));
+      await flush();
+      parent.settle(err(Skipped({ message: 'nothing to do' })));
+      await flush();
+
+      expect(byId(orchestrator, parent.spec.id)?.status).toBe(Status.SKIPPED);
+      expect(byId(orchestrator, child.spec.id)?.status).toBe(Status.CANCELLED);
+    });
+
+    /** A parent that finishes normally must leave its subtree alone. */
+    it('should not touch the subtree when a parent completes', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 10 } });
+      const { accounts, chain, root } = tree(orchestrator);
+      await flush();
+
+      root.settle(ok(undefined));
+      await flush();
+
+      expect(byId(orchestrator, root.spec.id)?.status).toBe(Status.COMPLETE);
+      expect(byId(orchestrator, chain.spec.id)?.status).toBe(Status.RUNNING);
+      for (const account of accounts)
+        expect(byId(orchestrator, account.spec.id)?.status).toBe(Status.RUNNING);
+    });
+
+    /** A producer's malformed parent chain is not a reason to hang the orchestrator. */
+    it('should terminate on a parent cycle', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 10 } });
+      const a = controllable('a');
+      orchestrator.submit(a.spec);
+      const b = controllable('b', { parent: a.spec.id });
+      orchestrator.submit(b.spec);
+      // `a` is re-submitted pointing at its own descendant, closing the loop.
+      orchestrator.submit({ ...a.spec, parent: b.spec.id });
+      await flush();
+
+      orchestrator.cancel(a.spec.id);
+
+      expect(byId(orchestrator, b.spec.id)?.status).toBe(Status.CANCELLED);
+    });
+  });
+
   describe('superseded records', () => {
     /**
      * `submitTask` resolves its caller a tick before the run reaches `settleTerminal`, so a caller

--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.ts
@@ -1,15 +1,11 @@
 import type { OrchestratorOptions, TaskOrchestrator } from './api';
 import { err, ok, type Result } from 'plainfp/result';
-import { type ResultAsync, retry, timeout } from 'plainfp/result-async';
-import { hasTag } from 'plainfp/tagged';
-import { type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { isTerminalStatus } from '../status';
 import {
   type Activity,
   type ActivityId,
   activityIdHasPrefix,
   type ActivityKind,
-  ActivitySourceType,
   type ActivityStatus,
   type ActivitySteps,
   type CompletionRecord,
@@ -20,7 +16,8 @@ import {
 } from '../types';
 import { AlreadyTerminal, type ControlError, NotCancellable, NotFound, NotRerunnable } from './errors';
 import { dropCompletions, markStaleAfter, recordCompletion, recordSettlement } from './ledger';
-import { aggregateStatus, childProgress, percentageOf, statusForId } from './projection';
+import { endedIncomplete, liveChildrenOf, runActivity, terminalStatus } from './lifecycle';
+import { aggregateStatus, childProgress, projectActivity, statusForId } from './projection';
 import { allRulesPass, DEFAULT_RULES } from './rules';
 import { createScheduler } from './scheduler';
 import { type ActivitySpec, DEFAULT_LANE, DEFAULT_PRIORITY, type ReportProgress, type StaleAfterEdge } from './spec';
@@ -92,6 +89,29 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
 
     if (status === Status.COMPLETE && markStaleAfter(record.spec.id, staleEdges, ledger))
       emit();
+
+    // 🔴 An activity that ends without completing takes its subtree with it — cancelled, failed or
+    // skipped alike. Hanging the cascade off the settle rather than off `cancel` is what makes it
+    // one rule instead of two: a parent that fails mid-flight orphans its queued children exactly
+    // the way an explicit cancel used to.
+    //
+    // ⭐ Recursion terminates on a malformed parent cycle without a seen-set, because `status` is
+    // already terminal by the time this runs, so a node reached a second time is skipped.
+    if (status !== Status.COMPLETE)
+      cancelDescendantsOf(record.spec.id);
+  }
+
+  /**
+   * Cancel everything beneath `id`. Each child settles through {@link settleTerminal}, which walks
+   * its own children in turn, so the whole subtree comes down from one call.
+   *
+   * ⚠️ A child that cannot be cancelled never stops the walk. A RUNNING node with no cancel handle
+   * is left alone and its siblings still come down; abandoning the rest of the subtree over one
+   * such node is the bug this fixes, not a safety property.
+   */
+  function cancelDescendantsOf(id: ActivityId): void {
+    for (const child of liveChildrenOf(records, id))
+      cancelOne(child);
   }
 
   /**
@@ -128,27 +148,8 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
     }
   }
 
-  function project(record: ActivityRecord, children?: Map<ActivityId, ActivitySteps>): Activity {
-    const { spec, status, steps, startedAt } = record;
-    const percentage = percentageOf(status, steps, children?.get(spec.id));
-    return {
-      cancellable: status === Status.RUNNING ? Boolean(spec.cancel) : status === Status.PENDING,
-      ephemeral: spec.ephemeral,
-      group: spec.group,
-      id: spec.id,
-      kind: spec.kind,
-      parent: spec.parent,
-      percentage,
-      rerunnable: Boolean(spec.rerunnable),
-      resets: spec.resets,
-      source: { type: ActivitySourceType.NATIVE },
-      startedAt,
-      status,
-      steps,
-      subtitle: spec.subtitle,
-      title: spec.title,
-    };
-  }
+  const project = (record: ActivityRecord, children?: Map<ActivityId, ActivitySteps>): Activity =>
+    projectActivity(record, children?.get(record.spec.id));
 
   function snapshot(): Activity[] {
     const children = childProgress(records);
@@ -182,6 +183,11 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
       const parent = records.get(record.spec.parent);
       if (parent?.status === Status.PENDING)
         return false;
+
+      // ⛔ No check for a parent that ended incomplete belongs here. Refusing is not settling, so a
+      // child nothing will ever make eligible would sit PENDING for the life of the process,
+      // holding its caller's await open with it. `settleTerminal` cancels the subtree and `submit`
+      // settles a late arrival — both *end* the child rather than leaving it queued forever.
     }
 
     const depsSatisfied = (record.spec.deps ?? []).every((depId) => {
@@ -194,45 +200,15 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
     return allRulesPass(rules, project(record), snapshot());
   }
 
-  function terminalStatus(record: ActivityRecord, outcome: Result<unknown, TaskError>): ActivityStatus {
-    if (record.cancelRequested)
-      return Status.CANCELLED;
-    if (outcome.ok)
-      return Status.COMPLETE;
-
-    const { error } = outcome;
-    if (hasTag(error, 'Cancelled') || hasTag(error, 'BackendCancelled'))
-      return Status.CANCELLED;
-    if (hasTag(error, 'Skipped'))
-      return Status.SKIPPED;
-
-    return Status.FAILED;
-  }
-
   async function execute(record: ActivityRecord): Promise<void> {
     record.status = Status.RUNNING;
     record.startedAt = now();
     emit();
 
     const report: ReportProgress = steps => reportProgress(record.spec.id, steps);
+    const outcome = await runActivity(record.spec, report);
 
-    const runOnce = async (): ResultAsync<unknown, TaskError> => {
-      const base = record.spec.run(report);
-      return record.spec.timeoutMs === undefined
-        ? base
-        : timeout(base, record.spec.timeoutMs, () => TaskFailed({ message: 'Timed out' }));
-    };
-
-    let outcome: Result<unknown, TaskError>;
-    try {
-      outcome = await (record.spec.retry ? retry(runOnce, record.spec.retry) : runOnce());
-    }
-    catch (error) {
-      // The producer's ResultAsync should never reject; guard so a misbehaving one can't hang.
-      outcome = err(TaskFailed({ cause: error, message: 'Unexpected error' }));
-    }
-
-    settleTerminal(record, terminalStatus(record, outcome));
+    settleTerminal(record, terminalStatus(record.cancelRequested, outcome));
   }
 
   function schedule(record: ActivityRecord): void {
@@ -259,23 +235,31 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
     records.set(spec.id, record);
     if (spec.staleAfter?.length)
       staleEdges.set(spec.id, spec.staleAfter);
+
+    // A child arriving after its parent already ended without completing belongs to a subtree that
+    // is gone, so it is settled here rather than scheduled. `eligible` would refuse to start it
+    // either way — but refusing is not settling, and a record nothing will ever make eligible sits
+    // PENDING for the life of the process, holding its caller's await open with it.
+    const parent = spec.parent === undefined ? undefined : records.get(spec.parent);
+    if (parent !== undefined && endedIncomplete(parent)) {
+      settleTerminal(record, Status.CANCELLED);
+      return spec.id;
+    }
+
     schedule(record);
     emit();
     return spec.id;
   }
 
-  function cancel(id: ActivityId): Result<void, ControlError> {
-    const record = records.get(id);
-    if (!record)
-      return err(NotFound({ id }));
+  /** One node's cancellation. No `pump` — {@link cancel} pumps once for the whole subtree. */
+  function cancelOne(record: ActivityRecord): Result<void, ControlError> {
+    const id = record.spec.id;
     if (isTerminalStatus(record.status))
       return err(AlreadyTerminal({ id }));
 
     if (record.status === Status.PENDING) {
       scheduler.drop(id);
       settleTerminal(record, Status.CANCELLED);
-      // A cancelled dep may unblock dependents / rules — re-evaluate the queue.
-      scheduler.pump();
       return ok(undefined);
     }
 
@@ -287,8 +271,32 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
     // Reflect the cancellation immediately; `cancelRequested` keeps it CANCELLED even if the
     // aborting task later settles ok. The scheduler slot frees once `run` actually resolves.
     settleTerminal(record, Status.CANCELLED);
-    scheduler.pump();
     return ok(undefined);
+  }
+
+  /**
+   * Cancel an activity **and everything beneath it**. "Stop this refresh" is one act.
+   *
+   * 🔴 Cancelling a parent alone settled its row and stopped nothing: the handle every native spec
+   * carries only aborts that activity's own backend task, which an umbrella never has, so the row
+   * went CANCELLED and vanished while its children kept running — and queued ones still started,
+   * because `eligible` only refused a child whose parent was still PENDING.
+   *
+   * ⭐ No new cancel handle is needed anywhere. Once the children settle, the parent's `Promise.all`
+   * resolves on its own and `cancelRequested` maps that outcome to CANCELLED.
+   *
+   * The walk itself lives in {@link settleTerminal}, so this is only the root's own cancellation:
+   * every path that ends an activity incomplete brings its subtree down, not just this one.
+   */
+  function cancel(id: ActivityId): Result<void, ControlError> {
+    const record = records.get(id);
+    if (!record)
+      return err(NotFound({ id }));
+
+    const outcome = cancelOne(record);
+    // Once, for the whole subtree: a cancelled dep may unblock dependents / rules.
+    scheduler.pump();
+    return outcome;
   }
 
   function cancelMatching(predicate: (record: ActivityRecord) => boolean): void {

--- a/frontend/app/src/modules/task-center/core/orchestrator/projection.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/projection.ts
@@ -1,5 +1,5 @@
 import { INDETERMINATE, isTerminalStatus, percentageFromSteps } from '../status';
-import { type ActivityId, type ActivityKind, type ActivityStatus, type ActivitySteps, type CompletionRecord, ActivityStatus as Status, type WorkStatus } from '../types';
+import { type Activity, type ActivityId, type ActivityKind, ActivitySourceType, type ActivityStatus, type ActivitySteps, type CompletionRecord, ActivityStatus as Status, type WorkStatus } from '../types';
 
 /**
  * The status projection: how live records and the completion ledger collapse into a
@@ -153,4 +153,53 @@ export function percentageOf(status: ActivityStatus, steps: ActivitySteps | unde
     return percentageFromSteps(children.current, children.total);
 
   return steps ? percentageFromSteps(steps.current, steps.total) : INDETERMINATE;
+}
+
+/**
+ * The subset of a record {@link projectActivity} reads — structurally satisfied by the
+ * orchestrator's `ActivityRecord`, so no adapter is required.
+ */
+export interface RenderableRecord {
+  readonly status: ActivityStatus;
+  readonly steps?: ActivitySteps;
+  readonly startedAt?: number;
+  readonly spec: {
+    readonly id: ActivityId;
+    readonly kind: ActivityKind;
+    readonly title: Activity['title'];
+    readonly subtitle?: Activity['subtitle'];
+    readonly group?: Activity['group'];
+    readonly parent?: ActivityId;
+    readonly resets?: Activity['resets'];
+    readonly ephemeral?: boolean;
+    readonly rerunnable?: boolean;
+    readonly cancel?: () => void;
+  };
+}
+
+/**
+ * A live record as the {@link Activity} every surface renders.
+ *
+ * ⚠️ `cancellable` is a projection, not a spec field: a PENDING activity can always be dropped from
+ * the queue, while a RUNNING one needs a handle to interrupt the work it started.
+ */
+export function projectActivity(record: RenderableRecord, childSteps?: ActivitySteps): Activity {
+  const { spec, status, steps, startedAt } = record;
+  return {
+    cancellable: status === Status.RUNNING ? Boolean(spec.cancel) : status === Status.PENDING,
+    ephemeral: spec.ephemeral,
+    group: spec.group,
+    id: spec.id,
+    kind: spec.kind,
+    parent: spec.parent,
+    percentage: percentageOf(status, steps, childSteps),
+    rerunnable: Boolean(spec.rerunnable),
+    resets: spec.resets,
+    source: { type: ActivitySourceType.NATIVE },
+    startedAt,
+    status,
+    steps,
+    subtitle: spec.subtitle,
+    title: spec.title,
+  };
 }


### PR DESCRIPTION
Cancelling a parent activity settled its own row and stopped nothing below it.

Every native spec carries a cancel handle, so the call always reported success, but the handle only aborts that activity's own backend task, and an umbrella never has one. The parent row went CANCELLED and disappeared while its children carried on, and children still queued went on to start, because `eligible` only refused a child whose parent was PENDING.

## What changed

The cascade hangs off `settleTerminal` rather than off `cancel`, so a single rule covers every way a parent ends without completing: cancelled, failed and skipped alike. Hanging it off `cancel` would have left a FAILED parent's children running.

A child submitted after its parent has already ended is settled CANCELLED at submit time rather than refused in `eligible`. Refusing is not settling: a record that nothing will ever make eligible sits PENDING for the life of the process and holds its caller's `await` open with it.

No new cancel handle is needed anywhere. Once the children settle, a parent awaiting them resolves on its own, and `cancelRequested` maps that to CANCELLED.

## Structure

The pure lifecycle helpers move to `lifecycle.ts` and the activity projection to `projection.ts`, which keeps `orchestrator.ts` under the 400-line cap.

## Tests

`orchestrator.spec.ts` gains coverage for the cascade: a cancelled parent cancels live descendants, a FAILED and a SKIPPED parent do the same, a late child is settled rather than parked, and a parent awaiting its children reaches a terminal status. Each was checked with a negative control (revert the fix, confirm exactly that test fails).

Full frontend suite green: 766 files, 7229 tests. Typecheck, ESLint, stylelint and the linked-key check all clean.