### PR TITLE
Pause background balance queries for a history sync

### DIFF
--- a/frontend/app/src/modules/accounts/use-account-migration.ts
+++ b/frontend/app/src/modules/accounts/use-account-migration.ts
@@ -6,6 +6,7 @@ import { useSessionStorage } from '@vueuse/core';
 import { useBlockchainAccountManagement } from '@/modules/accounts/use-blockchain-account-management';
 import { useLoggedUserIdentifier } from '@/modules/auth/use-logged-user-identifier';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { RefreshMode } from '@/modules/balances/types/refresh-mode';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -69,7 +70,7 @@ export function useAccountMigration(): UseAccountMigrationReturn {
         await fetchAccounts({ blockchain: chain });
         await refreshBlockchainBalances(
           { blockchain: chain },
-          'background',
+          RefreshMode.BACKGROUND,
           isEvm(chain) ? { detect: true, detectAddresses: chainAddresses } : {},
         );
       })());

--- a/frontend/app/src/modules/accounts/use-account-operations.ts
+++ b/frontend/app/src/modules/accounts/use-account-operations.ts
@@ -9,9 +9,9 @@ import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-
 import { useAccountFetching } from '@/modules/accounts/use-account-fetching';
 import { useAccountLoadState } from '@/modules/accounts/use-account-load-state';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
+import { RefreshMode } from '@/modules/balances/types/refresh-mode';
 import { useBalanceHydration } from '@/modules/balances/use-balance-hydration';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
-import { uniqueStrings } from '@/modules/core/common/data/data';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -156,7 +156,7 @@ export function useAccountOperations(): UseAccountOperationsReturn {
     if (!addresses?.length || !chain || supportsTransactions(chain))
       return undefined;
 
-    return addresses.filter(uniqueStrings);
+    return [...new Set(addresses)];
   };
 
   /**
@@ -183,7 +183,7 @@ export function useAccountOperations(): UseAccountOperationsReturn {
     // drives its own chain: nothing else will.
     const pending: Promise<any>[] = [];
     if (shouldRefresh)
-      pending.push(refreshBlockchainBalances({ addresses: uniqueAddresses, blockchain: chain, isXpub }, periodic ? 'periodic' : 'background'));
+      pending.push(refreshBlockchainBalances({ addresses: uniqueAddresses, blockchain: chain, isXpub }, periodic ? RefreshMode.PERIODIC : RefreshMode.BACKGROUND));
     else if (chain !== undefined)
       pending.push(hydrate({ addresses: uniqueAddresses, blockchain: chain, isXpub }));
 

--- a/frontend/app/src/modules/balances/types/refresh-mode.ts
+++ b/frontend/app/src/modules/balances/types/refresh-mode.ts
@@ -1,0 +1,19 @@
+/**
+ * Who asked for a balance refresh, which is what decides what happens when the chain is already busy.
+ *
+ * - `BACKGROUND`: join the run in flight. Two callers wanting the same thing share one query.
+ * - `PERIODIC`: settle SKIPPED with a reason. A tick that finds the chain busy has nothing to add,
+ *   and recording it as `ok` would mark the chain refreshed when nothing ran.
+ * - `USER`: supersede. Someone pressed refresh, so they get a fresh query with *their* parameters
+ *   rather than whatever the background run happened to be doing. Also the only mode exempt from
+ *   the orchestrator's history-sync pause.
+ *
+ * Lives apart from `use-blockchain-balances` so a spec mocking that composable keeps the enum.
+ */
+export const RefreshMode = {
+  BACKGROUND: 'background',
+  PERIODIC: 'periodic',
+  USER: 'user',
+} as const;
+
+export type RefreshMode = (typeof RefreshMode)[keyof typeof RefreshMode];

--- a/frontend/app/src/modules/balances/use-balance-fetching.ts
+++ b/frontend/app/src/modules/balances/use-balance-fetching.ts
@@ -8,6 +8,7 @@ import { useBalancesApi } from '@/modules/balances/api/use-balances-api';
 import { useAutoTokenDetection } from '@/modules/balances/blockchain/use-auto-token-detection';
 import { useExchanges } from '@/modules/balances/exchanges/use-exchanges';
 import { useManualBalances } from '@/modules/balances/manual/use-manual-balances';
