### PR TITLE
Show pending tasks as a tree

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5110,6 +5110,7 @@
       "done": "Done",
       "failed": "Failed",
       "queued": "Queued",
+      "running": "Running",
       "skipped": "Skipped"
     },
     "steps": "{current} of {total}"

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1992,7 +1992,8 @@
   "collapsed_pending_tasks": {
     "cancel_task": "Cancel task",
     "cancel_task_info": "This action will leave the running process ({title}) in an unfinished state, are you sure you want to cancel?",
-    "title": "{count} pending task | {count} pending tasks"
+    "steps": "{current} of {total} steps done",
+    "title": "{count} job running | {count} jobs running"
   },
   "common": {
     "account": "Account",
@@ -5100,6 +5101,18 @@
     "validation": {
       "range": "Value must be between 1 and 14 days"
     }
+  },
+  "pending_task": {
+    "collapse": "Collapse",
+    "expand": "Expand",
+    "status": {
+      "cancelled": "Cancelled",
+      "done": "Done",
+      "failed": "Failed",
+      "queued": "Queued",
+      "skipped": "Skipped"
+    },
+    "steps": "{current} of {total}"
   },
   "percentage_display": {
     "symbol": "%",

--- a/frontend/app/src/modules/core/notifications/CollapsedPendingTasks.spec.ts
+++ b/frontend/app/src/modules/core/notifications/CollapsedPendingTasks.spec.ts
@@ -1,0 +1,46 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import CollapsedPendingTasks from '@/modules/core/notifications/CollapsedPendingTasks.vue';
+
+function createWrapper(props: Partial<InstanceType<typeof CollapsedPendingTasks>['$props']> = {}): VueWrapper {
+  return mount(CollapsedPendingTasks, {
+    props: {
+      count: 1,
+      modelValue: true,
+      percentage: 36,
+      steps: { current: 4, total: 11 },
+      ...props,
+    },
+  });
+}
+
+describe('collapsedPendingTasks', () => {
+  it('should count jobs, not the activities they fan out into', () => {
+    expect(createWrapper({ count: 1 }).text()).toContain('collapsed_pending_tasks.title::1');
+  });
+
+  /**
+   * Producers declare their subtree up front, so the denominator exists from the first tick. The
+   * header used to render an indeterminate spinner beside that number and throw it away.
+   */
+  it('should show the tally and a determinate ring when the work is quantifiable', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.text()).toContain('collapsed_pending_tasks.steps::4, 11');
+    expect(wrapper.findComponent({ name: 'RuiProgress' }).props('variant')).toBe('determinate');
+  });
+
+  it('should fall back to an indeterminate ring with no tally', () => {
+    const wrapper = createWrapper({ percentage: -1, steps: { current: 0, total: 0 } });
+
+    expect(wrapper.text()).not.toContain('collapsed_pending_tasks.steps');
+    expect(wrapper.findComponent({ name: 'RuiProgress' }).props('variant')).toBe('indeterminate');
+  });
+
+  it('should toggle the panel', async () => {
+    const wrapper = createWrapper({ modelValue: true });
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+  });
+});

--- a/frontend/app/src/modules/core/notifications/CollapsedPendingTasks.vue
+++ b/frontend/app/src/modules/core/notifications/CollapsedPendingTasks.vue
@@ -1,23 +1,54 @@
 <script setup lang="ts">
+import type { ActivitySteps } from '@/modules/task-center/core/types';
+
 const model = defineModel<boolean>({ required: true });
