### PR TITLE
refactor(exchanges): validate the key form with zod

### DIFF
--- a/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysForm.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysForm.vue
@@ -364,9 +364,16 @@ onMounted(() => {
   }
 
   const model = get(modelValue);
+  // The locations come from the backend, so the store holds none until that fetch lands and the
+  // suggestion comes back empty. This runs once, so writing that over the name would leave the
+  // field blank with nothing left to restore it.
+  const suggestion = suggestedName(model.location);
+  if (!suggestion)
+    return;
+
   set(modelValue, {
     ...model,
-    name: suggestedName(model.location),
+    name: suggestion,
   });
 });
 

--- a/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysForm.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysForm.vue
@@ -1,20 +1,35 @@
 <script setup lang="ts">
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import { RuiRevealableTextField, RuiTextField } from '@rotki/ui-library';
-import useVuelidate from '@vuelidate/core';
-import { helpers, requiredIf, requiredUnless } from '@vuelidate/validators';
 import { type MessageKey, msg } from '@/message-key';
 import { useConnectedExchangesStore } from '@/modules/balances/exchanges/use-connected-exchanges-store';
 import { type ExchangeFormData, GateLocation, KrakenAccountType, OkxLocation } from '@/modules/balances/types/exchanges';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
 import { useLocationStore } from '@/modules/core/common/use-location-store';
 import { useLocations } from '@/modules/core/common/use-locations';
 import { refOptional, useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { toServerErrors } from '@/modules/core/form/server-errors';
+import { useForm } from '@/modules/core/form/use-form';
 import BinancePairsSelector from '@/modules/settings/api-keys/BinancePairsSelector.vue';
 import BinanceHistoryStartDate from '@/modules/settings/api-keys/exchange/BinanceHistoryStartDate.vue';
+import {
+  isBinance as binance,
+  type ExchangeCapabilities,
+  type ExchangeKeysFormState,
+  exchangeKeysSchema,
+  isGate as gate,
+  isEditing,
+  isKraken as kraken,
+  requiresApiSecret as needsApiSecret,
+  requiresPassphrase as needsPassphrase,
+  normalizeApiSecret,
+  isOkx as okx,
+  showsBinanceHistoryImport,
+  toExchangeKeysFormState,
+} from '@/modules/settings/api-keys/exchange/exchange-keys-form';
 import ExchangeKeysFormStructure from '@/modules/settings/api-keys/exchange/ExchangeKeysFormStructure.vue';
+import ExchangeNotices from '@/modules/settings/api-keys/exchange/ExchangeNotices.vue';
 import GateRegionSelectorItem from '@/modules/settings/api-keys/exchange/GateRegionSelectorItem.vue';
+import KrakenFuturesKeys from '@/modules/settings/api-keys/exchange/KrakenFuturesKeys.vue';
 import OkxRegionSelectorItem from '@/modules/settings/api-keys/exchange/OkxRegionSelectorItem.vue';
 import ExchangeInput from '@/modules/shell/components/inputs/ExchangeInput.vue';
 import InternalLink from '@/modules/shell/components/InternalLink.vue';
@@ -29,77 +44,37 @@ const editFuturesKeys = ref<boolean>(false);
 
 const locationStore = useLocationStore();
 const { exchangesWithoutApiSecret, exchangesWithPassphrase } = storeToRefs(locationStore);
-const { useIsExperimentalExchange } = locationStore;
+
 const { connectedExchanges } = storeToRefs(useConnectedExchangesStore());
 const { getLocationData } = useLocations();
 const { t } = useI18n({ useScope: 'global' });
 
-const requiresApiSecret = computed(() => {
-  const { location } = get(modelValue);
-  return !get(exchangesWithoutApiSecret).includes(location);
+const capabilities = computed<ExchangeCapabilities>(() => ({
+  withoutApiSecret: get(exchangesWithoutApiSecret),
+  withPassphrase: get(exchangesWithPassphrase),
+}));
+
+const location = computed<string>(() => get(modelValue).location);
+
+const requiresApiSecret = computed<boolean>(() => needsApiSecret(get(location), get(capabilities)));
+const requiresPassphrase = computed<boolean>(() => needsPassphrase(get(location), get(capabilities)));
+const isBinance = computed<boolean>(() => binance(get(location)));
+const isGate = computed<boolean>(() => gate(get(location)));
+const isKraken = computed<boolean>(() => kraken(get(location)));
+const isOkx = computed<boolean>(() => okx(get(location)));
+
+const editMode = computed<boolean>(() => isEditing(get(modelValue).mode));
+const showBinanceHistoryImport = computed<boolean>(() => {
+  const { location, mode } = get(modelValue);
+  return showsBinanceHistoryImport(location, mode);
 });
-
-const requiresPassphrase = computed(() => {
-  const { location } = get(modelValue);
-  return get(exchangesWithPassphrase).includes(location);
-});
-
-const isBinance = computed(() => {
-  const { location } = get(modelValue);
-  return ['binance', 'binanceus'].includes(location);
-});
-
-const isGate = computed<boolean>(() => {
-  const { location } = get(modelValue);
-  return location === 'gate';
-});
-
-const isKraken = computed<boolean>(() => {
-  const { location } = get(modelValue);
-  return ['kraken'].includes(location);
-});
-
-const isCoinbase = computed(() => {
-  const { location } = get(modelValue);
-  return ['coinbase'].includes(location);
-});
-
-const isCoinbasePro = computed(() => {
-  const { location } = get(modelValue);
-  return ['coinbaseprime'].includes(location);
-});
-
-const isOkx = computed(() => {
-  const { location } = get(modelValue);
-  return ['okx'].includes(location);
-});
-
-const experimental = useIsExperimentalExchange(() => get(modelValue).location);
-
-const showKeyWaitingTimeWarning = logicOr(isKraken, isCoinbase, isCoinbasePro);
-
-const historyLimitMessage = computed<string>(() => {
-  const { location } = get(modelValue);
-  if (location === 'bybit')
-    return t('exchange_keys_form.history_limit_warning.bybit');
-  if (location === 'htx')
-    return t('exchange_keys_form.history_limit_warning.htx');
-  if (location === 'cryptocom')
-    return t('exchange_keys_form.history_limit_warning.cryptocom');
-  return '';
-});
-
-const editMode = computed<boolean>(() => get(modelValue).mode === 'edit');
-const showBinanceHistoryImport = computed<boolean>(() => (
-  get(isBinance) && !get(editMode)
-));
 
 const nameProp = useRefPropVModel(modelValue, 'name');
 const newNameProp = useRefPropVModel(modelValue, 'newName');
 const apiKey = useRefPropVModel(modelValue, 'apiKey');
 const apiSecret = useRefPropVModel(modelValue, 'apiSecret', {
   transform(value) {
-    return get(isCoinbase) ? value.replace(/\\n/g, '\n') : value;
+    return normalizeApiSecret(get(location), value);
   },
 });
 
@@ -136,7 +111,6 @@ const passphrase = useRefPropVModel(modelValue, 'passphrase');
 const krakenAccountType = useRefPropVModel(modelValue, 'krakenAccountType');
 const krakenFuturesApiKey = useRefPropVModel(modelValue, 'krakenFuturesApiKey');
 const krakenFuturesApiSecret = useRefPropVModel(modelValue, 'krakenFuturesApiSecret');
-const binanceMarkets = useRefPropVModel(modelValue, 'binanceMarkets');
 const binanceHistoryStartTs = useRefPropVModel(modelValue, 'binanceHistoryStartTs');
 const gateLocation = useRefPropVModel(modelValue, 'gateLocation');
 const okxLocation = useRefPropVModel(modelValue, 'okxLocation');
@@ -155,30 +129,10 @@ const name = computed<string>({
   },
 });
 
-const krakenFuturesApiKeyComputed = refOptional(krakenFuturesApiKey, '');
-const krakenFuturesApiSecretComputed = refOptional(krakenFuturesApiSecret, '');
 const binanceHistoryStartTsModel = refOptional(
   binanceHistoryStartTs,
   Math.floor(Date.now() / 1000),
 );
-
-const krakenFuturesApiKeyModel = createRefWithAsterisk(krakenFuturesApiKeyComputed, editFuturesKeys);
-const krakenFuturesApiSecretModel = createRefWithAsterisk(krakenFuturesApiSecretComputed, editFuturesKeys);
-const futuresSensitiveInputComponent = createSensitiveInputComponent(editFuturesKeys);
-
-useFormStateWatcher({
-  apiKey,
-  apiSecret,
-  binanceHistoryStartTs,
-  binanceMarkets,
-  gateLocation,
-  krakenAccountType,
-  krakenFuturesApiKey,
-  krakenFuturesApiSecret,
-  name,
-  okxLocation,
-  passphrase,
-}, stateUpdated);
 
 function suggestedName(exchange: string): string {
   const location = getLocationData(exchange);
@@ -194,17 +148,6 @@ function toggleEdit() {
       ...get(modelValue),
       apiKey: '',
       apiSecret: '',
-    });
-  }
-}
-
-function toggleFuturesEdit() {
-  set(editFuturesKeys, !get(editFuturesKeys));
-  if (!get(editFuturesKeys)) {
-    set(modelValue, {
-      ...get(modelValue),
-      krakenFuturesApiKey: '',
-      krakenFuturesApiSecret: '',
     });
   }
 }