+import { RefreshMode } from '@/modules/balances/types/refresh-mode';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -92,7 +93,7 @@ export const useBalanceFetching = createSharedComposable(() => {
     // a stage *inside* the chain job that reads its result, a chain is one job either way and the
     // split has nothing left to express — a chain that cannot hold tokens simply has no detect
     // stage.
-    await refreshBlockchainBalances({}, 'background', { detect });
+    await refreshBlockchainBalances({}, RefreshMode.BACKGROUND, { detect });
   });
 
   const fetch = async (): Promise<void> => {
@@ -122,7 +123,7 @@ export const useBalanceFetching = createSharedComposable(() => {
     ]);
 
     await Promise.allSettled([
-      refreshBlockchainBalances({}, 'periodic'),
+      refreshBlockchainBalances({}, RefreshMode.PERIODIC),
       refreshPrices(true),
     ]);
   };

--- a/frontend/app/src/modules/balances/use-balance-refresh.ts
+++ b/frontend/app/src/modules/balances/use-balance-refresh.ts
@@ -1,6 +1,7 @@
 import type { MaybeRef } from 'vue';
 import { useTokenDetectionOrchestrator } from '@/modules/balances/blockchain/use-token-detection-orchestrator';
 import { useExchanges } from '@/modules/balances/exchanges/use-exchanges';
+import { RefreshMode } from '@/modules/balances/types/refresh-mode';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { arrayify } from '@/modules/core/common/data/array';
 import { BlockchainRefreshButtonBehaviour } from '@/modules/settings/types/frontend-settings';
