### PR TITLE
feat(balances): a refresh is a run of per-chain jobs

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -383,6 +383,7 @@
         }
       },
       "blockchain": {
+        "cancelled": "Cancelled before querying the network",
         "error": {
           "description": "Error at querying blockchain balances: {error}",
           "title": "Querying blockchain balances"

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -388,7 +388,8 @@
           "title": "Querying blockchain balances"
         },
         "skipped": {
-          "busy": "Already refreshing this chain"
+          "busy": "Already refreshing this chain",
+          "no_accounts": "No tracked accounts on this chain"
         }
       },
       "blockchain_account_removal": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -6047,7 +6047,8 @@
       },
       "blockchain_balances": {
         "cached": "Reading cached {chain} data",
-        "query": "Querying the {chain} network"
+        "chain": "Refreshing {chain}",
+        "run": "Refreshing {count} chains"
       },
       "csv_import": {
         "source": "Importing data from {source}"

--- a/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
@@ -273,7 +273,7 @@ export function useAccountManage(): UseAccountManageReturn {
       set(pending, true);
       if (edit) {
         await editAccount(state.data, chain);
-        startPromise(fetchAccounts(chain));
+        startPromise(fetchAccounts({ blockchain: chain }));
       }
       else {
         // Awaited, so an xpub that fails to add keeps its dialog open rather than closing as if it
@@ -320,7 +320,7 @@ export function useAccountManage(): UseAccountManageReturn {
           assert(payload.publicKey);
           assert(payload.ownershipPercentage);
           updateEthStakingOwnership(payload.publicKey, bigNumberify(payload.ownershipPercentage));
-          startPromise(fetchAccounts(Blockchain.ETH2));
+          startPromise(fetchAccounts({ blockchain: Blockchain.ETH2 }));
         }
         else {
           startPromise(refreshAccounts({ blockchain: Blockchain.ETH2 }));

--- a/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
@@ -299,7 +299,7 @@ describe('useAccountAdditionService', () => {
       );
       expect(h.fetchTags).toHaveBeenCalledOnce();
       expect(h.trackAddedAddresses).toHaveBeenCalledWith(['0xabc']);
-      expect(onFetchAccounts).toHaveBeenCalledWith('eth', true);
+      expect(onFetchAccounts).toHaveBeenCalledWith({ blockchain: 'eth', refreshEns: true });
       expect(onRefreshAccounts).not.toHaveBeenCalled();
       expect(h.detectTokens).toHaveBeenCalledWith('eth', ['0xabc']);
     });

--- a/frontend/app/src/modules/accounts/use-account-addition-service.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.ts
@@ -1,6 +1,6 @@
 import type { ResultAsync } from 'plainfp/result-async';
 import type { AccountPayload, XpubAccountPayload } from '@/modules/accounts/blockchain-accounts';
-import type { RefreshAccountsParams } from '@/modules/accounts/use-account-operations';
+import type { FetchAccountsParams, RefreshAccountsParams } from '@/modules/accounts/use-account-operations';
 import type { Module } from '@/modules/core/common/modules';
 import { type Account, Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
@@ -58,7 +58,7 @@ export interface AdditionSummary {
 
 type RefreshAccountsCallback = (params: RefreshAccountsParams) => Promise<void>;
 
-type FetchAccountsCallback = (blockchain?: string | string[], refreshEns?: boolean) => Promise<void>;
+type FetchAccountsCallback = (params?: FetchAccountsParams) => Promise<void>;
 
 type CompletionCallback = (params: AccountAdditionParams) => Promise<void>;
 
@@ -70,7 +70,7 @@ interface UseAccountAdditionServiceReturn {
   addAccounts: (chain: string, payload: AccountPayload[] | XpubAccountPayload, modules: Module[] | undefined, onComplete: CompletionCallback, options?: AdditionOptions) => Promise<AdditionSummary>;
   addSingleAccount: (account: AccountPayload | XpubAccountPayload, chain: string, options?: AdditionOptions) => ResultAsync<string, AccountAdditionFailure>;
   addSingleEvmAddress: (account: AccountPayload, options?: AdditionOptions) => ResultAsync<Account[], AccountAdditionFailure<AccountPayload>>;
-  completeAccountAddition: (params: AccountAdditionParams, onRefreshAccounts: RefreshAccountsCallback, onFetchAccounts?: FetchAccountsCallback) => Promise<void>;
+  completeAccountAddition: (params: AccountAdditionParams, onRefreshAccounts: RefreshAccountsCallback, onFetchAccounts: FetchAccountsCallback) => Promise<void>;
   getNewAccountPayload: (chain: string, payload: AccountPayload[]) => AccountPayload[];
 }
 
@@ -100,7 +100,7 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
   const completeAccountAddition = async (
     params: AccountAdditionParams,
     onRefreshAccounts: RefreshAccountsCallback,
-    onFetchAccounts?: FetchAccountsCallback,
+    onFetchAccounts: FetchAccountsCallback,
   ): Promise<void> => {
     const {
       addedAccounts,
@@ -114,14 +114,14 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
 
     trackAddedAddresses(addedAccounts.map(item => item.address));
 
-    const chainsSupportsTransactions = !chain || supportsTransactions(chain);
-    if (chainsSupportsTransactions && onFetchAccounts) {
-      // For EVM chains, only load account metadata without fetching balances.
-      // Token detection runs next and explicitly triggers a balance refresh.
-      await onFetchAccounts(chain, true);
+    // ⚠️ §6's known exception, and it is correct: a chain that will detect deliberately skips its
+    // own balance read, because detection ends in one. Only a chain that cannot hold tokens has to
+    // ask for balances itself.
+    if (chain !== undefined && !supportsTransactions(chain)) {
+      await onRefreshAccounts({ addresses: addedAccounts.map(item => item.address), blockchain: chain, isXpub });
     }
     else {
-      await onRefreshAccounts({ addresses: addedAccounts.map(item => item.address), blockchain: chain, isXpub });
+      await onFetchAccounts({ blockchain: chain, refreshEns: true });
     }
 
     // Enable modules for ETH accounts

--- a/frontend/app/src/modules/accounts/use-account-balances-refresh.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-balances-refresh.spec.ts
@@ -29,7 +29,7 @@ describe('useAccountBalancesRefresh', () => {
 
     await refreshClick();
 
-    expect(h.fetchAccounts).toHaveBeenCalledWith(['eth', 'optimism'], true);
+    expect(h.fetchAccounts).toHaveBeenCalledWith({ blockchain: ['eth', 'optimism'], refreshEns: true });
     expect(h.handleBlockchainRefresh).toHaveBeenCalledWith(['eth', 'optimism']);
     expect(h.refreshBlockchainBalances).not.toHaveBeenCalled();
     expect(fetchData).toHaveBeenCalledOnce();
@@ -56,7 +56,7 @@ describe('useAccountBalancesRefresh', () => {
     set(chainIds, ['btc']);
     await refreshClick();
 
-    expect(h.fetchAccounts).toHaveBeenCalledWith(['btc'], true);
+    expect(h.fetchAccounts).toHaveBeenCalledWith({ blockchain: ['btc'], refreshEns: true });
     expect(h.refreshBlockchainBalances).toHaveBeenCalledWith(['btc']);
   });
 });

--- a/frontend/app/src/modules/accounts/use-account-balances-refresh.ts
+++ b/frontend/app/src/modules/accounts/use-account-balances-refresh.ts
@@ -25,7 +25,7 @@ export function useAccountBalancesRefresh(
 
   async function refreshClick(): Promise<void> {
     const chains = toValue(chainIds);
-    await fetchAccounts(chains, true);
+    await fetchAccounts({ blockchain: chains, refreshEns: true });
     if (toValue(isEvm))
       await handleBlockchainRefresh(chains);
     else

--- a/frontend/app/src/modules/accounts/use-account-migration.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-migration.spec.ts
@@ -65,7 +65,7 @@ describe('useAccountMigration', () => {
     const { useAccountMigration } = await importModule();
     useAccountMigration().setUpgradedAddresses(migrated);
 
-    expect(h.fetchAccounts).toHaveBeenCalledWith('eth');
+    expect(h.fetchAccounts).toHaveBeenCalledWith({ blockchain: 'eth' });
     expect(h.detectTokens).toHaveBeenCalledWith('eth', ['0xabc']);
     expect(h.notify).toHaveBeenCalledOnce();
     await flushPromises();
@@ -80,7 +80,7 @@ describe('useAccountMigration', () => {
 
     set(canRequestData, true);
     await nextTick();
-    expect(h.fetchAccounts).toHaveBeenCalledWith('eth');
+    expect(h.fetchAccounts).toHaveBeenCalledWith({ blockchain: 'eth' });
   });
 
   it('should ignore addresses on chains without token detection', async () => {
@@ -97,7 +97,7 @@ describe('useAccountMigration', () => {
     set(canRequestData, true);
     const { useAccountMigration } = await importModule();
     useAccountMigration().setUpgradedAddresses([{ address: '0xdef', chain: 'zksync_lite' }]);
-    expect(h.fetchAccounts).toHaveBeenCalledWith('zksync_lite');
+    expect(h.fetchAccounts).toHaveBeenCalledWith({ blockchain: 'zksync_lite' });
     expect(h.detectTokens).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/src/modules/accounts/use-account-migration.ts
+++ b/frontend/app/src/modules/accounts/use-account-migration.ts
@@ -54,7 +54,7 @@ export function useAccountMigration(): UseAccountMigrationReturn {
     for (const chain in addresses) {
       const chainAddresses = addresses[chain];
       const chainName = getChainName(chain);
-      promises.push(fetchAccounts(chain));
+      promises.push(fetchAccounts({ blockchain: chain }));
       if (isEvm(chain))
         promises.push(detectTokens(chain, chainAddresses));
 

--- a/frontend/app/src/modules/accounts/use-account-operations.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.spec.ts
@@ -96,7 +96,7 @@ describe('useAccountOperations', () => {
     it('should fetch the given chain and resolve ens names for evm chains', async () => {
       h.getAddresses.mockReturnValue(['0xabc']);
       const { useAccountOperations } = await importModule();
-      await useAccountOperations().fetchAccounts('eth', true);
+      await useAccountOperations().fetchAccounts({ blockchain: 'eth', refreshEns: true });
       expect(h.fetch).toHaveBeenCalledWith('eth');
       await flushPromises();
       expect(h.fetchEnsNames).toHaveBeenCalledWith([{ address: '0xabc', blockchain: 'eth' }], true);
@@ -105,7 +105,7 @@ describe('useAccountOperations', () => {
     it('should not resolve ens names for non-evm chains', async () => {
       h.getAddresses.mockReturnValue(['bc1abc']);
       const { useAccountOperations } = await importModule();
-      await useAccountOperations().fetchAccounts('btc');
+      await useAccountOperations().fetchAccounts({ blockchain: 'btc' });
       expect(h.fetch).toHaveBeenCalledWith('btc');
       expect(h.fetchEnsNames).not.toHaveBeenCalled();
     });
@@ -196,7 +196,7 @@ describe('useAccountOperations', () => {
 
     it('should not sweep every chain again after the walk', async () => {
       const { useAccountOperations } = await importModule();
-      await useAccountOperations().refreshAccounts();
+      await useAccountOperations().fetchAccounts({ refreshEns: true });
       await flushPromises();
 
       // One read per chain, from the walk — not a second undirected sweep.

--- a/frontend/app/src/modules/accounts/use-account-operations.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.spec.ts
@@ -226,14 +226,14 @@ describe('useAccountOperations', () => {
     it('should refresh balances for the eth2 chain', async () => {
       const { useAccountOperations } = await importModule();
       await useAccountOperations().refreshAccounts({ blockchain: 'eth2' });
-      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith({ addresses: undefined, blockchain: 'eth2', isXpub: false }, false);
+      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith({ addresses: undefined, blockchain: 'eth2', isXpub: false }, 'background');
     });
 
     it('should pass unique addresses for a chain without transaction support', async () => {
       h.supportsTransactions.mockReturnValue(false);
       const { useAccountOperations } = await importModule();
       await useAccountOperations().refreshAccounts({ addresses: ['0xa', '0xa', '0xb'], blockchain: 'gnosis', isXpub: true });
-      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith({ addresses: ['0xa', '0xb'], blockchain: 'gnosis', isXpub: true }, false);
+      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith({ addresses: ['0xa', '0xb'], blockchain: 'gnosis', isXpub: true }, 'background');
     });
 
     it('should schedule an eth2 refresh when eth has validators', async () => {
@@ -241,7 +241,7 @@ describe('useAccountOperations', () => {
       const { useAccountOperations } = await importModule();
       await useAccountOperations().refreshAccounts({ blockchain: 'eth' });
       await flushPromises();
-      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith({ addresses: undefined, blockchain: 'eth2', isXpub: false }, false);
+      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith({ addresses: undefined, blockchain: 'eth2', isXpub: false }, 'background');
     });
   });
 

--- a/frontend/app/src/modules/accounts/use-account-operations.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.ts
@@ -165,7 +165,7 @@ export function useAccountOperations(): UseAccountOperationsReturn {
     // drives its own chain: nothing else will.
     const pending: Promise<any>[] = [];
     if (shouldRefresh)
-      pending.push(refreshBlockchainBalances({ addresses: uniqueAddresses, blockchain: chain, isXpub }, periodic));
+      pending.push(refreshBlockchainBalances({ addresses: uniqueAddresses, blockchain: chain, isXpub }, periodic ? 'periodic' : 'background'));
     else if (chain !== undefined)
       pending.push(hydrate({ addresses: uniqueAddresses, blockchain: chain, isXpub }));
 

--- a/frontend/app/src/modules/accounts/use-account-operations.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.ts
@@ -22,8 +22,16 @@ import { ActivityKind, ActivityPart, makeActivityId, useNativeTask } from '@/mod
 /** Chains read at a time during the account walk. */
 const ACCOUNT_READ_CONCURRENCY = 2;
 
+export interface FetchAccountsParams {
+  /** Omit for the full walk over every supported chain. */
+  blockchain?: string | string[];
+  /** Re-resolve ENS names for the chains that were read. */
+  refreshEns?: boolean;
+}
+
 export interface RefreshAccountsParams {
-  blockchain?: MaybeRef<string>;
+  /** Required: without a chain this is an accounts read, and that is {@link fetchAccounts}. */
+  blockchain: MaybeRef<string>;
   addresses?: string[];
   isXpub?: boolean;
   periodic?: boolean;
@@ -31,8 +39,8 @@ export interface RefreshAccountsParams {
 
 interface UseAccountOperationsReturn {
   detectEvmAccounts: () => Promise<void>;
-  fetchAccounts: (blockchain?: string | string[], refreshEns?: boolean) => Promise<void>;
-  refreshAccounts: (params?: RefreshAccountsParams) => Promise<void>;
+  fetchAccounts: (params?: FetchAccountsParams) => Promise<void>;
+  refreshAccounts: (params: RefreshAccountsParams) => Promise<void>;
 }
 
 export function useAccountOperations(): UseAccountOperationsReturn {
@@ -83,7 +91,8 @@ export function useAccountOperations(): UseAccountOperationsReturn {
     await allWithConcurrency(factories, ACCOUNT_READ_CONCURRENCY);
   };
 
-  const fetchAccounts = async (blockchain?: string | string[], refreshEns: boolean = false): Promise<void> => {
+  const fetchAccounts = async (params: FetchAccountsParams = {}): Promise<void> => {
+    const { blockchain, refreshEns = false } = params;
     let chains: string[];
     if (blockchain)
       chains = Array.isArray(blockchain) ? blockchain : [blockchain];
@@ -150,11 +159,20 @@ export function useAccountOperations(): UseAccountOperationsReturn {
     return addresses.filter(uniqueStrings);
   };
 
-  const refreshAccounts = async (params: RefreshAccountsParams = {}): Promise<void> => {
+  /**
+   * Read one chain's accounts, then bring its balances up to date.
+   *
+   * ⚠️ **A chain is required.** Called without one this used to be an accounts read and nothing
+   * else — both halves of the decision below need a chain — so the same name meant two different
+   * things depending on the argument, and the session load and the periodic tick both silently got
+   * the accounts-only meaning. Callers that want the walk call {@link fetchAccounts} directly; the
+   * flows that want balances say which kind they want.
+   */
+  const refreshAccounts = async (params: RefreshAccountsParams): Promise<void> => {
     const { addresses, blockchain, isXpub = false, periodic = false } = params;
     const chain = get(blockchain);
     const uniqueAddresses = targetAddresses(addresses, chain);
-    await fetchAccounts(chain, true);
+    await fetchAccounts({ blockchain: chain, refreshEns: true });
 
     const isEth = chain === Blockchain.ETH;
     const isEth2 = chain === Blockchain.ETH2;

--- a/frontend/app/src/modules/accounts/use-blockchain-account-management.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-account-management.ts
@@ -2,7 +2,7 @@ import type { AccountPayload, AddAccountsPayload, XpubAccountPayload } from '@/m
 import { startPromise } from '@shared/utils';
 import { isEveryEvmChain } from '@/modules/accounts/use-account-addition-batch';
 import { type AccountAdditionParams, type AdditionSummary, useAccountAdditionService } from '@/modules/accounts/use-account-addition-service';
-import { type RefreshAccountsParams, useAccountOperations } from '@/modules/accounts/use-account-operations';
+import { type FetchAccountsParams, type RefreshAccountsParams, useAccountOperations } from '@/modules/accounts/use-account-operations';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -21,8 +21,8 @@ const NOTHING_ADDED: AdditionSummary = { added: [], cancelled: false, failed: []
 interface UseBlockchainAccountManagementReturn {
   addAccounts: (chain: string, data: AddAccountsPayload | XpubAccountPayload, options?: AddAccountsOption) => Promise<AdditionSummary>;
   detectEvmAccounts: () => Promise<void>;
-  fetchAccounts: (blockchain?: string | string[], refreshEns?: boolean) => Promise<void>;
-  refreshAccounts: (params?: RefreshAccountsParams) => Promise<void>;
+  fetchAccounts: (params?: FetchAccountsParams) => Promise<void>;
+  refreshAccounts: (params: RefreshAccountsParams) => Promise<void>;
 }
 
 export function useBlockchainAccountManagement(): UseBlockchainAccountManagementReturn {

--- a/frontend/app/src/modules/assets/prices/use-fetch-prices.ts
+++ b/frontend/app/src/modules/assets/prices/use-fetch-prices.ts
@@ -5,6 +5,7 @@ import { msg } from '@/message-key';
 import { AssetPriceResponse } from '@/modules/assets/prices/price-types';
 import { usePriceApi } from '@/modules/balances/api/use-price-api';
 import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
+import { setDigest } from '@/modules/core/common/data/digest';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { onActionableError, type TaskError } from '@/modules/core/tasks/task-result';
 import { useSetting } from '@/modules/settings/use-setting';
@@ -29,17 +30,7 @@ interface UseFetchPricesReturn {
  * handful of price requests that can be in flight at once, that is far below the noise floor,
  * and the failure is a stale price rather than a wrong one.
  */
-export function assetSetDigest(assets: readonly string[]): string {
-  let hash = 0x811C9DC5;
-  for (const asset of [...assets].sort()) {
-    for (let index = 0; index < asset.length; index++) {
-      hash = Math.imul(hash ^ asset.charCodeAt(index), 0x01000193);
-    }
-    // Fold the separator too, so ['ab','c'] and ['a','bc'] cannot land on the same digest.
-    hash = Math.imul(hash ^ 0x2C, 0x01000193);
-  }
-  return (hash >>> 0).toString(36);
-}
+export const assetSetDigest = setDigest;
 
 /**
  * Fetches latest asset prices as a single native PRICES activity (Phase 2 migration). The whole

--- a/frontend/app/src/modules/balances/blockchain/use-auto-token-detection.spec.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-auto-token-detection.spec.ts
@@ -2,16 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAutoTokenDetection } from '@/modules/balances/blockchain/use-auto-token-detection';
 import { useSettingsRepo } from '@/modules/settings/settings-repo';
 
-const detectAllTokens = vi.fn();
 const updateFrontendSetting = vi.fn();
-
-vi.mock('@/modules/balances/blockchain/use-token-detection-orchestrator', () => ({
-  useTokenDetectionOrchestrator: (): Record<string, ReturnType<typeof vi.fn>> => ({
-    detectAllTokens,
-    detectTokens: vi.fn(),
-    useIsDetecting: vi.fn(),
-  }),
-}));
 
 vi.mock('@/modules/settings/use-settings-operations', () => ({
   useSettingsOperations: (): Record<string, ReturnType<typeof vi.fn>> => ({
@@ -25,10 +16,18 @@ vi.mock('@/modules/settings/use-settings-operations', () => ({
 
 const HOUR_MS = 60 * 60 * 1000;
 
+/**
+ * The pass this composable wraps. It no longer runs detection itself — detection is a stage inside
+ * each chain job — so what is under test is the gate and the cooldown bookkeeping: which value
+ * `pass` is handed, and whether the sweep is recorded.
+ */
+function spyPass(): ReturnType<typeof vi.fn<(detect: boolean) => Promise<void>>> {
+  return vi.fn<(detect: boolean) => Promise<void>>(async () => {});
+}
+
 describe('useAutoTokenDetection', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
-    detectAllTokens.mockReset().mockResolvedValue(undefined);
     updateFrontendSetting.mockReset().mockResolvedValue({ success: true });
     useSettingsRepo().updateFrontend({
       autoDetectTokensCooldownHours: 24,
@@ -37,60 +36,71 @@ describe('useAutoTokenDetection', () => {
     });
   });
 
-  it('should run detection when auto-detect is on and cooldown has elapsed', async () => {
-    const { maybeDetect } = useAutoTokenDetection();
-    await maybeDetect();
+  it('should ask for detection when auto-detect is on and cooldown has elapsed', async () => {
+    const pass = spyPass();
+    await useAutoTokenDetection().withDetection(pass);
 
-    expect(detectAllTokens).toHaveBeenCalledTimes(1);
+    expect(pass).toHaveBeenCalledWith(true);
     expect(updateFrontendSetting).toHaveBeenCalledWith({ lastAutoDetectAt: expect.any(Number) });
   });
 
-  it('should skip detection when auto-detect is disabled', async () => {
+  /**
+   * 🔴 The pass still runs — the refresh must happen either way. Only its `detect` argument
+   * changes, which is the whole point of threading the flag through rather than skipping the call.
+   */
+  it('should still run the pass, without detection, when auto-detect is disabled', async () => {
     useSettingsRepo().updateFrontend({ autoDetectTokensOnLogin: false });
-    const { maybeDetect } = useAutoTokenDetection();
-    await maybeDetect();
+    const pass = spyPass();
+    await useAutoTokenDetection().withDetection(pass);
 
-    expect(detectAllTokens).not.toHaveBeenCalled();
+    expect(pass).toHaveBeenCalledWith(false);
     expect(updateFrontendSetting).not.toHaveBeenCalled();
   });
 
-  it('should skip detection when last run is within the cooldown window', async () => {
+  it('should not ask for detection within the cooldown window', async () => {
     useSettingsRepo().updateFrontend({
       autoDetectTokensCooldownHours: 24,
       lastAutoDetectAt: Date.now() - 1 * HOUR_MS,
     });
-    const { maybeDetect } = useAutoTokenDetection();
-    await maybeDetect();
+    const pass = spyPass();
+    await useAutoTokenDetection().withDetection(pass);
 
-    expect(detectAllTokens).not.toHaveBeenCalled();
+    expect(pass).toHaveBeenCalledWith(false);
     expect(updateFrontendSetting).not.toHaveBeenCalled();
   });
 
-  it('should run detection when the cooldown window has elapsed', async () => {
+  it('should ask for detection once the cooldown window has elapsed', async () => {
     useSettingsRepo().updateFrontend({
       autoDetectTokensCooldownHours: 24,
       lastAutoDetectAt: Date.now() - 25 * HOUR_MS,
     });
-    const { maybeDetect } = useAutoTokenDetection();
-    await maybeDetect();
+    const pass = spyPass();
+    await useAutoTokenDetection().withDetection(pass);
 
-    expect(detectAllTokens).toHaveBeenCalledTimes(1);
+    expect(pass).toHaveBeenCalledWith(true);
     expect(updateFrontendSetting).toHaveBeenCalledTimes(1);
   });
 
-  it('should run detection once when called concurrently', async () => {
-    let resolve!: () => void;
-    detectAllTokens.mockReturnValueOnce(new Promise<void>((r) => {
-      resolve = r;
-    }));
-    const { maybeDetect } = useAutoTokenDetection();
+  it('should ask for detection only once when called concurrently', async () => {
+    let release!: () => void;
+    // Only the detecting pass blocks, so the second call is free to observe the in-flight sweep.
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const pass = vi.fn<(detect: boolean) => Promise<void>>(async (detect) => {
+      if (detect)
+        await blocked;
+    });
+    const { withDetection } = useAutoTokenDetection();
 
-    const first = maybeDetect();
-    const second = maybeDetect();
-    resolve();
-    await Promise.all([first, second]);
+    const first = withDetection(pass);
+    await withDetection(pass);
+    release();
+    await first;
 
-    expect(detectAllTokens).toHaveBeenCalledTimes(1);
+    // Both passes run — the second is a refresh too — but only the first was told to detect.
+    expect(pass).toHaveBeenCalledTimes(2);
+    expect(pass.mock.calls.filter(([detect]) => detect)).toHaveLength(1);
     expect(updateFrontendSetting).toHaveBeenCalledTimes(1);
   });
 
@@ -110,23 +120,25 @@ describe('useAutoTokenDetection', () => {
     expect(skipReason()).toMatch(/^within cooldown \(\d+m remaining\)$/);
   });
 
-  it('should run detection when lastAutoDetectAt is in the future (clock skew)', async () => {
+  it('should ask for detection when lastAutoDetectAt is in the future (clock skew)', async () => {
     useSettingsRepo().updateFrontend({
       autoDetectTokensCooldownHours: 24,
       lastAutoDetectAt: Date.now() + 48 * HOUR_MS,
     });
-    const { maybeDetect } = useAutoTokenDetection();
-    await maybeDetect();
+    const pass = spyPass();
+    await useAutoTokenDetection().withDetection(pass);
 
-    expect(detectAllTokens).toHaveBeenCalledTimes(1);
+    expect(pass).toHaveBeenCalledWith(true);
   });
 
-  it('should still update lastAutoDetectAt when detection throws', async () => {
-    detectAllTokens.mockRejectedValueOnce(new Error('boom'));
-    const { maybeDetect } = useAutoTokenDetection();
-    await maybeDetect();
+  /** So a persistently broken chain cannot trigger a sweep on every single login. */
+  it('should still record the sweep when the pass throws', async () => {
+    const pass = vi.fn<(detect: boolean) => Promise<void>>(async () => {
+      throw new Error('boom');
+    });
 
-    expect(detectAllTokens).toHaveBeenCalledTimes(1);
+    await expect(useAutoTokenDetection().withDetection(pass)).rejects.toThrow('boom');
+
     expect(updateFrontendSetting).toHaveBeenCalledWith({ lastAutoDetectAt: expect.any(Number) });
   });
 });

--- a/frontend/app/src/modules/balances/blockchain/use-auto-token-detection.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-auto-token-detection.ts
@@ -3,7 +3,6 @@ import { useSetting } from '@/modules/settings/use-setting';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
 
 interface UseAutoTokenDetectionReturn {
-  willDetect: () => boolean;
   /**
    * Run `pass`, telling it whether this login is due a detection sweep, and own the cooldown
    * bookkeeping around it.
@@ -49,10 +48,6 @@ export function useAutoTokenDetection(): UseAutoTokenDetectionReturn {
     return null;
   }
 
-  function willDetect(): boolean {
-    return skipReason() === null;
-  }
-
   async function withDetection<T>(pass: (detect: boolean) => Promise<T>): Promise<T> {
     const skip = skipReason();
     if (skip !== null) {
@@ -76,5 +71,5 @@ export function useAutoTokenDetection(): UseAutoTokenDetectionReturn {
     }
   }
 
-  return { skipReason, willDetect, withDetection };
+  return { skipReason, withDetection };
 }

--- a/frontend/app/src/modules/balances/blockchain/use-auto-token-detection.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-auto-token-detection.ts
@@ -1,18 +1,24 @@
-import { useTokenDetectionOrchestrator } from '@/modules/balances/blockchain/use-token-detection-orchestrator';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSetting } from '@/modules/settings/use-setting';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
 
 interface UseAutoTokenDetectionReturn {
   willDetect: () => boolean;
-  maybeDetect: () => Promise<void>;
+  /**
+   * Run `pass`, telling it whether this login is due a detection sweep, and own the cooldown
+   * bookkeeping around it.
+   *
+   * ⭐ It no longer runs detection itself. Detection is a stage *inside* each chain job now, so
+   * what belongs here is only the question "is a sweep due?" and the record that one happened —
+   * `pass` decides what detecting actually means.
+   */
+  withDetection: <T>(pass: (detect: boolean) => Promise<T>) => Promise<T>;
   skipReason: () => string | null;
 }
 
 const HOUR_IN_MS = 60 * 60 * 1000;
 
 export function useAutoTokenDetection(): UseAutoTokenDetectionReturn {
-  const { detectAllTokens } = useTokenDetectionOrchestrator();
   const autoDetectTokensCooldownHours = useSetting('autoDetectTokensCooldownHours');
   const autoDetectTokensOnLogin = useSetting('autoDetectTokensOnLogin');
   const lastAutoDetectAt = useSetting('lastAutoDetectAt');
@@ -47,11 +53,11 @@ export function useAutoTokenDetection(): UseAutoTokenDetectionReturn {
     return skipReason() === null;
   }
 
-  async function maybeDetect(): Promise<void> {
+  async function withDetection<T>(pass: (detect: boolean) => Promise<T>): Promise<T> {
     const skip = skipReason();
     if (skip !== null) {
       logger.debug(`Auto token detection skipped: ${skip}`);
-      return;
+      return pass(false);
     }
 
     const now = Date.now();
@@ -59,10 +65,7 @@ export function useAutoTokenDetection(): UseAutoTokenDetectionReturn {
 
     set(inFlight, true);
     try {
-      await detectAllTokens();
-    }
-    catch (error: unknown) {
-      logger.error('Auto token detection failed on initial load', error);
+      return await pass(true);
     }
     finally {
       // Always persist the timestamp, even on failure, so a persistently broken
@@ -73,5 +76,5 @@ export function useAutoTokenDetection(): UseAutoTokenDetectionReturn {
     }
   }
 
-  return { maybeDetect, skipReason, willDetect };
+  return { skipReason, willDetect, withDetection };
 }

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.spec.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.spec.ts
@@ -87,6 +87,47 @@ describe('useTokenDetectionOrchestrator', () => {
     set(mockActivities, []);
   });
 
+  describe('detectForChain', () => {
+    /**
+     * 🔴🔴 Detection must not share `BALANCES_LANE` with the chain job that awaits it. That job
+     * holds a balances slot for its whole body, and the cap is 2 — so children queued on the same
+     * lane could never get one, and two chain jobs would sit waiting on addresses that cannot
+     * start. A hang, not a slowdown, and no unit test that stubs `submitTask` can see it: the lane
+     * is only honoured by the real scheduler. Assert the lane itself.
+     */
+    it('should queue detection on the per-chain lane, never the balances lane', async () => {
+      set(mockAddresses, { eth: ['0xaddr1', '0xaddr2'] });
+      const { useTokenDetectionOrchestrator } = await loadOrchestrator();
+
+      await useTokenDetectionOrchestrator().detectForChain('eth', makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, 'eth'));
+
+      expect(mockSubmitTask).toHaveBeenCalledTimes(2);
+      for (const [spec] of mockSubmitTask.mock.calls) {
+        expect(spec.lane).toBe('detect:eth');
+        expect(spec.parent).toBe(makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, 'eth'));
+      }
+    });
+
+    it('should do nothing for a chain with no addresses', async () => {
+      set(mockAddresses, { eth: [] });
+      const { useTokenDetectionOrchestrator } = await loadOrchestrator();
+
+      await useTokenDetectionOrchestrator().detectForChain('eth', makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, 'eth'));
+
+      expect(mockSubmitTask).not.toHaveBeenCalled();
+    });
+
+    /** The chain job's own query follows immediately and reads the same rows. */
+    it('should not hydrate, unlike the standalone detection flow', async () => {
+      set(mockAddresses, { eth: ['0xaddr1'] });
+      const { useTokenDetectionOrchestrator } = await loadOrchestrator();
+
+      await useTokenDetectionOrchestrator().detectForChain('eth', makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, 'eth'));
+
+      expect(mockHydrate).not.toHaveBeenCalled();
+    });
+  });
+
   describe('detectTokens', () => {
     it('should submit a native detection activity per address and reload cached balances', async () => {
       const { useTokenDetectionOrchestrator } = await loadOrchestrator();

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
@@ -11,15 +11,17 @@ import { useBalanceHydration } from '@/modules/balances/use-balance-hydration';
 import { arrayify } from '@/modules/core/common/data/array';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
-import { BALANCES_LANE } from '@/modules/task-center/core/orchestrator/spec';
+import { DETECT_LANE_PREFIX, familyLane } from '@/modules/task-center/core/orchestrator/spec';
 import { isTerminalStatus } from '@/modules/task-center/core/status';
-import { ActivityKind, activityParts, makeActivityId } from '@/modules/task-center/core/types';
+import { type ActivityId, ActivityKind, activityParts, makeActivityId } from '@/modules/task-center/core/types';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
 
 interface UseTokenDetectionOrchestratorReturn {
   detectTokens: (chain: string | string[], addresses: string[]) => Promise<void>;
   detectAllTokens: (chains?: string | string[]) => Promise<void>;
+  /** Detection as a stage *inside* a chain job — see {@link useBlockchainBalances}. */
+  detectForChain: (chain: string, parent: ActivityId) => Promise<void>;
   /** Synchronous liveness probe — true while a matching detection activity is pending or running. */
   isDetecting: (chain: string, address?: string | null) => boolean;
   useIsDetecting: (chain: MaybeRefOrGetter<string | string[]>, address?: MaybeRefOrGetter<string | null>) => ComputedRef<boolean>;
@@ -47,17 +49,51 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
     });
   }
 
-  const queueDetectionForChain = async (chain: string, addrs: string[]): Promise<void> => {
+  /**
+   * One detection activity per address, resolving when they have all settled.
+   *
+   * ⭐ Per-address rather than one activity for the chain, and that is deliberate: `ActivitySteps`
+   * is `{ current, total }` and nothing else, so progress can say "3/9" but never *which* address;
+   * and `cancel` targets an activity id, so per-account cancel needs per-account activities.
+   * Folding them into the chain would delete both capabilities, not defer them.
+   *
+   * 🔴 On the per-chain `detect:` family, never {@link BALANCES_LANE}. The chain job that awaits
+   * this holds a balances slot for its whole body, so sharing that lane would deadlock it against
+   * its own children.
+   */
+  const queueDetectionForChain = async (chain: string, addrs: string[], parent?: ActivityId): Promise<void> => {
     assert(supportsTransactions(chain));
     await Promise.all(addrs.map(async addr => submitTask({
       id: makeActivityId(ActivityKind.TOKEN_DETECTION, chain, addr),
       kind: ActivityKind.TOKEN_DETECTION,
-      lane: BALANCES_LANE,
+      lane: familyLane(DETECT_LANE_PREFIX, chain),
+      parent,
       rerunnable: true,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => detectTokensForAddress(runTask, chain, addr),
       subtitle: activityLabelFor(msg.$t('task_center.activity.token_detection.detect'), { address: addr, chain: getChainName(chain) }),
       title: t('task_center.group.token_detection'),
     })));
+  };
+
+  /**
+   * Detection for one chain, as children of the chain job that awaits it.
+   *
+   * ⚠️ No hydration afterwards, unlike {@link detectTokens}: the chain job's own network query is
+   * the next statement, and it reads the tokens this just found. Hydrating in between would be a
+   * second read of the same rows.
+   *
+   * A chain with no addresses, or one that cannot hold tokens, is not an error — it simply has no
+   * detection stage, and the chain job carries straight on to its query.
+   */
+  const detectForChain = async (chain: string, parent: ActivityId): Promise<void> => {
+    if (!supportsTransactions(chain))
+      return;
+
+    const chainAddresses = get(addresses)[chain] ?? [];
+    if (chainAddresses.length === 0)
+      return;
+
+    await queueDetectionForChain(chain, chainAddresses, parent);
   };
 
   // Detection ends in a balance read, so the chains it touched are hydrated once it settles —
@@ -127,6 +163,7 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
 
   return {
     detectAllTokens,
+    detectForChain,
     detectTokens,
     isDetecting: (chain: string, address: string | null = null): boolean => isDetectingTokens(chain, address),
     useIsDetecting,

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
@@ -98,17 +98,13 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
 
   // Detection ends in a balance read, so the chains it touched are hydrated once it settles —
   // §4's only coupling between the layers: work finishing triggers hydration for its subject.
-  const reloadBalancesForChains = async (chains: string[]): Promise<void> => {
-    await hydrate({ blockchain: chains });
-  };
-
   const detectTokens = async (
     chain: string | string[],
     addrs: string[],
   ): Promise<void> => {
     const chains = arrayify(chain);
     await Promise.all(chains.map(async c => queueDetectionForChain(c, addrs)));
-    await reloadBalancesForChains(chains);
+    await hydrate({ blockchain: chains });
   };
 
   const detectAllTokens = async (
@@ -129,7 +125,7 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
           await queueDetectionForChain(c, tokenAddresses);
       }));
 
-      await reloadBalancesForChains(chains);
+      await hydrate({ blockchain: chains });
     }
     finally {
       setMassDetecting(undefined);

--- a/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
+++ b/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
@@ -1,6 +1,6 @@
 import type { RunBackendTask } from '@/modules/task-center/use-native-task';
 import { Blockchain } from '@rotki/common';
-import { isErr, map as mapResult, ok, type Result } from 'plainfp/result';
+import { err, isErr, map as mapResult, type Result } from 'plainfp/result';
 import { convertBtcBalances } from '@/modules/accounts/account-helpers';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useBlockchainBalancesApi } from '@/modules/balances/api/use-blockchain-balances-api';
@@ -14,7 +14,7 @@ import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { useBlockchainRefreshTimestampsStore } from '@/modules/balances/use-blockchain-refresh-timestamps-store';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
-import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
+import { isActionable, Skipped, type TaskError } from '@/modules/core/tasks/task-result';
 import { useBlockchainValidatorsStore } from '@/modules/staking/use-blockchain-validators-store';
 import { ActivityKind } from '@/modules/task-center/core/types';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
@@ -130,9 +130,14 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
     apiCall: () => Promise<{ taskId: number }>,
     notify: boolean = true,
   ): Promise<Result<void, TaskError>> => {
+    // 🔴🔴 SKIPPED with a reason, never `ok`. A chain with nothing to query is a real outcome the
+    // user can be told about ("no accounts on this chain"), and reporting it as success recorded a
+    // completion for work that never ran. §5 is the other half of the argument: the chain stays in
+    // its run's denominator instead of vanishing from it, so "11 of 17" counts every chain in scope
+    // rather than only the ones that happened to have accounts.
     if (!shouldQuery(blockchain)) {
       clearChainBalances(blockchain);
-      return ok(undefined);
+      return err(Skipped({ message: t('actions.balances.blockchain.skipped.no_accounts') }));
     }
 
     const result = await runTask<BlockchainBalances>(apiCall);

--- a/frontend/app/src/modules/balances/use-balance-fetching.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-fetching.spec.ts
@@ -3,13 +3,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useBalanceFetching } from './use-balance-fetching';
 import '@test/i18n';
 
-const { refreshBlockchainBalances, maybeDetect, skipReason, willDetect, queryBalancesAsync } = vi.hoisted(() => ({
-  maybeDetect: vi.fn().mockResolvedValue(undefined),
-  queryBalancesAsync: vi.fn().mockResolvedValue({ taskId: 1 }),
-  refreshBlockchainBalances: vi.fn().mockResolvedValue(undefined),
-  skipReason: vi.fn().mockReturnValue('auto-detect-tokens disabled'),
-  willDetect: vi.fn().mockReturnValue(false),
-}));
+const { refreshBlockchainBalances, detectDue, fetchAccounts, withDetection, skipReason, willDetect, queryBalancesAsync } = vi.hoisted(() => {
+  // Whether a detection sweep is due this run. The real composable decides it from the cooldown
+  // settings; here a test sets it directly and `withDetection` hands it to the pass.
+  const detectDue = { value: false };
+  return {
+    detectDue,
+    fetchAccounts: vi.fn().mockResolvedValue(undefined),
+    queryBalancesAsync: vi.fn().mockResolvedValue({ taskId: 1 }),
+    refreshBlockchainBalances: vi.fn().mockResolvedValue(undefined),
+    skipReason: vi.fn().mockReturnValue('auto-detect-tokens disabled'),
+    willDetect: vi.fn(() => detectDue.value),
+    withDetection: vi.fn(async (pass: (detect: boolean) => Promise<unknown>) => pass(detectDue.value)),
+  };
+});
 
 vi.mock('@/modules/balances/use-blockchain-balances', () => ({
   useBlockchainBalances: vi.fn().mockReturnValue({
@@ -19,10 +26,10 @@ vi.mock('@/modules/balances/use-blockchain-balances', () => ({
 }));
 
 vi.mock('@/modules/balances/blockchain/use-auto-token-detection', () => ({
-  useAutoTokenDetection: (): { maybeDetect: typeof maybeDetect; skipReason: typeof skipReason; willDetect: typeof willDetect } => ({
-    maybeDetect,
+  useAutoTokenDetection: (): { skipReason: typeof skipReason; willDetect: typeof willDetect; withDetection: typeof withDetection } => ({
     skipReason,
     willDetect,
+    withDetection,
   }),
 }));
 
@@ -88,7 +95,7 @@ vi.mock('@/modules/balances/manual/use-manual-balances', () => ({
 
 vi.mock('@/modules/accounts/use-blockchain-account-management', () => ({
   useBlockchainAccountManagement: vi.fn().mockReturnValue({
-    refreshAccounts: vi.fn().mockResolvedValue({}),
+    fetchAccounts,
   }),
 }));
 
@@ -129,34 +136,67 @@ describe('useBalanceFetching', () => {
     });
   });
 
+  describe('autoRefresh', () => {
+    it('should perform auto refresh of balances and prices', async () => {
+      const { autoRefresh } = useBalanceFetching();
+      await expect(autoRefresh()).resolves.not.toThrow();
+    });
+
+    /**
+     * 🔴 The periodic tick never asked a chain anything. `{ periodic: true }` went to
+     * `refreshAccounts`, whose no-chain branch is a *cached* read — the DB, not the network — so
+     * "Automatic balance refresh" only re-read what the backend had already written, and the
+     * `periodic` refresh mode had no caller that could reach it.
+     */
+    it('should run a periodic refresh over every chain', async () => {
+      refreshBlockchainBalances.mockClear();
+      const { autoRefresh } = useBalanceFetching();
+
+      await autoRefresh();
+
+      expect(refreshBlockchainBalances).toHaveBeenCalledWith({}, 'periodic');
+      // Accounts are re-read too, but as an accounts read — it no longer pretends to do more.
+      expect(fetchAccounts).toHaveBeenCalledWith({ refreshEns: true });
+    });
+  });
+
   describe('refreshFromChain', () => {
     beforeEach(() => {
       refreshBlockchainBalances.mockClear();
       queryBalancesAsync.mockClear();
-      maybeDetect.mockClear();
-      willDetect.mockReset();
+      withDetection.mockClear();
+      detectDue.value = false;
     });
 
-    it('should refresh all chains from network when detection is not going to run', async () => {
-      willDetect.mockReturnValue(false);
+    it('should refresh every chain, without detection, when none is due', async () => {
       const { refreshFromChain } = useBalanceFetching();
 
       await refreshFromChain();
 
       expect(refreshBlockchainBalances).toHaveBeenCalledTimes(1);
-      expect(refreshBlockchainBalances).toHaveBeenCalledWith();
-      expect(maybeDetect).not.toHaveBeenCalled();
+      expect(refreshBlockchainBalances).toHaveBeenCalledWith({}, 'background', { detect: false });
     });
 
-    it('should run detection and refresh only non-EVM chains from network when detection will run', async () => {
-      willDetect.mockReturnValue(true);
+    /**
+     * ⭐ §3/§10. This used to split: fire detection for the EVM chains and separately refresh only
+     * the non-EVM ones, because detection ended in its own balance read and refreshing an EVM chain
+     * too would have queried it twice. Detection is now a stage inside each chain job that the
+     * chain's own query follows, so it is one call for every chain either way.
+     */
+    it('should refresh every chain with detection when one is due', async () => {
+      detectDue.value = true;
       const { refreshFromChain } = useBalanceFetching();
 
       await refreshFromChain();
 
-      expect(maybeDetect).toHaveBeenCalledTimes(1);
       expect(refreshBlockchainBalances).toHaveBeenCalledTimes(1);
-      expect(refreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: ['btc'] });
+      expect(refreshBlockchainBalances).toHaveBeenCalledWith({}, 'background', { detect: true });
+      // No chain list: the old branch narrowed to non-EVM chains here.
+      expect(refreshBlockchainBalances).not.toHaveBeenCalledWith(
+        expect.objectContaining({ blockchain: expect.anything() }),
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
     /**
@@ -170,7 +210,6 @@ describe('useBalanceFetching', () => {
      * `forceSave`, which calls `fetchBalances` directly with `saveData: true`.
      */
     it('should not query all balances', async () => {
-      willDetect.mockReturnValue(false);
       const { refreshFromChain } = useBalanceFetching();
 
       await refreshFromChain();
@@ -179,21 +218,13 @@ describe('useBalanceFetching', () => {
       expect(queryBalancesAsync).not.toHaveBeenCalled();
     });
 
-    it('should not query all balances on the detecting branch either', async () => {
-      // The old ordering held in only one of the two branches, which was the other half of the bug.
-      willDetect.mockReturnValue(true);
+    it('should not query all balances when detecting either', async () => {
+      detectDue.value = true;
       const { refreshFromChain } = useBalanceFetching();
 
       await refreshFromChain();
 
       expect(queryBalancesAsync).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('autoRefresh', () => {
-    it('should perform auto refresh of balances and prices', async () => {
-      const { autoRefresh } = useBalanceFetching();
-      await expect(autoRefresh()).resolves.not.toThrow();
     });
   });
 });

--- a/frontend/app/src/modules/balances/use-balance-fetching.ts
+++ b/frontend/app/src/modules/balances/use-balance-fetching.ts
@@ -10,7 +10,6 @@ import { useExchanges } from '@/modules/balances/exchanges/use-exchanges';
 import { useManualBalances } from '@/modules/balances/manual/use-manual-balances';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { logger } from '@/modules/core/common/logging/logging';
-import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { onActionableError, type TaskError } from '@/modules/core/tasks/task-result';
 import { useStatisticsDataFetching } from '@/modules/statistics/use-statistics-data-fetching';
@@ -20,7 +19,7 @@ import { useNativeTask } from '@/modules/task-center/use-native-task';
 export const useBalanceFetching = createSharedComposable(() => {
   const { fetchManualBalances } = useManualBalances();
   const { fetchConnectedExchangeBalances } = useExchanges();
-  const { refreshAccounts } = useBlockchainAccountManagement();
+  const { fetchAccounts } = useBlockchainAccountManagement();
   const { queryBalancesAsync } = useBalancesApi();
   const { fetchExchangeRates } = usePriceTaskManager();
   const { refreshPrices } = usePriceRefresh();
@@ -29,15 +28,7 @@ export const useBalanceFetching = createSharedComposable(() => {
   const { t } = useI18n({ useScope: 'global' });
   const { fetchNetValue } = useStatisticsDataFetching();
   const { refreshBlockchainBalances } = useBlockchainBalances();
-  const { maybeDetect: maybeAutoDetectTokens, skipReason: autoDetectSkipReason, willDetect } = useAutoTokenDetection();
-  const { supportedChains, txEvmChains } = useSupportedChains();
-
-  function getNonEvmTxChains(): string[] {
-    const evmIds = new Set(get(txEvmChains).map(c => c.id));
-    return get(supportedChains)
-      .map(c => c.id)
-      .filter(id => !evmIds.has(id));
-  }
+  const { skipReason: autoDetectSkipReason, withDetection } = useAutoTokenDetection();
 
   const fetchBalances = async (payload: Partial<AllBalancePayload> = {}): Promise<void> => {
     const description = payload.ignoreErrors
@@ -65,9 +56,14 @@ export const useBalanceFetching = createSharedComposable(() => {
     ));
   };
 
+  /**
+   * ⭐ `fetchAccounts`, not `refreshAccounts`. Passing no chain made the latter an accounts read and
+   * nothing else — both halves of its balance decision need one — so the name promised work it
+   * never did here. Each chain's hydration still happens inside the walk, as its accounts land.
+   */
   const fetchCached = async (): Promise<void> => {
     await fetchExchangeRates();
-    await Promise.allSettled([fetchManualBalances(), refreshAccounts(), fetchConnectedExchangeBalances()]);
+    await Promise.allSettled([fetchManualBalances(), fetchAccounts({ refreshEns: true }), fetchConnectedExchangeBalances()]);
   };
 
   /**
@@ -85,34 +81,50 @@ export const useBalanceFetching = createSharedComposable(() => {
    * ⚠️ The result of that call was discarded anyway (`mapResult(…, () => {})`) — it was only ever
    * made for the backend side effect, never for data this app reads.
    */
-  const refreshFromChain = async (): Promise<void> => {
-    if (willDetect()) {
-      const nonEvmChains = getNonEvmTxChains();
-      logger.debug(`refreshFromChain: detect-and-refresh-non-evm, non-EVM chains=[${nonEvmChains.join(', ')}]`);
-      startPromise(maybeAutoDetectTokens());
-      if (nonEvmChains.length > 0)
-        await refreshBlockchainBalances({ blockchain: nonEvmChains });
-    }
-    else {
-      logger.debug(`refreshFromChain: refresh-all-no-detection (${autoDetectSkipReason() ?? 'unknown'}), refreshing all chains`);
-      await refreshBlockchainBalances();
-    }
-  };
+  const refreshFromChain = async (): Promise<void> => withDetection(async (detect) => {
+    logger.debug(detect
+      ? 'refreshFromChain: detect-then-query, every chain'
+      : `refreshFromChain: query only (${autoDetectSkipReason() ?? 'unknown'}), every chain`);
+
+    // ⭐ One call for every chain, detecting or not. This used to split into "fire detection for
+    // the EVM chains and separately refresh the non-EVM ones", because detection ended in its own
+    // balance read and refreshing an EVM chain as well would have queried it twice. With detection
+    // a stage *inside* the chain job that reads its result, a chain is one job either way and the
+    // split has nothing left to express — a chain that cannot hold tokens simply has no detect
+    // stage.
+    await refreshBlockchainBalances({}, 'background', { detect });
+  });
 
   const fetch = async (): Promise<void> => {
     await fetchCached();
     startPromise(refreshFromChain());
   };
 
+  /**
+   * §6's periodic flow: every chain, entering at the job, no detection.
+   *
+   * 🔴 The tick never asked a chain anything. It passed `{ periodic: true }` to `refreshAccounts`,
+   * whose no-chain branch is a *cached* read — the DB, not the network — so "Automatic balance
+   * refresh" re-read balances the backend had already written on its own schedule and never
+   * triggered a query itself. The `periodic` refresh mode, the one that settles SKIPPED on a busy
+   * chain rather than joining it, had no caller that could reach it at all.
+   *
+   * ⚠️ This does now cost network calls on a timer, which is why it belongs behind a setting the
+   * user turns on: `refreshPeriod` defaults to `-1` and the scheduler only starts when it is
+   * positive. A chain still mid-refresh is skipped rather than queued, so ticks cannot pile up.
+   */
   const autoRefresh = async (): Promise<void> => {
     await Promise.allSettled([
       fetchManualBalances(),
-      refreshAccounts({ periodic: true }),
+      fetchAccounts({ refreshEns: true }),
       fetchConnectedExchangeBalances(),
       fetchNetValue(),
     ]);
 
-    await refreshPrices(true);
+    await Promise.allSettled([
+      refreshBlockchainBalances({}, 'periodic'),
+      refreshPrices(true),
+    ]);
   };
 
   return {

--- a/frontend/app/src/modules/balances/use-balance-hydration.ts
+++ b/frontend/app/src/modules/balances/use-balance-hydration.ts
@@ -70,7 +70,14 @@ export const useBalanceHydration = createSharedComposable((): UseBalanceHydratio
   /** The read in flight per chain — the subject dedup. Entries exist only while a read is live. */
   const inflight = new Map<string, Promise<void>>();
 
-  const readChain = async (payload: BlockchainBalancePayload, chain: string): Promise<void> => {
+  /**
+   * Bumped by {@link reset}, so a read started before a session ended can tell that it has been
+   * abandoned. Clearing the map is not enough on its own: the abandoned read still settles later
+   * and still runs its own teardown, which would then act on the *next* session's state.
+   */
+  let generation = 0;
+
+  const readChain = async (payload: BlockchainBalancePayload, chain: string, era: number): Promise<void> => {
     const chainPayload = { addresses: payload.addresses, blockchain: chain, isXpub: payload.isXpub ?? false };
     const threshold = get(valueThreshold);
     // Names the backend task in the monitor's failure notification and the dev logs, the same way
@@ -96,7 +103,11 @@ export const useBalanceHydration = createSharedComposable((): UseBalanceHydratio
       await retry(readOnce, HYDRATION_RETRY);
     }
     finally {
-      stopHydration(chain);
+      // 🔴 Only if this read is still the current one. A read abandoned by `reset()` settles
+      // whenever its backend task does — possibly long into the *next* session — and clearing the
+      // flag then drops the new session's dashboard out of its loading state mid-load.
+      if (era === generation)
+        stopHydration(chain);
     }
   };
 
@@ -110,8 +121,13 @@ export const useBalanceHydration = createSharedComposable((): UseBalanceHydratio
     if (running)
       return running;
 
-    const read = readChain(payload, chain).finally(() => {
-      inflight.delete(chain);
+    const era = generation;
+    const read = readChain(payload, chain, era).finally(() => {
+      // 🔴 Same hazard on the dedup map: an abandoned read deleting the entry would drop the *new*
+      // session's read for this chain, so a later caller starts a second concurrent GET. Guarded on
+      // identity rather than key, the way `settleTerminal` compares the record and not just the id.
+      if (inflight.get(chain) === read)
+        inflight.delete(chain);
     });
     inflight.set(chain, read);
     return read;
@@ -143,6 +159,7 @@ export const useBalanceHydration = createSharedComposable((): UseBalanceHydratio
   };
 
   const reset = (): void => {
+    generation += 1;
     inflight.clear();
   };
 

--- a/frontend/app/src/modules/balances/use-balance-refresh.ts
+++ b/frontend/app/src/modules/balances/use-balance-refresh.ts
@@ -11,11 +11,17 @@ export const useBalanceRefresh = createSharedComposable(() => {
   const { fetchConnectedExchangeBalances, fetchSelectedExchangeBalances } = useExchanges();
   const blockchainRefreshButtonBehaviour = useSetting('blockchainRefreshButtonBehaviour');
 
+  /**
+   * ⭐ Everything reaching this composable came from a user pressing something — the refresh
+   * buttons, the accounts page, the dashboard tiles. So it refreshes in `user` mode, which
+   * supersedes a background run rather than joining it: a user asking for fresh data must not
+   * silently receive the periodic tick's result and its parameters.
+   */
   const refreshBlockchainBalancesFn = async (blockchain?: string | string[]): Promise<void> => {
     const chain = blockchain ? arrayify(blockchain) : undefined;
     await refreshBlockchainBalances({
       blockchain: chain,
-    });
+    }, 'user');
   };
 
   const { detectAllTokens } = useTokenDetectionOrchestrator();

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -242,7 +242,26 @@ describe('useBlockchainBalances', () => {
 
       expect(order).toStrictEqual(['detect', 'query']);
       // Parented to the chain job, which is what makes cancelling the chain stop its addresses.
-      expect(detectForChain).toHaveBeenCalledWith(Blockchain.ETH, makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH));
+      // 🔴 The id carries `detect`: sharing it with a plain refresh let `submitTask`'s dedup join
+      // this run to one that does no detection, silently skipping the sweep for that chain.
+      expect(detectForChain).toHaveBeenCalledWith(
+        Blockchain.ETH,
+        makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH, ActivityPart.DETECT),
+      );
+    });
+
+    /**
+     * 🔴🔴 A detecting run and a plain one must not share an id. `submitTask` dedups by id, so a
+     * login sweep landing while any background refresh is in flight (wallet transaction, websocket
+     * refresh, eth2 watcher) would join it and never detect — no row, no log, no error — while
+     * `withDetection` still recorded the sweep, suppressing the next login's too.
+     */
+    it('should not share an id between a detecting and a plain refresh', async () => {
+      await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.ETH }, 'background');
+      await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.ETH }, 'background', { detect: true });
+
+      const ids = submitTask.mock.calls.map(([spec]) => spec.id);
+      expect(new Set(ids).size).toBe(2);
     });
 
     /**
@@ -263,6 +282,29 @@ describe('useBlockchainBalances', () => {
         assert(child !== undefined);
         expect(child[0].parent).toBe(umbrella);
       }
+    });
+
+    /**
+     * 🔴🔴 The umbrella settles COMPLETE whenever its children settle — `allSettled`, so even when
+     * every one of them FAILED. Sharing its children's kind meant it wrote a success to the
+     * completion ledger, and `statusOf(BLOCKCHAIN_BALANCES).everCompleted` aggregates by kind: the
+     * dashboard then read "loaded" after a total failure and showed a settled, empty portfolio.
+     */
+    it('should mark the run umbrella as a container, so it claims no freshness', async () => {
+      await blockchainBalances.refreshBlockchainBalances({}, 'background');
+
+      const umbrella = submitTask.mock.calls
+        .map(([spec]) => spec)
+        .find(spec => spec.id.includes(`:${ActivityPart.RUN}:`));
+      assert(umbrella !== undefined);
+      expect(umbrella.container).toBe(true);
+
+      // The chains themselves are subjects and must keep writing their own entries.
+      const chainSpec = submitTask.mock.calls
+        .map(([spec]) => spec)
+        .find(spec => spec.id === makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH));
+      assert(chainSpec !== undefined);
+      expect(chainSpec.container).toBeUndefined();
     });
 
     it('should give a run a different identity per scope and per mode', async () => {

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -296,7 +296,7 @@ describe('useBlockchainBalances', () => {
      */
     it('should settle a chain with no accounts as skipped, not drop it', async () => {
       // btc is in scope but has no accounts in this fixture.
-      submitTask.mockImplementation(async (spec: SubmittedSpec) => spec.run({ report: () => {}, runTask }));
+      submitTask.mockImplementation(async (spec: SubmittedSpec) => spec.run({ cancelled: () => false, report: () => {}, runTask }));
 
       await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.BTC }, 'background');
 
@@ -309,6 +309,33 @@ describe('useBlockchainBalances', () => {
       assert(!result.ok);
       expect(hasTag(result.error, 'Skipped')).toBe(true);
       expect(api.refreshBlockchainBalances).not.toHaveBeenCalled();
+    });
+
+    /**
+     * 🔴🔴 Seen against a real backend. Cancelling Ethereum mid-detection aborted both running
+     * children (`DELETE /api/1/tasks/424` and `/425`) and left the other seven addresses never
+     * attempted — the cascade doing its job — and then the chain job's own body carried straight
+     * on and issued `POST /balances/blockchains/eth` anyway, writing balances and recording a
+     * completion for a chain the user had stopped. Nothing can interrupt a running async body, so
+     * the body has to ask.
+     */
+    it('should not query after being cancelled during detection', async () => {
+      let stageCancelled = false;
+      detectForChain.mockImplementation(async () => {
+        // The cancel lands while detection is in flight, exactly as a user click would.
+        stageCancelled = true;
+      });
+      submitTask.mockImplementation(async (spec: SubmittedSpec) =>
+        spec.run({ cancelled: () => stageCancelled, report: () => {}, runTask }));
+
+      await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.ETH }, 'background', { detect: true });
+
+      expect(detectForChain).toHaveBeenCalledOnce();
+      expect(api.refreshBlockchainBalances).not.toHaveBeenCalled();
+
+      const result = await submitTask.mock.results[0].value;
+      assert(!result.ok);
+      expect(hasTag(result.error, 'Cancelled')).toBe(true);
     });
 
     it('should not detect when the flow did not ask for it', async () => {

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -8,7 +8,7 @@ import { createAccount } from '@/modules/accounts/create-account';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useBlockchainBalancesApi } from '@/modules/balances/api/use-blockchain-balances-api';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
-import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
+import { type RefreshMode, useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 
 vi.mock('@/modules/core/notifications/use-notifications-store', () => ({
   useNotificationsStore: vi.fn().mockReturnValue({}),
@@ -48,7 +48,14 @@ vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
 
 // The balance processing service takes its runner from the activity, so the stub passes one that
 // resolves like the backend task would.
+//
+// `submitTask` and `supersedeTask` are separate stubs that both run the spec inline. The real
+// difference between them (cancel, await the cancelled promise, resubmit) belongs to
+// `useNativeTask` and is covered by its own spec; what this file owns is which of the two a given
+// refresh mode routes to.
 const { runTask } = vi.hoisted(() => ({ runTask: vi.fn() }));
+const submitTask = vi.fn();
+const supersedeTask = vi.fn();
 
 vi.mock('@/modules/task-center/use-native-task', async () => {
   const { ok } = await import('plainfp/result');
@@ -60,7 +67,8 @@ vi.mock('@/modules/task-center/use-native-task', async () => {
   return {
     useNativeTask: vi.fn(() => ({
       reportProgress: vi.fn(),
-      submitTask: vi.fn(runSpecWith(runTask)),
+      submitTask,
+      supersedeTask,
     })),
   };
 });
@@ -104,6 +112,8 @@ describe('useBlockchainBalances', () => {
     api = useBlockchainBalancesApi();
     blockchainBalances = useBlockchainBalances();
     vi.clearAllMocks();
+    submitTask.mockImplementation(runSpecWith(runTask));
+    supersedeTask.mockImplementation(runSpecWith(runTask));
   });
 
   describe('refreshBlockchainBalances', () => {
@@ -120,12 +130,12 @@ describe('useBlockchainBalances', () => {
     });
 
     it('should refresh particular blockchain - default', () => {
-      const call = async (periodic = true): Promise<void> => {
+      const call = async (mode: RefreshMode = 'periodic'): Promise<void> => {
         await blockchainBalances.refreshBlockchainBalances(
           {
             blockchain: Blockchain.ETH,
           },
-          periodic,
+          mode,
         );
       };
 
@@ -143,12 +153,12 @@ describe('useBlockchainBalances', () => {
     });
 
     it('should ignore periodic balance refresh, when there are other task running', async () => {
-      const call = async (periodic = true): Promise<void> => {
+      const call = async (mode: RefreshMode = 'periodic'): Promise<void> => {
         await blockchainBalances.refreshBlockchainBalances(
           {
             blockchain: Blockchain.ETH,
           },
-          periodic,
+          mode,
         );
       };
 
@@ -174,37 +184,35 @@ describe('useBlockchainBalances', () => {
       assert(1);
     });
 
-    it('should queue manual balance refresh, after other task is done', async () => {
-      const call = async (periodic = true): Promise<void> => {
-        await blockchainBalances.refreshBlockchainBalances(
-          {
-            blockchain: Blockchain.ETH,
-          },
-          periodic,
-        );
+    /**
+     * ⭐ §7. A user pressing refresh on a busy chain supersedes the run in flight instead of
+     * joining it, so they get a fresh query with their own parameters rather than the background
+     * run's. This replaced an `until(() => isChainRefreshing(chain)).toBe(false)` poll that reached
+     * a similar outcome by waiting out work the user had already superseded.
+     *
+     * The cancel/await/resubmit mechanics live in `useNativeTask` and are covered there; the
+     * routing decision is what belongs here.
+     */
+    it('should supersede a running refresh when the user asks for one', async () => {
+      const call = async (mode: RefreshMode): Promise<void> => {
+        await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.ETH }, mode);
       };
 
-      const assert = (times = 1): void => {
-        expect(api.refreshBlockchainBalances).toHaveBeenCalledTimes(times);
-        expect(api.refreshBlockchainBalances).toHaveBeenCalledWith({
-          addresses: undefined,
-          blockchain: Blockchain.ETH,
-          isXpub: false,
-        });
-      };
+      await call('periodic');
+      expect(submitTask).toHaveBeenCalledTimes(1);
+      expect(supersedeTask).not.toHaveBeenCalled();
 
-      const refreshState = useBalanceRefreshState();
-      const loading = refreshState.useIsRefreshing(Blockchain.ETH);
+      await call('user');
+      expect(supersedeTask).toHaveBeenCalledTimes(1);
+      // Not joined onto the background run: the user's press genuinely re-queried.
+      expect(api.refreshBlockchainBalances).toHaveBeenCalledTimes(2);
+    });
 
-      startPromise(call());
-      assert(1);
+    it('should join, not supersede, a background refresh', async () => {
+      await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.ETH }, 'background');
 
-      startPromise(call(false));
-      assert(1);
-
-      await until(loading).toBe(false);
-      await nextTick();
-      assert(2);
+      expect(submitTask).toHaveBeenCalledTimes(1);
+      expect(supersedeTask).not.toHaveBeenCalled();
     });
 
     it('should refresh balances with isXpub flag set to true', async () => {

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -2,13 +2,15 @@ import type { EvmChainInfo, SupportedChains } from '@/modules/core/api/types/cha
 import { Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { createCustomPinia } from '@test/utils/create-pinia';
-import { runSpecWith } from '@test/utils/mocks/native-task';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runSpecWith, type SubmittedSpec } from '@test/utils/mocks/native-task';
+import { hasTag } from 'plainfp/tagged';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAccount } from '@/modules/accounts/create-account';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useBlockchainBalancesApi } from '@/modules/balances/api/use-blockchain-balances-api';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { type RefreshMode, useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
+import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
 
 vi.mock('@/modules/core/notifications/use-notifications-store', () => ({
   useNotificationsStore: vi.fn().mockReturnValue({}),
@@ -18,6 +20,12 @@ vi.mock('@/modules/balances/use-balances-store', () => ({
   useBalancesStore: vi.fn().mockReturnValue({
     updateBalances: vi.fn(),
   }),
+}));
+
+const detectForChain = vi.fn<(chain: string, parent: string) => Promise<void>>(async () => {});
+
+vi.mock('@/modules/balances/blockchain/use-token-detection-orchestrator', () => ({
+  useTokenDetectionOrchestrator: vi.fn(() => ({ detectForChain })),
 }));
 
 vi.mock('@/modules/balances/api/use-blockchain-balances-api', () => ({
@@ -112,6 +120,7 @@ describe('useBlockchainBalances', () => {
     api = useBlockchainBalancesApi();
     blockchainBalances = useBlockchainBalances();
     vi.clearAllMocks();
+    detectForChain.mockReset().mockResolvedValue(undefined);
     submitTask.mockImplementation(runSpecWith(runTask));
     supersedeTask.mockImplementation(runSpecWith(runTask));
   });
@@ -213,6 +222,100 @@ describe('useBlockchainBalances', () => {
 
       expect(submitTask).toHaveBeenCalledTimes(1);
       expect(supersedeTask).not.toHaveBeenCalled();
+    });
+
+    /**
+     * ⭐ §3. The chain job's body is statement order: detection, then the query that reads what it
+     * found. Not a `deps` edge between two activities — one job, two stages.
+     */
+    it('should detect before querying, as children of the chain job', async () => {
+      const order: string[] = [];
+      detectForChain.mockImplementation(async () => {
+        order.push('detect');
+      });
+      vi.mocked(api.refreshBlockchainBalances).mockImplementation(async () => {
+        order.push('query');
+        return { taskId: 4 };
+      });
+
+      await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.ETH }, 'background', { detect: true });
+
+      expect(order).toStrictEqual(['detect', 'query']);
+      // Parented to the chain job, which is what makes cancelling the chain stop its addresses.
+      expect(detectForChain).toHaveBeenCalledWith(Blockchain.ETH, makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH));
+    });
+
+    /**
+     * ⭐ §5. The fan-out is a *run*, and its identity is scope + mode — so two identical runs dedup
+     * onto one umbrella while a full refresh and a single-chain one coexist.
+     */
+    it('should declare the chain jobs under a run umbrella', async () => {
+      await blockchainBalances.refreshBlockchainBalances({}, 'background');
+
+      const submitted = submitTask.mock.calls.map(([spec]) => spec.id);
+      const umbrella = submitted.find(id => id.includes(`:${ActivityPart.RUN}:`));
+      assert(umbrella !== undefined);
+      expect(umbrella).toContain('background');
+
+      // Every chain in scope is a child of it, including the one with nothing to query.
+      for (const chain of [Blockchain.ETH, Blockchain.BTC]) {
+        const child = submitTask.mock.calls.find(([spec]) => spec.id === makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain));
+        assert(child !== undefined);
+        expect(child[0].parent).toBe(umbrella);
+      }
+    });
+
+    it('should give a run a different identity per scope and per mode', async () => {
+      await blockchainBalances.refreshBlockchainBalances({}, 'background');
+      await blockchainBalances.refreshBlockchainBalances({}, 'periodic');
+
+      const runs = submitTask.mock.calls
+        .map(([spec]) => spec.id)
+        .filter(id => id.includes(`:${ActivityPart.RUN}:`));
+
+      // Same scope, different mode — two runs, not one.
+      expect(new Set(runs).size).toBe(2);
+    });
+
+    /**
+     * A parent over one child is a second row describing the same work, so a single-chain refresh
+     * has no umbrella at all — the caller never branches on the count.
+     */
+    it('should not raise an umbrella for a single-chain run', async () => {
+      await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.ETH }, 'background');
+
+      const submitted = submitTask.mock.calls.map(([spec]) => spec.id);
+      expect(submitted.some(id => id.includes(`:${ActivityPart.RUN}:`))).toBe(false);
+      expect(submitted).toContain(makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH));
+    });
+
+    /**
+     * 🔴🔴 §5. A chain with nothing to query used to return before submitting anything, so it
+     * vanished from its run's denominator — "11 of 11" over a scope of 17. It now settles SKIPPED
+     * with a reason, which is terminal-but-not-successful and raises no notification.
+     */
+    it('should settle a chain with no accounts as skipped, not drop it', async () => {
+      // btc is in scope but has no accounts in this fixture.
+      submitTask.mockImplementation(async (spec: SubmittedSpec) => spec.run({ report: () => {}, runTask }));
+
+      await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.BTC }, 'background');
+
+      // The chain still gets its own activity, so the run's denominator counts it...
+      const [spec] = submitTask.mock.calls[0];
+      expect(spec.id).toBe(makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.BTC));
+
+      // ...and it settles terminal-but-not-successful, with a reason the task centre can render.
+      const result = await submitTask.mock.results[0].value;
+      assert(!result.ok);
+      expect(hasTag(result.error, 'Skipped')).toBe(true);
+      expect(api.refreshBlockchainBalances).not.toHaveBeenCalled();
+    });
+
+    it('should not detect when the flow did not ask for it', async () => {
+      await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.ETH }, 'background');
+
+      expect(detectForChain).not.toHaveBeenCalled();
+      expect(api.refreshBlockchainBalances).toHaveBeenCalledTimes(1);
     });
 
     it('should refresh balances with isXpub flag set to true', async () => {

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -104,7 +104,15 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
 
     const chainJob = async (chain: string, parent: ActivityId | undefined): Promise<void> => {
       const chainPayload = { addresses, blockchain: chain, isXpub };
-      const id = makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain);
+      // 🔴 `detect` is part of the identity, not just the body. `submitTask` dedups by id, so with a
+      // shared id a login sweep landing while any plain background refresh is in flight (a wallet
+      // transaction, a websocket refresh, the eth2 watcher) joins that run and **detection for the
+      // chain never happens** — no row, no log, no error. `withDetection` still writes
+      // `lastAutoDetectAt` in its `finally`, so the cooldown then suppresses the next login's sweep
+      // too, and the tokens stay undetected for a day.
+      const id = detect
+        ? makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain, ActivityPart.DETECT)
+        : makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain);
       await submit({
         id,
         parent,
@@ -159,6 +167,11 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
     await runActivityBatch(
       {
         id: makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, ActivityPart.RUN, setDigest(chains), mode),
+        // 🔴 The chains are the subjects; this only contains them. Without it the umbrella settles
+        // COMPLETE whenever its children settle — including when every one of them FAILED — and
+        // writes a success under `BLOCKCHAIN_BALANCES`, so `everCompleted` for the whole kind reads
+        // true and the dashboard shows a settled, empty portfolio after a total failure.
+        container: true,
         kind: ActivityKind.BLOCKCHAIN_BALANCES,
         // ⚠️ Without this the umbrella is a bare group title, indistinguishable from a chain job in
         // the panel — every other row says what it is doing, and the parent has to as well.

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -6,7 +6,7 @@ import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-s
 import { arrayify } from '@/modules/core/common/data/array';
 import { setDigest } from '@/modules/core/common/data/digest';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { Skipped, type TaskError } from '@/modules/core/tasks/task-result';
+import { Cancelled, Skipped, type TaskError } from '@/modules/core/tasks/task-result';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
 import { BALANCES_LANE } from '@/modules/task-center/core/orchestrator/spec';
 import { type ActivityId, ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
@@ -111,7 +111,7 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
         kind: ActivityKind.BLOCKCHAIN_BALANCES,
         lane: BALANCES_LANE,
         rerunnable: true,
-        run: async ({ runTask }): Promise<Result<void, TaskError>> => {
+        run: async ({ cancelled, runTask }): Promise<Result<void, TaskError>> => {
           // 🔴 A dropped refresh is SKIPPED with a reason, never `ok`. Returning success here
           // recorded a completion for work that never ran, so the ledger — and `everCompleted`
           // with it — reported this chain as refreshed. Same class as a green "Sync Complete"
@@ -127,6 +127,14 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
           // second top-level activity, and cancelling this chain now stops the addresses too.
           if (detect)
             await detectForChain(chain, id);
+
+          // 🔴🔴 The cancel that stopped the children does not stop *this body* — nothing in
+          // JavaScript can interrupt a running async function. Without this check the await above
+          // simply resolved (cancelled children settle too) and the query ran anyway: observed as
+          // `POST /balances/blockchains/eth` landing *after* the `DELETE`s that aborted its
+          // detections, writing balances and recording a completion for a chain the user stopped.
+          if (cancelled())
+            return err(Cancelled({ message: t('actions.balances.blockchain.cancelled') }));
 
           return handleRefresh(runTask, chainPayload);
         },

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -1,13 +1,16 @@
 import type { BlockchainBalancePayload } from '@/modules/balances/types/blockchain-balances';
 import { err, type Result } from 'plainfp/result';
 import { msg } from '@/message-key';
+import { useTokenDetectionOrchestrator } from '@/modules/balances/blockchain/use-token-detection-orchestrator';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { arrayify } from '@/modules/core/common/data/array';
+import { setDigest } from '@/modules/core/common/data/digest';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { Skipped, type TaskError } from '@/modules/core/tasks/task-result';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
 import { BALANCES_LANE } from '@/modules/task-center/core/orchestrator/spec';
-import { ActivityKind, makeActivityId } from '@/modules/task-center/core/types';
+import { type ActivityId, ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
+import { useActivityBatch } from '@/modules/task-center/use-activity-batch';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 import { useBalanceProcessingService } from './services/use-balance-processing-service';
 
@@ -22,22 +25,46 @@ import { useBalanceProcessingService } from './services/use-balance-processing-s
  */
 export type RefreshMode = 'background' | 'periodic' | 'user';
 
+export interface RefreshOptions {
+  /**
+   * Run token detection before the network query. Per §6 this is a flow parameter, not a property
+   * of the chain: the same chain detects on a login refresh and does not on a periodic one.
+   */
+  readonly detect?: boolean;
+}
+
 interface UseBlockchainBalancesReturn {
-  refreshBlockchainBalances: (payload?: BlockchainBalancePayload, mode?: RefreshMode) => Promise<void>;
+  refreshBlockchainBalances: (payload?: BlockchainBalancePayload, mode?: RefreshMode, options?: RefreshOptions) => Promise<void>;
 }
 
 /**
- * Layer 2 — the work.
+ * Layer 2 — the work, as **one chain job per chain**.
  *
- * The network query a user watches, cancels and retries: one activity per chain, on a lane, in the
- * task centre. Reading a chain's balances back out of the user's own database is the *other*
- * layer and lives in {@link useBalanceHydration} — it is not work, so it is not here.
+ * The chain is the unit of identity, ordering and exclusion, and the job is a *parent*, not a leaf:
+ *
+ * ```
+ * chain job                 ← identity = chain
+ *   └─ per-address children ← only where the work is genuinely per-address (detection)
+ * ```
+ *
+ * ⭐ Its body is **statement order, not `deps`**: detect, then query. The query must see what
+ * detection found, and that is a sequence inside one activity rather than two activities with an
+ * edge between them — which is what let a chain's detection and its balance query drift apart into
+ * separate top-level rows with nothing tying them together.
+ *
+ * ⭐ Detection is the only genuinely per-address stage. The accounts read is one call per chain and
+ * so is the balance query, so neither earns children.
+ *
+ * Reading a chain's balances back out of the user's own database is the *other* layer and lives in
+ * {@link useBalanceHydration} — it is not work, so it is not here.
  */
 export function useBlockchainBalances(): UseBlockchainBalancesReturn {
   const { t } = useI18n({ useScope: 'global' });
   const { getChainName, supportedChains } = useSupportedChains();
 
-  const { clearChainBalances, handleRefresh, shouldQuery } = useBalanceProcessingService();
+  const { handleRefresh } = useBalanceProcessingService();
+  const { detectForChain } = useTokenDetectionOrchestrator();
+  const { runActivityBatch } = useActivityBatch();
   const { submitTask, supersedeTask } = useNativeTask();
   const refreshState = useBalanceRefreshState();
 
@@ -60,7 +87,9 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
   const refreshBlockchainBalances = async (
     payload: BlockchainBalancePayload = {},
     mode: RefreshMode = 'background',
+    options: RefreshOptions = {},
   ): Promise<void> => {
+    const { detect = false } = options;
     const { addresses, blockchain, isXpub = false } = payload;
     const chains = blockchain ? arrayify(blockchain) : get(supportedChains).map(chain => chain.id);
     // ⭐ A user-initiated refresh replaces the run in flight instead of joining it. `supersedeTask`
@@ -72,35 +101,57 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
     // the background run to finish and then re-query, which is the right *outcome* reached by
     // waiting out work the user had already superseded.
     const submit = mode === 'user' ? supersedeTask : submitTask;
-    await Promise.allSettled(
-      chains.map(async (chain) => {
-        const chainPayload = { addresses, blockchain: chain, isXpub };
-        if (!shouldQuery(chain)) {
-          clearChainBalances(chain);
-          return;
-        }
-        await submit({
-          id: makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain),
-          kind: ActivityKind.BLOCKCHAIN_BALANCES,
-          lane: BALANCES_LANE,
-          rerunnable: true,
-          run: async ({ runTask }): Promise<Result<void, TaskError>> => {
-            // 🔴 A dropped refresh is SKIPPED with a reason, never `ok`. Returning success here
-            // recorded a completion for work that never ran, so the ledger — and `everCompleted`
-            // with it — reported this chain as refreshed. Same class as a green "Sync Complete"
-            // over chains that were never synced.
-            //
-            // `Skipped` is not `isActionable`, so this raises no notification; it settles the
-            // activity terminal-but-not-successful and the task centre renders the reason.
-            if (mode === 'periodic' && isChainRefreshing(chain))
-              return err(Skipped({ message: t('actions.balances.blockchain.skipped.busy') }));
 
-            return handleRefresh(runTask, chainPayload);
-          },
-          subtitle: activityLabelFor(msg.$t('task_center.activity.blockchain_balances.query'), { chain: getChainName(chain) }),
-          title: t('task_center.group.blockchain_balances'),
-        });
-      }),
+    const chainJob = async (chain: string, parent: ActivityId | undefined): Promise<void> => {
+      const chainPayload = { addresses, blockchain: chain, isXpub };
+      const id = makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain);
+      await submit({
+        id,
+        parent,
+        kind: ActivityKind.BLOCKCHAIN_BALANCES,
+        lane: BALANCES_LANE,
+        rerunnable: true,
+        run: async ({ runTask }): Promise<Result<void, TaskError>> => {
+          // 🔴 A dropped refresh is SKIPPED with a reason, never `ok`. Returning success here
+          // recorded a completion for work that never ran, so the ledger — and `everCompleted`
+          // with it — reported this chain as refreshed. Same class as a green "Sync Complete"
+          // over chains that were never synced.
+          //
+          // `Skipped` is not `isActionable`, so this raises no notification; it settles the
+          // activity terminal-but-not-successful and the task centre renders the reason.
+          if (mode === 'periodic' && isChainRefreshing(chain))
+            return err(Skipped({ message: t('actions.balances.blockchain.skipped.busy') }));
+
+          // ⭐ Statement order is the ordering. Detection's children run under this job and are
+          // awaited here, so the query below sees the tokens they found — no `deps` edge, no
+          // second top-level activity, and cancelling this chain now stops the addresses too.
+          if (detect)
+            await detectForChain(chain, id);
+
+          return handleRefresh(runTask, chainPayload);
+        },
+        subtitle: activityLabelFor(msg.$t('task_center.activity.blockchain_balances.query'), { chain: getChainName(chain) }),
+        title: t('task_center.group.blockchain_balances'),
+      });
+    };
+
+    // ⭐ §5. The run is the fan-out, and its identity is **scope + mode**: two identical runs dedup
+    // onto one umbrella, while a full refresh and a single-chain one coexist because their scopes
+    // differ. `runActivityBatch` declares the children before the umbrella's body awaits them, and
+    // suppresses the umbrella entirely for a single chain — a parent over one child is a second row
+    // describing the same work.
+    //
+    // ⚠️ Scope is taken from `/blockchains/supported`, which lands before the account walk, so the
+    // denominator is honest from the first render. It must never be a function of a store that is
+    // still filling: that is what silently dropped chains from the history sync.
+    await runActivityBatch(
+      {
+        id: makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, ActivityPart.RUN, setDigest(chains), mode),
+        kind: ActivityKind.BLOCKCHAIN_BALANCES,
+        title: t('task_center.group.blockchain_balances'),
+      },
+      chains,
+      async (chain, parent) => chainJob(chain, parent),
     );
   };
 

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -11,8 +11,19 @@ import { ActivityKind, makeActivityId } from '@/modules/task-center/core/types';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 import { useBalanceProcessingService } from './services/use-balance-processing-service';
 
+/**
+ * Who asked for this refresh, which is what decides what happens when the chain is already busy.
+ *
+ * - `background`: join the run in flight. Two callers wanting the same thing share one query.
+ * - `periodic`: settle SKIPPED with a reason. A tick that finds the chain busy has nothing to add,
+ *   and recording it as `ok` would mark the chain refreshed when nothing ran.
+ * - `user`: supersede. Someone pressed refresh, so they get a fresh query with *their* parameters
+ *   rather than whatever the background run happened to be doing.
+ */
+export type RefreshMode = 'background' | 'periodic' | 'user';
+
 interface UseBlockchainBalancesReturn {
-  refreshBlockchainBalances: (payload?: BlockchainBalancePayload, periodic?: boolean) => Promise<void>;
+  refreshBlockchainBalances: (payload?: BlockchainBalancePayload, mode?: RefreshMode) => Promise<void>;
 }
 
 /**
@@ -27,7 +38,7 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
   const { getChainName, supportedChains } = useSupportedChains();
 
   const { clearChainBalances, handleRefresh, shouldQuery } = useBalanceProcessingService();
-  const { submitTask } = useNativeTask();
+  const { submitTask, supersedeTask } = useNativeTask();
   const refreshState = useBalanceRefreshState();
 
   /**
@@ -39,11 +50,8 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
    * discarded whichever order the two land in. Two mechanisms for one hazard, and the cheaper one
    * wins.
    *
-   * ⚠️ The remaining half is not redundant with `submitTask`'s id dedup, and must not be deleted
-   * with it. Dedup *joins* a caller to the run already in flight; this makes a manual refresh wait
-   * and then genuinely re-query, which is what a user asking for fresh data expects. Deleting it
-   * would silently hand them the periodic run's result instead — the supersede gap, which has no
-   * implementation yet.
+   * ⚠️ Read by the `periodic` branch only. It is not redundant with `submitTask`'s id dedup: dedup
+   * covers a run that is *submitted*, this covers the window where the POST itself is in flight.
    */
   const isChainRefreshing = (chain: string): boolean => get(refreshState.refreshingChains).has(chain);
 
@@ -51,10 +59,19 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
   // paused during decode by the orchestrator rule, replacing the old BalanceQueueService).
   const refreshBlockchainBalances = async (
     payload: BlockchainBalancePayload = {},
-    periodic = false,
+    mode: RefreshMode = 'background',
   ): Promise<void> => {
     const { addresses, blockchain, isXpub = false } = payload;
     const chains = blockchain ? arrayify(blockchain) : get(supportedChains).map(chain => chain.id);
+    // ⭐ A user-initiated refresh replaces the run in flight instead of joining it. `supersedeTask`
+    // is the single shared helper for that — cancel, *await the cancelled promise*, then submit —
+    // because `finish()` is what frees the id, and resubmitting before it dedups onto the corpse.
+    //
+    // This is what retired the old `until(() => isChainRefreshing(chain)).toBe(false)` poll on the
+    // non-periodic path. That poll was standing in for supersede: it made a manual refresh wait for
+    // the background run to finish and then re-query, which is the right *outcome* reached by
+    // waiting out work the user had already superseded.
+    const submit = mode === 'user' ? supersedeTask : submitTask;
     await Promise.allSettled(
       chains.map(async (chain) => {
         const chainPayload = { addresses, blockchain: chain, isXpub };
@@ -62,25 +79,22 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
           clearChainBalances(chain);
           return;
         }
-        await submitTask({
+        await submit({
           id: makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain),
           kind: ActivityKind.BLOCKCHAIN_BALANCES,
           lane: BALANCES_LANE,
           rerunnable: true,
           run: async ({ runTask }): Promise<Result<void, TaskError>> => {
-            if (isChainRefreshing(chain)) {
-              // 🔴 A dropped refresh is SKIPPED with a reason, never `ok`. Returning success here
-              // recorded a completion for work that never ran, so the ledger — and `everCompleted`
-              // with it — reported this chain as refreshed. Same class as a green "Sync Complete"
-              // over chains that were never synced.
-              //
-              // `Skipped` is not `isActionable`, so this raises no notification; it settles the
-              // activity terminal-but-not-successful and the task centre renders the reason.
-              if (periodic)
-                return err(Skipped({ message: t('actions.balances.blockchain.skipped.busy') }));
+            // 🔴 A dropped refresh is SKIPPED with a reason, never `ok`. Returning success here
+            // recorded a completion for work that never ran, so the ledger — and `everCompleted`
+            // with it — reported this chain as refreshed. Same class as a green "Sync Complete"
+            // over chains that were never synced.
+            //
+            // `Skipped` is not `isActionable`, so this raises no notification; it settles the
+            // activity terminal-but-not-successful and the task centre renders the reason.
+            if (mode === 'periodic' && isChainRefreshing(chain))
+              return err(Skipped({ message: t('actions.balances.blockchain.skipped.busy') }));
 
-              await until(() => isChainRefreshing(chain)).toBe(false);
-            }
             return handleRefresh(runTask, chainPayload);
           },
           subtitle: activityLabelFor(msg.$t('task_center.activity.blockchain_balances.query'), { chain: getChainName(chain) }),

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -130,7 +130,11 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
 
           return handleRefresh(runTask, chainPayload);
         },
-        subtitle: activityLabelFor(msg.$t('task_center.activity.blockchain_balances.query'), { chain: getChainName(chain) }),
+        // ⚠️ Stage-neutral, and it has to be: a subtitle is fixed at submit time while this job now
+        // has two stages, so "Querying the Ethereum network" sat there for minutes while the job
+        // was in fact still detecting tokens. `ActivitySteps` carries no text, so the row cannot
+        // narrate the stage — it can only avoid claiming the wrong one.
+        subtitle: activityLabelFor(msg.$t('task_center.activity.blockchain_balances.chain'), { chain: getChainName(chain) }),
         title: t('task_center.group.blockchain_balances'),
       });
     };
@@ -148,6 +152,9 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
       {
         id: makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, ActivityPart.RUN, setDigest(chains), mode),
         kind: ActivityKind.BLOCKCHAIN_BALANCES,
+        // ⚠️ Without this the umbrella is a bare group title, indistinguishable from a chain job in
+        // the panel — every other row says what it is doing, and the parent has to as well.
+        subtitle: activityLabelFor(msg.$t('task_center.activity.blockchain_balances.run'), { count: chains.length }),
         title: t('task_center.group.blockchain_balances'),
       },
       chains,

--- a/frontend/app/src/modules/core/common/data/digest.ts
+++ b/frontend/app/src/modules/core/common/data/digest.ts
@@ -1,0 +1,21 @@
+/**
+ * A short, stable digest of a set of strings — for activity ids whose identity is "which things",
+ * not "which order they arrived in".
+ *
+ * Order-independent by construction (the input is sorted first), so two callers naming the same
+ * subjects dedup onto one activity however each of them happened to build its list.
+ *
+ * ⚠️ FNV-1a over 32 bits: a compact id part, not a collision-proof hash. That is the right trade
+ * for an activity id, where a collision costs a shared row and never data.
+ */
+export function setDigest(values: readonly string[]): string {
+  let hash = 0x811C9DC5;
+  for (const value of [...values].sort()) {
+    for (let index = 0; index < value.length; index++) {
+      hash = Math.imul(hash ^ value.charCodeAt(index), 0x01000193);
+    }
+    // Fold the separator too, so ['ab','c'] and ['a','bc'] cannot land on the same digest.
+    hash = Math.imul(hash ^ 0x2C, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}

--- a/frontend/app/src/modules/dashboard/progress/use-balance-query-progress.spec.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-balance-query-progress.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
-import { type Activity, ActivityKind, ActivityStatus, makeActivityId } from '@/modules/task-center/core/types';
+import { type Activity, ActivityKind, ActivityPart, ActivityStatus, makeActivityId } from '@/modules/task-center/core/types';
 import '@test/i18n';
 
 const activities = ref<Activity[]>([]);
@@ -41,6 +41,34 @@ function balanceActivity(chain: string, status: ActivityStatus): Activity {
   };
 }
 
+function detectionActivity(chain: string, address: string, status: ActivityStatus): Activity {
+  return {
+    cancellable: true,
+    id: makeActivityId(ActivityKind.TOKEN_DETECTION, chain, address),
+    kind: ActivityKind.TOKEN_DETECTION,
+    parent: makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain),
+    percentage: -1,
+    rerunnable: true,
+    source: { type: 'native' },
+    status,
+    title: 'Token detection',
+  };
+}
+
+/** The §5 run umbrella: same kind as the chain jobs beneath it, but not a subject. */
+function runUmbrella(status: ActivityStatus): Activity {
+  return {
+    cancellable: true,
+    id: makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, ActivityPart.RUN, 'abc123', 'background'),
+    kind: ActivityKind.BLOCKCHAIN_BALANCES,
+    percentage: -1,
+    rerunnable: false,
+    source: { type: 'native' },
+    status,
+    title: 'Blockchain balances',
+  };
+}
+
 async function load(): Promise<typeof import('./use-balance-query-progress')> {
   vi.resetModules();
   return import('./use-balance-query-progress');
@@ -61,6 +89,60 @@ describe('useBalanceQueryProgress', () => {
     expect(get(isBalanceQuerying)).toBe(false);
     set(blockchainStatus, { active: true });
     expect(get(isBalanceQuerying)).toBe(true);
+  });
+
+  /**
+   * 🔴 Seen in the app as "(7/19) Querying Run balances...". The run umbrella carries the same
+   * kind as its chain jobs, so it was counted as one of them — inflating the denominator, and
+   * naming itself from its id's first part, which is the literal `run`.
+   */
+  it('should not count the run umbrella as a chain', async () => {
+    set(activities, [
+      runUmbrella(ActivityStatus.RUNNING),
+      balanceActivity('eth', ActivityStatus.RUNNING),
+      balanceActivity('optimism', ActivityStatus.PENDING),
+    ]);
+
+    const { useBalanceQueryProgress } = await load();
+    const { balanceProgress } = useBalanceQueryProgress();
+    await nextTick();
+
+    const progress = get(balanceProgress);
+    expect(progress?.totalSteps).toBe(2);
+    expect(progress?.currentOperationData?.chain).toBe('eth');
+    expect(progress?.currentOperation).not.toContain('run');
+  });
+
+  /**
+   * 🔴🔴 Watched live climbing 35 → 53 → 62 → 65 → 73. A chain's addresses are only submitted once
+   * its own job starts, so counting detections made the total grow through the run — the number
+   * moved while the user watched it. The count is the run's scope, which is fixed up front.
+   */
+  it('should not grow the denominator as detections are submitted', async () => {
+    set(activities, [
+      balanceActivity('eth', ActivityStatus.RUNNING),
+      balanceActivity('optimism', ActivityStatus.PENDING),
+    ]);
+
+    const { useBalanceQueryProgress } = await load();
+    const { balanceProgress } = useBalanceQueryProgress();
+    await nextTick();
+    expect(get(balanceProgress)?.totalSteps).toBe(2);
+
+    // eth's job starts and submits two addresses; optimism's follow later.
+    set(activities, [
+      balanceActivity('eth', ActivityStatus.RUNNING),
+      balanceActivity('optimism', ActivityStatus.PENDING),
+      detectionActivity('eth', '0xaaa', ActivityStatus.RUNNING),
+      detectionActivity('eth', '0xbbb', ActivityStatus.PENDING),
+    ]);
+    await nextTick();
+
+    const progress = get(balanceProgress);
+    expect(progress?.totalSteps).toBe(2);
+    // ...but the detection still names the operation, rather than being hidden entirely.
+    expect(progress?.currentOperationData?.type).toBe(ActivityKind.TOKEN_DETECTION);
+    expect(progress?.currentOperationData?.address).toBe('0xaaa');
   });
 
   it('should be undefined when no balance activities exist', async () => {

--- a/frontend/app/src/modules/dashboard/progress/use-balance-query-progress.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-balance-query-progress.ts
@@ -7,7 +7,7 @@ import type {
 import { get, set } from '@vueuse/shared';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { isTerminalStatus } from '@/modules/task-center/core/status';
-import { type Activity, type ActivityId, ActivityKind, activityParts, ActivityStatus } from '@/modules/task-center/core/types';
+import { type Activity, type ActivityId, ActivityKind, ActivityPart, activityParts, ActivityStatus } from '@/modules/task-center/core/types';
 import { useTaskCenter } from '@/modules/task-center/use-task-center';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
 
@@ -24,8 +24,6 @@ interface UseBalanceQueryProgressReturn {
   balanceProgress: ComputedRef<BalanceQueryProgress | undefined>;
   isBalanceQuerying: ComputedRef<boolean>;
 }
-
-const BALANCE_KINDS = new Set<ActivityKind>([ActivityKind.BLOCKCHAIN_BALANCES, ActivityKind.TOKEN_DETECTION]);
 
 function createPendingItemProgress(
   item: BalanceQueryQueueItem,
@@ -164,14 +162,37 @@ export const useBalanceQueryProgress = createSharedComposable((): UseBalanceQuer
   const { useIsActive } = useTaskCenter();
   const { activities } = useTaskOrchestrator();
 
-  const balanceActivities = computed<Activity[]>(() =>
-    get(activities).filter(activity => BALANCE_KINDS.has(activity.kind)),
+  /**
+   * What the counter counts: **one entry per chain**, never the run umbrella above them and never
+   * the per-address detections beneath them.
+   *
+   * 🔴 A run is an activity of the same kind as the chain jobs it contains, so it was counted as
+   * one of them: it inflated the denominator by one, and while it was the running item this read
+   * "Querying Run balances", because the chain name is derived from the id's first part and the
+   * umbrella's is the literal `run`.
+   *
+   * 🔴 Detections used to be counted here too, and the denominator *grew as the run progressed* —
+   * observed live climbing 35 → 53 → 62 → 65 → 73 — because a chain's addresses are only submitted
+   * once its own job starts. A total that moves while you watch it is the dishonest denominator
+   * this pipeline exists to remove, so the count is the run's scope, which is fixed up front.
+   *
+   * ⚠️ Detection is still *shown*: it names the current operation below, and every address keeps
+   * its own row in the task centre. It is the arithmetic it stays out of.
+   */
+  const chainSubjects = computed<Activity[]>(() =>
+    get(activities).filter(activity =>
+      activity.kind === ActivityKind.BLOCKCHAIN_BALANCES && activityParts(activity.id)[0] !== ActivityPart.RUN),
+  );
+
+  /** Live detections, for the operation text only — never for the count. */
+  const detections = computed<Activity[]>(() =>
+    get(activities).filter(activity => activity.kind === ActivityKind.TOKEN_DETECTION),
   );
 
   const waveIds = ref<Set<ActivityId>>(new Set());
   let clearTimer: ReturnType<typeof setTimeout> | undefined;
 
-  watch(balanceActivities, (items) => {
+  watch(chainSubjects, (items) => {
     const active = items.filter(activity => !isTerminalStatus(activity.status));
 
     if (active.length > 0) {
@@ -205,7 +226,7 @@ export const useBalanceQueryProgress = createSharedComposable((): UseBalanceQuer
 
   const waveItems = computed<Activity[]>(() => {
     const ids = get(waveIds);
-    return get(balanceActivities).filter(activity => ids.has(activity.id));
+    return get(chainSubjects).filter(activity => ids.has(activity.id));
   });
 
   const totalItems = computed<number>(() => get(waveItems).length);
@@ -228,6 +249,14 @@ export const useBalanceQueryProgress = createSharedComposable((): UseBalanceQuer
 
     if (total === 0) {
       return undefined;
+    }
+
+    // ⭐ A running detection names the operation, because it is the more specific thing happening:
+    // its chain's job is running too, but "detecting tokens for 0x… on Ethereum" says more than
+    // "querying Ethereum". The numbers beside it stay the chain count either way.
+    const runningDetection = get(detections).find(activity => activity.status === ActivityStatus.RUNNING);
+    if (runningDetection) {
+      return createRunningItemProgress(toQueueItem(runningDetection), completed, total, progressValue, getChainName, t);
     }
 
     const runningItem = items.find(activity => activity.status === ActivityStatus.RUNNING);

--- a/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.spec.ts
@@ -118,7 +118,7 @@ describe('useEthStakingRefresh', () => {
       const { refresh } = useEthStakingRefresh(createCallbacks());
       await refresh(true);
 
-      expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' });
+      expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' }, 'user');
       expect(mockHydrate).not.toHaveBeenCalled();
       expect(mockFetchEthStakingValidators).toHaveBeenCalledWith({ ignoreCache: true });
     });
@@ -129,7 +129,8 @@ describe('useEthStakingRefresh', () => {
       const { refresh } = useEthStakingRefresh(createCallbacks());
       await refresh(false);
 
-      expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' });
+      // A first load forces the query but has nothing to supersede — nobody asked for it.
+      expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: 'eth2' }, 'background');
       expect(mockHydrate).not.toHaveBeenCalled();
       expect(mockFetchEthStakingValidators).toHaveBeenCalledWith({ ignoreCache: true });
     });

--- a/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.ts
@@ -67,9 +67,11 @@ export function useEthStakingRefresh(callbacks: RefreshCallbacks): UseEthStaking
     const refreshValidators = async (userInitiated: boolean): Promise<void> => {
       const shouldRefresh = userInitiated || isFirstLoad();
       if (shouldRefresh) {
+        // Only the user's own press supersedes; a first load has nothing to supersede and should
+        // join whatever is already querying eth2.
         await refreshBlockchainBalances({
           blockchain: Blockchain.ETH2,
-        });
+        }, userInitiated ? 'user' : 'background');
       }
       else {
         await hydrate({

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-operations.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-operations.spec.ts
@@ -92,7 +92,8 @@ describe('useEthValidatorOperations', () => {
       const { refresh } = useEthValidatorOperations();
       await refresh();
       expect(mockFetchEthStakingValidators).toHaveBeenCalledWith({ ignoreCache: true });
-      expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: Blockchain.ETH2 });
+      // From the accounts page's refresh button, so it supersedes rather than joins.
+      expect(mockRefreshBlockchainBalances).toHaveBeenCalledWith({ blockchain: Blockchain.ETH2 }, 'user');
     });
   });
 

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-operations.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-operations.ts
@@ -49,11 +49,13 @@ export function useEthValidatorOperations(): UseEthValidatorOperationsReturn {
     };
   }
 
+  // Reached only from the accounts page's refresh button (exposed through `EthStakingValidators`),
+  // hence `user`: it supersedes a background eth2 query rather than joining it.
   async function refresh(): Promise<void> {
     await fetchEthStakingValidators({ ignoreCache: true });
     await refreshBlockchainBalances({
       blockchain: Blockchain.ETH2,
-    });
+    }, 'user');
   }
 
   function confirmDelete(item: EthereumValidator): void {

--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
@@ -855,6 +855,42 @@ describe('createTaskOrchestrator', () => {
     });
   });
 
+  describe('container activities', () => {
+    /**
+     * 🔴🔴 A fan-out umbrella settles COMPLETE whenever its children settle — `allSettled`, on
+     * purpose, because a failure belongs to the subject that failed. Sharing its children's kind
+     * then wrote a *success* to the completion ledger even when every child FAILED, and
+     * `statusOf(kind)` aggregates by kind: the dashboard read "loaded" after a total failure.
+     */
+    it('should not let a container claim freshness for its kind', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 10 } });
+      const umbrella = controllable('run', { container: true });
+      const child = controllable('subject', { parent: umbrella.spec.id });
+      orchestrator.submit(umbrella.spec);
+      orchestrator.submit(child.spec);
+
+      // Every subject fails; the container completes anyway, as a container does.
+      child.settle(err(TaskFailed({ message: 'backend unreachable' })));
+      umbrella.settle(ok(undefined));
+      await flush();
+
+      expect(byId(orchestrator, umbrella.spec.id)?.status).toBe(Status.COMPLETE);
+      expect(orchestrator.statusOf(Kind.OTHER).everCompleted).toBe(false);
+    });
+
+    it('should still let a non-container umbrella record its own completion', async () => {
+      const orchestrator = createTaskOrchestrator({ caps: { default: 10 } });
+      const umbrella = controllable('run-subject');
+      orchestrator.submit(umbrella.spec);
+
+      umbrella.settle(ok(undefined));
+      await flush();
+
+      // `HISTORY_SYNC`'s umbrella *is* the subject for its kind, and its entry is load-bearing.
+      expect(orchestrator.statusOf(Kind.OTHER).everCompleted).toBe(true);
+    });
+  });
+
   describe('cancel cascade', () => {
     /** An umbrella, one chain under it, two accounts under the chain — the history-refresh shape. */
     function tree(orchestrator: TaskOrchestrator): {

--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
@@ -3,7 +3,7 @@ import { err, isErr, isOk, ok, type Result } from 'plainfp/result';
 import { hasTag } from 'plainfp/tagged';
 import { assert, describe, expect, it, vi } from 'vitest';
 import { BackendCancelled, Cancelled, Skipped, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
-import { INDETERMINATE } from '../status';
+import { INDETERMINATE, isTerminalStatus } from '../status';
 import {
   type Activity,
   type ActivityId,
@@ -776,6 +776,73 @@ describe('createTaskOrchestrator', () => {
 
       expect(byId(orchestrator, parent.spec.id)?.status).toBe(Status.RUNNING);
       expect(byId(orchestrator, child.spec.id)?.status).toBe(Status.RUNNING);
+    });
+
+    /**
+     * 🔴🔴 The chain-job shape, against the real scheduler. A parent that *awaits its own children*
+     * holds its lane slot for the whole body, so the children must not need a slot on that lane —
+     * with a cap of 2, two such parents would wait forever on work that can never start.
+     *
+     * This is why token detection has its own `detect:<chain>` family instead of sharing
+     * `BALANCES_LANE` with the chain job. Nothing above the orchestrator can catch it: every
+     * producer spec stubs `submitTask` to run inline, where lanes do not exist.
+     */
+    it('should let a parent awaiting children hold its lane without deadlocking them', async () => {
+      // Two balances slots, both taken by the chain jobs; the detect family has room of its own.
+      const orchestrator = createTaskOrchestrator({ caps: { balances: 2 }, defaultCap: 4 });
+      const children = new Map<ActivityId, Controllable>();
+
+      /** Resolves when that activity reaches a terminal status — the parent's real await. */
+      const awaitTerminal = async (id: ActivityId): Promise<void> => new Promise<void>((resolve) => {
+        const stop = orchestrator.onChange(() => {
+          const activity = byId(orchestrator, id);
+          if (activity && isTerminalStatus(activity.status)) {
+            stop();
+            resolve();
+          }
+        });
+      });
+
+      const chainJob = (chain: string): ActivitySpec => ({
+        cancel: vi.fn(),
+        id: makeActivityId(Kind.BLOCKCHAIN_BALANCES, chain),
+        kind: Kind.BLOCKCHAIN_BALANCES,
+        lane: 'balances',
+        run: async (): Promise<Result<unknown, TaskError>> => {
+          const ids = ['0xaaa', '0xbbb'].map((address) => {
+            const child = controllable(`${chain}-${address}`, {
+              id: makeActivityId(Kind.TOKEN_DETECTION, chain, address),
+              kind: Kind.TOKEN_DETECTION,
+              lane: `detect:${chain}`,
+              parent: makeActivityId(Kind.BLOCKCHAIN_BALANCES, chain),
+            });
+            children.set(child.spec.id, child);
+            orchestrator.submit(child.spec);
+            return child.spec.id;
+          });
+          await Promise.all(ids.map(awaitTerminal));
+          return ok(undefined);
+        },
+        title: chain,
+      });
+
+      orchestrator.submit(chainJob('eth'));
+      orchestrator.submit(chainJob('gnosis'));
+      await vi.waitFor(() => {
+        expect(children.size).toBe(4);
+      });
+
+      // 🔴 The assertion that fails if detection shares the balances lane: with both slots held by
+      // the parents, every child would still be PENDING here and nothing could ever settle them.
+      for (const child of children.values()) {
+        expect(byId(orchestrator, child.spec.id)?.status).toBe(Status.RUNNING);
+        child.settle(ok(undefined));
+      }
+
+      await vi.waitFor(() => {
+        expect(byId(orchestrator, makeActivityId(Kind.BLOCKCHAIN_BALANCES, 'eth'))?.status).toBe(Status.COMPLETE);
+        expect(byId(orchestrator, makeActivityId(Kind.BLOCKCHAIN_BALANCES, 'gnosis'))?.status).toBe(Status.COMPLETE);
+      });
     });
 
     it('should not gate a child whose parent is unknown', async () => {

--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.ts
@@ -78,7 +78,10 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
       return;
 
     record.status = status;
-    recordSettlement(record.spec.id, record.spec.kind, status, now(), ledger);
+    // A container groups work and produces nothing of its own, so it never claims freshness for
+    // its kind — see {@link ActivitySpec.container}.
+    if (!record.spec.container)
+      recordSettlement(record.spec.id, record.spec.kind, status, now(), ledger);
     // Tear down producer side resources once — settleTerminal may run twice (cancel then the
     // aborted run resolving), so the flag keeps `cleanup` from double-firing.
     if (!record.cleanedUp) {

--- a/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
@@ -16,7 +16,7 @@ export type StaticLane = (typeof STATIC_LANES)[number];
  * (`tx-sync:<chain>`). Also a closed list, so a family cap cannot be keyed by a prefix no producer
  * ever mints.
  */
-export const LANE_FAMILIES = ['tx-sync:', 'exchange-events:', 'accounts-add:', 'accounts-remove:'] as const;
+export const LANE_FAMILIES = ['tx-sync:', 'exchange-events:', 'accounts-add:', 'accounts-remove:', 'detect:'] as const;
 
 export type LaneFamily = (typeof LANE_FAMILIES)[number];
 
@@ -78,6 +78,19 @@ export const DECODE_LANE: StaticLane = 'decode';
  * accounts sync at once *on each chain* rather than two across all of them.
  */
 export const ACCOUNT_SYNC_LANE_PREFIX: LaneFamily = 'tx-sync:';
+
+/**
+ * Family prefix for the per-chain token-detection lanes (`detect:<chain>`).
+ *
+ * 🔴🔴 Detection must NOT share {@link BALANCES_LANE} with the chain job that awaits it. The chain
+ * job holds a balances slot for its whole body — detection, then the network query — so children
+ * queued on the same lane could never get one: with a cap of 2, two chain jobs would sit waiting
+ * on addresses that cannot start, and the refresh would hang until the tab was reloaded.
+ *
+ * A separate family also gives the shape §8 asks for directly: 2 addresses per chain, with the
+ * balances cap deciding how many chains detect at once.
+ */
+export const DETECT_LANE_PREFIX: LaneFamily = 'detect:';
 
 /**
  * Family prefix for the per-location exchange lanes (`exchange-events:<location>`). Capped at 1 per

--- a/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/spec.ts
@@ -7,7 +7,7 @@ import type { TaskError } from '@/modules/core/tasks/task-result';
  * keyed by a lane that exists — a typo like `balnces` is a compile error rather than a silent
  * fallback to the default cap, which would otherwise surface only as unexplained concurrency.
  */
-export const STATIC_LANES = ['default', 'balances', 'balances-cached', 'exchange', 'session', 'umbrella', 'chain-sync', 'decode'] as const;
+export const STATIC_LANES = ['default', 'balances', 'exchange', 'session', 'umbrella', 'chain-sync', 'decode'] as const;
 
 export type StaticLane = (typeof STATIC_LANES)[number];
 
@@ -211,6 +211,22 @@ export interface ActivitySpec<T = unknown> {
    * account creation) that must not leave a stale entry once the shell mounts.
    */
   readonly ephemeral?: boolean;
+  /**
+   * This activity only *groups* other work and produces no data of its own, so it writes no
+   * completion-ledger entry.
+   *
+   * 🔴 `everCompleted` for a kind must mean "we have data", not "a run happened". A fan-out
+   * umbrella settles COMPLETE whenever its children settle — `allSettled`, deliberately, because a
+   * failure belongs to the subject that failed — so an umbrella sharing its children's kind writes
+   * a success even when **every** child FAILED. Concretely: backend unreachable at login, all 17
+   * chain jobs fail, umbrella completes, and the dashboard reads `hasCachedData` true and
+   * `isInitialLoading` false — a settled, empty portfolio instead of an error state.
+   *
+   * ⚠️ Opt-in, never blanket. `HISTORY_SYNC`'s umbrella *is* the subject for its kind and its
+   * ledger entry is load-bearing (`use-refresh-transactions.ts` reads `everCompleted` for
+   * `alreadyLoaded` / `everRefreshed`); silencing that one would make history re-sync every time.
+   */
+  readonly container?: boolean;
   /**
    * Marks work that deletes data before re-deriving it, so the eligibility rules can keep it from
    * overlapping work that writes to the same rows. Everything else may overlap harmlessly — the

--- a/frontend/app/src/modules/task-center/core/types.ts
+++ b/frontend/app/src/modules/task-center/core/types.ts
@@ -264,6 +264,11 @@ export interface WorkStatus {
 export const ActivityPart = {
   CACHED: 'cached',
   PULL: 'pull',
+  /**
+   * The umbrella over a fan-out, as opposed to one subject's own work. Keeps a run's id
+   * (`…:run:<scope>:<mode>`) from ever colliding with a subject's (`…:<chain>`).
+   */
+  RUN: 'run',
   EXPORT: 'export',
   EXCHANGE_RATES: 'exchange-rates',
   ORACLE_CACHE: 'oracle-cache',

--- a/frontend/app/src/modules/task-center/use-activity-batch.ts
+++ b/frontend/app/src/modules/task-center/use-activity-batch.ts
@@ -24,6 +24,14 @@ interface BatchUmbrella extends BatchLabels {
    * umbrella is suppressed, so a single-item batch does not orphan its child from the outer batch.
    */
   readonly parent?: ActivityId;
+  /**
+   * Keep this umbrella out of the completion ledger — see {@link ActivitySpec.container}.
+   *
+   * ⚠️ Opt-in per caller, because it is not always right: an umbrella that *is* the subject for its
+   * kind (`HISTORY_SYNC`) has a load-bearing ledger entry. Set it where the children are the
+   * subjects and the umbrella is only their container.
+   */
+  readonly container?: boolean;
 }
 
 interface UseActivityBatchReturn {
@@ -72,6 +80,7 @@ export function useActivityBatch(): UseActivityBatchReturn {
 
     const batch = submitTask({
       id: batchId,
+      container: umbrella.container,
       kind: umbrella.kind,
       lane: UMBRELLA_LANE,
       parent: umbrella.parent,

--- a/frontend/app/src/modules/task-center/use-native-task.spec.ts
+++ b/frontend/app/src/modules/task-center/use-native-task.spec.ts
@@ -2,7 +2,7 @@ import type { ResultAsync } from 'plainfp/result-async';
 import { err, isErr, isOk, ok, type Result } from 'plainfp/result';
 import { hasTag } from 'plainfp/tagged';
 import { assert, describe, expect, it, vi } from 'vitest';
-import { type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import { Cancelled, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { ActivityKind, makeActivityId } from './core/types';
 import { useNativeTask } from './use-native-task';
 import { useTaskOrchestrator } from './use-task-orchestrator';
@@ -70,6 +70,94 @@ describe('useNativeTask', () => {
     release();
     await Promise.all([first, second]);
     expect(run).toHaveBeenCalledOnce();
+  });
+
+  describe('ctx.cancelled', () => {
+    /**
+     * 🔴🔴 Cancelling settles the *record*; it cannot interrupt a running async body, because
+     * nothing in JavaScript can. A body with more than one stage therefore runs to completion after
+     * the row already says CANCELLED — observed against a real backend as a cancelled chain going
+     * on to issue its balance query, `POST /balances/blockchains/eth` landing after the `DELETE`s
+     * that aborted its detections.
+     */
+    it('should tell a running body that it was cancelled', async () => {
+      const { cancelActivity, submitTask } = useNativeTask();
+      const id = makeActivityId(ActivityKind.PRICES, 'cancel-signal');
+
+      let release!: () => void;
+      const firstStageDone = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const secondStage = vi.fn();
+
+      const outcome = submitTask({
+        id,
+        kind: ActivityKind.PRICES,
+        run: async ({ cancelled }): ResultAsync<void, TaskError> => {
+          await firstStageDone;
+          if (cancelled())
+            return err(Cancelled({ message: 'stopped between stages' }));
+
+          secondStage();
+          return ok(undefined);
+        },
+        title: 'prices',
+      });
+
+      cancelActivity(ActivityKind.PRICES, 'cancel-signal');
+      release();
+      await outcome;
+
+      // The stage after the cancel never ran.
+      expect(secondStage).not.toHaveBeenCalled();
+    });
+
+    it('should read false for a body that was never cancelled', async () => {
+      const { submitTask } = useNativeTask();
+      const seen: boolean[] = [];
+
+      await submitTask({
+        id: makeActivityId(ActivityKind.PRICES, 'cancel-signal-clean'),
+        kind: ActivityKind.PRICES,
+        run: async ({ cancelled }): ResultAsync<void, TaskError> => {
+          seen.push(cancelled());
+          return ok(undefined);
+        },
+        title: 'prices',
+      });
+
+      expect(seen).toStrictEqual([false]);
+    });
+
+    /** A session ending has to reach bodies mid-stage too, or they work on for a logged-out user. */
+    it('should tell a running body that the session ended', async () => {
+      const { reset, submitTask } = useNativeTask();
+      let release!: () => void;
+      const firstStageDone = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const secondStage = vi.fn();
+
+      const outcome = submitTask({
+        id: makeActivityId(ActivityKind.PRICES, 'cancel-signal-reset'),
+        kind: ActivityKind.PRICES,
+        run: async ({ cancelled }): ResultAsync<void, TaskError> => {
+          await firstStageDone;
+          if (cancelled())
+            return err(Cancelled({ message: 'session ended' }));
+
+          secondStage();
+          return ok(undefined);
+        },
+        title: 'prices',
+      });
+
+      reset();
+      release();
+      await outcome;
+
+      expect(secondStage).not.toHaveBeenCalled();
+    });
   });
 
   describe('supersedeTask', () => {

--- a/frontend/app/src/modules/task-center/use-native-task.spec.ts
+++ b/frontend/app/src/modules/task-center/use-native-task.spec.ts
@@ -72,6 +72,62 @@ describe('useNativeTask', () => {
     expect(run).toHaveBeenCalledOnce();
   });
 
+  describe('supersedeTask', () => {
+    const stalls = async (): ResultAsync<void, TaskError> => new Promise<Result<void, TaskError>>(() => {});
+
+    /**
+     * ⭐ `submitTask` dedups, so a user asking for fresh data while a background run is in flight
+     * would be handed that run's promise *and its parameters*. Superseding replaces it instead.
+     */
+    it('should replace a run already in flight', async () => {
+      const { submitTask, supersedeTask } = useNativeTask();
+      const id = makeActivityId(ActivityKind.PRICES, 'supersede-replaces');
+
+      const background = submitTask({ id, kind: ActivityKind.PRICES, run: stalls, title: 'prices' });
+
+      const run = vi.fn(async () => ok(undefined));
+      await supersedeTask({ id, kind: ActivityKind.PRICES, run, title: 'prices' });
+
+      // The new spec actually ran, rather than dedupping onto the stalled one.
+      expect(run).toHaveBeenCalledOnce();
+      // And the abandoned caller was settled, not stranded.
+      await expect(background).resolves.toBeDefined();
+    });
+
+    /**
+     * 🔴 The regression this helper exists to prevent. `finish()` is what frees the id, and it runs
+     * when the cancelled activity settles — so submitting without awaiting dedups onto the corpse
+     * and the new spec never runs. Dropping the `await` in `supersedeTask` fails this.
+     */
+    it('should not dedup the replacement onto the cancelled run', async () => {
+      const { submitTask, supersedeTask } = useNativeTask();
+      const id = makeActivityId(ActivityKind.PRICES, 'supersede-frees-id');
+
+      const background = submitTask({ id, kind: ActivityKind.PRICES, run: stalls, title: 'prices' });
+      const run = vi.fn(async () => ok(undefined));
+
+      const outcome = await supersedeTask({ id, kind: ActivityKind.PRICES, run, title: 'prices' });
+
+      expect(isOk(outcome)).toBe(true);
+      expect(run).toHaveBeenCalledOnce();
+      await background;
+    });
+
+    it('should just submit when nothing is in flight', async () => {
+      const { supersedeTask } = useNativeTask();
+      const run = vi.fn(async () => ok(undefined));
+
+      await supersedeTask({
+        id: makeActivityId(ActivityKind.PRICES, 'supersede-idle'),
+        kind: ActivityKind.PRICES,
+        run,
+        title: 'prices',
+      });
+
+      expect(run).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('reset', () => {
     /** Only the orchestrator can settle this, which is the whole point of the two tests below. */
     const neverSettles = async (): ResultAsync<void, TaskError> => new Promise<Result<void, TaskError>>(() => {});

--- a/frontend/app/src/modules/task-center/use-native-task.ts
+++ b/frontend/app/src/modules/task-center/use-native-task.ts
@@ -47,13 +47,29 @@ export type TaskOutcome<T = void> = Result<T, TaskError>;
 export type RunBackendTask = <R>(task: () => Promise<{ taskId: number }>) => Promise<Result<R, TaskError>>;
 
 /**
- * What the orchestrator hands a running activity: its progress sink and its own task runner.
+ * What the orchestrator hands a running activity: its progress sink, its own task runner, and
+ * whether it has since been cancelled.
  * Passing the runner explicitly (rather than reading an ambient "current activity") keeps the
  * binding correct for producers that await before submitting their backend task.
  */
 export interface ActivityContext {
   readonly report: ReportProgress;
   readonly runTask: RunBackendTask;
+  /**
+   * True once this activity has been cancelled — **a body with more than one stage must check it
+   * between them**.
+   *
+   * 🔴 Cancelling settles the *record*; it cannot interrupt a running async body, because nothing
+   * in JavaScript can. A multi-stage producer therefore runs to completion after the row already
+   * says CANCELLED. Observed against a real backend: cancelling a chain mid-detection aborted its
+   * detection children correctly, and then the body carried straight on and issued the balance
+   * query anyway — `POST /balances/blockchains/eth` *after* the `DELETE`s — writing balances and
+   * recording a completion for work the user had stopped.
+   *
+   * ⚠️ It only helps where it is *read*. There is no way to make a body stop on its own, so a
+   * producer that ignores this has the old behaviour.
+   */
+  readonly cancelled: () => boolean;
 }
 
 /**
@@ -169,6 +185,13 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
   const inflightFinish = new Map<ActivityId, (outcome: TaskOutcome<never>) => void>();
 
   /**
+   * How to tell each in-flight submission that it has been cancelled, so a multi-stage body can
+   * stop between stages. Kept beside {@link inflight} for the same reason: a session ending has to
+   * reach bodies it is about to abandon, and settling the caller does not stop the body.
+   */
+  const inflightCancel = new Map<ActivityId, () => void>();
+
+  /**
    * Drop every in-flight submission, settling its callers first.
    *
    * 🔴 Must run when a session ends. This map is app-scoped, so an id left here outlives the
@@ -181,11 +204,17 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
    * this promise; dropping the reference alone would suspend it forever.
    */
   function reset(): void {
+    // Before settling: a body that checks `cancelled()` between stages must see the session end,
+    // or it carries on doing work for a user who has logged out.
+    for (const requestCancel of inflightCancel.values())
+      requestCancel();
+
     for (const finishInflight of inflightFinish.values())
       finishInflight(err(Cancelled({ message: 'session ended' })));
 
     inflight.clear();
     inflightFinish.clear();
+    inflightCancel.clear();
   }
 
   /**
@@ -247,6 +276,7 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
       stop();
       inflight.delete(spec.id);
       inflightFinish.delete(spec.id);
+      inflightCancel.delete(spec.id);
       settle(outcome);
     }
 
@@ -269,10 +299,22 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
       }, label);
     }
 
+    /** Set once this activity is cancelled; read by the body through `ctx.cancelled()`. */
+    let cancelRequested = false;
+
+    function requestCancel(): void {
+      cancelRequested = true;
+    }
+
     // Cancelling the activity aborts whatever backend task it spawned. Producers no longer pass a
     // cancel handle: an activity that never started one still settles CANCELLED (the orchestrator
     // does that), this just stops the work on the backend.
+    //
+    // ⚠️ Aborting the backend task is not the same as stopping the body. A body between stages has
+    // spawned no task yet, so there is nothing here to abort — which is exactly the case that let a
+    // cancelled chain go on to run its query. The flag is what that body reads.
     function cancel(): void {
+      requestCancel();
       if (backendTaskId !== undefined)
         startPromise(cancelTaskById(backendTaskId));
     }
@@ -281,7 +323,7 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
     // awaits the work itself, not just a status flip.
     async function run(report: ReportProgress): Promise<Result<T, TaskError>> {
       backendTaskId = undefined;
-      const outcome = spec.run({ report, runTask });
+      const outcome = spec.run({ cancelled: () => cancelRequested, report, runTask });
       outcome.then(finish, (error: unknown) => finish(err(TaskFailed({ message: getErrorMessage(error) }))));
       return outcome;
     }
@@ -300,6 +342,7 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- a per-entry key/value type correlation TypeScript cannot express without existential types; contained to this line
     inflight.set(spec.id, promise as Promise<TaskOutcome<never>>);
     inflightFinish.set(spec.id, finish);
+    inflightCancel.set(spec.id, requestCancel);
     orchestrator.submit({ ...spec, cancel, run });
     return promise;
   }

--- a/frontend/app/src/modules/task-center/use-native-task.ts
+++ b/frontend/app/src/modules/task-center/use-native-task.ts
@@ -92,6 +92,11 @@ interface UseNativeTaskReturn {
    */
   readonly submitTask: <T = void>(spec: NativeActivitySpec<T>) => Promise<TaskOutcome<T>>;
   /**
+   * Like {@link submitTask}, but replaces the run already in flight for this id rather than joining
+   * it. For user-initiated work, which must not be handed a background run's parameters.
+   */
+  readonly supersedeTask: <T = void>(spec: NativeActivitySpec<T>) => Promise<TaskOutcome<T>>;
+  /**
    * Settle and drop every in-flight submission. Called when a session ends, so no id survives into
    * the next one — `submitTask` dedups by id, and a surviving id hands the next session a promise
    * that can never resolve.
@@ -181,6 +186,36 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
 
     inflight.clear();
     inflightFinish.clear();
+  }
+
+  /**
+   * Replace the run already in flight for this id, instead of joining it.
+   *
+   * ⭐ {@link submitTask} dedups: a second caller for a live id is handed the first run's promise
+   * and the first run's *parameters*. That is right for background work — two periodic ticks should
+   * share one run — and wrong for a user, who asked for fresh data and would silently receive
+   * whatever the background run happened to be doing.
+   *
+   * Cancelling settles the record immediately (`settleTerminal` inside `orchestrator.cancel`, for
+   * RUNNING as well as PENDING), so this does not wait on the aborted work itself.
+   *
+   * ⚠️ The `await` is defensive rather than demonstrated. `finish()` — which frees the id — runs
+   * from the resolver that `cancel`'s emit fires, and that chain is synchronous today, so the id is
+   * already free by the time `submitTask` is reached. Removing the await does not currently fail
+   * any test. It stays because the ordering is not guaranteed anywhere: if settling ever becomes
+   * async, submitting without it dedups the replacement onto the corpse — silently, and looking
+   * exactly like the bug this helper exists to fix.
+   */
+  async function supersedeTask<T = void>(spec: NativeActivitySpec<T>): Promise<TaskOutcome<T>> {
+    const running = inflight.get(spec.id);
+    if (running) {
+      // Result deliberately dropped: "nothing to cancel" (already terminal, or gone between the
+      // lookup and here) is the normal race, not something the caller can act on.
+      orchestrator.cancel(spec.id);
+      await running;
+    }
+
+    return submitTask(spec);
   }
 
   function cancelActivity(kind: ActivityKind, ...parts: (string | number)[]): void {
@@ -277,6 +312,7 @@ export const useNativeTask = createSharedComposable((): UseNativeTaskReturn => {
     statusOf,
     reset,
     submitTask,
+    supersedeTask,
     useIsActive,
     useWorkStatus,
   };

--- a/frontend/app/src/modules/task-center/use-task-orchestrator.ts
+++ b/frontend/app/src/modules/task-center/use-task-orchestrator.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { TaskOrchestrator } from './core/orchestrator/api';
 import { createTaskOrchestrator } from './core/orchestrator/orchestrator';
-import { ACCOUNT_SYNC_LANE_PREFIX, ACCOUNTS_ADD_LANE_PREFIX, ACCOUNTS_REMOVE_LANE_PREFIX, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
+import { ACCOUNT_SYNC_LANE_PREFIX, ACCOUNTS_ADD_LANE_PREFIX, ACCOUNTS_REMOVE_LANE_PREFIX, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, DETECT_LANE_PREFIX, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
 import { type Activity, type ActivityKind, makeActivityId, type WorkStatus } from './core/types';
 
 /**
@@ -67,10 +67,12 @@ export const useTaskOrchestrator = createSharedComposable((): UseTaskOrchestrato
     // Two accounts per chain, not two across every chain; one query per exchange location; two
     // addresses added at once per chain, replacing `addMultipleAccounts`'s own limiter. Removals
     // take 1 per chain and 1 active lane, which is the fully serial shape they always had.
-    laneFamilies: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [ACCOUNTS_ADD_LANE_PREFIX]: 2, [ACCOUNTS_REMOVE_LANE_PREFIX]: 1, [EXCHANGE_EVENTS_LANE_PREFIX]: 1 },
+    laneFamilies: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [ACCOUNTS_ADD_LANE_PREFIX]: 2, [ACCOUNTS_REMOVE_LANE_PREFIX]: 1, [DETECT_LANE_PREFIX]: 2, [EXCHANGE_EVENTS_LANE_PREFIX]: 1 },
     // ...and only two chains' lanes live at once. The accounts of every chain are declared up
     // front now, so without this the per-chain cap alone would let all of them progress together.
-    laneFamilyActive: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [ACCOUNTS_ADD_LANE_PREFIX]: 2, [ACCOUNTS_REMOVE_LANE_PREFIX]: 1, [EXCHANGE_EVENTS_LANE_PREFIX]: 2 },
+    // Detection's active cap matches the balances cap: a chain only detects inside its own chain
+    // job, and only two of those run at once, so a third would be a lane nothing can fill.
+    laneFamilyActive: { [ACCOUNT_SYNC_LANE_PREFIX]: 2, [ACCOUNTS_ADD_LANE_PREFIX]: 2, [ACCOUNTS_REMOVE_LANE_PREFIX]: 1, [DETECT_LANE_PREFIX]: 2, [EXCHANGE_EVENTS_LANE_PREFIX]: 2 },
   });
   const activities = shallowRef<Activity[]>([]);
   // Bumped on every orchestrator change so `useWorkStatus` computeds re-read the (non-reactive)

--- a/frontend/app/tests/unit/utils/mocks/native-task.ts
+++ b/frontend/app/tests/unit/utils/mocks/native-task.ts
@@ -11,6 +11,8 @@ export interface SubmittedSpec {
   /** Declared so a spec can assert scheduling intent (an umbrella's lane, a child's parent). */
   lane?: string;
   parent?: string;
+  /** Whether this activity claims freshness for its kind — an umbrella must not. */
+  container?: boolean;
 }
 
 /**

--- a/frontend/app/tests/unit/utils/mocks/native-task.ts
+++ b/frontend/app/tests/unit/utils/mocks/native-task.ts
@@ -22,5 +22,5 @@ export interface SubmittedSpec {
  * and keep asserting on `runTask` as before.
  */
 export function runSpecWith(runTask: RunBackendTask): (spec: SubmittedSpec) => Promise<unknown> {
-  return async (spec: SubmittedSpec): Promise<unknown> => spec.run({ report: () => {}, runTask });
+  return async (spec: SubmittedSpec): Promise<unknown> => spec.run({ cancelled: () => false, report: () => {}, runTask });
 }


### PR DESCRIPTION
Last of the balance pipeline changes. Follows #12823, #12824 and #12826, all merged.

This is the work layer: what the user sees in the task centre, cancels, and watches progress on. Hydration (#12826) was the other half.

## The chain becomes the unit

A chain's detection and its balance query were separate top-level activities with nothing tying them together, and the refresh had to compensate: it fired detection for the EVM chains and separately refreshed only the non-EVM ones, because detection ended in its own balance read and refreshing an EVM chain would have queried it twice.

The chain's activity is now a parent, not a leaf. Its body is statement order, detect then query, so the query reads what detection found without a deps edge, and detection's per-address children hang under the chain that owns them. Cancelling a chain stops its addresses, which the cascade from #12824 makes true.

Detection runs on a new per-chain `detect:` lane family, never `BALANCES_LANE`. The chain job holds a balances slot for its whole body, so children on that lane could never get one: with a cap of 2 the refresh would hang outright. That is covered by an orchestrator test against the real scheduler, because every producer spec stubs `submitTask` and cannot see lanes at all.

## The fan-out becomes a run

It was a bare `Promise.allSettled` with no umbrella, and a chain with nothing to query returned before submitting anything, so it vanished from the denominator. A scope of seventeen chains reported "11 of 11".

Chain jobs are now declared upfront as children of one umbrella, identified by scope + mode. Scope comes from `/blockchains/supported`, which lands before the account walk, so the denominator is honest from the first render. A chain with nothing to query settles SKIPPED with a reason rather than `ok`, so it stays in the denominator instead of recording a completion for work that never ran.

## Supersede

`submitTask` dedups by id, so a user pressing refresh on a busy chain was handed the background run's promise and its parameters. `refreshBlockchainBalances` now takes a `RefreshMode` that names the three cases: background joins, periodic settles SKIPPED, user supersedes.

## The periodic refresh actually queries chains

Automatic balance refresh never asked a chain anything. The tick passed `{ periodic: true }` to `refreshAccounts`, whose no-chain branch is a cached read, so the setting only re-read what the backend had already written on its own schedule. The `periodic` mode had no caller that could reach it at all.

It stays behind the existing setting (`refreshPeriod` defaults to `-1`, the scheduler only starts when positive), and a chain still mid-refresh is skipped rather than queued, so ticks cannot pile up.

## Fixes found by running it

Four of these came from a real refresh rather than the suite:

- A failed run read as **a settled, empty portfolio**. The umbrella settles COMPLETE whenever its children settle, so sharing its children's kind wrote a success to the completion ledger even when every chain FAILED. `ActivitySpec` gains `container`, opt-in per umbrella.
- The progress denominator **grew as the run went**: 35, 53, 62, 65, 73. Detections were counted alongside chains. The count is now the run's fixed scope.
- The umbrella showed as **"(7/19) Querying Run balances..."**, counted as one of its own children with the chain name taken from the id.
- A chain's subtitle read **"Querying the Ethereum network" while it was still detecting tokens**.

## Tests

Full frontend suite green: 767 files, 7270 tests. Typecheck, ESLint, stylelint and the linked-key check all clean.