### PR TITLE
feat(balances): hydration is a data refresh, not an activity

### DIFF
--- a/frontend/app/src/modules/accounts/EvmAccountPageButtons.vue
+++ b/frontend/app/src/modules/accounts/EvmAccountPageButtons.vue
@@ -4,6 +4,7 @@ import AccountBalancesExportImport from '@/modules/accounts/AccountBalancesExpor
 import { useBlockchainAccountLoading } from '@/modules/accounts/use-blockchain-account-loading';
 import BlockchainBalanceRefreshBehaviourMenu
   from '@/modules/balances/BlockchainBalanceRefreshBehaviourMenu.vue';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { ActivityPart } from '@/modules/task-center/core/types';
 import { ActivityKind, useTaskCenter } from '@/modules/task-center/use-task-center';
 
@@ -22,7 +23,11 @@ const { t } = useI18n({ useScope: 'global' });
 
 const { isSectionLoading, refreshDisabled } = useBlockchainAccountLoading('evm');
 const { useIsActive, useIsActivePrefix } = useTaskCenter();
-const eth2Loading = useIsActivePrefix(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH2);
+// Both layers — hydration is not an activity, so the orchestrator alone reports a DB read as idle.
+const eth2Loading = logicOr(
+  useIsActivePrefix(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH2),
+  useBalanceRefreshState().useIsHydrating(Blockchain.ETH2),
+);
 
 const isEth2Loading = logicOr(
   eth2Loading,

--- a/frontend/app/src/modules/accounts/table/use-account-loading-states.ts
+++ b/frontend/app/src/modules/accounts/table/use-account-loading-states.ts
@@ -20,7 +20,8 @@ export function useAccountLoadingStates<T extends BlockchainAccountBalance>(
 ): UseAccountLoadingStates<T> {
   const { useIsActivePrefix } = useTaskCenter();
   const { statusOf, statusOfPrefix, version } = useTaskOrchestrator();
-  const { refreshingChains } = storeToRefs(useBalanceRefreshState());
+  const refreshState = useBalanceRefreshState();
+  const { hydratingChains, refreshingChains } = storeToRefs(refreshState);
   const { isSectionLoading } = useBlockchainAccountLoading(category);
   const { chainIds } = useAccountCategoryHelper(category);
 
@@ -34,16 +35,21 @@ export function useAccountLoadingStates<T extends BlockchainAccountBalance>(
   // `active && !everCompleted` is false for both, so no "has this chain been touched" filter is
   // needed the way the status map required one. A category whose chain list is not resolved yet
   // falls back to every chain, as it did before.
+  //
+  // 🔴 "Active" is both layers. Hydration is not an activity, so the orchestrator alone reports a
+  // chain being read from the DB as idle — and with nothing yet completed that renders an empty
+  // table instead of a loading one, for the whole cached phase.
   const isInitialLoading = computed<boolean>(() => {
     get(version); // touch the change counter so this re-reads the non-reactive ledger
+    const hydrating = get(hydratingChains);
     const chains = get(chainIds);
     if (chains.length === 0) {
       const { active, everCompleted } = statusOf(ActivityKind.BLOCKCHAIN_BALANCES);
-      return active && !everCompleted;
+      return (active || hydrating.size > 0) && !everCompleted;
     }
     return chains.some((chain) => {
       const { active, everCompleted } = statusOfPrefix(ActivityKind.BLOCKCHAIN_BALANCES, chain);
-      return active && !everCompleted;
+      return (active || hydrating.has(chain)) && !everCompleted;
     });
   });
 

--- a/frontend/app/src/modules/accounts/use-account-operations.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.spec.ts
@@ -135,6 +135,50 @@ describe('useAccountOperations', () => {
       expect(h.fetch).toHaveBeenCalledWith('eth2');
     });
 
+    /**
+     * ⭐ The point of the per-chain pipeline: a chain's balances are read when *its* accounts land,
+     * not when all of them have. Previously the whole sweep ran after the walk, so the slowest
+     * chain gated every other chain's balances.
+     */
+    it('should read a chain\'s cached balances as that chain lands, not after the walk', async () => {
+      h.chainIds = ['eth', 'btc'];
+      let releaseBtc = (): void => {};
+      h.fetch.mockImplementation(async (chain: string) => {
+        if (chain === 'btc') {
+          return new Promise<void>((resolve): void => {
+            releaseBtc = resolve;
+          });
+        }
+
+        return undefined;
+      });
+
+      const { useAccountOperations } = await importModule();
+      const walk = useAccountOperations().fetchAccounts();
+      await vi.waitFor(() => {
+        expect(h.fetchBlockchainBalances).toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'eth' }));
+      });
+
+      // eth's balances were read while btc's accounts are still outstanding.
+      expect(h.fetchBlockchainBalances).not.toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'btc' }));
+
+      releaseBtc();
+      await walk;
+    });
+
+    it('should not sweep every chain again after the walk', async () => {
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().refreshAccounts();
+      await flushPromises();
+
+      // One read per chain, from the walk — not a second undirected sweep.
+      expect(h.fetchBlockchainBalances).toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'eth' }));
+      expect(h.fetchBlockchainBalances).toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'btc' }));
+      expect(h.fetchBlockchainBalances).not.toHaveBeenCalledWith(
+        expect.objectContaining({ blockchain: undefined }),
+      );
+    });
+
     it('should fall back to every supported chain when no chain is given', async () => {
       const { useAccountOperations } = await importModule();
       await useAccountOperations().fetchAccounts();

--- a/frontend/app/src/modules/accounts/use-account-operations.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.spec.ts
@@ -136,6 +136,31 @@ describe('useAccountOperations', () => {
     });
 
     /**
+     * 🔴 `allWithConcurrency` short-circuits on the first `err`: in-flight factories finish and no
+     * new ones start. With a bound of 2 and eth rejecting, optimism is the chain that would never
+     * be read — silently, with no failure anywhere. The factories are infallible for exactly this,
+     * and the naive version passes every other test in this file.
+     */
+    it('should read every chain even when one read rejects', async () => {
+      h.chainIds = ['eth', 'btc', 'optimism'];
+      h.fetch.mockImplementation(async (chain: string) => {
+        if (chain === 'eth')
+          throw new Error('boom');
+
+        return undefined;
+      });
+
+      const { useAccountOperations } = await importModule();
+      await useAccountOperations().fetchAccounts();
+      await flushPromises();
+
+      expect(h.fetch).toHaveBeenCalledWith('btc');
+      expect(h.fetch).toHaveBeenCalledWith('optimism');
+      // The chain behind the rejection still gets its data refresh.
+      expect(h.fetchBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'optimism' });
+    });
+
+    /**
      * ⭐ The point of the per-chain pipeline: a chain's balances are read when *its* accounts land,
      * not when all of them have. Previously the whole sweep ran after the walk, so the slowest
      * chain gated every other chain's balances.

--- a/frontend/app/src/modules/accounts/use-account-operations.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.spec.ts
@@ -10,7 +10,7 @@ const h = vi.hoisted(() => ({
   chainIds: ['eth', 'btc'],
   detectEvmAccounts: vi.fn(),
   fetch: vi.fn(),
-  fetchBlockchainBalances: vi.fn(),
+  hydrate: vi.fn(),
   fetchEnsNames: vi.fn(),
   getAddresses: vi.fn((_chain: string): string[] => []),
   isEvm: vi.fn((chain: string): boolean => chain === 'eth' || chain === 'optimism'),
@@ -28,9 +28,12 @@ vi.mock('@/modules/accounts/use-account-fetching', () => ({
 
 vi.mock('@/modules/balances/use-blockchain-balances', () => ({
   useBlockchainBalances: vi.fn(() => ({
-    fetchBlockchainBalances: h.fetchBlockchainBalances,
     refreshBlockchainBalances: h.refreshBlockchainBalances,
   })),
+}));
+
+vi.mock('@/modules/balances/use-balance-hydration', () => ({
+  useBalanceHydration: vi.fn(() => ({ hydrate: h.hydrate })),
 }));
 
 vi.mock('@/modules/accounts/address-book/use-ens-operations', () => ({
@@ -79,7 +82,7 @@ describe('useAccountOperations', () => {
     h.getAddresses.mockReturnValue([]);
     h.supportsTransactions.mockReturnValue(true);
     h.fetch.mockResolvedValue(undefined);
-    h.fetchBlockchainBalances.mockResolvedValue(undefined);
+    h.hydrate.mockResolvedValue(undefined);
     h.refreshBlockchainBalances.mockResolvedValue(undefined);
     h.fetchEnsNames.mockResolvedValue(undefined);
   });
@@ -157,7 +160,7 @@ describe('useAccountOperations', () => {
       expect(h.fetch).toHaveBeenCalledWith('btc');
       expect(h.fetch).toHaveBeenCalledWith('optimism');
       // The chain behind the rejection still gets its data refresh.
-      expect(h.fetchBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'optimism' });
+      expect(h.hydrate).toHaveBeenCalledWith({ blockchain: 'optimism' });
     });
 
     /**
@@ -181,11 +184,11 @@ describe('useAccountOperations', () => {
       const { useAccountOperations } = await importModule();
       const walk = useAccountOperations().fetchAccounts();
       await vi.waitFor(() => {
-        expect(h.fetchBlockchainBalances).toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'eth' }));
+        expect(h.hydrate).toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'eth' }));
       });
 
       // eth's balances were read while btc's accounts are still outstanding.
-      expect(h.fetchBlockchainBalances).not.toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'btc' }));
+      expect(h.hydrate).not.toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'btc' }));
 
       releaseBtc();
       await walk;
@@ -197,9 +200,9 @@ describe('useAccountOperations', () => {
       await flushPromises();
 
       // One read per chain, from the walk — not a second undirected sweep.
-      expect(h.fetchBlockchainBalances).toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'eth' }));
-      expect(h.fetchBlockchainBalances).toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'btc' }));
-      expect(h.fetchBlockchainBalances).not.toHaveBeenCalledWith(
+      expect(h.hydrate).toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'eth' }));
+      expect(h.hydrate).toHaveBeenCalledWith(expect.objectContaining({ blockchain: 'btc' }));
+      expect(h.hydrate).not.toHaveBeenCalledWith(
         expect.objectContaining({ blockchain: undefined }),
       );
     });
@@ -216,7 +219,7 @@ describe('useAccountOperations', () => {
     it('should fetch balances for a regular chain', async () => {
       const { useAccountOperations } = await importModule();
       await useAccountOperations().refreshAccounts({ blockchain: 'eth' });
-      expect(h.fetchBlockchainBalances).toHaveBeenCalledWith({ addresses: undefined, blockchain: 'eth', isXpub: false });
+      expect(h.hydrate).toHaveBeenCalledWith({ addresses: undefined, blockchain: 'eth', isXpub: false });
       expect(h.refreshBlockchainBalances).not.toHaveBeenCalled();
     });
 

--- a/frontend/app/src/modules/accounts/use-account-operations.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.ts
@@ -2,8 +2,8 @@ import type { MaybeRef } from 'vue';
 import type { AddressBookSimplePayload } from '@/modules/accounts/address-book/eth-names';
 import { Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
-import { Semaphore } from 'es-toolkit';
-import { isErr, map as mapResult, type Result } from 'plainfp/result';
+import { isErr, map as mapResult, ok, type Result } from 'plainfp/result';
+import { allWithConcurrency, type ResultAsync } from 'plainfp/result-async';
 import { useEnsOperations } from '@/modules/accounts/address-book/use-ens-operations';
 import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-accounts-api';
 import { useAccountFetching } from '@/modules/accounts/use-account-fetching';
@@ -17,6 +17,9 @@ import { useNotifications } from '@/modules/core/notifications/use-notifications
 import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
 import { activityLabel } from '@/modules/task-center/activity-labels';
 import { ActivityKind, ActivityPart, makeActivityId, useNativeTask } from '@/modules/task-center/use-native-task';
+
+/** Chains read at a time during the account walk. */
+const ACCOUNT_READ_CONCURRENCY = 2;
 
 export interface RefreshAccountsParams {
   blockchain?: MaybeRef<string>;
@@ -45,13 +48,21 @@ export function useAccountOperations(): UseAccountOperationsReturn {
   const { t } = useI18n({ useScope: 'global' });
 
   /**
-   * Two chains at a time. `fetch` reports its own failures, so one chain failing must not abandon
-   * the rest.
+   * Two chains at a time.
+   *
+   * ⭐ Bounded by `allWithConcurrency` rather than a semaphore. The fit is structural: the chain
+   * set is a fixed batch known upfront, with no dynamic arrival, no cancel and no progress —
+   * precisely the case the orchestrator is *not* for (`scheduler.ts:41` draws the same boundary
+   * from the other side). The bound is a function call, so there is no second scheduler and no
+   * lane to mistake for an ordering.
+   *
+   * 🔴 `allWithConcurrency` **short-circuits on the first `err`**: in-flight factories finish and
+   * no new ones start. One chain failing must not abandon the other sixteen, so each factory is
+   * infallible — `ResultAsync<void, never>`. Nothing in the package enforces that, and the naive
+   * call site silently drops chains.
    */
   const readChains = async (chains: string[], onChainRead?: (chain: string) => void): Promise<void> => {
-    const permits = new Semaphore(2);
-    await Promise.all(chains.map(async (chain) => {
-      await permits.acquire();
+    const factories = chains.map(chain => async (): ResultAsync<void, never> => {
       try {
         await fetch(chain);
         // ⭐ Per chain, not per walk. This chain's accounts are known now, and nothing about its
@@ -59,10 +70,15 @@ export function useAccountOperations(): UseAccountOperationsReturn {
         // slowest chain from gating every other chain's balances.
         onChainRead?.(chain);
       }
-      finally {
-        permits.release();
+      catch (error: unknown) {
+        // Swallowed rather than rethrown: a rejection here is a rejection of the whole batch. The
+        // paths `fetch` owns already notify; this covers the ones it does not.
+        logger.error(error);
       }
-    }));
+      return ok(undefined);
+    });
+
+    await allWithConcurrency(factories, ACCOUNT_READ_CONCURRENCY);
   };
 
   const fetchAccounts = async (blockchain?: string | string[], refreshEns: boolean = false): Promise<void> => {

--- a/frontend/app/src/modules/accounts/use-account-operations.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.ts
@@ -9,6 +9,7 @@ import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-
 import { useAccountFetching } from '@/modules/accounts/use-account-fetching';
 import { useAccountLoadState } from '@/modules/accounts/use-account-load-state';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
+import { useBalanceHydration } from '@/modules/balances/use-balance-hydration';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { uniqueStrings } from '@/modules/core/common/data/data';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -36,7 +37,8 @@ interface UseAccountOperationsReturn {
 
 export function useAccountOperations(): UseAccountOperationsReturn {
   const { fetch } = useAccountFetching();
-  const { fetchBlockchainBalances, refreshBlockchainBalances } = useBlockchainBalances();
+  const { hydrate } = useBalanceHydration();
+  const { refreshBlockchainBalances } = useBlockchainBalances();
   const { fetchEnsNames } = useEnsOperations();
   const { detectEvmAccounts: detectEvmAccountsCaller } = useBlockchainAccountsApi();
   const { isEvm, supportedChains, supportsTransactions } = useSupportedChains();
@@ -116,11 +118,11 @@ export function useAccountOperations(): UseAccountOperationsReturn {
     //
     // Not awaited either: the caller waits for *accounts*, and a chain's balances arriving later is
     // the point.
-    const readCachedBalances = (chain: string): void => {
-      startPromise(fetchBlockchainBalances({ blockchain: chain }));
+    const hydrateChain = (chain: string): void => {
+      startPromise(hydrate({ blockchain: chain }));
     };
 
-    const read = readChains(chains, blockchain ? undefined : readCachedBalances);
+    const read = readChains(chains, blockchain ? undefined : hydrateChain);
     await (blockchain ? read : track(read));
 
     const namesPayload: AddressBookSimplePayload[] = [];
@@ -158,14 +160,14 @@ export function useAccountOperations(): UseAccountOperationsReturn {
     const isEth2 = chain === Blockchain.ETH2;
 
     const shouldRefresh = !!(isEth2 || uniqueAddresses);
-    // ⚠️ On the full walk `fetchAccounts` has already read each chain's cached balances as that
-    // chain landed, so repeating the sweep here would query every chain a second time. A targeted
-    // refresh still drives its own chain: nothing else will.
+    // ⚠️ On the full walk `fetchAccounts` has already hydrated each chain as that chain landed, so
+    // repeating the sweep here would read every chain a second time. A targeted refresh still
+    // drives its own chain: nothing else will.
     const pending: Promise<any>[] = [];
     if (shouldRefresh)
       pending.push(refreshBlockchainBalances({ addresses: uniqueAddresses, blockchain: chain, isXpub }, periodic));
     else if (chain !== undefined)
-      pending.push(fetchBlockchainBalances({ addresses: uniqueAddresses, blockchain: chain, isXpub }));
+      pending.push(hydrate({ addresses: uniqueAddresses, blockchain: chain, isXpub }));
 
     if (isEth && getAddresses(Blockchain.ETH2).length > 0)
       startPromise(refreshAccounts({ blockchain: Blockchain.ETH2 }));

--- a/frontend/app/src/modules/accounts/use-account-operations.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.ts
@@ -48,12 +48,16 @@ export function useAccountOperations(): UseAccountOperationsReturn {
    * Two chains at a time. `fetch` reports its own failures, so one chain failing must not abandon
    * the rest.
    */
-  const readChains = async (chains: string[]): Promise<void> => {
+  const readChains = async (chains: string[], onChainRead?: (chain: string) => void): Promise<void> => {
     const permits = new Semaphore(2);
     await Promise.all(chains.map(async (chain) => {
       await permits.acquire();
       try {
         await fetch(chain);
+        // ⭐ Per chain, not per walk. This chain's accounts are known now, and nothing about its
+        // balances depends on the other sixteen — so handing it downstream here is what stops the
+        // slowest chain from gating every other chain's balances.
+        onChainRead?.(chain);
       }
       finally {
         permits.release();
@@ -85,7 +89,22 @@ export function useAccountOperations(): UseAccountOperationsReturn {
 
     // Only a full read is tracked: that is the one that leaves the store partially filled for long
     // enough for a consumer to snapshot it. A targeted read is already scoped to what it changed.
-    const read = readChains(chains);
+    //
+    // ⭐ On the full walk each chain's data refresh runs as that chain's accounts land, rather than
+    // all of them after all seventeen. A targeted read keeps its old shape — `refreshAccounts`
+    // still drives balances for the chain it was asked about.
+    //
+    // These stand alone: independent, deduplicated by chain, and deliberately NOT under an
+    // umbrella. A data refresh from the DB is plumbing, not work — the umbrella belongs to the job
+    // (detection and the network query), which is what a user watches, cancels or supersedes.
+    //
+    // Not awaited either: the caller waits for *accounts*, and a chain's balances arriving later is
+    // the point.
+    const readCachedBalances = (chain: string): void => {
+      startPromise(fetchBlockchainBalances({ blockchain: chain }));
+    };
+
+    const read = readChains(chains, blockchain ? undefined : readCachedBalances);
     await (blockchain ? read : track(read));
 
     const namesPayload: AddressBookSimplePayload[] = [];
@@ -123,11 +142,14 @@ export function useAccountOperations(): UseAccountOperationsReturn {
     const isEth2 = chain === Blockchain.ETH2;
 
     const shouldRefresh = !!(isEth2 || uniqueAddresses);
-    const pending: Promise<any>[] = [
-      shouldRefresh
-        ? refreshBlockchainBalances({ addresses: uniqueAddresses, blockchain: chain, isXpub }, periodic)
-        : fetchBlockchainBalances({ addresses: uniqueAddresses, blockchain: chain, isXpub }),
-    ];
+    // ⚠️ On the full walk `fetchAccounts` has already read each chain's cached balances as that
+    // chain landed, so repeating the sweep here would query every chain a second time. A targeted
+    // refresh still drives its own chain: nothing else will.
+    const pending: Promise<any>[] = [];
+    if (shouldRefresh)
+      pending.push(refreshBlockchainBalances({ addresses: uniqueAddresses, blockchain: chain, isXpub }, periodic));
+    else if (chain !== undefined)
+      pending.push(fetchBlockchainBalances({ addresses: uniqueAddresses, blockchain: chain, isXpub }));
 
     if (isEth && getAddresses(Blockchain.ETH2).length > 0)
       startPromise(refreshAccounts({ blockchain: Blockchain.ETH2 }));

--- a/frontend/app/src/modules/accounts/use-blockchain-account-loading.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-account-loading.ts
@@ -20,13 +20,13 @@ export function useBlockchainAccountLoading(category: MaybeRefOrGetter<string> =
   const { useIsActivePrefix } = useTaskCenter();
   const { activities } = useTaskOrchestrator();
   const { massDetecting } = storeToRefs(useTokenDetectionStore());
-  const { refreshingChains } = storeToRefs(useBalanceRefreshState());
+  const { busyChains } = storeToRefs(useBalanceRefreshState());
 
   const { chainIds, isEvm } = useAccountCategoryHelper(category);
 
   // Reads the live activities rather than a per-chain `useWorkStatus`, because the chain set is
-  // itself reactive. Matching on the id's first part covers both the network refresh
-  // (`blockchain-balances:<chain>`) and the cached read (`…:cached`).
+  // itself reactive. Matching on the id's first part covers the network refresh
+  // (`blockchain-balances:<chain>`); hydration has no activity and is folded in below.
   const isAnyBalancesFetching = computed<boolean>(() => {
     const fetching = get(activities).filter(activity =>
       activity.kind === ActivityKind.BLOCKCHAIN_BALANCES && !isTerminalStatus(activity.status));
@@ -38,17 +38,17 @@ export function useBlockchainAccountLoading(category: MaybeRefOrGetter<string> =
     return fetching.some(activity => chains.has(String(activityParts(activity.id)[0])));
   });
 
-  // `isAnyBalancesFetching` already narrows to the category, so the only thing left to add is the
-  // refresh side, which the orchestrator does not own: a POST that is in flight is tracked by
-  // `useBalanceRefreshState`, not by an activity status.
+  // `isAnyBalancesFetching` already narrows to the category, so what is left to add is everything
+  // the orchestrator does not own: an in-flight refresh POST and a hydration read, both tracked by
+  // `useBalanceRefreshState` rather than by an activity status.
   const isSectionLoading = computed<boolean>(() => {
     if (get(isAnyBalancesFetching))
       return true;
 
-    const refreshing = get(refreshingChains);
+    const busy = get(busyChains);
     return toValue(category)
-      ? get(chainIds).some(chain => refreshing.has(chain))
-      : refreshing.size > 0;
+      ? get(chainIds).some(chain => busy.has(chain))
+      : busy.size > 0;
   });
 
   const isDetectingTokens = computed<boolean>(() => get(isEvm) && isDefined(massDetecting));

--- a/frontend/app/src/modules/assets/use-asset-locations-data.spec.ts
+++ b/frontend/app/src/modules/assets/use-asset-locations-data.spec.ts
@@ -56,6 +56,9 @@ function options(over: Partial<Parameters<typeof useAssetLocationsData>[0]> = {}
 
 describe('useAssetLocationsData', () => {
   beforeEach(() => {
+    // `useBalancesLoading` reads hydration liveness off a pinia store now that hydration is not
+    // an activity the orchestrator can report on.
+    setActivePinia(createPinia());
     spies.getAssetPriceInfo.mockReturnValue({ value: bigNumberify(500) });
     spies.getAccountByAddress.mockReturnValue({ label: 'My Account' });
     spies.getAddressName.mockReturnValue(null);

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.spec.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.spec.ts
@@ -37,10 +37,10 @@ vi.mock('@/modules/core/common/use-supported-chains', () => ({
   }),
 }));
 
-const mockFetchBlockchainBalances = vi.fn().mockResolvedValue(undefined);
-vi.mock('@/modules/balances/use-blockchain-balances', () => ({
-  useBlockchainBalances: vi.fn().mockReturnValue({
-    fetchBlockchainBalances: mockFetchBlockchainBalances,
+const mockHydrate = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/modules/balances/use-balance-hydration', () => ({
+  useBalanceHydration: vi.fn().mockReturnValue({
+    hydrate: mockHydrate,
   }),
 }));
 
@@ -102,8 +102,8 @@ describe('useTokenDetectionOrchestrator', () => {
       });
       expect(mockDetectTokensForAddress).toHaveBeenCalledWith(mockRunTask, 'eth', '0xaddr1');
       expect(mockDetectTokensForAddress).toHaveBeenCalledWith(mockRunTask, 'eth', '0xaddr2');
-      expect(mockFetchBlockchainBalances).toHaveBeenCalledWith({
-        blockchain: 'eth',
+      expect(mockHydrate).toHaveBeenCalledWith({
+        blockchain: ['eth'],
       });
     });
 
@@ -114,7 +114,9 @@ describe('useTokenDetectionOrchestrator', () => {
       await detectTokens(['eth', 'optimism'], ['0xaddr1']);
 
       expect(mockSubmitTask).toHaveBeenCalledTimes(2);
-      expect(mockFetchBlockchainBalances).toHaveBeenCalledTimes(2);
+      // One hydration for the whole set, not one per chain: `hydrate` takes the chains and applies
+      // its own bound.
+      expect(mockHydrate).toHaveBeenCalledWith({ blockchain: ['eth', 'optimism'] });
     });
   });
 
@@ -131,7 +133,7 @@ describe('useTokenDetectionOrchestrator', () => {
       await detectAllTokens();
 
       expect(mockSubmitTask).toHaveBeenCalledTimes(2);
-      expect(mockFetchBlockchainBalances).toHaveBeenCalledTimes(2);
+      expect(mockHydrate).toHaveBeenCalledWith({ blockchain: ['eth', 'optimism'] });
     });
 
     it('should detect tokens only for specified chains', async () => {

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
@@ -7,7 +7,7 @@ import { msg } from '@/message-key';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
 import { useTokenDetectionApi } from '@/modules/balances/blockchain/use-token-detection-api';
 import { useTokenDetectionStore } from '@/modules/balances/blockchain/use-token-detection-store';
-import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
+import { useBalanceHydration } from '@/modules/balances/use-balance-hydration';
 import { arrayify } from '@/modules/core/common/data/array';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
@@ -31,7 +31,7 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
   const { setMassDetecting } = useTokenDetectionStore();
   const { addresses } = useAccountAddresses();
   const { getChainName, supportsTransactions, txEvmChains } = useSupportedChains();
-  const { fetchBlockchainBalances } = useBlockchainBalances();
+  const { hydrate } = useBalanceHydration();
   const { submitTask } = useNativeTask();
   const { activities } = useTaskOrchestrator();
 
@@ -60,12 +60,10 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
     })));
   };
 
+  // Detection ends in a balance read, so the chains it touched are hydrated once it settles —
+  // §4's only coupling between the layers: work finishing triggers hydration for its subject.
   const reloadBalancesForChains = async (chains: string[]): Promise<void> => {
-    await Promise.allSettled(chains.map(async chain =>
-      fetchBlockchainBalances({
-        blockchain: chain,
-      }),
-    ));
+    await hydrate({ blockchain: chains });
   };
 
   const detectTokens = async (

--- a/frontend/app/src/modules/balances/services/use-balance-processing-service.spec.ts
+++ b/frontend/app/src/modules/balances/services/use-balance-processing-service.spec.ts
@@ -73,6 +73,14 @@ const runTask = vi.fn().mockImplementation(async (taskFn: () => Promise<{ taskId
 
 const { useBalanceProcessingService } = await import('@/modules/balances/services/use-balance-processing-service');
 
+function balancesAt(blockchain: string, lastRefreshTs: number): unknown {
+  return {
+    lastRefreshTs: { [blockchain]: lastRefreshTs },
+    perAccount: { [blockchain]: {} },
+    totals: { assets: {}, liabilities: {} },
+  };
+}
+
 function emptyBalances(blockchain: string): unknown {
   return {
     perAccount: { [blockchain]: {} },
@@ -92,6 +100,62 @@ describe('useBalanceProcessingService', () => {
     updateAccounts(Blockchain.ETH, [
       createAccount({ address: '0x1', label: null, tags: null }, { chain: Blockchain.ETH, nativeAsset: 'ETH' }),
     ]);
+  });
+
+  /**
+   * ⭐ The guarantee that lets a DB data refresh and a network query overlap without being
+   * serialised: whichever carries the older `lastRefreshTs` is discarded, whatever order they land
+   * in. Without it the slower one wins and rolls the chain back to stale balances.
+   */
+  describe('stale payloads', () => {
+    // ⚠️ A chain of its own, not ETH. The orchestrator is a `createSharedComposable`, so its
+    // completion ledger survives `setActivePinia` and leaks between tests — marking ETH complete
+    // here makes a later test see `hasCachedData` already true.
+    const CHAIN = 'gnosis';
+
+    async function resolveCachedFetch(taskId: number, payload: unknown): Promise<void> {
+      const service = useBalanceProcessingService();
+      const pending = service.handleCachedFetch(
+        runTask,
+        { addresses: undefined, blockchain: CHAIN, isXpub: false },
+        undefined,
+      );
+      await vi.waitFor(() => {
+        expect(pendingTasks.has(taskId)).toBe(true);
+      });
+      pendingTasks.get(taskId)!.resolve(ok(payload));
+      await pending;
+    }
+
+    it('should ignore a payload older than the chain already holds', async () => {
+      mockQueryBlockchainBalances.mockImplementation(async () => ({ taskId: nextTaskId++ }));
+      useBlockchainAccountsStore().updateAccounts(CHAIN, [
+        createAccount({ address: '0x9', label: null, tags: null }, { chain: CHAIN, nativeAsset: 'ETH' }),
+      ]);
+      const { updateBalances } = useBalancesStore();
+
+      await resolveCachedFetch(1, balancesAt(CHAIN, 3000));
+      vi.mocked(updateBalances).mockClear();
+
+      await resolveCachedFetch(2, balancesAt(CHAIN, 1000));
+
+      expect(updateBalances).not.toHaveBeenCalled();
+    });
+
+    it('should accept a payload newer than the chain holds', async () => {
+      mockQueryBlockchainBalances.mockImplementation(async () => ({ taskId: nextTaskId++ }));
+      useBlockchainAccountsStore().updateAccounts(CHAIN, [
+        createAccount({ address: '0x9', label: null, tags: null }, { chain: CHAIN, nativeAsset: 'ETH' }),
+      ]);
+      const { updateBalances } = useBalancesStore();
+
+      await resolveCachedFetch(1, balancesAt(CHAIN, 1000));
+      vi.mocked(updateBalances).mockClear();
+
+      await resolveCachedFetch(2, balancesAt(CHAIN, 3000));
+
+      expect(updateBalances).toHaveBeenCalled();
+    });
   });
 
   describe('shouldQuery', () => {

--- a/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
+++ b/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
@@ -128,6 +128,7 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
     runTask: RunBackendTask,
     blockchain: string,
     apiCall: () => Promise<{ taskId: number }>,
+    notify: boolean = true,
   ): Promise<Result<void, TaskError>> => {
     if (!shouldQuery(blockchain)) {
       clearChainBalances(blockchain);
@@ -139,12 +140,18 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
     if (isErr(result)) {
       if (isActionable(result.error)) {
         logger.error(result.error.message);
-        notifyError(
-          t('actions.balances.blockchain.error.title'),
-          t('actions.balances.blockchain.error.description', {
-            error: result.error.message,
-          }),
-        );
+        // ⭐ `notify` is off for the hydration read. A data refresh from the DB retries silently —
+        // it is plumbing, not something the user asked for and can act on — and a notification per
+        // attempt would make one failing chain raise three toasts. The log stays either way, so a
+        // chain that never hydrates is still diagnosable.
+        if (notify) {
+          notifyError(
+            t('actions.balances.blockchain.error.title'),
+            t('actions.balances.blockchain.error.description', {
+              error: result.error.message,
+            }),
+          );
+        }
       }
       // Forget any earlier success for this chain, so a failed query reads as "no data" rather
       // than leaving the last good load standing. Runs before the activity settles, so the FAILED
@@ -167,7 +174,7 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
     threshold: string | undefined,
   ): Promise<Result<void, TaskError>> => {
     const { blockchain } = payload;
-    return executeBalanceQuery(runTask, blockchain, async () => queryBlockchainBalances(payload, threshold));
+    return executeBalanceQuery(runTask, blockchain, async () => queryBlockchainBalances(payload, threshold), false);
   };
 
   const handleRefresh = async (

--- a/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
+++ b/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
@@ -38,7 +38,7 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
   const { queryBlockchainBalances, refreshBlockchainBalances, queryXpubBalances } = useBlockchainBalancesApi();
   const { accounts } = storeToRefs(useBlockchainAccountsStore());
   const { updateBalances } = useBalancesStore();
-  const { updateTimestamps } = useBlockchainRefreshTimestampsStore();
+  const { isStale, updateTimestamps } = useBlockchainRefreshTimestampsStore();
   const { t } = useI18n({ useScope: 'global' });
   const { invalidate, markCompleted } = useTaskOrchestrator();
   const { isEth2Enabled } = useBlockchainValidatorsStore();
@@ -46,6 +46,13 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
 
   const processBalanceResult = (blockchain: string, result: unknown): void => {
     const parsedBalances: BlockchainBalances = BlockchainBalances.parse(result);
+
+    // 🔴 Drop a payload older than what this chain already holds. A data refresh from the DB and a
+    // network query are allowed to overlap by design, so the two can land out of order; without
+    // this the slower one wins and rolls the chain back to stale balances. Discarding by age is
+    // what makes the overlap harmless — and what lets the work stop being serialised to avoid it.
+    if (isStale(blockchain, parsedBalances.lastRefreshTs?.[blockchain]))
+      return;
 
     if (parsedBalances.lastRefreshTs)
       updateTimestamps(parsedBalances.lastRefreshTs);

--- a/frontend/app/src/modules/balances/use-balance-hydration.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-hydration.spec.ts
@@ -1,0 +1,250 @@
+import type { EvmChainInfo, SupportedChains } from '@/modules/core/api/types/chains';
+import { Blockchain } from '@rotki/common';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises } from '@vue/test-utils';
+import { err, ok } from 'plainfp/result';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAccount } from '@/modules/accounts/create-account';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { Cancelled, TaskFailed } from '@/modules/core/tasks/task-result';
+import '@test/i18n';
+
+const h = vi.hoisted(() => ({
+  queryBlockchainBalances: vi.fn(),
+  runTask: vi.fn(),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications-store', () => ({
+  useNotificationsStore: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  getErrorMessage: (error: unknown): string => String(error),
+  useNotifications: vi.fn(() => ({ notifyError: vi.fn() })),
+}));
+
+vi.mock('@/modules/balances/use-balances-store', () => ({
+  useBalancesStore: vi.fn().mockReturnValue({ updateBalances: vi.fn() }),
+}));
+
+vi.mock('@/modules/balances/api/use-blockchain-balances-api', () => ({
+  useBlockchainBalancesApi: vi.fn(() => ({
+    queryBlockchainBalances: h.queryBlockchainBalances,
+    queryXpubBalances: vi.fn().mockResolvedValue({ taskId: 3 }),
+    refreshBlockchainBalances: vi.fn().mockResolvedValue({ taskId: 4 }),
+  })),
+}));
+
+vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useTaskHandler: vi.fn(() => ({ cancelTaskById: vi.fn(), runTask: h.runTask })),
+}));
+
+vi.mock('@/modules/assets/amount-display/use-usd-value-threshold', async () => {
+  const { computed } = await import('vue');
+  return { useValueThreshold: vi.fn(() => computed<string | undefined>(() => undefined)) };
+});
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const { computed } = await import('vue');
+  const { Blockchain } = await import('@rotki/common');
+  return {
+    useSupportedChains: vi.fn().mockReturnValue({
+      getChainName: (chain: string): string => chain,
+      supportedChains: computed<SupportedChains>(() => [
+        {
+          evmChainName: 'ethereum',
+          id: Blockchain.ETH,
+          image: '',
+          name: 'Ethereum',
+          nativeToken: 'ETH',
+          type: 'evm',
+        } satisfies EvmChainInfo,
+        { id: Blockchain.BTC, image: '', name: 'Bitcoin', type: 'bitcoin' },
+        {
+          evmChainName: 'optimism',
+          id: 'optimism',
+          image: '',
+          name: 'Optimism',
+          nativeToken: 'ETH',
+          type: 'evm',
+        } satisfies EvmChainInfo,
+      ]),
+    }),
+  };
+});
+
+const EMPTY_BALANCES = { perAccount: {}, totals: { assets: {}, liabilities: {} } };
+
+/** `createSharedComposable` caches per module registry, so each test gets a fresh one. */
+async function importModule(): Promise<typeof import('./use-balance-hydration')> {
+  vi.resetModules();
+  return import('./use-balance-hydration');
+}
+
+function addAccount(chain: string): void {
+  useBlockchainAccountsStore().updateAccounts(chain, [
+    createAccount(
+      { address: '0x49ff149D649769033d43783E7456F626862CD160', label: null, tags: null },
+      { chain, nativeAsset: 'ETH' },
+    ),
+  ]);
+}
+
+describe('useBalanceHydration', () => {
+  beforeEach(() => {
+    setActivePinia(createCustomPinia());
+    vi.clearAllMocks();
+    h.queryBlockchainBalances.mockResolvedValue({ taskId: 1 });
+    h.runTask.mockImplementation(async (task: () => Promise<unknown>) => {
+      await task();
+      return ok(EMPTY_BALANCES);
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should read only the chains that have accounts', async () => {
+    const { useBalanceHydration } = await importModule();
+    await useBalanceHydration().hydrate();
+
+    expect(h.queryBlockchainBalances).not.toHaveBeenCalled();
+
+    addAccount(Blockchain.ETH);
+    await useBalanceHydration().hydrate();
+
+    expect(h.queryBlockchainBalances).toHaveBeenCalledTimes(1);
+    expect(h.queryBlockchainBalances).toHaveBeenCalledWith(
+      { addresses: undefined, blockchain: Blockchain.ETH, isXpub: false },
+      undefined,
+    );
+  });
+
+  /**
+   * ⭐ Dedup by subject. Two callers racing the same chain share one read — the guarantee
+   * `submitTask`'s id dedup used to provide before hydration stopped being an activity.
+   */
+  it('should share one read between callers racing the same chain', async () => {
+    addAccount(Blockchain.ETH);
+    let release = (): void => {};
+    h.runTask.mockImplementation(async (task: () => Promise<unknown>) => {
+      await task();
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return ok(EMPTY_BALANCES);
+    });
+
+    const { useBalanceHydration } = await importModule();
+    const { hydrate } = useBalanceHydration();
+    const first = hydrate({ blockchain: Blockchain.ETH });
+    const second = hydrate({ blockchain: Blockchain.ETH });
+    await flushPromises();
+
+    expect(h.queryBlockchainBalances).toHaveBeenCalledTimes(1);
+
+    release();
+    await Promise.all([first, second]);
+  });
+
+  /**
+   * 🔴 `allWithConcurrency` short-circuits on the first `err`: in-flight factories finish and no
+   * new ones start. A chain whose read throws would take every chain that had not started with it,
+   * silently. The factories are infallible for exactly this.
+   */
+  it('should read every chain even when one read throws', async () => {
+    addAccount(Blockchain.ETH);
+    addAccount(Blockchain.BTC);
+    addAccount('optimism');
+    h.queryBlockchainBalances.mockImplementation(async (payload: { blockchain: string }) => {
+      if (payload.blockchain === Blockchain.ETH)
+        throw new Error('boom');
+
+      return { taskId: 1 };
+    });
+
+    const { useBalanceHydration } = await importModule();
+    await useBalanceHydration().hydrate();
+
+    expect(h.queryBlockchainBalances).toHaveBeenCalledWith(
+      expect.objectContaining({ blockchain: Blockchain.BTC }),
+      undefined,
+    );
+    expect(h.queryBlockchainBalances).toHaveBeenCalledWith(
+      expect.objectContaining({ blockchain: 'optimism' }),
+      undefined,
+    );
+  });
+
+  /** §1: hydration's failure policy is to retry, silently. */
+  it('should retry an actionable failure', async () => {
+    addAccount(Blockchain.ETH);
+    h.runTask
+      .mockImplementationOnce(async (task: () => Promise<unknown>) => {
+        await task();
+        return err(TaskFailed({ message: 'nope' }));
+      })
+      .mockImplementationOnce(async (task: () => Promise<unknown>) => {
+        await task();
+        return ok(EMPTY_BALANCES);
+      });
+
+    const { useBalanceHydration } = await importModule();
+    await useBalanceHydration().hydrate({ blockchain: Blockchain.ETH });
+
+    expect(h.queryBlockchainBalances).toHaveBeenCalledTimes(2);
+  });
+
+  /**
+   * 🔴 `retry` takes no predicate, so without the actionable check a logout mid-walk would retry
+   * every chain twice more against a session that is gone.
+   */
+  it('should not retry a cancelled read', async () => {
+    addAccount(Blockchain.ETH);
+    h.runTask.mockImplementation(async (task: () => Promise<unknown>) => {
+      await task();
+      return err(Cancelled({ message: 'session ended' }));
+    });
+
+    const { useBalanceHydration } = await importModule();
+    await useBalanceHydration().hydrate({ blockchain: Blockchain.ETH });
+
+    expect(h.queryBlockchainBalances).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 🔴 Hydration is not an activity, so the orchestrator cannot report it. Every spinner that used
+   * to read `useIsActive(BLOCKCHAIN_BALANCES)` for the cached phase reads this instead; if it were
+   * never set the whole phase would render as settled-and-empty.
+   */
+  it('should report liveness while a chain is being read', async () => {
+    addAccount(Blockchain.ETH);
+    let release = (): void => {};
+    h.runTask.mockImplementation(async (task: () => Promise<unknown>) => {
+      await task();
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return ok(EMPTY_BALANCES);
+    });
+
+    const { useBalanceHydration } = await importModule();
+    const { useBalanceRefreshState } = await import('./use-balance-refresh-state');
+    const refreshState = useBalanceRefreshState();
+
+    expect(get(refreshState.isHydrating)).toBe(false);
+
+    const read = useBalanceHydration().hydrate({ blockchain: Blockchain.ETH });
+    await flushPromises();
+
+    expect(get(refreshState.isHydrating)).toBe(true);
+    expect(get(refreshState.hydratingChains).has(Blockchain.ETH)).toBe(true);
+
+    release();
+    await read;
+
+    expect(get(refreshState.isHydrating)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/balances/use-balance-hydration.ts
+++ b/frontend/app/src/modules/balances/use-balance-hydration.ts
@@ -1,0 +1,150 @@
+import type { BlockchainBalancePayload } from '@/modules/balances/types/blockchain-balances';
+import type { RunBackendTask } from '@/modules/task-center/use-native-task';
+import { err, isErr, ok, type Result } from 'plainfp/result';
+import { allWithConcurrency, type ResultAsync, retry, type RetryOptions } from 'plainfp/result-async';
+import { useValueThreshold } from '@/modules/assets/amount-display/use-usd-value-threshold';
+import { useBalanceProcessingService } from '@/modules/balances/services/use-balance-processing-service';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
+import { arrayify } from '@/modules/core/common/data/array';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
+import { useTaskHandler } from '@/modules/core/tasks/use-task-handler';
+import { BalanceSource } from '@/modules/settings/types/frontend-settings';
+
+/**
+ * Chains hydrated at a time. Hydration's own bound and nowhere else's — never a lane, and never
+ * the same piece of work bounded twice (the `DECODE_LANE` trap).
+ */
+const HYDRATION_CONCURRENCY = 4;
+
+/**
+ * A failed read is retried silently: hydration is plumbing, so a transient failure is not the
+ * user's problem to act on. Only a failure worth another attempt reaches this — see `readOnce`.
+ */
+const HYDRATION_RETRY: RetryOptions = { backoff: 'exponential', delayMs: 500, times: 3 };
+
+interface UseBalanceHydrationReturn {
+  /**
+   * Repopulate the store from the user's own database, one read per chain. Resolves when every
+   * chain in the payload has settled.
+   */
+  hydrate: (payload?: BlockchainBalancePayload) => Promise<void>;
+  /**
+   * Forget every read in flight. 🔴 Must run when a session ends: this map is app-scoped, so a
+   * read that can never settle (its backend task belongs to a session that is gone) would
+   * otherwise be handed to the next session's caller for that chain, which then never hydrates.
+   */
+  reset: () => void;
+}
+
+/**
+ * Layer 1 — the data refresh.
+ *
+ * ⭐ **Not a job, and deliberately not an activity.** It repopulates the store from the user's own
+ * database so the view paints fast: no task-centre row, no cancel, no progress, no umbrella. It
+ * never blocks work and is never blocked by it. Seventeen task-centre rows describing a read of
+ * local data was the symptom; conflating the two classes of operation was the cause.
+ *
+ * ⭐ Deduplicated by subject (the chain), so two callers racing the same chain share one read —
+ * the guarantee `submitTask`'s id dedup used to provide. A second caller for a live chain joins
+ * the read in flight and therefore its parameters, which is right for a data refresh: the rows it
+ * reads back are the same either way.
+ *
+ * ⚠️ It is still a *backend task* — the current GET escalates to a full node query on an empty
+ * cache, so it cannot simply drop `async_query`. That is a backend change, not a reason for this
+ * to be a job.
+ *
+ * 🔴 Overlapping a network refresh is harmless by construction rather than by exclusion:
+ * `processBalanceResult` discards a payload older than what the chain already holds, whichever
+ * order the two land in. That is what lets this layer stop being serialised against work at all.
+ */
+export const useBalanceHydration = createSharedComposable((): UseBalanceHydrationReturn => {
+  const { getChainName, supportedChains } = useSupportedChains();
+  const { clearChainBalances, handleCachedFetch, shouldQuery } = useBalanceProcessingService();
+  const { runTask: runBackendTask } = useTaskHandler();
+  const { startHydration, stopHydration } = useBalanceRefreshState();
+  const valueThreshold = useValueThreshold(BalanceSource.BLOCKCHAIN);
+  const { t } = useI18n({ useScope: 'global' });
+
+  /** The read in flight per chain — the subject dedup. Entries exist only while a read is live. */
+  const inflight = new Map<string, Promise<void>>();
+
+  const readChain = async (payload: BlockchainBalancePayload, chain: string): Promise<void> => {
+    const chainPayload = { addresses: payload.addresses, blockchain: chain, isXpub: payload.isXpub ?? false };
+    const threshold = get(valueThreshold);
+    // Names the backend task in the monitor's failure notification and the dev logs, the same way
+    // the orchestrator labels the run of an activity that owns one.
+    const label = t('task_center.activity.blockchain_balances.cached', { chain: getChainName(chain) });
+    const runTask: RunBackendTask = async task => runBackendTask(task, label);
+
+    /**
+     * One attempt, with its outcome placed in the channel `retry` reads.
+     *
+     * 🔴 `retry` takes no predicate — it retries anything in the `err` channel. A read that was
+     * cancelled (a logout mid-walk, a request the queue dropped) must settle where it is rather
+     * than be tried twice more against a session that is gone, so only an *actionable* failure
+     * goes in `err`; everything else short-circuits as `ok`.
+     */
+    const readOnce = async (): ResultAsync<Result<void, TaskError>, TaskError> => {
+      const outcome = await handleCachedFetch(runTask, chainPayload, threshold);
+      return isErr(outcome) && isActionable(outcome.error) ? err(outcome.error) : ok(outcome);
+    };
+
+    startHydration(chain);
+    try {
+      await retry(readOnce, HYDRATION_RETRY);
+    }
+    finally {
+      stopHydration(chain);
+    }
+  };
+
+  const hydrateChain = async (payload: BlockchainBalancePayload, chain: string): Promise<void> => {
+    if (!shouldQuery(chain)) {
+      clearChainBalances(chain);
+      return;
+    }
+
+    const running = inflight.get(chain);
+    if (running)
+      return running;
+
+    const read = readChain(payload, chain).finally(() => {
+      inflight.delete(chain);
+    });
+    inflight.set(chain, read);
+    return read;
+  };
+
+  const hydrate = async (payload: BlockchainBalancePayload = {}): Promise<void> => {
+    const { blockchain } = payload;
+    const chains = blockchain ? arrayify(blockchain) : get(supportedChains).map(chain => chain.id);
+
+    /**
+     * 🔴 `allWithConcurrency` **short-circuits on the first `err`**: in-flight factories finish and
+     * no new ones start. One chain's read failing must not abandon the rest, so every factory is
+     * infallible — `ResultAsync<void, never>`. Nothing in the package enforces that, and the naive
+     * call site silently drops chains while looking entirely correct.
+     */
+    const factories = chains.map(chain => async (): ResultAsync<void, never> => {
+      try {
+        await hydrateChain(payload, chain);
+      }
+      catch (error: unknown) {
+        // A rejection here is a rejection of the whole batch, so it never leaves this factory.
+        // `handleCachedFetch` reports what it owns; this covers a throw on the way to it.
+        logger.error(error);
+      }
+      return ok(undefined);
+    });
+
+    await allWithConcurrency(factories, HYDRATION_CONCURRENCY);
+  };
+
+  const reset = (): void => {
+    inflight.clear();
+  };
+
+  return { hydrate, reset };
+});

--- a/frontend/app/src/modules/balances/use-balance-loading.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-loading.spec.ts
@@ -1,8 +1,11 @@
+import { createCustomPinia } from '@test/utils/create-pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ActivityKind, type WorkStatus } from '@/modules/task-center/core/types';
 import { useBalancesLoading } from './use-balance-loading';
+import { useBalanceRefreshState } from './use-balance-refresh-state';
 
-// Every balance source now runs native, so all liveness comes off the orchestrator.
+// Work runs native, so its liveness comes off the orchestrator. Hydration is not an activity at
+// all, so its half comes from the refresh-state store.
 const activeKinds = ref<Set<ActivityKind>>(new Set());
 
 vi.mock('@/modules/task-center/use-task-center', () => ({
@@ -14,6 +17,7 @@ vi.mock('@/modules/task-center/use-task-center', () => ({
 
 describe('useBalancesLoading', () => {
   beforeEach(() => {
+    setActivePinia(createCustomPinia());
     set(activeKinds, new Set());
   });
 
@@ -44,5 +48,20 @@ describe('useBalancesLoading', () => {
     set(activeKinds, new Set([ActivityKind.TOKEN_DETECTION]));
     expect(get(loadingBalances)).toBe(false);
     expect(get(loadingBalancesAndDetection)).toBe(true);
+  });
+
+  /**
+   * 🔴 Hydration has no activity, so the orchestrator reports it as idle. This is the funnel every
+   * spinner reads; without the second source a chain being read from the DB renders as settled and
+   * empty for the whole cached phase.
+   */
+  it('should flag loading while a chain is hydrating', () => {
+    const { loadingBalances, loadingBlockchainBalances } = useBalancesLoading();
+    expect(get(loadingBlockchainBalances)).toBe(false);
+
+    useBalanceRefreshState().startHydration('eth');
+
+    expect(get(loadingBlockchainBalances)).toBe(true);
+    expect(get(loadingBalances)).toBe(true);
   });
 });

--- a/frontend/app/src/modules/balances/use-balance-loading.ts
+++ b/frontend/app/src/modules/balances/use-balance-loading.ts
@@ -1,4 +1,5 @@
 import type { ComputedRef } from 'vue';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { ActivityKind } from '@/modules/task-center/core/types';
 import { useTaskCenter } from '@/modules/task-center/use-task-center';
 
@@ -14,17 +15,21 @@ interface UseBalancesLoadingReturn {
  *
  * ⚠️ Read liveness from here rather than calling `useIsActive(ActivityKind.BLOCKCHAIN_BALANCES)`
  * directly. Consumers spread across the app reading the orchestrator themselves is what makes the
- * source of that liveness impossible to change: the cached read is due to stop being an activity,
- * and every direct reader would silently go dark for the whole cached phase — an empty dashboard
- * that looks settled rather than loading.
+ * source of that liveness impossible to change — and it has now changed: hydration is no longer an
+ * activity, so a direct reader goes silently dark for the whole cached phase, showing an empty
+ * dashboard that looks settled rather than loading.
  */
 export function useBalancesLoading(): UseBalancesLoadingReturn {
   const { useIsActive } = useTaskCenter();
+  const { isHydrating } = storeToRefs(useBalanceRefreshState());
 
-  // Every balance source now runs native, so liveness comes entirely off the orchestrator
-  // (which also covers the queued/pending window the task store could not see).
-
-  const loadingBlockchainBalances = useIsActive(ActivityKind.BLOCKCHAIN_BALANCES);
+  // Two sources, because there are two layers. Work is the orchestrator's (which also covers the
+  // queued/pending window the task store could not see); hydration is not an activity at all, so
+  // its liveness comes off the refresh-state store.
+  const loadingBlockchainBalances = logicOr(
+    useIsActive(ActivityKind.BLOCKCHAIN_BALANCES),
+    isHydrating,
+  );
 
   const loadingBalances = logicOr(
     useIsActive(ActivityKind.ALL_BALANCES),

--- a/frontend/app/src/modules/balances/use-balance-refresh-state.ts
+++ b/frontend/app/src/modules/balances/use-balance-refresh-state.ts
@@ -1,36 +1,87 @@
-import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 
+function addChain(chains: Ref<Set<string>>, chain: string): void {
+  const current = get(chains);
+  if (current.has(chain))
+    return;
+  const next = new Set(current);
+  next.add(chain);
+  set(chains, next);
+}
+
+function removeChain(chains: Ref<Set<string>>, chain: string): void {
+  const current = get(chains);
+  if (!current.has(chain))
+    return;
+  const next = new Set(current);
+  next.delete(chain);
+  set(chains, next);
+}
+
+/**
+ * Which chains have balance work in flight, split by the two layers that produce it.
+ *
+ * ⭐ `refreshingChains` is the *network* query — the work a user watches, cancels and retries.
+ * `hydratingChains` is the data refresh from the user's own database. They are tracked apart
+ * because they mean different things to the UI: a refresh spinner on a row belongs to the former,
+ * while "there is nothing to show yet" belongs to both.
+ *
+ * ⭐ Hydration's liveness lives here rather than in the orchestrator because hydration is not an
+ * activity: it has no task-centre row, no cancel and no progress. This store is what every spinner
+ * that used to read `useIsActive(BLOCKCHAIN_BALANCES)` for the cached phase now reads instead.
+ */
 export const useBalanceRefreshState = defineStore('balances/refresh-state', () => {
   const refreshingChains = ref<Set<string>>(new Set());
+  const hydratingChains = ref<Set<string>>(new Set());
 
   const start = (chain: string): void => {
-    const current = get(refreshingChains);
-    if (current.has(chain))
-      return;
-    const next = new Set(current);
-    next.add(chain);
-    set(refreshingChains, next);
+    addChain(refreshingChains, chain);
   };
 
   const stop = (chain: string): void => {
-    const current = get(refreshingChains);
-    if (!current.has(chain))
-      return;
-    const next = new Set(current);
-    next.delete(chain);
-    set(refreshingChains, next);
+    removeChain(refreshingChains, chain);
+  };
+
+  const startHydration = (chain: string): void => {
+    addChain(hydratingChains, chain);
+  };
+
+  const stopHydration = (chain: string): void => {
+    removeChain(hydratingChains, chain);
   };
 
   const isRefreshing = computed<boolean>(() => get(refreshingChains).size > 0);
 
+  const isHydrating = computed<boolean>(() => get(hydratingChains).size > 0);
+
+  /** Either layer. The read for "is this chain doing anything at all with its balances". */
+  const busyChains = computed<Set<string>>(() => new Set([...get(refreshingChains), ...get(hydratingChains)]));
+
   const useIsRefreshing = (chain: MaybeRefOrGetter<string>): ComputedRef<boolean> =>
     computed<boolean>(() => get(refreshingChains).has(toValue(chain)));
 
+  const useIsHydrating = (chain: MaybeRefOrGetter<string>): ComputedRef<boolean> =>
+    computed<boolean>(() => get(hydratingChains).has(toValue(chain)));
+
   const reset = (): void => {
     set(refreshingChains, new Set());
+    set(hydratingChains, new Set());
   };
 
-  return { isRefreshing, refreshingChains, reset, start, stop, useIsRefreshing };
+  return {
+    busyChains,
+    hydratingChains,
+    isHydrating,
+    isRefreshing,
+    refreshingChains,
+    reset,
+    start,
+    startHydration,
+    stop,
+    stopHydration,
+    useIsHydrating,
+    useIsRefreshing,
+  };
 });
 
 if (import.meta.hot)

--- a/frontend/app/src/modules/balances/use-balance-status.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-status.spec.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { ref } from 'vue';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { useBalanceStatus } from '@/modules/balances/use-balance-status';
-import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
+import { ActivityKind, makeActivityId } from '@/modules/task-center/core/types';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
 
 /** A fetch that never settles, so the chain stays live for as long as the test needs it. */
@@ -48,12 +48,29 @@ describe('useBalanceStatus', () => {
       expect(get(isInitialLoading)).toBe(false);
     });
 
-    it('should cover both the cached read and the network refresh of a chain', () => {
+    /**
+     * 🔴 Hydration is not an activity, so the orchestrator reports a chain being read from the DB
+     * as idle. Without the store half, the whole cached phase renders settled-and-empty.
+     */
+    it('should cover a chain being hydrated as well as refreshed', () => {
+      const refreshState = useBalanceRefreshState();
       const { isInitialLoading } = useBalanceStatus('eth');
 
-      // The two ids a chain runs under; a per-chain read is a prefix aggregate over both.
-      startFetch('eth', ActivityPart.CACHED);
+      expect(get(isInitialLoading)).toBe(false);
+
+      refreshState.startHydration('eth');
       expect(get(isInitialLoading)).toBe(true);
+
+      refreshState.stopHydration('eth');
+      expect(get(isInitialLoading)).toBe(false);
+    });
+
+    it('should not mistake a sibling chain\'s hydration for this one', () => {
+      const refreshState = useBalanceRefreshState();
+      const { isInitialLoading } = useBalanceStatus('eth');
+
+      refreshState.startHydration('btc');
+      expect(get(isInitialLoading)).toBe(false);
     });
 
     it('should not mistake a sibling chain for this one', () => {

--- a/frontend/app/src/modules/balances/use-balance-status.ts
+++ b/frontend/app/src/modules/balances/use-balance-status.ts
@@ -13,15 +13,21 @@ interface UseBalanceStatusReturn {
  * Per-chain or aggregate view of blockchain balance loading, answered by the orchestrator's
  * completion ledger rather than a hand-maintained status map.
  *
- * A chain runs under two activity ids (`…:<chain>` for the network refresh, `…:<chain>:cached` for
- * the DB read), so a per-chain read is a prefix aggregate over both. Chains that hold no accounts
- * never submit an activity at all: `markCompleted` is what puts those in the ledger.
+ * A chain's *work* runs under one activity id (`…:<chain>`), so a per-chain read is a prefix
+ * aggregate. Chains that hold no accounts never submit an activity at all: `markCompleted` is what
+ * puts those in the ledger — and it is also what records a hydration, which is not an activity, so
+ * `everCompleted` covers both layers on its own.
+ *
+ * 🔴 Liveness does not. Hydration has no activity to be active, so `isInitialLoading` reads it
+ * from the refresh-state store; without that a chain being read from the DB looks settled-and-empty
+ * rather than loading.
  *
  * Aggregate semantics (no chain arg):
  * - hasCachedData: at least one chain has ever completed
  * - isInitialLoading: nothing has ever completed and something is in flight, i.e. there is
  *   genuinely nothing to show yet. Once the first chain lands the rest fill in behind it.
- * - isRefreshing: at least one chain has an in-flight refresh POST
+ * - isRefreshing: at least one chain has an in-flight refresh POST. Deliberately *not* hydration:
+ *   this is the "user asked for fresh data" spinner, and a DB read is not that.
  */
 export function useBalanceStatus(chain?: MaybeRefOrGetter<string>): UseBalanceStatusReturn {
   const { useWorkStatus, useWorkStatusPrefix } = useTaskOrchestrator();
@@ -31,11 +37,16 @@ export function useBalanceStatus(chain?: MaybeRefOrGetter<string>): UseBalanceSt
     ? useWorkStatus(ActivityKind.BLOCKCHAIN_BALANCES)
     : useWorkStatusPrefix(ActivityKind.BLOCKCHAIN_BALANCES, () => toValue(chain));
 
+  const { isHydrating: anyIsHydrating } = storeToRefs(refreshState);
+  const hydrating = chain === undefined
+    ? anyIsHydrating
+    : refreshState.useIsHydrating(chain);
+
   const hasCachedData = computed<boolean>(() => get(status).everCompleted);
 
   const isInitialLoading = computed<boolean>(() => {
     const { active, everCompleted } = get(status);
-    return active && !everCompleted;
+    return (active || get(hydrating)) && !everCompleted;
   });
 
   const { isRefreshing: anyIsRefreshing } = storeToRefs(refreshState);

--- a/frontend/app/src/modules/balances/use-balance-watchers.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-watchers.spec.ts
@@ -4,7 +4,7 @@ import { BalanceSource, type BalanceValueThreshold } from '@/modules/settings/ty
 
 const fetchManualBalances = vi.fn(async (): Promise<void> => {});
 const fetchConnectedExchangeBalances = vi.fn(async (): Promise<void> => {});
-const fetchBlockchainBalances = vi.fn(async (): Promise<void> => {});
+const hydrate = vi.fn(async (): Promise<void> => {});
 const removeIgnoredAssets = vi.fn();
 
 const mockBalanceValueThreshold = ref<BalanceValueThreshold>({});
@@ -32,9 +32,9 @@ vi.mock('@/modules/balances/exchanges/use-exchanges', () => ({
   }),
 }));
 
-vi.mock('@/modules/balances/use-blockchain-balances', () => ({
-  useBlockchainBalances: vi.fn().mockReturnValue({
-    fetchBlockchainBalances,
+vi.mock('@/modules/balances/use-balance-hydration', () => ({
+  useBalanceHydration: vi.fn().mockReturnValue({
+    hydrate,
   }),
 }));
 
@@ -83,7 +83,7 @@ describe('useBalanceWatchers', () => {
     expect(fetchManualBalances).toHaveBeenCalledOnce();
     expect(fetchManualBalances).toHaveBeenCalledWith(true);
     expect(fetchConnectedExchangeBalances).not.toHaveBeenCalled();
-    expect(fetchBlockchainBalances).not.toHaveBeenCalled();
+    expect(hydrate).not.toHaveBeenCalled();
   });
 
   it('should refetch exchange balances when exchange threshold changes', async () => {
@@ -99,7 +99,7 @@ describe('useBalanceWatchers', () => {
     expect(fetchConnectedExchangeBalances).toHaveBeenCalledOnce();
     expect(fetchConnectedExchangeBalances).toHaveBeenCalledWith(false);
     expect(fetchManualBalances).not.toHaveBeenCalled();
-    expect(fetchBlockchainBalances).not.toHaveBeenCalled();
+    expect(hydrate).not.toHaveBeenCalled();
   });
 
   it('should refetch blockchain balances when blockchain threshold changes', async () => {
@@ -112,7 +112,7 @@ describe('useBalanceWatchers', () => {
     set(mockBalanceValueThreshold, { [BalanceSource.BLOCKCHAIN]: '200' });
     await nextTick();
 
-    expect(fetchBlockchainBalances).toHaveBeenCalledOnce();
+    expect(hydrate).toHaveBeenCalledOnce();
     expect(fetchManualBalances).not.toHaveBeenCalled();
     expect(fetchConnectedExchangeBalances).not.toHaveBeenCalled();
   });
@@ -133,7 +133,7 @@ describe('useBalanceWatchers', () => {
 
     expect(fetchManualBalances).not.toHaveBeenCalled();
     expect(fetchConnectedExchangeBalances).not.toHaveBeenCalled();
-    expect(fetchBlockchainBalances).not.toHaveBeenCalled();
+    expect(hydrate).not.toHaveBeenCalled();
   });
 
   it('should refetch blockchain balances when ignored assets are removed', async () => {
@@ -150,7 +150,7 @@ describe('useBalanceWatchers', () => {
     set(mockIgnoredAssets, ['asset-a']);
     await nextTick();
 
-    expect(fetchBlockchainBalances).toHaveBeenCalledOnce();
+    expect(hydrate).toHaveBeenCalledOnce();
   });
 
   it('should call removeIgnoredAssets when assets are added to ignored list', async () => {
@@ -170,6 +170,6 @@ describe('useBalanceWatchers', () => {
 
     expect(removeIgnoredAssets).toHaveBeenCalledOnce();
     expect(removeIgnoredAssets).toHaveBeenCalledWith(updatedAssets);
-    expect(fetchBlockchainBalances).not.toHaveBeenCalled();
+    expect(hydrate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/modules/balances/use-balance-watchers.ts
+++ b/frontend/app/src/modules/balances/use-balance-watchers.ts
@@ -3,15 +3,15 @@ import { isEqual } from 'es-toolkit';
 import { useAssetsStore } from '@/modules/assets/use-assets-store';
 import { useExchanges } from '@/modules/balances/exchanges/use-exchanges';
 import { useManualBalances } from '@/modules/balances/manual/use-manual-balances';
+import { useBalanceHydration } from '@/modules/balances/use-balance-hydration';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
-import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { BalanceSource } from '@/modules/settings/types/frontend-settings';
 import { useSetting } from '@/modules/settings/use-setting';
 
 export function useBalanceWatchers(): void {
   const { fetchManualBalances } = useManualBalances();
   const { fetchConnectedExchangeBalances } = useExchanges();
-  const { fetchBlockchainBalances } = useBlockchainBalances();
+  const { hydrate } = useBalanceHydration();
   const { removeIgnoredAssets } = useBalancesStore();
 
   const balanceValueThreshold = useSetting('balanceValueThreshold');
@@ -27,14 +27,14 @@ export function useBalanceWatchers(): void {
     }
 
     if (!isEqual(current[BalanceSource.BLOCKCHAIN], old[BalanceSource.BLOCKCHAIN])) {
-      startPromise(fetchBlockchainBalances());
+      startPromise(hydrate());
     }
   });
 
   watch(ignoredAssets, (curr, prev) => {
     const removedAssets = prev.filter(asset => !curr.includes(asset));
     if (removedAssets.length > 0) {
-      startPromise(fetchBlockchainBalances());
+      startPromise(hydrate());
     }
 
     const addedAssets = curr.filter(asset => !prev.includes(asset));

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -106,33 +106,6 @@ describe('useBlockchainBalances', () => {
     vi.clearAllMocks();
   });
 
-  describe('fetchBlockchainBalances', () => {
-    it('should fetch all supported blockchains', async () => {
-      const { updateAccounts } = useBlockchainAccountsStore();
-      // won't call if no account
-      await blockchainBalances.fetchBlockchainBalances();
-
-      expect(api.queryBlockchainBalances).toHaveBeenCalledTimes(0);
-
-      // call if there's account
-      updateAccounts(Blockchain.ETH, [
-        createAccount(
-          { address: '0x49ff149D649769033d43783E7456F626862CD160', label: null, tags: null },
-          { chain: Blockchain.ETH, nativeAsset: 'ETH' },
-        ),
-      ]);
-
-      await blockchainBalances.fetchBlockchainBalances();
-
-      expect(api.queryBlockchainBalances).toHaveBeenCalledTimes(1);
-      expect(api.queryBlockchainBalances).toHaveBeenCalledWith({
-        addresses: undefined,
-        blockchain: 'eth',
-        isXpub: false,
-      }, undefined);
-    });
-  });
-
   describe('refreshBlockchainBalances', () => {
     beforeEach(() => {
       // refresh only calls the api when the chain has an account (see executeBalanceQuery);

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -11,7 +11,6 @@ import { activityLabelFor } from '@/modules/task-center/activity-labels';
 import { BALANCES_CACHED_LANE, BALANCES_LANE } from '@/modules/task-center/core/orchestrator/spec';
 import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
-import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
 import { useBalanceProcessingService } from './services/use-balance-processing-service';
 
 interface UseBlockchainBalancesReturn {
@@ -22,21 +21,27 @@ interface UseBlockchainBalancesReturn {
 export function useBlockchainBalances(): UseBlockchainBalancesReturn {
   const { t } = useI18n({ useScope: 'global' });
   const { getChainName, supportedChains } = useSupportedChains();
-  const { statusOf, version } = useTaskOrchestrator();
   const valueThreshold = useValueThreshold(BalanceSource.BLOCKCHAIN);
 
   const { clearChainBalances, handleCachedFetch, handleRefresh, shouldQuery } = useBalanceProcessingService();
   const { submitTask } = useNativeTask();
   const refreshState = useBalanceRefreshState();
 
-  // Deliberately the *cached* activity and not the whole chain prefix: this runs inside the
-  // refresh activity itself, so a prefix read would see its own RUNNING status and wait forever.
-  // `version` is touched so the `until` below re-evaluates when the cached read settles.
-  const isChainBusy = (chain: string): boolean => {
-    get(version);
-    return statusOf(ActivityKind.BLOCKCHAIN_BALANCES, chain, ActivityPart.CACHED).active
-      || get(refreshState.refreshingChains).has(chain);
-  };
+  /**
+   * Whether a *network* refresh is already running for this chain.
+   *
+   * ⭐ It no longer waits on the chain's data refresh from the DB. That half existed because a
+   * cached read landing after a network result would overwrite fresh balances with stale ones —
+   * which balance writes being monotonic now prevents outright: the older payload is discarded
+   * whichever order the two land in. Two mechanisms for one hazard, and the cheaper one wins.
+   *
+   * ⚠️ The remaining half is not redundant with `submitTask`'s id dedup, and must not be deleted
+   * with it. Dedup *joins* a caller to the run already in flight; this makes a manual refresh wait
+   * and then genuinely re-query, which is what a user asking for fresh data expects. Deleting it
+   * would silently hand them the periodic run's result instead — the supersede gap, which has no
+   * implementation yet.
+   */
+  const isChainRefreshing = (chain: string): boolean => get(refreshState.refreshingChains).has(chain);
 
   /**
    * Refresh this app's data from the DB — one read per chain with accounts; empty chains are
@@ -106,7 +111,7 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
           lane: BALANCES_LANE,
           rerunnable: true,
           run: async ({ runTask }): Promise<Result<void, TaskError>> => {
-            if (isChainBusy(chain)) {
+            if (isChainRefreshing(chain)) {
               // 🔴 A dropped refresh is SKIPPED with a reason, never `ok`. Returning success here
               // recorded a completion for work that never ran, so the ledger — and `everCompleted`
               // with it — reported this chain as refreshed. Same class as a green "Sync Complete"
@@ -117,7 +122,7 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
               if (periodic)
                 return err(Skipped({ message: t('actions.balances.blockchain.skipped.busy') }));
 
-              await until(() => isChainBusy(chain)).toBe(false);
+              await until(() => isChainRefreshing(chain)).toBe(false);
             }
             return handleRefresh(runTask, chainPayload);
           },

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -1,39 +1,43 @@
 import type { BlockchainBalancePayload } from '@/modules/balances/types/blockchain-balances';
 import { err, type Result } from 'plainfp/result';
 import { msg } from '@/message-key';
-import { useValueThreshold } from '@/modules/assets/amount-display/use-usd-value-threshold';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { arrayify } from '@/modules/core/common/data/array';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { Skipped, type TaskError } from '@/modules/core/tasks/task-result';
-import { BalanceSource } from '@/modules/settings/types/frontend-settings';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
-import { BALANCES_CACHED_LANE, BALANCES_LANE } from '@/modules/task-center/core/orchestrator/spec';
-import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
+import { BALANCES_LANE } from '@/modules/task-center/core/orchestrator/spec';
+import { ActivityKind, makeActivityId } from '@/modules/task-center/core/types';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 import { useBalanceProcessingService } from './services/use-balance-processing-service';
 
 interface UseBlockchainBalancesReturn {
-  fetchBlockchainBalances: (payload?: BlockchainBalancePayload) => Promise<void>;
   refreshBlockchainBalances: (payload?: BlockchainBalancePayload, periodic?: boolean) => Promise<void>;
 }
 
+/**
+ * Layer 2 — the work.
+ *
+ * The network query a user watches, cancels and retries: one activity per chain, on a lane, in the
+ * task centre. Reading a chain's balances back out of the user's own database is the *other*
+ * layer and lives in {@link useBalanceHydration} — it is not work, so it is not here.
+ */
 export function useBlockchainBalances(): UseBlockchainBalancesReturn {
   const { t } = useI18n({ useScope: 'global' });
   const { getChainName, supportedChains } = useSupportedChains();
-  const valueThreshold = useValueThreshold(BalanceSource.BLOCKCHAIN);
 
-  const { clearChainBalances, handleCachedFetch, handleRefresh, shouldQuery } = useBalanceProcessingService();
+  const { clearChainBalances, handleRefresh, shouldQuery } = useBalanceProcessingService();
   const { submitTask } = useNativeTask();
   const refreshState = useBalanceRefreshState();
 
   /**
    * Whether a *network* refresh is already running for this chain.
    *
-   * ⭐ It no longer waits on the chain's data refresh from the DB. That half existed because a
-   * cached read landing after a network result would overwrite fresh balances with stale ones —
-   * which balance writes being monotonic now prevents outright: the older payload is discarded
-   * whichever order the two land in. Two mechanisms for one hazard, and the cheaper one wins.
+   * ⭐ It does not wait on the chain's hydration from the DB, and must not: the two layers overlap
+   * by design. A cached read landing after a network result would overwrite fresh balances with
+   * stale ones, which balance writes being monotonic prevents outright — the older payload is
+   * discarded whichever order the two land in. Two mechanisms for one hazard, and the cheaper one
+   * wins.
    *
    * ⚠️ The remaining half is not redundant with `submitTask`'s id dedup, and must not be deleted
    * with it. Dedup *joins* a caller to the run already in flight; this makes a manual refresh wait
@@ -42,53 +46,6 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
    * implementation yet.
    */
   const isChainRefreshing = (chain: string): boolean => get(refreshState.refreshingChains).has(chain);
-
-  /**
-   * Refresh this app's data from the DB — one read per chain with accounts; empty chains are
-   * cleared inline without spawning anything.
-   *
-   * ⭐ Independent, and deliberately not part of any umbrella. This is a *data refresh*, not work:
-   * it repopulates the store from the user's own database so the view paints fast. The umbrella
-   * belongs to the job — detection and the network query — which is what a user watches, cancels or
-   * supersedes.
-   *
-   * ⭐ Deduplicated by chain, so two callers racing the same chain share one read.
-   *
-   * ⭐ `ephemeral`: the orchestrator still schedules, tracks and caps these, but they never reach
-   * the task centre — seventeen rows describing a read of local data is noise. Liveness is
-   * unaffected, because `useIsActive` reads `orchestrator.statusOf` rather than the filtered render
-   * model, so every spinner still sees them.
-   *
-   * ⚠️ The old comment claimed "the default (uncapped) lane so initial load is not throttled". That
-   * lane was never uncapped — `defaultCap` bounded it at 4 incidentally. The cap is now explicit on
-   * {@link BALANCES_CACHED_LANE}.
-   */
-  const fetchBlockchainBalances = async (
-    payload: BlockchainBalancePayload = {},
-  ): Promise<void> => {
-    const { addresses, blockchain, isXpub = false } = payload;
-    const chains = blockchain ? arrayify(blockchain) : get(supportedChains).map(chain => chain.id);
-    const threshold = get(valueThreshold);
-    await Promise.allSettled(
-      chains.map(async (chain) => {
-        const chainPayload = { addresses, blockchain: chain, isXpub };
-        if (!shouldQuery(chain)) {
-          clearChainBalances(chain);
-          return;
-        }
-        await submitTask({
-          ephemeral: true,
-          id: makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain, ActivityPart.CACHED),
-          kind: ActivityKind.BLOCKCHAIN_BALANCES,
-          lane: BALANCES_CACHED_LANE,
-          rerunnable: true,
-          run: async ({ runTask }): Promise<Result<void, TaskError>> => handleCachedFetch(runTask, chainPayload, threshold),
-          subtitle: activityLabelFor(msg.$t('task_center.activity.blockchain_balances.cached'), { chain: getChainName(chain) }),
-          title: t('task_center.group.blockchain_balances'),
-        });
-      }),
-    );
-  };
 
   // Network refresh — one native BLOCKCHAIN_BALANCES activity per chain on BALANCES_LANE (cap 2,
   // paused during decode by the orchestrator rule, replacing the old BalanceQueueService).
@@ -134,7 +91,6 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
   };
 
   return {
-    fetchBlockchainBalances,
     refreshBlockchainBalances,
   };
 }

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -8,7 +8,7 @@ import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { Skipped, type TaskError } from '@/modules/core/tasks/task-result';
 import { BalanceSource } from '@/modules/settings/types/frontend-settings';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
-import { BALANCES_LANE } from '@/modules/task-center/core/orchestrator/spec';
+import { BALANCES_CACHED_LANE, BALANCES_LANE } from '@/modules/task-center/core/orchestrator/spec';
 import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
@@ -38,9 +38,26 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
       || get(refreshState.refreshingChains).has(chain);
   };
 
-  // Cached DB read — fires immediately. Each chain with accounts runs as a native
-  // BLOCKCHAIN_BALANCES activity on the default (uncapped) lane so initial load is not throttled;
-  // empty chains are cleared inline without spawning an activity.
+  /**
+   * Refresh this app's data from the DB — one read per chain with accounts; empty chains are
+   * cleared inline without spawning anything.
+   *
+   * ⭐ Independent, and deliberately not part of any umbrella. This is a *data refresh*, not work:
+   * it repopulates the store from the user's own database so the view paints fast. The umbrella
+   * belongs to the job — detection and the network query — which is what a user watches, cancels or
+   * supersedes.
+   *
+   * ⭐ Deduplicated by chain, so two callers racing the same chain share one read.
+   *
+   * ⭐ `ephemeral`: the orchestrator still schedules, tracks and caps these, but they never reach
+   * the task centre — seventeen rows describing a read of local data is noise. Liveness is
+   * unaffected, because `useIsActive` reads `orchestrator.statusOf` rather than the filtered render
+   * model, so every spinner still sees them.
+   *
+   * ⚠️ The old comment claimed "the default (uncapped) lane so initial load is not throttled". That
+   * lane was never uncapped — `defaultCap` bounded it at 4 incidentally. The cap is now explicit on
+   * {@link BALANCES_CACHED_LANE}.
+   */
   const fetchBlockchainBalances = async (
     payload: BlockchainBalancePayload = {},
   ): Promise<void> => {
@@ -55,8 +72,10 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
           return;
         }
         await submitTask({
+          ephemeral: true,
           id: makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain, ActivityPart.CACHED),
           kind: ActivityKind.BLOCKCHAIN_BALANCES,
+          lane: BALANCES_CACHED_LANE,
           rerunnable: true,
           run: async ({ runTask }): Promise<Result<void, TaskError>> => handleCachedFetch(runTask, chainPayload, threshold),
           subtitle: activityLabelFor(msg.$t('task_center.activity.blockchain_balances.cached'), { chain: getChainName(chain) }),

--- a/frontend/app/src/modules/balances/use-blockchain-refresh-timestamps-store.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-refresh-timestamps-store.spec.ts
@@ -49,4 +49,40 @@ describe('useBlockchainRefreshTimestampsStore', () => {
     store.reset();
     expect(get(store.refreshTimestamps)).toEqual({});
   });
+
+  /**
+   * ⭐ A data refresh from the DB and a network query write the same chain and are allowed to
+   * overlap, so they can land out of order. Merging blindly let whichever landed *last* win, which
+   * rolls a chain back to stale balances. Keeping the newest is what makes the ordering irrelevant.
+   */
+  describe('monotonicity', () => {
+    it('should ignore a timestamp older than the one stored', () => {
+      store.updateTimestamps({ eth: 3000 });
+      store.updateTimestamps({ eth: 1000 });
+      expect(get(store.refreshTimestamps)).toEqual({ eth: 3000 });
+    });
+
+    it('should keep the newest per chain when a payload mixes older and newer', () => {
+      store.updateTimestamps({ btc: 5000, eth: 3000 });
+      store.updateTimestamps({ btc: 9000, eth: 1000 });
+      expect(get(store.refreshTimestamps)).toEqual({ btc: 9000, eth: 3000 });
+    });
+
+    it('should report a payload older than the stored one as stale', () => {
+      store.updateTimestamps({ eth: 3000 });
+      expect(store.isStale('eth', 1000)).toBe(true);
+      expect(store.isStale('eth', 3000)).toBe(false);
+      expect(store.isStale('eth', 4000)).toBe(false);
+    });
+
+    /**
+     * ⚠️ The backend omits `last_refresh_ts` for a chain it has never queried. Treating that as
+     * stale would mean a chain that has never been refreshed could never receive its first
+     * balances.
+     */
+    it('should not report anything stale when either side is unknown', () => {
+      expect(store.isStale('eth', undefined)).toBe(false);
+      expect(store.isStale('never-queried', 1000)).toBe(false);
+    });
+  });
 });

--- a/frontend/app/src/modules/balances/use-blockchain-refresh-timestamps-store.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-refresh-timestamps-store.ts
@@ -3,8 +3,46 @@ import type { ComputedRef } from 'vue';
 export const useBlockchainRefreshTimestampsStore = defineStore('balances/refresh-timestamps', () => {
   const refreshTimestamps = ref<Record<string, number>>({});
 
+  /**
+   * Monotonic per chain: a timestamp older than the one already stored is ignored.
+   *
+   * ⭐ Two independent things write a chain's balances — a data refresh from the DB and a network
+   * query — and they are deliberately allowed to overlap. Merging blindly meant whichever *landed*
+   * last won, so a slow local read finishing after a fresh network result would roll the chain back
+   * to stale data. Keeping the newest timestamp is what makes the ordering irrelevant, so nothing
+   * has to serialise the two.
+   */
   const updateTimestamps = (timestamps: Record<string, number>): void => {
-    set(refreshTimestamps, { ...get(refreshTimestamps), ...timestamps });
+    const current = get(refreshTimestamps);
+    const next = { ...current };
+    let changed = false;
+
+    for (const [chain, timestamp] of Object.entries(timestamps)) {
+      const stored = next[chain];
+      if (stored !== undefined && stored >= timestamp)
+        continue;
+
+      next[chain] = timestamp;
+      changed = true;
+    }
+
+    if (changed)
+      set(refreshTimestamps, next);
+  };
+
+  /**
+   * Whether an incoming payload for this chain is older than what has already been stored.
+   *
+   * ⚠️ Only ever `true` when both sides are known. A payload with no timestamp is accepted: the
+   * backend omits `last_refresh_ts` when it has never queried the chain, and refusing those would
+   * mean a chain that has never been refreshed can never receive its first balances.
+   */
+  const isStale = (chain: string, timestamp: number | undefined): boolean => {
+    if (timestamp === undefined)
+      return false;
+
+    const stored = get(refreshTimestamps)[chain];
+    return stored !== undefined && timestamp < stored;
   };
 
   const getTimestamp = (chain: string): ComputedRef<number | undefined> =>
@@ -14,7 +52,7 @@ export const useBlockchainRefreshTimestampsStore = defineStore('balances/refresh
     set(refreshTimestamps, {});
   };
 
-  return { getTimestamp, refreshTimestamps, reset, updateTimestamps };
+  return { getTimestamp, isStale, refreshTimestamps, reset, updateTimestamps };
 });
 
 if (import.meta.hot)

--- a/frontend/app/src/modules/session/use-session-state-cleaner.spec.ts
+++ b/frontend/app/src/modules/session/use-session-state-cleaner.spec.ts
@@ -11,6 +11,7 @@ const reset = vi.fn();
 const resetState = vi.fn();
 const cancelByTag = vi.fn();
 const resetNativeTasks = vi.fn();
+const resetHydration = vi.fn();
 
 vi.mock('@/modules/auth/use-session-auth-store', () => ({
   useSessionAuthStore: (): object => ({ logged }),
@@ -31,6 +32,11 @@ vi.mock('@/modules/task-center/use-task-orchestrator', () => ({
 // Mocked rather than left real: it reaches `useTaskHandler`, which needs an active pinia.
 vi.mock('@/modules/task-center/use-native-task', () => ({
   useNativeTask: (): object => ({ reset: resetNativeTasks }),
+}));
+
+// Same reason: hydration reaches the balance stores.
+vi.mock('@/modules/balances/use-balance-hydration', () => ({
+  useBalanceHydration: (): object => ({ reset: resetHydration }),
 }));
 
 vi.mock('@/modules/shell/app/store-plugins', () => ({
@@ -73,6 +79,9 @@ describe('useSessionStateCleaner', () => {
     // An id left in the submission map outlives the session, and submitTask dedups by id, so the
     // next session would join a promise that can never resolve.
     expect(resetNativeTasks).toHaveBeenCalledOnce();
+    // Hydration dedups by chain against an app-scoped map, so a read that can never settle would
+    // be handed to the next session's caller for that chain — which then never hydrates.
+    expect(resetHydration).toHaveBeenCalledOnce();
     expect(resetState).toHaveBeenCalledOnce();
     // The login-time suggestion probes are not awaited by the login, so they can outlive it.
     expect(cancelByTag).toHaveBeenCalledWith(SUGGESTION_PROBE_TAG);
@@ -85,6 +94,7 @@ describe('useSessionStateCleaner', () => {
     expect(clearUploadStatus).not.toHaveBeenCalled();
     expect(reset).not.toHaveBeenCalled();
     expect(resetNativeTasks).not.toHaveBeenCalled();
+    expect(resetHydration).not.toHaveBeenCalled();
     expect(resetState).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/modules/session/use-session-state-cleaner.ts
+++ b/frontend/app/src/modules/session/use-session-state-cleaner.ts
@@ -1,5 +1,6 @@
 import { useAccountLoadState } from '@/modules/accounts/use-account-load-state';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { useBalanceHydration } from '@/modules/balances/use-balance-hydration';
 import { api } from '@/modules/core/api/rotki-api';
 import { useSync } from '@/modules/session/use-session-sync';
 import { SUGGESTION_PROBE_TAG } from '@/modules/settings/suggestions/use-suggestion-probes';
@@ -15,6 +16,7 @@ export function useSessionStateCleaner(): void {
   const orchestrator = useTaskOrchestrator();
   const { reset: resetNativeTasks } = useNativeTask();
   const { reset: resetAccountLoad } = useAccountLoadState();
+  const { reset: resetHydration } = useBalanceHydration();
 
   function cleanup(): void {
     clearUploadStatus();
@@ -32,6 +34,10 @@ export function useSessionStateCleaner(): void {
     resetNativeTasks();
     // Same reason, same scope: a read tracked here outlives the session that started it.
     resetAccountLoad();
+    // Hydration dedups by chain against an app-scoped map, so a read that can never settle (its
+    // backend task belonged to the session that just ended) would be handed to the next session's
+    // caller for that chain — which then never hydrates, silently.
+    resetHydration();
     resetState();
   }
 

--- a/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useEthStakingRefresh } from '@/modules/staking/eth/use-eth-staking-refresh';
 
 const mockFetchEthStakingValidators = vi.fn();
-const mockFetchBlockchainBalances = vi.fn();
+const mockHydrate = vi.fn();
 const mockRefreshBlockchainBalances = vi.fn();
 // `everCompleted === false` means "first load"; drives the isFirstLoad gate in the SUT.
 const mockFirstLoad = ref<boolean>(false);
@@ -28,8 +28,13 @@ vi.mock('@/modules/auth/use-session-auth-store', () => ({
 
 vi.mock('@/modules/balances/use-blockchain-balances', () => ({
   useBlockchainBalances: vi.fn(() => ({
-    fetchBlockchainBalances: mockFetchBlockchainBalances,
     refreshBlockchainBalances: mockRefreshBlockchainBalances,
+  })),
+}));
+
+vi.mock('@/modules/balances/use-balance-hydration', () => ({
+  useBalanceHydration: vi.fn(() => ({
+    hydrate: mockHydrate,
   })),
 }));
 
@@ -95,6 +100,7 @@ function createCallbacks(overrides: {
 
 describe('useEthStakingRefresh', () => {
   beforeEach(() => {
+    setActivePinia(createPinia());
     vi.clearAllMocks();
     set(mockFirstLoad, false);
     set(mockUsername, 'test-user');
@@ -103,7 +109,7 @@ describe('useEthStakingRefresh', () => {
     set(mockEth2Loading, false);
     set(mockBlockProductionLoading, false);
     mockFetchEthStakingValidators.mockResolvedValue(undefined);
-    mockFetchBlockchainBalances.mockResolvedValue(undefined);
+    mockHydrate.mockResolvedValue(undefined);
     mockRefreshBlockchainBalances.mockResolvedValue(undefined);
   });
 
@@ -113,7 +119,7 @@ describe('useEthStakingRefresh', () => {
       await refresh(true);
 
       expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' });
-      expect(mockFetchBlockchainBalances).not.toHaveBeenCalled();
+      expect(mockHydrate).not.toHaveBeenCalled();
       expect(mockFetchEthStakingValidators).toHaveBeenCalledWith({ ignoreCache: true });
     });
 
@@ -124,7 +130,7 @@ describe('useEthStakingRefresh', () => {
       await refresh(false);
 
       expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' });
-      expect(mockFetchBlockchainBalances).not.toHaveBeenCalled();
+      expect(mockHydrate).not.toHaveBeenCalled();
       expect(mockFetchEthStakingValidators).toHaveBeenCalledWith({ ignoreCache: true });
     });
 
@@ -132,7 +138,7 @@ describe('useEthStakingRefresh', () => {
       const { refresh } = useEthStakingRefresh(createCallbacks());
       await refresh(false);
 
-      expect(mockFetchBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' });
+      expect(mockHydrate).toHaveBeenCalledWith({ blockchain: 'eth2' });
       expect(mockRefreshBlockchainBalances).not.toHaveBeenCalled();
       expect(mockFetchEthStakingValidators).toHaveBeenCalledWith({ ignoreCache: false });
     });
@@ -141,7 +147,7 @@ describe('useEthStakingRefresh', () => {
       const { refresh } = useEthStakingRefresh(createCallbacks());
       await refresh();
 
-      expect(mockFetchBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' });
+      expect(mockHydrate).toHaveBeenCalledWith({ blockchain: 'eth2' });
       expect(mockRefreshBlockchainBalances).not.toHaveBeenCalled();
     });
 

--- a/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.ts
@@ -3,6 +3,8 @@ import { Blockchain } from '@rotki/common';
 import dayjs from 'dayjs';
 import { useEthStaking } from '@/modules/accounts/use-eth-staking';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { useBalanceHydration } from '@/modules/balances/use-balance-hydration';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { logger } from '@/modules/core/common/logging/logging';
 import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
@@ -28,7 +30,8 @@ export function useEthStakingRefresh(callbacks: RefreshCallbacks): UseEthStaking
   const { username } = storeToRefs(useSessionAuthStore());
   const { stakingValidatorsLimits } = storeToRefs(useBlockchainValidatorsStore());
   const { fetchEthStakingValidators } = useEthStaking();
-  const { fetchBlockchainBalances, refreshBlockchainBalances } = useBlockchainBalances();
+  const { hydrate } = useBalanceHydration();
+  const { refreshBlockchainBalances } = useBlockchainBalances();
   const { useIsActive, useWorkStatus, useIsActivePrefix } = useTaskCenter();
 
   const performanceStatus = useWorkStatus(ActivityKind.STAKING, ActivityPart.PERFORMANCE);
@@ -46,7 +49,12 @@ export function useEthStakingRefresh(callbacks: RefreshCallbacks): UseEthStaking
 
   // Loading states
   const performanceRefreshing = computed<boolean>(() => get(performanceStatus).active);
-  const eth2Loading = useIsActivePrefix(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH2);
+  // Both layers: eth2's balances are read from the DB as well as queried, and hydration is not an
+  // activity the orchestrator can report on.
+  const eth2Loading = logicOr(
+    useIsActivePrefix(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH2),
+    useBalanceRefreshState().useIsHydrating(Blockchain.ETH2),
+  );
   const blockProductionLoading = useIsActive(ActivityKind.ONLINE_EVENTS, OnlineHistoryEventsQueryType.BLOCK_PRODUCTIONS);
 
   const refreshing = logicOr(
@@ -64,7 +72,7 @@ export function useEthStakingRefresh(callbacks: RefreshCallbacks): UseEthStaking
         });
       }
       else {
-        await fetchBlockchainBalances({
+        await hydrate({
           blockchain: Blockchain.ETH2,
         });
       }

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-operations.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-operations.spec.ts
@@ -63,6 +63,7 @@ function validator(overrides: Partial<EthereumValidator> = {}): EthereumValidato
 
 describe('useEthValidatorOperations', () => {
   beforeEach(() => {
+    setActivePinia(createPinia());
     vi.clearAllMocks();
     set(mockLoading, false);
     set(mockAddRunning, false);

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-operations.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-operations.ts
@@ -4,6 +4,7 @@ import type { StakingValidatorManage } from '@/modules/accounts/blockchain/use-a
 import { Blockchain } from '@rotki/common';
 import { useAccountDelete } from '@/modules/accounts/blockchain/use-account-delete';
 import { useEthStaking } from '@/modules/accounts/use-eth-staking';
+import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { ActivityKind, ActivityPart } from '@/modules/task-center/core/types';
 import { useTaskCenter } from '@/modules/task-center/use-task-center';
@@ -22,7 +23,11 @@ export function useEthValidatorOperations(): UseEthValidatorOperationsReturn {
   const { fetchEthStakingValidators } = useEthStaking();
   const { refreshBlockchainBalances } = useBlockchainBalances();
   const { useIsActivePrefix } = useTaskCenter();
-  const loading = useIsActivePrefix(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH2);
+  // Both layers — hydration is not an activity, so the orchestrator alone reports a DB read as idle.
+  const loading = logicOr(
+    useIsActivePrefix(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH2),
+    useBalanceRefreshState().useIsHydrating(Blockchain.ETH2),
+  );
 
   const accountOperation = logicOr(
     useIsActivePrefix(ActivityKind.ACCOUNTS, ActivityPart.ADD),

--- a/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
@@ -7,7 +7,7 @@ import type { TaskError } from '@/modules/core/tasks/task-result';
  * keyed by a lane that exists — a typo like `balnces` is a compile error rather than a silent
  * fallback to the default cap, which would otherwise surface only as unexplained concurrency.
  */
-export const STATIC_LANES = ['default', 'balances', 'exchange', 'session', 'umbrella', 'chain-sync', 'decode'] as const;
+export const STATIC_LANES = ['default', 'balances', 'balances-cached', 'exchange', 'session', 'umbrella', 'chain-sync', 'decode'] as const;
 
 export type StaticLane = (typeof STATIC_LANES)[number];
 
@@ -39,6 +39,24 @@ export const DEFAULT_LANE: StaticLane = 'default';
  * so initial load is not throttled.
  */
 export const BALANCES_LANE: StaticLane = 'balances';
+
+/**
+ * Cached (DB-backed) blockchain balance reads.
+ *
+ * Their own lane rather than a share of {@link DEFAULT_LANE}: each chain's cached read is submitted
+ * as that chain's accounts land, so the fan-out follows the account walk instead of one bounded
+ * sweep. On `default` it would be capped only incidentally (by `defaultCap`) while contending with
+ * every other default-lane activity.
+ *
+ * ⚠️ The cap belongs here and nowhere else. These reads are `ephemeral`, so they never reach the
+ * task centre, which makes a limiter wrapped around them especially easy to add and impossible to
+ * notice — the trap {@link DECODE_LANE} describes.
+ *
+ * 🔴 Not free: `GET /balances/blockchains/<chain>` serves from the DB for a returning user, but
+ * falls back to a full node query when the cache is empty (first login, after a purge, a newly
+ * added chain). This cap is what bounds that case.
+ */
+export const BALANCES_CACHED_LANE: StaticLane = 'balances-cached';
 
 /** Exchange balance + savings queries run here; capped at 2, a pool separate from {@link BALANCES_LANE}. */
 export const EXCHANGE_LANE: StaticLane = 'exchange';

--- a/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
@@ -35,28 +35,14 @@ export const DEFAULT_LANE: StaticLane = 'default';
 
 /**
  * Blockchain-balance refreshes + token detection run here; capped at 2 to mirror the old
- * `BalanceQueueService` `maxConcurrency`. Cached blockchain reads stay on {@link DEFAULT_LANE}
- * so initial load is not throttled.
+ * `BalanceQueueService` `maxConcurrency`.
+ *
+ * ⛔ Balance *hydration* — reading a chain back out of the user's own database — has no lane here
+ * and must not be given one. It is not work: no task-centre row, no cancel, no progress. Its bound
+ * is `allWithConcurrency` inside `useBalanceHydration`, which is what makes the {@link DECODE_LANE}
+ * trap structurally unavailable rather than merely avoided.
  */
 export const BALANCES_LANE: StaticLane = 'balances';
-
-/**
- * Cached (DB-backed) blockchain balance reads.
- *
- * Their own lane rather than a share of {@link DEFAULT_LANE}: each chain's cached read is submitted
- * as that chain's accounts land, so the fan-out follows the account walk instead of one bounded
- * sweep. On `default` it would be capped only incidentally (by `defaultCap`) while contending with
- * every other default-lane activity.
- *
- * ⚠️ The cap belongs here and nowhere else. These reads are `ephemeral`, so they never reach the
- * task centre, which makes a limiter wrapped around them especially easy to add and impossible to
- * notice — the trap {@link DECODE_LANE} describes.
- *
- * 🔴 Not free: `GET /balances/blockchains/<chain>` serves from the DB for a returning user, but
- * falls back to a full node query when the cache is empty (first login, after a purge, a newly
- * added chain). This cap is what bounds that case.
- */
-export const BALANCES_CACHED_LANE: StaticLane = 'balances-cached';
 
 /** Exchange balance + savings queries run here; capped at 2, a pool separate from {@link BALANCES_LANE}. */
 export const EXCHANGE_LANE: StaticLane = 'exchange';

--- a/frontend/app/src/modules/task-center/use-task-orchestrator.ts
+++ b/frontend/app/src/modules/task-center/use-task-orchestrator.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { TaskOrchestrator } from './core/orchestrator/api';
 import { createTaskOrchestrator } from './core/orchestrator/orchestrator';
-import { ACCOUNT_SYNC_LANE_PREFIX, ACCOUNTS_ADD_LANE_PREFIX, ACCOUNTS_REMOVE_LANE_PREFIX, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
+import { ACCOUNT_SYNC_LANE_PREFIX, ACCOUNTS_ADD_LANE_PREFIX, ACCOUNTS_REMOVE_LANE_PREFIX, BALANCES_CACHED_LANE, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
 import { type Activity, type ActivityKind, makeActivityId, type WorkStatus } from './core/types';
 
 /**
@@ -57,6 +57,7 @@ export interface UseTaskOrchestratorReturn extends TaskOrchestrator {
 export const useTaskOrchestrator = createSharedComposable((): UseTaskOrchestratorReturn => {
   const orchestrator = createTaskOrchestrator({
     caps: {
+      [BALANCES_CACHED_LANE]: 2,
       [BALANCES_LANE]: 2,
       [CHAIN_SYNC_LANE]: 2,
       [DECODE_LANE]: 2,

--- a/frontend/app/src/modules/task-center/use-task-orchestrator.ts
+++ b/frontend/app/src/modules/task-center/use-task-orchestrator.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { TaskOrchestrator } from './core/orchestrator/api';
 import { createTaskOrchestrator } from './core/orchestrator/orchestrator';
-import { ACCOUNT_SYNC_LANE_PREFIX, ACCOUNTS_ADD_LANE_PREFIX, ACCOUNTS_REMOVE_LANE_PREFIX, BALANCES_CACHED_LANE, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
+import { ACCOUNT_SYNC_LANE_PREFIX, ACCOUNTS_ADD_LANE_PREFIX, ACCOUNTS_REMOVE_LANE_PREFIX, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
 import { type Activity, type ActivityKind, makeActivityId, type WorkStatus } from './core/types';
 
 /**
@@ -57,7 +57,6 @@ export interface UseTaskOrchestratorReturn extends TaskOrchestrator {
 export const useTaskOrchestrator = createSharedComposable((): UseTaskOrchestratorReturn => {
   const orchestrator = createTaskOrchestrator({
     caps: {
-      [BALANCES_CACHED_LANE]: 2,
       [BALANCES_LANE]: 2,
       [CHAIN_SYNC_LANE]: 2,
       [DECODE_LANE]: 2,

--- a/frontend/app/src/modules/wallet/send/use-balance-queries.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-balance-queries.spec.ts
@@ -25,6 +25,9 @@ vi.mock('@/modules/core/common/use-ref-debounce', () => ({
 
 describe('useBalanceQueries', () => {
   beforeEach(() => {
+    // `useBalancesLoading` reads hydration liveness off a pinia store now that hydration is not
+    // an activity the orchestrator can report on.
+    setActivePinia(createPinia());
     set(addressesRef, {});
     set(workStatusRef, { active: false });
   });

--- a/frontend/app/tests/unit/utils/mocks/native-task.ts
+++ b/frontend/app/tests/unit/utils/mocks/native-task.ts
@@ -8,6 +8,9 @@ export interface SubmittedSpec {
   id: string;
   kind: string;
   run: (ctx: ActivityContext) => Promise<unknown>;
+  /** Declared so a spec can assert scheduling intent (an umbrella's lane, a child's parent). */
+  lane?: string;
+  parent?: string;
 }
 
 /**


### PR DESCRIPTION
Second of the balance pipeline changes. Builds on #12823 and #12824, both merged.

Reading a chain's balances back out of the user's own database was submitted as a `BLOCKCHAIN_BALANCES` activity on a lane, flagged ephemeral so it stayed out of the task centre. That is a data refresh, not work: no row, no cancel, no progress, and nothing a user watches. This splits the two layers apart.

## What changed

**Hydration leaves the orchestrator.** It now lives in `useBalanceHydration` and is not an activity at all, which retires `BALANCES_CACHED_LANE`.

**One bound, not two.** Its concurrency bound is `allWithConcurrency` rather than a lane, so a single piece of work is never bounded by two mechanisms. Each factory is infallible on purpose: the combinator short-circuits on the first `err`, and a fallible factory would silently drop every chain that had not started yet.

**A data refresh's failure policy.** Failures retry with backoff and no notification. Only actionable errors are retried, so a read cancelled by logout settles where it is instead of retrying against a dead session.

**Dedup by chain** replaces `submitTask`'s id dedup, and the map is cleared when a session ends. A read that can never settle would otherwise be handed to the next session's caller for that chain.

**Liveness moves with it.** Hydration has no activity to be active, so every reader that previously covered the cached phase through the orchestrator now also reads the refresh-state store. Without that the whole phase renders as settled and empty rather than loading.

## Also here

- **Monotonic per-chain balance writes**, so a slow response can no longer overwrite a newer one.
- **Cached balances are read as each chain's accounts land**, rather than after the whole account walk finishes.
- **The account walk is bounded with `allWithConcurrency`**, replacing an unbounded fan-out.

## Tests

New `use-balance-hydration.spec.ts` covers dedup, the generation counter across a session reset, the retry predicate, and the concurrency bound. The liveness readers get coverage that they read the refresh-state store rather than a now-nonexistent activity id.

Full frontend suite green: 767 files, 7245 tests. Typecheck, ESLint, stylelint and the linked-key check all clean.