### PR TITLE
chore(deps): bump @rotki/eslint-plugin to 1.5.1

### DIFF
--- a/frontend/app/src/modules/core/table/filters/data-issue-fields.spec.ts
+++ b/frontend/app/src/modules/core/table/filters/data-issue-fields.spec.ts
@@ -60,7 +60,7 @@ const matchers: Matcher[] = [
     description: 'filter by asset',
     key: DataIssuesFilterKeys.ASSET,
     keyValue: DataIssuesFilterValueKeys.ASSET,
-    suggestions: async (): Promise<[]> => [],
+    suggestions: async (): Promise<string[]> => [],
   },
   {
     description: 'filter by account',

--- a/frontend/app/src/modules/core/table/filters/manual-balance-fields.spec.ts
+++ b/frontend/app/src/modules/core/table/filters/manual-balance-fields.spec.ts
@@ -49,7 +49,7 @@ const matchers: Matcher[] = [
     description: 'asset',
     key: ManualBalanceFilterKeys.ASSET,
     keyValue: ManualBalanceFilterValueKeys.ASSET,
-    suggestions: async (): Promise<[]> => [],
+    suggestions: async (): Promise<string[]> => [],
   },
 ];
 

--- a/frontend/app/src/modules/core/table/filters/oracle-price-fields.spec.ts
+++ b/frontend/app/src/modules/core/table/filters/oracle-price-fields.spec.ts
@@ -23,7 +23,7 @@ const matchers: Matcher[] = [
     description: 'filter by source asset',
     key: 'from_asset',
     keyValue: 'fromAsset',
-    suggestions: async (): Promise<[]> => [],
+    suggestions: async (): Promise<string[]> => [],
   },
   {
     description: 'filter by oracle source',

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 7.0.0
       version: 7.0.0
     '@rotki/eslint-plugin':
-      specifier: 1.5.0
-      version: 1.5.0
+      specifier: 1.5.1
+      version: 1.5.1
     '@rotki/ui-library':
       specifier: 2.23.2
       version: 2.23.2
@@ -312,10 +312,10 @@ importers:
         version: 4.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.1.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0)
       '@rotki/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.1.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.5.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.40)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10)
+        version: 7.0.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.1.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.40)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10)
       '@rotki/eslint-plugin':
         specifier: 'catalog:'
-        version: 1.5.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+        version: 1.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       cac:
         specifier: 'catalog:'
         version: 7.0.0
@@ -2226,8 +2226,8 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@rotki/eslint-plugin@1.5.0':
-    resolution: {integrity: sha512-uzH2nmKFlaSBWaCmJnH9lvR/ARMXxciaqCMWiyHOCjnIgwarfpdNOZG+8lndORe8BTJDkyQv5gWUiXiJTigNdA==}
+  '@rotki/eslint-plugin@1.5.1':
+    resolution: {integrity: sha512-4hzl8453hUgz6CKkdsllWpzhgjlLIYbD4d6vgexQI6Mu8MF+XPnpqZAmM9hfh0O6yxIaSiZCOkbS6fYCKoMLQQ==}
     engines: {node: '>=24 <25', pnpm: '>=10 <12'}
     peerDependencies:
       eslint: ^9.20.0 || ^10.0.0
@@ -8206,7 +8206,7 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.5
 
-  '@rotki/eslint-config@7.0.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.1.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.5.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.40)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10)':
+  '@rotki/eslint-config@7.0.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.1.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.40)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10)':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.7.0
@@ -8246,7 +8246,7 @@ snapshots:
       yaml-eslint-parser: 2.1.0
     optionalDependencies:
       '@intlify/eslint-plugin-vue-i18n': 4.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.1.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0)
-      '@rotki/eslint-plugin': 1.5.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@rotki/eslint-plugin': 1.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@eslint/json'
       - '@types/eslint'
@@ -8257,8 +8257,9 @@ snapshots:
       - typescript
       - vitest
 
-  '@rotki/eslint-plugin@1.5.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@rotki/eslint-plugin@1.5.1(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
+      '@typescript-eslint/parser': 8.64.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/utils': 8.64.0(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       debug: 4.4.3(supports-color@10.2.2)
       eslint: 10.7.0(jiti@2.7.0)(supports-color@10.2.2)
@@ -8494,7 +8495,7 @@ snapshots:
   '@typescript-eslint/project-service@8.61.0(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/types': 8.64.0
       debug: 4.4.3(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -9904,7 +9905,7 @@ snapshots:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
       minimatch: 9.0.9
-      semver: 7.8.4
+      semver: 7.8.5
 
   ee-first@1.1.1: {}
 
@@ -10558,10 +10559,6 @@ snapshots:
   fd-package-json@2.0.0:
     dependencies:
       walk-up-path: 4.0.0
-
-  fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
-      picomatch: 4.0.4
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -12980,8 +12977,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@2.1.0: {}
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -44,7 +44,7 @@ catalog:
   '@pinia/testing': 2.0.1
   '@playwright/test': 1.61.1
   '@rotki/eslint-config': 7.0.0
-  '@rotki/eslint-plugin': 1.5.0
+  '@rotki/eslint-plugin': 1.5.1
   '@rotki/ui-library': 2.23.2
   '@tsconfig/node24': 24.0.4
   '@types/body-parser': 1.19.6


### PR DESCRIPTION
Picks up [`@rotki/eslint-plugin` 1.5.1](https://github.com/rotki/eslint-plugin/pull/46), and fixes three spec files that typed a stub as an empty tuple.

## The plugin bump

`no-unused-i18n-keys` scans every source file to learn which keys are used, and recomputed that far more often than the tree changed: once per worker under `--concurrency`, and again in full whenever a single file was edited. It now shares the scan through a cache keyed by a hash of the contents, with one worker scanning while the rest wait.

Full `pnpm run lint` at `--concurrency=4` on this branch, same machine:

| | wall | CPU |
|---|---|---|
| 1.5.0 | 70.5s, 58.2s | 369s, 310s |
| 1.5.1 | **45.8s, 46.9s** | **~240s** |

The rule itself drops from 4712ms to 57ms warm, and out of the top ten rules entirely. It was #2 at 7475ms.

Opt out with `cache: false` in the rule options, or `ROTKI_ESLINT_I18N_CACHE=0` for one run.

## The spec fixes

Three filter specs typed an async suggestion stub as `Promise<[]>` — the empty tuple — where every sibling entry in the same files uses `string[]`. The stub returns no suggestions, but its type said it never can, which is a narrower claim than the matcher it stands in for.

These were found while evaluating [typescript-native-bridge](https://github.com/johnsoncodehk/typescript-native-bridge) (tsgo): the empty tuple type segfaults its bridge. That is upstream's bug, not the reason to change these, and this PR does not adopt tsgo.

## Verification

Run against the current `develop` after a rebase, not the branch point:

- `pnpm run lint` — 20 warnings, 0 errors, identical to develop's baseline
- `pnpm run typecheck` — clean
- `pnpm run test:unit src/modules/core/table/filters` — 161 passed

1.5.1 was confirmed to be the merged code before pinning: its published dependencies include `@typescript-eslint/parser`, which that PR moved from dev to runtime, and a cold run against the registry build logs the expected full scan.
