### PR TITLE
chore(deps): update @rotki/ui-library to 2.23.4

### DIFF
--- a/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.vue
+++ b/frontend/app/src/modules/history/events/action-picker/HistoryEventActionPicker.vue
@@ -242,16 +242,9 @@ function onUpdate(verbKey: string | undefined): void {
         >
           {{ subtitleFor(item) }}
         </span>
-        <!--
-          Pin the direction toward the chevron. RuiCategoryPicker's selection
-          layer applies `w-full` on top of its `left-4 right-8` box, so the
-          layer overflows ~16px past the field's right edge and reserves no room
-          for the chevron; the wide right margin clears it (verified ~12px gap).
-          Workaround for rotki/ui-library#559 — drop the margin once fixed.
-        -->
         <HistoryEventActionDirectionBadge
           :direction="item.direction"
-          class="shrink-0 ml-auto mr-16"
+          class="shrink-0 ml-auto"
         />
       </div>
     </template>

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.5.1
       version: 1.5.1
     '@rotki/ui-library':
-      specifier: 2.23.2
-      version: 2.23.2
+      specifier: 2.23.4
+      version: 2.23.4
     '@tsconfig/node24':
       specifier: 24.0.4
       version: 24.0.4
@@ -366,7 +366,7 @@ importers:
         version: link:../common
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.23.2(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+        version: 2.23.4(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
@@ -2222,8 +2222,8 @@ packages:
     peerDependencies:
       eslint: ^9.20.0 || ^10.0.0
 
-  '@rotki/ui-library@2.23.2':
-    resolution: {integrity: sha512-1JJuZ+ED4D9461w9B7RFaS5v8oe5yvcSCxeCOZRcqSvKlkcSCdHjk7PTQcRUQjMMP4ai8hmFbHvXUUJub7vatg==}
+  '@rotki/ui-library@2.23.4':
+    resolution: {integrity: sha512-TE2AT//RknlAO7Sw1EqzRiPZMElCIJXRCtR8jis8IAo45ol7JFI9gRIYe+TWZyQZ+SlGPPZaVO0vHh22z81Zlw==}
     engines: {node: '>=24 <25', pnpm: '>=11 <12'}
     peerDependencies:
       dayjs: '>=1.11.13 <12'
@@ -8245,7 +8245,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rotki/ui-library@2.23.2(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
+  '@rotki/ui-library@2.23.4(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ catalog:
   '@playwright/test': 1.62.1
   '@rotki/eslint-config': 7.0.0
   '@rotki/eslint-plugin': 1.5.1
-  '@rotki/ui-library': 2.23.2
+  '@rotki/ui-library': 2.23.4
   '@tsconfig/node24': 24.0.4
   '@types/body-parser': 1.19.6
   '@types/express': 5.0.6


### PR DESCRIPTION
The app was on 2.23.2, so this picks up two releases at once.

**2.23.3** — persistent menus no longer close on escape (rotki/ui-library#567), `RuiIcon` stops warning for app-registered icons (rotki/ui-library#568), and the category picker's selection overlay stays inside the field (rotki/ui-library#559).

**2.23.4** — a track behind the circular progress arc with a label that scales with its size, the menu select's clear button no longer overlapping the chevron, and a consumer class now beating the variant class on both `RuiNavigationDrawer` and `RuiIcon`.

## Changes

- Catalog bump in `frontend/pnpm-workspace.yaml`.
- Dropped the `mr-16` in `HistoryEventActionPicker.vue` that held the direction badge clear of the category picker's chevron. rotki/ui-library#559 shipped, so the selection layer no longer overflows the field.

## Two visible knock-on effects

Both are the markup finally doing what it already asked for, now that a consumer class beats the variant class:

- `HistoryRedecodeSelection.vue:97` — the chevron carries `size-4`, which until now lost to the icon's own `w-[var(--rui-icon-size)]` box and rendered at the button's icon size. It now renders at 16px.
- `PinnedSidebar` can drop the `!` from `!z-[6]` whenever convenient. The important flag still works either way, so nothing here is urgent.

## Follow-ups, deliberately not in this PR

- **The `stopPropagation` in `DateValueEditor.vue:50`** can go now that rotki/ui-library#567 has shipped — its own comment says as much. It is not in this PR because the spec guarding it stubs `RuiDateTimePicker`, so no unit test can show whether `RuiMenu` honours `persistent` in the real picker. It needs verifying in the app first, and removing the guard while editing the test to match would only reconcile the spec to its own output.
- **Deprecated ui-library props, 325 usages.** `popper` → `options` is 192 of them, but 175 pass only `placement`, an identical key, so those are a pure rename; 11 pass `resize`+`scroll` (superseded by `autoUpdate`, whose default already matches) and 6 pass `offsetDistance`/`offsetSkid` (now `offset: { mainAxis, crossAxis }`). Note `PopperOptions` and `FloatingOptions` are not the same shape — `gpuAcceleration`, `adaptive` and `locked` have no successor — so only the `placement`-only sites are safe to rename blind. The remaining 133 are `*-class` props superseded by `classNames.*`.

## Verification

`typecheck` clean, `lint` 0 errors, unit **7551/7551**.