### PR TITLE
Narrow accounting rule subtypes by event type

### DIFF
--- a/frontend/app/src/modules/history/events/mapping/event-type-subtypes.spec.ts
+++ b/frontend/app/src/modules/history/events/mapping/event-type-subtypes.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { type EventTypeSubtypeMapping, subtypesForTypes } from '@/modules/history/events/mapping/event-type-subtypes';
+
+const mapping: EventTypeSubtypeMapping = {
+  receive: { 'airdrop': {}, 'return wrapped': {} },
+  spend: { 'fee': {}, 'return wrapped': {} },
+};
+
+describe('subtypesForTypes', () => {
+  it('should offer the subtypes of the selected type', () => {
+    expect(subtypesForTypes(mapping, ['spend'])).toStrictEqual(['fee', 'return wrapped']);
+  });
+
+  it('should union the subtypes across several types, without repeating one', () => {
+    expect(subtypesForTypes(mapping, ['spend', 'receive']))
+      .toStrictEqual(['fee', 'return wrapped', 'airdrop']);
+  });
+
+  // No type picked narrows nothing, so every subtype is still on offer.
+  it('should offer every known subtype when no type is picked', () => {
+    expect(subtypesForTypes(mapping, [])).toStrictEqual(['airdrop', 'return wrapped', 'fee']);
+  });
+
+  it('should offer nothing for a type the mapping does not know', () => {
+    expect(subtypesForTypes(mapping, ['nonsense'])).toStrictEqual([]);
+  });
+
+  // The mapping is store-backed and starts empty. Callers read an empty result as "not known yet"
+  // and admit everything, so this must not be confused with "this type admits nothing".
+  it('should offer nothing while the mapping is empty', () => {
+    expect(subtypesForTypes({}, ['spend'])).toStrictEqual([]);
+  });
+});

--- a/frontend/app/src/modules/history/events/mapping/event-type-subtypes.ts
+++ b/frontend/app/src/modules/history/events/mapping/event-type-subtypes.ts
@@ -1,0 +1,30 @@
+import { uniqueStrings } from '@/modules/core/common/data/data';
+
+/**
+ * Only `Object.keys` is read off the mapping here, so the shape is kept deliberately loose to accept
+ * whatever the event-type schema currently produces.
+ */
+export type EventTypeSubtypeMapping = Record<string, Record<string, unknown>>;
+
+/**
+ * The subtypes a set of event types admits, deduplicated; every known subtype when no type is
+ * given, and none at all while the mapping is still empty.
+ *
+ * The backend reads event types and subtypes as a cross product, so a subtype no selected type
+ * admits matches nothing and the table goes silently empty. Both tables that filter on the pair
+ * (history events, accounting rules) narrow their option list with this and declare it as what the
+ * subtype field `admits`, so the two halves of the rule come from one lookup.
+ */
+export function subtypesForTypes(
+  mapping: EventTypeSubtypeMapping,
+  eventTypes: readonly string[],
+): string[] {
+  if (Object.keys(mapping).length === 0)
+    return [];
+
+  const keys = eventTypes.length === 0
+    ? Object.values(mapping).flatMap(entry => Object.keys(entry))
+    : eventTypes.flatMap(selected => Object.keys(mapping[selected] ?? {}));
+
+  return keys.filter(uniqueStrings);
+}

--- a/frontend/app/src/modules/history/events/use-history-event-fields.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-fields.ts
@@ -4,11 +4,11 @@ import type { AssetsWithId } from '@/modules/assets/types';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import type { Filters } from '@/modules/history/events/use-events-filter';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
-import { uniqueStrings } from '@/modules/core/common/data/data';
 import { assetSuggestions } from '@/modules/core/common/display/assets';
 import { useSharedFieldResolvers } from '@/modules/core/table/filters/shared/use-shared-field-resolvers';
 import { useEventActionPicker } from '@/modules/history/events/action-picker/use-event-action-picker';
 import { type ActionFieldOption, toHistoryAccountField, toHistoryActionField, toHistoryEventFields, toHistoryIgnoredField, toHistoryStateField } from '@/modules/history/events/history-event-fields';
+import { subtypesForTypes } from '@/modules/history/events/mapping/event-type-subtypes';
 import { useHistoryEventCounterpartyMappings } from '@/modules/history/events/mapping/use-history-event-counterparty-mappings';
 import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
 import { isValidHistoryEventState, useHistoryEventStateMapping } from '@/modules/history/events/mapping/use-history-event-state-mapping';
@@ -71,21 +71,11 @@ export function useHistoryEventFields(options: HistoryEventFieldsOptions): Compu
   const shared = useSharedFieldResolvers();
 
   /**
-   * The subtypes a set of event types admits, deduplicated; every known subtype when no type is
-   * picked. The field declares it twice over — as the option list it offers, and as what it
-   * `admits` — so the narrowing and the pruning of an already-picked subtype cannot disagree.
+   * The field declares this twice over — as the option list it offers, and as what it `admits` —
+   * so the narrowing and the pruning of an already-picked subtype cannot disagree.
    */
