### PR TITLE
Run the e2e suite as parallel local shards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ assistants must pass an explicit timeout on these commands rather than relying o
 | `pnpm run lint:file <paths>`, `pnpm run lint:file:check <paths>`, `pnpm run lint-staged` | 2 minutes (usually the default) |
 | `pnpm run test:unit <path>` narrowed to one file or folder | 5 minutes |
 | `pnpm run lint`, `pnpm run lint:all`, `pnpm run typecheck`, `pnpm run build`, `pnpm run test:unit` (full suite), `pnpm install` | 10 minutes |
-| `pnpm run test:e2e`, `pnpm run electron:build`, docker builds | run in the background instead. The unsharded e2e suite takes ~20 minutes locally, which outlasts any foreground timeout. |
+| `pnpm run test:e2e`, `pnpm run test:e2e:shards`, `pnpm run electron:build`, docker builds | run in the background instead. The unsharded e2e suite takes ~20 minutes locally and the sharded one ~7, both of which outlast any foreground timeout. |
 
 Reference measurements (2026-08-09), so a later reader can tell whether this has drifted. The
 frontend gates run as separate steps of one **"Frontend checks"** job (3m50s-5m10s including
@@ -111,6 +111,7 @@ install), so the CI column names the step rather than a whole job:
 | `pnpm run lint:style` | 2s | Stylelint step: 2s |
 | `pnpm run check:linked-keys` | 1s | Linked i18n keys step: 1s |
 | `pnpm run test:e2e` (full, unsharded) | ~20 minutes | 240-637s per shard, across four shards |
+| `pnpm run test:e2e:shards` (full, four local shards) | 7.1 minutes, 806 MB peak per shard | not used; CI shards across runners |
 
 Runner speed varies by about 1.4x between runs, and it moves every step together, so compare a
 step against its own range rather than reading one slow run as a regression.
@@ -870,6 +871,38 @@ Key files:
 - Test utilities (fixtures, mocks, setup) remain in `frontend/app/tests/unit/`
 - Playwright for E2E testing (specs in `frontend/app/tests/e2e/specs/`, page objects in `frontend/app/tests/e2e/pages/`, helpers in `frontend/app/tests/e2e/helpers/`)
 - Test descriptions must follow the `it('should ...'` pattern
+
+#### Running e2e locally, sharded
+
+The backend is single-user, so one Playwright run is pinned to `workers: 1` and takes about
+twenty minutes. `pnpm run test:e2e:shards` starts several complete stacks side by side instead -
+each with its own starling supervisor, rpc mock, preview server, port block and data directory -
+and gives each one a shard of the suite. The whole suite takes about seven minutes across four
+shards, at roughly 800 MB peak per shard.
+
+```bash
+cd frontend
+pnpm run test:e2e:shards                                              # four shards
+pnpm run test:e2e:shards -n 2                                         # two
+pnpm run test:e2e:shards -n 2 tests/e2e/specs/app/tag-manager.spec.ts # only these specs
+pnpm run test:e2e:shards -n 2 -- --grep @slow                         # raw playwright flags
+```
+
+Spec paths are positional, so no `--` is needed for them; pnpm forwards arguments verbatim.
+A `--` separates flags meant for Playwright rather than for the runner.
+
+Useful to know:
+- Shard N takes the port block at offset `N * 10`, so the base block stays free and a plain
+  `pnpm test:e2e` can run alongside a sharded one.
+- Every shard is served the same bundle, built once with an empty `VITE_BACKEND_URL` so it
+  addresses the backend same-origin; each preview server proxies `/api/`, `/ws/` and `/colibri/`
+  to its own shard's starling. Those proxy keys are anchored regexes on purpose: a bare `/api`
+  also matches the `/api-<hash>.js` chunk and the app renders a blank page.
+- Each shard starts from a pristine copy of the packaged global database, so manual prices and
+  other global-database residue cannot leak between runs.
+- Per-shard output lands in `.e2e/shard-N/logs/shard.log`; the terminal only gets summary and
+  failure lines unless `--verbose` is passed. The blob reports are merged into one
+  `playwright-report` at the end.
 
 ## Packaging
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ assistants must pass an explicit timeout on these commands rather than relying o
 | `pnpm run lint:file <paths>`, `pnpm run lint:file:check <paths>`, `pnpm run lint-staged` | 2 minutes (usually the default) |
 | `pnpm run test:unit <path>` narrowed to one file or folder | 5 minutes |
 | `pnpm run lint`, `pnpm run lint:all`, `pnpm run typecheck`, `pnpm run build`, `pnpm run test:unit` (full suite), `pnpm install` | 10 minutes |
-| `pnpm run test:e2e`, `pnpm run electron:build`, docker builds | run in the background instead. The unsharded e2e suite takes ~20 minutes locally, which outlasts any foreground timeout. |
+| `pnpm run test:e2e`, `pnpm run test:e2e:shards`, `pnpm run electron:build`, docker builds | run in the background instead. The unsharded e2e suite takes ~20 minutes locally and the sharded one ~7, both of which outlast any foreground timeout. |
 
 Reference measurements (2026-08-09), so a later reader can tell whether this has drifted. The
 frontend gates run as separate steps of one **"Frontend checks"** job (3m50s-5m10s including
@@ -111,6 +111,7 @@ install), so the CI column names the step rather than a whole job:
 | `pnpm run lint:style` | 2s | Stylelint step: 2s |
 | `pnpm run check:linked-keys` | 1s | Linked i18n keys step: 1s |
 | `pnpm run test:e2e` (full, unsharded) | ~20 minutes | 240-637s per shard, across four shards |
