### PR TITLE
Close gaps on ignore chains or accounts

### DIFF
--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3188,7 +3188,7 @@ class RestAPI:
     ) -> dict[str, Any]:
         manager: EvmManager = self.rotkehlchen.chains_aggregator.get_chain_manager(blockchain)
         if addresses is None:
-            addresses = self.rotkehlchen.chains_aggregator.accounts.get(blockchain)
+            addresses = self.rotkehlchen.chains_aggregator.get_active_addresses(blockchain)
 
         try:
             account_tokens_info = manager.tokens.detect_tokens(

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -739,7 +739,10 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         if addresses is None or len(addresses) == 0:
             chains_to_query = [
                 chain for chain in chains_to_query
-                if chain == SupportedBlockchain.ETHEREUM_BEACONCHAIN or len(self.accounts.get(chain)) > 0  # noqa: E501
+                if (
+                    chain == SupportedBlockchain.ETHEREUM_BEACONCHAIN or
+                    self.get_active_addresses(chain)
+                )
             ]
 
         def _query_one(chain: SupportedBlockchain) -> None:
@@ -782,6 +785,20 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
 
         return self.get_balances_update(blockchain)
 
+    @overload
+    def get_active_addresses(
+            self,
+            blockchain: SUPPORTED_EVM_EVMLIKE_CHAINS_TYPE,
+    ) -> tuple[ChecksumEvmAddress, ...]:
+        ...
+
+    @overload
+    def get_active_addresses(
+            self,
+            blockchain: SupportedBlockchain,
+    ) -> TuplesOfBlockchainAddresses:
+        ...
+
     def get_active_addresses(
             self,
             blockchain: SupportedBlockchain,
@@ -815,8 +832,6 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         if addresses is None or len(addresses) == 0:
             full_query = True
             if len(accounts := self.get_active_addresses(blockchain)) == 0:
-                with self.balances_lock:
-                    self.balances.get(chain=blockchain).clear()
                 return
         else:
             full_query = False
@@ -826,11 +841,10 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
             self.query_eth_balances(accounts) if blockchain == SupportedBlockchain.ETHEREUM  # type: ignore[arg-type]  # will be checksum addresses
             else self.get_chain_manager(blockchain).query_balances(accounts)
         )
-        if full_query is False:
-            # Protocol balance queries return entries for any tracked address with protocol
-            # activity, not only the queried ones. Keep only the requested addresses so the
-            # other accounts' full balance sheets don't get replaced by protocol-only data.
-            new_balances = {address: balance for address, balance in new_balances.items() if address in accounts}  # type: ignore[assignment]  # per-chain key/value types are preserved  # noqa: E501
+        # Protocol balance queries can return entries for any tracked address with protocol
+        # activity, not only the queried ones. Keep only active addresses so a disabled
+        # address is not refreshed accidentally and its frozen balance is preserved.
+        new_balances = {address: balance for address, balance in new_balances.items() if address in accounts}  # type: ignore[assignment]  # per-chain key/value types are preserved  # noqa: E501
 
         # Swap the results in only after the slow remote query and atomically under the
         # lock: sibling chain tasks recalculating totals and API threads serializing
@@ -839,7 +853,13 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         with self.balances_lock:
             existing_balances = self.balances.get(chain=blockchain)
             if full_query is True:
-                existing_balances.clear()
+                disabled = CachedSettings().get_settings().disabled_chain_queries.get(blockchain)
+                if disabled is None:
+                    existing_balances.clear()
+                else:
+                    for address in tuple(existing_balances):
+                        if address not in disabled:
+                            existing_balances.pop(address, None)  # type: ignore[call-overload]
             else:
                 for account in accounts:
                     existing_balances.pop(account, None)  # type: ignore[arg-type]

--- a/rotkehlchen/history/manager.py
+++ b/rotkehlchen/history/manager.py
@@ -211,7 +211,7 @@ class HistoryQueryingManager:
                 evm_manager.transactions.query_chain(
                     from_timestamp=Timestamp(0),  # We need to have history of transactions since before the range  # noqa: E501
                     to_timestamp=end_ts,
-                    addresses=list(active_addresses),  # type: ignore[arg-type]  # EVM chains => ChecksumEvmAddress tuple
+                    addresses=list(active_addresses),  # EVM chains => ChecksumEvmAddress tuple
                 )
             except RemoteError as e:
                 msg = str(e)

--- a/rotkehlchen/tasks/assets.py
+++ b/rotkehlchen/tasks/assets.py
@@ -429,9 +429,11 @@ def update_spark_underlying_assets(chains_aggregator: ChainsAggregator) -> None:
 
 def maybe_detect_new_tokens(database: DBHandler) -> None:
     """Checks newly found history events with IN direction and saves their assets as detected."""
-    if not CachedSettings().get_settings().auto_detect_tokens:
+    settings = CachedSettings().get_settings()
+    if not settings.auto_detect_tokens:
         return
 
+    disabled_per_chain = settings.disabled_chain_queries
     with database.conn.read_ctx() as cursor:
         tracked_accounts = {address_tuple[0] for address_tuple in cursor.execute(
             'SELECT DISTINCT account FROM blockchain_accounts;',
@@ -467,6 +469,11 @@ def maybe_detect_new_tokens(database: DBHandler) -> None:
                     f'Found invalid or non-tracked location label {event.location_label} in '
                     f'history {event=} in {event.location} while detecting new tokens. Skipping.',
                 )
+                continue
+
+            if (disabled := disabled_per_chain.get(chain)) is not None and (
+                len(disabled) == 0 or event.location_label in disabled
+            ):
                 continue
 
             detected_tokens[chain, event.location_label].add(event.asset)

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -357,9 +357,8 @@ class TaskManager:
         now = ts_now()
         dbevmtx = DBEvmTx(self.database)
         with self.database.conn.read_ctx() as cursor:
-            tracked_accounts = self.database.get_blockchain_accounts(cursor)
             for blockchain in shuffled_chains:
-                if len(accounts := tracked_accounts.get(blockchain)) == 0:
+                if len(accounts := self.chains_aggregator.get_active_addresses(blockchain)) == 0:
                     continue
 
                 queriable_accounts: list[ChecksumEvmAddress] = []

--- a/rotkehlchen/tests/api/test_balances.py
+++ b/rotkehlchen/tests/api/test_balances.py
@@ -28,6 +28,7 @@ from rotkehlchen.constants.assets import (
     A_USDC,
     A_USDT,
 )
+from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
@@ -1050,6 +1051,41 @@ def test_ethereum_tokens_detection(
     result = query_detect_eth_tokens()
     assert set(result[account]['tokens']) == {A_DAI.identifier, A_RDN.identifier}
     assert result[account]['last_update_timestamp'] >= cur_time
+
+
+@pytest.mark.parametrize('number_of_eth_accounts', [2])
+def test_ethereum_tokens_detection_skips_disabled_addresses(
+        rotkehlchen_api_server: APIServer,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Implicit token detection queries only addresses enabled by the user setting."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    disabled_address = ethereum_accounts[0]
+    active_address = ethereum_accounts[1]
+    CachedSettings().update_entry(
+        'disabled_chain_queries',
+        {SupportedBlockchain.ETHEREUM: frozenset({disabled_address})},
+    )
+    try:
+        with patch.object(
+            rotki.chains_aggregator.ethereum.tokens,
+            'detect_tokens',
+            return_value={},
+        ) as detect_tokens:
+            response = requests.post(
+                api_url_for(
+                    rotkehlchen_api_server,
+                    'detecttokensresource',
+                    blockchain=SupportedBlockchain.ETHEREUM.serialize(),
+                ),
+                json={'async_query': False},
+            )
+
+        assert_proper_sync_response_with_result(response)
+        detect_tokens.assert_called_once()
+        assert detect_tokens.call_args.kwargs['addresses'] == (active_address,)
+    finally:
+        CachedSettings().update_entry('disabled_chain_queries', {})
 
 
 @pytest.mark.freeze_time('2026-06-05 04:27:20 GMT', tick=True)

--- a/rotkehlchen/tests/unit/test_blockchain_balances.py
+++ b/rotkehlchen/tests/unit/test_blockchain_balances.py
@@ -12,6 +12,7 @@ from rotkehlchen.chain.structures import EvmTokenDetectionData
 from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ONE, ZERO
 from rotkehlchen.constants.assets import A_BCH, A_BTC, A_DAI, A_ETH, A_EUR, A_LQTY, A_POL
 from rotkehlchen.db.cache import DBCacheDynamic
+from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
@@ -220,6 +221,78 @@ def test_partial_balance_refresh_keeps_other_accounts(blockchain: ChainsAggregat
 
     assert blockchain.balances.eth[refreshed_address] == refreshed_sheet
     assert blockchain.balances.eth[other_address] == other_sheet
+
+
+@pytest.mark.parametrize('number_of_eth_accounts', [2])
+def test_full_balance_refresh_preserves_disabled_addresses(
+        blockchain: ChainsAggregator,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """A full refresh replaces active addresses but freezes disabled-address balances."""
+    active_address, disabled_address = ethereum_accounts
+    old_active_sheet = BalanceSheet()
+    old_active_sheet.assets[A_ETH][DEFAULT_BALANCE_LABEL] = Balance(amount=ONE)
+    old_disabled_sheet = BalanceSheet()
+    old_disabled_sheet.assets[A_ETH][DEFAULT_BALANCE_LABEL] = Balance(amount=FVal('2'))
+    blockchain.balances.eth[active_address] = old_active_sheet
+    blockchain.balances.eth[disabled_address] = old_disabled_sheet
+
+    new_active_sheet = BalanceSheet()
+    new_active_sheet.assets[A_ETH][DEFAULT_BALANCE_LABEL] = Balance(amount=FVal('3'))
+    new_disabled_sheet = BalanceSheet()
+    new_disabled_sheet.assets[A_ETH][DEFAULT_BALANCE_LABEL] = Balance(amount=FVal('4'))
+
+    CachedSettings().update_entry(
+        'disabled_chain_queries',
+        {SupportedBlockchain.ETHEREUM: frozenset({disabled_address})},
+    )
+    try:
+        with patch.object(
+            blockchain,
+            'query_eth_balances',
+            return_value={
+                active_address: new_active_sheet,
+                disabled_address: new_disabled_sheet,
+            },
+        ) as query_eth_balances:
+            blockchain._query_chain_balances(
+                blockchain=SupportedBlockchain.ETHEREUM,
+                ignore_cache=True,
+            )
+
+        query_eth_balances.assert_called_once_with((active_address,))
+        assert blockchain.balances.eth[active_address] == new_active_sheet
+        assert blockchain.balances.eth[disabled_address] == old_disabled_sheet
+    finally:
+        CachedSettings().update_entry('disabled_chain_queries', {})
+
+
+@pytest.mark.parametrize('number_of_eth_accounts', [1])
+def test_fully_disabled_chain_balance_refresh_is_frozen(
+        blockchain: ChainsAggregator,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """A fully disabled chain keeps its balances and is not queried by a full refresh."""
+    account = ethereum_accounts[0]
+    sheet = BalanceSheet()
+    sheet.assets[A_ETH][DEFAULT_BALANCE_LABEL] = Balance(amount=ONE)
+    blockchain.balances.eth[account] = sheet
+
+    CachedSettings().update_entry(
+        'disabled_chain_queries',
+        {SupportedBlockchain.ETHEREUM: frozenset()},
+    )
+    try:
+        with patch.object(blockchain, 'query_eth_balances') as query_eth_balances:
+            blockchain.query_balances(
+                blockchain=SupportedBlockchain.ETHEREUM,
+                ignore_cache=True,
+            )
+
+        query_eth_balances.assert_not_called()
+        assert blockchain.balances.eth[account] == sheet
+    finally:
+        CachedSettings().update_entry('disabled_chain_queries', {})
 
 
 def test_blockchain_balances_cache_removes_spent_token(blockchain: ChainsAggregator) -> None:

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -44,7 +44,7 @@ from rotkehlchen.premium.premium import (
 )
 from rotkehlchen.premium.sync import PremiumSyncManager
 from rotkehlchen.serialization.deserialize import deserialize_timestamp
-from rotkehlchen.tasks.assets import _find_missing_tokens
+from rotkehlchen.tasks.assets import _find_missing_tokens, maybe_detect_new_tokens
 from rotkehlchen.tasks.manager import PREMIUM_STATUS_CHECK, TaskManager
 from rotkehlchen.tasks.utils import (
     prefetch_scheduler_task_timestamps,
@@ -179,6 +179,76 @@ def test_maybe_query_evm_transactions_skips_repeat_range_reads(task_manager, eth
         task_manager.schedule()
         time.sleep(.2)
         assert range_mock.call_count == first_tick_reads, 'later ticks skip the read (memoized)'
+
+
+@pytest.mark.parametrize('number_of_eth_accounts', [1])
+def test_maybe_query_evm_transactions_skips_disabled_chain(
+        task_manager,
+        ethereum_accounts,
+) -> None:
+    """A disabled chain must not be scheduled by the periodic transaction task."""
+    CachedSettings().update_entry(
+        'disabled_chain_queries',
+        {SupportedBlockchain.ETHEREUM: frozenset()},
+    )
+    try:
+        with (
+            patch.object(DBEvmTx, 'get_queried_range') as get_queried_range,
+            patch.object(task_manager.task_supervisor, 'spawn_and_track') as spawn_and_track,
+        ):
+            assert task_manager._maybe_query_evm_transactions() is None
+
+        get_queried_range.assert_not_called()
+        spawn_and_track.assert_not_called()
+    finally:
+        CachedSettings().update_entry('disabled_chain_queries', {})
+
+
+@pytest.mark.parametrize('number_of_eth_accounts', [1])
+def test_maybe_detect_new_tokens_skips_disabled_address(
+        rotkehlchen_instance: Rotkehlchen,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Token detection must not process events for a disabled address."""
+    database = rotkehlchen_instance.data.db
+    account = ethereum_accounts[0]
+    with database.user_write() as write_cursor:
+        DBHistoryEvents(database).add_history_event(
+            write_cursor=write_cursor,
+            event=EvmEvent(
+                group_identifier='disabled-token-detection',
+                sequence_index=0,
+                timestamp=TimestampMS(2_000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_DAI,
+                amount=ONE,
+                location_label=account,
+                tx_ref=make_evm_tx_hash(),
+            ),
+        )
+
+    CachedSettings().update_entry(
+        'disabled_chain_queries',
+        {SupportedBlockchain.ETHEREUM: frozenset({account})},
+    )
+    try:
+        with (
+            patch.object(database, 'get_last_balance_save_time', return_value=Timestamp(0)),
+            patch.object(
+                database,
+                'get_tokens_for_address',
+                return_value=(None, None),
+            ) as get_tokens,
+            patch.object(database, 'save_tokens_for_address') as save_tokens,
+        ):
+            maybe_detect_new_tokens(database)
+
+        get_tokens.assert_not_called()
+        save_tokens.assert_not_called()
+    finally:
+        CachedSettings().update_entry('disabled_chain_queries', {})
 
 
 @pytest.mark.parametrize('max_tasks_num', [5])


### PR DESCRIPTION
Honor disabled_chain_queries in periodic EVM transaction queries and automatic/API token detection, preventing skipped chains and addresses from consuming remote API calls.

Preserve cached balances for disabled chains and addresses during full refreshes while updating only active accounts. Add regression coverage for scheduler filtering, frozen balances, and token detection.
