### PR TITLE
Let the session cookie opt into Secure

### DIFF
--- a/crates/starling-proxy/src/access_log.rs
+++ b/crates/starling-proxy/src/access_log.rs
@@ -125,7 +125,7 @@ pub fn is_default_trusted(ip: IpAddr) -> bool {
 }
 
 /// Whether `ip` may be believed when it forwards a client address.
-fn is_trusted_hop(ip: IpAddr, trusted: &[Cidr]) -> bool {
+pub fn is_trusted_hop(ip: IpAddr, trusted: &[Cidr]) -> bool {
     is_default_trusted(ip) || trusted.iter().any(|cidr| cidr.contains(ip))
 }
 

--- a/crates/starling-proxy/src/lib.rs
+++ b/crates/starling-proxy/src/lib.rs
@@ -193,6 +193,9 @@ pub(crate) struct ProxyState {
     mcp_enabled: bool,
     health: Option<HealthProbe>,
     pub(crate) control: Option<ControlDispatch>,
+    /// Whose `X-Forwarded-*` we believe. Shared with the access log so an
+    /// operator has one `--trusted-proxy` knob rather than two.
+    trusted_proxies: Arc<Vec<access_log::Cidr>>,
 }
 
 /// Bind the proxy listener on `host`. Done before serving so a bind failure
@@ -326,6 +329,7 @@ fn router(config: &ProxyConfig) -> Router {
         mcp_enabled: config.mcp_enabled,
         health: config.health.clone(),
         control: config.control.clone(),
+        trusted_proxies: Arc::new(config.access_log.trusted_proxies.clone()),
     };
 
     // nginx `location /prefix/` is a prefix match that also matches the bare
@@ -562,7 +566,7 @@ async fn proxy_core(State(state): State<ProxyState>, mut req: Request) -> Respon
     req.headers_mut().remove(MCP_BACKEND_PROOF_HEADER);
     let target = format!("http://{}{}", state.core_addr, path_and_query(&req));
     let peer = peer_addr(&req);
-    let req = req_with_target(req, target, peer);
+    let req = req_with_target(req, target, peer, &state.trusted_proxies);
     forward(&state, req).await
 }
 
@@ -571,7 +575,7 @@ async fn proxy_colibri(State(state): State<ProxyState>, req: Request) -> Respons
     let stripped = strip_colibri_prefix(&path_and_query(&req));
     let target = format!("http://{}{}", state.colibri_addr, stripped);
     let peer = peer_addr(&req);
-    let req = req_with_target(req, target, peer);
+    let req = req_with_target(req, target, peer, &state.trusted_proxies);
     forward(&state, req).await
 }
 
@@ -596,7 +600,7 @@ async fn proxy_mcp(State(state): State<ProxyState>, mut req: Request) -> Respons
     req.headers_mut().remove(MCP_BACKEND_PROOF_HEADER);
     let target = format!("http://{}{}", state.mcp_addr, path_and_query(&req));
     let peer = peer_addr(&req);
-    let req = req_with_target(req, target, peer);
+    let req = req_with_target(req, target, peer, &state.trusted_proxies);
     forward(&state, req).await
 }
 