+| `pnpm run test:e2e:shards` (full, four local shards) | 7.1 minutes, 806 MB peak per shard | not used; CI shards across runners |
 
 Runner speed varies by about 1.4x between runs, and it moves every step together, so compare a
 step against its own range rather than reading one slow run as a regression.
@@ -826,6 +827,38 @@ Always keep the fresh-create schema (`schema.py`) in sync with the upgrade so ne
 - Test utilities (fixtures, mocks, setup) remain in `frontend/app/tests/unit/`
 - Playwright for E2E testing (specs in `frontend/app/tests/e2e/specs/`, page objects in `frontend/app/tests/e2e/pages/`, helpers in `frontend/app/tests/e2e/helpers/`)
 - Test descriptions must follow the `it('should ...'` pattern
+
+#### Running e2e locally, sharded
+
+The backend is single-user, so one Playwright run is pinned to `workers: 1` and takes about
+twenty minutes. `pnpm run test:e2e:shards` starts several complete stacks side by side instead -
+each with its own starling supervisor, rpc mock, preview server, port block and data directory -
+and gives each one a shard of the suite. The whole suite takes about seven minutes across four
+shards, at roughly 800 MB peak per shard.
+
+```bash
+cd frontend
+pnpm run test:e2e:shards                                              # four shards
+pnpm run test:e2e:shards -n 2                                         # two
+pnpm run test:e2e:shards -n 2 tests/e2e/specs/app/tag-manager.spec.ts # only these specs
+pnpm run test:e2e:shards -n 2 -- --grep @slow                         # raw playwright flags
+```
+
+Spec paths are positional, so no `--` is needed for them; pnpm forwards arguments verbatim.
+A `--` separates flags meant for Playwright rather than for the runner.
+
+Useful to know:
+- Shard N takes the port block at offset `N * 10`, so the base block stays free and a plain
+  `pnpm test:e2e` can run alongside a sharded one.
+- Every shard is served the same bundle, built once with an empty `VITE_BACKEND_URL` so it
+  addresses the backend same-origin; each preview server proxies `/api/`, `/ws/` and `/colibri/`
+  to its own shard's starling. Those proxy keys are anchored regexes on purpose: a bare `/api`
+  also matches the `/api-<hash>.js` chunk and the app renders a blank page.
+- Each shard starts from a pristine copy of the packaged global database, so manual prices and
+  other global-database residue cannot leak between runs.
+- Per-shard output lands in `.e2e/shard-N/logs/shard.log`; the terminal only gets summary and
+  failure lines unless `--verbose` is passed. The blob reports are merged into one
+  `playwright-report` at the end.
 
 ## Packaging
 ```bash

--- a/frontend/app/.gitignore
+++ b/frontend/app/.gitignore
@@ -28,7 +28,7 @@ yarn-error.log*
 
 #Electron-builder output
 /dist_electron
-tests/e2e/test-results
+tests/e2e/test-results*
 playwright-report
 tests/**/coverage
 tests/**/.v8-coverage

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -33,6 +33,7 @@
     "postuninstall": "electron-builder install-app-deps",
     "serve": "tsx scripts/serve.ts --web",
     "test:e2e": "playwright test",
+    "test:e2e:shards": "tsx scripts/e2e-shards.ts",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:debug": "playwright test --debug",

--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -2,7 +2,15 @@ import { execSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices, type PlaywrightTestConfig } from '@playwright/test';
+
+/**
+ * A shard is one complete stack of its own, started by `scripts/e2e-shards.ts`.
+ * `E2E_SHARD` is its 1-based number and is set only by that runner; everything
+ * below falls back to the single-stack behaviour when it is absent, so a plain
+ * `pnpm test:e2e` and CI are untouched.
+ */
+const shard = Number(process.env.E2E_SHARD ?? 0);
 
 const BASE_FRONTEND_PORT = 30301;
 const BASE_BACKEND_PORT = 30302;
@@ -97,10 +105,16 @@ const colibriUrl = `${backendUrl}/colibri`;
 const mockRpcUrl = `http://127.0.0.1:${MOCK_RPC_PORT}`;
 
 // `.e2e` is resolved from the cwd, so parallel runs in different worktrees already get
-// their own data and log directories.
+// their own data and log directories. Shards run inside ONE worktree, so they need a
+// subdirectory each: they share a cwd and would otherwise hand the same user database
+// to several backends at once.
 const testDir = path.join(process.cwd(), '.e2e');
