### PR TITLE
fix(exchanges): baseline the key form from the entry it wrote

### DIFF
--- a/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysForm.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysForm.vue
@@ -223,11 +223,24 @@ onUnmounted(() => {
   set(stateUpdated, false);
 });
 
+/**
+ * The dialog owns the entry, so a write to `modelValue` only comes back on the next tick. Every
+ * caller therefore hands the entry it just wrote straight to the baseline instead of reading it
+ * back: re-reading `modelValue` here returns the value from before the write, which re-takes the
+ * baseline the form already had and leaves the write itself looking like a user edit.
+ */
+function replaceEntry(next: ExchangeFormData): void {
+  set(modelValue, next);
+  form.reset(toExchangeKeysFormState(next));
+}
+
 function onExchangeChange(exchange?: string) {
   const name = exchange ?? '';
   const isKraken = name === 'kraken';
 
-  set(modelValue, {
+  // Picking a different exchange starts a different connection, so the errors from the last one
+  // must not be left decorating the new form.
+  replaceEntry({
     apiKey: '',
     apiSecret: '',
     binanceHistoryStartTs: undefined,
@@ -243,21 +256,16 @@ function onExchangeChange(exchange?: string) {
     okxLocation: name === 'okx' ? 'global' : undefined,
     passphrase: '',
   });
-
-  // Picking a different exchange starts a different connection, so the errors from the last one
-  // must not be left decorating the new form.
-  nextTick(() => {
-    form.reset(toExchangeKeysFormState(get(modelValue)));
-  });
 }
 
 function seedName(): void {
+  const model = get(modelValue);
+
   if (get(editMode)) {
-    set(newNameProp, get(nameProp));
+    replaceEntry({ ...model, newName: model.name });
     return;
   }
 
-  const model = get(modelValue);
   // The locations come from the backend, so the store holds none until that fetch lands and the
   // suggestion comes back empty. This runs once, so writing that over the name would leave the
   // field blank with nothing left to restore it.
@@ -265,20 +273,12 @@ function seedName(): void {
   if (!suggestion)
     return;
 
-  set(modelValue, {
-    ...model,
-    name: suggestion,
-  });
+  replaceEntry({ ...model, name: suggestion });
 }
 
-onMounted(() => {
-  seedName();
-  // The seeded name lands after `useForm` took its baseline, so take it again. Otherwise a dialog
-  // the user has not touched counts as dirty and prompts to discard on close. This has to run in
-  // the same tick as the seeding: a deferred reset lets `dirty` flip on the way, and the dialog
-  // latches the flag it is handed.
-  form.reset(toExchangeKeysFormState(get(modelValue)));
-});
+// Seeding lands after `useForm` took its baseline, so `replaceEntry` takes it again. Otherwise a
+// dialog the user has not touched counts as dirty and prompts to discard on close.
+onMounted(seedName);
 
 defineExpose({
   validate: (): boolean => form.validate(),

--- a/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-validation.spec.ts
+++ b/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-validation.spec.ts
@@ -3,6 +3,7 @@ import { createCustomPinia } from '@test/utils/create-pinia';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { type Pinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, ref, type VNode } from 'vue';
 import ExchangeKeysForm from '@/modules/settings/api-keys/exchange/ExchangeKeysForm.vue';
 import '@test/i18n';
 
@@ -107,25 +108,94 @@ describe('settings/api-keys/exchange validation', () => {
   }
 
   /**
+   * 🔴 These mount through a parent that owns the entry, the way the dialog does. Bound by props
+   * alone the form's own `modelValue` writes resolve immediately, which hides the tick the real
+   * binding takes and makes a re-taken baseline look correct when it is not.
+   */
+  function createDialogHarness(overrides: Partial<ExchangeFormData> = {}): {
+    dirty: () => boolean;
+    switchExchange: (location: string) => Promise<void>;
+    edit: (patch: Partial<ExchangeFormData>) => Promise<void>;
+  } {
+    const dirty = ref<boolean>(false);
+    const entry = ref<ExchangeFormData>({
+      apiKey: 'key',
+      apiSecret: 'secret',
+      binanceMarkets: [],
+      location: 'kucoin',
+      mode: 'add',
+      name: 'Kucoin 1',
+      passphrase: '',
+      ...overrides,
+    });
+
+    const parent = mount(defineComponent({
+      name: 'DialogHarness',
+      setup: () => (): VNode => h(ExchangeKeysForm, {
+        'errorMessages': {},
+        'modelValue': entry.value,
+        'onUpdate:modelValue': (value: ExchangeFormData) => { entry.value = value; },
+        'onUpdate:stateUpdated': (value: boolean) => { dirty.value = value; },
+        'stateUpdated': dirty.value,
+      }),
+    }), {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          BinanceHistoryStartDate: true,
+          BinancePairsSelector: true,
+          ExchangeInput: true,
+          I18nT: true,
+          InternalLink: true,
+        },
+      },
+    });
+
+    return {
+      dirty: (): boolean => dirty.value,
+      edit: async (patch: Partial<ExchangeFormData>): Promise<void> => {
+        entry.value = { ...entry.value, ...patch };
+        await nextTick();
+        await nextTick();
+      },
+      switchExchange: async (location: string): Promise<void> => {
+        parent.findComponent({ name: 'ExchangeInput' }).vm.$emit('update:modelValue', location);
+        await nextTick();
+        await nextTick();
+      },
+    };
+  }
+
+  /**
    * The dialog turns this flag into its discard-on-close prompt, so anything the form writes into
-   * the entry by itself must not raise it. `onMounted` seeds the name, which lands after the form
-   * took its baseline.
+   * the entry by itself must not raise it. Both the `onMounted` name seeding and the exchange switch
+   * write to the entry, and both land after the form took its baseline.
    */
   describe('the unsaved changes flag', () => {
     it('should stay down for a form the user has not touched', async () => {
-      const form = createWrapper({ name: '' });
+      const harness = createDialogHarness({ name: '' });
+      await nextTick();
       await nextTick();
 
-      expect((form.emitted('update:stateUpdated') ?? []).flat()).not.toContain(true);
+      expect(harness.dirty()).toBe(false);
+    });
+
+    it('should stay down when the exchange is switched', async () => {
+      const harness = createDialogHarness();
+      await nextTick();
+
+      await harness.switchExchange('kraken');
+
+      expect(harness.dirty()).toBe(false);
     });
 
     it('should go up once a field is edited', async () => {
-      const form = createWrapper();
+      const harness = createDialogHarness();
       await nextTick();
 
-      await form.setProps({ modelValue: { ...form.props('modelValue'), apiKey: 'edited' } });
+      await harness.edit({ apiKey: 'edited' });
 
-      expect(form.emitted('update:stateUpdated')?.at(-1)?.[0]).toBe(true);
+      expect(harness.dirty()).toBe(true);
     });
   });
 


### PR DESCRIPTION
Follow-up to #12831, which shipped a fix for this that does not work. On develop today, opening **Add an exchange**, touching nothing and pressing Escape asks you to discard changes.

### Why the previous fix missed

The dialog owns the entry, so `modelValue` is prop backed: a write emits and the value only comes back on the next tick. Both writers wrote the entry and then re-read `modelValue` to re-take the form's baseline:

```ts
set(modelValue, { ...model, name: suggestion });
form.reset(toExchangeKeysFormState(get(modelValue)));  // still the pre-write value
```

So the baseline was re-taken exactly as it already was, the seeded name landed a tick later, and `form.dirty` read it as a user edit. Instrumenting `useForm` shows the mismatch directly: the snapshot holds `"name":""` while the state holds `"name":"Kraken 1"`.

Both writers now hand the entry they just wrote straight to the baseline, through one `replaceEntry` helper. That also drops the `nextTick` the exchange switch was using.

### Why the specs did not catch it

Mounted with props alone there is no `update:modelValue` listener, so `defineModel` keeps a local value and the write resolves immediately: the exact tick the bug lives in does not exist in the harness. The unsaved-changes tests now mount through a parent that owns the entry, the way the dialog does.

Negative control against develop's file: only "should stay down for a form the user has not touched" fails, which is the live bug. The exchange-switch test passes on develop too and is kept as a regression guard for the `replaceEntry` refactor.

### Verification

Gates: typecheck clean, unit 773 files / 7390 tests green, eslint clean on both files, typos clean.

In the app, checked from screenshots rather than DOM text (the confirm's markup stays in the DOM after it is dismissed, so a text probe reports it as showing when it is not):
- untouched dialog + Escape closes silently;
- switch exchange + Escape closes silently;
- type an API key + Escape still prompts.