-defineProps<{
+
+const { count, percentage, steps } = defineProps<{
+  /** Jobs, not activities: what the user started, not what it fanned out into. */
   count: number;
+  steps: ActivitySteps;
+  /** 0-100, or `-1` when nothing in flight can be quantified. */
+  percentage: number;
 }>();
+
 const { t } = useI18n({ useScope: 'global' });
+
+// Producers declare their subtrees up front, so a refresh knows its own denominator from the first
+// tick. The header used to spin indeterminately beside that number and throw it away.
+const isDeterminate = computed<boolean>(() => percentage >= 0 && steps.total > 0);
 </script>
 
 <template>
   <div class="flex justify-between items-center">
     <div class="flex items-center gap-4">
       <RuiProgress
+        v-if="isDeterminate"
+        color="primary"
+        variant="determinate"
+        circular
+        :value="percentage"
+        size="24"
+        thickness="2"
+        show-label
+      />
+      <RuiProgress
+        v-else
         color="primary"
         variant="indeterminate"
         circular
         size="20"
         thickness="2"
       />
-      <div class="font-medium">
-        {{ t('collapsed_pending_tasks.title', { count }, count) }}
+      <div class="flex flex-col">
+        <div class="font-medium">
+          {{ t('collapsed_pending_tasks.title', { count }, count) }}
+        </div>
+        <div
+          v-if="isDeterminate"
+          class="text-xs text-rui-text-secondary tabular-nums"
+        >
+          {{ t('collapsed_pending_tasks.steps', { current: steps.current, total: steps.total }) }}
+        </div>
       </div>
     </div>
 
@@ -26,6 +57,7 @@ const { t } = useI18n({ useScope: 'global' });
       variant="text"
       icon
       size="sm"
+      :aria-label="model ? t('pending_task.collapse') : t('pending_task.expand')"
       @click="model = !model"
     >
       <RuiIcon

--- a/frontend/app/src/modules/core/notifications/CollapsedPendingTasks.vue
+++ b/frontend/app/src/modules/core/notifications/CollapsedPendingTasks.vue
@@ -20,7 +20,9 @@ const isDeterminate = computed<boolean>(() => percentage >= 0 && steps.total > 0
 
 <template>
   <div class="flex justify-between items-center">
-    <div class="flex items-center gap-4">
+    <!-- gap-3 and size 24 on both rings, so the header keeps its metrics when it flips determinate
+         and its indicator column lines up with the rows beneath it. -->
+    <div class="flex items-center gap-3 min-w-0">
       <RuiProgress
         v-if="isDeterminate"
         color="primary"
@@ -36,16 +38,16 @@ const isDeterminate = computed<boolean>(() => percentage >= 0 && steps.total > 0
         color="primary"
         variant="indeterminate"
         circular
-        size="20"
+        size="24"
         thickness="2"
       />
-      <div class="flex flex-col">
-        <div class="font-medium">
+      <div class="flex flex-col gap-0.5 min-w-0">
+        <div class="font-medium leading-5 truncate">
           {{ t('collapsed_pending_tasks.title', { count }, count) }}
         </div>
         <div
           v-if="isDeterminate"
-          class="text-xs text-rui-text-secondary tabular-nums"
+          class="text-xs leading-4 text-rui-text-secondary tabular-nums"
         >
           {{ t('collapsed_pending_tasks.steps', { current: steps.current, total: steps.total }) }}
         </div>

--- a/frontend/app/src/modules/core/notifications/PendingTask.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTask.spec.ts
@@ -84,6 +84,14 @@ describe('pendingTask', () => {
     expect(text).toContain('pending_task.steps::1, 4');
   });
 
+  /**
+   * The chip shows an icon and no text, so the label lives on `aria-label` (and in the tooltip).
+   * Asserting on it is also the only check that a status reaches the row at all.
+   */
+  function outcomeLabel(wrapper: VueWrapper): string | undefined {
+    return wrapper.find('[data-testid=activity-outcome]').attributes('aria-label');
+  }
+
   it.each([
     [ActivityStatus.PENDING, 'pending_task.status.queued'],
     [ActivityStatus.FAILED, 'pending_task.status.failed'],
@@ -91,14 +99,43 @@ describe('pendingTask', () => {
     [ActivityStatus.CANCELLED, 'pending_task.status.cancelled'],
     [ActivityStatus.COMPLETE, 'pending_task.status.done'],
   ])('should label a %s row with its outcome', (status, key) => {
-    expect(createWrapper({ activity: activity({ status }) }).text()).toContain(key);
+    expect(outcomeLabel(createWrapper({ activity: activity({ status }) }))).toBe(key);
   });
 
-  it('should show a spinner, not a chip, while running', () => {
-    const wrapper = createWrapper({ activity: activity({ status: ActivityStatus.RUNNING }) });
+  /**
+   * No spinner. A running row the producer never counted steps for shows a chip — the panel
+   * already has rings, and the elapsed counter beside the chip is what shows it is alive.
+   */
+  it('should label a running row with no percentage instead of spinning', () => {
+    const wrapper = createWrapper({ activity: activity({ status: ActivityStatus.RUNNING }), percentage: -1 });
 
-    expect(wrapper.text()).not.toContain('pending_task.status');
-    expect(wrapper.find('.animate-spin').exists()).toBe(true);
+    expect(outcomeLabel(wrapper)).toBe('pending_task.status.running');
+    expect(wrapper.findComponent({ name: 'RuiProgress' }).exists()).toBe(false);
+  });
+
+  /** The chip carries no text of its own — the drawer is 400px and the label needs the room. */
+  it('should show the outcome as an icon, not a word', () => {
+    const wrapper = createWrapper({ activity: activity({ status: ActivityStatus.COMPLETE }) });
+
+    expect(wrapper.text()).not.toContain('pending_task.status.done');
+    expect(wrapper.find('[data-testid=activity-outcome]').exists()).toBe(true);
+  });
+
+  it('should show a determinate ring once there is a percentage', () => {
+    const wrapper = createWrapper({ activity: activity({ status: ActivityStatus.RUNNING }), percentage: 40 });
+
+    const progress = wrapper.findComponent({ name: 'RuiProgress' });
+    expect(progress.props('variant')).toBe('determinate');
+    expect(progress.props('value')).toBe(40);
+    expect(wrapper.find('[data-testid=activity-outcome]').exists()).toBe(false);
+  });
+
+  /** A settled row keeps its outcome chip even when a percentage survives on the activity. */
+  it('should prefer the outcome chip to the ring once the work has settled', () => {
+    const wrapper = createWrapper({ activity: activity({ status: ActivityStatus.FAILED }), percentage: 40 });
+
+    expect(outcomeLabel(wrapper)).toBe('pending_task.status.failed');
+    expect(wrapper.findComponent({ name: 'RuiProgress' }).exists()).toBe(false);
   });
 
   it('should emit cancel only when the caller allows it', async () => {

--- a/frontend/app/src/modules/core/notifications/PendingTask.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTask.spec.ts
@@ -1,0 +1,114 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import PendingTask from '@/modules/core/notifications/PendingTask.vue';
+import {
+  type Activity,
+  ActivityKind,
+  ActivitySourceType,
+  ActivityStatus,
+  makeActivityId,
+} from '@/modules/task-center/core/types';
+
+const NOW = 1_000_000;
+
+function activity(partial: Partial<Activity> = {}): Activity {
+  return {
+    cancellable: true,
+    id: makeActivityId(ActivityKind.TX_SYNC, 'ethereum'),
+    kind: ActivityKind.TX_SYNC,
+    percentage: -1,
+    rerunnable: false,
+    source: { type: ActivitySourceType.NATIVE },
+    status: ActivityStatus.RUNNING,
+    title: 'Transaction sync',
+    ...partial,
+  };
+}
+
+function createWrapper(props: Partial<InstanceType<typeof PendingTask>['$props']> = {}): VueWrapper {
+  return mount(PendingTask, {
+    props: {
+      activity: activity(),
+      cancellable: false,
+      now: NOW,
+      percentage: -1,
+      ...props,
+    },
+  });
+}
+
+describe('pendingTask', () => {
+  it('should show the title and subtitle at the top level', () => {
+    const text = createWrapper({ activity: activity({ subtitle: 'Ethereum' }) }).text();
+
+    expect(text).toContain('Transaction sync');
+    expect(text).toContain('Ethereum');
+  });
+
+  /**
+   * A chain and its accounts carry the same title, so repeating it under a parent that already
+   * names the job produced three identical-looking rows told apart only by their subtitle.
+   */
+  it('should show only its own identity when nested', () => {
+    const text = createWrapper({
+      activity: activity({ subtitle: 'Ethereum' }),
+      nested: true,
+    }).text();
+
+    expect(text).toContain('Ethereum');
+    expect(text).not.toContain('Transaction sync');
+  });
+
+  it('should render elapsed time for running work', () => {
+    const text = createWrapper({ activity: activity({ startedAt: NOW - 14_000 }) }).text();
+
+    expect(text).toContain('14s');
+  });
+
+  /** An absolute date on a live row answers a question nobody asked; a settled row has no elapsed at all. */
+  it('should not render elapsed time once the work settled', () => {
+    const text = createWrapper({
+      activity: activity({ startedAt: NOW - 14_000, status: ActivityStatus.COMPLETE }),
+    }).text();
+
+    expect(text).not.toContain('14s');
+  });
+
+  it('should render its subtree tally next to the elapsed time', () => {
+    const text = createWrapper({
+      activity: activity({ startedAt: NOW - 5000 }),
+      percentage: 25,
+      steps: { current: 1, total: 4 },
+    }).text();
+
+    expect(text).toContain('pending_task.steps::1, 4');
+  });
+
+  it.each([
+    [ActivityStatus.PENDING, 'pending_task.status.queued'],
+    [ActivityStatus.FAILED, 'pending_task.status.failed'],
+    [ActivityStatus.SKIPPED, 'pending_task.status.skipped'],
+    [ActivityStatus.CANCELLED, 'pending_task.status.cancelled'],
+    [ActivityStatus.COMPLETE, 'pending_task.status.done'],
+  ])('should label a %s row with its outcome', (status, key) => {
+    expect(createWrapper({ activity: activity({ status }) }).text()).toContain(key);
+  });
+
+  it('should show a spinner, not a chip, while running', () => {
+    const wrapper = createWrapper({ activity: activity({ status: ActivityStatus.RUNNING }) });
+
+    expect(wrapper.text()).not.toContain('pending_task.status');
+    expect(wrapper.find('.animate-spin').exists()).toBe(true);
+  });
+
+  it('should emit cancel only when the caller allows it', async () => {
+    const wrapper = createWrapper({ cancellable: true });
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1);
+  });
+
+  it('should render no cancel control when the caller withholds it', () => {
+    expect(createWrapper({ cancellable: false }).find('button').exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/core/notifications/PendingTask.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTask.spec.ts
@@ -121,6 +121,19 @@ describe('pendingTask', () => {
     expect(wrapper.find('[data-testid=activity-outcome]').exists()).toBe(true);
   });
 
+  /**
+   * RuiChip hardcodes `role="button"` and `tabindex="0"` on its root regardless of `clickable`, so
+   * an untouched status chip is a focusable fake button — one extra tab stop and one "Done, button"
+   * announcement per settled child, on a decoration that does nothing.
+   */
+  it('should present the outcome as an image, not a focusable button', () => {
+    const chip = createWrapper({ activity: activity({ status: ActivityStatus.COMPLETE }) })
+      .find('[data-testid=activity-outcome]');
+
+    expect(chip.attributes('role')).toBe('img');
+    expect(chip.attributes('tabindex')).toBe('-1');
+  });
+
   it('should show a determinate ring once there is a percentage', () => {
     const wrapper = createWrapper({ activity: activity({ status: ActivityStatus.RUNNING }), percentage: 40 });
 

--- a/frontend/app/src/modules/core/notifications/PendingTask.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTask.vue
@@ -57,7 +57,11 @@ const meta = computed<string | undefined>(() => {
   return parts.length > 0 ? parts.join(' · ') : undefined;
 });
 
-const outcome = computed<ActivityOutcome | undefined>(() => activityOutcome(activity.status));
+const outcome = computed<ActivityOutcome>(() => activityOutcome(activity.status));
+
+// The ring only earns the slot when it has a real number to put in it. Everything else — including
+// a running row the producer never counted steps for — says its status in words instead.
+const showRing = computed<boolean>(() => get(isRunning) && get(hasDeterminateProgress));
 </script>
 
 <template>
@@ -83,16 +87,8 @@ const outcome = computed<ActivityOutcome | undefined>(() => activityOutcome(acti
       </div>
     </div>
 
-    <RuiChip
-      v-if="outcome"
-      size="sm"
-      :color="outcome.color"
-      class="shrink-0"
-    >
-      {{ t(outcome.key) }}
-    </RuiChip>
     <RuiProgress
-      v-else-if="hasDeterminateProgress"
+      v-if="showRing"
       color="primary"
       circular
       variant="determinate"
@@ -101,12 +97,35 @@ const outcome = computed<ActivityOutcome | undefined>(() => activityOutcome(acti
       show-label
       thickness="2"
     />
-    <RuiIcon
+    <!--
+      Icon only. The drawer is 400px and a nested row spends most of it on its label; "Refreshing
+      Arbitrum One" wrapped to two lines to make room for the word "Running". Colour plus icon
+      carries the status, the tooltip carries the word, and `aria-label` keeps it for anyone not
+      reading either.
+    -->
+    <RuiTooltip
       v-else
-      name="lu-loader-circle"
-      size="20"
-      class="text-rui-primary shrink-0 animate-spin"
-    />
+      :popper="{ placement: 'top' }"
+      :open-delay="400"
+    >
+      <template #activator>
+        <RuiChip
+          size="sm"
+          :color="outcome.color"
+          :variant="outcome.variant"
+          :aria-label="t(outcome.key)"
+          :class-names="{ content: '!px-1' }"
+          class="shrink-0"
+          data-testid="activity-outcome"
+        >
+          <RuiIcon
+            :name="outcome.icon"
+            size="14"
+          />
+        </RuiChip>
+      </template>
+      {{ t(outcome.key) }}
+    </RuiTooltip>
 
     <RuiTooltip
       v-if="cancellable"

--- a/frontend/app/src/modules/core/notifications/PendingTask.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTask.vue
@@ -66,22 +66,29 @@ const showRing = computed<boolean>(() => get(isRunning) && get(hasDeterminatePro
 
 <template>
   <div class="flex items-center justify-between flex-nowrap gap-3">
-    <div class="flex flex-col flex-1 min-w-0">
+    <div class="flex flex-col flex-1 min-w-0 gap-0.5">
+      <!--
+        `truncate`, not `text-ellipsis`: the latter is inert without `whitespace-nowrap`, so every
+        long chain name wrapped to two lines and the panel had no vertical rhythm at all. One line
+        per row, with the full text on hover.
+      -->
       <div
-        class="overflow-hidden text-ellipsis text-sm leading-4"
+        class="truncate text-sm leading-5"
         :class="[nested ? 'font-normal' : 'font-medium', { 'text-rui-text-secondary': isTerminalStatus(activity.status) }]"
+        :title="label"
       >
         {{ label }}
       </div>
       <div
         v-if="secondary"
-        class="text-xs text-rui-text-secondary mt-1"
+        class="truncate text-xs leading-4 text-rui-text-secondary"
+        :title="secondary"
       >
         {{ secondary }}
       </div>
       <div
         v-if="meta"
-        class="text-xs text-rui-text-secondary mt-1 tabular-nums"
+        class="text-xs leading-4 text-rui-text-secondary tabular-nums"
       >
         {{ meta }}
       </div>
@@ -109,8 +116,16 @@ const showRing = computed<boolean>(() => get(isRunning) && get(hasDeterminatePro
       :open-delay="400"
     >
       <template #activator>
+        <!--
+          ⚠️ `role` and `tabindex` are overrides, not decoration. RuiChip hardcodes `role="button"`
+          and `tabindex="0"` on its root whether or not it is clickable, so an untouched status chip
+          is a focusable fake button: a keyboard user tabs through a "Done" button on every row and
+          hears one announced per settled child. `role="img"` makes the icon carry its `aria-label`.
+        -->
         <RuiChip
           size="sm"
+          role="img"
+          tabindex="-1"
           :color="outcome.color"
           :variant="outcome.variant"
           :aria-label="t(outcome.key)"

--- a/frontend/app/src/modules/core/notifications/PendingTask.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTask.vue
@@ -1,60 +1,115 @@
 <script setup lang="ts">
-import dayjs from 'dayjs';
-import { type Activity, resolveText } from '@/modules/task-center/core/types';
+import { type ActivityOutcome, activityOutcome } from '@/modules/task-center/activity-outcome';
+import { formatElapsed } from '@/modules/task-center/core/elapsed';
+import { isTerminalStatus } from '@/modules/task-center/core/status';
+import { type Activity, ActivityStatus, type ActivitySteps, resolveText } from '@/modules/task-center/core/types';
 
-const { activity } = defineProps<{ activity: Activity }>();
+const { activity, cancellable, nested = false, now, percentage, steps } = defineProps<{
+  activity: Activity;
+  /** Ticks once a second, owned by the panel so one timer serves every row. */
+  now: number;
+  /** 0-100, or `-1` for indeterminate. Parents pass their subtree's; leaves their own. */
+  percentage: number;
+  /** Present for a parent: the leaf tally behind {@link percentage}. */
+  steps?: ActivitySteps;
+  /** Decided by the caller — a parent is not cancellable until cancel cascades. */
+  cancellable: boolean;
+  /** A child row: the job above it already names the work, so its own label is enough. */
+  nested?: boolean;
+}>();
+
 const emit = defineEmits<{
   cancel: [activity: Activity];
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
-// `-1` is the orchestrator's "indeterminate": no producer reported steps for this activity.
-const hasDeterminateProgress = computed<boolean>(() => activity.percentage >= 0);
-
-const time = computed<string>(() => (activity.startedAt ? dayjs(activity.startedAt).format('LLL') : ''));
-
 // Resolved here rather than at submit time, so a language change updates work already in flight.
 const subtitle = computed<string | undefined>(() => resolveText(t, activity.subtitle));
+
+// A child of "History refresh" reads better as "Ethereum" than as "Transaction sync / Ethereum":
+// a chain and its accounts carry the same title, so under a parent the subtitle is the identity.
+const label = computed<string>(() => (nested ? get(subtitle) ?? activity.title : activity.title));
+
+const secondary = computed<string | undefined>(() => (nested ? undefined : get(subtitle)));
+
+const isRunning = computed<boolean>(() => activity.status === ActivityStatus.RUNNING);
+
+// `-1` is the orchestrator's "indeterminate": no producer reported steps for this activity.
+const hasDeterminateProgress = computed<boolean>(() => percentage >= 0);
+
+const elapsed = computed<string | undefined>(() => {
+  if (!get(isRunning) || activity.startedAt === undefined)
+    return undefined;
+
+  return formatElapsed(now - activity.startedAt);
+});
+
+const meta = computed<string | undefined>(() => {
+  const parts: string[] = [];
+  const elapsedTime = get(elapsed);
+  if (elapsedTime)
+    parts.push(elapsedTime);
+
+  if (steps && steps.total > 0)
+    parts.push(t('pending_task.steps', { current: steps.current, total: steps.total }));
+
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+});
+
+const outcome = computed<ActivityOutcome | undefined>(() => activityOutcome(activity.status));
 </script>
 
 <template>
-  <div class="flex items-center justify-between flex-nowrap gap-4">
-    <div class="flex flex-col flex-1 break-words">
-      <div class="overflow-hidden text-ellipsis text-sm font-medium mb-1 leading-4">
-        {{ activity.title }}
+  <div class="flex items-center justify-between flex-nowrap gap-3">
+    <div class="flex flex-col flex-1 min-w-0">
+      <div
+        class="overflow-hidden text-ellipsis text-sm leading-4"
+        :class="[nested ? 'font-normal' : 'font-medium', { 'text-rui-text-secondary': isTerminalStatus(activity.status) }]"
+      >
+        {{ label }}
       </div>
       <div
-        v-if="subtitle"
-        class="text-xs text-rui-text-secondary mb-2"
+        v-if="secondary"
+        class="text-xs text-rui-text-secondary mt-1"
       >
-        {{ subtitle }}
+        {{ secondary }}
       </div>
       <div
-        v-if="time"
-        class="text-caption text-xs"
+        v-if="meta"
+        class="text-xs text-rui-text-secondary mt-1 tabular-nums"
       >
-        {{ time }}
+        {{ meta }}
       </div>
     </div>
+
+    <RuiChip
+      v-if="outcome"
+      size="sm"
+      :color="outcome.color"
+      class="shrink-0"
+    >
+      {{ t(outcome.key) }}
+    </RuiChip>
     <RuiProgress
-      v-if="hasDeterminateProgress"
+      v-else-if="hasDeterminateProgress"
       color="primary"
       circular
       variant="determinate"
-      :value="activity.percentage"
+      :value="percentage"
       size="24"
       show-label
       thickness="2"
     />
     <RuiIcon
       v-else
-      name="lu-loader"
+      name="lu-loader-circle"
       size="20"
-      class="text-rui-text-secondary shrink-0"
+      class="text-rui-primary shrink-0 animate-spin"
     />
+
     <RuiTooltip
-      v-if="activity.cancellable"
+      v-if="cancellable"
       :popper="{ placement: 'top' }"
       :open-delay="400"
     >
@@ -65,6 +120,7 @@ const subtitle = computed<string | undefined>(() => resolveText(t, activity.subt
           class="shrink-0"
           size="sm"
           icon
+          data-testid="cancel-activity"
           @click="emit('cancel', activity)"
         >
           <RuiIcon name="lu-x" />

--- a/frontend/app/src/modules/core/notifications/PendingTaskNode.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTaskNode.spec.ts
@@ -80,12 +80,18 @@ describe('pendingTaskNode', () => {
   });
 
   /**
-   * ⚠️ Cancelling a parent today settles its row and stops nothing — the handle aborts a backend
-   * task id an umbrella never has, and cancel does not walk descendants. The control comes back
-   * when cancellation cascades.
+   * ⭐ The control is back now that `orchestrator.cancel` cascades. It was withheld while
+   * cancelling a parent settled its row and stopped nothing — the handle aborts a backend task id
+   * an umbrella never has.
    */
-  it('should offer no cancel control on a parent', () => {
-    expect(createWrapper().findAll('[data-testid=cancel-activity]')).toHaveLength(0);
+  it('should offer a cancel control on a parent', async () => {
+    const wrapper = createWrapper();
+    const control = wrapper.find('[data-testid=cancel-activity]');
+    expect(control.exists()).toBe(true);
+
+    await control.trigger('click');
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1);
   });
 
   it('should bubble a leaf cancel up to the panel', async () => {

--- a/frontend/app/src/modules/core/notifications/PendingTaskNode.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTaskNode.spec.ts
@@ -53,20 +53,29 @@ function createWrapper(): VueWrapper {
 }
 
 describe('pendingTaskNode', () => {
-  it('should render a job with its children expanded', () => {
+  /**
+   * Collapsed at every level, the job's own fan-out included. The rolled-up row already says what
+   * is running and how far along; unfolding eleven chains times four accounts into a 400px drawer
+   * to repeat it pushes every other job off the panel.
+   */
+  it('should render a job with its children collapsed', () => {
     const text = createWrapper().text();
 
     expect(text).toContain('History refresh');
-    expect(text).toContain('ethereum');
+    expect(text).not.toContain('ethereum');
   });
 
-  /** Eleven chains times four accounts is not something to unfold into a 400px drawer unasked. */
-  it('should keep levels below the first collapsed until asked', async () => {
+  it('should unfold one level per click', async () => {
     const wrapper = createWrapper();
 
+    const jobDisclosure = wrapper.find('[aria-expanded]');
+    assert(jobDisclosure.exists(), 'the job rendered no disclosure');
+    await jobDisclosure.trigger('click');
+
+    // The chain is now visible, but its own accounts are not: one click, one level.
+    expect(wrapper.text()).toContain('ethereum');
     expect(wrapper.text()).not.toContain('0xbb');
 
-    // The last disclosure is the chain's; the first is the job's, already open.
     const chainDisclosure = wrapper.findAll('[aria-expanded]').at(-1);
     assert(chainDisclosure, 'the chain rendered no disclosure');
     await chainDisclosure.trigger('click');
@@ -99,7 +108,7 @@ describe('pendingTaskNode', () => {
     const chain = children.get(root.id)?.[0];
     const wrapper = mount(PendingTaskNode, { props: { activity: chain!, children, depth: 1, now: NOW } });
 
-    // Mounted below the first level, so it starts collapsed; its accounts carry the control.
+    // Starts collapsed like every parent; its accounts carry the control once it is open.
     await wrapper.find('[aria-expanded]').trigger('click');
     await wrapper.find('[data-testid=cancel-activity]').trigger('click');
 

--- a/frontend/app/src/modules/core/notifications/PendingTaskNode.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTaskNode.spec.ts
@@ -1,0 +1,102 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { assert, describe, expect, it } from 'vitest';
+import PendingTaskNode from '@/modules/core/notifications/PendingTaskNode.vue';
+import { buildTree } from '@/modules/task-center/core/tree';
+import {
+  type Activity,
+  type ActivityId,
+  ActivityKind,
+  ActivitySourceType,
+  ActivityStatus,
+  makeActivityId,
+} from '@/modules/task-center/core/types';
+
+const NOW = 1_000_000;
+
+function activity(name: string, partial: Partial<Activity> = {}): Activity {
+  return {
+    cancellable: true,
+    id: makeActivityId(ActivityKind.TX_SYNC, name),
+    kind: ActivityKind.TX_SYNC,
+    percentage: -1,
+    rerunnable: false,
+    source: { type: ActivitySourceType.NATIVE },
+    status: ActivityStatus.RUNNING,
+    subtitle: name,
+    title: 'Transaction sync',
+    ...partial,
+  };
+}
+
+function id(name: string): ActivityId {
+  return makeActivityId(ActivityKind.TX_SYNC, name);
+}
+
+/**
+ * A three-level tree, the shape a history refresh actually declares: one job, a chain under it,
+ * two accounts under the chain.
+ */
+function tree(): { children: ReadonlyMap<ActivityId, Activity[]>; root: Activity } {
+  const activities = [
+    activity('refresh', { kind: ActivityKind.HISTORY_SYNC, subtitle: undefined, title: 'History refresh' }),
+    activity('ethereum', { parent: id('refresh') }),
+    activity('0xaa', { parent: id('ethereum'), status: ActivityStatus.COMPLETE }),
+    activity('0xbb', { parent: id('ethereum') }),
+  ];
+  const { children, roots } = buildTree(activities, (a, b) => a.id.localeCompare(b.id));
+  return { children, root: roots[0] };
+}
+
+function createWrapper(): VueWrapper {
+  const { children, root } = tree();
+  return mount(PendingTaskNode, { props: { activity: root, children, now: NOW } });
+}
+
+describe('pendingTaskNode', () => {
+  it('should render a job with its children expanded', () => {
+    const text = createWrapper().text();
+
+    expect(text).toContain('History refresh');
+    expect(text).toContain('ethereum');
+  });
+
+  /** Eleven chains times four accounts is not something to unfold into a 400px drawer unasked. */
+  it('should keep levels below the first collapsed until asked', async () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.text()).not.toContain('0xbb');
+
+    // The last disclosure is the chain's; the first is the job's, already open.
+    const chainDisclosure = wrapper.findAll('[aria-expanded]').at(-1);
+    assert(chainDisclosure, 'the chain rendered no disclosure');
+    await chainDisclosure.trigger('click');
+
+    expect(wrapper.text()).toContain('0xbb');
+  });
+
+  it('should show a parent its subtree tally in leaves', () => {
+    // One of the two accounts is done: the job is 1 of 2, not 1 of 3 activities.
+    expect(createWrapper().text()).toContain('pending_task.steps::1, 2');
+  });
+
+  /**
+   * ⚠️ Cancelling a parent today settles its row and stops nothing — the handle aborts a backend
+   * task id an umbrella never has, and cancel does not walk descendants. The control comes back
+   * when cancellation cascades.
+   */
+  it('should offer no cancel control on a parent', () => {
+    expect(createWrapper().findAll('[data-testid=cancel-activity]')).toHaveLength(0);
+  });
+
+  it('should bubble a leaf cancel up to the panel', async () => {
+    const { children, root } = tree();
+    const chain = children.get(root.id)?.[0];
+    const wrapper = mount(PendingTaskNode, { props: { activity: chain!, children, depth: 1, now: NOW } });
+
+    // Mounted below the first level, so it starts collapsed; its accounts carry the control.
+    await wrapper.find('[aria-expanded]').trigger('click');
+    await wrapper.find('[data-testid=cancel-activity]').trigger('click');
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/core/notifications/PendingTaskNode.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTaskNode.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import type { Activity, ActivityId, ActivitySteps } from '@/modules/task-center/core/types';
+import PendingTask from '@/modules/core/notifications/PendingTask.vue';
+import { percentageFromSteps } from '@/modules/task-center/core/status';
+import { subtreeSteps } from '@/modules/task-center/core/tree';
+
+const { activity, children, depth = 0, now } = defineProps<{
+  activity: Activity;
+  /** The whole tree, passed down rather than looked up per node. */
+  children: ReadonlyMap<ActivityId, Activity[]>;
+  now: number;
+  depth?: number;
+}>();
+
+const emit = defineEmits<{
+  cancel: [activity: Activity];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+// A job's own fan-out is the interesting part, so it opens; a chain's forty accounts are not, so
+// anything deeper starts closed and costs one click.
+const expanded = ref<boolean>(depth === 0);
+
+const descendants = computed<Activity[]>(() => children.get(activity.id) ?? []);
+
+const isParent = computed<boolean>(() => get(descendants).length > 0);
+
+// A parent shows its subtree's leaf tally, so its ring and its "4 of 11" agree. A leaf shows what
+// the orchestrator derived for it.
+const steps = computed<ActivitySteps | undefined>(() => (get(isParent) ? subtreeSteps(children, activity) : undefined));
+
+const percentage = computed<number>(() => {
+  const tally = get(steps);
+  return tally ? percentageFromSteps(tally.current, tally.total) : activity.percentage;
+});
+
+/**
+ * ⚠️ Parents are deliberately not cancellable here. Cancelling one today settles its row and stops
+ * nothing: the handle only aborts a backend task id an umbrella never has, `cancel` does not walk
+ * descendants, and a cancelled parent no longer holds the refresh re-entrancy guard. Restore this
+ * once cancellation cascades.
+ */
+const cancellable = computed<boolean>(() => activity.cancellable && !get(isParent));
+</script>
+
+<template>
+  <div class="flex flex-col">
+    <div class="flex items-start gap-1">
+      <RuiButton
+        v-if="isParent"
+        variant="text"
+        size="sm"
+        icon
+        class="shrink-0 mt-0.5"
+        :aria-expanded="expanded"
+        :aria-label="expanded ? t('pending_task.collapse') : t('pending_task.expand')"
+        @click="expanded = !expanded"
+      >
+        <RuiIcon
+          :name="expanded ? 'lu-chevron-down' : 'lu-chevron-right'"
+          size="16"
+        />
+      </RuiButton>
+      <div
+        v-else-if="depth > 0"
+        class="w-6 shrink-0"
+      />
+
+      <PendingTask
+        class="flex-1 min-w-0 py-1"
+        :activity="activity"
+        :now="now"
+        :percentage="percentage"
+        :steps="steps"
+        :cancellable="cancellable"
+        :nested="depth > 0"
+        @cancel="emit('cancel', $event)"
+      />
+    </div>
+
+    <div
+      v-if="isParent && expanded"
+      class="flex flex-col ml-3 pl-3 border-l border-default"
+    >
+      <PendingTaskNode
+        v-for="child in descendants"
+        :key="child.id"
+        :activity="child"
+        :children="children"
+        :now="now"
+        :depth="depth + 1"
+        @cancel="emit('cancel', $event)"
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/core/notifications/PendingTaskNode.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTaskNode.vue
@@ -18,9 +18,10 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-// A job's own fan-out is the interesting part, so it opens; a chain's forty accounts are not, so
-// anything deeper starts closed and costs one click.
-const expanded = ref<boolean>(depth === 0);
+// Every parent starts closed, at every depth. The rolled-up row already answers the question a
+// reader arrives with — what is running and how far along — and a refresh that opened its own
+// fan-out pushed the other jobs off the panel to say the same thing twice. Opening one is a click.
+const expanded = ref<boolean>(false);
 
 const descendants = computed<Activity[]>(() => children.get(activity.id) ?? []);
 

--- a/frontend/app/src/modules/core/notifications/PendingTaskNode.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTaskNode.vue
@@ -36,12 +36,12 @@ const percentage = computed<number>(() => {
 });
 
 /**
- * ⚠️ Parents are deliberately not cancellable here. Cancelling one today settles its row and stops
- * nothing: the handle only aborts a backend task id an umbrella never has, `cancel` does not walk
- * descendants, and a cancelled parent no longer holds the refresh re-entrancy guard. Restore this
- * once cancellation cascades.
+ * ⭐ A parent's stop control ends its whole subtree, because `orchestrator.cancel` cascades: the
+ * settle walks the children, each of which walks its own. Until that landed this row deliberately
+ * rendered no control at all — cancelling a parent settled its row and stopped nothing, since the
+ * handle only aborts a backend task id an umbrella never has.
  */
-const cancellable = computed<boolean>(() => activity.cancellable && !get(isParent));
+const cancellable = computed<boolean>(() => activity.cancellable);
 </script>
 
 <template>

--- a/frontend/app/src/modules/core/notifications/PendingTaskNode.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTaskNode.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import type { Activity, ActivityId, ActivitySteps } from '@/modules/task-center/core/types';
 import PendingTask from '@/modules/core/notifications/PendingTask.vue';
-import { percentageFromSteps } from '@/modules/task-center/core/status';
-import { subtreeSteps } from '@/modules/task-center/core/tree';
+import { subtreeProgress, subtreeSteps } from '@/modules/task-center/core/tree';
 
 const { activity, children, depth = 0, now } = defineProps<{
   activity: Activity;
@@ -31,10 +30,9 @@ const isParent = computed<boolean>(() => get(descendants).length > 0);
 // the orchestrator derived for it.
 const steps = computed<ActivitySteps | undefined>(() => (get(isParent) ? subtreeSteps(children, activity) : undefined));
 
-const percentage = computed<number>(() => {
-  const tally = get(steps);
-  return tally ? percentageFromSteps(tally.current, tally.total) : activity.percentage;
-});
+// A parent rolls its subtree up, giving each leaf fractional credit for its own progress; a leaf
+// shows what the orchestrator derived for it.
+const percentage = computed<number>(() => (get(isParent) ? subtreeProgress(children, activity) : activity.percentage));
 
 /**
  * ⭐ A parent's stop control ends its whole subtree, because `orchestrator.cancel` cascades: the
@@ -69,7 +67,7 @@ const cancellable = computed<boolean>(() => activity.cancellable);
       />
 
       <PendingTask
-        class="flex-1 min-w-0 py-1"
+        class="flex-1 min-w-0 py-1.5"
         :activity="activity"
         :now="now"
         :percentage="percentage"
@@ -80,9 +78,13 @@ const cancellable = computed<boolean>(() => activity.cancellable);
       />
     </div>
 
+    <!--
+      16px of indent per level, not 24. The drawer is 400px and a history refresh nests three deep,
+      so the wider step spent a fifth of the width on guide lines and truncated the labels instead.
+    -->
     <div
       v-if="isParent && expanded"
-      class="flex flex-col ml-3 pl-3 border-l border-default"
+      class="flex flex-col ml-2 pl-2 border-l border-default"
     >
       <PendingTaskNode
         v-for="child in descendants"

--- a/frontend/app/src/modules/core/notifications/PendingTasks.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTasks.spec.ts
@@ -1,46 +1,66 @@
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PendingTasks from '@/modules/core/notifications/PendingTasks.vue';
-import { type Activity, ActivityKind, ActivitySourceType, ActivityStatus, makeActivityId } from '@/modules/task-center/core/types';
+import { assembleActivityModel } from '@/modules/task-center/core/model';
+import {
+  type Activity,
+  type ActivityId,
+  ActivityKind,
+  type ActivityModel,
+  ActivitySourceType,
+  ActivityStatus,
+  makeActivityId,
+} from '@/modules/task-center/core/types';
 
-const active = ref<Activity[]>([]);
 const activities = ref<Activity[]>([]);
-const isActive = ref<boolean>(false);
+const confirmCancel = vi.fn();
 
+// The real model and the real job derivation run; only the orchestrator underneath is faked, so
+// what the panel shows is what the tree actually produces.
 vi.mock('@/modules/task-center/use-task-center', () => ({
-  useTaskCenter: (): { active: Ref<Activity[]>; isActive: Ref<boolean> } => ({ active, isActive }),
+  useTaskCenter: (): { model: ComputedRef<ActivityModel> } => ({
+    model: computed<ActivityModel>(() => assembleActivityModel(get(activities), (key: string): string => key)),
+  }),
 }));
 
-vi.mock('@/modules/task-center/use-task-orchestrator', () => ({
-  useTaskOrchestrator: (): { activities: Ref<Activity[]> } => ({ activities }),
+vi.mock('@/modules/task-center/use-cancel-confirmation', () => ({
+  useCancelConfirmation: (): { confirmCancel: (activity: Activity) => void } => ({ confirmCancel }),
 }));
 
-vi.mock('@/modules/task-center/use-task-controller', () => ({
-  useTaskController: (): { cancel: () => Promise<void> } => ({ cancel: async (): Promise<void> => {} }),
-}));
-
-vi.mock('@/modules/core/common/use-confirm-store', () => ({
-  useConfirmStore: (): { dismiss: () => void; show: () => void } => ({ dismiss: (): void => {}, show: (): void => {} }),
-}));
-
-function activity(id: string, status: ActivityStatus): Activity {
+function activity(name: string, status: ActivityStatus, parent?: ActivityId): Activity {
   return {
     cancellable: true,
-    id: makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, id),
-    kind: ActivityKind.BLOCKCHAIN_BALANCES,
+    id: makeActivityId(ActivityKind.TX_SYNC, name),
+    kind: ActivityKind.TX_SYNC,
+    parent,
     percentage: -1,
     rerunnable: false,
     source: { type: ActivitySourceType.NATIVE },
     status,
-    title: 'Blockchain balances',
+    subtitle: name,
+    title: 'Transaction sync',
   };
 }
 
+function umbrella(status: ActivityStatus): Activity {
+  return {
+    cancellable: true,
+    id: makeActivityId(ActivityKind.HISTORY_SYNC),
+    kind: ActivityKind.HISTORY_SYNC,
+    percentage: -1,
+    rerunnable: false,
+    source: { type: ActivitySourceType.NATIVE },
+    status,
+    title: 'History refresh',
+  };
+}
+
+const umbrellaId = makeActivityId(ActivityKind.HISTORY_SYNC);
+
 describe('pendingTasks', () => {
   beforeEach(() => {
-    set(active, []);
     set(activities, []);
-    set(isActive, false);
+    confirmCancel.mockClear();
   });
 
   function createWrapper(): VueWrapper {
@@ -48,28 +68,67 @@ describe('pendingTasks', () => {
   }
 
   it('should list the running activities when work is in flight', () => {
-    set(active, [activity('a', ActivityStatus.RUNNING)]);
-    set(isActive, true);
+    set(activities, [activity('ethereum', ActivityStatus.RUNNING)]);
 
     expect(createWrapper().text()).toContain('collapsed_pending_tasks.title::1');
   });
 
   /**
    * The regression: `isActive` is WORKING while anything is RUNNING *or PENDING*, but this panel
-   * lists RUNNING only. Cancelling the last running activity while queued siblings remained left
+   * lists live work only. Cancelling the last running activity while queued siblings remained left
    * the card rendered and spinning above the heading "0 pending tasks".
-   *
-   * Producers declare their whole tree up front, so queued siblings are the normal case, not an
-   * edge one — every account of every chain exists as a PENDING activity from the moment a refresh
-   * starts.
    */
   it('should not render the card when everything left is still queued', () => {
-    set(active, []);
     set(activities, [activity('queued', ActivityStatus.PENDING)]);
-    set(isActive, true);
 
     const text = createWrapper().text();
     expect(text).not.toContain('collapsed_pending_tasks.title');
     expect(text).toContain('no_task_running.description');
+  });
+
+  /**
+   * The point of the whole change: one user action is one row with its work nested beneath it, not
+   * four sibling rows that repeat the same title.
+   */
+  it('should show one job for a whole subtree, with its children under it', () => {
+    set(activities, [
+      umbrella(ActivityStatus.RUNNING),
+      activity('ethereum', ActivityStatus.RUNNING, umbrellaId),
+      activity('gnosis', ActivityStatus.PENDING, umbrellaId),
+    ]);
+
+    const text = createWrapper().text();
+
+    expect(text).toContain('collapsed_pending_tasks.title::1');
+    expect(text).toContain('History refresh');
+    expect(text).toContain('ethereum');
+    expect(text).toContain('gnosis');
+  });
+
+  it('should count steps in leaves, so intermediate rows do not inflate the total', () => {
+    set(activities, [
+      umbrella(ActivityStatus.RUNNING),
+      activity('ethereum', ActivityStatus.COMPLETE, umbrellaId),
+      activity('gnosis', ActivityStatus.RUNNING, umbrellaId),
+    ]);
+
+    expect(createWrapper().text()).toContain('collapsed_pending_tasks.steps::1, 2');
+  });
+
+  it('should hide the rows but keep the header when collapsed', () => {
+    set(activities, [activity('ethereum', ActivityStatus.RUNNING)]);
+    const wrapper = mount(PendingTasks, { props: { modelValue: false } });
+
+    expect(wrapper.text()).toContain('collapsed_pending_tasks.title::1');
+    expect(wrapper.text()).not.toContain('ethereum');
+  });
+
+  it('should ask for confirmation before cancelling a leaf', async () => {
+    set(activities, [activity('ethereum', ActivityStatus.RUNNING)]);
+    const wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=cancel-activity]').trigger('click');
+
+    expect(confirmCancel).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/app/src/modules/core/notifications/PendingTasks.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTasks.spec.ts
@@ -90,19 +90,24 @@ describe('pendingTasks', () => {
    * The point of the whole change: one user action is one row with its work nested beneath it, not
    * four sibling rows that repeat the same title.
    */
-  it('should show one job for a whole subtree, with its children under it', () => {
+  it('should show one job for a whole subtree, with its children under it', async () => {
     set(activities, [
       umbrella(ActivityStatus.RUNNING),
       activity('ethereum', ActivityStatus.RUNNING, umbrellaId),
       activity('gnosis', ActivityStatus.PENDING, umbrellaId),
     ]);
 
-    const text = createWrapper().text();
+    const wrapper = createWrapper();
 
-    expect(text).toContain('collapsed_pending_tasks.title::1');
-    expect(text).toContain('History refresh');
-    expect(text).toContain('ethereum');
-    expect(text).toContain('gnosis');
+    // One row, not three siblings repeating the same title — the children are behind its disclosure.
+    expect(wrapper.text()).toContain('collapsed_pending_tasks.title::1');
+    expect(wrapper.text()).toContain('History refresh');
+    expect(wrapper.text()).not.toContain('ethereum');
+
+    await wrapper.find('[aria-expanded]').trigger('click');
+
+    expect(wrapper.text()).toContain('ethereum');
+    expect(wrapper.text()).toContain('gnosis');
   });
 
   it('should count steps in leaves, so intermediate rows do not inflate the total', () => {

--- a/frontend/app/src/modules/core/notifications/PendingTasks.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTasks.vue
@@ -1,81 +1,46 @@
 <script setup lang="ts">
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import CollapsedPendingTasks from '@/modules/core/notifications/CollapsedPendingTasks.vue';
 import NoTasksRunning from '@/modules/core/notifications/NoTasksRunning.vue';
-import PendingTask from '@/modules/core/notifications/PendingTask.vue';
-import { isTerminalStatus } from '@/modules/task-center/core/status';
-import { type Activity, resolveText } from '@/modules/task-center/core/types';
-import { useTaskCenter } from '@/modules/task-center/use-task-center';
-import { useTaskController } from '@/modules/task-center/use-task-controller';
-import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
+import PendingTaskNode from '@/modules/core/notifications/PendingTaskNode.vue';
+import { useCancelConfirmation } from '@/modules/task-center/use-cancel-confirmation';
+import { usePendingJobs } from '@/modules/task-center/use-pending-jobs';
 
 const expanded = defineModel<boolean>({ required: true });
 
-const { t } = useI18n({ useScope: 'global' });
-const { active } = useTaskCenter();
-const { activities } = useTaskOrchestrator();
-const { cancel } = useTaskController();
-const { dismiss, show } = useConfirmStore();
+const { children, jobs, percentage, steps } = usePendingJobs();
+const { confirmCancel } = useCancelConfirmation();
 
-// Only work that is actually in flight. Producers now declare their whole tree up front, so every
-// account of every chain exists as a queued activity from the moment a refresh starts — listing
-// those would bury the running work under dozens of rows that have not begun. This is what the
-// panel showed before the orchestrator too, when it read in-flight backend tasks.
-const running = computed<Activity[]>(() => get(active));
+// One timer for the whole panel; every row reads its elapsed time off it.
+const now = useTimestamp({ interval: 1000 });
 
-// Visibility follows the list, not the orchestrator's phase. `isActive` is WORKING while anything
-// is RUNNING *or PENDING*, but this panel lists RUNNING only — so cancelling the last running
-// activity while queued siblings remained left the card up, spinning, headed "0 pending tasks".
-const hasRunning = computed<boolean>(() => get(running).length > 0);
-
-const debounceDismiss = useDebounceFn((live: boolean) => !live && dismiss(), 1000);
-
-function showConfirmation(activity: Activity): void {
-  // Close the dialog by itself if the work settles while it is open.
-  const live = computed<boolean>(() => get(activities)
-    .some(item => item.id === activity.id && !isTerminalStatus(item.status)));
-  const unwatch = watch(live, debounceDismiss);
-
-  show(
-    {
-      message: t('collapsed_pending_tasks.cancel_task_info', {
-        title: resolveText(t, activity.subtitle) ?? activity.title,
-      }),
-      title: t('collapsed_pending_tasks.cancel_task'),
-      type: 'warning',
-    },
-    async () => {
-      unwatch();
-      await cancel(activity);
-    },
-    () => {
-      unwatch();
-    },
-  );
-}
+const hasJobs = computed<boolean>(() => get(jobs).length > 0);
 </script>
 
 <template>
   <div class="px-3.5 mb-2">
     <RuiCard
-      v-if="hasRunning"
+      v-if="hasJobs"
       dense
-      class="flex flex-col gap-2 max-h-[50vh]"
+      class="flex flex-col gap-2"
     >
       <CollapsedPendingTasks
         v-model="expanded"
-        :count="running.length"
+        :count="jobs.length"
+        :steps="steps"
+        :percentage="percentage"
       />
       <div
         v-if="expanded"
-        class="flex flex-col pt-3 -mb-3"
+        class="flex flex-col pt-2 max-h-[50vh] overflow-y-auto"
       >
-        <PendingTask
-          v-for="activity in running"
-          :key="activity.id"
-          :activity="activity"
-          class="border-t border-default py-2"
-          @cancel="showConfirmation($event)"
+        <PendingTaskNode
+          v-for="job in jobs"
+          :key="job.activity.id"
+          :activity="job.activity"
+          :children="children"
+          :now="now"
+          class="border-t border-default py-1"
+          @cancel="confirmCancel($event)"
         />
       </div>
     </RuiCard>

--- a/frontend/app/src/modules/core/notifications/PendingTasks.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTasks.vue
@@ -29,9 +29,14 @@ const hasJobs = computed<boolean>(() => get(jobs).length > 0);
         :steps="steps"
         :percentage="percentage"
       />
+      <!--
+        The rule separates one job from the next, so it goes between them rather than above each:
+        a leading border drew a second line directly under the header's own divider. No padding
+        here — every row owns its vertical space, so a job row and a nested row measure the same.
+      -->
       <div
         v-if="expanded"
-        class="flex flex-col pt-2 max-h-[50vh] overflow-y-auto"
+        class="flex flex-col divide-y divide-rui-grey-200 dark:divide-rui-grey-800 max-h-[50vh] overflow-y-auto"
       >
         <PendingTaskNode
           v-for="job in jobs"
@@ -39,7 +44,6 @@ const hasJobs = computed<boolean>(() => get(jobs).length > 0);
           :activity="job.activity"
           :children="children"
           :now="now"
-          class="border-t border-default py-1"
           @cancel="confirmCancel($event)"
         />
       </div>

--- a/frontend/app/src/modules/task-center/activity-outcome.spec.ts
+++ b/frontend/app/src/modules/task-center/activity-outcome.spec.ts
@@ -3,8 +3,27 @@ import { activityOutcome } from './activity-outcome';
 import { ActivityStatus } from './core/types';
 
 describe('activityOutcome', () => {
-  it('should leave a running activity to its progress indicator', () => {
-    expect(activityOutcome(ActivityStatus.RUNNING)).toBeUndefined();
+  /**
+   * A running row without a percentage used to fall back to a spinner. The elapsed counter beside
+   * it already ticks, so the spin carried no information the row was not already showing.
+   */
+  it('should give a running activity a label of its own', () => {
+    expect(activityOutcome(ActivityStatus.RUNNING).color).toBe('primary');
+  });
+
+  /**
+   * Filled means it needs attention. A refresh settles dozens of children successfully, so filling
+   * those made a wall of green the loudest thing in the panel and buried the chain still at 0%.
+   */
+  it('should fill only the outcomes that need attention', () => {
+    const filled = Object.values(ActivityStatus).filter(status => activityOutcome(status).variant === 'filled');
+
+    expect(filled).toStrictEqual([ActivityStatus.FAILED, ActivityStatus.SKIPPED]);
+  });
+
+  it('should give every status an icon', () => {
+    for (const status of Object.values(ActivityStatus))
+      expect(activityOutcome(status).icon).toBeDefined();
   });
 
   /**
@@ -13,20 +32,18 @@ describe('activityOutcome', () => {
    * A subtree at 100% with two failed chains is otherwise indistinguishable from a clean one.
    */
   it('should separate a failure from a skip', () => {
-    expect(activityOutcome(ActivityStatus.FAILED)?.color).toBe('error');
-    expect(activityOutcome(ActivityStatus.SKIPPED)?.color).toBe('warning');
+    expect(activityOutcome(ActivityStatus.FAILED).color).toBe('error');
+    expect(activityOutcome(ActivityStatus.SKIPPED).color).toBe('warning');
   });
 
   it('should mark a success and leave the neutral outcomes grey', () => {
-    expect(activityOutcome(ActivityStatus.COMPLETE)?.color).toBe('success');
-    expect(activityOutcome(ActivityStatus.CANCELLED)?.color).toBe('grey');
-    expect(activityOutcome(ActivityStatus.PENDING)?.color).toBe('grey');
+    expect(activityOutcome(ActivityStatus.COMPLETE).color).toBe('success');
+    expect(activityOutcome(ActivityStatus.CANCELLED).color).toBe('grey');
+    expect(activityOutcome(ActivityStatus.PENDING).color).toBe('grey');
   });
 
-  it('should give every non-running status a label', () => {
-    const statuses = Object.values(ActivityStatus).filter(status => status !== ActivityStatus.RUNNING);
-
-    for (const status of statuses)
-      expect(activityOutcome(status)?.key).toBeDefined();
+  it('should give every status a label', () => {
+    for (const status of Object.values(ActivityStatus))
+      expect(activityOutcome(status).key).toBeDefined();
   });
 });

--- a/frontend/app/src/modules/task-center/activity-outcome.spec.ts
+++ b/frontend/app/src/modules/task-center/activity-outcome.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { activityOutcome } from './activity-outcome';
+import { ActivityStatus } from './core/types';
+
+describe('activityOutcome', () => {
+  it('should leave a running activity to its progress indicator', () => {
+    expect(activityOutcome(ActivityStatus.RUNNING)).toBeUndefined();
+  });
+
+  /**
+   * Failed and skipped both count as *done* in the progress rollup (`projection.ts`), which is
+   * correct — no further progress is coming — and is exactly why the row has to say what happened.
+   * A subtree at 100% with two failed chains is otherwise indistinguishable from a clean one.
+   */
+  it('should separate a failure from a skip', () => {
+    expect(activityOutcome(ActivityStatus.FAILED)?.color).toBe('error');
+    expect(activityOutcome(ActivityStatus.SKIPPED)?.color).toBe('warning');
+  });
+
+  it('should mark a success and leave the neutral outcomes grey', () => {
+    expect(activityOutcome(ActivityStatus.COMPLETE)?.color).toBe('success');
+    expect(activityOutcome(ActivityStatus.CANCELLED)?.color).toBe('grey');
+    expect(activityOutcome(ActivityStatus.PENDING)?.color).toBe('grey');
+  });
+
+  it('should give every non-running status a label', () => {
+    const statuses = Object.values(ActivityStatus).filter(status => status !== ActivityStatus.RUNNING);
+
+    for (const status of statuses)
+      expect(activityOutcome(status)?.key).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/task-center/activity-outcome.ts
+++ b/frontend/app/src/modules/task-center/activity-outcome.ts
@@ -1,19 +1,38 @@
+import type { RuiIcons } from '@rotki/ui-library';
 import { type MessageKey, msg } from '@/message-key';
 import { type ActivityStatus, ActivityStatus as Status } from './core/types';
 
-/** RUI chip colours, narrowed to the four an outcome can take. */
-export type OutcomeColor = 'error' | 'warning' | 'success' | 'grey';
+/** RUI chip colours, narrowed to the five a status can take. */
+export type OutcomeColor = 'error' | 'warning' | 'success' | 'grey' | 'primary';
 
 export interface ActivityOutcome {
   readonly color: OutcomeColor;
   readonly key: MessageKey;
+  /**
+   * ⚠️ Named here rather than in the template, so the plugin's source scan cannot see it — every
+   * icon below has to be listed in `vite.config.ts` `ruiIconsPlugin.include` or it silently
+   * renders as nothing.
+   */
+  readonly icon: RuiIcons;
+  /**
+   * **Filled means it needs your attention; outlined means it is expected.**
+   *
+   * Only FAILED and SKIPPED are filled. A history refresh settles dozens of children successfully,
+   * and filling those made a wall of green "Done" the loudest thing in the panel — drowning the
+   * one chain at 60% and the one at 0%, which is the only part a reader is actually there for.
+   */
+  readonly variant: 'filled' | 'outlined';
 }
 
 /**
- * How a non-running status reads on a row.
+ * How a status reads on a row.
  *
- * Only RUNNING has no entry: a running row shows progress, which says more than a chip could.
- * Everything else is a state the reader has to be told about — including the two the progress
+ * Every status has an entry, RUNNING included. A running row only shows the percentage ring when
+ * there is a percentage to show, and most rows have none — the orchestrator reports `-1` unless a
+ * producer counted steps. The slot used to fall back to a spinner, which said nothing the ticking
+ * elapsed time did not already say and added one more spinning thing to a screen that has plenty.
+ *
+ * The settled statuses are states the reader has to be told about — including the two the progress
  * rollup deliberately counts as done (`projection.ts` `percentageOf`), which is exactly why they
  * need saying. A subtree at 100% with two failed chains is otherwise indistinguishable from a
  * clean one.
@@ -21,14 +40,45 @@ export interface ActivityOutcome {
  * Kept out of the component so the mapping can be asserted without mounting anything, and out of
  * `core/` because it names i18n keys — `msg.$t` is what makes the key-usage lint count them.
  */
-const OUTCOME: Partial<Record<ActivityStatus, ActivityOutcome>> = {
-  [Status.CANCELLED]: { color: 'grey', key: msg.$t('pending_task.status.cancelled') },
-  [Status.COMPLETE]: { color: 'success', key: msg.$t('pending_task.status.done') },
-  [Status.FAILED]: { color: 'error', key: msg.$t('pending_task.status.failed') },
-  [Status.PENDING]: { color: 'grey', key: msg.$t('pending_task.status.queued') },
-  [Status.SKIPPED]: { color: 'warning', key: msg.$t('pending_task.status.skipped') },
+const OUTCOME: Record<ActivityStatus, ActivityOutcome> = {
+  [Status.CANCELLED]: {
+    color: 'grey',
+    icon: 'lu-ban',
+    key: msg.$t('pending_task.status.cancelled'),
+    variant: 'outlined',
+  },
+  [Status.COMPLETE]: {
+    color: 'success',
+    icon: 'lu-check',
+    key: msg.$t('pending_task.status.done'),
+    variant: 'outlined',
+  },
+  [Status.FAILED]: {
+    color: 'error',
+    icon: 'lu-circle-x',
+    key: msg.$t('pending_task.status.failed'),
+    variant: 'filled',
+  },
+  [Status.PENDING]: {
+    color: 'grey',
+    icon: 'lu-clock',
+    key: msg.$t('pending_task.status.queued'),
+    variant: 'outlined',
+  },
+  [Status.RUNNING]: {
+    color: 'primary',
+    icon: 'lu-activity',
+    key: msg.$t('pending_task.status.running'),
+    variant: 'outlined',
+  },
+  [Status.SKIPPED]: {
+    color: 'warning',
+    icon: 'lu-skip-forward',
+    key: msg.$t('pending_task.status.skipped'),
+    variant: 'filled',
+  },
 };
 
-export function activityOutcome(status: ActivityStatus): ActivityOutcome | undefined {
+export function activityOutcome(status: ActivityStatus): ActivityOutcome {
   return OUTCOME[status];
 }

--- a/frontend/app/src/modules/task-center/activity-outcome.ts
+++ b/frontend/app/src/modules/task-center/activity-outcome.ts
@@ -1,0 +1,34 @@
+import { type MessageKey, msg } from '@/message-key';
+import { type ActivityStatus, ActivityStatus as Status } from './core/types';
+
+/** RUI chip colours, narrowed to the four an outcome can take. */
+export type OutcomeColor = 'error' | 'warning' | 'success' | 'grey';
+
+export interface ActivityOutcome {
+  readonly color: OutcomeColor;
+  readonly key: MessageKey;
+}
+
+/**
+ * How a non-running status reads on a row.
+ *
+ * Only RUNNING has no entry: a running row shows progress, which says more than a chip could.
+ * Everything else is a state the reader has to be told about — including the two the progress
+ * rollup deliberately counts as done (`projection.ts` `percentageOf`), which is exactly why they
+ * need saying. A subtree at 100% with two failed chains is otherwise indistinguishable from a
+ * clean one.
+ *
+ * Kept out of the component so the mapping can be asserted without mounting anything, and out of
+ * `core/` because it names i18n keys — `msg.$t` is what makes the key-usage lint count them.
+ */
+const OUTCOME: Partial<Record<ActivityStatus, ActivityOutcome>> = {
+  [Status.CANCELLED]: { color: 'grey', key: msg.$t('pending_task.status.cancelled') },
+  [Status.COMPLETE]: { color: 'success', key: msg.$t('pending_task.status.done') },
+  [Status.FAILED]: { color: 'error', key: msg.$t('pending_task.status.failed') },
+  [Status.PENDING]: { color: 'grey', key: msg.$t('pending_task.status.queued') },
+  [Status.SKIPPED]: { color: 'warning', key: msg.$t('pending_task.status.skipped') },
+};
+
+export function activityOutcome(status: ActivityStatus): ActivityOutcome | undefined {
+  return OUTCOME[status];
+}

--- a/frontend/app/src/modules/task-center/core/elapsed.spec.ts
+++ b/frontend/app/src/modules/task-center/core/elapsed.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { formatElapsed } from './elapsed';
+
+describe('formatElapsed', () => {
+  it('should show whole seconds under a minute', () => {
+    expect(formatElapsed(0)).toBe('0s');
+    expect(formatElapsed(14_400)).toBe('14s');
+    expect(formatElapsed(59_999)).toBe('59s');
+  });
+
+  it('should pad the seconds once minutes appear, so the column does not jump', () => {
+    expect(formatElapsed(60_000)).toBe('1m 00s');
+    expect(formatElapsed(192_000)).toBe('3m 12s');
+  });
+
+  it('should switch to hours and minutes past an hour', () => {
+    expect(formatElapsed(3_600_000)).toBe('1h 00m');
+    expect(formatElapsed(3_840_000)).toBe('1h 04m');
+  });
+
+  /** Clock skew, or a `startedAt` from a snapshot taken a tick ahead — neither should render "-3s". */
+  it('should floor a negative elapsed at zero', () => {
+    expect(formatElapsed(-3000)).toBe('0s');
+  });
+});

--- a/frontend/app/src/modules/task-center/core/elapsed.ts
+++ b/frontend/app/src/modules/task-center/core/elapsed.ts
@@ -1,0 +1,30 @@
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
+/**
+ * How long a running activity has been going, as a compact badge (`14s`, `3m 12s`, `1h 04m`).
+ *
+ * The panel used to print an absolute `LLL` timestamp per row ("August 7, 2026 3:42 PM") on work
+ * that had started four seconds earlier. Nobody reads a live task list to learn the date; the
+ * question a reader has is which leaf is stuck, and only elapsed time answers it.
+ *
+ * Unit-free digits on purpose — no i18n key, so it cannot drift between locales, and it stays
+ * legible in the narrow column the row leaves for it.
+ */
+export function formatElapsed(milliseconds: number): string {
+  const safe = Math.max(0, milliseconds);
+
+  if (safe < MINUTE)
+    return `${Math.floor(safe / SECOND)}s`;
+
+  if (safe < HOUR) {
+    const minutes = Math.floor(safe / MINUTE);
+    const seconds = Math.floor((safe % MINUTE) / SECOND);
+    return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+  }
+
+  const hours = Math.floor(safe / HOUR);
+  const minutes = Math.floor((safe % HOUR) / MINUTE);
+  return `${hours}h ${minutes.toString().padStart(2, '0')}m`;
+}

--- a/frontend/app/src/modules/task-center/core/model.spec.ts
+++ b/frontend/app/src/modules/task-center/core/model.spec.ts
@@ -98,4 +98,51 @@ describe('assembleActivityModel', () => {
     const model = assembleActivityModel([a, b], t);
     expect(model.overall.percentage).toBe(75);
   });
+
+  it('should expose the tree, keeping children out of the roots', () => {
+    const umbrella = activity({ id: makeActivityId(Kind.HISTORY_SYNC), kind: Kind.HISTORY_SYNC, status: Status.RUNNING });
+    const chain = activity({
+      id: makeActivityId(Kind.TX_SYNC, 'ethereum'),
+      kind: Kind.TX_SYNC,
+      parent: umbrella.id,
+      status: Status.RUNNING,
+    });
+
+    const model = assembleActivityModel([chain, umbrella], t);
+
+    expect(model.roots.map(root => root.id)).toEqual([umbrella.id]);
+    expect(model.children.get(umbrella.id)?.map(child => child.id)).toEqual([chain.id]);
+  });
+
+  /**
+   * The regression: rolling up per-kind groups counted a subtree twice, because an umbrella's
+   * percentage is already the mean of its children. Here the umbrella and its three finished
+   * children are one job at 100% and the unrelated activity is at 0, so the honest answer is 50.
+   * Group-based rollup answered 67 — the same finished work, weighted twice.
+   */
+  it('should roll up overall from roots only, not once per kind', () => {
+    const umbrella = activity({
+      id: makeActivityId(Kind.HISTORY_SYNC),
+      kind: Kind.HISTORY_SYNC,
+      percentage: 100,
+      status: Status.RUNNING,
+    });
+    const children = [1, 2, 3].map(index => activity({
+      id: makeActivityId(Kind.TX_SYNC, index),
+      kind: Kind.TX_SYNC,
+      parent: umbrella.id,
+      percentage: 100,
+      status: Status.COMPLETE,
+    }));
+    const unrelated = activity({
+      id: makeActivityId(Kind.PRICES, 'latest'),
+      kind: Kind.PRICES,
+      percentage: 0,
+      status: Status.RUNNING,
+    });
+
+    const model = assembleActivityModel([umbrella, ...children, unrelated], t);
+
+    expect(model.overall.percentage).toBe(50);
+  });
 });

--- a/frontend/app/src/modules/task-center/core/model.ts
+++ b/frontend/app/src/modules/task-center/core/model.ts
@@ -1,5 +1,6 @@
 import { groupTitle, kindRank } from './kinds';
 import { INDETERMINATE, rollupPercentage, rollupStatus, statusRank } from './status';
+import { buildTree } from './tree';
 import {
   type Activity,
   type ActivityGroup,
@@ -62,8 +63,8 @@ function dedupeById(activities: Activity[]): Activity[] {
 
 /**
  * Pure assembly of the flat activity list into the render model: dedup by id, groups (ordered
- * by kind priority), the active/pending splits, the overall rollup + phase, and the single
- * `current` activity the header bar labels. No Vue, no stores — unit-tested with literal
+ * by kind priority), the tree, the active/pending splits, the overall rollup + phase, and the
+ * single `current` activity the header bar labels. No Vue, no stores — unit-tested with literal
  * inputs.
  */
 export function assembleActivityModel(activities: Activity[], t: TranslateFn): ActivityModel {
@@ -83,11 +84,18 @@ export function assembleActivityModel(activities: Activity[], t: TranslateFn): A
   const active = ordered.filter(a => a.status === ActivityStatus.RUNNING);
   const pending = ordered.filter(a => a.status === ActivityStatus.PENDING);
 
-  const overallPercentage = rollupPercentage(groups.map(g => g.percentage));
+  const { children, roots } = buildTree(deduped, compareActivities);
+
+  // Roots only. Rolling up the per-kind groups counted every subtree twice — an umbrella's
+  // percentage is already the mean of its children (`projection.ts` `percentageOf`), so a history
+  // refresh contributed once as HISTORY_SYNC and again as TX_SYNC, each weighted like a single
+  // unrelated activity.
+  const overallPercentage = rollupPercentage(roots.map(root => root.percentage));
   const current = active[0] ?? pending[0];
 
   return {
     active,
+    children,
     current,
     groups,
     overall: {
@@ -95,5 +103,6 @@ export function assembleActivityModel(activities: Activity[], t: TranslateFn): A
       phase: phaseOf(activities),
     },
     pending,
+    roots,
   };
 }

--- a/frontend/app/src/modules/task-center/core/tree.spec.ts
+++ b/frontend/app/src/modules/task-center/core/tree.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildTree, someInSubtree, subtreeSteps } from './tree';
+import { buildTree, someInSubtree, subtreeProgress, subtreeSteps } from './tree';
 import { type Activity, type ActivityId, ActivityKind, ActivitySourceType, ActivityStatus, makeActivityId } from './types';
 
 function activity(id: string, status: ActivityStatus, parent?: string, startedAt?: number): Activity {
@@ -138,5 +138,66 @@ describe('someInSubtree', () => {
     ], byId);
 
     expect(someInSubtree(children, roots[0], isRunning)).toBe(false);
+  });
+});
+
+describe('subtreeProgress', () => {
+  function withPercentage(base: Activity, percentage: number): Activity {
+    return { ...base, percentage };
+  }
+
+  /**
+   * The bug this exists for: a job that is a single running leaf has no settled leaves, so a tally
+   * of whole steps can only ever say `0 of 1`. The leaf's own percentage is the one number it has,
+   * and the header used to throw it away and render a ring pinned at 0 above a row showing 45%.
+   */
+  it('should give a leaf fractional credit for its own progress', () => {
+    const root = withPercentage(activity('prices', ActivityStatus.RUNNING), 45);
+    const { children } = buildTree([root], byId);
+
+    expect(subtreeProgress(children, root)).toBe(45);
+    expect(subtreeSteps(children, root)).toEqual({ current: 0, total: 1 });
+  });
+
+  it('should count a settled leaf as whole regardless of its percentage', () => {
+    const root = withPercentage(activity('prices', ActivityStatus.COMPLETE), 20);
+    const { children } = buildTree([root], byId);
+
+    expect(subtreeProgress(children, root)).toBe(100);
+  });
+
+  /** Unknown work is unfinished work: it drags the mean down rather than leaving the denominator. */
+  it('should count an unquantifiable leaf as zero without dropping it', () => {
+    const activities = [
+      activity('umbrella', ActivityStatus.RUNNING),
+      withPercentage(activity('eth', ActivityStatus.COMPLETE, 'umbrella'), 100),
+      activity('gno', ActivityStatus.RUNNING, 'umbrella'),
+    ];
+    const { children, roots } = buildTree(activities, byId);
+
+    expect(subtreeProgress(children, roots[0])).toBe(50);
+  });
+
+  it('should say so when nothing in the subtree can be quantified', () => {
+    const activities = [
+      activity('umbrella', ActivityStatus.RUNNING),
+      activity('eth', ActivityStatus.RUNNING, 'umbrella'),
+    ];
+    const { children, roots } = buildTree(activities, byId);
+
+    expect(subtreeProgress(children, roots[0])).toBe(-1);
+  });
+
+  it('should average the leaves of a deep tree, not its rows', () => {
+    const activities = [
+      activity('umbrella', ActivityStatus.RUNNING),
+      activity('eth', ActivityStatus.RUNNING, 'umbrella'),
+      activity('eth-a', ActivityStatus.COMPLETE, 'eth'),
+      withPercentage(activity('eth-b', ActivityStatus.RUNNING, 'eth'), 50),
+    ];
+    const { children, roots } = buildTree(activities, byId);
+
+    // Two leaves: one whole, one half. The two intermediate rows count for nothing.
+    expect(subtreeProgress(children, roots[0])).toBe(75);
   });
 });

--- a/frontend/app/src/modules/task-center/core/tree.spec.ts
+++ b/frontend/app/src/modules/task-center/core/tree.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { buildTree, someInSubtree, subtreeSteps } from './tree';
+import { type Activity, type ActivityId, ActivityKind, ActivitySourceType, ActivityStatus, makeActivityId } from './types';
+
+function activity(id: string, status: ActivityStatus, parent?: string, startedAt?: number): Activity {
+  return {
+    cancellable: false,
+    id: makeActivityId(ActivityKind.TX_SYNC, id),
+    kind: ActivityKind.TX_SYNC,
+    parent: parent === undefined ? undefined : makeActivityId(ActivityKind.TX_SYNC, parent),
+    percentage: -1,
+    rerunnable: false,
+    source: { type: ActivitySourceType.NATIVE },
+    startedAt,
+    status,
+    title: id,
+  };
+}
+
+function id(value: string): ActivityId {
+  return makeActivityId(ActivityKind.TX_SYNC, value);
+}
+
+/** Insertion order, so a tree is never accidentally correct because the input was already sorted. */
+const byId = (a: Activity, b: Activity): number => a.id.localeCompare(b.id);
+
+describe('buildTree', () => {
+  it('should nest children under their declared parent', () => {
+    const { children, roots } = buildTree([
+      activity('umbrella', ActivityStatus.RUNNING),
+      activity('eth', ActivityStatus.RUNNING, 'umbrella'),
+      activity('eth-a', ActivityStatus.RUNNING, 'eth'),
+    ], byId);
+
+    expect(roots.map(root => root.id)).toEqual([id('umbrella')]);
+    expect(children.get(id('umbrella'))?.map(child => child.id)).toEqual([id('eth')]);
+    expect(children.get(id('eth'))?.map(child => child.id)).toEqual([id('eth-a')]);
+  });
+
+  /**
+   * `clearTerminal` prunes settled records, so a parent can legitimately vanish while its children
+   * still run. Dropping those children would hide live work entirely — the panel would show
+   * nothing while the app kept querying.
+   */
+  it('should treat an activity whose parent is absent as a root', () => {
+    const { roots } = buildTree([activity('orphan', ActivityStatus.RUNNING, 'gone')], byId);
+
+    expect(roots.map(root => root.id)).toEqual([id('orphan')]);
+  });
+
+  it('should order siblings by start time, with unstarted ones last', () => {
+    const { children } = buildTree([
+      activity('parent', ActivityStatus.RUNNING),
+      activity('queued', ActivityStatus.PENDING, 'parent'),
+      activity('second', ActivityStatus.RUNNING, 'parent', 200),
+      activity('first', ActivityStatus.RUNNING, 'parent', 100),
+    ], byId);
+
+    expect(children.get(id('parent'))?.map(child => child.id)).toEqual([
+      id('first'),
+      id('second'),
+      id('queued'),
+    ]);
+  });
+
+  it('should leave a parent with no children out of the map', () => {
+    const { children, roots } = buildTree([activity('lonely', ActivityStatus.RUNNING)], byId);
+
+    expect(roots).toHaveLength(1);
+    expect(children.size).toBe(0);
+  });
+});
+
+describe('subtreeSteps', () => {
+  /**
+   * Leaves only. Counting rows instead would let every intermediate node inflate the denominator:
+   * the tree below is 2 accounts of work, not 4 activities of it.
+   */
+  it('should count leaves, not rows', () => {
+    const activities = [
+      activity('umbrella', ActivityStatus.RUNNING),
+      activity('eth', ActivityStatus.RUNNING, 'umbrella'),
+      activity('eth-a', ActivityStatus.COMPLETE, 'eth'),
+      activity('eth-b', ActivityStatus.RUNNING, 'eth'),
+    ];
+    const { children, roots } = buildTree(activities, byId);
+
+    expect(subtreeSteps(children, roots[0])).toEqual({ current: 1, total: 2 });
+  });
+
+  it('should count a childless activity as one step', () => {
+    const { children, roots } = buildTree([activity('solo', ActivityStatus.RUNNING)], byId);
+
+    expect(subtreeSteps(children, roots[0])).toEqual({ current: 0, total: 1 });
+  });
+
+  /**
+   * The rollup counts both as done on purpose (`projection.ts`): no further progress is coming, so
+   * a bar that excluded them would stall. The chip on the row is what tells the user they were not
+   * successes.
+   */
+  it('should count failed and skipped leaves as done', () => {
+    const { children, roots } = buildTree([
+      activity('parent', ActivityStatus.RUNNING),
+      activity('failed', ActivityStatus.FAILED, 'parent'),
+      activity('skipped', ActivityStatus.SKIPPED, 'parent'),
+      activity('running', ActivityStatus.RUNNING, 'parent'),
+    ], byId);
+
+    expect(subtreeSteps(children, roots[0])).toEqual({ current: 2, total: 3 });
+  });
+
+  it('should not hang on a parent cycle', () => {
+    const a = activity('a', ActivityStatus.RUNNING, 'b');
+    const b = activity('b', ActivityStatus.RUNNING, 'a');
+    const { children } = buildTree([a, b], byId);
+
+    expect(subtreeSteps(children, a).total).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('someInSubtree', () => {
+  const isRunning = (item: Activity): boolean => item.status === ActivityStatus.RUNNING;
+
+  it('should find a running descendant under a queued root', () => {
+    const { children, roots } = buildTree([
+      activity('parent', ActivityStatus.PENDING),
+      activity('child', ActivityStatus.RUNNING, 'parent'),
+    ], byId);
+
+    expect(someInSubtree(children, roots[0], isRunning)).toBe(true);
+  });
+
+  it('should be false when the whole subtree is queued', () => {
+    const { children, roots } = buildTree([
+      activity('parent', ActivityStatus.PENDING),
+      activity('child', ActivityStatus.PENDING, 'parent'),
+    ], byId);
+
+    expect(someInSubtree(children, roots[0], isRunning)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/task-center/core/tree.ts
+++ b/frontend/app/src/modules/task-center/core/tree.ts
@@ -63,20 +63,6 @@ export function buildTree(activities: Activity[], compareRoots: (a: Activity, b:
   return { children, roots: [...roots].sort(compareRoots) };
 }
 
-/**
- * How much of a subtree is done, counted in **leaves**.
- *
- * Leaves are the only nodes that do work: an umbrella awaits its chains, a chain awaits its
- * accounts, and only the accounts talk to the backend. Counting them is what makes "4 of 11 steps"
- * mean something to a reader — counting rows instead would have every intermediate node inflate
- * the total, and a two-chain refresh would claim more work than it does.
- *
- * ⚠️ Deliberately not the same denominator as `Activity.percentage`, which the orchestrator
- * derives from **direct** children only (`projection.ts` `childProgress`). For a two-level tree
- * they agree; for three levels the percentage is "how many chains finished" while this is "how
- * many accounts finished". Whichever a surface shows, it must show both its number and its bar
- * from the same one.
- */
 /** True when `root` or anything beneath it satisfies `predicate`. Same guarded walk as {@link subtreeSteps}. */
 export function someInSubtree(
   children: ReadonlyMap<ActivityId, Activity[]>,
@@ -101,6 +87,20 @@ export function someInSubtree(
   return false;
 }
 
+/**
+ * How much of a subtree is done, counted in **leaves**.
+ *
+ * Leaves are the only nodes that do work: an umbrella awaits its chains, a chain awaits its
+ * accounts, and only the accounts talk to the backend. Counting them is what makes "4 of 11 steps"
+ * mean something to a reader — counting rows instead would have every intermediate node inflate
+ * the total, and a two-chain refresh would claim more work than it does.
+ *
+ * ⚠️ Deliberately not the same denominator as `Activity.percentage`, which the orchestrator
+ * derives from **direct** children only (`projection.ts` `childProgress`). For a two-level tree
+ * they agree; for three levels the percentage is "how many chains finished" while this is "how
+ * many accounts finished". Whichever a surface shows, it must show both its number and its bar
+ * from the same one.
+ */
 export function subtreeSteps(children: ReadonlyMap<ActivityId, Activity[]>, root: Activity): ActivitySteps {
   let current = 0;
   let total = 0;

--- a/frontend/app/src/modules/task-center/core/tree.ts
+++ b/frontend/app/src/modules/task-center/core/tree.ts
@@ -1,5 +1,5 @@
 import type { Activity, ActivityId, ActivitySteps } from './types';
-import { isTerminalStatus } from './status';
+import { INDETERMINATE, isTerminalStatus } from './status';
 
 /**
  * The activity tree, read off `Activity.parent`.
@@ -129,4 +129,55 @@ export function subtreeSteps(children: ReadonlyMap<ActivityId, Activity[]>, root
   }
 
   return { current, total };
+}
+
+/**
+ * How far along a subtree is, 0-100, or {@link INDETERMINATE} when nothing in it can be quantified.
+ *
+ * Same leaves as {@link subtreeSteps}, but a leaf counts fractionally: a running leaf that reports
+ * 45% contributes 0.45, not 0. Counting only settled leaves made the header discard the one number
+ * a single-task job actually has — a price refresh at 45% rendered its own row at 45% under a
+ * header ring pinned at 0%, because "0 of 1 steps" was all the tally could say.
+ *
+ * A leaf nobody counted contributes 0 while still counting toward the denominator, so unknown work
+ * reads as unfinished rather than quietly leaving the average. Only when *no* leaf anywhere is
+ * quantifiable does this give up and say so.
+ *
+ * ⚠️ This is the number a bar or ring shows; {@link subtreeSteps} is the number the text shows.
+ * They are the same denominator but not the same precision, so a subtree can legitimately read
+ * "0 of 1 steps" beside a 45% ring. Never pair this with a *different* denominator's text.
+ */
+export function subtreeProgress(children: ReadonlyMap<ActivityId, Activity[]>, root: Activity): number {
+  let done = 0;
+  let total = 0;
+  let quantifiable = 0;
+
+  const seen = new Set<ActivityId>();
+  const stack: Activity[] = [root];
+
+  while (stack.length > 0) {
+    const activity = stack.pop();
+    if (activity === undefined || seen.has(activity.id))
+      continue;
+
+    seen.add(activity.id);
+    const descendants = children.get(activity.id);
+
+    if (descendants !== undefined && descendants.length > 0) {
+      stack.push(...descendants);
+      continue;
+    }
+
+    total += 1;
+    if (isTerminalStatus(activity.status)) {
+      done += 1;
+      quantifiable += 1;
+    }
+    else if (activity.percentage >= 0) {
+      done += activity.percentage / 100;
+      quantifiable += 1;
+    }
+  }
+
+  return quantifiable === 0 || total === 0 ? INDETERMINATE : Math.round((done / total) * 100);
 }

--- a/frontend/app/src/modules/task-center/core/tree.ts
+++ b/frontend/app/src/modules/task-center/core/tree.ts
@@ -1,0 +1,132 @@
+import type { Activity, ActivityId, ActivitySteps } from './types';
+import { isTerminalStatus } from './status';
+
+/**
+ * The activity tree, read off `Activity.parent`.
+ *
+ * Producers declare their whole subtree in one tick — a history refresh submits the umbrella, a
+ * chain per group and an account per chain before any of it runs — so the shape is known from the
+ * first snapshot. Everything downstream of the orchestrator used to flatten it: the render model
+ * bucketed by kind, which put a parent and its children in different buckets and (via `kindRank`)
+ * guaranteed they were never adjacent.
+ *
+ * Pure over a snapshot, like the rest of `core/`: no Vue, no orchestrator.
+ */
+export interface ActivityTree {
+  /** Activities with no parent, plus any whose parent is absent from the snapshot. */
+  readonly roots: Activity[];
+  /** Direct children by parent id. A parent with no children has no entry. */
+  readonly children: ReadonlyMap<ActivityId, Activity[]>;
+}
+
+/**
+ * Running work first, then queued, each oldest first. Inside a subtree the kind is nearly always
+ * the same (a chain and its accounts are both TX_SYNC), so `kindRank` — which orders the flat
+ * list — carries no information here and start order is what a reader can follow.
+ */
+function compareSiblings(a: Activity, b: Activity): number {
+  const byStart = (a.startedAt ?? Number.MAX_SAFE_INTEGER) - (b.startedAt ?? Number.MAX_SAFE_INTEGER);
+  return byStart !== 0 ? byStart : a.id.localeCompare(b.id);
+}
+
+/**
+ * Groups a flat snapshot into {@link ActivityTree}.
+ *
+ * An activity whose declared parent is not in the snapshot is treated as a **root**, never
+ * dropped: `clearTerminal` prunes settled records, so a parent can legitimately disappear while
+ * its children are still live. This mirrors the orchestrator's own stance, where an unknown parent
+ * does not gate a child (`orchestrator.ts` `eligible`), so nothing can be wedged — or here,
+ * hidden — by a parent that no longer exists.
+ */
+export function buildTree(activities: Activity[], compareRoots: (a: Activity, b: Activity) => number): ActivityTree {
+  const present = new Set(activities.map(activity => activity.id));
+  const children = new Map<ActivityId, Activity[]>();
+  const roots: Activity[] = [];
+
+  for (const activity of activities) {
+    const { parent } = activity;
+    if (parent === undefined || !present.has(parent)) {
+      roots.push(activity);
+      continue;
+    }
+
+    const bucket = children.get(parent);
+    if (bucket)
+      bucket.push(activity);
+    else
+      children.set(parent, [activity]);
+  }
+
+  for (const bucket of children.values())
+    bucket.sort(compareSiblings);
+
+  return { children, roots: [...roots].sort(compareRoots) };
+}
+
+/**
+ * How much of a subtree is done, counted in **leaves**.
+ *
+ * Leaves are the only nodes that do work: an umbrella awaits its chains, a chain awaits its
+ * accounts, and only the accounts talk to the backend. Counting them is what makes "4 of 11 steps"
+ * mean something to a reader — counting rows instead would have every intermediate node inflate
+ * the total, and a two-chain refresh would claim more work than it does.
+ *
+ * ⚠️ Deliberately not the same denominator as `Activity.percentage`, which the orchestrator
+ * derives from **direct** children only (`projection.ts` `childProgress`). For a two-level tree
+ * they agree; for three levels the percentage is "how many chains finished" while this is "how
+ * many accounts finished". Whichever a surface shows, it must show both its number and its bar
+ * from the same one.
+ */
+/** True when `root` or anything beneath it satisfies `predicate`. Same guarded walk as {@link subtreeSteps}. */
+export function someInSubtree(
+  children: ReadonlyMap<ActivityId, Activity[]>,
+  root: Activity,
+  predicate: (activity: Activity) => boolean,
+): boolean {
+  const seen = new Set<ActivityId>();
+  const stack: Activity[] = [root];
+
+  while (stack.length > 0) {
+    const activity = stack.pop();
+    if (activity === undefined || seen.has(activity.id))
+      continue;
+
+    if (predicate(activity))
+      return true;
+
+    seen.add(activity.id);
+    stack.push(...(children.get(activity.id) ?? []));
+  }
+
+  return false;
+}
+
+export function subtreeSteps(children: ReadonlyMap<ActivityId, Activity[]>, root: Activity): ActivitySteps {
+  let current = 0;
+  let total = 0;
+
+  // Iterative, with a seen-set: a malformed parent chain would otherwise recurse forever, and a
+  // task panel is not where a producer's mistake should take the renderer down with it.
+  const seen = new Set<ActivityId>();
+  const stack: Activity[] = [root];
+
+  while (stack.length > 0) {
+    const activity = stack.pop();
+    if (activity === undefined || seen.has(activity.id))
+      continue;
+
+    seen.add(activity.id);
+    const descendants = children.get(activity.id);
+
+    if (descendants === undefined || descendants.length === 0) {
+      total += 1;
+      if (isTerminalStatus(activity.status))
+        current += 1;
+      continue;
+    }
+
+    stack.push(...descendants);
+  }
+
+  return { current, total };
+}

--- a/frontend/app/src/modules/task-center/core/types.ts
+++ b/frontend/app/src/modules/task-center/core/types.ts
@@ -218,6 +218,12 @@ export interface ActivityModel {
   readonly active: Activity[];
   /** Flat, waiting to start. */
   readonly pending: Activity[];
+  /**
+   * The tops of the activity tree — what a user actually started, as opposed to the work it fanned
+   * out into. See {@link ./tree}; `children` holds the rest, keyed by parent id.
+   */
+  readonly roots: Activity[];
+  readonly children: ReadonlyMap<ActivityId, Activity[]>;
   readonly overall: ActivityOverall;
   /** The single activity the header bar labels; see selection rule in {@link ./model}. */
   readonly current?: Activity;

--- a/frontend/app/src/modules/task-center/use-cancel-confirmation.spec.ts
+++ b/frontend/app/src/modules/task-center/use-cancel-confirmation.spec.ts
@@ -1,0 +1,146 @@
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type Activity,
+  ActivityKind,
+  ActivitySourceType,
+  ActivityStatus,
+  makeActivityId,
+} from './core/types';
+import { useCancelConfirmation } from './use-cancel-confirmation';
+
+const activities = ref<Activity[]>([]);
+const cancel = vi.fn();
+const dismiss = vi.fn();
+const show = vi.fn();
+
+vi.mock('./use-task-orchestrator', () => ({
+  useTaskOrchestrator: (): { activities: Ref<Activity[]> } => ({ activities }),
+}));
+
+vi.mock('./use-task-controller', () => ({
+  useTaskController: (): { cancel: (activity: Activity) => Promise<void> } => ({ cancel }),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): { dismiss: () => void; show: typeof show } => ({ dismiss, show }),
+}));
+
+function activity(status: ActivityStatus, subtitle?: string): Activity {
+  return {
+    cancellable: true,
+    id: makeActivityId(ActivityKind.TX_SYNC, 'ethereum'),
+    kind: ActivityKind.TX_SYNC,
+    percentage: -1,
+    rerunnable: false,
+    source: { type: ActivitySourceType.NATIVE },
+    status,
+    subtitle,
+    title: 'Transaction sync',
+  };
+}
+
+describe('useCancelConfirmation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(activities, [activity(ActivityStatus.RUNNING)]);
+  });
+
+  /** Closes the dialog the way a user backing out would, so its watcher does not outlive the test. */
+  function dismissDialog(): void {
+    const call = show.mock.calls.at(-1);
+    assert(call, 'no confirmation was shown');
+    call[2]();
+  }
+
+  it('should name the activity in the prompt, preferring its subtitle', () => {
+    useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING, 'Ethereum'));
+
+    expect(show).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'collapsed_pending_tasks.cancel_task_info::Ethereum' }),
+      expect.any(Function),
+      expect.any(Function),
+    );
+    dismissDialog();
+  });
+
+  it('should fall back to the title when there is no subtitle', () => {
+    useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING));
+
+    expect(show).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'collapsed_pending_tasks.cancel_task_info::Transaction sync' }),
+      expect.any(Function),
+      expect.any(Function),
+    );
+    dismissDialog();
+  });
+
+  it('should cancel the activity when the user confirms', async () => {
+    const target = activity(ActivityStatus.RUNNING);
+    useCancelConfirmation().confirmCancel(target);
+
+    await show.mock.calls[0][1]();
+
+    expect(cancel).toHaveBeenCalledWith(target);
+  });
+
+  it('should cancel nothing when the user backs out', () => {
+    useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING));
+
+    show.mock.calls[0][2]();
+
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The dialog names one activity, and work settles on its own schedule. Left up, it asks the user
+   * to confirm cancelling something already finished — and confirming would cancel nothing, since
+   * the orchestrator refuses a terminal id.
+   */
+  it('should dismiss itself when the work settles first', async () => {
+    vi.useFakeTimers();
+    useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING));
+
+    set(activities, [activity(ActivityStatus.COMPLETE)]);
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(dismiss).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+
+  /**
+   * The watcher belongs to no component scope, so one that outlives its dialog is never collected.
+   * Before the self-dismiss stopped it, it went on firing for the life of the session and closed
+   * whatever confirmation happened to be open at the next settle.
+   */
+  it('should stop watching once it has dismissed itself', async () => {
+    vi.useFakeTimers();
+    useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING));
+
+    set(activities, [activity(ActivityStatus.COMPLETE)]);
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(1000);
+    dismiss.mockClear();
+
+    set(activities, [activity(ActivityStatus.RUNNING)]);
+    await nextTick();
+    set(activities, [activity(ActivityStatus.CANCELLED)]);
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(dismiss).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('should stay up while the work is still running', async () => {
+    vi.useFakeTimers();
+    useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING));
+
+    set(activities, [activity(ActivityStatus.RUNNING), activity(ActivityStatus.PENDING)]);
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(dismiss).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/frontend/app/src/modules/task-center/use-cancel-confirmation.spec.ts
+++ b/frontend/app/src/modules/task-center/use-cancel-confirmation.spec.ts
@@ -132,6 +132,41 @@ describe('useCancelConfirmation', () => {
     vi.useRealTimers();
   });
 
+  /**
+   * Unwatching does not unschedule a debounce that is already pending. The settle arms the 1s
+   * self-dismiss, the user backs out inside that second, and the timer still fires — dismissing
+   * whatever confirmation is open by then rather than the one it was armed for.
+   */
+  it('should not dismiss anything when the user backs out inside the debounce window', async () => {
+    vi.useFakeTimers();
+    useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING));
+
+    set(activities, [activity(ActivityStatus.COMPLETE)]);
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(500);
+
+    dismissDialog();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(dismiss).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('should not dismiss anything when the user confirms inside the debounce window', async () => {
+    vi.useFakeTimers();
+    useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING));
+
+    set(activities, [activity(ActivityStatus.COMPLETE)]);
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(500);
+
+    await show.mock.calls[0][1]();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(dismiss).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
   it('should stay up while the work is still running', async () => {
     vi.useFakeTimers();
     useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING));

--- a/frontend/app/src/modules/task-center/use-cancel-confirmation.spec.ts
+++ b/frontend/app/src/modules/task-center/use-cancel-confirmation.spec.ts
@@ -11,7 +11,18 @@ import { useCancelConfirmation } from './use-cancel-confirmation';
 const activities = ref<Activity[]>([]);
 const cancel = vi.fn();
 const dismiss = vi.fn();
-const show = vi.fn();
+
+/**
+ * The real store is a single global slot: `show` overwrites the message and both handlers, so the
+ * mock has to model that rather than just record the call. A mock that only recorded it let the
+ * supersede case pass while the composable could not see it.
+ */
+const visible = ref<boolean>(false);
+const confirmation = ref<object>({});
+const show = vi.fn((message: object, _onConfirm: () => unknown, _onDismiss?: () => unknown): void => {
+  set(confirmation, message);
+  set(visible, true);
+});
 
 vi.mock('./use-task-orchestrator', () => ({
   useTaskOrchestrator: (): { activities: Ref<Activity[]> } => ({ activities }),
@@ -22,7 +33,12 @@ vi.mock('./use-task-controller', () => ({
 }));
 
 vi.mock('@/modules/core/common/use-confirm-store', () => ({
-  useConfirmStore: (): { dismiss: () => void; show: typeof show } => ({ dismiss, show }),
+  useConfirmStore: (): {
+    confirmation: Ref<object>;
+    dismiss: () => void;
+    show: typeof show;
+    visible: Ref<boolean>;
+  } => ({ confirmation, dismiss, show, visible }),
 }));
 
 function activity(status: ActivityStatus, subtitle?: string): Activity {
@@ -43,13 +59,17 @@ describe('useCancelConfirmation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     set(activities, [activity(ActivityStatus.RUNNING)]);
+    set(visible, false);
+    set(confirmation, {});
   });
 
   /** Closes the dialog the way a user backing out would, so its watcher does not outlive the test. */
   function dismissDialog(): void {
     const call = show.mock.calls.at(-1);
     assert(call, 'no confirmation was shown');
-    call[2]();
+    const onDismiss = call[2];
+    assert(onDismiss, 'the confirmation was shown without a dismiss handler');
+    onDismiss();
   }
 
   it('should name the activity in the prompt, preferring its subtitle', () => {
@@ -86,7 +106,7 @@ describe('useCancelConfirmation', () => {
   it('should cancel nothing when the user backs out', () => {
     useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING));
 
-    show.mock.calls[0][2]();
+    dismissDialog();
 
     expect(cancel).not.toHaveBeenCalled();
   });
@@ -164,6 +184,43 @@ describe('useCancelConfirmation', () => {
     await vi.advanceTimersByTimeAsync(1000);
 
     expect(dismiss).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  /**
+   * `useConfirmStore` is a single global slot, so an unrelated `show()` overwrites the dismiss
+   * handler and this composable's own `stop` never runs. Left unwatched, the watcher would outlive
+   * the process and close that unrelated dialog the moment this activity settled.
+   */
+  it('should stop watching when another dialog takes the slot', async () => {
+    vi.useFakeTimers();
+    useCancelConfirmation().confirmCancel(activity(ActivityStatus.RUNNING));
+
+    show({ title: 'something else entirely' }, () => {});
+    await nextTick();
+    dismiss.mockClear();
+
+    set(activities, [activity(ActivityStatus.COMPLETE)]);
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(dismiss).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  /**
+   * The row renders from a snapshot that is a tick old, so the work can already be terminal by the
+   * time it is clicked. A non-immediate watcher never sees a transition and leaves the dialog up
+   * asking to cancel finished work — which `orchestrator.cancel` would then refuse anyway.
+   */
+  it('should dismiss itself when the work settled before the click', async () => {
+    vi.useFakeTimers();
+    set(activities, [activity(ActivityStatus.COMPLETE)]);
+
+    useCancelConfirmation().confirmCancel(activity(ActivityStatus.COMPLETE));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(dismiss).toHaveBeenCalledOnce();
     vi.useRealTimers();
   });
 

--- a/frontend/app/src/modules/task-center/use-cancel-confirmation.ts
+++ b/frontend/app/src/modules/task-center/use-cancel-confirmation.ts
@@ -31,14 +31,24 @@ export function useCancelConfirmation(): UseCancelConfirmationReturn {
     // belongs to no component scope, so one that outlives its dialog is never collected: it would
     // go on calling `dismiss()` on every later settle, closing whatever confirmation happened to
     // be open at the time.
+    //
+    // `done` closes the same hole on the debounce timer. Unwatching does not unschedule an already
+    // pending `dismissWhenSettled`, so a user who confirms or backs out inside the debounce window
+    // would still get a `dismiss()` a second later — aimed at whatever dialog is open by then, not
+    // at this one.
     let unwatch: () => void = () => {};
+    let done = false;
     const stop = (): void => {
+      done = true;
       unwatch();
     };
 
     // Debounced: a settle emits more than once in quick succession (the status, then the ledger
     // write), and the dialog should not blink shut on the first of them.
     const dismissWhenSettled = useDebounceFn(async () => {
+      if (done)
+        return;
+
       stop();
       await dismiss();
     }, 1000);

--- a/frontend/app/src/modules/task-center/use-cancel-confirmation.ts
+++ b/frontend/app/src/modules/task-center/use-cancel-confirmation.ts
@@ -1,0 +1,68 @@
+import { startPromise } from '@shared/utils';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { isTerminalStatus } from './core/status';
+import { type Activity, resolveText } from './core/types';
+import { useTaskController } from './use-task-controller';
+import { useTaskOrchestrator } from './use-task-orchestrator';
+
+interface UseCancelConfirmationReturn {
+  confirmCancel: (activity: Activity) => void;
+}
+
+/**
+ * Asks before cancelling an activity, and gets out of the way if the work settles first.
+ *
+ * The self-dismiss is the whole reason this is not two lines in the component: the dialog names
+ * one activity, and work in a task panel finishes on its own schedule. Leaving it up asks the user
+ * to confirm cancelling something that already completed, and confirming it would then cancel
+ * nothing — `orchestrator.cancel` refuses a terminal id.
+ */
+export function useCancelConfirmation(): UseCancelConfirmationReturn {
+  const { t } = useI18n({ useScope: 'global' });
+  const { activities } = useTaskOrchestrator();
+  const { cancel } = useTaskController();
+  const { dismiss, show } = useConfirmStore();
+
+  function confirmCancel(activity: Activity): void {
+    const live = computed<boolean>(() => get(activities)
+      .some(item => item.id === activity.id && !isTerminalStatus(item.status)));
+
+    // Every exit runs through `stop`, including the self-dismiss below. A watcher created here
+    // belongs to no component scope, so one that outlives its dialog is never collected: it would
+    // go on calling `dismiss()` on every later settle, closing whatever confirmation happened to
+    // be open at the time.
+    let unwatch: () => void = () => {};
+    const stop = (): void => {
+      unwatch();
+    };
+
+    // Debounced: a settle emits more than once in quick succession (the status, then the ledger
+    // write), and the dialog should not blink shut on the first of them.
+    const dismissWhenSettled = useDebounceFn(async () => {
+      stop();
+      await dismiss();
+    }, 1000);
+
+    unwatch = watch(live, (isLive) => {
+      if (!isLive)
+        startPromise(dismissWhenSettled());
+    });
+
+    show(
+      {
+        message: t('collapsed_pending_tasks.cancel_task_info', {
+          title: resolveText(t, activity.subtitle) ?? activity.title,
+        }),
+        title: t('collapsed_pending_tasks.cancel_task'),
+        type: 'warning',
+      },
+      async () => {
+        stop();
+        await cancel(activity);
+      },
+      stop,
+    );
+  }
+
+  return { confirmCancel };
+}

--- a/frontend/app/src/modules/task-center/use-cancel-confirmation.ts
+++ b/frontend/app/src/modules/task-center/use-cancel-confirmation.ts
@@ -21,26 +21,30 @@ export function useCancelConfirmation(): UseCancelConfirmationReturn {
   const { t } = useI18n({ useScope: 'global' });
   const { activities } = useTaskOrchestrator();
   const { cancel } = useTaskController();
-  const { dismiss, show } = useConfirmStore();
+  const confirmStore = useConfirmStore();
+  const { dismiss, show } = confirmStore;
+  const { confirmation, visible } = storeToRefs(confirmStore);
 
   function confirmCancel(activity: Activity): void {
     const live = computed<boolean>(() => get(activities)
       .some(item => item.id === activity.id && !isTerminalStatus(item.status)));
 
-    // Every exit runs through `stop`, including the self-dismiss below. A watcher created here
-    // belongs to no component scope, so one that outlives its dialog is never collected: it would
-    // go on calling `dismiss()` on every later settle, closing whatever confirmation happened to
-    // be open at the time.
+    // Every exit runs through `stop`, and there are three of them, because a watcher created here
+    // belongs to no component scope: one that outlives its dialog is never collected, and would go
+    // on calling `dismiss()` at every later settle, closing whatever confirmation happened to be
+    // open at the time.
     //
-    // `done` closes the same hole on the debounce timer. Unwatching does not unschedule an already
-    // pending `dismissWhenSettled`, so a user who confirms or backs out inside the debounce window
-    // would still get a `dismiss()` a second later — aimed at whatever dialog is open by then, not
-    // at this one.
-    let unwatch: () => void = () => {};
+    // 1. `done` covers the debounce timer. Unwatching does not unschedule an already pending
+    //    `dismissWhenSettled`, so a user who acts inside the debounce window would still get a
+    //    `dismiss()` a second later, aimed at whatever dialog is open by then.
+    // 2. `unwatchOwnership` covers being superseded. `useConfirmStore` is a single global slot, so
+    //    any other `show()` overwrites the dismiss handler below and our own `stop` never runs.
+    const stops: (() => void)[] = [];
     let done = false;
     const stop = (): void => {
       done = true;
-      unwatch();
+      for (const off of stops.splice(0))
+        off();
     };
 
     // Debounced: a settle emits more than once in quick succession (the status, then the ledger
@@ -53,25 +57,36 @@ export function useCancelConfirmation(): UseCancelConfirmationReturn {
       await dismiss();
     }, 1000);
 
-    unwatch = watch(live, (isLive) => {
+    // `immediate`, because the work can already be terminal by the time the row is clicked — the
+    // snapshot the row rendered from is one tick old. Without it `live` starts false, never
+    // transitions, and the dialog sits there asking to cancel something already finished.
+    stops.push(watch(live, (isLive) => {
       if (!isLive)
         startPromise(dismissWhenSettled());
-    });
+    }, { immediate: true }));
 
-    show(
-      {
-        message: t('collapsed_pending_tasks.cancel_task_info', {
-          title: resolveText(t, activity.subtitle) ?? activity.title,
-        }),
-        title: t('collapsed_pending_tasks.cancel_task'),
-        type: 'warning',
-      },
-      async () => {
+    const message = {
+      message: t('collapsed_pending_tasks.cancel_task_info', {
+        title: resolveText(t, activity.subtitle) ?? activity.title,
+      }),
+      title: t('collapsed_pending_tasks.cancel_task'),
+      type: 'warning' as const,
+    };
+
+    // The slot is ours only until someone else claims it; identity, not visibility, is what says so.
+    // ⚠️ `toRaw` is load-bearing: the store holds the message in a plain `ref`, which deeply
+    // reactifies it, so `get(confirmation)` is a proxy *of* `message` and never `message` itself.
+    // Comparing them directly is always unequal — it stopped the self-dismiss the instant the
+    // dialog opened, disabling the whole composable.
+    stops.push(watch([visible, confirmation], ([shown, current]) => {
+      if (!shown || toRaw(current) !== message)
         stop();
-        await cancel(activity);
-      },
-      stop,
-    );
+    }));
+
+    show(message, async () => {
+      stop();
+      await cancel(activity);
+    }, stop);
   }
 
   return { confirmCancel };

--- a/frontend/app/src/modules/task-center/use-pending-jobs.spec.ts
+++ b/frontend/app/src/modules/task-center/use-pending-jobs.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { assembleActivityModel } from './core/model';
+import {
+  type Activity,
+  type ActivityKind,
+  type ActivityModel,
+  ActivitySourceType,
+  type ActivityStatus,
+  ActivityKind as Kind,
+  makeActivityId,
+  ActivityStatus as Status,
+} from './core/types';
+import { usePendingJobs } from './use-pending-jobs';
+
+const activities = ref<Activity[]>([]);
+
+vi.mock('./use-task-center', () => ({
+  useTaskCenter: (): { model: ComputedRef<ActivityModel> } => ({
+    model: computed<ActivityModel>(() => assembleActivityModel(get(activities), (key: string): string => key)),
+  }),
+}));
+
+function activity(
+  id: string,
+  status: ActivityStatus,
+  options: { kind?: ActivityKind; parent?: string; percentage?: number } = {},
+): Activity {
+  const { kind = Kind.TX_SYNC, parent, percentage = -1 } = options;
+  return {
+    cancellable: false,
+    id: makeActivityId(kind, id),
+    kind,
+    parent: parent === undefined ? undefined : makeActivityId(Kind.HISTORY_SYNC, parent),
+    percentage,
+    rerunnable: false,
+    source: { type: ActivitySourceType.NATIVE },
+    status,
+    title: id,
+  };
+}
+
+function umbrella(status: ActivityStatus): Activity {
+  return {
+    cancellable: false,
+    id: makeActivityId(Kind.HISTORY_SYNC, 'refresh'),
+    kind: Kind.HISTORY_SYNC,
+    percentage: -1,
+    rerunnable: false,
+    source: { type: ActivitySourceType.NATIVE },
+    status,
+    title: 'History refresh',
+  };
+}
+
+describe('usePendingJobs', () => {
+  beforeEach(() => {
+    set(activities, []);
+  });
+
+  it('should list one job for a whole subtree, not one per activity', () => {
+    set(activities, [
+      umbrella(Status.RUNNING),
+      activity('ethereum', Status.RUNNING, { parent: 'refresh' }),
+      activity('gnosis', Status.PENDING, { parent: 'refresh' }),
+    ]);
+
+    const { jobs } = usePendingJobs();
+
+    expect(get(jobs)).toHaveLength(1);
+    expect(get(jobs)[0].activity.title).toBe('History refresh');
+  });
+
+  /**
+   * The old panel listed RUNNING activities, so a job whose only running work was one leaf
+   * disappeared the moment that leaf settled, even with queued siblings behind it. Listing by
+   * subtree keeps the job up for as long as any of it is actually moving.
+   */
+  it('should list a queued root that has a running descendant', () => {
+    set(activities, [
+      umbrella(Status.PENDING),
+      activity('ethereum', Status.RUNNING, { parent: 'refresh' }),
+    ]);
+
+    expect(get(usePendingJobs().jobs)).toHaveLength(1);
+  });
+
+  it('should list nothing while the whole tree is still queued', () => {
+    set(activities, [
+      umbrella(Status.PENDING),
+      activity('ethereum', Status.PENDING, { parent: 'refresh' }),
+    ]);
+
+    expect(get(usePendingJobs().jobs)).toEqual([]);
+  });
+
+  it('should count steps in leaves across every live job', () => {
+    set(activities, [
+      umbrella(Status.RUNNING),
+      activity('ethereum', Status.COMPLETE, { parent: 'refresh' }),
+      activity('gnosis', Status.RUNNING, { parent: 'refresh' }),
+      activity('prices', Status.RUNNING, { kind: Kind.PRICES }),
+    ]);
+
+    const { jobs, percentage, steps } = usePendingJobs();
+
+    expect(get(jobs)).toHaveLength(2);
+    // Two leaves under the umbrella, one of them done, plus the standalone price fetch.
+    expect(get(steps)).toEqual({ current: 1, total: 3 });
+    expect(get(percentage)).toBe(33);
+  });
+
+  it('should expose the tree so the row component can walk it', () => {
+    set(activities, [
+      umbrella(Status.RUNNING),
+      activity('ethereum', Status.RUNNING, { parent: 'refresh' }),
+    ]);
+
+    const { children, jobs } = usePendingJobs();
+
+    expect(get(children).get(get(jobs)[0].activity.id)?.map(child => child.title)).toEqual(['ethereum']);
+  });
+
+  it('should report an indeterminate percentage when nothing is in flight', () => {
+    expect(get(usePendingJobs().percentage)).toBe(-1);
+  });
+});

--- a/frontend/app/src/modules/task-center/use-pending-jobs.ts
+++ b/frontend/app/src/modules/task-center/use-pending-jobs.ts
@@ -1,0 +1,67 @@
+import type { ComputedRef } from 'vue';
+import { percentageFromSteps } from './core/status';
+import { someInSubtree, subtreeSteps } from './core/tree';
+import { type Activity, type ActivityId, ActivityStatus, type ActivitySteps } from './core/types';
+import { useTaskCenter } from './use-task-center';
+
+/**
+ * One thing the user started, with its subtree rolled up. A "job" is a root activity: the history
+ * refresh, not the eleven chain syncs and forty account queries it fans out into.
+ */
+export interface PendingJob {
+  readonly activity: Activity;
+  /** Leaf-based, so it agrees with {@link percentage}. See {@link subtreeSteps}. */
+  readonly steps: ActivitySteps;
+  /** 0-100, or -1 when the subtree is a single indeterminate leaf. */
+  readonly percentage: number;
+}
+
+interface UsePendingJobsReturn {
+  jobs: ComputedRef<PendingJob[]>;
+  /** Leaves across every live job — the panel's denominator. */
+  steps: ComputedRef<ActivitySteps>;
+  percentage: ComputedRef<number>;
+  /** The whole tree, so the recursive row component walks it without re-deriving anything. */
+  children: ComputedRef<ReadonlyMap<ActivityId, Activity[]>>;
+}
+
+function isRunning(activity: Activity): boolean {
+  return activity.status === ActivityStatus.RUNNING;
+}
+
+/**
+ * The panel's view of the orchestrator: live work as a list of jobs rather than a flat list of
+ * every activity in flight.
+ *
+ * A job is listed while **anything in its subtree is RUNNING**. That keeps the rule the flat panel
+ * had — a fully queued tree is not shown, since producers declare every account of every chain up
+ * front and listing those would bury the running work under dozens of rows that have not begun —
+ * while fixing what it got wrong: cancelling the last running leaf no longer leaves a card headed
+ * "0 pending tasks" spinning above its queued siblings, because the job goes with them.
+ */
+export function usePendingJobs(): UsePendingJobsReturn {
+  const { model } = useTaskCenter();
+
+  const children = computed<ReadonlyMap<ActivityId, Activity[]>>(() => get(model).children);
+
+  const jobs = computed<PendingJob[]>(() => {
+    const tree = get(children);
+
+    return get(model).roots.filter(root => someInSubtree(tree, root, isRunning)).map((activity) => {
+      const steps = subtreeSteps(tree, activity);
+      return { activity, percentage: percentageFromSteps(steps.current, steps.total), steps };
+    });
+  });
+
+  const steps = computed<ActivitySteps>(() => get(jobs).reduce<ActivitySteps>(
+    (total, job) => ({ current: total.current + job.steps.current, total: total.total + job.steps.total }),
+    { current: 0, total: 0 },
+  ));
+
+  const percentage = computed<number>(() => {
+    const { current, total } = get(steps);
+    return percentageFromSteps(current, total);
+  });
+
+  return { children, jobs, percentage, steps };
+}

--- a/frontend/app/src/modules/task-center/use-pending-jobs.ts
+++ b/frontend/app/src/modules/task-center/use-pending-jobs.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef } from 'vue';
-import { percentageFromSteps } from './core/status';
-import { someInSubtree, subtreeSteps } from './core/tree';
+import { INDETERMINATE } from './core/status';
+import { someInSubtree, subtreeProgress, subtreeSteps } from './core/tree';
 import { type Activity, type ActivityId, ActivityStatus, type ActivitySteps } from './core/types';
 import { useTaskCenter } from './use-task-center';
 
@@ -10,9 +10,9 @@ import { useTaskCenter } from './use-task-center';
  */
 export interface PendingJob {
   readonly activity: Activity;
-  /** Leaf-based, so it agrees with {@link percentage}. See {@link subtreeSteps}. */
+  /** The integer leaf tally the row's text shows. See {@link subtreeSteps}. */
   readonly steps: ActivitySteps;
-  /** 0-100, or -1 when the subtree is a single indeterminate leaf. */
+  /** 0-100, or -1 when no leaf in the subtree can be quantified. See {@link subtreeProgress}. */
   readonly percentage: number;
 }
 
@@ -47,10 +47,11 @@ export function usePendingJobs(): UsePendingJobsReturn {
   const jobs = computed<PendingJob[]>(() => {
     const tree = get(children);
 
-    return get(model).roots.filter(root => someInSubtree(tree, root, isRunning)).map((activity) => {
-      const steps = subtreeSteps(tree, activity);
-      return { activity, percentage: percentageFromSteps(steps.current, steps.total), steps };
-    });
+    return get(model).roots.filter(root => someInSubtree(tree, root, isRunning)).map(activity => ({
+      activity,
+      percentage: subtreeProgress(tree, activity),
+      steps: subtreeSteps(tree, activity),
+    }));
   });
 
   const steps = computed<ActivitySteps>(() => get(jobs).reduce<ActivitySteps>(
@@ -58,9 +59,19 @@ export function usePendingJobs(): UsePendingJobsReturn {
     { current: 0, total: 0 },
   ));
 
+  // Weighted by leaves, so a one-leaf job does not count for as much as an eleven-chain refresh.
+  // A job nobody can quantify keeps its leaves in the denominator and contributes nothing, which is
+  // the same rule `subtreeProgress` applies inside one subtree — unknown work reads as unfinished.
   const percentage = computed<number>(() => {
-    const { current, total } = get(steps);
-    return percentageFromSteps(current, total);
+    const list = get(jobs);
+    const total = get(steps).total;
+    const quantifiable = list.filter(job => job.percentage >= 0);
+
+    if (total === 0 || quantifiable.length === 0)
+      return INDETERMINATE;
+
+    const done = quantifiable.reduce((sum, job) => sum + (job.percentage / 100) * job.steps.total, 0);
+    return Math.round((done / total) * 100);
   });
 
   return { children, jobs, percentage, steps };

--- a/frontend/app/src/modules/task-center/use-smart-rerun.spec.ts
+++ b/frontend/app/src/modules/task-center/use-smart-rerun.spec.ts
@@ -36,9 +36,11 @@ function activity(kind: ActivityKind, status: ActivityStatus, rerunnable: boolea
 function model(activities: Activity[]): ActivityModel {
   return {
     active: [],
+    children: new Map(),
     groups: [{ activities, kind: ActivityKind.OTHER, percentage: -1, status: ActivityStatus.COMPLETE, title: 'g' }],
     overall: { percentage: 100, phase: 'done' },
     pending: [],
+    roots: activities,
   };
 }
 

--- a/frontend/app/src/modules/task-center/use-task-controller.spec.ts
+++ b/frontend/app/src/modules/task-center/use-task-controller.spec.ts
@@ -31,10 +31,12 @@ function activity(overrides: Partial<Activity> & Pick<Activity, 'source'>): Acti
 function emptyModel(activities: Activity[] = []): ActivityModel {
   return {
     active: activities,
+    children: new Map(),
     current: activities[0],
     groups: [{ activities, kind: ActivityKind.OTHER, percentage: -1, status: ActivityStatus.RUNNING, title: 'g' }],
     overall: { percentage: 0, phase: 'working' },
     pending: [],
+    roots: activities,
   };
 }
 

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -259,6 +259,14 @@ export default defineConfig({
         'lu-palette',
         'lu-slash',
         'lu-monitor',
+        // task-center activity outcomes: named in activity-outcome.ts, so the source scan of
+        // templates never sees them (see the warning on `ActivityOutcome.icon`)
+        'lu-activity',
+        'lu-ban',
+        'lu-check',
+        'lu-circle-x',
+        'lu-clock',
+        'lu-skip-forward',
       ],
       customIcons: ['lu-github', 'lu-discord', 'lu-x-twitter'],
     }),


### PR DESCRIPTION
The task-center pending panel rendered the orchestrator's job tree as a flat list. A history
refresh declares its whole subtree up front - an umbrella, a chain per group, an account per chain -
and the panel bucketed those by kind, which put a parent and its children in different buckets and
guaranteed they were never adjacent. Eleven chains and forty accounts arrived as forty-plus sibling
rows repeating the same title.

This nests them under what the user actually started.

## What changed

**A job is a root activity, listed while anything in its subtree is running.** That keeps the rule
the flat panel had - a fully queued tree is not shown - while fixing what it got wrong: cancelling
the last running leaf used to leave a card headed "0 pending tasks" spinning above its queued
siblings, because visibility followed the orchestrator's phase rather than the list.

**Progress is counted in leaves.** Leaves are the only nodes that do work: an umbrella awaits its
chains, a chain awaits its accounts, and only the accounts talk to the backend. Counting rows would
let every intermediate node inflate the denominator. The header's "15 of 41 steps" and each row's
ring now come from the same count.

Note this is deliberately *not* the denominator `Activity.percentage` uses - the orchestrator
derives that from direct children only (`projection.ts` `childProgress`). For a two-level tree they
agree; for three levels the percentage is "how many chains finished" while this is "how many
accounts finished". Both are correct, so the rule is that a surface must take its number and its
bar from the same one.

A leaf also counts *fractionally*, via its own reported percentage. Counting whole steps only
discarded the one number a single-task job has: a price refresh at 45% rendered its own row at 45%
under a header ring pinned at 0%, because "0 of 1 steps" was all a whole-step tally could say.

**Every parent starts collapsed** and unfolds one level per click. The rolled-up row already answers
what a reader arrives with.

**A status is an icon chip, not a spinner.** Most rows have no percentage - the orchestrator reports
`-1` unless a producer counted steps - and a spinner said nothing the ticking elapsed time did not
already say. The chip is icon-only because the drawer is 400px and a nested row spends most of it on
its label; the word is on a tooltip and on `aria-label`. Filled means it needs attention, outlined
means it is expected, so only FAILED and SKIPPED are filled: a refresh settles dozens of children
successfully, and filling those made a wall of green the loudest thing in the panel.

**Rows show elapsed time** rather than an absolute `LLL` timestamp. The panel used to print
"August 7, 2026 3:42 PM" on work that started four seconds earlier; the question a reader has is
which leaf is stuck.

**A parent row can stop its subtree**, which works because `orchestrator.cancel` cascades on
`settleTerminal`. Until that landed the control was deliberately withheld: cancelling a parent
settled its row and stopped nothing, since the handle only aborts a backend task id an umbrella
never has.

## Bugs found on the way

- **`useCancelConfirmation`'s self-dismiss never stopped its own watcher.** Inside the component it
  was at least scoped to the mount; extracted as a plain composable it belongs to no scope, so it
  would `dismiss()` whatever confirmation was open at every later settle. Three separate exits had
  to close: unwatching does not unschedule an already pending debounce; `useConfirmStore` is a
  single global slot, so any other `show()` overwrites the dismiss handler; and the watcher was not
  `immediate`, so work already terminal at click time never transitioned and left the dialog up
  asking to cancel finished work.

- **The outcome chip presented as a button.** `RuiChip` hardcodes `role="button"` and `tabindex="0"`
  on its root whether or not it is clickable, so every settled child added a tab stop and announced
  itself as a button. Overridden locally with `role="img"`.

- **`text-ellipsis` without `whitespace-nowrap` is inert**, so every long chain name wrapped to two
  lines and the panel had no vertical rhythm.

- **The overall rollup counted every subtree twice.** Rolling up the per-kind groups meant a history
  refresh contributed once as HISTORY_SYNC and again as TX_SYNC, each weighted like a single
  unrelated activity. It rolls up roots now.

## Notes for review

- An activity whose declared parent is absent from the snapshot becomes a **root**, never dropped:
  `clearTerminal` prunes settled records, so a parent can legitimately vanish while its children
  still run. This mirrors the orchestrator, where an unknown parent does not gate a child.
- The outcome icons are named in `activity-outcome.ts`, where the icon plugin's source scan cannot
  see them, so they are listed in `vite.config.ts` too.
- Logic is extracted so it can be asserted without mounting anything: `core/tree.ts`,
  `core/elapsed.ts`, `activity-outcome.ts`, `use-pending-jobs.ts`, `use-cancel-confirmation.ts`.

## Testing

Full suite green: 7463 tests / 781 files, plus typecheck, eslint, stylelint and the linked-key
check.

Verified in the app against a real history refresh: the tree nests, parents start collapsed, elapsed
ticks, Done/Skipped/Running chips render on real children, and the header's leaf denominator
reconciles with the rows.

Still to verify in the app, which is why this is a draft: the cancel cascade actually stopping a
subtree, and the header ring against a single-task job after the fractional-leaf change.
