### PR TITLE
Honour skipped chains and addresses across the frontend

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -384,6 +384,7 @@
         },
         "skipped": {
           "busy": "Already refreshing this chain",
+          "disabled": "Skipped in settings",
           "no_accounts": "No tracked accounts on this chain"
         }
       },

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -54,6 +54,7 @@
         "type": "Type the chain"
       },
       "tooltip": {
+        "disabled": "Skipped in Settings → Chains, so rotki does not query it",
         "last_detected": "Last detected: {time}",
         "redetect": "Re-detect tokens",
         "redetect_all": "Re-detect tokens for all addresses"

--- a/frontend/app/src/modules/accounts/blockchain/TokenDetection.vue
+++ b/frontend/app/src/modules/accounts/blockchain/TokenDetection.vue
@@ -8,7 +8,7 @@ const { address, loading, chains } = defineProps<{
   chains: string[];
 }>();
 
-const { detectedTokens, detectingTokens, detectTokens } = useTokenDetectionUi(() => chains, () => address);
+const { detectedTokens, detectingTokens, detectionDisabled, detectTokens } = useTokenDetectionUi(() => chains, () => address);
 
 const { t } = useI18n({ useScope: 'global' });
 </script>
@@ -24,7 +24,7 @@ const { t } = useI18n({ useScope: 'global' });
         <RuiButton
           variant="text"
           icon
-          :disabled="detectingTokens || loading"
+          :disabled="detectingTokens || loading || detectionDisabled"
           class="[&_span]:!flex [&_span]:items-center"
           color="primary"
           @click="detectTokens()"
@@ -46,7 +46,9 @@ const { t } = useI18n({ useScope: 'global' });
       </template>
       <div class="text-center">
         <div>
-          {{ t('account_balances.detect_tokens.tooltip.redetect') }}
+          {{ detectionDisabled
+            ? t('account_balances.detect_tokens.tooltip.disabled')
+            : t('account_balances.detect_tokens.tooltip.redetect') }}
         </div>
         <div v-if="detectedTokens.timestamp">
           <i18n-t

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.spec.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.spec.ts
@@ -1,6 +1,7 @@
 import { runSpecWith } from '@test/utils/mocks/native-task';
 import { ok } from 'plainfp/result';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
 import { type Activity, ActivityKind, ActivityStatus, makeActivityId } from '@/modules/task-center/core/types';
 
 const mockDetectTokensForAddress = vi.fn().mockResolvedValue(ok(undefined));
@@ -81,7 +82,14 @@ async function loadOrchestrator(): Promise<typeof import('./use-token-detection-
 }
 
 describe('useTokenDetectionOrchestrator', () => {
+  /** `useDisabledChains` reads the settings repo, so detection needs a live pinia. */
+  function setDisabled(value: Record<string, string[]>): void {
+    const repo = useSettingsRepo();
+    repo.updateGeneral({ ...repo.general, disabledChainQueries: value });
+  }
+
   beforeEach(() => {
+    setActivePinia(createPinia());
     vi.clearAllMocks();
     set(mockAddresses, {});
     set(mockActivities, []);
@@ -111,6 +119,33 @@ describe('useTokenDetectionOrchestrator', () => {
     it('should do nothing for a chain with no addresses', async () => {
       set(mockAddresses, { eth: [] });
       const { useTokenDetectionOrchestrator } = await loadOrchestrator();
+
+      await useTokenDetectionOrchestrator().detectForChain('eth', makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, 'eth'));
+
+      expect(mockSubmitTask).not.toHaveBeenCalled();
+    });
+
+    /**
+     * ⭐ Every detection path queues through `queueDetectionForChain`, so filtering there covers
+     * `detectTokens` and `detectAllTokens` too — automated detection was still firing
+     * `POST /blockchains/<chain>/tokens/detect` for chains the user had switched off.
+     */
+    it('should not detect an address excluded by disabledChainQueries', async () => {
+      set(mockAddresses, { eth: ['0xaddr1', '0xaddr2'] });
+      const { useTokenDetectionOrchestrator } = await loadOrchestrator();
+      setDisabled({ eth: ['0xADDR1'] });
+
+      await useTokenDetectionOrchestrator().detectForChain('eth', makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, 'eth'));
+
+      expect(mockSubmitTask).toHaveBeenCalledTimes(1);
+      const [spec] = mockSubmitTask.mock.calls[0];
+      expect(spec.id).toBe(makeActivityId(ActivityKind.TOKEN_DETECTION, 'eth', '0xaddr2'));
+    });
+
+    it('should detect nothing on a fully excluded chain', async () => {
+      set(mockAddresses, { eth: ['0xaddr1', '0xaddr2'] });
+      const { useTokenDetectionOrchestrator } = await loadOrchestrator();
+      setDisabled({ eth: [] });
 
       await useTokenDetectionOrchestrator().detectForChain('eth', makeActivityId(ActivityKind.BLOCKCHAIN_BALANCES, 'eth'));
 

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-orchestrator.ts
@@ -10,6 +10,7 @@ import { useTokenDetectionStore } from '@/modules/balances/blockchain/use-token-
 import { useBalanceHydration } from '@/modules/balances/use-balance-hydration';
 import { arrayify } from '@/modules/core/common/data/array';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useDisabledChains } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chains';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
 import { DETECT_LANE_PREFIX, familyLane } from '@/modules/task-center/core/orchestrator/spec';
 import { isTerminalStatus } from '@/modules/task-center/core/status';
@@ -38,6 +39,7 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
   const { addresses } = useAccountAddresses();
   const { getChainName, supportsTransactions, txEvmChains } = useSupportedChains();
   const { hydrate } = useBalanceHydration();
+  const { isAddressExcluded } = useDisabledChains();
   const { submitTask } = useNativeTask();
   const { activities } = useTaskOrchestrator();
 
@@ -67,7 +69,13 @@ export const useTokenDetectionOrchestrator = createSharedComposable((): UseToken
    */
   const queueDetectionForChain = async (chain: string, addrs: string[], parent?: ActivityId): Promise<void> => {
     assert(supportsTransactions(chain));
-    await Promise.all(addrs.map(async addr => submitTask({
+    // ⭐ Every detection path queues here, so `disabledChainQueries` is applied once rather than at
+    // each caller. Per *address*: an address rule must lose that address, not the whole chain.
+    const detectable = addrs.filter(addr => !isAddressExcluded(chain, addr));
+    if (detectable.length === 0)
+      return;
+
+    await Promise.all(detectable.map(async addr => submitTask({
       id: makeActivityId(ActivityKind.TOKEN_DETECTION, chain, addr),
       kind: ActivityKind.TOKEN_DETECTION,
       lane: familyLane(DETECT_LANE_PREFIX, chain),

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-ui.spec.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-ui.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
 import { useTokenDetectionStore } from './use-token-detection-store';
 
 vi.mock('@/modules/core/common/use-supported-chains', () => ({
@@ -208,6 +209,55 @@ describe('useTokenDetectionUi', () => {
 
       expect(get(detectingTokens)).toBe(true);
       expect(mockUseIsDetecting).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * ⭐ The orchestrator drops excluded addresses silently, so without this the button stays
+   * enabled and pressing it does nothing at all — no row, no toast, no error.
+   */
+  describe('detectionDisabled', () => {
+    function setDisabled(value: Record<string, string[]>): void {
+      const repo = useSettingsRepo();
+      repo.updateGeneral({ ...repo.general, disabledChainQueries: value });
+    }
+
+    it('should be false when no rule applies', () => {
+      const { detectionDisabled } = useTokenDetectionUi('eth', '0xaddr1');
+
+      expect(get(detectionDisabled)).toBe(false);
+    });
+
+    it('should be true for an address excluded on its only chain', () => {
+      setDisabled({ eth: ['0xaddr1'] });
+
+      const { detectionDisabled } = useTokenDetectionUi('eth', '0xaddr1');
+
+      expect(get(detectionDisabled)).toBe(true);
+    });
+
+    it('should be false while any chain in scope still allows the address', () => {
+      setDisabled({ eth: ['0xaddr1'] });
+
+      const { detectionDisabled } = useTokenDetectionUi(['eth', 'optimism'], '0xaddr1');
+
+      expect(get(detectionDisabled)).toBe(false);
+    });
+
+    it('should read the chain rule when no address is given', () => {
+      setDisabled({ eth: [] });
+
+      const { detectionDisabled } = useTokenDetectionUi('eth');
+
+      expect(get(detectionDisabled)).toBe(true);
+    });
+
+    it('should stay false for an address rule when no address is given', () => {
+      setDisabled({ eth: ['0xaddr1'] });
+
+      const { detectionDisabled } = useTokenDetectionUi('eth');
+
+      expect(get(detectionDisabled)).toBe(false);
     });
   });
 });

--- a/frontend/app/src/modules/balances/blockchain/use-token-detection-ui.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-token-detection-ui.ts
@@ -7,6 +7,7 @@ import { useTokenDetectionStore } from '@/modules/balances/blockchain/use-token-
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { arrayify } from '@/modules/core/common/data/array';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useDisabledChains } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chains';
 
 function noTokens(): EthDetectedTokensInfo {
   return {
@@ -50,6 +51,13 @@ function resolveDetectedTokensInfo(
 }
 
 interface UseTokenDetectionUiReturn {
+  /**
+   * `disabledChainQueries` excludes every chain in scope, so detection would queue nothing.
+   *
+   * The UI has to ask, because the orchestrator drops excluded addresses silently: without this
+   * the button stays enabled and does nothing at all when pressed.
+   */
+  detectionDisabled: ComputedRef<boolean>;
   detectingTokens: ComputedRef<boolean>;
   detectedTokens: ComputedRef<EthDetectedTokensInfo>;
   useEthDetectedTokensInfo: (chain: MaybeRefOrGetter<string>, address: MaybeRefOrGetter<string | null>) => ComputedRef<EthDetectedTokensInfo>;
@@ -65,10 +73,21 @@ export function useTokenDetectionUi(
   const { balances } = storeToRefs(useBalancesStore());
   const { isAssetIgnored } = useAssetsStore();
   const { supportsTransactions } = useSupportedChains();
+  const { isAddressExcluded, isChainExcluded } = useDisabledChains();
   const { detectAllTokens, detectTokens: orchestratorDetect, useIsDetecting } = useTokenDetectionOrchestrator();
 
   const chains = computed<string[]>(() => arrayify(toValue(chain)));
   const detectingTokens = useIsDetecting(chain, accountAddress);
+
+  // `every`, not `some`: a row spanning several chains still has work to do while one of them is
+  // allowed, and only the excluded ones drop out of the queue.
+  const detectionDisabled = computed<boolean>(() => {
+    const chainsValue = get(chains);
+    const address = toValue(accountAddress);
+    return chainsValue.length > 0 && chainsValue.every(blockchain => address
+      ? isAddressExcluded(blockchain, address)
+      : isChainExcluded(blockchain));
+  });
 
   function findDetectedTokensInfo(blockchain: string, address: string | null): EthDetectedTokensInfo {
     return resolveDetectedTokensInfo(blockchain, address, get(tokensState), get(balances), supportsTransactions, isAssetIgnored);
@@ -119,6 +138,7 @@ export function useTokenDetectionUi(
   return {
     detectedTokens,
     detectingTokens,
+    detectionDisabled,
     detectTokens,
     detectTokensOfAllAddresses,
     useEthDetectedTokensInfo,

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -11,6 +11,7 @@ import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-ac
 import { useBlockchainBalancesApi } from '@/modules/balances/api/use-blockchain-balances-api';
 import { useBalanceRefreshState } from '@/modules/balances/use-balance-refresh-state';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
 import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
 
 vi.mock('@/modules/core/notifications/use-notifications-store', () => ({
@@ -113,6 +114,11 @@ vi.mock('@/modules/core/common/use-supported-chains', async () => {
 });
 
 describe('useBlockchainBalances', () => {
+  function setDisabled(value: Record<string, string[]>): void {
+    const repo = useSettingsRepo();
+    repo.updateGeneral({ ...repo.general, disabledChainQueries: value });
+  }
+
   let api: ReturnType<typeof useBlockchainBalancesApi>;
   let blockchainBalances: ReturnType<typeof useBlockchainBalances>;
 
@@ -431,6 +437,70 @@ describe('useBlockchainBalances', () => {
       const result = await submitTask.mock.results[0].value;
       assert(!result.ok);
       expect(hasTag(result.error, 'Cancelled')).toBe(true);
+    });
+
+    /**
+     * ⭐ `disabledChainQueries` reaches the query path, not just the sync panel. Without this the
+     * app kept issuing `POST /balances/blockchains/<chain>` and `tokens/detect` for a chain the
+     * user switched off — observed against a real backend.
+     */
+    it('should skip an excluded chain instead of querying or detecting it', async () => {
+      setDisabled({ [Blockchain.ETH]: [] });
+
+      await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.ETH }, 'background', { detect: true });
+
+      expect(api.refreshBlockchainBalances).not.toHaveBeenCalled();
+      expect(detectForChain).not.toHaveBeenCalled();
+
+      // Submitted, not dropped: the chain is still in the run's scope, so it owes it a row.
+      const result = await submitTask.mock.results[0].value;
+      assert(!result.ok);
+      expect(hasTag(result.error, 'Skipped')).toBe(true);
+    });
+
+    it('should still query a chain whose rule only names other addresses', async () => {
+      setDisabled({ [Blockchain.ETH]: ['0xdeadbeef'] });
+
+      await blockchainBalances.refreshBlockchainBalances({ blockchain: Blockchain.ETH }, 'background');
+
+      expect(api.refreshBlockchainBalances).toHaveBeenCalledTimes(1);
+    });
+
+    it('should narrow the payload to the addresses the rule still allows', async () => {
+      setDisabled({ [Blockchain.ETH]: ['0xexcluded'] });
+
+      await blockchainBalances.refreshBlockchainBalances(
+        { addresses: ['0xexcluded', '0xallowed'], blockchain: Blockchain.ETH },
+        'background',
+      );
+
+      expect(api.refreshBlockchainBalances).toHaveBeenCalledWith({
+        addresses: ['0xallowed'],
+        blockchain: Blockchain.ETH,
+        isXpub: false,
+      });
+    });
+
+    it('should skip a chain whose every requested address is excluded', async () => {
+      setDisabled({ [Blockchain.ETH]: ['0xexcluded'] });
+
+      await blockchainBalances.refreshBlockchainBalances(
+        { addresses: ['0xexcluded'], blockchain: Blockchain.ETH },
+        'background',
+      );
+
+      expect(api.refreshBlockchainBalances).not.toHaveBeenCalled();
+    });
+
+    it('should match the rule regardless of address case', async () => {
+      setDisabled({ [Blockchain.ETH]: ['0XEXCLUDED'] });
+
+      await blockchainBalances.refreshBlockchainBalances(
+        { addresses: ['0xexcluded'], blockchain: Blockchain.ETH },
+        'background',
+      );
+
+      expect(api.refreshBlockchainBalances).not.toHaveBeenCalled();
     });
 
     it('should not detect when the flow did not ask for it', async () => {

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -8,6 +8,7 @@ import { arrayify } from '@/modules/core/common/data/array';
 import { setDigest } from '@/modules/core/common/data/digest';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { Cancelled, Skipped, type TaskError } from '@/modules/core/tasks/task-result';
+import { useDisabledChains } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chains';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
 import { BALANCES_LANE, DEFAULT_PRIORITY, Priority } from '@/modules/task-center/core/orchestrator/spec';
 import { type ActivityId, ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
@@ -62,6 +63,7 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
   const { runActivityBatch } = useActivityBatch();
   const { submitTask, supersedeTask } = useNativeTask();
   const refreshState = useBalanceRefreshState();
+  const { isAddressExcluded, isChainExcluded } = useDisabledChains();
 
   /**
    * Whether a *network* refresh is already running for this chain.
@@ -87,6 +89,12 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
     const { detect = false, detectAddresses } = options;
     const { addresses, blockchain, isXpub = false } = payload;
     const chains = blockchain ? arrayify(blockchain) : get(supportedChains).map(chain => chain.id);
+    // ⚠️ An empty list means "every address", same as omitting it, so it must not be narrowed.
+    const requestedAddresses = addresses?.length ? addresses : undefined;
+
+    /** Addresses of `chain` `disabledChainQueries` still allows, or `undefined` for the whole chain. */
+    const allowedAddresses = (chain: string): string[] | undefined =>
+      requestedAddresses?.filter(address => !isAddressExcluded(chain, address));
     // ⭐ A user-initiated refresh replaces the run in flight instead of joining it. `supersedeTask`
     // is the single shared helper for that — cancel, *await the cancelled promise*, then submit —
     // because `finish()` is what frees the id, and resubmitting before it dedups onto the corpse.
@@ -98,7 +106,8 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
     const submit = mode === RefreshMode.USER ? supersedeTask : submitTask;
 
     const chainJob = async (chain: string, parent: ActivityId | undefined): Promise<void> => {
-      const chainPayload = { addresses, blockchain: chain, isXpub };
+      const chainAddresses = allowedAddresses(chain);
+      const chainPayload = { addresses: chainAddresses ?? addresses, blockchain: chain, isXpub };
       // 🔴 `detect` is part of the identity, not just the body. `submitTask` dedups by id, so with a
       // shared id a login sweep landing while any plain background refresh is in flight (a wallet
       // transaction, a websocket refresh, the eth2 watcher) joins that run and **detection for the
@@ -137,6 +146,16 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
           // activity terminal-but-not-successful and the task centre renders the reason.
           if (mode === RefreshMode.PERIODIC && isChainRefreshing(chain))
             return err(Skipped({ message: t('actions.balances.blockchain.skipped.busy') }));
+
+          // ⭐ `disabledChainQueries` is honoured here, before detection, so an excluded target
+          // costs neither a detect nor a query. SKIPPED rather than dropped from `chains`: the
+          // scope is what the user tracks, and a chain that silently leaves it takes the run's
+          // denominator with it.
+          //
+          // ⚠️ `chainAddresses` empty means the payload named addresses and every one of them is
+          // excluded — not the same as naming none, which leaves it `undefined`.
+          if (isChainExcluded(chain) || chainAddresses?.length === 0)
+            return err(Skipped({ message: t('actions.balances.blockchain.skipped.disabled') }));
 
           // ⭐ Statement order is the ordering. Detection's children run under this job and are
           // awaited here, so the query below sees the tokens they found — no `deps` edge, no

--- a/frontend/app/src/modules/history/events/tx/use-history-transaction-accounts.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-transaction-accounts.ts
@@ -2,7 +2,7 @@ import { get } from '@vueuse/core';
 import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { type ChainAddress, TransactionChainType } from '@/modules/history/events/event-payloads';
-import { useSetting } from '@/modules/settings/use-setting';
+import { useDisabledChains } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chains';
 
 interface UseHistoryTransactionAccountsReturn {
   filterDisabledChainAccounts: (accounts: ChainAddress[]) => ChainAddress[];
@@ -17,7 +17,7 @@ interface UseHistoryTransactionAccountsReturn {
 export function useHistoryTransactionAccounts(): UseHistoryTransactionAccountsReturn {
   const { addresses } = useAccountAddresses();
   const { isBtcChains, isEvmLikeChains, isSolanaChains, supportsTransactions } = useSupportedChains();
-  const disabledChainQueries = useSetting('disabledChainQueries');
+  const { filterAccounts } = useDisabledChains();
 
   const getAccountsByChainType = (
     chainFilter: (chain: string) => boolean,
@@ -51,18 +51,10 @@ export function useHistoryTransactionAccounts(): UseHistoryTransactionAccountsRe
     ...getSolanaAccounts(chains),
   ];
 
-  const filterDisabledChainAccounts = (accounts: ChainAddress[]): ChainAddress[] => {
-    const disabled = get(disabledChainQueries);
-    return accounts.filter(({ address, chain }) => {
-      const rule = disabled[chain];
-      if (rule === undefined)
-        return true;
-      // Backend contract: an empty rule array means the entire chain is disabled.
-      if (rule.length === 0)
-        return false;
-      return !rule.includes(address);
-    });
-  };
+  // Kept as a named member of this composable because `use-refresh-transactions` calls it at a
+  // deliberate point in the flow (before novelty detection), which the call site documents.
+  const filterDisabledChainAccounts = (accounts: ChainAddress[]): ChainAddress[] =>
+    filterAccounts(accounts);
 
   const getTransactionTypeFromChain = (chain: string): TransactionChainType => {
     if (isEvmLikeChains(chain))

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/use-disabled-chains.spec.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/use-disabled-chains.spec.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
+import { useDisabledChains } from './use-disabled-chains';
+
+describe('useDisabledChains', () => {
+  const ETH_ADDRESS = '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c';
+  const OTHER_ETH_ADDRESS = '0x71C7656EC7ab88b098defB751B7401B5f6d8976F';
+
+  let composable: ReturnType<typeof useDisabledChains>;
+
+  function setDisabled(value: Record<string, string[]>): void {
+    const store = useSettingsRepo();
+    store.updateGeneral({ ...store.general, disabledChainQueries: value });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    composable = useDisabledChains();
+  });
+
+  describe('isChainExcluded', () => {
+    it('should be false for a chain with no rule', () => {
+      expect(composable.isChainExcluded('eth')).toBe(false);
+    });
+
+    it('should be true only for the empty-array rule that disables the whole chain', () => {
+      setDisabled({ eth: [] });
+      expect(composable.isChainExcluded('eth')).toBe(true);
+    });
+
+    it('should be false when only some addresses on the chain are excluded', () => {
+      setDisabled({ eth: [ETH_ADDRESS] });
+      expect(composable.isChainExcluded('eth')).toBe(false);
+    });
+
+    it('should match the chain id regardless of case', () => {
+      setDisabled({ polygon_pos: [] });
+      expect(composable.isChainExcluded('POLYGON_POS')).toBe(true);
+    });
+  });
+
+  describe('isAddressExcluded', () => {
+    it('should be false when the chain has no rule', () => {
+      expect(composable.isAddressExcluded('eth', ETH_ADDRESS)).toBe(false);
+    });
+
+    it('should be true for every address once the whole chain is disabled', () => {
+      setDisabled({ eth: [] });
+      expect(composable.isAddressExcluded('eth', ETH_ADDRESS)).toBe(true);
+      expect(composable.isAddressExcluded('eth', OTHER_ETH_ADDRESS)).toBe(true);
+    });
+
+    it('should be true only for the listed addresses on a partially disabled chain', () => {
+      setDisabled({ eth: [ETH_ADDRESS] });
+      expect(composable.isAddressExcluded('eth', ETH_ADDRESS)).toBe(true);
+      expect(composable.isAddressExcluded('eth', OTHER_ETH_ADDRESS)).toBe(false);
+    });
+
+    it('should match an address that differs only by case', () => {
+      // The setting is written from tracked accounts while the sync panel's addresses arrive over
+      // the websocket, so a case-only difference must not silently defeat the rule.
+      setDisabled({ eth: [ETH_ADDRESS.toLowerCase()] });
+      expect(composable.isAddressExcluded('eth', ETH_ADDRESS)).toBe(true);
+    });
+  });
+
+  describe('filterAccounts', () => {
+    const sample = [
+      { address: ETH_ADDRESS, chain: 'eth' },
+      { address: OTHER_ETH_ADDRESS, chain: 'eth' },
+      { address: '0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199', chain: 'optimism' },
+      { address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh', chain: 'btc' },
+    ];
+
+    it('should return the input unchanged when nothing is disabled', () => {
+      expect(composable.filterAccounts(sample)).toEqual(sample);
+    });
+
+    it('should combine full-chain and per-address rules', () => {
+      setDisabled({ eth: [ETH_ADDRESS], optimism: [] });
+      expect(composable.filterAccounts(sample)).toEqual([
+        { address: OTHER_ETH_ADDRESS, chain: 'eth' },
+        { address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh', chain: 'btc' },
+      ]);
+    });
+
+    it('should preserve extra properties on the accounts it keeps', () => {
+      setDisabled({ eth: [] });
+      const withExtras = [
+        { address: ETH_ADDRESS, chain: 'eth', status: 'querying' },
+        { address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh', chain: 'btc', status: 'complete' },
+      ];
+      expect(composable.filterAccounts(withExtras)).toEqual([
+        { address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh', chain: 'btc', status: 'complete' },
+      ]);
+    });
+
+    it('should react to the setting changing', () => {
+      expect(composable.filterAccounts(sample)).toHaveLength(4);
+      setDisabled({ eth: [] });
+      expect(composable.filterAccounts(sample)).toHaveLength(2);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/use-disabled-chains.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/use-disabled-chains.ts
@@ -1,0 +1,66 @@
+import { get } from '@vueuse/core';
+import { useSetting } from '@/modules/settings/use-setting';
+
+interface AccountLike {
+  chain: string;
+  address: string;
+}
+
+export interface UseDisabledChainsReturn {
+  /** True when the whole chain is switched off, i.e. every address on it is excluded. */
+  isChainExcluded: (chain: string) => boolean;
+  /** True when this address is excluded on this chain, whether by an address rule or a chain one. */
+  isAddressExcluded: (chain: string, address: string) => boolean;
+  /** Drop every account the user excluded. Keeps the input order and identity of what survives. */
+  filterAccounts: <T extends AccountLike>(accounts: T[]) => T[];
+}
+
+/**
+ * Read side of the `disabledChainQueries` setting: "is this chain/address switched off?".
+ *
+ * Backend contract, and the part that is easy to get wrong: the setting is
+ * `Record<chainId, address[]>` where an **empty array disables the entire chain** and a non-empty
+ * one disables only those addresses on it. A missing key means the chain is fully enabled.
+ *
+ * Lives next to the setting rather than in the feature that first needed it: history, the sync
+ * panel and (later) balances all have to answer the same question, and a second copy of the
+ * empty-array rule is how the two surfaces drift apart.
+ *
+ * Comparisons are case-insensitive on both chain and address. The setting is written from tracked
+ * accounts while the sync panel's addresses arrive over the websocket, so a case-only difference
+ * between the two would silently defeat a rule the user did set. No two distinct addresses differ
+ * only by case in any chain rotki supports.
+ */
+export function useDisabledChains(): UseDisabledChainsReturn {
+  const disabledChainQueries = useSetting('disabledChainQueries');
+
+  const rules = computed<Record<string, Set<string>>>(() => {
+    const entries = Object.entries(get(disabledChainQueries)).map(
+      ([chain, addresses]): [string, Set<string>] => [
+        chain.toLowerCase(),
+        new Set(addresses.map(address => address.toLowerCase())),
+      ],
+    );
+    return Object.fromEntries(entries);
+  });
+
+  const ruleFor = (chain: string): Set<string> | undefined => get(rules)[chain.toLowerCase()];
+
+  const isChainExcluded = (chain: string): boolean => ruleFor(chain)?.size === 0;
+
+  const isAddressExcluded = (chain: string, address: string): boolean => {
+    const rule = ruleFor(chain);
+    if (rule === undefined)
+      return false;
+    return rule.size === 0 || rule.has(address.toLowerCase());
+  };
+
+  const filterAccounts = <T extends AccountLike>(accounts: T[]): T[] =>
+    accounts.filter(({ address, chain }) => !isAddressExcluded(chain, address));
+
+  return {
+    filterAccounts,
+    isAddressExcluded,
+    isChainExcluded,
+  };
+}

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/use-disabled-chains.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/use-disabled-chains.ts
@@ -26,10 +26,15 @@ export interface UseDisabledChainsReturn {
  * panel and (later) balances all have to answer the same question, and a second copy of the
  * empty-array rule is how the two surfaces drift apart.
  *
- * Comparisons are case-insensitive on both chain and address. The setting is written from tracked
- * accounts while the sync panel's addresses arrive over the websocket, so a case-only difference
- * between the two would silently defeat a rule the user did set. No two distinct addresses differ
- * only by case in any chain rotki supports.
+ * Comparisons are case-insensitive on both chain and address, because the two sides are written by
+ * different parties: the rule comes from the settings dialog, while what it is matched against
+ * arrives over the websocket. Addresses are the case that bites - nothing normalizes them on the
+ * way in, so a checksummed address on the wire against a lower-cased one in the rule would silently
+ * defeat a rule the user did set. Chains are already lower-cased by `useTxQueryStatusStore`, so
+ * normalizing them here is only belt-and-braces for callers that do not.
+ *
+ * No two distinct addresses differ only by case in any chain rotki supports, so folding case cannot
+ * over-match.
  */
 export function useDisabledChains(): UseDisabledChainsReturn {
   const disabledChainQueries = useSetting('disabledChainQueries');

--- a/frontend/app/src/modules/shell/sync-progress/use-chain-progress.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-chain-progress.ts
@@ -1,6 +1,7 @@
 import type { ComputedRef, Ref } from 'vue';
 import type { TxQueryStatusData } from '@/modules/history/use-tx-query-status-store';
 import { TransactionsQueryStatus } from '@/modules/core/messaging/types';
+import { useDisabledChains } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chains';
 import { type AddressProgress, AddressStatus, AddressStep, type ChainProgress } from './types';
 
 /**
@@ -112,11 +113,20 @@ function calculateChainProgress(addresses: AddressProgress[]): number {
 export function useChainProgress(
   queryStatus: Ref<Record<string, TxQueryStatusData>> | ComputedRef<Record<string, TxQueryStatusData>>,
 ): ComputedRef<ChainProgress[]> {
+  const { isAddressExcluded } = useDisabledChains();
+
   return computed<ChainProgress[]>(() => {
     const statusMap = get(queryStatus);
     const grouped = new Map<string, { key: string; data: TxQueryStatusData }[]>();
 
     for (const [key, item] of Object.entries(statusMap)) {
+      // Dropped before grouping so an excluded chain leaves no row *and* no denominator: these
+      // entries are backend websocket status, not work we submitted, so the backend still reports
+      // on chains the user switched off. Per address, not per chain - the setting excludes single
+      // addresses on an otherwise active chain, and those must not pad the chain's total either.
+      if (isAddressExcluded(item.chain, item.address))
+        continue;
+
       const chain = item.chain.toLowerCase();
       if (!grouped.has(chain)) {
         grouped.set(chain, []);

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-progress.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-progress.spec.ts
@@ -11,6 +11,7 @@ import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-st
 import { useEventsQueryStatusStore } from '@/modules/history/use-events-query-status-store';
 import { useProtocolCacheStatusStore } from '@/modules/history/use-protocol-cache-status-store';
 import { useTxQueryStatusStore } from '@/modules/history/use-tx-query-status-store';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
 import { LocationStatus, SyncPhase } from './types';
 import { useSyncProgress } from './use-sync-progress';
 
@@ -347,6 +348,95 @@ describe('useSyncProgress', () => {
       const { overallProgress } = useSyncProgress();
       // All activities at 100%
       expect(get(overallProgress)).toBe(100);
+    });
+  });
+
+  describe('disabled chain queries', () => {
+    // These entries come from backend websocket status, not from work the frontend submitted, so
+    // the backend still reports on chains the user switched off. Without filtering here, a disabled
+    // chain keeps a row in the panel and drags the percentage down - the whole point of the setting
+    // is that whatever is skipped is treated as not being there.
+    function disableChains(value: Record<string, string[]>): void {
+      const store = useSettingsRepo();
+      store.updateGeneral({ ...store.general, disabledChainQueries: value });
+    }
+
+    it('should exclude a disabled chain from the transaction progress', () => {
+      setupTxStore([
+        createEvmTxStatus('0x111', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
+        createEvmTxStatus('0x222', 'polygon_pos', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
+      ]);
+
+      // 1 of 2 accounts done while polygon counts, so the bar sits at 50%.
+      expect(get(useSyncProgress().overallProgress)).toBe(50);
+
+      disableChains({ polygon_pos: [] });
+      // With polygon treated as absent the only tracked account is finished, so the run is done.
+      expect(get(useSyncProgress().overallProgress)).toBe(100);
+    });
+
+    it('should exclude a disabled chain from the chain and account counts', () => {
+      setupTxStore([
+        createEvmTxStatus('0x111', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
+        createEvmTxStatus('0x222', 'polygon_pos', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
+        createEvmTxStatus('0x333', 'polygon_pos', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
+      ]);
+      disableChains({ polygon_pos: [] });
+
+      const { chains, completedChains, totalAccounts, totalChains } = useSyncProgress();
+      expect(get(totalChains)).toBe(1);
+      expect(get(completedChains)).toBe(1);
+      expect(get(totalAccounts)).toBe(1);
+      expect(get(chains).map(chain => chain.chain)).toEqual(['eth']);
+    });
+
+    it('should exclude a single disabled address but keep the rest of its chain', () => {
+      setupTxStore([
+        createEvmTxStatus('0x111', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
+        createEvmTxStatus('0x222', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
+      ]);
+      disableChains({ eth: ['0x222'] });
+
+      const { chains, totalAccounts, totalChains } = useSyncProgress();
+      expect(get(totalChains)).toBe(1);
+      expect(get(totalAccounts)).toBe(1);
+      expect(get(chains)[0].addresses.map(a => a.address)).toEqual(['0x111']);
+    });
+
+    it('should exclude a disabled chain from decoding, which carries a fifth of the bar', () => {
+      const decodingStatusStore = useDecodingStatusStore();
+      decodingStatusStore.resetDecodingSyncProgress();
+      decodingStatusStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 100));
+      decodingStatusStore.setUndecodedTransactionsStatus(createDecodingStatus('polygon_pos', 100, 0));
+
+      // Decoding is the only running phase, so it owns the whole bar: one chain done, one not.
+      expect(get(useSyncProgress().overallProgress)).toBe(50);
+
+      disableChains({ polygon_pos: [] });
+      const { decoding, overallProgress } = useSyncProgress();
+      expect(get(decoding).map(item => item.chain)).toEqual(['eth']);
+      expect(get(overallProgress)).toBe(100);
+    });
+
+    it('should exclude a disabled chain from the protocol cache list', () => {
+      const protocolCacheStatusStore = useProtocolCacheStatusStore();
+      protocolCacheStatusStore.setProtocolCacheStatus(createProtocolCacheStatus('eth', 'uniswap', 200, 100));
+      protocolCacheStatusStore.setProtocolCacheStatus(createProtocolCacheStatus('polygon_pos', 'uniswap', 200, 100));
+      disableChains({ polygon_pos: [] });
+
+      expect(get(useSyncProgress().protocolCache).map(item => item.chain)).toEqual(['eth']);
+    });
+
+    it('should not report a warning for a failed address on a disabled chain', () => {
+      setupTxStore([
+        createEvmTxStatus('0x456', 'gnosis', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
+      ]);
+      useTxQueryStatusStore().markAddressFailed({ address: '0x456', chain: 'gnosis' });
+      disableChains({ gnosis: [] });
+
+      const { hasWarnings, warnings } = useSyncProgress();
+      expect(get(warnings)).toHaveLength(0);
+      expect(get(hasWarnings)).toBe(false);
     });
   });
 

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-progress.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-progress.spec.ts
@@ -361,10 +361,14 @@ describe('useSyncProgress', () => {
       store.updateGeneral({ ...store.general, disabledChainQueries: value });
     }
 
+    // The transaction messages carry `SupportedBlockchain.value` ('ETH') while the setting is keyed
+    // by its serialized form ('eth'), so the fixtures use the real casing of each side. The chain
+    // half is already normalized by `useTxQueryStatusStore`; the address half is not, which is why
+    // the per-address test below pairs a checksummed address on the wire with a lower-cased rule.
     it('should exclude a disabled chain from the transaction progress', () => {
       setupTxStore([
-        createEvmTxStatus('0x111', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
-        createEvmTxStatus('0x222', 'polygon_pos', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
+        createEvmTxStatus('0x111', 'ETH', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
+        createEvmTxStatus('0x222', 'POLYGON_POS', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
       ]);
 
       // 1 of 2 accounts done while polygon counts, so the bar sits at 50%.
@@ -377,9 +381,9 @@ describe('useSyncProgress', () => {
 
     it('should exclude a disabled chain from the chain and account counts', () => {
       setupTxStore([
-        createEvmTxStatus('0x111', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
-        createEvmTxStatus('0x222', 'polygon_pos', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
-        createEvmTxStatus('0x333', 'polygon_pos', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
+        createEvmTxStatus('0x111', 'ETH', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
+        createEvmTxStatus('0x222', 'POLYGON_POS', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
+        createEvmTxStatus('0x333', 'POLYGON_POS', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
       ]);
       disableChains({ polygon_pos: [] });
 
@@ -392,10 +396,11 @@ describe('useSyncProgress', () => {
 
     it('should exclude a single disabled address but keep the rest of its chain', () => {
       setupTxStore([
-        createEvmTxStatus('0x111', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
-        createEvmTxStatus('0x222', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
+        createEvmTxStatus('0x111', 'ETH', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
+        createEvmTxStatus('0xAbC', 'ETH', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
       ]);
-      disableChains({ eth: ['0x222'] });
+      // Checksummed on the wire, lower-cased in the rule: a case-only difference must not defeat it.
+      disableChains({ eth: ['0xabc'] });
 
       const { chains, totalAccounts, totalChains } = useSyncProgress();
       expect(get(totalChains)).toBe(1);

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-progress.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-progress.ts
@@ -5,6 +5,7 @@ import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-st
 import { useEventsQueryStatusStore } from '@/modules/history/use-events-query-status-store';
 import { useProtocolCacheStatusStore } from '@/modules/history/use-protocol-cache-status-store';
 import { useTxQueryStatusStore } from '@/modules/history/use-tx-query-status-store';
+import { useDisabledChains } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chains';
 import {
   type ChainProgress,
   type DecodingProgress,
@@ -98,6 +99,7 @@ function decodingRatio(items: { cancelled: boolean; progress: number }[]): numbe
 export function useSyncProgress(): UseSyncProgressReturn {
   const { t } = useI18n({ useScope: 'global' });
   const { getChainName } = useSupportedChains();
+  const { isChainExcluded } = useDisabledChains();
   const txStore = useTxQueryStatusStore();
   const eventsStore = useEventsQueryStatusStore();
   const decodingStatusStore = useDecodingStatusStore();
@@ -152,25 +154,36 @@ export function useSyncProgress(): UseSyncProgressReturn {
       });
   });
 
+  /**
+   * Decoding and protocol cache are per-chain and, like the transaction status above, are reported
+   * by the backend rather than derived from work we submitted. Excluding them here matters for more
+   * than the row: decoding carries 20% of `overallProgress`, so a chain the user switched off would
+   * otherwise keep a fifth of the bar from completing. Only chain-level rules apply - neither
+   * message carries an address.
+   */
   const decoding = computed<DecodingProgress[]>(() =>
-    get(rawDecodingStatus).map(item => ({
-      cancelled: item.cancelled ?? false,
-      chain: item.chain,
-      processed: item.processed,
-      progress: item.total > 0 ? Math.round((item.processed / item.total) * 100) : 0,
-      total: item.total,
-    })),
+    get(rawDecodingStatus)
+      .filter(item => !isChainExcluded(item.chain))
+      .map(item => ({
+        cancelled: item.cancelled ?? false,
+        chain: item.chain,
+        processed: item.processed,
+        progress: item.total > 0 ? Math.round((item.processed / item.total) * 100) : 0,
+        total: item.total,
+      })),
   );
 
   const protocolCache = computed<ProtocolCacheProgress[]>(() =>
-    get(rawProtocolCacheStatus).map(item => ({
-      cancelled: item.cancelled ?? false,
-      chain: item.chain,
-      processed: item.processed,
-      progress: item.total > 0 ? Math.round((item.processed / item.total) * 100) : 0,
-      protocol: item.protocol,
-      total: item.total,
-    })),
+    get(rawProtocolCacheStatus)
+      .filter(item => !isChainExcluded(item.chain))
+      .map(item => ({
+        cancelled: item.cancelled ?? false,
+        chain: item.chain,
+        processed: item.processed,
+        progress: item.total > 0 ? Math.round((item.processed / item.total) * 100) : 0,
+        protocol: item.protocol,
+        total: item.total,
+      })),
   );
 
   const totalChains = computed<number>(() => get(chains).length);


### PR DESCRIPTION
Makes the `disabledChainQueries` setting ("Skip chains and addresses") mean the same thing everywhere in the frontend. Until now only history transactions read it, so a chain the user had switched off was still counted in the sync percentage, still had its balances queried, and still had its tokens detected.

### What changes

**One shared rule.** `filterDisabledChainAccounts` moves out of `use-history-transaction-accounts.ts` into `modules/settings/general/disabled-chain-queries/use-disabled-chains.ts`, exposing `isChainExcluded` / `isAddressExcluded` / `filterAccounts`. History's helper becomes a thin wrapper, so its existing tests are the extraction's regression proof.

The empty-array-means-whole-chain rule now lives in one place. Comparisons fold case on both sides: the rule comes from the settings dialog while what it is matched against arrives over the websocket, and nothing normalizes addresses on the way in, so a checksummed address on the wire would silently defeat a rule the user did set.

**Sync progress stops counting excluded chains.** Transaction status is filtered per *address* before grouping, so an excluded chain leaves no row and no denominator, and an excluded address on an otherwise tracked chain drops out of its chain's count. `decoding` and `protocolCache` are filtered per chain.

`overallProgress` is weighted transactions .5 / events .3 / decoding .2, so filtering only the chain progress would have left a fifth of the bar counting the switched-off chain. Events needs nothing, it is keyed by exchange locations rather than chains.

**Balance queries and token detection honour it.** An excluded chain settles `SKIPPED` before it detects or queries, so no `tokens/detect` and no `balances/blockchains/<chain>` go out. It is submitted and skipped rather than dropped from the work set: the scope is what the user tracks, and a chain that silently leaves it takes the run's denominator with it.

Detection filters per address at `queueDetectionForChain`, which every detection path funnels through, so `detectForChain`, `detectTokens` and `detectAllTokens` are covered at once.

**The detection button is disabled for a skipped address**, with a tooltip pointing at the setting. Previously it stayed enabled and queued nothing when pressed: no row, no toast, no error.

### Scope

Frontend only, and deliberately so. The backend already filters on the request path (`ChainsAggregator.get_active_addresses`), so nothing here is load-bearing for correctness except one case: `_query_chain_balances` does **not** consult the setting when the payload names explicit addresses, and account addition is a caller that does. The narrowing in `useBlockchainBalances` covers that.

Three backend gaps remain, each worth its own issue:

- `_maybe_query_evm_transactions` (`tasks/manager.py:362`) builds from `get_blockchain_accounts` and never consults the setting, so excluded chains are still queried on a timer and still emit `transactions_status` messages. **The sync-panel filter here is the only thing keeping them out of the percentage**, and API credits are still spent.
- `_query_chain_balances` (`aggregator.py:817-820`) *clears* a disabled chain's balances on a full query rather than freezing them. The frontend no longer triggers that, but the periodic snapshot task still does, so a skipped chain's balances vanish with no explanation.
- `maybe_detect_new_tokens` (`tasks/assets.py:430`) and `detect_evm_tokens` (`rest.py:3190`) read tracked accounts directly and never consult the setting.

There is no per-request override flag, so a manual refresh cannot deliberately bypass the setting. This PR does not invent one client-side: manual and background behave identically for now.

### Testing

Unit tests for the shared composable, the three progress filters, the balance and detection paths, and the button state.

Each filter has a negative control: removing it fails exactly the tests that cover it and nothing else. Ran separately for the skip guard, the address narrowing, the detection filter and the button state, since they are independent mechanisms.

⚠️ **Not yet verified in the app.** The sync-panel half needs a login sync with a rule active, and `RuiTooltip` on a disabled `RuiButton` needs a look to confirm the hint actually shows on hover.