-const dataDir = path.join(testDir, 'data');
-const logDir = path.join(testDir, 'logs');
+const shardDir = shard > 0 ? path.join(testDir, `shard-${shard}`) : testDir;
+const dataDir = path.join(shardDir, 'data');
+const logDir = path.join(shardDir, 'logs');
+// Shards report into one shared directory under distinct names; the runner merges the
+// blobs into a single html report once every shard has finished.
+const blobDir = path.join(testDir, 'blob-report');
 
 function ensureDirectories(): void {
   if (!fs.existsSync(dataDir)) {
@@ -193,11 +207,30 @@ function buildFrontendCommand(): string {
   // --strictPort: fail loudly instead of silently serving on another port, which would
   // leave the tests pointing at a URL nothing is listening on.
   const preview = `vite preview --port ${FRONTEND_PORT} --strictPort`;
-  // CI builds the frontend in its own workflow job and downloads the artifact.
-  return process.env.CI ? preview : `pnpm run build:app --mode e2e && ${preview}`;
+  // CI builds the frontend in its own workflow job and downloads the artifact, and the
+  // shard runner builds the one bundle every shard shares before starting any of them.
+  return process.env.CI || shard > 0 ? preview : `pnpm run build:app --mode e2e && ${preview}`;
 }
 
 const frontendCommand = buildFrontendCommand();
+
+/**
+ * A plain local run reuses whatever stack is still up from the previous run, which
+ * makes iterating on a single spec fast. A shard must not: the runner resets each
+ * shard's data directory before starting it, so a stack left over from an earlier run
+ * would be holding a database that no longer exists.
+ */
+const reuseExistingServer = !process.env.CI && shard === 0;
+
+function getReporter(): PlaywrightTestConfig['reporter'] {
+  if (process.env.CI)
+    return [['github'], ['html', { open: 'never' }]];
+
+  if (shard > 0)
+    return [['blob', { fileName: `shard-${shard}.zip`, outputDir: blobDir }], ['list']];
+
+  return 'list';
+}
 
 // Get the test group from environment (app or balances)
 const testGroup = process.env.GROUP;
@@ -214,8 +247,8 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   // Backend is single-user, must use 1 worker
   workers: 1,
-  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
-  outputDir: 'tests/e2e/test-results',
+  reporter: getReporter(),
+  outputDir: path.join('tests', 'e2e', shard > 0 ? `test-results-${shard}` : 'test-results'),
 
   use: {
     baseURL: frontendUrl,
@@ -255,7 +288,7 @@ export default defineConfig({
     {
       command: `tsx tests/e2e/rpc-mock/server.ts`,
       url: `${mockRpcUrl}/health`,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer,
       timeout: 10_000,
       env: {
         MOCK_RPC_PORT: String(MOCK_RPC_PORT),
@@ -272,7 +305,7 @@ export default defineConfig({
       // tree is brought up, so core answering says nothing about the rest.
       command: `tsx scripts/start-starling.ts --port ${PROXY_PORT} --core-port ${BACKEND_PORT} --colibri-port ${COLIBRI_PORT} --mcp-port ${MCP_PORT} --data ${dataDir} --logs ${logDir}`,
       url: `${backendUrl}/health`,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer,
       // Covers a cold `cargo run` for both Rust services on a fresh checkout.
       timeout: 180_000,
       // Playwright otherwise SIGKILLs the server's process tree. starling puts
@@ -288,7 +321,7 @@ export default defineConfig({
     {
       command: frontendCommand,
       url: frontendUrl,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer,
       // The local non-interactive path builds before serving (~15s on a warm machine),
       // so it gets more headroom than starting a dev server or serving an existing dist.
       timeout: interactive || process.env.CI ? 180_000 : 300_000,

--- a/frontend/app/scripts/build.ts
+++ b/frontend/app/scripts/build.ts
@@ -66,6 +66,12 @@ function cleanupDist(): void {
 /**
  * If the env already contains env variables about the backend urls,
  * e.g., from the e2e script, then we want to keep these settings.
+ *
+ * An empty value counts as a setting: `.env` points the backend at port 4242, and a
+ * bundle that has to address the backend same-origin (the sharded e2e run, where one
+ * bundle is served by several preview servers) can only say so by clearing it. The app
+ * reads an empty url as "same origin" (modules/core/api/api-urls.ts), so what matters
+ * here is set-to-empty versus not set at all.
  */
 function loadUrlConfig(mode: string): Record<string, string> {
   const urlsVars: Record<string, string> = {};
@@ -73,7 +79,7 @@ function loadUrlConfig(mode: string): Record<string, string> {
     return urlsVars;
   }
   const backendUrl = process.env.VITE_BACKEND_URL;
-  if (backendUrl)
+  if (backendUrl !== undefined)
     urlsVars.VITE_BACKEND_URL = backendUrl;
   return urlsVars;
 }
@@ -87,7 +93,7 @@ function updateEnvVars(vars: Record<string, string>): void {
   }
 }
 
-async function setup(mode: string): Promise<void> {
+async function setup(mode: string, rendererOnly: boolean): Promise<void> {
   consola.info(`Building for ${mode}...`);
   const urlsVars: Record<string, string> = loadUrlConfig(mode);
 
@@ -103,8 +109,13 @@ async function setup(mode: string): Promise<void> {
         injectEnv(`.env.${mode}`);
       updateEnvVars(urlsVars);
 
-      await setupPreloadBuilder(mode);
-      await setupMainBuilder(mode);
+      // The preload and main bundles are electron-only, and a web-served build never
+      // loads them. Skipping them is what makes the e2e build cheap enough to run
+      // before every sharded run.
+      if (!rendererOnly) {
+        await setupPreloadBuilder(mode);
+        await setupMainBuilder(mode);
+      }
     }
 
     await setupRendererBuilder(mode);
@@ -122,8 +133,9 @@ const cli = cac();
 
 cli.command('', 'Rotki frontend build')
   .option('--mode <mode>', 'Build mode (production, docker, e2e)', { default: 'production' })
+  .option('--renderer-only', 'Build only the renderer, skipping the electron preload and main bundles', { default: false })
   .action(async (options) => {
-    await setup(options.mode);
+    await setup(options.mode, Boolean(options.rendererOnly));
   });
 
 cli.help();

--- a/frontend/app/scripts/e2e-shards.ts
+++ b/frontend/app/scripts/e2e-shards.ts
@@ -1,0 +1,525 @@
+import type { Buffer } from 'node:buffer';
+import { type ChildProcess, spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import process from 'node:process';
+import { cac } from 'cac';
+import consola from 'consola';
+
+/**
+ * Runs the e2e suite as several shards in parallel on one machine.
+ *
+ * The backend is single-user, so a single Playwright run is pinned to one worker and
+ * takes around twenty minutes. This starts N complete stacks instead - each its own
+ * starling supervisor (core, colibri, the proxy), rpc mock and preview server - and
+ * gives each one a shard of the suite.
+ *
+ * Shards are numbered from 1 and take the port block at that number's offset, so the
+ * base block stays free and a plain `pnpm test:e2e` can run alongside a sharded one.
+ * `playwright.config.ts` derives every port, data directory and report path from
+ * `E2E_SHARD` plus `E2E_PORT_OFFSET`, both set here.
+ *
+ * Every shard serves the same bundle. It can, because the bundle names no port: it is
+ * built with an empty `VITE_BACKEND_URL` so all calls go same-origin, and each preview
+ * server proxies them to its own shard's starling (see `preview.proxy` in
+ * vite.config.ts). One build, N stacks.
+ */
+
+/** Matches PORT_BLOCK_STRIDE and the base ports in playwright.config.ts. */
+const PORT_STRIDE = 10;
+const BASE_PORTS = [30301, 30302, 30303, 30304, 30305, 30306];
+const PORT_LABELS = ['frontend', 'core', 'colibri', 'rpc-mock', 'proxy', 'mcp'];
+
+/** playwright.config.ts probes ten blocks, and shard 1 takes the second of them. */
+const MAX_SHARDS = 9;
+
+/**
+ * Rough resident-set cost of one shard: preview server, core, colibri, starling,
+ * Playwright and its chromium. Used only to warn before a run; the measured peaks
+ * printed at the end are the number to trust.
+ */
+const ESTIMATED_SHARD_MEMORY_MB = 1500;
+
+/** How often the memory sampler reads the process table. */
+const SAMPLE_INTERVAL_MS = 10_000;
+
+/** Lines worth surfacing from a shard's output when not running verbose. */
+const INTERESTING_OUTPUT = /^\s*(?:\d+ (?:passed|failed|flaky|skipped)|Running \d+ test|✘|Error:|\d+\) )/;
+
+const appDir = path.resolve(import.meta.dirname, '..');
+const e2eDir = path.join(appDir, '.e2e');
+const templateDir = path.join(e2eDir, 'template');
+const blobDir = path.join(e2eDir, 'blob-report');
+const reportDir = path.join(appDir, 'playwright-report');
+const packagedGlobalDb = path.join(appDir, '..', '..', 'rotkehlchen', 'data', 'global.db');
+
+interface RunOptions {
+  shards: number;
+  resetTemplate: boolean;
+  skipBuild: boolean;
+  verbose: boolean;
+  passthrough: string[];
+}
+
+function shardDir(shard: number): string {
+  return path.join(e2eDir, `shard-${shard}`);
+}
+
+function portOffsetFor(shard: number): number {
+  return shard * PORT_STRIDE;
+}
+
+/**
+ * Checks whether something is already listening on a port. Connects over both loopback
+ * families: vite binds ::1 while core binds 127.0.0.1, so checking one family misses
+ * half the stack.
+ */
+async function isPortFree(port: number): Promise<boolean> {
+  const probes = ['127.0.0.1', '::1'].map(async host => new Promise<boolean>((resolve) => {
+    const socket = net.connect({ host, port });
+    const done = (inUse: boolean): void => {
+      socket.destroy();
+      resolve(inUse);
+    };
+    socket.setTimeout(500);
+    socket.on('connect', () => done(true));
+    socket.on('timeout', () => done(false));
+    socket.on('error', () => done(false));
+  }));
+
+  const results = await Promise.all(probes);
+  return !results.includes(true);
+}
+
+/**
+ * Best-effort description of whoever holds a port, so a collision names the culprit
+ * instead of failing minutes later as an opaque webServer timeout.
+ */
+function describePortHolder(port: number): string {
+  try {
+    const listeners = spawnSync('ss', ['-ltnp'], { encoding: 'utf-8' });
+    const line = listeners.stdout?.split('\n').find(entry => new RegExp(`[.:]${port}\\s`).test(entry));
+    const pid = line?.match(/pid=(\d+)/)?.[1];
+    if (!pid) {
+      return line?.trim() ?? 'unknown process';
+    }
+    const cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8').replaceAll('\0', ' ').trim();
+    return `pid ${pid}: ${cmdline}`;
+  }
+  catch {
+    return 'unknown process';
+  }
+}
+
+async function preflightPorts(shards: number): Promise<void> {
+  const conflicts: string[] = [];
+
+  for (let shard = 1; shard <= shards; shard++) {
+    for (const [index, basePort] of BASE_PORTS.entries()) {
+      const port = basePort + portOffsetFor(shard);
+      if (!await isPortFree(port)) {
+        conflicts.push(`  shard ${shard} ${PORT_LABELS[index]} port ${port}: ${describePortHolder(port)}`);
+      }
+    }
+  }
+
+  if (conflicts.length > 0) {
+    consola.error(`Cannot start, ports are already in use:\n${conflicts.join('\n')}`);
+    consola.info('Stop the processes above, or run with fewer shards (-n).');
+    process.exit(1);
+  }
+}
+
+/**
+ * Reads MemAvailable, the kernel's own estimate of what can be handed out without
+ * swapping. `os.freemem()` is the wrong number on linux: it excludes reclaimable page
+ * cache and so understates what is available, often by tens of gigabytes.
+ */
+function availableMemoryMb(): number | undefined {
+  try {
+    const meminfo = fs.readFileSync('/proc/meminfo', 'utf-8');
+    const kb = meminfo.match(/^MemAvailable:\s+(\d+) kB$/m)?.[1];
+    return kb ? Math.round(Number(kb) / 1024) : undefined;
+  }
+  catch {
+    return undefined;
+  }
+}
+
+/** Warns, never blocks: the estimate is coarse and the machine is the user's to fill. */
+function warnOnMemory(shards: number): void {
+  const available = availableMemoryMb();
+  if (available === undefined) {
+    return;
+  }
+
+  const needed = shards * ESTIMATED_SHARD_MEMORY_MB;
+  const format = (mb: number): string => `${(mb / 1024).toFixed(1)} GB`;
+
+  if (needed > available) {
+    consola.warn(
+      `${shards} shards need roughly ${format(needed)} but only ${format(available)} is available. `
+      + 'Expect swapping or an out-of-memory kill; run with fewer shards (-n) if that matters.',
+    );
+  }
+  else {
+    consola.info(`${shards} shards need roughly ${format(needed)}, ${format(available)} available`);
+  }
+}
+
+/** Uses cp so copy-on-write is used where the filesystem supports it. */
+function copyTree(source: string, target: string): void {
+  const result = spawnSync('cp', ['-a', '--reflink=auto', source, target], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    throw new Error(`Failed to copy ${source} to ${target}`);
+  }
+}
+
+/**
+ * Builds the template data directory every shard starts from.
+ *
+ * The template is the packaged global database, which is what the backend copies into a
+ * fresh data directory itself (globaldb/handler.py). Seeding it here means no shard pays
+ * for that bootstrap, and every run starts from a pristine database rather than one
+ * carrying state from previous runs - the manual price rows that accumulate in a reused
+ * data directory break the price-manager specs.
+ *
+ * The icon cache is carried over from a previous run when there is one. It is a pure
+ * cache, so a missing one only costs a little time.
+ */
+function prepareTemplate(resetTemplate: boolean): void {
+  if (resetTemplate && fs.existsSync(templateDir)) {
+    fs.rmSync(templateDir, { recursive: true, force: true });
+  }
+
+  const templateDb = path.join(templateDir, 'global', 'global.db');
+  if (!fs.existsSync(packagedGlobalDb)) {
+    throw new Error(`Packaged global database not found at ${packagedGlobalDb}`);
+  }
+
+  // Rebuild when the packaged database has moved on, e.g. after a data submodule bump.
+  const stale = fs.existsSync(templateDb)
+    && fs.statSync(templateDb).mtimeMs < fs.statSync(packagedGlobalDb).mtimeMs;
+
+  if (stale || !fs.existsSync(templateDb)) {
+    consola.info('Seeding the data template from the packaged global database');
+    fs.rmSync(path.join(templateDir, 'global'), { recursive: true, force: true });
+    fs.mkdirSync(path.join(templateDir, 'global'), { recursive: true });
+    copyTree(packagedGlobalDb, templateDb);
+  }
+
+  const cachedIcons = path.join(e2eDir, 'data', 'images');
+  const templateIcons = path.join(templateDir, 'images');
+  if (fs.existsSync(cachedIcons) && !fs.existsSync(templateIcons)) {
+    copyTree(cachedIcons, templateIcons);
+  }
+}
+
+function resetShardData(shard: number): void {
+  const dataDir = path.join(shardDir(shard), 'data');
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(dataDir), { recursive: true });
+  copyTree(templateDir, dataDir);
+}
+
+/**
+ * Builds the one bundle every shard shares.
+ *
+ * Clearing `VITE_BACKEND_URL` rather than omitting it is what makes the bundle portable:
+ * `.env` points the backend at port 4242 and the build injects it, so an omitted value
+ * would bake that in and the app would boot against a port nothing is listening on.
+ */
+function buildFrontend(): void {
+  consola.info('Building the frontend bundle shared by every shard');
+  const started = Date.now();
+
+  const result = spawnSync('npx', ['tsx', 'scripts/build.ts', '--mode', 'e2e', '--renderer-only'], {
+    cwd: appDir,
+    env: { ...process.env, VITE_BACKEND_URL: '' },
+    stdio: ['ignore', 'ignore', 'inherit'],
+  });
+
+  if (result.status !== 0) {
+    throw new Error('Frontend build failed');
+  }
+
+  consola.success(`Frontend built in ${((Date.now() - started) / 1000).toFixed(0)}s`);
+}
+
+/** Every shard process group started by this run, so they can all be cleaned up. */
+const shardGroups = new Set<number>();
+
+/**
+ * Kills a shard and everything it started. Playwright's webServer children are in the
+ * shard's process group, so killing the group takes starling, the rpc mock and the
+ * preview server with it. Without this an interrupted run leaves a full stack per shard
+ * resident indefinitely.
+ */
+function killGroup(pgid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-pgid, signal);
+  }
+  catch {
+    // Already gone.
+  }
+}
+
+function killAllShards(signal: NodeJS.Signals): void {
+  for (const pgid of shardGroups) {
+    killGroup(pgid, signal);
+  }
+}
+
+function installCleanupHandlers(): void {
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+    process.on(signal, () => {
+      consola.warn(`Received ${signal}, stopping ${shardGroups.size} shard(s)`);
+      killAllShards('SIGTERM');
+      // Give the stacks a moment to shut down cleanly, then insist.
+      setTimeout(() => {
+        killAllShards('SIGKILL');
+        process.exit(130);
+      }, 5000).unref();
+    });
+  }
+
+  process.on('exit', () => killAllShards('SIGKILL'));
+}
+
+/**
+ * Sums resident memory per process group, so each shard's whole stack is measured as one
+ * number. Returns megabytes keyed by process group id.
+ */
+function sampleGroupMemoryMb(): Map<number, number> {
+  const totals = new Map<number, number>();
+  const result = spawnSync('ps', ['-eo', 'pgid=,rss='], { encoding: 'utf-8' });
+
+  for (const line of result.stdout?.split('\n') ?? []) {
+    const [pgid, rss] = line.trim().split(/\s+/).map(Number);
+    if (!shardGroups.has(pgid) || Number.isNaN(rss)) {
+      continue;
+    }
+    totals.set(pgid, (totals.get(pgid) ?? 0) + rss / 1024);
+  }
+
+  return totals;
+}
+
+/**
+ * Streams a shard's output to its own log file and forwards only the lines worth reading
+ * to the terminal. Several shards each emitting a full reporter for twenty minutes is
+ * far more than anything capturing this run wants to hold.
+ */
+function pipeOutput(child: ChildProcess, shard: number, verbose: boolean): void {
+  const logPath = path.join(shardDir(shard), 'logs', 'shard.log');
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  const log = fs.createWriteStream(logPath);
+  const prefix = `[${shard}] `;
+  let pending = '';
+
+  for (const stream of [child.stdout, child.stderr]) {
+    stream?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      log.write(text);
+
+      pending += text;
+      const lines = pending.split('\n');
+      pending = lines.pop() ?? '';
+
+      const shown = verbose ? lines : lines.filter(line => INTERESTING_OUTPUT.test(line));
+      if (shown.length > 0) {
+        process.stdout.write(`${shown.map(line => `${prefix}${line}`).join('\n')}\n`);
+      }
+    });
+  }
+
+  child.on('exit', () => log.end());
+}
+
+interface ShardResult {
+  code: number;
+  peakMemoryMb: number;
+}
+
+async function runShard(
+  shard: number,
+  shards: number,
+  passthrough: string[],
+  verbose: boolean,
+): Promise<ShardResult> {
+  const args = ['playwright', 'test', `--shard=${shard}/${shards}`, ...passthrough];
+  const child = spawn('npx', args, {
+    cwd: appDir,
+    // Its own process group, so cleanup and memory accounting can address the whole
+    // stack rather than just the playwright process.
+    detached: true,
+    env: {
+      ...process.env,
+      E2E_SHARD: String(shard),
+      E2E_PORT_OFFSET: String(portOffsetFor(shard)),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const pgid = child.pid;
+  if (pgid !== undefined) {
+    shardGroups.add(pgid);
+  }
+
+  pipeOutput(child, shard, verbose);
+
+  const logPath = path.join(shardDir(shard), 'logs', 'shard.log');
+  consola.info(`Shard ${shard}/${shards} started, full output in ${path.relative(appDir, logPath)}`);
+
+  return new Promise<ShardResult>((resolve) => {
+    let peakMemoryMb = 0;
+    const sampler = setInterval(() => {
+      if (pgid === undefined) {
+        return;
+      }
+      peakMemoryMb = Math.max(peakMemoryMb, sampleGroupMemoryMb().get(pgid) ?? 0);
+    }, SAMPLE_INTERVAL_MS);
+    sampler.unref();
+
+    child.on('exit', (code) => {
+      clearInterval(sampler);
+      if (pgid !== undefined) {
+        // Playwright stops its own webServers, but a crashed or killed shard may not
+        // have; make sure nothing outlives the run.
+        killGroup(pgid, 'SIGKILL');
+        shardGroups.delete(pgid);
+      }
+      consola.info(`Shard ${shard}/${shards} finished with code ${code ?? 0}, peak ${peakMemoryMb.toFixed(0)} MB`);
+      resolve({ code: code ?? 1, peakMemoryMb });
+    });
+  });
+}
+
+function mergeReports(): void {
+  if (!fs.existsSync(blobDir) || fs.readdirSync(blobDir).length === 0) {
+    consola.warn('No blob reports to merge');
+    return;
+  }
+
+  const result = spawnSync('npx', ['playwright', 'merge-reports', '--reporter', 'html', blobDir], {
+    cwd: appDir,
+    env: { ...process.env, PLAYWRIGHT_HTML_OPEN: 'never', PLAYWRIGHT_HTML_OUTPUT_DIR: reportDir },
+    stdio: 'inherit',
+  });
+
+  if (result.status === 0) {
+    consola.success(`Merged report written to ${path.relative(appDir, reportDir)}`);
+  }
+  else {
+    consola.error('Failed to merge shard reports');
+  }
+}
+
+function hasBundle(): boolean {
+  return fs.existsSync(path.join(appDir, 'dist', 'index.html'));
+}
+
+async function run(options: RunOptions): Promise<void> {
+  const { shards, resetTemplate, skipBuild, verbose, passthrough } = options;
+
+  if (shards < 1 || shards > MAX_SHARDS) {
+    consola.error(`The number of shards must be between 1 and ${MAX_SHARDS}`);
+    process.exit(1);
+  }
+
+  if (shards > 1 && process.env.MOCK_RPC_MODE === 'record') {
+    consola.error('Cassette recording writes shared files and cannot be sharded. Record with a single shard.');
+    process.exit(1);
+  }
+
+  warnOnMemory(shards);
+  await preflightPorts(shards);
+  prepareTemplate(resetTemplate);
+
+  if (skipBuild) {
+    if (!hasBundle()) {
+      consola.error('--skip-build was given but there is no bundle in dist/. Run without it once.');
+      process.exit(1);
+    }
+    consola.info('Reusing the existing frontend bundle');
+  }
+  else {
+    buildFrontend();
+  }
+
+  fs.rmSync(blobDir, { recursive: true, force: true });
+
+  for (let shard = 1; shard <= shards; shard++) {
+    resetShardData(shard);
+  }
+
+  installCleanupHandlers();
+
+  consola.box(`Running the e2e suite across ${shards} shards`);
+  const started = Date.now();
+
+  const results = await Promise.all(
+    Array.from({ length: shards }, async (_, index) => runShard(index + 1, shards, passthrough, verbose)),
+  );
+
+  const minutes = ((Date.now() - started) / 60_000).toFixed(1);
+  mergeReports();
+
+  const peak = Math.max(...results.map(result => result.peakMemoryMb));
+  const total = results.reduce((sum, result) => sum + result.peakMemoryMb, 0);
+  consola.info(`Peak memory: ${peak.toFixed(0)} MB for the heaviest shard, ${total.toFixed(0)} MB across all shards`);
+
+  const failed = results.filter(result => result.code !== 0).length;
+  if (failed > 0) {
+    consola.error(`${failed} of ${shards} shards failed after ${minutes} minutes`);
+    process.exit(1);
+  }
+
+  consola.success(`All ${shards} shards passed in ${minutes} minutes`);
+}
+
+/**
+ * Splits our own flags from what is forwarded to Playwright.
+ *
+ * Spec paths are plain positional arguments, so the common case needs no separator:
+ * `pnpm run test:e2e:shards -n 2 tests/e2e/specs/app/tag-manager.spec.ts`. A `--` is
+ * still honoured for raw Playwright flags this script knows nothing about, e.g.
+ * `... -n 2 -- --grep @slow`.
+ *
+ * pnpm 11 forwards arguments verbatim, so a `--` typed out of npm habit arrives as a
+ * literal leading token rather than being eaten by the package manager. Dropping it
+ * here keeps both spellings working.
+ */
+function splitArguments(): { own: string[]; forwarded: string[] } {
+  const argv = process.argv.slice(2);
+  if (argv[0] === '--') {
+    argv.shift();
+  }
+
+  const separator = argv.indexOf('--');
+  return separator === -1
+    ? { own: argv, forwarded: [] }
+    : { own: argv.slice(0, separator), forwarded: argv.slice(separator + 1) };
+}
+
+const { own, forwarded } = splitArguments();
+const cli = cac();
+
+cli.command('[...specs]', 'Run the e2e suite as parallel shards')
+  .option('-n, --shards <count>', 'Number of parallel shards', { default: 4 })
+  .option('--reset-template', 'Rebuild the data template before running', { default: false })
+  .option('--skip-build', 'Reuse the frontend bundle from a previous run', { default: false })
+  .option('--verbose', 'Stream every shard\'s full output instead of a summary', { default: false })
+  .action(async (specs: string[], options) => {
+    await run({
+      passthrough: [...specs, ...forwarded],
+      resetTemplate: Boolean(options.resetTemplate),
+      shards: Number(options.shards),
+      skipBuild: Boolean(options.skipBuild),
+      verbose: Boolean(options.verbose),
+    });
+  });
+
+cli.help();
+cli.parse([process.argv[0], process.argv[1], ...own]);

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -46,6 +46,36 @@ const isDevelopment = process.env.NODE_ENV === 'development';
 const isTest = !!process.env.VITE_TEST;
 const isCoverage = !!process.env.VITE_COVERAGE;
 const hmrEnabled = isDevelopment && !(process.env.CI && isTest);
+
+/**
+ * Sharded e2e runs (`scripts/e2e-shards.ts`) serve ONE bundle from several `vite preview`
+ * servers, one per shard. That only works because the bundle names no port: it is built
+ * with an empty `VITE_BACKEND_URL`, so every call goes same-origin, and each preview
+ * server forwards those calls to its own shard's starling proxy.
+ *
+ * The port is read when preview starts rather than when the bundle is built, which is
+ * what lets one build serve every shard. `E2E_PORT_OFFSET` is the block the run settled
+ * on and 30305 is the proxy inside it, matching playwright.config.ts.
+ */
+const E2E_BASE_PROXY_PORT = 30305;
+const e2eShard = Number(process.env.E2E_SHARD ?? 0);
+const e2eProxyTarget = `http://127.0.0.1:${E2E_BASE_PROXY_PORT + Number(process.env.E2E_PORT_OFFSET ?? 0)}`;
+/**
+ * The keys are anchored regexes, not plain prefixes, because the bundle's own chunks sit
+ * at the root and are named after the module they came from: a bare `/api` key also
+ * matches the `/api-<hash>.js` chunk, which is then forwarded to a backend that has
+ * never heard of it. The 404 arrives as a failed dynamic import of the login chunk, and
+ * the app renders a blank page with nothing in the console naming the proxy.
+ */
+const previewProxy = e2eShard > 0
+  ? {
+      '^/api/': { target: e2eProxyTarget },
+      // Task and balance updates the backend pushes over a websocket.
+      '^/ws/': { target: e2eProxyTarget, ws: true },
+      // starling strips the prefix itself, so this is a plain forward.
+      '^/colibri/': { target: e2eProxyTarget },
+    }
+  : undefined;
 // Single source of truth for the accounting-update feature: the backend gates its
 // endpoints behind ROTKI_ACCOUNTING_UPDATE, so we mirror that same shell var into a
 // VITE_-prefixed entry, which Vite then exposes on import.meta.env. Exporting the one
@@ -138,6 +168,9 @@ export default defineConfig({
     dedupe: ['vue'],
   },
   base: publicPath,
+  preview: {
+    proxy: previewProxy,
+  },
   customLogger: createConfigLogger(),
   define: {
     __APP_VERSION__: JSON.stringify(process.env.npm_package_version),

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -45,7 +45,10 @@ export default rotki({
     'app/backend-strings.generated.js',
     'app/premium-keys.generated.js',
     'app/tests/e2e/.v8-coverage/**',
-    'app/tests/e2e/test-results/**',
+    // A sharded run writes one output directory per shard: `test-results-1`, `-2`, ...
+    'app/tests/e2e/test-results*/**',
+    // The merged html report a sharded run leaves behind: a bundled trace viewer.
+    'app/playwright-report/**',
   ],
   vue: true,
   typescript: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "test:unit": "pnpm run --filter rotki test:unit:run",
     "test:unit:watch": "pnpm run --filter rotki test:unit",
     "test:e2e": "pnpm run --filter rotki test:e2e",
+    "test:e2e:shards": "pnpm run --filter rotki test:e2e:shards",
     "test:e2e:coverage": "pnpm run --filter rotki test:e2e:coverage",
     "test:e2e:coverage:report": "pnpm run --filter rotki test:e2e:coverage:report",
     "typecheck": "pnpm run --filter rotki typecheck",


### PR DESCRIPTION
## Summary

The backend is single-user, so a Playwright run is pinned to `workers: 1` and the suite takes about twenty minutes locally. `pnpm run test:e2e:shards` starts several complete stacks side by side instead - each with its own starling supervisor, rpc mock, preview server, port block and data directory - and gives each one a shard of the suite.

Measured on a 16-core workstation: **231 tests pass in 7.1 minutes across four shards**, peaking at ~800 MB per shard and 3.0 GB in total.

Everything is gated on `E2E_SHARD`, which only the runner sets. With it absent, ports, directories, reporters and the frontend command are exactly what they are today, so CI and a plain `pnpm test:e2e` are untouched.

## How it works

- Shard N takes the port block at offset `N * 10` by setting `E2E_PORT_OFFSET`, reusing the resolve-once probing already in `playwright.config.ts`. The base block stays free, so a plain run can happen alongside a sharded one.
- Data and logs go to `.e2e/shard-N/`. `.e2e` is resolved from the cwd, so without this shards in one worktree would hand the same user database to several backends.
- Every shard is served the same bundle, built once with an empty `VITE_BACKEND_URL` so it addresses the backend same-origin; each preview server forwards `/api/`, `/ws/` and `/colibri/` to its own shard's starling.
- Each shard's data directory is a copy of a template seeded from the packaged global database, so global-database residue cannot leak between runs.
- Shards run in their own process group and are tree-killed on interrupt, so an aborted run cannot strand a stack. Per-shard output goes to `.e2e/shard-N/logs/shard.log`, with only summary and failure lines on the terminal unless `--verbose` is passed. Blob reports are merged into one `playwright-report`.

## Notes for review

- The preview proxy keys are anchored regexes (`^/api/`) rather than plain prefixes on purpose. A bare `/api` also matches the bundle's own `/api-<hash>.js` chunk, which is then forwarded to a backend that 404s; the failure surfaces as a failed dynamic import and a blank page with nothing naming the proxy.
- `scripts/build.ts` now distinguishes an explicitly empty `VITE_BACKEND_URL` from an unset one. `.env` points the backend at port 4242 and the build injects it, so clearing the variable was previously indistinguishable from omitting it and 4242 was baked in.
- `--renderer-only` skips the electron preload and main bundles, which a web-served build never loads: 22s down to 9s.
- The eslint ignores needed `test-results*` and `playwright-report`, which a sharded run leaves behind. Without them a full lint reports ~198k errors from the bundled trace viewer.

## Testing

- `pnpm run test:e2e:shards` - 231 passed, 7.1 minutes, four shards.
- `playwright test tests/e2e/specs/app/tag-manager.spec.ts` unsharded on the base block - 5 passed, unchanged behaviour.
- `pnpm run lint` (0 errors), `pnpm run typecheck`, `typos` - all clean.