-  function subtypesFor(eventTypes: readonly string[]): string[] {
-    const mapping = get(historyEventTypeGlobalMapping);
-    if (Object.keys(mapping).length === 0)
-      return [];
-
-    const keys = eventTypes.length === 0
-      ? Object.values(mapping).flatMap(entry => Object.keys(entry))
-      : eventTypes.flatMap(selected => Object.keys(mapping[selected] ?? {}));
-
-    return keys.filter(uniqueStrings);
-  }
+  const subtypesFor = (eventTypes: readonly string[]): string[] =>
+    subtypesForTypes(get(historyEventTypeGlobalMapping), eventTypes);
 
   const selectedEventTypes = computed<string[]>(() => {
     const picked = get(filters)?.eventTypes;

--- a/frontend/app/src/modules/settings/accounting/rule/accounting-rule-fields.spec.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/accounting-rule-fields.spec.ts
@@ -25,6 +25,9 @@ const options: AccountingRuleFieldOptions = {
   eventSubtypes: (): string[] => ['deposit asset'],
   eventTypeName: (value: string): string => (value === 'deposit' ? 'Deposit' : value),
   eventTypes: (): string[] => ['deposit'],
+  // What each event type admits, the lookup the subtype field declares as `admits`.
+  subtypesFor: (eventTypes: readonly string[]): string[] =>
+    eventTypes.includes('deposit') ? ['deposit asset'] : [],
 };
 
 const fields = (): FieldDef[] => toAccountingRuleFields(resolvers, t, options);
@@ -72,6 +75,16 @@ describe('toAccountingRuleFields', () => {
 
     expect(type.suggest?.()).toStrictEqual(['deposit']);
     expect(subtype.suggest?.()).toStrictEqual(['deposit asset']);
+  });
+
+  // A rule is written for a type/subtype pair and the request reads the two as a cross product, so
+  // a subtype the selected types do not admit matches no rule. The bar drops it through
+  // `pruneInadmissible`; here it is the declaration that is pinned.
+  it('should admit only the subtypes of the types it is asked about', () => {
+    const [, subtype] = fields();
+
+    expect(subtype.admits?.({ eventTypes: ['deposit'] })).toStrictEqual(['deposit asset']);
+    expect(subtype.admits?.({ eventTypes: ['spend'] })).toStrictEqual([]);
   });
 
   // The table names the same values through the backend's event mappings, so the pill uses them

--- a/frontend/app/src/modules/settings/accounting/rule/accounting-rule-fields.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/accounting-rule-fields.ts
@@ -18,6 +18,11 @@ export interface AccountingRuleFieldOptions {
   readonly eventTypeName: (value: string) => string;
   readonly eventSubtypes: () => string[];
   readonly eventSubtypeName: (value: string) => string;
+  /**
+   * The same lookup as a function of the types, rather than of the current selection: what the
+   * subtype field `admits` is asked for the types the bar is about to hold, not the ones it holds.
+   */
+  readonly subtypesFor: (eventTypes: readonly string[]) => string[];
   readonly counterparties: () => string[];
 }
 
@@ -44,6 +49,10 @@ export function toAccountingRuleFields(
       suggest: options.eventTypes,
     }),
     toMatchFieldDef({
+      // A rule is written for a type/subtype pair, and the request reads the two as a cross
+      // product, so a subtype the selected types do not admit matches no rule at all. The bar
+      // narrows what can be added and drops what stops being admitted, both off one lookup.
+      admits: values => options.subtypesFor(values[AccountingRuleFilterKeys.EVENT_TYPE] ?? []),
       key: AccountingRuleFilterKeys.EVENT_SUBTYPE,
       label: t('accounting_settings.rule.filter_field_labels.event_subtype'),
       multiple: true,

--- a/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-fields.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-fields.ts
@@ -1,6 +1,8 @@
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
+import type { Filters } from '@/modules/settings/accounting/rule/use-accounting-rule-filter';
 import { useSharedFieldResolvers } from '@/modules/core/table/filters/shared/use-shared-field-resolvers';
+import { subtypesForTypes } from '@/modules/history/events/mapping/event-type-subtypes';
 import { useHistoryEventCounterpartyMappings } from '@/modules/history/events/mapping/use-history-event-counterparty-mappings';
 import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
 import { toAccountingRuleFields } from '@/modules/settings/accounting/rule/accounting-rule-fields';
@@ -9,8 +11,12 @@ import { toAccountingRuleFields } from '@/modules/settings/accounting/rule/accou
  * The pill-bar fields for the accounting rules table. Built inside a computed so the labels track
  * the locale: fields built once at setup keep the language they were created in until the component
  * remounts.
+ *
+ * Reads the table's filter bag because the subtype field narrows by the picked event types, which
+ * is why the caller owns the bag rather than leaving it to `useServerTable`. Read-only: the bar
+ * prunes what a narrowing no longer admits, through the field's own `admits`.
  */
-export function useAccountingRuleFields(): ComputedRef<FieldDef[]> {
+export function useAccountingRuleFields(filters: MaybeRefOrGetter<Filters>): ComputedRef<FieldDef[]> {
   const { t } = useI18n({ useScope: 'global' });
   // Protocol resolution is the same for every table filtering on one, so it comes from one place
   // rather than being restated here.
@@ -19,16 +25,32 @@ export function useAccountingRuleFields(): ComputedRef<FieldDef[]> {
   const {
     getHistoryEventSubTypeName,
     getHistoryEventTypeName,
-    historyEventSubTypes,
+    historyEventTypeGlobalMapping,
     historyEventTypes,
   } = useHistoryEventMappings();
   const { counterparties } = useHistoryEventCounterpartyMappings();
 
+  /**
+   * Declared twice over — as the option list the subtype field offers, and as what it `admits` — so
+   * the narrowing and the pruning of an already-picked subtype cannot disagree.
+   */
+  const subtypesFor = (eventTypes: readonly string[]): string[] =>
+    subtypesForTypes(get(historyEventTypeGlobalMapping), eventTypes);
+
+  const selectedEventTypes = computed<string[]>(() => {
+    const picked = toValue(filters)?.eventTypes;
+    if (picked === undefined)
+      return [];
+
+    return (Array.isArray(picked) ? picked : [picked]).map(entry => entry.toString());
+  });
+
   return computed<FieldDef[]>(() => toAccountingRuleFields(shared, t, {
     counterparties: (): string[] => get(counterparties),
     eventSubtypeName: getHistoryEventSubTypeName,
-    eventSubtypes: (): string[] => get(historyEventSubTypes),
+    eventSubtypes: (): string[] => subtypesFor(get(selectedEventTypes)),
     eventTypeName: getHistoryEventTypeName,
     eventTypes: (): string[] => get(historyEventTypes),
+    subtypesFor,
   }));
 }

--- a/frontend/app/src/modules/settings/accounting/rule/use-accounting-rules-table.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/use-accounting-rules-table.ts
@@ -31,7 +31,10 @@ export function useAccountingRulesTable(): UseAccountingRulesTableReturn {
   const { getAccountingRules } = useAccountingSettings();
 
   const modelCustomRuleHandling = shallowRef<CustomRuleHandling>(CustomRuleHandling.EXCLUDE);
-  const fields = useAccountingRuleFields();
+  // Owned here rather than left to the table: the subtype field narrows by the picked event types,
+  // so the fields read the bag, and they are built before the table that would otherwise own it.
+  const modelFilters = ref<Filters>({});
+  const fields = useAccountingRuleFields(modelFilters);
 
   const {
     collection,
@@ -42,6 +45,7 @@ export function useAccountingRulesTable(): UseAccountingRulesTableReturn {
   } = useServerTable<AccountingRuleEntry, AccountingRuleRequestPayload, Filters>({
     fetch: getAccountingRules,
     fields,
+    filters: modelFilters,
     params: [{
       to: 'both',
       values: computed<Record<string, unknown>>(() => ({


### PR DESCRIPTION
The accounting rules bar offered **every** event subtype the backend knows, whatever event type was picked. A rule is written for a type/subtype pair and the request reads the two as a cross product, so an incompatible pair matches no rule: the table empties and nothing says why. Picking `deposit` and then `fee` is enough to do it.

History events had this same trap and was guarded; accounting rules never was.

## What changes

The subtype field declares `admits` (added in #12835), so the bar narrows what can be added **and** drops a value that stops being admitted when the type selection changes. Both halves come from one lookup, which is what keeps them from drifting apart.

That lookup — "which subtypes does this set of event types allow" — now lives in `subtypesForTypes`, moved out of `use-history-event-fields.ts` since it has a second caller. It carries the guard both callers depend on: an empty mapping returns nothing, and callers read that as "not known yet" rather than "nothing is allowed", so a restored selection is not wiped while the store-backed mapping is still loading.

The accounting rules table now owns its filter bag, for the same reason history and manual balances do: its fields read what is picked, and they are built before the table.

## Tests

`subtypesForTypes` gets its own spec — the union across several types, an unknown type, and the empty-mapping case that the guard depends on. The accounting rule field spec pins the declaration.

Typecheck clean, lint 0 errors, 771 files / 7399 tests.

## Note

Not driven in the app. It is the same mechanism verified end-to-end on history events in #12835 (pill drops the value, page resets, one request per action), and this change only declares the rule for a second table rather than altering how it is applied. Happy to run it through the UI if you would rather see it.