@@ -245,91 +188,40 @@ const okxLocations = OkxLocation.options.map(item => ({
   label: t(OKX_LOCATION_KEYS[item]),
 }));
 
-const sensitiveFieldEditable = logicOr(logicNot(editMode), editKeys);
-const futuresFieldEditable = logicOr(logicNot(editMode), editFuturesKeys);
-const hasFuturesApiKey = computed<boolean>(() => !!get(krakenFuturesApiKey));
-const hasFuturesApiSecret = computed<boolean>(() => !!get(krakenFuturesApiSecret));
+/**
+ * The dialog owns the entry, so the form mirrors it rather than holding its own copy: the fields
+ * keep writing where they always did, and the rules always read what is on screen.
+ */
+const form = useForm<ExchangeKeysFormState, ExchangeKeysFormState>({
+  initial: (): ExchangeKeysFormState => toExchangeKeysFormState(get(modelValue)),
+  schema: computed(() => exchangeKeysSchema({
+    capabilities: get(capabilities),
+    editingFutures: get(editFuturesKeys),
+    editingKeys: get(editKeys),
+    location: get(location),
+    mode: get(modelValue).mode,
+  })),
+  // The dialog persists; there is nothing to submit from here.
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): ExchangeKeysFormState => ({ ...state }),
+});
 
-const v$ = useVuelidate({
-  apiKey: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.validation.non_empty'),
-      requiredIf(sensitiveFieldEditable),
-    ),
-  },
-  apiSecret: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.validation.non_empty'),
-      requiredIf(logicAnd(sensitiveFieldEditable, requiresApiSecret)),
-    ),
-  },
-  krakenFuturesApiKey: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.validation.futures_both_required'),
-      requiredIf(logicAnd(futuresFieldEditable, hasFuturesApiSecret)),
-    ),
-  },
-  krakenFuturesApiSecret: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.validation.futures_both_required'),
-      requiredIf(logicAnd(futuresFieldEditable, hasFuturesApiKey)),
-    ),
-  },
-  binanceMarkets: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.validation.non_empty'),
-      requiredIf(isBinance),
-    ),
-  },
-  binanceHistoryStartTs: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.validation.non_empty'),
-      requiredIf(showBinanceHistoryImport),
-    ),
-  },
-  name: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.name.non_empty'),
-      requiredUnless(editMode),
-    ),
-  },
-  newName: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.name.non_empty'),
-      requiredIf(editMode),
-    ),
-  },
-  gateLocation: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.validation.non_empty'),
-      requiredIf(isGate),
-    ),
-  },
-  okxLocation: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.validation.non_empty'),
-      requiredIf(isOkx),
-    ),
-  },
-  passphrase: {
-    required: helpers.withMessage(
-      t('exchange_keys_form.validation.non_empty'),
-      requiredIf(logicAnd(sensitiveFieldEditable, requiresPassphrase)),
-    ),
-  },
-}, {
-  apiKey,
-  apiSecret,
-  binanceHistoryStartTs,
-  krakenFuturesApiKey,
-  krakenFuturesApiSecret,
-  binanceMarkets,
-  name: nameProp,
-  newName: newNameProp,
-  gateLocation,
-  okxLocation,
-  passphrase,
-}, { $autoDirty: true, $externalResults: errorMessages });
+watchDeep(modelValue, (value) => {
+  Object.assign(form.state, toExchangeKeysFormState(value));
+});
+
+watch(errorMessages, (value) => {
+  form.setServerErrors(toServerErrors(value));
+}, { deep: true, immediate: true });
+
+watch(form.dirty, (dirty) => {
+  set(stateUpdated, dirty);
+});
+
+// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
+onUnmounted(() => {
+  set(stateUpdated, false);
+});
 
 function onExchangeChange(exchange?: string) {
   const name = exchange ?? '';
@@ -352,12 +244,14 @@ function onExchangeChange(exchange?: string) {
     passphrase: '',
   });
 
+  // Picking a different exchange starts a different connection, so the errors from the last one
+  // must not be left decorating the new form.
   nextTick(() => {
-    get(v$).$reset();
+    form.reset(toExchangeKeysFormState(get(modelValue)));
   });
 }
 
