### PR TITLE
perf: shrink the eager startup bundles in both processes

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -165,6 +165,11 @@ jobs:
         working-directory: ./frontend
         run: pnpm run --filter rotki build:app
 
+      - name: Check bundle placement
+        if: ${{ !cancelled() && steps.install.outcome == 'success' && github.event_name != 'push' }}
+        working-directory: ./frontend
+        run: pnpm run --filter rotki check:bundle
+
       - name: ESLint
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         working-directory: ./frontend

--- a/frontend/app/electron/main/ipc-handlers/update-handlers.ts
+++ b/frontend/app/electron/main/ipc-handlers/update-handlers.ts
@@ -1,11 +1,9 @@
 import type { AppConfig } from '@electron/main/app-config';
 import type { LogService } from '@electron/main/log-service';
 import type { ProgressInfo } from 'electron-builder';
+import type { AppUpdater } from 'electron-updater';
 import { IpcCommands } from '@electron/ipc-commands';
 import { startPromise } from '@shared/utils';
-import electronUpdater from 'electron-updater';
-
-const { autoUpdater } = electronUpdater;
 
 interface UpdateHandlersCallbacks {
   terminateSubprocesses: (update?: boolean) => Promise<void>;
@@ -14,14 +12,13 @@ interface UpdateHandlersCallbacks {
 
 export class UpdateHandlers {
   private callbacks: UpdateHandlersCallbacks | null = null;
+  private updater?: Promise<AppUpdater>;
   private static readonly updateTimeout = 5000;
 
   constructor(
     private readonly logger: LogService,
     private readonly config: AppConfig,
-  ) {
-    this.setupAutoUpdater();
-  }
+  ) {}
 
   initialize(callbacks: UpdateHandlersCallbacks): void {
     this.callbacks = callbacks;
@@ -35,7 +32,18 @@ export class UpdateHandlers {
     return callbacks;
   }
 
-  private setupAutoUpdater(): void {
+  /**
+   * electron-updater and its dependencies are ~290 KB that only an update check needs, so it is
+   * imported on first use rather than at startup. The promise is memoized, not the resolved
+   * updater, so concurrent callers share one import and one setup.
+   */
+  private async getAutoUpdater(): Promise<AppUpdater> {
+    this.updater ??= this.loadAutoUpdater();
+    return this.updater;
+  }
+
+  private async loadAutoUpdater(): Promise<AppUpdater> {
+    const { autoUpdater } = (await import('electron-updater')).default;
     autoUpdater.autoDownload = false;
     autoUpdater.logger = {
       error: (message?: any) => this.logger.error(message),
@@ -43,6 +51,7 @@ export class UpdateHandlers {
       debug: (message: string) => this.logger.debug(message),
       warn: (message?: any) => this.logger.warn(message),
     };
+    return autoUpdater;
   }
 
   checkForUpdates = async (): Promise<boolean> => {
@@ -50,6 +59,8 @@ export class UpdateHandlers {
       console.warn('Running in development skipping auto-updater check');
       return false;
     }
+
+    const autoUpdater = await this.getAutoUpdater();
 
     return new Promise<boolean>((resolve) => {
       autoUpdater.once('update-available', () => resolve(true));
@@ -71,6 +82,8 @@ export class UpdateHandlers {
       event.sender.send(IpcCommands.DOWNLOAD_PROGRESS, progress.percent);
       this.requireCallbacks.updateDownloadProgress(progress.percent);
     };
+
+    const autoUpdater = await this.getAutoUpdater();
 
     return new Promise<boolean>((resolve) => {
       autoUpdater.on('download-progress', progress);
@@ -111,6 +124,7 @@ export class UpdateHandlers {
   };
 
   private async quitAndInstallUpdates(): Promise<void> {
+    const autoUpdater = await this.getAutoUpdater();
     await this.requireCallbacks.terminateSubprocesses(true);
     autoUpdater.quitAndInstall();
   }

--- a/frontend/app/electron/main/password-manager.spec.ts
+++ b/frontend/app/electron/main/password-manager.spec.ts
@@ -15,17 +15,22 @@ const { isEncryptionAvailable, encryptString, decryptString, backing } = vi.hois
 });
 
 vi.mock('electron', () => ({
+  app: { getPath: vi.fn<() => string>(() => '/tmp/rotki-test-user-data') },
   safeStorage: { isEncryptionAvailable, encryptString, decryptString },
 }));
 
-vi.mock('electron-store', () => ({
-  default: class {
-    get store(): Record<string, string> {
-      return backing.data;
+vi.mock('@electron/main/password-store', () => ({
+  PasswordStore: class {
+    get(key: string): string | undefined {
+      return backing.data[key];
     }
 
     set(key: string, value: string): void {
       backing.data[key] = value;
+    }
+
+    isEmpty(): boolean {
+      return Object.keys(backing.data).length === 0;
     }
 
     clear(): void {

--- a/frontend/app/electron/main/password-manager.ts
+++ b/frontend/app/electron/main/password-manager.ts
@@ -1,12 +1,13 @@
 import type { Credentials } from '@shared/ipc';
 import { Buffer } from 'node:buffer';
-import { safeStorage } from 'electron';
-import Store from 'electron-store';
+import path from 'node:path';
+import { PasswordStore } from '@electron/main/password-store';
+import { app, safeStorage } from 'electron';
 
 const ENCODING = 'latin1';
 
 export class PasswordManager {
-  private readonly store = new Store<Record<string, string>>();
+  private readonly store = new PasswordStore(path.join(app.getPath('userData'), 'config.json'));
 
   private readonly getEncryptionAvailability = (): boolean => safeStorage.isEncryptionAvailable();
 
@@ -19,12 +20,12 @@ export class PasswordManager {
     this.store.clear();
   };
 
-  private readonly hasStoredPassword = (key: string): boolean => Boolean(this.store.store?.[key]);
+  private readonly hasStoredPassword = (key: string): boolean => Boolean(this.store.get(key));
 
-  private readonly hasAnyStoredPassword = (): boolean => Object.keys(this.store.store ?? {}).length > 0;
+  private readonly hasAnyStoredPassword = (): boolean => !this.store.isEmpty();
 
   private readonly getPassword = (key: string) => {
-    const buffer = this.store.store?.[key];
+    const buffer = this.store.get(key);
     if (buffer)
       return safeStorage.decryptString(Buffer.from(buffer, ENCODING));
 

--- a/frontend/app/electron/main/password-store.spec.ts
+++ b/frontend/app/electron/main/password-store.spec.ts
@@ -1,0 +1,171 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { PasswordStore } from './password-store';
+
+describe('passwordStore', () => {
+  let directory: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'rotki-password-store-'));
+    filePath = path.join(directory, 'config.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(directory, { force: true, recursive: true });
+  });
+
+  function writeStore(contents: unknown): void {
+    fs.writeFileSync(filePath, JSON.stringify(contents, undefined, '\t'), { encoding: 'utf8' });
+  }
+
+  it('should return undefined when no file exists', () => {
+    expect(new PasswordStore(filePath).get('alice')).toBeUndefined();
+    expect(new PasswordStore(filePath).isEmpty()).toBe(true);
+  });
+
+  it('should read an existing electron-store file', () => {
+    writeStore({ alice: 'ciphertext' });
+    expect(new PasswordStore(filePath).get('alice')).toBe('ciphertext');
+  });
+
+  it('should write the file in the format conf used', () => {
+    new PasswordStore(filePath).set('alice', 'ciphertext');
+    // Tab-indented, matching `JSON.stringify(value, undefined, '\t')`.
+    expect(fs.readFileSync(filePath, { encoding: 'utf8' })).toBe('{\n\t"alice": "ciphertext"\n}');
+  });
+
+  it('should keep other entries when setting one', () => {
+    writeStore({ alice: 'first', bob: 'second' });
+    const store = new PasswordStore(filePath);
+    store.set('alice', 'updated');
+
+    expect(store.get('alice')).toBe('updated');
+    expect(store.get('bob')).toBe('second');
+  });
+
+  it('should recover a dot-prop nested entry written by electron-store', () => {
+    // conf's dot-prop `set` turned the username `john.doe` into nested objects, which every read
+    // path then missed. The password was saved and could never be restored.
+    writeStore({ john: { doe: 'ciphertext' } });
+
+    expect(new PasswordStore(filePath).get('john.doe')).toBe('ciphertext');
+  });
+
+  it('should flatten a legacy nested entry back to disk', () => {
+    writeStore({ john: { doe: 'ciphertext' } });
+    new PasswordStore(filePath).get('john.doe');
+
+    expect(JSON.parse(fs.readFileSync(filePath, { encoding: 'utf8' }))).toStrictEqual({
+      'john.doe': 'ciphertext',
+    });
+  });
+
+  it('should not rewrite a file that is already flat', () => {
+    writeStore({ alice: 'ciphertext' });
+    const before = fs.statSync(filePath).mtimeMs;
+
+    new PasswordStore(filePath).get('alice');
+
+    expect(fs.statSync(filePath).mtimeMs).toBe(before);
+  });
+
+  it('should write new entries flat even when the username has a dot', () => {
+    const store = new PasswordStore(filePath);
+    store.set('john.doe', 'ciphertext');
+
+    expect(JSON.parse(fs.readFileSync(filePath, { encoding: 'utf8' }))).toStrictEqual({
+      'john.doe': 'ciphertext',
+    });
+    expect(store.get('john.doe')).toBe('ciphertext');
+  });
+
+  it('should recover an entry nested more than one level deep', () => {
+    writeStore({ a: { b: { c: 'ciphertext' } } });
+
+    expect(new PasswordStore(filePath).get('a.b.c')).toBe('ciphertext');
+  });
+
+  it('should recover a nested entry without disturbing a flat neighbour', () => {
+    writeStore({ alice: 'flat', john: { doe: 'nested' } });
+    const store = new PasswordStore(filePath);
+
+    expect(store.get('alice')).toBe('flat');
+    expect(store.get('john.doe')).toBe('nested');
+    expect(JSON.parse(fs.readFileSync(filePath, { encoding: 'utf8' }))).toStrictEqual({
+      'alice': 'flat',
+      'john.doe': 'nested',
+    });
+  });
+
+  it('should keep a recovered entry when a later password is saved', () => {
+    writeStore({ john: { doe: 'nested' } });
+    const store = new PasswordStore(filePath);
+    store.set('alice', 'ciphertext');
+
+    expect(store.get('john.doe')).toBe('nested');
+    expect(store.get('alice')).toBe('ciphertext');
+  });
+
+  it('should ignore values that are not passwords', () => {
+    // Only strings are credentials. Anything else is not something this store wrote, and it is
+    // dropped on the next write rather than being carried around.
+    writeStore({ alice: 'ciphertext', count: 42, empty: null, list: ['a'] });
+    const store = new PasswordStore(filePath);
+    store.set('bob', 'second');
+
+    expect(JSON.parse(fs.readFileSync(filePath, { encoding: 'utf8' }))).toStrictEqual({
+      alice: 'ciphertext',
+      bob: 'second',
+    });
+  });
+
+  it('should create the directory when the user data path does not exist yet', () => {
+    const nested = path.join(directory, 'missing', 'config.json');
+    new PasswordStore(nested).set('alice', 'ciphertext');
+
+    expect(new PasswordStore(nested).get('alice')).toBe('ciphertext');
+  });
+
+  it('should clear without a file present', () => {
+    const store = new PasswordStore(filePath);
+    store.clear();
+
+    expect(store.isEmpty()).toBe(true);
+  });
+
+  it('should replace the file wholesale rather than merging into stale content', () => {
+    writeStore({ alice: 'first', bob: 'second' });
+    const store = new PasswordStore(filePath);
+    store.clear();
+    store.set('carol', 'third');
+
+    expect(JSON.parse(fs.readFileSync(filePath, { encoding: 'utf8' }))).toStrictEqual({
+      carol: 'third',
+    });
+  });
+
+  it('should treat a corrupt file as empty rather than throwing', () => {
+    fs.writeFileSync(filePath, 'not json', { encoding: 'utf8' });
+
+    expect(new PasswordStore(filePath).get('alice')).toBeUndefined();
+    expect(new PasswordStore(filePath).isEmpty()).toBe(true);
+  });
+
+  it('should clear every entry', () => {
+    writeStore({ alice: 'first', bob: 'second' });
+    const store = new PasswordStore(filePath);
+    store.clear();
+
+    expect(store.isEmpty()).toBe(true);
+    expect(fs.readFileSync(filePath, { encoding: 'utf8' })).toBe('{}');
+  });
+
+  it('should leave no temporary file behind', () => {
+    new PasswordStore(filePath).set('alice', 'ciphertext');
+
+    expect(fs.readdirSync(directory)).toStrictEqual(['config.json']);
+  });
+});

--- a/frontend/app/electron/main/password-store.ts
+++ b/frontend/app/electron/main/password-store.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+
+/**
+ * The on-disk half of {@link PasswordManager}, replacing electron-store.
+ *
+ * electron-store cost ~230 KB of the main bundle, most of it ajv, pulled in for JSON-schema
+ * validation we never asked for. What it actually gave us was a JSON file, so this keeps the file
+ * and drops the dependency. Every default it applied is reproduced below, because an installed
+ * client already has one of these files: `<userData>/config.json`, serialized exactly as conf did
+ * (`JSON.stringify(value, undefined, '\t')`), written with mode 0o666.
+ */
+
+const CONFIG_FILE_MODE = 0o666;
+
+/** Values are read as unknown so a legacy nested entry parses instead of throwing. */
+const StoredPasswords = z.record(z.string(), z.unknown());
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+interface LoadedStore {
+  entries: Record<string, string>;
+  /** True when the file held dot-prop nesting that has been flattened and needs writing back. */
+  legacy: boolean;
+}
+
+/**
+ * conf wrote through dot-prop, so a username containing a dot landed as nested objects
+ * (`john.doe` became `{ john: { doe: ... } }`) while every read here is a flat lookup. Those
+ * entries were therefore unreachable: the password saved and never restored. Flattening rejoins
+ * them with the dot, which both recovers them and matches how they are written from now on.
+ */
+function flatten(value: Record<string, unknown>, prefix = ''): LoadedStore {
+  const entries: Record<string, string> = {};
+  let legacy = false;
+
+  for (const [key, entry] of Object.entries(value)) {
+    const name = prefix ? `${prefix}.${key}` : key;
+    if (typeof entry === 'string') {
+      entries[name] = entry;
+    }
+    else if (isRecord(entry)) {
+      const nested = flatten(entry, name);
+      Object.assign(entries, nested.entries);
+      legacy = true;
+    }
+  }
+
+  return { entries, legacy };
+}
+
+export class PasswordStore {
+  constructor(private readonly filePath: string) {}
+
+  private load(): Record<string, string> {
+    if (!fs.existsSync(this.filePath))
+      return {};
+
+    let loaded: LoadedStore;
+    try {
+      const file = fs.readFileSync(this.filePath, { encoding: 'utf8' });
+      loaded = flatten(StoredPasswords.parse(JSON.parse(file)));
+    }
+    catch (error: any) {
+      console.error(error, 'Could not read the password store');
+      return {};
+    }
+
+    // Rewrite once so the nesting does not have to be understood again.
+    if (loaded.legacy)
+      this.write(loaded.entries);
+
+    return loaded.entries;
+  }
+
+  private write(entries: Record<string, string>): void {
+    const data = JSON.stringify(entries, undefined, '\t');
+    const temporary = `${this.filePath}.tmp`;
+    try {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      // Written to a sibling and renamed, because a half-written file here loses every saved
+      // password. This is what `atomically` did for us under electron-store.
+      fs.writeFileSync(temporary, data, { encoding: 'utf8', mode: CONFIG_FILE_MODE });
+      fs.renameSync(temporary, this.filePath);
+    }
+    catch (error: any) {
+      console.error(error, 'Could not write the password store');
+    }
+  }
+
+  get(key: string): string | undefined {
+    return this.load()[key];
+  }
+
+  set(key: string, value: string): void {
+    const entries = this.load();
+    entries[key] = value;
+    this.write(entries);
+  }
+
+  isEmpty(): boolean {
+    return Object.keys(this.load()).length === 0;
+  }
+
+  clear(): void {
+    this.write({});
+  }
+}

--- a/frontend/app/electron/main/password-store.ts
+++ b/frontend/app/electron/main/password-store.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { z } from 'zod';
+import * as z from 'zod/mini';
 
 /**
  * The on-disk half of {@link PasswordManager}, replacing electron-store.

--- a/frontend/app/electron/main/settings-manager.spec.ts
+++ b/frontend/app/electron/main/settings-manager.spec.ts
@@ -1,0 +1,87 @@
+import type { App } from 'electron';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SettingsManager } from './settings-manager';
+
+describe('settingsManager', () => {
+  let directory: string;
+  let app: App;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'rotki-settings-'));
+    app = createMock<App>({ getPath: () => directory });
+  });
+
+  afterEach(() => {
+    fs.rmSync(directory, { force: true, recursive: true });
+  });
+
+  function writeSettings(contents: unknown): void {
+    fs.writeFileSync(path.join(directory, 'app.config.json'), JSON.stringify(contents), { encoding: 'utf8' });
+  }
+
+  it('should apply the defaults when no file exists', () => {
+    expect(new SettingsManager(app).appSettings).toStrictEqual({
+      displayTray: true,
+      mcpAutoStart: false,
+      showNetWorthOnTray: false,
+    });
+  });
+
+  it('should read the stored settings', () => {
+    writeSettings({ displayTray: false, mcpAutoStart: true, persistStore: true, showNetWorthOnTray: true });
+
+    expect(new SettingsManager(app).appSettings).toStrictEqual({
+      displayTray: false,
+      mcpAutoStart: true,
+      persistStore: true,
+      showNetWorthOnTray: true,
+    });
+  });
+
+  it('should default the keys a stored file omits', () => {
+    // The tray defaults to on, so a file predating the setting must not silently disable it.
+    writeSettings({ mcpAutoStart: true });
+    const settings = new SettingsManager(app).appSettings;
+
+    expect(settings.displayTray).toBe(true);
+    expect(settings.showNetWorthOnTray).toBe(false);
+    expect(settings.mcpAutoStart).toBe(true);
+  });
+
+  it('should leave persistStore unset when the file omits it', () => {
+    writeSettings({ displayTray: true });
+
+    expect(new SettingsManager(app).appSettings.persistStore).toBeUndefined();
+  });
+
+  it('should fall back to the defaults when the file is corrupt', () => {
+    fs.writeFileSync(path.join(directory, 'app.config.json'), 'not json', { encoding: 'utf8' });
+
+    expect(new SettingsManager(app).appSettings.displayTray).toBe(true);
+  });
+
+  it('should fall back to the defaults when a value has the wrong type', () => {
+    writeSettings({ displayTray: 'yes' });
+
+    expect(new SettingsManager(app).appSettings.displayTray).toBe(true);
+  });
+
+  it('should persist a change so a later instance reads it', () => {
+    const manager = new SettingsManager(app);
+    manager.setMcpAutoStart(true);
+
+    expect(new SettingsManager(app).appSettings.mcpAutoStart).toBe(true);
+  });
+
+  it('should persist edits made through appSettings on save', () => {
+    const manager = new SettingsManager(app);
+    manager.appSettings.showNetWorthOnTray = true;
+    manager.save();
+
+    expect(new SettingsManager(app).appSettings.showNetWorthOnTray).toBe(true);
+  });
+});

--- a/frontend/app/electron/main/settings-manager.ts
+++ b/frontend/app/electron/main/settings-manager.ts
@@ -1,13 +1,13 @@
 import type { App } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
-import { z } from 'zod';
+import * as z from 'zod/mini';
 
 const AppSettingsSchema = z.object({
-  displayTray: z.boolean().default(true),
-  mcpAutoStart: z.boolean().default(false),
-  persistStore: z.boolean().optional(),
-  showNetWorthOnTray: z.boolean().default(false),
+  displayTray: z._default(z.boolean(), true),
+  mcpAutoStart: z._default(z.boolean(), false),
+  persistStore: z.optional(z.boolean()),
+  showNetWorthOnTray: z._default(z.boolean(), false),
 });
 
 type AppSettings = z.infer<typeof AppSettingsSchema>;

--- a/frontend/app/electron/main/tray-manager.ts
+++ b/frontend/app/electron/main/tray-manager.ts
@@ -3,7 +3,6 @@ import type { SettingsManager } from '@electron/main/settings-manager';
 import type { TrayUpdate } from '@shared/ipc';
 import path from 'node:path';
 import { assert } from '@rotki/common';
-import { isDefined } from '@vueuse/core';
 import { Menu, type MenuItem, type MenuItemConstructorOptions, nativeImage, Tray } from 'electron';
 
 interface TrayManagerListener {
@@ -106,7 +105,7 @@ export class TrayManager {
       icon = 'rotki-trayTemplate@5x.png';
 
     if (this.settings.appSettings.showNetWorthOnTray) {
-      if (isDefined(netWorth)) {
+      if (netWorth !== undefined) {
         title += ` ${netWorth} ${currency}`;
         tooltip.unshift(`Net worth ${netWorth} ${currency}.`);
       }

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -107,7 +107,6 @@
     "dotenv": "catalog:",
     "electron": "catalog:",
     "electron-builder": "catalog:",
-    "electron-store": "catalog:",
     "fake-indexeddb": "catalog:",
     "flush-promises": "catalog:",
     "happy-dom": "catalog:",

--- a/frontend/app/package.json
+++ b/frontend/app/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "run-p typecheck \"build:app {@}\" --",
     "build:app": "tsx scripts/build.ts",
+    "check:bundle": "tsx scripts/check-bundle.ts",
     "build:preview": "pnpm run build:app && vite preview",
     "preview": "vite preview",
     "electron:build": "pnpm run build && pnpm run electron:package",

--- a/frontend/app/scripts/check-bundle.ts
+++ b/frontend/app/scripts/check-bundle.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+/**
+ * Bundle placement regression check.
+ *
+ * Asserts *where* modules land, not how big anything is: a lazy chunk costs nothing however
+ * big it gets, while one wrongly-placed helper module drags a whole lazy chunk into the eager
+ * startup graph.
+ *
+ * It runs the renderer build in-process because it needs the module to chunk map, which the
+ * production bundle does not carry (no sourcemaps) and cannot be recovered from `dist/`.
+ */
+
+import process from 'node:process';
+import consola from 'consola';
+import { build } from 'vite';
+import {
+  expectedChunkFor,
+  HELPERS_CHUNK,
+  knownViolations,
+  lazyChunks,
+  packageNameFor,
+} from './chunk-groups';
+import { sharedConfig } from './setup';
+
+process.env.NODE_ENV = 'production';
+
+interface Chunk {
+  name: string;
+  fileName: string;
+  moduleIds: string[];
+}
+
+interface Bundle {
+  chunks: Chunk[];
+  html: string | undefined;
+}
+
+function isChunkLike(value: unknown): value is { type: string; name?: string; fileName: string; modules?: Record<string, unknown> } {
+  return typeof value === 'object' && value !== null && 'type' in value && 'fileName' in value;
+}
+
+function textOf(source: unknown): string | undefined {
+  if (typeof source === 'string')
+    return source;
+  if (source instanceof Uint8Array)
+    return new TextDecoder().decode(source);
+  return undefined;
+}
+
+/**
+ * Flattens whatever `vite.build` returned into the chunks plus the emitted `index.html`.
+ * The return type is a union of single output, output array, and watcher, so it is narrowed
+ * structurally rather than asserted.
+ */
+function collectBundle(result: unknown): Bundle {
+  const outputs: unknown[] = [];
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    if (typeof value === 'object' && value !== null && 'output' in value) {
+      visit(Reflect.get(value, 'output'));
+      return;
+    }
+    outputs.push(value);
+  };
+  visit(result);
+
+  const chunks: Chunk[] = [];
+  let html: string | undefined;
+
+  for (const item of outputs) {
+    if (!isChunkLike(item))
+      continue;
+
+    if (item.type === 'chunk') {
+      chunks.push({
+        name: item.name ?? item.fileName,
+        fileName: item.fileName,
+        moduleIds: Object.keys(item.modules ?? {}),
+      });
+    }
+    else if (item.fileName.endsWith('index.html')) {
+      html = textOf(Reflect.get(item, 'source'));
+    }
+  }
+
+  return { chunks, html };
+}
+
+/** A package lands in a chunk other than the one the shared rules assign it. */
+function checkOwnership(chunks: Chunk[]): string[] {
+  // Keyed by "<package> -> <actual>" so a package split across chunks reports once per chunk
+  // rather than once per module.
+  const violations = new Set<string>();
+
+  for (const chunk of chunks) {
+    for (const id of chunk.moduleIds) {
+      const expected = expectedChunkFor(id);
+      if (!expected || expected === chunk.name)
+        continue;
+
+      const owner = packageNameFor(id) ?? id;
+      violations.add(`${owner} -> ${chunk.name} (expected ${expected})`);
+    }
+  }
+
+  return [...violations].sort();
+}
+
+/** A chunk that should only ever be reached by dynamic import is preloaded at startup. */
+function checkLaziness(chunks: Chunk[], html: string | undefined): string[] {
+  if (html === undefined)
+    return ['index.html was not emitted, cannot verify the eager startup graph'];
+
+  const byFileName = new Map(chunks.map(chunk => [chunk.fileName, chunk.name]));
+  const preloaded = new Set<string>();
+
+  for (const match of html.matchAll(/<link[^>]+rel="modulepreload"[^>]*>/g)) {
+    const href = /href="([^"]+)"/.exec(match[0])?.[1];
+    if (!href)
+      continue;
+    const name = byFileName.get(href.replace(/^\.?\//, ''));
+    if (name)
+      preloaded.add(name);
+  }
+
+  // A script tag counts too: it is the entry's own static graph.
+  for (const match of html.matchAll(/<script[^>]+src="([^"]+)"[^>]*>/g)) {
+    const name = byFileName.get(match[1].replace(/^\.?\//, ''));
+    if (name)
+      preloaded.add(name);
+  }
+
+  return lazyChunks
+    .filter(name => preloaded.has(name))
+    .map(name => `${name} is in the eager startup graph (index.html preloads it)`);
+}
+
+/** The helpers chunk must exist, or the virtual helper ids have drifted and nothing is pinned. */
+function checkHelpersChunk(chunks: Chunk[]): string[] {
+  const helpers = chunks.find(chunk => chunk.name === HELPERS_CHUNK);
+  if (!helpers)
+    return [`no "${HELPERS_CHUNK}" chunk was emitted; the injected helper module ids in chunk-groups.ts have probably changed`];
+  if (helpers.moduleIds.length === 0)
+    return [`the "${HELPERS_CHUNK}" chunk is empty`];
+  return [];
+}
+
+async function run(): Promise<void> {
+  consola.info('Building the renderer to inspect chunk placement...');
+
+  const result = await build({
+    ...sharedConfig,
+    mode: 'production',
+    configFile: 'vite.config.ts',
+    logLevel: 'warn',
+    // Never touch dist/: the CI Build step's artifact must survive this check.
+    build: { write: false },
+    plugins: [{ name: 'check-bundle' }],
+  });
+
+  const { chunks, html } = collectBundle(result);
+  if (chunks.length === 0) {
+    consola.error('The build produced no chunks.');
+    process.exit(1);
+  }
+
+  const hard = [...checkHelpersChunk(chunks), ...checkLaziness(chunks, html)];
+  const ownership = checkOwnership(chunks);
+
+  const known = new Set(knownViolations);
+  const unexpected = ownership.filter(violation => !known.has(violation));
+  const healed = [...known].filter(violation => !ownership.includes(violation));
+
+  if (ownership.some(violation => known.has(violation))) {
+    consola.warn(`Known misplacements, tracked in chunk-groups.ts:\n${ownership.filter(v => known.has(v)).map(v => `  - ${v}`).join('\n')}`);
+  }
+
+  const failures = [
+    ...hard,
+    ...unexpected.map(violation => `new misplacement: ${violation}`),
+    ...healed.map(violation => `known misplacement no longer happens, remove it from knownViolations: ${violation}`),
+  ];
+
+  if (failures.length > 0) {
+    consola.error(`Bundle placement check failed:\n${failures.map(failure => `  - ${failure}`).join('\n')}`);
+    process.exit(1);
+  }
+
+  consola.success(`Bundle placement is intact (${chunks.length} chunks, ${lazyChunks.join(' and ')} stayed lazy).`);
+  process.exit(0);
+}
+
+try {
+  await run();
+}
+catch (error) {
+  consola.error(error);
+  process.exit(1);
+}

--- a/frontend/app/scripts/chunk-groups.ts
+++ b/frontend/app/scripts/chunk-groups.ts
@@ -1,0 +1,127 @@
+/**
+ * Chunk placement rules, shared by `vite.config.ts` and `check:bundle` so the build and its
+ * regression check cannot drift apart.
+ *
+ * The rules assert *placement*, not size. A lazy chunk costs nothing however big it is; what
+ * costs is a chunk being pulled into the eager startup graph by a static import.
+ */
+
+/** Chunk that collects the injected helper modules. */
+export const HELPERS_CHUNK = 'helpers';
+
+/**
+ * Virtual helper modules Vite and Rolldown inject into the graph.
+ *
+ * They are not real files, so `manualChunks` never sees them. Left unassigned, Rolldown parks
+ * each one in whichever big lazy chunk claims it first, and every importer of that helper then
+ * statically imports the whole chunk, dragging it into the eager startup graph. Pinning them to
+ * one tiny `helpers` chunk is what keeps `editor` and `wallet-connect` lazy.
+ */
+export const sharedHelperModules = new Set<string>([
+  '\0plugin-vue:export-helper',
+  '\0rolldown_dynamic_import_helper.js',
+  '\0vite/modulepreload-polyfill.js',
+  '\0vite/preload-helper.js',
+]);
+
+/**
+ * Package to chunk assignment. A module under `node_modules/<pkg>/` is placed in the chunk
+ * whose list names `<pkg>`.
+ */
+export const vendorGroups: Record<string, string[]> = {
+  'chart': ['echarts', 'vue-echarts'],
+  'common': ['@rotki/common', 'bignumber.js'],
+  'editor': ['vanilla-jsoneditor'],
+  'ui-vendor': ['@rotki/ui-library'],
+  'utils': [
+    '@vueuse/math',
+    '@vueuse/core',
+    '@vueuse/shared',
+    '@vuelidate/core',
+    '@vuelidate/validators',
+    'ofetch',
+    'es-toolkit',
+    'imask',
+    'dayjs',
+    'consola',
+    'zod',
+  ],
+  'vue-vendor': ['vue', 'vue-router', 'pinia', 'vue-i18n'],
+  'wallet-connect': [
+    '@walletconnect/core',
+    '@walletconnect/universal-provider',
+    'viem',
+  ],
+};
+
+/**
+ * Chunks that must never appear in an `index.html` modulepreload. Each is only reachable
+ * through a dynamic import, so a preload link means something started importing it statically.
+ */
+export const lazyChunks: string[] = ['editor', 'wallet-connect'];
+
+/**
+ * Misplacements that exist today and are not fixed yet. The check stays green for these but
+ * fails on anything new, and it also fails once one of them stops happening, which is the
+ * prompt to delete the entry rather than let the list rot.
+ *
+ * `vue` in `chart`: Rolldown emits the vue runtime into `chart` even though the rule resolves
+ * it to `vue-vendor`. Every chunk needs vue, so all of them statically import `chart` and
+ * echarts ends up eager. Cause is Rolldown-side and still unknown. This is the big remaining
+ * win, worth roughly 257 KB gzip.
+ *
+ * The `ui-vendor` entries are a few kB each: Rolldown hoists a handful of modules shared with
+ * `@rotki/ui-library` into its chunk instead of leaving them in the group they resolve to.
+ * Low impact, and it predates the codeSplitting migration.
+ */
+export const knownViolations: string[] = [
+  '@vueuse/core -> ui-vendor (expected utils)',
+  '@vueuse/shared -> ui-vendor (expected utils)',
+  'dayjs -> ui-vendor (expected utils)',
+  'vue -> chart (expected vue-vendor)',
+  'vue-router -> ui-vendor (expected vue-vendor)',
+];
+
+function packageOf(id: string): string | undefined {
+  const normalized = id.replaceAll('\\', '/');
+  const marker = '/node_modules/';
+  const index = normalized.lastIndexOf(marker);
+  if (index === -1)
+    return undefined;
+
+  const rest = normalized.slice(index + marker.length);
+  const parts = rest.split('/');
+  if (parts.length < 2)
+    return undefined;
+
+  return parts[0].startsWith('@') ? `${parts[0]}/${parts[1]}` : parts[0];
+}
+
+/**
+ * Chunk a module belongs to, or `null` to leave the decision to Rolldown.
+ */
+export function vendorChunkFor(id: string): string | null {
+  const pkg = packageOf(id);
+  if (!pkg)
+    return null;
+
+  for (const [chunk, packages] of Object.entries(vendorGroups)) {
+    if (packages.includes(pkg))
+      return chunk;
+  }
+  return null;
+}
+
+/**
+ * Chunk a module is *expected* to land in, covering helpers as well as vendors.
+ */
+export function expectedChunkFor(id: string): string | null {
+  if (sharedHelperModules.has(id))
+    return HELPERS_CHUNK;
+  return vendorChunkFor(id);
+}
+
+/** The owning package of a module, for reporting a violation in terms a reader can act on. */
+export function packageNameFor(id: string): string | undefined {
+  return packageOf(id);
+}

--- a/frontend/app/scripts/chunk-groups.ts
+++ b/frontend/app/scripts/chunk-groups.ts
@@ -24,63 +24,84 @@ export const sharedHelperModules = new Set<string>([
   '\0vite/preload-helper.js',
 ]);
 
+export interface VendorGroup {
+  chunk: string;
+  priority: number;
+  packages: string[];
+}
+
 /**
- * Package to chunk assignment. A module under `node_modules/<pkg>/` is placed in the chunk
- * whose list names `<pkg>`.
+ * Package to chunk assignment, highest priority first. A module under `node_modules/<pkg>/`
+ * is placed in the chunk whose list names `<pkg>`.
+ *
+ * **Priority is load-bearing, not cosmetic.** Rolldown lets the highest-priority matching
+ * group claim a module and removes it from the others, and a widely shared dependency that
+ * the wrong group claims drags that whole group into the eager startup graph. `vue-vendor`
+ * ranks above everything because every chunk needs the vue runtime: while `chart` outranked
+ * it, vue was emitted into `chart`, so all 369 chunks statically imported `chart` and echarts
+ * loaded at startup. Raising `vue-vendor` is what makes `chart` lazy.
  */
-export const vendorGroups: Record<string, string[]> = {
-  'chart': ['echarts', 'vue-echarts'],
-  'common': ['@rotki/common', 'bignumber.js'],
-  'editor': ['vanilla-jsoneditor'],
-  'ui-vendor': ['@rotki/ui-library'],
-  'utils': [
-    '@vueuse/math',
-    '@vueuse/core',
-    '@vueuse/shared',
-    '@vuelidate/core',
-    '@vuelidate/validators',
-    'ofetch',
-    'es-toolkit',
-    'imask',
-    'dayjs',
-    'consola',
-    'zod',
-  ],
-  'vue-vendor': ['vue', 'vue-router', 'pinia', 'vue-i18n'],
-  'wallet-connect': [
-    '@walletconnect/core',
-    '@walletconnect/universal-provider',
-    'viem',
-  ],
-};
+export const vendorGroups: VendorGroup[] = [
+  { chunk: 'vue-vendor', priority: 90, packages: ['vue', 'vue-router', 'pinia', 'vue-i18n'] },
+  { chunk: 'common', priority: 80, packages: ['@rotki/common', 'bignumber.js'] },
+  {
+    chunk: 'utils',
+    priority: 70,
+    packages: [
+      '@vueuse/math',
+      '@vueuse/core',
+      '@vueuse/shared',
+      '@vuelidate/core',
+      '@vuelidate/validators',
+      'ofetch',
+      'es-toolkit',
+      'imask',
+      'dayjs',
+      'consola',
+      'zod',
+    ],
+  },
+  { chunk: 'ui-vendor', priority: 60, packages: ['@rotki/ui-library'] },
+  { chunk: 'chart', priority: 50, packages: ['echarts', 'vue-echarts'] },
+  { chunk: 'editor', priority: 40, packages: ['vanilla-jsoneditor'] },
+  {
+    chunk: 'wallet-connect',
+    priority: 30,
+    packages: ['@walletconnect/core', '@walletconnect/universal-provider', 'viem'],
+  },
+];
+
+/**
+ * The vendor groups as one explicit `test` + `priority` entry per chunk. A single group with
+ * a shared dynamic `name()` cannot express the ordering above, because every name it returns
+ * gets the same priority.
+ */
+export function vendorGroupEntries(): { name: string; priority: number; test: (id: string) => boolean }[] {
+  return vendorGroups.map(({ chunk, priority, packages }) => ({
+    name: chunk,
+    priority,
+    test: (id: string): boolean => {
+      const pkg = packageOf(id);
+      return pkg !== undefined && packages.includes(pkg);
+    },
+  }));
+}
 
 /**
  * Chunks that must never appear in an `index.html` modulepreload. Each is only reachable
  * through a dynamic import, so a preload link means something started importing it statically.
  */
-export const lazyChunks: string[] = ['editor', 'wallet-connect'];
+export const lazyChunks: string[] = ['chart', 'editor', 'wallet-connect'];
 
 /**
  * Misplacements that exist today and are not fixed yet. The check stays green for these but
  * fails on anything new, and it also fails once one of them stops happening, which is the
  * prompt to delete the entry rather than let the list rot.
  *
- * `vue` in `chart`: Rolldown emits the vue runtime into `chart` even though the rule resolves
- * it to `vue-vendor`. Every chunk needs vue, so all of them statically import `chart` and
- * echarts ends up eager. Cause is Rolldown-side and still unknown. This is the big remaining
- * win, worth roughly 257 KB gzip.
- *
- * The `ui-vendor` entries are a few kB each: Rolldown hoists a handful of modules shared with
- * `@rotki/ui-library` into its chunk instead of leaving them in the group they resolve to.
- * Low impact, and it predates the codeSplitting migration.
+ * Empty on purpose: every package currently lands where the rules say it should. Add an entry
+ * only to record a misplacement you are deliberately not fixing.
  */
-export const knownViolations: string[] = [
-  '@vueuse/core -> ui-vendor (expected utils)',
-  '@vueuse/shared -> ui-vendor (expected utils)',
-  'dayjs -> ui-vendor (expected utils)',
-  'vue -> chart (expected vue-vendor)',
-  'vue-router -> ui-vendor (expected vue-vendor)',
-];
+export const knownViolations: string[] = [];
 
 function packageOf(id: string): string | undefined {
   const normalized = id.replaceAll('\\', '/');
@@ -105,7 +126,7 @@ export function vendorChunkFor(id: string): string | null {
   if (!pkg)
     return null;
 
-  for (const [chunk, packages] of Object.entries(vendorGroups)) {
+  for (const { chunk, packages } of vendorGroups) {
     if (packages.includes(pkg))
       return chunk;
   }

--- a/frontend/app/shared/ipc.ts
+++ b/frontend/app/shared/ipc.ts
@@ -1,6 +1,6 @@
 import type { DebugSettings } from '@rotki/common';
 import { LogLevel } from '@shared/log-level';
-import z from 'zod';
+import * as z from 'zod/mini';
 
 export const BackendCode = {
   TERMINATED: 0,
@@ -58,21 +58,21 @@ export interface SystemVersion {
   readonly arch: string;
 }
 
-export const ActiveLogLevel = z.preprocess(
-  s => (typeof s === 'string' ? s.toLowerCase() : s),
+export const ActiveLogLevel = z.pipe(
+  z.transform(s => (typeof s === 'string' ? s.toLowerCase() : s)),
   z.enum(LogLevel),
 );
 
 export const BackendOptions = z.object({
-  loglevel: ActiveLogLevel.optional(),
-  dataDirectory: z.string().optional(),
-  logDirectory: z.string().optional(),
-  sleepSeconds: z.number().nonnegative().optional(),
-  logFromOtherModules: z.boolean().optional(),
-  maxSizeInMbAllLogs: z.number().int().positive().optional(),
-  sqliteInstructions: z.number().int().positive().optional(),
-  maxLogfilesNum: z.number().int().positive().optional(),
-  mcpAutoStart: z.boolean().optional(),
+  loglevel: z.optional(ActiveLogLevel),
+  dataDirectory: z.optional(z.string()),
+  logDirectory: z.optional(z.string()),
+  sleepSeconds: z.optional(z.number().check(z.nonnegative())),
+  logFromOtherModules: z.optional(z.boolean()),
+  maxSizeInMbAllLogs: z.optional(z.int().check(z.positive())),
+  sqliteInstructions: z.optional(z.int().check(z.positive())),
+  maxLogfilesNum: z.optional(z.int().check(z.positive())),
+  mcpAutoStart: z.optional(z.boolean()),
 });
 
 type StoredBackendOptions = z.infer<typeof BackendOptions>;

--- a/frontend/app/shared/wallet-bridge-types.ts
+++ b/frontend/app/shared/wallet-bridge-types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod/mini';
 
 /**
  * Unified Wallet Bridge Types with Runtime Validation
@@ -12,9 +12,9 @@ const JsonRpcBaseSchema = z.object({
 });
 
 // Wallet Bridge Request Schema (JSON-RPC format)
-const WalletBridgeRequestSchema = JsonRpcBaseSchema.extend({
-  method: z.string().min(1),
-  params: z.array(z.unknown()).optional(),
+const WalletBridgeRequestSchema = z.extend(JsonRpcBaseSchema, {
+  method: z.string().check(z.minLength(1)),
+  params: z.optional(z.array(z.unknown())),
 });
 
 export type WalletBridgeRequest = z.infer<typeof WalletBridgeRequestSchema>;
@@ -23,17 +23,17 @@ export type WalletBridgeRequest = z.infer<typeof WalletBridgeRequestSchema>;
 const RpcErrorSchema = z.object({
   code: z.number(),
   message: z.string(),
-  data: z.unknown().optional(),
+  data: z.optional(z.unknown()),
 });
 
 // Wallet Bridge Response Schema
-export const WalletBridgeResponseSchema = JsonRpcBaseSchema.extend({
-  result: z.unknown().optional(),
-  error: RpcErrorSchema.optional(),
-}).refine(
+export const WalletBridgeResponseSchema = z.extend(JsonRpcBaseSchema, {
+  result: z.optional(z.unknown()),
+  error: z.optional(RpcErrorSchema),
+}).check(z.refine(
   data => (data.result !== undefined) !== (data.error !== undefined),
   { message: 'Response must have either result or error, but not both' },
-);
+));
 
 export type WalletBridgeResponse = z.infer<typeof WalletBridgeResponseSchema>;
 
@@ -47,9 +47,9 @@ const NotificationTypeSchema = z.enum([
 // Wallet Bridge Notification Schema
 const WalletBridgeNotificationSchema = z.object({
   type: NotificationTypeSchema,
-  eventName: z.string().optional(),
-  eventData: z.unknown().optional(),
-  data: z.unknown().optional(),
+  eventName: z.optional(z.string()),
+  eventData: z.optional(z.unknown()),
+  data: z.optional(z.unknown()),
 });
 
 export type WalletBridgeNotification = z.infer<typeof WalletBridgeNotificationSchema>;

--- a/frontend/app/vite.config.main.ts
+++ b/frontend/app/vite.config.main.ts
@@ -35,13 +35,32 @@ export default defineConfig({
       external: ['electron', 'httpxy', ...builtinModules.flatMap(p => [p, `node:${p}`])],
       output: {
         entryFileNames: 'main.js',
-        manualChunks(id) {
-          if (id.includes('node_modules'))
-            return 'background-vendor';
-          if (id.includes('electron-updater'))
-            return 'background-vendor-updater';
-          if (id.includes('http'))
-            return 'background-http';
+        // Keep our code in `main.js` and dependencies in `background-vendor`, so a stack frame from
+        // the minified production bundle (no sourcemaps here) says which side it came from.
+        //
+        // Only *statically* reachable dependencies are claimed. A blanket `node_modules` test also
+        // swallows lazily imported subtrees, and since `background-vendor` is itself statically
+        // imported by the entry, that silently drags them back into the startup path: it is what
+        // kept electron-updater's 290 KB eager. Reachability is derived from the module graph rather
+        // than a hand-listed exclusion, so it stays correct as dependencies move around. A module
+        // needed by both sides is statically reachable, lands in the vendor chunk, and the lazy
+        // chunk simply imports it from there.
+        manualChunks(id, { getModuleInfo }) {
+          if (!id.includes('node_modules'))
+            return;
+
+          const seen = new Set<string>();
+          const reachedStatically = (moduleId: string): boolean => {
+            if (seen.has(moduleId))
+              return false;
+            seen.add(moduleId);
+            const info = getModuleInfo(moduleId);
+            if (!info)
+              return false;
+            return info.isEntry || info.importers.some(reachedStatically);
+          };
+
+          return reachedStatically(id) ? 'background-vendor' : undefined;
         },
       },
     },

--- a/frontend/app/vite.config.main.ts
+++ b/frontend/app/vite.config.main.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import process from 'node:process';
 import { defineConfig } from 'vite';
 
-const PACKAGE_ROOT = __dirname;
+const PACKAGE_ROOT = import.meta.dirname;
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 export default defineConfig({

--- a/frontend/app/vite.config.preload.ts
+++ b/frontend/app/vite.config.preload.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import process from 'node:process';
 import { defineConfig } from 'vite';
 
-const PACKAGE_ROOT = __dirname;
+const PACKAGE_ROOT = import.meta.dirname;
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 export default defineConfig({

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -15,7 +15,7 @@ import { defineConfig } from 'vitest/config';
 import { VueRouterAutoImports } from 'vue-router/unplugin';
 import VueRouter from 'vue-router/vite';
 import { backendIcons } from './backend-icons.generated';
-import { sharedHelperModules, vendorChunkFor } from './scripts/chunk-groups';
+import { sharedHelperModules, vendorGroupEntries } from './scripts/chunk-groups';
 import { backendIconsCachePlugin } from './scripts/extract-backend-icons';
 
 const PACKAGE_ROOT = __dirname;
@@ -333,9 +333,7 @@ export default defineConfig({
               priority: 100,
               test: (id: string): boolean => sharedHelperModules.has(id),
             },
-            {
-              name: (id: string): string | null => vendorChunkFor(id),
-            },
+            ...vendorGroupEntries(),
           ],
         },
       },

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -18,7 +18,7 @@ import { backendIcons } from './backend-icons.generated';
 import { sharedHelperModules, vendorGroupEntries } from './scripts/chunk-groups';
 import { backendIconsCachePlugin } from './scripts/extract-backend-icons';
 
-const PACKAGE_ROOT = __dirname;
+const PACKAGE_ROOT = import.meta.dirname;
 const PROJECT_ROOT = resolve(PACKAGE_ROOT, '../..');
 
 // Read from the manifest instead of npm_package_version: the latter depends on how

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -15,6 +15,7 @@ import { defineConfig } from 'vitest/config';
 import { VueRouterAutoImports } from 'vue-router/unplugin';
 import VueRouter from 'vue-router/vite';
 import { backendIcons } from './backend-icons.generated';
+import { sharedHelperModules, vendorChunkFor } from './scripts/chunk-groups';
 import { backendIconsCachePlugin } from './scripts/extract-backend-icons';
 
 const PACKAGE_ROOT = __dirname;
@@ -323,38 +324,19 @@ export default defineConfig({
             : currentName;
           return `${name}-[hash].js`;
         },
-        manualChunks: (id: string): string | undefined => {
-          const chunkGroups: Record<string, string[]> = {
-            'vue-vendor': ['vue', 'vue-router', 'pinia', 'vue-i18n'],
-            'common': ['@rotki/common', 'bignumber.js'],
-            'ui-vendor': ['@rotki/ui-library'],
-            'chart': ['echarts', 'vue-echarts'],
-            'editor': ['vanilla-jsoneditor'],
-            'utils': [
-              '@vueuse/math',
-              '@vueuse/core',
-              '@vueuse/shared',
-              '@vuelidate/core',
-              '@vuelidate/validators',
-              'ofetch',
-              'es-toolkit',
-              'imask',
-              'dayjs',
-              'consola',
-              'zod',
-            ],
-            'wallet-connect': [
-              '@walletconnect/core',
-              '@walletconnect/universal-provider',
-              'viem',
-            ],
-          };
-          for (const [chunk, packages] of Object.entries(chunkGroups)) {
-            if (packages.some(pkg => id.includes(`/node_modules/${pkg}/`))) {
-              return chunk;
-            }
-          }
-          return undefined;
+        codeSplitting: {
+          groups: [
+            // Must outrank the vendor groups below so these land in `helpers` rather than
+            // in whichever vendor chunk happens to claim them first.
+            {
+              name: 'helpers',
+              priority: 100,
+              test: (id: string): boolean => sharedHelperModules.has(id),
+            },
+            {
+              name: (id: string): string | null => vendorChunkFor(id),
+            },
+          ],
         },
       },
     },

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -217,6 +217,13 @@ export default rotki({
   files: ['app/electron/**/*.ts', 'app/shared/**/*.ts'],
   rules: {
     'no-restricted-imports': ['error', {
+      // Matched by exact name, so `zod/mini` itself is untouched. Classic zod does not tree-shake:
+      // its chained methods keep the whole surface reachable, and it measured 421.9 KB here against
+      // 112.4 KB for mini. One classic import anywhere in this graph brings all of it back.
+      paths: [{
+        name: 'zod',
+        message: 'Use `zod/mini` under electron/ and shared/. Classic zod costs the main bundle ~310 KB more.',
+      }],
       patterns: [{
         group: ['vue', 'vue-*', '@vue/*', '@vueuse/*'],
         message: 'The electron main/preload bundles are plain Node. A vue or @vueuse import drags the vue runtime and compiler into them.',

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -208,6 +208,22 @@ export default rotki({
     }],
   },
 }, {
+  // The electron main and preload bundles are plain Node, and `shared/` is compiled into them.
+  // Importing anything vue-shaped there pulls the vue runtime *and* its compiler (via
+  // @vue/compiler-core -> @babel/parser) into a process that never renders: one `isDefined` from
+  // @vueuse/core cost the main bundle 727 KB raw, 41% of it. Reach for a plain helper instead.
+  // Anchored to the two real directories rather than `**/shared/**`, which also matches any folder
+  // named `shared` under `src/` (for example `core/table/filters/shared`), where vue is expected.
+  files: ['app/electron/**/*.ts', 'app/shared/**/*.ts'],
+  rules: {
+    'no-restricted-imports': ['error', {
+      patterns: [{
+        group: ['vue', 'vue-*', '@vue/*', '@vueuse/*'],
+        message: 'The electron main/preload bundles are plain Node. A vue or @vueuse import drags the vue runtime and compiler into them.',
+      }],
+    }],
+  },
+}, {
   // Unit specs must never wait on the real clock. A fixed sleep is a race, not a wait: it passes on an
   // idle laptop and fails on a loaded CI box, and it costs its full duration even when the work it
   // waits for finished immediately. Use what vitest gives you instead - `vi.useFakeTimers()` plus

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -141,9 +141,6 @@ catalogs:
     electron-builder:
       specifier: 26.15.3
       version: 26.15.3
-    electron-store:
-      specifier: 11.0.2
-      version: 11.0.2
     electron-updater:
       specifier: 6.8.9
       version: 6.8.9
@@ -530,9 +527,6 @@ importers:
       electron-builder:
         specifier: 'catalog:'
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
-      electron-store:
-        specifier: 'catalog:'
-        version: 11.0.2
       fake-indexeddb:
         specifier: 'catalog:'
         version: 6.2.5
@@ -2842,14 +2836,6 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -2951,9 +2937,6 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
-
-  atomically@2.1.1:
-    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
 
   autoprefixer@10.5.4:
     resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
@@ -3233,10 +3216,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  conf@15.1.0:
-    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
-    engines: {node: '>=20'}
-
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -3342,10 +3321,6 @@ packages:
 
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
-
-  debounce-fn@6.0.0:
-    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
-    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -3473,10 +3448,6 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
-  dot-prop@10.1.0:
-    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
-    engines: {node: '>=20'}
-
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
     engines: {node: '>=12'}
@@ -3525,10 +3496,6 @@ packages:
 
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
-
-  electron-store@11.0.2:
-    resolution: {integrity: sha512-4VkNRdN+BImL2KcCi41WvAYbh6zLX5AUTi4so68yPqiItjbgTjqpEnGAqasgnG+lB6GuAyUltKwVopp6Uv+gwQ==}
-    engines: {node: '>=20'}
 
   electron-to-chromium@1.5.393:
     resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
@@ -4557,9 +4524,6 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
-
   json-source-map@0.6.1:
     resolution: {integrity: sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==}
 
@@ -4981,10 +4945,6 @@ packages:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
-
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
 
   mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
@@ -5948,12 +5908,6 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
-  stubborn-fs@2.0.0:
-    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
-
-  stubborn-utils@1.0.2:
-    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
-
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
@@ -6213,10 +6167,6 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
-
-  uint8array-extras@1.5.0:
-    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
-    engines: {node: '>=18'}
 
   uint8arrays@3.1.1:
     resolution: {integrity: sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==}
@@ -6704,9 +6654,6 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  when-exit@2.1.5:
-    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -8597,7 +8544,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10)':
     dependencies:
@@ -8637,6 +8584,7 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@24.13.3)(typescript@6.0.3)
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
+    optional: true
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -8665,7 +8613,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -9190,10 +9138,6 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-jsx@5.3.2(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
@@ -9203,10 +9147,6 @@ snapshots:
   acorn@8.18.0: {}
 
   agent-base@7.1.4: {}
-
-  ajv-formats@3.0.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:
@@ -9337,11 +9277,6 @@ snapshots:
   at-least-node@1.0.0: {}
 
   atomic-sleep@1.0.0: {}
-
-  atomically@2.1.1:
-    dependencies:
-      stubborn-fs: 2.0.0
-      when-exit: 2.1.5
 
   autoprefixer@10.5.4(postcss@8.5.25):
     dependencies:
@@ -9628,18 +9563,6 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  conf@15.1.0:
-    dependencies:
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      atomically: 2.1.1
-      debounce-fn: 6.0.0
-      dot-prop: 10.1.0
-      env-paths: 3.0.0
-      json-schema-typed: 8.0.2
-      semver: 7.8.5
-      uint8array-extras: 1.5.0
-
   confbox@0.1.8: {}
 
   confbox@0.2.4: {}
@@ -9725,10 +9648,6 @@ snapshots:
   csstype@3.2.3: {}
 
   dayjs@1.11.21: {}
-
-  debounce-fn@6.0.0:
-    dependencies:
-      mimic-function: 5.0.1
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -9852,10 +9771,6 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
-  dot-prop@10.1.0:
-    dependencies:
-      type-fest: 5.7.0
-
   dotenv-expand@11.0.7:
     dependencies:
       dotenv: 16.6.1
@@ -9932,11 +9847,6 @@ snapshots:
       mime: 2.6.0
     transitivePeerDependencies:
       - supports-color
-
-  electron-store@11.0.2:
-    dependencies:
-      conf: 15.1.0
-      type-fest: 5.7.0
 
   electron-to-chromium@1.5.393: {}
 
@@ -10414,8 +10324,8 @@ snapshots:
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 5.0.1
 
   espree@9.6.1:
@@ -11117,8 +11027,6 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
-  json-schema-typed@8.0.2: {}
-
   json-source-map@0.6.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -11705,8 +11613,6 @@ snapshots:
       mime-db: 1.54.0
 
   mime@2.6.0: {}
-
-  mimic-function@5.0.1: {}
 
   mimic-response@1.0.1: {}
 
@@ -12699,12 +12605,6 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stubborn-fs@2.0.0:
-    dependencies:
-      stubborn-utils: 1.0.2
-
-  stubborn-utils@1.0.2: {}
-
   style-mod@4.1.3: {}
 
   stylelint-config-html@2.0.0(postcss-html@2.0.0(postcss@8.5.25))(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3)):
@@ -13016,8 +12916,6 @@ snapshots:
   typescript@6.0.3: {}
 
   ufo@1.6.4: {}
-
-  uint8array-extras@1.5.0: {}
 
   uint8arrays@3.1.1:
     dependencies:
@@ -13350,6 +13248,7 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.5
       yaml: 2.9.0
+    optional: true
 
   vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0)):
     dependencies:
@@ -13410,6 +13309,7 @@ snapshots:
       happy-dom: 20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - msw
+    optional: true
 
   vscode-uri@3.1.0: {}
 
@@ -13519,8 +13419,6 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  when-exit@2.1.5: {}
 
   which-module@2.0.1: {}
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -80,7 +80,6 @@ catalog:
   echarts: 6.1.0
   electron: 43.2.0
   electron-builder: 26.15.3
-  electron-store: 11.0.2
   electron-updater: 6.8.9
   electron-window-state: 5.0.3
   es-toolkit: 1.50.0


### PR DESCRIPTION
Shrinks what both processes parse before the app is usable. Everything here is measured, and the numbers below are reproducible with the scripts described at the end.

| eager startup | before | after |
|---|---|---|
| renderer graph | 999.0 KB gzip | **491.6 KB** (-51%) |
| main process | 422.6 KB gzip | **55.9 KB** (-87%) |

The renderer half is chunk placement. The main-process half is four dependencies that were being parsed at boot for no benefit.

## Renderer

Vite/Rolldown inject virtual helper modules (`\0vite/preload-helper.js`, `\0plugin-vue:export-helper` and friends). `manualChunks` never receives virtual modules, so they were unassigned and Rolldown parked each one in whichever large lazy chunk claimed it first. Every importer then statically pulled that whole chunk in, which is how the `editor` chunk (289.9 KB) ended up in the startup graph. `codeSplitting`'s `test` function does receive them, so they now have a home.

Separately, one `codeSplitting` group with a dynamic `name()` gives every name it returns the same priority, leaving `chart` free to claim the vue runtime. Since every chunk needs vue, 369 statically imported modules plus echarts went eager. The fix is one explicit entry per chunk with `vue-vendor` outranking the rest.

`chart`, `editor` and `wallet-connect` are all lazy now.

## Main process

- **vue, 727 KB, 41% of the bundle.** `tray-manager.ts` imported `isDefined` from `@vueuse/core` for a single call. `@vueuse/core` imports vue, vue's full build reaches `@vue/compiler-core`, which depends on `@babel/parser`, so the vue runtime *and* template compiler shipped in a process that never renders.
- **electron-updater, 290.7 KB**, imported at module level and wired from a constructor, so it was parsed at boot. It now loads on first use behind a memoized accessor shared by the check, download and install handlers.
- **electron-store, 230.5 KB**, most of it `ajv`, pulled in for JSON-schema validation we never asked for: we constructed it with no options at all. What it gave us was a JSON file, so `PasswordStore` keeps the file and drops the dependency.
- **zod, 379.5 KB.** Classic zod does not tree-shake, since chained methods keep the whole surface reachable. The four schema files here use a small part of it, so they move to `zod/mini`.

The vendor chunking had to change alongside the updater. A blanket `node_modules` test also claims lazily imported subtrees, and because `background-vendor` is itself statically imported by the entry, that silently dragged them back into the startup path: the lazy import measured *zero* gain until this was fixed. It now claims only statically reachable modules, derived from the module graph rather than a hand-listed exclusion, which keeps our code isolated in `main.js` for stack traces.

## A bug fixed along the way

`conf` wrote through dot-prop, so a username containing a dot was stored as nested objects (`john.doe` became `{ john: { doe: ... } }`) while every read in `PasswordManager` is a flat lookup. Dots are legal in usernames, so for those users the password saved successfully and then never restored. Legacy nesting is now flattened on read, recovered, and rewritten once.

Existing stores keep working. Every electron-store default is reproduced, since installed clients already have one of these files: `<userData>/config.json`, serialized as conf did with `JSON.stringify(value, undefined, '\t')`, mode `0o666`, written to a sibling and renamed so a crash cannot lose every saved password.

## Guards

Three lint rules and one CI check, so none of this silently comes back:

- `check:bundle` asserts chunk *placement* rather than size, because a lazy chunk costs nothing however big it gets while one misplaced helper drags a whole chunk into the startup graph. It runs as a CI step after Build.
- No `vue`/`vue-*`/`@vue/*`/`@vueuse/*` imports under `electron/` and `shared/`.
- No classic `zod` under `electron/` and `shared/`, matched by exact name so `zod/mini` passes. This is not cosmetic: one classic import anywhere in that graph pulls the full surface back, which the rule caught immediately in a file added by this PR, worth 70 KB on its own.

Each rule was negative-controlled: reintroducing the exact import it bans produces an error.

## Testing

- Unit suite green, 7577 tests. `PasswordStore` gains 18 cases covering the on-disk format, the legacy recovery and the failure paths; `SettingsManager` gains 8 and previously had none. Both sets were negative-controlled, failing exactly the intended cases when the logic under test is broken.
- Sharded e2e green, 230 passed / 1 skipped across 4 shards.
- Smoke-tested as a packaged AppImage: saved password restores and auto-logins from a `config.json` that electron-store wrote, the updater check reaches the release feed with our logger intact after the deferred import, and navigation resolves lazy chunks with no errors.

Measurements were taken by building each config in memory with `build: { write: false }`, so they never clobber a real `dist/`. The renderer figure is the gzip sum of `index.html`'s script and modulepreload set; the main-process figure is the entry plus its statically imported chunks.