@@ -631,7 +635,7 @@ pub(crate) fn origin_matches_host(headers: &HeaderMap) -> bool {
 async fn proxy_ws(State(state): State<ProxyState>, req: Request) -> Response {
     let target = format!("http://{}{}", state.core_addr, path_and_query(&req));
     let peer = peer_addr(&req);
-    let req = req_with_target(req, target, peer);
+    let req = req_with_target(req, target, peer, &state.trusted_proxies);
     forward_upgrade(&state, req).await
 }
 
@@ -664,18 +668,30 @@ fn strip_colibri_prefix(path_and_query: &str) -> String {
 }
 
 /// Rewrite the request URI to `target` and add the forwarding headers nginx set.
-fn req_with_target(mut req: Request, target: String, peer: Option<SocketAddr>) -> Request {
+fn req_with_target(
+    mut req: Request,
+    target: String,
+    peer: Option<SocketAddr>,
+    trusted: &[access_log::Cidr],
+) -> Request {
     match Uri::try_from(&target) {
         Ok(uri) => *req.uri_mut() = uri,
         Err(err) => warn!(%target, %err, "invalid upstream uri; forwarding original"),
     }
-    add_forwarding_headers(&mut req, peer);
+    add_forwarding_headers(&mut req, peer, trusted);
     req
 }
 
 /// Mirror nginx's `X-Real-IP` / `X-Forwarded-For` (append). `Set-Cookie` and
 /// `Host` pass through untouched (rotki auth depends on the cookie).
-fn add_forwarding_headers(req: &mut Request, peer: Option<SocketAddr>) {
+///
+/// Also normalises `X-Forwarded-Proto`, see [`sanitize_forwarded_proto`].
+fn add_forwarding_headers(
+    req: &mut Request,
+    peer: Option<SocketAddr>,
+    trusted: &[access_log::Cidr],
+) {
+    sanitize_forwarded_proto(req, peer, trusted);
     let Some(peer) = peer else { return };
     let ip = peer.ip().to_string();
     if let Ok(value) = HeaderValue::from_str(&ip) {
@@ -688,6 +704,51 @@ fn add_forwarding_headers(req: &mut Request, peer: Option<SocketAddr>) {
     if let Ok(value) = HeaderValue::from_str(&forwarded) {
         req.headers_mut().insert("x-forwarded-for", value);
     }
+}
+
+/// Replace `X-Forwarded-Proto` with a value the backends may believe.
+///
+/// Starling always speaks plain http, so the only source for "the browser used
+/// https" is a TLS-terminating proxy in front of us. That claim is only worth
+/// anything if the hop making it is one we trust, judged by the same
+/// `--trusted-proxy` set the access log uses.
+///
+/// **Always writes the header**, never merely leaves it alone: an inbound value
+/// from an untrusted peer must not survive, and an absent one must not be
+/// confusable with a stripped one. An unknown peer (no `ConnectInfo`) cannot be
+/// judged, so it is treated as untrusted.
+///
+/// Core reads this to decide whether the session cookie gets `Secure`. Getting
+/// it wrong in the trusting direction would let anyone who can reach the port
+/// dictate a cookie attribute, so the default is the pessimistic one.
+fn sanitize_forwarded_proto(
+    req: &mut Request,
+    peer: Option<SocketAddr>,
+    trusted: &[access_log::Cidr],
+) {
+    const HEADER: &str = "x-forwarded-proto";
+    let from_trusted_hop = peer
+        .map(|addr| access_log::is_trusted_hop(addr.ip(), trusted))
+        .unwrap_or(false);
+
+    // A trusted hop's claim is kept, but only when it is one of the two schemes
+    // that mean anything here; anything else is treated as no claim at all.
+    let claimed = from_trusted_hop
+        .then(|| {
+            req.headers()
+                .get(HEADER)
+                .and_then(|value| value.to_str().ok())
+                .map(str::trim)
+                // A chain appends, so the leftmost entry is the original scheme.
+                .and_then(|value| value.split(',').next())
+                .map(str::trim)
+                .filter(|scheme| scheme.eq_ignore_ascii_case("https"))
+        })
+        .flatten();
+
+    let scheme = if claimed.is_some() { "https" } else { "http" };
+    req.headers_mut()
+        .insert(HEADER, HeaderValue::from_static(scheme));
 }
 
 /// A small built-in HTML error page for proxy-generated gateway failures -
@@ -857,6 +918,231 @@ mod tests {
 
     use super::*;
     use crate::control::AUTH_BURST;
+
+    /// Build a request carrying `inbound` as `X-Forwarded-Proto` (when `Some`),
+    /// sanitize it as if it arrived from `peer`, and return what the backends
+    /// would see.
+    fn sanitized_proto(
+        inbound: Option<&str>,
+        peer: Option<&str>,
+        trusted: &[&str],
+    ) -> Option<String> {
+        let mut builder = Request::builder().uri("/api/1/ping");
+        if let Some(value) = inbound {
+            builder = builder.header("x-forwarded-proto", value);
+        }
+        let mut req = builder.body(Body::empty()).unwrap();
+        let peer = peer.map(|addr| addr.parse::<SocketAddr>().unwrap());
+        let trusted: Vec<_> = trusted
+            .iter()
+            .map(|spec| access_log::Cidr::parse(spec).unwrap())
+            .collect();
+        sanitize_forwarded_proto(&mut req, peer, &trusted);
+        req.headers()
+            .get("x-forwarded-proto")
+            .map(|value| value.to_str().unwrap().to_string())
+    }
+
+    /// The header must never simply be passed through: core decides the session
+    /// cookie's `Secure` attribute from it, and core sees every request as
+    /// coming from loopback, so it cannot make this judgement itself.
+    ///
+    /// Negative control: deleting the `insert` at the end of
+    /// `sanitize_forwarded_proto` makes the first two cases return the
+    /// attacker's `https` instead of `http`.
+    #[test]
+    fn forwarded_proto_from_an_untrusted_peer_is_overwritten() {
+        // A public peer is not a trusted hop, so its claim is discarded.
+        assert_eq!(
+            sanitized_proto(Some("https"), Some("203.0.113.9:443"), &[]),
+            Some("http".to_string()),
+        );
+        // An unknown peer cannot be judged, so it is treated as untrusted.
+        assert_eq!(
+            sanitized_proto(Some("https"), None, &[]),
+            Some("http".to_string()),
+        );
+    }
+
+    #[test]
+    fn forwarded_proto_from_a_trusted_hop_is_kept() {
+        // Private ranges are trusted by default, which is where a docker-network
+        // reverse proxy sits.
+        assert_eq!(
+            sanitized_proto(Some("https"), Some("172.18.0.5:443"), &[]),
+            Some("https".to_string()),
+        );
+        // And an operator can name a public one with --trusted-proxy.
+        assert_eq!(
+            sanitized_proto(Some("https"), Some("203.0.113.9:443"), &["203.0.113.0/24"]),
+            Some("https".to_string()),
+        );
+    }
+
+    #[test]
+    fn forwarded_proto_is_always_present_and_only_ever_the_two_schemes() {
+        // Absent inbound must not be confusable with a stripped one.
+        assert_eq!(
+            sanitized_proto(None, Some("172.18.0.5:443"), &[]),
+            Some("http".to_string()),
+        );
+        // A trusted hop reporting plain http stays http.
+        assert_eq!(
+            sanitized_proto(Some("http"), Some("172.18.0.5:443"), &[]),
+            Some("http".to_string()),
+        );
+        // Anything that is not one of the two schemes is no claim at all.
+        assert_eq!(
+            sanitized_proto(Some("gopher"), Some("172.18.0.5:443"), &[]),
+            Some("http".to_string()),
+        );
+    }
+
+    /// A chain appends, so the *leftmost* entry is the scheme the original
+    /// client used. Reading the rightmost would report our own hop's http and
+    /// silently drop the flag on a correctly configured two-proxy deployment.
+    #[test]
+    fn forwarded_proto_reads_the_original_scheme_from_a_chain() {
+        assert_eq!(
+            sanitized_proto(Some("https, http"), Some("172.18.0.5:443"), &[]),
+            Some("https".to_string()),
+        );
+        assert_eq!(
+            sanitized_proto(Some("http, https"), Some("172.18.0.5:443"), &[]),
+            Some("http".to_string()),
+        );
+    }
+
+    /// A stub upstream that echoes back the `X-Forwarded-Proto` it was handed,
+    /// so a test can assert what core would actually read. Reports `<absent>`
+    /// rather than an empty body when the header never arrived, so a missing
+    /// header cannot be mistaken for an empty one.
+    async fn spawn_proto_report_upstream() -> u16 {
+        let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let app = Router::new().fallback(any(|req: Request| async move {
+            req.headers()
+                .get("x-forwarded-proto")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or("<absent>")
+                .to_string()
+        }));
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        port
+    }
+
+    /// Drive a request through the real router to `upstream` as if it arrived
+    /// from `peer`, and return the `X-Forwarded-Proto` the upstream received.
+    async fn proxied_proto(
+        path: &str,
+        inbound: Option<&str>,
+        peer: Option<&str>,
+        trusted: &[&str],
+        upstream: u16,
+    ) -> String {
+        let app = router(&ProxyConfig {
+            port: 0,
+            core_port: upstream,
+            colibri_port: upstream,
+            mcp_port: upstream,
+            mcp_enabled: true,
+            frontend_dir: None,
+            max_body_bytes: 50 * 1024 * 1024,
+            access_log: access_log::AccessLog {
+                trusted_proxies: trusted
+                    .iter()
+                    .map(|spec| access_log::Cidr::parse(spec).unwrap())
+                    .collect(),
+                ..Default::default()
+            },
+            health: None,
+            control: None,
+        });
+        let mut builder = Request::builder().uri(path);
+        if let Some(value) = inbound {
+            builder = builder.header("x-forwarded-proto", value);
+        }
+        let mut req = builder.body(Body::empty()).unwrap();
+        // What `serve` does per connection. Absent when the peer is unknown,
+        // which is the case the sanitizer must treat as untrusted.
+        if let Some(addr) = peer {
+            req.extensions_mut()
+                .insert(ConnectInfo(addr.parse::<SocketAddr>().unwrap()));
+        }
+        body_string(app.oneshot(req).await.unwrap()).await
+    }
+
+    /// The unit tests above call `sanitize_forwarded_proto` directly, so they
+    /// would all still pass if nothing ever called it. This drives a real
+    /// request through the router and asserts on what the upstream received,
+    /// which is the claim core's `forwarded` mode actually depends on.
+    ///
+    /// Negative control: deleting the `sanitize_forwarded_proto` call from
+    /// `add_forwarding_headers` leaves every other test in this module green
+    /// and fails this one.
+    #[tokio::test]
+    async fn forwarded_proto_is_sanitized_on_the_proxied_path() {
+        let upstream = spawn_proto_report_upstream().await;
+
+        // A public client's spoofed claim does not survive the hop, on either
+        // proxied prefix.
+        for path in ["/api/1/ping", "/colibri/health"] {
+            assert_eq!(
+                proxied_proto(path, Some("https"), None, &[], upstream).await,
+                "http",
+                "a spoofed claim from an unknown peer reached the upstream on {path}",
+            );
+            assert_eq!(
+                proxied_proto(path, Some("https"), Some("203.0.113.9:443"), &[], upstream).await,
+                "http",
+                "a spoofed claim from an untrusted peer reached the upstream on {path}",
+            );
+        }
+
+        // A real TLS terminator on the docker network is believed, which is the
+        // whole point of the mode.
+        assert_eq!(
+            proxied_proto(
+                "/api/1/ping",
+                Some("https"),
+                Some("172.18.0.5:443"),
+                &[],
+                upstream,
+            )
+            .await,
+            "https",
+        );
+
+        // The trust set is all of RFC1918 and cannot be narrowed, only extended,
+        // so a client on the same LAN as the container is a trusted hop too and
+        // its claim is kept. Pinned because it bounds what the sanitizing buys:
+        // it stops a *public* peer, not everyone who can reach the published
+        // port. Harmless in itself (the cookie goes back to that same client, so
+        // forcing Secure on only breaks its own login), but it means an operator
+        // publishing the port to an untrusted LAN cannot rely on this.
+        assert_eq!(
+            proxied_proto(
+                "/api/1/ping",
+                Some("https"),
+                Some("192.168.1.50:443"),
+                &[],
+                upstream,
+            )
+            .await,
+            "https",
+        );
+
+        // And the header is always written, so core never has to guess whether
+        // an absent value means "no proxy" or "stripped".
+        assert_eq!(
+            proxied_proto("/api/1/ping", None, Some("172.18.0.5:443"), &[], upstream).await,
+            "http",
+        );
+    }
 
     #[test]
     fn colibri_prefix_is_stripped() {

--- a/docs/dev_changelog.rst
+++ b/docs/dev_changelog.rst
@@ -17,6 +17,11 @@ When rotki is set up with the ``ROTKI_SESSION_KEY`` environment variable (the Do
   - Accepts the account ``password`` and issues the session cookie before the asynchronous unlock, so the gated task poll and websocket handshake are authorized.
   - Has no effect when ``ROTKI_SESSION_KEY`` is unset (desktop/Electron deployment), where the API stays session-less as before.
 
+* **New Environment Variable**: ``ROTKI_SESSION_COOKIE_SECURE``
+
+  - Opts the session cookie into the ``Secure`` attribute, which stays off by default because the image serves plain http on loopback or a LAN, where the flag would stop the cookie being sent at all. ``1``/``true`` always sets it; ``forwarded`` derives it per request from ``X-Forwarded-Proto``; an unrecognised value warns and is treated as off.
+  - Starling now normalises ``X-Forwarded-Proto`` on every proxied request, keeping an inbound value only when the peer is a trusted hop (the ``--trusted-proxy`` set the access log already uses) and overwriting it with ``http`` otherwise. Previously the header was passed through untouched, so it must not be trusted by anything reading it on an older build. core cannot judge the hop itself, since it sits on loopback behind starling.
+
 * **New Endpoint**: ``POST /api/(version)/mcp/token``
 
   - Issues an MCP-only bearer linked to the authenticated active session for the streamable HTTP transport exposed by Docker at ``/mcp``. It cannot be used as a REST API session cookie.

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -91,6 +91,7 @@ Every resolved value is logged at startup with the layer it came from, so
 | `MAX_SIZE_IN_MB_ALL_LOGS` | backend default | Total log size budget |
 | `SQLITE_INSTRUCTIONS` | backend default | SQLite instructions-per-context |
 | `ROTKI_SESSION_KEY` | unset | Enables session-cookie auth (see below) |
+| `ROTKI_SESSION_COOKIE_SECURE` | unset | `Secure` on the session cookie: `1` always, `forwarded` from `X-Forwarded-Proto` |
 
 To mount a config file:
 
@@ -226,6 +227,44 @@ The value is inherited by both backends, which sign and validate the cookie with
 it. Keep it stable across restarts or existing sessions are invalidated. Note it
 is visible in `/proc/<pid>/environ` to the owning uid, the same exposure the
 previous entrypoint had.
+
+### The `Secure` cookie attribute
+
+The cookie is **not** marked `Secure` by default, because the image serves plain
+http and the flag would stop the browser sending it at all. Behind a TLS
+terminator, turn it on with `ROTKI_SESSION_COOKIE_SECURE`:
+
+- `1` (or `true`) always marks it. Use this when TLS is terminated in front and
+  the proxy does not send `X-Forwarded-Proto`.
+- `forwarded` derives it per request from `X-Forwarded-Proto`.
+- unset, `0`, or absent leaves it off. An **unrecognised** value logs a warning
+  and is treated as off rather than silently meaning something.
+
+`forwarded` is only safe because starling rewrites `X-Forwarded-Proto` on every
+proxied request, keeping an inbound value solely when the peer is a trusted hop
+(loopback, private and link-local by default, plus any `--trusted-proxy` CIDR),
+and overwriting it with `http` otherwise. core cannot make that call itself: it
+listens on loopback behind starling, so every request appears to come from
+`127.0.0.1`.
+
+That cuts both ways, so match the mode to where your terminator sits:
+
+- If it reaches the container from a **public** address, name it with
+  `--trusted-proxy`. Without that its `X-Forwarded-Proto: https` is overwritten
+  like any other untrusted peer's, and the cookie is quietly never marked
+  `Secure` even though TLS is working. It fails safe (logins keep working) and
+  warns about nothing, so it is easy to miss.
+- The default trust set covers the whole private range and can only be extended,
+  never narrowed. A client on the same LAN as the container is therefore a
+  trusted hop too, and can set the header on its own requests. That only affects
+  the cookie in its own response, so it forces `Secure` onto its own session
+  rather than weakening anyone else's. If you do not want that at all, use `1`
+  instead of `forwarded` and do not publish the port to an untrusted network.
+
+Setting the flag is not a substitute for HSTS. `Secure` stops the cookie being
+sent over plaintext, but a browser that has never seen an HSTS header will still
+*make* the plaintext request. Send `Strict-Transport-Security` from the same
+proxy that terminates TLS.
 
 With authentication enabled, starling also starts the MCP service and exposes its
 streamable HTTP transport at `/mcp`. Obtain a bearer token from an authenticated

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -46,6 +46,7 @@ from rotkehlchen.api.session_token import (
     clear_session_cookie,
     read_mcp_token,
     read_session_token,
+    session_cookie_is_secure,
     set_session_cookie,
 )
 from rotkehlchen.api.v1.types import IncludeExcludeFilterData, TaskName
@@ -380,7 +381,11 @@ def async_api_call(session_token: bool = False) -> Callable:
                 response = make_response_from_dict(result)
 
             if token is not None:
-                set_session_cookie(response, token)
+                set_session_cookie(
+                    response=response,
+                    token=token,
+                    secure=session_cookie_is_secure(request.headers),
+                )
             return response
 
         return inner
@@ -1232,7 +1237,11 @@ class RestAPI:
                     self.api_tasks_stop_reason = None
 
         response = api_response(_wrap_in_ok_result({}), status_code=HTTPStatus.OK)
-        set_session_cookie(response, token)
+        set_session_cookie(
+            response=response,
+            token=token,
+            secure=session_cookie_is_secure(request.headers),
+        )
         return response
 
     def issue_mcp_token(self) -> Response:
@@ -1482,7 +1491,10 @@ class RestAPI:
         # Electron/dev logout response).
         if self.session_store is not None:
             self.session_store.revoke(name)
-            clear_session_cookie(response)
+            clear_session_cookie(
+                response=response,
+                secure=session_cookie_is_secure(request.headers),
+            )
         return response
 
     def user_set_premium_credentials(

--- a/rotkehlchen/api/server.py
+++ b/rotkehlchen/api/server.py
@@ -22,6 +22,7 @@ from rotkehlchen.api.session_token import (
     SessionClaims,
     read_mcp_token,
     read_session_token,
+    session_cookie_is_secure,
     set_session_cookie,
     verify_mcp_backend_proof,
 )
@@ -663,7 +664,11 @@ class APIServer:
         ):
             token = self.rest_api.session_store.reissue(session_user, session_sid)
             if token is not None:
-                set_session_cookie(response, token)
+                set_session_cookie(
+                    response=response,
+                    token=token,
+                    secure=session_cookie_is_secure(request.headers),
+                )
 
         # Always pop the internal header so it never leaks to the client.
         log_result = response.headers.pop('rotki-log-result', 'True') == 'True'

--- a/rotkehlchen/api/session_token.py
+++ b/rotkehlchen/api/session_token.py
@@ -34,11 +34,16 @@ import binascii
 import hashlib
 import hmac
 import json
+import logging
+import os
 import time
-from typing import TYPE_CHECKING, Final, NamedTuple, TypedDict
+from typing import TYPE_CHECKING, Final, Literal, NamedTuple, TypedDict
 
 if TYPE_CHECKING:
+    from werkzeug.datastructures import Headers
     from werkzeug.wrappers import Response
+
+log = logging.getLogger(__name__)
 
 # Token lifetime. Matters mainly for a stable Docker key; on expiry the validators
 # return 401 and the frontend falls back to its login redirect.
@@ -57,6 +62,13 @@ SESSION_ABSOLUTE_TTL: Final = 7 * 24 * 60 * 60  # 7 days
 
 # Name of the signed HttpOnly cookie carrying the session token.
 SESSION_COOKIE_NAME: Final = 'rotki_session'
+
+# Opt-in control over the cookie's `Secure` attribute. See `cookie_secure_mode`.
+SESSION_COOKIE_SECURE_ENV: Final = 'ROTKI_SESSION_COOKIE_SECURE'
+
+# Set by starling on every proxied request, never passed through from the client.
+FORWARDED_PROTO_HEADER: Final = 'X-Forwarded-Proto'
+
 MCP_BACKEND_PROOF_HEADER: Final = 'X-Rotki-MCP-Proof'
 MCP_TOKEN_AUDIENCE: Final = 'mcp'
 _MCP_TOKEN_KEY_CONTEXT: Final = b'rotki-mcp-access-v1'
@@ -76,13 +88,67 @@ class MintedSessionToken(TypedDict):
     exp: int
 
 
-def set_session_cookie(response: Response, token: str) -> None:
+def cookie_secure_mode() -> Literal['off', 'on', 'forwarded']:
+    """Read ``ROTKI_SESSION_COOKIE_SECURE``.
+
+    ``off`` (unset) keeps the cookie usable over plain http, which is what a
+    loopback or LAN deployment needs. ``on`` always marks it ``Secure``, for an
+    operator who knows TLS is terminated in front and whose proxy may not send
+    ``X-Forwarded-Proto``. ``forwarded`` derives it per request from that header.
+
+    An unrecognised value warns rather than silently meaning ``off``: this
+    decides whether a credential may cross a plaintext connection, so a typo
+    must not quietly leave it unset.
+    """
+    raw = os.environ.get(SESSION_COOKIE_SECURE_ENV, '').strip().lower()
+    if raw in {'', '0', 'false', 'no', 'off'}:
+        return 'off'
+    if raw in {'1', 'true', 'yes', 'on'}:
+        return 'on'
+    if raw == 'forwarded':
+        return 'forwarded'
+
+    log.warning(
+        'Unrecognised %s value %r; treating it as "off" so the session cookie is not '
+        'marked Secure. Use "1", "forwarded" or leave it unset.',
+        SESSION_COOKIE_SECURE_ENV,
+        raw,
+    )
+    return 'off'
+
+
+def session_cookie_is_secure(headers: Headers) -> bool:
+    """Whether the session cookie should carry ``Secure`` for this request.
+
+    In ``forwarded`` mode this trusts ``X-Forwarded-Proto``, which is safe only
+    because starling rewrites that header on every proxied request, keeping an
+    inbound value solely when the peer is a trusted hop. core cannot make that
+    judgement itself: it sits on loopback behind starling, so every request
+    looks like it came from ``127.0.0.1``.
+    """
+    mode = cookie_secure_mode()
+    if mode == 'on':
+        return True
+    if mode == 'forwarded':
+        # Read the leftmost entry, the same way starling does. It always writes a
+        # single token, so today the two agree on any input; parsing it the same
+        # way here means they cannot drift apart if that ever stops being true.
+        raw = headers.get(FORWARDED_PROTO_HEADER, '')
+        return raw.split(',')[0].strip().lower() == 'https'
+    return False
+
+
+def set_session_cookie(response: Response, token: str, secure: bool = False) -> None:
     """Attach the signed session token as the HttpOnly ``rotki_session`` cookie.
 
     ``HttpOnly`` keeps it out of JS (XSS can't exfiltrate it); ``SameSite=Lax``
     stops a third-party site riding it on a navigation while still allowing the
-    same-origin SPA. Not ``Secure`` — the Docker deployment is plain http on
-    loopback / a LAN; a TLS terminator in front can upgrade it.
+    same-origin SPA.
+
+    ``secure`` defaults to off because the Docker deployment is plain http on
+    loopback / a LAN, where the flag would stop the cookie being sent at all.
+    Behind a TLS terminator the operator turns it on with
+    ``ROTKI_SESSION_COOKIE_SECURE``; see :func:`session_cookie_is_secure`.
     """
     response.set_cookie(
         SESSION_COOKIE_NAME,
@@ -91,12 +157,26 @@ def set_session_cookie(response: Response, token: str) -> None:
         httponly=True,
         samesite='Lax',
         path='/',
+        secure=secure,
     )
 
 
-def clear_session_cookie(response: Response) -> None:
-    """Delete the session cookie (logout)."""
-    response.delete_cookie(SESSION_COOKIE_NAME, path='/')
+def clear_session_cookie(response: Response, secure: bool = False) -> None:
+    """Delete the session cookie (logout).
+
+    ``path`` must match the one it was set with, since a cookie is keyed on
+    (name, domain, path). The flags are *not* part of that key, so clearing does
+    not depend on them matching; ``secure`` is passed to keep the clearing cookie
+    consistent with the scheme of the request it answers, which in ``forwarded``
+    mode is the scheme the live cookie was set under.
+    """
+    response.delete_cookie(
+        SESSION_COOKIE_NAME,
+        path='/',
+        httponly=True,
+        samesite='Lax',
+        secure=secure,
+    )
 
 
 def _b64url(raw: bytes) -> str:

--- a/rotkehlchen/tests/api/test_user_authenticate.py
+++ b/rotkehlchen/tests/api/test_user_authenticate.py
@@ -7,6 +7,7 @@ cookie's `sid` is the single active session (so a new login revokes old windows 
 `rest_api` (the same live-attribute trick the backend tests use), so the gate is
 exercised end-to-end through real HTTP.
 """
+import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
@@ -25,8 +26,10 @@ from rotkehlchen.api.session_store import (
     is_persisted_mcp_session_active,
 )
 from rotkehlchen.api.session_token import (
+    FORWARDED_PROTO_HEADER,
     MCP_BACKEND_PROOF_HEADER,
     SESSION_COOKIE_NAME,
+    SESSION_COOKIE_SECURE_ENV,
     SESSION_IDLE_TTL,
     create_mcp_backend_proof,
     mint_session_token,
@@ -162,6 +165,134 @@ def test_authenticate_sets_cookie_for_correct_password(
         set_cookie_header = response.headers['Set-Cookie']
         assert 'HttpOnly' in set_cookie_header
         assert 'SameSite=Lax' in set_cookie_header
+        # Not Secure by default: the docker deployment is plain http on loopback or a
+        # LAN, where the flag would stop the cookie being sent at all.
+        assert 'Secure' not in set_cookie_header
+    finally:
+        _disable_session(rotkehlchen_api_server)
+
+
+@pytest.mark.parametrize('start_with_logged_in_user', [True])
+@pytest.mark.parametrize(('env_value', 'forwarded_proto', 'expect_secure'), [
+    (None, None, False),  # unset: today's behaviour
+    (None, 'https', False),  # the header alone must not be enough
+    ('1', None, True),  # always on, for a proxy that sends no header
+    ('true', None, True),
+    ('0', 'https', False),  # explicitly off stays off
+    ('forwarded', 'https', True),  # derived from the (starling-sanitized) header
+    ('forwarded', 'http', False),
+    ('forwarded', None, False),  # absent header is not a claim
+    # A chain is read leftmost-first, the same way starling reads it, so the two
+    # parses cannot drift. starling writes a single token today, so this only
+    # matters if that ever changes.
+    ('forwarded', 'https, http', True),
+    ('forwarded', 'http, https', False),
+    ('nonsense', 'https', False),  # unrecognised is off, and warns
+])
+def test_session_cookie_secure_is_opt_in(
+        rotkehlchen_api_server: APIServer,
+        username: str,
+        env_value: str | None,
+        forwarded_proto: str | None,
+        expect_secure: bool,
+) -> None:
+    """`Secure` is off unless ROTKI_SESSION_COOKIE_SECURE asks for it.
+
+    In `forwarded` mode the X-Forwarded-Proto header decides. Trusting it is only
+    safe because starling rewrites that header on every proxied request, keeping
+    an inbound value solely when the peer is a trusted hop; core sits on loopback
+    and cannot tell a spoofed one from a real one itself.
+    """
+    _logout(rotkehlchen_api_server, username)
+    _enable_session(rotkehlchen_api_server)
+    url = api_url_for(rotkehlchen_api_server, 'userauthenticateresource', name=username)
+    env = {} if env_value is None else {SESSION_COOKIE_SECURE_ENV: env_value}
+    headers = {} if forwarded_proto is None else {FORWARDED_PROTO_HEADER: forwarded_proto}
+    try:
+        with patch.dict(os.environ, env, clear=False):
+            if env_value is None:  # patch.dict cannot unset, so do it explicitly
+                os.environ.pop(SESSION_COOKIE_SECURE_ENV, None)
+            response = requests.post(url, json={'password': '123'}, headers=headers)
+
+        assert_proper_sync_response_with_result(response)
+        set_cookie_header = response.headers['Set-Cookie']
+        assert ('Secure' in set_cookie_header) is expect_secure
+        # The other attributes are unaffected by the flag.
+        assert 'HttpOnly' in set_cookie_header
+        assert 'SameSite=Lax' in set_cookie_header
+    finally:
+        _disable_session(rotkehlchen_api_server)
+
+
+@pytest.mark.parametrize('start_with_logged_in_user', [True])
+@pytest.mark.parametrize('secure', [False, True])
+def test_logout_clears_the_cookie_with_matching_attributes(
+        rotkehlchen_api_server: APIServer,
+        username: str,
+        secure: bool,
+) -> None:
+    """The clearing cookie tracks the scheme, like the one it replaces.
+
+    Clearing does not *depend* on the flags matching (a cookie is keyed on name,
+    domain and path, not on `Secure`), but the two must not disagree: a browser
+    refuses a `Secure` cookie that arrives over plaintext, so a clear that set
+    the flag on a plain-http response would be dropped and leave the live cookie
+    in place.
+    """
+    store = _enable_session(rotkehlchen_api_server)
+    env = {SESSION_COOKIE_SECURE_ENV: '1'} if secure else {}
+    try:
+        token = store.login(username)  # the fixture's user is already unlocked
+        with patch.dict(os.environ, env, clear=False):
+            if not secure:
+                os.environ.pop(SESSION_COOKIE_SECURE_ENV, None)
+            response = requests.patch(
+                api_url_for(rotkehlchen_api_server, 'usersbynameresource', name=username),
+                json={'action': 'logout'},
+                cookies={SESSION_COOKIE_NAME: token},
+            )
+
+        assert_proper_sync_response_with_result(response)
+        cleared = response.headers['Set-Cookie']
+        # It really is the clearing cookie, not another live one.
+        assert 'Expires=Thu, 01 Jan 1970' in cleared or 'Max-Age=0' in cleared
+        assert ('Secure' in cleared) is secure
+        assert 'HttpOnly' in cleared
+        assert 'SameSite=Lax' in cleared
+    finally:
+        _disable_session(rotkehlchen_api_server)
+
+
+@pytest.mark.parametrize('start_with_logged_in_user', [True])
+def test_rolling_refresh_carries_secure(
+        rotkehlchen_api_server: APIServer,
+        username: str,
+) -> None:
+    """The rolling re-issue marks `Secure` too.
+
+    This is the path that fires on an ordinary authenticated request rather than
+    at login, so it is where a missed `secure=` would silently downgrade the
+    cookie for the rest of the session.
+    """
+    store = _enable_session(rotkehlchen_api_server)
+    now = int(time.time())
+    try:
+        # a cookie already past half its idle window, so the response rolls it forward
+        old_token = mint_session_token(
+            SESSION_KEY,
+            username,
+            _cookie_sid(store.login(username)),
+            expires_at=now + SESSION_IDLE_TTL // 4,
+        )['token']
+        with patch.dict(os.environ, {SESSION_COOKIE_SECURE_ENV: '1'}, clear=False):
+            response = requests.get(
+                api_url_for(rotkehlchen_api_server, 'settingsresource'),
+                cookies={SESSION_COOKIE_NAME: old_token},
+            )
+
+        assert response.status_code == HTTPStatus.OK
+        assert SESSION_COOKIE_NAME in response.cookies  # it did re-issue
+        assert 'Secure' in response.headers['Set-Cookie']
     finally:
         _disable_session(rotkehlchen_api_server)
 
@@ -614,6 +745,38 @@ def test_failed_create_revokes_the_minted_session(
         assert_error_response(response=response, status_code=HTTPStatus.BAD_REQUEST)
         assert SESSION_COOKIE_NAME not in response.cookies  # no live cookie shipped
         assert store.active_sid('ghost') is None  # the minted session was revoked
+    finally:
+        _disable_session(rotkehlchen_api_server)
+
+
+@pytest.mark.parametrize('start_with_logged_in_user', [False])
+@pytest.mark.parametrize('secure', [False, True])
+def test_created_account_cookie_carries_secure(
+        rotkehlchen_api_server: APIServer,
+        secure: bool,
+) -> None:
+    """Account creation mints its own cookie, on a different code path to login.
+
+    The mint happens in the `session_token=True` decorator rather than in
+    `authenticate_user`, so it needs its own assertion: a new account is the one
+    case where the very first cookie a browser ever receives comes from here.
+    """
+    _enable_session(rotkehlchen_api_server)
+    env = {SESSION_COOKIE_SECURE_ENV: '1'} if secure else {}
+    try:
+        with patch.dict(os.environ, env, clear=False):
+            if not secure:
+                os.environ.pop(SESSION_COOKIE_SECURE_ENV, None)
+            response = requests.put(
+                api_url_for(rotkehlchen_api_server, 'usersresource'),
+                json={'name': 'freshuser', 'password': '123'},
+            )
+
+        assert_proper_sync_response_with_result(response)
+        set_cookie_header = response.headers['Set-Cookie']
+        assert ('Secure' in set_cookie_header) is secure
+        assert 'HttpOnly' in set_cookie_header
+        assert 'SameSite=Lax' in set_cookie_header
     finally:
         _disable_session(rotkehlchen_api_server)
 


### PR DESCRIPTION
The code and tests are complete and green, and this has been exercised in a real container behind a TLS terminator (see Verification). The one piece still outstanding is the docs.rotki.com page, which is tracked separately and does not block this.

## Problem

The session cookie is never marked `Secure`, and there was no way to make it so. `set_session_cookie` hardcoded the attributes, no env var or config touched it, and nothing anywhere read `X-Forwarded-Proto`, so core had no idea whether it was behind TLS.

That is awkward now that the docker docs recommend running behind a TLS-terminating proxy: we recommend a deployment shape the cookie cannot adapt to.

The gap is narrow but real. `Secure` only ever *restricts* a cookie, so without it TLS still protects what actually travels over TLS. What is lost is the guarantee: if the same host is ever reachable over plain http, the browser will happily attach the session cookie to that request, which is exactly what `Secure` exists to prevent.

## Why it is opt-in and off by default

The flag cannot simply be turned on. The image serves plain http on loopback or a LAN, where `Secure` would stop the cookie being sent at all and break login outright. Only the operator knows whether TLS is terminated in front, so only the operator can say.

`ROTKI_SESSION_COOKIE_SECURE`:

- unset / `0` / `false` — off, today's behaviour
- `1` / `true` — always set it, for a proxy that terminates TLS but sends no forwarded header
- `forwarded` — derive it per request from `X-Forwarded-Proto`

An unrecognised value logs a warning and is treated as off, rather than silently deciding whether a credential may cross a plaintext connection.

## The starling half, which is the load-bearing part

`forwarded` mode is only safe if the header can be believed, and today it cannot: `add_forwarding_headers` set `X-Real-IP` and appended `X-Forwarded-For`, but passed any inbound `X-Forwarded-Proto` straight through to core. That is inert only because nothing reads it. The moment core does, a client that can reach the published port could dictate the value.

core also cannot make the judgement itself. It listens on loopback behind starling, so every request appears to come from `127.0.0.1` and a spoofed header is indistinguishable from a real one.

So starling now normalises the header on every proxied request, keeping an inbound value only when the peer is a trusted hop and overwriting it with `http` otherwise. It reuses the trust set the access log already has (`is_trusted_hop`: loopback, private and link-local by default, plus any `--trusted-proxy` CIDR), so operators get one knob rather than two. It always writes the header, so an absent value is never confusable with a stripped one, and an unknown peer counts as untrusted.

Worth saying that the risk here runs backwards from the usual forwarded-header case: a spoofed `https` would only force `Secure` on, breaking logins rather than exposing anything. The sanitizing is cheap insurance, not the thing holding the door shut.

### What the trust set does and does not buy

The default set is the whole private range, and `--trusted-proxy` can only extend it, never narrow it. So the sanitizing stops a **public** peer, not everyone who can reach the published port: a client on the same LAN as the container is a trusted hop and its claim is kept. That only ever affects the cookie in its own response, so it forces `Secure` onto its own session rather than weakening anyone else's, but it is a real bound and the README now states it.

The mirror case is easier to trip over and now documented too: if the terminator reaches the container from a **public** address and the operator forgets `--trusted-proxy`, its `X-Forwarded-Proto: https` is overwritten like any other untrusted peer's and the cookie is quietly never marked `Secure` while TLS is working fine. It fails safe and warns about nothing.

## Tests

Rust, on the sanitizer: untrusted and unknown peers get their claim overwritten; a trusted hop's is kept, both from the default private ranges and from an explicit `--trusted-proxy`; the header is always present and only ever one of the two schemes; a chain is read leftmost-first, since that is the original client's scheme.

Those call `sanitize_forwarded_proto` directly, so they prove it works but not that anything calls it — deleting the call from `add_forwarding_headers` left all four green. A further test drives a real request through the router and asserts on what the upstream received, across both proxied prefixes and public / unknown / LAN peers, which fails when the wiring is removed.

Python, end to end through real HTTP: eleven parametrized cases across the env values and the header, asserting the `Set-Cookie` attribute, including chained values so core's parse cannot drift from starling's. All four paths that set or clear the cookie are covered rather than just login: login, account creation (which mints in the `session_token=True` decorator, not in `authenticate_user`), the rolling re-issue in `after_request`, and logout.

Every one of these carries a verified negative control: deleting the `insert` in `sanitize_forwarded_proto` fails 3 of the 4 unit tests, removing the call from `add_forwarding_headers` fails only the router test, and forcing `secure=False` at each of the four python call sites fails exactly the case that expects the flag.

Gates: `cargo test -p starling-proxy` 66/66, clippy and rustfmt clean, `test_user_authenticate` 35/35, ruff, mypy and pyright clean.

## Verification in a container

Built the image from this branch and ran it behind traefik with a self-signed certificate, with `ROTKI_SESSION_COOKIE_SECURE=forwarded`:

| Peer | Inbound `X-Forwarded-Proto` | `Secure` on the cookie |
|---|---|---|
| traefik on the docker network, real TLS | `https` (set by traefik) | yes |
| host via the published port | none | no |
| host via the published port | spoofed `https` | yes (private peer, trusted) |
| client on a public address (`203.0.113.50`) | spoofed `https` | no (discarded) |

The last row is the one that matters: the request arrived un-NAT'd from a public address (confirmed in the access log) and its claim was dropped. Docker preserves the source address for external traffic, so an internet-exposed deployment gets the protection; the third row is the LAN bound described above.

## Note

`Secure` is not a substitute for HSTS, and the docs should say so: the flag stops the cookie being *sent* over plaintext, but a browser that has never seen a `Strict-Transport-Security` header will still make the plaintext request. That belongs in the docs.rotki.com page, which is the other half of this.