@@ -21,7 +22,7 @@ export const useBalanceRefresh = createSharedComposable(() => {
     const chain = blockchain ? arrayify(blockchain) : undefined;
     await refreshBlockchainBalances({
       blockchain: chain,
-    }, 'user');
+    }, RefreshMode.USER);
   };
 
   const { detectAllTokens } = useTokenDetectionOrchestrator();

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -1,3 +1,4 @@
+import type { RefreshMode } from '@/modules/balances/types/refresh-mode';
 import type { EvmChainInfo, SupportedChains } from '@/modules/core/api/types/chains';
 import { Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
@@ -9,7 +10,7 @@ import { createAccount } from '@/modules/accounts/create-account';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useBlockchainBalancesApi } from '@/modules/balances/api/use-blockchain-balances-api';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
-import { type RefreshMode, useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
+import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
 
 vi.mock('@/modules/core/notifications/use-notifications-store', () => ({

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -2,28 +2,18 @@ import type { BlockchainBalancePayload } from '@/modules/balances/types/blockcha
 import { err, type Result } from 'plainfp/result';
 import { msg } from '@/message-key';
 import { useTokenDetectionOrchestrator } from '@/modules/balances/blockchain/use-token-detection-orchestrator';
+import { RefreshMode } from '@/modules/balances/types/refresh-mode';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { arrayify } from '@/modules/core/common/data/array';
 import { setDigest } from '@/modules/core/common/data/digest';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { Cancelled, Skipped, type TaskError } from '@/modules/core/tasks/task-result';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
-import { BALANCES_LANE } from '@/modules/task-center/core/orchestrator/spec';
+import { BALANCES_LANE, DEFAULT_PRIORITY, Priority } from '@/modules/task-center/core/orchestrator/spec';
 import { type ActivityId, ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
 import { useActivityBatch } from '@/modules/task-center/use-activity-batch';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 import { useBalanceProcessingService } from './services/use-balance-processing-service';
-
-/**
- * Who asked for this refresh, which is what decides what happens when the chain is already busy.
- *
- * - `background`: join the run in flight. Two callers wanting the same thing share one query.
- * - `periodic`: settle SKIPPED with a reason. A tick that finds the chain busy has nothing to add,
- *   and recording it as `ok` would mark the chain refreshed when nothing ran.
- * - `user`: supersede. Someone pressed refresh, so they get a fresh query with *their* parameters
- *   rather than whatever the background run happened to be doing.
- */
-export type RefreshMode = 'background' | 'periodic' | 'user';
 
 export interface RefreshOptions {
   /**
@@ -87,11 +77,11 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
    */
   const isChainRefreshing = (chain: string): boolean => get(refreshState.refreshingChains).has(chain);
 
-  // Network refresh — one native BLOCKCHAIN_BALANCES activity per chain on BALANCES_LANE (cap 2,
-  // paused during decode by the orchestrator rule, replacing the old BalanceQueueService).
+  // Network refresh: one native BLOCKCHAIN_BALANCES activity per chain on BALANCES_LANE (cap 2;
+  // background runs pause while a history sync is running, per the orchestrator rule).
   const refreshBlockchainBalances = async (
     payload: BlockchainBalancePayload = {},
-    mode: RefreshMode = 'background',
+    mode: RefreshMode = RefreshMode.BACKGROUND,
     options: RefreshOptions = {},
   ): Promise<void> => {
     const { detect = false, detectAddresses } = options;
@@ -105,7 +95,7 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
     // non-periodic path. That poll was standing in for supersede: it made a manual refresh wait for
     // the background run to finish and then re-query, which is the right *outcome* reached by
     // waiting out work the user had already superseded.
-    const submit = mode === 'user' ? supersedeTask : submitTask;
+    const submit = mode === RefreshMode.USER ? supersedeTask : submitTask;
 
     const chainJob = async (chain: string, parent: ActivityId | undefined): Promise<void> => {
       const chainPayload = { addresses, blockchain: chain, isXpub };
@@ -133,6 +123,9 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
         parent,
         kind: ActivityKind.BLOCKCHAIN_BALANCES,
         lane: BALANCES_LANE,
+        // Jumps queued background work, and exempts the job from `pauseBalancesDuringHistorySync`:
+        // a user pressing refresh must not wait out a whole history sync.
+        priority: mode === RefreshMode.USER ? Priority.USER : DEFAULT_PRIORITY,
         rerunnable: true,
         run: async ({ cancelled, runTask }): Promise<Result<void, TaskError>> => {
           // 🔴 A dropped refresh is SKIPPED with a reason, never `ok`. Returning success here
@@ -142,7 +135,7 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
           //
           // `Skipped` is not `isActionable`, so this raises no notification; it settles the
           // activity terminal-but-not-successful and the task centre renders the reason.
-          if (mode === 'periodic' && isChainRefreshing(chain))
+          if (mode === RefreshMode.PERIODIC && isChainRefreshing(chain))
             return err(Skipped({ message: t('actions.balances.blockchain.skipped.busy') }));
 
           // ⭐ Statement order is the ordering. Detection's children run under this job and are

--- a/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-staking-refresh.ts
@@ -3,6 +3,7 @@ import { Blockchain } from '@rotki/common';
 import dayjs from 'dayjs';
 import { useEthStaking } from '@/modules/accounts/use-eth-staking';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { RefreshMode } from '@/modules/balances/types/refresh-mode';
 import { useBalanceHydration } from '@/modules/balances/use-balance-hydration';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
@@ -71,7 +72,7 @@ export function useEthStakingRefresh(callbacks: RefreshCallbacks): UseEthStaking
         // join whatever is already querying eth2.
         await refreshBlockchainBalances({
           blockchain: Blockchain.ETH2,
-        }, userInitiated ? 'user' : 'background');
+        }, userInitiated ? RefreshMode.USER : RefreshMode.BACKGROUND);
       }
       else {
         await hydrate({

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-operations.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-operations.ts
@@ -4,6 +4,7 @@ import type { StakingValidatorManage } from '@/modules/accounts/blockchain/use-a
 import { Blockchain } from '@rotki/common';
 import { useAccountDelete } from '@/modules/accounts/blockchain/use-account-delete';
 import { useEthStaking } from '@/modules/accounts/use-eth-staking';
+import { RefreshMode } from '@/modules/balances/types/refresh-mode';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
 import { ActivityKind, ActivityPart } from '@/modules/task-center/core/types';
@@ -55,7 +56,7 @@ export function useEthValidatorOperations(): UseEthValidatorOperationsReturn {
     await fetchEthStakingValidators({ ignoreCache: true });
     await refreshBlockchainBalances({
       blockchain: Blockchain.ETH2,
-    }, 'user');
+    }, RefreshMode.USER);
   }
 
   function confirmDelete(item: EthereumValidator): void {

--- a/frontend/app/src/modules/task-center/activity-outcome.spec.ts
+++ b/frontend/app/src/modules/task-center/activity-outcome.spec.ts
@@ -18,7 +18,7 @@ describe('activityOutcome', () => {
   it('should fill only the outcomes that need attention', () => {
     const filled = Object.values(ActivityStatus).filter(status => activityOutcome(status).variant === 'filled');
 
-    expect(filled).toStrictEqual([ActivityStatus.FAILED, ActivityStatus.SKIPPED]);
+    expect(filled).toStrictEqual([ActivityStatus.FAILED]);
   });
 
   it('should give every status an icon', () => {

--- a/frontend/app/src/modules/task-center/activity-outcome.ts
+++ b/frontend/app/src/modules/task-center/activity-outcome.ts
@@ -17,9 +17,10 @@ export interface ActivityOutcome {
   /**
    * **Filled means it needs your attention; outlined means it is expected.**
    *
-   * Only FAILED and SKIPPED are filled. A history refresh settles dozens of children successfully,
-   * and filling those made a wall of green "Done" the loudest thing in the panel — drowning the
-   * one chain at 60% and the one at 0%, which is the only part a reader is actually there for.
+   * Only FAILED is filled. A history refresh settles dozens of children successfully, and filling
+   * those made a wall of green "Done" the loudest thing in the panel, drowning the one chain at 60%
+   * and the one at 0%, which is the only part a reader is actually there for. A skip is expected
+   * too: filled amber shouted over every neighbouring row for something nobody has to act on.
    */
   readonly variant: 'filled' | 'outlined';
 }
@@ -75,7 +76,7 @@ const OUTCOME: Record<ActivityStatus, ActivityOutcome> = {
     color: 'warning',
     icon: 'lu-skip-forward',
     key: msg.$t('pending_task.status.skipped'),
-    variant: 'filled',
+    variant: 'outlined',
   },
 };
 

--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
@@ -182,20 +182,34 @@ describe('createTaskOrchestrator', () => {
     expect(byId(orchestrator, secondId)?.status).toBe(Status.RUNNING);
   });
 
-  it('should pause balances while decoding runs (default rule)', async () => {
+  it('should pause background balances while a history sync runs (default rule)', async () => {
     const orchestrator = createTaskOrchestrator();
-    const decode = controllable('decode', { id: makeActivityId(Kind.TX_DECODING, 'eth'), kind: Kind.TX_DECODING });
+    const sync = controllable('sync', { id: makeActivityId(Kind.HISTORY_SYNC), kind: Kind.HISTORY_SYNC });
     const balances = controllable('bal', {
       id: makeActivityId(Kind.BLOCKCHAIN_BALANCES, 'eth'),
       kind: Kind.BLOCKCHAIN_BALANCES,
     });
-    orchestrator.submit(decode.spec);
+    orchestrator.submit(sync.spec);
     const balId = orchestrator.submit(balances.spec);
 
     expect(byId(orchestrator, balId)?.status).toBe(Status.PENDING);
 
-    decode.settle({ ok: true, value: 1 });
+    sync.settle({ ok: true, value: 1 });
     await flush();
+
+    expect(byId(orchestrator, balId)?.status).toBe(Status.RUNNING);
+  });
+
+  it('should let a user-initiated balance refresh run during a history sync', () => {
+    const orchestrator = createTaskOrchestrator();
+    const sync = controllable('sync', { id: makeActivityId(Kind.HISTORY_SYNC), kind: Kind.HISTORY_SYNC });
+    const balances = controllable('bal', {
+      id: makeActivityId(Kind.BLOCKCHAIN_BALANCES, 'eth'),
+      kind: Kind.BLOCKCHAIN_BALANCES,
+      priority: Priority.USER,
+    });
+    orchestrator.submit(sync.spec);
+    const balId = orchestrator.submit(balances.spec);
 
     expect(byId(orchestrator, balId)?.status).toBe(Status.RUNNING);
   });

--- a/frontend/app/src/modules/task-center/core/orchestrator/projection.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/projection.ts
@@ -171,6 +171,7 @@ export interface RenderableRecord {
     readonly group?: Activity['group'];
     readonly parent?: ActivityId;
     readonly resets?: Activity['resets'];
+    readonly priority?: Activity['priority'];
     readonly ephemeral?: boolean;
     readonly rerunnable?: boolean;
     readonly cancel?: () => void;
@@ -193,6 +194,7 @@ export function projectActivity(record: RenderableRecord, childSteps?: ActivityS
     kind: spec.kind,
     parent: spec.parent,
     percentage: percentageOf(status, steps, childSteps),
+    priority: spec.priority,
     rerunnable: Boolean(spec.rerunnable),
     resets: spec.resets,
     source: { type: ActivitySourceType.NATIVE },

--- a/frontend/app/src/modules/task-center/core/orchestrator/rules.spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/rules.spec.ts
@@ -7,7 +7,8 @@ import {
   makeActivityId,
   ActivityStatus as Status,
 } from '../types';
-import { excludeMatchingDuringReset } from './rules';
+import { excludeMatchingDuringReset, pauseBalancesDuringHistorySync } from './rules';
+import { Priority } from './spec';
 
 function activity(overrides: Partial<Activity> & Pick<Activity, 'id' | 'kind' | 'status'>): Activity {
   return {
@@ -44,6 +45,46 @@ function reset(status: Activity['status']): Activity {
     status,
   });
 }
+
+function historySync(status: Activity['status']): Activity {
+  return activity({ id: makeActivityId(Kind.HISTORY_SYNC), kind: Kind.HISTORY_SYNC, status });
+}
+
+function balances(priority?: number): Activity {
+  return activity({
+    id: makeActivityId(Kind.BLOCKCHAIN_BALANCES, 'eth'),
+    kind: Kind.BLOCKCHAIN_BALANCES,
+    priority,
+    status: Status.PENDING,
+  });
+}
+
+describe('pauseBalancesDuringHistorySync', () => {
+  it('should hold a background balance query back while a sync is running', () => {
+    const candidate = balances();
+    expect(pauseBalancesDuringHistorySync(candidate, [candidate, historySync(Status.RUNNING)])).toBe(false);
+  });
+
+  it('should let a background balance query run once the sync has settled', () => {
+    const candidate = balances();
+    expect(pauseBalancesDuringHistorySync(candidate, [candidate, historySync(Status.COMPLETE)])).toBe(true);
+  });
+
+  it('should ignore a sync that is only queued', () => {
+    const candidate = balances();
+    expect(pauseBalancesDuringHistorySync(candidate, [candidate, historySync(Status.PENDING)])).toBe(true);
+  });
+
+  it('should let a user-initiated balance query through', () => {
+    const candidate = balances(Priority.USER);
+    expect(pauseBalancesDuringHistorySync(candidate, [candidate, historySync(Status.RUNNING)])).toBe(true);
+  });
+
+  it('should ignore non-balance candidates', () => {
+    const candidate = activity({ id: makeActivityId(Kind.TX_SYNC, 'eth'), kind: Kind.TX_SYNC, status: Status.PENDING });
+    expect(pauseBalancesDuringHistorySync(candidate, [candidate, historySync(Status.RUNNING)])).toBe(true);
+  });
+});
 
 describe('excludeMatchingDuringReset', () => {
   it('should hold matching back while a reset is running', () => {

--- a/frontend/app/src/modules/task-center/core/orchestrator/rules.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/rules.ts
@@ -1,5 +1,6 @@
 import { isTerminalStatus } from '../status';
 import { type Activity, ActivityKind, ActivityPart, activityParts, ActivityStatus } from '../types';
+import { Priority } from './spec';
 
 /**
  * Decides whether a queued `candidate` may start, given a snapshot of `all` activities. Pure
@@ -15,21 +16,19 @@ const BALANCE_KINDS = new Set<ActivityKind>([
   ActivityKind.EXCHANGE_BALANCES,
 ]);
 
-const DECODE_KINDS = new Set<ActivityKind>([
-  ActivityKind.TX_DECODING,
-  ActivityKind.ETH_BLOCK_DECODING,
-]);
-
 /**
- * Balances must not query while transaction or block-event decoding is running — mirrors the
- * existing `BalanceQueueService.setCanProcess(() => !anyEventsDecoding)` pause. Non-balance
- * candidates are unaffected.
+ * Background balance queries wait for a history refresh to finish. The gate is the `HISTORY_SYNC`
+ * umbrella rather than the decodes under it: decoding was only ever a proxy for "a sync is running",
+ * and it let balances through during the `TX_SYNC`/`EXCHANGE_EVENTS` stretch that is most of a sync.
+ *
+ * ⭐ `Priority.USER` is exempt. The umbrella stays RUNNING for the whole refresh, so without the
+ * exemption a user pressing refresh would wait out the entire sync.
  */
-export const pauseBalancesDuringDecode: EligibilityRule = (candidate, all) => {
-  if (!BALANCE_KINDS.has(candidate.kind))
+export const pauseBalancesDuringHistorySync: EligibilityRule = (candidate, all) => {
+  if (!BALANCE_KINDS.has(candidate.kind) || candidate.priority === Priority.USER)
     return true;
 
-  return !all.some(activity => DECODE_KINDS.has(activity.kind) && activity.status === ActivityStatus.RUNNING);
+  return !all.some(activity => activity.kind === ActivityKind.HISTORY_SYNC && activity.status === ActivityStatus.RUNNING);
 };
 
 /**
@@ -67,7 +66,7 @@ export const excludeMatchingDuringReset: EligibilityRule = (candidate, all) => {
 };
 
 /** The rule set the reactive orchestrator is configured with by default. */
-export const DEFAULT_RULES: readonly EligibilityRule[] = [pauseBalancesDuringDecode, excludeMatchingDuringReset];
+export const DEFAULT_RULES: readonly EligibilityRule[] = [pauseBalancesDuringHistorySync, excludeMatchingDuringReset];
 
 /** True when every rule admits the candidate. */
 export function allRulesPass(rules: readonly EligibilityRule[], candidate: Activity, all: readonly Activity[]): boolean {

--- a/frontend/app/src/modules/task-center/core/types.ts
+++ b/frontend/app/src/modules/task-center/core/types.ts
@@ -195,6 +195,11 @@ export interface Activity {
    * duplicate effort. See {@link HistoryFlow.resets}, which is where a flow declares it.
    */
   readonly resets?: boolean;
+  /**
+   * Scheduling priority, defaulted from the spec. Read by the eligibility rules to tell
+   * user-initiated work from background work; see {@link ./orchestrator/spec}'s `Priority`.
+   */
+  readonly priority?: number;
 }
 
 export interface ActivityGroup {


### PR DESCRIPTION
### Balance queries wait for the history sync, not for a decode

The orchestrator's eligibility rule that held balance work back keyed on decoding being
`RUNNING` (`TX_DECODING`/`ETH_BLOCK_DECODING`), inherited from the old
`BalanceQueueService.setCanProcess(() => !anyEventsDecoding)`.

Decoding is only a late, intermittent stage of a refresh. A websocket `refresh_balances`, a
periodic tick or a login sweep landing during the `TX_SYNC`/`EXCHANGE_EVENTS` stretch went
straight through and contended with the sync anyway, which is the thing the pause exists to
prevent.

The gate is now the `HISTORY_SYNC` umbrella, which stays `RUNNING` for the whole refresh.

`Priority.USER` is exempt. The umbrella can be up for minutes, so without the exemption a user
pressing refresh would wait out the entire sync. To make that expressible:

- the projected `Activity` carries its `priority`, so the rules can tell user work from
  background work (same pattern `resets` already uses);
- the chain job tags itself `Priority.USER` in `user` mode. That also lets a user refresh jump
  queued background work in the lane, which it did not do before.

Two consequences worth naming:

- Decodes that are **not** children of the umbrella (a user-triggered `REDECODE`, repulling,
  block decoding from staking) no longer pause balances. They are user-initiated and bounded,
  and starving the user's own refresh behind them is the worse outcome.
- Background holds are longer than before. Queued periodic ticks cannot pile up, since
  `submitTask` dedups them onto one id.

`RefreshMode` becomes an `as const` object instead of a string union, per the project
convention. It lives in its own module (`balances/types/refresh-mode.ts`) because four specs
`vi.mock` the composable wholesale, which would strip a value export from it.

### The skipped chip is outlined

Filled amber made a skipped row the loudest thing next to neighbours that read as done or
queued in outlined chips. A skip needs no action, so it joins them; filled stays reserved for a
failure.

### Testing

- `pnpm run test:unit` over balances / task-center / staking / accounts / wallet: 1467 pass.
- New pure tests for `pauseBalancesDuringHistorySync`, including the user-priority exemption,
  plus the orchestrator-level pair.
- `pnpm run typecheck` and `pnpm run lint:file` clean.
