### PR TITLE
dev: quieter dev server and self-healing instance slots

### DIFF
--- a/frontend/app/scripts/serve.ts
+++ b/frontend/app/scripts/serve.ts
@@ -115,15 +115,54 @@ async function setupPreloadPackageWatcher({ ws }: ViteDevServer, mode: string): 
   }, mode);
 }
 
+/**
+ * Environment variables set by coding agents that run `pnpm dev:web` on the
+ * developer's behalf. A browser tab popping up belongs to an interactive run,
+ * not to an agent's background dev server, so these suppress the auto-open the
+ * same way CI does. Set `ROTKI_OPEN_BROWSER=1` to force it back on.
+ */
+const agentEnvVars = [
+  'AI_AGENT', // claude code
+  'CLAUDECODE', // claude code
+  'CLAUDE_CODE_ENTRYPOINT', // claude code
+  'CODEX_SANDBOX', // openai codex cli
+  'CURSOR_AGENT', // cursor
+  'GEMINI_CLI', // gemini cli
+];
+
+function isAgentRun(): boolean {
+  return agentEnvVars.some(name => !!process.env[name]);
+}
+
+/**
+ * Only auto-open a browser tab in web mode: in electron mode the renderer is loaded
+ * inside the electron window, so a browser tab would be spurious. Neither CI nor a
+ * coding agent opens one either, since nobody is watching that screen.
+ */
+function shouldOpenBrowser(web: boolean, open: boolean): boolean {
+  if (!web || !open) {
+    return false;
+  }
+  if (process.env.ROTKI_OPEN_BROWSER) {
+    return true;
+  }
+  if (process.env.CI) {
+    return false;
+  }
+  if (isAgentRun()) {
+    consola.info('not opening a browser tab (agent environment detected); set ROTKI_OPEN_BROWSER=1 to override');
+    return false;
+  }
+  return true;
+}
+
 async function serve(options: ServeOptions): Promise<void> {
   const { web, remoteDebuggingPort, mode, port, open } = options;
 
   try {
-    // Only auto-open a browser tab in web mode: in electron mode the renderer is
-    // loaded inside the electron window, so a browser tab would be spurious. `open`
-    // is a plain boolean here (Vite opens the resolved server URL, honouring the
-    // instance's port), and CI never opens.
-    const openBrowser = web && open && !process.env.CI;
+    // A plain boolean here, so Vite opens the resolved server URL and honours the
+    // instance's port.
+    const openBrowser = shouldOpenBrowser(web, open);
     const viteDevServer = await createServer({
       ...sharedConfig,
       mode: process.env.CI && process.env.VITE_TEST ? 'production' : mode,
@@ -172,7 +211,7 @@ cli.command('', 'Rotki frontend development server')
   .option('--remote-debugging-port <port>', 'Chrome remote debugging port')
   .option('--mode <mode>', 'Development mode', { default: 'development' })
   .option('--port <port>', 'Listening port', { default: 8080 })
-  .option('--open', 'Open the web app in the browser on start (web mode only, default: on; use --no-open to disable)', { default: true })
+  .option('--open', 'Open the web app in the browser on start (web mode only, default: on, off under CI and coding agents; use --no-open to disable)', { default: true })
   .action(async (options) => {
     await serve({
       web: options.web ?? false,

--- a/frontend/scripts/dev-instance/atomic-json.ts
+++ b/frontend/scripts/dev-instance/atomic-json.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs';
+import process from 'node:process';
+
+/**
+ * Write JSON through a temp file + rename, so a reader never observes a
+ * half-written file and a crash mid-write cannot truncate the original.
+ */
+export function atomicWriteJson(file: string, value: unknown): void {
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+  fs.renameSync(tmp, file);
+}

--- a/frontend/scripts/dev-instance/instance.ts
+++ b/frontend/scripts/dev-instance/instance.ts
@@ -181,7 +181,10 @@ export async function prepareInstance(opts: PrepareInstanceOptions): Promise<Ins
   // look exactly like one of those to a second `dev:web` running concurrently.
   // `ensureInstanceData` still treats an empty directory as needing a seed.
   fs.mkdirSync(dir, { recursive: true });
-  const slot = await allocatePortSlot(name, opts.slotHint);
+  const slot = await allocatePortSlot(name, {
+    hint: opts.slotHint,
+    isSlotLive: async (candidate: number): Promise<boolean> => (await probePortsLive(candidate)).length > 0,
+  });
   const ports = portsForSlot(slot);
 
   await refuseIfSlotLive(name, slot);

--- a/frontend/scripts/dev-instance/instance.ts
+++ b/frontend/scripts/dev-instance/instance.ts
@@ -176,6 +176,11 @@ function buildMeta(
 export async function prepareInstance(opts: PrepareInstanceOptions): Promise<InstanceRuntime> {
   const name = sanitizeName(opts.name);
   const dir = resolveInstanceDir(name);
+  // Claim the directory before the slot: the allocator releases slots whose
+  // directory is gone, and an instance that has not created its own yet would
+  // look exactly like one of those to a second `dev:web` running concurrently.
+  // `ensureInstanceData` still treats an empty directory as needing a seed.
+  fs.mkdirSync(dir, { recursive: true });
   const slot = await allocatePortSlot(name, opts.slotHint);
   const ports = portsForSlot(slot);
 

--- a/frontend/scripts/dev-instance/port-registry.ts
+++ b/frontend/scripts/dev-instance/port-registry.ts
@@ -1,11 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import process from 'node:process';
 import { z } from 'zod/v4';
 import { DEFAULT_COLIBRI_PORT, DEFAULT_MCP_PORT, DEFAULT_PORT, DEFAULT_PROXY_PORT } from '../../app/shared/port-utils';
 import { createDevLogger } from '../dev/logger';
+import { atomicWriteJson } from './atomic-json';
 import { errorCode, errorMessage } from './format';
 import { ensureInstanceParent, resolveInstanceDir, resolveInstanceParent, sanitizeName } from './paths';
+import { readMetadata } from './sidecar';
 
 /**
  * Note the two distinct proxies: `proxy` is the optional premium dev-proxy
@@ -129,12 +130,6 @@ export function readPortIndex(): PortIndex {
   }
 }
 
-export function atomicWriteJson(file: string, value: unknown): void {
-  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
-  fs.writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
-  fs.renameSync(tmp, file);
-}
-
 export function writePortIndex(index: PortIndex): void {
   ensureInstanceParent();
   atomicWriteJson(path.join(resolveInstanceParent(), PORT_INDEX_FILENAME), index);
@@ -210,38 +205,108 @@ function isSlotInUse(index: PortIndex, slot: number, exceptName?: string): boole
 }
 
 /**
- * Drop slot reservations whose instance directory is gone.
+ * How long a slot reservation outlives its last use. An instance keeps its ports
+ * across restarts, but not forever: worktrees get deleted and branches get
+ * merged, and their instances are rarely cleaned up, so without an expiry the
+ * allocator keeps climbing while the low slots sit idle.
+ */
+export const SLOT_EXPIRY_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * When the instance was last started, or null when that cannot be determined.
+ * Falls back to the directory mtime for an instance with no (or an unreadable)
+ * metadata sidecar.
+ */
+function lastUsedAt(dir: string): number | null {
+  const meta = readMetadata(dir);
+  if (meta?.lastUsedAt) {
+    const parsed = Date.parse(meta.lastUsedAt);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  try {
+    return fs.statSync(dir).mtimeMs;
+  }
+  catch {
+    return null;
+  }
+}
+
+/** Why this instance's reservation is stale, or null when it is still current. */
+function staleReason(dir: string, now: number): string | null {
+  if (!fs.existsSync(dir)) {
+    return 'removed';
+  }
+  const used = lastUsedAt(dir);
+  if (used === null || now - used <= SLOT_EXPIRY_MS) {
+    return null;
+  }
+  return `unused for ${Math.floor((now - used) / (24 * 60 * 60 * 1000))}d`;
+}
+
+/**
+ * Drop slot reservations that no longer describe an instance you are using:
+ * one whose directory is gone (only `--clean` calls `releasePortSlot`, so an
+ * instance deleted by hand keeps its slot forever), and one untouched for
+ * longer than `SLOT_EXPIRY_MS`. Both are how you end up being handed slot 8
+ * while slots 1-7 sit idle.
  *
- * `releasePortSlot` only runs on `--clean`, so an instance deleted by hand (or a
- * seed that was aborted before the directory existed) keeps its slot reserved
- * forever, and the allocator walks past it. That is how you end up being handed
- * slot 8 with no instances on disk at all.
+ * An expired instance keeps its data directory; it just loses its claim on
+ * those ports, and picks up a fresh slot the next time it starts.
  *
  * `keepName` is the instance currently being allocated: `prepareInstance`
  * creates its directory before it calls in here, but keeping it exempt means a
  * caller that has not done so yet cannot have its own reservation pruned.
  *
- * Returns the names that were dropped.
+ * Returns a line per dropped name, for logging.
  */
-function pruneOrphanedSlots(index: PortIndex, keepName: string): string[] {
+async function pruneOrphanedSlots(
+  index: PortIndex,
+  keepName: string,
+  now: number,
+  isSlotLive: (slot: number) => Promise<boolean>,
+): Promise<string[]> {
   const dropped: string[] = [];
-  for (const name of Object.keys(index.slots)) {
-    if (name === keepName || fs.existsSync(resolveInstanceDir(name))) {
+  for (const [name, slot] of Object.entries(index.slots)) {
+    if (name === keepName) {
+      continue;
+    }
+    const reason = staleReason(resolveInstanceDir(name), now);
+    if (reason === null) {
+      continue;
+    }
+    // Never take ports out from under a process that is still serving on them:
+    // the reservation is stale on paper, but the instance is demonstrably alive.
+    if (await isSlotLive(slot)) {
       continue;
     }
     delete index.slots[name];
-    dropped.push(name);
+    dropped.push(`${name} (${reason})`);
   }
   return dropped;
 }
 
-export async function allocatePortSlot(name: string, hint?: number): Promise<number> {
+export interface AllocateSlotOptions {
+  /** Explicit slot from `INSTANCE_PORT_SLOT`. */
+  hint?: number;
+  /**
+   * Liveness probe, injected by the caller so this module does not depend on
+   * `port-probe` (which depends on this one). Defaults to "nothing is live",
+   * which only ever makes the prune more eager, so callers that cannot probe
+   * still get correct-on-paper behaviour.
+   */
+  isSlotLive?: (slot: number) => Promise<boolean>;
+}
+
+export async function allocatePortSlot(name: string, options: AllocateSlotOptions = {}): Promise<number> {
+  const { hint, isSlotLive = async (): Promise<boolean> => false } = options;
   const sanitized = sanitizeName(name);
-  return withRegistryLock(() => {
+  return withRegistryLock(async () => {
     const index = readPortIndex();
-    const orphaned = pruneOrphanedSlots(index, sanitized);
+    const orphaned = await pruneOrphanedSlots(index, sanitized, Date.now(), isSlotLive);
     if (orphaned.length > 0) {
-      logger.info(`Released port slot(s) for removed instance(s): ${orphaned.join(', ')}`);
+      logger.info(`Released port slot(s): ${orphaned.join(', ')}`);
       writePortIndex(index);
     }
 

--- a/frontend/scripts/dev-instance/port-registry.ts
+++ b/frontend/scripts/dev-instance/port-registry.ts
@@ -5,7 +5,7 @@ import { z } from 'zod/v4';
 import { DEFAULT_COLIBRI_PORT, DEFAULT_MCP_PORT, DEFAULT_PORT, DEFAULT_PROXY_PORT } from '../../app/shared/port-utils';
 import { createDevLogger } from '../dev/logger';
 import { errorCode, errorMessage } from './format';
-import { ensureInstanceParent, resolveInstanceParent, sanitizeName } from './paths';
+import { ensureInstanceParent, resolveInstanceDir, resolveInstanceParent, sanitizeName } from './paths';
 
 /**
  * Note the two distinct proxies: `proxy` is the optional premium dev-proxy
@@ -209,10 +209,41 @@ function isSlotInUse(index: PortIndex, slot: number, exceptName?: string): boole
   return false;
 }
 
+/**
+ * Drop slot reservations whose instance directory is gone.
+ *
+ * `releasePortSlot` only runs on `--clean`, so an instance deleted by hand (or a
+ * seed that was aborted before the directory existed) keeps its slot reserved
+ * forever, and the allocator walks past it. That is how you end up being handed
+ * slot 8 with no instances on disk at all.
+ *
+ * `keepName` is the instance currently being allocated: `prepareInstance`
+ * creates its directory before it calls in here, but keeping it exempt means a
+ * caller that has not done so yet cannot have its own reservation pruned.
+ *
+ * Returns the names that were dropped.
+ */
+function pruneOrphanedSlots(index: PortIndex, keepName: string): string[] {
+  const dropped: string[] = [];
+  for (const name of Object.keys(index.slots)) {
+    if (name === keepName || fs.existsSync(resolveInstanceDir(name))) {
+      continue;
+    }
+    delete index.slots[name];
+    dropped.push(name);
+  }
+  return dropped;
+}
+
 export async function allocatePortSlot(name: string, hint?: number): Promise<number> {
   const sanitized = sanitizeName(name);
   return withRegistryLock(() => {
     const index = readPortIndex();
+    const orphaned = pruneOrphanedSlots(index, sanitized);
+    if (orphaned.length > 0) {
+      logger.info(`Released port slot(s) for removed instance(s): ${orphaned.join(', ')}`);
+      writePortIndex(index);
+    }
 
     if (hint !== undefined) {
       if (slotHasReservedConflict(hint)) {

--- a/frontend/scripts/dev-instance/sidecar.ts
+++ b/frontend/scripts/dev-instance/sidecar.ts
@@ -2,8 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { z } from 'zod/v4';
 import { createDevLogger } from '../dev/logger';
+import { atomicWriteJson } from './atomic-json';
 import { errorMessage } from './format';
-import { atomicWriteJson } from './port-registry';
 
 const SIDECAR_FILENAME = '.rotki-instance.json';
 


### PR DESCRIPTION
Two independent quality-of-life fixes to the dev scripts.

### 1. No browser tab when an agent starts the dev server

`pnpm dev:web` opens a browser tab on start. That is right for an interactive run, but when a coding agent starts the dev server on your behalf nobody is looking at that tab.

`serve.ts` now suppresses the auto-open when a known agent environment variable is set (`AI_AGENT`, `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CODEX_SANDBOX`, `CURSOR_AGENT`, `GEMINI_CLI`), the same way `CI` already suppressed it, and logs one line saying so. `ROTKI_OPEN_BROWSER=1` forces it back on; `--no-open` still works as before.

### 2. Instance port slots free themselves

A slot reservation in `.port-index.json` was only released by `--clean`, so it survived both an instance directory deleted by hand and an instance nobody had run in weeks. The allocator kept climbing: on my machine it was handing out slot 10 while slots 1, 3, 4, 6, 7 and 8 were reserved by instances whose worktrees no longer existed.

`allocatePortSlot` now releases a reservation when the instance directory is gone, or when the instance has not been started for 48h. Two guards:

- The data directory is never touched. An expired instance just picks up a fresh slot the next time it runs.
- A slot whose ports are still serving is never released. Without that, expiring a long-running instance would hand its slot to a new one, `refuseIfSlotLive` would kill the new run, and that instance could never start again. The liveness probe is injected from `instance.ts` because `port-probe` imports `port-registry`.

`prepareInstance` also creates the instance directory before claiming a slot, so a second `dev:web` starting concurrently cannot mistake an instance mid-setup for a removed one. `atomicWriteJson` moves to its own module so `port-registry` can read instance metadata without an import cycle through `sidecar.ts`.

### Testing

Browser auto-open, against a real dev server with a stub browser:

| Env | Result |
|---|---|
| agent vars set | suppression line, browser never invoked |
| agent vars unset | stub browser invoked with the server URL |
| agent vars set, same stub | stub never invoked |

Slot allocation, against a scratch `ROTKI_DEV_INSTANCES_DIR`:

| Case | Result |
|---|---|
| all instances fresh | nothing pruned, new instance goes above them |
| one 3d-old instance | its slot released and reused |
| one 3d-old instance, ports live | kept, new instance goes above |
| 47h vs 49h | only the 49h one released |
| no metadata sidecar | directory mtime decides |
| directory removed | released |
| expired instance restarting | keeps its own slot |