### PR TITLE
Avoid extra zksync lite ws message

### DIFF
--- a/rotkehlchen/chain/zksync_lite/manager.py
+++ b/rotkehlchen/chain/zksync_lite/manager.py
@@ -1071,6 +1071,9 @@ class ZksyncLiteManager(ChainManagerWithTransactions[ChecksumEvmAddress], ChainW
             queryfilter, bindings = ' WHERE is_decoded=?', (0,)  # type: ignore
 
         transactions = self.get_db_transactions(queryfilter, bindings)
+        if len(transactions) == 0:
+            return 0
+
         with self.database.conn.read_ctx() as cursor:
             tracked_addresses = self.database.get_blockchain_accounts(cursor).zksync_lite
 

--- a/rotkehlchen/tests/api/test_evmlike.py
+++ b/rotkehlchen/tests/api/test_evmlike.py
@@ -42,6 +42,26 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
+def test_decode_empty_evmlike_does_not_emit_progress(
+        rotkehlchen_api_server: APIServer,
+) -> None:
+    """An empty forced redecode should neither look up accounts nor report progress."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    manager = rotki.chains_aggregator.zksync_lite
+    with (
+        patch.object(rotki.data.db, 'get_blockchain_accounts') as get_accounts,
+        patch.object(rotki.data.db.msg_aggregator, 'add_message') as add_message,
+    ):
+        assert manager.decode_undecoded_transactions(
+            force_redecode=True,
+            send_ws_notifications=True,
+        ) == 0
+
+    get_accounts.assert_not_called()
+    add_message.assert_not_called()
+
+
+@pytest.mark.parametrize('number_of_eth_accounts', [0])
 @pytest.mark.parametrize('zksync_lite_accounts', [[make_evm_address(), make_evm_address()]])
 def test_evmlike_transactions_refresh(
         rotkehlchen_api_server: APIServer,


### PR DESCRIPTION
## Summary
- Return early when zkSync Lite has no transactions to decode.
- Prevent unnecessary account lookups and progress notifications during empty forced redecodes.
- Add regression coverage for the empty redecode path.

## Testing
- Added and ran the targeted pytest coverage for empty zkSync Lite redecode progress handling.