### PR TITLE
feat(history): flag the group row being re-decoded

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -6603,6 +6603,7 @@
       "note": {
         "merchant_code": "Merchant Code: {code}"
       },
+      "redecoding": "Re-decoding",
       "selection_mode": {
         "all_matching_selected": "All events in {count} groups are selected",
         "create_rule": "Set custom accounting rule",

--- a/frontend/app/src/modules/history/events/HistoryEventsAction.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsAction.vue
@@ -33,10 +33,15 @@ import {
   isGroupEditableHistoryEvent,
 } from '@/modules/history/management/forms/form-guards';
 
-const { event, loading, duplicateHandlingStatus, groupEvents } = defineProps<{
+const { event, loading, redecoding, duplicateHandlingStatus, groupEvents } = defineProps<{
   event: HistoryEventEntry;
   groupEvents?: HistoryEventEntry[];
   loading: boolean;
+  /**
+   * This group's own re-decode is in flight. Kept apart from `loading`, which follows every events
+   * fetch (paging, scrolling, filtering) and so would disable the action on routine refreshes.
+   */
+  redecoding?: boolean;
   duplicateHandlingStatus?: DuplicateHandlingStatus;
 }>();
 
@@ -293,7 +298,7 @@ function confirmIgnoreDuplicate(): void {
       <template v-if="blockEvent">
         <RuiButton
           variant="list"
-          :disabled="loading || ethBlockEventsDecoding"
+          :disabled="loading || redecoding || ethBlockEventsDecoding"
           @click="redecode(blockEvent)"
         >
           <template #prepend>
@@ -304,7 +309,7 @@ function confirmIgnoreDuplicate(): void {
       </template>
       <template v-else-if="eventWithDecoding">
         <RedecodeEventsButton
-          :disabled="loading || txEventsDecoding"
+          :disabled="loading || redecoding || txEventsDecoding"
           :has-options="!!decodableEvmEvent"
           @redecode="redecode(eventWithDecoding)"
           @redecode-with-options="decodableEvmEvent && redecodeWithOptions(decodableEvmEvent)"

--- a/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
@@ -5,6 +5,7 @@ import { type DuplicateHandlingStatus, getHighlightClass, type HighlightType } f
 import HistoryEventAccount from '@/modules/history/events/HistoryEventAccount.vue';
 import HistoryEventsAction from '@/modules/history/events/HistoryEventsAction.vue';
 import HistoryEventsIdentifier from '@/modules/history/events/HistoryEventsIdentifier.vue';
+import { useEventRedecodeStatus } from '@/modules/history/events/use-event-redecode-status';
 import IgnoredInAccountingIcon from '@/modules/history/IgnoredInAccountingIcon.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import LocationIcon from '@/modules/shell/components/display/LocationIcon.vue';
@@ -51,6 +52,8 @@ const { t } = useI18n({ useScope: 'global' });
 const showingIgnoredAssets = computed<boolean>(() => ignoredAssets === 'showing');
 
 const isCard = computed<boolean>(() => variant === 'card');
+
+const redecoding = useEventRedecodeStatus(() => group, () => groupEvents);
 </script>
 
 <template>
@@ -107,6 +110,14 @@ const isCard = computed<boolean>(() => variant === 'card');
           :group-events="groupEvents"
           class="min-w-0 flex-1"
         />
+
+        <span
+          v-if="redecoding"
+          data-testid="event-redecoding"
+          class="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide text-rui-primary bg-rui-primary/10 animate-pulse"
+        >
+          {{ t('transactions.events.redecoding') }}
+        </span>
       </div>
 
       <HistoryEventsAction
@@ -114,6 +125,7 @@ const isCard = computed<boolean>(() => variant === 'card');
         :event="group"
         :group-events="groupEvents"
         :loading="loading"
+        :redecoding="redecoding"
         :duplicate-handling-status="duplicateHandlingStatus"
         class="shrink-0"
         @add-event="emit('add-event', $event)"
@@ -200,6 +212,14 @@ const isCard = computed<boolean>(() => variant === 'card');
         class="min-w-0"
       />
 
+      <span
+        v-if="redecoding"
+        data-testid="event-redecoding"
+        class="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide text-rui-primary bg-rui-primary/10 animate-pulse"
+      >
+        {{ t('transactions.events.redecoding') }}
+      </span>
+
       <template v-if="group.locationLabel">
         <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
         <span class="text-[10px] text-rui-text-secondary shrink-0">●</span>
@@ -222,6 +242,7 @@ const isCard = computed<boolean>(() => variant === 'card');
       :event="group"
       :group-events="groupEvents"
       :loading="loading"
+      :redecoding="redecoding"
       :duplicate-handling-status="duplicateHandlingStatus"
       class="shrink-0"
       @add-event="emit('add-event', $event)"

--- a/frontend/app/src/modules/history/events/use-event-redecode-status.spec.ts
+++ b/frontend/app/src/modules/history/events/use-event-redecode-status.spec.ts
@@ -1,0 +1,114 @@
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import { HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { blockDecodeActivityId, targetedDecodeActivityId } from '@/modules/history/events/tx/decode-activity';
+import { ActivityKind, makeActivityId } from '@/modules/task-center/core/types';
+import { useEventRedecodeStatus } from './use-event-redecode-status';
+
+const mocks = vi.hoisted(() => ({
+  statusOf: vi.fn(),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({
+    getChain: vi.fn((location: string) => (location === 'ethereum' ? 'eth' : location)),
+  })),
+}));
+
+vi.mock('@/modules/task-center/use-task-orchestrator', () => ({
+  useTaskOrchestrator: vi.fn(() => ({
+    statusOf: mocks.statusOf,
+    version: ref(0),
+  })),
+}));
+
+function evmEvent(txRef: string): HistoryEventEntry {
+  return createMock<HistoryEventEntry>({
+    entryType: HistoryEventEntryType.EVM_EVENT,
+    location: 'ethereum',
+    txRef,
+  });
+}
+
+function blockEvent(blockNumber: number): HistoryEventEntry {
+  return createMock<HistoryEventEntry>({
+    blockNumber,
+    entryType: HistoryEventEntryType.ETH_BLOCK_EVENT,
+    location: 'ethereum',
+  });
+}
+
+/** The id the composable asked about, rebuilt from the arguments `statusOf` received. */
+function queriedId(): string {
+  const [kind, ...parts] = mocks.statusOf.mock.calls[0];
+  return makeActivityId(kind, ...parts);
+}
+
+describe('useEventRedecodeStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.statusOf.mockReturnValue({ active: false, everCompleted: false, pending: false, running: false });
+  });
+
+  it('should ask about the same activity id the targeted redecode submits', () => {
+    const status = useEventRedecodeStatus(() => evmEvent('0xabc'), () => []);
+    get(status);
+
+    expect(mocks.statusOf).toHaveBeenCalledWith(ActivityKind.TX_DECODING, 'eth', 'pull', '0xabc');
+    expect(queriedId()).toBe(targetedDecodeActivityId('eth', ['0xabc']));
+  });
+
+  it('should ask about the block decode id for a block event', () => {
+    const status = useEventRedecodeStatus(() => blockEvent(21_000_000), () => []);
+    get(status);
+
+    expect(queriedId()).toBe(blockDecodeActivityId([21_000_000]));
+  });
+
+  it('should report the orchestrator liveness for that activity', () => {
+    mocks.statusOf.mockReturnValue({ active: true, everCompleted: false, pending: false, running: true });
+
+    const status = useEventRedecodeStatus(() => evmEvent('0xabc'), () => []);
+
+    expect(get(status)).toBe(true);
+  });
+
+  it('should fall back to the first decodable child when the group header is not decodable', () => {
+    const header = createMock<HistoryEventEntry>({
+      entryType: HistoryEventEntryType.HISTORY_EVENT,
+      location: 'ethereum',
+    });
+
+    const status = useEventRedecodeStatus(() => header, () => [evmEvent('0xdef')]);
+    get(status);
+
+    expect(queriedId()).toBe(targetedDecodeActivityId('eth', ['0xdef']));
+  });
+
+  it('should stay inactive for an event that cannot be redecoded', () => {
+    const header = createMock<HistoryEventEntry>({
+      entryType: HistoryEventEntryType.HISTORY_EVENT,
+      location: 'kraken',
+    });
+
+    const status = useEventRedecodeStatus(() => header, () => []);
+
+    expect(get(status)).toBe(false);
+    expect(mocks.statusOf).not.toHaveBeenCalled();
+  });
+
+  it('should track the event it is given rather than the one it started with', () => {
+    // A getter over a plain ref of the tx ref, rather than a ref holding the mock itself: the mock
+    // is a Proxy and Vue's `toRaw` recurses forever on one placed in reactive state.
+    const txRef = ref<string>('0xabc');
+    const status = useEventRedecodeStatus(() => evmEvent(get(txRef)), () => []);
+    get(status);
+
+    set(txRef, '0xfeed');
+    get(status);
+
+    const [kind, ...parts] = mocks.statusOf.mock.calls[1];
+    expect(makeActivityId(kind, ...parts)).toBe(targetedDecodeActivityId('eth', ['0xfeed']));
+  });
+});

--- a/frontend/app/src/modules/history/events/use-event-redecode-status.ts
+++ b/frontend/app/src/modules/history/events/use-event-redecode-status.ts
@@ -1,0 +1,82 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import type { DecodableEventType } from '@/modules/history/management/forms/form-guards';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import {
+  isEthBlockEvent,
+  isEvmEvent,
+  isEvmSwapEvent,
+  isSolanaEvent,
+  isSolanaSwapEvent,
+  toLocationAndTxRef,
+} from '@/modules/history/event-utils';
+import { blockDecodeActivityId, targetedDecodeActivityId } from '@/modules/history/events/tx/decode-activity';
+import { type ActivityId, ActivityKind, activityParts } from '@/modules/task-center/core/types';
+import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
+
+/** The decode activity a group row would produce if it were re-decoded right now. */
+interface DecodeTarget {
+  kind: ActivityKind;
+  id: ActivityId;
+}
+
+/**
+ * Whether the re-decode of *this* group row is in flight.
+ *
+ * The row does not track its own pending state: a targeted re-decode is submitted under an activity
+ * id that is deterministic from the request, so the row can rebuild that id from the event it
+ * already holds and read the orchestrator. Nothing has to be threaded down from the view, and the
+ * indicator cannot drift out of sync with the work.
+ *
+ * ⚠️ The id is built by {@link targetedDecodeActivityId}/{@link blockDecodeActivityId} and taken
+ * apart again by {@link activityParts}, rather than by restating the parts here. A divergence
+ * between the two would not fail loudly — the row would simply never light up.
+ *
+ * Scoped to a single-row re-decode, which is what it is for. A bulk re-decode is submitted as one
+ * activity over the whole comma-joined set, so its id is not any single row's, and the page-level
+ * progress covers it.
+ */
+export function useEventRedecodeStatus(
+  event: MaybeRefOrGetter<HistoryEventEntry>,
+  groupEvents: MaybeRefOrGetter<HistoryEventEntry[] | undefined>,
+): ComputedRef<boolean> {
+  const { getChain } = useSupportedChains();
+  const { statusOf, version } = useTaskOrchestrator();
+
+  /** The event a re-decode would actually act on — the group header, or the first decodable child. */
+  function resolveDecodable(group: HistoryEventEntry, children: HistoryEventEntry[]): DecodableEventType | undefined {
+    for (const item of [group, ...children]) {
+      if (isEvmEvent(item) || isEvmSwapEvent(item) || isSolanaEvent(item) || isSolanaSwapEvent(item))
+        return item;
+    }
+
+    return undefined;
+  }
+
+  const target = computed<DecodeTarget | undefined>(() => {
+    const group = toValue(event);
+
+    if (isEthBlockEvent(group)) {
+      return {
+        id: blockDecodeActivityId([group.blockNumber]),
+        kind: ActivityKind.ETH_BLOCK_DECODING,
+      };
+    }
+
+    const decodable = resolveDecodable(group, toValue(groupEvents) ?? []);
+    if (!decodable)
+      return undefined;
+
+    const { location, txRef } = toLocationAndTxRef(decodable);
+    return {
+      id: targetedDecodeActivityId(getChain(location), [txRef]),
+      kind: ActivityKind.TX_DECODING,
+    };
+  });
+
+  return computed<boolean>(() => {
+    get(version); // touch the change counter so the read recomputes on every orchestrator mutation
+    const current = get(target);
+    return current ? statusOf(current.kind, ...activityParts(current.id)).active : false;
+  });
+}


### PR DESCRIPTION
Closes #12677

Re-decoding a single event from the row kebab menu only surfaced in the page-level decoding status at the top of the page. The row the user actually acted on gave no sign anything was happening, so it was easy to think the click had not registered until the row silently updated.

While a re-decode of that group is in flight, the group row now shows a small "Re-decoding" pill next to the identifier, and the group's own re-decode menu entries are disabled until it settles. The pill pulses rather than spinning, matching the treatment already used for in-progress decoding in `DecodingProgressItem.vue`.

## Implementation

The row does not track any pending state of its own. A targeted re-decode is submitted under an activity id that is deterministic from the request, so `use-event-redecode-status.ts` rebuilds that id from the event the row already holds and reads the orchestrator. Nothing has to be threaded down from the view, and the indicator cannot drift out of sync with the work.

Two details worth pointing out for review:

- The id is built by the shared `targetedDecodeActivityId` / `blockDecodeActivityId` helpers and taken apart again by `activityParts()` to feed `statusOf`, rather than restating the parts at this call site. A divergence between the two would not fail loudly, it would just mean the row never lights up, so the spec asserts the rebuilt id equals the helper's output.
- It reads `useTaskOrchestrator()` rather than `useIsActive` from `useTaskCenter()`. `useIsActive` fixes its part count at call time, and a transaction target has four parts against a block target's two, which breaks on a recycled virtual-table row.

The new prop is `redecoding`, kept separate from the existing `loading`. `loading` follows every events fetch (paging, scrolling, filtering), so binding the indicator to it would light up every row on routine refreshes.

Scoped to a single-row re-decode, which is what the issue asks for. A bulk re-decode is submitted as one activity over the whole set, so its id is not any single row's, and the existing page-level progress covers it.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

No user guide change: this adds in-progress feedback to an existing action rather than changing how it is used.
