### PR TITLE
Derive the url filter shape from the declared fields

### DIFF
--- a/frontend/app/src/modules/accounts/EthStakingValidators.vue
+++ b/frontend/app/src/modules/accounts/EthStakingValidators.vue
@@ -14,7 +14,6 @@ import HashLink from '@/modules/shell/components/HashLink.vue';
 import RowActions from '@/modules/shell/components/RowActions.vue';
 import RowAppend from '@/modules/shell/components/RowAppend.vue';
 import { useEthValidatorData } from '@/modules/staking/eth/use-eth-validator-data';
-import { useEthValidatorFields } from '@/modules/staking/eth/use-eth-validator-fields';
 import { useEthValidatorOperations } from '@/modules/staking/eth/use-eth-validator-operations';
 import { useEthValidatorUtils } from '@/modules/staking/eth/use-eth-validator-utils';
 import ValidatorStatus from '@/modules/staking/eth/ValidatorStatus.vue';
@@ -29,6 +28,7 @@ const { t } = useI18n({ useScope: 'global' });
 const {
   cols,
   ethStakingValidators,
+  fields,
   filters,
   pagination,
   rows,
@@ -36,7 +36,6 @@ const {
   sort,
 } = useEthValidatorData();
 
-const fields = useEthValidatorFields();
 const pillLabels = usePillBarLabels();
 
 // Every pill on this table is filter-bound, so a saved view is its `matches` alone. `params` stays

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagement.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagement.vue
@@ -50,6 +50,7 @@ const {
   Filters
 >({
   fetch: filter => getAddressBook(get(location), get(filter)),
+  fields,
   filterSchema,
   params: [{
     to: 'both',

--- a/frontend/app/src/modules/accounts/address-book/address-book-fields.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/address-book-fields.spec.ts
@@ -6,6 +6,7 @@ import {
   toAddressBookStrictField,
 } from '@/modules/accounts/address-book/address-book-fields';
 import { DisplayKinds } from '@/modules/core/table/pill/core/types';
+import { routeSchemaFromFields } from '@/modules/core/table/route';
 
 const t = (key: string): string => key;
 
@@ -22,6 +23,28 @@ const resolvers: SharedFieldResolvers = {
 };
 
 describe('toAddressBookFields', () => {
+  // The url shape of the filter bag is derived from these fields, so the round-trip is asserted
+  // here rather than against a second hand-written declaration.
+  describe('route query', () => {
+    const schema = routeSchemaFromFields(toAddressBookFields(resolvers, t));
+
+    it('should keep the name value as a single string', () => {
+      expect(schema.parse({ nameSubstring: 'alice' })).toEqual({ nameSubstring: 'alice' });
+    });
+
+    it('should coerce a single address into an array', () => {
+      expect(schema.parse({ address: '0xabc' })).toEqual({ address: ['0xabc'] });
+    });
+
+    it('should keep multiple addresses as an array', () => {
+      expect(schema.parse({ address: ['0xabc', '0xdef'] })).toEqual({ address: ['0xabc', '0xdef'] });
+    });
+
+    it('should allow an empty route filter', () => {
+      expect(schema.parse({})).toEqual({});
+    });
+  });
+
   it('should keep the wire keys the table already sends', () => {
     expect(toAddressBookFields(resolvers, t).map(field => field.key)).toStrictEqual([
       'nameSubstring',

--- a/frontend/app/src/modules/accounts/address-book/use-address-book-filter.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-book-filter.spec.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { useAddressBookFilter } from '@/modules/accounts/address-book/use-address-book-filter';
 
 vi.mock('vue-i18n', async importOriginal => ({
@@ -12,29 +12,6 @@ describe('useAddressBookFilter', () => {
     expect(get(filters)).toEqual({});
   });
 
-  // The fields are declared in `address-book-fields.ts` and covered by its own spec. What is left
-  // here is the URL round-trip, which is the only thing this schema still owns.
-  it('should keep the name value as a single string', () => {
-    const { RouteFilterSchema } = useAddressBookFilter();
-    assert(RouteFilterSchema);
-    expect(RouteFilterSchema.parse({ nameSubstring: 'alice' })).toEqual({ nameSubstring: 'alice' });
-  });
-
-  it('should coerce a single address into an array', () => {
-    const { RouteFilterSchema } = useAddressBookFilter();
-    assert(RouteFilterSchema);
-    expect(RouteFilterSchema.parse({ address: '0xabc' })).toEqual({ address: ['0xabc'] });
-  });
-
-  it('should keep multiple addresses as an array', () => {
-    const { RouteFilterSchema } = useAddressBookFilter();
-    assert(RouteFilterSchema);
-    expect(RouteFilterSchema.parse({ address: ['0xabc', '0xdef'] })).toEqual({ address: ['0xabc', '0xdef'] });
-  });
-
-  it('should allow an empty route filter', () => {
-    const { RouteFilterSchema } = useAddressBookFilter();
-    assert(RouteFilterSchema);
-    expect(RouteFilterSchema.parse({})).toEqual({});
-  });
+  // The URL round-trip is asserted in `address-book-fields.spec.ts`: the url shape is derived from
+  // the fields, so it is proved against the field list rather than against a second declaration.
 });

--- a/frontend/app/src/modules/accounts/address-book/use-address-book-filter.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-book-filter.ts
@@ -1,6 +1,5 @@
 import type { MatchedKeyword } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { FilterKeyArities, filterRouteSchema } from '@/modules/core/table/route';
 
 export const AddressBookFilterKeys = {
   ADDRESS: 'address',
@@ -16,9 +15,5 @@ export function useAddressBookFilter(): FilterSchema<Filters> {
 
   return {
     filters: modelFilters,
-    RouteFilterSchema: filterRouteSchema({
-      [AddressBookFilterKeys.ADDRESS]: FilterKeyArities.MANY,
-      [AddressBookFilterKeys.NAME]: FilterKeyArities.ONE,
-    }),
   };
 }

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalanceTable.vue
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalanceTable.vue
@@ -54,6 +54,7 @@ const {
   Filters
 >({
   fetch,
+  fields,
   filterSchema,
   params: [{
     fromQuery(query): void {

--- a/frontend/app/src/modules/accounts/manual-balances/manual-balance-fields.spec.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/manual-balance-fields.spec.ts
@@ -4,6 +4,7 @@ import type { SharedFieldResolvers } from '@/modules/core/table/filters/shared/u
 import { describe, expect, it } from 'vitest';
 import { toManualBalanceFields } from '@/modules/accounts/manual-balances/manual-balance-fields';
 import { DisplayKinds } from '@/modules/core/table/pill/core/types';
+import { routeSchemaFromFields } from '@/modules/core/table/route';
 
 const t = (key: string): string => key;
 
@@ -30,6 +31,19 @@ const options = {
 const fields = (): ReturnType<typeof toManualBalanceFields> => toManualBalanceFields(resolvers, t, options);
 
 describe('toManualBalanceFields', () => {
+  // The url shape of the filter bag is derived from these fields, so the round-trip is asserted
+  // here rather than against a second hand-written declaration.
+  it('should parse optional route filter values', () => {
+    const schema = routeSchemaFromFields(fields());
+
+    expect(schema.parse({ asset: 'ETH', label: 'x', location: 'kraken' })).toEqual({
+      asset: 'ETH',
+      label: 'x',
+      location: 'kraken',
+    });
+    expect(schema.parse({})).toEqual({});
+  });
+
   // The tags pill is the whole point of the migration here: it was a selector of its own beside
   // the bar, and it is param-bound rather than part of the filter bag.
   it('should offer the tags beside the table own fields', () => {

--- a/frontend/app/src/modules/accounts/manual-balances/use-manual-balances-filter.spec.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/use-manual-balances-filter.spec.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   ManualBalancesFilterSchema,
   useManualBalanceFilter,
@@ -11,17 +11,8 @@ describe('useManualBalanceFilter', () => {
     expect(get(filters)).toEqual({});
   });
 
-  it('should parse optional route filter values', () => {
-    const { RouteFilterSchema } = useManualBalanceFilter();
-    assert(RouteFilterSchema);
-
-    expect(RouteFilterSchema.parse({ asset: 'ETH', label: 'x', location: 'kraken' })).toEqual({
-      asset: 'ETH',
-      label: 'x',
-      location: 'kraken',
-    });
-    expect(RouteFilterSchema.parse({})).toEqual({});
-  });
+  // The URL round-trip is asserted in `manual-balance-fields.spec.ts`, against the field list the
+  // url shape is now derived from.
 });
 
 describe('manualBalancesFilterSchema', () => {

--- a/frontend/app/src/modules/accounts/manual-balances/use-manual-balances-filter.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/use-manual-balances-filter.ts
@@ -1,7 +1,7 @@
 import type { MatchedKeyword } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
 import z from 'zod';
-import { CommaSeparatedStringSchema, FilterKeyArities, filterRouteSchema } from '@/modules/core/table/route';
+import { CommaSeparatedStringSchema } from '@/modules/core/table/route';
 
 /** The wire keys the manual balances table filters on, which the URL carries too. */
 export const ManualBalanceFilterKeys = {
@@ -19,11 +19,6 @@ export function useManualBalanceFilter(): FilterSchema<Filters> {
 
   return {
     filters: modelFilters,
-    RouteFilterSchema: filterRouteSchema({
-      [ManualBalanceFilterKeys.ASSET]: FilterKeyArities.ONE,
-      [ManualBalanceFilterKeys.LABEL]: FilterKeyArities.ONE,
-      [ManualBalanceFilterKeys.LOCATION]: FilterKeyArities.ONE,
-    }),
   };
 }
 

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetContent.vue
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetContent.vue
@@ -57,6 +57,7 @@ const {
   Filters
 >({
   fetch: queryAllCustomAssets,
+  fields,
   filterSchema,
   sort: {
     default: [{

--- a/frontend/app/src/modules/assets/admin/custom/custom-asset-fields.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/custom-asset-fields.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { toCustomAssetFields } from '@/modules/assets/admin/custom/custom-asset-fields';
+import { routeSchemaFromFields } from '@/modules/core/table/route';
 
 const t = (key: string): string => key;
 
@@ -30,5 +31,17 @@ describe('toCustomAssetFields', () => {
 
   it('should keep the wire keys the table already sends', () => {
     expect(toCustomAssetFields(types, t).map(field => field.key)).toStrictEqual(['name', 'custom_asset_type']);
+  });
+
+  // The url shape of the filter bag is derived from these fields, so the round-trip is asserted
+  // here rather than against a second hand-written declaration.
+  it('should keep name and type route values as optional strings', () => {
+    const schema = routeSchemaFromFields(toCustomAssetFields(types, t));
+
+    expect(schema.parse({ custom_asset_type: 'fiat', name: 'gold' })).toEqual({
+      custom_asset_type: 'fiat',
+      name: 'gold',
+    });
+    expect(schema.parse({})).toEqual({});
   });
 });

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-assets-filter.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-assets-filter.spec.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { useCustomAssetFilter } from '@/modules/assets/admin/custom/use-custom-assets-filter';
 
 vi.mock('vue-i18n', async importOriginal => ({
@@ -13,14 +13,6 @@ describe('useCustomAssetFilter', () => {
   });
 
   // The fields are declared in `custom-asset-fields.ts`, with their suggestions and validation, and
-  // covered by its own spec. What is left here is the URL round-trip.
-  it('should keep name and type route values as optional strings', () => {
-    const { RouteFilterSchema } = useCustomAssetFilter();
-    assert(RouteFilterSchema);
-    expect(RouteFilterSchema.parse({ custom_asset_type: 'fiat', name: 'gold' })).toEqual({
-      custom_asset_type: 'fiat',
-      name: 'gold',
-    });
-    expect(RouteFilterSchema.parse({})).toEqual({});
-  });
+  // covered by its own spec, which is also where the URL round-trip is now asserted: the url shape
+  // is derived from those fields.
 });

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-assets-filter.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-assets-filter.ts
@@ -1,6 +1,5 @@
 import type { MatchedKeyword } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { FilterKeyArities, filterRouteSchema } from '@/modules/core/table/route';
 
 /** The wire keys the custom assets table filters on, which the URL carries too. */
 export const CustomAssetFilterKeys = {
@@ -17,9 +16,5 @@ export function useCustomAssetFilter(): FilterSchema<Filters> {
 
   return {
     filters: modelFilters,
-    RouteFilterSchema: filterRouteSchema({
-      [CustomAssetFilterKeys.CUSTOM_ASSET_TYPE]: FilterKeyArities.ONE,
-      [CustomAssetFilterKeys.NAME]: FilterKeyArities.ONE,
-    }),
   };
 }

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
@@ -78,6 +78,7 @@ const {
   Filters
 >({
   fetch: queryAllAssets,
+  fields,
   filterSchema,
   params: [{
     fromQuery(query): void {

--- a/frontend/app/src/modules/assets/admin/managed/managed-asset-fields.spec.ts
+++ b/frontend/app/src/modules/assets/admin/managed/managed-asset-fields.spec.ts
@@ -94,10 +94,13 @@ describe('toManagedAssetFields', () => {
     expect(fieldOf('evmChain')?.excludes).toStrictEqual(['assetType']);
   });
 
-  // The endpoint takes one of each, as the matchers this replaced declared.
-  it('should let no field take more than one value', () => {
-    expect(fields().every(field => !field.multiple)).toBe(true);
+  // `AssetsPostSchema` takes one of each of these; only `identifiers` is a list
+  // (`DelimitedOrNormalList`, matched with `IN (...)`), which is also what the url has always
+  // carried for it.
+  it('should let only the identifiers field take more than one value', () => {
+    expect(fields().filter(field => field.multiple).map(field => field.key)).toStrictEqual(['identifiers']);
   });
+
 });
 
 describe('the status fields', () => {

--- a/frontend/app/src/modules/assets/admin/managed/managed-asset-fields.spec.ts
+++ b/frontend/app/src/modules/assets/admin/managed/managed-asset-fields.spec.ts
@@ -8,6 +8,7 @@ import {
   toAssetWhitelistedField,
   toManagedAssetFields,
 } from '@/modules/assets/admin/managed/managed-asset-fields';
+import { routeSchemaFromFields } from '@/modules/core/table/route';
 
 const t = (key: string): string => key;
 
@@ -101,6 +102,16 @@ describe('toManagedAssetFields', () => {
     expect(fields().filter(field => field.multiple).map(field => field.key)).toStrictEqual(['identifiers']);
   });
 
+  // The url shape of the filter bag is derived from these fields, so the round-trip is asserted
+  // here rather than against a second hand-written declaration.
+  it('should read identifiers as a list and everything else as one value', () => {
+    const schema = routeSchemaFromFields(fields());
+
+    expect(schema.parse({ identifiers: 'eip155:1/erc20:0xdai', name: 'dai' }))
+      .toEqual({ identifiers: ['eip155:1/erc20:0xdai'], name: 'dai' });
+    expect(schema.parse({ identifiers: ['a', 'b'] })).toEqual({ identifiers: ['a', 'b'] });
+    expect(schema.parse({})).toEqual({});
+  });
 });
 
 describe('the status fields', () => {

--- a/frontend/app/src/modules/assets/admin/managed/managed-asset-fields.ts
+++ b/frontend/app/src/modules/assets/admin/managed/managed-asset-fields.ts
@@ -45,12 +45,14 @@ export function toManagedAssetFields(
   options: ManagedAssetFieldOptions,
 ): FieldDef[] {
   return [
+    // The backend takes identifiers as a list (`DelimitedOrNormalList` -> `IN (...)`), and the URL
+    // has always carried several, so the field offers several rather than only the first.
     toMatchFieldDef({
       freeText: true,
       hint: t('assets.filter.identifier_hint'),
       key: AssetFilterKeys.IDENTIFIER,
       label: t('assets.filter_field_labels.identifier'),
-      multiple: false,
+      multiple: true,
     }),
     // A backend asset type is already spaced words (`evm token`), so it only needs its casing fixed.
     decorateSharedField(

--- a/frontend/app/src/modules/assets/admin/managed/use-assets-filter.ts
+++ b/frontend/app/src/modules/assets/admin/managed/use-assets-filter.ts
@@ -1,6 +1,5 @@
 import type { MatchedKeyword } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { FilterKeyArities, filterRouteSchema } from '@/modules/core/table/route';
 
 /** The wire keys the managed assets table filters on, which the URL carries too. */
 export const AssetFilterKeys = {
@@ -22,14 +21,5 @@ export function useAssetFilter(): FilterSchema<Filters> {
 
   return {
     filters: modelFilters,
-    RouteFilterSchema: filterRouteSchema({
-      [AssetFilterKeys.ADDRESS]: FilterKeyArities.ONE,
-      [AssetFilterKeys.ASSET_FLAG]: FilterKeyArities.ONE,
-      [AssetFilterKeys.ASSET_TYPE]: FilterKeyArities.ONE,
-      [AssetFilterKeys.CHAIN]: FilterKeyArities.ONE,
-      [AssetFilterKeys.IDENTIFIER]: FilterKeyArities.MANY,
-      [AssetFilterKeys.NAME]: FilterKeyArities.ONE,
-      [AssetFilterKeys.SYMBOL]: FilterKeyArities.ONE,
-    }),
   };
 }

--- a/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceContent.vue
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceContent.vue
@@ -36,6 +36,7 @@ const {
   Filters
 >({
   fetch: fetchData,
+  fields,
   filterSchema,
   sort: {
     default: {

--- a/frontend/app/src/modules/assets/prices/use-oracle-prices-filter.ts
+++ b/frontend/app/src/modules/assets/prices/use-oracle-prices-filter.ts
@@ -1,6 +1,5 @@
 import type { MatchedKeyword } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { FilterKeyArities, filterRouteSchema } from '@/modules/core/table/route';
 
 /** The wire keys the oracle prices table filters on, which the URL carries too. */
 export const OraclePriceFilterKeys = {
@@ -20,12 +19,5 @@ export function useOraclePricesFilter(): FilterSchema<Filters> {
 
   return {
     filters: modelFilters,
-    RouteFilterSchema: filterRouteSchema({
-      [OraclePriceFilterKeys.END]: FilterKeyArities.ONE,
-      [OraclePriceFilterKeys.FROM_ASSET]: FilterKeyArities.ONE,
-      [OraclePriceFilterKeys.SOURCE]: FilterKeyArities.ONE,
-      [OraclePriceFilterKeys.START]: FilterKeyArities.ONE,
-      [OraclePriceFilterKeys.TO_ASSET]: FilterKeyArities.ONE,
-    }),
   };
 }

--- a/frontend/app/src/modules/core/table/pagination-filter-types.ts
+++ b/frontend/app/src/modules/core/table/pagination-filter-types.ts
@@ -1,6 +1,5 @@
 import type { DataTableSortColumn } from '@rotki/ui-library';
 import type { Ref } from 'vue';
-import type { Schema } from 'zod';
 
 export type TableRowKey<T> = keyof T extends string ? keyof T : never;
 
@@ -8,17 +7,11 @@ export type SingleColumnSorting<T extends NonNullable<unknown>> = Required<DataT
 
 export type Sorting<T extends NonNullable<unknown>> = SingleColumnSorting<T> | SingleColumnSorting<T>[];
 
+/**
+ * A table's filter bag. The url shape of the bag and the keys the request wraps as
+ * `{ behaviour, values }` used to be declared here too; both are now read off the table's fields
+ * (`routeSchemaFromFields`, `behaviourKeysFromFields`), which already state them.
+ */
 export interface FilterSchema<F> {
   filters: Ref<F>;
-  RouteFilterSchema?: Schema;
-  /**
-   * Wire keys the backend takes as `{ behaviour, values }` rather than a bare list (its
-   * `IncludeExcludeListField` requires the wrapper and rejects a plain list), so an excluded value
-   * can be expressed. The pill codec writes exclusion as a `!` prefix, which is also what the URL
-   * carries; the wrapping happens at request assembly, where this is read.
-   *
-   * Declared per table: it describes the request. Typed against the filter's own keys so a key
-   * that is not one of them fails to compile.
-   */
-  behaviourKeys?: readonly (keyof F & string)[];
 }

--- a/frontend/app/src/modules/core/table/route.spec.ts
+++ b/frontend/app/src/modules/core/table/route.spec.ts
@@ -1,11 +1,16 @@
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import { describe, expect, it } from 'vitest';
+import { FilterValueTypes } from '@/modules/core/table/filtering';
+import { toMatchFieldDef, toParamFieldDef, toRangeFieldDef } from '@/modules/core/table/pill/core/field-adapter';
 import {
+  behaviourKeysFromFields,
   CommaSeparatedStringSchema,
   HistoryPaginationSchema,
   HistorySortOrderSchema,
   RouterAccountsSchema,
   RouterExpandedIdsSchema,
   RouterLocationLabelsSchema,
+  routeSchemaFromFields,
 } from '@/modules/core/table/route';
 
 describe('route query schemas', () => {
@@ -92,6 +97,69 @@ describe('route query schemas', () => {
 
     it('should skip entries with an unknown chain', () => {
       expect(RouterAccountsSchema.parse({ accounts: '0xaaa#notachain' })).toStrictEqual({ accounts: [] });
+    });
+  });
+
+  // The url shape used to be restated per table beside a field list that already said the same
+  // thing, so the two could disagree with nothing to catch it.
+  describe('routeSchemaFromFields', () => {
+    const single: FieldDef = toMatchFieldDef({ key: 'location', label: 'Location', multiple: false });
+    const many: FieldDef = toMatchFieldDef({ key: 'counterparties', label: 'Protocol', multiple: true });
+
+    it('should read a single-value field as one optional string', () => {
+      expect(routeSchemaFromFields([single]).parse({ location: 'kraken' })).toStrictEqual({ location: 'kraken' });
+    });
+
+    it('should read a multi-value field as a list, however the url spells it', () => {
+      const schema = routeSchemaFromFields([many]);
+
+      expect(schema.parse({ counterparties: 'uniswap-v2' })).toStrictEqual({ counterparties: ['uniswap-v2'] });
+      expect(schema.parse({ counterparties: ['uniswap-v2', 'curve'] }))
+        .toStrictEqual({ counterparties: ['uniswap-v2', 'curve'] });
+    });
+
+    // A collapsed range/date pill carries its own display key ('amount', 'period'), which is not a
+    // wire key: what the url and the request carry are its two bounds.
+    it('should expand a bounds field into its two wire keys and leave its own key out', () => {
+      const amount = toRangeFieldDef({ key: 'amount', label: 'Amount', lowerKey: 'minAmount', upperKey: 'maxAmount' });
+
+      expect(routeSchemaFromFields([amount]).parse({ amount: '5', maxAmount: '10', minAmount: '1' }))
+        .toStrictEqual({ maxAmount: '10', minAmount: '1' });
+    });
+
+    // A param-bound field is not part of the filter bag: its own source reads it back off the query.
+    it('should leave a param-bound field out of the filter bag', () => {
+      const owned = toParamFieldDef({
+        key: 'owned',
+        label: 'Owned',
+        paramKey: 'showUserOwnedAssetsOnly',
+        to: 'both',
+        valueType: FilterValueTypes.BOOLEAN,
+      });
+
+      expect(routeSchemaFromFields([owned]).parse({ owned: 'true' })).toStrictEqual({});
+    });
+
+    it('should allow an empty query', () => {
+      expect(routeSchemaFromFields([single, many]).parse({})).toStrictEqual({});
+    });
+  });
+
+  describe('behaviourKeysFromFields', () => {
+    it('should name the fields that can express an exclusion', () => {
+      const fields = [
+        toMatchFieldDef({ allowExclusion: true, key: 'entryTypes', label: 'Type', multiple: true }),
+        toMatchFieldDef({ key: 'location', label: 'Location', multiple: false }),
+      ];
+
+      expect(behaviourKeysFromFields(fields)).toStrictEqual(['entryTypes']);
+    });
+
+    // A param carries a plain list with no form for the `!` negation, so it never wraps.
+    it('should never name a param-bound field', () => {
+      const state = toParamFieldDef({ key: 'state', label: 'State', paramKey: 'stateMarkers', to: 'request' });
+
+      expect(behaviourKeysFromFields([state])).toStrictEqual([]);
     });
   });
 });

--- a/frontend/app/src/modules/core/table/route.ts
+++ b/frontend/app/src/modules/core/table/route.ts
@@ -1,4 +1,5 @@
 import type { LocationQueryValue, LocationQueryValueRaw } from 'vue-router';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import { type Account, Blockchain } from '@rotki/common';
 import { z } from 'zod';
 import { arrayify } from '@/modules/core/common/data/array';
@@ -46,6 +47,44 @@ export function filterRouteSchema(keys: Record<string, FilterKeyArity>): z.ZodOb
       arity === FilterKeyArities.MANY ? OptionalValues : OptionalValue,
     ]),
   ));
+}
+
+/**
+ * The same url shape, read off the fields the table already declares instead of restated by hand.
+ *
+ * A field says everything the schema needs: which wire key it writes, and whether that key takes
+ * one value or a list (`multiple`). A collapsed range/date field writes two scalar bounds rather
+ * than its own key, and a param-bound field is not part of the filter bag at all, so neither
+ * contributes its `key`.
+ */
+export function routeSchemaFromFields(fields: readonly FieldDef[]): ReturnType<typeof filterRouteSchema> {
+  const keys: Record<string, FilterKeyArity> = {};
+
+  for (const field of fields) {
+    if (field.binding.kind !== 'filter')
+      continue;
+
+    if (field.bounds) {
+      keys[field.bounds.lower] = FilterKeyArities.ONE;
+      keys[field.bounds.upper] = FilterKeyArities.ONE;
+      continue;
+    }
+
+    keys[field.key] = field.multiple ? FilterKeyArities.MANY : FilterKeyArities.ONE;
+  }
+
+  return filterRouteSchema(keys);
+}
+
+/**
+ * The keys the backend takes as `{ behaviour, values }`, read off the fields that declare they can
+ * express an exclusion. The two were declared separately, and a field offering `is_not` for a key
+ * the request never wraps applies as a plain `is`, silently keeping what the user excluded.
+ */
+export function behaviourKeysFromFields(fields: readonly FieldDef[]): string[] {
+  return fields
+    .filter(field => field.binding.kind === 'filter' && field.allowExclusion)
+    .map(field => field.key);
 }
 
 export const RouterExpandedIdsSchema = z.object({

--- a/frontend/app/src/modules/core/table/use-server-table.spec.ts
+++ b/frontend/app/src/modules/core/table/use-server-table.spec.ts
@@ -3,11 +3,11 @@ import type { Collection } from '@/modules/core/common/collection';
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
 import type { MatchedKeywordWithBehaviour } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import type { LocationQuery } from '@/modules/core/table/route';
 import flushPromises from 'flush-promises';
 import { afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, it, type Mock, vi } from 'vitest';
-import { z } from 'zod';
-import { arrayify } from '@/modules/core/common/data/array';
+import { toMatchFieldDef } from '@/modules/core/table/pill/core/field-adapter';
 import { TableId } from '@/modules/core/table/use-remember-table-sorting';
 import { useServerTable } from '@/modules/core/table/use-server-table';
 
@@ -125,18 +125,19 @@ function mockRequestWithExtras(): (payload: MaybeRef<TestPayloadWithExtras>) => 
   });
 }
 
-function createTestFilterSchema(): FilterSchema<TestFilters> {
-  const OptionalString = z.string().optional();
-  const OptionalMultipleString = z.array(z.string()).or(z.string()).transform(arrayify).optional();
-
+/**
+ * The filter bag and the fields it is declared by. The url shape is derived from the fields, so a
+ * table under test states its keys once, the same way a real one does.
+ */
+function createTestFilterOptions(): { fields: FieldDef[]; filterSchema: FilterSchema<TestFilters> } {
   return {
-    filters: ref<TestFilters>({}),
-    RouteFilterSchema: z.object({
-      asset: OptionalString,
-      identifiers: OptionalString,
-      tempFilter: OptionalString,
-      txRefs: OptionalMultipleString,
-    }),
+    fields: [
+      toMatchFieldDef({ key: 'asset', label: 'Asset', multiple: false }),
+      toMatchFieldDef({ key: 'identifiers', label: 'Identifiers', multiple: false }),
+      toMatchFieldDef({ key: 'tempFilter', label: 'Temp filter', multiple: false }),
+      toMatchFieldDef({ key: 'txRefs', label: 'Tx refs', multiple: true }),
+    ],
+    filterSchema: { filters: ref<TestFilters>({}) },
   };
 }
 
@@ -188,7 +189,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { identifiers: 'never', groupIdentifiers: 'never' }, tableId: TableId.HISTORY },
         params: [{
           values: computed(() => ({
@@ -219,7 +220,7 @@ describe('filter-persistence', () => {
       scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { identifiers: 'never' }, tableId: TableId.HISTORY },
         params: [{
           values: computed(() => ({ identifiers: 'some-id' })),
@@ -244,7 +245,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { tableId: TableId.HISTORY },
         params: [{
           values: computed(() => ({ identifiers: 'some-id' })),
@@ -270,7 +271,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { identifiers: 'never', groupIdentifiers: 'never', duplicateHandlingStatus: 'never' }, tableId: TableId.HISTORY },
         params: [
           {
@@ -310,7 +311,7 @@ describe('filter-persistence', () => {
       scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { txRefs: 'untilChanged' }, tableId: TableId.HISTORY },
       }));
 
@@ -332,7 +333,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { txRefs: 'untilChanged' }, tableId: TableId.HISTORY },
       }))!;
 
@@ -354,7 +355,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { txRefs: 'untilChanged' }, tableId: TableId.HISTORY },
       }))!;
 
@@ -382,7 +383,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { txRefs: 'untilChanged' }, tableId: TableId.HISTORY },
       }))!;
 
@@ -411,7 +412,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { txRefs: 'untilChanged' }, tableId: TableId.HISTORY },
       }))!;
 
@@ -439,7 +440,7 @@ describe('filter-persistence', () => {
       scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { txRefs: 'untilChanged', tempFilter: 'untilChanged' }, tableId: TableId.HISTORY },
       }));
 
@@ -461,7 +462,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { txRefs: 'untilChanged', tempFilter: 'untilChanged' }, tableId: TableId.HISTORY },
       }))!;
 
@@ -491,7 +492,7 @@ describe('filter-persistence', () => {
       scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { identifiers: 'never', groupIdentifiers: 'never', txRefs: 'untilChanged' }, tableId: TableId.HISTORY },
         params: [{
           values: computed(() => ({ identifiers: 'id-1' })),
@@ -519,7 +520,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { identifiers: 'never', txRefs: 'untilChanged' }, tableId: TableId.HISTORY },
         params: [{
           values: computed(() => ({ identifiers: 'id-1' })),
@@ -548,7 +549,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
       }))!;
 
       await nextTick();
@@ -565,7 +566,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         params: [{
           values: computed(() => ({ identifiers: 'some-id' })),
           to: 'both',
@@ -592,7 +593,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { tableId: TableId.HISTORY },
         params: [{
           values: computed(() => ({ identifiers: 'some-id' })),
@@ -621,7 +622,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { txRefs: 'untilChanged' }, tableId: TableId.HISTORY },
       }))!;
 
@@ -655,7 +656,7 @@ describe('filter-persistence', () => {
       scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { tableId: TableId.HISTORY },
       }));
 
@@ -675,7 +676,7 @@ describe('filter-persistence', () => {
       scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { tableId: TableId.HISTORY },
       }));
 
@@ -691,7 +692,7 @@ describe('filter-persistence', () => {
       scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
       }));
 
       await nextTick();
@@ -705,7 +706,7 @@ describe('filter-persistence', () => {
       scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { tableId: TableId.HISTORY },
       }));
 
@@ -721,7 +722,7 @@ describe('filter-persistence', () => {
       const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { nonExistentKey: 'never', anotherMissing: 'never' }, tableId: TableId.HISTORY },
       }))!;
 
@@ -743,7 +744,7 @@ describe('filter-persistence', () => {
       scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
         fetch: mockRequestData(),
         urlState: { mode: 'route' },
-        filterSchema: createTestFilterSchema(),
+        ...createTestFilterOptions(),
         persist: { keys: { txRefs: 'untilChanged' }, tableId: TableId.HISTORY },
       }));
 
@@ -796,7 +797,7 @@ describe('request.debounce', () => {
       fetch: requestFn,
       request: { debounce: 200 },
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -833,7 +834,7 @@ describe('request.debounce', () => {
     const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: requestFn,
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -879,7 +880,7 @@ describe('request.cancelTag', () => {
       fetch: requestFn,
       request: { cancelTag: 'test-cancel-tag' },
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -904,7 +905,7 @@ describe('request.cancelTag', () => {
     const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: requestFn,
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -926,7 +927,7 @@ describe('request.cancelTag', () => {
       fetch: requestFn,
       request: { cancelTag: 'test-cancel-tag' },
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }));
 
     await nextTick();
@@ -952,7 +953,7 @@ describe('request.cancelTag', () => {
       fetch: requestFn,
       request: { debounce: 200 },
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [
         {
           values: computed<Partial<{ locationLabels: string[] }>>(() => {
@@ -1008,7 +1009,7 @@ describe('request.cancelTag', () => {
       fetch: requestFn,
       request: { debounce: 200 },
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [
         {
           values: computed<Partial<{ locationLabels: string[] }>>(() => {
@@ -1055,7 +1056,7 @@ describe('request.cancelTag', () => {
     const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: requestFn,
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -1084,7 +1085,7 @@ describe('request.cancelTag', () => {
       fetch: requestFn,
       request: { cancelTag: 'debounced-cancel-tag', debounce: 200 },
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -1137,7 +1138,7 @@ describe('sources precedence', () => {
     const { filter, requestPayload } = scope.run(() => useServerTable<TestItem, TestPayloadWithExtras, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [{
         values: computed(() => ({ asset: 'FROM_BASE' })),
         to: 'request',
@@ -1162,7 +1163,7 @@ describe('sources precedence', () => {
     const { filter, requestPayload } = scope.run(() => useServerTable<TestItem, TestPayloadWithExtras, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [{
         values: computed(() => ({ asset: 'FROM_SOURCE' })),
         to: 'request',
@@ -1183,7 +1184,7 @@ describe('sources precedence', () => {
     const { requestPayload } = scope.run(() => useServerTable<TestItem, TestPayloadWithExtras, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [
         { values: computed(() => ({ asset: 'FIRST' })), to: 'request' },
         { values: computed(() => ({ asset: 'SECOND' })), to: 'request' },
@@ -1219,7 +1220,7 @@ describe('source destinations', () => {
     const { filter, requestPayload } = scope.run(() => useServerTable<TestItem, TestPayloadWithExtras, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [
         { values: computed(() => ({ requestParam: 'req' })), to: 'request' },
         { values: computed(() => ({ urlParam: 'url' })), to: 'url' },
@@ -1254,7 +1255,7 @@ describe('source destinations', () => {
     const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -1283,7 +1284,7 @@ describe('source destinations', () => {
     scope.run(() => useServerTable<TestItem, TestPayloadWithExtras, TestFilters>({
       fetch: requestFn,
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [{
         values: computed(() => ({ urlParam: get(urlOnly) })),
         to: 'url',
@@ -1309,7 +1310,7 @@ describe('source destinations', () => {
     const { filter, requestPayload } = scope.run(() => useServerTable<TestItem, TestPayloadWithExtras, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [{
         values: computed(() => ({ emptyArr: [], emptyStr: '', filled: 'x' })),
         to: 'both',
@@ -1340,7 +1341,7 @@ describe('source destinations', () => {
     const { requestPayload } = scope.run(() => useServerTable<TestItem, TestPayloadWithExtras, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [{
         values: computed(() => ({ emptyArr: [], emptyStr: '' })),
         to: 'request',
@@ -1385,7 +1386,7 @@ describe('urlState modes', () => {
     const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: requestFn,
       urlState: { mode: 'none' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -1414,7 +1415,7 @@ describe('urlState modes', () => {
     const { filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'ref', query },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -1453,7 +1454,7 @@ describe('sort.fallbackColumn', () => {
     const { requestPayload } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -1466,7 +1467,7 @@ describe('sort.fallbackColumn', () => {
     const { requestPayload } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       sort: { fallbackColumn: 'name' },
     }))!;
 
@@ -1480,7 +1481,7 @@ describe('sort.fallbackColumn', () => {
     const { requestPayload } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       sort: { default: { column: 'id', direction: 'asc' }, fallbackColumn: 'name' },
     }))!;
 
@@ -1517,7 +1518,7 @@ describe('error', () => {
     const { error, filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: requestFn,
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -1535,7 +1536,7 @@ describe('error', () => {
     const { error, filter } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -1573,7 +1574,7 @@ describe('generic inference', () => {
     const table = scope.run(() => useServerTable({
       fetch: mockRequestWithExtras(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [{ values: computed(() => ({ asset: 'INFERRED' })), to: 'request' }],
     }))!;
 
@@ -1613,7 +1614,7 @@ describe('page reset', () => {
   it('should reset to page 1 when the filter changes', async () => {
     const { filter, pagination } = scope.run(() => useServerTable<TestItem, TestPayload, TestFilters>({
       fetch: mockRequestData(),
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
     }))!;
 
     await nextTick();
@@ -1636,7 +1637,7 @@ describe('page reset', () => {
     const { pagination } = scope.run(() => useServerTable<TestItem, TestPayloadWithExtras, TestFilters>({
       fetch: mockRequestData(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [{ values: computed(() => ({ urlParam: get(highlight) })), to: 'url' }],
     }))!;
 
@@ -1662,7 +1663,7 @@ describe('page reset', () => {
     const { pagination } = scope.run(() => useServerTable<TestItem, TestPayloadWithExtras, TestFilters>({
       fetch: mockRequestWithExtras(),
       urlState: { mode: 'route' },
-      filterSchema: createTestFilterSchema(),
+      ...createTestFilterOptions(),
       params: [{ skipEmpty: true, to: 'request', values: computed(() => ({ requestParam: get(account) })) }],
     }))!;
 

--- a/frontend/app/src/modules/core/table/use-server-table.ts
+++ b/frontend/app/src/modules/core/table/use-server-table.ts
@@ -1,12 +1,15 @@
 import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
-import type { ComputedRef, MaybeRef, Ref, WritableComputedRef } from 'vue';
+import type { ComputedRef, MaybeRef, MaybeRefOrGetter, Ref, WritableComputedRef } from 'vue';
+import type { Schema } from 'zod';
 import type { Collection } from '@/modules/core/common/collection';
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
 import type { MatchedKeywordWithBehaviour } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import { isEqual } from 'es-toolkit';
 import { getApiSortingParams } from '@/modules/core/table/pagination-filter-utils';
 import { collectSources, mergeParams, type ParamSource, transformFilters } from '@/modules/core/table/param-sources';
+import { behaviourKeysFromFields, routeSchemaFromFields } from '@/modules/core/table/route';
 import { type ChangeSource, useChangeIntent } from '@/modules/core/table/use-change-intent';
 import { useTableData } from '@/modules/core/table/use-table-data';
 import { useTablePagination } from '@/modules/core/table/use-table-pagination';
@@ -53,6 +56,12 @@ interface UseServerTableOptions<
    * filter bag. Named `filterSchema` because `filter` is the returned value.
    */
   filterSchema?: FilterSchema<TFilter>;
+  /**
+   * The pill-bar fields this table filters on, the same list the bar is given. The url shape of the
+   * filter bag and the keys the request wraps as `{ behaviour, values }` are read off them, rather
+   * than restated per table beside a field list that already says both.
+   */
+  fields?: MaybeRefOrGetter<FieldDef[]>;
   /** External parameter sources merged into the request payload and/or URL. */
   params?: ParamSource[];
   /** Default sort column and fallback column applied when none is persisted. */
@@ -98,13 +107,13 @@ export function useServerTable<
 
   const {
     fetch: requestData,
+    fields,
     filterSchema = {
       // The fallback for a table with no filter schema (a dialog listing rows it never filters).
       // Such a table has no filter bag at all, and neither an empty one nor undefined is provably
       // the TFilter its caller declared, so the hole is stated here rather than at every read.
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       filters: ref({}) as Ref<TFilter>,
-      RouteFilterSchema: undefined,
     },
     params = [],
     persist,
@@ -115,7 +124,15 @@ export function useServerTable<
 
   const { markUserIntent, pendingIntent, pendingUrlSource } = useChangeIntent();
 
-  const { behaviourKeys = [], filters, RouteFilterSchema } = filterSchema;
+  const { filters } = filterSchema;
+
+  // Both derived from the declared fields, and cached against them: a gated field list can change
+  // while the table is mounted, and the URL must be read with the keys in play at that moment.
+  const behaviourKeys = computed<string[]>(() => behaviourKeysFromFields(toValue(fields) ?? []));
+  const routeFilterSchema = computed<Schema | undefined>(() => {
+    const declared = toValue(fields);
+    return declared ? routeSchemaFromFields(declared) : undefined;
+  });
 
   // Commit callbacks feed the reducer. They are defined before the sub-composables that
   // receive them and call the hoisted `dispatch`.
@@ -158,7 +175,7 @@ export function useServerTable<
     const offset = (page - 1) * limit;
 
     const merged = mergeParams(params, 'request', get(filters) ?? {});
-    const transformed = transformFilters(merged, behaviourKeys);
+    const transformed = transformFilters(merged, get(behaviourKeys));
 
     // The one assertion left here, and the boundary it belongs to: what a table sends is its
     // filter bag plus whatever its param sources contribute, which only the caller's own payload
@@ -194,7 +211,7 @@ export function useServerTable<
     resetTransientValues,
     restorePersistedFilter,
     params,
-    routeFilterSchema: RouteFilterSchema,
+    routeFilterSchema: (): Schema | undefined => get(routeFilterSchema),
     urlState,
   });
 

--- a/frontend/app/src/modules/core/table/use-url-state-sync.ts
+++ b/frontend/app/src/modules/core/table/use-url-state-sync.ts
@@ -46,8 +46,11 @@ interface UseUrlStateSyncOptions<TItem extends NonNullable<unknown>, TFilter> {
   params: ParamSource[];
   /** The filter state, overwritten when the URL is applied. */
   filters: Ref<TFilter>;
-  /** Deserializes the raw query into the filter shape. */
-  routeFilterSchema?: Schema;
+  /**
+   * Deserializes the raw query into the filter shape. Read on each application rather than captured
+   * once: it is derived from the table's fields, which a view can gate at runtime.
+   */
+  routeFilterSchema?: () => Schema | undefined;
   /** The global page size, used when resetting to defaults. */
   itemsPerPage: Ref<number>;
   /** The raw page/limit state, overwritten when the URL is applied. */
@@ -134,14 +137,14 @@ export function useUrlStateSync<TItem extends NonNullable<unknown>, TFilter>(
     if (isEmpty(routeQuery)) {
       // for empty query, we reset the filters, and pagination to defaults
       applySourceReads(params, routeQuery);
-      set(filters, routeFilterSchema?.parse({}));
+      set(filters, routeFilterSchema?.()?.parse({}));
       set(internalPagination, applyPaginationDefaults(get(itemsPerPage)));
       set(internalSorting, defaultSorting());
       return;
     }
 
     applySourceReads(params, routeQuery);
-    set(filters, routeFilterSchema?.parse(routeQuery));
+    set(filters, routeFilterSchema?.()?.parse(routeQuery));
     set(internalPagination, parseQueryPagination(routeQuery, get(internalPagination)));
     set(internalSorting, parseQueryHistory(routeQuery, defaultSorting(), fallbackColumn));
   };

--- a/frontend/app/src/modules/history/data-issues/DataIssuesView.vue
+++ b/frontend/app/src/modules/history/data-issues/DataIssuesView.vue
@@ -35,6 +35,7 @@ const { baselineTotal, counts, dismissInlinePanels, refreshSummary } = useDataIs
 const { syncCompleted } = useSyncCompleted();
 
 const filterSchema = useDataIssuesFilter();
+const fields = useDataIssueFields();
 
 const {
   collection: state,
@@ -45,6 +46,7 @@ const {
   setFilter: updateFilter,
 } = useServerTable<DataIssue, DataIssuesRequestPayload, Filters>({
   fetch: fetchData,
+  fields,
   filterSchema,
   params: [{
     isDefault: true,
@@ -54,7 +56,6 @@ const {
   urlState: routeWhen(mainPage),
 });
 
-const fields = useDataIssueFields();
 const pillLabels = usePillBarLabels();
 
 // Tracks whether the first load has finished. The all-clear screen keys off this

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-filter.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-filter.ts
@@ -1,6 +1,5 @@
 import type { MatchedKeyword } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { FilterKeyArities, filterRouteSchema } from '@/modules/core/table/route';
 
 /** The wire keys the data issues table filters on, which the URL carries too. */
 export const DataIssuesFilterKeys = {
@@ -21,13 +20,5 @@ export function useDataIssuesFilter(): FilterSchema<Filters> {
 
   return {
     filters: modelFilters,
-    RouteFilterSchema: filterRouteSchema({
-      [DataIssuesFilterKeys.ACCOUNT]: FilterKeyArities.ONE,
-      [DataIssuesFilterKeys.ASSET]: FilterKeyArities.ONE,
-      [DataIssuesFilterKeys.END]: FilterKeyArities.ONE,
-      [DataIssuesFilterKeys.KIND]: FilterKeyArities.MANY,
-      [DataIssuesFilterKeys.START]: FilterKeyArities.ONE,
-      [DataIssuesFilterKeys.STATE]: FilterKeyArities.MANY,
-    }),
   };
 }

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -2,6 +2,7 @@
 import type { Account, Blockchain, HistoryEventEntryType } from '@rotki/common';
 import type { PullLocationTransactionPayload } from '@/modules/history/events/event-payloads';
 import type { HistoryEventRow } from '@/modules/history/events/schemas';
+import type { Filters } from '@/modules/history/events/use-events-filter';
 import { isAccountingUpdateEnabled } from '@/modules/core/common/feature-flags';
 import { AccountingOverlayToggle, BalanceDivergenceToggle } from '@/modules/history/balances/components';
 import { OverlayMode, type OverlayPair, useAccountingOverlay } from '@/modules/history/balances/use-accounting-overlay';
@@ -116,6 +117,11 @@ const filterOptions = {
   validators: () => validators,
 };
 
+// The filter bag, and the fields bound to it, in that order: the fields read the bag to scope
+// their option lists, and the table below reads the url shape of the bag off the fields.
+const modelFilters = ref<Filters>({});
+const fields = useHistoryEventFields({ ...filterOptions, modelFilters });
+
 const {
   clearFilters,
   duplicateHandlingStatus,
@@ -132,16 +138,13 @@ const {
   includes,
   action,
   locationLabels,
-  modelFilters,
   onActionChanged,
   onLocationLabelsChanged,
   pagination,
   requestPayload,
   setPage,
   sort,
-} = useHistoryEventsFilters(filterOptions, toggles, overlayMode);
-
-const fields = useHistoryEventFields({ ...filterOptions, modelFilters });
+} = useHistoryEventsFilters({ ...filterOptions, fields, filters: modelFilters }, toggles, overlayMode);
 
 // Accounting overlay: shows the known balance after each event. Keys off each event's own
 // (account, asset) pair, so no extra filter is required. Gated by VITE_ACCOUNTING_UPDATE,

--- a/frontend/app/src/modules/history/events/composables.ts
+++ b/frontend/app/src/modules/history/events/composables.ts
@@ -7,13 +7,14 @@
 // can go away.
 export { useHistoryEventFields } from './use-history-event-fields';
 
+export { useHistoryEventNavigationConsumer } from './use-history-event-navigation-consumer';
+
 export { useHistoryEventsActions } from './use-history-events-actions';
 
 export { useHistoryEventsDeletion } from './use-history-events-deletion';
 
 export {
   getDefaultToggles,
-  useHistoryEventNavigationConsumer,
   useHistoryEventsFilters,
 } from './use-history-events-filters';
 

--- a/frontend/app/src/modules/history/events/history-event-fields.spec.ts
+++ b/frontend/app/src/modules/history/events/history-event-fields.spec.ts
@@ -2,6 +2,9 @@ import type { AssetsWithId } from '@/modules/assets/types';
 import type { FieldDef, ValueIcon } from '@/modules/core/table/pill/core/types';
 import { HistoryEventEntryType } from '@rotki/common';
 import { describe, expect, it } from 'vitest';
+import { FilterBehaviours } from '@/modules/core/table/filtering';
+import { transformFilters } from '@/modules/core/table/param-sources';
+import { behaviourKeysFromFields, routeSchemaFromFields } from '@/modules/core/table/route';
 import { type HistoryEventFieldOptions, toHistoryAccountField, toHistoryActionField, toHistoryEventFields, toHistoryIgnoredField, toHistoryStateField } from '@/modules/history/events/history-event-fields';
 
 const t = (key: string): string => key;
@@ -46,6 +49,40 @@ function keysOf(overrides: Partial<HistoryEventFieldOptions> = {}): string[] {
 }
 
 describe('toHistoryEventFields', () => {
+  // Both the url shape of the filter bag and the keys the request wraps as `{ behaviour, values }`
+  // are derived from these fields, so they are asserted here rather than against a second
+  // hand-written declaration that could disagree with the field list.
+  describe('route query', () => {
+    it('should coerce single route values into arrays where the request takes many', () => {
+      expect(routeSchemaFromFields(fields()).parse({ asset: 'ETH', entryTypes: 'evm event', txRefs: '0xabc' }))
+        .toEqual({ asset: 'ETH', entryTypes: ['evm event'], txRefs: ['0xabc'] });
+    });
+
+    // The period pill collapses the two bounds, which is what the url and the request carry.
+    it('should keep the two period bounds as they are sent', () => {
+      expect(routeSchemaFromFields(fields()).parse({ fromTimestamp: '1700000000', toTimestamp: '1700086400' }))
+        .toEqual({ fromTimestamp: '1700000000', toTimestamp: '1700086400' });
+    });
+
+    it('should allow an empty route filter', () => {
+      expect(routeSchemaFromFields(fields()).parse({})).toEqual({});
+    });
+  });
+
+  // The backend takes entry types as `{ behaviour, values }` so a type can be excluded. The pill
+  // writes exclusion as a `!` prefix, which is what the URL carries too; the wrapping happens at
+  // request assembly, from the keys named here.
+  describe('behaviour keys', () => {
+    it('should declare entry types as the only behaviour-carrying key', () => {
+      expect(behaviourKeysFromFields(fields())).toStrictEqual(['entryTypes']);
+    });
+
+    it('should wrap an excluded entry type for the request', () => {
+      expect(transformFilters({ entryTypes: ['!evm event'] }, behaviourKeysFromFields(fields())))
+        .toStrictEqual({ entryTypes: { behaviour: FilterBehaviours.EXCLUDE, values: ['evm event'] } });
+    });
+  });
+
   it('should offer every field in a stable display order when nothing is restricted', () => {
     expect(keysOf()).toStrictEqual([
       'period',

--- a/frontend/app/src/modules/history/events/use-events-filter.spec.ts
+++ b/frontend/app/src/modules/history/events/use-events-filter.spec.ts
@@ -1,6 +1,4 @@
-import { assert, describe, expect, it } from 'vitest';
-import { FilterBehaviours } from '@/modules/core/table/filtering';
-import { transformFilters } from '@/modules/core/table/param-sources';
+import { describe, expect, it } from 'vitest';
 import { useHistoryEventFilter } from '@/modules/history/events/use-events-filter';
 
 describe('useHistoryEventFilter', () => {
@@ -10,46 +8,7 @@ describe('useHistoryEventFilter', () => {
     expect(get(filters)).toEqual({});
   });
 
-  // The backend takes entry types as `{ behaviour, values }` so a type can be excluded. Nothing
-  // covered that before: the flag lived on the matcher and no test read it, so losing it would have
-  // sent a bare list and silently dropped the exclusion.
-  describe('behaviour keys', () => {
-    it('should declare entry types as behaviour-carrying', () => {
-      const schema = useHistoryEventFilter();
-
-      expect(schema.behaviourKeys).toStrictEqual(['entryTypes']);
-    });
-
-    it('should wrap an excluded entry type for the request', () => {
-      const schema = useHistoryEventFilter();
-
-      expect(transformFilters({ entryTypes: ['!evm event'] }, schema.behaviourKeys ?? []))
-        .toStrictEqual({ entryTypes: { behaviour: FilterBehaviours.EXCLUDE, values: ['evm event'] } });
-    });
-  });
-
-  describe('route filters', () => {
-    it('should coerce single route values into arrays where the request takes many', () => {
-      const { RouteFilterSchema } = useHistoryEventFilter();
-      assert(RouteFilterSchema);
-
-      expect(RouteFilterSchema.parse({ asset: 'ETH', entryTypes: 'evm event', txRefs: '0xabc' }))
-        .toEqual({ asset: 'ETH', entryTypes: ['evm event'], txRefs: ['0xabc'] });
-    });
-
-    it('should keep the two period bounds as they are sent', () => {
-      const { RouteFilterSchema } = useHistoryEventFilter();
-      assert(RouteFilterSchema);
-
-      expect(RouteFilterSchema.parse({ fromTimestamp: '1700000000', toTimestamp: '1700086400' }))
-        .toEqual({ fromTimestamp: '1700000000', toTimestamp: '1700086400' });
-    });
-
-    it('should allow an empty route filter', () => {
-      const { RouteFilterSchema } = useHistoryEventFilter();
-      assert(RouteFilterSchema);
-
-      expect(RouteFilterSchema.parse({})).toEqual({});
-    });
-  });
+  // The URL round-trip and the behaviour-carrying keys are asserted in
+  // `history-event-fields.spec.ts`: both are derived from the fields, so they are proved against
+  // the field list rather than against a second declaration that could disagree with it.
 });

--- a/frontend/app/src/modules/history/events/use-events-filter.ts
+++ b/frontend/app/src/modules/history/events/use-events-filter.ts
@@ -1,6 +1,5 @@
 import type { MatchedKeywordWithBehaviour } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { FilterKeyArities, filterRouteSchema } from '@/modules/core/table/route';
 
 /** The wire keys the history events table filters on, which the URL carries too. */
 export const HistoryEventFilterKeys = {
@@ -28,26 +27,6 @@ export function useHistoryEventFilter(): FilterSchema<Filters> {
   const modelFilters = ref<Filters>({});
 
   return {
-    // The backend takes entry types as `{ behaviour, values }` so a type can be excluded. The pill
-    // writes exclusion as a `!` prefix, which is what the URL carries too; the wrapping happens at
-    // request assembly.
-    behaviourKeys: [HistoryEventFilterKeys.ENTRY_TYPE],
     filters: modelFilters,
-    RouteFilterSchema: filterRouteSchema({
-      [HistoryEventFilterKeys.ADDRESSES]: FilterKeyArities.MANY,
-      [HistoryEventFilterKeys.ASSET]: FilterKeyArities.ONE,
-      [HistoryEventFilterKeys.END]: FilterKeyArities.ONE,
-      [HistoryEventFilterKeys.ENTRY_TYPE]: FilterKeyArities.MANY,
-      [HistoryEventFilterKeys.EVENT_SUBTYPE]: FilterKeyArities.MANY,
-      [HistoryEventFilterKeys.EVENT_TYPE]: FilterKeyArities.MANY,
-      [HistoryEventFilterKeys.LOCATION]: FilterKeyArities.ONE,
-      [HistoryEventFilterKeys.MAX_AMOUNT]: FilterKeyArities.ONE,
-      [HistoryEventFilterKeys.MIN_AMOUNT]: FilterKeyArities.ONE,
-      [HistoryEventFilterKeys.NOTES]: FilterKeyArities.ONE,
-      [HistoryEventFilterKeys.PROTOCOL]: FilterKeyArities.MANY,
-      [HistoryEventFilterKeys.START]: FilterKeyArities.ONE,
-      [HistoryEventFilterKeys.TX_HASHES]: FilterKeyArities.MANY,
-      [HistoryEventFilterKeys.VALIDATOR_INDICES]: FilterKeyArities.MANY,
-    }),
   };
 }

--- a/frontend/app/src/modules/history/events/use-history-events-filters.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-filters.spec.ts
@@ -1,7 +1,9 @@
 import type { Account, HistoryEventEntryType } from '@rotki/common';
 import type { ComputedRef, Ref } from 'vue';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
+import type { Filters } from '@/modules/history/events/use-events-filter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHistoryEventsFilters } from './use-history-events-filters';
 
@@ -44,20 +46,6 @@ vi.mock('@/modules/core/table/use-server-table', () => ({
   }),
 }));
 
-// The filter schema is now built by the caller rather than by the mocked table, so
-// it has to be stubbed too: the real one reaches into the settings store.
-vi.mock('@/modules/history/events/use-events-filter', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/modules/history/events/use-events-filter')>();
-  return {
-    ...actual,
-    useHistoryEventFilter: vi.fn(() => ({
-      filters: ref({}),
-      matchers: computed(() => []),
-      RouteFilterSchema: undefined,
-    })),
-  };
-});
-
 vi.mock('@/modules/history/events/use-history-events', () => ({
   useHistoryEvents: vi.fn(() => ({
     fetchHistoryEvents: vi.fn().mockResolvedValue({ data: [], found: 0, limit: 10, total: 0 }),
@@ -82,12 +70,6 @@ vi.mock('@/modules/history/events/use-history-event-navigation-consumer', () => 
   useHistoryEventNavigationConsumer: vi.fn(),
 }));
 
-// The pill-bar field assembly is its own composable (and store-backed); this spec covers the
-// server-table wiring, not the fields, so stub it to an empty list.
-vi.mock('@/modules/history/events/use-history-event-fields', () => ({
-  useHistoryEventFields: vi.fn(() => computed(() => [])),
-}));
-
 // Store-backed too, and only consulted to expand an action verb into its type/subtype pair. One
 // row is enough for the wiring this spec covers.
 vi.mock('@/modules/history/events/action-picker/use-event-action-picker', () => ({
@@ -110,6 +92,8 @@ interface DefaultOptions {
     eventSubTypes: Ref<string[]>;
     eventTypes: Ref<string[]>;
     externalAccountFilter: Ref<Account[]>;
+    fields: Ref<FieldDef[]>;
+    filters: Ref<Filters>;
     location: Ref<string | undefined>;
     mainPage: Ref<boolean>;
     period: Ref<undefined>;
@@ -135,6 +119,10 @@ function createDefaultOptions(locationValue?: string): DefaultOptions {
       eventSubTypes: ref<string[]>([]),
       eventTypes: ref<string[]>([]),
       externalAccountFilter: ref([]),
+      // The view builds both and hands them in: the fields are what the table reads its url shape
+      // off, and nothing here exercises the URL.
+      fields: ref<FieldDef[]>([]),
+      filters: ref<Filters>({}),
       location: locationRef,
       mainPage: ref(false),
       period: ref(undefined),

--- a/frontend/app/src/modules/history/events/use-history-events-filters.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-filters.ts
@@ -3,10 +3,11 @@ import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
 import type { ComputedRef, MaybeRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { Collection } from '@/modules/core/common/collection';
 import type { WritableRef } from '@/modules/core/common/common-types';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { HistoryEventRow } from '@/modules/history/events/schemas';
-import { objectOmit } from '@vueuse/shared';
+import type { Filters } from '@/modules/history/events/use-events-filter';
 import { isEqual } from 'es-toolkit';
 import { useRefWithDebounce } from '@/modules/core/common/use-ref-debounce';
 import { TableId } from '@/modules/core/table/use-remember-table-sorting';
@@ -18,16 +19,31 @@ import {
 } from '@/modules/history/event-utils';
 import { DuplicateHandlingStatus, type HighlightType } from '@/modules/history/events/action-types';
 import { buildHistoryEventSources } from '@/modules/history/events/history-event-query';
-import { type Filters, useHistoryEventFilter } from '@/modules/history/events/use-events-filter';
 import { useHistoryEventHighlights, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
 import { useHistoryEvents } from '@/modules/history/events/use-history-events';
 
-export { useHistoryEventNavigationConsumer } from '@/modules/history/events/use-history-event-navigation-consumer';
-
 type Period = { fromTimestamp?: string; toTimestamp?: string } | { fromTimestamp?: number; toTimestamp?: number };
+
+/**
+ * The payload without its sorting, so a re-sort is not read as a change of what is being asked for.
+ * Written out rather than pulled from a helper: this file is at the dependency cap.
+ */
+function withoutSorting(
+  { ascending, orderByAttributes, ...rest }: HistoryEventRequestPayload,
+): Partial<HistoryEventRequestPayload> {
+  return rest;
+}
 
 interface HistoryEventsFiltersOptions {
   entryTypes: MaybeRefOrGetter<HistoryEventEntryType[] | undefined>;
+  /**
+   * The pill-bar fields, and the filter bag they are bound to. Both are built by the view: the
+   * fields read the bag to scope their option lists, and the table reads the url shape of the bag
+   * (and the keys the request wraps as `{ behaviour, values }`) off the fields, so the bag has to
+   * exist before either.
+   */
+  fields: MaybeRefOrGetter<FieldDef[]>;
+  filters: Ref<Filters>;
   eventSubTypes: MaybeRefOrGetter<string[]>;
   eventTypes: MaybeRefOrGetter<string[]>;
   externalAccountFilter: MaybeRefOrGetter<Account[]>;
@@ -66,12 +82,6 @@ interface UseHistoryEventsFiltersReturn {
   identifiers: ComputedRef<string[] | undefined>;
   includes: ComputedRef<{ evmEvents: boolean; onlineEvents: boolean }>;
   locations: ComputedRef<string[]>;
-  /**
-   * The filter bag itself, writable. The pill-bar fields read it to scope their option lists and
-   * prune what a narrowing selection no longer admits, which the table's own `filter` (a computed)
-   * cannot express.
-   */
-  modelFilters: Ref<Filters>;
   onLocationLabelsChanged: (locationLabels: string[]) => void;
   requestPayload: ComputedRef<HistoryEventRequestPayload>;
   pagination: ComputedRef<TablePaginationData>;
@@ -93,6 +103,8 @@ export function useHistoryEventsFilters(
     eventSubTypes,
     eventTypes,
     externalAccountFilter,
+    fields,
+    filters: modelFilters,
     location,
     mainPage,
     period,
@@ -178,8 +190,6 @@ export function useHistoryEventsFilters(
     validators,
   });
 
-  const filterSchema = useHistoryEventFilter();
-
   const {
     collection: groups,
     filter: filters,
@@ -197,7 +207,8 @@ export function useHistoryEventsFilters(
     Filters
   >({
     fetch: fetchHistoryEventsTagged,
-    filterSchema,
+    fields,
+    filterSchema: { filters: modelFilters },
     params: sources,
     persist: {
       keys: {
@@ -285,8 +296,8 @@ export function useHistoryEventsFilters(
     if (!oldParams || !get(shouldPreserveHighlights) || get(isNavigating))
       return;
 
-    const current = objectOmit(params, ['orderByAttributes', 'ascending']);
-    const previous = objectOmit(oldParams, ['orderByAttributes', 'ascending']);
+    const current = withoutSorting(params);
+    const previous = withoutSorting(oldParams);
 
     if (isEqual(current, previous))
       return;
@@ -317,7 +328,6 @@ export function useHistoryEventsFilters(
     includes,
     locationLabels: shallowReadonly(locationLabels),
     locations,
-    modelFilters: filterSchema.filters,
     onActionChanged,
     onLocationLabelsChanged,
     pagination,

--- a/frontend/app/src/modules/history/events/use-history-events.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events.spec.ts
@@ -2,6 +2,7 @@ import type { MaybeRef } from 'vue';
 import type * as Vue from 'vue';
 import type { Collection } from '@/modules/core/common/collection';
 import type { ParamSource } from '@/modules/core/table/param-sources';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { HistoryEvent, HistoryEventRow } from '@/modules/history/events/schemas';
 import { type Account, Blockchain } from '@rotki/common';
@@ -10,6 +11,7 @@ import flushPromises from 'flush-promises';
 import { afterEach, assertType, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { useMainStore } from '@/modules/core/common/use-main-store';
 import { FilterBehaviours } from '@/modules/core/table/filtering';
+import { toMatchFieldDef } from '@/modules/core/table/pill/core/field-adapter';
 import { type LocationQuery, RouterAccountsSchema } from '@/modules/core/table/route';
 import { useServerTable } from '@/modules/core/table/use-server-table';
 import { type Filters, useHistoryEventFilter } from '@/modules/history/events/use-events-filter';
@@ -23,6 +25,18 @@ vi.mock('vue', async (): Promise<Record<string, unknown>> => {
     onBeforeMount: vi.fn().mockImplementation((fn: () => void): void => fn()),
   };
 });
+
+/**
+ * The keys these tests exercise, declared the way the real fields declare them: the table reads the
+ * url shape of its filter bag and the `{ behaviour, values }` wrapping off the fields it is given.
+ * Only the handful in play here, so a test states what it depends on.
+ */
+const fields: FieldDef[] = [
+  toMatchFieldDef({ key: 'asset', label: 'Asset', multiple: false }),
+  toMatchFieldDef({ key: 'location', label: 'Location', multiple: false }),
+  toMatchFieldDef({ key: 'counterparties', label: 'Protocol', multiple: true }),
+  toMatchFieldDef({ allowExclusion: true, key: 'entryTypes', label: 'Type', multiple: true }),
+];
 
 describe('useHistoryEvents', () => {
   let fetchHistoryEvents: (payload: MaybeRef<HistoryEventRequestPayload>) => Promise<Collection<HistoryEventRow>>;
@@ -104,6 +118,7 @@ describe('useHistoryEvents', () => {
       >({
         fetch: fetchHistoryEvents,
         urlState: get(mainPage) ? { mode: 'route' } : { mode: 'none' },
+        fields,
         filterSchema: useHistoryEventFilter(),
         params: sources,
       });
@@ -156,6 +171,7 @@ describe('useHistoryEvents', () => {
       >({
         fetch: fetchHistoryEvents,
         urlState: get(mainPage) ? { mode: 'route' } : { mode: 'none' },
+        fields,
         filterSchema: useHistoryEventFilter(),
         params: sources,
       });
@@ -212,6 +228,7 @@ describe('useHistoryEvents', () => {
       >({
         fetch: fetchHistoryEvents,
         urlState: get(mainPage) ? { mode: 'route' } : { mode: 'none' },
+        fields,
         filterSchema: useHistoryEventFilter(),
         params: sources,
       });
@@ -248,6 +265,7 @@ describe('useHistoryEvents', () => {
       >({
         fetch: fetchHistoryEvents,
         urlState: get(mainPage) ? { mode: 'route' } : { mode: 'none' },
+        fields,
         filterSchema: useHistoryEventFilter(),
         params: sources,
       });

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleSetting.vue
@@ -15,6 +15,7 @@ import { anchorId } from '@/modules/settings/settings-actions';
 
 const {
   collection,
+  fields,
   filter,
   isLoading,
   modelCustomRuleHandling,
@@ -89,6 +90,7 @@ onMounted(async () => {
           <AccountingRuleToolbar
             v-model:custom-rule-handling="modelCustomRuleHandling"
             v-model:filter="filter"
+            :fields="fields"
           />
         </div>
       </template>

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleToolbar.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleToolbar.vue
@@ -1,18 +1,26 @@
 <script setup lang="ts">
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import type { Filters } from '@/modules/settings/accounting/rule/use-accounting-rule-filter';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import { CustomRuleHandling } from '@/modules/settings/accounting/rule/accounting-rule-query';
-import { useAccountingRuleFields } from '@/modules/settings/accounting/rule/use-accounting-rule-fields';
 
 /** Which half of the rules the table shows: the regular ones, or the event-specific ones. */
 const customRuleHandling = defineModel<CustomRuleHandling>('customRuleHandling', { required: true });
+
 /** The filter is a v-model rather than a prop pair so the bar writes straight back to the table. */
 const filter = defineModel<Filters>('filter', { required: true });
 
+/**
+ * The fields come from the table rather than being built here: the table reads the url shape of
+ * its filter bag off them, so both halves have to be looking at the same list.
+ */
+const { fields } = defineProps<{
+  fields: FieldDef[];
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 
-const fields = useAccountingRuleFields();
 const pillLabels = usePillBarLabels();
 </script>
 

--- a/frontend/app/src/modules/settings/accounting/rule/accounting-rule-fields.spec.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/accounting-rule-fields.spec.ts
@@ -1,6 +1,7 @@
 import type { SharedFieldResolvers } from '@/modules/core/table/filters/shared/use-shared-field-resolvers';
 import { describe, expect, it } from 'vitest';
 import { DisplayKinds, type FieldDef } from '@/modules/core/table/pill/core/types';
+import { routeSchemaFromFields } from '@/modules/core/table/route';
 import { type AccountingRuleFieldOptions, toAccountingRuleFields } from '@/modules/settings/accounting/rule/accounting-rule-fields';
 
 const t = (key: string): string => key;
@@ -29,6 +30,19 @@ const options: AccountingRuleFieldOptions = {
 const fields = (): FieldDef[] => toAccountingRuleFields(resolvers, t, options);
 
 describe('toAccountingRuleFields', () => {
+  // The url shape of the filter bag is derived from these fields, so the round-trip is asserted
+  // here rather than against a second hand-written declaration.
+  describe('route query', () => {
+    it('should coerce single route values into arrays', () => {
+      expect(routeSchemaFromFields(fields()).parse({ counterparties: 'uniswap', eventTypes: 'spend' }))
+        .toEqual({ counterparties: ['uniswap'], eventTypes: ['spend'] });
+    });
+
+    it('should allow an empty route filter', () => {
+      expect(routeSchemaFromFields(fields()).parse({})).toEqual({});
+    });
+  });
+
   it('should keep the wire keys the table already sends', () => {
     expect(fields().map(field => field.key)).toStrictEqual([
       'eventTypes',

--- a/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-filter.spec.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-filter.spec.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { useAccountingRuleFilter } from '@/modules/settings/accounting/rule/use-accounting-rule-filter';
 
 describe('useAccountingRuleFilter', () => {
@@ -8,18 +8,6 @@ describe('useAccountingRuleFilter', () => {
     expect(get(filters)).toEqual({});
   });
 
-  it('should coerce single route values into arrays', () => {
-    const { RouteFilterSchema } = useAccountingRuleFilter();
-    assert(RouteFilterSchema);
-
-    expect(RouteFilterSchema.parse({ counterparties: 'uniswap', eventTypes: 'spend' }))
-      .toEqual({ counterparties: ['uniswap'], eventTypes: ['spend'] });
-  });
-
-  it('should allow an empty route filter', () => {
-    const { RouteFilterSchema } = useAccountingRuleFilter();
-    assert(RouteFilterSchema);
-
-    expect(RouteFilterSchema.parse({})).toEqual({});
-  });
+  // The URL round-trip is asserted in `accounting-rule-fields.spec.ts`, against the field list the
+  // url shape is now derived from.
 });

--- a/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-filter.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-filter.ts
@@ -1,6 +1,5 @@
 import type { MatchedKeywordWithBehaviour } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { FilterKeyArities, filterRouteSchema } from '@/modules/core/table/route';
 
 /** The wire keys the accounting rules table filters on, which the URL carries too. */
 export const AccountingRuleFilterKeys = {
@@ -18,10 +17,5 @@ export function useAccountingRuleFilter(): FilterSchema<Filters> {
 
   return {
     filters: modelFilters,
-    RouteFilterSchema: filterRouteSchema({
-      [AccountingRuleFilterKeys.COUNTERPARTY]: FilterKeyArities.MANY,
-      [AccountingRuleFilterKeys.EVENT_SUBTYPE]: FilterKeyArities.MANY,
-      [AccountingRuleFilterKeys.EVENT_TYPE]: FilterKeyArities.MANY,
-    }),
   };
 }

--- a/frontend/app/src/modules/settings/accounting/rule/use-accounting-rules-table.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/use-accounting-rules-table.ts
@@ -1,14 +1,18 @@
 import type { TablePaginationData } from '@rotki/ui-library';
 import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
 import type { Collection } from '@/modules/core/common/collection';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import type { AccountingRuleEntry, AccountingRuleRequestPayload } from '@/modules/settings/types/accounting';
 import { useServerTable } from '@/modules/core/table/use-server-table';
 import { CustomRuleHandling } from '@/modules/settings/accounting/rule/accounting-rule-query';
+import { useAccountingRuleFields } from '@/modules/settings/accounting/rule/use-accounting-rule-fields';
 import { type Filters, useAccountingRuleFilter } from '@/modules/settings/accounting/rule/use-accounting-rule-filter';
 import { useAccountingSettings } from '@/modules/settings/accounting/use-accounting-settings';
 
 interface UseAccountingRulesTableReturn {
   collection: Ref<Collection<AccountingRuleEntry>>;
+  /** The pill-bar fields, built here because the table's url shape is read off them. */
+  fields: ComputedRef<FieldDef[]>;
   filter: WritableComputedRef<Filters>;
   isLoading: Ref<boolean>;
   /** Which half of the rules is shown; a tab, and a request/url param. */
@@ -28,6 +32,7 @@ export function useAccountingRulesTable(): UseAccountingRulesTableReturn {
 
   const modelCustomRuleHandling = shallowRef<CustomRuleHandling>(CustomRuleHandling.EXCLUDE);
   const filterSchema = useAccountingRuleFilter();
+  const fields = useAccountingRuleFields();
 
   const {
     collection,
@@ -37,6 +42,7 @@ export function useAccountingRulesTable(): UseAccountingRulesTableReturn {
     refetch,
   } = useServerTable<AccountingRuleEntry, AccountingRuleRequestPayload, Filters>({
     fetch: getAccountingRules,
+    fields,
     filterSchema,
     params: [{
       to: 'both',
@@ -49,6 +55,7 @@ export function useAccountingRulesTable(): UseAccountingRulesTableReturn {
 
   return {
     collection,
+    fields,
     filter,
     isLoading,
     modelCustomRuleHandling,

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-data.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-data.spec.ts
@@ -1,4 +1,5 @@
 import type { EthereumValidator } from '@/modules/accounts/blockchain-accounts';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import { bigNumberify } from '@rotki/common';
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type EffectScope, effectScope, type Ref } from 'vue';
@@ -57,8 +58,11 @@ vi.mock('@/modules/staking/eth/use-eth-validator-filter', () => ({
   useEthValidatorAccountFilter: (): Record<string, unknown> => ({
     filters: mockFilters,
     matchers: mockMatchers,
-    RouteFilterSchema: undefined,
   }),
+}));
+
+vi.mock('@/modules/staking/eth/use-eth-validator-fields', () => ({
+  useEthValidatorFields: (): Ref<FieldDef[]> => ref([]),
 }));
 
 vi.mock('@/modules/core/table/use-server-table', () => ({

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-data.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-data.ts
@@ -5,15 +5,19 @@ import type {
   EthereumValidatorRequestPayload,
 } from '@/modules/accounts/blockchain-accounts';
 import type { Collection } from '@/modules/core/common/collection';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import { useServerTable } from '@/modules/core/table/use-server-table';
 import { useSetting } from '@/modules/settings/use-setting';
+import { useEthValidatorFields } from '@/modules/staking/eth/use-eth-validator-fields';
 import { type Filters, useEthValidatorAccountFilter } from '@/modules/staking/eth/use-eth-validator-filter';
 import { useBlockchainValidatorsStore } from '@/modules/staking/use-blockchain-validators-store';
 
 interface UseEthValidatorDataReturn {
   cols: ComputedRef<DataTableColumn<EthereumValidator>[]>;
   ethStakingValidators: ComputedRef<EthereumValidator[]>;
+  /** The pill-bar fields, built here because the table's url shape is read off them. */
+  fields: ComputedRef<FieldDef[]>;
   fetchData: () => Promise<void>;
   filters: WritableComputedRef<Filters>;
   pagination: Ref<TablePaginationData>;
@@ -32,6 +36,7 @@ export function useEthValidatorData(): UseEthValidatorDataReturn {
   const currencySymbol = useSetting('currencySymbol');
 
   const filterSchema = useEthValidatorAccountFilter();
+  const fields = useEthValidatorFields();
 
   const {
     collection: rows,
@@ -45,6 +50,7 @@ export function useEthValidatorData(): UseEthValidatorDataReturn {
     Filters
   >({
     fetch: fetchValidators,
+    fields,
     filterSchema,
     sort: {
       default: {
@@ -115,6 +121,7 @@ export function useEthValidatorData(): UseEthValidatorDataReturn {
   return {
     cols,
     ethStakingValidators,
+    fields,
     fetchData,
     filters,
     pagination,

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-fields.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-fields.spec.ts
@@ -2,6 +2,7 @@ import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import { createCustomPinia } from '@test/utils/create-pinia';
 import { withSetup } from '@test/utils/with-setup';
 import { describe, expect, it } from 'vitest';
+import { routeSchemaFromFields } from '@/modules/core/table/route';
 import { useEthValidatorFields } from './use-eth-validator-fields';
 import '@test/i18n';
 
@@ -18,6 +19,24 @@ function fieldOf(key: string): FieldDef | undefined {
 }
 
 describe('useEthValidatorFields', () => {
+  // The url shape of the filter bag is derived from these fields, so the round-trip is asserted
+  // here rather than against a second hand-written declaration.
+  describe('route query', () => {
+    it('should coerce single route values into arrays', () => {
+      expect(routeSchemaFromFields(fields()).parse({ index: '5', publicKey: '0xabc', status: 'active' }))
+        .toEqual({ index: ['5'], publicKey: ['0xabc'], status: ['active'] });
+    });
+
+    it('should keep array route values as arrays', () => {
+      expect(routeSchemaFromFields(fields()).parse({ status: ['active', 'exited'] }))
+        .toEqual({ status: ['active', 'exited'] });
+    });
+
+    it('should allow an empty route filter', () => {
+      expect(routeSchemaFromFields(fields()).parse({})).toEqual({});
+    });
+  });
+
   it('should send the keys the validators request takes', () => {
     expect(fields().map(field => field.key)).toStrictEqual(['index', 'publicKey', 'status']);
   });

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-filter.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-filter.spec.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   isValidStatus,
   useEthValidatorAccountFilter,
@@ -25,26 +25,6 @@ describe('useEthValidatorAccountFilter', () => {
     expect(get(filters)).toEqual({});
   });
 
-  it('should coerce single route values into arrays', () => {
-    const { RouteFilterSchema } = useEthValidatorAccountFilter();
-    assert(RouteFilterSchema);
-
-    expect(RouteFilterSchema.parse({ index: '5', publicKey: '0xabc', status: 'active' }))
-      .toEqual({ index: ['5'], publicKey: ['0xabc'], status: ['active'] });
-  });
-
-  it('should keep array route values as arrays', () => {
-    const { RouteFilterSchema } = useEthValidatorAccountFilter();
-    assert(RouteFilterSchema);
-
-    expect(RouteFilterSchema.parse({ status: ['active', 'exited'] }))
-      .toEqual({ status: ['active', 'exited'] });
-  });
-
-  it('should allow an empty route filter', () => {
-    const { RouteFilterSchema } = useEthValidatorAccountFilter();
-    assert(RouteFilterSchema);
-
-    expect(RouteFilterSchema.parse({})).toEqual({});
-  });
+  // The URL round-trip is asserted in `use-eth-validator-fields.spec.ts`, against the field list
+  // the url shape is now derived from.
 });

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-filter.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-filter.ts
@@ -1,6 +1,5 @@
 import type { MatchedKeywordWithBehaviour } from '@/modules/core/table/filtering';
 import type { FilterSchema } from '@/modules/core/table/pagination-filter-types';
-import { FilterKeyArities, filterRouteSchema } from '@/modules/core/table/route';
 
 /** The wire keys the validators table filters on, which the URL carries too. */
 export const EthValidatorFilterKeys = {
@@ -24,10 +23,5 @@ export function useEthValidatorAccountFilter(): FilterSchema<Filters> {
 
   return {
     filters: modelFilters,
-    RouteFilterSchema: filterRouteSchema({
-      [EthValidatorFilterKeys.INDEX]: FilterKeyArities.MANY,
-      [EthValidatorFilterKeys.PUBLIC_KEY]: FilterKeyArities.MANY,
-      [EthValidatorFilterKeys.STATUS]: FilterKeyArities.MANY,
-    }),
   };
 }


### PR DESCRIPTION
Every table declared its filter keys twice: once as the pill-bar fields it offers, and once as a route schema naming the same keys and whether each takes one value or a list. The fields already say both, and nothing kept the two in step, so they could disagree silently — and one of them did.

## What changes

`useServerTable` now takes the field list and reads off it:

- `routeSchemaFromFields(fields)` — the url shape of the filter bag. A collapsed range/date field contributes its two bounds rather than its own display key (`amount`, `period` are not wire keys), and a param-bound field contributes nothing, since its own `ParamSource.fromQuery` reads it back.
- `behaviourKeysFromFields(fields)` — the keys the request wraps as `{ behaviour, values }`, read from `allowExclusion`. Declaring these separately was how a field could offer `is_not` for a key the request never wraps, which applies as a plain `is` and silently keeps what the user excluded.

`FilterSchema` is down to `{ filters }`, and the 63 lines of `filterRouteSchema({…})` across nine composables are gone. The schema is read through a getter on each application rather than captured once at setup, so it stays correct for a view that gates its field list at runtime.

Three tables built their fields downstream of their table, which would have parsed the url against an empty field list; they now build them first and hand them on. `use-history-events-filters.ts` hit the 20-dependency cap on the way, so the navigation-consumer re-export moved into the barrel that already exists for that view, and `objectOmit` became a local helper.

## The one disagreement, settled by the backend

Managed assets declared `identifiers` as single-valued while its route schema declared the key as a list. `AssetsPostSchema` reads it as a `DelimitedOrNormalList` and matches with `IN (...)`, so the url was right and the field was wrong: the pill offered one identifier while the url had always carried several. Fixed in its own commit.

Every other key was checked against its marshmallow schema (history events, data issues, accounting rules, custom assets, address book) and agreed. Oracle prices, ETH validators and manual balances filter client-side, so there is no backend contract to compare against there.

## Tests

The per-table url round-trips move from the filter specs to the field specs, where they now prove the shape against the field list instead of a second declaration that could drift from it. `routeSchemaFromFields` and `behaviourKeysFromFields` get direct coverage in `route.spec.ts`.

Typecheck clean, lint 0 errors, 769 files / 7268 tests pass.

Verified in the app against a seeded profile, all via live url changes with no reload: repeated multi-value keys, `entryTypes=!evm event` producing `{behaviour: "exclude"}`, a two-bound period collapsing into one Date pill, both identifiers surviving on managed assets, param-bound pills (owned / ignored handling), the gated embedded Liquity table, plus accounting rules, address book and custom assets.