### PR TITLE
fix(balances): make cached chain reads cache-only

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -6026,7 +6026,6 @@
         "versions": "Checking for asset database updates"
       },
       "blockchain_balances": {
-        "cached": "Reading cached {chain} data",
         "chain": "Refreshing {chain}",
         "run": "Refreshing {count} chains"
       },

--- a/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.spec.ts
@@ -11,12 +11,12 @@ const h = vi.hoisted(() => ({
   addAccount: vi.fn(),
   addEvmAccount: vi.fn(),
   createFailureNotification: vi.fn(),
-  detectTokens: vi.fn(),
   enableModule: vi.fn(),
   fetchTags: vi.fn(),
   getAddresses: vi.fn((): string[] => []),
   notifyFailedToAddAddress: vi.fn(),
   notifyUser: vi.fn(),
+  refreshBlockchainBalances: vi.fn(),
   supportsTransactions: vi.fn((): boolean => true),
   trackAddedAddresses: vi.fn(),
 }));
@@ -51,8 +51,8 @@ vi.mock('@/modules/accounts/use-account-addition-batch', () => ({
   })),
 }));
 
-vi.mock('@/modules/balances/blockchain/use-token-detection-orchestrator', () => ({
-  useTokenDetectionOrchestrator: vi.fn(() => ({ detectTokens: h.detectTokens })),
+vi.mock('@/modules/balances/use-blockchain-balances', () => ({
+  useBlockchainBalances: vi.fn(() => ({ refreshBlockchainBalances: h.refreshBlockchainBalances })),
 }));
 
 vi.mock('@/modules/accounts/use-blockchain-accounts-store', () => ({
@@ -301,7 +301,59 @@ describe('useAccountAdditionService', () => {
       expect(h.trackAddedAddresses).toHaveBeenCalledWith(['0xabc']);
       expect(onFetchAccounts).toHaveBeenCalledWith({ blockchain: 'eth', refreshEns: true });
       expect(onRefreshAccounts).not.toHaveBeenCalled();
-      expect(h.detectTokens).toHaveBeenCalledWith('eth', ['0xabc']);
+    });
+
+    /**
+     * 🔴 The regression this guards: the cached GET used to escalate to a node query on an empty
+     * cache, which is the only reason a just-added address ever got its native balance. It is
+     * cache-only now, so the addition has to run the query itself — and it must run *after*
+     * detection, whose cache write deletes the address's default-label asset rows (the native coin
+     * among them). A `detect: false` job, or a plain hydrate, leaves the new account showing its
+     * tokens and no ETH.
+     */
+    it('should run a chain job that detects the new addresses before querying', async () => {
+      const onRefreshAccounts = vi.fn<() => Promise<void>>(async () => {});
+      const onFetchAccounts = vi.fn<() => Promise<void>>(async () => {});
+      const { useAccountAdditionService } = await importModule();
+      await useAccountAdditionService().completeAccountAddition(
+        { addedAccounts: added, chain: 'eth' },
+        onRefreshAccounts,
+        onFetchAccounts,
+      );
+      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith(
+        { blockchain: 'eth' },
+        'background',
+        { detect: true, detectAddresses: ['0xabc'] },
+      );
+    });
+
+    /** Detection is narrowed to what was added — the chain's other addresses are nobody's business here. */
+    it('should narrow detection to the added addresses, per chain', async () => {
+      const onRefreshAccounts = vi.fn<() => Promise<void>>(async () => {});
+      const onFetchAccounts = vi.fn<() => Promise<void>>(async () => {});
+      const { useAccountAdditionService } = await importModule();
+      await useAccountAdditionService().completeAccountAddition(
+        {
+          addedAccounts: [
+            { address: '0xabc', chain: Blockchain.ETH },
+            { address: '0xdef', chain: Blockchain.ETH },
+            { address: '0x123', chain: Blockchain.OPTIMISM },
+          ],
+        },
+        onRefreshAccounts,
+        onFetchAccounts,
+      );
+      expect(h.refreshBlockchainBalances).toHaveBeenCalledTimes(2);
+      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith(
+        { blockchain: Blockchain.ETH },
+        'background',
+        { detect: true, detectAddresses: ['0xabc', '0xdef'] },
+      );
+      expect(h.refreshBlockchainBalances).toHaveBeenCalledWith(
+        { blockchain: Blockchain.OPTIMISM },
+        'background',
+        { detect: true, detectAddresses: ['0x123'] },
+      );
     });
 
     it('should refresh accounts when the chain does not support transactions', async () => {
@@ -316,7 +368,9 @@ describe('useAccountAdditionService', () => {
       );
       expect(onRefreshAccounts).toHaveBeenCalledWith({ addresses: ['0xabc'], blockchain: 'btc', isXpub: true });
       expect(onFetchAccounts).not.toHaveBeenCalled();
-      expect(h.detectTokens).not.toHaveBeenCalled();
+      // `refreshAccounts` already ran the job for this chain; a chain that cannot hold tokens has
+      // no detection stage, so there is nothing for a second job to add.
+      expect(h.refreshBlockchainBalances).not.toHaveBeenCalled();
     });
 
     it('should enable the requested modules for eth accounts', async () => {

--- a/frontend/app/src/modules/accounts/use-account-addition-service.ts
+++ b/frontend/app/src/modules/accounts/use-account-addition-service.ts
@@ -11,7 +11,7 @@ import { useAccountAdditionNotifications } from '@/modules/accounts/use-account-
 import { type AdditionOptions, useAccountAdditions } from '@/modules/accounts/use-account-additions';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
-import { useTokenDetectionOrchestrator } from '@/modules/balances/blockchain/use-token-detection-orchestrator';
+import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { isBlockchain } from '@/modules/core/common/chains';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -76,7 +76,7 @@ interface UseAccountAdditionServiceReturn {
 
 export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
   const { addAccount, addEvmAccount } = useAccountAdditions();
-  const { detectTokens: detectTokensForChain } = useTokenDetectionOrchestrator();
+  const { refreshBlockchainBalances } = useBlockchainBalances();
   const { trackAddedAddresses } = useBlockchainAccountsStore();
   const { fetchTags } = useTagOperations();
   const { enableModule } = useSettingsOperations();
@@ -114,9 +114,9 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
 
     trackAddedAddresses(addedAccounts.map(item => item.address));
 
-    // ⚠️ §6's known exception, and it is correct: a chain that will detect deliberately skips its
-    // own balance read, because detection ends in one. Only a chain that cannot hold tokens has to
-    // ask for balances itself.
+    // A chain that cannot hold tokens gets its balances here — `refreshAccounts` reads the accounts
+    // and then runs a job narrowed to the added addresses. Everything else only reads accounts; its
+    // job runs below, after the modules are enabled, because detection is a stage inside it.
     if (chain !== undefined && !supportsTransactions(chain)) {
       await onRefreshAccounts({ addresses: addedAccounts.map(item => item.address), blockchain: chain, isXpub });
     }
@@ -146,10 +146,22 @@ export function useAccountAdditionService(): UseAccountAdditionServiceReturn {
       accountsByChain.set(accountChain, existing);
     }
 
-    // Detect tokens per chain — orchestrator handles queuing + balance refresh
-    for (const [accountChain, chainAddresses] of accountsByChain) {
-      await detectTokensForChain(accountChain, chainAddresses);
-    }
+    // ⭐ One chain job per chain that gained addresses: detect the new addresses, then query. This
+    // was §6's "known exception" — addition skipped its own balance read because detection ended in
+    // one — and that premise is gone. The cached GET is cache-only now, so nothing escalates to a
+    // node query on its behalf; and detection's cache write *deletes* the address's default-label
+    // asset rows (`dbhandler.py:1321`), taking the native coin with them. Only a query after
+    // detection puts it back, which is exactly the chain job's body order.
+    //
+    // ⚠️ Concurrently, not one chain at a time. Each iteration is now detection *plus* a full
+    // network query, so an every-EVM-chain addition would serialise ~20 of them; `BALANCES_LANE`
+    // (cap 2) is where this is meant to be throttled, and awaiting in a loop never reaches it.
+    await Promise.allSettled(Array.from(accountsByChain, async ([accountChain, chainAddresses]) =>
+      refreshBlockchainBalances(
+        { blockchain: accountChain },
+        'background',
+        { detect: true, detectAddresses: chainAddresses },
+      )));
   };
 
   const addSingleEvmAddress = async (

--- a/frontend/app/src/modules/accounts/use-account-migration.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-migration.spec.ts
@@ -7,10 +7,10 @@ import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import '@test/i18n';
 
 const h = vi.hoisted(() => ({
-  detectTokens: vi.fn(),
   fetchAccounts: vi.fn(),
   isEvm: vi.fn((chain: string): boolean => chain === 'eth' || chain === 'optimism'),
   notify: vi.fn(),
+  refreshBlockchainBalances: vi.fn(),
 }));
 
 vi.mock('@/modules/core/common/use-supported-chains', async () => {
@@ -28,8 +28,8 @@ vi.mock('@/modules/accounts/use-blockchain-account-management', () => ({
   useBlockchainAccountManagement: vi.fn(() => ({ fetchAccounts: h.fetchAccounts })),
 }));
 
-vi.mock('@/modules/balances/blockchain/use-token-detection-orchestrator', () => ({
-  useTokenDetectionOrchestrator: vi.fn(() => ({ detectTokens: h.detectTokens })),
+vi.mock('@/modules/balances/use-blockchain-balances', () => ({
+  useBlockchainBalances: vi.fn(() => ({ refreshBlockchainBalances: h.refreshBlockchainBalances })),
 }));
 
 vi.mock('@/modules/auth/use-logged-user-identifier', async () => {
@@ -50,7 +50,7 @@ describe('useAccountMigration', () => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
     h.fetchAccounts.mockResolvedValue(undefined);
-    h.detectTokens.mockResolvedValue(undefined);
+    h.refreshBlockchainBalances.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -66,9 +66,16 @@ describe('useAccountMigration', () => {
     useAccountMigration().setUpgradedAddresses(migrated);
 
     expect(h.fetchAccounts).toHaveBeenCalledWith({ blockchain: 'eth' });
-    expect(h.detectTokens).toHaveBeenCalledWith('eth', ['0xabc']);
     expect(h.notify).toHaveBeenCalledOnce();
+    // The query waits on the accounts read, so it is not called in the same tick.
     await flushPromises();
+    // A migrated address is new to the chain, so the cache cannot have its balances. Detect, then
+    // query — the same order an addition needs, and for the same reason.
+    expect(h.refreshBlockchainBalances).toHaveBeenCalledWith(
+      { blockchain: 'eth' },
+      'background',
+      { detect: true, detectAddresses: ['0xabc'] },
+    );
   });
 
   it('should defer migration until data can be requested', async () => {
@@ -92,12 +99,37 @@ describe('useAccountMigration', () => {
     expect(h.notify).not.toHaveBeenCalled();
   });
 
-  it('should fetch accounts but skip token detection for evmlike chains', async () => {
+  /**
+   * 🔴 `isEvm` gates *detection*, never the query. `tokenChains` is built from
+   * `evmAndEvmLikeTxChainsInfo`, so an evm-like chain reaches the loop with `isEvm` false; gating
+   * the query on it too would leave a migrated zksync_lite address with no balances at all, because
+   * the cache-only read cannot fetch what was never queried.
+   */
+  it('should still query balances for evmlike chains, without detecting', async () => {
     const { canRequestData } = storeToRefs(useSessionAuthStore());
     set(canRequestData, true);
     const { useAccountMigration } = await importModule();
     useAccountMigration().setUpgradedAddresses([{ address: '0xdef', chain: 'zksync_lite' }]);
+    await flushPromises();
     expect(h.fetchAccounts).toHaveBeenCalledWith({ blockchain: 'zksync_lite' });
-    expect(h.detectTokens).not.toHaveBeenCalled();
+    expect(h.refreshBlockchainBalances).toHaveBeenCalledWith(
+      { blockchain: 'zksync_lite' },
+      'background',
+      {},
+    );
+  });
+
+  /**
+   * 🔴 The job's `shouldQuery` reads the accounts store, so a job that starts before the accounts
+   * land sees none, clears the chain and settles SKIPPED. Ordering, not concurrency.
+   */
+  it('should read the accounts before querying the chain', async () => {
+    const { canRequestData } = storeToRefs(useSessionAuthStore());
+    set(canRequestData, true);
+    const { useAccountMigration } = await importModule();
+    useAccountMigration().setUpgradedAddresses([{ address: '0xabc', chain: 'eth' }]);
+    await flushPromises();
+    expect(h.fetchAccounts.mock.invocationCallOrder[0])
+      .toBeLessThan(h.refreshBlockchainBalances.mock.invocationCallOrder[0]);
   });
 });

--- a/frontend/app/src/modules/accounts/use-account-migration.ts
+++ b/frontend/app/src/modules/accounts/use-account-migration.ts
@@ -6,7 +6,7 @@ import { useSessionStorage } from '@vueuse/core';
 import { useBlockchainAccountManagement } from '@/modules/accounts/use-blockchain-account-management';
 import { useLoggedUserIdentifier } from '@/modules/auth/use-logged-user-identifier';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
-import { useTokenDetectionOrchestrator } from '@/modules/balances/blockchain/use-token-detection-orchestrator';
+import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 
@@ -24,7 +24,7 @@ export function useAccountMigration(): UseAccountMigrationReturn {
   const { canRequestData } = storeToRefs(useSessionAuthStore());
   const { evmAndEvmLikeTxChainsInfo, getChainName, isEvm } = useSupportedChains();
   const { fetchAccounts } = useBlockchainAccountManagement();
-  const { detectTokens } = useTokenDetectionOrchestrator();
+  const { refreshBlockchainBalances } = useBlockchainBalances();
   const loggedUserIdentifier = useLoggedUserIdentifier();
 
   const { t } = useI18n({ useScope: 'global' });
@@ -54,9 +54,25 @@ export function useAccountMigration(): UseAccountMigrationReturn {
     for (const chain in addresses) {
       const chainAddresses = addresses[chain];
       const chainName = getChainName(chain);
-      promises.push(fetchAccounts({ blockchain: chain }));
-      if (isEvm(chain))
-        promises.push(detectTokens(chain, chainAddresses));
+      // A migrated address is new to this chain, so its balances are not in the cache and the
+      // cache-only read cannot fetch them. Same reason as an addition: detect, then query.
+      //
+      // 🔴 The accounts read is awaited *before* the job, not raced with it. The job's own
+      // `shouldQuery` reads the accounts store, so on a chain whose first account this is, a job
+      // that starts first sees none, clears the chain and settles SKIPPED — no detection, no
+      // query, and nothing to retry it.
+      //
+      // ⚠️ `isEvm` gates detection only. `tokenChains` comes from `evmAndEvmLikeTxChainsInfo`, so
+      // evm-*like* chains (zksync_lite) reach this loop and `isEvm` is false for them; gating the
+      // query too would leave their migrated addresses with no balances at all.
+      promises.push((async (): Promise<void> => {
+        await fetchAccounts({ blockchain: chain });
+        await refreshBlockchainBalances(
+          { blockchain: chain },
+          'background',
+          isEvm(chain) ? { detect: true, detectAddresses: chainAddresses } : {},
+        );
+      })());
 
       notifications.push({
         category: NotificationCategory.ADDRESS_MIGRATION,

--- a/frontend/app/src/modules/balances/api/use-blockchain-balances-api.spec.ts
+++ b/frontend/app/src/modules/balances/api/use-blockchain-balances-api.spec.ts
@@ -6,6 +6,13 @@ import { Module } from '@/modules/core/common/modules';
 import { useBlockchainBalancesApi } from './use-blockchain-balances-api';
 
 const backendUrl = process.env.VITE_BACKEND_URL;
+const emptyBalances = {
+  per_account: {},
+  totals: {
+    assets: {},
+    liabilities: {},
+  },
+};
 
 describe('composables/api/balances/blockchain', () => {
   beforeEach(() => {
@@ -23,9 +30,7 @@ describe('composables/api/balances/blockchain', () => {
           const url = new URL(request.url);
           capturedParams = url.searchParams;
           return HttpResponse.json({
-            result: {
-              task_id: 456,
-            },
+            result: emptyBalances,
             message: '',
           });
         }),
@@ -36,8 +41,9 @@ describe('composables/api/balances/blockchain', () => {
       const result = await queryBlockchainBalances(payload);
 
       expect(capturedUrl).toContain('/balances/blockchains/btc');
-      expect(capturedParams!.get('async_query')).toBe('true');
-      expect(result.taskId).toBe(456);
+      expect(capturedParams!.get('async_query')).toBeNull();
+      expect(capturedParams!.get('only_cache')).toBe('true');
+      expect(result.perAccount).toEqual({});
     });
 
     it('should fetch specific blockchain balances', async () => {
@@ -48,9 +54,7 @@ describe('composables/api/balances/blockchain', () => {
           const url = new URL(request.url);
           capturedParams = url.searchParams;
           return HttpResponse.json({
-            result: {
-              task_id: 789,
-            },
+            result: emptyBalances,
             message: '',
           });
         }),
@@ -62,8 +66,9 @@ describe('composables/api/balances/blockchain', () => {
       };
       const result = await queryBlockchainBalances(payload);
 
-      expect(capturedParams!.get('async_query')).toBe('true');
-      expect(result.taskId).toBe(789);
+      expect(capturedParams!.get('async_query')).toBeNull();
+      expect(capturedParams!.get('only_cache')).toBe('true');
+      expect(result.perAccount).toEqual({});
     });
 
     it('should include addresses param', async () => {
@@ -74,9 +79,7 @@ describe('composables/api/balances/blockchain', () => {
           const url = new URL(request.url);
           capturedParams = url.searchParams;
           return HttpResponse.json({
-            result: {
-              task_id: 100,
-            },
+            result: emptyBalances,
             message: '',
           });
         }),
@@ -89,7 +92,8 @@ describe('composables/api/balances/blockchain', () => {
       };
       await queryBlockchainBalances(payload);
 
-      expect(capturedParams!.get('async_query')).toBe('true');
+      expect(capturedParams!.get('async_query')).toBeNull();
+      expect(capturedParams!.get('only_cache')).toBe('true');
       expect(capturedParams!.get('addresses')).toBe('0x1234,0x5678');
       expect(capturedParams!.get('ignore_cache')).toBeNull();
     });
@@ -102,9 +106,7 @@ describe('composables/api/balances/blockchain', () => {
           const url = new URL(request.url);
           capturedParams = url.searchParams;
           return HttpResponse.json({
-            result: {
-              task_id: 200,
-            },
+            result: emptyBalances,
             message: '',
           });
         }),

--- a/frontend/app/src/modules/balances/api/use-blockchain-balances-api.ts
+++ b/frontend/app/src/modules/balances/api/use-blockchain-balances-api.ts
@@ -6,6 +6,15 @@ import { api } from '@/modules/core/api/rotki-api';
 import { VALID_WITH_PARAMS_SESSION_AND_EXTERNAL_SERVICE } from '@/modules/core/api/utils';
 import { type PendingTask, PendingTaskSchema } from '@/modules/core/tasks/types';
 
+/**
+ * Tag the cache-only read carries so logging out can cancel whatever is still in flight.
+ *
+ * 🔴 It used to be a backend task, so `orchestrator.reset()` settled it as part of ending the
+ * session. A plain GET has no such owner: without this its response lands after logout and
+ * `processBalanceResult` writes one user's balances into the next user's store.
+ */
+export const BALANCE_HYDRATION_TAG = 'balance-hydration';
+
 interface UseBlockchainBalancesApiReturn {
   queryBlockchainBalances: (payload: FetchBlockchainBalancePayload, valueThreshold?: string) => Promise<BlockchainBalances>;
   refreshBlockchainBalances: (payload: FetchBlockchainBalancePayload) => Promise<PendingTask>;
@@ -27,6 +36,7 @@ export function useBlockchainBalancesApi(): UseBlockchainBalancesApiReturn {
         onlyCache: true,
         valueThreshold,
       },
+      tags: [BALANCE_HYDRATION_TAG],
       validStatuses: VALID_WITH_PARAMS_SESSION_AND_EXTERNAL_SERVICE,
     });
     return BlockchainBalances.parse(response);

--- a/frontend/app/src/modules/balances/api/use-blockchain-balances-api.ts
+++ b/frontend/app/src/modules/balances/api/use-blockchain-balances-api.ts
@@ -1,13 +1,13 @@
 import type { Nullable } from '@rotki/common';
-import type { FetchBlockchainBalancePayload } from '@/modules/balances/types/blockchain-balances';
 import type { PurgeableModule } from '@/modules/core/common/modules';
 import { EvmTokensRecord } from '@/modules/balances/types/balances';
+import { BlockchainBalances, type FetchBlockchainBalancePayload } from '@/modules/balances/types/blockchain-balances';
 import { api } from '@/modules/core/api/rotki-api';
 import { VALID_WITH_PARAMS_SESSION_AND_EXTERNAL_SERVICE } from '@/modules/core/api/utils';
 import { type PendingTask, PendingTaskSchema } from '@/modules/core/tasks/types';
 
 interface UseBlockchainBalancesApiReturn {
-  queryBlockchainBalances: (payload: FetchBlockchainBalancePayload, valueThreshold?: string) => Promise<PendingTask>;
+  queryBlockchainBalances: (payload: FetchBlockchainBalancePayload, valueThreshold?: string) => Promise<BlockchainBalances>;
   refreshBlockchainBalances: (payload: FetchBlockchainBalancePayload) => Promise<PendingTask>;
   queryXpubBalances: (payload: FetchBlockchainBalancePayload) => Promise<PendingTask>;
   fetchDetectedTokens: (chain: string, addresses: string[] | null) => Promise<EvmTokensRecord>;
@@ -16,20 +16,20 @@ interface UseBlockchainBalancesApiReturn {
 }
 
 export function useBlockchainBalancesApi(): UseBlockchainBalancesApiReturn {
-  const queryBlockchainBalances = async ({ addresses, blockchain }: FetchBlockchainBalancePayload, valueThreshold?: string): Promise<PendingTask> => {
+  const queryBlockchainBalances = async ({ addresses, blockchain }: FetchBlockchainBalancePayload, valueThreshold?: string): Promise<BlockchainBalances> => {
     let url = '/balances/blockchains';
     if (blockchain)
       url += `/${blockchain}`;
 
-    const response = await api.get<PendingTask>(url, {
+    const response = await api.get<BlockchainBalances>(url, {
       query: {
         addresses,
-        asyncQuery: true,
+        onlyCache: true,
         valueThreshold,
       },
       validStatuses: VALID_WITH_PARAMS_SESSION_AND_EXTERNAL_SERVICE,
     });
-    return PendingTaskSchema.parse(response);
+    return BlockchainBalances.parse(response);
   };
 
   const refreshBlockchainBalances = async ({ addresses, blockchain }: FetchBlockchainBalancePayload): Promise<PendingTask> => {

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
@@ -20,8 +20,12 @@ import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator
 interface UseTokenDetectionOrchestratorReturn {
   detectTokens: (chain: string | string[], addresses: string[]) => Promise<void>;
   detectAllTokens: (chains?: string | string[]) => Promise<void>;
-  /** Detection as a stage *inside* a chain job — see {@link useBlockchainBalances}. */
-  detectForChain: (chain: string, parent: ActivityId) => Promise<void>;
+  /**
+   * Detection as a stage *inside* a chain job — see {@link useBlockchainBalances}.
+   *
+   * `addrs` narrows the stage to specific addresses; omitted, it covers the whole chain.
+   */
+  detectForChain: (chain: string, parent: ActivityId, addrs?: string[]) => Promise<void>;
   /** Synchronous liveness probe — true while a matching detection activity is pending or running. */
   isDetecting: (chain: string, address?: string | null) => boolean;
   useIsDetecting: (chain: MaybeRefOrGetter<string | string[]>, address?: MaybeRefOrGetter<string | null>) => ComputedRef<boolean>;
@@ -84,12 +88,16 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
    *
    * A chain with no addresses, or one that cannot hold tokens, is not an error — it simply has no
    * detection stage, and the chain job carries straight on to its query.
+   *
+   * ⭐ `addrs` narrows the stage. An account addition knows exactly which addresses are new, and
+   * detecting the chain's other fifty would be work nobody asked for; every other caller wants the
+   * whole chain and passes nothing.
    */
-  const detectForChain = async (chain: string, parent: ActivityId): Promise<void> => {
+  const detectForChain = async (chain: string, parent: ActivityId, addrs?: string[]): Promise<void> => {
     if (!supportsTransactions(chain))
       return;
 
-    const chainAddresses = get(addresses)[chain] ?? [];
+    const chainAddresses = addrs ?? get(addresses)[chain] ?? [];
     if (chainAddresses.length === 0)
       return;
 

--- a/frontend/app/src/modules/balances/services/use-balance-processing-service.spec.ts
+++ b/frontend/app/src/modules/balances/services/use-balance-processing-service.spec.ts
@@ -1,3 +1,4 @@
+import type { BlockchainBalances } from '@/modules/balances/types/blockchain-balances';
 import { Blockchain } from '@rotki/common';
 import { err, ok, type Result } from 'plainfp/result';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -73,7 +74,7 @@ const runTask = vi.fn().mockImplementation(async (taskFn: () => Promise<{ taskId
 
 const { useBalanceProcessingService } = await import('@/modules/balances/services/use-balance-processing-service');
 
-function balancesAt(blockchain: string, lastRefreshTs: number): unknown {
+function balancesAt(blockchain: string, lastRefreshTs: number): BlockchainBalances {
   return {
     lastRefreshTs: { [blockchain]: lastRefreshTs },
     perAccount: { [blockchain]: {} },
@@ -81,7 +82,7 @@ function balancesAt(blockchain: string, lastRefreshTs: number): unknown {
   };
 }
 
-function emptyBalances(blockchain: string): unknown {
+function emptyBalances(blockchain: string): BlockchainBalances {
   return {
     perAccount: { [blockchain]: {} },
     totals: { assets: {}, liabilities: {} },
@@ -113,46 +114,39 @@ describe('useBalanceProcessingService', () => {
     // here makes a later test see `hasCachedData` already true.
     const CHAIN = 'gnosis';
 
-    async function resolveCachedFetch(taskId: number, payload: unknown): Promise<void> {
+    async function resolveCachedFetch(payload: BlockchainBalances): Promise<void> {
       const service = useBalanceProcessingService();
-      const pending = service.handleCachedFetch(
-        runTask,
+      mockQueryBlockchainBalances.mockResolvedValue(payload);
+      await service.handleCachedFetch(
         { addresses: undefined, blockchain: CHAIN, isXpub: false },
         undefined,
       );
-      await vi.waitFor(() => {
-        expect(pendingTasks.has(taskId)).toBe(true);
-      });
-      pendingTasks.get(taskId)!.resolve(ok(payload));
-      await pending;
     }
 
     it('should ignore a payload older than the chain already holds', async () => {
-      mockQueryBlockchainBalances.mockImplementation(async () => ({ taskId: nextTaskId++ }));
       useBlockchainAccountsStore().updateAccounts(CHAIN, [
         createAccount({ address: '0x9', label: null, tags: null }, { chain: CHAIN, nativeAsset: 'ETH' }),
       ]);
       const { updateBalances } = useBalancesStore();
 
-      await resolveCachedFetch(1, balancesAt(CHAIN, 3000));
+      await resolveCachedFetch(balancesAt(CHAIN, 3000));
       vi.mocked(updateBalances).mockClear();
 
-      await resolveCachedFetch(2, balancesAt(CHAIN, 1000));
+      await resolveCachedFetch(balancesAt(CHAIN, 1000));
 
       expect(updateBalances).not.toHaveBeenCalled();
     });
 
     it('should accept a payload newer than the chain holds', async () => {
-      mockQueryBlockchainBalances.mockImplementation(async () => ({ taskId: nextTaskId++ }));
       useBlockchainAccountsStore().updateAccounts(CHAIN, [
         createAccount({ address: '0x9', label: null, tags: null }, { chain: CHAIN, nativeAsset: 'ETH' }),
       ]);
       const { updateBalances } = useBalancesStore();
 
-      await resolveCachedFetch(1, balancesAt(CHAIN, 1000));
+      await resolveCachedFetch(balancesAt(CHAIN, 1000));
       vi.mocked(updateBalances).mockClear();
 
-      await resolveCachedFetch(2, balancesAt(CHAIN, 3000));
+      await resolveCachedFetch(balancesAt(CHAIN, 3000));
 
       expect(updateBalances).toHaveBeenCalled();
     });
@@ -253,14 +247,14 @@ describe('useBalanceProcessingService', () => {
   });
 
   it('should flip hasCachedData when the cached GET resolves, before refresh POST completes', async () => {
-    mockQueryBlockchainBalances.mockImplementation(async () => ({ taskId: nextTaskId++ }));
+    const cachedBalances = deferred<BlockchainBalances>();
+    mockQueryBlockchainBalances.mockReturnValue(cachedBalances.promise);
     mockRefreshBlockchainBalances.mockImplementation(async () => ({ taskId: nextTaskId++ }));
 
     const service = useBalanceProcessingService();
     const { hasCachedData, isRefreshing } = useBalanceStatus(Blockchain.ETH);
 
     const cachedPromise = service.handleCachedFetch(
-      runTask,
       { addresses: undefined, blockchain: Blockchain.ETH, isXpub: false },
       undefined,
     );
@@ -269,23 +263,21 @@ describe('useBalanceProcessingService', () => {
       { addresses: undefined, blockchain: Blockchain.ETH, isXpub: false },
     );
 
-    // wait for both api calls to have registered their tasks
+    // Only the refresh registers a backend task. The cached GET is a direct request.
     await vi.waitFor(() => {
-      expect(pendingTasks.size).toBe(2);
+      expect(pendingTasks.size).toBe(1);
     });
 
     expect(get(hasCachedData)).toBe(false);
     expect(get(isRefreshing)).toBe(true);
 
-    // resolve the cached GET task first (taskId 1)
-    pendingTasks.get(1)!.resolve(ok(emptyBalances(Blockchain.ETH)));
+    cachedBalances.resolve(emptyBalances(Blockchain.ETH));
     await cachedPromise;
 
     expect(get(hasCachedData)).toBe(true);
     expect(get(isRefreshing)).toBe(true); // refresh POST still in flight
 
-    // resolve the refresh POST task
-    pendingTasks.get(2)!.resolve(ok(emptyBalances(Blockchain.ETH)));
+    pendingTasks.get(1)!.resolve(ok(emptyBalances(Blockchain.ETH)));
     await refreshPromise;
 
     expect(get(hasCachedData)).toBe(true);

--- a/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
+++ b/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
@@ -1,6 +1,6 @@
 import type { RunBackendTask } from '@/modules/task-center/use-native-task';
 import { Blockchain } from '@rotki/common';
-import { err, isErr, map as mapResult, type Result } from 'plainfp/result';
+import { err, isErr, map as mapResult, ok, type Result } from 'plainfp/result';
 import { convertBtcBalances } from '@/modules/accounts/account-helpers';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useBlockchainBalancesApi } from '@/modules/balances/api/use-blockchain-balances-api';
@@ -12,9 +12,11 @@ import {
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { useBlockchainRefreshTimestampsStore } from '@/modules/balances/use-blockchain-refresh-timestamps-store';
+import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
-import { isActionable, Skipped, type TaskError } from '@/modules/core/tasks/task-result';
+import { Cancelled, isActionable, Skipped, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { useBlockchainValidatorsStore } from '@/modules/staking/use-blockchain-validators-store';
 import { ActivityKind } from '@/modules/task-center/core/types';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
@@ -26,7 +28,7 @@ function isBtcBalances(data?: BtcBalances | any): data is BtcBalances {
 interface UseBalanceProcessingServiceReturn {
   /** Empties a chain's balances and marks it loaded. No backend task, so no activity involved. */
   clearChainBalances: (blockchain: string) => void;
-  handleCachedFetch: (runTask: RunBackendTask, payload: FetchBlockchainBalancePayload, threshold: string | undefined) => Promise<Result<void, TaskError>>;
+  handleCachedFetch: (payload: FetchBlockchainBalancePayload, threshold: string | undefined) => Promise<Result<void, TaskError>>;
   handleRefresh: (runTask: RunBackendTask, payload: FetchBlockchainBalancePayload) => Promise<Result<void, TaskError>>;
   hasAccounts: (blockchain: string) => boolean;
   /** Whether the chain has anything to query — `hasAccounts`, except eth2. */
@@ -174,12 +176,30 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
   };
 
   const handleCachedFetch = async (
-    runTask: RunBackendTask,
     payload: FetchBlockchainBalancePayload,
     threshold: string | undefined,
   ): Promise<Result<void, TaskError>> => {
     const { blockchain } = payload;
-    return executeBalanceQuery(runTask, blockchain, async () => queryBlockchainBalances(payload, threshold), false);
+    if (!shouldQuery(blockchain)) {
+      clearChainBalances(blockchain);
+      return err(Skipped({ message: t('actions.balances.blockchain.skipped.no_accounts') }));
+    }
+
+    try {
+      processBalanceResult(blockchain, await queryBlockchainBalances(payload, threshold));
+      markCompleted(ActivityKind.BLOCKCHAIN_BALANCES, blockchain);
+      return ok(undefined);
+    }
+    catch (error: unknown) {
+      const taskError = isRequestCancellation(error)
+        ? Cancelled({ message: 'Request cancelled' })
+        : TaskFailed({ cause: error, message: getErrorMessage(error) });
+      if (isActionable(taskError))
+        logger.error(taskError.message);
+
+      invalidate(ActivityKind.BLOCKCHAIN_BALANCES, blockchain);
+      return err(taskError);
+    }
   };
 
   const handleRefresh = async (

--- a/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
+++ b/frontend/app/src/modules/balances/services/use-balance-processing-service.ts
@@ -46,9 +46,7 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
   const { isEth2Enabled } = useBlockchainValidatorsStore();
   const refreshState = useBalanceRefreshState();
 
-  const processBalanceResult = (blockchain: string, result: unknown): void => {
-    const parsedBalances: BlockchainBalances = BlockchainBalances.parse(result);
-
+  const processBalanceResult = (blockchain: string, parsedBalances: BlockchainBalances): void => {
     // 🔴 Drop a payload older than what this chain already holds. A data refresh from the DB and a
     // network query are allowed to overlap by design, so the two can land out of order; without
     // this the slower one wins and rolls the chain back to stale balances. Discarding by age is
@@ -126,24 +124,35 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
     markCompleted(ActivityKind.BLOCKCHAIN_BALANCES, blockchain);
   };
 
-  const executeBalanceQuery = async (
-    runTask: RunBackendTask,
+  /**
+   * Whether this chain is worth asking about at all.
+   *
+   * 🔴🔴 SKIPPED with a reason, never `ok`. A chain with nothing to query is a real outcome the
+   * user can be told about ("no accounts on this chain"), and reporting it as success recorded a
+   * completion for work that never ran. §5 is the other half of the argument: the chain stays in
+   * its run's denominator instead of vanishing from it, so "11 of 17" counts every chain in scope
+   * rather than only the ones that happened to have accounts.
+   */
+  const skipUnlessQueryable = (blockchain: string): Result<void, TaskError> | undefined => {
+    if (shouldQuery(blockchain))
+      return undefined;
+
+    clearChainBalances(blockchain);
+    return err(Skipped({ message: t('actions.balances.blockchain.skipped.no_accounts') }));
+  };
+
+  /**
+   * Record one chain's outcome, whichever layer produced it.
+   *
+   * Both layers land here so the ledger is written in exactly one place: the network query owns its
+   * result through a backend task, the cache-only read resolves directly, and neither difference
+   * reaches the bookkeeping.
+   */
+  const settleChain = (
     blockchain: string,
-    apiCall: () => Promise<{ taskId: number }>,
-    notify: boolean = true,
-  ): Promise<Result<void, TaskError>> => {
-    // 🔴🔴 SKIPPED with a reason, never `ok`. A chain with nothing to query is a real outcome the
-    // user can be told about ("no accounts on this chain"), and reporting it as success recorded a
-    // completion for work that never ran. §5 is the other half of the argument: the chain stays in
-    // its run's denominator instead of vanishing from it, so "11 of 17" counts every chain in scope
-    // rather than only the ones that happened to have accounts.
-    if (!shouldQuery(blockchain)) {
-      clearChainBalances(blockchain);
-      return err(Skipped({ message: t('actions.balances.blockchain.skipped.no_accounts') }));
-    }
-
-    const result = await runTask<BlockchainBalances>(apiCall);
-
+    result: Result<BlockchainBalances, TaskError>,
+    notify: boolean,
+  ): Result<void, TaskError> => {
     if (isErr(result)) {
       if (isActionable(result.error)) {
         logger.error(result.error.message);
@@ -175,31 +184,49 @@ export function useBalanceProcessingService(): UseBalanceProcessingServiceReturn
     return mapResult(result, () => {});
   };
 
+  const executeBalanceQuery = async (
+    runTask: RunBackendTask,
+    blockchain: string,
+    apiCall: () => Promise<{ taskId: number }>,
+  ): Promise<Result<void, TaskError>> => {
+    const skipped = skipUnlessQueryable(blockchain);
+    if (skipped)
+      return skipped;
+
+    // ⚠️ `runTask` types the payload but does not validate it — the schema is only applied here.
+    return settleChain(
+      blockchain,
+      mapResult(await runTask<unknown>(apiCall), result => BlockchainBalances.parse(result)),
+      true,
+    );
+  };
+
+  /**
+   * Layer 1's read. A plain cache-only GET, so its outcome is a rejection rather than a task result
+   * — the only difference from {@link executeBalanceQuery}, and it ends at the same bookkeeping.
+   */
   const handleCachedFetch = async (
     payload: FetchBlockchainBalancePayload,
     threshold: string | undefined,
   ): Promise<Result<void, TaskError>> => {
     const { blockchain } = payload;
-    if (!shouldQuery(blockchain)) {
-      clearChainBalances(blockchain);
-      return err(Skipped({ message: t('actions.balances.blockchain.skipped.no_accounts') }));
-    }
+    const skipped = skipUnlessQueryable(blockchain);
+    if (skipped)
+      return skipped;
 
+    let result: Result<BlockchainBalances, TaskError>;
     try {
-      processBalanceResult(blockchain, await queryBlockchainBalances(payload, threshold));
-      markCompleted(ActivityKind.BLOCKCHAIN_BALANCES, blockchain);
-      return ok(undefined);
+      result = ok(await queryBlockchainBalances(payload, threshold));
     }
     catch (error: unknown) {
-      const taskError = isRequestCancellation(error)
-        ? Cancelled({ message: 'Request cancelled' })
-        : TaskFailed({ cause: error, message: getErrorMessage(error) });
-      if (isActionable(taskError))
-        logger.error(taskError.message);
-
-      invalidate(ActivityKind.BLOCKCHAIN_BALANCES, blockchain);
-      return err(taskError);
+      // A cancellation is expected — logout tags and cancels this read — so it must stay
+      // non-actionable, which is what keeps hydration from retrying it against a dead session.
+      result = err(isRequestCancellation(error)
+        ? Cancelled({ message: t('actions.balances.blockchain.cancelled') })
+        : TaskFailed({ cause: error, message: getErrorMessage(error) }));
     }
+
+    return settleChain(blockchain, result, false);
   };
 
   const handleRefresh = async (

--- a/frontend/app/src/modules/balances/use-balance-hydration.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-hydration.spec.ts
@@ -2,16 +2,13 @@ import type { EvmChainInfo, SupportedChains } from '@/modules/core/api/types/cha
 import { Blockchain } from '@rotki/common';
 import { createCustomPinia } from '@test/utils/create-pinia';
 import { flushPromises } from '@vue/test-utils';
-import { err, ok } from 'plainfp/result';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAccount } from '@/modules/accounts/create-account';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
-import { Cancelled, TaskFailed } from '@/modules/core/tasks/task-result';
 import '@test/i18n';
 
 const h = vi.hoisted(() => ({
   queryBlockchainBalances: vi.fn(),
-  runTask: vi.fn(),
 }));
 
 vi.mock('@/modules/core/notifications/use-notifications-store', () => ({
@@ -33,11 +30,6 @@ vi.mock('@/modules/balances/api/use-blockchain-balances-api', () => ({
     queryXpubBalances: vi.fn().mockResolvedValue({ taskId: 3 }),
     refreshBlockchainBalances: vi.fn().mockResolvedValue({ taskId: 4 }),
   })),
-}));
-
-vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  useTaskHandler: vi.fn(() => ({ cancelTaskById: vi.fn(), runTask: h.runTask })),
 }));
 
 vi.mock('@/modules/assets/amount-display/use-usd-value-threshold', async () => {
@@ -95,11 +87,7 @@ describe('useBalanceHydration', () => {
   beforeEach(() => {
     setActivePinia(createCustomPinia());
     vi.clearAllMocks();
-    h.queryBlockchainBalances.mockResolvedValue({ taskId: 1 });
-    h.runTask.mockImplementation(async (task: () => Promise<unknown>) => {
-      await task();
-      return ok(EMPTY_BALANCES);
-    });
+    h.queryBlockchainBalances.mockResolvedValue(EMPTY_BALANCES);
   });
 
   afterEach(() => {
@@ -129,12 +117,11 @@ describe('useBalanceHydration', () => {
   it('should share one read between callers racing the same chain', async () => {
     addAccount(Blockchain.ETH);
     let release = (): void => {};
-    h.runTask.mockImplementation(async (task: () => Promise<unknown>) => {
-      await task();
+    h.queryBlockchainBalances.mockImplementation(async () => {
       await new Promise<void>((resolve) => {
         release = resolve;
       });
-      return ok(EMPTY_BALANCES);
+      return EMPTY_BALANCES;
     });
 
     const { useBalanceHydration } = await importModule();
@@ -162,7 +149,7 @@ describe('useBalanceHydration', () => {
       if (payload.blockchain === Blockchain.ETH)
         throw new Error('boom');
 
-      return { taskId: 1 };
+      return EMPTY_BALANCES;
     });
 
     const { useBalanceHydration } = await importModule();
@@ -181,15 +168,9 @@ describe('useBalanceHydration', () => {
   /** §1: hydration's failure policy is to retry, silently. */
   it('should retry an actionable failure', async () => {
     addAccount(Blockchain.ETH);
-    h.runTask
-      .mockImplementationOnce(async (task: () => Promise<unknown>) => {
-        await task();
-        return err(TaskFailed({ message: 'nope' }));
-      })
-      .mockImplementationOnce(async (task: () => Promise<unknown>) => {
-        await task();
-        return ok(EMPTY_BALANCES);
-      });
+    h.queryBlockchainBalances
+      .mockRejectedValueOnce(new Error('nope'))
+      .mockResolvedValueOnce(EMPTY_BALANCES);
 
     const { useBalanceHydration } = await importModule();
     await useBalanceHydration().hydrate({ blockchain: Blockchain.ETH });
@@ -203,10 +184,7 @@ describe('useBalanceHydration', () => {
    */
   it('should not retry a cancelled read', async () => {
     addAccount(Blockchain.ETH);
-    h.runTask.mockImplementation(async (task: () => Promise<unknown>) => {
-      await task();
-      return err(Cancelled({ message: 'session ended' }));
-    });
+    h.queryBlockchainBalances.mockRejectedValue(new DOMException('session ended', 'AbortError'));
 
     const { useBalanceHydration } = await importModule();
     await useBalanceHydration().hydrate({ blockchain: Blockchain.ETH });
@@ -222,12 +200,11 @@ describe('useBalanceHydration', () => {
   it('should report liveness while a chain is being read', async () => {
     addAccount(Blockchain.ETH);
     let release = (): void => {};
-    h.runTask.mockImplementation(async (task: () => Promise<unknown>) => {
-      await task();
+    h.queryBlockchainBalances.mockImplementation(async () => {
       await new Promise<void>((resolve) => {
         release = resolve;
       });
-      return ok(EMPTY_BALANCES);
+      return EMPTY_BALANCES;
     });
 
     const { useBalanceHydration } = await importModule();

--- a/frontend/app/src/modules/balances/use-balance-hydration.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-hydration.spec.ts
@@ -1,14 +1,17 @@
+import type { AssetPrices } from '@/modules/assets/prices/price-types';
 import type { EvmChainInfo, SupportedChains } from '@/modules/core/api/types/chains';
-import { Blockchain } from '@rotki/common';
+import { bigNumberify, Blockchain } from '@rotki/common';
 import { createCustomPinia } from '@test/utils/create-pinia';
 import { flushPromises } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAccount } from '@/modules/accounts/create-account';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
 import '@test/i18n';
 
 const h = vi.hoisted(() => ({
   queryBlockchainBalances: vi.fn(),
+  updatePrices: vi.fn(),
 }));
 
 vi.mock('@/modules/core/notifications/use-notifications-store', () => ({
@@ -21,7 +24,10 @@ vi.mock('@/modules/core/notifications/use-notifications', () => ({
 }));
 
 vi.mock('@/modules/balances/use-balances-store', () => ({
-  useBalancesStore: vi.fn().mockReturnValue({ updateBalances: vi.fn() }),
+  useBalancesStore: vi.fn().mockReturnValue({
+    updateBalances: vi.fn(),
+    updatePrices: h.updatePrices,
+  }),
 }));
 
 vi.mock('@/modules/balances/api/use-blockchain-balances-api', () => ({
@@ -108,6 +114,25 @@ describe('useBalanceHydration', () => {
       { addresses: undefined, blockchain: Blockchain.ETH, isXpub: false },
       undefined,
     );
+  });
+
+  it('should reapply frontend prices once after hydrating cached balances', async () => {
+    const prices: AssetPrices = {
+      ETH: {
+        isManualPrice: false,
+        oracle: 'coingecko',
+        value: bigNumberify(2500),
+      },
+    };
+    const { prices: storedPrices } = storeToRefs(useBalancePricesStore());
+    set(storedPrices, prices);
+    addAccount(Blockchain.ETH);
+
+    const { useBalanceHydration } = await importModule();
+    await useBalanceHydration().hydrate({ blockchain: Blockchain.ETH });
+
+    expect(h.updatePrices).toHaveBeenCalledOnce();
+    expect(h.updatePrices).toHaveBeenCalledWith(prices);
   });
 
   /**

--- a/frontend/app/src/modules/balances/use-balance-hydration.ts
+++ b/frontend/app/src/modules/balances/use-balance-hydration.ts
@@ -1,5 +1,4 @@
 import type { BlockchainBalancePayload } from '@/modules/balances/types/blockchain-balances';
-import type { RunBackendTask } from '@/modules/task-center/use-native-task';
 import { err, isErr, ok, type Result } from 'plainfp/result';
 import { allWithConcurrency, type ResultAsync, retry, type RetryOptions } from 'plainfp/result-async';
 import { useValueThreshold } from '@/modules/assets/amount-display/use-usd-value-threshold';
@@ -9,7 +8,6 @@ import { arrayify } from '@/modules/core/common/data/array';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
-import { useTaskHandler } from '@/modules/core/tasks/use-task-handler';
 import { BalanceSource } from '@/modules/settings/types/frontend-settings';
 
 /**
@@ -32,7 +30,7 @@ interface UseBalanceHydrationReturn {
   hydrate: (payload?: BlockchainBalancePayload) => Promise<void>;
   /**
    * Forget every read in flight. 🔴 Must run when a session ends: this map is app-scoped, so a
-   * read that can never settle (its backend task belongs to a session that is gone) would
+   * read that can never settle (its request belongs to a session that is gone) would
    * otherwise be handed to the next session's caller for that chain, which then never hydrates.
    */
   reset: () => void;
@@ -51,21 +49,18 @@ interface UseBalanceHydrationReturn {
  * the read in flight and therefore its parameters, which is right for a data refresh: the rows it
  * reads back are the same either way.
  *
- * ⚠️ It is still a *backend task* — the current GET escalates to a full node query on an empty
- * cache, so it cannot simply drop `async_query`. That is a backend change, not a reason for this
- * to be a job.
+ * ⭐ The GET is cache-only and returns directly. An empty cache returns empty balances instead of
+ * escalating to a node query, so hydration does not need the backend task monitor.
  *
  * 🔴 Overlapping a network refresh is harmless by construction rather than by exclusion:
  * `processBalanceResult` discards a payload older than what the chain already holds, whichever
  * order the two land in. That is what lets this layer stop being serialised against work at all.
  */
 export const useBalanceHydration = createSharedComposable((): UseBalanceHydrationReturn => {
-  const { getChainName, supportedChains } = useSupportedChains();
+  const { supportedChains } = useSupportedChains();
   const { clearChainBalances, handleCachedFetch, shouldQuery } = useBalanceProcessingService();
-  const { runTask: runBackendTask } = useTaskHandler();
   const { startHydration, stopHydration } = useBalanceRefreshState();
   const valueThreshold = useValueThreshold(BalanceSource.BLOCKCHAIN);
-  const { t } = useI18n({ useScope: 'global' });
 
   /** The read in flight per chain — the subject dedup. Entries exist only while a read is live. */
   const inflight = new Map<string, Promise<void>>();
@@ -80,10 +75,6 @@ export const useBalanceHydration = createSharedComposable((): UseBalanceHydratio
   const readChain = async (payload: BlockchainBalancePayload, chain: string, era: number): Promise<void> => {
     const chainPayload = { addresses: payload.addresses, blockchain: chain, isXpub: payload.isXpub ?? false };
     const threshold = get(valueThreshold);
-    // Names the backend task in the monitor's failure notification and the dev logs, the same way
-    // the orchestrator labels the run of an activity that owns one.
-    const label = t('task_center.activity.blockchain_balances.cached', { chain: getChainName(chain) });
-    const runTask: RunBackendTask = async task => runBackendTask(task, label);
 
     /**
      * One attempt, with its outcome placed in the channel `retry` reads.
@@ -94,7 +85,7 @@ export const useBalanceHydration = createSharedComposable((): UseBalanceHydratio
      * goes in `err`; everything else short-circuits as `ok`.
      */
     const readOnce = async (): ResultAsync<Result<void, TaskError>, TaskError> => {
-      const outcome = await handleCachedFetch(runTask, chainPayload, threshold);
+      const outcome = await handleCachedFetch(chainPayload, threshold);
       return isErr(outcome) && isActionable(outcome.error) ? err(outcome.error) : ok(outcome);
     };
 
@@ -104,7 +95,7 @@ export const useBalanceHydration = createSharedComposable((): UseBalanceHydratio
     }
     finally {
       // 🔴 Only if this read is still the current one. A read abandoned by `reset()` settles
-      // whenever its backend task does — possibly long into the *next* session — and clearing the
+      // whenever its request does — possibly long into the *next* session — and clearing the
       // flag then drops the new session's dashboard out of its loading state mid-load.
       if (era === generation)
         stopHydration(chain);

--- a/frontend/app/src/modules/balances/use-balance-hydration.ts
+++ b/frontend/app/src/modules/balances/use-balance-hydration.ts
@@ -3,7 +3,9 @@ import { err, isErr, ok, type Result } from 'plainfp/result';
 import { allWithConcurrency, type ResultAsync, retry, type RetryOptions } from 'plainfp/result-async';
 import { useValueThreshold } from '@/modules/assets/amount-display/use-usd-value-threshold';
 import { useBalanceProcessingService } from '@/modules/balances/services/use-balance-processing-service';
+import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
+import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { arrayify } from '@/modules/core/common/data/array';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -59,6 +61,8 @@ interface UseBalanceHydrationReturn {
 export const useBalanceHydration = createSharedComposable((): UseBalanceHydrationReturn => {
   const { supportedChains } = useSupportedChains();
   const { clearChainBalances, handleCachedFetch, shouldQuery } = useBalanceProcessingService();
+  const { prices } = storeToRefs(useBalancePricesStore());
+  const { updatePrices } = useBalancesStore();
   const { startHydration, stopHydration } = useBalanceRefreshState();
   const valueThreshold = useValueThreshold(BalanceSource.BLOCKCHAIN);
 
@@ -147,6 +151,11 @@ export const useBalanceHydration = createSharedComposable((): UseBalanceHydratio
     });
 
     await allWithConcurrency(factories, HYDRATION_CONCURRENCY);
+    // A cache-only backend read deliberately avoids price oracles, so balances without a local
+    // backend price arrive with a zero value. Reapply the frontend's already-fetched prices once
+    // the batch settles; otherwise a late hydration response can zero a correctly priced chain
+    // and make it disappear from the dashboard until the next price refresh.
+    updatePrices(get(prices));
   };
 
   const reset = (): void => {

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -247,7 +247,59 @@ describe('useBlockchainBalances', () => {
       expect(detectForChain).toHaveBeenCalledWith(
         Blockchain.ETH,
         makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH, ActivityPart.DETECT),
+        undefined,
       );
+    });
+
+    /**
+     * ⭐ Account addition and account migration are the flows that know which addresses are new, and
+     * detecting the chain's other fifty on their behalf is work nobody asked for. Without the
+     * forward the option is silently inert — the call still succeeds and still detects everything.
+     */
+    it('should forward the detection narrowing to the chain job', async () => {
+      await blockchainBalances.refreshBlockchainBalances(
+        { blockchain: Blockchain.ETH },
+        'background',
+        { detect: true, detectAddresses: ['0xabc'] },
+      );
+
+      // The id carries a digest of the narrowing, so match the parent the job actually submitted
+      // rather than restating the id here.
+      const [[spec]] = submitTask.mock.calls;
+      expect(detectForChain).toHaveBeenCalledWith(Blockchain.ETH, spec.id, ['0xabc']);
+    });
+
+    /**
+     * 🔴🔴 Two additions on one chain differ only in their narrowing, so a shared id makes the
+     * second dedup onto the first and its addresses are never detected. A CSV import starts every
+     * row in the same tick, which is exactly this shape.
+     */
+    it('should not share an id between differently narrowed detections', async () => {
+      await blockchainBalances.refreshBlockchainBalances(
+        { blockchain: Blockchain.ETH },
+        'background',
+        { detect: true, detectAddresses: ['0xaaa'] },
+      );
+      await blockchainBalances.refreshBlockchainBalances(
+        { blockchain: Blockchain.ETH },
+        'background',
+        { detect: true, detectAddresses: ['0xbbb'] },
+      );
+
+      const ids = submitTask.mock.calls.map(([spec]) => spec.id);
+      expect(new Set(ids).size).toBe(2);
+    });
+
+    /** Every reader of this id is prefix-based, so `(kind, chain)` has to keep matching. */
+    it('should keep the chain prefix when the detection is narrowed', async () => {
+      await blockchainBalances.refreshBlockchainBalances(
+        { blockchain: Blockchain.ETH },
+        'background',
+        { detect: true, detectAddresses: ['0xaaa'] },
+      );
+
+      const [[spec]] = submitTask.mock.calls;
+      expect(spec.id.startsWith(makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, Blockchain.ETH))).toBe(true);
     });
 
     /**

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -31,6 +31,11 @@ export interface RefreshOptions {
    * of the chain: the same chain detects on a login refresh and does not on a periodic one.
    */
   readonly detect?: boolean;
+  /**
+   * Narrow the detection stage to these addresses. Ignored without `detect`, and omitted it covers
+   * every address on the chain — an account addition is the one flow that knows a smaller answer.
+   */
+  readonly detectAddresses?: string[];
 }
 
 interface UseBlockchainBalancesReturn {
@@ -89,7 +94,7 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
     mode: RefreshMode = 'background',
     options: RefreshOptions = {},
   ): Promise<void> => {
-    const { detect = false } = options;
+    const { detect = false, detectAddresses } = options;
     const { addresses, blockchain, isXpub = false } = payload;
     const chains = blockchain ? arrayify(blockchain) : get(supportedChains).map(chain => chain.id);
     // ⭐ A user-initiated refresh replaces the run in flight instead of joining it. `supersedeTask`
@@ -110,8 +115,18 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
       // chain never happens** — no row, no log, no error. `withDetection` still writes
       // `lastAutoDetectAt` in its `finally`, so the cooldown then suppresses the next login's sweep
       // too, and the tokens stay undetected for a day.
+      //
+      // 🔴🔴 The *narrowing* is part of it for the same reason. Two additions on one chain differ
+      // only in `detectAddresses`, so a shared id makes the second dedup onto the first and its
+      // addresses are never detected — silently, and with the first job's wholesale query possibly
+      // already gone. A CSV import is the worst case: `use-account-import.ts` starts every row in
+      // the same tick, so rows 2..N all collapse onto row 1.
+      //
+      // ⚠️ Appended, never substituted: every reader of this id is prefix-based
+      // (`useIsActivePrefix`, `useWorkStatusPrefix`, `activityParts(id)[0]`), so `(kind, chain)`
+      // must keep matching.
       const id = detect
-        ? makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain, ActivityPart.DETECT)
+        ? makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain, ActivityPart.DETECT, ...(detectAddresses?.length ? [setDigest(detectAddresses)] : []))
         : makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, chain);
       await submit({
         id,
@@ -134,7 +149,7 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
           // awaited here, so the query below sees the tokens they found — no `deps` edge, no
           // second top-level activity, and cancelling this chain now stops the addresses too.
           if (detect)
-            await detectForChain(chain, id);
+            await detectForChain(chain, id, detectAddresses);
 
           // 🔴🔴 The cancel that stopped the children does not stop *this body* — nothing in
           // JavaScript can interrupt a running async function. Without this check the await above

--- a/frontend/app/src/modules/core/messaging/index.spec.ts
+++ b/frontend/app/src/modules/core/messaging/index.spec.ts
@@ -53,19 +53,22 @@ vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
   }),
 }));
 
-const { mockDetectTokens } = vi.hoisted((): { mockDetectTokens: ReturnType<typeof vi.fn> } => ({
-  mockDetectTokens: vi.fn(),
+const { mockRefreshBalances } = vi.hoisted((): { mockRefreshBalances: ReturnType<typeof vi.fn> } => ({
+  mockRefreshBalances: vi.fn(),
 }));
 vi.mock('@/modules/balances/blockchain/use-token-detection-orchestrator', async () => {
   const { computed } = await import('vue');
   return {
     useTokenDetectionOrchestrator: vi.fn().mockReturnValue({
-      detectTokens: mockDetectTokens,
+      detectTokens: vi.fn(),
       detectAllTokens: vi.fn(),
       useIsDetecting: vi.fn().mockReturnValue(computed(() => false)),
     }),
   };
 });
+vi.mock('@/modules/balances/use-blockchain-balances', () => ({
+  useBlockchainBalances: vi.fn().mockReturnValue({ refreshBlockchainBalances: mockRefreshBalances }),
+}));
 
 vi.mock('@/modules/accounts/use-blockchain-account-management', () => ({
   useBlockchainAccountManagement: vi.fn().mockReturnValue({
@@ -140,8 +143,12 @@ describe('useMessageHandling', () => {
       }),
     );
 
-    expect(mockDetectTokens).toHaveBeenCalledTimes(1);
-    expect(mockDetectTokens).toHaveBeenCalledWith('optimism', ['0xdead']);
+    expect(mockRefreshBalances).toHaveBeenCalledTimes(1);
+    expect(mockRefreshBalances).toHaveBeenCalledWith(
+      { blockchain: 'optimism' },
+      'background',
+      { detect: true, detectAddresses: ['0xdead'] },
+    );
     expect(notify).toHaveBeenCalledTimes(1);
   });
 
@@ -189,7 +196,11 @@ describe('useMessageHandling', () => {
 
     await consume();
 
-    expect(mockDetectTokens).toHaveBeenCalledWith('optimism', ['0xdead']);
+    expect(mockRefreshBalances).toHaveBeenCalledWith(
+      { blockchain: 'optimism' },
+      'background',
+      { detect: true, detectAddresses: ['0xdead'] },
+    );
     expect(notify).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/app/src/modules/session/use-session-state-cleaner.spec.ts
+++ b/frontend/app/src/modules/session/use-session-state-cleaner.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { effectScope, type EffectScope, nextTick } from 'vue';
+import { BALANCE_HYDRATION_TAG } from '@/modules/balances/api/use-blockchain-balances-api';
 import { SUGGESTION_PROBE_TAG } from '@/modules/settings/suggestions/use-suggestion-probes';
 import { useSessionStateCleaner } from './use-session-state-cleaner';
 
@@ -85,6 +86,10 @@ describe('useSessionStateCleaner', () => {
     expect(resetState).toHaveBeenCalledOnce();
     // The login-time suggestion probes are not awaited by the login, so they can outlive it.
     expect(cancelByTag).toHaveBeenCalledWith(SUGGESTION_PROBE_TAG);
+    // 🔴 The cache-only read is a plain GET, so nothing above settles it. Uncancelled, it resolves
+    // against the session that just ended and writes that user's balances into the next user's
+    // store — `resetHydration` only clears the dedup map, it cannot stop a request.
+    expect(cancelByTag).toHaveBeenCalledWith(BALANCE_HYDRATION_TAG);
   });
 
   it('should not clean up while the user stays logged in', async () => {

--- a/frontend/app/src/modules/session/use-session-state-cleaner.ts
+++ b/frontend/app/src/modules/session/use-session-state-cleaner.ts
@@ -1,5 +1,6 @@
 import { useAccountLoadState } from '@/modules/accounts/use-account-load-state';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { BALANCE_HYDRATION_TAG } from '@/modules/balances/api/use-blockchain-balances-api';
 import { useBalanceHydration } from '@/modules/balances/use-balance-hydration';
 import { api } from '@/modules/core/api/rotki-api';
 import { useSync } from '@/modules/session/use-session-sync';
@@ -34,9 +35,12 @@ export function useSessionStateCleaner(): void {
     resetNativeTasks();
     // Same reason, same scope: a read tracked here outlives the session that started it.
     resetAccountLoad();
-    // Hydration dedups by chain against an app-scoped map, so a read that can never settle (its
-    // backend task belonged to the session that just ended) would be handed to the next session's
-    // caller for that chain — which then never hydrates, silently.
+    // 🔴 Cancel before clearing the map. The cache-only read is a plain GET, not a backend task, so
+    // nothing above settles it: left alone it resolves against the session that just ended and
+    // `processBalanceResult` writes that user's balances into the next user's store.
+    api.cancelByTag(BALANCE_HYDRATION_TAG);
+    // Hydration dedups by chain against an app-scoped map, so a read that can never settle would be
+    // handed to the next session's caller for that chain — which then never hydrates, silently.
     resetHydration();
     resetState();
   }

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -936,6 +936,7 @@ class RestAPI:
     def query_blockchain_balances(
             self,
             blockchain: SupportedBlockchain | None,
+            only_cache: bool = False,
             value_threshold: FVal | None = None,
             addresses: ListOfBlockchainAddresses | None = None,
     ) -> dict[str, Any]:
@@ -947,8 +948,9 @@ class RestAPI:
                 chain=blockchain,
                 from_cache=True,
                 addresses=addresses,
+                only_cache=only_cache,
             )
-            if self._should_refresh_blockchain_balances(
+            if only_cache is False and self._should_refresh_blockchain_balances(
                 blockchain=blockchain,
                 balances=balances,
                 last_refresh_ts=self.rotkehlchen.chains_aggregator.get_blockchain_balances_last_query_ts(blockchain),

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -1200,12 +1200,14 @@ class BlockchainBalancesResource(BaseMethodView):
             self,
             blockchain: SupportedBlockchain | None,
             async_query: bool,
+            only_cache: bool,
             value_threshold: FVal | None,
             addresses: ListOfBlockchainAddresses | None,
     ) -> Response:
         return self.rest_api.query_blockchain_balances(
             blockchain=blockchain,
             async_query=async_query,
+            only_cache=only_cache,
             value_threshold=value_threshold,
             addresses=addresses,
         )

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -2221,7 +2221,11 @@ class BlockchainBalanceBaseSchema(AsyncQueryArgumentSchema):
                 )
 
 
-class BlockchainBalanceQuerySchema(BlockchainBalanceBaseSchema, ValueThresholdSchema):
+class BlockchainBalanceQuerySchema(
+        BlockchainBalanceBaseSchema,
+        ValueThresholdSchema,
+        OnlyCacheQuerySchema,
+):
     ...
 
 

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -71,6 +71,7 @@ from rotkehlchen.chain.substrate.utils import SUBSTRATE_NODE_CONNECTION_TIMEOUT
 from rotkehlchen.concurrency import exception_of, result_of, spawn, wait
 from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ONE, ZERO
 from rotkehlchen.constants.assets import A_BCH, A_BTC, A_DAI, A_ETH, A_ETH2
+from rotkehlchen.constants.prices import ZERO_PRICE
 from rotkehlchen.constants.timing import HOUR_IN_SECONDS
 from rotkehlchen.db.addressbook import DBAddressbook
 from rotkehlchen.db.cache import DBCacheDynamic, DBCacheStatic
@@ -524,6 +525,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             chain: SupportedBlockchain | None,
             from_cache: bool = False,
             addresses: ListOfBlockchainAddresses | None = None,
+            only_cache: bool = False,
     ) -> BlockchainBalancesUpdate:
         """Returns a balances update to be consumed by the API."""
         if from_cache is True:
@@ -541,6 +543,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             self._populate_cached_balances_values(
                 balances=balances,
                 last_query_ts=last_query_ts,
+                only_cache=only_cache,
             )
             return BlockchainBalancesUpdate(
                 given_chain=chain,
@@ -582,6 +585,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             main_currency: Asset,
             price_cache: dict[tuple[str, Timestamp], FVal],
             manual_current_prices: dict[str, tuple[Asset, Price]],
+            only_cache: bool = False,
     ) -> FVal:
         cache_key = (asset.identifier, timestamp)
         if cache_key in price_cache:
@@ -594,10 +598,18 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             if current_to_asset == main_currency:
                 price = FVal(current_price)
             else:
-                current_to_asset_price = Inquirer.find_price(
-                    from_asset=current_to_asset,
-                    to_asset=main_currency,
-                )
+                if only_cache is True:
+                    cached_price = Inquirer.get_cached_current_price_entry(
+                        cache_key=(current_to_asset, main_currency),
+                    )
+                    current_to_asset_price = (
+                        cached_price.price if cached_price is not None else ZERO_PRICE
+                    )
+                else:
+                    current_to_asset_price = Inquirer.find_price(
+                        from_asset=current_to_asset,
+                        to_asset=main_currency,
+                    )
                 price = FVal(current_price * current_to_asset_price)
         elif (price_entry := GlobalDBHandler.get_historical_price(
             from_asset=asset,
@@ -616,6 +628,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             self,
             balances: BlockchainBalances,
             last_query_ts: dict[str, Timestamp],
+            only_cache: bool = False,
     ) -> None:
         main_currency = CachedSettings().main_currency
         price_cache: dict[tuple[str, Timestamp], FVal] = {}
@@ -637,6 +650,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
                             main_currency=main_currency,
                             price_cache=price_cache,
                             manual_current_prices=manual_current_prices,
+                            only_cache=only_cache,
                         )
                         for balance in labeled_balances.values():
                             balance.value = balance.amount * price
@@ -654,6 +668,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
                 main_currency=main_currency,
                 price_cache=price_cache,
                 manual_current_prices=manual_current_prices,
+                only_cache=only_cache,
             )
 
             for balance in chain_balances.values():

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -837,6 +837,29 @@ def test_multiple_balance_queries_not_concurrent(
 
 
 @pytest.mark.parametrize('number_of_eth_accounts', [1])
+def test_blockchain_balances_only_cache_does_not_query_chain(
+        rotkehlchen_api_server: APIServer,
+) -> None:
+    """A cache-only GET returns an empty result without falling back to the chain."""
+    chains_aggregator = rotkehlchen_api_server.rest_api.rotkehlchen.chains_aggregator
+    with patch.object(chains_aggregator, 'query_balances') as query_mock:
+        result = assert_proper_sync_response_with_result(requests.get(
+            api_url_for(
+                rotkehlchen_api_server,
+                'named_blockchain_balances_resource',
+                blockchain=SupportedBlockchain.ETHEREUM.serialize(),
+            ),
+            params={'only_cache': True},
+        ))
+
+    query_mock.assert_not_called()
+    assert result == {
+        'per_account': {},
+        'totals': {'assets': {}, 'liabilities': {}},
+    }
+
+
+@pytest.mark.parametrize('number_of_eth_accounts', [1])
 def test_balances_caching_mixup(
         rotkehlchen_api_server: APIServer,
         ethereum_accounts: list[ChecksumEvmAddress],

--- a/rotkehlchen/tests/unit/test_blockchain_balances.py
+++ b/rotkehlchen/tests/unit/test_blockchain_balances.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.assets.asset import EvmToken
+from rotkehlchen.chain.aggregator import ChainsAggregator
 from rotkehlchen.chain.balances import BlockchainBalances
 from rotkehlchen.chain.ethereum.modules.liquity.constants import CPT_LIQUITY
 from rotkehlchen.chain.evm.types import string_to_evm_address
@@ -15,6 +15,7 @@ from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
+from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.tests.utils.factories import UNIT_BTC_ADDRESS1, make_evm_address
 from rotkehlchen.tests.utils.xpubs import setup_db_for_xpub_tests_impl
 from rotkehlchen.types import (
@@ -25,9 +26,6 @@ from rotkehlchen.types import (
     Timestamp,
     TokenKind,
 )
-
-if TYPE_CHECKING:
-    from rotkehlchen.chain.aggregator import ChainsAggregator
 
 OPTIMISM_OP_TOKEN = EvmToken.initialize(
     address=string_to_evm_address('0x4200000000000000000000000000000000000042'),
@@ -384,3 +382,27 @@ def test_cached_gnosis_balance_uses_manual_current_price(
 
     assert gnosis_token in balances_update.totals.assets
     assert balances_update.totals.assets[gnosis_token]['aave-v3'].value == amount * manual_price
+
+
+def test_only_cache_repricing_does_not_query_price_oracles() -> None:
+    """A cache-only balance read must not fetch a missing manual-price conversion online."""
+    with (
+        patch.object(Inquirer, 'get_cached_current_price_entry', return_value=None),
+        patch.object(
+            Inquirer,
+            'find_price',
+            side_effect=AssertionError(
+                'cache-only balance repricing must not query price oracles',
+            ),
+        ),
+    ):
+        price = ChainsAggregator.get_price_for_cached_balances(
+            asset=A_ETH.resolve_to_crypto_asset(),
+            timestamp=Timestamp(1_700_000_000),
+            main_currency=A_EUR,
+            price_cache={},
+            manual_current_prices={A_ETH.identifier: (A_BTC, Price(ONE))},
+            only_cache=True,
+        )
+
+    assert price == ZERO


### PR DESCRIPTION
Return cached chain balances directly without falling back to network queries or remote price oracles. Update frontend hydration to avoid backend task polling while preserving retries, cancellation handling, and stale-result protection.

