### PR TITLE
Stop a failed history sync recording that history loaded

### DIFF
--- a/frontend/app/src/modules/core/tasks/task-result.spec.ts
+++ b/frontend/app/src/modules/core/tasks/task-result.spec.ts
@@ -3,10 +3,12 @@ import { assert, describe, expect, it, vi } from 'vitest';
 import {
   BackendCancelled,
   Cancelled,
+  combineOutcomes,
   errorOf,
   isActionable,
   isCancellation,
   onActionableError,
+  Skipped,
   TaskFailed,
 } from './task-result';
 
@@ -36,6 +38,64 @@ describe('isActionable', () => {
   it('should be false for either cancellation', () => {
     expect(isActionable(Cancelled({ message: 'boom' }))).toBe(false);
     expect(isActionable(BackendCancelled({ message: 'boom' }))).toBe(false);
+  });
+});
+
+describe('combineOutcomes', () => {
+  it('should succeed when a single child succeeded', () => {
+    const combined = combineOutcomes([
+      err(TaskFailed({ message: 'eth' })),
+      ok(undefined),
+      err(TaskFailed({ message: 'gnosis' })),
+    ]);
+
+    expect(combined.ok).toBe(true);
+  });
+
+  it('should fail when every child failed', () => {
+    const combined = combineOutcomes([
+      err(TaskFailed({ message: 'eth' })),
+      err(TaskFailed({ message: 'gnosis' })),
+    ]);
+
+    assert(!combined.ok);
+    expect(combined.error.message).toBe('eth');
+  });
+
+  it('should prefer an actionable failure over a cancellation', () => {
+    const combined = combineOutcomes([
+      err(Cancelled({ message: 'stopped' })),
+      err(TaskFailed({ message: 'real failure' })),
+    ]);
+
+    assert(!combined.ok);
+    expect(isActionable(combined.error)).toBe(true);
+  });
+
+  it('should prefer a cancellation over a skip', () => {
+    const combined = combineOutcomes([
+      err(Skipped({ message: 'no api key' })),
+      err(BackendCancelled({ message: 'stopped' })),
+    ]);
+
+    assert(!combined.ok);
+    expect(isCancellation(combined.error)).toBe(true);
+  });
+
+  it('should report a skip when every child was skipped', () => {
+    const combined = combineOutcomes([err(Skipped({ message: 'disabled' }))]);
+
+    assert(!combined.ok);
+    expect(combined.error.message).toBe('disabled');
+  });
+
+  it('should not report a success when nothing ran', () => {
+    // 🔴 The empty case is the whole point: a parent that ran no children has produced no data, so
+    // it must not write a completion its consumers read as "we already have this".
+    const combined = combineOutcomes([]);
+
+    assert(!combined.ok);
+    expect(isActionable(combined.error)).toBe(false);
   });
 });
 

--- a/frontend/app/src/modules/core/tasks/task-result.ts
+++ b/frontend/app/src/modules/core/tasks/task-result.ts
@@ -1,4 +1,4 @@
-import { isErr, type Result } from 'plainfp/result';
+import { err, isErr, ok, type Result } from 'plainfp/result';
 import { hasTag, tag } from 'plainfp/tagged';
 
 /**
@@ -61,6 +61,40 @@ export function errorOf(error: TaskError): Error {
     return error.cause;
 
   return new Error(error.message);
+}
+
+/**
+ * Fold a fan-out's child outcomes into the one verdict its parent should settle on.
+ *
+ * 🔴 A parent must not claim a success its children did not earn. The shape this exists to kill is
+ * `await Promise.all(children); return ok(undefined)`, which completes even when every child
+ * failed — and where the parent's completion-ledger entry is load-bearing, that writes "we have
+ * data" over nothing at all. Concretely: backend unreachable on the first history sync, every
+ * account fails, the umbrella completes anyway, `everCompleted` goes true and every later
+ * non-user-initiated refresh short-circuits on it, so history silently never syncs again.
+ *
+ * ⭐ One success is enough. A fan-out is partial by nature — one chain failing is that chain's
+ * failure, not the refresh's — so this reports a failure only when *nothing* got through. An empty
+ * batch is `Skipped`: no work ran, so no work succeeded, and a parent that ran nothing must not
+ * record a completion either.
+ *
+ * The losing errors are dropped rather than merged. Each child has already surfaced its own
+ * failure where it happened; this only has to pick the most actionable one for the parent's row,
+ * which is why an actionable failure outranks a cancellation and a cancellation outranks a skip.
+ */
+export function combineOutcomes(outcomes: readonly Result<unknown, TaskError>[]): Result<void, TaskError> {
+  const errors: TaskError[] = [];
+  for (const outcome of outcomes) {
+    if (!isErr(outcome))
+      return ok(undefined);
+    errors.push(outcome.error);
+  }
+
+  const failure = errors.find(error => isActionable(error))
+    ?? errors.find(error => isCancellation(error))
+    ?? errors.at(0);
+
+  return err(failure ?? Skipped({ message: 'nothing ran' }));
 }
 
 /**

--- a/frontend/app/src/modules/history/events/tx/use-exchange-events-refresh.ts
+++ b/frontend/app/src/modules/history/events/tx/use-exchange-events-refresh.ts
@@ -15,7 +15,8 @@ import { type ActivityId, ActivityKind } from '@/modules/task-center/core/types'
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 
 interface UseExchangeEventsRefreshReturn {
-  queryAllExchangeEvents: (exchanges: Exchange[], parent?: ActivityId) => Promise<void>;
+  /** One outcome per exchange account, so the caller's umbrella can settle on what actually ran. */
+  queryAllExchangeEvents: (exchanges: Exchange[], parent?: ActivityId) => Promise<Result<void, TaskError>[]>;
 }
 
 /**
@@ -31,7 +32,7 @@ export function useExchangeEventsRefresh(): UseExchangeEventsRefreshReturn {
   const { queryExchangeEvents } = useHistoryEventsApi();
   const { submitTask } = useNativeTask();
 
-  const queryExchange = async (payload: Exchange, parent?: ActivityId): Promise<void> => {
+  const queryExchange = async (payload: Exchange, parent?: ActivityId): Promise<Result<void, TaskError>> => {
     logger.debug(`querying exchange events for ${payload.location} (${payload.name})`);
     const exchange = omit(payload, ['gateLocation', 'krakenAccountType', 'okxLocation']);
     const parsedPayload = QueryExchangeEventsPayload.parse(exchange);
@@ -68,6 +69,8 @@ export function useExchangeEventsRefresh(): UseExchangeEventsRefreshReturn {
         );
       }
     }
+
+    return outcome;
   };
 
   /**
@@ -78,9 +81,8 @@ export function useExchangeEventsRefresh(): UseExchangeEventsRefreshReturn {
    * around work the scheduler was already governing, so the effective limit was the tighter of two
    * mechanisms and neither was written down.
    */