-onMounted(() => {
+function seedName(): void {
   if (get(editMode)) {
     set(newNameProp, get(nameProp));
     return;
@@ -375,10 +269,19 @@ onMounted(() => {
     ...model,
     name: suggestion,
   });
+}
+
+onMounted(() => {
+  seedName();
+  // The seeded name lands after `useForm` took its baseline, so take it again. Otherwise a dialog
+  // the user has not touched counts as dirty and prompts to discard on close. This has to run in
+  // the same tick as the seeding: a deferred reset lets `dirty` flip on the way, and the dialog
+  // latches the flag it is handed.
+  form.reset(toExchangeKeysFormState(get(modelValue)));
 });
 
 defineExpose({
-  validate: async (): Promise<boolean> => await get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -401,7 +304,7 @@ defineExpose({
         v-model="name"
         variant="outlined"
         color="primary"
-        :error-messages="editMode ? toMessages(v$.newName) : toMessages(v$.name)"
+        :error-messages="editMode ? form.errors('newName') : form.errors('name')"
         data-cy="name"
         :label="t('common.name')"
       />
@@ -477,6 +380,7 @@ defineExpose({
       >
         <template #activator>
           <RuiButton
+            data-cy="toggle-edit-keys"
             variant="text"
             class="!p-2"
             icon
@@ -499,11 +403,11 @@ defineExpose({
         <Component
           :is="sensitiveInputComponent"
           v-model.trim="apiKeyModel"
-          :text-color="editMode && !editKeys && toMessages(v$.apiKey).length === 0 ? 'success' : undefined"
+          :text-color="editMode && !editKeys && form.errors('apiKey').length === 0 ? 'success' : undefined"
           variant="outlined"
           color="primary"
           :disabled="editMode && !editKeys"
-          :error-messages="toMessages(v$.apiKey)"
+          :error-messages="form.errors('apiKey')"
           data-cy="api-key"
           prepend-icon="lu-key"
           :label="label"
@@ -519,9 +423,9 @@ defineExpose({
           v-model.trim="apiSecretModel"
           variant="outlined"
           color="primary"
-          :text-color="editMode && !editKeys && toMessages(v$.apiKey).length === 0 ? 'success' : undefined"
+          :text-color="editMode && !editKeys && form.errors('apiKey').length === 0 ? 'success' : undefined"
           :disabled="editMode && !editKeys"
-          :error-messages="toMessages(v$.apiSecret)"
+          :error-messages="form.errors('apiSecret')"
           data-cy="api-secret"
           prepend-icon="lu-lock-keyhole"
           :label="label"
@@ -538,7 +442,7 @@ defineExpose({
           :disabled="editMode && !editKeys"
           variant="outlined"
           color="primary"
-          :error-messages="toMessages(v$.passphrase)"
+          :error-messages="form.errors('passphrase')"
           prepend-icon="lu-key"
           data-cy="passphrase"
           :label="label"
@@ -576,93 +480,28 @@ defineExpose({
         </i18n-t>
         <BinanceHistoryStartDate
           v-model="binanceHistoryStartTsModel"
-          :error-messages="toMessages(v$.binanceHistoryStartTs)"
+          :error-messages="form.errors('binanceHistoryStartTs')"
         />
       </div>
     </RuiAlert>
-    <template v-if="isKraken">
-      <div
-        class="flex items-center gap-2 text-subtitle-2 pb-4"
-      >
-        {{ t('exchange_settings.inputs.kraken_futures_keys') }}
-        <RuiTooltip
-          v-if="editMode"
-          :popper="{ placement: 'top' }"
-          :open-delay="400"
-        >
-          <template #activator>
-            <RuiButton
-              variant="text"
-              class="!p-2"
-              icon
-              @click="toggleFuturesEdit()"
-            >
-              <RuiIcon
-                size="20"
-                :name="!editFuturesKeys ? 'lu-pencil' : 'lu-x'"
-              />
-            </RuiButton>
-          </template>
-          {{
-            !editFuturesKeys ? t('exchange_keys_form.edit.activate_tooltip') : t('exchange_keys_form.edit.deactivate_tooltip')
-          }}
-        </RuiTooltip>
-      </div>
-      <Component
-        :is="futuresSensitiveInputComponent"
-        v-model.trim="krakenFuturesApiKeyModel"
-        variant="outlined"
-        color="primary"
-        :disabled="editMode && !editFuturesKeys"
-        :error-messages="toMessages(v$.krakenFuturesApiKey)"
-        data-cy="kraken-futures-api-key"
-        prepend-icon="lu-key"
-        :label="t('exchange_settings.inputs.futures_api_key')"
-      />
-      <Component
-        :is="futuresSensitiveInputComponent"
-        v-model.trim="krakenFuturesApiSecretModel"
-        variant="outlined"
-        color="primary"
-        :disabled="editMode && !editFuturesKeys"
-        :error-messages="toMessages(v$.krakenFuturesApiSecret)"
-        data-cy="kraken-futures-api-secret"
-        prepend-icon="lu-lock-keyhole"
-        :label="t('exchange_settings.inputs.futures_api_secret')"
-      />
-    </template>
-
+    <KrakenFuturesKeys
+      v-if="isKraken"
+      v-model:api-key="krakenFuturesApiKey"
+      v-model:api-secret="krakenFuturesApiSecret"
+      v-model:editing="editFuturesKeys"
+      :edit-mode="editMode"
+      :key-errors="form.errors('krakenFuturesApiKey')"
+      :secret-errors="form.errors('krakenFuturesApiSecret')"
+    />
     <BinancePairsSelector
       v-if="isBinance"
       :name="modelValue.name"
       :edit="editMode"
       :location="modelValue.location"
-      :error-messages="toMessages(v$.binanceMarkets)"
+      :error-messages="form.errors('binanceMarkets')"
       @update:selection="modelValue = { ...modelValue, binanceMarkets: $event }"
     />
   </div>
 
-  <RuiAlert
-    v-if="showKeyWaitingTimeWarning"
-    class="mt-4"
-    type="info"
-  >
-    {{ t('exchange_keys_form.waiting_time_warning') }}
-  </RuiAlert>
-
-  <RuiAlert
-    v-if="historyLimitMessage"
-    class="mt-4"
-    type="warning"
-  >
-    {{ historyLimitMessage }}
-  </RuiAlert>
-
-  <RuiAlert
-    v-if="experimental"
-    type="info"
-    class="mt-4"
-  >
-    {{ t('exchange_settings.inputs.experimental') }}
-  </RuiAlert>
+  <ExchangeNotices :location="modelValue.location" />
 </template>

--- a/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.spec.ts
+++ b/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.spec.ts
@@ -1,0 +1,186 @@
+import type { ExchangeFormData } from '@/modules/balances/types/exchanges';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, type VNode } from 'vue';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+import ExchangeKeysFormDialog from '@/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.vue';
+import '@test/i18n';
+
+/**
+ * The dialog owns the save: it decides whether a rename is really a rename, which failures belong
+ * on a field and which become a message, and when the caller is told an exchange was added. None of
+ * that was covered, and the form's `validate()` contract is about to change under it.
+ */
+const { setMessage, setupExchange, validate } = vi.hoisted(() => ({
+  setMessage: vi.fn(),
+  setupExchange: vi.fn(),
+  validate: vi.fn(),
+}));
+
+vi.mock('@/modules/balances/exchanges/use-exchanges', () => ({
+  useExchanges: (): Record<string, unknown> => ({ setupExchange }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+// Stubbed down to the seam the dialog uses: the exposed `validate` and the two models it writes.
+vi.mock('@/modules/settings/api-keys/exchange/ExchangeKeysForm.vue', async () => {
+  const { defineComponent, h } = await import('vue');
+  return {
+    default: defineComponent({
+      emits: ['update:modelValue', 'update:stateUpdated', 'update:errorMessages'],
+      name: 'ExchangeKeysForm',
+      props: {
+        errorMessages: { default: () => ({}), type: Object },
+        modelValue: { required: true, type: Object },
+        stateUpdated: { default: false, type: Boolean },
+      },
+      setup: (_props, { expose }) => {
+        expose({ validate });
+        return (): VNode => h('div', { class: 'exchange-keys-form' });
+      },
+    }),
+  };
+});
+
+const BigDialogStub = defineComponent({
+  emits: ['confirm', 'cancel'],
+  name: 'BigDialog',
+  setup: (_props, { slots }) => (): VNode => h('div', slots.default?.()),
+});
+
+function exchange(overrides: Partial<ExchangeFormData> = {}): ExchangeFormData {
+  return {
+    apiKey: 'key',
+    apiSecret: 'secret',
+    binanceMarkets: [],
+    location: 'kucoin',
+    mode: 'add',
+    name: 'Kucoin 1',
+    passphrase: '',
+    ...overrides,
+  };
+}
+
+describe('settings/api-keys/exchange/ExchangeKeysFormDialog.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<InstanceType<typeof ExchangeKeysFormDialog>>;
+
+  beforeEach(() => {
+    pinia = createCustomPinia();
+    setActivePinia(pinia);
+    setMessage.mockReset();
+    setupExchange.mockReset().mockResolvedValue(true);
+    validate.mockReset().mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function createWrapper(modelValue: ExchangeFormData | undefined): VueWrapper<InstanceType<typeof ExchangeKeysFormDialog>> {
+    wrapper = mount(ExchangeKeysFormDialog, {
+      global: {
+        plugins: [pinia],
+        stubs: { BigDialog: BigDialogStub, Teleport: true },
+      },
+      props: { modelValue },
+    });
+    return wrapper;
+  }
+
+  /** Saving goes through the dialog's confirm action, which also covers that it is wired up. */
+  async function save(modelValue: ExchangeFormData): Promise<void> {
+    createWrapper(modelValue);
+    wrapper.findComponent(BigDialogStub).vm.$emit('confirm');
+    await flushPromises();
+  }
+
+  it('should not save a form that does not validate', async () => {
+    validate.mockReturnValue(false);
+
+    await save(exchange());
+
+    expect(setupExchange).not.toHaveBeenCalled();
+  });
+
+  it('should save a form that validates', async () => {
+    await save(exchange());
+
+    expect(setupExchange).toHaveBeenCalledOnce();
+  });
+
+  describe('the rename', () => {
+    /**
+     * The backend reads `newName` as a rename request, so sending the unchanged name would ask it
+     * to rename the exchange to what it is already called.
+     */
+    it('should not send a rename when the name is unchanged', async () => {
+      await save(exchange({ mode: 'edit', name: 'Kucoin 1', newName: 'Kucoin 1' }));
+
+      expect(setupExchange).toHaveBeenCalledWith(expect.objectContaining({ newName: undefined }));
+    });
+
+    it('should send a rename when the name changed', async () => {
+      await save(exchange({ mode: 'edit', name: 'Kucoin 1', newName: 'Kucoin 2' }));
+
+      expect(setupExchange).toHaveBeenCalledWith(expect.objectContaining({ newName: 'Kucoin 2' }));
+    });
+  });
+
+  describe('reporting a failure', () => {
+    it('should put field errors back on the form', async () => {
+      const error = new ApiValidationError(JSON.stringify({ apiKey: ['bad key'] }));
+      setupExchange.mockRejectedValue(error);
+
+      await save(exchange());
+
+      expect(wrapper.findComponent({ name: 'ExchangeKeysForm' }).props('errorMessages'))
+        .toMatchObject({ apiKey: ['bad key'] });
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+
+    it('should surface anything else as a message', async () => {
+      setupExchange.mockRejectedValue(new Error('the exchange is unreachable'));
+
+      await save(exchange());
+
+      expect(setMessage).toHaveBeenCalledOnce();
+    });
+
+    it('should keep the dialog open when the save failed', async () => {
+      setupExchange.mockResolvedValue(false);
+
+      await save(exchange());
+
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+    });
+  });
+
+  describe('after a successful save', () => {
+    it('should announce an exchange that was added', async () => {
+      await save(exchange({ location: 'kucoin', name: 'Kucoin 1' }));
+
+      expect(wrapper.emitted('added')?.at(-1)?.[0]).toStrictEqual({
+        location: 'kucoin',
+        name: 'Kucoin 1',
+      });
+    });
+
+    it('should not announce one that was only edited', async () => {
+      await save(exchange({ mode: 'edit', newName: 'Kucoin 2' }));
+
+      expect(wrapper.emitted('added')).toBeUndefined();
+    });
+
+    it('should close the dialog', async () => {
+      await save(exchange());
+
+      expect(wrapper.emitted('update:modelValue')?.at(-1)).toStrictEqual([undefined]);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysFormDialog.vue
@@ -34,7 +34,7 @@ const title = computed<string>(() => {
 
 async function save(): Promise<void> {
   assert(isDefined(modelValue));
-  if (!await get(form)?.validate()) {
+  if (!get(form)?.validate()) {
     return;
   }
 

--- a/frontend/app/src/modules/settings/api-keys/exchange/ExchangeNotices.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/ExchangeNotices.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { useLocationStore } from '@/modules/core/common/use-location-store';
+import {
+  historyLimitMessage,
+  showsKeyWaitingTimeWarning,
+} from '@/modules/settings/api-keys/exchange/exchange-keys-form';
+
+/**
+ * What the form has to say about the chosen exchange before its keys are saved. All three notices
+ * are decided by the exchange alone, so they need nothing from the form itself.
+ */
+const { location } = defineProps<{
+  location: string;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const { useIsExperimentalExchange } = useLocationStore();
+const experimental = useIsExperimentalExchange(() => location);
+
+const showsWaitingTime = computed<boolean>(() => showsKeyWaitingTimeWarning(location));
+
+const limitMessage = computed<string>(() => {
+  const key = historyLimitMessage(location);
+  return key ? t(key) : '';
+});
+</script>
+
+<template>
+  <RuiAlert
+    v-if="showsWaitingTime"
+    class="mt-4"
+    type="info"
+  >
+    {{ t('exchange_keys_form.waiting_time_warning') }}
+  </RuiAlert>
+
+  <RuiAlert
+    v-if="limitMessage"
+    class="mt-4"
+    type="warning"
+  >
+    {{ limitMessage }}
+  </RuiAlert>
+
+  <RuiAlert
+    v-if="experimental"
+    type="info"
+    class="mt-4"
+  >
+    {{ t('exchange_settings.inputs.experimental') }}
+  </RuiAlert>
+</template>

--- a/frontend/app/src/modules/settings/api-keys/exchange/KrakenFuturesKeys.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/KrakenFuturesKeys.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { RuiRevealableTextField, RuiTextField } from '@rotki/ui-library';
+
+/**
+ * Kraken carries a second pair of credentials for its futures API. They are optional, but only
+ * together, and like the main pair they are shown masked until the user asks to replace them —
+ * the app never held the saved secret, so there is nothing behind the asterisks to reveal.
+ */
+const apiKey = defineModel<string | undefined>('apiKey', { required: true });
+const apiSecret = defineModel<string | undefined>('apiSecret', { required: true });
+/** Owned by the parent because the rules have to know whether a replacement is under way. */
+const editing = defineModel<boolean>('editing', { required: true });
+
+const { editMode = false, keyErrors = [], secretErrors = [] } = defineProps<{
+  editMode?: boolean;
+  keyErrors?: string[];
+  secretErrors?: string[];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const ASTERISKS = '*'.repeat(30);
+
+const masked = computed<boolean>(() => editMode && !get(editing));
+
+const inputComponent = computed(() => get(masked) ? RuiTextField : RuiRevealableTextField);
+
+function maskedModel(model: Ref<string | undefined>): WritableComputedRef<string> {
+  return computed<string>({
+    get: () => get(masked) ? ASTERISKS : (get(model) ?? ''),
+    set: value => set(model, value),
+  });
+}
+
+const keyModel = maskedModel(apiKey);
+const secretModel = maskedModel(apiSecret);
+
+/** Abandoning the replacement must not leave a half typed pair behind to be saved. */
+function toggle(): void {
+  const next = !get(editing);
+  set(editing, next);
+
+  if (!next) {
+    set(apiKey, '');
+    set(apiSecret, '');
+  }
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-2 text-subtitle-2 pb-4">
+    {{ t('exchange_settings.inputs.kraken_futures_keys') }}
+    <RuiTooltip
+      v-if="editMode"
+      :popper="{ placement: 'top' }"
+      :open-delay="400"
+    >
+      <template #activator>
+        <RuiButton
+          data-cy="toggle-edit-futures-keys"
+          variant="text"
+          class="!p-2"
+          icon
+          @click="toggle()"
+        >
+          <RuiIcon
+            size="20"
+            :name="!editing ? 'lu-pencil' : 'lu-x'"
+          />
+        </RuiButton>
+      </template>
+      {{ !editing ? t('exchange_keys_form.edit.activate_tooltip') : t('exchange_keys_form.edit.deactivate_tooltip') }}
+    </RuiTooltip>
+  </div>
+
+  <Component
+    :is="inputComponent"
+    v-model.trim="keyModel"
+    variant="outlined"
+    color="primary"
+    :disabled="masked"
+    :error-messages="keyErrors"
+    data-cy="kraken-futures-api-key"
+    prepend-icon="lu-key"
+    :label="t('exchange_settings.inputs.futures_api_key')"
+  />
+  <Component
+    :is="inputComponent"
+    v-model.trim="secretModel"
+    variant="outlined"
+    color="primary"
+    :disabled="masked"
+    :error-messages="secretErrors"
+    data-cy="kraken-futures-api-secret"
+    prepend-icon="lu-lock-keyhole"
+    :label="t('exchange_settings.inputs.futures_api_secret')"
+  />
+</template>

--- a/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-form.spec.ts
+++ b/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-form.spec.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+import {
+  acceptsSensitiveEdit,
+  type ExchangeCapabilities,
+  type ExchangeKeysContext,
+  type ExchangeKeysFormState,
+  exchangeKeysSchema,
+  historyLimitMessage,
+  isBinance,
+  isCoinbase,
+  isEditing,
+  isGate,
+  isKraken,
+  isOkx,
+  normalizeApiSecret,
+  requiresApiSecret,
+  requiresPassphrase,
+  showsBinanceHistoryImport,
+  showsKeyWaitingTimeWarning,
+} from '@/modules/settings/api-keys/exchange/exchange-keys-form';
+
+const capabilities: ExchangeCapabilities = {
+  withoutApiSecret: ['bitpanda'],
+  withPassphrase: ['kucoin', 'okx'],
+};
+
+describe('settings/api-keys/exchange/exchange-keys-form', () => {
+  describe('identifying the exchange', () => {
+    it.each([
+      ['binance', true],
+      ['binanceus', true],
+      ['kraken', false],
+      ['', false],
+    ])('should read %s as binance: %s', (location, expected) => {
+      expect(isBinance(location)).toBe(expected);
+    });
+
+    it.each([
+      ['gate', isGate],
+      ['kraken', isKraken],
+      ['okx', isOkx],
+      ['coinbase', isCoinbase],
+    ])('should match %s only against itself', (location, predicate) => {
+      expect(predicate(location)).toBe(true);
+      expect(predicate('kucoin')).toBe(false);
+    });
+
+    // `coinbaseprime` is a separate exchange, and only plain coinbase mangles its secret.
+    it('should not read coinbaseprime as coinbase', () => {
+      expect(isCoinbase('coinbaseprime')).toBe(false);
+    });
+  });
+
+  describe('the api secret', () => {
+    it('should be required by an exchange that has one', () => {
+      expect(requiresApiSecret('kucoin', capabilities)).toBe(true);
+    });
+
+    it('should not be required by an exchange that has none', () => {
+      expect(requiresApiSecret('bitpanda', capabilities)).toBe(false);
+    });
+
+    // An empty list is what the store holds before the backend answers; treating every exchange as
+    // needing a secret is the safe reading, since that is the common case.
+    it('should be required while the capabilities are unknown', () => {
+      expect(requiresApiSecret('bitpanda', { withoutApiSecret: [], withPassphrase: [] })).toBe(true);
+    });
+
+    it('should turn coinbase escaped newlines into real ones', () => {
+      expect(normalizeApiSecret('coinbase', 'a\\nb')).toBe('a\nb');
+    });
+
+    it('should leave other exchange secrets untouched', () => {
+      expect(normalizeApiSecret('kraken', 'a\\nb')).toBe('a\\nb');
+    });
+  });
+
+  describe('the passphrase', () => {
+    it('should be required by an exchange that uses one', () => {
+      expect(requiresPassphrase('kucoin', capabilities)).toBe(true);
+    });
+
+    it('should not be required by an exchange that does not', () => {
+      expect(requiresPassphrase('kraken', capabilities)).toBe(false);
+    });
+  });
+
+  describe('the mode', () => {
+    it('should read edit as editing', () => {
+      expect(isEditing('edit')).toBe(true);
+    });
+
+    it('should read add as not editing', () => {
+      expect(isEditing('add')).toBe(false);
+    });
+
+    it.each([
+      ['add', false, true],
+      ['add', true, true],
+      ['edit', false, false],
+      ['edit', true, true],
+    ])('should accept a sensitive edit in %s mode while editing is %s: %s', (mode, editing, expected) => {
+      expect(acceptsSensitiveEdit(mode, editing)).toBe(expected);
+    });
+  });
+
+  describe('the conditional sections', () => {
+    it('should offer the binance history import when adding', () => {
+      expect(showsBinanceHistoryImport('binance', 'add')).toBe(true);
+    });
+
+    it('should not offer it when editing', () => {
+      expect(showsBinanceHistoryImport('binance', 'edit')).toBe(false);
+    });
+
+    it('should not offer it for another exchange', () => {
+      expect(showsBinanceHistoryImport('kraken', 'add')).toBe(false);
+    });
+
+    it.each(['kraken', 'coinbase', 'coinbaseprime'])('should warn about the key delay for %s', (location) => {
+      expect(showsKeyWaitingTimeWarning(location)).toBe(true);
+    });
+
+    it('should not warn for an exchange whose keys work at once', () => {
+      expect(showsKeyWaitingTimeWarning('kucoin')).toBe(false);
+    });
+
+    it.each(['bybit', 'htx', 'cryptocom'])('should carry a history limit message for %s', (location) => {
+      expect(historyLimitMessage(location)).toBeDefined();
+    });
+
+    it('should carry none for an exchange with a full history', () => {
+      expect(historyLimitMessage('kraken')).toBeUndefined();
+    });
+  });
+});
+
+describe('settings/api-keys/exchange/exchangeKeysSchema', () => {
+  function context(overrides: Partial<ExchangeKeysContext> = {}): ExchangeKeysContext {
+    return {
+      capabilities,
+      editingFutures: false,
+      editingKeys: false,
+      location: 'kucoin',
+      mode: 'add',
+      ...overrides,
+    };
+  }
+
+  // The default location is kucoin, which the fixture marks as needing a passphrase, so a complete
+  // form has to carry one.
+  function state(overrides: Partial<ExchangeKeysFormState> = {}): ExchangeKeysFormState {
+    return {
+      apiKey: 'key',
+      apiSecret: 'secret',
+      name: 'Kucoin 1',
+      passphrase: 'phrase',
+      ...overrides,
+    };
+  }
+
+  function errorsFor(
+    contextOverrides: Partial<ExchangeKeysContext> = {},
+    stateOverrides: Partial<ExchangeKeysFormState> = {},
+  ): string[] {
+    const result = exchangeKeysSchema(context(contextOverrides)).safeParse(state(stateOverrides));
+    if (result.success)
+      return [];
+
+    return result.error.issues.map(issue => issue.path.join('.'));
+  }
+
+  describe('the sensitive fields', () => {
+    it('should accept a complete form', () => {
+      expect(errorsFor()).toStrictEqual([]);
+    });
+
+    it('should demand the api key', () => {
+      expect(errorsFor({}, { apiKey: '' })).toStrictEqual(['apiKey']);
+    });
+
+    // vuelidate's required trims, so whitespace alone never counted as an answer.
+    it('should not accept whitespace as an api key', () => {
+      expect(errorsFor({}, { apiKey: '   ' })).toStrictEqual(['apiKey']);
+    });
+
+    it('should demand the secret only from an exchange that has one', () => {
+      expect(errorsFor({ location: 'bitpanda' }, { apiSecret: '' })).toStrictEqual([]);
+      expect(errorsFor({}, { apiSecret: '' })).toStrictEqual(['apiSecret']);
+    });
+
+    it('should demand the passphrase only from an exchange that uses one', () => {
+      expect(errorsFor({}, { passphrase: '' })).toStrictEqual(['passphrase']);
+      expect(errorsFor({ location: 'kraken' }, { passphrase: '' })).toStrictEqual([]);
+    });
+
+    it('should demand nothing sensitive while the saved pair stays masked', () => {
+      expect(errorsFor(
+        { mode: 'edit' },
+        { apiKey: '', apiSecret: '', newName: 'Kucoin 1', passphrase: '' },
+      )).toStrictEqual([]);
+    });
+
+    it('should demand them again once a replacement is started', () => {
+      expect(errorsFor(
+        { editingKeys: true, mode: 'edit' },
+        { apiKey: '', apiSecret: '', newName: 'Kucoin 1', passphrase: '' },
+      )).toStrictEqual(['apiKey', 'apiSecret', 'passphrase']);
+    });
+  });
+
+  describe('the kraken futures pair', () => {
+    const kraken = { location: 'kraken' };
+
+    it('should accept neither', () => {
+      expect(errorsFor(kraken)).toStrictEqual([]);
+    });
+
+    it('should accept both', () => {
+      expect(errorsFor(kraken, {
+        krakenFuturesApiKey: 'fkey',
+        krakenFuturesApiSecret: 'fsecret',
+      })).toStrictEqual([]);
+    });
+
+    it('should demand the secret when only the key is given', () => {
+      expect(errorsFor(kraken, { krakenFuturesApiKey: 'fkey' }))
+        .toStrictEqual(['krakenFuturesApiSecret']);
+    });
+
+    it('should demand the key when only the secret is given', () => {
+      expect(errorsFor(kraken, { krakenFuturesApiSecret: 'fsecret' }))
+        .toStrictEqual(['krakenFuturesApiKey']);
+    });
+
+    /**
+     * The pair is read from one state, so clearing the half that caused the demand clears the
+     * demand with it. Judging each field against whatever the other last held is what let an
+     * invalid pair through in an earlier form.
+     */
+    it('should stop demanding once the other half is cleared again', () => {
+      expect(errorsFor(kraken, { krakenFuturesApiKey: '', krakenFuturesApiSecret: '' }))
+        .toStrictEqual([]);
+    });
+  });
+
+  describe('the per exchange fields', () => {
+    it('should demand the binance markets', () => {
+      expect(errorsFor({ location: 'binance' }, { binanceHistoryStartTs: 1 }))
+        .toStrictEqual(['binanceMarkets']);
+    });
+
+    it('should demand the binance start date when adding', () => {
+      expect(errorsFor({ location: 'binance' }, { binanceMarkets: ['BTCUSDT'] }))
+        .toStrictEqual(['binanceHistoryStartTs']);
+    });
+
+    it('should not demand the start date when editing', () => {
+      expect(errorsFor(
+        { location: 'binance', mode: 'edit' },
+        { binanceMarkets: ['BTCUSDT'], newName: 'Binance 1' },
+      )).toStrictEqual([]);
+    });
+
+    it('should demand the gate region', () => {
+      expect(errorsFor({ location: 'gate' })).toStrictEqual(['gateLocation']);
+    });
+
+    it('should demand the okx region', () => {
+      expect(errorsFor({ location: 'okx' }, { passphrase: 'phrase' })).toStrictEqual(['okxLocation']);
+    });
+
+    it('should demand neither region from another exchange', () => {
+      expect(errorsFor()).toStrictEqual([]);
+    });
+  });
+
+  describe('the name', () => {
+    it('should be demanded when adding', () => {
+      expect(errorsFor({}, { name: '' })).toStrictEqual(['name']);
+    });
+
+    it('should be ignored when editing, where the new name is demanded instead', () => {
+      expect(errorsFor({ mode: 'edit' }, { name: '', newName: '' })).toStrictEqual(['newName']);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-form.ts
+++ b/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-form.ts
@@ -1,0 +1,212 @@
+import { z, type ZodType } from 'zod';
+import { type MessageKey, msg } from '@/message-key';
+
+/**
+ * Which fields the exchange key form demands, and which parts of it render, is decided entirely by
+ * the chosen exchange and whether the form is adding or editing. Keeping those decisions here means
+ * they are answerable without mounting anything, and that the rules and the template read from one
+ * description rather than from a dozen inline `computed`s.
+ */
+
+/** Exchanges that need more than the usual key and secret, or that render an extra section. */
+const BINANCE_EXCHANGES = ['binance', 'binanceus'];
+
+/** Exchanges whose keys take a while to become usable, so the form warns before saving. */
+const SLOW_KEY_EXCHANGES = ['kraken', 'coinbase', 'coinbaseprime'];
+
+/** Exchanges whose API only serves a limited history window. */
+const HISTORY_LIMIT_MESSAGES: Record<string, MessageKey> = {
+  bybit: msg.$t('exchange_keys_form.history_limit_warning.bybit'),
+  cryptocom: msg.$t('exchange_keys_form.history_limit_warning.cryptocom'),
+  htx: msg.$t('exchange_keys_form.history_limit_warning.htx'),
+};
+
+/** What the backend says a given exchange supports. Empty lists mean "not loaded yet". */
+export interface ExchangeCapabilities {
+  readonly withoutApiSecret: string[];
+  readonly withPassphrase: string[];
+}
+
+export function isEditing(mode: string): boolean {
+  return mode === 'edit';
+}
+
+export function isBinance(location: string): boolean {
+  return BINANCE_EXCHANGES.includes(location);
+}
+
+export function isGate(location: string): boolean {
+  return location === 'gate';
+}
+
+export function isKraken(location: string): boolean {
+  return location === 'kraken';
+}
+
+export function isOkx(location: string): boolean {
+  return location === 'okx';
+}
+
+export function isCoinbase(location: string): boolean {
+  return location === 'coinbase';
+}
+
+/** Coinbase pastes its secret with literal `\n`, which has to become a real newline before saving. */
+export function normalizeApiSecret(location: string, secret: string): string {
+  return isCoinbase(location) ? secret.replace(/\\n/g, '\n') : secret;
+}
+
+export function requiresApiSecret(location: string, capabilities: ExchangeCapabilities): boolean {
+  return !capabilities.withoutApiSecret.includes(location);
+}
+
+export function requiresPassphrase(location: string, capabilities: ExchangeCapabilities): boolean {
+  return capabilities.withPassphrase.includes(location);
+}
+
+/** The one-off history import is offered while connecting, not when editing an existing entry. */
+export function showsBinanceHistoryImport(location: string, mode: string): boolean {
+  return isBinance(location) && !isEditing(mode);
+}
+
+export function showsKeyWaitingTimeWarning(location: string): boolean {
+  return SLOW_KEY_EXCHANGES.includes(location);
+}
+
+export function historyLimitMessage(location: string): MessageKey | undefined {
+  return HISTORY_LIMIT_MESSAGES[location];
+}
+
+/**
+ * The saved key and secret are shown masked until the user asks to replace them, and only then are
+ * they demanded again. While masked there is nothing to validate: the stored pair still stands.
+ */
+export function acceptsSensitiveEdit(mode: string, editing: boolean): boolean {
+  return !isEditing(mode) || editing;
+}
+
+/** The fields the form validates. The rest of the entry is carried but never rejected. */
+export interface ExchangeKeysFormState {
+  apiKey: string;
+  apiSecret: string;
+  binanceHistoryStartTs?: number;
+  binanceMarkets?: string[];
+  gateLocation?: string;
+  krakenFuturesApiKey?: string;
+  krakenFuturesApiSecret?: string;
+  name: string;
+  newName?: string;
+  okxLocation?: string;
+  passphrase?: string;
+}
+
+/**
+ * The validated fields, taken out of the entry the dialog owns. The entry carries more than this —
+ * the location, the mode, the kraken account type — none of which can be wrong on its own.
+ */
+export function toExchangeKeysFormState(entry: {
+  apiKey: string;
+  apiSecret: string;
+  binanceHistoryStartTs?: number;
+  binanceMarkets?: string[];
+  gateLocation?: string;
+  krakenFuturesApiKey?: string;
+  krakenFuturesApiSecret?: string;
+  name: string;
+  newName?: string;
+  okxLocation?: string;
+  passphrase?: string;
+}): ExchangeKeysFormState {
+  return {
+    apiKey: entry.apiKey,
+    apiSecret: entry.apiSecret,
+    binanceHistoryStartTs: entry.binanceHistoryStartTs,
+    binanceMarkets: entry.binanceMarkets,
+    gateLocation: entry.gateLocation,
+    krakenFuturesApiKey: entry.krakenFuturesApiKey,
+    krakenFuturesApiSecret: entry.krakenFuturesApiSecret,
+    name: entry.name,
+    newName: entry.newName,
+    okxLocation: entry.okxLocation,
+    passphrase: entry.passphrase,
+  };
+}
+
+/** Everything outside the fields that decides which of them are demanded. */
+export interface ExchangeKeysContext {
+  readonly capabilities: ExchangeCapabilities;
+  readonly editingFutures: boolean;
+  readonly editingKeys: boolean;
+  readonly location: string;
+  readonly mode: string;
+}
+
+/**
+ * Matches vuelidate's `required`: a string counts once trimmed, a list once it has an entry, and a
+ * number always. Keeping the same reading is what lets the rules move without changing which forms
+ * are accepted.
+ */
+function isPresent(value: unknown): boolean {
+  if (value === undefined || value === null)
+    return false;
+  if (Array.isArray(value))
+    return value.length > 0;
+  if (typeof value === 'string')
+    return value.trim().length > 0;
+
+  return true;
+}
+
+/**
+ * The rules are conditional on the exchange and the mode rather than on the values, so they are
+ * added by a refinement over the whole object instead of being attached per field. The kraken
+ * futures pair in particular has to see both fields at once: each is demanded only because the
+ * other was filled in.
+ */
+export function exchangeKeysSchema(context: ExchangeKeysContext): ZodType<ExchangeKeysFormState> {
+  const { capabilities, editingFutures, editingKeys, location, mode } = context;
+
+  const sensitiveEditable = acceptsSensitiveEdit(mode, editingKeys);
+  const futuresEditable = acceptsSensitiveEdit(mode, editingFutures);
+  const editing = isEditing(mode);
+
+  return z.object({
+    apiKey: z.string(),
+    apiSecret: z.string(),
+    binanceHistoryStartTs: z.number().optional(),
+    binanceMarkets: z.array(z.string()).optional(),
+    gateLocation: z.string().optional(),
+    krakenFuturesApiKey: z.string().optional(),
+    krakenFuturesApiSecret: z.string().optional(),
+    name: z.string(),
+    newName: z.string().optional(),
+    okxLocation: z.string().optional(),
+    passphrase: z.string().optional(),
+  }).superRefine((state, ctx) => {
+    const demand = (required: boolean, path: keyof ExchangeKeysFormState, message: MessageKey): void => {
+      if (required && !isPresent(state[path]))
+        ctx.addIssue({ code: 'custom', message, path: [path] });
+    };
+
+    const nonEmpty = msg.$t('exchange_keys_form.validation.non_empty');
+    const bothFutures = msg.$t('exchange_keys_form.validation.futures_both_required');
+    const nameRequired = msg.$t('exchange_keys_form.name.non_empty');
+
+    demand(sensitiveEditable, 'apiKey', nonEmpty);
+    demand(sensitiveEditable && requiresApiSecret(location, capabilities), 'apiSecret', nonEmpty);
+    demand(sensitiveEditable && requiresPassphrase(location, capabilities), 'passphrase', nonEmpty);
+
+    // Each half is demanded only because the other was given, so both are read from the state in
+    // front of us rather than from whatever either field last held.
+    demand(futuresEditable && isPresent(state.krakenFuturesApiSecret), 'krakenFuturesApiKey', bothFutures);
+    demand(futuresEditable && isPresent(state.krakenFuturesApiKey), 'krakenFuturesApiSecret', bothFutures);
+
+    demand(isBinance(location), 'binanceMarkets', nonEmpty);
+    demand(showsBinanceHistoryImport(location, mode), 'binanceHistoryStartTs', nonEmpty);
+    demand(isGate(location), 'gateLocation', nonEmpty);
+    demand(isOkx(location), 'okxLocation', nonEmpty);
+
+    demand(!editing, 'name', nameRequired);
+    demand(editing, 'newName', nameRequired);
+  });
+}

--- a/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-rendering.spec.ts
+++ b/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-rendering.spec.ts
@@ -1,0 +1,314 @@
+import type { ExchangeFormData } from '@/modules/balances/types/exchanges';
+import { RuiAlert } from '@rotki/ui-library';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import BinancePairsSelector from '@/modules/settings/api-keys/BinancePairsSelector.vue';
+import BinanceHistoryStartDate from '@/modules/settings/api-keys/exchange/BinanceHistoryStartDate.vue';
+import ExchangeKeysForm from '@/modules/settings/api-keys/exchange/ExchangeKeysForm.vue';
+import InternalLink from '@/modules/shell/components/InternalLink.vue';
+import '@test/i18n';
+
+/**
+ * Which sections the form renders is decided by the exchange and the mode, through the same
+ * predicates that decide what it validates. The validation spec deliberately asserts nothing about
+ * structure so that it survives a refactor, which leaves this as the net for the template: every
+ * conditional section, checked per exchange, so moving one into a sub-component cannot quietly drop
+ * it or wire it to the wrong exchange.
+ */
+const capabilities = vi.hoisted(() => ({
+  experimental: false,
+  locations: new Array<string>(),
+  withoutSecret: new Array<string>(),
+  withPassphrase: new Array<string>(),
+}));
+
+const KNOWN_LOCATIONS = ['binance', 'binanceus', 'bitpanda', 'bybit', 'cryptocom', 'gate', 'htx', 'kraken', 'kucoin', 'okx'];
+
+vi.mock('@/modules/core/common/use-location-store', async () => {
+  const { defineStore } = await import('pinia');
+  const { computed } = await import('vue');
+  return {
+    useLocationStore: defineStore('location-stub', () => ({
+      exchangesWithoutApiSecret: computed(() => capabilities.withoutSecret),
+      exchangesWithPassphrase: computed(() => capabilities.withPassphrase),
+      tradeLocations: computed(() => capabilities.locations.map(
+        identifier => ({ identifier, name: identifier }),
+      )),
+      useIsExperimentalExchange: (): ComputedRef<boolean> => computed<boolean>(() => capabilities.experimental),
+    })),
+  };
+});
+
+describe('settings/api-keys/exchange rendering', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<InstanceType<typeof ExchangeKeysForm>>;
+
+  beforeEach(() => {
+    pinia = createCustomPinia();
+    setActivePinia(pinia);
+    capabilities.experimental = false;
+    capabilities.locations = [...KNOWN_LOCATIONS];
+    capabilities.withoutSecret = [];
+    capabilities.withPassphrase = [];
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function createWrapper(overrides: Partial<ExchangeFormData> = {}): VueWrapper<InstanceType<typeof ExchangeKeysForm>> {
+    wrapper = mount(ExchangeKeysForm, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          ExchangeInput: true,
+          I18nT: { template: '<span><slot name="csvImport" /></span>' },
+          // `InternalLink` renders a `RouterLink` with a scoped slot, which needs a real router.
+          RouterLink: true,
+        },
+      },
+      props: {
+        errorMessages: {},
+        modelValue: {
+          apiKey: 'key',
+          apiSecret: 'secret',
+          binanceMarkets: [],
+          location: 'kucoin',
+          mode: 'add',
+          name: 'Kucoin 1',
+          passphrase: '',
+          ...overrides,
+        },
+        stateUpdated: false,
+      },
+    });
+    return wrapper;
+  }
+
+  function has(testId: string): boolean {
+    return wrapper.find(`[data-cy=${testId}]`).exists();
+  }
+
+  describe('the fields every exchange shows', () => {
+    it('should show the name and the api key', () => {
+      createWrapper();
+
+      expect(has('name')).toBe(true);
+      expect(has('api-key')).toBe(true);
+    });
+
+    it('should show the api secret for an exchange that has one', () => {
+      createWrapper();
+
+      expect(has('api-secret')).toBe(true);
+    });
+
+    it('should hide the api secret for an exchange that has none', () => {
+      capabilities.withoutSecret = ['bitpanda'];
+      createWrapper({ location: 'bitpanda' });
+
+      expect(has('api-secret')).toBe(false);
+    });
+
+    it('should hide the passphrase unless the exchange uses one', () => {
+      createWrapper();
+
+      expect(has('passphrase')).toBe(false);
+    });
+
+    it('should show the passphrase for an exchange that uses one', () => {
+      capabilities.withPassphrase = ['kucoin'];
+      createWrapper();
+
+      expect(has('passphrase')).toBe(true);
+    });
+  });
+
+  describe('the per exchange sections', () => {
+    it('should show the kraken account type and futures fields', () => {
+      createWrapper({ location: 'kraken', name: 'kraken 1' });
+
+      expect(has('account-type')).toBe(true);
+      expect(has('kraken-futures-api-key')).toBe(true);
+      expect(has('kraken-futures-api-secret')).toBe(true);
+    });
+
+    it('should keep the kraken sections off other exchanges', () => {
+      createWrapper();
+
+      expect(has('account-type')).toBe(false);
+      expect(has('kraken-futures-api-key')).toBe(false);
+      expect(has('kraken-futures-api-secret')).toBe(false);
+    });
+
+    it('should show the gate region only for gate', () => {
+      createWrapper({ gateLocation: 'global', location: 'gate', name: 'gate 1' });
+
+      expect(has('gate-location')).toBe(true);
+      expect(has('okx-location')).toBe(false);
+    });
+
+    it('should show the okx region only for okx', () => {
+      createWrapper({ location: 'okx', name: 'okx 1', okxLocation: 'global' });
+
+      expect(has('okx-location')).toBe(true);
+      expect(has('gate-location')).toBe(false);
+    });
+
+    it('should show the binance pairs selector for binance', () => {
+      createWrapper({ location: 'binance', name: 'binance 1' });
+
+      expect(wrapper.findComponent(BinancePairsSelector).exists()).toBe(true);
+    });
+
+    it('should not show the pairs selector for another exchange', () => {
+      createWrapper();
+
+      expect(wrapper.findComponent(BinancePairsSelector).exists()).toBe(false);
+    });
+  });
+
+  describe('the binance history import', () => {
+    it('should offer the csv import and the start date when adding', () => {
+      createWrapper({ location: 'binance', name: 'binance 1' });
+
+      expect(wrapper.findComponent(InternalLink).exists()).toBe(true);
+      expect(wrapper.findComponent(BinanceHistoryStartDate).exists()).toBe(true);
+    });
+
+    it('should offer neither when editing', () => {
+      createWrapper({ location: 'binance', mode: 'edit', name: 'binance 1', newName: 'binance 1' });
+
+      expect(wrapper.findComponent(InternalLink).exists()).toBe(false);
+      expect(wrapper.findComponent(BinanceHistoryStartDate).exists()).toBe(false);
+    });
+  });
+
+  describe('the notices', () => {
+    function alertTypes(): (string | undefined)[] {
+      return wrapper.findAllComponents(RuiAlert).map(alert => alert.props('type'));
+    }
+
+    it('should show none for a plain exchange', () => {
+      createWrapper();
+
+      expect(alertTypes()).toStrictEqual([]);
+    });
+
+    it.each(['kraken', 'coinbase', 'coinbaseprime'])('should warn about the key delay for %s', (location) => {
+      capabilities.locations = [...KNOWN_LOCATIONS, location];
+      createWrapper({ location, name: `${location} 1` });
+
+      expect(alertTypes()).toContain('info');
+    });
+
+    it.each(['bybit', 'htx', 'cryptocom'])('should warn about the history limit for %s', (location) => {
+      createWrapper({ location, name: `${location} 1` });
+
+      expect(alertTypes()).toContain('warning');
+    });
+
+    it('should flag an experimental exchange', () => {
+      capabilities.experimental = true;
+      createWrapper();
+
+      expect(alertTypes()).toContain('info');
+    });
+  });
+
+  describe('the saved keys', () => {
+    const edit: Partial<ExchangeFormData> = { mode: 'edit', name: 'Kucoin 1', newName: 'Kucoin 1' };
+
+    function value(testId: string): string {
+      return wrapper.find<HTMLInputElement>(`[data-cy=${testId}] input`).element.value;
+    }
+
+    it('should mask the saved key and secret while editing', () => {
+      createWrapper(edit);
+
+      expect(value('api-key')).toBe('*'.repeat(30));
+      expect(value('api-secret')).toBe('*'.repeat(30));
+    });
+
+    it('should show what was typed when adding', () => {
+      createWrapper();
+
+      expect(value('api-key')).toBe('key');
+    });
+
+    it('should mask the saved futures credentials while editing', () => {
+      createWrapper({
+        ...edit,
+        krakenFuturesApiKey: 'fkey',
+        krakenFuturesApiSecret: 'fsecret',
+        location: 'kraken',
+      });
+
+      expect(value('kraken-futures-api-key')).toBe('*'.repeat(30));
+    });
+
+    it('should offer no replace toggle while adding', () => {
+      createWrapper();
+
+      expect(has('toggle-edit-keys')).toBe(false);
+    });
+
+    /**
+     * A masked field must not be revealable: there is nothing behind the asterisks to reveal, and
+     * offering the eye on a credential the app does not hold is misleading.
+     */
+    it('should not offer to reveal a masked key', () => {
+      createWrapper(edit);
+
+      expect(wrapper.find('[data-cy=api-key]').findComponent({ name: 'RuiRevealableTextField' }).exists())
+        .toBe(false);
+    });
+
+    it('should offer to reveal a key being typed', () => {
+      createWrapper();
+
+      expect(wrapper.find('[data-cy=api-key]').findComponent({ name: 'RuiRevealableTextField' }).exists())
+        .toBe(true);
+    });
+
+    it('should reveal the field for typing when asked to replace the keys', async () => {
+      createWrapper(edit);
+
+      await wrapper.find('[data-cy=toggle-edit-keys]').trigger('click');
+
+      expect(value('api-key')).toBe('key');
+    });
+
+    /**
+     * The clear happens on the way back, not on the way in: turning the toggle off abandons the
+     * replacement, and whatever was typed must not be left behind to be saved.
+     */
+    it('should drop what was typed when the replacement is abandoned', async () => {
+      createWrapper(edit);
+      const toggle = wrapper.find('[data-cy=toggle-edit-keys]');
+
+      await toggle.trigger('click');
+      await toggle.trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toMatchObject({
+        apiKey: '',
+        apiSecret: '',
+      });
+    });
+
+    it('should drop the futures pair when its replacement is abandoned', async () => {
+      createWrapper({ ...edit, location: 'kraken' });
+      const toggle = wrapper.find('[data-cy=toggle-edit-futures-keys]');
+
+      await toggle.trigger('click');
+      await toggle.trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toMatchObject({
+        krakenFuturesApiKey: '',
+        krakenFuturesApiSecret: '',
+      });
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-validation.spec.ts
+++ b/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-validation.spec.ts
@@ -106,6 +106,29 @@ describe('settings/api-keys/exchange validation', () => {
     return form.vm.validate();
   }
 
+  /**
+   * The dialog turns this flag into its discard-on-close prompt, so anything the form writes into
+   * the entry by itself must not raise it. `onMounted` seeds the name, which lands after the form
+   * took its baseline.
+   */
+  describe('the unsaved changes flag', () => {
+    it('should stay down for a form the user has not touched', async () => {
+      const form = createWrapper({ name: '' });
+      await nextTick();
+
+      expect((form.emitted('update:stateUpdated') ?? []).flat()).not.toContain(true);
+    });
+
+    it('should go up once a field is edited', async () => {
+      const form = createWrapper();
+      await nextTick();
+
+      await form.setProps({ modelValue: { ...form.props('modelValue'), apiKey: 'edited' } });
+
+      expect(form.emitted('update:stateUpdated')?.at(-1)?.[0]).toBe(true);
+    });
+  });
+
   describe('the common fields', () => {
     it('should accept a complete form', async () => {
       await expect(validate()).resolves.toBe(true);

--- a/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-validation.spec.ts
+++ b/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-validation.spec.ts
@@ -1,0 +1,263 @@
+import type { ExchangeFormData } from '@/modules/balances/types/exchanges';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ExchangeKeysForm from '@/modules/settings/api-keys/exchange/ExchangeKeysForm.vue';
+import '@test/i18n';
+
+/**
+ * Which fields an exchange demands is decided entirely by `location` and `mode`, through a handful
+ * of predicates over the location store's capability lists. These tests drive the form through its
+ * exposed `validate()` rather than through the markup, so they keep their meaning when the rules
+ * move to a pure module and when the template is split into per-exchange sub-components.
+ */
+// Plain state rather than refs: `vi.hoisted` runs before the auto-imported `ref` exists. The store
+// is constructed per mount, so setting these before `createWrapper` is enough.
+const capabilities = vi.hoisted(() => ({
+  locations: new Array<string>(),
+  withoutSecret: new Array<string>(),
+  withPassphrase: new Array<string>(),
+}));
+
+const KNOWN_LOCATIONS = ['binance', 'binanceus', 'bitpanda', 'gate', 'kraken', 'kucoin', 'okx'];
+
+// A real store, not a plain object: the form reads it through `storeToRefs`.
+vi.mock('@/modules/core/common/use-location-store', async () => {
+  const { defineStore } = await import('pinia');
+  const { computed } = await import('vue');
+  return {
+    useLocationStore: defineStore('location-stub', () => ({
+      exchangesWithoutApiSecret: computed(() => capabilities.withoutSecret),
+      exchangesWithPassphrase: computed(() => capabilities.withPassphrase),
+      // 🔴 Not optional padding: `onMounted` rewrites `name` to `suggestedName(location)` in add
+      // mode, and an unknown location yields `''` — which fails the required-name rule and makes
+      // every scenario look invalid for the wrong reason. Emptying it models the store before its
+      // locations have been fetched.
+      tradeLocations: computed(() => capabilities.locations.map(
+        identifier => ({ identifier, name: identifier }),
+      )),
+      useIsExperimentalExchange: (): ComputedRef<boolean> => computed<boolean>(() => false),
+    })),
+  };
+});
+
+describe('settings/api-keys/exchange validation', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<InstanceType<typeof ExchangeKeysForm>>;
+
+  beforeEach(() => {
+    pinia = createCustomPinia();
+    setActivePinia(pinia);
+    capabilities.locations = [...KNOWN_LOCATIONS];
+    capabilities.withoutSecret = [];
+    capabilities.withPassphrase = [];
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function createWrapper(overrides: Partial<ExchangeFormData> = {}): VueWrapper<InstanceType<typeof ExchangeKeysForm>> {
+    wrapper = mount(ExchangeKeysForm, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          BinanceHistoryStartDate: true,
+          BinancePairsSelector: true,
+          ExchangeInput: true,
+          I18nT: true,
+          InternalLink: true,
+        },
+      },
+      props: {
+        errorMessages: {},
+        modelValue: {
+          apiKey: 'key',
+          apiSecret: 'secret',
+          binanceMarkets: [],
+          location: 'kucoin',
+          mode: 'add',
+          name: 'Kucoin 1',
+          passphrase: '',
+          ...overrides,
+        },
+        stateUpdated: false,
+      },
+    });
+    return wrapper;
+  }
+
+  async function validate(overrides: Partial<ExchangeFormData> = {}): Promise<boolean> {
+    return createWrapper(overrides).vm.validate();
+  }
+
+  /**
+   * `onMounted` fills the name in — the suggestion when adding, the existing name when editing — so
+   * a blank name cannot be produced by the initial props. Clearing it has to happen after mount,
+   * which is also the only way a user reaches that state.
+   */
+  async function validateAfterClearing(
+    field: 'name' | 'newName',
+    overrides: Partial<ExchangeFormData> = {},
+  ): Promise<boolean> {
+    const form = createWrapper(overrides);
+    await form.setProps({ modelValue: { ...form.props('modelValue'), [field]: '' } });
+    return form.vm.validate();
+  }
+
+  describe('the common fields', () => {
+    it('should accept a complete form', async () => {
+      await expect(validate()).resolves.toBe(true);
+    });
+
+    it('should suggest a name when adding rather than leave it blank', () => {
+      const emitted = createWrapper({ name: '' }).emitted('update:modelValue');
+      expect(emitted?.at(-1)?.[0]).toMatchObject({ name: 'kucoin 1' });
+    });
+
+    it('should require a name when adding', async () => {
+      await expect(validateAfterClearing('name')).resolves.toBe(false);
+    });
+
+    /**
+     * The locations arrive from the backend, so the store holds none until that fetch lands. The
+     * suggestion runs once in `onMounted`, so writing an empty one over the given name leaves the
+     * field blank with nothing to restore it.
+     */
+    it('should keep the given name when the locations have not loaded', async () => {
+      capabilities.locations = [];
+
+      await expect(validate({ name: 'Kucoin 1' })).resolves.toBe(true);
+    });
+
+    it('should require an api key', async () => {
+      await expect(validate({ apiKey: '' })).resolves.toBe(false);
+    });
+
+    it('should require an api secret', async () => {
+      await expect(validate({ apiSecret: '' })).resolves.toBe(false);
+    });
+  });
+
+  describe('the per exchange capabilities', () => {
+    it('should not require a secret for an exchange that has none', async () => {
+      capabilities.withoutSecret = ['bitpanda'];
+
+      await expect(validate({ apiSecret: '', location: 'bitpanda' })).resolves.toBe(true);
+    });
+
+    it('should still require a secret for an exchange that has one', async () => {
+      capabilities.withoutSecret = ['bitpanda'];
+
+      await expect(validate({ apiSecret: '', location: 'kucoin' })).resolves.toBe(false);
+    });
+
+    it('should require the passphrase for an exchange that uses one', async () => {
+      capabilities.withPassphrase = ['kucoin'];
+
+      await expect(validate({ passphrase: '' })).resolves.toBe(false);
+    });
+
+    it('should accept the passphrase once given', async () => {
+      capabilities.withPassphrase = ['kucoin'];
+
+      await expect(validate({ passphrase: 'phrase' })).resolves.toBe(true);
+    });
+
+    it('should not require a passphrase for an exchange that has none', async () => {
+      await expect(validate({ passphrase: '' })).resolves.toBe(true);
+    });
+  });
+
+  describe('editing an existing exchange', () => {
+    const edit: Partial<ExchangeFormData> = { mode: 'edit', name: 'Kucoin 1', newName: 'Kucoin 1' };
+
+    it('should seed the new name from the existing one', () => {
+      const emitted = createWrapper({ ...edit, newName: '' }).emitted('update:modelValue');
+      expect(emitted?.at(-1)?.[0]).toMatchObject({ newName: 'Kucoin 1' });
+    });
+
+    it('should require the new name', async () => {
+      await expect(validateAfterClearing('newName', edit)).resolves.toBe(false);
+    });
+
+    it('should not demand the keys again while they stay masked', async () => {
+      await expect(validate({ ...edit, apiKey: '', apiSecret: '' })).resolves.toBe(true);
+    });
+  });
+
+  describe('the kraken futures pair', () => {
+    const kraken: Partial<ExchangeFormData> = { location: 'kraken', name: 'Kraken 1' };
+
+    it('should accept neither futures credential', async () => {
+      await expect(validate(kraken)).resolves.toBe(true);
+    });
+
+    it('should accept both futures credentials', async () => {
+      await expect(validate({
+        ...kraken,
+        krakenFuturesApiKey: 'fkey',
+        krakenFuturesApiSecret: 'fsecret',
+      })).resolves.toBe(true);
+    });
+
+    it('should reject a futures key with no futures secret', async () => {
+      await expect(validate({ ...kraken, krakenFuturesApiKey: 'fkey' })).resolves.toBe(false);
+    });
+
+    it('should reject a futures secret with no futures key', async () => {
+      await expect(validate({ ...kraken, krakenFuturesApiSecret: 'fsecret' })).resolves.toBe(false);
+    });
+  });
+
+  describe('the region selectors', () => {
+    it('should require the gate region', async () => {
+      await expect(validate({ location: 'gate', name: 'Gate 1' })).resolves.toBe(false);
+    });
+
+    it('should accept a chosen gate region', async () => {
+      await expect(validate({ gateLocation: 'global', location: 'gate', name: 'Gate 1' })).resolves.toBe(true);
+    });
+
+    it('should require the okx region', async () => {
+      await expect(validate({ location: 'okx', name: 'Okx 1' })).resolves.toBe(false);
+    });
+
+    it('should accept a chosen okx region', async () => {
+      await expect(validate({ location: 'okx', name: 'Okx 1', okxLocation: 'global' })).resolves.toBe(true);
+    });
+  });
+
+  describe('binance', () => {
+    const binance: Partial<ExchangeFormData> = {
+      binanceHistoryStartTs: 1700000000,
+      binanceMarkets: ['BTCUSDT'],
+      location: 'binance',
+      name: 'Binance 1',
+    };
+
+    it('should accept binance with markets and a start date', async () => {
+      await expect(validate(binance)).resolves.toBe(true);
+    });
+
+    it('should require the markets', async () => {
+      await expect(validate({ ...binance, binanceMarkets: [] })).resolves.toBe(false);
+    });
+
+    it('should require the history start date when adding', async () => {
+      await expect(validate({ ...binance, binanceHistoryStartTs: undefined })).resolves.toBe(false);
+    });
+
+    // `showBinanceHistoryImport` is `isBinance && !editMode`, so the date is only demanded while
+    // adding — an existing connection already has its history.
+    it('should not require the history start date when editing', async () => {
+      await expect(validate({
+        ...binance,
+        binanceHistoryStartTs: undefined,
+        mode: 'edit',
+        newName: 'Binance 1',
+      })).resolves.toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Ports `ExchangeKeysForm` off vuelidate, the last exchange form still on it, and decomposes it while the rules move. Settings now has one `useVuelidate` root left (`OnboardingSettings`); app-wide 37 -> 36.

### The two commits

1. **fix: keep the name when locations are missing** — an unknown location made `suggestedName` return `''`, which `onMounted` wrote over the name it was given, leaving the field blank with nothing to restore it. Standalone fix against the vuelidate version, with the characterization spec that found it.
2. **refactor: validate the key form with zod** — the migration and the decomposition.

### What moved

- The predicates that decide what each exchange shows and demands are now a pure `exchange-keys-form.ts`, with the zod schema beside them.
- `ExchangeNotices` and `KrakenFuturesKeys` come out of the template.
- The dialog was at 0% coverage and its `await validate()` had to change, so it got a spec first.
- A rendering spec pins what every exchange shows: components are not auto-imported here, so a split-out section renders nothing with lint still green.

The form mirrors the entry the dialog owns rather than holding its own state, so `useForm` supplies only touched/dirty/server-errors/`validate`. `onMounted` seeds the name after that baseline is taken, so the baseline is taken again in the same tick; otherwise an untouched dialog counts as dirty and prompts to discard on close.

### Deliberate behaviour changes

- `validate()` is sync, so the dialog dropped its `await`.
- A server error shows immediately instead of staying invisible until the field is dirty (vuelidate read `$externalResults` through `$errors`, so a failed save was invisible on an untouched field).

### Numbers

Form 661 -> 498 lines. Folder coverage 62 -> 85% lines, 55 -> 81% branches; the dialog 0 -> 89%. Tests in the folder 5 -> 127.

### Verification

Gates on the rebased tip: typecheck clean, unit 773 files / 7381 tests green, lint 0 errors / 20 warnings (develop's baseline), stylelint clean, typos clean.

Driven in the app, since this form has no e2e: name suggestion and its overwrite on switching exchange, the required-name rule post-mount, per-exchange rendering (kraken account type + futures, kucoin/okx passphrase, bitpanda with no secret, and the waiting-time / history-limit / experimental notices), the kraken futures pair rule in both directions, a real save rejected by the backend, and the discard-on-close prompt firing only after an actual edit.