### PR TITLE
fix: provide cargo for arm64 docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,18 @@ FROM python:3.14-bookworm AS backend-build-stage
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
+# arm64 has no wheels for the Rust-backed bindings (py-bip39, py-ed25519-zebra,
+# py-sr25519), so uv builds them from source with maturin. With no cargo in the
+# image, maturin bootstraps its own toolchain per package into one shared cache,
+# and the concurrent builds race on exec'ing the half-written binary:
+# "failed to start `cargo metadata`: Text file busy". Copied from the image
+# rather than from rust-build-stage, so the two stages still build in parallel.
+COPY --from=rust:1.91-bookworm /usr/local/cargo /usr/local/cargo
+COPY --from=rust:1.91-bookworm /usr/local/rustup /usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:$PATH
+
 ARG TARGETARCH
 ARG ROTKI_VERSION
 ENV PACKAGE_FALLBACK_VERSION=$ROTKI_VERSION


### PR DESCRIPTION
The arm64 docker build fails intermittently while installing python dependencies:

```
failed to start `cargo metadata`: Text file busy (os error 26)
Error: command ['maturin', 'pep517', 'build-wheel', ...] returned non-zero exit status 1
hint: `py-bip39-bindings` (v0.3.0) was included because `rotkehlchen` depends on `py-bip39-bindings`
```

## Cause

`py-bip39-bindings`, `py-ed25519-zebra-bindings` and `py-sr25519-bindings` publish no aarch64 wheels, so on arm64 uv builds all three from source with maturin (visible in the arm64 build log; amd64 uses wheels and never hits this path).

`python:3.14-bookworm` ships no cargo. Since 1.9, maturin bootstraps its own rust toolchain through puccinialin when cargo is missing, into `~/.cache/puccinialin`. uv builds those sdists concurrently, so several maturin processes bootstrap into that same directory, and one execs the cargo binary while another is still writing it. Linux returns `ETXTBSY` for exec of a file open for writing, which is the `Text file busy` above. Transient by nature, and arm-only.

## Fix

Copy a toolchain into the backend build stage so cargo is already on `PATH` and the bootstrap never runs. Copying from the `rust:1.91-bookworm` image rather than from `rust-build-stage` keeps the stages independent so they still build in parallel, and it is an image the build already pulls.

Side effect: the bootstrap cache lives outside the mounted uv cache, so a full rust toolchain was being downloaded on every arm64 build. That goes away too.

## Verification

Locally, on amd64:

- `docker buildx build --check`: no warnings.
- Built the backend stage up to `uv sync --frozen --no-dev --no-install-workspace` against the repo lockfile: sync succeeds, `cargo 1.91.1` resolves to `/usr/local/cargo/bin/cargo`, and `/root/.cache/puccinialin` is never created.
- Confirmed the mechanism both ways: in stock `python:3.14-bookworm` a source build of `py-bip39-bindings==0.3.0` creates `/root/.cache/puccinialin/cargo/bin/cargo`; with the toolchain copied in, it does not.

The arm64 leg itself can only be confirmed by CI. Reproducing it here would need qemu, which produces its own spurious `ETXTBSY` and would prove nothing either way.