### PR TITLE
Seed the app version from the frontend build

### DIFF
--- a/frontend/app/src/modules/core/common/use-main-store.ts
+++ b/frontend/app/src/modules/core/common/use-main-store.ts
@@ -84,11 +84,16 @@ function applyDemoMode(version: string): string {
   return sanitized;
 }
 
+/**
+ * Until the backend answers, the frontend build version is the closest thing we have.
+ * It keeps the about dialog and the release notes link sane on the login screen,
+ * and gets overwritten by the backend version as soon as the connection is up.
+ */
 function defaultVersion(): Version {
   return {
     downloadUrl: '',
     latestVersion: '',
-    version: '',
+    version: __APP_VERSION__,
   };
 }
 

--- a/frontend/app/src/modules/shell/app/use-backend-connection.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-connection.spec.ts
@@ -79,7 +79,7 @@ describe('useBackendConnection', () => {
       });
     });
 
-    it('should not update version when info returns no version', async () => {
+    it('should keep the frontend version when info returns no version', async () => {
       mockInfo.mockResolvedValue({});
 
       const { useBackendConnection } = await importModule();
@@ -87,7 +87,7 @@ describe('useBackendConnection', () => {
       await getVersion();
 
       const store = useMainStore();
-      expect(get(store.version).version).toBe('');
+      expect(get(store.version).version).toBe(__APP_VERSION__);
     });
   });
 

--- a/frontend/app/src/modules/shell/components/About.vue
+++ b/frontend/app/src/modules/shell/components/About.vue
@@ -52,11 +52,11 @@ const electronVersion = computed<SystemVersion | null>(() => {
 const frontendVersion = __APP_VERSION__;
 
 const versionText = computed(() => {
-  const appVersion = t('about.app_version');
-  const frontendVersion = t('about.frontend_version');
+  const appVersionLabel = t('about.app_version');
+  const frontendVersionLabel = t('about.frontend_version');
   let versionText = '';
-  versionText += `${appVersion} ${get(version).version}\r\n`;
-  versionText += `${frontendVersion} ${frontendVersion}\r\n`;
+  versionText += `${appVersionLabel} ${get(version).version}\r\n`;
+  versionText += `${frontendVersionLabel} ${frontendVersion}\r\n`;
 
   const web = get(webVersion);
   const app = get(electronVersion);

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -1,4 +1,5 @@
 import type { ComponentResolver } from 'unplugin-vue-components';
+import { readFileSync } from 'node:fs';
 import { builtinModules } from 'node:module';
 import { join, resolve } from 'node:path';
 import process from 'node:process';
@@ -18,6 +19,11 @@ import { backendIconsCachePlugin } from './scripts/extract-backend-icons';
 
 const PACKAGE_ROOT = __dirname;
 const PROJECT_ROOT = resolve(PACKAGE_ROOT, '../..');
+
+// Read from the manifest instead of npm_package_version: the latter depends on how
+// the process was launched and is the workspace root's version when it is not vite
+// that pnpm invoked directly.
+const appVersion: string = JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf8')).version;
 
 /**
  * Under `pnpm dev` the process forwarder already prefixes every line with its own
@@ -173,7 +179,7 @@ export default defineConfig({
   },
   customLogger: createConfigLogger(),
   define: {
-    __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+    __APP_VERSION__: JSON.stringify(appVersion),
   },
   optimizeDeps: {
     include: [


### PR DESCRIPTION
Before the backend connects, the main store held an empty version. The about dialog on the login screen therefore showed a blank version and its release-notes link pointed at `releases/tag/v`.

The store now defaults to the frontend build version and the backend version overwrites it as soon as the connection is up.

Two related fixes:
- `__APP_VERSION__` was defined from `process.env.npm_package_version`, which is whichever package pnpm invoked (the workspace root's `1.0.0` when vite is not started directly). It now reads `app/package.json`.
- The about dialog's copy-to-clipboard text had a shadowed variable, so the frontend row printed the label twice instead of the version.

Lint, typecheck and the related unit specs pass. Not verified in a running app.