-  const queryAllExchangeEvents = async (exchanges: Exchange[], parent?: ActivityId): Promise<void> => {
-    await Promise.all(exchanges.map(async exchange => queryExchange(exchange, parent)));
-  };
+  const queryAllExchangeEvents = async (exchanges: Exchange[], parent?: ActivityId): Promise<Result<void, TaskError>[]> =>
+    Promise.all(exchanges.map(async exchange => queryExchange(exchange, parent)));
 
   return {
     queryAllExchangeEvents,

--- a/frontend/app/src/modules/history/events/tx/use-history-refresh-policy.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-refresh-policy.ts
@@ -103,9 +103,18 @@ export function useHistoryRefreshPolicy(): UseHistoryRefreshPolicyReturn {
     return alreadyLoaded && novelty.newAccounts.length === 0 && novelty.newExchanges.length === 0;
   }
 
-  function resolveForFullRefresh(novelty: NoveltyDetection, chains: string[], userInitiated: boolean): { accounts: ChainAddress[]; exchanges: Exchange[] } {
+  /**
+   * ⚠️ `!everRefreshed` is a scope condition, not a duplicate of the entry guard. Novelty is "never
+   * attempted", so an account whose sync *failed* is no longer novel — which meant a first load
+   * where every account failed resolved to an empty account set on every later background refresh,
+   * and history only recovered if the user pressed refresh. Reaching here at all already means
+   * history has never loaded (`shouldNotRefresh` returns before this once it has), so the honest
+   * scope for that case is the full first load.
+   */
+  function resolveForFullRefresh(novelty: NoveltyDetection, chains: string[], opts: { userInitiated: boolean; everRefreshed: boolean }): { accounts: ChainAddress[]; exchanges: Exchange[] } {
+    const wantsAllAccounts = novelty.newAccounts.length > 0 || opts.userInitiated || !opts.everRefreshed;
     return {
-      accounts: (novelty.newAccounts.length > 0 || userInitiated) ? getAllAccounts(chains) : [],
+      accounts: wantsAllAccounts ? getAllAccounts(chains) : [],
       exchanges: get(syncingExchanges),
     };
   }
@@ -128,7 +137,7 @@ export function useHistoryRefreshPolicy(): UseHistoryRefreshPolicyReturn {
     let resolved: { accounts: ChainAddress[]; exchanges: Exchange[] };
 
     if (fullRefresh)
-      resolved = resolveForFullRefresh(novelty, chains, userInitiated);
+      resolved = resolveForFullRefresh(novelty, chains, { everRefreshed, userInitiated });
     else if (hasNovelty)
       resolved = resolveForNovelItems(novelty);
     else

--- a/frontend/app/src/modules/history/events/tx/use-refresh-handlers.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-handlers.ts
@@ -1,10 +1,10 @@
 import type { Exchange } from '@/modules/balances/types/exchanges';
-import { isErr, map as mapResult, type Result } from 'plainfp/result';
+import { err, isErr, map as mapResult, type Result } from 'plainfp/result';
 import { msg } from '@/message-key';
 import { ApiKeyMissingError } from '@/modules/core/api/types/errors';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
-import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
+import { isActionable, Skipped, type TaskError } from '@/modules/core/tasks/task-result';
 import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
 import { onlineEventsActivityId } from '@/modules/history/events/tx/sync-activity';
@@ -19,8 +19,8 @@ import { type ActivityId, ActivityKind } from '@/modules/task-center/core/types'
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 
 interface UseRefreshHandlersReturn {
-  queryAllExchangeEvents: (exchanges: Exchange[], parent?: ActivityId) => Promise<void>;
-  queryOnlineEvent: (queryType: OnlineHistoryEventsQueryType, parent?: ActivityId) => Promise<void>;
+  queryAllExchangeEvents: (exchanges: Exchange[], parent?: ActivityId) => Promise<Result<void, TaskError>[]>;
+  queryOnlineEvent: (queryType: OnlineHistoryEventsQueryType, parent?: ActivityId) => Promise<Result<void, TaskError>>;
   resetOnlineWarnings: () => void;
 }
 
@@ -86,9 +86,11 @@ export function useRefreshHandlers(): UseRefreshHandlersReturn {
     return true;
   };
 
-  const queryOnlineEvent = async (queryType: OnlineHistoryEventsQueryType, parent?: ActivityId): Promise<void> => {
+  const queryOnlineEvent = async (queryType: OnlineHistoryEventsQueryType, parent?: ActivityId): Promise<Result<void, TaskError>> => {
+    // A source the user has switched off or never authenticated is a skip, not a success: it submits
+    // no activity at all, so reporting it as one would let a refresh that ran nothing look complete.
     if (!(await canQueryOnlineEvent(queryType)))
-      return;
+      return err(Skipped({ message: `${queryType} is not available` }));
 
     logger.debug(`querying for ${queryType} events`);
 
@@ -128,6 +130,7 @@ export function useRefreshHandlers(): UseRefreshHandlersReturn {
       }
     }
     logger.debug(`finished querying for ${queryType} events`);
+    return outcome;
   };
 
   const resetOnlineWarnings = (): void => {

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
@@ -121,6 +121,23 @@ const mockDecodingStatusStore = {
 
 type SyncOutcomes = Promise<Result<void, TaskError>[]>;
 
+/**
+ * The default behaviours, named so `beforeEach` can restore them. ⚠️ `failEverything` below uses
+ * `mockResolvedValue`, which `vi.clearAllMocks()` does not undo — without restoring these, one
+ * failure test silently turned every later test's first refresh into a failed one.
+ */
+async function defaultSyncByChains(accounts: ChainAddress[]): SyncOutcomes {
+  for (const account of accounts)
+    attempted.add(`tx-sync:${account.chain}:${account.address}`);
+  return accounts.map(() => ok(undefined));
+}
+
+async function defaultQueryExchanges(exchanges: Exchange[] = []): SyncOutcomes {
+  for (const exchange of exchanges)
+    attempted.add(`exchange-events:${exchange.location}:${exchange.name}`);
+  return exchanges.map(() => ok(undefined));
+}
+
 const mockTransactionSync = {
   // Records what it synced. The real one settles a TX_SYNC activity per account, and the completion
   // ledger those settles write is exactly what the drain reads to decide what was never attempted —
@@ -129,11 +146,7 @@ const mockTransactionSync = {
   // ⚠️ It also has to *report* an outcome per chain: the umbrella settles on what its children did,
   // so a mock returning nothing would make every refresh look like it synced nothing at all.
   syncTransactionsByChains: vi.fn<(accounts: ChainAddress[], showProgress: boolean, parent?: string) => SyncOutcomes>(
-    async (accounts: ChainAddress[]): SyncOutcomes => {
-      for (const account of accounts)
-        attempted.add(`tx-sync:${account.chain}:${account.address}`);
-      return accounts.map(() => ok(undefined));
-    },
+    defaultSyncByChains,
   ),
 };
 
@@ -143,11 +156,7 @@ const mockSupportedChains = {
 
 const mockRefreshHandlers = {
   // Same contract as the sync mock above: settling is what makes an exchange stop being novel.
-  queryAllExchangeEvents: vi.fn(async (exchanges: Exchange[] = []): SyncOutcomes => {
-    for (const exchange of exchanges)
-      attempted.add(`exchange-events:${exchange.location}:${exchange.name}`);
-    return exchanges.map(() => ok(undefined));
-  }),
+  queryAllExchangeEvents: vi.fn(defaultQueryExchanges),
   queryOnlineEvent: vi.fn().mockResolvedValue(ok(undefined)),
   resetOnlineWarnings: vi.fn(),
 };
@@ -224,6 +233,9 @@ describe('useRefreshTransactions', () => {
     attempted.clear();
 
     // Reset mock return values to defaults
+    mockTransactionSync.syncTransactionsByChains.mockImplementation(defaultSyncByChains);
+    mockRefreshHandlers.queryAllExchangeEvents.mockImplementation(defaultQueryExchanges);
+    mockRefreshHandlers.queryOnlineEvent.mockResolvedValue(ok(undefined));
     mockHistoryTransactionAccounts.getAllAccounts.mockReturnValue([...mockEvmAccounts, ...mockBitcoinAccounts]);
     mockHistoryTransactionAccounts.filterDisabledChainAccounts.mockImplementation((accounts: ChainAddress[]) => accounts);
     set(mockExchangeData.syncingExchanges, mockExchanges);
@@ -596,17 +608,17 @@ describe('useRefreshTransactions', () => {
   });
 
   describe('error handling', () => {
-    it('should settle the umbrella when an operation fails', async () => {
+    it('should settle the umbrella when an operation throws', async () => {
       mockTransactionSync.syncTransactionsByChains.mockRejectedValue(new Error('Sync failed'));
       const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
       await settleRefresh();
 
-      // The failure is swallowed inside `run`, so history still reads as loaded and, crucially,
-      // nothing is left in flight to block the next refresh.
+      // A throw is contained inside `run`, so nothing is left in flight to block the next refresh —
+      // but it is still the account half failing, so no completion is recorded.
       expect(historySyncStatus().active).toBe(false);
-      expect(historySyncStatus().everCompleted).toBe(true);
+      expect(historySyncStatus().everCompleted).toBe(false);
     });
 
     it('should not record a completion when every operation failed', async () => {
@@ -621,6 +633,22 @@ describe('useRefreshTransactions', () => {
       // later background refresh. Nothing is left in flight either way.
       expect(historySyncStatus().everCompleted).toBe(false);
       expect(historySyncStatus().active).toBe(false);
+    });
+
+    it('should not let a successful online query mask a total chain failure', async () => {
+      // 🔴 Found by running this in the app: every transaction request failed, but the protocol
+      // queries succeeded ("7/7 protocols refreshed"), and one success anywhere was enough to record
+      // the completion — so `alreadyLoaded` short-circuited the background chain re-sync exactly as
+      // before. The umbrella's freshness gates the *account* scope, so chains failing wholesale has
+      // to fail it whatever else happened to succeed.
+      failEverything();
+      mockRefreshHandlers.queryOnlineEvent.mockResolvedValue(ok(undefined));
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+
+      await refreshTransactions();
+      await settleRefresh();
+
+      expect(historySyncStatus().everCompleted).toBe(false);
     });
 
     it('should still sync every account on a background refresh after an all-failed first sync', async () => {

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
@@ -4,7 +4,7 @@ import type { ChainAddress } from '@/modules/history/events/event-payloads';
 import flushPromises from 'flush-promises';
 import { err, ok, type Result } from 'plainfp/result';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import { Cancelled, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
 import { ActivityKind, makeActivityId, type WorkStatus } from '@/modules/task-center/core/types';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
@@ -631,6 +631,19 @@ describe('useRefreshTransactions', () => {
       // 🔴 The defect this guards: the umbrella used to return `ok` whatever its children did, so an
       // all-failed first sync wrote "history has loaded" and `alreadyLoaded` short-circuited every
       // later background refresh. Nothing is left in flight either way.
+      expect(historySyncStatus().everCompleted).toBe(false);
+      expect(historySyncStatus().active).toBe(false);
+    });
+
+    it('should not record a completion when the sync was cancelled', async () => {
+      // Cancelling is not loading. If a stopped sync wrote the completion, `alreadyLoaded` would
+      // suppress the next background refresh and the data the user interrupted would never arrive.
+      mockTransactionSync.syncTransactionsByChains.mockResolvedValue([err(Cancelled({ message: 'stopped' }))]);
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+
+      await refreshTransactions();
+      await settleRefresh();
+
       expect(historySyncStatus().everCompleted).toBe(false);
       expect(historySyncStatus().active).toBe(false);
     });

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
@@ -2,7 +2,9 @@ import type { RefreshTransactionsParams } from './types';
 import type { Exchange } from '@/modules/balances/types/exchanges';
 import type { ChainAddress } from '@/modules/history/events/event-payloads';
 import flushPromises from 'flush-promises';
+import { err, ok, type Result } from 'plainfp/result';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
 import { ActivityKind, makeActivityId, type WorkStatus } from '@/modules/task-center/core/types';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
@@ -117,14 +119,20 @@ const mockDecodingStatusStore = {
   stopDecodingSyncProgress: vi.fn(),
 };
 
+type SyncOutcomes = Promise<Result<void, TaskError>[]>;
+
 const mockTransactionSync = {
   // Records what it synced. The real one settles a TX_SYNC activity per account, and the completion
   // ledger those settles write is exactly what the drain reads to decide what was never attempted —
   // so a mock that settled nothing would leave every account novel forever and drain on every run.
-  syncTransactionsByChains: vi.fn<(accounts: ChainAddress[], showProgress: boolean, parent?: string) => Promise<void>>(
-    async (accounts: ChainAddress[]): Promise<void> => {
+  //
+  // ⚠️ It also has to *report* an outcome per chain: the umbrella settles on what its children did,
+  // so a mock returning nothing would make every refresh look like it synced nothing at all.
+  syncTransactionsByChains: vi.fn<(accounts: ChainAddress[], showProgress: boolean, parent?: string) => SyncOutcomes>(
+    async (accounts: ChainAddress[]): SyncOutcomes => {
       for (const account of accounts)
         attempted.add(`tx-sync:${account.chain}:${account.address}`);
+      return accounts.map(() => ok(undefined));
     },
   ),
 };
@@ -135,11 +143,12 @@ const mockSupportedChains = {
 
 const mockRefreshHandlers = {
   // Same contract as the sync mock above: settling is what makes an exchange stop being novel.
-  queryAllExchangeEvents: vi.fn(async (exchanges: Exchange[] = []): Promise<void> => {
+  queryAllExchangeEvents: vi.fn(async (exchanges: Exchange[] = []): SyncOutcomes => {
     for (const exchange of exchanges)
       attempted.add(`exchange-events:${exchange.location}:${exchange.name}`);
+    return exchanges.map(() => ok(undefined));
   }),
-  queryOnlineEvent: vi.fn().mockResolvedValue(undefined),
+  queryOnlineEvent: vi.fn().mockResolvedValue(ok(undefined)),
   resetOnlineWarnings: vi.fn(),
 };
 
@@ -147,6 +156,21 @@ const mockExchangeData = {
   isSameExchange: (a: Exchange, b: Exchange): boolean => a.location === b.location && a.name === b.name,
   syncingExchanges: ref<Exchange[]>(mockExchanges),
 };
+
+/** Every kind of child reports a failure, so the umbrella has no success to settle on. */
+function failEverything(): void {
+  const failure = err(TaskFailed({ message: 'backend unreachable' }));
+  mockTransactionSync.syncTransactionsByChains.mockResolvedValue([failure]);
+  mockRefreshHandlers.queryAllExchangeEvents.mockResolvedValue([failure]);
+  mockRefreshHandlers.queryOnlineEvent.mockResolvedValue(failure);
+}
+
+/** The inverse of {@link failEverything}, for the second half of a recovery test. */
+function succeedEverything(): void {
+  mockTransactionSync.syncTransactionsByChains.mockResolvedValue([ok(undefined)]);
+  mockRefreshHandlers.queryAllExchangeEvents.mockResolvedValue([ok(undefined)]);
+  mockRefreshHandlers.queryOnlineEvent.mockResolvedValue(ok(undefined));
+}
 
 vi.mock('./use-history-transaction-accounts', () => ({
   useHistoryTransactionAccounts: vi.fn(() => mockHistoryTransactionAccounts),
@@ -585,6 +609,43 @@ describe('useRefreshTransactions', () => {
       expect(historySyncStatus().everCompleted).toBe(true);
     });
 
+    it('should not record a completion when every operation failed', async () => {
+      failEverything();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+
+      await refreshTransactions();
+      await settleRefresh();
+
+      // 🔴 The defect this guards: the umbrella used to return `ok` whatever its children did, so an
+      // all-failed first sync wrote "history has loaded" and `alreadyLoaded` short-circuited every
+      // later background refresh. Nothing is left in flight either way.
+      expect(historySyncStatus().everCompleted).toBe(false);
+      expect(historySyncStatus().active).toBe(false);
+    });
+
+    it('should still sync every account on a background refresh after an all-failed first sync', async () => {
+      failEverything();
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+      await refreshTransactions();
+      await settleRefresh();
+
+      // Every account has now been *attempted*, so none is novel — which is why the failed first
+      // load has to be recovered by scope, not by novelty.
+      markAttempted();
+      succeedEverything();
+      mockTransactionSync.syncTransactionsByChains.mockClear();
+
+      await refreshTransactions();
+      await settleRefresh();
+
+      expect(mockTransactionSync.syncTransactionsByChains).toHaveBeenCalledWith(
+        expect.arrayContaining(mockEvmAccounts),
+        expect.anything(),
+        HISTORY_SYNC_ID,
+      );
+      expect(historySyncStatus().everCompleted).toBe(true);
+    });
+
     it('should continue with other operations when one fails', async () => {
       mockTransactionSync.syncTransactionsByChains.mockRejectedValue(new Error('Sync failed'));
       const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
@@ -744,8 +805,9 @@ describe('useRefreshTransactions', () => {
       mockOnHistoryStarted.mockImplementation(() => {
         callOrder.push('onHistoryStarted');
       });
-      mockTransactionSync.syncTransactionsByChains.mockImplementation(async () => {
+      mockTransactionSync.syncTransactionsByChains.mockImplementation(async (): SyncOutcomes => {
         callOrder.push('syncTransactionsByChains');
+        return [ok(undefined)];
       });
 
       const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
@@ -760,8 +822,9 @@ describe('useRefreshTransactions', () => {
 
       // The umbrella awaits its children, so the WS progress updates decoding pushes cannot be
       // dropped by an early `stopDecodingSyncProgress()`. This used to be `waitForDecoding()`.
-      mockTransactionSync.syncTransactionsByChains.mockImplementation(async () => {
+      mockTransactionSync.syncTransactionsByChains.mockImplementation(async (): SyncOutcomes => {
         callOrder.push('syncTransactionsByChains');
+        return [ok(undefined)];
       });
       mockDecodingStatusStore.stopDecodingSyncProgress.mockImplementation(() => {
         callOrder.push('stopDecodingSyncProgress');
@@ -777,8 +840,9 @@ describe('useRefreshTransactions', () => {
     it('should call onHistoryFinished after all operations complete', async () => {
       const callOrder: string[] = [];
 
-      mockTransactionSync.syncTransactionsByChains.mockImplementation(async () => {
+      mockTransactionSync.syncTransactionsByChains.mockImplementation(async (): SyncOutcomes => {
         callOrder.push('syncTransactionsByChains');
+        return [ok(undefined)];
       });
       mockOnHistoryFinished.mockImplementation(() => {
         callOrder.push('onHistoryFinished');
@@ -845,15 +909,33 @@ describe('useRefreshTransactions', () => {
   });
 
   describe('full refresh with no new accounts', () => {
-    it('should not refresh accounts when all accounts are already known and not user initiated', async () => {
-      // All accounts already attempted, so none are novel and it is not user initiated.
+    it('should not refresh accounts when history has loaded and none are new', async () => {
+      const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
+      // A real completed load, which is what makes "none are novel" mean "we already have it".
+      await refreshTransactions();
+      await settleRefresh();
+
+      markAttempted();
+      mockTransactionSync.syncTransactionsByChains.mockClear();
+
+      await refreshTransactions();
+
+      expect(mockTransactionSync.syncTransactionsByChains).not.toHaveBeenCalled();
+    });
+
+    it('should refresh every account when nothing is novel but history never loaded', async () => {
+      // ⚠️ The distinguishing case: attempted but never completed is what an all-failed or cancelled
+      // first sync leaves behind, and novelty alone reads it as "nothing to do".
       markAttempted();
       const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
-      // No accounts to sync since none are new and not userInitiated
-      expect(mockTransactionSync.syncTransactionsByChains).not.toHaveBeenCalled();
+      expect(mockTransactionSync.syncTransactionsByChains).toHaveBeenCalledWith(
+        expect.arrayContaining(mockEvmAccounts),
+        expect.anything(),
+        HISTORY_SYNC_ID,
+      );
     });
   });
 

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
@@ -147,29 +147,33 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     // sequence with two locations at a time. Driving those per child would silently discard both.
     // The declaration still names every child, and names them with the same id constructors the
     // producers submit under, so the tree and the umbrella's progress stay accurate.
-    const asyncOperations: Promise<Result<void, TaskError>[]>[] = [
+    // Tagged by whether the work is the *account* half, because only that half votes on the
+    // umbrella's freshness — see the return below.
+    const asyncOperations: { accounts: boolean; work: Promise<Result<void, TaskError>[]> }[] = [
       ...(targets.accounts.length > 0
-        ? [syncTransactionsByChains(targets.accounts, targets.shouldShowSyncProgress, umbrella)]
+        ? [{ accounts: true, work: syncTransactionsByChains(targets.accounts, targets.shouldShowSyncProgress, umbrella) }]
         : []),
-      ...(exchanges.length > 0 ? [queryAllExchangeEvents(exchanges, umbrella)] : []),
+      ...(exchanges.length > 0 ? [{ accounts: false, work: queryAllExchangeEvents(exchanges, umbrella) }] : []),
       ...children.flatMap(child => child.payload.type === 'online'
-        ? [queryOnlineEvent(child.payload.query, umbrella).then(outcome => [outcome])]
+        ? [{ accounts: false, work: queryOnlineEvent(child.payload.query, umbrella).then(outcome => [outcome]) }]
         : []),
     ];
 
     // Collected, not discarded: the umbrella settles on these, and a run whose every child failed
     // must not write the completion that `alreadyLoaded` reads.
-    const outcomes: Result<void, TaskError>[] = [];
+    const accountOutcomes: Result<void, TaskError>[] = [];
+    const otherOutcomes: Result<void, TaskError>[] = [];
 
     for (const operation of asyncOperations) {
+      const sink = operation.accounts ? accountOutcomes : otherOutcomes;
       try {
-        outcomes.push(...await operation);
+        sink.push(...await operation.work);
       }
       catch (error: unknown) {
         logger.error(error);
         // The thrown value rides along as `cause`; the operation itself is what failed, and each
         // producer has already logged its own detail.
-        outcomes.push(err(TaskFailed({ cause: error, message: 'a refresh operation threw' })));
+        sink.push(err(TaskFailed({ cause: error, message: 'a refresh operation threw' })));
       }
     }
 
@@ -180,7 +184,18 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     // count is a display concern. Re-entry is the activity's own to dedup.
     startPromise(fetchUndecodedTransactionsBreakdown());
 
-    return combineOutcomes(outcomes);
+    // 🔴 The accounts decide whenever they are in scope, and nothing else may vote. Combining all
+    // three kinds together let a protocol query that happened to succeed record the completion over
+    // a run where *every* chain failed — the same silent short-circuit, reached by a narrower road.
+    // Found in the app, not by the unit suite, which failed all three kinds together.
+    //
+    // ⚠️ Not "every kind must succeed" either: an online source failing is ordinary (a missing key,
+    // an unauthenticated integration), and letting that fail the umbrella would make history re-sync
+    // on every single refresh forever. Those failures have their own rows and warnings; this entry
+    // answers one question, "has the account history loaded", so the account half owns it.
+    return accountOutcomes.length > 0
+      ? combineOutcomes(accountOutcomes)
+      : combineOutcomes(otherOutcomes);
   }
 
   /**

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
@@ -1,10 +1,10 @@
 import type { RefreshTransactionsParams } from './types';
-import type { TaskError } from '@/modules/core/tasks/task-result';
 import { startPromise } from '@shared/utils';
-import { ok, type Result } from 'plainfp/result';
+import { err, type Result } from 'plainfp/result';
 import { useAccountLoadState } from '@/modules/accounts/use-account-load-state';
 import { logger } from '@/modules/core/common/logging/logging';
 import { sigilBus } from '@/modules/core/sigil/event-bus';
+import { combineOutcomes, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
 import { historySyncFlow } from '@/modules/history/events/tx/history-sync.flow';
 import { HISTORY_STALE_AFTER, type RefreshTargets, useHistoryRefreshPolicy } from '@/modules/history/events/tx/use-history-refresh-policy';
@@ -123,7 +123,7 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     queries: OnlineHistoryEventsQueryType[] | undefined,
     umbrella: ActivityId,
     wave: RefreshWave,
-  ): Promise<void> {
+  ): Promise<Result<void, TaskError>> {
     if (targets.fullRefresh || targets.decodableAccounts.length > 0)
       await fetchUndecodedTransactionsBreakdown();
 
@@ -147,22 +147,29 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     // sequence with two locations at a time. Driving those per child would silently discard both.
     // The declaration still names every child, and names them with the same id constructors the
     // producers submit under, so the tree and the umbrella's progress stay accurate.
-    const asyncOperations = [
+    const asyncOperations: Promise<Result<void, TaskError>[]>[] = [
       ...(targets.accounts.length > 0
         ? [syncTransactionsByChains(targets.accounts, targets.shouldShowSyncProgress, umbrella)]
         : []),
       ...(exchanges.length > 0 ? [queryAllExchangeEvents(exchanges, umbrella)] : []),
       ...children.flatMap(child => child.payload.type === 'online'
-        ? [queryOnlineEvent(child.payload.query, umbrella)]
+        ? [queryOnlineEvent(child.payload.query, umbrella).then(outcome => [outcome])]
         : []),
     ];
 
+    // Collected, not discarded: the umbrella settles on these, and a run whose every child failed
+    // must not write the completion that `alreadyLoaded` reads.
+    const outcomes: Result<void, TaskError>[] = [];
+
     for (const operation of asyncOperations) {
       try {
-        await operation;
+        outcomes.push(...await operation);
       }
       catch (error: unknown) {
         logger.error(error);
+        // The thrown value rides along as `cause`; the operation itself is what failed, and each
+        // producer has already logged its own detail.
+        outcomes.push(err(TaskFailed({ cause: error, message: 'a refresh operation threw' })));
       }
     }
 
@@ -172,6 +179,8 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
     // guard precisely because the first had finished. Not awaited: the refresh is over and the
     // count is a display concern. Re-entry is the activity's own to dedup.
     startPromise(fetchUndecodedTransactionsBreakdown());
+
+    return combineOutcomes(outcomes);
   }
 
   /**
@@ -265,14 +274,23 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
       lane: UMBRELLA_LANE,
       rerunnable: false,
       staleAfter: HISTORY_STALE_AFTER,
+      // 🔴 The outcome is the children's, not a foregone `ok`. This umbrella *is* the subject for
+      // its kind — `alreadyLoaded` below reads its `everCompleted` — so returning success
+      // unconditionally meant an all-failed first sync (backend unreachable at login, every chain
+      // fails) still wrote "history has loaded", and every later non-user-initiated refresh
+      // short-circuited on it: history silently never synced again for the session. It cannot be a
+      // `container` for the same reason — the entry is needed, it just has to be true. A run that
+      // targeted nothing settles SKIPPED for the same reason, which is what stops a refresh fired
+      // before any account has loaded from claiming the whole history.
       run: async (): Promise<Result<void, TaskError>> => {
         initializeRefresh(targets, wave);
 
         try {
-          await executeOperations(targets, disableEvmEvents, payload.queries, umbrellaId, wave);
+          return await executeOperations(targets, disableEvmEvents, payload.queries, umbrellaId, wave);
         }
         catch (error) {
           logger.error(error);
+          return err(TaskFailed({ cause: error, message: 'the history refresh threw' }));
         }
         finally {
           onHistoryFinished();
@@ -281,8 +299,6 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
           stopDecodingSyncProgress();
           sigilBus.emit('history:ready');
         }
-
-        return ok(undefined);
       },
       title: t('task_center.group.history_sync'),
     });

--- a/frontend/app/src/modules/history/events/tx/use-transaction-sync.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-transaction-sync.spec.ts
@@ -1,7 +1,7 @@
 import type { NativeActivitySpec } from '@/modules/task-center/use-native-task';
 import { err, ok, type Result } from 'plainfp/result';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
-import { BackendCancelled, Cancelled, Skipped, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import { BackendCancelled, Cancelled, isCancellation, Skipped, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { type ChainAddress, TransactionChainType } from '@/modules/history/events/event-payloads';
 import { ActivityKind, makeActivityId } from '@/modules/task-center/core/types';
 import { useTransactionSync } from './use-transaction-sync';
@@ -178,6 +178,32 @@ describe('useTransactionSync', () => {
 
       assert(!outcome.ok);
       expect(outcome.error.message).toBe('boom');
+    });
+
+    it('should settle cancelled, not failed, when its accounts were cancelled', async () => {
+      // The chain's verdict now folds its children's outcomes, so cancellation has to survive that
+      // fold: reporting a user-stopped chain as FAILED would put an error row in the task centre for
+      // something the user chose to stop.
+      runChainBody(err(Cancelled({ message: 'stopped' })), err(BackendCancelled({ message: 'stopped' })));
+      const { syncAndReDecodeEvents } = useTransactionSync();
+
+      const outcome = await syncAndReDecodeEvents('eth', { accounts, type: TransactionChainType.EVM });
+
+      assert(!outcome.ok);
+      expect(isCancellation(outcome.error)).toBe(true);
+    });
+
+    it('should report a real failure over a cancellation', async () => {
+      // The other side of the same fold: a chain where one address genuinely failed and the rest were
+      // cancelled is a failure worth surfacing. (A user cancelling the chain *itself* still reads
+      // CANCELLED — `cancelRequested` overrides the run's outcome in the orchestrator.)
+      runChainBody(err(TaskFailed({ message: 'boom' })), err(Cancelled({ message: 'stopped' })));
+      const { syncAndReDecodeEvents } = useTransactionSync();
+
+      const outcome = await syncAndReDecodeEvents('eth', { accounts, type: TransactionChainType.EVM });
+
+      assert(!outcome.ok);
+      expect(isCancellation(outcome.error)).toBe(false);
     });
 
     it('should declare the chain activity as a container', async () => {

--- a/frontend/app/src/modules/history/events/tx/use-transaction-sync.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-transaction-sync.spec.ts
@@ -1,6 +1,7 @@
-import { err, ok } from 'plainfp/result';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { BackendCancelled, Cancelled, Skipped, TaskFailed } from '@/modules/core/tasks/task-result';
+import type { NativeActivitySpec } from '@/modules/task-center/use-native-task';
+import { err, ok, type Result } from 'plainfp/result';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BackendCancelled, Cancelled, Skipped, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { type ChainAddress, TransactionChainType } from '@/modules/history/events/event-payloads';
 import { ActivityKind, makeActivityId } from '@/modules/task-center/core/types';
 import { useTransactionSync } from './use-transaction-sync';
@@ -133,6 +134,61 @@ describe('useTransactionSync', () => {
 
       expect(mocks.setEvmlikeStatus).toHaveBeenNthCalledWith(1, account, 'started');
       expect(mocks.setEvmlikeStatus).toHaveBeenNthCalledWith(2, account, 'finished');
+    });
+  });
+
+  describe('syncAndReDecodeEvents', () => {
+    const chainId = makeActivityId(ActivityKind.TX_SYNC, 'eth');
+    const accounts: ChainAddress[] = [
+      { address: '0xAAA', chain: 'eth' },
+      { address: '0xBBB', chain: 'eth' },
+    ];
+
+    /**
+     * Runs the chain activity's own body instead of stubbing its outcome — the verdict it computes
+     * from its children is the thing under test, and a `submitTask` that only resolves `ok` would
+     * report every one of these tests as passing whatever the body did.
+     */
+    function runChainBody(...accountOutcomes: Result<void, TaskError>[]): void {
+      let account = 0;
+      mocks.submitTask.mockImplementation(async (spec: NativeActivitySpec) => {
+        if (spec.id !== chainId)
+          return accountOutcomes[account++] ?? ok(undefined);
+
+        return spec.run({ cancelled: (): boolean => false, report: vi.fn(), runTask: vi.fn() });
+      });
+    }
+
+    it('should complete when at least one account synced', async () => {
+      runChainBody(err(TaskFailed({ message: 'boom' })), ok(undefined));
+      const { syncAndReDecodeEvents } = useTransactionSync();
+
+      const outcome = await syncAndReDecodeEvents('eth', { accounts, type: TransactionChainType.EVM });
+
+      expect(outcome.ok).toBe(true);
+    });
+
+    it('should fail when every account failed', async () => {
+      // 🔴 The children never reject — each handles its own error and returns — so the chain used to
+      // return `ok` unconditionally and report a whole failed chain as synced.
+      runChainBody(err(TaskFailed({ message: 'boom' })), err(TaskFailed({ message: 'boom' })));
+      const { syncAndReDecodeEvents } = useTransactionSync();
+
+      const outcome = await syncAndReDecodeEvents('eth', { accounts, type: TransactionChainType.EVM });
+
+      assert(!outcome.ok);
+      expect(outcome.error.message).toBe('boom');
+    });
+
+    it('should declare the chain activity as a container', async () => {
+      runChainBody();
+      const { syncAndReDecodeEvents } = useTransactionSync();
+
+      await syncAndReDecodeEvents('eth', { accounts, type: TransactionChainType.EVM });
+
+      // It groups the per-account syncs, which carry the same kind and write their own ledger
+      // entries; a completion recorded here would claim freshness for the chain on their behalf.
+      expect(mocks.submitTask).toHaveBeenCalledWith(expect.objectContaining({ container: true, id: chainId }));
     });
   });
 

--- a/frontend/app/src/modules/history/events/tx/use-transaction-sync.ts
+++ b/frontend/app/src/modules/history/events/tx/use-transaction-sync.ts
@@ -1,11 +1,11 @@
 import { groupBy } from 'es-toolkit';
-import { isErr, map as mapResult, ok, type Result } from 'plainfp/result';
+import { isErr, map as mapResult, type Result } from 'plainfp/result';
 import { hasTag } from 'plainfp/tagged';
 import { msg } from '@/message-key';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
-import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
+import { combineOutcomes, isActionable, type TaskError } from '@/modules/core/tasks/task-result';
 import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import { type BlockchainAddress, type ChainAddress, TransactionChainType, TransactionChainTypeNeedDecoding, type TransactionRequestPayload } from '@/modules/history/events/event-payloads';
 import { accountSyncActivityId, chainSyncActivityId } from '@/modules/history/events/tx/sync-activity';
@@ -23,10 +23,21 @@ interface TransactionSyncParams {
   trackProgress?: boolean;
 }
 
+/** A chain activity's declared children, split by whether they decide the chain's own outcome. */
+interface ChainSubtree {
+  readonly accounts: readonly Promise<Result<void, TaskError>>[];
+  readonly decode: readonly Promise<void>[];
+}
+
+/**
+ * The per-chain and per-account syncs report their outcome rather than swallowing it: a parent
+ * settles on what its children actually did, and the sync's own error handling (status store,
+ * notifications) still happens where the failure is, not at the caller.
+ */
 interface UseTransactionSyncReturn {
-  syncAndReDecodeEvents: (chain: string, params: TransactionSyncParams, parent?: ActivityId) => Promise<void>;
-  syncTransactionTask: (account: ChainAddress, type: TransactionChainType, trackProgress?: boolean, parent?: ActivityId) => Promise<void>;
-  syncTransactionsByChains: (accounts: ChainAddress[], trackProgress?: boolean, parent?: ActivityId) => Promise<void>;
+  syncAndReDecodeEvents: (chain: string, params: TransactionSyncParams, parent?: ActivityId) => Promise<Result<void, TaskError>>;
+  syncTransactionTask: (account: ChainAddress, type: TransactionChainType, trackProgress?: boolean, parent?: ActivityId) => Promise<Result<void, TaskError>>;
+  syncTransactionsByChains: (accounts: ChainAddress[], trackProgress?: boolean, parent?: ActivityId) => Promise<Result<void, TaskError>[]>;
 }
 
 export function useTransactionSync(): UseTransactionSyncReturn {
@@ -83,7 +94,7 @@ export function useTransactionSync(): UseTransactionSyncReturn {
     type: TransactionChainType,
     trackProgress = true,
     parent?: ActivityId,
-  ): Promise<void> => {
+  ): Promise<Result<void, TaskError>> => {
     const { address, chain } = account;
     const isEvmlike = type === TransactionChainType.EVMLIKE;
 
@@ -138,6 +149,8 @@ export function useTransactionSync(): UseTransactionSyncReturn {
     // setEvmlikeStatus already guards against overwriting cancelled entries
     if (isEvmlike && trackProgress)
       setEvmlikeStatus(account, 'finished');
+
+    return outcome;
   };
 
   /**
@@ -155,19 +168,26 @@ export function useTransactionSync(): UseTransactionSyncReturn {
     chain: string,
     params: TransactionSyncParams,
     parent?: ActivityId,
-  ): Promise<void> => {
+  ): Promise<Result<void, TaskError>> => {
     const { accounts, trackProgress = true, type } = params;
     const chainId = chainSyncActivityId(chain);
 
     // The chain activity is submitted before its children so the parent gate applies to them, but
     // its `run` needs their promises — which only exist once they are submitted. It waits on this
     // rather than on an array that would still be empty when the run body first executes.
-    let declared!: (work: readonly Promise<void>[]) => void;
-    const subtree = new Promise<readonly Promise<void>[]>((resolve) => {
+    //
+    // The two halves are handed over separately because only one of them decides the chain's
+    // verdict: the accounts are what a TX_SYNC activity is *about*, while the decode is follow-on
+    // work carrying its own kind and its own row.
+    let declared!: (work: ChainSubtree) => void;
+    const subtree = new Promise<ChainSubtree>((resolve) => {
       declared = resolve;
     });
 
     const chainWork = submitTask({
+      // Produces no data of its own — the per-account children carry the same kind and write their
+      // own ledger entries, so this row must not claim freshness for the chain on their behalf.
+      container: true,
       id: chainId,
       kind: ActivityKind.TX_SYNC,
       lane: CHAIN_SYNC_LANE,
@@ -175,8 +195,12 @@ export function useTransactionSync(): UseTransactionSyncReturn {
       rerunnable: false,
       run: async (): Promise<Result<void, TaskError>> => {
         logger.debug(`syncing ${chain} transactions for ${accounts.length} addresses`);
-        await Promise.all(await subtree);
-        return ok(undefined);
+        const { accounts: accountWork, decode } = await subtree;
+        // Both halves are already in flight, so awaiting them in sequence costs nothing and keeps
+        // the verdict off the decode.
+        const outcomes = await Promise.all(accountWork);
+        await Promise.all(decode);
+        return combineOutcomes(outcomes);
       },
       subtitle: activityLabelFor(msg.$t('task_center.activity.tx_sync.chain'), { chain: getChainName(chain) }),
       title: t('task_center.group.tx_sync'),
@@ -195,17 +219,17 @@ export function useTransactionSync(): UseTransactionSyncReturn {
         })]
       : [];
 
-    declared([...accountWork, ...decodeWork]);
+    declared({ accounts: accountWork, decode: decodeWork });
 
-    await chainWork;
+    return chainWork;
   };
 
-  const syncTransactionsByChains = async (accounts: ChainAddress[], trackProgress = true, parent?: ActivityId): Promise<void> => {
+  const syncTransactionsByChains = async (accounts: ChainAddress[], trackProgress = true, parent?: ActivityId): Promise<Result<void, TaskError>[]> => {
     logger.debug(`refreshing transactions for ${accounts.length} addresses`);
 
     // The account set is known here, synchronously, so every chain and every account below it is
     // declared in this pass. No limiter: CHAIN_SYNC_LANE caps how many chains run at once.
-    await Promise.all(Object.entries(groupBy(accounts, item => item.chain))
+    return Promise.all(Object.entries(groupBy(accounts, item => item.chain))
       .map(async ([chain, chainAccounts]) => syncAndReDecodeEvents(chain, {
         accounts: chainAccounts,
         trackProgress,


### PR DESCRIPTION
## Problem

The `HISTORY_SYNC` umbrella caught every error and returned `ok(undefined)` unconditionally, so a
refresh recorded a completion whatever its children did. `refreshTransactions` reads that entry as
`alreadyLoaded`, so once it was written every later non-user-initiated refresh short-circuited.

The visible consequence: if the backend is unreachable on the first sync of a session, every chain
fails, the umbrella completes anyway, and history silently never syncs again for that session. Only
pressing refresh recovers it.

The per-chain `TX_SYNC` activity had the same shape. Its children never reject - each account sync
handles its own error and returns normally - so `await Promise.all(...); return ok(undefined)`
reported a chain whose every address had failed as synced.

## Changes

- `combineOutcomes` folds a fan-out's child outcomes into the parent's verdict. One success is
  enough, since a fan-out is partial by nature; an empty batch is `Skipped`, because a parent that
  ran nothing produced nothing. Among failures an actionable error outranks a cancellation, which
  outranks a skip.
- The chain activity settles on its accounts, and is marked `container` so it writes no ledger entry
  of its own - the per-account children carry the same kind and record their own freshness. The
  decode is excluded from the verdict: it is follow-on work with its own kind and its own row.
- The umbrella settles on its children. It cannot be a `container` like the chain parent, because it
  is the subject for its kind and its entry is load-bearing; the entry just has to be true.
- Only the account half votes on that entry. Combining all three kinds of child together let a
  protocol query that happened to succeed record the completion over a run where every chain failed.
  Not "every kind must succeed" either: an online source failing is ordinary - a missing key, an
  unauthenticated integration - and letting that fail the umbrella would make history re-sync on
  every refresh forever. Those failures already carry their own rows and warnings.
- `resolveForFullRefresh` takes the full first-load scope while history has never loaded. Novelty
  means "never attempted", so an account whose sync *failed* is no longer novel, and without this a
  background refresh after a failed first load resolved to an empty account set even with the
  umbrella correctly incomplete.

To carry the outcomes, `syncTransactionTask`, `syncAndReDecodeEvents`, `syncTransactionsByChains`,
`queryExchange`/`queryAllExchangeEvents` and `queryOnlineEvent` report their result instead of
returning `void`. Each still handles its own errors where they happen; only the outcome propagates.

## Verifying

Run a sync with the transaction requests failing and it now ends without recording a completion, so
the next refresh still shows the sync progress panel; let it succeed and the completion is recorded
and the panel is suppressed. Cancelling the `History refresh` row brings its chain and account rows
down with it and records no completion either.

## Note

A partial failure still records a completion - if one chain succeeds and another fails, one success
is enough. The failed chain's accounts are no longer novel, so only a user-initiated refresh retries
them. That is much narrower than the bug fixed here, but it is the same shape; fixing it properly
means per-chain freshness rather than one umbrella entry gating the whole account scope.